### PR TITLE
TYP,MAINT: Change more overloads to play nice with pyright

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -36,6 +36,8 @@ from numpy._typing import (
     _ArrayLikeObject_co,
     _ArrayLikeStr_co,
     _ArrayLikeBytes_co,
+    _ArrayLikeUnknown,
+    _UnknownType,
 
     # DTypes
     DTypeLike,
@@ -2051,6 +2053,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     def __radd__(self: NDArray[Any], other: _ArrayLikeObject_co) -> Any: ...
 
     @overload
+    def __sub__(self: NDArray[_UnknownType], other: _ArrayLikeUnknown) -> NDArray[Any]: ...
+    @overload
     def __sub__(self: NDArray[bool_], other: _ArrayLikeBool_co) -> NoReturn: ...
     @overload
     def __sub__(self: _ArrayUInt_co, other: _ArrayLikeUInt_co) -> NDArray[unsignedinteger[Any]]: ...  # type: ignore[misc]
@@ -2073,6 +2077,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     @overload
     def __sub__(self: NDArray[Any], other: _ArrayLikeObject_co) -> Any: ...
 
+    @overload
+    def __rsub__(self: NDArray[_UnknownType], other: _ArrayLikeUnknown) -> NDArray[Any]: ...
     @overload
     def __rsub__(self: NDArray[bool_], other: _ArrayLikeBool_co) -> NoReturn: ...
     @overload

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -199,6 +199,7 @@ from ._array_like import (
     _ArrayLikeStr_co as _ArrayLikeStr_co,
     _ArrayLikeBytes_co as _ArrayLikeBytes_co,
     _ArrayLikeUnknown as _ArrayLikeUnknown,
+    _UnknownType as _UnknownType,
 )
 from ._generic_alias import (
     NDArray as NDArray,


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/22146, follow up on https://github.com/numpy/numpy/pull/22193

Mask the first overload of `ndarray.__sub__`/`.__rsub__` with a "dummy-overload" in order to prevent pyright's overload resolver from hitting the `NoReturn` return type upon encountering overload ambiguity.