### PR TITLE
DOC: How to partition domains

### DIFF
--- a/doc/source/user/how-to-index.rst
+++ b/doc/source/user/how-to-index.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: numpy
 
-.. _how-to-index.rst:
+.. _how-to-index:
 
 *****************************************
 How to index :class:`ndarrays <.ndarray>`

--- a/doc/source/user/how-to-partition.rst
+++ b/doc/source/user/how-to-partition.rst
@@ -1,0 +1,270 @@
+.. _how-to-partition:
+
+=====================================
+How to partition a domain using NumPy
+=====================================
+
+There are a few NumPy functions that are similar in application, but which
+provide slightly different results, which may cause confusion if one is not sure
+when and how to use them. The following guide aims to list these functions and
+describe their recommended usage.
+
+The functions mentioned here are
+
+* `numpy.linspace`
+* `numpy.arange`
+* `numpy.geomspace`
+* `numpy.logspace`
+* `numpy.meshgrid`
+* `numpy.mgrid`
+* `numpy.ogrid`
+
+1D domains (intervals)
+======================
+
+``linspace`` vs. ``arange``
+---------------------------
+
+Both `numpy.linspace` and `numpy.arange` provide ways to partition an interval
+(a 1D domain) into equal-length subintervals. These partitions will vary
+depending on the chosen starting and ending points, and the **step** (the length 
+of the subintervals).
+
+* Use `numpy.arange` if you want integer steps.
+
+  `numpy.arange` relies on step size to determine how many elements are in the
+  returned array, which excludes the endpoint. This is determined through the
+  ``step`` argument to ``arange``.
+
+  Example::
+
+    >>> np.arange(0, 10, 2)  # np.arange(start, stop, step)
+    array([0, 2, 4, 6, 8])
+
+  The arguments ``start`` and ``stop`` should be integer or real, but not
+  complex numbers.
+
+* Use `numpy.linspace` if you want the endpoint to be included in the result, or
+  if you are using a non-integer step size.
+
+  `numpy.linspace` *can* include the endpoint and determines step size from the
+  `num` argument, which specifies the number of elements in the returned
+  array.
+  
+  The inclusion of the endpoint is determined by an optional boolean
+  argument ``endpoint``, which defaults to ``True``. Note that selecting
+  ``endpoint=False`` will change the step size computation, and the subsequent
+  output for the function.
+
+  Example::
+
+    >>> np.linspace(0.1, 0.2, num=5)  # np.linspace(start, stop, num)
+    array([0.1  , 0.125, 0.15 , 0.175, 0.2  ])
+    >>> np.linspace(0.1, 0.2, num=5, endpoint=False)
+    array([0.1, 0.12, 0.14, 0.16, 0.18])
+
+  `numpy.linspace` can also be used with complex arguments::
+
+    >>> np.linspace(1+1.j, 4, 5, dtype=np.complex64)
+    array([1.  +1.j  , 1.75+0.75j, 2.5 +0.5j , 3.25+0.25j, 4.  +0.j  ],
+          dtype=complex64)
+
+Other examples
+--------------
+
+1. Unexpected results may happen if floating point values are used as ``step``
+   in ``numpy.arange``. To avoid this, make sure all floating point conversion
+   happens after the computation of results. For example, replace
+
+   ::
+
+     >>> list(np.arange(0.1,0.4,0.1).round(1))
+     [0.1, 0.2, 0.3, 0.4]  # endpoint should not be included!
+
+   with
+
+   ::
+
+     >>> list(np.arange(1, 4, 1) / 10.0)
+     [0.1, 0.2, 0.3]  # expected result
+
+2. Note that
+
+   ::
+
+     >>> np.arange(0, 1.12, 0.04)
+     array([0.  , 0.04, 0.08, 0.12, 0.16, 0.2 , 0.24, 0.28, 0.32, 0.36, 0.4 ,
+            0.44, 0.48, 0.52, 0.56, 0.6 , 0.64, 0.68, 0.72, 0.76, 0.8 , 0.84,
+            0.88, 0.92, 0.96, 1.  , 1.04, 1.08, 1.12])
+
+   and
+
+   ::
+
+     >>> np.arange(0, 1.08, 0.04)
+     array([0.  , 0.04, 0.08, 0.12, 0.16, 0.2 , 0.24, 0.28, 0.32, 0.36, 0.4 ,
+            0.44, 0.48, 0.52, 0.56, 0.6 , 0.64, 0.68, 0.72, 0.76, 0.8 , 0.84,
+            0.88, 0.92, 0.96, 1.  , 1.04])
+
+   These differ because of numeric noise. When using floating point values, it
+   is possible that ``0 + 0.04 * 28 < 1.12``, and so ``1.12`` is in the
+   interval. In fact, this is exactly the case::
+
+     >>> 1.12/0.04
+     28.000000000000004
+
+   But ``0 + 0.04 * 27 >= 1.08`` so that 1.08 is excluded::
+
+     >>> 1.08/0.04
+     27.0
+
+   Alternatively, you could use ``np.arange(0, 28)*0.04`` which would always
+   give you precise control of the end point since it is integral::
+
+    >>> np.arange(0, 28)*0.04
+    array([0.  , 0.04, 0.08, 0.12, 0.16, 0.2 , 0.24, 0.28, 0.32, 0.36, 0.4 ,
+           0.44, 0.48, 0.52, 0.56, 0.6 , 0.64, 0.68, 0.72, 0.76, 0.8 , 0.84,
+           0.88, 0.92, 0.96, 1.  , 1.04, 1.08])
+
+
+``geomspace`` and ``logspace``
+------------------------------
+
+``numpy.geomspace`` is similar to ``numpy.linspace``, but with numbers spaced
+evenly on a log scale (a geometric progression). The endpoint is included in the
+result.
+
+Example::
+
+  >>> np.geomspace(2, 3, num=5)
+  array([2.        , 2.21336384, 2.44948974, 2.71080601, 3.        ])
+
+``numpy.logspace`` is similar to ``numpy.geomspace``, but with the start and end
+points specified as logarithms (with base 10 as default)::
+
+  >>> np.logspace(2, 3, num=5)
+  array([ 100.        ,  177.827941  ,  316.22776602,  562.34132519, 1000.        ])
+
+In linear space, the sequence starts at ``base ** start`` (``base`` to the power
+of ``start``) and ends with ``base ** stop``::
+
+  >>> np.logspace(2, 3, num=5, base=2)
+  array([4.        , 4.75682846, 5.65685425, 6.72717132, 8.        ])
+
+nD domains
+==========
+
+nD domains can be partitioned into *grids*.
+
+    Two instances of `nd_grid` are made available in the NumPy namespace,
+    `mgrid` and `ogrid`, approximately defined as::
+
+        mgrid = nd_grid(sparse=False)
+        ogrid = nd_grid(sparse=True)
+        xs, ys = np.meshgrid(x, y, sparse=True)
+
+``meshgrid``
+------------
+
+The purpose of ``numpy.meshgrid`` is to create a rectangular grid out of a set of
+one-dimensional coordinate arrays.
+
+Given arrays
+
+ ::
+   
+   >>> x = np.array([0, 1, 2, 3])
+   >>> y = np.array([0, 1, 2, 3, 4, 5])
+
+``meshgrid`` will create two coordinate arrays, which can be used to generate
+the coordinate pairs determining this grid.
+
+ ::
+
+   >>> xx, yy = np.meshgrid(x, y)
+   >>> xx
+   array([[0, 1, 2, 3],
+          [0, 1, 2, 3],
+          [0, 1, 2, 3],
+          [0, 1, 2, 3],
+          [0, 1, 2, 3],
+          [0, 1, 2, 3]])
+   >>> yy
+   array([[0, 0, 0, 0],
+          [1, 1, 1, 1],
+          [2, 2, 2, 2],
+          [3, 3, 3, 3],
+          [4, 4, 4, 4],
+          [5, 5, 5, 5]])
+
+   >>> import matplotlib.pyplot as plt
+   >>> plt.plot(xx, yy, marker='.', color='k', linestyle='none')
+
+.. plot:: user/plots/meshgrid_plot.py
+  :align: center
+  :include-source: 0
+
+``mgrid``
+---------
+
+``numpy.mgrid`` can be used as a shortcut for creating meshgrids. It is not a
+function, but a ``nd_grid`` instance that, when indexed, returns a
+multidimensional meshgrid.
+
+::
+
+  >>> xx, yy = np.meshgrid(np.array([0, 1, 2, 3]), np.array([0, 1, 2, 3, 4, 5]))
+  >>> xx.T, yy.T
+  (array([[0, 0, 0, 0, 0, 0],
+          [1, 1, 1, 1, 1, 1],
+          [2, 2, 2, 2, 2, 2],
+          [3, 3, 3, 3, 3, 3]]),
+   array([[0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5]]))
+
+  >>> np.mgrid[0:4, 0:6]
+  array([[[0, 0, 0, 0, 0, 0],
+          [1, 1, 1, 1, 1, 1],
+          [2, 2, 2, 2, 2, 2],
+          [3, 3, 3, 3, 3, 3]],
+  <BLANKLINE>
+         [[0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5],
+          [0, 1, 2, 3, 4, 5]]])
+
+
+``ogrid``
+---------
+
+Similar to ``numpy.mgrid``, ``numpy.ogrid`` returns a ``nd_grid`` instance, but
+the result is an *open* multidimensional meshgrid. This means that when it is
+indexed, so that only one dimension of each returned array is greater than 1.
+
+These sparse coordinate grids are intended to be use with :ref:`broadcasting`.
+When all coordinates are used in an expression, broadcasting still leads to a
+fully-dimensonal result array.
+
+::
+
+   >>> np.ogrid[0:4, 0:6]
+   [array([[0],
+           [1],
+           [2],
+           [3]]), array([[0, 1, 2, 3, 4, 5]])]
+
+All three methods described here can be used to evaluate function values on a
+grid.
+
+::
+
+   >>> g = np.ogrid[0:4, 0:6]
+   >>> zg = np.sqrt(g[0]**2 + g[1]**2)
+   >>> g[0].shape, g[1].shape, zg.shape
+   ((4, 1), (1, 6), (4, 6))
+   >>> m = np.mgrid[0:4, 0:6]
+   >>> zm = np.sqrt(m[0]**2 + m[1]**2)
+   >>> np.array_equal(zm, zg)
+   True

