### PR TITLE
TYP: Fix a spelling disagreement in array flags Literal

### DIFF
--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -972,7 +972,7 @@ _GetItemKeys = L[
 ]
 _SetItemKeys = L[
     "A", "ALIGNED",
-    "W", "WRITABLE",
+    "W", "WRITEABLE",
     "X", "WRITEBACKIFCOPY",
 ]
 

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -65,7 +65,7 @@ class TestScalarPEP3118:
     def test_scalar_buffers_readonly(self, scalar):
         x = scalar()
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
-            get_buffer_info(x, ["WRITABLE"])
+            get_buffer_info(x, ["WRITEABLE"])
 
     def test_void_scalar_structured_data(self):
         dt = np.dtype([('name', np.unicode_, 16), ('grades', np.float64, (2,))])
@@ -90,7 +90,7 @@ class TestScalarPEP3118:
         # Check that we do not allow writeable buffer export (technically
         # we could allow it sometimes here...)
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
-            get_buffer_info(x, ["WRITABLE"])
+            get_buffer_info(x, ["WRITEABLE"])
 
     def _as_dict(self, m):
         return dict(strides=m.strides, shape=m.shape, itemsize=m.itemsize,
@@ -117,7 +117,7 @@ class TestScalarPEP3118:
 
         # Check that we do not allow writeable buffer export
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
-            get_buffer_info(dt1, ["WRITABLE"])
+            get_buffer_info(dt1, ["WRITEABLE"])
 
     @pytest.mark.parametrize('s', [
         pytest.param("\x32\x32", id="ascii"),
@@ -141,7 +141,7 @@ class TestScalarPEP3118:
 
         # Check that we do not allow writeable buffer export
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
-            get_buffer_info(s, ["WRITABLE"])
+            get_buffer_info(s, ["WRITEABLE"])
 
     def test_user_scalar_fails_buffer(self):
         r = rational(1)
@@ -150,4 +150,4 @@ class TestScalarPEP3118:
 
         # Check that we do not allow writeable buffer export
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
-            get_buffer_info(r, ["WRITABLE"])
+            get_buffer_info(r, ["WRITEABLE"])


### PR DESCRIPTION
This fixes a spelling disagrement in numpy/core/multiarray.pyi and the documentation at https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html

Note also the spelling disagreement between _GetItemKeys and _SetItemKeys in the same file.

This is the result of getting the following feedback from mypy:
```
error: Invalid index type "Literal['WRITEABLE']" for "flagsobj"; expected type "Literal['A', 'ALIGNED', 'W', 'WRITABLE', 'X', 'WRITEBACKIFCOPY']"
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
