### PR TITLE
DOC: Update NEP 50 text since integer conversion errors now exist.

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -88,19 +88,20 @@ more important than the casting change itself.
     Valid values are ``weak``, ``weak_and_warn``, and ``legacy``.  Note that
     ``weak_and_warn`` implements the optional warnings proposed in this NEP
     and is expected to be *very* noisy.
-    We recommend using it mainly to track down a *specific* change rather than
-    running it on a full test-suite or program.
+    We recommend starting using the ``weak`` option and use ``weak_and_warn``
+    mainly to understand a specific observed change in behaviour.
 
-    The following further API exists:
+    The following additional API exists:
 
     * ``np._set_promotion_state()`` and ``np._get_promotion_state()`` which is
-      equivalent to the environment variable.
-    * ``with np._no_nep50_warning():`` allows to safely suppress warnings when
-      ``weak_and_warn`` promotion is used.
+      equivalent to the environment variable.  (Not thread/context safe.)
+    * ``with np._no_nep50_warning():`` allows to suppress warnings when
+      ``weak_and_warn`` promotion is used.  (Thread and context safe.)
 
-    The main *limitations* are that proposed integer errors (for example for
-    ``np.uint8(1) + 400``) are not yet given and that integer overflow warnings
-    on many scalar operations are missing.
+    At this time overflow warnings on some scalar integer operations are still
+    missing.  Further, ``np.can_cast`` fails to give warnings in the
+    ``weak_and_warn`` mode.  Its behavior with respect to Python scalar input
+    may still be in flux (this should affect very few users).
 
 
 Schema of the new proposed promotion rules


### PR DESCRIPTION
Small clarification and status update for NEP 50. ``can_cast`` still needs some thoughts, but I don't think it matters for updating the docs.

On ``can_cast``:  It probably does not always behave quite as I would like for Python scalar input.  I need to think about it a bit more, the main issue is making it well defined not just for our DTypes, but also for future user DTypes.

In case someone has quick thoughts on some questions ;):
* Should `np.can_cast(12., dtype=np.float32)` be considered a "safe" or a "same-kind" cast?  Weak promotion means we accept it as a float32 in ufuncs, but technically it is "same-kind" (both should be OK as ufuncs default to `casting="same-kind"`
* Do we want to anticipate ever changing the default assignment safety?