### PR TITLE
DOC: Update delimiter param description.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1085,7 +1085,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         comment. None implies no comments. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is '#'.
     delimiter : str, optional
-        The string used to separate values. For backwards compatibility, byte
+        The character used to separate the values. Only single character
+        delimiters are supported. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is whitespace.
     converters : dict or callable, optional
         Converter functions to customize value parsing. If `converters` is

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1085,9 +1085,13 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         comment. None implies no comments. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is '#'.
     delimiter : str, optional
-        The character used to separate the values. Only single character
-        delimiters are supported. For backwards compatibility, byte
-        strings will be decoded as 'latin1'. The default is whitespace.
+        The character used to separate the values. For backwards compatibility,
+        byte strings will be decoded as 'latin1'. The default is whitespace.
+
+        .. versionchanged:: 1.23.0
+           Only single character delimiters are supported. Newline characters
+           cannot be used as the delimiter.
+
     converters : dict or callable, optional
         Converter functions to customize value parsing. If `converters` is
         callable, the function is applied to all columns, else it must be a


### PR DESCRIPTION
Update the description for the `delimiter` parameter in `loadtxt` to note that only single-character strings are supported. In principle, this new info could be in a `.. versionchanged:: 1.23` directive - any preference there @seberg ?

Closes #22311