### PR TITLE
REV: Loosen ``lookfor``'s import try/except again

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -972,8 +972,12 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
                             finally:
                                 sys.stdout = old_stdout
                                 sys.stderr = old_stderr
-                        # Catch SystemExit, too
-                        except (Exception, SystemExit):
+                        except KeyboardInterrupt:
+                            # Assume keyboard interrupt came from a user
+                            raise
+                        except BaseException:
+                            # Ignore also SystemExit and pytests.importorskip
+                            # `Skipped` (these are BaseExceptions; gh-22345)
                             continue
 
             for n, v in _getmembers(item):


### PR DESCRIPTION
Some BaseExceptions (at least the Skipped that pytest uses) need to be caught as well.  It seems easiest to be practical and keep ignoring almost all exception in this particular code path.

Effectively reverts parts of gh-19393

Closes gh-22345


---

Doesn't seem worth sweating over the details here.  I might consider deprecating the whole function...