### PR TITLE
DOC: Update concatenate exception message.

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -436,7 +436,7 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
             /* Validate that the rest of the dimensions match */
             else if (shape[idim] != arr_shape[idim]) {
                 PyErr_Format(PyExc_ValueError,
-                             "all the input array dimensions for the "
+                             "all the input array dimensions except for the "
                              "concatenation axis must match exactly, but "
                              "along dimension %d, the array at index %d has "
                              "size %d and the array at index %d has size %d",

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -260,7 +260,7 @@ class TestConcatenate:
             np.concatenate((a, b), axis=axis[0])  # OK
             assert_raises_regex(
                 ValueError,
-                "all the input array dimensions for the concatenation axis "
+                "all the input array dimensions except for the concatenation axis "
                 "must match exactly, but along dimension {}, the array at "
                 "index 0 has size 1 and the array at index 1 has size 2"
                 .format(i),


### PR DESCRIPTION
Add missing word to correct exception message when concatenate axes don't match.

Closes #22250 