### PR TITLE
ENH, SIMD: Add CPU feature detection and simd functions for AArch64 SVE

### DIFF
--- a/numpy/core/src/common/npy_cpu_features.c
+++ b/numpy/core/src/common/npy_cpu_features.c
@@ -101,7 +101,8 @@ static struct {
                 {NPY_CPU_FEATURE_FPHP, "FPHP"},
                 {NPY_CPU_FEATURE_ASIMDHP, "ASIMDHP"},
                 {NPY_CPU_FEATURE_ASIMDDP, "ASIMDDP"},
-                {NPY_CPU_FEATURE_ASIMDFHM, "ASIMDFHM"}};
+                {NPY_CPU_FEATURE_ASIMDFHM, "ASIMDFHM"},
+                {NPY_CPU_FEATURE_SVE, "SVE"}};
 
 
 NPY_VISIBILITY_HIDDEN PyObject *
@@ -708,6 +709,7 @@ npy__cpu_init_features_linux(void)
         npy__cpu_have[NPY_CPU_FEATURE_ASIMDHP]    = (hwcap & NPY__HWCAP_ASIMDHP)  != 0;
         npy__cpu_have[NPY_CPU_FEATURE_ASIMDDP]    = (hwcap & NPY__HWCAP_ASIMDDP)  != 0;
         npy__cpu_have[NPY_CPU_FEATURE_ASIMDFHM]   = (hwcap & NPY__HWCAP_ASIMDFHM) != 0;
+        npy__cpu_have[NPY_CPU_FEATURE_SVE]        = (hwcap & NPY__HWCAP_SVE)      != 0;
         npy__cpu_init_features_arm8();
     } else {
         npy__cpu_have[NPY_CPU_FEATURE_NEON]       = (hwcap & NPY__HWCAP_NEON)   != 0;
@@ -741,6 +743,9 @@ npy__cpu_init_features(void)
     #endif
     #if defined(NPY_HAVE_ASIMDFHM) || defined(__ARM_FEATURE_FP16FML)
     npy__cpu_have[NPY_CPU_FEATURE_ASIMDFHM] = 1;
+    #endif
+    #if defined(NPY_HAVE_SVE) || defined(__ARM_FEATURE_SVE)
+    npy__cpu_have[NPY_CPU_FEATURE_SVE] = 1;
     #endif
     npy__cpu_init_features_arm8();
 #else

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -83,6 +83,8 @@ enum npy_cpu_features
     NPY_CPU_FEATURE_ASIMDDP           = 306,
     // ARMv8.2 single&half-precision multiply
     NPY_CPU_FEATURE_ASIMDFHM          = 307,
+    // ARMv8.2 sve
+    NPY_CPU_FEATURE_SVE               = 308,
 
     // IBM/ZARCH
     NPY_CPU_FEATURE_VX                = 350,

--- a/numpy/core/src/common/npy_cpuinfo_parser.h
+++ b/numpy/core/src/common/npy_cpuinfo_parser.h
@@ -52,6 +52,7 @@
 #define NPY__HWCAP_FPHP     (1 << 9)
 #define NPY__HWCAP_ASIMDHP  (1 << 10)
 #define NPY__HWCAP_ASIMDDP  (1 << 20)
+#define NPY__HWCAP_SVE      (1 << 22)
 #define NPY__HWCAP_ASIMDFHM (1 << 23)
 /* 
  * Get the size of a file by reading it until the end. This is needed

--- a/numpy/core/src/common/simd/intdiv.h
+++ b/numpy/core/src/common/simd/intdiv.h
@@ -208,7 +208,7 @@ NPY_FINLINE npyv_u8x3 npyv_divisor_u8(npy_uint8 d)
     divisor.val[0] = npyv_setall_u16(m);
     divisor.val[1] = npyv_set_u8(sh1);
     divisor.val[2] = npyv_set_u8(sh2);
-#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
     divisor.val[0] = npyv_setall_u8(m);
     divisor.val[1] = npyv_setall_u8(sh1);
     divisor.val[2] = npyv_setall_u8(sh2);
@@ -249,7 +249,7 @@ NPY_FINLINE npyv_s8x3 npyv_divisor_s8(npy_int8 d)
     npyv_s8x3 divisor;
     divisor.val[0] = npyv_setall_s8(m);
     divisor.val[2] = npyv_setall_s8(d < 0 ? -1 : 0);
-    #if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+    #if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
         divisor.val[1] = npyv_setall_s8(sh);
     #elif defined(NPY_HAVE_NEON)
         divisor.val[1] = npyv_setall_s8(-sh);
@@ -285,7 +285,7 @@ NPY_FINLINE npyv_u16x3 npyv_divisor_u16(npy_uint16 d)
 #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
     divisor.val[1] = npyv_set_u16(sh1);
     divisor.val[2] = npyv_set_u16(sh2);
-#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
     divisor.val[1] = npyv_setall_u16(sh1);
     divisor.val[2] = npyv_setall_u16(sh2);
 #elif defined(NPY_HAVE_NEON)
@@ -317,7 +317,7 @@ NPY_FINLINE npyv_s16x3 npyv_divisor_s16(npy_int16 d)
     divisor.val[2] = npyv_setall_s16(d < 0 ? -1 : 0); // sign of divisor
 #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
     divisor.val[1] = npyv_set_s16(sh);
-#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
     divisor.val[1] = npyv_setall_s16(sh);
 #elif defined(NPY_HAVE_NEON)
     divisor.val[1] = npyv_setall_s16(-sh);
@@ -352,7 +352,7 @@ NPY_FINLINE npyv_u32x3 npyv_divisor_u32(npy_uint32 d)
 #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
     divisor.val[1] = npyv_set_u32(sh1);
     divisor.val[2] = npyv_set_u32(sh2);
-#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
     divisor.val[1] = npyv_setall_u32(sh1);
     divisor.val[2] = npyv_setall_u32(sh2);
 #elif defined(NPY_HAVE_NEON)
@@ -389,7 +389,7 @@ NPY_FINLINE npyv_s32x3 npyv_divisor_s32(npy_int32 d)
     divisor.val[2] = npyv_setall_s32(d < 0 ? -1 : 0); // sign of divisor
 #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
     divisor.val[1] = npyv_set_s32(sh);
-#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX)
+#elif defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_SVE)
     divisor.val[1] = npyv_setall_s32(sh);
 #elif defined(NPY_HAVE_NEON)
     divisor.val[1] = npyv_setall_s32(-sh);
@@ -402,7 +402,8 @@ NPY_FINLINE npyv_s32x3 npyv_divisor_s32(npy_int32 d)
 NPY_FINLINE npyv_u64x3 npyv_divisor_u64(npy_uint64 d)
 {
     npyv_u64x3 divisor;
-#if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_NEON)
+#if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) \
+    || (defined(NPY_HAVE_NEON) && !defined(NPY_HAVE_SVE))
     divisor.val[0] = npyv_setall_u64(d);
 #else
     npy_uint64 l, l2, sh1, sh2, m;
@@ -427,6 +428,9 @@ NPY_FINLINE npyv_u64x3 npyv_divisor_u64(npy_uint64 d)
     #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
         divisor.val[1] = npyv_set_u64(sh1);
         divisor.val[2] = npyv_set_u64(sh2);
+    #elif defined(NPY_HAVE_SVE)
+        divisor.val[1] = npyv_setall_u64(sh1);
+        divisor.val[2] = npyv_setall_u64(sh2);
     #else
         #error "please initialize the shifting operand for the new architecture"
     #endif
@@ -437,7 +441,8 @@ NPY_FINLINE npyv_u64x3 npyv_divisor_u64(npy_uint64 d)
 NPY_FINLINE npyv_s64x3 npyv_divisor_s64(npy_int64 d)
 {
     npyv_s64x3 divisor;
-#if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) || defined(NPY_HAVE_NEON)
+#if defined(NPY_HAVE_VSX2) || defined(NPY_HAVE_VX) \
+    || (defined(NPY_HAVE_NEON) && !defined(NPY_HAVE_SVE))
     divisor.val[0] = npyv_setall_s64(d);
     divisor.val[1] = npyv_cvt_s64_b64(
         npyv_cmpeq_s64(npyv_setall_s64(-1), divisor.val[0])
@@ -465,6 +470,8 @@ NPY_FINLINE npyv_s64x3 npyv_divisor_s64(npy_int64 d)
     divisor.val[2] = npyv_setall_s64(d < 0 ? -1 : 0);  // sign of divisor
     #ifdef NPY_HAVE_SSE2 // SSE/AVX2/AVX512
     divisor.val[1] = npyv_set_s64(sh);
+    #elif defined(NPY_HAVE_SVE)
+    divisor.val[1] = npyv_setall_s64(sh);
     #else
         #error "please initialize the shifting operand for the new architecture"
     #endif

--- a/numpy/core/src/common/simd/simd.h
+++ b/numpy/core/src/common/simd/simd.h
@@ -63,7 +63,9 @@ typedef double     npyv_lanetype_f64;
     #include "vec/vec.h"
 #endif
 
-#ifdef NPY_HAVE_NEON
+#if defined(NPY_HAVE_SVE)
+    #include "sve/sve.h"
+#elif defined(NPY_HAVE_NEON)
     #include "neon/neon.h"
 #endif
 

--- a/numpy/core/src/common/simd/simd.h
+++ b/numpy/core/src/common/simd/simd.h
@@ -86,8 +86,10 @@ typedef double     npyv_lanetype_f64;
     #define NPY_SIMD_BIGENDIAN 0
 #endif
 
-// enable emulated mask operations for all SIMD extension except for AVX512
-#if !defined(NPY_HAVE_AVX512F) && NPY_SIMD && NPY_SIMD < 512
+// enable emulated mask operations for all SIMD extension
+// except for AVX512 and SVE
+#if (!defined(NPY_HAVE_AVX512F) && !defined(NPY_HAVE_SVE)) \
+    && NPY_SIMD && NPY_SIMD < 512
     #include "emulate_maskop.h"
 #endif
 

--- a/numpy/core/src/common/simd/sve/arithmetic.h
+++ b/numpy/core/src/common/simd/sve/arithmetic.h
@@ -1,0 +1,228 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_ARITHMETIC_H
+#define _NPY_SIMD_SVE_ARITHMETIC_H
+
+#include "operators.h"
+
+#define NPYV_IMPL_SVE_OP(OP, S, W)                                           \
+    NPY_FINLINE npyv_##S##W npyv_##OP##_##S##W(npyv_##S##W a, npyv_##S##W b) \
+    {                                                                        \
+        return sv##OP##_##S##W##_x(svptrue_b##W(), a, b);                    \
+    }
+#define NPYV_IMPL_SVE_OP2(FUNC, OP, S, W)                                      \
+    NPY_FINLINE npyv_##S##W npyv_##FUNC##_##S##W(npyv_##S##W a, npyv_##S##W b) \
+    {                                                                          \
+        return sv##op##_##S##W##_x(svptrue_b##W(), a, b);                      \
+    }
+#define NPYV_IMPL_SVE_FUSED_OP(FUNC, OP, S, W)               \
+    NPY_FINLINE npyv_##S##W npyv_##FUNC##_##S##W(            \
+            npyv_##S##W a, npyv_##S##W b, npyv_##S##W c)     \
+    {                                                        \
+        return sv##OP##_##S##W##_x(svptrue_b##W(), c, a, b); \
+}
+#define NPYV_IMPL_SVE_FUSED_OP2(FUNC, OP, S, W)              \
+    NPY_FINLINE npyv_##S##W npyv_##FUNC##_##S##W(            \
+            npyv_##S##W a, npyv_##S##W b, npyv_##S##W c)     \
+    {                                                        \
+        return sv##OP##_##S##W##_x(svptrue_b##W(), c, b, a); \
+}
+#define NPYV_IMPL_SVE_SUM(FUNC, OP, S, W, T)          \
+    NPY_FINLINE T npyv_##FUNC##_##S##W(npyv_##S##W a) \
+    {                                                 \
+        return sv##OP##_##S##W(svptrue_b##W(), a);    \
+    }
+
+/***************************
+ * Addition
+ ***************************/
+// non-saturated
+NPYV_IMPL_SVE_OP(add, u, 8)
+NPYV_IMPL_SVE_OP(add, u, 16)
+NPYV_IMPL_SVE_OP(add, u, 32)
+NPYV_IMPL_SVE_OP(add, u, 64)
+NPYV_IMPL_SVE_OP(add, s, 8)
+NPYV_IMPL_SVE_OP(add, s, 16)
+NPYV_IMPL_SVE_OP(add, s, 32)
+NPYV_IMPL_SVE_OP(add, s, 64)
+NPYV_IMPL_SVE_OP(add, f, 32)
+NPYV_IMPL_SVE_OP(add, f, 64)
+
+// saturated
+#define npyv_adds_u8 svqadd_u8
+#define npyv_adds_s8 svqadd_s8
+#define npyv_adds_u16 svqadd_u16
+#define npyv_adds_s16 svqadd_s16
+
+/***************************
+ * Subtraction
+ ***************************/
+// non-saturated
+NPYV_IMPL_SVE_OP(sub, u, 8)
+NPYV_IMPL_SVE_OP(sub, u, 16)
+NPYV_IMPL_SVE_OP(sub, u, 32)
+NPYV_IMPL_SVE_OP(sub, u, 64)
+NPYV_IMPL_SVE_OP(sub, s, 8)
+NPYV_IMPL_SVE_OP(sub, s, 16)
+NPYV_IMPL_SVE_OP(sub, s, 32)
+NPYV_IMPL_SVE_OP(sub, s, 64)
+NPYV_IMPL_SVE_OP(sub, f, 32)
+NPYV_IMPL_SVE_OP(sub, f, 64)
+
+// saturated
+#define npyv_subs_u8 svqsub_u8
+#define npyv_subs_s8 svqsub_s8
+#define npyv_subs_u16 svqsub_u16
+#define npyv_subs_s16 svqsub_s16
+
+/***************************
+ * Multiplication
+ ***************************/
+// non-saturated
+NPYV_IMPL_SVE_OP(mul, u, 8)
+NPYV_IMPL_SVE_OP(mul, u, 16)
+NPYV_IMPL_SVE_OP(mul, u, 32)
+NPYV_IMPL_SVE_OP(mul, u, 64)
+NPYV_IMPL_SVE_OP(mul, s, 8)
+NPYV_IMPL_SVE_OP(mul, s, 16)
+NPYV_IMPL_SVE_OP(mul, s, 32)
+NPYV_IMPL_SVE_OP(mul, s, 64)
+NPYV_IMPL_SVE_OP(mul, f, 32)
+NPYV_IMPL_SVE_OP(mul, f, 64)
+
+/***************************
+ * Integer Division
+ ***************************/
+// See simd/intdiv.h for more clarification
+// divide each unsigned 8-bit element by divisor
+// mulhi: high part of unsigned multiplication
+// floor(a/d)      = (mulhi + ((a-mulhi) >> sh1)) >> sh2
+#define NPYV_IMPL_SVE_DIVC_U(W)                               \
+    NPY_FINLINE npyv_u##W npyv_divc_u##W(                     \
+        npyv_u##W a, const npyv_u##W##x3 divisor)             \
+    {                                                         \
+        const svbool_t mask_all = svptrue_b##W();             \
+                                                              \
+        svuint##W##_t mulhi =                                 \
+                svmulh_u##W##_x(mask_all, a, divisor.val[0]); \
+        svuint##W##_t q = svsub_u##W##_x(mask_all, a, mulhi); \
+        q = svlsr_u##W##_x(mask_all, q, divisor.val[1]);      \
+        q = svadd_u##W##_x(mask_all, mulhi, q);               \
+        q = svlsr_u##W##_x(mask_all, q, divisor.val[2]);      \
+        return q;                                             \
+    }
+
+NPYV_IMPL_SVE_DIVC_U(8)
+NPYV_IMPL_SVE_DIVC_U(16)
+NPYV_IMPL_SVE_DIVC_U(32)
+
+// divide each signed 16-bit element by divisor (round towards zero)
+// q               = ((a + mulhi) >> sh1) - XSIGN(a)
+// trunc(a/d)      = (q ^ dsign) - dsign
+#define NPYV_IMPL_SVE_DIVC_S(W)                                       \
+    NPY_FINLINE npyv_s##W npyv_divc_s##W(                             \
+        npyv_s##W a, const npyv_s##W##x3 divisor)                     \
+    {                                                                 \
+        const svbool_t mask_all = svptrue_b##W();                     \
+        const svint##W##_t dsign = divisor.val[2];                    \
+                                                                      \
+        svint##W##_t mulhi =                                          \
+                svmulh_s##W##_x(mask_all, a, divisor.val[0]);         \
+        svint##W##_t q = svasr_s##W##_x(                              \
+                mask_all, svadd_s##W##_x(mask_all, a, mulhi),         \
+            svreinterpret_u##W##_s##W(divisor.val[1]));               \
+        q = svsub_s##W##_x(mask_all, q,                               \
+                svasr_n_s##W##_x(mask_all, a, W - 1));                \
+        q = svsub_s##W##_x(                                           \
+                mask_all, sveor_s##W##_x(mask_all, q, dsign), dsign); \
+        return q;                                                     \
+    }
+
+NPYV_IMPL_SVE_DIVC_S(8)
+NPYV_IMPL_SVE_DIVC_S(16)
+NPYV_IMPL_SVE_DIVC_S(32)
+
+// divide each unsigned 64-bit element by a divisor
+NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 divisor)
+{
+    // high part of unsigned multiplication
+    npyv_u64 mulhi = svmulh_u64_x(svptrue_b64(), a, divisor.val[0]);
+    // floor(a/d) = (mulhi + ((a-mulhi) >> sh1)) >> sh2
+    npyv_u64 q = svsub_u64_x(svptrue_b64(), a, mulhi);
+
+    q = svlsr_u64_x(svptrue_b64(), q, divisor.val[1]);
+    q = svadd_u64_x(svptrue_b64(), mulhi, q);
+    q = svlsr_x(svptrue_b64(), q, divisor.val[2]);
+    return q;
+}
+// divide each unsigned 64-bit element by a divisor (round towards zero)
+NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
+{
+    // high part of unsigned multiplication
+    npyv_s64 mulhi = svreinterpret_s64_u64(svmulh_u64_x(svptrue_b64(),
+        svreinterpret_u64_s64(a), svreinterpret_u64_s64(divisor.val[0])));
+    // convert unsigned to signed high multiplication
+    // mulhi - ((a < 0) ? m : 0) - ((m < 0) ? a : 0);
+    npyv_s64 asign   = svasr_n_s64_x(svptrue_b64(), a, 63);
+    npyv_s64 msign   = svasr_n_s64_x(svptrue_b64(), divisor.val[0], 63);
+    npyv_s64 m_asign = svand_s64_x(svptrue_b64(), divisor.val[0], asign);
+    npyv_s64 a_msign = svand_s64_x(svptrue_b64(), a, msign);
+
+    mulhi = svsub_s64_x(svptrue_b64(), mulhi, m_asign);
+    mulhi = svsub_s64_x(svptrue_b64(), mulhi, a_msign);
+
+    // q               = ((a + mulhi) >> sh1) - XSIGN(a)
+    // trunc(a/d)      = (q ^ dsign) - dsign
+    npyv_s64 q = svasr_s64_x(svptrue_b64(), svadd_s64_x(svptrue_b64(),
+        a, mulhi), svreinterpret_u64_s64(divisor.val[1]));
+
+    q = svsub_s64_x(svptrue_b64(), q, asign);
+    q = svsub_s64_x(svptrue_b64(), sveor_s64_x(svptrue_b64(), q,
+        divisor.val[2]), divisor.val[2]);
+    return  q;
+}
+
+/***************************
+ * Division
+ ***************************/
+NPYV_IMPL_SVE_OP(div, f, 32)
+NPYV_IMPL_SVE_OP(div, f, 64)
+
+/***************************
+ * FUSED F32
+ ***************************/
+// a*b + c
+NPYV_IMPL_SVE_FUSED_OP2(muladd, mla, f, 32)
+// a*b - c
+NPYV_IMPL_SVE_FUSED_OP2(mulsub, nmls, f, 32)
+// -(a*b) + c
+NPYV_IMPL_SVE_FUSED_OP(nmuladd, mls, f, 32)  
+// -(a*b) - c
+NPYV_IMPL_SVE_FUSED_OP(nmulsub, nmla, f, 32)  
+
+/***************************
+ * FUSED F64
+ ***************************/
+// a*b + c
+NPYV_IMPL_SVE_FUSED_OP2(muladd, mla, f, 64)
+// a*b - c
+NPYV_IMPL_SVE_FUSED_OP2(mulsub, nmls, f, 64)
+// -(a*b) + c
+NPYV_IMPL_SVE_FUSED_OP(nmuladd, mls, f, 64)
+// -(a*b) - c
+NPYV_IMPL_SVE_FUSED_OP(nmulsub, nmla, f, 64)
+
+/***************************
+ * Summation
+ ***************************/
+// reduce sum across vector
+NPYV_IMPL_SVE_SUM(sum,   addv, u, 32, npy_uint32)
+NPYV_IMPL_SVE_SUM(sum,   addv, u, 64, npy_uint64)
+NPYV_IMPL_SVE_SUM(sum,   addv, f, 32, float)
+NPYV_IMPL_SVE_SUM(sum,   addv, f, 64, double)
+NPYV_IMPL_SVE_SUM(sumup, addv, u, 8,  npy_uint16)
+NPYV_IMPL_SVE_SUM(sumup, addv, u, 16, npy_uint32)
+
+#endif  // _NPY_SIMD_SVE_ARITHMETIC_H

