### PR TITLE
TST: Fix failing aarch64 wheel builds.

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6693,7 +6693,7 @@ class TestDot:
 
     @pytest.mark.slow
     @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-    @requires_memory(free_bytes=9*10**9)  # complex case needs 8GiB+
+    @requires_memory(free_bytes=18e9)  # complex case needs 18GiB+
     def test_huge_vectordot(self, dtype):
         # Large vector multiplications are chunked with 32bit BLAS
         # Test that the chunking does the right thing, see also gh-22262

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -11,7 +11,11 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     PY_DIR=$(python -c "import sys; print(sys.prefix)")
     mkdir $PY_DIR/libs
 fi
-python -c "import sys; import numpy; sys.exit(not numpy.test('full', extra_argv=['-vvv']))"
+
+# Set available memory value to avoid OOM problems on aarch64.
+# See gh-22418.
+export NPY_AVAILABLE_MEM="4 GB"
+python -c "import sys; import numpy; sys.exit(not numpy.test('full'))"
 
 python $PROJECT_DIR/tools/wheels/check_license.py
 if [[ $UNAME == "Linux" || $UNAME == "Darwin" ]] ; then


### PR DESCRIPTION
Backport of #22418.

The aarch64 wheel build tests are failing with OOM. The new test for complex128 dot for huge vectors is responsible as the useable memory is incorrectly determined and the check for sufficient memory fails. The fix here is to define the `NPY_AVAILABLE_MEM="4 GB"` environment variable before the test call in `cibw_test_command.sh`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
