### PR TITLE
MAINT: remove permission restrictions for PR labeler [skip ci]

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,9 +3,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
-permissions:
-  contents: write # to add labels
-
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems #22367 caused the CI run of the labeller action [to fail](https://github.com/numpy/numpy/actions/runs/3170446275/jobs/5163034251) for new PRs. Disable this setting. I asked in gerrymanoim/pr-prefix-labeler#19 what permissions are needed.