### PR TITLE
MAINT, CI: Switch to cygwin/cygwin-install-action@v2

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -27,9 +27,9 @@ jobs:
           submodules: recursive
           fetch-depth: 3000
       - name: Install Cygwin
-        uses: egor-tensin/setup-cygwin@v3
+        uses: cygwin/cygwin-install-action@v2
         with:
-          platform: x64
+          platform: x86_64
           install-dir: 'C:\tools\cygwin'
           packages: >-
             python38-devel python38-zipp python38-importlib-metadata


### PR DESCRIPTION
egor-tensin/setup-cygwin@v3 was crashing with chocolatey 1.2.0; let's see if this gets CI passing again.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
