### PR TITLE
MAINT: fix an incorrect pointer type usage in f2py

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1146,12 +1146,12 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
         return 1;
     }
     if (PyArray_CheckScalar(obj)) { /* 0-dim array or still array scalar */
-        PyObject *arr;
+        PyArrayObject *arr;
         if (PyArray_Check(obj)) {
-            arr = PyArray_Cast((PyArrayObject *)obj, NPY_CDOUBLE);
+            arr = (PyArrayObject *)PyArray_Cast((PyArrayObject *)obj, NPY_CDOUBLE);
         }
         else {
-            arr = PyArray_FromScalar(obj, PyArray_DescrFromType(NPY_CDOUBLE));
+            arr = (PyArrayObject *)PyArray_FromScalar(obj, PyArray_DescrFromType(NPY_CDOUBLE));
         }
         if (arr == NULL) {
             return 0;


### PR DESCRIPTION
This was giving many warnings like this one in the SciPy build:
```
scipy/special/_specfunmodule.c: In function 'complex_double_from_pyobj':
scipy/special/_specfunmodule.c:198:47: warning: passing argument 1 of 'PyArray_DATA' from incompatible pointer type [-Wincompatible-pointer-types]
  198 |         (*v).r = ((npy_cdouble *)PyArray_DATA(arr))->real;
      |                                               ^~~
      |                                               |
      |                                               PyObject * {aka struct _object *}
In file included from /home/rgommers/code/numpy/numpy/core/include/numpy/ndarrayobject.h:12,
                 from /home/rgommers/code/numpy/numpy/core/include/numpy/arrayobject.h:5,
                 from /home/rgommers/code/numpy/numpy/f2py/src/fortranobject.h:16,
                 from scipy/special/_specfunmodule.c:22:
/home/rgommers/code/numpy/numpy/core/include/numpy/ndarraytypes.h:1524:29: note: expected 'PyArrayObject *' {aka 'struct tagPyArrayObject *'} but argument is of type 'PyObject *' {aka 'struct _object *'}
 1524 | PyArray_DATA(PyArrayObject *arr)
      |              ~~~~~~~~~~~~~~~^~~
```

Fixing pointer mismatches is important for Pyodide/Emscripten.