### PR TITLE
DOC: Update the docstrings for np.around and np.round_

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3279,7 +3279,8 @@ def around(a, decimals=0, out=None):
 
     Notes
     -----
-    `~numpy.round` is often used as an alias for `~numpy.around`.
+    `~numpy.round` and `~np.round_` are disrecommended backwards-compatibility aliases of `~numpy.around`.
+    Wherever possible, neither should be used.
     
     For values exactly halfway between rounded decimal values, NumPy
     rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0,
@@ -3748,13 +3749,17 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
                          **kwargs)
 
 
-# Aliases of other functions. These have their own definitions only so that
-# they can have unique docstrings.
+# Aliases of other functions. Provided unique docstrings are reference purposes only.
+# Wherever possible, avoid using them.
 
 @array_function_dispatch(_around_dispatcher)
 def round_(a, decimals=0, out=None):
     """
     Round an array to the given number of decimals.
+
+    Notes
+    --------
+    `~numpy.round_` is a disrecommended backwards-compatibility alias of `~numpy.around`.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3279,7 +3279,8 @@ def around(a, decimals=0, out=None):
 
     Notes
     -----
-    `~numpy.round` and `~np.round_` are disrecommended backwards-compatibility aliases of `~numpy.around`.
+    `~numpy.round` and `~np.round_` are disrecommended 
+    backwards-compatibility aliases of `~numpy.around`. 
     Wherever possible, neither should be used.
     
     For values exactly halfway between rounded decimal values, NumPy
@@ -3749,8 +3750,9 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
                          **kwargs)
 
 
-# Aliases of other functions. Provided unique docstrings are reference purposes only.
-# Wherever possible, avoid using them.
+# Aliases of other functions. Provided unique docstrings 
+# are reference purposes only. Wherever possible,
+# avoid using them.
 
 @array_function_dispatch(_around_dispatcher)
 def round_(a, decimals=0, out=None):
@@ -3759,7 +3761,8 @@ def round_(a, decimals=0, out=None):
 
     Notes
     --------
-    `~numpy.round_` is a disrecommended backwards-compatibility alias of `~numpy.around`.
+    `~numpy.round_` is a disrecommended backwards-compatibility
+    alias of `~numpy.around`.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3279,9 +3279,9 @@ def around(a, decimals=0, out=None):
 
     Notes
     -----
-    `~numpy.round` and `~np.round_` are disrecommended 
-    backwards-compatibility aliases of `~numpy.around`. 
-    Wherever possible, neither should be used.
+    `~numpy.round` is often used as an alias for `~numpy.around`.
+    `~np.round_` is another alias of `~numpy.around`. Its use is
+    not recommended.
     
     For values exactly halfway between rounded decimal values, NumPy
     rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0,
@@ -3762,7 +3762,7 @@ def round_(a, decimals=0, out=None):
     Notes
     --------
     `~numpy.round_` is a disrecommended backwards-compatibility
-    alias of `~numpy.around`.
+    alias of `~numpy.around` and `~numpy.round`.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3280,8 +3280,6 @@ def around(a, decimals=0, out=None):
     Notes
     -----
     `~numpy.round` is often used as an alias for `~numpy.around`.
-    `~np.round_` is another alias of `~numpy.around`. Its use is
-    not recommended.
     
     For values exactly halfway between rounded decimal values, NumPy
     rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0,
@@ -3759,8 +3757,6 @@ def round_(a, decimals=0, out=None):
     """
     Round an array to the given number of decimals.
 
-    Notes
-    --------
     `~numpy.round_` is a disrecommended backwards-compatibility
     alias of `~numpy.around` and `~numpy.round`.
 


### PR DESCRIPTION
Update the docstrings for np.around and np.round_ to address #19717. Added additional info based on the comments in https://github.com/numpy/numpy/pull/21853.
