### PR TITLE
ENH: Add `dtype` argument to `np.append`

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5421,6 +5421,8 @@ def append(arr, values, dtype=None, axis=None):
         correct shape (the same shape as `arr`, excluding `axis`).  If
         `axis` is not specified, `values` can be any shape and will be
         flattened before use.
+    dtype : data-type, optional
+        If provided, the copy of `arr` will have this dtype.
     axis : int, optional
         The axis along which `values` are appended.  If `axis` is not
         given, both `arr` and `values` are flattened before use.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5460,13 +5460,13 @@ def append(arr, values, dtype=None, axis=None):
         arr = asanyarray(arr, dtype=dtype)
     else:
         arr = asanyarray(arr)
-        
+
     if axis is None:
         if arr.ndim != 1:
             arr = arr.ravel()
         values = ravel(values)
         axis = arr.ndim-1
-    return concatenate((arr, values), axis=axis)
+    return concatenate((arr, values), dtype=dtype, axis=axis)
 
 
 def _digitize_dispatcher(x, bins, right=None):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5403,12 +5403,12 @@ def insert(arr, obj, values, axis=None):
     return new
 
 
-def _append_dispatcher(arr, values, dtype=None, axis=None):
+def _append_dispatcher(arr, values, axis=None, dtype=None):
     return (arr, values)
 
 
 @array_function_dispatch(_append_dispatcher)
-def append(arr, values, dtype=None, axis=None):
+def append(arr, values, axis=None, dtype=None):
     """
     Append values to the end of an array.
 
@@ -5421,11 +5421,11 @@ def append(arr, values, dtype=None, axis=None):
         correct shape (the same shape as `arr`, excluding `axis`).  If
         `axis` is not specified, `values` can be any shape and will be
         flattened before use.
-    dtype : data-type, optional
-        If provided, the copy of `arr` will have this dtype.
     axis : int, optional
         The axis along which `values` are appended.  If `axis` is not
         given, both `arr` and `values` are flattened before use.
+    dtype : data-type, optional
+        If provided, the copy of `arr` will have this dtype.
 
     Returns
     -------
@@ -5458,11 +5458,7 @@ def append(arr, values, dtype=None, axis=None):
     dimension(s)
 
     """
-    if dtype is not None:
-        arr = asanyarray(arr, dtype=dtype)
-    else:
-        arr = asanyarray(arr)
-
+    arr = asanyarray(arr)
     if axis is None:
         if arr.ndim != 1:
             arr = arr.ravel()

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5403,12 +5403,12 @@ def insert(arr, obj, values, axis=None):
     return new
 
 
-def _append_dispatcher(arr, values, axis=None):
+def _append_dispatcher(arr, values, dtype=None, axis=None):
     return (arr, values)
 
 
 @array_function_dispatch(_append_dispatcher)
-def append(arr, values, axis=None):
+def append(arr, values, dtype=None, axis=None):
     """
     Append values to the end of an array.
 
@@ -5456,7 +5456,11 @@ def append(arr, values, axis=None):
     dimension(s)
 
     """
-    arr = asanyarray(arr)
+    if dtype is not None:
+        arr = asanyarray(arr, dtype=dtype)
+    else:
+        arr = asanyarray(arr)
+        
     if axis is None:
         if arr.ndim != 1:
             arr = arr.ravel()


### PR DESCRIPTION
This pull request is for solving the [#22427](https://github.com/numpy/numpy/issues/22427#issue-1405255240) issue. I solved it by adding a new parameter ```dtype``` to the append function so it can overwrite the default ```dtype``` in the generated copy from the array which has not the same type as the original one .
