### PR TITLE
CI: Only fetch in actions/checkout

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 3000
+          fetch-depth: 0
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v2
         with:
@@ -47,11 +47,9 @@ jobs:
         run: |
           command bash
           bash -c "uname -svrmo"
-      - name: Update with Cygwin git
-        # fetch-depth=0 above should make this short.
+      - name: Tell Cygwin's git about this repository.
         run: |
           dash -c "which git; /usr/bin/git config --system --add safe.directory /cygdrive/d/a/numpy/numpy"
-          dash -c "which git; /usr/bin/git fetch --all -p"
       - name: Verify python version
         # Make sure it's the Cygwin one, not a Windows one
         run: |


### PR DESCRIPTION
I had the workflow fetch the repository in two steps earlier.  That was failing after the switch from egor-tensin/install-cygwin to cygwin/install-cygwin-action.  This avoids that step and hopefully sidesteps whatever the problem is; I'm hoping the problem is just internet access by an untrusted binary.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
