### PR TITLE
DOC: Update broken link to diataxis framework.

### DIFF
--- a/doc/neps/nep-0044-restructuring-numpy-docs.rst
+++ b/doc/neps/nep-0044-restructuring-numpy-docs.rst
@@ -233,7 +233,7 @@ Discussion around this NEP can be found on the NumPy mailing list:
 References and Footnotes
 ========================
 
-.. [1] `What nobody tells you about documentation <https://www.divio.com/blog/documentation/>`_
+.. [1] `Diátaxis - A systematic framework for technical documentation authoring <https://diataxis.fr/>`_
 
 .. [2] `Preparing to Teach <https://carpentries.github.io/instructor-training/15-lesson-study/index.html>`_ (from the `Software Carpentry <https://software-carpentry.org/>`_ Instructor Training materials)
 


### PR DESCRIPTION
I was just looking for the link to the documentation framework discussed in NEP 44 and noticed that the link to the original article is now broken. I've updated the reference to point to the diataxis framework home page, which I believe is the successor to the orig - @melissawm is that right?