### PR TITLE
TST, MAINT: Replace most setup with setup_method (also teardown)

### DIFF
--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -178,30 +178,33 @@ Similarly for methods::
 Easier setup and teardown functions / methods
 ---------------------------------------------
 
-Testing looks for module-level or class-level setup and teardown functions by
-name; thus::
+Testing looks for module-level or class method-level setup and teardown
+functions by name; thus::
 
-  def setup():
+  def setup_module():
       """Module-level setup"""
       print('doing setup')
 
-  def teardown():
+  def teardown_module():
       """Module-level teardown"""
       print('doing teardown')
 
 
   class TestMe:
-      def setup():
+      def setup_method(self):
           """Class-level setup"""
           print('doing setup')
 
-      def teardown():
+      def teardown_method():
           """Class-level teardown"""
           print('doing teardown')
 
 
 Setup and teardown functions to functions and methods are known as "fixtures",
-and their use is not encouraged.
+and they should be used sparingly.
+``pytest`` supports more general fixture at various scopes which may be used
+automatically via special arguments.  For example,  the special argument name
+``tmpdir`` is used in test to create a temporary directory.
 
 Parametric tests
 ----------------

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -498,10 +498,10 @@ class TestArray2String:
 class TestPrintOptions:
     """Test getting and setting global print options."""
 
-    def setup(self):
+    def setup_method(self):
         self.oldopts = np.get_printoptions()
 
