### PR TITLE
TYP,BUG: Reduce argument validation in C-based ``__class_getitem__`` 

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2829,7 +2829,7 @@ array_class_getitem(PyObject *cls, PyObject *args)
     Py_ssize_t args_len;
 
     args_len = PyTuple_Check(args) ? PyTuple_Size(args) : 1;
-    if (args_len != 2) {
+    if ((args_len > 2) || (args_len == 0)) {
         return PyErr_Format(PyExc_TypeError,
                             "Too %s arguments for %s",
                             args_len > 2 ? "many" : "few",

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1855,7 +1855,7 @@ numbertype_class_getitem_abc(PyObject *cls, PyObject *args)
     }
 
     args_len = PyTuple_Check(args) ? PyTuple_Size(args) : 1;
-    if (args_len != args_len_expected) {
+    if ((args_len > args_len_expected) || (args_len == 0)) {
         return PyErr_Format(PyExc_TypeError,
                             "Too %s arguments for %s",
                             args_len > args_len_expected ? "many" : "few",

--- a/numpy/core/tests/test_scalar_methods.py
+++ b/numpy/core/tests/test_scalar_methods.py
@@ -153,6 +153,16 @@ class TestClassGetItem:
         assert isinstance(alias, types.GenericAlias)
         assert alias.__origin__ is np.complexfloating
 
+    @pytest.mark.parametrize("arg_len", range(4))
+    def test_abc_complexfloating_subscript_tuple(self, arg_len: int) -> None:
+        arg_tup = (Any,) * arg_len
+        if arg_len in (1, 2):
+            assert np.complexfloating[arg_tup]
+        else:
+            match = f"Too {'few' if arg_len == 0 else 'many'} arguments"
+            with pytest.raises(TypeError, match=match):
+                np.complexfloating[arg_tup]
+
     @pytest.mark.parametrize("cls", [np.generic, np.flexible, np.character])
     def test_abc_non_numeric(self, cls: Type[np.generic]) -> None:
         with pytest.raises(TypeError):


### PR DESCRIPTION
Backport of #22212.

Closes https://github.com/numpy/numpy/issues/22185

The `__class_getitem__` implementations would previously perform basic validation of the passed value, _i.e._ it would check whether a tuple of the appropriate length was passed (_e.g._ `np.dtype.__class_getitem__` would expect a single item or a length-1 tuple). As noted in aforementioned issue: this approach can cause issues when (a. 2 or more parameters are involved and (b. a subclasses is created one or more parameters are declared constant (_e.g._ a fixed dtype & variably shaped array).

This PR fixes aforementioned issue by removing any and all runtime argument validation, thus mimicking the behavior of the standard library. While we could alternatively fix this by adding more special casing (_e.g._ only disable validation when `cls is not np.ndarray`), I'm not convinced this would be worth the additional complexity, especially since the standard library also has zero runtime validation for all of its `Py_GenericAlias`-based implementations of `__class_getitem__`.

Examples
---------
The issue prior to this PR:
``` python
In [1]: import numpy as np
   ...: from typing import TypeVar, Any

In [2]: ShapeType = TypeVar("ShapeType")

# Variable shaped & fixed dtype
In [3]: class FooArray(np.ndarray[ShapeType , np.dtype[np.int64]]): ...

# Uhoh, __class_getitem__ still expects both a shape and dtype parameter
In [4]: FooArray[Any]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 FooArray[Any]

TypeError: Too few arguments for FooArray
```