### PR TITLE
MAINT: Remove long deprecated functionality from np.ma

### DIFF
--- a/doc/release/upcoming_changes/22228.expired.rst
+++ b/doc/release/upcoming_changes/22228.expired.rst
@@ -1,6 +1,5 @@
-The mini() method of np.ma.MaskedArray has been removed. Use either
-np.ma.MaskedArray.min() or np.ma.minimum.reduce().
+* The mini() method of ``np.ma.MaskedArray`` has been removed. Use either
+  ``np.ma.MaskedArray.min()`` or ``np.ma.minimum.reduce()``.
 
-
-The single-argument form of np.ma.minimum and np.ma.maximum has been
-removed. Use np.ma.minimum.reduce() or np.ma.maximum.reduce() instead.
+* The single-argument form of ``np.ma.minimum`` and ``np.ma.maximum`` has been
+  removed. Use ``np.ma.minimum.reduce()`` or ``np.ma.maximum.reduce()`` instead.

--- a/doc/release/upcoming_changes/22228.expired.rst
+++ b/doc/release/upcoming_changes/22228.expired.rst
@@ -1,0 +1,6 @@
+The mini() method of np.ma.MaskedArray has been removed. Use either
+np.ma.MaskedArray.min() or np.ma.minimum.reduce().
+
+
+The single-argument form of np.ma.minimum and np.ma.maximum has been
+removed. Use np.ma.minimum.reduce() or np.ma.maximum.reduce() instead.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5804,74 +5804,6 @@ class MaskedArray(ndarray):
             np.copyto(out, np.nan, where=newmask)
         return out
 
-    # unique to masked arrays
-    def mini(self, axis=None):
-        """
-        Return the array minimum along the specified axis.
-
-        .. deprecated:: 1.13.0
-           This function is identical to both:
-
-            * ``self.min(keepdims=True, axis=axis).squeeze(axis=axis)``
-            * ``np.ma.minimum.reduce(self, axis=axis)``
-
-           Typically though, ``self.min(axis=axis)`` is sufficient.
-
-        Parameters
-        ----------
-        axis : int, optional
-            The axis along which to find the minima. Default is None, in which case
-            the minimum value in the whole array is returned.
-
-        Returns
-        -------
-        min : scalar or MaskedArray
-            If `axis` is None, the result is a scalar. Otherwise, if `axis` is
-            given and the array is at least 2-D, the result is a masked array with
-            dimension one smaller than the array on which `mini` is called.
-
-        Examples
-        --------
-        >>> x = np.ma.array(np.arange(6), mask=[0 ,1, 0, 0, 0 ,1]).reshape(3, 2)
-        >>> x
-        masked_array(
-          data=[[0, --],
-                [2, 3],
-                [4, --]],
-          mask=[[False,  True],
-                [False, False],
-                [False,  True]],
-          fill_value=999999)
-        >>> x.mini()
-        masked_array(data=0,
-                     mask=False,
-               fill_value=999999)
-        >>> x.mini(axis=0)
-        masked_array(data=[0, 3],
-                     mask=[False, False],
-               fill_value=999999)
-        >>> x.mini(axis=1)
-        masked_array(data=[0, 2, 4],
-                     mask=[False, False, False],
-               fill_value=999999)
-
-        There is a small difference between `mini` and `min`:
-
-        >>> x[:,1].mini(axis=0)
-        masked_array(data=3,
-                     mask=False,
-               fill_value=999999)
-        >>> x[:,1].min(axis=0)
-        3
-        """
-
-        # 2016-04-13, 1.13.0, gh-8764
-        warnings.warn(
-            "`mini` is deprecated; use the `min` method or "
-            "`np.ma.minimum.reduce instead.",
-            DeprecationWarning, stacklevel=2)
-        return minimum.reduce(self, axis)
-
     def max(self, axis=None, out=None, fill_value=None, keepdims=np._NoValue):
         """
         Return the maximum along a given axis.
@@ -6719,15 +6651,9 @@ class _extrema_operation(_MaskedUFunc):
         self.compare = compare
         self.fill_value_func = fill_value
 
-    def __call__(self, a, b=None):
+    def __call__(self, a, b):
         "Executes the call behavior."
-        if b is None:
-            # 2016-04-13, 1.13.0
-            warnings.warn(
-                f"Single-argument form of np.ma.{self.__name__} is deprecated. Use "
-                f"np.ma.{self.__name__}.reduce instead.",
-                DeprecationWarning, stacklevel=2)
-            return self.reduce(a)
+
         return where(self.compare(a, b), a, b)
 
     def reduce(self, target, axis=np._NoValue):
@@ -8089,12 +8015,6 @@ def asanyarray(a, dtype=None):
 ##############################################################################
 #                               Pickling                                     #
 ##############################################################################
-
-def _pickle_warn(method):
-    # NumPy 1.15.0, 2017-12-10
-    warnings.warn(
-        f"np.ma.{method} is deprecated, use pickle.{method} instead",
-        DeprecationWarning, stacklevel=3)
 
 
 def fromfile(file, dtype=float, count=-1, sep=''):

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -39,11 +39,6 @@ class TestArgsort:
 
 
 class TestMinimumMaximum:
-    def test_minimum(self):
-        assert_warns(DeprecationWarning, np.ma.minimum, np.ma.array([1, 2]))
-
-    def test_maximum(self):
-        assert_warns(DeprecationWarning, np.ma.maximum, np.ma.array([1, 2]))
 
     def test_axis_default(self):
         # NumPy 1.13, 2017-05-06


### PR DESCRIPTION
I've run into these long deprecated functionalities, they are probably long overdue for removal.

There is one more remaining deprecation from 1.13 regarding the default for the `axis` kwarg, but that seemed a bit more complex case, so I left it out from this quick evening fix.