### PR TITLE
docs: Fix small grammar slip

### DIFF
--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -208,7 +208,7 @@ concepts to remember include:
 
 - You may use slicing to set values in the array, but (unlike lists) you
   can never grow the array. The size of the value to be set in
-  ``x[obj] = value`` must be (broadcastable) to the same shape as
+  ``x[obj] = value`` must be (broadcastable to) the same shape as
   ``x[obj]``.
 
 - A slicing tuple can always be constructed as *obj*


### PR DESCRIPTION
This PR fixes a small grammar mistake in the `doc/source/user/basic.indexing.rst` page.