### PR TITLE
MAINT: switch sponsor link from numfocus to opencollective

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-NumPy has a Code of Conduct, please see: https://numpy.org/code-of-conduct

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-open_collective: numpy
-tidelift: pypi/numpy
-custom: https://numpy.org/about#donate

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
-github: [numfocus]
+open_collective: numpy
 tidelift: pypi/numpy
 custom: https://numpy.org/about#donate


### PR DESCRIPTION
As proposed in the community call from Sept 28.

I checked this on [my fork](https://github.com/mattip/numpy), you can compare the "Sponsor" link there to the one here to see the change. 

I am leaving this for visibility, but I think it should actually be removed and the file in https://github.com/numpy/.github updated instead/also. If that is correct, we should remove the other community health files from this repo, but also see numpy/.github#4