### PR TITLE
MAINT: Use SPDX license expression in project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,7 @@ def setup_package():
             "Documentation": get_docs_url(),
             "Source Code": "https://github.com/numpy/numpy",
         },
-        license='BSD',
+        license='BSD-3-Clause',
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='pytest',


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression. In particular, BSD is ambiguous as there are multiple BSD licenses.

If PEP 639 is accepted, this package would be ready for the change just by changing the `license` key to `license_expression` or whatever key the PEP lands on.