### PR TITLE
MAINT: Unpin towncrier

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -10,4 +10,4 @@ pandas
 breathe
 
 # needed to build release notes
-towncrier==21.9.0
+towncrier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 [tool.towncrier]
     # Do no set this since it is hard to import numpy inside the source directory
     # the name is hardcoded. Use "--version 1.18.0" to set the version
-    single_file = true
+    single_file = false
     filename = "doc/source/release/{version}-notes.rst"
     directory = "doc/release/upcoming_changes/"
     issue_format = "`gh-{issue} <https://github.com/numpy/numpy/pull/{issue}>`__"


### PR DESCRIPTION
This sets ``single_file=false`` in pyproject.toml instead of pinning the
towncrier version.

[skip azp] [skip github] [skip travis]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
