### PR TITLE
MAINT: Fix typos found by codespell

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -91,7 +91,7 @@ more important than the casting change itself.
     We recommend using it mainly to track down a *specific* change rather than
     running it on a full test-suite or program.
 
-    The following futher API exists:
+    The following further API exists:
 
     * ``np._set_promotion_state()`` and ``np._get_promotion_state()`` which is
       equivalent to the environment variable.
@@ -546,7 +546,7 @@ retaining the previous datatype is intuitive.
 Replacing this example with ``np.float32`` is maybe even more clear,
 as float will rarely have overflows.
 Without this behaviour, the above example would require writing ``np.uint8(4)``
-and lack of the behaviour would make the following suprising::
+and lack of the behaviour would make the following surprising::
 
     result = np.array([1, 2, 3], dtype=np.float32) * 2.
     result.dtype == np.float32
@@ -609,7 +609,7 @@ or be unspecified though:
 Implementation
 ==============
 
-Implemeting this NEP requires some additional machinery to be added to all
+Implementing this NEP requires some additional machinery to be added to all
 binary operators (or ufuncs), so that they attempt to use the "weak" logic
 if possible.
 There are two possible approaches to this:
@@ -676,7 +676,7 @@ This has advantages and disadvantages:
 
 * The main advantage is that limiting it to Python operators means that these
   "weak" types/dtypes are clearly ephemeral to short Python statements.
-* A disadvantage is that ``np.multiply`` and ``*`` are less interchangable.
+* A disadvantage is that ``np.multiply`` and ``*`` are less interchangeable.
 * Using "weak" promotion only for operators means that libraries do not have
   to worry about whether they want to "remember" that an input was a Python
   scalar initially.  On the other hand, it would add a the need for slightly
@@ -703,7 +703,7 @@ are "stronger" than Python scalars, but NumPy scalars are not).
 Such a distinction is very much possible, however, at this time NumPy will
 often (and silently) convert 0-D arrays to scalars.
 It may thus make sense, to only consider this alternative if we also
-change this silent conversion (sometimes refered to as "decay") behaviour.
+change this silent conversion (sometimes referred to as "decay") behaviour.
 
 
 Handling conversion of scalars when unsafe

--- a/doc/release/upcoming_changes/21437.improvement.rst
+++ b/doc/release/upcoming_changes/21437.improvement.rst
@@ -21,7 +21,7 @@ be platform dependent.  For example::
     arr = np.full(100, value=1000, dtype=np.float64)
     arr.astype(np.int8)
 
-May give a result equivalent to (the intermediat means no warning is given)::
+May give a result equivalent to (the intermediate cast means no warning is given)::
 
     arr.astype(np.int64).astype(np.int8)
 

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -231,7 +231,7 @@ https://anaconda.org/scipy-wheels-nightly/ on the following conditions:
 - by a weekly cron job or
 - if the github action or travis build has been manually triggered, which requires appropriate permissions
 
-The wheels wil be uploaded to https://anaconda.org/multibuild-wheels-staging/
+The wheels will be uploaded to https://anaconda.org/multibuild-wheels-staging/
 if the build was triggered by a tag to the repo that begins with ``v``
 
 .. _Action: https://github.com/numpy/numpy/actions

--- a/doc/source/f2py/windows/conda.rst
+++ b/doc/source/f2py/windows/conda.rst
@@ -4,7 +4,7 @@
 F2PY and Conda on Windows
 =========================
 
-As a convienience measure, we will additionally assume the
+As a convenience measure, we will additionally assume the
 existence of ``scoop``, which can be used to install tools without
 administrative access.
 

--- a/doc/source/f2py/windows/index.rst
+++ b/doc/source/f2py/windows/index.rst
@@ -83,7 +83,7 @@ LFortran (FOSS)
 Baseline
 ========
 
-For this document we will asume the following basic tools:
+For this document we will assume the following basic tools:
 
 - The IDE being considered is the community supported `Microsoft Visual Studio Code`_
 - The terminal being used is the `Windows Terminal`_