--- a/doc/source/user/how-to-partition.rst
+++ b/doc/source/user/how-to-partition.rst
@@ -1,8 +1,8 @@
 .. _how-to-partition:
 
-=====================================
-How to partition a domain using NumPy
-=====================================
+=================================================
+How to create arrays with regularly-spaced values
+=================================================
 
 There are a few NumPy functions that are similar in application, but which
 provide slightly different results, which may cause confusion if one is not sure
@@ -30,7 +30,7 @@ Both `numpy.linspace` and `numpy.arange` provide ways to partition an interval
 depending on the chosen starting and ending points, and the **step** (the length 
 of the subintervals).
 
-* Use `numpy.arange` if you want integer steps.
+* **Use** `numpy.arange` **if you want integer steps.**
 
   `numpy.arange` relies on step size to determine how many elements are in the
   returned array, which excludes the endpoint. This is determined through the
@@ -42,10 +42,14 @@ of the subintervals).
     array([0, 2, 4, 6, 8])
 
   The arguments ``start`` and ``stop`` should be integer or real, but not
-  complex numbers.
+  complex numbers. `numpy.arange` is similar to the Python built-in
+  :py:class:`range`.
 
-* Use `numpy.linspace` if you want the endpoint to be included in the result, or
-  if you are using a non-integer step size.
+  Floating-point inaccuracies can make ``arange`` results with floating-point
+  numbers confusing. In this case, you should use `numpy.linspace` instead.
+
+* **Use** `numpy.linspace` **if you want the endpoint to be included in the
+  result, or if you are using a non-integer step size.**
 
   `numpy.linspace` *can* include the endpoint and determines step size from the
   `num` argument, which specifies the number of elements in the returned
