### PR TITLE
wheel CI: Always use latest minor version of cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,7 +118,7 @@ jobs:
         if: ${{ env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
         - EXPECT_CPU_FEATURES: "NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM"
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -73,7 +73,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -86,7 +86,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -99,7 +99,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp311-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh


### PR DESCRIPTION
By removing the exact minor and patch version of the cibuildwheel action, it will always use the latest minor/patch version. For cirrus, it will use the latest version even for new major versions.

This ensures the latest Python versions are always used to build wheels.

Major version updates will be handled by https://github.com/numpy/numpy/pull/22514 for GitHub Actions.
