### PR TITLE
BLD: use macos-11 image on azure, macos-1015 is deprecated

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,14 +104,7 @@ stages:
 
   - job: macOS
     pool:
-      # NOTE: at time of writing, there is a danger
-      # that using an invalid vmIMage string for macOS
-      # image silently redirects to a Windows build on Azure;
-      # for now, use the only image name officially present in
-      # the docs even though i.e., numba uses another in their
-      # azure config for mac os -- Microsoft has indicated
-      # they will patch this issue
-      vmImage: 'macOS-1015'
+      vmImage: 'macOS-11'
     strategy:
       maxParallel: 3
       matrix:
@@ -205,9 +198,14 @@ stages:
     - script: python runtests.py -g --refguide-check
       displayName: 'Run Refguide Check'
       condition: eq(variables['USE_OPENBLAS'], '1')
-    - script: python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
+    - script: |
+        echo LIBRARY_PATH ${LIBRARY_PATH}
+        python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
       displayName: 'Run Full NumPy Test Suite'
       condition: eq(variables['USE_OPENBLAS'], '1')
+      env:
+        # gfortran installed above adds -lSystem, so this is needed to find it (gh-22043)
+        LIBRARY_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
     - bash: python tools/openblas_support.py --check_version
       displayName: 'Verify OpenBLAS version'
       condition: eq(variables['USE_OPENBLAS'], '1')


### PR DESCRIPTION
Backport of #22043.

There is [a warning](https://dev.azure.com/numpy/numpy/_build/results?buildId=25324&view=logs&j=9d7fb089-bdae-57e1-a4ec-9025f62c646c) in the CI runs that the macos-1015 image is deprecated.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
