### PR TITLE
NEP: Make NEP 51 to propose changing the scalar representation

### DIFF
--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -284,6 +284,15 @@ concise.  Alternatives for booleans were also discussed previously in [1]_.
 For the string scalars, the confusion is generally less pronounced.  It may be
 reasonable to defer changing these.
 
+Non-finite values
+-----------------
+The proposal does not allow copy pasting ``nan`` and ``inf`` values.
+They could be represented by ``np.float64('nan')`` or ``np.float64(np.nan)``
+instead.
+This is more concise and Python also uses ``nan`` and ``inf`` rather than
+allowing copy-pasting by showing it as ``float('nan')``.  Arguably, it would be
+a smaller addition in NumPy, where the will already be always printed.
+
 ``get_formatter()``
 -------------------
 When ``fmt=`` is passed, and specifically for the main use (in this NEP) to

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -1,0 +1,208 @@
+.. _NEP51:
+
+=====================================================
+NEP 51 — Changing the representation of NumPy scalars
+=====================================================
+:Author: Sebastian Berg
+:Status: Draft
+:Type: Standards Track
+:Created: 2022-09-13
+
+
+Abstract
+========
+
+NumPy has scalar objects ("NumPy scalar") representing a single value
+corresponding to a NumPy DType.  The representation of these currently
+matches that of the Python builtins, giving::
+
+    >>> np.float32(3.0)
+    3.0
+
+In this NEP we propose to change the representation to include the
+NumPy scalar type information.  Changing the above example to::
+
+    >>> np.float32(3.0)
+    float32(3.0)
+
+We expect that this change will help users distinguish the NumPy scalars
+from the Python builtin types and clarify their behavior.
+
+The distinction between NumPy scalars and Python builtins will further become
+more important for users once :ref:`NEP 50 <NEP50>` is adopted.
+
+Motivation and Scope
+====================
+
+This NEP proposes to change the representation of the following
+NumPy scalars types:
+
+* ``np.bool_``
+* ``np.uint8``, ``np.int8``, and all other integer scalars
+* ``np.float16``, ``np.float32``, ``np.float64``, ``np.longdouble``
+* ``np.complex64``, ``np.complex128``, ``np.clongdouble``
+* ``np.str_``, ``np.bytes_``
+
+The NEP does not propose to change how these scalars print – only
+their representation (``__repr__``) will be changed.
+Further, array representation will not be affected since it already
+includes the ``dtype=`` when necessary. 
+
+The main motivation behind the change is that the Python numerical types 
+behave differently from the NumPy scalars.
+For example numbers with lower precision (e.g. ``uint8`` or ``float16``)
+should be used with care and users should be aware when they are working
+with them.  All NumPy integers can experience overflow which Python integers
+do not.
+This differences will be exacerbated when adopting :ref:`NEP 50 <NEP50>`
+because the lower precision NumPy scalar will be preserved more often.
+Even ``float64``, which is very similar to Python's ``float`` and inherits
+from it, does behave differently for example when dividing by zero.
+
+A common confusion are also the NumPy booleans.  Python programmers
+somtimes write ``obj is True`` and will surprised when an object that shows
+as ``True`` fails to pass the test.
+It is much easier to understand this behavior when the value is
+shown as ``np.True_``.
+
+Not only do we expect the change to help users better understand and be
+reminded of the differences between NumPy and Python scalars, but we also
+believe that the awareness will greatly help debugging.
+
+Usage and Impact
+================
+
+Most user code should not be impacted by the change, but users will now
+often see NumPy values shown as::
+
+    np.True_
+    float64(3.0)
+    int64(34)
+
+and so on.  This will also mean that documentation and output in
+Jupyter notebook cells will often show the type information intact.
+
+``longdouble`` and ``clongdouble`` will print with single quotes::
+
+    longdouble('3.0')
+
+to allow round-tripping.  Addtionally to this change, ``float128`` will
+now always be printed as ``longdouble`` since the old name gives a wrong
+impression of precision.
+
+Backward compatibility
+======================
+
+We expect that most workflows will not be affected as only printing
+changes.  In general we believe that informing users about the type
+they are working with outweighs the need for adapting printing in
+some instances.
+
+An exception to this are downstream libraries with documentation and
+especially documentation testing.
+Since the representation of many values will change, in many cases
+the documentationi will have to be updated to use the new representation.
+Further, it may be necessary to adept tools for doctest testing to
+allow approximate value checking for the new representation.
+
+.. admonition:: TODO
+
+    While astropy's `pytest-doctestplus <https://github.com/astropy/pytest-doctestplus>`_
+    itself should not be affected by this change, if other checkers are
+    affected, these should be given a chance to release a new version
+    before NumPy goes ahead with the change.
+
+    Testing should happen before the final release to see how certain
+    large downstream libraries (SciPy, astropy, etc.) are affected.
+    These are expected to require larger changes to their documentation.
+
+
+Detailed description
+====================
+
+This NEP proposes to change the represenatation for NumPy scalars to:
+
+* ``np.True_`` and ``np.False_`` for booleans
+* ``scalar(<value>)``, i.e. ``float64(3.0)`` for all numerical dtypes.
+* The value for ``longdouble`` and ``clongdouble`` will be given in quotes:
+  ``longdouble('3.0')``.  This ensures that it can always roundtrip correctly
+  and matches ``decimal.Decimal``.
+  Further, for these two the size based name such as ``float128`` will not
+  be adopted, as it is platform dependend and imprecise. 
+* ``np.str_("string")`` and ``np.bytes_(b"byte_string")`` for string dtypes.
+
+Where booleans are printed as their singletons since this is more concise.
+For strings we include the ``np.`` as ``str_`` and ``bytes_`` on their
+own may not be sufficient to indicate NumPy involvement.
+
+Details about ``longdouble`` and ``clongdouble``
+------------------------------------------------
+
+For ``longdouble`` and ``clongdouble`` values such as::
+
+    np.sqrt(np.longdouble(2.))
+
+may not roundtrip unless quoted as strings (as the conversion to a Python float
+would lose precision).  This NEP proposes to use a single quote similar to
+Python's decimal which prints as ``Decimal('3.0')``
+
+``longdouble`` can have different precision and storage sizes varying from
+8 to 16 bytes.  However, even if ``float128`` is correct because the number
+is stored as 128 bits, it normally does not have 128 bit precision.
+(``clongdouble`` is the same, but with twice the storage size.)
+
+This NEP thus includes the proposal of changing the name of ``longdouble``
+to always print as ``longdouble`` and never ``float128`` or ``float96``.
+It does not include deprecating the ``np.float128`` alias.
+However, such a deprecation may occur independently of the NEP.
+
+Related Work
+============
+
+A PR to only change the representation of booleans was previously
+made `here <https://github.com/numpy/numpy/pull/17592>`_.
+
+Implementation
+==============
+
+The new representations can be implemented on the scalar types.
+Additional work may be necessary to ensure that the changes do not affect
+array representation as well.
+
+Alternatives
+============
+
+Different representation could be discussed, main alternatives are inclusion
+of ``numpy`` or ``np`` for the numerical types to give for example
+``np.float64(3.0)``.
+We believe that the numerical types are sufficiently clear without the ``np``
+and thus prefer to not include the ``np.`` part.
+
+For booleans an alternative would be to use ``np.bool_(True)`` or ``bool_(True)``.
+However, NumPy boolean scalars are singletons and the proposed formatting is more
+concise.  In general, ``numpy.True_`` would be a more verbose alternative.
+These were also discussed previously in [1]_.
+
+For the string scalars, the confusion is generally less pronounced.  It may be
+reasonable to defer changing these.
+
+
+Discussion
+==========
+
+* An initial discussion on this changed happened in the mailing list:
+  https://mail.python.org/archives/list/numpy-discussion@python.org/thread/7GLGFHTZHJ6KQPOLMVY64OM6IC6KVMYI/
+* There was a previous issue [1]_ and PR [2]_ to change only the
+  representation of the NumPy booleans
+
+
+References and Footnotes
+========================
+
+.. [1] https://github.com/numpy/numpy/issues/12950
+.. [2] https://github.com/numpy/numpy/pull/17592
+
+Copyright
+=========
+
+This document has been placed in the public domain.

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -52,9 +52,9 @@ with the new scheme to use the ``np`` prefix consistently:
 The NEP does not propose to change how these scalars print – only
 their representation (``__repr__``) will be changed.
 Further, array representation will not be affected since it already
