### PR TITLE
MAINT: change subprocess arguments from Python>=3.7

### DIFF
--- a/benchmarks/asv_pip_nopep517.py
+++ b/benchmarks/asv_pip_nopep517.py
@@ -5,7 +5,7 @@ import subprocess, sys
 # pip ignores '--global-option' when pep517 is enabled therefore we disable it.
 cmd = [sys.executable, '-mpip', 'wheel', '--no-use-pep517']
 try:
-    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
 except Exception as e:
     output = str(e.output)
 if "no such option" in output:

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -747,7 +747,7 @@ class _Distutils:
     def _dist_test_spawn(cmd, display=None):
         try:
             o = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                        universal_newlines=True)
+                                        text=True)
             if o and re.match(_Distutils._dist_warn_regex, o):
                 _Distutils.dist_error(
                     "Flags in command", cmd ,"aren't supported by the compiler"

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -276,14 +276,13 @@ def _exec_command(command, use_shell=None, use_tee = None, **env):
     # Inherit environment by default
     env = env or None
     try:
-        # universal_newlines is set to False so that communicate()
+        # text is set to False so that communicate()
         # will return bytes. We need to decode the output ourselves
         # so that Python will not raise a UnicodeDecodeError when
         # it encounters an invalid character; rather, we simply replace it
-        proc = subprocess.Popen(command, shell=use_shell, env=env,
+        proc = subprocess.Popen(command, shell=use_shell, env=env, text=False,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT,
-                                universal_newlines=False)
+                                stderr=subprocess.STDOUT)
     except OSError:
         # Return 127, as os.spawn*() and /bin/sh do
         return 127, ''

--- a/numpy/distutils/lib2def.py
+++ b/numpy/distutils/lib2def.py
@@ -64,7 +64,7 @@ def getnm(nm_cmd=['nm', '-Cs', 'python%s.lib' % py_ver], shell=True):
 
 nm_output = getnm(nm_cmd = 'nm -Cs py_lib')"""
     p = subprocess.Popen(nm_cmd, shell=shell, stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE, universal_newlines=True)
+                         stderr=subprocess.PIPE, text=True)
     nm_output, nm_err = p.communicate()
     if p.returncode != 0:
         raise RuntimeError('failed to run "%s": "%s"' % (

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -416,7 +416,7 @@ def cyg2win32(path: str) -> str:
     if sys.platform != "cygwin":
         return path
     return subprocess.check_output(
-        ["/usr/bin/cygpath", "--windows", path], universal_newlines=True
+        ["/usr/bin/cygpath", "--windows", path], text=True
     )
 
 

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -104,8 +104,7 @@ def compile(source,
              '-c',
              'import numpy.f2py as f2py2e;f2py2e.main()'] + args
         try:
-            cp = subprocess.run(c, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+            cp = subprocess.run(c, capture_output=True)
         except OSError:
             # preserve historic status code used by exec_command()
             cp = subprocess.CompletedProcess(c, 127, stdout=b'', stderr=b'')

--- a/setup.py
+++ b/setup.py
@@ -219,8 +219,8 @@ def get_build_overrides():
             return False
 
         # will print something like '4.2.1\n'
-        out = subprocess.run([cc, '-dumpversion'], stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
+        out = subprocess.run([cc, '-dumpversion'],
+                             capture_output=True, text=True)
         # -std=c99 is default from this version on
         if _pep440.parse(out.stdout) >= _pep440.Version('5.0'):
             return False


### PR DESCRIPTION
This PR updates some of the arguments for [subprocess](https://docs.python.org/3/library/subprocess.html) introduced from Python 3.7:

- Change parameter `universal_newlines` to the more understandable `text` alias
- Use `capture_output=True` when both `stdout=PIPE` and `stderr=PIPE` are specified with `run`