--- a/numpy/core/src/common/simd/sve/arithmetic.h
+++ b/numpy/core/src/common/simd/sve/arithmetic.h
@@ -34,6 +34,11 @@
     {                                                 \
         return sv##OP##_##S##W(svptrue_b##W(), a);    \
     }
+#define NPYV_IMPL_SVE_SUM0(FUNC, OP, S, W, T)          \
+    NPY_FINLINE T npyv_##FUNC##_##S##W(npyv_##S##W a)  \
+    {                                                  \
+        return sv##OP##_##S##W(svptrue_b##W(), 0., a); \
+    }
 
 /***************************
  * Addition
@@ -220,8 +225,8 @@ NPYV_IMPL_SVE_FUSED_OP(nmulsub, nmla, f, 64)
 // reduce sum across vector
 NPYV_IMPL_SVE_SUM(sum,   addv, u, 32, npy_uint32)
 NPYV_IMPL_SVE_SUM(sum,   addv, u, 64, npy_uint64)
-NPYV_IMPL_SVE_SUM(sum,   addv, f, 32, float)
-NPYV_IMPL_SVE_SUM(sum,   addv, f, 64, double)
+NPYV_IMPL_SVE_SUM0(sum,   adda, f, 32, float)
+NPYV_IMPL_SVE_SUM0(sum,   adda, f, 64, double)
 NPYV_IMPL_SVE_SUM(sumup, addv, u, 8,  npy_uint16)
 NPYV_IMPL_SVE_SUM(sumup, addv, u, 16, npy_uint32)
 

--- a/numpy/core/src/common/simd/sve/conversion.h
+++ b/numpy/core/src/common/simd/sve/conversion.h
@@ -1,0 +1,275 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_CVT_H
+#define _NPY_SIMD_SVE_CVT_H
+
+#define NPYV_IMPL_SVE_CVT_TO_B(S, W)                            \
+    NPY_FINLINE npyv_b##W npyv_cvt_b##W##_##S##W(npyv_##S##W a) \
+    {                                                           \
+        return svcmpne_n_##S##W(svptrue_b##W(), a, 0);          \
+    }
+
+// convert mask to integer vectors
+#define npyv_cvt_u8_b8(b)   svreinterpret_u8_s8(svdup_s8_z(b,  -1))
+#define npyv_cvt_u16_b16(b) svreinterpret_u16_s16(svdup_s16_z(b, -1))
+#define npyv_cvt_u32_b32(b) svreinterpret_u32_s32(svdup_s32_z(b, -1))
+#define npyv_cvt_u64_b64(b) svreinterpret_u64_s64(svdup_s64_z(b, -1))
+#define npyv_cvt_s8_b8(b)   svdup_s8_z(b, -1)
+#define npyv_cvt_s16_b16(b) svdup_s16_z(b, -1)
+#define npyv_cvt_s32_b32(b) svdup_s32_z(b, -1)
+#define npyv_cvt_s64_b64(b) svdup_s64_z(b, -1)
+#define npyv_cvt_f32_b32(b) svdup_f32_z(b, 1.0)
+#define npyv_cvt_f64_b64(b) svdup_f64_z(b, 1.0)
+
+// convert integer vectors to mask
+NPYV_IMPL_SVE_CVT_TO_B(u, 8)  
+NPYV_IMPL_SVE_CVT_TO_B(u, 16)  
+NPYV_IMPL_SVE_CVT_TO_B(u, 32)  
+NPYV_IMPL_SVE_CVT_TO_B(u, 64)  
+NPYV_IMPL_SVE_CVT_TO_B(s, 8)  
+NPYV_IMPL_SVE_CVT_TO_B(s, 16)  
+NPYV_IMPL_SVE_CVT_TO_B(s, 32)  
+NPYV_IMPL_SVE_CVT_TO_B(s, 64)  
+NPYV_IMPL_SVE_CVT_TO_B(f, 32)  
+NPYV_IMPL_SVE_CVT_TO_B(f, 64)  
+
+// expand
+NPY_FINLINE npyv_u16x2
+npyv_expand_u16_u8(npyv_u8 data)
+{
+    npyv_u16x2 r;
+
+    r.val[0] = svunpklo_u16(data);
+    r.val[1] = svunpkhi_u16(data);
+    return r;
+}
+
+NPY_FINLINE npyv_u32x2
+npyv_expand_u32_u16(npyv_u16 data)
+{
+    npyv_u32x2 r;
+
+    r.val[0] = svunpklo_u32(data);
+    r.val[1] = svunpkhi_u32(data);
+    return r;
+}
+
+// pack two 16-bit boolean into one 8-bit boolean vector
+NPY_FINLINE npyv_b8
+npyv_pack_b8_b16(npyv_b16 a, npyv_b16 b) {
+    svuint8_t z0 = svdup_n_u8_z(svuzp1_b8(a, a), 1);
+    svuint8_t z1 = svdup_n_u8_z(svuzp1_b8(b, b), 1);
+
+    z0 = svext_u8(z0, z0, npyv_nlanes_u8 / 2);
+    z0 = svext_u8(z0, z1, npyv_nlanes_u8 / 2);
+    return svcmpeq_n_u8(svptrue_b8(), z0, 1);
+}
+
+// pack four 32-bit boolean vectors into one 8-bit boolean vector
+NPY_FINLINE npyv_b8
+npyv_pack_b8_b32(npyv_b32 a, npyv_b32 b, npyv_b32 c, npyv_b32 d) {
+    npyv_u8 buf;
+    uint8_t *ptr = (uint8_t *)(&buf);
+
+    svst1b_vnum_u32(svptrue_b32(), ptr, 0, svdup_n_u32_z(a, 1));
+    svst1b_vnum_u32(svptrue_b32(), ptr, 1, svdup_n_u32_z(b, 1));
+    svst1b_vnum_u32(svptrue_b32(), ptr, 2, svdup_n_u32_z(c, 1));
+    svst1b_vnum_u32(svptrue_b32(), ptr, 3, svdup_n_u32_z(d, 1));
+
+    svuint8_t z0 = svld1_u8(svptrue_b8(), ptr);
+
+    return svcmpeq_n_u8(svptrue_b8(), z0, 1);
+}
+
+// pack eight 64-bit boolean vectors into one 8-bit boolean vector
+NPY_FINLINE npyv_b8
+npyv_pack_b8_b64(npyv_b64 a, npyv_b64 b, npyv_b64 c, npyv_b64 d,
+                 npyv_b64 e, npyv_b64 f, npyv_b64 g, npyv_b64 h) {
+    npyv_u8 buf;
+    uint8_t *ptr = (uint8_t *)(&buf);
+
+    svst1b_vnum_u64(svptrue_b64(), ptr, 0, svdup_n_u64_z(a, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 1, svdup_n_u64_z(b, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 2, svdup_n_u64_z(c, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 3, svdup_n_u64_z(d, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 4, svdup_n_u64_z(e, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 5, svdup_n_u64_z(f, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 6, svdup_n_u64_z(g, 1));
+    svst1b_vnum_u64(svptrue_b64(), ptr, 7, svdup_n_u64_z(h, 1));
+
+    svuint8_t z0 = svld1_u8(svptrue_b8(), ptr);
+
+    return svcmpeq_n_u8(svptrue_b8(), z0, 1);
+}
+
+#define NPYV_IMPL_SVE_TOBIT(W)                           \
+    NPY_FINLINE npy_uint64 npyv_tobits_b##W(npyv_b##W a) \
+    {                                                    \
+        const svbool_t mask_all = svptrue_b##W();        \
+                                                         \
+        svuint##W##_t mask = svdup_n_u##W##_z(a, 0x1);   \
+        return svorv_u##W(mask_all, mask);               \
+    }
+
+NPY_FINLINE npy_uint64
+npyv_tobits_b8(npyv_b8 a)
+{
+    const __pred mask_zero = svpfalse();
+    const uint64_t len = svcntb();
+    npyv_b8 l, h, l_l, l_h, h_l, h_h;
+    npyv_b8 l_l_l, l_l_h, l_h_l, l_h_h, h_l_l, h_l_h, h_h_l, h_h_h;
+
+    if (len >= 16) {
+        l = svzip1_b8(a, mask_zero);
+        h = svzip2_b8(a, mask_zero);
+    }
+    if (len >= 32) {
+        l_l = svzip1_b8(l, mask_zero);
+        l_h = svzip2_b8(l, mask_zero);
+        h_l = svzip1_b8(h, mask_zero);
+        h_h = svzip2_b8(h, mask_zero);
+    }
+    if (len >= 64) {
+        l_l_l = svzip1_b8(l_l, mask_zero);
+        l_l_h = svzip2_b8(l_l, mask_zero);
+        l_h_l = svzip1_b8(l_h, mask_zero);
+        l_h_h = svzip2_b8(l_h, mask_zero);
+        h_l_l = svzip1_b8(h_l, mask_zero);
+        h_l_h = svzip2_b8(h_l, mask_zero);
+        h_h_l = svzip1_b8(h_h, mask_zero);
+        h_h_h = svzip2_b8(h_h, mask_zero);
+    }
+
+    switch (len) {
+        case 16: {
+            const npyv_u16 one = svdup_u16(1);
+            npyv_u16 idx0 = svindex_u16(0, 1);
+            npyv_u16 idx1 = svindex_u16(8, 1);
+            idx0 = svlsl_u16_x(svptrue_b16(), one, idx0);
+            idx1 = svlsl_u16_x(svptrue_b16(), one, idx1);
+            uint64_t retVal = svorv_u16(l, idx0);
+            retVal |= svorv_u16(h, idx1);
+            return retVal;
+        }
+        case 32: {
+            const npyv_u32 one = svdup_u32(1);
+            npyv_u32 idx0 = svindex_u32(0, 1);
+            npyv_u32 idx1 = svindex_u32(8, 1);
+            npyv_u32 idx2 = svindex_u32(16, 1);
+            npyv_u32 idx3 = svindex_u32(24, 1);
+            idx0 = svlsl_u32_x(svptrue_b32(), one, idx0);
+            idx1 = svlsl_u32_x(svptrue_b32(), one, idx1);
+            idx2 = svlsl_u32_x(svptrue_b32(), one, idx2);
+            idx3 = svlsl_u32_x(svptrue_b32(), one, idx3);
+            uint64_t retVal = svorv_u32(l_l, idx0);
+            retVal |= svorv_u32(l_h, idx1);
+            retVal |= svorv_u32(h_l, idx2);
+            retVal |= svorv_u32(h_h, idx3);
+            return retVal;
+        }
+        case 64: {
+            const npyv_u64 one = svdup_u64(1);
+            npyv_u64 idx0 = svindex_u64(0, 1);
+            npyv_u64 idx1 = svindex_u64(8, 1);
+            npyv_u64 idx2 = svindex_u64(16, 1);
+            npyv_u64 idx3 = svindex_u64(24, 1);
+            npyv_u64 idx4 = svindex_u64(32, 1);
+            npyv_u64 idx5 = svindex_u64(40, 1);
+            npyv_u64 idx6 = svindex_u64(48, 1);
+            npyv_u64 idx7 = svindex_u64(56, 1);
+            idx0 = svlsl_u64_x(svptrue_b64(), one, idx0);
+            idx1 = svlsl_u64_x(svptrue_b64(), one, idx1);
+            idx2 = svlsl_u64_x(svptrue_b64(), one, idx2);
+            idx3 = svlsl_u64_x(svptrue_b64(), one, idx3);
+            idx4 = svlsl_u64_x(svptrue_b64(), one, idx4);
+            idx5 = svlsl_u64_x(svptrue_b64(), one, idx5);
+            idx6 = svlsl_u64_x(svptrue_b64(), one, idx6);
+            idx7 = svlsl_u64_x(svptrue_b64(), one, idx7);
+            uint64_t retVal = svorv_u64(l_l_l, idx0);
+            retVal |= svorv_u64(l_l_h, idx1);
+            retVal |= svorv_u64(l_h_l, idx2);
+            retVal |= svorv_u64(l_h_h, idx3);
+            retVal |= svorv_u64(h_l_l, idx4);
+            retVal |= svorv_u64(h_l_h, idx5);
+            retVal |= svorv_u64(h_h_l, idx6);
+            retVal |= svorv_u64(h_h_h, idx7);
+            return retVal;
+        }
+        default:
+            assert(!"unsupported SVE size!");
+    }
+
+    return 0;
+}
+
+NPY_FINLINE npy_uint64
+npyv_tobits_b16(npyv_b16 a)
+{
+    const uint64_t len = svcntb();
+
+    switch (len) {
+        case 16:
+        case 32: {
+            const npyv_u16 one = svdup_u16(1);
+            npyv_u16 idx = svindex_u16(0, 1);
+            idx = svlsl_u16_x(svptrue_b16(), one, idx);
+            uint64_t retVal = svorv_u16(a, idx);
+            return retVal;
+        }
+        case 64: {
+            const npyv_b16 mask_zero = svpfalse();
+            const npyv_u32 one = svdup_u32(1);
+            npyv_b16 l = svzip1_b16(a, mask_zero);
+            npyv_b16 h = svzip1_b16(a, mask_zero);
+            npyv_u32 idx0 = svindex_u32(0, 1);
+            npyv_u32 idx1 = svindex_u32(16, 1);
+            idx0 = svlsl_u32_x(svptrue_b32(), one, idx0);
+            idx1 = svlsl_u32_x(svptrue_b32(), one, idx1);
+            uint64_t retVal = svorv_u32(l, idx0);
+            retVal |= svorv_u32(h, idx1);
+            return retVal;
+        }
+        default:
+            assert(!"unsupported SVE size!");
+    }
+
+    return 0;
+}
+
+NPY_FINLINE npy_uint64
+npyv_tobits_b32(npyv_b32 a)
+{
+    const npyv_u32 one = svdup_u32(1);
+    npyv_u32 idx = svindex_u32(0, 1);
+    idx = svlsl_u32_x(svptrue_b32(), one, idx);
+    return svorv_u32(a, idx);
+}
+
+NPY_FINLINE npy_uint64
+npyv_tobits_b64(npyv_b64 a)
+{
+    const npyv_u64 one = svdup_u64(1);
+    npyv_u64 idx = svindex_u64(0, 1);
+    idx = svlsl_u64_x(svptrue_b64(), one, idx);
+    return svorv_u64(a, idx);
+}
+
+// round to nearest integer (assuming even)
+NPY_FINLINE npyv_s32
+npyv_round_s32_f32(npyv_f32 a)
+{
+    return svcvt_s32_f32_x(svptrue_b32(), svrinti_f32_x(svptrue_b32(), a));
+}
+NPY_FINLINE npyv_s32
+npyv_round_s32_f64(npyv_f64 a, npyv_f64 b)
+{
+    svfloat64_t a_rinti = svrinti_f64_x(svptrue_b64(), a);
+    svfloat64_t b_rinti = svrinti_f64_x(svptrue_b64(), b);
+    svint32_t a_cvt = svcvt_s32_f64_x(svptrue_b64(), a_rinti);
+    svint32_t b_cvt = svcvt_s32_f64_x(svptrue_b64(), b_rinti);
+    return svuzp1_s32(a_cvt, b_cvt);
+}
+
+#endif  // _NPY_SIMD_SVE_CVT_H

--- a/numpy/core/src/common/simd/sve/maskop.h
+++ b/numpy/core/src/common/simd/sve/maskop.h
@@ -1,0 +1,40 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header, use simd/simd.h instead"
+#endif
+
+#ifndef _NPY_SIMD_SVE_MASKOP_H
+#define _NPY_SIMD_SVE_MASKOP_H
+
+/**
+ * Implements conditional addition and subtraction.
+ * e.g. npyv_ifadd_f32(m, a, b, c) -> m ? a + b : c
+ * e.g. npyv_ifsub_f32(m, a, b, c) -> m ? a - b : c
+ */
+#define NPYV_IMPL_SVE_MASK_ADDSUB(BITS, TYPE, SFX)                  \
+    NPY_FINLINE npyv_##SFX##BITS npyv_ifadd_##SFX##BITS(            \
+            npyv_b##BITS m, npyv_##SFX##BITS a, npyv_##SFX##BITS b, \
+            npyv_##SFX##BITS c)                                     \
+    {                                                               \
+        sv##TYPE##BITS##_t tmp = svadd_##SFX##BITS##_m(m, a, b);    \
+        return svsel_##SFX##BITS(m, tmp, c);                        \
+    }                                                               \
+    NPY_FINLINE npyv_##SFX##BITS npyv_ifsub_##SFX##BITS(            \
+            npyv_b##BITS m, npyv_##SFX##BITS a, npyv_##SFX##BITS b, \
+            npyv_##SFX##BITS c)                                     \
+    {                                                               \
+        sv##TYPE##BITS##_t tmp = svsub_##SFX##BITS##_m(m, a, b);    \
+        return svsel_##SFX##BITS(m, tmp, c);                        \
+    }
+
+NPYV_IMPL_SVE_MASK_ADDSUB(8, uint, u)
+NPYV_IMPL_SVE_MASK_ADDSUB(16, uint, u)
+NPYV_IMPL_SVE_MASK_ADDSUB(32, uint, u)
+NPYV_IMPL_SVE_MASK_ADDSUB(64, uint, u)
+NPYV_IMPL_SVE_MASK_ADDSUB(8, int, s)
+NPYV_IMPL_SVE_MASK_ADDSUB(16, int, s)
+NPYV_IMPL_SVE_MASK_ADDSUB(32, int, s)
+NPYV_IMPL_SVE_MASK_ADDSUB(64, int, s)
+NPYV_IMPL_SVE_MASK_ADDSUB(32, float, f)
+NPYV_IMPL_SVE_MASK_ADDSUB(64, float, f)
+
+#endif  // _NPY_SIMD_SVE_MASKOP_H

