### PR TITLE
DOC: remove reference to Python 2

### DIFF
--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -46,7 +46,7 @@ class config(old_config):
             # XXX: hack to circumvent a python 2.6 bug with msvc9compiler:
             # initialize call query_vcvarsall, which throws an IOError, and
             # causes an error along the way without much information. We try to
-            # catch it here, hoping it is early enough, and print an helpful
+            # catch it here, hoping it is early enough, and print a helpful
             # message instead of Error: None.
             if not self.compiler.initialized:
                 try:
@@ -56,8 +56,7 @@ class config(old_config):
                         Could not initialize compiler instance: do you have Visual Studio
                         installed?  If you are trying to build with MinGW, please use "python setup.py
                         build -c mingw32" instead.  If you have Visual Studio installed, check it is
-                        correctly installed, and the right version (VS 2008 for python 2.6, 2.7 and 3.2,
-                        VS 2010 for >= 3.3).
+                        correctly installed, and the right version (VS 2015 as of this writing).
 
                         Original exception was: %s, and the Compiler class was %s
                         ============================================================================""") \


### PR DESCRIPTION
This is a follow-up to https://github.com/numpy/numpy/pull/22411. The reason why this is a separate merge request, is that it may eventually remove actual code specific to Python 2, not only documentation.

Fixes more of https://github.com/numpy/numpy/issues/22400.

Remove reference to Visual Studio version required by old versions of Python. Python >= 3.5 is built with Microsoft Visual C++ 14.0, bundled with Visual Studio 2015:
	https://wiki.python.org/moin/WindowsCompilers

To the reviewers:

Should we remove the whole `IOError` handling code instead? It is documented "_to circumvent a python 2.6 bug with msvc9compiler_" so I suspect it is not needed any more:
https://github.com/numpy/numpy/blob/ae6a3524acc38edfdc3951622fcc598414cc78ec/numpy/distutils/command/config.py#L46-L67
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->