### PR TITLE
BLD: add back stdlib.h include in pcg64.h

### DIFF
--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -52,8 +52,11 @@
 
 #include <inttypes.h>
 
-#if defined(_WIN32) && !defined (__MINGW32__)
+#ifdef _WIN32
 #include <stdlib.h>
+#endif
+
+#if defined(_WIN32) && !defined (__MINGW32__)
 #define inline __forceinline
 #endif
 


### PR DESCRIPTION
This seems to have been removed by accident in #21887
stdlib.h is required for _rotr64() further down.

Fixes (using clang 15.0.0):
> error: call to undeclared function '_rotr64'; ISO C99 and later do not support
  implicit function declarations [-Wimplicit-function-declaration]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
