### PR TITLE
MAINT: remove redundant open() modes and io.open() alias

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -2,7 +2,7 @@
 """
 Post-processes HTML and Latex files output by Sphinx.
 """
-import io
+
 
 def main():
     import argparse
@@ -15,13 +15,13 @@ def main():
     mode = args.mode
 
     for fn in args.file:
-        with io.open(fn, 'r', encoding="utf-8") as f:
+        with open(fn, encoding="utf-8") as f:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())
             elif mode == 'tex':
                 lines = process_tex(f.readlines())
 
-        with io.open(fn, 'w', encoding="utf-8") as f:
+        with open(fn, 'w', encoding="utf-8") as f:
             f.write("".join(lines))
 
 def process_html(fn, lines):

--- a/doc/preprocess.py
+++ b/doc/preprocess.py
@@ -32,7 +32,7 @@ def doxy_config(root_path):
     confs = []
     dsrc_path = os.path.join(root_path, "doc", "source")
     sub = dict(ROOT_DIR=root_path)
-    with open(os.path.join(dsrc_path, "doxyfile"), "r") as fd:
+    with open(os.path.join(dsrc_path, "doxyfile")) as fd:
         conf = DoxyTpl(fd.read())
         confs.append(conf.substitute(CUR_DIR=dsrc_path, **sub))
 
@@ -40,7 +40,7 @@ def doxy_config(root_path):
         if ".doxyfile" not in files:
             continue
         conf_path = os.path.join(dpath, ".doxyfile")
-        with open(conf_path, "r") as fd:
+        with open(conf_path) as fd:
             conf = DoxyTpl(fd.read())
             confs.append(conf.substitute(CUR_DIR=dpath, **sub))
     return confs

--- a/doc/source/reference/simd/gen_features.py
+++ b/doc/source/reference/simd/gen_features.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
     gen_path = path.join(
         path.dirname(path.realpath(__file__)), "generated_tables"
     )
