### PR TITLE
MAINT: Shorten wheel test output on travis builds

### DIFF
--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -11,7 +11,7 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     PY_DIR=$(python -c "import sys; print(sys.prefix)")
     mkdir $PY_DIR/libs
 fi
-python -c "import sys; import numpy; sys.exit(not numpy.test('full', extra_argv=['-vvv']))"
+python -c "import sys; import numpy; sys.exit(not numpy.test('full'))"
 
 python $PROJECT_DIR/tools/wheels/check_license.py
 if [[ $UNAME == "Linux" || $UNAME == "Darwin" ]] ; then


### PR DESCRIPTION
Travis has a limit on log length that is causing test failures, so decrease the verbosity of the test output. Travis has been on the edge for a while and less drastic fixes haven't sufficed.

The choice here is to use the default pytest verbosity as "-v" is hard to read and all greater verbosities are very long.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
