### PR TITLE
BUG: -unsigned_int(0) no overflow warning

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -98,7 +98,7 @@ more important than the casting change itself.
     * ``with np._no_nep50_warning():`` allows to suppress warnings when
       ``weak_and_warn`` promotion is used.  (Thread and context safe.)
 
-    At this time overflow warnings on integer power missing.
+    At this time overflow warnings on integer power are missing.
     Further, ``np.can_cast`` fails to give warnings in the
     ``weak_and_warn`` mode.  Its behavior with respect to Python scalar input
     may still be in flux (this should affect very few users).

--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -98,8 +98,8 @@ more important than the casting change itself.
     * ``with np._no_nep50_warning():`` allows to suppress warnings when
       ``weak_and_warn`` promotion is used.  (Thread and context safe.)
 
-    At this time overflow warnings on some scalar integer operations are still
-    missing.  Further, ``np.can_cast`` fails to give warnings in the
+    At this time overflow warnings on integer power missing.
+    Further, ``np.can_cast`` fails to give warnings in the
     ``weak_and_warn`` mode.  Its behavior with respect to Python scalar input
     may still be in flux (this should affect very few users).
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -532,9 +532,12 @@ static NPY_INLINE int
         *out = a;
         return NPY_FPE_OVERFLOW;
     }
-#endif
     *out = -a;
     return 0;
+#else  /* floats */
+    *out = -a;
+    return 0;
+#endif
 }
 /**end repeat**/
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -523,9 +523,12 @@ static NPY_INLINE int
 {
 #if @uns@
     *out = -a;
+    if (a == 0) {
+        return 0;
+    }
     return NPY_FPE_OVERFLOW;
 #elif @int@
-    if(a == NPY_MIN_@NAME@){
+    if (a == NPY_MIN_@NAME@){
         *out = a;
         return NPY_FPE_OVERFLOW;
     }

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -923,6 +923,8 @@ def test_scalar_unsigned_integer_overflow(dtype):
     with pytest.warns(RuntimeWarning, match="overflow encountered"):
         -val
 
+    zero = np.dtype(dtype).type(0)
+    -zero  # does not warn
 
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
 @pytest.mark.parametrize("operation", [


### PR DESCRIPTION
There is no reason `-np.uint8(0)`, etc. should give a warning.

Also removes a compile time warning (on clang at least).  The reason for this was checking which integer operations are missing the warnings.
It seems the only one is now the `**` operator but adding it there should be a separate PR, and needs a bit of thought.