### PR TITLE
TST,BUG: Use fork context to fix MacOS savez test

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -13,7 +13,7 @@ from tempfile import NamedTemporaryFile
 from io import BytesIO, StringIO
 from datetime import datetime
 import locale
-from multiprocessing import Process, Value
+from multiprocessing import Value, get_context
 from ctypes import c_bool
 
 import numpy as np
@@ -595,7 +595,12 @@ class TestSaveTxt:
         # Use an object in shared memory to re-raise the MemoryError exception
         # in our process if needed, see gh-16889
         memoryerror_raised = Value(c_bool)
-        p = Process(target=check_large_zip, args=(memoryerror_raised,))
+
+        # Since Python 3.8, the default start method for multiprocessing has 
+        # been changed from 'fork' to 'spawn' on macOS, causing inconsistency 
+        # on memory sharing model, lead to failed test for check_large_zip
+        ctx = get_context('fork')
+        p = ctx.Process(target=check_large_zip, args=(memoryerror_raised,))
         p.start()
         p.join()
         if memoryerror_raised.value:


### PR DESCRIPTION
Backport of #22204.

Why the test failed

 * Since Python 3.8, the default start method for multiprocessing has been changed from `fork` to `spawn` on macOS
 * The default start method is still `fork` on other Unix platforms[1], causing inconsistency on memory sharing model
 * It will cause a memory-sharing problem for the test `test_large_zip` on macOS as the memory sharing model between `spawn` and `fork` is different

The fix

 * Change the start method for this test back to `fork` under this testcase context
 * In this test case context, [the bug](/python/cpython/issues/77906) that caused default start method changed to `spawn` for macOS will not be triggered
 * It is context limited, so this change will not affect default start method other than `test_large_zip`
 * All platforms have the **same memory sharing model** now
 * After the change, `test_large_zip` is passed on macOS

1. https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

Closes gh-22203.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
