### PR TITLE
DOC: Clarify that `like` is not passed to `function`

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1836,7 +1836,7 @@ def fromfunction(function, shape, *, dtype=float, like=None, **kwargs):
 
     Notes
     -----
-    Keywords other than `dtype` are passed to `function`.
+    Keywords other than `dtype` and `like` are passed to `function`.
 
     Examples
     --------


### PR DESCRIPTION
When the `like` argument was added in 1.20 this line in the docs was not updated. This PR fixes that.