### PR TITLE
DOC: Adopt a harmonic color scheme with the dark mode of pydata-sphinx-theme

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -47,7 +47,7 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 #version_switcher_button[data-active-version-name*="dev"] {
   background-color: #E69F00;
   border-color: #E69F00;
-  color:#4A4A4A; /* numpy.org body color */
+  color:#000000;
 }
 
 /* green for `stable` */

--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -9,7 +9,6 @@
 
 body {
   font-family: 'Open Sans', sans-serif;
-  color:#4A4A4A; /* numpy.org body color */
 }
 
 pre, code {
@@ -48,6 +47,7 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 #version_switcher_button[data-active-version-name*="dev"] {
   background-color: #E69F00;
   border-color: #E69F00;
+  color:#4A4A4A; /* numpy.org body color */
 }
 
 /* green for `stable` */


### PR DESCRIPTION
This PR provides a simple solution to the 1st and 2nd issues documented in #22408.

Specifically, the body text color setting has been removed from numpy.css so that the setting in pydata-sphinx-theme is used. Also, the label color of "dev" version selection button is set to `#4a4a4a`, which was originally used as the body text color.

Since the 3rd issue may be a matter of taste and other section heading colors might need to be changed as well, it is left as is here at this moment.

The choice of colors may depend on the project policy and personal preferences, and I am not a professional colorist. So, any suggestions would be greatly appreciated.
Many thanks.