### PR TITLE
MAINT: refactor mandatory npymath functions to #define macros

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -159,48 +159,46 @@ NPY_INPLACE uint8_t npy_popcountl(npy_long a);
 NPY_INPLACE uint8_t npy_popcountll(npy_longlong a);
 
 /*
- * C99 double math funcs
+ * C99 double math funcs that need fixups or are blocklist-able
  */
 NPY_INPLACE double npy_sin(double x);
 NPY_INPLACE double npy_cos(double x);
 NPY_INPLACE double npy_tan(double x);
-NPY_INPLACE double npy_sinh(double x);
-NPY_INPLACE double npy_cosh(double x);
-NPY_INPLACE double npy_tanh(double x);
-
-NPY_INPLACE double npy_asin(double x);
-NPY_INPLACE double npy_acos(double x);
-NPY_INPLACE double npy_atan(double x);
-
-NPY_INPLACE double npy_log(double x);
-NPY_INPLACE double npy_log10(double x);
-NPY_INPLACE double npy_exp(double x);
-NPY_INPLACE double npy_sqrt(double x);
-NPY_INPLACE double npy_cbrt(double x);
-
-NPY_INPLACE double npy_fabs(double x);
-NPY_INPLACE double npy_ceil(double x);
-NPY_INPLACE double npy_fmod(double x, double y);
-NPY_INPLACE double npy_floor(double x);
-
-NPY_INPLACE double npy_expm1(double x);
-NPY_INPLACE double npy_log1p(double x);
 NPY_INPLACE double npy_hypot(double x, double y);
-NPY_INPLACE double npy_acosh(double x);
-NPY_INPLACE double npy_asinh(double xx);
-NPY_INPLACE double npy_atanh(double x);
-NPY_INPLACE double npy_rint(double x);
-NPY_INPLACE double npy_trunc(double x);
-NPY_INPLACE double npy_exp2(double x);
 NPY_INPLACE double npy_log2(double x);
-
 NPY_INPLACE double npy_atan2(double x, double y);
-NPY_INPLACE double npy_pow(double x, double y);
-NPY_INPLACE double npy_modf(double x, double* y);
-NPY_INPLACE double npy_frexp(double x, int* y);
-NPY_INPLACE double npy_ldexp(double n, int y);
 
-NPY_INPLACE double npy_copysign(double x, double y);
+/* Mandatory C99 double math funcs, no blocklisting or fixups */
+/* defined for legacy reasons, should be deprecated at some point */
+#define npy_sinh sinh
+#define npy_cosh cosh
+#define npy_tanh tanh
+#define npy_asin asin
+#define npy_acos acos
+#define npy_atan atan
+#define npy_log log
+#define npy_log10 log10
+#define npy_cbrt cbrt
+#define npy_fabs fabs
+#define npy_ceil ceil
+#define npy_fmod fmod
+#define npy_floor floor
+#define npy_expm1 expm1
+#define npy_log1p log1p
+#define npy_acosh acosh
+#define npy_asinh asinh
+#define npy_atanh atanh
+#define npy_rint rint
+#define npy_trunc trunc
+#define npy_exp2 exp2
+#define npy_frexp frexp
+#define npy_ldexp ldexp
+#define npy_copysign copysign
+#define npy_exp exp
+#define npy_sqrt sqrt
+#define npy_pow pow
+#define npy_modf modf
+
 double npy_nextafter(double x, double y);
 double npy_spacing(double x);
 
@@ -260,88 +258,91 @@ double npy_spacing(double x);
 #endif
 
 /*
- * float C99 math functions
+ * float C99 math funcs that need fixups or are blocklist-able
  */
 NPY_INPLACE float npy_sinf(float x);
 NPY_INPLACE float npy_cosf(float x);
 NPY_INPLACE float npy_tanf(float x);
-NPY_INPLACE float npy_sinhf(float x);
-NPY_INPLACE float npy_coshf(float x);
-NPY_INPLACE float npy_tanhf(float x);
-NPY_INPLACE float npy_fabsf(float x);
-NPY_INPLACE float npy_floorf(float x);
-NPY_INPLACE float npy_ceilf(float x);
-NPY_INPLACE float npy_rintf(float x);
-NPY_INPLACE float npy_truncf(float x);
-NPY_INPLACE float npy_sqrtf(float x);
-NPY_INPLACE float npy_cbrtf(float x);
-NPY_INPLACE float npy_log10f(float x);
-NPY_INPLACE float npy_logf(float x);
 NPY_INPLACE float npy_expf(float x);