--- a/numpy/core/src/common/simd/sve/math.h
+++ b/numpy/core/src/common/simd/sve/math.h
@@ -1,0 +1,115 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_MATH_H
+#define _NPY_SIMD_SVE_MATH_H
+
+/***************************
+ * Elementary
+ ***************************/
+// Square root
+NPY_FINLINE npyv_f32
+npyv_sqrt_f32(npyv_f32 a)
+{
+    return svsqrt_f32_x(svptrue_b32(), a);
+}
+NPY_FINLINE npyv_f64
+npyv_sqrt_f64(npyv_f64 a)
+{
+    return svsqrt_f64_x(svptrue_b64(), a);
+}
+
+// Reciprocal
+NPY_FINLINE npyv_f32
+npyv_recip_f32(npyv_f32 a)
+{
+    return svdiv_f32_x(svptrue_b32(), svdup_f32(1.0f), a);
+}
+NPY_FINLINE npyv_f64
+npyv_recip_f64(npyv_f64 a)
+{
+    return svdiv_f64_x(svptrue_b64(), svdup_f64(1.0f), a);
+}
+
+// Absolute
+NPY_FINLINE npyv_f32
+npyv_abs_f32(npyv_f32 a)
+{
+    return svabs_f32_x(svptrue_b32(), a);
+}
+NPY_FINLINE npyv_f64
+npyv_abs_f64(npyv_f64 a)
+{
+    return svabs_f64_x(svptrue_b64(), a);
+}
+
+// Square
+NPY_FINLINE npyv_f32
+npyv_square_f32(npyv_f32 a)
+{
+    return svmul_f32_x(svptrue_b32(), a, a);
+}
+NPY_FINLINE npyv_f64
+npyv_square_f64(npyv_f64 a)
+{
+    return svmul_f64_x(svptrue_b64(), a, a);
+}
+
+// Maximum, natively mapping with no guarantees to handle NaN.
+#define npyv_max_f32(A, B) svmax_f32_x(svptrue_b32(), A, B)
+#define npyv_max_f64(A, B) svmax_f64_x(svptrue_b64(), A, B)
+// Maximum, supports IEEE floating-point arithmetic (IEC 60559),
+// - If one of the two vectors contains NaN, the equivalent element of the
+// other vector is set
+// - Only if both corresponded elements are NaN, NaN is set.
+#define npyv_maxp_f32(A, B) svmaxnm_f32_x(svptrue_b32(), A, B)
+#define npyv_maxp_f64(A, B) svmaxnm_f64_x(svptrue_b64(), A, B)
+
+// Maximum, integer operations
+#define npyv_max_u8(A, B) svmax_u8_x(svptrue_b8(), A, B)
+#define npyv_max_u16(A, B) svmax_u16_x(svptrue_b16(), A, B)
+#define npyv_max_u32(A, B) svmax_u32_x(svptrue_b32(), A, B)
+#define npyv_max_u64(A, B) svmax_u64_x(svptrue_b64(), A, B)
+#define npyv_max_s8(A, B) svmax_s8_x(svptrue_b8(), A, B)
+#define npyv_max_s16(A, B) svmax_s16_x(svptrue_b16(), A, B)
+#define npyv_max_s32(A, B) svmax_s32_x(svptrue_b32(), A, B)
+#define npyv_max_s64(A, B) svmax_s64_x(svptrue_b64(), A, B)
+
+// Minimum, natively mapping with no guarantees to handle NaN.
+#define npyv_min_f32(A, B) svmin_f32_x(svptrue_b32(), A, B)
+#define npyv_min_f64(A, B) svmin_f64_x(svptrue_b64(), A, B)
+// Minimum, supports IEEE floating-point arithmetic (IEC 60559),
+// - If one of the two vectors contains NaN, the equivalent element of the
+// other vector is set
+// - Only if both corresponded elements are NaN, NaN is set.
+#define npyv_minp_f32(A, B) svminnm_f32_x(svptrue_b32(), A, B)
+#define npyv_minp_f64(A, B) svminnm_f64_x(svptrue_b64(), A, B)
+
+// Minimum, integer operations
+#define npyv_min_u8(A, B) svmin_u8_x(svptrue_b8(), A, B)
+#define npyv_min_u16(A, B) svmin_u16_x(svptrue_b16(), A, B)
+#define npyv_min_u32(A, B) svmin_u32_x(svptrue_b32(), A, B)
+#define npyv_min_u64(A, B) svmin_u64_x(svptrue_b64(), A, B)
+#define npyv_min_s8(A, B) svmin_s8_x(svptrue_b8(), A, B)
+#define npyv_min_s16(A, B) svmin_s16_x(svptrue_b16(), A, B)
+#define npyv_min_s32(A, B) svmin_s32_x(svptrue_b32(), A, B)
+#define npyv_min_s64(A, B) svmin_s64_x(svptrue_b64(), A, B)
+
+// round to nearest integer even
+#define npyv_rint_f32(A) svrintn_f32_x(svptrue_b32(), A)
+#define npyv_rint_f64(A) svrintn_f64_x(svptrue_b64(), A)
+
+// ceil
+#define npyv_ceil_f32(A) svrintp_f32_x(svptrue_b32(), A)
+#define npyv_ceil_f64(A) svrintp_f64_x(svptrue_b64(), A)
+
+// trunc
+#define npyv_trunc_f32(A) svrintz_f32_x(svptrue_b32(), A)
+#define npyv_trunc_f64(A) svrintz_f64_x(svptrue_b64(), A)
+
+// floor
+#define npyv_floor_f32(A) svrintm_f32_x(svptrue_b32(), A)
+#define npyv_floor_f64(A) svrintm_f64_x(svptrue_b64(), A)
+
+#endif  // _NPY_SIMD_SVE_MATH_H

--- a/numpy/core/src/common/simd/sve/math.h
+++ b/numpy/core/src/common/simd/sve/math.h
@@ -66,6 +66,11 @@ npyv_square_f64(npyv_f64 a)
 #define npyv_maxp_f32(A, B) svmaxnm_f32_x(svptrue_b32(), A, B)
 #define npyv_maxp_f64(A, B) svmaxnm_f64_x(svptrue_b64(), A, B)
 
+// Maximum, propagates NaNs
+// If any of corresponded element is NaN, NaN is set.
+#define npyv_maxn_f32(A, B) svmax_f32_x(svptrue_b32(), A, B)
+#define npyv_maxn_f64(A, B) svmax_f64_x(svptrue_b64(), A, B)
+
 // Maximum, integer operations
 #define npyv_max_u8(A, B) svmax_u8_x(svptrue_b8(), A, B)
 #define npyv_max_u16(A, B) svmax_u16_x(svptrue_b16(), A, B)
@@ -86,6 +91,11 @@ npyv_square_f64(npyv_f64 a)
 #define npyv_minp_f32(A, B) svminnm_f32_x(svptrue_b32(), A, B)
 #define npyv_minp_f64(A, B) svminnm_f64_x(svptrue_b64(), A, B)
 
+// Mininum, propagates NaNs
+// If any of corresponded element is NaN, NaN is set.
+#define npyv_minn_f32(A, B) svmin_f32_x(svptrue_b32(), A, B)
+#define npyv_minn_f64(A, B) svmin_f64_x(svptrue_b64(), A, B)
+
 // Minimum, integer operations
 #define npyv_min_u8(A, B) svmin_u8_x(svptrue_b8(), A, B)
 #define npyv_min_u16(A, B) svmin_u16_x(svptrue_b16(), A, B)
@@ -95,6 +105,36 @@ npyv_square_f64(npyv_f64 a)
 #define npyv_min_s16(A, B) svmin_s16_x(svptrue_b16(), A, B)
 #define npyv_min_s32(A, B) svmin_s32_x(svptrue_b32(), A, B)
 #define npyv_min_s64(A, B) svmin_s64_x(svptrue_b64(), A, B)
+
+#define npyv_reduce_min_u8(A) svminv_u8(svptrue_b8(), A)
+#define npyv_reduce_min_u16(A) svminv_u16(svptrue_b16(), A)
+#define npyv_reduce_min_u32(A) svminv_u32(svptrue_b32(), A)
+#define npyv_reduce_min_u64(A) svminv_u64(svptrue_b64(), A)
+#define npyv_reduce_min_s8(A) svminv_s8(svptrue_b8(), A)
+#define npyv_reduce_min_s16(A) svminv_s16(svptrue_b16(), A)
+#define npyv_reduce_min_s32(A) svminv_s32(svptrue_b32(), A)
+#define npyv_reduce_min_s64(A) svminv_s64(svptrue_b64(), A)
+#define npyv_reduce_min_f32(A) svminv_f32(svptrue_b32(), A)
+#define npyv_reduce_min_f64(A) svminv_f64(svptrue_b64(), A)
+#define npyv_reduce_minn_f32(A) svminv_f32(svptrue_b32(), A)
+#define npyv_reduce_minn_f64(A) svminv_f64(svptrue_b64(), A)
+#define npyv_reduce_minp_f32(A) svminnmv_f32(svptrue_b32(), A)
+#define npyv_reduce_minp_f64(A) svminnmv_f64(svptrue_b64(), A)
+
+#define npyv_reduce_max_u8(A) svmaxv_u8(svptrue_b8(), A)
+#define npyv_reduce_max_u16(A) svmaxv_u16(svptrue_b16(), A)
+#define npyv_reduce_max_u32(A) svmaxv_u32(svptrue_b32(), A)
+#define npyv_reduce_max_u64(A) svmaxv_u64(svptrue_b64(), A)
+#define npyv_reduce_max_s8(A) svmaxv_s8(svptrue_b8(), A)
+#define npyv_reduce_max_s16(A) svmaxv_s16(svptrue_b16(), A)
+#define npyv_reduce_max_s32(A) svmaxv_s32(svptrue_b32(), A)
+#define npyv_reduce_max_s64(A) svmaxv_s64(svptrue_b64(), A)
+#define npyv_reduce_max_f32(A) svmaxv_f32(svptrue_b32(), A)
+#define npyv_reduce_max_f64(A) svmaxv_f64(svptrue_b64(), A)
+#define npyv_reduce_maxn_f32(A) svmaxv_f32(svptrue_b32(), A)
+#define npyv_reduce_maxn_f64(A) svmaxv_f64(svptrue_b64(), A)
+#define npyv_reduce_maxp_f32(A) svmaxnmv_f32(svptrue_b32(), A)
+#define npyv_reduce_maxp_f64(A) svmaxnmv_f64(svptrue_b64(), A)
 
 // round to nearest integer even
 #define npyv_rint_f32(A) svrintn_f32_x(svptrue_b32(), A)

