### PR TITLE
REL: readme in PyPI plus test

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -184,6 +184,12 @@ jobs:
           pip install -r test_requirements.txt
           cd .. # Can't import numpy within numpy src directory
           python -c "import numpy; print(numpy.__version__); numpy.test();"
+
+      - name: Check README rendering for PyPI
+        run: |
+          python -mpip install twine
+          twine check dist/*
+
       - uses: actions/upload-artifact@v3
         with:
           name: sdist

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ installation with::
 DOCLINES = (__doc__ or '').split("\n")
 
 import os
+from pathlib import Path
 import sys
 import subprocess
 import textwrap
@@ -435,7 +436,8 @@ def setup_package():
         maintainer="NumPy Developers",
         maintainer_email="numpy-discussion@python.org",
         description=DOCLINES[0],
-        long_description="\n".join(DOCLINES[2:]),
+        long_description= Path("README.md").read_text(encoding="utf-8"),
+        long_description_content_type="text/markdown",
         url="https://www.numpy.org",
         author="Travis E. Oliphant et al.",
         download_url="https://pypi.python.org/pypi/numpy",

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,8 @@
 #!/usr/bin/env python3
-""" NumPy is the fundamental package for array computing with Python.
-
-It provides:
-
-- a powerful N-dimensional array object
-- sophisticated (broadcasting) functions
-- tools for integrating C/C++ and Fortran code
-- useful linear algebra, Fourier transform, and random number capabilities
-- and much more
-
-Besides its obvious scientific uses, NumPy can also be used as an efficient
-multi-dimensional container of generic data. Arbitrary data-types can be
-defined. This allows NumPy to seamlessly and speedily integrate with a wide
-variety of databases.
-
-All NumPy wheels distributed on PyPI are BSD licensed.
-
-NumPy requires ``pytest`` and ``hypothesis``.  Tests can then be run after
-installation with::
-
-    python -c 'import numpy; numpy.test()'
-
 """
-DOCLINES = (__doc__ or '').split("\n")
+Numpy build options can be modified with a site.cfg file. 
+See site.cfg.example for a template and more information.
+"""
 
 import os
 from pathlib import Path
@@ -435,8 +415,8 @@ def setup_package():
         name='numpy',
         maintainer="NumPy Developers",
         maintainer_email="numpy-discussion@python.org",
-        description=DOCLINES[0],
-        long_description= Path("README.md").read_text(encoding="utf-8"),
+        description="Fundamental package for array computing in Python",
+        long_description=Path("README.md").read_text(encoding="utf-8"),
         long_description_content_type="text/markdown",
         url="https://www.numpy.org",
         author="Travis E. Oliphant et al.",


### PR DESCRIPTION
Hi folks,
This sets up the PyPI long description to be the README and adds a test. I put it in the `build_sdist` 'cause that's where it lives on matplotlib. 

I will %100 understand if you close this as a don't want, but (and I get how obnoxious this sounds/is) it was quicker to do this than to start bugging folks and I didn't know if it qualified for the mailing list.

Also not sure this is REL but that's when this would most take effect I think?

ETA: I have no idea how I broke the cygwin test