### PR TITLE
DEV: Update GH actions and Dockerfile for Gitpod

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,35 +1,35 @@
 name: Build Base Docker Image
 
 on:
-  push: 
+  push:
     branches:
       - main
     paths:
-      - 'environment.yml'
+      - "environment.yml"
 
 permissions:
   contents: read # to fetch code (actions/checkout)
 
-jobs: 
-  build:
-    name: Build base Docker image 
+jobs:
+  build_docker:
+    name: Build base Docker image
     runs-on: ubuntu-latest
     environment: numpy-dev
     if: "github.repository_owner == 'numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
-      - name: Lint Docker 
+      - name: Lint Docker
         uses: brpaz/hadolint-action@v1.2.1
-        with: 
+        with:
           dockerfile: ./tools/gitpod/Dockerfile
       - name: Get refs
         shell: bash
         run: |
           export raw_branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${raw_branch//\//-}"
-          echo "::set-output name=date::$(date +'%Y%m%d')"
-          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+          echo "branch=${raw_branch//\//-}" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -55,6 +55,6 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             numpy/numpy-dev:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, numpy/numpy-dev:latest
-      - name: Image digest 
+      - name: Image digest
         # Return details of the image build: sha and shell
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  build:
+  build_gitpod:
     name: Build Gitpod Docker image
     runs-on: ubuntu-latest
     environment: numpy-dev

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           export raw_branch=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=branch::${raw_branch//\//-}"
-          echo "::set-output name=date::$(date +'%Y%m%d')"
-          echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+          echo "branch=${raw_branch//\//-}" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,16 +15,16 @@ name: Wheel builder
 
 on:
   schedule:
-  #        ┌───────────── minute (0 - 59)
-  #        │  ┌───────────── hour (0 - 23)
-  #        │  │ ┌───────────── day of the month (1 - 31)
-  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  #        │  │ │ │ │
-  - cron: "42 1 * * 4"
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    - cron: "42 1 * * 4"
   push:
   pull_request:
-      types: [labeled, opened, synchronize, reopened]
+    types: [labeled, opened, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -xe
           COMMIT_MSG=$(git log --no-merges -1 --oneline)
-          echo "::set-output name=message::$COMMIT_MSG"
+          echo "message=$COMMIT_MSG" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
 
   build_wheels:
@@ -74,20 +74,20 @@ jobs:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
-        - [ubuntu-20.04, manylinux_x86_64]
-        - [macos-10.15, macosx_*]
-        - [windows-2019, win_amd64]
-        - [windows-2019, win32]
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [macos-10.15, macosx_*]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
         # TODO: uncomment PyPy 3.9 builds once PyPy
         # re-releases a new minor version
         # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
         python: ["cp38", "cp39", "cp310", "cp311", "pp38"] #, "pp39"]
         exclude:
-        # Don't build PyPy 32-bit windows
-        - buildplat: [windows-2019, win32]
-          python: "pp38"
-        - buildplat: [windows-2019, win32]
-          python: "pp39"
+          # Don't build PyPy 32-bit windows
+          - buildplat: [windows-2019, win32]
+            python: "pp38"
+          - buildplat: [windows-2019, win32]
+            python: "pp39"
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
@@ -106,7 +106,7 @@ jobs:
       # Used to push the built wheels
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Configure mingw for 32-bit builds
         run: |
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           # Build sdist on lowest supported Python
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Build sdist
         run: |
           python setup.py sdist

--- a/tools/gitpod/Dockerfile
+++ b/tools/gitpod/Dockerfile
@@ -53,10 +53,10 @@ RUN apt-get update && \
     texlive-latex-extra \
     vim && \
     # this needs to be done after installing dirmngr
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 && \
-    apt-add-repository https://cli.github.com/packages && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059 && \ 
+    apt-add-repository https://cli.github.com/packages && \ 
     apt-get install -yq --no-install-recommends \
-    gh && \
+    gh && \ 
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/cache/apt/* &&\


### PR DESCRIPTION
This PR adds the following

- Updates the GPG key for the gh CLI (recently changed)
- Remove deprecated syntax to set GH job outputs (see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)
- Replaces GH action workflows with a more descriptive name

Checks done:
- Docker containers build locally
- GH actions for Docker images work locally (using act)

I did not run the `build wheels` action locally -  so not skipping ci this time as I modified the workflow file