--- a/numpy/core/src/common/simd/sve/memory.h
+++ b/numpy/core/src/common/simd/sve/memory.h
@@ -1,0 +1,250 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_MEMORY_H
+#define _NPY_SIMD_SVE_MEMORY_H
+
+#include "misc.h"
+
+/***************************
+ * load/store
+ ***************************/
+// GCC requires literal type definitions for pointers types otherwise it causes
+// ambiguous errors
+#define NPYV_IMPL_SVE_MEM(VL_PAT, HALF_LANE, S, W, T)                         \
+    NPY_FINLINE npyv_##S##W npyv_load_##S##W(const npyv_lanetype_##S##W *ptr) \
+    {                                                                         \
+        return svld1_##S##W(svptrue_b##W(), (const T##_t *)ptr);              \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_loada_##S##W(                                \
+            const npyv_lanetype_##S##W *ptr)                                  \
+    {                                                                         \
+        return svld1_##S##W(svptrue_b##W(), (const T##_t *)ptr);              \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_loadl_##S##W(                                \
+            const npyv_lanetype_##S##W *ptr)                                  \
+    {                                                                         \
+        return svld1_##S##W(svptrue_pat_b##W(VL_PAT), (const T##_t *)ptr);    \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_loads_##S##W(                                \
+            const npyv_lanetype_##S##W *ptr)                                  \
+    {                                                                         \
+        return svld1_##S##W(svptrue_b##W(), (const T##_t *)ptr);              \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_load_till_##S##W(                            \
+            const npy_##T *ptr, npy_uintp nlane, npy_##T fill)                \
+    {                                                                         \
+        assert(nlane > 0);                                                    \
+        if (nlane == NPY_SIMD_WIDTH / sizeof(T##_t)) {                        \
+            return svld1_##S##W(svptrue_b##W(), ptr);                         \
+        }                                                                     \
+        else {                                                                \
+            const sv##T##_t vfill = svdup_##S##W(fill);                       \
+            const svbool_t mask = svwhilelt_b##W##_u32(0, nlane);             \
+            return svsel_##S##W(mask, svld1_##S##W(mask, ptr), vfill);        \
+        }                                                                     \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_load_tillz_##S##W(const npy_##T *ptr,        \
+                                                   npy_uintp nlane)           \
+    {                                                                         \
+        assert(nlane > 0);                                                    \
+        if (nlane == NPY_SIMD_WIDTH / sizeof(T##_t)) {                        \
+            return svld1_##S##W(svptrue_b##W(), ptr);                         \
+        }                                                                     \
+        else {                                                                \
+            const svbool_t mask = svwhilelt_b##W##_u32(0, nlane);             \
+            return svld1_##S##W(mask, ptr);                                   \
+        }                                                                     \
+    }                                                                         \
+    NPY_FINLINE void npyv_store_##S##W(npyv_lanetype_##S##W *ptr,             \
+                                       npyv_##S##W vec)                       \
+    {                                                                         \
+        svst1_##S##W(svptrue_b##W(), (T##_t *)ptr, vec);                      \
+    }                                                                         \
+    NPY_FINLINE void npyv_storea_##S##W(npyv_lanetype_##S##W *ptr,            \
+                                        npyv_##S##W vec)                      \
+    {                                                                         \
+        svst1_##S##W(svptrue_b##W(), (T##_t *)ptr, vec);                      \
+    }                                                                         \
+    NPY_FINLINE void npyv_stores_##S##W(npyv_lanetype_##S##W *ptr,            \
+                                        npyv_##S##W vec)                      \
+    {                                                                         \
+        svst1_##S##W(svptrue_b##W(), (T##_t *)ptr, vec);                      \
+    }                                                                         \
+    NPY_FINLINE void npyv_storel_##S##W(npyv_lanetype_##S##W *ptr,            \
+                                        npyv_##S##W vec)                      \
+    {                                                                         \
+        svst1_##S##W(svptrue_pat_b##W(VL_PAT), (T##_t *)ptr, vec);            \
+    }                                                                         \
+    NPY_FINLINE void npyv_storeh_##S##W(npyv_lanetype_##S##W *ptr,            \
+                                        npyv_##S##W vec)                      \
+    {                                                                         \
+        svbool_t mask = svptrue_pat_b##W(VL_PAT);                             \
+                                                                              \
+        sv##T##_t tmp = svext_##S##W(vec, vec, HALF_LANE);                    \
+        svst1_##S##W(mask, (T##_t *)ptr, tmp);                                \
+    }                                                                         \
+    NPY_FINLINE void npyv_store_till_##S##W(npy_##T *ptr, npy_uintp nlane,    \
+                                            npyv_##S##W a)                    \
+    {                                                                         \
+        assert(nlane > 0);                                                    \
+        if (nlane == NPY_SIMD_WIDTH / sizeof(T##_t)) {                        \
+            svst1_##S##W(svptrue_b##W(), ptr, a);                             \
+        }                                                                     \
+        else {                                                                \
+            const svbool_t mask = svwhilelt_b##W##_u32(0, nlane);             \
+            svst1_##S##W(mask, ptr, a);                                       \
+        }                                                                     \
+    }
+
+#if NPY_SIMD == 512
+NPYV_IMPL_SVE_MEM(SV_VL32, 32, u, 8, uint8)
+NPYV_IMPL_SVE_MEM(SV_VL16, 16, u, 16, uint16)
+NPYV_IMPL_SVE_MEM(SV_VL8, 8, u, 32, uint32)
+NPYV_IMPL_SVE_MEM(SV_VL4, 4, u, 64, uint64)
+NPYV_IMPL_SVE_MEM(SV_VL32, 32, s, 8, int8)
+NPYV_IMPL_SVE_MEM(SV_VL16, 16, s, 16, int16)
+NPYV_IMPL_SVE_MEM(SV_VL8, 8, s, 32, int32)
+NPYV_IMPL_SVE_MEM(SV_VL4, 4, s, 64, int64)
+NPYV_IMPL_SVE_MEM(SV_VL8, 8, f, 32, float32)
+NPYV_IMPL_SVE_MEM(SV_VL4, 4, f, 64, float64)
+#else
+#error "unsupported sve size"
+#endif
+
+/***************************
+ * Non-contiguous (partial) Load/Store
+ ***************************/
+#define NPYV_IMPL_SVE_LOADN(S, W, T)                                          \
+    NPY_FINLINE npyv_##S##W npyv_loadn_##S##W(const npy_##T *ptr,             \
+                                              npy_intp stride)                \
+    {                                                                         \
+        assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE##W);                  \
+        const svint##W##_t steps = svindex_s##W(0, 1);                        \
+        const svint##W##_t idx =                                              \
+                svmul_n_s##W##_x(svptrue_b##W(), steps, stride);              \
+                                                                              \
+        return svld1_gather_s##W##index_##S##W(svptrue_b##W(), ptr, idx);     \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_loadn_till_##S##W(                           \
+            const npy_##T *ptr, npy_intp stride, npy_uintp nlane,             \
+            npy_##T fill)                                                     \
+    {                                                                         \
+        assert(nlane > 0);                                                    \
+        assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE##W);                  \
+        const svint##W##_t steps = svindex_s##W(0, 1);                        \
+        const svint##W##_t idx =                                              \
+                svmul_n_s##W##_x(svptrue_b##W(), steps, stride);              \
+                                                                              \
+        if (nlane == NPY_SIMD_WIDTH / sizeof(T##_t)) {                        \
+            return svld1_gather_s##W##index_##S##W(svptrue_b##W(), ptr, idx); \
+        }                                                                     \
+        else {                                                                \
+            const svbool_t mask = svwhilelt_b##W##_u32(0, nlane);             \
+            const sv##T##_t vfill = svdup_##S##W(fill);                       \
+                                                                              \
+            return svsel_##S##W(                                              \
+                    mask, svld1_gather_s##W##index_##S##W(mask, ptr, idx),    \
+                    vfill);                                                   \
+        }                                                                     \
+    }                                                                         \
+    NPY_FINLINE npyv_##S##W npyv_loadn_tillz_##S##W(                          \
+            const npy_##T *ptr, npy_intp stride, npy_uintp nlane)             \
+    {                                                                         \
+        return npyv_loadn_till_##S##W(ptr, stride, nlane, 0);                 \
+    }                                                                         \
+    NPY_FINLINE void npyv_storen_##S##W(npy_##T *ptr, npy_intp stride,        \
+                                        npyv_##S##W a)                        \
+    {                                                                         \
+        assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE##W);                  \
+        const svint##W##_t steps = svindex_s##W(0, 1);                        \
+        const svint##W##_t idx =                                              \
+                svmul_n_s##W##_x(svptrue_b##W(), steps, stride);              \
+                                                                              \
+        svst1_scatter_s##W##index_##S##W(svptrue_b##W(), ptr, idx, a);        \
+    }                                                                         \
+    NPY_FINLINE void npyv_storen_till_##S##W(npy_##T *ptr, npy_intp stride,   \
+                                             npy_uintp nlane, npyv_##S##W a)  \
+    {                                                                         \
+        assert(nlane > 0);                                                    \
+        assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE##W);                  \
+        const svint##W##_t steps = svindex_s##W(0, 1);                        \
+        const svint##W##_t idx =                                              \
+                svmul_n_s##W##_x(svptrue_b##W(), steps, stride);              \
+                                                                              \
+        if (nlane == NPY_SIMD_WIDTH / sizeof(T##_t)) {                        \
+            svst1_scatter_s##W##index_##S##W(svptrue_b##W(), ptr, idx, a);    \
+        }                                                                     \
+        else {                                                                \
+            const svbool_t mask = svwhilelt_b##W##_u32(0, nlane);             \
+                                                                              \
+            svst1_scatter_s##W##index_##S##W(mask, ptr, idx, a);              \
+        }                                                                     \
+    }
+
+NPYV_IMPL_SVE_LOADN(u, 32, uint32)
+NPYV_IMPL_SVE_LOADN(s, 32, int32)
+NPYV_IMPL_SVE_LOADN(u, 64, uint64)
+NPYV_IMPL_SVE_LOADN(s, 64, int64)
+NPYV_IMPL_SVE_LOADN(f, 32, float32)
+NPYV_IMPL_SVE_LOADN(f, 64, float64)
+
+/**************************************************
+ * Lookup table
+ *************************************************/
+// uses vector as indexes into a table
+// that contains 32 elements of float32.
+NPY_FINLINE npyv_f32
+npyv_lut32_f32(const float *table, npyv_u32 idx)
+{
+    const npyv_u32 t_idx =
+            svand_n_u32_m(svptrue_b32(), idx, npyv_nlanes_f32 - 1);
+    const npyv_f32 table0 = npyv_load_f32(table);
+    const npyv_f32 table1 = npyv_load_f32(table + npyv_nlanes_f32);
+    const svbool_t mask = svcmplt_n_u32(svptrue_b32(), idx, npyv_nlanes_f32);
+    npyv_f32 t0 = svtbl_f32(table0, t_idx);
+    npyv_f32 t1 = svtbl_f32(table1, t_idx);
+
+    return svsel_f32(mask, t0, t1);
+}
+NPY_FINLINE npyv_u32
+npyv_lut32_u32(const npy_uint32 *table, npyv_u32 idx)
+{
+    return npyv_reinterpret_u32_f32(npyv_lut32_f32((const float *)table, idx));
+}
+NPY_FINLINE npyv_s32
+npyv_lut32_s32(const npy_int32 *table, npyv_u32 idx)
+{
+    return npyv_reinterpret_s32_f32(npyv_lut32_f32((const float *)table, idx));
+}
+
+// uses vector as indexes into a table
+// that contains 16 elements of float64.
+NPY_FINLINE npyv_f64
+npyv_lut16_f64(const double *table, npyv_u64 idx)
+{
+    const npyv_u64 t_idx =
+            svand_n_u64_m(svptrue_b64(), idx, npyv_nlanes_f64 - 1);
+    const npyv_f64 table0 = npyv_load_f64(table);
+    const npyv_f64 table1 = npyv_load_f64(table + npyv_nlanes_f64);
+    const svbool_t mask = svcmplt_n_u64(svptrue_b64(), idx, npyv_nlanes_f64);
+    npyv_f64 t0 = svtbl_f64(table0, t_idx);
+    npyv_f64 t1 = svtbl_f64(table1, t_idx);
+
+    return svsel_f64(mask, t0, t1);
+}
+NPY_FINLINE npyv_u64
+npyv_lut16_u64(const npy_uint64 *table, npyv_u64 idx)
+{
+    return npyv_reinterpret_u64_f64(
+            npyv_lut16_f64((const double *)table, idx));
+}
+NPY_FINLINE npyv_s64
+npyv_lut16_s64(const npy_int64 *table, npyv_u64 idx)
+{
+    return npyv_reinterpret_s64_f64(
+            npyv_lut16_f64((const double *)table, idx));
+}
+
+#endif  // _NPY_SIMD_SVE_MEMORY_H

--- a/numpy/core/src/common/simd/sve/misc.h
+++ b/numpy/core/src/common/simd/sve/misc.h
@@ -1,0 +1,317 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_MISC_H
+#define _NPY_SIMD_SVE_MISC_H
+
+// vector with zero lanes
+#define npyv_zero_u8()  svdup_n_u8(0)
+#define npyv_zero_u16() svdup_n_u16(0)
+#define npyv_zero_u32() svdup_n_u32(0)
+#define npyv_zero_u64() svdup_n_u64(0)
+#define npyv_zero_s8()  svdup_n_s8(0)
+#define npyv_zero_s16() svdup_n_s16(0)
+#define npyv_zero_s32() svdup_n_s32(0)
+#define npyv_zero_s64() svdup_n_s64(0)
+#define npyv_zero_f32() svdup_n_f32(0.0)
+#define npyv_zero_f64() svdup_n_f64(0.0)
+
+// vector with a specific value set to all lanes
+#define npyv_setall_u8 svdup_n_u8
+#define npyv_setall_s8 svdup_n_s8
+#define npyv_setall_u16 svdup_n_u16
+#define npyv_setall_s16 svdup_n_s16
+#define npyv_setall_u32 svdup_n_u32
+#define npyv_setall_s32 svdup_n_s32
+#define npyv_setall_u64 svdup_n_u64
+#define npyv_setall_s64 svdup_n_s64
+#define npyv_setall_f32 svdup_n_f32
+#define npyv_setall_f64 svdup_n_f64
+
+#define npyv__set_8(T, S)                                                 \
+    NPY_FINLINE npyv_##S##8 npyv__set_##S##8(                             \
+            T i0,  T i1,  T i2,  T i3,  T i4,  T i5,  T i6,  T i7,        \
+            T i8,  T i9,  T i10, T i11, T i12, T i13, T i14, T i15,       \
+            T i16, T i17, T i18, T i19, T i20, T i21, T i22, T i23,       \
+            T i24, T i25, T i26, T i27, T i28, T i29, T i30, T i31,       \
+            T i32, T i33, T i34, T i35, T i36, T i37, T i38, T i39,       \
+            T i40, T i41, T i42, T i43, T i44, T i45, T i46, T i47,       \
+            T i48, T i49, T i50, T i51, T i52, T i53, T i54, T i55,       \
+            T i56, T i57, T i58, T i59, T i60, T i61, T i62, T i63)       \
+    {                                                                     \
+        const T NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) data[npyv_nlanes_u8] = { \
+                i0,  i1,  i2,  i3,  i4,  i5,  i6,  i7,                    \
+                i8,  i9,  i10, i11, i12, i13, i14, i15,                   \
+                i16, i17, i18, i19, i20, i21, i22, i23,                   \
+                i24, i25, i26, i27, i28, i29, i30, i31,                   \
+                i32, i33, i34, i35, i36, i37, i38, i39,                   \
+                i40, i41, i42, i43, i44, i45, i46, i47,                   \
+                i48, i49, i50, i51, i52, i53, i54, i55,                   \
+                i56, i57, i58, i59, i60, i61, i62, i63};                  \
+        return svld1_##S##8(svptrue_b8(), (const void *)data);            \
+    }
+
+#define npyv__set_16(T, S)                                                 \
+    NPY_FINLINE npyv_##S##16 npyv__set_##S##16(                            \
+            T i0,  T i1,  T i2,  T i3,  T i4,  T i5,  T i6,  T i7,         \
+            T i8,  T i9,  T i10, T i11, T i12, T i13, T i14, T i15,        \
+            T i16, T i17, T i18, T i19, T i20, T i21, T i22, T i23,        \
+            T i24, T i25, T i26, T i27, T i28, T i29, T i30, T i31)        \
+    {                                                                      \
+        const T NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) data[npyv_nlanes_u16] = { \
+                i0,  i1,  i2,  i3,  i4,  i5,  i6,  i7,                     \
+                i8,  i9,  i10, i11, i12, i13, i14, i15,                    \
+                i16, i17, i18, i19, i20, i21, i22, i23,                    \
+                i24, i25, i26, i27, i28, i29, i30, i31};                   \
+        return svld1_##S##16(svptrue_b8(), (const void *)data);            \
+    }
+
+#define npyv__set_32(T, S)                                                    \
+    NPY_FINLINE npyv_##S##32 npyv__set_##S##32(                               \
+            T i0, T i1, T i2,  T i3,  T i4,  T i5,  T i6,  T i7,              \
+            T i8, T i9, T i10, T i11, T i12, T i13, T i14, T i15)             \
+    {                                                                         \
+        const T NPY_DECL_ALIGNED(NPY_SIMD_WIDTH)                              \
+                data[npyv_nlanes_u32] = {i0, i1, i2,  i3,  i4,  i5,  i6,  i7, \
+                        i8, i9, i10, i11, i12, i13, i14, i15};                \
+        return svld1_##S##32(svptrue_b8(), (const void *)data);               \
+    }
+
+#define npyv__set_64(T, S)                                                   \
+    NPY_FINLINE npyv_##S##64 npyv__set_##S##64(T i0, T i1, T i2, T i3, T i4, \
+                                               T i5, T i6, T i7)             \
+    {                                                                        \
+        const T NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) data[npyv_nlanes_u64] =     \
+                {i0, i1, i2, i3, i4, i5, i6, i7};                            \
+        return svld1_##S##64(svptrue_b8(), (const void *)data);              \
+    }
+
+npyv__set_8(uint8_t, u)
+npyv__set_8(int8_t, s)
+npyv__set_16(uint16_t, u)
+npyv__set_16(int16_t, s)
+npyv__set_32(uint32_t, u)
+npyv__set_32(int32_t, s)
+npyv__set_64(uint64_t, u)
+npyv__set_64(int64_t, s)
+npyv__set_32(float32_t, f)
+npyv__set_64(float64_t, f)
+
+#define npyv_setf_u8(FILL, ...) \
+    npyv__set_u8(NPYV__SET_FILL_64(char, FILL, __VA_ARGS__))
+#define npyv_setf_s8(FILL, ...) \
+    npyv__set_s8(NPYV__SET_FILL_64(char, FILL, __VA_ARGS__))
+#define npyv_setf_u16(FILL, ...) \
+    npyv__set_u16(NPYV__SET_FILL_32(short, FILL, __VA_ARGS__))
+#define npyv_setf_s16(FILL, ...) \
+    npyv__set_s16(NPYV__SET_FILL_32(short, FILL, __VA_ARGS__))
+#define npyv_setf_u32(FILL, ...) \
+    npyv__set_u32(NPYV__SET_FILL_16(int, FILL, __VA_ARGS__))
+#define npyv_setf_s32(FILL, ...) \
+    npyv__set_s32(NPYV__SET_FILL_16(int, FILL, __VA_ARGS__))
+#define npyv_setf_u64(FILL, ...) \
+    npyv__set_u64(NPYV__SET_FILL_8(npy_int64, FILL, __VA_ARGS__))
+#define npyv_setf_s64(FILL, ...) \
+    npyv__set_s64(NPYV__SET_FILL_8(npy_int64, FILL, __VA_ARGS__))
+#define npyv_setf_f32(FILL, ...) \
+    npyv__set_f32(NPYV__SET_FILL_16(float, FILL, __VA_ARGS__))
+#define npyv_setf_f64(FILL, ...) \
+    npyv__set_f64(NPYV__SET_FILL_8(double, FILL, __VA_ARGS__))
+
+// vector with specific values set to each lane and
+// set zero to all remained lanes
+#define npyv_set_u8(...) npyv_setf_u8(0, __VA_ARGS__)
+#define npyv_set_s8(...) npyv_setf_s8(0, __VA_ARGS__)
+#define npyv_set_u16(...) npyv_setf_u16(0, __VA_ARGS__)
+#define npyv_set_s16(...) npyv_setf_s16(0, __VA_ARGS__)
+#define npyv_set_u32(...) npyv_setf_u32(0, __VA_ARGS__)
+#define npyv_set_s32(...) npyv_setf_s32(0, __VA_ARGS__)
+#define npyv_set_u64(...) npyv_setf_u64(0, __VA_ARGS__)
+#define npyv_set_s64(...) npyv_setf_s64(0, __VA_ARGS__)
+#define npyv_set_f32(...) npyv_setf_f32(0, __VA_ARGS__)
+#define npyv_set_f64(...) npyv_setf_f64(0, __VA_ARGS__)
+
+// Set mask for lane #0 - #(a-1)
+#define NPYV_IMPL_SVE_SET_B(BITS)                    \
+    NPY_FINLINE npyv_b##BITS npyv_set_b##BITS(int a) \
+    {                                                \
+        return svwhilelt_b##BITS##_s32(0, a);        \
+    }
+
+NPYV_IMPL_SVE_SET_B(8) NPYV_IMPL_SVE_SET_B(16)
+NPYV_IMPL_SVE_SET_B(32)
+NPYV_IMPL_SVE_SET_B(64)
+
+// Per lane select
+#define npyv_select_u8 svsel_u8
+#define npyv_select_s8 svsel_s8
+#define npyv_select_u16 svsel_u16
+#define npyv_select_s16 svsel_s16
+#define npyv_select_u32 svsel_u32
+#define npyv_select_s32 svsel_s32
+#define npyv_select_u64 svsel_u64
+#define npyv_select_s64 svsel_s64
+#define npyv_select_f32 svsel_f32
+#define npyv_select_f64 svsel_f64
+
+// Reinterpret
+#define npyv_reinterpret_u8_u8(X) X
+#define npyv_reinterpret_u8_s8 svreinterpret_u8_s8
+#define npyv_reinterpret_u8_u16 svreinterpret_u8_u16
+#define npyv_reinterpret_u8_s16 svreinterpret_u8_s16
+#define npyv_reinterpret_u8_u32 svreinterpret_u8_u32
+#define npyv_reinterpret_u8_s32 svreinterpret_u8_s32
+#define npyv_reinterpret_u8_u64 svreinterpret_u8_u64
+#define npyv_reinterpret_u8_s64 svreinterpret_u8_s64
+#define npyv_reinterpret_u8_f32 svreinterpret_u8_f32
+#define npyv_reinterpret_u8_f64 svreinterpret_u8_f64
+
+#define npyv_reinterpret_s8_s8(X) X
+#define npyv_reinterpret_s8_u8 svreinterpret_s8_u8
+#define npyv_reinterpret_s8_u16 svreinterpret_s8_u16
+#define npyv_reinterpret_s8_s16 svreinterpret_s8_s16
+#define npyv_reinterpret_s8_u32 svreinterpret_s8_u32
+#define npyv_reinterpret_s8_s32 svreinterpret_s8_s32
+#define npyv_reinterpret_s8_u64 svreinterpret_s8_u64
+#define npyv_reinterpret_s8_s64 svreinterpret_s8_s64
+#define npyv_reinterpret_s8_f32 svreinterpret_s8_f32
+#define npyv_reinterpret_s8_f64 svreinterpret_s8_f64
+
+#define npyv_reinterpret_u16_u16(X) X
+#define npyv_reinterpret_u16_u8 svreinterpret_u16_u8
+#define npyv_reinterpret_u16_s8 svreinterpret_u16_s8
+#define npyv_reinterpret_u16_s16 svreinterpret_u16_s16
+#define npyv_reinterpret_u16_u32 svreinterpret_u16_u32
+#define npyv_reinterpret_u16_s32 svreinterpret_u16_s32
+#define npyv_reinterpret_u16_u64 svreinterpret_u16_u64
+#define npyv_reinterpret_u16_s64 svreinterpret_u16_s64
+#define npyv_reinterpret_u16_f32 svreinterpret_u16_f32
+#define npyv_reinterpret_u16_f64 svreinterpret_u16_f64
+
+#define npyv_reinterpret_s16_s16(X) X
+#define npyv_reinterpret_s16_u8 svreinterpret_s16_u8
+#define npyv_reinterpret_s16_s8 svreinterpret_s16_s8
+#define npyv_reinterpret_s16_u16 svreinterpret_s16_u16
+#define npyv_reinterpret_s16_u32 svreinterpret_s16_u32
+#define npyv_reinterpret_s16_s32 svreinterpret_s16_s32
+#define npyv_reinterpret_s16_u64 svreinterpret_s16_u64
+#define npyv_reinterpret_s16_s64 svreinterpret_s16_s64
+#define npyv_reinterpret_s16_f32 svreinterpret_s16_f32
+#define npyv_reinterpret_s16_f64 svreinterpret_s16_f64
+
+#define npyv_reinterpret_u32_u32(X) X
+#define npyv_reinterpret_u32_u8 svreinterpret_u32_u8
+#define npyv_reinterpret_u32_s8 svreinterpret_u32_s8
+#define npyv_reinterpret_u32_u16 svreinterpret_u32_u16
+#define npyv_reinterpret_u32_s16 svreinterpret_u32_s16
+#define npyv_reinterpret_u32_s32 svreinterpret_u32_s32
+#define npyv_reinterpret_u32_u64 svreinterpret_u32_u64
+#define npyv_reinterpret_u32_s64 svreinterpret_u32_s64
+#define npyv_reinterpret_u32_f32 svreinterpret_u32_f32
+#define npyv_reinterpret_u32_f64 svreinterpret_u32_f64
+
+#define npyv_reinterpret_s32_s32(X) X
+#define npyv_reinterpret_s32_u8 svreinterpret_s32_u8
+#define npyv_reinterpret_s32_s8 svreinterpret_s32_s8
+#define npyv_reinterpret_s32_u16 svreinterpret_s32_u16
+#define npyv_reinterpret_s32_s16 svreinterpret_s32_s16
+#define npyv_reinterpret_s32_u32 svreinterpret_s32_u32
+#define npyv_reinterpret_s32_u64 svreinterpret_s32_u64
+#define npyv_reinterpret_s32_s64 svreinterpret_s32_s64
+#define npyv_reinterpret_s32_f32 svreinterpret_s32_f32
+#define npyv_reinterpret_s32_f64 svreinterpret_s32_f64
+
+#define npyv_reinterpret_u64_u64(X) X
+#define npyv_reinterpret_u64_u8 svreinterpret_u64_u8
+#define npyv_reinterpret_u64_s8 svreinterpret_u64_s8
+#define npyv_reinterpret_u64_u16 svreinterpret_u64_u16
+#define npyv_reinterpret_u64_s16 svreinterpret_u64_s16
+#define npyv_reinterpret_u64_u32 svreinterpret_u64_u32
+#define npyv_reinterpret_u64_s32 svreinterpret_u64_s32
+#define npyv_reinterpret_u64_s64 svreinterpret_u64_s64
+#define npyv_reinterpret_u64_f32 svreinterpret_u64_f32
+#define npyv_reinterpret_u64_f64 svreinterpret_u64_f64
+
+#define npyv_reinterpret_s64_s64(X) X
+#define npyv_reinterpret_s64_u8 svreinterpret_s64_u8
+#define npyv_reinterpret_s64_s8 svreinterpret_s64_s8
+#define npyv_reinterpret_s64_u16 svreinterpret_s64_u16
+#define npyv_reinterpret_s64_s16 svreinterpret_s64_s16
+#define npyv_reinterpret_s64_u32 svreinterpret_s64_u32
+#define npyv_reinterpret_s64_s32 svreinterpret_s64_s32
+#define npyv_reinterpret_s64_u64 svreinterpret_s64_u64
+#define npyv_reinterpret_s64_f32 svreinterpret_s64_f32
+#define npyv_reinterpret_s64_f64 svreinterpret_s64_f64
+
+#define npyv_reinterpret_f32_f32(X) X
+#define npyv_reinterpret_f32_u8 svreinterpret_f32_u8
+#define npyv_reinterpret_f32_s8 svreinterpret_f32_s8
+#define npyv_reinterpret_f32_u16 svreinterpret_f32_u16
+#define npyv_reinterpret_f32_s16 svreinterpret_f32_s16
+#define npyv_reinterpret_f32_u32 svreinterpret_f32_u32
+#define npyv_reinterpret_f32_s32 svreinterpret_f32_s32
+#define npyv_reinterpret_f32_u64 svreinterpret_f32_u64
+#define npyv_reinterpret_f32_s64 svreinterpret_f32_s64
+#define npyv_reinterpret_f32_f64 svreinterpret_f32_f64
+
+#define npyv_reinterpret_f64_f64(X) X
+#define npyv_reinterpret_f64_u8 svreinterpret_f64_u8
+#define npyv_reinterpret_f64_s8 svreinterpret_f64_s8
+#define npyv_reinterpret_f64_u16 svreinterpret_f64_u16
+#define npyv_reinterpret_f64_s16 svreinterpret_f64_s16
+#define npyv_reinterpret_f64_u32 svreinterpret_f64_u32
+#define npyv_reinterpret_f64_s32 svreinterpret_f64_s32
+#define npyv_reinterpret_f64_u64 svreinterpret_f64_u64
+#define npyv_reinterpret_f64_s64 svreinterpret_f64_s64
+#define npyv_reinterpret_f64_f32 svreinterpret_f64_f32
+
+// broadcast simd lane#0 to others
+
+#define NPYV_IMPL_SVE_BROADCAST_LANE0(W, S)              \
+    NPY_FINLINE npyv_##S##W npyv_broadcast_lane0_##S##W( \
+            npyv_##S##W a)                               \
+    {                                                    \
+        return svdup_lane_##S##W(a, 0);                  \
+    }
+
+NPYV_IMPL_SVE_BROADCAST_LANE0(8, u)
+NPYV_IMPL_SVE_BROADCAST_LANE0(16, u)
+NPYV_IMPL_SVE_BROADCAST_LANE0(32, u)
+NPYV_IMPL_SVE_BROADCAST_LANE0(64, u)
+NPYV_IMPL_SVE_BROADCAST_LANE0(8, s)
+NPYV_IMPL_SVE_BROADCAST_LANE0(16, s)
+NPYV_IMPL_SVE_BROADCAST_LANE0(32, s)
+NPYV_IMPL_SVE_BROADCAST_LANE0(64, s)
+NPYV_IMPL_SVE_BROADCAST_LANE0(32, f)
+NPYV_IMPL_SVE_BROADCAST_LANE0(64, f)
+
+// get simd lane#0
+#define NPYV_IMPL_SVE_GET_LANE0(W, S, T)                  \
+    NPY_FINLINE npy_##T##W npyv__get_simd_lane0_##S##W(   \
+            npyv_##S##W a)                                \
+    {                                                     \
+        return svorv_##S##W(svptrue_pat_b##W(SV_VL1), a); \
+    }
+
+NPYV_IMPL_SVE_GET_LANE0(8, u, uint)
+NPYV_IMPL_SVE_GET_LANE0(16, u, uint)
+NPYV_IMPL_SVE_GET_LANE0(32, u, uint)
+NPYV_IMPL_SVE_GET_LANE0(64, u, uint)
+NPYV_IMPL_SVE_GET_LANE0(8, s, int)
+NPYV_IMPL_SVE_GET_LANE0(16, s, int)
+NPYV_IMPL_SVE_GET_LANE0(32, s, int)
+NPYV_IMPL_SVE_GET_LANE0(64, s, int)
+
+/* Following npyv_popcnt_b(8/16/32/64) function requried
+   to declare #define NPY_SIMD_POPCNT 1. */
+#define npyv_popcnt_b8(a)  svcntp_b8(svptrue_b8(), a)
+#define npyv_popcnt_b16(a) svcntp_b16(svptrue_b16(), a)
+#define npyv_popcnt_b32(a) svcntp_b32(svptrue_b32(), a)
+#define npyv_popcnt_b64(a) svcntp_b64(svptrue_b64(), a)
+
+
+// Only required by AVX2/AVX512
+#define npyv_cleanup() ((void)0)
+
+#endif  // _NPY_SIMD_NEON_MISC_H

--- a/numpy/core/src/common/simd/sve/misc.h
+++ b/numpy/core/src/common/simd/sve/misc.h
@@ -155,6 +155,18 @@ NPYV_IMPL_SVE_SET_B(64)
 #define npyv_select_f32 svsel_f32
 #define npyv_select_f64 svsel_f64
 
+// extract the first vector's lane
+#define npyv_extract0_u8(A) svlastb_u8(svptrue_pat_b8(SV_VL1), A)
+#define npyv_extract0_u16(A) svlastb_u16(svptrue_pat_b16(SV_VL1), A)
+#define npyv_extract0_u32(A) svlastb_u32(svptrue_pat_b32(SV_VL1), A)
+#define npyv_extract0_u64(A) svlastb_u64(svptrue_pat_b64(SV_VL1), A)
+#define npyv_extract0_s8(A) svlastb_s8(svptrue_pat_b8(SV_VL1), A)
+#define npyv_extract0_s16(A) svlastb_s16(svptrue_pat_b16(SV_VL1), A)
+#define npyv_extract0_s32(A) svlastb_s32(svptrue_pat_b32(SV_VL1), A)
+#define npyv_extract0_s64(A) svlastb_s64(svptrue_pat_b64(SV_VL1), A)
+#define npyv_extract0_f32(A) svlastb_f32(svptrue_pat_b32(SV_VL1), A)
+#define npyv_extract0_f64(A) svlastb_f64(svptrue_pat_b64(SV_VL1), A)
+
 // Reinterpret
 #define npyv_reinterpret_u8_u8(X) X
 #define npyv_reinterpret_u8_s8 svreinterpret_u8_s8
@@ -285,23 +297,6 @@ NPYV_IMPL_SVE_BROADCAST_LANE0(32, s)
 NPYV_IMPL_SVE_BROADCAST_LANE0(64, s)
 NPYV_IMPL_SVE_BROADCAST_LANE0(32, f)
 NPYV_IMPL_SVE_BROADCAST_LANE0(64, f)
-
-// get simd lane#0
-#define NPYV_IMPL_SVE_GET_LANE0(W, S, T)                  \
-    NPY_FINLINE npy_##T##W npyv__get_simd_lane0_##S##W(   \
-            npyv_##S##W a)                                \
-    {                                                     \
-        return svorv_##S##W(svptrue_pat_b##W(SV_VL1), a); \
-    }
-
-NPYV_IMPL_SVE_GET_LANE0(8, u, uint)
-NPYV_IMPL_SVE_GET_LANE0(16, u, uint)
-NPYV_IMPL_SVE_GET_LANE0(32, u, uint)
-NPYV_IMPL_SVE_GET_LANE0(64, u, uint)
-NPYV_IMPL_SVE_GET_LANE0(8, s, int)
-NPYV_IMPL_SVE_GET_LANE0(16, s, int)
-NPYV_IMPL_SVE_GET_LANE0(32, s, int)
-NPYV_IMPL_SVE_GET_LANE0(64, s, int)
 
 /* Following npyv_popcnt_b(8/16/32/64) function requried
    to declare #define NPY_SIMD_POPCNT 1. */

--- a/numpy/core/src/common/simd/sve/operators.h
+++ b/numpy/core/src/common/simd/sve/operators.h
@@ -1,0 +1,217 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_OPERATORS_H
+#define _NPY_SIMD_SVE_OPERATORS_H
+
+/***************************
+ * Shifting
+ ***************************/
+// left
+#define NPYV_IMPL_SVE_SHIFT_L(S, W)                      \
+    NPY_FINLINE npyv_##S##W npyv_shl_##S##W(             \
+            npyv_##S##W a, npy_uintp b)                  \
+    {                                                    \
+        return svlsl_##S##W##_x(svptrue_b##W(), a,       \
+                                       svdup_n_u##W(b)); \
+    }
+
+NPYV_IMPL_SVE_SHIFT_L(u, 8)
+NPYV_IMPL_SVE_SHIFT_L(u, 16)
+NPYV_IMPL_SVE_SHIFT_L(u, 32)
+NPYV_IMPL_SVE_SHIFT_L(u, 64)
+NPYV_IMPL_SVE_SHIFT_L(s, 8)
+NPYV_IMPL_SVE_SHIFT_L(s, 16)
+NPYV_IMPL_SVE_SHIFT_L(s, 32)
+NPYV_IMPL_SVE_SHIFT_L(s, 64)
+
+// left by an immediate constant
+#define NPYV_IMPL_SVE_SHIFT_L_IMM(W)                    \
+    NPY_FINLINE npyv_u##W npyv_shli_u##W(npyv_u##W a,   \
+            npy_uint##W b)                              \
+    {                                                   \
+        return svlsl_n_u##W##_x(svptrue_b##W(), a, b);  \
+    }                                                   \
+    NPY_FINLINE npyv_s##W npyv_shli_s##W(npyv_s##W a,   \
+            npy_uint##W b)                              \
+    {                                                   \
+        return svlsl_n_s##W##_x(svptrue_b##W(), a, b);  \
+    }
+
+NPYV_IMPL_SVE_SHIFT_L_IMM(8)
+NPYV_IMPL_SVE_SHIFT_L_IMM(16)
+NPYV_IMPL_SVE_SHIFT_L_IMM(32)
+NPYV_IMPL_SVE_SHIFT_L_IMM(64)
+
+// right
+#define NPYV_IMPL_SVE_SHIFT_R(W)                                 \
+    NPY_FINLINE npyv_u##W npyv_shr_u##W(npyv_u##W a, npy_intp b) \
+    {                                                            \
+        return svlsr_u##W##_x(svptrue_b##W(), a,                 \
+                svdup_n_u##W(b));                                \
+    }                                                            \
+    NPY_FINLINE npyv_s##W npyv_shr_s##W(npyv_s##W a, npy_intp b) \
+    {                                                            \
+        return svasr_s##W##_x(svptrue_b##W(), a,                 \
+                svdup_n_u##W(b));                                \
+    }
+
+NPYV_IMPL_SVE_SHIFT_R(8)
+NPYV_IMPL_SVE_SHIFT_R(16)
+NPYV_IMPL_SVE_SHIFT_R(32)
+NPYV_IMPL_SVE_SHIFT_R(64)
+
+// right by an immediate constant
+#define NPYV_IMPL_SVE_SHIFT_R_IMM(W)                   \
+    NPY_FINLINE npyv_u##W npyv_shri_u##W(npyv_u##W a,  \
+            npy_uint##W b)                             \
+    {                                                  \
+        return svlsr_n_u##W##_x(svptrue_b##W(), a, b); \
+    }                                                  \
+    NPY_FINLINE npyv_s##W npyv_shri_s##W(npyv_s##W a,  \
+            npy_uint##W b)                             \
+    {                                                  \
+        return svasr_n_s##W##_x(svptrue_b##W(), a, b); \
+    }
+
+NPYV_IMPL_SVE_SHIFT_R_IMM(8)
+NPYV_IMPL_SVE_SHIFT_R_IMM(16)
+NPYV_IMPL_SVE_SHIFT_R_IMM(32)
+NPYV_IMPL_SVE_SHIFT_R_IMM(64)
+
+/***************************
+ * Logical
+ ***************************/
+#define NPYV_IMPL_SVE_LOGICAL(SFX0, SFX1, SFX2)                            \
+    NPY_FINLINE npyv_##SFX0 npyv_and_##SFX0(npyv_##SFX0 a, npyv_##SFX0 b)  \
+    {                                                                      \
+        return svreinterpret_##SFX0##_##SFX2(svand_##SFX2##_x(             \
+                svptrue_##SFX1(), svreinterpret_##SFX2##_##SFX0(a),        \
+                svreinterpret_##SFX2##_##SFX0(b)));                        \
+    }                                                                      \
+    NPY_FINLINE npyv_##SFX0 npyv_or_##SFX0(npyv_##SFX0 a, npyv_##SFX0 b)   \
+    {                                                                      \
+        return svreinterpret_##SFX0##_##SFX2(svorr_##SFX2##_x(             \
+                svptrue_##SFX1(), svreinterpret_##SFX2##_##SFX0(a),        \
+                svreinterpret_##SFX2##_##SFX0(b)));                        \
+    }                                                                      \
+    NPY_FINLINE npyv_##SFX0 npyv_xor_##SFX0(npyv_##SFX0 a, npyv_##SFX0 b)  \
+    {                                                                      \
+        return svreinterpret_##SFX0##_##SFX2(sveor_##SFX2##_x(             \
+                svptrue_##SFX1(), svreinterpret_##SFX2##_##SFX0(a),        \
+                svreinterpret_##SFX2##_##SFX0(b)));                        \
+    }                                                                      \
+    NPY_FINLINE npyv_##SFX0 npyv_not_##SFX0(npyv_##SFX0 a)                 \
+    {                                                                      \
+        return svreinterpret_##SFX0##_##SFX2(svnot_##SFX2##_x(             \
+                svptrue_##SFX1(), svreinterpret_##SFX2##_##SFX0(a)));      \
+    }                                                                      \
+    NPY_FINLINE npyv_##SFX0 npyv_andc_##SFX0(npyv_##SFX0 a, npyv_##SFX0 b) \
+    {                                                                      \
+        return svreinterpret_##SFX0##_##SFX2(svbic_##SFX2##_x(             \
+                svptrue_##SFX1(), svreinterpret_##SFX2##_##SFX0(a),        \
+                svreinterpret_##SFX2##_##SFX0(b)));                        \
+    }
+NPYV_IMPL_SVE_LOGICAL(u8, b8, u8)
+NPYV_IMPL_SVE_LOGICAL(u16, b16, u16)
+NPYV_IMPL_SVE_LOGICAL(u32, b32, u32)
+NPYV_IMPL_SVE_LOGICAL(u64, b64, u64)
+NPYV_IMPL_SVE_LOGICAL(s8, b8, u8)
+NPYV_IMPL_SVE_LOGICAL(s16, b16, u16)
+NPYV_IMPL_SVE_LOGICAL(s32, b32, u32)
+NPYV_IMPL_SVE_LOGICAL(s64, b64, u64)
+NPYV_IMPL_SVE_LOGICAL(f32, b32, u32)
+NPYV_IMPL_SVE_LOGICAL(f64, b64, u64)
+
+/***************************
+ * Logical (boolean)
+ ***************************/
+#define NPYV_IMPL_SVE_LOGICAL_MASK(SFX)                                \
+    NPY_FINLINE npyv_##SFX npyv_and_##SFX(npyv_##SFX a, npyv_##SFX b)  \
+    {                                                                  \
+        return svand_b_z(svptrue_##SFX(), a, b);                       \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_or_##SFX(npyv_##SFX a, npyv_##SFX b)   \
+    {                                                                  \
+        return svorr_b_z(svptrue_b8(), a, b);                          \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_xor_##SFX(npyv_##SFX a, npyv_##SFX b)  \
+    {                                                                  \
+        return sveor_b_z(svptrue_b8(), a, b);                          \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_not_##SFX(npyv_##SFX a)                \
+    {                                                                  \
+        return svnot_b_z(svptrue_b8(), a);                             \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_andc_##SFX(npyv_##SFX a, npyv_##SFX b) \
+    {                                                                  \
+      return svbic_b_z(svptrue_b8(), a, b);                            \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_orc_##SFX(npyv_##SFX a, npyv_##SFX b)  \
+    {                                                                  \
+      return npyv_or_##SFX(npyv_not_##SFX(b), a);                      \
+    }                                                                  \
+    NPY_FINLINE npyv_##SFX npyv_xnor_##SFX(npyv_##SFX a, npyv_##SFX b) \
+    {                                                                  \
+      return npyv_not_##SFX(npyv_xor_##SFX(a, b));                     \
+    }
+NPYV_IMPL_SVE_LOGICAL_MASK(b8)
+NPYV_IMPL_SVE_LOGICAL_MASK(b16)
+NPYV_IMPL_SVE_LOGICAL_MASK(b32)
+NPYV_IMPL_SVE_LOGICAL_MASK(b64)
+
+/***************************
+ * Comparison
+ ***************************/
+// int equal
+#define NPYV_IMPL_SVE_COMPARE(SFX, BSFX, SFX1)                \
+    NPY_FINLINE npyv_##BSFX npyv_cmpeq_##SFX(SFX1 a, SFX1 b)  \
+    {                                                         \
+       return svcmpeq_##SFX(svptrue_##BSFX(), a, b);          \
+    }                                                         \
+    NPY_FINLINE npyv_##BSFX npyv_cmpneq_##SFX(SFX1 a, SFX1 b) \
+    {                                                         \
+        return svcmpne_##SFX(svptrue_##BSFX(), a, b);         \
+    }                                                         \
+    NPY_FINLINE npyv_##BSFX npyv_cmpgt_##SFX(SFX1 a, SFX1 b)  \
+    {                                                         \
+        return svcmpgt_##SFX(svptrue_##BSFX(), a, b);         \
+    }                                                         \
+    NPY_FINLINE npyv_##BSFX npyv_cmpge_##SFX(SFX1 a, SFX1 b)  \
+    {                                                         \
+        return svcmpge_##SFX(svptrue_##BSFX(), a, b);         \
+    }                                                         \
+    NPY_FINLINE npyv_##BSFX npyv_cmplt_##SFX(SFX1 a, SFX1 b)  \
+    {                                                         \
+        return svcmplt_##SFX(svptrue_##BSFX(), a, b);         \
+    }                                                         \
+    NPY_FINLINE npyv_##BSFX npyv_cmple_##SFX(SFX1 a, SFX1 b)  \
+    {                                                         \
+        return svcmple_##SFX(svptrue_##BSFX(), a, b);         \
+    }
+
+NPYV_IMPL_SVE_COMPARE(u8, b8, svuint8_t)
+NPYV_IMPL_SVE_COMPARE(u16, b16, svuint16_t)
+NPYV_IMPL_SVE_COMPARE(u32, b32, svuint32_t)
+NPYV_IMPL_SVE_COMPARE(u64, b64, svuint64_t)
+NPYV_IMPL_SVE_COMPARE(s8, b8, svint8_t)
+NPYV_IMPL_SVE_COMPARE(s16, b16, svint16_t)
+NPYV_IMPL_SVE_COMPARE(s32, b32, svint32_t)
+NPYV_IMPL_SVE_COMPARE(s64, b64, svint64_t)
+NPYV_IMPL_SVE_COMPARE(f32, b32, svfloat32_t)
+NPYV_IMPL_SVE_COMPARE(f64, b64, svfloat64_t)
+
+// check special cases
+NPY_FINLINE npyv_b32
+npyv_notnan_f32(npyv_f32 a)
+{
+    return svcmpeq(svptrue_b32(), a, a);
+}
+NPY_FINLINE npyv_b64
+npyv_notnan_f64(npyv_f64 a)
+{
+    return svcmpeq(svptrue_b64(), a, a);
+}
+
+#endif  // _NPY_SIMD_SVE_OPERATORS_H

--- a/numpy/core/src/common/simd/sve/operators.h
+++ b/numpy/core/src/common/simd/sve/operators.h
@@ -214,4 +214,53 @@ npyv_notnan_f64(npyv_f64 a)
     return svcmpeq(svptrue_b64(), a, a);
 }
 
+// Test cross all vector lanes
+// any: returns true if any of the elements is not equal to zero
+// all: returns true if all elements are not equal to zero
+#define NPYV_IMPL_SVE_ANYALL(SFX, T)	\
+  NPY_FINLINE bool npyv_any_##SFX(npyv_##SFX a) \
+  { return svcntp_##SFX(svptrue_##SFX(), a) != 0; } \
+  NPY_FINLINE bool npyv_all_##SFX(npyv_##SFX a) \
+  { return svcntp_##SFX(svptrue_##SFX(), a) == svcnt##T(); }
+NPYV_IMPL_SVE_ANYALL(b8,  b)
+NPYV_IMPL_SVE_ANYALL(b16, h)
+NPYV_IMPL_SVE_ANYALL(b32, w)
+NPYV_IMPL_SVE_ANYALL(b64, d)
+#undef NPYV_IMPL_SVE_ANYALL
+
+#define NPYV_IMPL_SVE_ANYALL(SFX, BSFX, T)	\
+  NPY_FINLINE bool npyv_any_##SFX(npyv_##SFX a) \
+  { \
+    return svorv_##SFX(svptrue_##BSFX(), a) != 0; \
+  } \
+  NPY_FINLINE bool npyv_all_##SFX(npyv_##SFX a) \
+  { \
+  const svbool_t cmp = svcmpne_n_##SFX(svptrue_##BSFX(), a, 0); \
+  return svcntp_##BSFX(svptrue_##BSFX(), cmp) == svcnt##T(); \
+  }
+NPYV_IMPL_SVE_ANYALL(u8,  b8,  b)
+NPYV_IMPL_SVE_ANYALL(u16, b16, h)
+NPYV_IMPL_SVE_ANYALL(u32, b32, w)
+NPYV_IMPL_SVE_ANYALL(u64, b64, d)
+NPYV_IMPL_SVE_ANYALL(s8,  b8,  b)
+NPYV_IMPL_SVE_ANYALL(s16, b16, h)
+NPYV_IMPL_SVE_ANYALL(s32, b32, w)
+NPYV_IMPL_SVE_ANYALL(s64, b64, d)
+#undef NPYV_IMPL_SVE_ANYALL
+
+#define NPYV_IMPL_SVE_ANYALL(SFX, BSFX, T) \
+  NPY_FINLINE bool npyv_any_##SFX(npyv_##SFX a) \
+{ \
+  const svbool_t cmp = svcmpne_n_##SFX(svptrue_##BSFX(), a, 0); \
+  return svcntp_##BSFX(svptrue_##BSFX(), cmp) != 0; \
+} \
+  NPY_FINLINE bool npyv_all_##SFX(npyv_##SFX a) \
+{ \
+  const svbool_t cmp = svcmpne_n_##SFX(svptrue_##BSFX(), a, 0); \
+  return svcntp_##BSFX(svptrue_##BSFX(), cmp) == svcnt##T(); \
+}
+NPYV_IMPL_SVE_ANYALL(f32, b32, w)
+NPYV_IMPL_SVE_ANYALL(f64, b64, d)
+#undef NPYV_IMPL_SVE_ANYALL
+
 #endif  // _NPY_SIMD_SVE_OPERATORS_H

--- a/numpy/core/src/common/simd/sve/reorder.h
+++ b/numpy/core/src/common/simd/sve/reorder.h
@@ -6,46 +6,46 @@
 #define _NPY_SIMD_SVE_REORDER_H
 
 // combine lower part of two vectors
-#define NPYV_IMPL_SVE_COMBINEL(T, S, W, V)              \
-    NPY_FINLINE npyv_##S##W npyv_combinel_##S##W(       \
-            npyv_##S##W a, npyv_##S##W b)               \
-    {                                                   \
-        sv##T t = svext_##S##W(b, b,                    \
-                NPY_SIMD_WIDTH / sizeof(T) / 2);        \
-        return svsel_##S##W(svptrue_pat_b##W(V), a, t); \
+#define NPYV_IMPL_SVE_COMBINEL(T, S, W)                                  \
+    NPY_FINLINE npyv_##S##W npyv_combinel_##S##W(                        \
+            npyv_##S##W a, npyv_##S##W b)                                \
+    {                                                                    \
+        const svbool_t mask = svwhilelt_b##W##_u32(0, NPY_SIMD / W / 2); \
+        sv##T t = svext_##S##W(b, b, NPY_SIMD / W / 2);                  \
+        return svsel_##S##W(mask, a, t);                                 \
     }
 
-NPYV_IMPL_SVE_COMBINEL(uint8_t, u, 8, SV_VL32)
-NPYV_IMPL_SVE_COMBINEL(uint16_t, u, 16, SV_VL16)
-NPYV_IMPL_SVE_COMBINEL(uint32_t, u, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEL(uint64_t, u, 64, SV_VL4)
-NPYV_IMPL_SVE_COMBINEL(int8_t, s, 8, SV_VL32)
-NPYV_IMPL_SVE_COMBINEL(int16_t, s, 16, SV_VL16)
-NPYV_IMPL_SVE_COMBINEL(int32_t, s, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEL(int64_t, s, 64, SV_VL4)
-NPYV_IMPL_SVE_COMBINEL(float32_t, f, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEL(float64_t, f, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEL(uint8_t, u, 8)
+NPYV_IMPL_SVE_COMBINEL(uint16_t, u, 16)
+NPYV_IMPL_SVE_COMBINEL(uint32_t, u, 32)
+NPYV_IMPL_SVE_COMBINEL(uint64_t, u, 64)
+NPYV_IMPL_SVE_COMBINEL(int8_t, s, 8)
+NPYV_IMPL_SVE_COMBINEL(int16_t, s, 16)
+NPYV_IMPL_SVE_COMBINEL(int32_t, s, 32)
+NPYV_IMPL_SVE_COMBINEL(int64_t, s, 64)
+NPYV_IMPL_SVE_COMBINEL(float32_t, f, 32)
+NPYV_IMPL_SVE_COMBINEL(float64_t, f, 64)
 
 // combine higher part of two vectors
-#define NPYV_IMPL_SVE_COMBINEH(T, S, W, V)              \
-    NPY_FINLINE npyv_##S##W npyv_combineh_##S##W(       \
-            npyv_##S##W a, npyv_##S##W b)               \
-    {                                                   \
-        sv##T t = svext_##S##W(a, a,                    \
-                NPY_SIMD_WIDTH / sizeof(T) / 2);        \
-        return svsel_##S##W(svptrue_pat_b##W(V), t, b); \
+#define NPYV_IMPL_SVE_COMBINEH(T, S, W)                                  \
+    NPY_FINLINE npyv_##S##W npyv_combineh_##S##W(                        \
+            npyv_##S##W a, npyv_##S##W b)                                \
+    {                                                                    \
+        const svbool_t mask = svwhilelt_b##W##_u32(0, NPY_SIMD / W / 2); \
+        sv##T t = svext_##S##W(a, a, NPY_SIMD / W / 2);                  \
+        return svsel_##S##W(mask, t, b);                                 \
     }
 
-NPYV_IMPL_SVE_COMBINEH(uint8_t, u, 8, SV_VL32)
-NPYV_IMPL_SVE_COMBINEH(uint16_t, u, 16, SV_VL16)
-NPYV_IMPL_SVE_COMBINEH(uint32_t, u, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEH(uint64_t, u, 64, SV_VL4)
-NPYV_IMPL_SVE_COMBINEH(int8_t, s, 8, SV_VL32)
-NPYV_IMPL_SVE_COMBINEH(int16_t, s, 16, SV_VL16)
-NPYV_IMPL_SVE_COMBINEH(int32_t, s, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEH(int64_t, s, 64, SV_VL4)
-NPYV_IMPL_SVE_COMBINEH(float32_t, f, 32, SV_VL8)
-NPYV_IMPL_SVE_COMBINEH(float64_t, f, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEH(uint8_t, u, 8)
+NPYV_IMPL_SVE_COMBINEH(uint16_t, u, 16)
+NPYV_IMPL_SVE_COMBINEH(uint32_t, u, 32)
+NPYV_IMPL_SVE_COMBINEH(uint64_t, u, 64)
+NPYV_IMPL_SVE_COMBINEH(int8_t, s, 8)
+NPYV_IMPL_SVE_COMBINEH(int16_t, s, 16)
+NPYV_IMPL_SVE_COMBINEH(int32_t, s, 32)
+NPYV_IMPL_SVE_COMBINEH(int64_t, s, 64)
+NPYV_IMPL_SVE_COMBINEH(float32_t, f, 32)
+NPYV_IMPL_SVE_COMBINEH(float64_t, f, 64)
 
 // combine two vectors from lower and higher parts of two other vectors
 #define NPYV_IMPL_SVE_COMBINE(S, W)                  \
@@ -71,19 +71,17 @@ NPYV_IMPL_SVE_COMBINE(f, 32)
 NPYV_IMPL_SVE_COMBINE(f, 64)
 
 // interleave two vectors
-#define NPYV_IMPL_SVE_ZIP(T, S, W)               \
-    NPY_FINLINE npyv_##S##W##x2 npyv_zip_##S##W( \
-            npyv_##S##W a, npyv_##S##W b)        \
-    {                                            \
-        npyv_##S##W##x2 r;                       \
-                                                 \
-        r.val[0] = svzip1_##S##W(a, b);          \
-        sv##T t0 = svext_##S##W(a, a,            \
-                NPY_SIMD_WIDTH / sizeof(T) / 2); \
-        sv##T t1 = svext_##S##W(b, b,            \
-                NPY_SIMD_WIDTH / sizeof(T) / 2); \
-        r.val[1] = svzip1_##S##W(t0, t1);        \
-        return r;                                \
+#define NPYV_IMPL_SVE_ZIP(T, S, W)                       \
+    NPY_FINLINE npyv_##S##W##x2 npyv_zip_##S##W(         \
+            npyv_##S##W a, npyv_##S##W b)                \
+    {                                                    \
+        npyv_##S##W##x2 r;                               \
+                                                         \
+        r.val[0] = svzip1_##S##W(a, b);                  \
+        sv##T t0 = svext_##S##W(a, a, NPY_SIMD / W / 2); \
+        sv##T t1 = svext_##S##W(b, b, NPY_SIMD / W / 2); \
+        r.val[1] = svzip1_##S##W(t0, t1);                \
+        return r;                                        \
     }
 
 NPYV_IMPL_SVE_ZIP(uint8_t, u, 8)

--- a/numpy/core/src/common/simd/sve/reorder.h
+++ b/numpy/core/src/common/simd/sve/reorder.h
@@ -1,0 +1,119 @@
+#ifndef NPY_SIMD
+#error "Not a standalone header"
+#endif
+
+#ifndef _NPY_SIMD_SVE_REORDER_H
+#define _NPY_SIMD_SVE_REORDER_H
+
+// combine lower part of two vectors
+#define NPYV_IMPL_SVE_COMBINEL(T, S, W, V)              \
+    NPY_FINLINE npyv_##S##W npyv_combinel_##S##W(       \
+            npyv_##S##W a, npyv_##S##W b)               \
+    {                                                   \
+        sv##T t = svext_##S##W(b, b,                    \
+                NPY_SIMD_WIDTH / sizeof(T) / 2);        \
+        return svsel_##S##W(svptrue_pat_b##W(V), a, t); \
+    }
+
+NPYV_IMPL_SVE_COMBINEL(uint8_t, u, 8, SV_VL32)
+NPYV_IMPL_SVE_COMBINEL(uint16_t, u, 16, SV_VL16)
+NPYV_IMPL_SVE_COMBINEL(uint32_t, u, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEL(uint64_t, u, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEL(int8_t, s, 8, SV_VL32)
+NPYV_IMPL_SVE_COMBINEL(int16_t, s, 16, SV_VL16)
+NPYV_IMPL_SVE_COMBINEL(int32_t, s, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEL(int64_t, s, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEL(float32_t, f, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEL(float64_t, f, 64, SV_VL4)
+
+// combine higher part of two vectors
+#define NPYV_IMPL_SVE_COMBINEH(T, S, W, V)              \
+    NPY_FINLINE npyv_##S##W npyv_combineh_##S##W(       \
+            npyv_##S##W a, npyv_##S##W b)               \
+    {                                                   \
+        sv##T t = svext_##S##W(a, a,                    \
+                NPY_SIMD_WIDTH / sizeof(T) / 2);        \
+        return svsel_##S##W(svptrue_pat_b##W(V), t, b); \
+    }
+
+NPYV_IMPL_SVE_COMBINEH(uint8_t, u, 8, SV_VL32)
+NPYV_IMPL_SVE_COMBINEH(uint16_t, u, 16, SV_VL16)
+NPYV_IMPL_SVE_COMBINEH(uint32_t, u, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEH(uint64_t, u, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEH(int8_t, s, 8, SV_VL32)
+NPYV_IMPL_SVE_COMBINEH(int16_t, s, 16, SV_VL16)
+NPYV_IMPL_SVE_COMBINEH(int32_t, s, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEH(int64_t, s, 64, SV_VL4)
+NPYV_IMPL_SVE_COMBINEH(float32_t, f, 32, SV_VL8)
+NPYV_IMPL_SVE_COMBINEH(float64_t, f, 64, SV_VL4)
+
+// combine two vectors from lower and higher parts of two other vectors
+#define NPYV_IMPL_SVE_COMBINE(S, W)                  \
+    NPY_FINLINE npyv_##S##W##x2 npyv_combine_##S##W( \
+            npyv_##S##W a, npyv_##S##W b)            \
+    {                                                \
+        npyv_##S##W##x2 r;                           \
+                                                     \
+        r.val[0] = npyv_combinel_##S##W(a, b);       \
+        r.val[1] = npyv_combineh_##S##W(a, b);       \
+        return r;                                    \
+    }
+
+NPYV_IMPL_SVE_COMBINE(u, 8)
+NPYV_IMPL_SVE_COMBINE(u, 16)
+NPYV_IMPL_SVE_COMBINE(u, 32)
+NPYV_IMPL_SVE_COMBINE(u, 64)
+NPYV_IMPL_SVE_COMBINE(s, 8)
+NPYV_IMPL_SVE_COMBINE(s, 16)
+NPYV_IMPL_SVE_COMBINE(s, 32)
+NPYV_IMPL_SVE_COMBINE(s, 64)
+NPYV_IMPL_SVE_COMBINE(f, 32)
+NPYV_IMPL_SVE_COMBINE(f, 64)
+
+// interleave two vectors
+#define NPYV_IMPL_SVE_ZIP(T, S, W)               \
+    NPY_FINLINE npyv_##S##W##x2 npyv_zip_##S##W( \
+            npyv_##S##W a, npyv_##S##W b)        \
+    {                                            \
+        npyv_##S##W##x2 r;                       \
+                                                 \
+        r.val[0] = svzip1_##S##W(a, b);          \
+        sv##T t0 = svext_##S##W(a, a,            \
+                NPY_SIMD_WIDTH / sizeof(T) / 2); \
+        sv##T t1 = svext_##S##W(b, b,            \
+                NPY_SIMD_WIDTH / sizeof(T) / 2); \
+        r.val[1] = svzip1_##S##W(t0, t1);        \
+        return r;                                \
+    }
+
+NPYV_IMPL_SVE_ZIP(uint8_t, u, 8)
+NPYV_IMPL_SVE_ZIP(uint16_t, u, 16)
+NPYV_IMPL_SVE_ZIP(uint32_t, u, 32)
+NPYV_IMPL_SVE_ZIP(uint64_t, u, 64)
+NPYV_IMPL_SVE_ZIP(int8_t, s, 8)
+NPYV_IMPL_SVE_ZIP(int16_t, s, 16)
+NPYV_IMPL_SVE_ZIP(int32_t, s, 32)
+NPYV_IMPL_SVE_ZIP(int64_t, s, 64)
+NPYV_IMPL_SVE_ZIP(float32_t, f, 32)
+NPYV_IMPL_SVE_ZIP(float64_t, f, 64)
+
+// Reverse elements of each 64-bit lane
+#define npyv_rev64_u8(a) \
+    svrev_u8(svreinterpret_u8_u64(svrev_u64(svreinterpret_u64_u8(a))))
+#define npyv_rev64_u16(a) \
+    svrev_u16(svreinterpret_u16_u64(svrev_u64(svreinterpret_u64_u16(a))))
+#define npyv_rev64_u32(a) \
+    svrev_u32(svreinterpret_u32_u64(svrev_u64(svreinterpret_u64_u32(a))))
+#define npyv_rev64_u64(a) svrev_u64(a)
+#define npyv_rev64_s8(a) \
+    svrev_s8(svreinterpret_s8_u64(svrev_u64(svreinterpret_u64_s8(a))))
+#define npyv_rev64_s16(a) \
+    svrev_s16(svreinterpret_s16_u64(svrev_u64(svreinterpret_u64_s16(a))))
+#define npyv_rev64_s32(a) \
+    svrev_s32(svreinterpret_s32_u64(svrev_u64(svreinterpret_u64_s32(a))))
+#define npyv_rev64_s64(a) svrev_s64(a)
+#define npyv_rev64_f32(a) \
+    svrev_f32(svreinterpret_f32_u64(svrev_u64(svreinterpret_u64_f32(a))))
+#define npyv_rev64_f64(a) svrev_f64(a)
+
+#endif  // _NPY_SIMD_SVE_REORDER_H

--- a/numpy/core/src/common/simd/sve/sve.h
+++ b/numpy/core/src/common/simd/sve/sve.h
@@ -13,6 +13,9 @@
 #if __ARM_FEATURE_SVE_BITS == 512
 #define NPY_SIMD 512
 #define __SVE_ATTRIBUTE_SIZE_ __attribute__((arm_sve_vector_bits(NPY_SIMD)))
+#elif __ARM_FEATURE_SVE_BITS == 256
+#define NPY_SIMD 256
+#define __SVE_ATTRIBUTE_SIZE_ __attribute__((arm_sve_vector_bits(NPY_SIMD)))
 #else
 #error "unsupported sve size"
 #endif

--- a/numpy/core/src/common/simd/sve/sve.h
+++ b/numpy/core/src/common/simd/sve/sve.h
@@ -1,0 +1,112 @@
+#ifndef _NPY_SIMD_H_
+#error "Not a standalone header"
+#endif
+
+/* simd_data is defined as the union in core/src/_simd/_simd_inc.h.src.
+   It includes vector data as member variables. For Arm64 SVE architecture,
+   vector data size is depend on runtime environment.
+   Arm C Language Extension (ACLE), which enables C/C++ to handle intrinsics
+   with vector-length agnostic (VLA) data, prohibits use of
+   VLA data as member variables of unions. To avoid this restriction,
+   ACLE provides "arm_sve_vector_bits" attribute to fix the SVE size at compile 
+   time. */
+#if __ARM_FEATURE_SVE_BITS == 512
+#define NPY_SIMD 512
+#define __SVE_ATTRIBUTE_SIZE_ __attribute__((arm_sve_vector_bits(NPY_SIMD)))
+#else
+#error "unsupported sve size"
+#endif
+
+#define NPY_SIMD_WIDTH (NPY_SIMD / 8)
+
+#define NPY_SIMD_F64 1
+#define NPY_SIMD_F32 1
+#define NPY_SIMD_FMA3 1
+#define NPY_SIMD_POPCNT 1
+#define NPY_SIMD_BIGENDIAN 0
+
+#define NPY_SIMD_MAXLOAD_STRIDE32  (0x7fffffff / npyv_nlanes_s32)
+#define NPY_SIMD_MAXSTORE_STRIDE32 (0x7fffffff / npyv_nlanes_s32)
+#define NPY_SIMD_MAXLOAD_STRIDE64  (0x7fffffffffffffff / npyv_nlanes_s64)
+#define NPY_SIMD_MAXSTORE_STRIDE64 (0x7fffffffffffffff / npyv_nlanes_s64)
+
+
+typedef svbool_t __pred __SVE_ATTRIBUTE_SIZE_;
+
+#define NPYV_IMPL_SVE_TYPE(T, S)                            \
+    typedef sv##T##8_t npyv_##S##8 __SVE_ATTRIBUTE_SIZE_;   \
+    typedef sv##T##16_t npyv_##S##16 __SVE_ATTRIBUTE_SIZE_; \
+    typedef sv##T##32_t npyv_##S##32 __SVE_ATTRIBUTE_SIZE_; \
+    typedef sv##T##64_t npyv_##S##64 __SVE_ATTRIBUTE_SIZE_;
+
+NPYV_IMPL_SVE_TYPE(uint, u)
+NPYV_IMPL_SVE_TYPE(int, s)
+
+#define NPYV_IMPL_SVE_TUPLE(S) \
+    typedef struct {           \
+        npyv_##S##8 val[2];    \
+    } npyv_##S##8x2;           \
+    typedef struct {           \
+        npyv_##S##16 val[2];   \
+    } npyv_##S##16x2;          \
+    typedef struct {           \
+        npyv_##S##32 val[2];   \
+    } npyv_##S##32x2;          \
+    typedef struct {           \
+        npyv_##S##64 val[2];   \
+    } npyv_##S##64x2;          \
+    typedef struct {           \
+        npyv_##S##8 val[3];    \
+    } npyv_##S##8x3;           \
+    typedef struct {           \
+        npyv_##S##16 val[3];   \
+    } npyv_##S##16x3;          \
+    typedef struct {           \
+        npyv_##S##32 val[3];   \
+    } npyv_##S##32x3;          \
+    typedef struct {           \
+        npyv_##S##64 val[3];   \
+    } npyv_##S##64x3;
+
+NPYV_IMPL_SVE_TUPLE(u)
+NPYV_IMPL_SVE_TUPLE(s)
+
+typedef svfloat32_t npyv_f32 __SVE_ATTRIBUTE_SIZE_;
+typedef svfloat64_t npyv_f64 __SVE_ATTRIBUTE_SIZE_;
+typedef struct {
+    npyv_f32 val[2];
+} npyv_f32x2;
+typedef struct {
+    npyv_f32 val[3];
+} npyv_f32x3;
+typedef struct {
+    npyv_f64 val[2];
+} npyv_f64x2;
+typedef struct {
+    npyv_f64 val[3];
+} npyv_f64x3;
+
+typedef __pred npyv_b8;
+typedef __pred npyv_b16;
+typedef __pred npyv_b32;
+typedef __pred npyv_b64;
+
+#define npyv_nlanes_u8  (NPY_SIMD / 8)
+#define npyv_nlanes_u16 (NPY_SIMD / 16)
+#define npyv_nlanes_u32 (NPY_SIMD / 32)
+#define npyv_nlanes_u64 (NPY_SIMD / 64)
+#define npyv_nlanes_s8  (NPY_SIMD / 8)
+#define npyv_nlanes_s16 (NPY_SIMD / 16)
+#define npyv_nlanes_s32 (NPY_SIMD / 32)
+#define npyv_nlanes_s64 (NPY_SIMD / 64)
+#define npyv_nlanes_f32 (NPY_SIMD / 32)
+#define npyv_nlanes_f64 (NPY_SIMD / 64)
+
+#include "arithmetic.h"
+#include "conversion.h"
+#include "maskop.h"
+#include "math.h"
+#include "memory.h"
+#include "misc.h"
+#include "operators.h"
+#include "reorder.h"

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2228,9 +2228,8 @@ count_nonzero_u8(const char *data, npy_intp bstride, npy_uintp len)
             npyv_b8 b = npyv_cmpneq_u8(d, zero);
 
             count += npyv_popcnt_b8(b);
-            len = 0;
-      }
-      return count;
+        }
+        return count;
     #else
         npy_uintp len_m = len & -npyv_nlanes_u8;
         npy_uintp zcount = 0;
@@ -2277,15 +2276,15 @@ count_nonzero_u16(const char *data, npy_intp bstride, npy_uintp len)
             npyv_u16 d = npyv_load_u16(data_u16);
             npyv_b16 b = npyv_cmpneq_u16(d, zero);
             count += npyv_popcnt_b16(b);
-      }
-      if (len) {
-          npyv_u16 d = npyv_load_tillz_u16(data_u16, len);
-          npyv_b16 b = npyv_cmpneq_u16(d, zero);
+        }
+        if (len) {
+            npyv_u16 d = npyv_load_tillz_u16(data_u16, len);
+            npyv_b16 b = npyv_cmpneq_u16(d, zero);
 
-          count += npyv_popcnt_b16(b);
-          len = 0;
-      }
-      return count;
+            count += npyv_popcnt_b16(b);
+            len = 0;
+        }
+        return count;
     #else
         npy_uintp zcount = 0, len_m = len & -npyv_nlanes_u16;
         const npyv_u16 vone  = npyv_setall_u16(1);
@@ -2335,7 +2334,6 @@ count_nonzero_u32(const char *data, npy_intp bstride, npy_uintp len)
             npyv_b32 b = npyv_cmpneq_u32(d, zero);
 
             count += npyv_popcnt_b32(b);
-            len = 0;
         }
         return count;
     #else
@@ -2385,9 +2383,8 @@ count_nonzero_u64(const char *data, npy_intp bstride, npy_uintp len)
             npyv_b64 b = npyv_cmpneq_u64(d, zero);
 
             count += npyv_popcnt_b64(b);
-            len = 0;
         }
-      return count;
+        return count;
     #else
         const npy_uintp len_m = len & -npyv_nlanes_u64;
         const npyv_u64 vone   = npyv_setall_u64(1);

--- a/numpy/core/src/umath/_umath_tests.dispatch.c
+++ b/numpy/core/src/umath/_umath_tests.dispatch.c
@@ -4,7 +4,7 @@
  * @targets $werror baseline
  * SSE2 SSE41 AVX2
  * VSX VSX2 VSX3
- * NEON ASIMD ASIMDHP
+ * NEON ASIMD ASIMDHP SVE
  */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -2,6 +2,7 @@
  ** $maxopt baseline
  ** sse2 avx2 avx512f
  ** vx vxe
+ ** sve
  **/
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
@@ -365,6 +366,8 @@ sse2_binary_scalar2_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_i
  *  #type = npy_float, npy_double#
  *  #TYPE = FLOAT, DOUBLE#
  *  #sfx = f32, f64#
+ *  #mask = b32, b64#
+ *  #bits = 32, 64#
  *  #CHK = _F32, _F64#
  */
 #if NPY_SIMD@CHK@
@@ -378,9 +381,25 @@ sse2_binary_scalar2_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_i
 static void
 simd_binary_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_intp n)
 {
+#ifdef NPY_HAVE_SVE
+    npy_intp i = 0, peel;
+    {
+        peel = npy_aligned_block_offset(op, sizeof(@type@),
+                                                 NPY_SIMD_WIDTH, n);
+        if(peel) {
+            npyv_@sfx@ v1 = npyv_load_till_@sfx@(&ip1[i], peel, 1.0);
+            npyv_@sfx@ v2 = npyv_load_till_@sfx@(&ip2[i], peel, 1.0);
+            npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+            npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], peel, npyv_reinterpret_s@bits@_@sfx@(v3));
+            i += peel;
+        }
+    }
+#else
     LOOP_BLOCK_ALIGN_VAR(op, @type@, NPY_SIMD_WIDTH) {
         op[i] = ip1[i] @OP@ ip2[i];
     }
+#endif
+
     /* lots of specializations, to squeeze out max performance */
     if (ip1 == ip2) {
         LOOP_BLOCKED(@type@, NPY_SIMD_WIDTH) {
@@ -397,43 +416,96 @@ simd_binary_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_intp n)
             npyv_store_@sfx@(&op[i], c);
         }
     }
+#ifdef NPY_HAVE_SVE
+    if(n - i > 0) {
+        npyv_@sfx@ v1 = npyv_load_till_@sfx@(&ip1[i], n-i, 1.0);
+        npyv_@sfx@ v2 = npyv_load_till_@sfx@(&ip2[i], n-i, 1.0);
+        npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+        npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], n-i, npyv_reinterpret_s@bits@_@sfx@(v3));
+    }
+#else
     LOOP_BLOCKED_END {
         op[i] = ip1[i] @OP@ ip2[i];
     }
+#endif
 }
 
 static void
 simd_binary_scalar1_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_intp n)
 {
     const npyv_@sfx@ v1 = npyv_setall_@sfx@(ip1[0]);
+#ifdef NPY_HAVE_SVE
+    npy_intp i = 0, peel;
+    {
+        peel = npy_aligned_block_offset(op, sizeof(@type@),
+                                                 NPY_SIMD_WIDTH, n);
+        if(peel) {
+            npyv_@sfx@ v2 = npyv_load_till_@sfx@(&ip2[i], peel, 1.0);
+            npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+            npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], peel, npyv_reinterpret_s@bits@_@sfx@(v3));
+            i += peel;
+        }
+    }
+#else
     LOOP_BLOCK_ALIGN_VAR(op, @type@, NPY_SIMD_WIDTH) {
         op[i] = ip1[0] @OP@ ip2[i];
     }
+#endif
     LOOP_BLOCKED(@type@, NPY_SIMD_WIDTH) {
         npyv_@sfx@ v2 = npyv_load_@sfx@(&ip2[i]);
         npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
         npyv_store_@sfx@(&op[i], v3);
     }
+#ifdef NPY_HAVE_SVE
+    if(n - i > 0) {
+        npyv_@sfx@ v2 = npyv_load_till_@sfx@(&ip2[i], n-i, 1.0);
+        npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+        npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], n-i, npyv_reinterpret_s@bits@_@sfx@(v3));
+    }
+#else
     LOOP_BLOCKED_END {
         op[i] = ip1[0] @OP@ ip2[i];
     }
+#endif
 }
 
 static void
 simd_binary_scalar2_@kind@_@TYPE@(@type@ * op, @type@ * ip1, @type@ * ip2, npy_intp n)
 {
     const npyv_@sfx@ v2 = npyv_setall_@sfx@(ip2[0]);
+#ifdef NPY_HAVE_SVE
+    npy_intp i = 0, peel;
+    {
+        peel = npy_aligned_block_offset(op, sizeof(@type@),
+                                                 NPY_SIMD_WIDTH, n);
+        if(peel) {
+            npyv_@sfx@ v1 = npyv_load_till_@sfx@(&ip1[i], peel, 1.0);
+            npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+            npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], peel, npyv_reinterpret_s@bits@_@sfx@(v3));
+	    i += peel;
+        }
+    }
+#else
     LOOP_BLOCK_ALIGN_VAR(op, @type@, NPY_SIMD_WIDTH) {
         op[i] = ip1[i] @OP@ ip2[0];
     }
