### PR TITLE
CI, SIMD: Test and build without the support of AVX2 and AVX512

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -134,6 +134,36 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
+  without_avx512:
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    env:
+      CPU_DISPATCH: "max -xop -fma4 -avx512f -avx512cd -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v3
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  without_avx512_avx2_fma3:
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    env:
+      CPU_DISPATCH: "SSSE3 SSE41 POPCNT SSE42 AVX F16C"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v3
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
   debug:
     needs: [smoke_test]
     runs-on: ubuntu-20.04

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -44,6 +44,8 @@ setup_base()
   # only disable SIMD optimizations
   elif [ -n "$WITHOUT_SIMD" ]; then
       build_args+=("--cpu-baseline=none" "--cpu-dispatch=none")
+  elif [ -n "$CPU_DISPATCH" ]; then
+      build_args+=("--cpu-dispatch=$CPU_DISPATCH")
   else
     # SIMD extensions that need to be tested on both runtime and compile-time via (test_simd.py)
     # any specified features will be ignored if they're not supported by compiler or platform


### PR DESCRIPTION
  Most CI nodes have the support of AVX 512, and AVX2 which
  leaves the SSE SIMD kernels untested and only counts on
  internal universal intrinsic tests wich may not be enough.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
