### PR TITLE
BLD: update OpenBLAS to 0.3.21 and clean up openblas download test

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -2,6 +2,8 @@
 #
 # if: github.repository == 'numpy/numpy'
 
+name: CircleCI artifact redirector
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,14 +108,21 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Configure mingw for 32-bit builds
+      - uses: actions/checkout@v2
+
+      - name: install-rtools
         run: |
-          # Force 32-bit mingw
-          choco uninstall mingw
-          choco install -y mingw --forcex86 --force --version=7.3.0
-          echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          refreshenv
-        if: ${{ env.IS_32_BIT == 'true' }}
+          choco install rtools --no-progress
+          if ($IS_32_BIT -eq "true") {
+            echo "PLAT=i686" >> $env:GITHUB_ENV
+            echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
+            echo "LDFLAGS=-static -static-libgcc" >> $env:GITHUB_ENV
+          } else {
+            echo "PLAT=x86_64" >> $env:GITHUB_ENV
+            echo "MSYSTEM=UCRT64" >> $env:GITHUB_ENV
+            echo "LDFLAGS=-lucrt -static -static-libgcc" >> $env:GITHUB_ENV
+          }
+        if: ${{ matrix.buildplat[0] == 'windows-2019' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,7 +113,6 @@ jobs:
           choco install rtools --no-progress
           if ($IS_32_BIT -eq "true") {
             echo "PLAT=i686" >> $env:GITHUB_ENV
-            echo "RTOOLS40_HOME\mingw64\bin;$env:PATH" >> $env:GITHUB_ENV
             echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
             echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           } else {

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,11 +104,9 @@ jobs:
           fetch-depth: 0
 
       # Used to push the built wheels
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-
-      - uses: actions/checkout@v2
 
       - name: install-rtools
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,8 @@ jobs:
 
       - name: install-rtools
         run: |
-          choco install rtools --no-progress
+          # Already installed
+          # choco install rtools --no-progress
           if ($IS_32_BIT -eq "true") {
             echo "PLAT=i686" >> $env:GITHUB_ENV
             echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
@@ -120,6 +121,7 @@ jobs:
             echo "MSYSTEM=UCRT64" >> $env:GITHUB_ENV
             echo "PATH=$env:RTOOLS40_HOME\mingw64\bin;$env:PATH" >> $env:GITHUB_ENV
           }
+          gfortran --version
         if: ${{ matrix.buildplat[0] == 'windows-2019' }}
 
       - name: Build wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,21 +108,13 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: install-rtools
+      - name: setup rtools for 32-bit
         run: |
-          # Already installed
-          # choco install rtools --no-progress
-          if ($IS_32_BIT -eq "true") {
-            echo "PLAT=i686" >> $env:GITHUB_ENV
-            echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
-            echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
-          } else {
-            echo "PLAT=x86_64" >> $env:GITHUB_ENV
-            echo "MSYSTEM=UCRT64" >> $env:GITHUB_ENV
-            echo "PATH=$env:RTOOLS40_HOME\mingw64\bin;$env:PATH" >> $env:GITHUB_ENV
-          }
+          echo "PLAT=i686" >> $env:GITHUB_ENV
+          echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
+          echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           gfortran --version
-        if: ${{ matrix.buildplat[0] == 'windows-2019' }}
+        if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,12 +113,13 @@ jobs:
           choco install rtools --no-progress
           if ($IS_32_BIT -eq "true") {
             echo "PLAT=i686" >> $env:GITHUB_ENV
+            echo "RTOOLS40_HOME\mingw64\bin;$env:PATH" >> $env:GITHUB_ENV
             echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
-            echo "LDFLAGS=-static -static-libgcc" >> $env:GITHUB_ENV
+            echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           } else {
             echo "PLAT=x86_64" >> $env:GITHUB_ENV
             echo "MSYSTEM=UCRT64" >> $env:GITHUB_ENV
-            echo "LDFLAGS=-lucrt -static -static-libgcc" >> $env:GITHUB_ENV
+            echo "PATH=$env:RTOOLS40_HOME\mingw64\bin;$env:PATH" >> $env:GITHUB_ENV
           }
         if: ${{ matrix.buildplat[0] == 'windows-2019' }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
-       - NPY_USE_BLAS_ILP64=1
+       # - NPY_USE_BLAS_ILP64=1   # the openblas build fails
        - ATLAS=None
        # VSX4 still not supported by ubuntu/gcc-11
        - EXPECT_CPU_FEATURES="VSX VSX2 VSX3"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,8 +158,8 @@ stages:
     - script: |
         set -xe
         # same version of gfortran as the open-libs and numpy-wheel builds
-        local arch="x86_64"
-        local type="native"
+        arch="x86_64"
+        type="native"
         curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
         GFORTRAN_SHA=$(shasum gfortran.dmg)
         KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,30 +151,14 @@ stages:
         [ -n "$USE_XCODE_10" ] && /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
         clang --version
       displayName: 'report clang version'
-    # NOTE: might be better if we could avoid installing
-    # two C compilers, but with homebrew looks like we're
-    # now stuck getting the full gcc toolchain instead of
-    # just pulling in gfortran
+
     - script: |
-        set -xe
-        # same version of gfortran as the open-libs and numpy-wheel builds
-        arch="x86_64"
-        type="native"
-        curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
-        GFORTRAN_SHA=$(shasum gfortran.dmg)
-        KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"
-        if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-            echo sha256 mismatch
-            exit 1
+        if [[ $PLATFORM == "macosx-arm64" ]]; then
+            PLAT="arm64"
         fi
-        hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-        sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-        otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
-        # Manually symlink gfortran-4.9 to plain gfortran for f2py.
-        # No longer needed after Feb 13 2020 as gfortran is already present
-        # and the attempted link errors. Keep this for future reference.
-        # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
-      displayName: 'make libgfortran available on mac os for openblas'
+        source tools/wheels/gfortran_utils.sh
+        install_gfortran
+      displayName: 'install gfortran'
     # use the pre-built openblas binary that most closely
     # matches our MacOS wheel builds -- currently based
     # primarily on file size / name details

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,6 +113,7 @@ stages:
             echo CFLAGS \$CFLAGS && \
             python3 -m pip install -v . && \
             python3 runtests.py -n --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml && \
+            python3 -m pip install threadpoolctl && \
             python3 tools/openblas_support.py --check_version"
       displayName: 'Run 32-bit manylinux2014 Docker Build / Tests'
     - task: PublishTestResults@2
@@ -227,7 +228,9 @@ stages:
       env:
         # gfortran installed above adds -lSystem, so this is needed to find it (gh-22043)
         LIBRARY_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-    - bash: python tools/openblas_support.py --check_version
+    - bash: |
+        python -m pip install threadpoolctl
+        python tools/openblas_support.py --check_version
       displayName: 'Verify OpenBLAS version'
       condition: eq(variables['USE_OPENBLAS'], '1')
     # import doesn't work when in numpy src directory , so do a pip dev install of build lib to test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,16 +158,18 @@ stages:
     - script: |
         set -xe
         # same version of gfortran as the open-libs and numpy-wheel builds
-        curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-        GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-        KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
+        local arch="x86_64"
+        local type="native"
+        curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
+        GFORTRAN_SHA=$(shasum gfortran.dmg)
+        KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"
         if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
             echo sha256 mismatch
             exit 1
         fi
         hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
         sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-        otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
+        otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
         # Manually symlink gfortran-4.9 to plain gfortran for f2py.
         # No longer needed after Feb 13 2020 as gfortran is already present
         # and the attempted link errors. Keep this for future reference.

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -34,7 +34,7 @@ steps:
 - powershell: |
     choco install -y rtools
     refreshenv
-  displayName: 'Install rtools
+  displayName: 'Install rtools'
 
 - powershell: |
     $target = $(python tools/openblas_support.py)

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -76,6 +76,11 @@ steps:
     }
   displayName: 'Build NumPy'
 
+- script: |
+    python -m pip install threadpoolctl
+    python tools/openblas_support.py --check_version
+  displayName: 'Check OpenBLAS version"
+
 - powershell: |
     If ($(BITS) -eq 32) {
         $env:CFLAGS = "-m32"

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -34,47 +34,20 @@ steps:
 - powershell: |
     choco install -y rtools
     refreshenv
-  displayName: 'Install rtools for 64-bit builds
-  condition: eq(variables['BITS'], 32)
+  displayName: 'Install rtools
 
 - powershell: |
-    choco install -y mingw --forcex86 --force --version=7.3.0
-    refreshenv
-  displayName: 'Install 32-bit mingw for 32-bit builds'
-  condition: eq(variables['BITS'], 32)
-
-- powershell: |
-    $ErrorActionPreference = "Stop"
-    # Download and get the path to "openblas.a". We cannot copy it
-    # to $PYTHON_EXE's directory since that is on a different drive which
-    # mingw does not like. Instead copy it to a directory and set OPENBLAS,
-    # since OPENBLAS will be picked up by the openblas discovery
     $target = $(python tools/openblas_support.py)
-    mkdir openblas
-    echo "Copying $target to openblas/"
-    cp $target openblas/
+    $env:OPENBLAS = $target
   displayName: 'Download / Install OpenBLAS'
 
 # NOTE: for Windows builds it seems much more tractable to use runtests.py
 # vs. manual setup.py and then runtests.py for testing only
 
 - powershell: |
-    ls openblas
-    If ($(BITS) -eq 32) {
-        $env:CFLAGS = "-m32"
-        $env:LDFLAGS = "-m32"
-        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-    }
-    Else
-    {
-        $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
-    }
     If ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
-        $env:OPENBLAS64_ = "openblas"
-    } else {
-        $env:OPENBLAS = "openblas"
+        $env:OPENBLAS64_ = $env:OPENBLAS
     }
-    gfortran --version
     python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
     python -m pip wheel -v -v -v --no-build-isolation --no-use-pep517 --wheel-dir=dist .
 
@@ -83,7 +56,18 @@ steps:
     }
   displayName: 'Build NumPy'
 
-- script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
+- powershell: |
+    # gfortran from rtools is needed for tests
+    If ($(BITS) -eq 32) {
+        $env:CFLAGS = "-m32"
+        $env:LDFLAGS = "-m32"
+        $env:PATH = "$env:RTOOLS40_HOME\\mingw32\\bin;$env:PATH"
+    }
+    Else
+    {
+        $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
+    }
+    python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
   displayName: 'Run NumPy Test Suite'
 
 - task: PublishTestResults@2

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -37,7 +37,15 @@ steps:
   displayName: 'Install rtools'
 
 - powershell: |
+    $ErrorActionPreference = "Stop"
+    # Download and get the path to "openblas". We cannot copy it
+    # to $PYTHON_EXE's directory since that is on a different drive which
+    # mingw does not like. Instead copy it to a directory and set OPENBLAS,
+    # since OPENBLAS will be picked up by the openblas discovery
     $target = $(python tools/openblas_support.py)
+    mkdir openblas
+    echo "Copying $target to openblas/"
+    cp -r $target/* openblas/
     $env:OPENBLAS = $target
   displayName: 'Download / Install OpenBLAS'
 
@@ -45,8 +53,20 @@ steps:
 # vs. manual setup.py and then runtests.py for testing only
 
 - powershell: |
+    ls openblas
+    If ($(BITS) -eq 32) {
+        $env:CFLAGS = "-m32"
+        $env:LDFLAGS = "-m32"
+        $env:PATH = "$env:RTOOLS40_HOME\\mingw32\\bin;$env:PATH"
+    }
+    Else
+    {
+        $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
+    }
     If ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
-        $env:OPENBLAS64_ = $env:OPENBLAS
+        $env:OPENBLAS64_ = "openblas"
+    } else {
+        $env:OPENBLAS = "openblas"
     }
     python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
     python -m pip wheel -v -v -v --no-build-isolation --no-use-pep517 --wheel-dir=dist .
@@ -57,7 +77,6 @@ steps:
   displayName: 'Build NumPy'
 
 - powershell: |
-    # gfortran from rtools is needed for tests
     If ($(BITS) -eq 32) {
         $env:CFLAGS = "-m32"
         $env:LDFLAGS = "-m32"

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -79,7 +79,7 @@ steps:
 - script: |
     python -m pip install threadpoolctl
     python tools/openblas_support.py --check_version
-  displayName: 'Check OpenBLAS version"
+  displayName: 'Check OpenBLAS version'
 
 - powershell: |
     If ($(BITS) -eq 32) {

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -32,6 +32,12 @@ steps:
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
 - powershell: |
+    choco install -y rtools
+    refreshenv
+  displayName: 'Install rtools for 64-bit builds
+  condition: eq(variables['BITS'], 32)
+
+- powershell: |
     choco install -y mingw --forcex86 --force --version=7.3.0
     refreshenv
   displayName: 'Install 32-bit mingw for 32-bit builds'
@@ -61,13 +67,14 @@ steps:
     }
     Else
     {
-        $env:LDFLAGS = "-lucrt"
+        $env:PATH = "$env:RTOOLS40_HOME\\mingw64\\bin;$env:PATH"
     }
     If ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
         $env:OPENBLAS64_ = "openblas"
     } else {
         $env:OPENBLAS = "openblas"
     }
+    gfortran --version
     python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
     python -m pip wheel -v -v -v --no-build-isolation --no-use-pep517 --wheel-dir=dist .
 

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -59,6 +59,10 @@ steps:
         $env:LDFLAGS = "-m32"
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
     }
+    Else
+    {
+        $env:LDFLAGS = "-lucrt"
+    }
     If ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
         $env:OPENBLAS64_ = "openblas"
     } else {

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -586,6 +586,13 @@ class build_ext (old_build_ext):
             # not using fcompiler linker
             self._libs_with_msvc_and_fortran(
                 fcompiler, libraries, library_dirs)
+            if ext.runtime_library_dirs:
+                # gcc adds RPATH to the link. On windows, copy the dll into
+                # self.extra_dll_dir instead.
+                for d in ext.runtime_library_dirs:
+                    for f in glob(d + '/*.dll'):
+                        copy_file(f, self.extra_dll_dir)
+                ext.runtime_library_dirs = []
 
         elif ext.language in ['f77', 'f90'] and fcompiler is not None:
             linker = fcompiler.link_shared_object

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -68,23 +68,7 @@ def test_f2py_init_compile(extra_args):
         # check for sensible result of Fortran function; that means
         # we can import the module name in Python and retrieve the
         # result of the sum operation
-        if sys.platform == 'darwin':
-            print("xxxxxxxxxxxxxxxxxxxxxxxxxxx")
-            import subprocess
-            print(moddir, modname)
-            try:
-                print("----- ls moddir -----------")
-                subprocess.run(["ls", moddir])
-                print("----- ls /usr/local/lib/ -----------")
-                subprocess.run(["ls", "/usr/local/lib"])
-                print("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")
-                subprocess.run(["otool", "-L", moddir + '/' + modname + '.cpython-38-darwin.so'])
-                print("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")
-                return_check = import_module(modname)
-            finally:
-                print("xxxxxxxxxxxxxxxxxxxxxxxxxxx")
-        else:
-            return_check = import_module(modname)
+        return_check = import_module(modname)
         calc_result = return_check.foo()
         assert calc_result == 15
         # Removal from sys.modules, is not as such necessary. Even with

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -68,7 +68,23 @@ def test_f2py_init_compile(extra_args):
         # check for sensible result of Fortran function; that means
         # we can import the module name in Python and retrieve the
         # result of the sum operation
-        return_check = import_module(modname)
+        if sys.platform == 'darwin':
+            print("xxxxxxxxxxxxxxxxxxxxxxxxxxx")
+            import subprocess
+            print(moddir, modname)
+            try:
+                print("----- ls moddir -----------")
+                subprocess.run(["ls", moddir])
+                print("----- ls /usr/local/lib/ -----------")
+                subprocess.run(["ls", "/usr/local/lib"])
+                print("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")
+                subprocess.run(["otool", "-L", moddir + '/' + modname + '.cpython-38-darwin.so'])
+                print("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")
+                return_check = import_module(modname)
+            finally:
+                print("xxxxxxxxxxxxxxxxxxxxxxxxxxx")
+        else:
+            return_check = import_module(modname)
         calc_result = return_check.foo()
         assert calc_result == 15
         # Removal from sys.modules, is not as such necessary. Even with

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -920,6 +920,7 @@ def test_large_file_support(tmpdir):
     assert_array_equal(r, d)
 
 
+@pytest.mark.skipif(IS_PYPY, reason="flaky on PyPy")
 @pytest.mark.skipif(np.dtype(np.intp).itemsize < 8,
                     reason="test requires 64-bit system")
 @pytest.mark.slow

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -284,32 +284,25 @@ def test_setup(plats):
         raise errs[0]
 
 
-def test_version(expected_version, ilp64=get_ilp64()):
+
+def test_version(expected_version=None):
     """
     Assert that expected OpenBLAS version is
-    actually available via NumPy
+    actually available via NumPy. Requires threadpoolctl
     """
     import numpy
-    import ctypes
+    import threadpoolctl
 
-    dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__)
-    if ilp64 == "64_":
-        get_config = dll.openblas_get_config64_
-    else:
-        get_config = dll.openblas_get_config
-    get_config.restype = ctypes.c_char_p
-    res = get_config()
-    print('OpenBLAS get_config returned', str(res))
+    data = threadpoolctl.threadpool_info()
+    if len(data) != 1:
+        raise ValueError(f"expected single threadpool_info result, got {data}")
     if not expected_version:
         expected_version = OPENBLAS_V
-    check_str = b'OpenBLAS %s' % expected_version.encode()
-    print(check_str)
-    assert check_str in res, f'{expected_version} not found in {res}'
-    if ilp64:
-        assert b"USE64BITINT" in res
-    else:
-        assert b"USE64BITINT" not in res
-
+    if data[0]['version'] != expected_version:
+        raise ValueError(
+            f"expected OpenBLAS version {expected_version}, got {data}"
+        )
+    print("OK")
 
 if __name__ == '__main__':
     import argparse

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -284,7 +284,6 @@ def test_setup(plats):
         raise errs[0]
 
 
-
 def test_version(expected_version=None):
     """
     Assert that expected OpenBLAS version is

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.20'
-OPENBLAS_LONG = 'v0.3.20'
+OPENBLAS_V = '0.3.21'
+OPENBLAS_LONG = 'v0.3.21'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [
@@ -54,13 +54,10 @@ def get_ilp64():
 
 
 def get_manylinux(arch):
-    if arch in ('x86_64', 'i686'):
-        default = '2010'
-    else:
-        default = '2014'
+    default = '2014'
     ret = os.environ.get("MB_ML_VER", default)
     # XXX For PEP 600 this can be a glibc version
-    assert ret in ('1', '2010', '2014', '_2_24'), f'invalid MB_ML_VER {ret}'
+    assert ret in ('2010', '2014', '_2_24'), f'invalid MB_ML_VER {ret}'
     return ret
 
 
@@ -84,9 +81,9 @@ def download_openblas(target, plat, ilp64):
         typ = 'tar.gz'
     elif osname == 'win':
         if plat == "win-32":
-            suffix = 'win32-gcc_8_1_0.zip'
+            suffix = 'win32-gcc_8_3_0.zip'
         else:
-            suffix = 'win_amd64-gcc_8_1_0.zip'
+            suffix = 'win_amd64-gcc_10_3_0.zip'
         typ = 'zip'
 
     if not suffix:
@@ -102,11 +99,11 @@ def download_openblas(target, plat, ilp64):
     if response.status != 200:
         print(f'Could not download "{filename}"', file=sys.stderr)
         return None
-    print(f"Downloading {length} from {filename}", file=sys.stderr)
+    # print(f"Downloading {length} from {filename}", file=sys.stderr)
     data = response.read()
     # Verify hash
     key = os.path.basename(filename)
-    print("Saving to file", file=sys.stderr)
+    # print("Saving to file", file=sys.stderr)
     with open(target, 'wb') as fid:
         fid.write(data)
     return typ
@@ -235,7 +232,8 @@ def make_init(dirname):
 
 def test_setup(plats):
     '''
-    Make sure all the downloadable files exist and can be opened
+    Make sure all the downloadable files needed for wheel building
+    exist and can be opened
     '''
     def items():
         """ yields all combinations of arch, ilp64
@@ -243,19 +241,8 @@ def test_setup(plats):
         for plat in plats:
             yield plat, None
             osname, arch = plat.split("-")
-            if arch not in ('i686', 'arm64', '32'):
+            if arch not in ('i686', '32'):
                 yield plat, '64_'
-            if osname == "linux" and arch in ('i686', 'x86_64'):
-                oldval = os.environ.get('MB_ML_VER', None)
-                os.environ['MB_ML_VER'] = '1'
-                yield plat, None
-                # Once we create x86_64 and i686 manylinux2014 wheels...
-                # os.environ['MB_ML_VER'] = '2014'
-                # yield arch, None, False
-                if oldval:
-                    os.environ['MB_ML_VER'] = oldval
-                else:
-                    os.environ.pop('MB_ML_VER')
 
     errs = []
     for plat, ilp64 in items():
@@ -273,7 +260,7 @@ def test_setup(plats):
                 continue
             if not target:
                 raise RuntimeError(f'Could not setup {plat}')
-            print(target)
+            print('success with', plat, ilp64)
             if osname == 'win':
                 if not target.endswith('.a'):
                     raise RuntimeError("Not .a extracted!")

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -153,6 +153,7 @@ def unpack_windows_zip(fname, plat):
     assert len(lib) == 1
     for f in lib:
         shutil.copy(f, os.path.join(target, 'lib', 'openblas.lib'))
+        shutil.copy(f, os.path.join(target, 'lib', 'openblas64_.lib'))
     # Copy the dll from bin to lib so system_info can pick it up
     dll = glob.glob(os.path.join(target, 'bin', '*.dll'))
     for f in dll:

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -74,10 +74,10 @@ def download_openblas(target, plat, ilp64):
         suffix = f'manylinux{ml_ver}_{arch}.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-x86_64':
-        suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
+        suffix = 'macosx_10_9_x86_64-gf_c469a42.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-arm64':
-        suffix = 'macosx_11_0_arm64-gf_f26990f.tar.gz'
+        suffix = 'macosx_11_0_arm64-gf_5272328.tar.gz'
         typ = 'tar.gz'
     elif osname == 'win':
         if plat == "win-32":

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -143,6 +143,7 @@ EOF
   fi
 
   if [ -n "$CHECK_BLAS" ]; then
+    $PYTHON -m pip install threadpoolctl 
     $PYTHON ../tools/openblas_support.py --check_version
   fi
 

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -27,7 +27,7 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
-    for f in ls $target; do
+    for f in $(ls $target); do
         cp -r $f openblas
     done
     ls openblas

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -38,28 +38,9 @@ fi
 # Install GFortran
 if [[ $RUNNER_OS == "macOS" ]]; then
     # same version of gfortran as the openblas-libs and numpy-wheel builds
-    arch="x86_64"
-    type="native"
-    curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
-    GFORTRAN_SHA=$(shasum  gfortran.dmg)
-    KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"
-    if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
-        echo sha256 mismatch
-        exit 1
-    fi
-
-    hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-    sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-    otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
-
-    # arm64 stuff from gfortran_utils
     if [[ $PLATFORM == "macosx-arm64" ]]; then
-        source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
-        install_arm64_cross_gfortran
+        PLAT="arm64"
     fi
-
-    # Manually symlink gfortran-4.9 to plain gfortran for f2py.
-    # No longer needed after Feb 13 2020 as gfortran is already present
-    # and the attempted link errors. Keep this for future reference.
-    # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
+    source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
+    install_gfortran
 fi

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -27,8 +27,9 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
-    ls $target
-    cp -r $target\\* openblas
+    for f in ls $target; do
+        cp -r $f openblas
+    done
     ls openblas
 fi
 

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -26,9 +26,11 @@ if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]] ; then
 elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
+    ls /tmp
     mkdir -p openblas
+    # bash on windows does not like cp -r $target/* openblas
     for f in $(ls $target); do
-        cp -r $f openblas
+        cp -r $target/$f openblas
     done
     ls openblas
 fi
@@ -36,9 +38,11 @@ fi
 # Install GFortran
 if [[ $RUNNER_OS == "macOS" ]]; then
     # same version of gfortran as the openblas-libs and numpy-wheel builds
-    curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
-    GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-    KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
+    local arch="x86_64"
+    local type="native"
+    curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
+    GFORTRAN_SHA=$(shasum  gfortran.dmg)
+    KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"
     if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
         echo sha256 mismatch
         exit 1
@@ -46,7 +50,7 @@ if [[ $RUNNER_OS == "macOS" ]]; then
 
     hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
     sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-    otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
+    otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
 
     # arm64 stuff from gfortran_utils
     if [[ $PLATFORM == "macosx-arm64" ]]; then

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -28,7 +28,7 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
     ls $target
-    cp -r $target\* openblas
+    cp -r $target\\* openblas
     ls openblas
 fi
 

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -27,7 +27,7 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
-    cp $target openblas
+    cp -r $target openblas
 fi
 
 # Install GFortran

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -38,8 +38,8 @@ fi
 # Install GFortran
 if [[ $RUNNER_OS == "macOS" ]]; then
     # same version of gfortran as the openblas-libs and numpy-wheel builds
-    local arch="x86_64"
-    local type="native"
+    arch="x86_64"
+    type="native"
     curl -L https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz -o gfortran.dmg
     GFORTRAN_SHA=$(shasum  gfortran.dmg)
     KNOWN_SHA="c469a420d2d003112749dcdcbe3c684eef42127e  gfortran.dmg"

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -35,12 +35,13 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     ls openblas
 fi
 
-# Install GFortran
 if [[ $RUNNER_OS == "macOS" ]]; then
-    # same version of gfortran as the openblas-libs and numpy-wheel builds
+    # Install same version of gfortran as the openblas-libs builds
     if [[ $PLATFORM == "macosx-arm64" ]]; then
         PLAT="arm64"
     fi
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
+    # Try a newer version of delocate that knows about /usr/local/lib
+    pip install git+https://github.com/isuruf/delocate@search_usr_local#egg=delocate
 fi

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -27,7 +27,8 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
-    cp -r $target openblas
+    cp -r $target/* openblas
+    ls openblas
 fi
 
 # Install GFortran

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -27,7 +27,8 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
     mkdir -p openblas
-    cp -r $target/* openblas
+    ls $target
+    cp -r $target\* openblas
     ls openblas
 fi
 

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -12,13 +12,10 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     PY_DIR=$(python -c "import sys; print(sys.prefix)")
     mkdir $PY_DIR/libs
 fi
-if [[ $RUNNER_OS == "macOS" ]]; then
-    # Install same version of gfortran as the openblas-libs builds
-    if [[ $PLATFORM == "macosx-arm64" ]]; then
-        PLAT="arm64"
-    fi
-    source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
-    install_gfortran
+if [[ $RUNNER_OS == "macOS"  && $RUNNER_ARCH == "X64" ]]; then
+    # Not clear why this is needed but it seems on x86_64 this is not the default
+    # and without it f2py tests fail
+    export DYLD_LIBRARY_PATH=/usr/local/lib
 fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -12,7 +12,14 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     PY_DIR=$(python -c "import sys; print(sys.prefix)")
     mkdir $PY_DIR/libs
 fi
-
+if [[ $RUNNER_OS == "macOS" ]]; then
+    # Install same version of gfortran as the openblas-libs builds
+    if [[ $PLATFORM == "macosx-arm64" ]]; then
+        PLAT="arm64"
+    fi
+    source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
+    install_gfortran
+fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.
 export NPY_AVAILABLE_MEM="4 GB"

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -23,7 +23,12 @@ fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.
 export NPY_AVAILABLE_MEM="4 GB"
-python -c "import sys; import numpy; sys.exit(not numpy.test('full'))"
-
+if [[ $(python -c "import sys; print(sys.implementation.name)") == "pypy" ]]; then
+  # make PyPy more verbose, try to catc a segfault in
+  # numpy/lib/tests/test_function_base.py
+  python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', verbose=2))"
+else
+  python -c "import sys; import numpy; sys.exit(not numpy.test(label='full'))"
+fi
 python $PROJECT_DIR/tools/wheels/check_license.py
 python $PROJECT_DIR/tools/openblas_support.py --check_version

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -5,6 +5,7 @@ set -xe
 
 PROJECT_DIR="$1"
 
+python -m pip install threadpoolctl
 python -c "import numpy; numpy.show_config()"
 if [[ $RUNNER_OS == "Windows" ]]; then
     # GH 20391
@@ -18,6 +19,4 @@ export NPY_AVAILABLE_MEM="4 GB"
 python -c "import sys; import numpy; sys.exit(not numpy.test('full'))"
 
 python $PROJECT_DIR/tools/wheels/check_license.py
-if [[ $UNAME == "Linux" || $UNAME == "Darwin" ]] ; then
-    python $PROJECT_DIR/tools/openblas_support.py --check_version
-fi
+python $PROJECT_DIR/tools/openblas_support.py --check_version


### PR DESCRIPTION
The builds have changed slightly:
- no longer need to check for manylinux1, manylinux2010 OpenBLAS builds: we exclusively build manylinux2014 wheels
- windows 64 bits compiles with gcc 10.3
- windows 32 bits compiles with gcc 8.3
- macos builds with gfortran from [MacPython/gfortran-install](https://github.com/MacPython/gfortran-install/blob/master/gfortran_utils.sh)
- consistently re-use the gfortran_utils.sh install script to provide the macos gfortran compiler
- check the OpenBLAS version on all wheels via `tools/openblas_support.py` and `threadpoolctl`

Maybe related to #22502