+#endif
     LOOP_BLOCKED(@type@, NPY_SIMD_WIDTH) {
         npyv_@sfx@ v1 = npyv_load_@sfx@(&ip1[i]);
         npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
         npyv_store_@sfx@(&op[i], v3);
     }
+#ifdef NPY_HAVE_SVE
+    if(n - i > 0) {
+        npyv_@sfx@ v1 = npyv_load_till_@sfx@(&ip1[i], n-i, 1.0);
+        npyv_@sfx@ v3 = npyv_@VOP@_@sfx@(v1, v2);
+        npyv_store_till_s@bits@((npy_int@bits@ *)&op[i], n-i, npyv_reinterpret_s@bits@_@sfx@(v3));
+    }
+#else
     LOOP_BLOCKED_END {
         op[i] = ip1[i] @OP@ ip2[0];
     }
+#endif
 }
 /**end repeat1**/
 #endif /* NPY_SIMD@CHK@ */
@@ -520,7 +592,17 @@ run_binary_simd_@kind@_@TYPE@(char **args, npy_intp const *dimensions, npy_intp 
  * # kind = add, subtract, multiply, divide#
  * # OP = +, -, *, /#
  * # PW = 1, 0, 0, 0#
+ * # NO_SVE = 0, 0, 0, 1#
  */
+#define NPY_KIND_@kind@
+/* Because GCC has the bug for vectorizing with SVE.
+   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105922
+   Divition can not be vectorized with SVE,
+   otherwise the zero-division flag is set and NumPy detects it.
+   To avoid this issue, SVE is disabled for division. */
+#if @NO_SVE@ && defined(NPY_HAVE_SVE)
+__attribute__((target("arch=armv8-a")))
+#endif
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -2,7 +2,7 @@
  ** $maxopt baseline
  ** sse2 sse41 avx2 avx512f avx512_skx
  ** vsx2 vsx4
- ** neon
+ ** neon sve
  ** vx
  **/
 #define _UMATHMODULE
@@ -336,7 +336,8 @@ vsx4_simd_divide_contig_@sfx@(char **args, npy_intp len)
 /**end repeat1**/
 #endif
 
-#if NPY_BITSOF_@TYPE@ == 64 && !defined(NPY_HAVE_VSX4) && (defined(NPY_HAVE_VSX) || defined(NPY_HAVE_NEON))
+#if NPY_BITSOF_@TYPE@ == 64 && !defined(NPY_HAVE_VSX4) && (defined(NPY_HAVE_VSX) \
+        || defined(NPY_HAVE_NEON) || defined(NPY_HAVE_SVE))
     #undef TO_SIMD_SFX
 #endif
 