--- a/doc/source/f2py/windows/pgi.rst
+++ b/doc/source/f2py/windows/pgi.rst
@@ -19,7 +19,7 @@ as classic Flang requires a custom LLVM and compilation from sources.
 
 	**As of November 2021**
 
-	As of 29-01-2022, `PGI compiler toolchains`_ have been superceeded by the Nvidia
+	As of 29-01-2022, `PGI compiler toolchains`_ have been superseded by the Nvidia
   	HPC SDK, with no `native Windows support`_.
 
 However, 

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -508,7 +508,7 @@ Linear Algebra Functions
    * - ``vector_norm`` (*)
      - Floating-point
 
-(*) Thes functions are split from ``norm`` from the main ``numpy`` namespace.
+(*) These functions are split from ``norm`` from the main ``numpy`` namespace.
 See :ref:`array_api-name-changes`.
 
 (**) These functions are new in the array API and are not in the main

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1337,7 +1337,7 @@ Special functions for NPY_OBJECT
     by NumPy.  Users **should** also ensure to pass fully initialized buffers
     to NumPy, since NumPy may make this a strong requirement in the future.
 
-    There is currently an intention to ensure that NumPy always initalizes
+    There is currently an intention to ensure that NumPy always initializes
     object arrays before they may be read.  Any failure to do so will be
     regarded as a bug.
     In the future, users may be able to rely on non-NULL values when reading

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -3,7 +3,7 @@ NumPy security
 
 Security issues can be reported privately as described in the project README
 and when opening a `new issue on the issue tracker <https://github.com/numpy/numpy/issues/new/choose>`_.
-The `Python security reporting guidlines <https://www.python.org/dev/security/>`_
+The `Python security reporting guidelines <https://www.python.org/dev/security/>`_
 are a good resource and its notes apply also to NumPy.
 
 NumPy's maintainers are not security experts.  However, we are conscientious

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1435,7 +1435,7 @@ _ShapeType2 = TypeVar("_ShapeType2", bound=Any)
 _NumberType = TypeVar("_NumberType", bound=number[Any])
 
 # There is currently no exhaustive way to type the buffer protocol,
-# as it is implemented exclusivelly in the C API (python/typing#593)
+# as it is implemented exclusively in the C API (python/typing#593)
 _SupportsBuffer = Union[
     bytes,
     bytearray,
@@ -3754,7 +3754,7 @@ class memmap(ndarray[_ShapeType, _DType_co]):
     ) -> Any: ...
     def flush(self) -> None: ...
 
-# TODO: Add a mypy plugin for managing functions whose output type is dependant
+# TODO: Add a mypy plugin for managing functions whose output type is dependent
 # on the literal value of some sort of signature (e.g. `einsum` and `vectorize`)
 class vectorize:
     pyfunc: Callable[..., Any]

--- a/numpy/_pyinstaller/pyinstaller-smoke.py
+++ b/numpy/_pyinstaller/pyinstaller-smoke.py
@@ -4,7 +4,7 @@ PyInstaller typically goes wrong by forgetting to package modules, extension
 modules or shared libraries. This script should aim to touch as many of those
 as possible in an attempt to trip a ModuleNotFoundError or a DLL load failure
 due to an uncollected resource. Missing resources are unlikely to lead to
