### PR TITLE
DOC: Remove "current" from byte-order note and expand it slightly

### DIFF
--- a/doc/source/user/byteswapping.rst
+++ b/doc/source/user/byteswapping.rst
@@ -61,12 +61,14 @@ is also big-endian).  However, sometimes you need to flip these around.
 
 .. warning::
 
-    Scalars currently do not include byte order information, so extracting
-    a scalar from an array will return an integer in native byte order.
-    Hence:
+    Scalars do not include byte order information, so extracting a scalar from
+    an array will return an integer in native byte order.  Hence:
 
     >>> big_end_arr[0].dtype.byteorder == little_end_u4[0].dtype.byteorder
     True
+
+    NumPy intentionally does not attempt to always preserve byte-order
+    and for example converts to native byte-order in `numpy.concatenate`.
 
 Changing byte ordering
 ======================


### PR DESCRIPTION
We don't preserve non-native byte-order and we have no wish to do so. (If someone disagrees, they better wite a NEP ;))
Spell it out, and thus:

closes gh-1866