### PR TITLE
DOC: Update delimiter param description.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1087,7 +1087,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         comment. None implies no comments. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is '#'.
     delimiter : str, optional
-        The string used to separate values. For backwards compatibility, byte
+        The character used to separate the values. Only single character
+        delimiters are supported. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is whitespace.
     converters : dict or callable, optional
         A function to parse all columns strings into the desired value, or

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1087,9 +1087,13 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         comment. None implies no comments. For backwards compatibility, byte
         strings will be decoded as 'latin1'. The default is '#'.
     delimiter : str, optional
-        The character used to separate the values. Only single character
-        delimiters are supported. For backwards compatibility, byte
-        strings will be decoded as 'latin1'. The default is whitespace.
+        The character used to separate the values. For backwards compatibility,
+        byte strings will be decoded as 'latin1'. The default is whitespace.
+
+        .. versionchanged:: 1.23.0
+           Only single character delimiters are supported. Newline characters
+           cannot be used as the delimiter.
+
     converters : dict or callable, optional
         A function to parse all columns strings into the desired value, or
         a dictionary mapping column number to a parser function.


### PR DESCRIPTION
Backport of #22372.

Update the description for the `delimiter` parameter in `loadtxt` to note that only single-character strings are supported. In principle, this new info could be in a `.. versionchanged:: 1.23` directive - any preference there @seberg ?

Closes #22311

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