-arithmitic errors so there's generally no need to verify any calculation's
+arithmetic errors so there's generally no need to verify any calculation's
 output - merely that it made it to the end OK. This script should not
 explicitly import any of numpy's submodules as that gives PyInstaller undue
 hints that those submodules exist and should be collected (accessing implicitly

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1878,7 +1878,7 @@ typedef void (PyDataMem_EventHookFunc)(void *inp, void *outp, size_t size,
     /*
      * The Structures defined in this block are currently considered
      * private API and may change without warning!
-     * Part of this (at least the size) is exepcted to be public API without
+     * Part of this (at least the size) is expected to be public API without
      * further modifications.
      */
     /* TODO: Make this definition public in the API, as soon as its settled */

--- a/numpy/core/src/common/simd/avx2/math.h
+++ b/numpy/core/src/common/simd/avx2/math.h
@@ -234,7 +234,7 @@ NPY_IMPL_AVX256_REDUCE_MINMAX(npy_uint, max_u, max_epu)
 NPY_IMPL_AVX256_REDUCE_MINMAX(npy_int,  max_s, max_epi)
 #undef NPY_IMPL_AVX256_REDUCE_MINMAX
 
-// round to nearest intger even
+// round to nearest integer even
 #define npyv_rint_f32(A) _mm256_round_ps(A, _MM_FROUND_TO_NEAREST_INT)
 #define npyv_rint_f64(A) _mm256_round_pd(A, _MM_FROUND_TO_NEAREST_INT)
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -391,7 +391,7 @@ static int
         temp.imag = (@ftype@) oop.imag;
 
 #if NPY_SIZEOF_@NAME@ < NPY_SIZEOF_CDOUBLE  /* really just float... */
-        /* Overflow could have occured converting double to float */
+        /* Overflow could have occurred converting double to float */
         if (NPY_UNLIKELY((npy_isinf(temp.real) && !npy_isinf(oop.real)) ||
                          (npy_isinf(temp.imag) && !npy_isinf(oop.imag)))) {
             if (PyUFunc_GiveFloatingpointErrors("cast", NPY_FPE_OVERFLOW) < 0) {

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -109,7 +109,7 @@ PyArray_UpdateFlags(PyArrayObject *ret, int flagmask)
  * a single element).
  * We correct this, however.  When a dimension has length 1, its stride is
  * never used and thus has no effect on the  memory layout.
- * The above rules thus only apply when ignorning all size 1 dimenions.
+ * The above rules thus only apply when ignoring all size 1 dimensions.
  */
 static void
 _UpdateContiguousFlags(PyArrayObject *ap)

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -85,7 +85,7 @@ static int _array_descr_builtin(PyArray_Descr* descr, PyObject *l)
         item = PyTuple_GetItem(t, i);
         if (item == NULL) {
             PyErr_SetString(PyExc_SystemError,
-                    "(Hash) Error while computing builting hash");
+                    "(Hash) Error while computing builtin hash");
             goto clean_t;
         }
         PyList_Append(l, item);

--- a/numpy/core/src/multiarray/textreading/conversions.c
+++ b/numpy/core/src/multiarray/textreading/conversions.c
@@ -99,7 +99,7 @@ double_from_ucs4(
     }
 
     if (strip_whitespace) {
-        /* and then skip any remainig whitespace: */
+        /* and then skip any remaining whitespace: */
         while (Py_UNICODE_ISSPACE(*end)) {
             end++;
         }

--- a/numpy/core/src/multiarray/textreading/field_types.h
+++ b/numpy/core/src/multiarray/textreading/field_types.h
@@ -31,7 +31,7 @@
  *       considered boolean True or False).
  *
  * TODO: Aside from nailing down the above notes, it may be nice to expose
- *       these function publically.  This could allow user DTypes to provide
+ *       these function publicly.  This could allow user DTypes to provide
  *       a converter or custom converters written in C rather than Python.
  *
  * @param descr The NumPy descriptor of the field (may be byte-swapped, etc.)

--- a/numpy/core/src/multiarray/textreading/rows.c
+++ b/numpy/core/src/multiarray/textreading/rows.c
@@ -19,7 +19,7 @@
 #include "textreading/growth.h"
 
 /*
- * Minimum size to grow the allcoation by (or 25%). The 8KiB means the actual
+ * Minimum size to grow the allocation by (or 25%). The 8KiB means the actual
  * growths is within `8 KiB <= size < 16 KiB` (depending on the row size).
  */
 #define MIN_BLOCK_SIZE (1 << 13)

--- a/numpy/core/src/npysort/x86-qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/x86-qsort.dispatch.cpp
@@ -637,7 +637,7 @@ get_pivot(type_t *arr, const npy_intp left, const npy_intp right)
 }
 
 /*
- * Parition one ZMM register based on the pivot and returns the index of the
+ * Partition one ZMM register based on the pivot and returns the index of the
  * last element that is less than equal to the pivot.
  */
 template <typename vtype, typename type_t, typename zmm_t>
@@ -657,7 +657,7 @@ partition_vec(type_t *arr, npy_intp left, npy_intp right, const zmm_t curr_vec,
 }
 
 /*
- * Parition an array based on the pivot and returns the index of the
+ * Partition an array based on the pivot and returns the index of the
  * last element that is less than equal to the pivot.
  */
 template <typename vtype, typename type_t>
@@ -746,7 +746,7 @@ static inline void
 qsort_(type_t *arr, npy_intp left, npy_intp right, npy_int max_iters)
 {
     /*
-     * Resort to heapsort if quicksort isnt making any progress
+     * Resort to heapsort if quicksort isn't making any progress
      */
     if (max_iters <= 0) {
         heapsort_<typename vtype::tag>(arr + left, right + 1 - left);

--- a/numpy/core/src/umath/loops_hyperbolic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_hyperbolic.dispatch.c.src
@@ -38,7 +38,7 @@
  *
  *  ALGORITHM DETAILS
  *
- *  SVML handel |x| > HUGE_THRESHOLD, INF and NaNs by scalar callout as following:
+ *  SVML handle |x| > HUGE_THRESHOLD, INF and NaNs by scalar callout as following:
  *  1. check special cases
  *  2. return `+-1` for `|x| > HUGE_THRESHOLD`  otherwise return `x`
  *

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -792,7 +792,7 @@ typedef enum {
      */
     CONVERSION_SUCCESS,
     /*
-     * Other object is an unkown scalar or array-like, we (typically) use
+     * Other object is an unknown scalar or array-like, we (typically) use
      * the generic path, which normally ends up in the ufunc machinery.
      */
     OTHER_IS_UNKNOWN_OBJECT,

--- a/numpy/core/tests/test_array_interface.py
+++ b/numpy/core/tests/test_array_interface.py
@@ -136,7 +136,7 @@ def test_cstruct(get_module):
         This class is for testing the timing of the PyCapsule destructor
         invoked when numpy release its reference to the shared data as part of
         the numpy array interface protocol. If the PyCapsule destructor is
-        called early the shared data is freed and invlaid memory accesses will
+        called early the shared data is freed and invalid memory accesses will
         occur.
         """
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4614,7 +4614,7 @@ class TestArgmax:
             ([np.nan, 0, 1, 2, 3], 0),
             ([np.nan, 0, np.nan, 2, 3], 0),
             # To hit the tail of SIMD multi-level(x4, x1) inner loops
-            # on varient SIMD widthes
+            # on variant SIMD widthes
             ([1] * (2*5-1) + [np.nan], 2*5-1),
             ([1] * (4*5-1) + [np.nan], 4*5-1),
             ([1] * (8*5-1) + [np.nan], 8*5-1),
@@ -4757,7 +4757,7 @@ class TestArgmin:
             ([np.nan, 0, 1, 2, 3], 0),
             ([np.nan, 0, np.nan, 2, 3], 0),
             # To hit the tail of SIMD multi-level(x4, x1) inner loops
-            # on varient SIMD widthes
+            # on variant SIMD widthes
             ([1] * (2*5-1) + [np.nan], 2*5-1),
             ([1] * (4*5-1) + [np.nan], 4*5-1),
             ([1] * (8*5-1) + [np.nan], 8*5-1),

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -804,7 +804,7 @@ class TestHash:
             assert hash(val) == hash(numpy_val)
 
         if hash(float(np.nan)) != hash(float(np.nan)):
-            # If Python distinguises different NaNs we do so too (gh-18833)
+            # If Python distinguishes different NaNs we do so too (gh-18833)
             assert hash(scalar(np.nan)) != hash(scalar(np.nan))
 
     @pytest.mark.parametrize("type_code", np.typecodes['Complex'])

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -288,11 +288,11 @@ class TestComparisons:
 
         # Sequence: Binary, Scalar1 and Scalar2
         assert_(comp_b.tolist() == comp_b_list,
-            f"Failed comparision ({py_comp.__name__})")
+            f"Failed comparison ({py_comp.__name__})")
         assert_(comp_s1.tolist() == comp_s1_list,
-            f"Failed comparision ({py_comp.__name__})")
+            f"Failed comparison ({py_comp.__name__})")
         assert_(comp_s2.tolist() == comp_s2_list,
-            f"Failed comparision ({py_comp.__name__})")
+            f"Failed comparison ({py_comp.__name__})")
 
     def test_ignore_object_identity_in_equal(self):
         # Check comparing identical objects whose comparison

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -795,7 +795,7 @@ static int
 get_elsize(PyObject *obj) {
   /*
     get_elsize determines array itemsize from a Python object.  Returns
-    elsize if succesful, -1 otherwise.
+    elsize if successful, -1 otherwise.
 
     Supported types of the input are: numpy.ndarray, bytes, str, tuple,
     list.

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2495,7 +2495,7 @@ M   33  21.99
 
     @pytest.mark.parametrize("ndim", [0, 1, 2])
     def test_ndmin_keyword(self, ndim: int):
-        # lets have the same behaivour of ndmin as loadtxt
+        # lets have the same behaviour of ndmin as loadtxt
         # as they should be the same for non-missing values
         txt = "42"
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3014,7 +3014,7 @@ cdef class Generator:
         intermediate distribution exceeding the max acceptable value of the 
         ``Generator.poisson`` method. This happens when :math:`p` is too low 
         (a lot of failures happen for every success) and :math:`n` is too big (
-        a lot of sucesses are allowed).
+        a lot of successes are allowed).
         Therefore, the :math:`n` and :math:`p` values must satisfy the constraint:
 
         .. math:: n\\frac{1-p}{p}+10n\\sqrt{n}\\frac{1-p}{p}<2^{63}-1-10\\sqrt{2^{63}-1},
@@ -4433,7 +4433,7 @@ cdef class Generator:
             is shuffled independently of the others.  If `axis` is
             None, the flattened array is shuffled.
         out : ndarray, optional
-            If given, this is the destinaton of the shuffled array.
+            If given, this is the destination of the shuffled array.
             If `out` is None, a shuffled copy of the array is returned.
 
         Returns

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [codespell]
-skip = *-changelog.rst,*-notes.rst,f2c_blas.c,f2c_c_lapack.c,f2c_d_lapack.c,f2c_s_lapack.c,f2c_z_lapack.c
+skip = .git,*-changelog.rst,*-notes.rst,LICENSE_win32.txt,f2c_lapack.c,f2c_blas.c,f2c_c_lapack.c,f2c_d_lapack.c,f2c_s_lapack.c,f2c_z_lapack.c
+ignore-words-list = inout,dedented,nd,nin,asign
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -46,7 +46,7 @@ os.chdir(workdir)
 
 run(['git', 'init'])
 # ensure the working branch is called "main"
-# (`--initial-branch=main` appared to have failed on older git versions):
+# (`--initial-branch=main` appeared to have failed on older git versions):
 run(['git', 'checkout', '-b', 'main'])
 run(['git', 'remote', 'add', 'origin',  args.remote])
 run(['git', 'config', '--local', 'user.name', args.committer])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Also fix this sentence in the documentation, I guess the word `cast` was missing:
> May give a result equivalent to (the intermediat means no warning is given):
> 
> ```
> arr.astype(np.int64).astype(np.int8)
> ```