### PR TITLE
DOC: Add code-formatting on install instructions

### DIFF
--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -178,8 +178,8 @@ the maintainers of the package that is causing problem
 so that they can solve the problem properly.
 
 However, while you wait for a solution, a work around
-that usually works is to upgrade the NumPy version:
+that usually works is to upgrade the NumPy version::
 
 
-    ``pip install numpy --upgrade``
+    pip install numpy --upgrade
 

--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -181,5 +181,5 @@ However, while you wait for a solution, a work around
 that usually works is to upgrade the NumPy version:
 
 
-    pip install numpy --upgrade
+    ``pip install numpy --upgrade``
 


### PR DESCRIPTION
The docs seem to be collapsing `--` into `-`, leading the live [page](https://numpy.org/devdocs/user/troubleshooting-importerror.html) to show an invalid command:
```
pip install numpy –upgrade
```

This adds backticks to force both of the `-`'s to be visible

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
