### PR TITLE
DOC: Update for return value of np.ptp()

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -835,17 +835,6 @@ def isdigit(a):
     See Also
     --------
     str.isdigit
-
-    Examples
-    --------
-    >>> a = np.array(['a', 'b', '0'])
-    >>> np.char.isdigit(a)                
-    array([False, False,  True])
-
-    >>> a = np.array([['a', 'b', '0'], ['c','1','2']])
-    >>> np.char.isdigit(a)
-    array([[False, False,  True],
-       [False,  True,  True]])
     """
     return _vec_string(a, bool_, 'isdigit')
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -835,6 +835,17 @@ def isdigit(a):
     See Also
     --------
     str.isdigit
+
+    Examples
+    --------
+    >>> a = np.array(['a', 'b', '0'])
+    >>> np.char.isdigit(a)                
+    array([False, False,  True])
+
+    >>> a = np.array([['a', 'b', '0'], ['c','1','2']])
+    >>> np.char.isdigit(a)
+    array([[False, False,  True],
+       [False,  True,  True]])
     """
     return _vec_string(a, bool_, 'isdigit')
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2647,9 +2647,9 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
 
     Returns
     -------
-    ptp : ndarray
-        A new array holding the result, unless `out` was
-        specified, in which case a reference to `out` is returned.
+    ptp : ndarray or int
+        The range of a given array - `int` if array is one-dimensional
+        or a new array holding the result along the given axis
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2647,8 +2647,8 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
 
     Returns
     -------
-    ptp : ndarray or int
-        The range of a given array - `int` if array is one-dimensional
+     ptp : ndarray or scalar
+        The range of a given array - `scalar` if array is one-dimensional
         or a new array holding the result along the given axis
 
     Examples

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2647,7 +2647,7 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
 
     Returns
     -------
-     ptp : ndarray or scalar
+    ptp : ndarray or scalar
         The range of a given array - `scalar` if array is one-dimensional
         or a new array holding the result along the given axis
 


### PR DESCRIPTION
Update the documentation for return type and its description of [np.ptp()](https://numpy.org/doc/stable/reference/generated/numpy.ptp.html) based on [issue#18719](https://github.com/numpy/numpy/issues/18719).