-    with open(path.join(gen_path, 'cpu_features.inc'), 'wt') as fd:
+    with open(path.join(gen_path, 'cpu_features.inc'), 'w') as fd:
         fd.write(f'.. generated via {__file__}\n\n')
         for arch in (
             ("x86", "PPC64", "PPC64LE", "ARMHF", "AARCH64", "S390X")
@@ -177,7 +177,7 @@ if __name__ == '__main__':
             table = Features(arch, 'gcc').table()
             fd.write(wrapper_section(title, table))
 
-    with open(path.join(gen_path, 'compilers-diff.inc'), 'wt') as fd:
+    with open(path.join(gen_path, 'compilers-diff.inc'), 'w') as fd:
         fd.write(f'.. generated via {__file__}\n\n')
         for arch, cc_names in (
             ("x86", ("clang", "ICC", "MSVC")),

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -498,7 +498,7 @@ def get_versions_hash():
     d = []
 
     file = os.path.join(os.path.dirname(__file__), 'cversions.txt')
-    with open(file, 'r') as fid:
+    with open(file) as fid:
         for line in fid:
             m = VERRE.match(line)
             if m:

--- a/numpy/core/tests/test_cpu_features.py
+++ b/numpy/core/tests/test_cpu_features.py
@@ -8,7 +8,7 @@ def assert_features_equal(actual, desired, fname):
         return
     detected = str(__cpu_features__).replace("'", "")
     try:
-        with open("/proc/cpuinfo", "r") as fd:
+        with open("/proc/cpuinfo") as fd:
             cpuinfo = fd.read(2048)
     except Exception as err:
         cpuinfo = str(err)

--- a/numpy/core/tests/test_longdouble.py
+++ b/numpy/core/tests/test_longdouble.py
@@ -142,7 +142,7 @@ class TestFileBased:
 
     def test_fromfile_bogus(self):
         with temppath() as path:
-            with open(path, 'wt') as f:
+            with open(path, 'w') as f:
                 f.write("1. 2. 3. flop 4.\n")
 
             with assert_warns(DeprecationWarning):
@@ -153,7 +153,7 @@ class TestFileBased:
         for ctype in ["complex", "cdouble", "cfloat"]:
             # Check spacing between separator and only real component specified
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1, 2 ,  3  ,4\n")
 
                 res = np.fromfile(path, dtype=ctype, sep=",")
@@ -161,7 +161,7 @@ class TestFileBased:
 
             # Real component not specified
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1j, -2j,  3j, 4e1j\n")
 
                 res = np.fromfile(path, dtype=ctype, sep=",")
@@ -169,7 +169,7 @@ class TestFileBased:
 
             # Both components specified
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1+1j,2-2j, -3+3j,  -4e1+4j\n")
 
                 res = np.fromfile(path, dtype=ctype, sep=",")
@@ -177,7 +177,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1+2 j,3\n")
 
                 with assert_warns(DeprecationWarning):
@@ -186,7 +186,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1+ 2j,3\n")
 
                 with assert_warns(DeprecationWarning):
@@ -195,7 +195,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1 +2j,3\n")
 
                 with assert_warns(DeprecationWarning):
@@ -204,7 +204,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1+j\n")
 
                 with assert_warns(DeprecationWarning):
@@ -213,7 +213,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1+\n")
 
                 with assert_warns(DeprecationWarning):
@@ -222,7 +222,7 @@ class TestFileBased:
 
             # Spaces at wrong places
             with temppath() as path:
-                with open(path, 'wt') as f:
+                with open(path, 'w') as f:
                     f.write("1j+1\n")
 
                 with assert_warns(DeprecationWarning):
@@ -235,7 +235,7 @@ class TestFileBased:
                         reason="Need strtold_l")
     def test_fromfile(self):
         with temppath() as path:
-            with open(path, 'wt') as f:
+            with open(path, 'w') as f:
                 f.write(self.out)
             res = np.fromfile(path, dtype=np.longdouble, sep="\n")
         assert_equal(res, self.tgt)
@@ -244,7 +244,7 @@ class TestFileBased:
                         reason="Need strtold_l")
     def test_genfromtxt(self):
         with temppath() as path:
-            with open(path, 'wt') as f:
+            with open(path, 'w') as f:
                 f.write(self.out)
             res = np.genfromtxt(path, dtype=np.longdouble)
         assert_equal(res, self.tgt)
@@ -253,7 +253,7 @@ class TestFileBased:
                         reason="Need strtold_l")
     def test_loadtxt(self):
         with temppath() as path:
-            with open(path, 'wt') as f:
+            with open(path, 'w') as f:
                 f.write(self.out)
             res = np.loadtxt(path, dtype=np.longdouble)
         assert_equal(res, self.tgt)

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -57,7 +57,7 @@ def _needs_build(obj, cc_args, extra_postargs, pp_opts):
     # the last line contains the compiler commandline arguments as some
     # projects may compile an extension multiple times with different
     # arguments
-    with open(dep_file, "r") as f:
+    with open(dep_file) as f:
         lines = f.readlines()
 
     cmdline =_commandline_dep_string(cc_args, extra_postargs, pp_opts)

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -634,12 +634,12 @@ class build_ext (old_build_ext):
                 if os.path.isfile(fake_lib):
                     # Replace fake static library
                     libraries.remove(lib)
-                    with open(fake_lib, 'r') as f:
+                    with open(fake_lib) as f:
                         unlinkable_fobjects.extend(f.read().splitlines())
 
                     # Expand C objects
                     c_lib = os.path.join(libdir, lib + '.cobjects')
-                    with open(c_lib, 'r') as f:
+                    with open(c_lib) as f:
                         objects.extend(f.read().splitlines())
 
         # Wrap unlinkable objects to a linkable one

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -725,7 +725,7 @@ _has_c_header = re.compile(r'-\*-\s*c\s*-\*-', re.I).search
 _has_cpp_header = re.compile(r'-\*-\s*c\+\+\s*-\*-', re.I).search
 
 def get_swig_target(source):
