### PR TITLE
BUILD: add permissions to github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   lint:
     if: "github.repository == 'numpy/numpy' && github.ref != 'refs/heads/main' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,6 +1,10 @@
 # To enable this workflow on a fork, comment out:
 #
 # if: github.repository == 'numpy/numpy'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   cygwin_build_test:
     runs-on: windows-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'environment.yml'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs: 
   build:
     name: Build base Docker image 

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build Gitpod Docker image

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: write # to add labels
+
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   get_commit_message:
     name: Get commit message


### PR DESCRIPTION
Inspired by cython/cython#5038, here is the comment by @sashashuri there

> This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from on: pull_request [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.