### PR TITLE
DOC: fix typo in advanced_debugging.rst [skip ci]

### DIFF
--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -23,7 +23,7 @@ But for example memory leaks can be particularly subtle or difficult to
 narrow down.
 
 We do not expect any of these tools to be run by most contributors.
-However, you can ensure that we can track down such issues more easily easier:
+However, you can ensure that we can track down such issues more easily:
 
 * Tests should cover all code paths, including error paths.
 * Try to write short and simple tests. If you have a very complicated test


### PR DESCRIPTION
It came across my sight when I 'm learning the debugging methods on this page.

I don't know whether fixing typo deserves a PR, but I decided to give it a try.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
