### PR TITLE
DOC: added example in char

### DIFF
--- a/doc/source/reference/routines.char.rst
+++ b/doc/source/reference/routines.char.rst
@@ -8,8 +8,8 @@ String operations
 The `numpy.char` module provides a set of vectorized string
 operations for arrays of type `numpy.str_` or `numpy.bytes_`. For example
 
-      >>> np.char.capitalize("numpy")
-      array('Numpy', dtype='<U5')
+      >>> np.char.capitalize(["python", "numpy"])
+      array(['Python', 'Numpy'], dtype='<U6')
       >>> np.char.add(["num", "doc"], ["py", "umentation"])
       array(['numpy', 'documentation'], dtype='<U13')
 

--- a/doc/source/reference/routines.char.rst
+++ b/doc/source/reference/routines.char.rst
@@ -6,8 +6,14 @@ String operations
 .. module:: numpy.char
 
 The `numpy.char` module provides a set of vectorized string
-operations for arrays of type `numpy.str_` or `numpy.bytes_`.
-All of them are based on the string methods in the Python standard library.
+operations for arrays of type `numpy.str_` or `numpy.bytes_`. For example
+
+      >>> np.char.capitalize("numpy")
+      array('Numpy', dtype='<U5')
+      >>> np.char.add(["num", "doc"], ["py", "umentation"])
+      array(['numpy', 'documentation'], dtype='<U13')
+
+The methods in this module are based on the methods in :py:mod:`String`
 
 String operations
 -----------------


### PR DESCRIPTION
Added small examples to [String Operations: np.char](https://numpy.org/devdocs/reference/routines.char.html) because honestly I was having trouble parsing the very clear and consistent signatures and had to double check with [geeksforgeeks](https://www.geeksforgeeks.org/numpy-string-operations/)

Um I'm also not actually sure how I can check the docs on .gitpod, tips would be much appreciated. 