### PR TITLE
TST,TYP: Bump mypy to 0.981

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.950
+  - mypy=0.981
   - typing_extensions>=4.2.0
   # For building docs
   - sphinx=4.5.0

--- a/numpy/typing/tests/data/fail/scalars.pyi
+++ b/numpy/typing/tests/data/fail/scalars.pyi
@@ -70,8 +70,6 @@ np.timedelta64(value=0)  # E: Unexpected keyword argument
 np.bytes_(b"hello", encoding='utf-8')  # E: No overload variant
 np.str_("hello", encoding='utf-8')  # E: No overload variant
 
-complex(np.bytes_("1"))  # E: No overload variant
-
 f8.item(1)  # E: incompatible type
 f8.item((0, 1))  # E: incompatible type
 f8.squeeze(axis=1)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/ctypeslib.pyi
+++ b/numpy/typing/tests/data/reveal/ctypeslib.pyi
@@ -20,7 +20,7 @@ AR_double: npt.NDArray[np.double]
 AR_longdouble: npt.NDArray[np.longdouble]
 AR_void: npt.NDArray[np.void]
 
-pointer: ctypes.pointer[Any]
+pointer: ctypes._Pointer[Any]
 
 reveal_type(np.ctypeslib.c_intp())  # E: {c_intp}
 

--- a/numpy/typing/tests/data/reveal/flatiter.pyi
+++ b/numpy/typing/tests/data/reveal/flatiter.pyi
@@ -7,7 +7,7 @@ reveal_type(a.base)  # E: ndarray[Any, dtype[str_]]
 reveal_type(a.copy())  # E: ndarray[Any, dtype[str_]]
 reveal_type(a.coords)  # E: tuple[builtins.int, ...]
 reveal_type(a.index)  # E: int
-reveal_type(iter(a))  # E: flatiter[ndarray[Any, dtype[str_]]]
+reveal_type(iter(a))  # E: Any
 reveal_type(next(a))  # E: str_
 reveal_type(a[0])  # E: str_
 reveal_type(a[[0, 1, 2]])  # E: ndarray[Any, dtype[str_]]

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,5 @@ filterwarnings =
 # Ignore DeprecationWarnings from distutils
     ignore::DeprecationWarning:.*distutils
     ignore:\n\n  `numpy.distutils`:DeprecationWarning
+# Ignore mypy >= 0.971 DeprecationWarnings
+    ignore:path is deprecated\. Use files\(\) instead:DeprecationWarning:mypy

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,5 +10,5 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==0.950; platform_python_implementation != "PyPy"
+mypy==0.981; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0


### PR DESCRIPTION
Backport of #22360.

Bump mypy to version 0.981.

Marked as backport due as the test set required a few updates.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
