### PR TITLE
BUG: Fix complex vector dot with more than NPY_CBLAS_CHUNK elements

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3637,7 +3637,8 @@ NPY_NO_EXPORT void
             CBLAS_INT chunk = n < NPY_CBLAS_CHUNK ? n : NPY_CBLAS_CHUNK;
             @type@ tmp[2];
 
-            CBLAS_FUNC(cblas_@prefix@dotu_sub)((CBLAS_INT)n, ip1, is1b, ip2, is2b, tmp);
+            CBLAS_FUNC(cblas_@prefix@dotu_sub)(
+                    (CBLAS_INT)chunk, ip1, is1b, ip2, is2b, tmp);
             sum[0] += (double)tmp[0];
             sum[1] += (double)tmp[1];
             /* use char strides here */


### PR DESCRIPTION
The iteration was simply using the wrong value, the larger value might even work sometimes, but then we do another iteration counting the remaining elements twice.

Closes gh-22262