### PR TITLE
DOC: Clarify docstring of `masked_equal` and `masked_values`

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2081,11 +2081,13 @@ def masked_equal(x, value, copy=True):
     """
     Mask an array where equal to a given value.
 
+    Return a MaskedArray, masked where the data in array `x` are
+    equal to `value`. The fill_value of the returned MaskedArray
+    is set to `value`.
+
     This function is a shortcut to ``masked_where``, with
     `condition` = (x == value).  For floating point arrays,
     consider using ``masked_values(x, value)``.
-
-    The fill_value is set to `value`.
 
     See Also
     --------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2085,9 +2085,7 @@ def masked_equal(x, value, copy=True):
     equal to `value`. The fill_value of the returned MaskedArray
     is set to `value`.
 
-    This function is a shortcut to ``masked_where``, with
-    `condition` = (x == value).  For floating point arrays,
-    consider using ``masked_values(x, value)``.
+    For floating point arrays, consider using ``masked_values(x, value)``.
 
     See Also
     --------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2085,6 +2085,8 @@ def masked_equal(x, value, copy=True):
     `condition` = (x == value).  For floating point arrays,
     consider using ``masked_values(x, value)``.
 
+    The fill_value is set to `value`.
+
     See Also
     --------
     masked_where : Mask where a condition is met.
@@ -2303,25 +2305,17 @@ def masked_values(x, value, rtol=1e-5, atol=1e-8, copy=True, shrink=True):
 
     Note that `mask` is set to ``nomask`` if possible.
 
-    >>> ma.masked_values(x, 1.5)
+    >>> ma.masked_values(x, 2.1)
     masked_array(data=[1. , 1.1, 2. , 1.1, 3. ],
                  mask=False,
-           fill_value=1.5)
+           fill_value=2.1)
 
-    For integers, the fill value will be different in general to the
-    result of ``masked_equal``.
+    Unlike `masked_equal`, `masked_values` can perform approximate equalities. 
 
-    >>> x = np.arange(5)
-    >>> x
-    array([0, 1, 2, 3, 4])
-    >>> ma.masked_values(x, 2)
-    masked_array(data=[0, 1, --, 3, 4],
+    >>> ma.masked_values(x, 2.1, atol=1e-1)
+    masked_array(data=[1.0, 1.1, --, 1.1, 3.0],
                  mask=[False, False,  True, False, False],
-           fill_value=2)
-    >>> ma.masked_equal(x, 2)
-    masked_array(data=[0, 1, --, 3, 4],
-                 mask=[False, False,  True, False, False],
-           fill_value=2)
+           fill_value=2.1)
 
     """
     xnew = filled(x, value)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This pull request clarifies the documentation of the functions `masked_equal` and `masked_values`.
It is supposed to fix #5408.

With respect to the issue description, the example of `masked_equal` was already modified to be consistent with the implementation.
- I have made explicit the behavior of `fill_value` for `masked_equal`
- I have added an example in `masked_values` to clarify its difference with respect to `masked_equal` (as the homogenization of the `fill_value` implementation made this difference less explicit, ...in my opinion,... :) )

Thanks for considering this PR. 