-    def teardown(self):
+    def teardown_method(self):
         np.set_printoptions(**self.oldopts)
 
     def test_basic(self):

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -132,7 +132,7 @@ class TestVecString:
 
 
 class TestWhitespace:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([['abc ', '123  '],
                            ['789 ', 'xyz ']]).view(np.chararray)
         self.B = np.array([['abc', '123'],
@@ -147,7 +147,7 @@ class TestWhitespace:
         assert_(not np.any(self.A != self.B))
 
 class TestChar:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array('abc1', dtype='c').view(np.chararray)
 
     def test_it(self):
@@ -155,7 +155,7 @@ class TestChar:
         assert_equal(self.A.upper()[:2].tobytes(), b'AB')
 
 class TestComparisons:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']]).view(np.chararray)
         self.B = np.array([['efg', '123  '],
@@ -188,21 +188,21 @@ class TestComparisons:
 class TestComparisonsMixed1(TestComparisons):
     """Ticket #1276"""
 
-    def setup(self):
-        TestComparisons.setup(self)
+    def setup_method(self):
+        TestComparisons.setup_method(self)
         self.B = np.array([['efg', '123  '],
                            ['051', 'tuv']], np.unicode_).view(np.chararray)
 
 class TestComparisonsMixed2(TestComparisons):
     """Ticket #1276"""
 
-    def setup(self):
-        TestComparisons.setup(self)
+    def setup_method(self):
+        TestComparisons.setup_method(self)
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']], np.unicode_).view(np.chararray)
 
 class TestInformation:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']]).view(np.chararray)
@@ -308,7 +308,7 @@ class TestInformation:
 
 
 class TestMethods:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']],
@@ -581,7 +581,7 @@ class TestMethods:
 
 
 class TestOperations:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']]).view(np.chararray)
         self.B = np.array([['efg', '456'],

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -32,7 +32,7 @@ class _DeprecationTestCase:
     message = ''
     warning_cls = DeprecationWarning
 
-    def setup(self):
+    def setup_method(self):
         self.warn_ctx = warnings.catch_warnings(record=True)
         self.log = self.warn_ctx.__enter__()
 
@@ -46,7 +46,7 @@ class _DeprecationTestCase:
         warnings.filterwarnings("always", message=self.message,
                                 category=self.warning_cls)
 
-    def teardown(self):
+    def teardown_method(self):
         self.warn_ctx.__exit__()
 
     def assert_deprecated(self, function, num=1, ignore_others=False,
@@ -297,7 +297,7 @@ class TestDTypeAttributeIsDTypeDeprecation(_DeprecationTestCase):
 class TestTestDeprecated:
     def test_assert_deprecated(self):
         test_case_instance = _DeprecationTestCase()
-        test_case_instance.setup()
+        test_case_instance.setup_method()
         assert_raises(AssertionError,
                       test_case_instance.assert_deprecated,
                       lambda: None)
@@ -306,7 +306,7 @@ class TestTestDeprecated:
             warnings.warn("foo", category=DeprecationWarning, stacklevel=2)
 
         test_case_instance.assert_deprecated(foo)
-        test_case_instance.teardown()
+        test_case_instance.teardown_method()
 
 
 class TestNonNumericConjugate(_DeprecationTestCase):

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -17,7 +17,7 @@ def assert_raises_fpe(strmatch, callable, *args, **kwargs):
                 "Did not raise floating point %s error" % strmatch)
 
 class TestHalf:
-    def setup(self):
+    def setup_method(self):
         # An array of all possible float16 values
         self.all_f16 = np.arange(0x10000, dtype=uint16)
         self.all_f16.dtype = float16

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -826,7 +826,7 @@ class TestMultiIndexingAutomated:
 
     """
 
-    def setup(self):
+    def setup_method(self):
         self.a = np.arange(np.prod([3, 1, 5, 6])).reshape(3, 1, 5, 6)
         self.b = np.empty((3, 0, 5, 6))
         self.complex_indices = ['skip', Ellipsis,

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -15,14 +15,14 @@ from numpy.testing import (
     )
 
 class TestMemmap:
-    def setup(self):
+    def setup_method(self):
         self.tmpfp = NamedTemporaryFile(prefix='mmap')
         self.shape = (3, 4)
         self.dtype = 'float32'
         self.data = arange(12, dtype=self.dtype)
         self.data.resize(self.shape)
 
-    def teardown(self):
+    def teardown_method(self):
         self.tmpfp.close()
         self.data = None
         if IS_PYPY:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -74,7 +74,7 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
 
 
 class TestFlags:
-    def setup(self):
+    def setup_method(self):
         self.a = np.arange(10)
 
     def test_writeable(self):
@@ -275,7 +275,7 @@ class TestHash:
 
 
 class TestAttributes:
-    def setup(self):
+    def setup_method(self):
         self.one = np.arange(10)
         self.two = np.arange(20).reshape(4, 5)
         self.three = np.arange(60, dtype=np.float64).reshape(2, 5, 6)
@@ -652,7 +652,7 @@ class TestDtypedescr:
 
 
 class TestZeroRank:
-    def setup(self):
+    def setup_method(self):
         self.d = np.array(0), np.array('x', object)
 
     def test_ellipsis_subscript(self):
@@ -756,7 +756,7 @@ class TestZeroRank:
 
 
 class TestScalarIndexing:
-    def setup(self):
+    def setup_method(self):
         self.d = np.array([0, 1])[0]
 
     def test_ellipsis_subscript(self):
@@ -5672,7 +5672,7 @@ class TestFromBuffer:
             mm.close()
 
 class TestFlat:
-    def setup(self):
+    def setup_method(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)
         a0.shape = (4, 5)
@@ -5995,7 +5995,7 @@ class TestStats:
 
     funcs = [_mean, _var, _std]
 
-    def setup(self):
+    def setup_method(self):
         np.random.seed(range(3))
         self.rmat = np.random.random((4, 5))
         self.cmat = self.rmat + 1j * self.rmat
@@ -6422,7 +6422,7 @@ class TestVdot:
 
 
 class TestDot:
-    def setup(self):
+    def setup_method(self):
         np.random.seed(128)
         self.A = np.random.rand(4, 2)
         self.b1 = np.random.rand(2, 1)
@@ -7214,7 +7214,7 @@ class TestInner:
 
 
 class TestChoose:
-    def setup(self):
+    def setup_method(self):
         self.x = 2*np.ones((3,), dtype=int)
         self.y = 3*np.ones((3,), dtype=int)
         self.x2 = 2*np.ones((2, 3), dtype=int)
@@ -7244,7 +7244,7 @@ class TestChoose:
 
 
 class TestRepeat:
-    def setup(self):
+    def setup_method(self):
         self.m = np.array([1, 2, 3, 4, 5, 6])
         self.m_rect = self.m.reshape((2, 3))
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -347,7 +347,7 @@ class TestBoolScalar:
 
 
 class TestBoolArray:
-    def setup(self):
+    def setup_method(self):
         # offset for simd tests
         self.t = np.array([True] * 41, dtype=bool)[1::]
         self.f = np.array([False] * 41, dtype=bool)[1::]
@@ -434,7 +434,7 @@ class TestBoolArray:
 
 
 class TestBoolCmp:
-    def setup(self):
+    def setup_method(self):
         self.f = np.ones(256, dtype=np.float32)
         self.ef = np.ones(self.f.size, dtype=bool)
         self.d = np.ones(128, dtype=np.float64)
@@ -1813,7 +1813,7 @@ def assert_array_strict_equal(x, y):
 
 
 class TestClip:
-    def setup(self):
+    def setup_method(self):
         self.nr = 5
         self.nc = 3
 
@@ -2442,10 +2442,10 @@ class TestAllclose:
     rtol = 1e-5
     atol = 1e-8
 
-    def setup(self):
+    def setup_method(self):
         self.olderr = np.seterr(invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.olderr)
 
     def tst_allclose(self, x, y):
@@ -2527,7 +2527,7 @@ class TestIsclose:
     rtol = 1e-5
     atol = 1e-8
 
-    def setup(self):
+    def _setup(self):
         atol = self.atol
         rtol = self.rtol
         arr = np.array([100, 1000])
@@ -2573,7 +2573,7 @@ class TestIsclose:
                 ]
 
     def test_ip_isclose(self):
-        self.setup()
+        self._setup()
         tests = self.some_close_tests
         results = self.some_close_results
         for (x, y), result in zip(tests, results):
@@ -2595,17 +2595,17 @@ class TestIsclose:
             assert_array_equal(np.isclose(x, y).all(), np.allclose(x, y), msg % (x, y))
 
     def test_ip_all_isclose(self):
-        self.setup()
+        self._setup()
         for (x, y) in self.all_close_tests:
             self.tst_all_isclose(x, y)
 
     def test_ip_none_isclose(self):
-        self.setup()
+        self._setup()
         for (x, y) in self.none_close_tests:
             self.tst_none_isclose(x, y)
 
     def test_ip_isclose_allclose(self):
-        self.setup()
+        self._setup()
         tests = (self.all_close_tests + self.none_close_tests +
                  self.some_close_tests)
         for (x, y) in tests:
@@ -2671,7 +2671,7 @@ class TestIsclose:
 
 
 class TestStdVar:
-    def setup(self):
+    def setup_method(self):
         self.A = np.array([1, -1, 1, -1])
         self.real_var = 1
 
@@ -2724,7 +2724,7 @@ class TestStdVarComplex:
 class TestCreationFuncs:
     # Test ones, zeros, empty and full.
 
-    def setup(self):
+    def setup_method(self):
         dtypes = {np.dtype(tp) for tp in itertools.chain(*np.sctypes.values())}
         # void, bytes, str
         variable_sized = {tp for tp in dtypes if tp.str.endswith('0')}
@@ -2795,7 +2795,7 @@ class TestCreationFuncs:
 class TestLikeFuncs:
     '''Test ones_like, zeros_like, empty_like and full_like'''
 
-    def setup(self):
+    def setup_method(self):
         self.data = [
                 # Array scalars
                 (np.array(3.), None),

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -357,7 +357,7 @@ class TestCommonType:
         assert_(res == 'f8')
 
 class TestMultipleFields:
-    def setup(self):
+    def setup_method(self):
         self.ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
 
     def _bad_call(self):

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -431,7 +431,7 @@ class TestNumPyFunctions:
 
 
 class TestArrayLike:
-    def setup(self):
+    def setup_method(self):
         class MyArray():
             def __init__(self, function=None):
                 self.function = function

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -337,7 +337,7 @@ class TestPathUsage:
 
 
 class TestRecord:
-    def setup(self):
+    def setup_method(self):
         self.data = np.rec.fromrecords([(1, 2, 3), (4, 5, 6)],
                             dtype=[("col1", "<i4"),
                                    ("col2", "<i4"),

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -103,10 +103,10 @@ def bad_arcsinh():
 
 
 class _FilterInvalids:
-    def setup(self):
+    def setup_method(self):
         self.olderr = np.seterr(invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.olderr)
 
 

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -354,10 +354,10 @@ class TestCsqrt:
         # cuts first)
 
 class TestCpow:
-    def setup(self):
+    def setup_method(self):
         self.olderr = np.seterr(invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.olderr)
 
     def test_simple(self):
@@ -407,10 +407,10 @@ class TestCpow:
             assert_almost_equal(n_r[i], p_r[i], err_msg='Loop %d\n' % i)
 
 class TestCabs:
-    def setup(self):
+    def setup_method(self):
         self.olderr = np.seterr(invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.olderr)
 
     def test_simple(self):

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -78,7 +78,7 @@ class _Test_CCompilerOpt:
     arch = None # x86_64
     cc   = None # gcc
 
-    def setup(self):
+    def setup_class(self):
         FakeCCompilerOpt.conf_nocache = True
         self._opt = None
 
@@ -780,7 +780,7 @@ def new_test(arch, cc):
         cc   = '{cc}'
         def __init__(self, methodName="runTest"):
             unittest.TestCase.__init__(self, methodName)
-            self.setup()
+            self.setup_class()
     """).format(
         class_name=arch + '_' + cc, arch=arch, cc=cc
     )

--- a/numpy/distutils/tests/test_ccompiler_opt_conf.py
+++ b/numpy/distutils/tests/test_ccompiler_opt_conf.py
@@ -161,9 +161,9 @@ class _TestConfFeatures(FakeCCompilerOpt):
 class TestConfFeatures(unittest.TestCase):
     def __init__(self, methodName="runTest"):
         unittest.TestCase.__init__(self, methodName)
-        self.setup()
+        self._setup()
 
-    def setup(self):
+    def _setup(self):
         FakeCCompilerOpt.conf_nocache = True
 
     def test_features(self):

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -94,7 +94,7 @@ def test_exec_command_stderr():
 
 
 class TestExecCommand:
-    def setup(self):
+    def setup_method(self):
         self.pyexe = get_pythonexe()
 
     def check_nt(self, **kws):

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -130,7 +130,7 @@ class DuplicateOptionInfo(_system_info):
 
 class TestSystemInfoReading:
 
-    def setup(self):
+    def setup_method(self):
         """ Create the libraries """
         # Create 2 sources and 2 libraries
         self._dir1 = mkdtemp()
@@ -172,7 +172,7 @@ class TestSystemInfoReading:
                                             self._sitecfg)
 
 
-    def teardown(self):
+    def teardown_method(self):
         # Do each removal separately
         try:
             shutil.rmtree(self._dir1)

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -171,7 +171,6 @@ class TestSystemInfoReading:
         self.c_dup_options = site_and_parse(get_class('duplicate_options'),
                                             self._sitecfg)
 
-
     def teardown_method(self):
         # Do each removal separately
         try:

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -30,7 +30,7 @@ class TestAssumedShapeSumExample(util.F2PyTest):
 
 
 class TestF2cmapOption(TestAssumedShapeSumExample):
-    def setup(self):
+    def setup_method(self):
         # Use a custom file name for .f2py_f2cmap
         self.sources = list(self.sources)
         f2cmap_src = self.sources.pop(-1)
@@ -45,5 +45,5 @@ class TestF2cmapOption(TestAssumedShapeSumExample):
 
         super().setup()
 
-    def teardown(self):
+    def teardown_method(self):
         os.unlink(self.f2cmap_file.name)

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -43,7 +43,7 @@ class TestF2cmapOption(TestAssumedShapeSumExample):
         self.sources.append(self.f2cmap_file.name)
         self.options = ["--f2cmap", self.f2cmap_file.name]
 
-        super().setup()
+        super().setup_method()
 
     def teardown_method(self):
         os.unlink(self.f2cmap_file.name)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -334,7 +334,7 @@ class F2PyTest:
     module = None
     module_name = None
 
-    def setup(self):
+    def setup_method(self):
         if sys.platform == "win32":
             pytest.skip("Fails with MinGW64 Gfortran (Issue #9673)")
 

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -87,11 +87,11 @@ def invalid_httpfile():
 
 
 class TestDataSourceOpen:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = mkdtemp()
         self.ds = datasource.DataSource(self.tmpdir)
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
         del self.ds
 
@@ -156,11 +156,11 @@ class TestDataSourceOpen:
 
 
 class TestDataSourceExists:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = mkdtemp()
         self.ds = datasource.DataSource(self.tmpdir)
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
         del self.ds
 
@@ -186,11 +186,11 @@ class TestDataSourceExists:
 
 
 class TestDataSourceAbspath:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = os.path.abspath(mkdtemp())
         self.ds = datasource.DataSource(self.tmpdir)
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
         del self.ds
 
@@ -251,11 +251,11 @@ class TestDataSourceAbspath:
 
 
 class TestRepositoryAbspath:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = os.path.abspath(mkdtemp())
         self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
         del self.repos
 
@@ -284,11 +284,11 @@ class TestRepositoryAbspath:
 
 
 class TestRepositoryExists:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = mkdtemp()
         self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
         del self.repos
 
@@ -317,10 +317,10 @@ class TestRepositoryExists:
 
 
 class TestOpenFunc:
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         rmtree(self.tmpdir)
 
     def test_DataSourceOpen(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -845,7 +845,7 @@ class TestDiff:
 
 class TestDelete:
 
-    def setup(self):
+    def setup_method(self):
         self.a = np.arange(5)
         self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -11,10 +11,10 @@ import pytest
 
 class TestHistogram:
 
-    def setup(self):
+    def setup_method(self):
         pass
 
-    def teardown(self):
+    def teardown_method(self):
         pass
 
     def test_simple(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -689,6 +689,7 @@ class TestLoadTxt(LoadTxtBase):
         # lower chunksize for testing
         self.orig_chunk = np.lib.npyio._loadtxt_chunksize
         np.lib.npyio._loadtxt_chunksize = 1
+
     def teardown_method(self):
         np.lib.npyio._loadtxt_chunksize = self.orig_chunk
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -685,11 +685,11 @@ class LoadTxtBase:
 class TestLoadTxt(LoadTxtBase):
     loadfunc = staticmethod(np.loadtxt)
 
-    def setup(self):
+    def setup_method(self):
         # lower chunksize for testing
         self.orig_chunk = np.lib.npyio._loadtxt_chunksize
         np.lib.npyio._loadtxt_chunksize = 1
-    def teardown(self):
+    def teardown_method(self):
         np.lib.npyio._loadtxt_chunksize = self.orig_chunk
 
     def test_record(self):

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -20,7 +20,7 @@ zip_dtype = np.lib.recfunctions._zip_dtype
 class TestRecFunctions:
     # Misc tests
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array([('A', 1.), ('B', 2.)],
@@ -372,7 +372,7 @@ class TestRecursiveFillFields:
 class TestMergeArrays:
     # Test merge_arrays
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
@@ -505,7 +505,7 @@ class TestMergeArrays:
 class TestAppendFields:
     # Test append_fields
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
@@ -558,7 +558,7 @@ class TestAppendFields:
 
 class TestStackArrays:
     # Test stack_arrays
-    def setup(self):
+    def setup_method(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
@@ -728,7 +728,7 @@ class TestStackArrays:
 
 
 class TestJoinBy:
-    def setup(self):
+    def setup_method(self):
         self.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
                                    np.arange(100, 110))),
                           dtype=[('a', int), ('b', int), ('c', int)])
@@ -893,7 +893,7 @@ class TestJoinBy:
 
 class TestJoinBy2:
     @classmethod
-    def setup(cls):
+    def setup_method(cls):
         cls.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
                                   np.arange(100, 110))),
                          dtype=[('a', int), ('b', int), ('c', int)])
@@ -962,7 +962,7 @@ class TestAppendFieldsObj:
     """
     # https://github.com/numpy/numpy/issues/2346
 
-    def setup(self):
+    def setup_method(self):
         from datetime import date
         self.data = dict(obj=date(2000, 1, 1))
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -66,7 +66,7 @@ num_ids = [dt_.char for dt_ in num_dts]
 class TestMaskedArray:
     # Base test class for MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -997,7 +997,7 @@ class TestMaskedArray:
 class TestMaskedArrayArithmetic:
     # Base test class for MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -1014,7 +1014,7 @@ class TestMaskedArrayArithmetic:
         self.err_status = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.err_status)
 
     def test_basic_arithmetic(self):
@@ -2338,14 +2338,14 @@ class TestFillingValues:
 class TestUfuncs:
     # Test class for the application of ufuncs on MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
         self.err_status = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.err_status)
 
     def test_testUfuncRegression(self):
@@ -2482,7 +2482,7 @@ class TestUfuncs:
 class TestMaskedArrayInPlaceArithmetic:
     # Test MaskedArray Arithmetic
 
-    def setup(self):
+    def setup_method(self):
         x = arange(10)
         y = arange(10)
         xm = arange(10)
@@ -2995,7 +2995,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
 class TestMaskedArrayMethods:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -3757,7 +3757,7 @@ class TestMaskedArrayMethods:
 
 class TestMaskedArrayMathMethods:
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -4057,7 +4057,7 @@ class TestMaskedArrayMathMethods:
 
 class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375j, 7.545j, 8.828j, 8.5j, 1.757j, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -4111,7 +4111,7 @@ class TestMaskedArrayMathMethodsComplex:
 class TestMaskedArrayFunctions:
     # Test class for miscellaneous functions.
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
@@ -4749,7 +4749,7 @@ class TestMaskedArrayFunctions:
 
 class TestMaskedFields:
 
-    def setup(self):
+    def setup_method(self):
         ilist = [1, 2, 3, 4, 5]
         flist = [1.1, 2.2, 3.3, 4.4, 5.5]
         slist = ['one', 'two', 'three', 'four', 'five']
@@ -4959,7 +4959,7 @@ class TestMaskedObjectArray:
 
 class TestMaskedView:
 
-    def setup(self):
+    def setup_method(self):
         iterator = list(zip(np.arange(10), np.random.rand(10)))
         data = np.array(iterator)
         a = array(iterator, dtype=[('a', float), ('b', float)])

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1163,7 +1163,7 @@ class TestMedian:
 
 class TestCov:
 
-    def setup(self):
+    def setup_method(self):
         self.data = array(np.random.rand(12))
 
     def test_1d_without_missing(self):
@@ -1230,7 +1230,7 @@ class TestCov:
 
 class TestCorrcoef:
 
-    def setup(self):
+    def setup_method(self):
         self.data = array(np.random.rand(12))
         self.data2 = array(np.random.rand(12))
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -348,7 +348,7 @@ class TestMRecords:
 
 class TestView:
 
-    def setup(self):
+    def setup_method(self):
         (a, b) = (np.arange(10), np.random.rand(10))
         ndtype = [('a', float), ('b', float)]
         arr = np.array(list(zip(a, b)), dtype=ndtype)

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -1,5 +1,7 @@
 from functools import reduce
 
+import pytest
+
 import numpy as np
 import numpy.core.umath as umath
 import numpy.core.fromnumeric as fromnumeric
@@ -33,7 +35,7 @@ def eq(v, w, msg=''):
 
 class TestMa:
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         a10 = 10.
@@ -62,27 +64,26 @@ class TestMa:
         assert_(eq(filled(xm, 1.e20), xf))
         assert_(eq(x, xm))
 
-    def test_testBasic2d(self):
+    @pytest.mark.parametrize("s", [(4, 3), (6, 2)])
+    def test_testBasic2d(self, s):
         # Test of basic array creation and properties in 2 dimensions.
-        for s in [(4, 3), (6, 2)]:
-            (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
-            x.shape = s
-            y.shape = s
-            xm.shape = s
-            ym.shape = s
-            xf.shape = s
+        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x.shape = s
+        y.shape = s
+        xm.shape = s
+        ym.shape = s
+        xf.shape = s
 
-            assert_(not isMaskedArray(x))
-            assert_(isMaskedArray(xm))
-            assert_equal(shape(xm), s)
-            assert_equal(xm.shape, s)
-            assert_equal(xm.size, reduce(lambda x, y:x * y, s))
-            assert_equal(count(xm),
-                             len(m1) - reduce(lambda x, y:x + y, m1))
-            assert_(eq(xm, xf))
-            assert_(eq(filled(xm, 1.e20), xf))
-            assert_(eq(x, xm))
-            self.setup()
+        assert_(not isMaskedArray(x))
+        assert_(isMaskedArray(xm))
+        assert_equal(shape(xm), s)
+        assert_equal(xm.shape, s)
+        assert_equal(xm.size, reduce(lambda x, y:x * y, s))
+        assert_equal(count(xm),
+                            len(m1) - reduce(lambda x, y:x + y, m1))
+        assert_(eq(xm, xf))
+        assert_(eq(filled(xm, 1.e20), xf))
+        assert_(eq(x, xm))
 
     def test_testArithmetic(self):
         # Test of basic arithmetic.
@@ -715,7 +716,7 @@ class TestMa:
 
 
 class TestUfuncs:
-    def setup(self):
+    def setup_method(self):
         self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
 
@@ -781,7 +782,7 @@ class TestUfuncs:
 
 class TestArrayMethods:
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -78,9 +78,8 @@ class TestMa:
         assert_(isMaskedArray(xm))
         assert_equal(shape(xm), s)
         assert_equal(xm.shape, s)
-        assert_equal(xm.size, reduce(lambda x, y:x * y, s))
-        assert_equal(count(xm),
-                            len(m1) - reduce(lambda x, y:x + y, m1))
+        assert_equal(xm.size, reduce(lambda x, y: x * y, s))
+        assert_equal(count(xm), len(m1) - reduce(lambda x, y: x + y, m1))
         assert_(eq(xm, xf))
         assert_(eq(filled(xm, 1.e20), xf))
         assert_(eq(x, xm))

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -173,7 +173,7 @@ class TestMaskedMatrix:
 class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
 
-    def setup(self):
+    def setup_method(self):
         x = np.arange(5, dtype='float')
         mx = MMatrix(x, mask=[0, 1, 0, 0, 0])
         self.data = (x, mx)

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -147,7 +147,7 @@ class TestMultinomial:
 
 class TestMultivariateHypergeometric:
 
-    def setup(self):
+    def setup_method(self):
         self.seed = 8675309
 
     def test_argument_validation(self):
@@ -280,7 +280,7 @@ class TestMultivariateHypergeometric:
 
 
 class TestSetState:
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
         self.rg = Generator(MT19937(self.seed))
         self.bit_generator = self.rg.bit_generator
@@ -707,7 +707,7 @@ class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
 
     def test_integers(self):
@@ -1823,7 +1823,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup(self):
+    def setup_method(self):
         self.seed = 123456789
 
 
@@ -2436,7 +2436,7 @@ class TestBroadcast:
 
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup(self):
+    def setup_method(self):
         self.seeds = range(4)
 
     def check_function(self, function, sz):
@@ -2482,7 +2482,7 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup(self):
+    def setup_method(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])
         self.argThree = np.array([4])

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -101,7 +101,7 @@ class TestMultinomial:
 
 
 class TestSetState:
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
         self.prng = random.RandomState(self.seed)
         self.state = self.prng.get_state()
@@ -290,7 +290,7 @@ class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
 
     def test_rand(self):
@@ -1048,7 +1048,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup(self):
+    def setup_method(self):
         self.seed = 123456789
 
     def setSeed(self):
@@ -1617,7 +1617,7 @@ class TestBroadcast:
 
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup(self):
+    def setup_method(self):
         self.seeds = range(4)
 
     def check_function(self, function, sz):
@@ -1660,7 +1660,7 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup(self):
+    def setup_method(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])
         self.argThree = np.array([4])

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -177,7 +177,7 @@ class TestMultinomial:
 
 
 class TestSetState:
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
         self.random_state = random.RandomState(self.seed)
         self.state = self.random_state.get_state()
@@ -428,7 +428,7 @@ class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
-    def setup(self):
+    def setup_method(self):
         self.seed = 1234567890
 
     def test_rand(self):
@@ -1293,7 +1293,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup(self):
+    def setup_method(self):
         self.seed = 123456789
 
     def set_seed(self):
@@ -1879,7 +1879,7 @@ class TestBroadcast:
 
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup(self):
+    def setup_method(self):
         self.seeds = range(4)
 
     def check_function(self, function, sz):
@@ -1925,7 +1925,7 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup(self):
+    def setup_method(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])
         self.argThree = np.array([4])

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -65,7 +65,7 @@ class _GenericTest:
 
 class TestArrayEqual(_GenericTest):
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_array_equal
 
     def test_generic_rank1(self):
@@ -262,7 +262,7 @@ class TestBuildErrorMessage:
 
 class TestEqual(TestArrayEqual):
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_equal
 
     def test_nan_items(self):
@@ -357,7 +357,7 @@ class TestEqual(TestArrayEqual):
 
 class TestArrayAlmostEqual(_GenericTest):
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_array_almost_equal
 
     def test_closeness(self):
@@ -455,7 +455,7 @@ class TestArrayAlmostEqual(_GenericTest):
 
 class TestAlmostEqual(_GenericTest):
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_almost_equal
 
     def test_closeness(self):
@@ -606,7 +606,7 @@ class TestAlmostEqual(_GenericTest):
 
 class TestApproxEqual:
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_approx_equal
 
     def test_simple_0d_arrays(self):
@@ -649,7 +649,7 @@ class TestApproxEqual:
 
 class TestArrayAssertLess:
 
-    def setup(self):
+    def setup_method(self):
         self._assert_func = assert_array_less
 
     def test_simple_arrays(self):
@@ -759,7 +759,7 @@ class TestArrayAssertLess:
 @pytest.mark.skip(reason="The raises decorator depends on Nose")
 class TestRaises:
 
-    def setup(self):
+    def setup_method(self):
         class MyException(Exception):
             pass
 


### PR DESCRIPTION
Backport of #22487.

In some cases, the replacement is clearly not what is intended,
in those (where setup was called explicitly), I mostly renamed
`setup` to `_setup`.
The `test_ccompile_opt` is a bit confusing, so left it right now
(this will probably fail)

---

Also changed the docs a little bit.  (Draft, just because I expect one failure still.)

Closes gh-22486
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