-    with open(source, 'r') as f:
+    with open(source) as f:
         result = None
         line = f.readline()
         if _has_cpp_header(line):
@@ -735,7 +735,7 @@ def get_swig_target(source):
     return result
 
 def get_swig_modulename(source):
-    with open(source, 'r') as f:
+    with open(source) as f:
         name = None
         for line in f:
             m = _swig_module_name_match(line)

--- a/numpy/distutils/command/install.py
+++ b/numpy/distutils/command/install.py
@@ -62,7 +62,7 @@ class install(old_install):
             # bdist_rpm fails when INSTALLED_FILES contains
             # paths with spaces. Such paths must be enclosed
             # with double-quotes.
-            with open(self.record, 'r') as f:
+            with open(self.record) as f:
                 lines = []
                 need_rewrite = False
                 for l in f:

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -76,7 +76,7 @@ class IBMFCompiler(FCompiler):
                 xlf_cfg = '/etc/opt/ibmcmp/xlf/%s/xlf.cfg' % version
             fo, new_cfg = make_temp_file(suffix='_xlf.cfg')
             log.info('Creating '+new_cfg)
-            with open(xlf_cfg, 'r') as fi:
+            with open(xlf_cfg) as fi:
                 crt1_match = re.compile(r'\s*crt\s*=\s*(?P<path>.*)/crt1.o').match
                 for line in fi:
                     m = crt1_match(line)

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -475,7 +475,7 @@ def _get_f90_modules(source):
     if not f90_ext_match(source):
         return []
     modules = []
-    with open(source, 'r') as f:
+    with open(source) as f:
         for line in f:
             m = f90_module_name_match(line)
             if m:
@@ -1932,7 +1932,7 @@ class Configuration:
                 revision0 = f.read().strip()
 
             branch_map = {}
-            with open(branch_cache_fn, 'r') as f:
+            with open(branch_cache_fn) as f:
                 for line in f:
                     branch1, revision1  = line.split()[:2]
                     if revision1==revision0:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1260,7 +1260,7 @@ class mkl_info(system_info):
         paths = os.environ.get('LD_LIBRARY_PATH', '').split(os.pathsep)
         ld_so_conf = '/etc/ld.so.conf'
         if os.path.isfile(ld_so_conf):
-            with open(ld_so_conf, 'r') as f:
+            with open(ld_so_conf) as f:
                 for d in f:
                     d = d.strip()
                     if d:
@@ -2190,7 +2190,7 @@ class blas_info(system_info):
             }""")
         src = os.path.join(tmpdir, 'source.c')
         try:
-            with open(src, 'wt') as f:
+            with open(src, 'w') as f:
                 f.write(s)
 
             try:
@@ -2345,7 +2345,7 @@ class openblas_info(blas_info):
         except Exception:
             extra_args = []
         try:
-            with open(src, 'wt') as f:
+            with open(src, 'w') as f:
                 f.write(s)
             obj = c.compile([src], output_dir=tmpdir)
             try:
@@ -2456,7 +2456,7 @@ class flame_info(system_info):
         # Add the additional "extra" arguments
         extra_args = info.get('extra_link_args', [])
         try:
-            with open(src, 'wt') as f:
+            with open(src, 'w') as f:
                 f.write(s)
             obj = c.compile([src], output_dir=tmpdir)
             try:

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -271,7 +271,7 @@ class TestSystemInfoReading:
 
             # But if we copy the values to a '[mkl]' section the value
             # is correct
-            with open(cfg, 'r') as fid:
+            with open(cfg) as fid:
                 mkl = fid.read().replace('[ALL]', '[mkl]', 1)
             with open(cfg, 'w') as fid:
                 fid.write(mkl)
@@ -279,7 +279,7 @@ class TestSystemInfoReading:
             assert info.get_lib_dirs() == lib_dirs
 
             # Also, the values will be taken from a section named '[DEFAULT]'
-            with open(cfg, 'r') as fid:
+            with open(cfg) as fid:
                 dflt = fid.read().replace('[mkl]', '[DEFAULT]', 1)
             with open(cfg, 'w') as fid:
                 fid.write(dflt)

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -196,7 +196,7 @@ def load_f2cmap_file(f2cmap_file):
     # they use PARAMETERS in type specifications.
     try:
         outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
-        with open(f2cmap_file, 'r') as f:
+        with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
         for k, d1 in d.items():
             for k1 in d1.keys():

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -297,7 +297,7 @@ def scrubSource(source, nsteps=None, verbose=False):
 if __name__ == '__main__':
     filename = sys.argv[1]
     outfilename = os.path.join(sys.argv[2], os.path.basename(filename))
-    with open(filename, 'r') as fo:
+    with open(filename) as fo:
         source = fo.read()
 
     if len(sys.argv) > 3:

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -253,7 +253,7 @@ def dumpRoutineNames(library, output_dir):
 def concatenateRoutines(routines, output_file):
     with open(output_file, 'w') as output_fo:
         for r in routines:
-            with open(r.filename, 'r') as fo:
+            with open(r.filename) as fo:
                 source = fo.read()
             output_fo.write(source)
 
@@ -296,7 +296,7 @@ def create_name_header(output_dir):
         if not fn.endswith('.f'):
             continue
 
-        with open(fn, 'r') as f:
+        with open(fn) as f:
             for line in f:
                 m = routine_re.match(line)
                 if m:
@@ -304,7 +304,7 @@ def create_name_header(output_dir):
 
     # f2c symbols
     f2c_symbols = set()
-    with open('f2c.h', 'r') as f:
+    with open('f2c.h') as f:
         for line in f:
             m = extern_re.match(line)
             if m:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -197,7 +197,7 @@ elif sys.platform[:5] == 'linux':
 
         """
         try:
-            with open(_proc_pid_stat, 'r') as f:
+            with open(_proc_pid_stat) as f:
                 l = f.readline().split(' ')
             return int(l[22])
         except Exception:
@@ -224,7 +224,7 @@ if sys.platform[:5] == 'linux':
         if not _load_time:
             _load_time.append(time.time())
         try:
-            with open(_proc_pid_stat, 'r') as f:
+            with open(_proc_pid_stat) as f:
                 l = f.readline().split(' ')
             return int(l[13])
         except Exception:
@@ -2545,7 +2545,7 @@ def _get_mem_available():
 
     if sys.platform.startswith('linux'):
         info = {}
-        with open('/proc/meminfo', 'r') as f:
+        with open('/proc/meminfo') as f:
             for line in f:
                 p = line.split()
                 info[p[0].strip(':').lower()] = int(p[1]) * 1024

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -431,7 +431,7 @@ def test_extended_precision() -> None:
     output_mypy = OUTPUT_MYPY
     assert path in output_mypy
 
-    with open(path, "r") as f:
+    with open(path) as f:
         expression_list = f.readlines()
 
     for _msg in output_mypy[path]:

--- a/runtests.py
+++ b/runtests.py
@@ -220,7 +220,7 @@ def main(argv):
             # Don't use subprocess, since we don't want to include the
             # current path in PYTHONPATH.
             sys.argv = extra_argv