@@ -419,7 +420,8 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)
  * Therefore it's better to disable NPYV in this special case to avoid any unnecessary shuffles.
  * Power10(VSX4) is an exception here since it has native support for integer vector division.
  */
-#if NPY_BITSOF_@STYPE@ == 64 && !defined(NPY_HAVE_VSX4) && (defined(NPY_HAVE_VSX) || defined(NPY_HAVE_NEON))
+#if NPY_BITSOF_@STYPE@ == 64 && !defined(NPY_HAVE_VSX4) && (defined(NPY_HAVE_VSX) \
+        || defined(NPY_HAVE_NEON) || defined(NPY_HAVE_SVE))
     #undef TO_SIMD_SFX
 #endif
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)

--- a/numpy/core/src/umath/loops_comparison.dispatch.c.src
+++ b/numpy/core/src/umath/loops_comparison.dispatch.c.src
@@ -2,7 +2,7 @@
  ** $maxopt baseline
  ** sse2 sse42 avx2 avx512f avx512_skx
  ** vsx2 vsx3
- ** neon
+ ** neon sve
  ** vx vxe
  **/
 #define _UMATHMODULE

--- a/numpy/core/src/umath/loops_exponent_log.dispatch.c.src
+++ b/numpy/core/src/umath/loops_exponent_log.dispatch.c.src
@@ -1,6 +1,7 @@
 /*@targets
  ** $maxopt baseline
  ** (avx2 fma3) avx512f avx512_skx
+ ** sve
  **/
 
 #define _UMATHMODULE

