### PR TITLE
ENH: Allow all allocated operands in nditer/NpyIter

### DIFF
--- a/doc/release/upcoming_changes/22457.change.rst
+++ b/doc/release/upcoming_changes/22457.change.rst
@@ -1,0 +1,8 @@
+``nditer``/``NpyIter`` allows all allocating all operands
+---------------------------------------------------------
+The NumPy iterator available through `np.nditer` in Python
+and as ``NpyIter`` in C now supports allocating all arrays.
+
+The iterator shape defaults to ``()`` in this case.  The operands
+dtype must be provided, since a "common dtype" cannot be inferred
+from the other inputs.

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1225,22 +1225,6 @@ npyiter_prepare_operands(int nop, PyArrayObject **op_in,
         }
     }
 
-    /* If all the operands were NULL, it's an error */
-    if (op[0] == NULL) {
-        int all_null = 1;
-        for (iop = 1; iop < nop; ++iop) {
-            if (op[iop] != NULL) {
-                all_null = 0;
-                break;
-            }
-        }
-        if (all_null) {
-            PyErr_SetString(PyExc_ValueError,
-                    "At least one iterator operand must be non-NULL");
-            goto fail_nop;
-        }
-    }
-
     if (any_writemasked_ops && maskop < 0) {
         PyErr_SetString(PyExc_ValueError,
                 "An iterator operand was flagged as WRITEMASKED, "

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1594,11 +1594,12 @@ def test_iter_allocate_output_errors():
     # Allocated output can't have buffering without delayed bufalloc
     assert_raises(ValueError, nditer, [a, None], ['buffered'],
                                             ['allocate', 'readwrite'])
-    # Must specify at least one input
-    assert_raises(ValueError, nditer, [None, None], [],
+    # Must specify dtype if there are no inputs (cannot promote existing ones;
+    # maybe this should use the 'f4' here, but it does not historically.)
+    assert_raises(TypeError, nditer, [None, None], [],
                         [['writeonly', 'allocate'],
                          ['writeonly', 'allocate']],
-                        op_dtypes=[np.dtype('f4'), np.dtype('f4')])
+                        op_dtypes=[None, np.dtype('f4')])
     # If using op_axes, must specify all the axes
     a = arange(24, dtype='i4').reshape(2, 3, 4)
     assert_raises(ValueError, nditer, [a, None], [],
@@ -1622,6 +1623,15 @@ def test_iter_allocate_output_errors():
                         [['readonly'], ['readwrite', 'allocate']],
                         op_dtypes=[None, np.dtype('f4')],
                         op_axes=[None, [0, np.newaxis, 2]])
+
+def test_all_allocated():
+    # When no output and no shape is given, `()` is used as shape.
+    i = np.nditer([None], op_dtypes=["int64"])
+    assert i.operands[0].shape == ()
+    assert i.dtypes == (np.dtype("int64"),)
+
+    i = np.nditer([None], op_dtypes=["int64"], itershape=(2, 3, 4))
+    assert i.operands[0].shape == (2, 3, 4)
 
 def test_iter_remove_axis():
     a = arange(24).reshape(2, 3, 4)


### PR DESCRIPTION
This allows all operands to be allocated,  it is necessary to provide the dtype in this case, if missing the error changes from ``ValueError`` to ``TypeError``

Closes gh-13934, gh-15140


---

Seemed like a quick thing and stumbled on it yesterday.  I think refusing to guess the dtype (and the error change) is fine.  So we just need to be OK with defaulting to `()` for the iterator shape as the identity of broadcasting 0 arrays.

(The refusal may well due to the fact that `()` was not really supported as an iterator shape for a time...)

Ping @mhvk in case you want to have a quick look :).