### PR TITLE
BUG: Add ``__array_api_version__`` to ``numpy.array_api`` namespace

### DIFF
--- a/numpy/array_api/__init__.py
+++ b/numpy/array_api/__init__.py
@@ -121,7 +121,9 @@ warnings.warn(
     "The numpy.array_api submodule is still experimental. See NEP 47.", stacklevel=2
 )
 
-__all__ = []
+__array_api_version__ = "2021.12"
+
+__all__ = ["__array_api_version__"]
 
 from ._constants import e, inf, nan, pi
 


### PR DESCRIPTION
The Array API has always required namespaces have a `__array_api_version__` attribute (see [Versioning](https://data-apis.org/array-api/latest/future_API_evolution.html#versioning)), although we all missed it heh (hopefully we can make this more visible in the spec https://github.com/data-apis/array-api/pull/480). This PR introduces such an attribute.

This also fixes the issue identified in https://github.com/numpy/numpy/pull/22357#issuecomment-1264537728 where a Hypothesis update ([`6.55.0`](https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.55.0)) broke CI, as it required using this (specified!) attribute when using `hypothesis.extra.array_api.make_strategies_namespace()`, like we do in

https://github.com/numpy/numpy/blob/7191d9a4773d77205349ac151f84b72c0ffcf848/numpy/array_api/tests/test_set_functions.py#L7

This PR should mean this PR works on Hypothesis versions both before and after `6.55.0`.