### PR TITLE
ENH: `array_creation` able to handle `like=NoneType`. Addresses #22069

### DIFF
--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -175,7 +175,7 @@ def array(
     order: _OrderKACF = ...,
     subok: L[True],
     ndmin: int = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> _ArrayType: ...
 @overload
 def array(
@@ -186,7 +186,7 @@ def array(
     order: _OrderKACF = ...,
     subok: bool = ...,
     ndmin: int = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def array(
@@ -197,7 +197,7 @@ def array(
     order: _OrderKACF = ...,
     subok: bool = ...,
     ndmin: int = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def array(
@@ -208,7 +208,7 @@ def array(
     order: _OrderKACF = ...,
     subok: bool = ...,
     ndmin: int = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def array(
@@ -219,7 +219,7 @@ def array(
     order: _OrderKACF = ...,
     subok: bool = ...,
     ndmin: int = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -228,7 +228,7 @@ def zeros(
     dtype: None = ...,
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[float64]: ...
 @overload
 def zeros(
@@ -236,7 +236,7 @@ def zeros(
     dtype: _DTypeLike[_SCT],
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def zeros(
@@ -244,7 +244,7 @@ def zeros(
     dtype: DTypeLike,
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -253,7 +253,7 @@ def empty(
     dtype: None = ...,
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[float64]: ...
 @overload
 def empty(
@@ -261,7 +261,7 @@ def empty(
     dtype: _DTypeLike[_SCT],
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def empty(
@@ -269,7 +269,7 @@ def empty(
     dtype: DTypeLike,
     order: _OrderCF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -467,7 +467,7 @@ def asarray(
     dtype: None = ...,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asarray(
@@ -475,7 +475,7 @@ def asarray(
     dtype: None = ...,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def asarray(
@@ -483,7 +483,7 @@ def asarray(
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asarray(
@@ -491,7 +491,7 @@ def asarray(
     dtype: DTypeLike,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -500,7 +500,7 @@ def asanyarray(
     dtype: None = ...,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> _ArrayType: ...
 @overload
 def asanyarray(
@@ -508,7 +508,7 @@ def asanyarray(
     dtype: None = ...,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asanyarray(
@@ -516,7 +516,7 @@ def asanyarray(
     dtype: None = ...,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def asanyarray(
@@ -524,7 +524,7 @@ def asanyarray(
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asanyarray(
@@ -532,7 +532,7 @@ def asanyarray(
     dtype: DTypeLike,
     order: _OrderKACF = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -540,28 +540,28 @@ def ascontiguousarray(
     a: _ArrayLike[_SCT],
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def ascontiguousarray(
     a: object,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def ascontiguousarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def ascontiguousarray(
     a: Any,
     dtype: DTypeLike,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -569,28 +569,28 @@ def asfortranarray(
     a: _ArrayLike[_SCT],
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asfortranarray(
     a: object,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def asfortranarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def asfortranarray(
     a: Any,
     dtype: DTypeLike,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 # In practice `list[Any]` is list with an int, int and a valid
@@ -608,7 +608,7 @@ def fromstring(
     count: SupportsIndex = ...,
     *,
     sep: str,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[float64]: ...
 @overload
 def fromstring(
@@ -617,7 +617,7 @@ def fromstring(
     count: SupportsIndex = ...,
     *,
     sep: str,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def fromstring(
@@ -626,7 +626,7 @@ def fromstring(
     count: SupportsIndex = ...,
     *,
     sep: str,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 def frompyfunc(
@@ -645,7 +645,7 @@ def fromfile(
     sep: str = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[float64]: ...
 @overload
 def fromfile(
@@ -655,7 +655,7 @@ def fromfile(
     sep: str = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def fromfile(
@@ -665,7 +665,7 @@ def fromfile(
     sep: str = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -674,7 +674,7 @@ def fromiter(
     dtype: _DTypeLike[_SCT],
     count: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def fromiter(
@@ -682,7 +682,7 @@ def fromiter(
     dtype: DTypeLike,
     count: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -692,7 +692,7 @@ def frombuffer(
     count: SupportsIndex = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[float64]: ...
 @overload
 def frombuffer(
@@ -701,7 +701,7 @@ def frombuffer(
     count: SupportsIndex = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def frombuffer(
@@ -710,7 +710,7 @@ def frombuffer(
     count: SupportsIndex = ...,
     offset: SupportsIndex = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 @overload
@@ -718,7 +718,7 @@ def arange(  # type: ignore[misc]
     stop: _IntLike_co,
     /, *,
     dtype: None = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[signedinteger[Any]]: ...
 @overload
 def arange(  # type: ignore[misc]
@@ -727,14 +727,14 @@ def arange(  # type: ignore[misc]
     step: _IntLike_co = ...,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[signedinteger[Any]]: ...
 @overload
 def arange(  # type: ignore[misc]
     stop: _FloatLike_co,
     /, *,
     dtype: None = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[floating[Any]]: ...
 @overload
 def arange(  # type: ignore[misc]
@@ -743,14 +743,14 @@ def arange(  # type: ignore[misc]
     step: _FloatLike_co = ...,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[floating[Any]]: ...
 @overload
 def arange(
     stop: _TD64Like_co,
     /, *,
     dtype: None = ...,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[timedelta64]: ...
 @overload
 def arange(
@@ -759,7 +759,7 @@ def arange(
     step: _TD64Like_co = ...,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[timedelta64]: ...
 @overload
 def arange(  # both start and stop must always be specified for datetime64
@@ -768,14 +768,14 @@ def arange(  # both start and stop must always be specified for datetime64
     step: datetime64 = ...,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[datetime64]: ...
 @overload
 def arange(
     stop: Any,
     /, *,
     dtype: _DTypeLike[_SCT],
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def arange(
@@ -784,14 +784,14 @@ def arange(
     step: Any = ...,
     dtype: _DTypeLike[_SCT] = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def arange(
     stop: Any, /,
     *,
     dtype: DTypeLike,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 @overload
 def arange(
@@ -800,7 +800,7 @@ def arange(
     step: Any = ...,
     dtype: DTypeLike = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
 def datetime_data(

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -348,11 +348,7 @@ array_implement_array_function(
      */
     if (kwargs != NULL && PyDict_Contains(kwargs, npy_ma_str_like)) {
         PyObject *like_arg = PyDict_GetItem(kwargs, npy_ma_str_like);
-        if (like_arg == Py_None){
-            PyDict_SetItem(kwargs, "like", NULL);
-            like_arg == NULL;
-        }
-        if (like_arg != NULL) {
+        if (like_arg != NULL && like_arg != Py_None) {
             PyObject *tmp_has_override = get_array_function(like_arg);
             if (tmp_has_override == NULL) {
                 return PyErr_Format(PyExc_TypeError,
@@ -371,6 +367,9 @@ array_implement_array_function(
              * equality/identity comparisons when `like=` is present.
              */
             public_api = implementation;
+        }
+        if (like_arg == Py_None){
+            PyDict_DelItem(kwargs, npy_ma_str_like);
         }
     }
 

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -403,12 +403,14 @@ array_implement_c_array_function_creation(
 
     /* If `like` doesn't implement `__array_function__`, raise a `TypeError` */
     PyObject *tmp_has_override = get_array_function(like);
-    if (tmp_has_override == NULL) {
+    if (tmp_has_override == NULL && like != Py_None) {
         return PyErr_Format(PyExc_TypeError,
                 "The `like` argument must be an array-like that "
                 "implements the `__array_function__` protocol.");
     }
-    Py_DECREF(tmp_has_override);
+    if (tmp_has_override != NULL){
+        Py_DECREF(tmp_has_override);
+    }
 
     if (fast_args != NULL) {
         /*

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -348,6 +348,10 @@ array_implement_array_function(
      */
     if (kwargs != NULL && PyDict_Contains(kwargs, npy_ma_str_like)) {
         PyObject *like_arg = PyDict_GetItem(kwargs, npy_ma_str_like);
+        if (like_arg == Py_None){
+            PyDict_SetItem(kwargs, "like", NULL);
+            like_arg == NULL;
+        }
         if (like_arg != NULL) {
             PyObject *tmp_has_override = get_array_function(like_arg);
             if (tmp_has_override == NULL) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1004,11 +1004,6 @@ class TestCreation:
         assert_array_equal(np.zeros_like(d), d)
         assert_equal(np.zeros_like(d).dtype, d.dtype)
 
-    def test_zeros_like_as_none(self):
-        arr = np.zeros(3, like=None)
-        expected = np.array(3)
-        assert_array_equal(arr, expected)
-
     def test_empty_unicode(self):
         # don't throw decode errors on garbage memory
         for i in range(5, 100, 5):
@@ -1190,11 +1185,21 @@ class TestCreation:
         expected = expected * (arr.nbytes // len(expected))
         assert arr.tobytes() == expected
 
-    def test_like_as_none(self):
-        arr = np.array([1, 2, 3], like=None)
-        expected = np.array([1, 2, 3])
+    @pytest.mark.parametrize("func, func_input",
+            [(np.array, [1, 2, 3]),
+             (np.asarray, [1, 2, 3]),
+             (np.asanyarray, [1, 2, 3]),
+             (np.ascontiguousarray, [1, 2, 3]),
+             (np.asfortranarray, [1, 2, 3]),
+             (np.zeros, 5),
+             (np.ones, 5),
+             (np.empty_like, np.zeros(5)),
+             (np.arange, 5),
+             ])
+    def test_like_as_none(self, func, func_input):
+        arr = func(func_input, like=None)
+        expected = func(func_input, like=None)
         assert_array_equal(arr, expected)
-
 
 class TestStructured:
     def test_subarray_field_access(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1195,8 +1195,9 @@ class TestCreation:
              (np.ones, 5),
              (np.empty_like, np.zeros(5)),
              (np.arange, 5),
-             (np.fromstring, map(int, "123"),)  # mapping needed as expects bytes
-             (np.frombuffer, np.zeros(5),)
+             (np.frombuffer, np.zeros(5),),
+             # mapped as fromstring expects bytes
+             (np.fromstring, map(int, "123"),)
              ])
     def test_like_as_none(self, func, func_input):
         arr = func(func_input, like=None)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1195,6 +1195,8 @@ class TestCreation:
              (np.ones, 5),
              (np.empty_like, np.zeros(5)),
              (np.arange, 5),
+             (np.fromstring, map(int, "123"),)  # mapping needed as expects bytes
+             (np.frombuffer, np.zeros(5),)
              ])
     def test_like_as_none(self, func, func_input):
         arr = func(func_input, like=None)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1193,7 +1193,6 @@ class TestCreation:
              (np.asfortranarray, [1, 2, 3]),
              (np.zeros, 5),
              (np.ones, 5),
-             (np.empty_like, np.zeros(5)),
              (np.arange, 5),
              (np.frombuffer, np.zeros(5),),
              # mapped as fromstring expects bytes

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1198,7 +1198,7 @@ class TestCreation:
              ])
     def test_like_as_none(self, func, func_input):
         arr = func(func_input, like=None)
-        expected = func(func_input, like=None)
+        expected = func(func_input)
         assert_array_equal(arr, expected)
 
 class TestStructured:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1004,6 +1004,11 @@ class TestCreation:
         assert_array_equal(np.zeros_like(d), d)
         assert_equal(np.zeros_like(d).dtype, d.dtype)
 
+    def test_zeros_like_as_none(self):
+        arr = np.zeros(3, like=None)
+        expected = np.array(3)
+        assert_array_equal(arr, expected)
+
     def test_empty_unicode(self):
         # don't throw decode errors on garbage memory
         for i in range(5, 100, 5):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1190,6 +1190,11 @@ class TestCreation:
         expected = expected * (arr.nbytes // len(expected))
         assert arr.tobytes() == expected
 
+    def test_like_as_none(self):
+        arr = np.array([1, 2, 3], like=None)
+        expected = np.array([1, 2, 3])
+        assert_array_equal(arr, expected)
+
 
 class TestStructured:
     def test_subarray_field_access(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1195,8 +1195,6 @@ class TestCreation:
              (np.ones, 5),
              (np.arange, 5),
              (np.frombuffer, np.zeros(5),),
-             # mapped as fromstring expects bytes
-             (np.fromstring, map(int, "123"),)
              ])
     def test_like_as_none(self, func, func_input):
         arr = func(func_input, like=None)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Addresses #22069. As discussed in the existing [issue](https://github.com/numpy/numpy/issues/22069) @seberg stated that it would be best to support explicitly defined `like=None` when creating `arange` objects. 

Extended to all other `array_creation` methods which did not currently support `like=None`.

Added parameteric unit test to cover all cases. Did not include `fromiter` or `fromfile` as they didn't fit the current `parametric` structure of that test, however I can do if required?

First PR to this repos so sorry if I missed something.

Cheers