### PR TITLE
MAINT,DOC: Revert "MAINT: fix typo in f2c_lapack.c"

### DIFF
--- a/numpy/linalg/lapack_lite/f2c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_lapack.c
@@ -61,7 +61,7 @@ integer ieeeck_(integer *ispec, real *zero, real *one)
     =========
 
     ISPEC   (input) INTEGER
-            Specifies whether to test just for infinity arithmetic
+            Specifies whether to test just for inifinity arithmetic
             or whether to test for infinity and NaN arithmetic.
             = 0: Verify infinity arithmetic only.
             = 1: Verify infinity and NaN arithmetic.


### PR DESCRIPTION
As discussed in https://github.com/numpy/numpy/pull/22440#issuecomment-1279853540 and https://github.com/numpy/numpy/pull/22440#issuecomment-1279845218