### PR TITLE
TST,BUG: Use fork context to fix MacOS savez test

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -596,11 +596,11 @@ class TestSaveTxt:
         # in our process if needed, see gh-16889
         memoryerror_raised = Value(c_bool)
 
-        # Use the same start method between Linux and macOS, the default method of
-        # Linux is 'fork', and the default method of macOS is spawn. 'spawn' will
-        # cause problem in the check_large_zip since the data sharing model is
-        # built on 'fork'
-        p = get_context('fork').Process(target=check_large_zip, args=(memoryerror_raised,))
+        # Since Python 3.8, the default start method for multiprocessing has 
+        # been changed from 'fork' to 'spawn' on macOS, causing inconsistency 
+        # on memory sharing model, lead to failed test for check_large_zip
+        ctx = get_context('fork')
+        p = ctx.Process(target=check_large_zip, args=(memoryerror_raised,))
         p.start()
         p.join()
         if memoryerror_raised.value:


### PR DESCRIPTION
Why the test failed

 * Since Python 3.8, the default start method for multiprocessing has been changed from `fork` to `spawn` on macOS
 * The default start method is still `fork` on other Unix platforms[1], causing inconsistency on memory sharing model
 * It will cause a memory-sharing problem for the test `test_large_zip` on macOS as the memory sharing model between `spawn` and `fork` is different

The fix

 * Change the start method for this test back to `fork` under this testcase context
 * In this test case context, [the bug](/python/cpython/issues/77906) that caused default start method changed to `spawn` for macOS will not be triggered
 * It is context limited, so this change will not affect default start method other than `test_large_zip`
 * All platforms have the **same memory sharing model** now
 * After the change, `test_large_zip` is passed on macOS

1. https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods