### PR TITLE
API: Always use BufferError when dlpack export fails

### DIFF
--- a/doc/release/upcoming_changes/22542.compatibility.rst
+++ b/doc/release/upcoming_changes/22542.compatibility.rst
@@ -1,0 +1,7 @@
+DLPack export raises ``BufferError``
+------------------------------------
+When an array buffer cannot be exported via DLPack a
+``BufferError`` is now always raised where previously
+``TypeError`` or ``RuntimeError`` was raised.
+This allows falling back to the buffer protocol or
+``__array_interface__`` when DLPack was tried first.

--- a/numpy/core/tests/test_dlpack.py
+++ b/numpy/core/tests/test_dlpack.py
@@ -26,7 +26,7 @@ class TestDLPack:
         y = np.zeros((5,), dtype=dt)
         z = y['int']
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(BufferError):
             np.from_dlpack(z)
 
     @pytest.mark.skipif(IS_PYPY, reason="PyPy can't get refcounts.")
@@ -53,14 +53,14 @@ class TestDLPack:
     def test_invalid_dtype(self):
         x = np.asarray(np.datetime64('2021-05-27'))
 
-        with pytest.raises(TypeError):
+        with pytest.raises(BufferError):
             np.from_dlpack(x)
 
     def test_invalid_byte_swapping(self):
         dt = np.dtype('=i8').newbyteorder()
         x = np.arange(5, dtype=dt)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(BufferError):
             np.from_dlpack(x)
 
     def test_non_contiguous(self):
@@ -100,7 +100,7 @@ class TestDLPack:
         x = np.arange(5)
         _ = x.__dlpack__()
         raise RuntimeError
-    
+
     def test_dlpack_destructor_exception(self):
         with pytest.raises(RuntimeError):
             self.dlpack_deleter_exception()
@@ -108,7 +108,7 @@ class TestDLPack:
     def test_readonly(self):
         x = np.arange(5)
         x.flags.writeable = False
-        with pytest.raises(TypeError):
+        with pytest.raises(BufferError):
             x.__dlpack__()
 
     def test_ndim0(self):


### PR DESCRIPTION
See also https://github.com/data-apis/array-api/pull/498.

I think we should just change this.  It is a niche feature and just an error type change.

Closes gh-20742