### PR TITLE
DOC: fix description of arctanh in `Notes` (a mistake of domain)

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -545,7 +545,7 @@ add_newdoc('numpy.core.umath', 'arctanh',
     -----
     `arctanh` is a multivalued function: for each `x` there are infinitely
     many numbers `z` such that ``tanh(z) = x``. The convention is to return
-    the `z` whose imaginary part lies in `[-pi/2, pi/2]`.
+    the `z` whose imaginary part lies in `[-1, 1]`.
 
     For real-valued input data types, `arctanh` always returns real output.
     For each value that cannot be expressed as a real number or infinity,


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Hi! I couldn't find it from Issues, but there was a mistake in the description of arctanh's domain, which has been fixed ([-pi/2, pi/2] → [-1, 1]).
Please review this PR and let me know if there are any changes required. 
