### PR TITLE
BUG: Fix incorrect refcounting in new `asarray` path

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1631,8 +1631,8 @@ _array_fromobject_generic(
         oldtype = PyArray_DESCR(oparr);
         if (PyArray_EquivTypes(oldtype, type)) {
             if (copy != NPY_COPY_ALWAYS && STRIDING_OK(oparr, order)) {
-                Py_INCREF(op);
                 if (oldtype == type) {
+                    Py_INCREF(op);
                     ret = oparr;
                 }
                 else {


### PR DESCRIPTION
The new path to preserve dtypes provided by creating a view got the reference counting wrong, because it also hit the incref path that was needed for returning the identity.

This fixes up gh-21995

Closes gh-22233


@charris I keep forgetting how (should note it somewhere :)). Could you retrigger the nightlies, since this seems to affect downstream CI quite annoyingly.