### PR TITLE
BUG: change overloads to play nice with pyright.

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -198,6 +198,7 @@ from ._array_like import (
     _ArrayLikeVoid_co as _ArrayLikeVoid_co,
     _ArrayLikeStr_co as _ArrayLikeStr_co,
     _ArrayLikeBytes_co as _ArrayLikeBytes_co,
+    _ArrayLikeUnknown as _ArrayLikeUnknown,
 )
 from ._generic_alias import (
     NDArray as NDArray,

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -141,3 +141,16 @@ _ArrayLikeInt = _DualArrayLike[
     "dtype[integer[Any]]",
     int,
 ]
+
+# Extra ArrayLike type so that pyright can deal with NDArray[Any]
+# Used as the first overload, should only match NDArray[Any],
+# not any actual types.
+# https://github.com/numpy/numpy/pull/22193
+class _UnknownType: 
+    ...
+
+
+_ArrayLikeUnknown = _DualArrayLike[
+    "dtype[_UnknownType]",
+    _UnknownType,
+]

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -43,6 +43,7 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
     _ArrayLikeObject_co,
+    _ArrayLikeUnknown,
 )
 
 _T = TypeVar("_T")
@@ -257,10 +258,10 @@ def flatnonzero(a: ArrayLike) -> NDArray[intp]: ...
 
 @overload
 def correlate(
-    a: _ArrayLikeObject_co,
-    v: _ArrayLikeObject_co,
+    a: _ArrayLikeUnknown,
+    v: _ArrayLikeUnknown,
     mode: _CorrelateMode = ...,
-) -> NDArray[object_]: ...
+) -> NDArray[Any]: ...
 @overload
 def correlate(
     a: _ArrayLikeBool_co,
@@ -297,13 +298,19 @@ def correlate(
     v: _ArrayLikeTD64_co,
     mode: _CorrelateMode = ...,
 ) -> NDArray[timedelta64]: ...
+@overload
+def correlate(
+    a: _ArrayLikeObject_co,
+    v: _ArrayLikeObject_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def convolve(
-    a: _ArrayLikeObject_co,
-    v: _ArrayLikeObject_co,
+    a: _ArrayLikeUnknown,
+    v: _ArrayLikeUnknown,
     mode: _CorrelateMode = ...,
-) -> NDArray[object_]: ...
+) -> NDArray[Any]: ...
 @overload
 def convolve(
     a: _ArrayLikeBool_co,
@@ -340,13 +347,19 @@ def convolve(
     v: _ArrayLikeTD64_co,
     mode: _CorrelateMode = ...,
 ) -> NDArray[timedelta64]: ...
+@overload
+def convolve(
+    a: _ArrayLikeObject_co,
+    v: _ArrayLikeObject_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def outer(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
+    a: _ArrayLikeUnknown,
+    b: _ArrayLikeUnknown,
     out: None = ...,
-) -> NDArray[object_]: ...
+) -> NDArray[Any]: ...
 @overload
 def outer(
     a: _ArrayLikeBool_co,
@@ -383,6 +396,12 @@ def outer(
     b: _ArrayLikeTD64_co,
     out: None = ...,
 ) -> NDArray[timedelta64]: ...
+@overload
+def outer(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    out: None = ...,
+) -> NDArray[object_]: ...
 @overload
 def outer(
     a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
@@ -392,10 +411,10 @@ def outer(
 
 @overload
 def tensordot(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
+    a: _ArrayLikeUnknown,
+    b: _ArrayLikeUnknown,
     axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
-) -> NDArray[object_]: ...
+) -> NDArray[Any]: ...
 @overload
 def tensordot(
     a: _ArrayLikeBool_co,
@@ -432,6 +451,12 @@ def tensordot(
     b: _ArrayLikeTD64_co,
     axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
 ) -> NDArray[timedelta64]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def roll(
@@ -460,13 +485,13 @@ def moveaxis(
 
 @overload
 def cross(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
+    a: _ArrayLikeUnknown,
+    b: _ArrayLikeUnknown,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
     axis: None | int = ...,
-) -> NDArray[object_]: ...
+) -> NDArray[Any]: ...
 @overload
 def cross(
     a: _ArrayLikeBool_co,
@@ -512,6 +537,15 @@ def cross(
     axisc: int = ...,
     axis: None | int = ...,
 ) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def cross(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def indices(

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -257,6 +257,12 @@ def flatnonzero(a: ArrayLike) -> NDArray[intp]: ...
 
 @overload
 def correlate(
+    a: _ArrayLikeObject_co,
+    v: _ArrayLikeObject_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[object_]: ...
+@overload
+def correlate(
     a: _ArrayLikeBool_co,
     v: _ArrayLikeBool_co,
     mode: _CorrelateMode = ...,
@@ -291,13 +297,13 @@ def correlate(
     v: _ArrayLikeTD64_co,
     mode: _CorrelateMode = ...,
 ) -> NDArray[timedelta64]: ...
+
 @overload
-def correlate(
+def convolve(
     a: _ArrayLikeObject_co,
     v: _ArrayLikeObject_co,
     mode: _CorrelateMode = ...,
 ) -> NDArray[object_]: ...
-
 @overload
 def convolve(
     a: _ArrayLikeBool_co,
@@ -334,13 +340,13 @@ def convolve(
     v: _ArrayLikeTD64_co,
     mode: _CorrelateMode = ...,
 ) -> NDArray[timedelta64]: ...
-@overload
-def convolve(
-    a: _ArrayLikeObject_co,
-    v: _ArrayLikeObject_co,
-    mode: _CorrelateMode = ...,
-) -> NDArray[object_]: ...
 
+@overload
+def outer(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    out: None = ...,
+) -> NDArray[object_]: ...
 @overload
 def outer(
     a: _ArrayLikeBool_co,
@@ -377,12 +383,6 @@ def outer(
     b: _ArrayLikeTD64_co,
     out: None = ...,
 ) -> NDArray[timedelta64]: ...
-@overload
-def outer(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
-    out: None = ...,
-) -> NDArray[object_]: ...
 @overload
 def outer(
     a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
@@ -392,6 +392,12 @@ def outer(
 
 @overload
 def tensordot(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[object_]: ...
+@overload
+def tensordot(
     a: _ArrayLikeBool_co,
     b: _ArrayLikeBool_co,
     axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
@@ -426,12 +432,6 @@ def tensordot(
     b: _ArrayLikeTD64_co,
     axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
 ) -> NDArray[timedelta64]: ...
-@overload
-def tensordot(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
-    axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
-) -> NDArray[object_]: ...
 
 @overload
 def roll(
@@ -458,6 +458,15 @@ def moveaxis(
     destination: _ShapeLike,
 ) -> NDArray[_SCT]: ...
 
+@overload
+def cross(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[object_]: ...
 @overload
 def cross(
     a: _ArrayLikeBool_co,
@@ -503,15 +512,6 @@ def cross(
     axisc: int = ...,
     axis: None | int = ...,
 ) -> NDArray[complexfloating[Any, Any]]: ...
-@overload
-def cross(
-    a: _ArrayLikeObject_co,
-    b: _ArrayLikeObject_co,
-    axisa: int = ...,
-    axisb: int = ...,
-    axisc: int = ...,
-    axis: None | int = ...,
-) -> NDArray[object_]: ...
 
 @overload
 def indices(


### PR DESCRIPTION
Backport of #22193.

It seems Pyright just chooses the first matching type whenever there is ambiguity in type resolution, which leads to a `NoReturn` for `numpy.cross` in certain situations (See #22146.) As far as I can tell, there is no agreed-upon behavior or guidelines for dealing with ambiguity in type resolution, so this is valid behavior on Pyright's side (see microsoft/pyright#2521 for a discussion on this topic.)

I suppose the ideal solution would be to resolve the ambiguity, but AFAIK there is no way to do that for constructs like `numpy.array([1, 2, 3])` on the numpy side, short of asking every user to include a dtype in these cases. I would love to be proven wrong though.

I think the second best solution is to have the more general overload also be the first one that matches, so that we make as few assumptions as possible about what might happen inside the function when given an `NDArray[Any]`. The other overloads were just changed so that they match the one for `numpy.cross`.

I would also consider changing the overload order in functions elsewhere in the library, if it makes sense.

I am very open to suggestions if someone has a better idea on how to deal with this.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
