### PR TITLE
DEP: Expire deprecation of dtype/signature allowing instances

### DIFF
--- a/doc/release/upcoming_changes/22540.expired.rst
+++ b/doc/release/upcoming_changes/22540.expired.rst
@@ -1,3 +1,5 @@
-* Passing dtype instances other than the default ones to
-  ``dtype=`` or ``signature=` in ufuncs will now raise a
-  ``TypeError``.  (Initially deprecated in NumPy 1.21.)
+* Passing dtype instances other than the canonical (mainly native byte-order)
+  ones to ``dtype=`` or ``signature=` in ufuncs will now raise a ``TypeError``.
+  We recommend passing the strings ``"int8"`` or scalar types ``np.int8``
+  since the byte-order, datetime/timedelta unit, etc. are never enforced.
+  (Initially deprecated in NumPy 1.21.)

--- a/doc/release/upcoming_changes/22540.expired.rst
+++ b/doc/release/upcoming_changes/22540.expired.rst
@@ -1,5 +1,5 @@
 * Passing dtype instances other than the canonical (mainly native byte-order)
-  ones to ``dtype=`` or ``signature=` in ufuncs will now raise a ``TypeError``.
+  ones to ``dtype=`` or ``signature=`` in ufuncs will now raise a ``TypeError``.
   We recommend passing the strings ``"int8"`` or scalar types ``np.int8``
   since the byte-order, datetime/timedelta unit, etc. are never enforced.
   (Initially deprecated in NumPy 1.21.)

--- a/doc/release/upcoming_changes/22540.expired.rst
+++ b/doc/release/upcoming_changes/22540.expired.rst
@@ -1,0 +1,3 @@
+* Passing dtype instances other than the default ones to
+  ``dtype=`` or ``signature=` in ufuncs will now raise a
+  ``TypeError``.  (Initially deprecated in NumPy 1.21.)

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4361,23 +4361,16 @@ _get_dtype(PyObject *dtype_obj) {
         }
         else if (NPY_UNLIKELY(out->singleton != descr)) {
             /* This does not warn about `metadata`, but units is important. */
-            if (!PyArray_EquivTypes(out->singleton, descr)) {
-                /* Deprecated NumPy 1.21.2 (was an accidental error in 1.21) */
-                if (DEPRECATE(
+            if (out->singleton == NULL
+                    || !PyArray_EquivTypes(out->singleton, descr)) {
+                PyErr_SetString(PyExc_TypeError,
                         "The `dtype` and `signature` arguments to "
                         "ufuncs only select the general DType and not details "
-                        "such as the byte order or time unit (with rare "
-                        "exceptions see release notes).  To avoid this warning "
-                        "please use the scalar types `np.float64`, or string "
-                        "notation.\n"
-                        "In rare cases where the time unit was preserved, "
-                        "either cast the inputs or provide an output array. "
-                        "In the future NumPy may transition to allow providing "
-                        "`dtype=` to denote the outputs `dtype` as well. "
-                        "(Deprecated NumPy 1.21)") < 0) {
-                    Py_DECREF(descr);
-                    return NULL;
-                }
+                        "such as the byte order or time unit. "
+                        "You can avoid this error by using the scalar types "
+                        "`np.float64` or the dtype string notation.");
+                Py_DECREF(descr);
+                return NULL;
             }
         }
         Py_INCREF(out);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1044,39 +1044,6 @@ class TestCtypesGetter(_DeprecationTestCase):
         self.assert_not_deprecated(lambda: getattr(self.ctypes, name))
 
 
-class TestUFuncForcedDTypeWarning(_DeprecationTestCase):
-    message = "The `dtype` and `signature` arguments to ufuncs only select the"
-
-    def test_not_deprecated(self):
-        import pickle
-        # does not warn (test relies on bad pickling behaviour, simply remove
-        # it if the `assert int64 is not int64_2` should start failing.
-        int64 = np.dtype("int64")
-        int64_2 = pickle.loads(pickle.dumps(int64))
-        assert int64 is not int64_2
-        self.assert_not_deprecated(lambda: np.add(3, 4, dtype=int64_2))
-
-    def test_deprecation(self):
-        int64 = np.dtype("int64")
-        self.assert_deprecated(lambda: np.add(3, 5, dtype=int64.newbyteorder()))
-        self.assert_deprecated(lambda: np.add(3, 5, dtype="m8[ns]"))
-
-    def test_behaviour(self):
-        int64 = np.dtype("int64")
-        arr = np.arange(10, dtype="m8[s]")
-
-        with pytest.warns(DeprecationWarning, match=self.message):
-            np.add(3, 5, dtype=int64.newbyteorder())
-        with pytest.warns(DeprecationWarning, match=self.message):
-            np.add(3, 5, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.warns(DeprecationWarning, match=self.message):
-            np.add(arr, arr, dtype="m8[ns]")  # never preserved the "ns"
-        with pytest.warns(DeprecationWarning, match=self.message):
-            np.maximum(arr, arr, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.warns(DeprecationWarning, match=self.message):
-            np.maximum.reduce(arr, dtype="m8[ns]")  # never preserved the "ns"
-
-
 PARTITION_DICT = {
     "partition method": np.arange(10).partition,
     "argpartition method": np.arange(10).argpartition,


### PR DESCRIPTION
We never really allowed instances here and deprecated it since NumPy 1.21 (it just failed completely in 1.21.0).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
