### PR TITLE
DOC: Added missing dtype attribute to `iinfo` and `finfo` docstring

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -373,7 +373,9 @@ class finfo:
     bits : int
         The number of bits occupied by the type.
     dtype : dtype
-        Returns the dtype for which finfo returns information. For complex input, the returned dtype is the associated `float` dtype for its real and complex components.
+        Returns the dtype for which `finfo` returns information. For complex
+        input, the returned dtype is the associated ``float*`` dtype for its
+        real and complex components.
     eps : float
         The difference between 1.0 and the next smallest representable float
         larger than 1.0. For example, for 64-bit binary floats in the IEEE-754
@@ -620,7 +622,7 @@ class iinfo:
     bits : int
         The number of bits occupied by the type.
     dtype : dtype
-        Returns the dtype for which iinfo returns information.
+        Returns the dtype for which `iinfo` returns information.
     min : int
         The smallest integer expressible by the type.
     max : int

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -372,6 +372,8 @@ class finfo:
     ----------
     bits : int
         The number of bits occupied by the type.
+    dtype : dtype
+        Returns the type.
     eps : float
         The difference between 1.0 and the next smallest representable float
         larger than 1.0. For example, for 64-bit binary floats in the IEEE-754
@@ -609,6 +611,8 @@ class iinfo:
     ----------
     bits : int
         The number of bits occupied by the type.
+    dtype : dtype
+        Returns the type.
     min : int
         The smallest integer expressible by the type.
     max : int

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -373,7 +373,7 @@ class finfo:
     bits : int
         The number of bits occupied by the type.
     dtype : dtype
-        Returns the type.
+        Returns the dtype for which finfo returns information. For complex input, the returned dtype is the associated `float` dtype for its real and complex components.
     eps : float
         The difference between 1.0 and the next smallest representable float
         larger than 1.0. For example, for 64-bit binary floats in the IEEE-754
@@ -459,6 +459,14 @@ class finfo:
            pp.1-70, 2008, http://www.doi.org/10.1109/IEEESTD.2008.4610935
     .. [2] Wikipedia, "Denormal Numbers",
            https://en.wikipedia.org/wiki/Denormal_number
+
+    Examples
+    --------
+    >>> np.finfo(np.float64).dtype
+    dtype('float64')
+    >>> np.finfo(np.complex64).dtype
+    dtype('float32')
+
     """
 
     _finfo_cache = {}
@@ -612,7 +620,7 @@ class iinfo:
     bits : int
         The number of bits occupied by the type.
     dtype : dtype
-        Returns the type.
+        Returns the dtype for which iinfo returns information.
     min : int
         The smallest integer expressible by the type.
     max : int


### PR DESCRIPTION
finfo() and iinfo() both have a dtype attribute, which was undocumented before this commit.

Closes gh-22330

skip ci

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
