### PR TITLE
MAINT: Ensure that fmin loops do not show up multiple times

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -545,16 +545,14 @@ defdict = {
     Ufunc(2, 1, ReorderableNone,
           docstrings.get('numpy.core.umath.fmax'),
           'PyUFunc_SimpleUniformOperationTypeResolver',
-          TD('fdg', dispatch=[('loops_minmax', 'fdg')]),
-          TD(noobj),
+          TD(noobj, dispatch=[('loops_minmax', 'fdg')]),
           TD(O, f='npy_ObjectMax')
           ),
 'fmin':
     Ufunc(2, 1, ReorderableNone,
           docstrings.get('numpy.core.umath.fmin'),
           'PyUFunc_SimpleUniformOperationTypeResolver',
-          TD('fdg', dispatch=[('loops_minmax', 'fdg')]),
-          TD(noobj),
+          TD(noobj, dispatch=[('loops_minmax', 'fdg')]),
           TD(O, f='npy_ObjectMin')
           ),
 'logaddexp':


### PR DESCRIPTION
This is not problematic for NumPy, because fmin/fmax have a custom type resolver, however, Numba relies on the order (they should not ideally, but probably have little choice currently). Even without Numba, having the multiple loops is not nice though.

Closes gh-22376