### PR TITLE
Remove incorrect comment about checking generated C files in

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -18,10 +18,6 @@ Simple script to invoke Cython (and Tempita) on all .pyx (.pyx.in)
 files; while waiting for a proper build system. Uses file hashes to
 figure out if rebuild is needed.
 
-For now, this script should be run by developers when changing Cython files
-only, and the resulting C files checked in, so that end-users (and Python-only
-developers) do not get the Cython/Tempita dependencies.
-
 Originally written by Dag Sverre Seljebotn, and copied here from:
 
 https://raw.github.com/dagss/private-scipy-refactor/cythonize/cythonize.py


### PR DESCRIPTION
Evidently the decision was made at some point not to do what Dag suggests in the documentation of this file.  So delete that suggestion, which conflicts with reality.  I agree with not checking in the C files, and think Cython isn't an unreasonable dependency for building from git.  Also, cython is clearly stated to be a build dependency here: https://github.com/numpy/numpy/blob/main/INSTALL.rst#id9

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
