### PR TITLE
MAINT: always use sys.base_prefix, never use sys.real_prefix

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -184,14 +184,11 @@ def find_python_dll():
     # We can't do much here:
     # - find it in the virtualenv (sys.prefix)
     # - find it in python main dir (sys.base_prefix, if in a virtualenv)
-    # - sys.real_prefix is main dir for virtualenvs in Python 2.7
     # - in system32,
     # - ortherwise (Sxs), I don't know how to get it.
     stems = [sys.prefix]
-    if hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
+    if sys.base_prefix != sys.prefix:
         stems.append(sys.base_prefix)
-    elif hasattr(sys, 'real_prefix') and sys.real_prefix != sys.prefix:
-        stems.append(sys.real_prefix)
 
     sub_dirs = ['', 'lib', 'bin']
     # generate possible combinations of directory trees and sub-directories


### PR DESCRIPTION
This is a follow-up to https://github.com/numpy/numpy/pull/22411. The reason why this is a separate merge request, is that it removes actual code specific to Python 2, not only documentation.

Fixes more of #22400.

`sys.base_prefix` was introduced in Python 3.3, so it will always be available in supported versions of Python >= 3.3:
	https://docs.python.org/3/library/sys.html#sys.base_prefix

As a result, `sys.real_prefix` will never be used in supported versions of Python >= 3.3. Besides, it has been removed from recent versions of virtualenv:
	https://github.com/pypa/virtualenv/issues/1622
