### PR TITLE
ENH: add `out` parameter to arange

### DIFF
--- a/doc/release/upcoming_changes/22512.new_feature.rst
+++ b/doc/release/upcoming_changes/22512.new_feature.rst
@@ -1,0 +1,6 @@
+``out=`` argument for ``np.arange``
+-----------------------------------
+
+``np.arange`` now has an ``out=`` argument allowing for an existing
+array to be specified which will be filled by the function.
+If the array is of incompatible size, a `ValueError` will be raised.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1687,7 +1687,7 @@ add_newdoc('numpy.core.multiarray', 'correlate',
 
 add_newdoc('numpy.core.multiarray', 'arange',
     """
-    arange([start,] stop[, step,], dtype=None, *, like=None)
+    arange([start,] stop[, step,], dtype=None, *, like=None, out=None)
 
     Return evenly spaced values within a given interval.
 
@@ -1731,6 +1731,12 @@ add_newdoc('numpy.core.multiarray', 'arange',
     ${ARRAY_FUNCTION_LIKE}
 
         .. versionadded:: 1.20.0
+
+    out : ndarray, optional
+        If provided, fill this array instead of returning a new one.
+        Can not be be used together with `dtype` or `like`.
+
+        .. versionadded:: 1.23.5
 
     Returns
     -------

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -802,6 +802,14 @@ def arange(
     *,
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
+@overload
+def arange(
+    start: Any,
+    stop: Any,
+    step: Any = ...,
+    *,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
 def datetime_data(
     dtype: str | _DTypeLike[datetime64] | _DTypeLike[timedelta64], /,

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -363,7 +363,7 @@ is_any_numpy_datetime_or_timedelta(PyObject *obj);
  */
 NPY_NO_EXPORT PyArrayObject *
 datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
-                PyArray_Descr *dtype);
+                PyObject *out, PyArray_Descr *dtype);
 
 /*
  * Examines all the objects in the given Python object by

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3254,7 +3254,7 @@ convert_pyobjects_to_datetimes(int count,
 
 NPY_NO_EXPORT PyArrayObject *
 datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
-                PyArray_Descr *dtype)
+                PyObject *out, PyArray_Descr *dtype)
 {
 
     /*
@@ -3283,6 +3283,10 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
         PyErr_SetString(PyExc_ValueError,
                     "cannot use a datetime as a step in arange");
         return NULL;
+    }
+
+    if(out != Py_None) {
+        dtype = PyArray_DESCR((PyArrayObject *)out);
     }
 
     /* Check if the units of the given dtype are generic, in which
@@ -3415,7 +3419,7 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
     }
 
     /* Create the dtype of the result */
-    if (dtype != NULL) {
+    if (dtype != NULL && out != Py_None) {
         Py_INCREF(dtype);
     }
     else {
@@ -3426,9 +3430,15 @@ datetime_arange(PyObject *start, PyObject *stop, PyObject *step,
     }
 
     /* Create the result array */
-    PyArrayObject *ret = (PyArrayObject *)PyArray_NewFromDescr(
+    PyArrayObject *ret = NULL;
+
+    if(out == Py_None) {
+        ret = (PyArrayObject *)PyArray_NewFromDescr(
             &PyArray_Type, dtype, 1, &length, NULL,
             NULL, 0, NULL);
+    } else {
+        ret = (PyArrayObject *)out;
+    }
 
     if (ret == NULL) {
         return NULL;

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -381,6 +381,25 @@ class TestLinspace:
             assert_equal(linspace(0, j, j+1, dtype=int),
                          arange(j+1, dtype=int))
 
+    def test_arange_out(self):
+        for j in range(1000):
+            out = array([0] * j, dtype=int)
+            returned = arange(0, j)
+            arange(0, j, out=out)
+            assert_equal(out, returned)
+
+    def test_arange_wrong_arguments(self):
+        out = array([0, 0, 0, 0], dtype=int)
+
+        # wrong length
+        assert_raises(ValueError, arange, 0, len(out) + 1, out=out)
+        # wrong dimensionality
+        assert_raises(TypeError, arange, 0, len(out), out=out[None, ...])
+        # both dtype and out
+        assert_raises(TypeError, arange, 0, len(out), dtype=out.dtype, out=out)
+        # both like and out
+        assert_raises(TypeError, arange, 0, len(out), like=out, out=out)
+
     def test_retstep(self):
         for num in [0, 1, 2]:
             for ept in [False, True]:


### PR DESCRIPTION
This PR adds an `out` keyword parameter to the `np.arange` function, to provide an array to be filled in-place with the range.
Looking around I did not spot any other way to perform this operation without allocating new arrays and copying them.

Maybe someone more habituated with Python's refcounting could check the C code for proper refcounting behavior. Thanks.

Example: 
```python
import numpy as np
arr = np.zeros(10)
print(arr)
# [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
np.arange(0, len(arr), out=arr)
print(arr)
# [0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]
```