### PR TITLE
DOC: Add `isupper` examples

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -947,15 +947,15 @@ def isupper(a):
     --------
     >>> string = "hello"
     >>> np.char.isupper(string)
-    False
+    array(False)
 
     >>> string2 = "HELLO"
     >>> np.char.isupper(string2)
-    True
+    array(True)
 
     >>> string3 = "Hello"
     >>> np.char.isupper(string3)
-    False
+    array(False)
     """
     return _vec_string(a, bool_, 'isupper')
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -949,7 +949,7 @@ def isupper(a):
     >>> np.char.isupper(string)
     array(False)
 
-    >>> string2 = "HELLO"
+    >>> string2 = "HELLO" # upper case
     >>> np.char.isupper(string2)
     array(True)
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -945,7 +945,7 @@ def isupper(a):
 
     Examples
     --------
-    >>> string = "hello"
+    >>> string = "hello" # lower case
     >>> np.char.isupper(string)
     array(False)
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -953,7 +953,7 @@ def isupper(a):
     >>> np.char.isupper(string2)
     array(True)
 
-    >>> string3 = "Hello"
+    >>> string3 = "Hello" # mixed case
     >>> np.char.isupper(string3)
     array(False)
     """

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -922,7 +922,7 @@ def istitle(a):
 @array_function_dispatch(_unary_op_dispatcher)
 def isupper(a):
     """
-    Returns true for each element if all cased characters in the
+    Return true for each element if all cased characters in the
     string are uppercase and there is at least one character, false
     otherwise.
 
@@ -942,6 +942,20 @@ def isupper(a):
     See Also
     --------
     str.isupper
+
+    Examples
+    --------
+    >>> string = "hello"
+    >>> np.char.isupper(string)
+    False
+
+    >>> string2 = "HELLO"
+    >>> np.char.isupper(string2)
+    True
+
+    >>> string3 = "Hello"
+    >>> np.char.isupper(string3)
+    False
     """
     return _vec_string(a, bool_, 'isupper')
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -945,17 +945,9 @@ def isupper(a):
 
     Examples
     --------
-    >>> string = "hello" # lower case
-    >>> np.char.isupper(string)
-    array(False)
-
-    >>> string2 = "HELLO" # upper case
-    >>> np.char.isupper(string2)
-    array(True)
-
-    >>> string3 = "Hello" # mixed case
-    >>> np.char.isupper(string3)
-    array(False)
+    >>> a = np.array(["hello", "HELLO", "Hello"])
+    >>> np.char.isupper(a)
+    array([False,  True, False])
     """
     return _vec_string(a, bool_, 'isupper')
 


### PR DESCRIPTION
Partially addresses `np.char` #22267 by adding `isupper` examples