-includes the ``dtype=`` when necessary. 
+includes the ``dtype=`` when necessary.
 
-The main motivation behind the change is that the Python numerical types 
+The main motivation behind the change is that the Python numerical types
 behave differently from the NumPy scalars.
 For example numbers with lower precision (e.g. ``uint8`` or ``float16``)
 should be used with care and users should be aware when they are working
@@ -104,6 +104,14 @@ changes.  In general we believe that informing users about the type
 they are working with outweighs the need for adapting printing in
 some instances.
 
+The NumPy test suite includes code such as ``decimal.Decimal(repr(scalar))``.
+This code needs to be modified to use the ```str()``.
+
+.. admonition:: TODO
+
+    If there is a lot of similar code, we may need a better solution than
+    ``str()``, since it is plausible that ``str()`` should honor
+
 An exception to this are downstream libraries with documentation and
 especially documentation testing.
 Since the representation of many values will change, in many cases
@@ -136,7 +144,7 @@ This NEP proposes to change the represenatation for NumPy scalars to:
   ``np.longdouble('3.0')``.  This ensures that it can always roundtrip correctly
   and matches ``decimal.Decimal``.
   Further, for these two the size based name such as ``float128`` will not
-  be adopted, as it is platform dependend and imprecise. 
+  be adopted, as it is platform dependend and imprecise.
 * ``np.str_("string")`` and ``np.bytes_(b"byte_string")`` for string dtypes.
 
 Where booleans are printed as their singletons since this is more concise.
@@ -163,6 +171,24 @@ This NEP thus includes the proposal of changing the name of ``longdouble``
 to always print as ``longdouble`` and never ``float128`` or ``float96``.
 It does not include deprecating the ``np.float128`` alias.
 However, such a deprecation may occur independently of the NEP.
+
+Integer scalar type name and instance represenatation
+-----------------------------------------------------
+
+One detail is that due to NumPy scalar types being based on the C types,
+NumPy sometimes distinguishes them, for example on most 64 bit systems
+(not windows)::
+
+     >>> np.longlong
+     numpy.longlong
+     >>> np.longlong(3)
+     np.int64(3)
+
+The proposal will lead to the ``longlong`` name for the type while
+using the ``int64`` form for the scalar.
+This choice is made since ``int64`` is generally the more useful
+information for users, but the type name itself must be precise.
+
 
 Related Work
 ============

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -23,7 +23,7 @@ In this NEP we propose to change the representation to include the
 NumPy scalar type information.  Changing the above example to::
 
     >>> np.float32(3.0)
-    float32(3.0)
+    np.float32(3.0)
 
 We expect that this change will help users distinguish the NumPy scalars
 from the Python builtin types and clarify their behavior.
@@ -35,13 +35,19 @@ Motivation and Scope
 ====================
 
 This NEP proposes to change the representation of the following
-NumPy scalars types:
+NumPy scalars types to distinguish them from the Python scalars:
 
 * ``np.bool_``
 * ``np.uint8``, ``np.int8``, and all other integer scalars
 * ``np.float16``, ``np.float32``, ``np.float64``, ``np.longdouble``
 * ``np.complex64``, ``np.complex128``, ``np.clongdouble``
 * ``np.str_``, ``np.bytes_``
+
+Additionally, these representation will be slightly modified to align
+with the new scheme to use the ``np`` prefix consistently:
+
+* ``np.datetime64`` and ``np.timedelta64``
+* ``np.void``
 
 The NEP does not propose to change how these scalars print – only
 their representation (``__repr__``) will be changed.
@@ -76,15 +82,15 @@ Most user code should not be impacted by the change, but users will now
 often see NumPy values shown as::
 
     np.True_
-    float64(3.0)
-    int64(34)
+    np.float64(3.0)
+    np.int64(34)
 
 and so on.  This will also mean that documentation and output in
 Jupyter notebook cells will often show the type information intact.
 
-``longdouble`` and ``clongdouble`` will print with single quotes::
+``np.longdouble`` and ``np.clongdouble`` will print with single quotes::
 
-    longdouble('3.0')
+    np.longdouble('3.0')
 
 to allow round-tripping.  Addtionally to this change, ``float128`` will
 now always be printed as ``longdouble`` since the old name gives a wrong
@@ -101,7 +107,9 @@ some instances.
 An exception to this are downstream libraries with documentation and
 especially documentation testing.
 Since the representation of many values will change, in many cases
-the documentationi will have to be updated to use the new representation.
+the documentation will have to be updated to use the new representation.
+This is expected to require larger documentation fixups.
+
 Further, it may be necessary to adept tools for doctest testing to
 allow approximate value checking for the new representation.
 
@@ -123,9 +131,9 @@ Detailed description
 This NEP proposes to change the represenatation for NumPy scalars to:
 
 * ``np.True_`` and ``np.False_`` for booleans
-* ``scalar(<value>)``, i.e. ``float64(3.0)`` for all numerical dtypes.
-* The value for ``longdouble`` and ``clongdouble`` will be given in quotes:
-  ``longdouble('3.0')``.  This ensures that it can always roundtrip correctly
+* ``np.scalar(<value>)``, i.e. ``np.float64(3.0)`` for all numerical dtypes.
+* The value for ``np.longdouble`` and ``np.clongdouble`` will be given in quotes:
+  ``np.longdouble('3.0')``.  This ensures that it can always roundtrip correctly
   and matches ``decimal.Decimal``.
   Further, for these two the size based name such as ``float128`` will not
   be adopted, as it is platform dependend and imprecise. 
@@ -172,16 +180,19 @@ array representation as well.
 Alternatives
 ============
 
-Different representation could be discussed, main alternatives are inclusion
+Different representation could be discussed, main alternatives are spelling
+``np.`` as ``numpy.`` or dropping the ``np.`` part from the numerical scalars.
+We believe that using ``np.`` is sufficiently clear, concise, and does allow
+copy pasting the representation.
+Using only ``float64(3.0)`` without the ``np.`` prefix is more concise but
+contexts may exists where the NumPy dependency is not fully clear and the name
+could clash with other libraries.
 of ``numpy`` or ``np`` for the numerical types to give for example
 ``np.float64(3.0)``.
-We believe that the numerical types are sufficiently clear without the ``np``
-and thus prefer to not include the ``np.`` part.
 
 For booleans an alternative would be to use ``np.bool_(True)`` or ``bool_(True)``.
 However, NumPy boolean scalars are singletons and the proposed formatting is more
-concise.  In general, ``numpy.True_`` would be a more verbose alternative.
-These were also discussed previously in [1]_.
+concise.  Alternatives for booleans were also discussed previously in [1]_.
 
 For the string scalars, the confusion is generally less pronounced.  It may be
 reasonable to defer changing these.

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -245,17 +245,17 @@ two things compared to the old function:
 * ``data`` may be ``None`` (if ``dtype`` is passed) allowing to not pass
   multiple values that will be printed/formatted later.
 * ``fmt=`` will allow passing on format strings to a DType specific element
-  formatter in the future.  For now, it will allow passing ``repr``
-  (the function) to format the elements representation without type
-  information.  The implementation has to ensure that the scalars ``repr``
-  matches with this method of formatting.
+  formatter in the future.  For now, ``get_formatter()`` it will accept
+  ``repr`` or ``str`` (the singletons not strings) to format the elements
+  without type information (``'3.1'`` rather than ``np.longdouble('3.1')``).
+  The implementation ensures that formatting matches except for the type
+  information.
 
-  The empty format string should print identically to ``str()`` (with possibly
+  The empty format string will print identically to ``str()`` (with possibly
   extra padding when data is passed).
 
-  (This NEP does not specify how ``get_formatter()`` will interact with new
-  user DTypes, it returns a callable for formatting a single scalar or 0-D
-  array.)
+``get_formatter()`` is expected to query a user DTypes method in the future
+allowing customized formatting for all DTypes.
 
 Making it public allows the use for ``np.record`` and masked arrays.
 Currenlty, the formatters themselves seem semi-public and using a single
@@ -287,8 +287,8 @@ reasonable to defer changing these.
 ``get_formatter()``
 -------------------
 When ``fmt=`` is passed, and specifically for the main use (in this NEP) to
-format to a ``repr``, it would also be possible to use a ufunc or a direct
-formatting function instead.
+format to a ``repr`` or ``str``.
+It would also be possible to use a ufunc or a direct formatting function.
 
 This NEP does not preclude creating a ufunc or making a special path.
 However, NumPy array formatting commonly looks at all values to be formatted
@@ -297,6 +297,9 @@ In this case ``data=`` is passed and used in preparation.  This form of
 formatting (unlike the scalar case where ``data=None`` would be desired) is
 unfortunately fundamentally incompatible with UFuncs.
 
+The use of the singleton ``str`` and ``repr`` ensures that future formatting
+strings like ``f"{arr:r}"`` are not in any way limited by using ``"r"`` or
+``"s"`` instead.
 
 Discussion
 ==========

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -177,6 +177,9 @@ The new representations can be implemented on the scalar types.
 Additional work may be necessary to ensure that the changes do not affect
 array representation as well.
 
+A large part of the implementation work has already been done by Ganesh
+Kathiresan in the open draft PR [2]_.
+
 Alternatives
 ============
 
@@ -204,7 +207,8 @@ Discussion
 * An initial discussion on this changed happened in the mailing list:
   https://mail.python.org/archives/list/numpy-discussion@python.org/thread/7GLGFHTZHJ6KQPOLMVY64OM6IC6KVMYI/
 * There was a previous issue [1]_ and PR [2]_ to change only the
-  representation of the NumPy booleans
+  representation of the NumPy booleans.  The PR was later updated to change
+  the representation of all (or at least most) NumPy scalars.
 
 
 References and Footnotes


### PR DESCRIPTION
As mentioned on the mailing list, I have been looking into changing the representation of scalars.  This is also because the distinction between NumPy scalars and Python scalars would become larger with NEP 50.

This is an early draft for broad feedback for now.  The current (not quite settled!) angle is that everything should print as:
* `np.float32(3.0)`, etc.
* ``longdouble`` would have additional quotes (to round trip) and always use ``longdouble`` as name.  (same for the type name)
* Bool (as suggested in gh-17592) should be `np.True_`  (although that PR spells out `numpy`)
* There is a fun fact that (64bit linux), ``np.longlong`` prints as ``numpy.longlong`` but ``np.longlong(3)`` would show as ``np.int64(3)``.  I think that is the best way to do it.

In any case, there are some details that can be discussed, and I am not sure if we may need a better way to spell `decimal.Decimal(repr(numpy_scalar))`  (which is used in our tests).

**EDIT:  The implementation to this is in gh-22449 (besides quite a bit of janitorial work, e.g. to actually update all of the docs.  It seems refguide-check executes the `repr` and doesn't actually notice the change mostly.)**