-            with open(extra_argv[0], 'r') as f:
+            with open(extra_argv[0]) as f:
                 script = f.read()
             sys.modules['__main__'] = types.ModuleType('__main__')
             ns = dict(__name__='__main__',
@@ -540,7 +540,7 @@ def build_project(args):
         print("Build OK")
     else:
         if not args.show_build_log:
-            with open(log_filename, 'r') as f:
+            with open(log_filename) as f:
                 print(f.read())
             print("Build failed!")
         sys.exit(1)
@@ -624,7 +624,7 @@ def asv_substitute_config(in_config, out_config, **custom_vars):
 
     vars_hash = sdbm_hash(custom_vars, os.path.getmtime(in_config))
     try:
-        with open(out_config, "r") as wfd:
+        with open(out_config) as wfd:
             hash_line = wfd.readline().split('hash:')
             if len(hash_line) > 1 and int(hash_line[1]) == vars_hash:
                 return True

--- a/setup.py
+++ b/setup.py
@@ -177,11 +177,11 @@ class concat_license_files():
 
     def __enter__(self):
         """Concatenate files and remove LICENSES_bundled.txt"""
-        with open(self.f1, 'r') as f1:
+        with open(self.f1) as f1:
             self.bsd_text = f1.read()
 
         with open(self.f1, 'a') as f1:
-            with open(self.f2, 'r') as f2:
+            with open(self.f2) as f2:
                 self.bundled_text = f2.read()
                 f1.write('\n\n')
                 f1.write(self.bundled_text)

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -52,7 +52,7 @@ def process_tempita_pyx(fromfile, tofile):
     import npy_tempita as tempita
 
     assert fromfile.endswith('.pyx.in')
-    with open(fromfile, "r") as f:
+    with open(fromfile) as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
     pyxfile = fromfile[:-len('.pyx.in')] + '.pyx'
@@ -66,7 +66,7 @@ def process_tempita_pyd(fromfile, tofile):
 
     assert fromfile.endswith('.pxd.in')
     assert tofile.endswith('.pxd')
-    with open(fromfile, "r") as f:
+    with open(fromfile) as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
     with open(tofile, "w") as f:
@@ -77,7 +77,7 @@ def process_tempita_pxi(fromfile, tofile):
 
     assert fromfile.endswith('.pxi.in')
     assert tofile.endswith('.pxi')
-    with open(fromfile, "r") as f:
+    with open(fromfile) as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
     with open(tofile, "w") as f:
@@ -88,7 +88,7 @@ def process_tempita_pxd(fromfile, tofile):
 
     assert fromfile.endswith('.pxd.in')
     assert tofile.endswith('.pxd')
-    with open(fromfile, "r") as f:
+    with open(fromfile) as f:
         tmpl = f.read()
     pyxcontent = tempita.sub(tmpl)
     with open(tofile, "w") as f:
@@ -109,7 +109,7 @@ def load_hashes(filename):
     # Return { filename : (sha256 of input, sha256 of output) }
     if os.path.isfile(filename):
         hashes = {}
-        with open(filename, 'r') as f:
+        with open(filename) as f:
             for line in f:
                 filename, inhash, outhash = line.split()
                 hashes[filename] = (inhash, outhash)

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -197,7 +197,7 @@ def make_init(dirname):
     '''
     Create a _distributor_init.py file for OpenBlas
     '''
-    with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
+    with open(os.path.join(dirname, '_distributor_init.py'), 'w') as fid:
         fid.write(textwrap.dedent("""
             '''
             Helper to preload windows dlls to prevent dll not found errors.

--- a/tools/wheels/check_license.py
+++ b/tools/wheels/check_license.py
@@ -9,7 +9,6 @@ distribution.
 """
 import os
 import sys
-import io
 import re
 import argparse
 
@@ -36,7 +35,7 @@ def main():
 
     # Check license text
     license_txt = os.path.join(os.path.dirname(mod.__file__), "LICENSE.txt")
-    with io.open(license_txt, "r", encoding="utf-8") as f:
+    with open(license_txt, encoding="utf-8") as f:
         text = f.read()
 
     ok = check_text(text)


### PR DESCRIPTION
This PR removes redundant [open](https://docs.python.org/3/library/functions.html#open) modes and aliases.

- the default mode for the open builtin is 'r' for read and 't' for text mode, so neither of these need to be specified
- [io.open](https://docs.python.org/3/library/io.html#io.open) is an alias for the open builtin

These edits were mostly automated using [pyupgrade](https://github.com/asottile/pyupgrade/). Happy to keep any exceptions to these edits, please specify.