### PR TITLE
ENH,TYP: Add special casing for `ndarray`-based indexing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1549,6 +1549,12 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     ) -> ndarray[_ShapeType2, _DType]: ...
 
     @overload
+    def __getitem__(self, key: (
+        NDArray[integer[Any]]
+        | NDArray[bool_]
+        | tuple[NDArray[integer[Any]] | NDArray[bool_], ...]
+    )) -> ndarray[Any, _DType_co]: ...
+    @overload
     def __getitem__(self, key: SupportsIndex | tuple[SupportsIndex, ...]) -> Any: ...
     @overload
     def __getitem__(self, key: (

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -200,8 +200,8 @@ reveal_type(AR_f8.__array_wrap__(B))  # E: ndarray[Any, dtype[object_]]
 
 reveal_type(AR_V[0])  # E: Any
 reveal_type(AR_V[0, 0])  # E: Any
-reveal_type(AR_V[AR_i8])  # E: Any
-reveal_type(AR_V[AR_i8, AR_i8])  # E: Any
+reveal_type(AR_V[AR_i8])  # E: ndarray[Any, dtype[void]]
+reveal_type(AR_V[AR_i8, AR_i8])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V[AR_i8, None])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V[0, ...])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V[[0]])  # E: ndarray[Any, dtype[void]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/22328

The typing of `ndarray`-based indexing was previously caught by the `__index__`overload, which always return `Any`. This PR adds a more precise return type via adding a new `ndarray` overload.