### PR TITLE
BUG: Memory leaks in numpy.nested_iters

### DIFF
--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1045,6 +1045,7 @@ NpyIter_NestedIters(PyObject *NPY_UNUSED(self),
 
         if (iter->iter == NULL) {
             Py_DECREF(ret);
+            Py_DECREF(iter);
             goto fail;
         }
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Bug fix for this issue: https://github.com/numpy/numpy/issues/19400 as part of the Grace Hopper OSD NumPy sprint