--- a/numpy/core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/core/src/umath/loops_minmax.dispatch.c.src
@@ -1,6 +1,6 @@
 /*@targets
  ** $maxopt baseline
- ** neon asimd
+ ** neon asimd sve
  ** sse2 avx2 avx512_skx
  ** vsx2
  ** vx vxe

--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -2,7 +2,7 @@
  ** $maxopt baseline
  ** (avx2 fma3) avx512f
  ** vsx2 vsx3 vsx4
- ** neon_vfpv4
+ ** neon_vfpv4 sve
  ** vxe vxe2
  **/
 #include "numpy/npy_math.h"

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -2,7 +2,7 @@
  ** $maxopt baseline
  ** sse2 sse41
  ** vsx2
- ** neon asimd
+ ** neon asimd sve
  ** vx vxe
  **/
 /**

--- a/numpy/core/tests/test_cpu_dispatcher.py
+++ b/numpy/core/tests/test_cpu_dispatcher.py
@@ -9,7 +9,7 @@ def test_dispatcher():
     targets = (
         "SSE2", "SSE41", "AVX2",
         "VSX", "VSX2", "VSX3",
-        "NEON", "ASIMD", "ASIMDHP"
+        "NEON", "ASIMD", "ASIMDHP", "SVE"
     )
     highest_sfx = "" # no suffix for the baseline
     all_sfx = []

--- a/numpy/core/tests/test_cpu_features.py
+++ b/numpy/core/tests/test_cpu_features.py
@@ -161,7 +161,7 @@ is_arm = re.match("^(arm|aarch64)", machine, re.IGNORECASE)
 @pytest.mark.skipif(not is_linux or not is_arm, reason="Only for Linux and ARM")
 class Test_ARM_Features(AbstractTest):
     features = [
-        "NEON", "ASIMD", "FPHP", "ASIMDHP", "ASIMDDP", "ASIMDFHM"
+        "NEON", "ASIMD", "FPHP", "ASIMDHP", "ASIMDDP", "ASIMDFHM", "SVE"
     ]
     features_groups = dict(
         NEON_FP16  = ["NEON", "HALF"],

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -325,6 +325,8 @@ class _Config:
         ASIMDDP = dict(interest=6, implies="ASIMD"),
         ## ARMv8.2 Single & half-precision Multiply
         ASIMDFHM = dict(interest=7, implies="ASIMDHP"),
+        ## ARMv8.2 SVE
+        SVE = dict(interest=8, implies="ASIMDHP", headers="arm_sve.h"),
     )
     def conf_features_partial(self):
         """Return a dictionary of supported CPU features by the platform,
@@ -533,6 +535,11 @@ class _Config:
             ),
             ASIMDFHM = dict(
                 flags="-march=armv8.2-a+fp16fml"
+            ),
+            SVE = dict(
+                implies="ASIMDHP",
+                flags="-march=armv8.2-a+sve -msve-vector-bits=512",
+                autovec=True
             ),
         )
         if self.cc_on_armhf and is_unix: return dict(

--- a/numpy/distutils/checks/cpu_sve.c
+++ b/numpy/distutils/checks/cpu_sve.c
@@ -1,0 +1,8 @@
+#include <arm_sve.h>
+
+int main(void)
+{
+    svbool_t p = svptrue_b32();
+    svint32_t a = svdup_s32(0);
+    return (int)svaddv(p, a);
+}

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -48,7 +48,8 @@ class build(old_build):
             - not supported by compiler or platform
         """
         self.simd_test = "BASELINE SSE2 SSE42 XOP FMA4 (FMA3 AVX2) AVX512F " \
-                         "AVX512_SKX VSX VSX2 VSX3 VSX4 NEON ASIMD VX VXE VXE2"
+                         "AVX512_SKX VSX VSX2 VSX3 VSX4 NEON ASIMD SVE " \
+                         "VX VXE VXE2"
 
     def finalize_options(self):
         build_scripts = self.build_scripts

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -320,10 +320,11 @@ class _Test_CCompilerOpt:
             x86="sse", ppc64="vsx", armhf="neon", unknown=""
         )
         self.expect(
-            "sse41 avx avx2 vsx2 vsx3 neon_vfpv4 asimd",
+            "sse41 avx avx2 vsx2 vsx3 neon_vfpv4 asimd sve",
             x86   = "sse41 avx avx2",
             ppc64 = "vsx2 vsx3",
             armhf = "neon_vfpv4 asimd",
+            aarch64="neon_vfpv4 asimd sve",
             unknown = ""
         )
         # any features in cpu_dispatch must be ignored if it's part of baseline


### PR DESCRIPTION
This PR enhances the CPU feature detection function so as to detect [Arm SVE architecture](https://developer.arm.com/Architectures/SVE). It also includes vectorized functions for SVE that is implemented similarly to AVX/AVX2/ASIMD. The regression test (runtest.py) was executed on Fujtisu FX700 with A64FX which is one of Armv8.2a + SVE architecture compliant CPU. The result was "21354 passed, 203 skipped, 1302 deselected, 30 xfailed, 7 xpassed".

Because SVE2 (Armv9) is upper-compatible instruction set of SVE, I believe this PR also improves NumPy preformance running on SVE2 environment. 