### PR TITLE
BLD: Update to macos-11 for x86_64 wheels.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,7 +75,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64]
-          - [macos-10.15, macosx_*]
+          - [macos-11, macosx_*]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
         # TODO: uncomment PyPy 3.9 builds once PyPy

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.20'
-OPENBLAS_LONG = 'v0.3.20'
+OPENBLAS_V = '0.3.21'
+OPENBLAS_LONG = 'v0.3.21'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [
@@ -77,7 +77,7 @@ def download_openblas(target, plat, ilp64):
         suffix = f'manylinux{ml_ver}_{arch}.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-x86_64':
-        suffix = 'macosx_10_9_x86_64-gf_1becaaa.tar.gz'
+        suffix = 'macosx_10_11_x86_64-gf_dd3e148.tar.gz'
         typ = 'tar.gz'
     elif plat == 'macosx-arm64':
         suffix = 'macosx_11_0_arm64-gf_f26990f.tar.gz'

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -33,17 +33,22 @@ fi
 # Install GFortran
 if [[ $RUNNER_OS == "macOS" ]]; then
     # same version of gfortran as the openblas-libs and numpy-wheel builds
-    curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
+    curl -L https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg -o gfortran.dmg
     GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
-    KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
+    KNOWN_SHA256="81d379231ba5671a5ef1b7832531f53be5a1c651701a61d87e1d877c4f06d369  gfortran.dmg"
+    #curl -L https://github.com/MacPython/gfortran-install/raw/master/archives/gfortran-4.9.0-Mavericks.dmg -o gfortran.dmg
+    #GFORTRAN_SHA256=$(shasum -a 256 gfortran.dmg)
+    #KNOWN_SHA256="d2d5ca5ba8332d63bbe23a07201c4a0a5d7e09ee56f0298a96775f928c3c4b30  gfortran.dmg"
     if [ "$GFORTRAN_SHA256" != "$KNOWN_SHA256" ]; then
         echo sha256 mismatch
         exit 1
     fi
 
     hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-    sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
-    otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
+    sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave.pkg -target /
+    otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
+    #sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
+    #otool -L /usr/local/gfortran/lib/libgfortran.3.dylib
 
     # arm64 stuff from gfortran_utils
     if [[ $PLATFORM == "macosx-arm64" ]]; then

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -45,7 +45,7 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     fi
 
     hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
-    sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave.pkg -target /
+    sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave -target /
     otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
     #sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
     #otool -L /usr/local/gfortran/lib/libgfortran.3.dylib

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -45,6 +45,7 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     fi
 
     hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
+    ls  /Volumes/gfortran/
     sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave -target /
     otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
     #sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -46,7 +46,7 @@ if [[ $RUNNER_OS == "macOS" ]]; then
 
     hdiutil attach -mountpoint /Volumes/gfortran gfortran.dmg
     ls  /Volumes/gfortran/
-    sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave -target /
+    sudo installer -pkg /Volumes/gfortran/gfortran-8.2-Mojave/gfortran.pkg -target /
     otool -L /usr/local/gfortran/lib/libgfortran.5.dylib
     #sudo installer -pkg /Volumes/gfortran/gfortran.pkg -target /
     #otool -L /usr/local/gfortran/lib/libgfortran.3.dylib


### PR DESCRIPTION
The tests were already updated, but the wheels remained at macos-10.15. This updates the wheel builds as well and should avoid the warning that 10.15 will be removed in December 2022.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