-NPY_INPLACE float npy_expm1f(float x);
-NPY_INPLACE float npy_asinf(float x);
-NPY_INPLACE float npy_acosf(float x);
-NPY_INPLACE float npy_atanf(float x);
-NPY_INPLACE float npy_asinhf(float x);
-NPY_INPLACE float npy_acoshf(float x);
-NPY_INPLACE float npy_atanhf(float x);
-NPY_INPLACE float npy_log1pf(float x);
-NPY_INPLACE float npy_exp2f(float x);
-NPY_INPLACE float npy_log2f(float x);
-
-NPY_INPLACE float npy_atan2f(float x, float y);
+NPY_INPLACE float npy_sqrtf(float x);
 NPY_INPLACE float npy_hypotf(float x, float y);
+NPY_INPLACE float npy_log2f(float x);
+NPY_INPLACE float npy_atan2f(float x, float y);
 NPY_INPLACE float npy_powf(float x, float y);
-NPY_INPLACE float npy_fmodf(float x, float y);
-
 NPY_INPLACE float npy_modff(float x, float* y);
-NPY_INPLACE float npy_frexpf(float x, int* y);
-NPY_INPLACE float npy_ldexpf(float x, int y);
 
-NPY_INPLACE float npy_copysignf(float x, float y);
+/* Mandatory C99 float math funcs, no blocklisting or fixups */
+/* defined for legacy reasons, should be deprecated at some point */
+
+#define npy_sinhf sinhf
+#define npy_coshf coshf
+#define npy_tanhf tanhf
+#define npy_asinf asinf
+#define npy_acosf acosf
+#define npy_atanf atanf
+#define npy_logf logf
+#define npy_log10f log10f
+#define npy_cbrtf cbrtf
+#define npy_fabsf fabsf
+#define npy_ceilf ceilf
+#define npy_fmodf fmodf
+#define npy_floorf floorf
+#define npy_expm1f expm1f
+#define npy_log1pf log1pf
+#define npy_asinhf asinhf
+#define npy_acoshf acoshf
+#define npy_atanhf atanhf
+#define npy_rintf rintf
+#define npy_truncf truncf
+#define npy_exp2f exp2f
+#define npy_frexpf frexpf
+#define npy_ldexpf ldexpf
+#define npy_copysignf copysignf
+
 float npy_nextafterf(float x, float y);
 float npy_spacingf(float x);
 
 /*
- * long double C99 math functions
+ * long double C99 double math funcs that need fixups or are blocklist-able
  */
 NPY_INPLACE npy_longdouble npy_sinl(npy_longdouble x);
 NPY_INPLACE npy_longdouble npy_cosl(npy_longdouble x);
 NPY_INPLACE npy_longdouble npy_tanl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_sinhl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_coshl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_tanhl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_fabsl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_floorl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_ceill(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_rintl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_truncl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_sqrtl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_cbrtl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_log10l(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_logl(npy_longdouble x);
 NPY_INPLACE npy_longdouble npy_expl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_expm1l(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_asinl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_acosl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_atanl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_asinhl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_acoshl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_atanhl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_log1pl(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_exp2l(npy_longdouble x);
-NPY_INPLACE npy_longdouble npy_log2l(npy_longdouble x);
-
-NPY_INPLACE npy_longdouble npy_atan2l(npy_longdouble x, npy_longdouble y);
+NPY_INPLACE npy_longdouble npy_sqrtl(npy_longdouble x);
 NPY_INPLACE npy_longdouble npy_hypotl(npy_longdouble x, npy_longdouble y);
+NPY_INPLACE npy_longdouble npy_log2l(npy_longdouble x);
+NPY_INPLACE npy_longdouble npy_atan2l(npy_longdouble x, npy_longdouble y);
 NPY_INPLACE npy_longdouble npy_powl(npy_longdouble x, npy_longdouble y);
-NPY_INPLACE npy_longdouble npy_fmodl(npy_longdouble x, npy_longdouble y);
-
 NPY_INPLACE npy_longdouble npy_modfl(npy_longdouble x, npy_longdouble* y);
-NPY_INPLACE npy_longdouble npy_frexpl(npy_longdouble x, int* y);
-NPY_INPLACE npy_longdouble npy_ldexpl(npy_longdouble x, int y);
 
-NPY_INPLACE npy_longdouble npy_copysignl(npy_longdouble x, npy_longdouble y);
+/* Mandatory C99 double math funcs, no blocklisting or fixups */
+/* defined for legacy reasons, should be deprecated at some point */
+#define npy_sinhl sinhl
+#define npy_coshl coshl
+#define npy_tanhl tanhl
+#define npy_fabsl fabsl
+#define npy_floorl floorl
+#define npy_ceill ceill
+#define npy_rintl rintl
+#define npy_truncl truncl
+#define npy_cbrtl cbrtl
+#define npy_log10l log10l
+#define npy_logl logl
+#define npy_expm1l expm1l
+#define npy_asinl asinl
+#define npy_acosl acosl
+#define npy_atanl atanl
+#define npy_asinhl asinhl
+#define npy_acoshl acoshl
+#define npy_atanhl atanhl
+#define npy_log1pl log1pl
+#define npy_exp2l exp2l
+#define npy_fmodl fmodl
+#define npy_frexpl frexpl
+#define npy_ldexpl ldexpl
+#define npy_copysignl copysignl
+
 npy_longdouble npy_nextafterl(npy_longdouble x, npy_longdouble y);
 npy_longdouble npy_spacingl(npy_longdouble x);
 

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -122,6 +122,8 @@ for file in [
             set_sig(line)
 
 # Mandatory functions: if not found, fail the build
+# Some of these can still be blocklisted if the C99 implementation
+# is buggy, see numpy/core/src/common/npy_config.h
 MANDATORY_FUNCS = [
     "sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs",
     "floor", "ceil", "sqrt", "log10", "log", "exp", "asin",

--- a/numpy/core/src/npymath/ieee754.cpp
+++ b/numpy/core/src/npymath/ieee754.cpp
@@ -9,18 +9,6 @@
 #include "npy_math_common.h"
 #include "npy_math_private.h"
 
-#ifndef HAVE_COPYSIGN
-double
-npy_copysign(double x, double y)
-{
-    npy_uint32 hx, hy;
-    GET_HIGH_WORD(hx, x);
-    GET_HIGH_WORD(hy, y);
-    SET_HIGH_WORD(x, (hx & 0x7fffffff) | (hy & 0x80000000));
-    return x;
-}
-#endif
-
 /*
  The below code is provided for compilers which do not yet provide C11
  compatibility (gcc 4.5 and older)

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -87,27 +87,6 @@ static const npy_uint64 MAGIC64[] = {0x5555555555555555ull, 0x3333333333333333ul
  *****************************************************************************
  */
 
-/* The double variant for these functions are never blocked */
-
-NPY_INPLACE double npy_exp(double x){
-    return exp(x);
-}
-
-NPY_INPLACE double npy_pow(double x, double y)
-{
-    return pow(x, y);
-}
-
-NPY_INPLACE double npy_sqrt(double x)
-{
-    return sqrt(x);
-}
-
-NPY_INPLACE double npy_modf(double x, double *iptr)
-{
-    return modf(x, iptr);
-}
-
 /* The following functions can be blocked, even for doubles */
 
 /* Original code by Konrad Hinsen.  */
@@ -320,9 +299,8 @@ NPY_INPLACE double npy_hypot(double x, double y)
 #endif
 
 /**begin repeat1
- * #kind = sin,cos,tan,sinh,cosh,tanh,fabs,floor,ceil,rint,trunc,log10,
- *         log,expm1,asin,acos,atan,asinh,acosh,atanh,log1p,exp2#
- * #TRIG_WORKAROUND = WORKAROUND_APPLE_TRIG_BUG*3, 0*19#
+ * #kind = sin,cos,tan#
+ * #TRIG_WORKAROUND = WORKAROUND_APPLE_TRIG_BUG*3#
  */
 NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
 {
@@ -337,33 +315,6 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
 /**end repeat1**/
 
 #undef WORKAROUND_APPLE_TRIG_BUG
-
-/* C99 mandatory */
-
-/**begin repeat1
- * #kind = fmod,copysign#
- * #KIND = FMOD,COPYSIGN#
- */
-NPY_INPLACE @type@ npy_@kind@@c@(@type@ x, @type@ y)
-{
-    return NPY__FP_SFX(@kind@)(x, y);
-}
-/**end repeat1**/
-
-NPY_INPLACE @type@ npy_ldexp@c@(@type@ x, int exp)
-{
-    return NPY__FP_SFX(ldexp)(x, exp);
-}
-
-NPY_INPLACE @type@ npy_frexp@c@(@type@ x, int* exp)
-{
-    return NPY__FP_SFX(frexp)(x, exp);
-}
-
-NPY_INPLACE @type@ npy_cbrt@c@(@type@ x)
-{
-    return NPY__FP_SFX(cbrt)(x);
-}
 
 /**end repeat**/
 


### PR DESCRIPTION
Another cleanup of npymath, this time convert the mandatory C99 double, float, and long double math functions to defines.

One thought we had in #20880 was to make npymath source only. It has 6 source files and various headers, these are the functions still exported.

<details><summary>`npymath` functions in the library</summary>

```
$ nm build/temp.linux-x86_64-cpython-38/libnpymath.a |grep "\(\.o\)\| T "
npy_math.o:
0000000000000000 T npy_atan2
0000000000000000 T npy_atan2f
0000000000000000 T npy_atan2l
0000000000000000 T npy_cos
0000000000000000 T npy_cosf
0000000000000000 T npy_cosl
0000000000000000 T npy_deg2rad
0000000000000000 T npy_deg2radf
0000000000000000 T npy_deg2radl
0000000000000000 T npy_divmod
0000000000000000 T npy_divmodf
0000000000000000 T npy_divmodl
0000000000000000 T npy_exp2_m1
0000000000000000 T npy_exp2_m1f
0000000000000000 T npy_exp2_m1l
0000000000000000 T npy_expf
0000000000000000 T npy_expl
0000000000000000 T npy_floor_divide
0000000000000000 T npy_floor_dividef
0000000000000000 T npy_floor_dividel
0000000000000000 T npy_gcd
0000000000000000 T npy_gcdl
0000000000000000 T npy_gcdll
0000000000000000 T npy_gcdu
0000000000000000 T npy_gcdul
0000000000000000 T npy_gcdull
0000000000000000 T npy_heaviside
0000000000000000 T npy_heavisidef
0000000000000000 T npy_heavisidel
0000000000000000 T npy_hypot
0000000000000000 T npy_hypotf
0000000000000000 T npy_hypotl
0000000000000000 T npy_lcm
0000000000000000 T npy_lcml
0000000000000000 T npy_lcmll
0000000000000000 T npy_lcmu
0000000000000000 T npy_lcmul
0000000000000000 T npy_lcmull
0000000000000000 T npy_log2
0000000000000000 T npy_log2_1p
0000000000000000 T npy_log2_1pf
0000000000000000 T npy_log2_1pl
0000000000000000 T npy_log2f
0000000000000000 T npy_log2l
0000000000000000 T npy_logaddexp
0000000000000000 T npy_logaddexp2
0000000000000000 T npy_logaddexp2f
0000000000000000 T npy_logaddexp2l
0000000000000000 T npy_logaddexpf
0000000000000000 T npy_logaddexpl
0000000000000000 T npy_lshift
0000000000000000 T npy_lshifth
0000000000000000 T npy_lshifthh
0000000000000000 T npy_lshiftl
0000000000000000 T npy_lshiftll
0000000000000000 T npy_lshiftu
0000000000000000 T npy_lshiftuh
0000000000000000 T npy_lshiftuhh
0000000000000000 T npy_lshiftul
0000000000000000 T npy_lshiftull
0000000000000000 T npy_modff
0000000000000000 T npy_modfl
0000000000000000 T npy_popcount
0000000000000000 T npy_popcounth
0000000000000000 T npy_popcounthh
0000000000000000 T npy_popcountl
0000000000000000 T npy_popcountll
0000000000000000 T npy_popcount_parallel
0000000000000000 T npy_popcount_parallelh
0000000000000000 T npy_popcount_parallelhh
0000000000000000 T npy_popcount_parallell
0000000000000000 T npy_popcount_parallelll
0000000000000000 T npy_popcountu
0000000000000000 T npy_popcountuh
0000000000000000 T npy_popcountuhh
0000000000000000 T npy_popcountul
0000000000000000 T npy_popcountull
0000000000000000 T npy_powf
0000000000000000 T npy_powl
0000000000000000 T npy_rad2deg
0000000000000000 T npy_rad2degf
0000000000000000 T npy_rad2degl
0000000000000000 T npy_remainder
0000000000000000 T npy_remainderf
0000000000000000 T npy_remainderl
0000000000000000 T npy_rshift
0000000000000000 T npy_rshifth
0000000000000000 T npy_rshifthh
0000000000000000 T npy_rshiftl
0000000000000000 T npy_rshiftll
0000000000000000 T npy_rshiftu
0000000000000000 T npy_rshiftuh
0000000000000000 T npy_rshiftuhh
0000000000000000 T npy_rshiftul
0000000000000000 T npy_rshiftull
0000000000000000 T npy_sin
0000000000000000 T npy_sinf
0000000000000000 T npy_sinl
0000000000000000 T npy_sqrtf
0000000000000000 T npy_sqrtl
0000000000000000 T npy_tan
0000000000000000 T npy_tanf
0000000000000000 T npy_tanl
ieee754.o:
0000000000000000 T npy_clear_floatstatus
0000000000000000 T npy_clear_floatstatus_barrier
0000000000000000 T npy_get_floatstatus
0000000000000000 T npy_get_floatstatus_barrier
0000000000000000 T npy_nextafter
0000000000000000 T npy_nextafterf
0000000000000000 T npy_nextafterl
0000000000000000 T npy_set_floatstatus_divbyzero
0000000000000000 T npy_set_floatstatus_invalid
0000000000000000 T npy_set_floatstatus_overflow
0000000000000000 T npy_set_floatstatus_underflow
0000000000000000 T npy_spacing
0000000000000000 T npy_spacingf
0000000000000000 T npy_spacingl
npy_math_complex.o:
0000000000000000 T npy_cabs
0000000000000000 T npy_cabsf
0000000000000000 T npy_cabsl
0000000000000000 T npy_cacos
0000000000000000 T npy_cacosf
0000000000000000 T npy_cacosh
0000000000000000 T npy_cacoshf
0000000000000000 T npy_cacoshl
0000000000000000 T npy_cacosl
0000000000000000 T npy_carg
0000000000000000 T npy_cargf
0000000000000000 T npy_cargl
0000000000000000 T npy_casin
0000000000000000 T npy_casinf
0000000000000000 T npy_casinh
0000000000000000 T npy_casinhf
0000000000000000 T npy_casinhl
0000000000000000 T npy_casinl
0000000000000000 T npy_catan
0000000000000000 T npy_catanf
0000000000000000 T npy_catanh
0000000000000000 T npy_catanhf
0000000000000000 T npy_catanhl
0000000000000000 T npy_catanl
0000000000000000 T npy_ccos
0000000000000000 T npy_ccosf
0000000000000000 T npy_ccosh
0000000000000000 T npy_ccoshf
0000000000000000 T npy_ccoshl
0000000000000000 T npy_ccosl
0000000000000000 T npy_cexp
0000000000000000 T npy_cexpf
0000000000000000 T npy_cexpl
0000000000000000 T npy_clog
0000000000000000 T npy_clogf
0000000000000000 T npy_clogl
0000000000000000 T npy_cpow
0000000000000000 T npy_cpowf
0000000000000000 T npy_cpowl
0000000000000000 T npy_csin
0000000000000000 T npy_csinf
0000000000000000 T npy_csinh
0000000000000000 T npy_csinhf
0000000000000000 T npy_csinhl
0000000000000000 T npy_csinl
0000000000000000 T npy_csqrt
0000000000000000 T npy_csqrtf
0000000000000000 T npy_csqrtl
0000000000000000 T npy_ctan
0000000000000000 T npy_ctanf
0000000000000000 T npy_ctanh
0000000000000000 T npy_ctanhf
0000000000000000 T npy_ctanhl
0000000000000000 T npy_ctanl
halffloat.o:
0000000000000000 T npy_doublebits_to_halfbits
0000000000000000 T npy_double_to_half
0000000000000000 T npy_floatbits_to_halfbits
0000000000000000 T npy_float_to_half
0000000000000000 T npy_halfbits_to_doublebits
0000000000000000 T npy_halfbits_to_floatbits
0000000000000000 T npy_half_copysign
0000000000000000 T npy_half_divmod
0000000000000000 T npy_half_eq
0000000000000000 T npy_half_eq_nonan
0000000000000000 T npy_half_ge
0000000000000000 T npy_half_gt
0000000000000000 T npy_half_isfinite
0000000000000000 T npy_half_isinf
0000000000000000 T npy_half_isnan
0000000000000000 T npy_half_iszero
0000000000000000 T npy_half_le
0000000000000000 T npy_half_le_nonan
0000000000000000 T npy_half_lt
0000000000000000 T npy_half_lt_nonan
0000000000000000 T npy_half_ne
0000000000000000 T npy_half_nextafter
0000000000000000 T npy_half_signbit
0000000000000000 T npy_half_spacing
0000000000000000 T npy_half_to_double
0000000000000000 T npy_half_to_float
```
