### PR TITLE
ENH: Added mant_dig attribute to finfo (#22333)

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -374,10 +374,6 @@ class finfo:
 
     Machine limits for floating point types.
 
-    .. note::
-       finfo.nmant is inaccurate and set to be deprecated in the future.
-       To get the number of bits in the mantissa, use finfo.mant_dig instead.
-
     Attributes
     ----------
     bits : int
@@ -419,7 +415,9 @@ class finfo:
         The number of bits in the exponent including its sign and bias.
     nmant : int
         The number of bits in the mantissa.
-        nmant is always off by 1 and should no longer be used.
+        .. note::
+        finfo.nmant is inaccurate and set to be deprecated in the future.
+        To get the number of bits in the mantissa, use ``finfo.mant_dig`` instead.
     mant_dig: int
         The number of bits in the mantissa.
     precision : int

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -165,6 +165,7 @@ def _register_known_types():
                             minexp=-14,
                             maxexp=16,
                             it=10,
+                            it_2=11,
                             iexp=5,
                             ibeta=2,
                             irnd=5,
@@ -184,6 +185,7 @@ def _register_known_types():
                             minexp=-126,
                             maxexp=128,
                             it=23,
+                            it_2=24,
                             iexp=8,
                             ibeta=2,
                             irnd=5,
@@ -205,6 +207,7 @@ def _register_known_types():
                             minexp=-1022,
                             maxexp=1024,
                             it=52,
+                            it_2=53,
                             iexp=11,
                             ibeta=2,
                             irnd=5,
@@ -229,6 +232,7 @@ def _register_known_types():
                              minexp=-16382,
                              maxexp=16384,
                              it=112,
+                             it_2=113,
                              iexp=15,
                              ibeta=2,
                              irnd=5,
@@ -256,6 +260,7 @@ def _register_known_types():
                             minexp=-16382,
                             maxexp=16384,
                             it=63,
+                            it_2=64,
                             iexp=15,
                             ibeta=2,
                             irnd=5,
@@ -284,6 +289,7 @@ def _register_known_types():
                              minexp=-1022,
                              maxexp=1024,
                              it=105,
+                             it_2=106,
                              iexp=11,
                              ibeta=2,
                              irnd=5,
@@ -368,6 +374,10 @@ class finfo:
 
     Machine limits for floating point types.
 
+    .. note::
+       finfo.nmant is inaccurate and set to be deprecated in the future.
+       To get the number of bits in the mantissa, use finfo.mant_dig instead.
+
     Attributes
     ----------
     bits : int
@@ -408,6 +418,9 @@ class finfo:
     nexp : int
         The number of bits in the exponent including its sign and bias.
     nmant : int
+        The number of bits in the mantissa.
+        nmant is always off by 1 and should no longer be used.
+    mant_dig: int
         The number of bits in the mantissa.
     precision : int
         The approximate number of decimal digits to which this kind of
@@ -522,6 +535,7 @@ class finfo:
         self.eps = machar.eps.flat[0]
         self.nexp = machar.iexp
         self.nmant = machar.it
+        self.mant_dig = machar.it_2
         self._machar = machar
         self._str_tiny = machar._str_xmin.strip()
         self._str_max = machar._str_xmax.strip()

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -416,7 +416,9 @@ class finfo:
     nmant : int
         The number of bits in the mantissa.
         .. note::
-        finfo.nmant is inaccurate and set to be deprecated in the future.
+        finfo.nmant only shows the explicitly stored digits, which is
+        always off because floating point numbers have an implicitly
+        leading 1. Because of this, finfo.nmant is due to be deprecated.
         To get the number of bits in the mantissa, use ``finfo.mant_dig``.
     mant_dig: int
         The number of bits in the mantissa.

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -416,7 +416,7 @@ class finfo:
     nmant : int
         The number of bits in the mantissa.
         .. note::
-        finfo.nmant only shows the explicitly stored digits, which is
+        ``finfo.nmant`` only shows the explicitly stored digits, which is
         always off because floating point numbers have an implicitly
         leading 1. Because of this, finfo.nmant is due to be deprecated.
         To get the number of bits in the mantissa, use ``finfo.mant_dig``.

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -417,7 +417,7 @@ class finfo:
         The number of bits in the mantissa.
         .. note::
         finfo.nmant is inaccurate and set to be deprecated in the future.
-        To get the number of bits in the mantissa, use ``finfo.mant_dig`` instead.
+        To get the number of bits in the mantissa, use ``finfo.mant_dig``.
     mant_dig: int
         The number of bits in the mantissa.
     precision : int

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -48,11 +48,18 @@ class TestFinfo:
         for dt1, dt2 in dts:
             for attr in ('bits', 'eps', 'epsneg', 'iexp', 'machep',
                          'max', 'maxexp', 'min', 'minexp', 'negep', 'nexp',
-                         'nmant', 'precision', 'resolution', 'tiny',
-                         'smallest_normal', 'smallest_subnormal'):
+                         'nmant', 'mant_dig', 'precision', 'resolution',
+                         'tiny', 'smallest_normal', 'smallest_subnormal'):
                 assert_equal(getattr(finfo(dt1), attr),
                              getattr(finfo(dt2), attr), attr)
         assert_raises(ValueError, finfo, 'i4')
+
+    def test_mant_dig(self):
+        dts = list(zip(['f2', 'f4', 'f8', 'c8', 'c16'],
+                       [np.float16, np.float32, np.float64, np.complex64,
+                        np.complex128]))
+        for dt in dts:
+            assert_equal(finfo(dt).nmant + 1, finfo(dt).mant_dig)
 
 class TestIinfo:
     def test_basic(self):
@@ -141,5 +148,6 @@ def test_plausible_finfo():
     for ftype in np.sctypes['float'] + np.sctypes['complex']:
         info = np.finfo(ftype)
         assert_(info.nmant > 1)
+        assert_(info.mant_dig > 1)
         assert_(info.minexp < -1)
         assert_(info.maxexp > 1)


### PR DESCRIPTION
The normal attribute for getting the mantissa is nmant, but this is always off by 1. 
However, other packages (like sympy) require the nmant attribute,  so we would end up breaking code 
downstream if we changed it. Instead, I introduced a new attribute called mant_dig, as member 
Sebastian Berg suggested. In the documentation for finfo, I added a small disclaimer
saying that nmant should not be used anymore. Since nmant is going to have to be
deprecated eventually, I also added a small disclaimer that nmant is inaccurate, set for
depreciation at some point in the future, and that mant_dig should be used from here on out.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