@@ -154,20 +158,14 @@ of ``start``) and ends with ``base ** stop``::
 nD domains
 ==========
 
-nD domains can be partitioned into *grids*.
-
-    Two instances of `nd_grid` are made available in the NumPy namespace,
-    `mgrid` and `ogrid`, approximately defined as::
-
-        mgrid = nd_grid(sparse=False)
-        ogrid = nd_grid(sparse=True)
-        xs, ys = np.meshgrid(x, y, sparse=True)
+nD domains can be partitioned into *grids*. This can be done using one of the
+following functions.
 
 ``meshgrid``
 ------------
 
-The purpose of ``numpy.meshgrid`` is to create a rectangular grid out of a set of
-one-dimensional coordinate arrays.
+The purpose of ``numpy.meshgrid`` is to create a rectangular grid out of a set
+of one-dimensional coordinate arrays.
 
 Given arrays
 
@@ -208,8 +206,7 @@ the coordinate pairs determining this grid.
 ---------
 
 ``numpy.mgrid`` can be used as a shortcut for creating meshgrids. It is not a
-function, but a ``nd_grid`` instance that, when indexed, returns a
-multidimensional meshgrid.
+function, but when indexed, returns a multidimensional meshgrid.
 
 ::
 
@@ -239,9 +236,10 @@ multidimensional meshgrid.
 ``ogrid``
 ---------
 
