### PR TITLE
MAINT, BLD: Wheel CI: Update cibuildwheel to 2.11.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,7 +118,7 @@ jobs:
         if: ${{ env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
         - EXPECT_CPU_FEATURES: "NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM"
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel==2.11.2
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -73,7 +73,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel==2.11.2
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -86,7 +86,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel==2.11.2
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -99,7 +99,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp311-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.9.0
+      install: python3 -m pip install cibuildwheel==2.11.2
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh


### PR DESCRIPTION
This PR updates [cibuildwheel](https://github.com/pypa/cibuildwheel) from 2.9.0 to 2.11.2 ([changelog](https://cibuildwheel.readthedocs.io/en/stable/changelog/#v2112)). This is mainly to use Python 3.11.0 (the stable release) in the CI instead of the 3.11.0rc1 release candidate 2.9.0 uses.

What's interesting, is that cibuildwheel now also supports cross-compiling Windows ARM64 wheels (see [`CIBW_ARCHS`](https://cibuildwheel.readthedocs.io/en/stable/options/#archs)).