### PR TITLE
ENH: Added Fourier transform option for numpy.polynomial.polymul

### DIFF
--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -72,7 +72,16 @@ class TestArithmetic:
             tgt = [0]*(i + 1) + [1]
             assert_equal(poly.polymulx(ser), tgt)
 
-    def test_polymul(self):
+    def test_polymul(self, fourier=True):
+        for i in range(5):
+            for j in range(5):
+                msg = f"At i={i}, j={j}"
+                tgt = np.zeros(i + j + 1)
+                tgt[i + j] += 1
+                res = poly.polymul([0]*i + [1], [0]*j + [1])
+                assert_equal(trim(res), trim(tgt), err_msg=msg)
+
+    def test_polymul(self, fourier=False):
         for i in range(5):
             for j in range(5):
                 msg = f"At i={i}, j={j}"


### PR DESCRIPTION
By default, numpy.polynomial.polymul uses convolution between polynomials A and B to find the product between the two. However, the discrete Fourier transformation (DFT) of this convolution is the DFT of A multiplied by the DFT of B. From there, we can get the product of A and B by taking the inverse DFT. Since this completely avoids the need to convolve the two polynomials, it's the faster option when the number of coefficients is very large.

Using Fourier transforms is kept optional and chosen with the `fourier` flag. By default, this flag is set to false, since it can be the inferior option when the polynomials are small and pushing code that slows down existing programs using this function would be a mistake. The code itself is just a few lines using the pre-existing numpy.fft.fft and numpy.fft.ifft functions, as well as a small comment explaining one of the steps.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