-Similar to ``numpy.mgrid``, ``numpy.ogrid`` returns a ``nd_grid`` instance, but
-the result is an *open* multidimensional meshgrid. This means that when it is
-indexed, so that only one dimension of each returned array is greater than 1.
+Similar to ``numpy.mgrid``, ``numpy.ogrid`` returns an *open* multidimensional
+meshgrid. This means that when it is indexed, only one dimension of each
+returned array is greater than 1. This avoids repeating the data and thus saves
+memory, which is often desirable.
 
 These sparse coordinate grids are intended to be use with :ref:`broadcasting`.
 When all coordinates are used in an expression, broadcasting still leads to a

--- a/doc/source/user/howtos_index.rst
+++ b/doc/source/user/howtos_index.rst
@@ -15,3 +15,4 @@ the package, see the :ref:`API reference <reference>`.
    how-to-io
    how-to-index
    how-to-verify-bug
+   how-to-partition

--- a/doc/source/user/plots/meshgrid_plot.py
+++ b/doc/source/user/plots/meshgrid_plot.py
@@ -1,0 +1,7 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.array([0, 1, 2, 3])
+y = np.array([0, 1, 2, 3, 4, 5])
+xx, yy = np.meshgrid(x, y)
+plt.plot(xx, yy, marker='o', color='k', linestyle='none')

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1774,6 +1774,7 @@ add_newdoc('numpy.core.multiarray', 'arange',
     numpy.linspace : Evenly spaced numbers with careful handling of endpoints.
     numpy.ogrid: Arrays of evenly spaced numbers in N-dimensions.
     numpy.mgrid: Grid-shaped arrays of evenly spaced numbers in N-dimensions.
+    :ref:`how-to-partition`
 
     Examples
     --------

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -91,6 +91,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
                 scale (a geometric progression).
     logspace : Similar to `geomspace`, but with the end points specified as
                logarithms.
+    :ref:`how-to-partition`
 
     Examples
     --------
@@ -242,6 +243,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
     linspace : Similar to logspace, but with the samples uniformly distributed
                in linear space, instead of log space.
     geomspace : Similar to logspace, but with endpoints specified directly.
+    :ref:`how-to-partition`
 
     Notes
     -----
@@ -338,6 +340,7 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
                progression.
     arange : Similar to linspace, with the step size specified instead of the
              number of samples.
+    :ref:`how-to-partition`
 
     Notes
     -----

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4943,6 +4943,7 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     mgrid : Construct a multi-dimensional "meshgrid" using indexing notation.
     ogrid : Construct an open multi-dimensional "meshgrid" using indexing
             notation.
+    how-to-index
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4956,16 +4956,25 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     >>> yv
     array([[0.,  0.,  0.],
            [1.,  1.,  1.]])
-    >>> xv, yv = np.meshgrid(x, y, sparse=True)  # make sparse output arrays
+
+    The result of `meshgrid` is a coordinate grid:
+
+    >>> import matplotlib.pyplot as plt
+    >>> plt.plot(xv, yv, marker='o', color='k', linestyle='none')
+    >>> plt.show()
+
+    You can create sparse output arrays to save memory and computation time.
+
+    >>> xv, yv = np.meshgrid(x, y, sparse=True)
     >>> xv
     array([[0. ,  0.5,  1. ]])
     >>> yv
     array([[0.],
            [1.]])
 
-    `meshgrid` is very useful to evaluate functions on a grid.  If the
-    function depends on all coordinates, you can use the parameter
-    ``sparse=True`` to save memory and computation time.
+    `meshgrid` is very useful to evaluate functions on a grid. If the
+    function depends on all coordinates, both dense and sparse outputs can be
+    used.
 
     >>> x = np.linspace(-5, 5, 101)
     >>> y = np.linspace(-5, 5, 101)
@@ -4982,7 +4991,6 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     >>> np.array_equal(zz, zs)
     True
 
-    >>> import matplotlib.pyplot as plt
     >>> h = plt.contourf(x, y, zs)
     >>> plt.axis('scaled')
     >>> plt.colorbar()

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -232,6 +232,7 @@ class MGridClass(nd_grid):
     --------
     lib.index_tricks.nd_grid : class of `ogrid` and `mgrid` objects
     ogrid : like mgrid but returns open (not fleshed out) mesh grids
+    meshgrid: return coordinate matrices from coordinate vectors
     r_ : array concatenator
 
     Examples
@@ -283,6 +284,7 @@ class OGridClass(nd_grid):
     --------
     np.lib.index_tricks.nd_grid : class of `ogrid` and `mgrid` objects
     mgrid : like `ogrid` but returns dense (or fleshed out) mesh grids
+    meshgrid: return coordinate matrices from coordinate vectors
     r_ : array concatenator
 
     Examples

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -234,6 +234,7 @@ class MGridClass(nd_grid):
     ogrid : like mgrid but returns open (not fleshed out) mesh grids
     meshgrid: return coordinate matrices from coordinate vectors
     r_ : array concatenator
+    :ref:`how-to-partition`
 
     Examples
     --------
@@ -286,6 +287,7 @@ class OGridClass(nd_grid):
     mgrid : like `ogrid` but returns dense (or fleshed out) mesh grids
     meshgrid: return coordinate matrices from coordinate vectors
     r_ : array concatenator
+    :ref:`how-to-partition`
 
     Examples
     --------


### PR DESCRIPTION
Adds a how-to guide on partitioning domains with NumPy. Covers usage of

- linspace
- arange
- geomspace
- logspace
- meshgrid
- mgrid
- ogrid

The main goal of this document is to avoid issues around usage of linspace and arange, but also to elaborate on the usage of all cited functions/tools. This is a first stab at a guide, feedback is appreciated!

Possibly, fixes #9616, #18625, #19670,  #17339

Related issues: #18099, #13349, #12715, #2457, #630, #7009