### PR TITLE
MAINT: Avoid C++ keywords in C code

### DIFF
--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -462,7 +462,7 @@ static int malloc_free_counts[2];
 static PyDataMem_EventHookFunc *old_hook = NULL;
 static void *old_data;
 
-static void test_hook(void *old, void *new, size_t size, void *user_data)
+static void test_hook(void *old, void *_new, size_t size, void *user_data)
 {
     int* counters = (int *) user_data;
     if (old == NULL) {

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -235,13 +235,13 @@ validate_spec(PyArrayMethod_Spec *spec)
  *
  * @param res The new PyBoundArrayMethodObject to be filled.
  * @param spec The specification list passed by the user.
- * @param private Private flag to limit certain slots to use in NumPy.
+ * @param _private Private flag to limit certain slots to use in NumPy.
  * @return -1 on error 0 on success
  */
 static int
 fill_arraymethod_from_slots(
         PyBoundArrayMethodObject *res, PyArrayMethod_Spec *spec,
-        int private)
+        int _private)
 {
     PyArrayMethodObject *meth = res->method;
 
@@ -390,13 +390,13 @@ PyArrayMethod_FromSpec(PyArrayMethod_Spec *spec)
  *        the method (such as usually needing the API, and the DTypes).
  *        Unused fields must be NULL.
  * @param slots Slots with the correct pair of IDs and (function) pointers.
- * @param private Some slots are currently considered private, if not true,
+ * @param _private Some slots are currently considered private, if not true,
  *        these will be rejected.
  *
  * @returns A new (bound) ArrayMethod object.
  */
 NPY_NO_EXPORT PyBoundArrayMethodObject *
-PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
+PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int _private)
 {
     int nargs = spec->nin + spec->nout;
 
@@ -439,7 +439,7 @@ PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
     res->method->nout = spec->nout;
     res->method->flags = spec->flags;
     res->method->casting = spec->casting;
-    if (fill_arraymethod_from_slots(res, spec, private) < 0) {
+    if (fill_arraymethod_from_slots(res, spec, _private) < 0) {
         Py_DECREF(res);
         return NULL;
     }

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -870,17 +870,17 @@ VOID_getitem(void *input, void *vap)
         ret = PyTuple_New(n);
         for (i = 0; i < n; i++) {
             npy_intp offset;
-            PyArray_Descr *new;
+            PyArray_Descr *_new;
             key = PyTuple_GET_ITEM(names, i);
             tup = PyDict_GetItem(descr->fields, key);
-            if (_unpack_field(tup, &new, &offset) < 0) {
+            if (_unpack_field(tup, &_new, &offset) < 0) {
                 Py_DECREF(ret);
                 return NULL;
             }
-            dummy_fields.descr = new;
+            dummy_fields.descr = _new;
             /* update alignment based on offset */
-            if ((new->alignment > 1)
-                    && ((((npy_intp)(ip+offset)) % new->alignment) != 0)) {
+            if ((_new->alignment > 1)
+                    && ((((npy_intp)(ip+offset)) % _new->alignment) != 0)) {
                 PyArray_CLEARFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
             else {
@@ -960,18 +960,18 @@ _setup_field(int i, PyArray_Descr *descr, PyArrayObject *arr,
 {
     PyObject *key;
     PyObject *tup;
-    PyArray_Descr *new;
+    PyArray_Descr *_new;
     npy_intp offset;
 
     key = PyTuple_GET_ITEM(descr->names, i);
     tup = PyDict_GetItem(descr->fields, key);
-    if (_unpack_field(tup, &new, &offset) < 0) {
+    if (_unpack_field(tup, &_new, &offset) < 0) {
         return -1;
     }
 
-    ((PyArrayObject_fields *)(arr))->descr = new;
-    if ((new->alignment > 1) &&
-                ((((uintptr_t)dstdata + offset) % new->alignment) != 0)) {
+    ((PyArrayObject_fields *)(arr))->descr = _new;
+    if ((_new->alignment > 1) &&
+                ((((uintptr_t)dstdata + offset) % _new->alignment) != 0)) {
         PyArray_CLEARFLAGS(arr, NPY_ARRAY_ALIGNED);
     }
     else {
@@ -2522,23 +2522,23 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
         while (PyDict_Next(descr->fields, &pos, &key, &value)) {
             npy_intp offset;
-            PyArray_Descr *new;
+            PyArray_Descr *_new;
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (_unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &_new, &offset) < 0) {
                 return;
             }
 
-            dummy_fields.descr = new;
-            new->f->copyswapn(dst+offset, dstride,
+            dummy_fields.descr = _new;
+            _new->f->copyswapn(dst+offset, dstride,
                     (src != NULL ? src+offset : NULL),
                     sstride, n, swap, dummy_arr);
         }
         return;
     }
     if (PyDataType_HASSUBARRAY(descr)) {
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         npy_intp num;
         npy_intp i;
         int subitemsize;
@@ -2559,10 +2559,10 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             return;
         }
 
-        new = descr->subarray->base;
+        _new = descr->subarray->base;
         dstptr = dst;
         srcptr = src;
-        subitemsize = new->elsize;
+        subitemsize = _new->elsize;
         if (subitemsize == 0) {
             /* There cannot be any elements, so return */
             return;
@@ -2570,11 +2570,11 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
         PyArrayObject_fields dummy_fields = get_dummy_stack_array(arr);
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
-        ((PyArrayObject_fields *)dummy_arr)->descr = new;
+        ((PyArrayObject_fields *)dummy_arr)->descr = _new;
 
         num = descr->elsize / subitemsize;
         for (i = 0; i < n; i++) {
-            new->f->copyswapn(dstptr, subitemsize, srcptr,
+            _new->f->copyswapn(dstptr, subitemsize, srcptr,
                     subitemsize, num, swap, dummy_arr);
             dstptr += dstride;
             if (srcptr) {
@@ -2610,22 +2610,22 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
         while (PyDict_Next(descr->fields, &pos, &key, &value)) {
             npy_intp offset;
 
-            PyArray_Descr * new;
+            PyArray_Descr * _new;
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (_unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &_new, &offset) < 0) {
                 return;
             }
-            dummy_fields.descr = new;
-            new->f->copyswap(dst+offset,
+            dummy_fields.descr = _new;
+            _new->f->copyswap(dst+offset,
                     (src != NULL ? src+offset : NULL),
                     swap, dummy_arr);
         }
         return;
     }
     if (PyDataType_HASSUBARRAY(descr)) {
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         npy_intp num;
         int subitemsize;
         /*
@@ -2644,8 +2644,8 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
             return;
         }
 
-        new = descr->subarray->base;
-        subitemsize = new->elsize;
+        _new = descr->subarray->base;
+        subitemsize = _new->elsize;
         if (subitemsize == 0) {
             /* There cannot be any elements, so return */
             return;
@@ -2653,10 +2653,10 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
 
         PyArrayObject_fields dummy_fields = get_dummy_stack_array(arr);
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
-        dummy_fields.descr = new;
+        dummy_fields.descr = _new;
 
         num = descr->elsize / subitemsize;
-        new->f->copyswapn(dst, subitemsize, src,
+        _new->f->copyswapn(dst, subitemsize, src,
                 subitemsize, num, swap, dummy_arr);
         return;
     }
@@ -2918,25 +2918,25 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
 
         descr = PyArray_DESCR(ap);
         while (PyDict_Next(descr->fields, &pos, &key, &value)) {
-            PyArray_Descr * new;
+            PyArray_Descr * _new;
             npy_intp offset;
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (_unpack_field(value, &new, &offset) < 0) {
+            if (_unpack_field(value, &_new, &offset) < 0) {
                 PyErr_Clear();
                 continue;
             }
 
-            dummy_fields.descr = new;
-            if ((new->alignment > 1) && !__ALIGNED(ip + offset,
-                        new->alignment)) {
+            dummy_fields.descr = _new;
+            if ((_new->alignment > 1) && !__ALIGNED(ip + offset,
+                        _new->alignment)) {
                 PyArray_CLEARFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
             else {
                 PyArray_ENABLEFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
-            if (new->f->nonzero(ip+offset, dummy_arr)) {
+            if (_new->f->nonzero(ip+offset, dummy_arr)) {
                 nonz = NPY_TRUE;
                 break;
             }
@@ -3276,60 +3276,60 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
      */
     names = descr->names;
     for (i = 0; i < PyTuple_GET_SIZE(names); i++) {
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         npy_intp offset;
         key = PyTuple_GET_ITEM(names, i);
         tup = PyDict_GetItem(descr->fields, key);
-        if (_unpack_field(tup, &new, &offset) < 0) {
+        if (_unpack_field(tup, &_new, &offset) < 0) {
             goto finish;
         }
         /* Set the fields needed by compare or copyswap */
-        dummy_struct.descr = new;
+        dummy_struct.descr = _new;
 
         swap = PyArray_ISBYTESWAPPED(dummy);
         nip1 = ip1 + offset;
         nip2 = ip2 + offset;
-        if (swap || new->alignment > 1) {
-            if (swap || !npy_is_aligned(nip1, new->alignment)) {
+        if (swap || _new->alignment > 1) {
+            if (swap || !npy_is_aligned(nip1, _new->alignment)) {
                 /*
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip1 = PyDataMem_UserNEW(new->elsize, mem_handler);
+                nip1 = PyDataMem_UserNEW(_new->elsize, mem_handler);
                 if (nip1 == NULL) {
                     goto finish;
                 }
-                memcpy(nip1, ip1 + offset, new->elsize);
+                memcpy(nip1, ip1 + offset, _new->elsize);
                 if (swap)
-                    new->f->copyswap(nip1, NULL, swap, dummy);
+                    _new->f->copyswap(nip1, NULL, swap, dummy);
             }
-            if (swap || !npy_is_aligned(nip2, new->alignment)) {
+            if (swap || !npy_is_aligned(nip2, _new->alignment)) {
                 /*
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip2 = PyDataMem_UserNEW(new->elsize, mem_handler);
+                nip2 = PyDataMem_UserNEW(_new->elsize, mem_handler);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
                         /* destroy temporary buffer */
-                        PyDataMem_UserFREE(nip1, new->elsize, mem_handler);
+                        PyDataMem_UserFREE(nip1, _new->elsize, mem_handler);
                     }
                     goto finish;
                 }
-                memcpy(nip2, ip2 + offset, new->elsize);
+                memcpy(nip2, ip2 + offset, _new->elsize);
                 if (swap)
-                    new->f->copyswap(nip2, NULL, swap, dummy);
+                    _new->f->copyswap(nip2, NULL, swap, dummy);
             }
         }
-        res = new->f->compare(nip1, nip2, dummy);
-        if (swap || new->alignment > 1) {
+        res = _new->f->compare(nip1, nip2, dummy);
+        if (swap || _new->alignment > 1) {
             if (nip1 != ip1 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip1, new->elsize, mem_handler);
+                PyDataMem_UserFREE(nip1, _new->elsize, mem_handler);
             }
             if (nip2 != ip2 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip2, new->elsize, mem_handler);
+                PyDataMem_UserFREE(nip2, _new->elsize, mem_handler);
             }
         }
         if (res != 0) {

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1421,8 +1421,8 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
         }
 
     if (Py_TYPE(obj) == &PyCFunction_Type) {
-        PyCFunctionObject *new = (PyCFunctionObject *)obj;
-        _ADDDOC(new->m_ml->ml_doc, new->m_ml->ml_name);
+        PyCFunctionObject *_new = (PyCFunctionObject *)obj;
+        _ADDDOC(_new->m_ml->ml_doc, _new->m_ml->ml_name);
     }
     else if (PyObject_TypeCheck(obj, &PyType_Type)) {
         /*
@@ -1435,27 +1435,27 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
          * If `__doc__` as stored in `tp_dict` is None, we assume this was
          * filled in by `PyType_Ready()` and should also be replaced.
          */
-        PyTypeObject *new = (PyTypeObject *)obj;
-        _ADDDOC(new->tp_doc, new->tp_name);
-        if (new->tp_dict != NULL && PyDict_CheckExact(new->tp_dict) &&
-                PyDict_GetItemString(new->tp_dict, "__doc__") == Py_None) {
+        PyTypeObject *_new = (PyTypeObject *)obj;
+        _ADDDOC(_new->tp_doc, _new->tp_name);
+        if (_new->tp_dict != NULL && PyDict_CheckExact(_new->tp_dict) &&
+                PyDict_GetItemString(_new->tp_dict, "__doc__") == Py_None) {
             /* Warning: Modifying `tp_dict` is not generally safe! */
-            if (PyDict_SetItemString(new->tp_dict, "__doc__", str) < 0) {
+            if (PyDict_SetItemString(_new->tp_dict, "__doc__", str) < 0) {
                 return NULL;
             }
         }
     }
     else if (Py_TYPE(obj) == &PyMemberDescr_Type) {
-        PyMemberDescrObject *new = (PyMemberDescrObject *)obj;
-        _ADDDOC(new->d_member->doc, new->d_member->name);
+        PyMemberDescrObject *_new = (PyMemberDescrObject *)obj;
+        _ADDDOC(_new->d_member->doc, _new->d_member->name);
     }
     else if (Py_TYPE(obj) == &PyGetSetDescr_Type) {
-        PyGetSetDescrObject *new = (PyGetSetDescrObject *)obj;
-        _ADDDOC(new->d_getset->doc, new->d_getset->name);
+        PyGetSetDescrObject *_new = (PyGetSetDescrObject *)obj;
+        _ADDDOC(_new->d_getset->doc, _new->d_getset->name);
     }
     else if (Py_TYPE(obj) == &PyMethodDescr_Type) {
-        PyMethodDescrObject *new = (PyMethodDescrObject *)obj;
-        _ADDDOC(new->d_method->ml_doc, new->d_method->ml_name);
+        PyMethodDescrObject *_new = (PyMethodDescrObject *)obj;
+        _ADDDOC(_new->d_method->ml_doc, _new->d_method->ml_name);
     }
     else {
         PyObject *doc_attr;
@@ -1614,7 +1614,7 @@ static PyObject *
 pack_bits(PyObject *input, int axis, char order)
 {
     PyArrayObject *inp;
-    PyArrayObject *new = NULL;
+    PyArrayObject *_new = NULL;
     PyArrayObject *out = NULL;
     npy_intp outdims[NPY_MAXDIMS];
     int i;
@@ -1633,26 +1633,26 @@ pack_bits(PyObject *input, int axis, char order)
         goto fail;
     }
 
-    new = (PyArrayObject *)PyArray_CheckAxis(inp, &axis, 0);
+    _new = (PyArrayObject *)PyArray_CheckAxis(inp, &axis, 0);
     Py_DECREF(inp);
-    if (new == NULL) {
+    if (_new == NULL) {
         return NULL;
     }
 
-    if (PyArray_NDIM(new) == 0) {
+    if (PyArray_NDIM(_new) == 0) {
         char *optr, *iptr;
 
         out = (PyArrayObject *)PyArray_NewFromDescr(
-                Py_TYPE(new), PyArray_DescrFromType(NPY_UBYTE),
+                Py_TYPE(_new), PyArray_DescrFromType(NPY_UBYTE),
                 0, NULL, NULL, NULL,
                 0, NULL);
         if (out == NULL) {
             goto fail;
         }
         optr = PyArray_DATA(out);
-        iptr = PyArray_DATA(new);
+        iptr = PyArray_DATA(_new);
         *optr = 0;
-        for (i = 0; i < PyArray_ITEMSIZE(new); i++) {
+        for (i = 0; i < PyArray_ITEMSIZE(_new); i++) {
             if (*iptr != 0) {
                 *optr = 1;
                 break;
@@ -1664,8 +1664,8 @@ pack_bits(PyObject *input, int axis, char order)
 
 
     /* Setup output shape */
-    for (i = 0; i < PyArray_NDIM(new); i++) {
-        outdims[i] = PyArray_DIM(new, i);
+    for (i = 0; i < PyArray_NDIM(_new); i++) {
+        outdims[i] = PyArray_DIM(_new, i);
     }
 
     /*
@@ -1676,14 +1676,14 @@ pack_bits(PyObject *input, int axis, char order)
 
     /* Create output array */
     out = (PyArrayObject *)PyArray_NewFromDescr(
-            Py_TYPE(new), PyArray_DescrFromType(NPY_UBYTE),
-            PyArray_NDIM(new), outdims, NULL, NULL,
-            PyArray_ISFORTRAN(new), NULL);
+            Py_TYPE(_new), PyArray_DescrFromType(NPY_UBYTE),
+            PyArray_NDIM(_new), outdims, NULL, NULL,
+            PyArray_ISFORTRAN(_new), NULL);
     if (out == NULL) {
         goto fail;
     }
     /* Setup iterators to iterate over all but given axis */
-    it = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)new, &axis);
+    it = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)_new, &axis);
     ot = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)out, &axis);
     if (it == NULL || ot == NULL) {
         Py_XDECREF(it);
@@ -1693,8 +1693,8 @@ pack_bits(PyObject *input, int axis, char order)
     const PACK_ORDER ordere = order == 'b' ? PACK_ORDER_BIG : PACK_ORDER_LITTLE;
     NPY_BEGIN_THREADS_THRESHOLDED(PyArray_DIM(out, axis));
     while (PyArray_ITER_NOTDONE(it)) {
-        pack_inner(PyArray_ITER_DATA(it), PyArray_ITEMSIZE(new),
-                   PyArray_DIM(new, axis), PyArray_STRIDE(new, axis),
+        pack_inner(PyArray_ITER_DATA(it), PyArray_ITEMSIZE(_new),
+                   PyArray_DIM(_new, axis), PyArray_STRIDE(_new, axis),
                    PyArray_ITER_DATA(ot), PyArray_DIM(out, axis),
                    PyArray_STRIDE(out, axis), ordere);
         PyArray_ITER_NEXT(it);
@@ -1706,11 +1706,11 @@ pack_bits(PyObject *input, int axis, char order)
     Py_DECREF(ot);
 
 finish:
-    Py_DECREF(new);
+    Py_DECREF(_new);
     return (PyObject *)out;
 
 fail:
-    Py_XDECREF(new);
+    Py_XDECREF(_new);
     Py_XDECREF(out);
     return NULL;
 }
@@ -1728,7 +1728,7 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
         npy_uint64 uint64;
     } unpack_lookup_big[256];
     PyArrayObject *inp;
-    PyArrayObject *new = NULL;
+    PyArrayObject *_new = NULL;
     PyArrayObject *out = NULL;
     npy_intp outdims[NPY_MAXDIMS];
     int i;
@@ -1748,30 +1748,30 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
         goto fail;
     }
 
-    new = (PyArrayObject *)PyArray_CheckAxis(inp, &axis, 0);
+    _new = (PyArrayObject *)PyArray_CheckAxis(inp, &axis, 0);
     Py_DECREF(inp);
-    if (new == NULL) {
+    if (_new == NULL) {
         return NULL;
     }
 
-    if (PyArray_NDIM(new) == 0) {
+    if (PyArray_NDIM(_new) == 0) {
         /* Handle 0-d array by converting it to a 1-d array */
         PyArrayObject *temp;
         PyArray_Dims newdim = {NULL, 1};
         npy_intp shape = 1;
 
         newdim.ptr = &shape;
-        temp = (PyArrayObject *)PyArray_Newshape(new, &newdim, NPY_CORDER);
-        Py_DECREF(new);
+        temp = (PyArrayObject *)PyArray_Newshape(_new, &newdim, NPY_CORDER);
+        Py_DECREF(_new);
         if (temp == NULL) {
             return NULL;
         }
-        new = temp;
+        _new = temp;
     }
 
     /* Setup output shape */
-    for (i = 0; i < PyArray_NDIM(new); i++) {
-        outdims[i] = PyArray_DIM(new, i);
+    for (i = 0; i < PyArray_NDIM(_new); i++) {
+        outdims[i] = PyArray_DIM(_new, i);
     }
 
     /* Multiply axis dimension by 8 */
@@ -1796,15 +1796,15 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
 
     /* Create output array */
     out = (PyArrayObject *)PyArray_NewFromDescr(
-            Py_TYPE(new), PyArray_DescrFromType(NPY_UBYTE),
-            PyArray_NDIM(new), outdims, NULL, NULL,
-            PyArray_ISFORTRAN(new), NULL);
+            Py_TYPE(_new), PyArray_DescrFromType(NPY_UBYTE),
+            PyArray_NDIM(_new), outdims, NULL, NULL,
+            PyArray_ISFORTRAN(_new), NULL);
     if (out == NULL) {
         goto fail;
     }
 
     /* Setup iterators to iterate over all but given axis */
-    it = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)new, &axis);
+    it = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)_new, &axis);
     ot = (PyArrayIterObject *)PyArray_IterAllButAxis((PyObject *)out, &axis);
     if (it == NULL || ot == NULL) {
         Py_XDECREF(it);
@@ -1828,7 +1828,7 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
         unpack_init = 1;
     }
 
-    count = PyArray_DIM(new, axis) * 8;
+    count = PyArray_DIM(_new, axis) * 8;
     if (outdims[axis] > count) {
         in_n = count / 8;
         in_tail = 0;
@@ -1840,7 +1840,7 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
         out_pad = 0;
     }
 
-    in_stride = PyArray_STRIDE(new, axis);
+    in_stride = PyArray_STRIDE(_new, axis);
     out_stride = PyArray_STRIDE(out, axis);
 
     NPY_BEGIN_THREADS_THRESHOLDED(PyArray_Size((PyObject *)out) / 8);
@@ -1928,11 +1928,11 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
     Py_DECREF(it);
     Py_DECREF(ot);
 
-    Py_DECREF(new);
+    Py_DECREF(_new);
     return (PyObject *)out;
 
 fail:
-    Py_XDECREF(new);
+    Py_XDECREF(_new);
     Py_XDECREF(out);
     return NULL;
 }

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -320,20 +320,20 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
         ret = PyBytes_FromStringAndSize(PyArray_DATA(self), (Py_ssize_t) numbytes);
     }
     else {
-        PyObject *new;
+        PyObject *_new;
         if (order == NPY_FORTRANORDER) {
             /* iterators are always in C-order */
-            new = PyArray_Transpose(self, NULL);
-            if (new == NULL) {
+            _new = PyArray_Transpose(self, NULL);
+            if (_new == NULL) {
                 return NULL;
             }
         }
         else {
             Py_INCREF(self);
-            new = (PyObject *)self;
+            _new = (PyObject *)self;
         }
-        it = (PyArrayIterObject *)PyArray_IterNew(new);
-        Py_DECREF(new);
+        it = (PyArrayIterObject *)PyArray_IterNew(_new);
+        Py_DECREF(_new);
         if (it == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1709,9 +1709,9 @@ should_use_min_scalar_weak_literals(int narrs, PyArrayObject **arr) {
     for (int i = 0; i < narrs; i++) {
         if (PyArray_FLAGS(arr[i]) & NPY_ARRAY_WAS_PYTHON_INT) {
             /* A Python integer could be `u` so is effectively that: */
-            int new = dtype_kind_to_simplified_ordering('u');
-            if (new > max_scalar_kind) {
-                max_scalar_kind = new;
+            int _new = dtype_kind_to_simplified_ordering('u');
+            if (_new > max_scalar_kind) {
+                max_scalar_kind = _new;
             }
         }
         /* For the new logic, only complex or not matters: */

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -2438,14 +2438,14 @@ PyArray_AddCastingImplementation(PyBoundArrayMethodObject *meth)
  * Add a new casting implementation using a PyArrayMethod_Spec.
  *
  * @param spec
- * @param private If private, allow slots not publicly exposed.
+ * @param _private If private, allow slots not publicly exposed.
  * @return 0 on success -1 on failure
  */
 NPY_NO_EXPORT int
-PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
+PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int _private)
 {
     /* Create a bound method, unbind and store it */
-    PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, private);
+    PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, _private);
     if (meth == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1122,7 +1122,7 @@ PyArray_New(
         PyObject *obj)
 {
     PyArray_Descr *descr;
-    PyObject *new;
+    PyObject *_new;
 
     if (subtype == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1147,9 +1147,9 @@ PyArray_New(
         }
         descr->elsize = itemsize;
     }
-    new = PyArray_NewFromDescr(subtype, descr, nd, dims, strides,
+    _new = PyArray_NewFromDescr(subtype, descr, nd, dims, strides,
                                data, flags, obj);
-    return new;
+    return _new;
 }
 
 
@@ -2490,7 +2490,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr_int(
         PyObject *op, PyArray_Descr *descr, int never_copy)
 {
-    PyObject *new;
+    PyObject *_new;
     PyObject *array_meth;
 
     array_meth = PyArray_LookupSpecial_OnInstance(op, npy_ma_str_array);
@@ -2521,23 +2521,23 @@ PyArray_FromArrayAttr_int(
         return Py_NotImplemented;
     }
     if (descr == NULL) {
-        new = PyObject_CallFunction(array_meth, NULL);
+        _new = PyObject_CallFunction(array_meth, NULL);
     }
     else {
-        new = PyObject_CallFunction(array_meth, "O", descr);
+        _new = PyObject_CallFunction(array_meth, "O", descr);
     }
     Py_DECREF(array_meth);
-    if (new == NULL) {
+    if (_new == NULL) {
         return NULL;
     }
-    if (!PyArray_Check(new)) {
+    if (!PyArray_Check(_new)) {
         PyErr_SetString(PyExc_ValueError,
                         "object __array__ method not "  \
                         "producing an array");
-        Py_DECREF(new);
+        Py_DECREF(_new);
         return NULL;
     }
-    return new;
+    return _new;
 }
 
 
@@ -2623,23 +2623,23 @@ PyArray_FromDims(int NPY_UNUSED(nd), int *NPY_UNUSED(d), int NPY_UNUSED(type))
 NPY_NO_EXPORT PyObject *
 PyArray_EnsureArray(PyObject *op)
 {
-    PyObject *new;
+    PyObject *_new;
 
     if ((op == NULL) || (PyArray_CheckExact(op))) {
-        new = op;
-        Py_XINCREF(new);
+        _new = op;
+        Py_XINCREF(_new);
     }
     else if (PyArray_Check(op)) {
-        new = PyArray_View((PyArrayObject *)op, NULL, &PyArray_Type);
+        _new = PyArray_View((PyArrayObject *)op, NULL, &PyArray_Type);
     }
     else if (PyArray_IsScalar(op, Generic)) {
-        new = PyArray_FromScalar(op, NULL);
+        _new = PyArray_FromScalar(op, NULL);
     }
     else {
-        new = PyArray_FROM_OF(op, NPY_ARRAY_ENSUREARRAY);
+        _new = PyArray_FROM_OF(op, NPY_ARRAY_ENSUREARRAY);
     }
     Py_XDECREF(op);
-    return new;
+    return _new;
 }
 
 /*NUMPY_API*/
@@ -3374,9 +3374,9 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
  finish:
     /* TODO: This swapping could be handled on the fly by the nditer */
     if (swap) {
-        PyObject *new;
-        new = PyArray_Byteswap(range, 1);
-        Py_DECREF(new);
+        PyObject *_new;
+        _new = PyArray_Byteswap(range, 1);
+        Py_DECREF(_new);
         Py_DECREF(PyArray_DESCR(range));
         /* steals the reference */
         ((PyArrayObject_fields *)range)->descr = dtype;

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -112,7 +112,7 @@ static int
 array_strides_set(PyArrayObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyArray_Dims newstrides = {NULL, -1};
-    PyArrayObject *new;
+    PyArrayObject *_new;
     npy_intp numbytes = 0;
     npy_intp offset = 0;
     npy_intp lower_offset = 0;
@@ -134,27 +134,27 @@ array_strides_set(PyArrayObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
                      " same length as shape (%d)", PyArray_NDIM(self));
         goto fail;
     }
-    new = self;
-    while(PyArray_BASE(new) && PyArray_Check(PyArray_BASE(new))) {
-        new = (PyArrayObject *)(PyArray_BASE(new));
+    _new = self;
+    while(PyArray_BASE(_new) && PyArray_Check(PyArray_BASE(_new))) {
+        _new = (PyArrayObject *)(PyArray_BASE(_new));
     }
     /*
      * Get the available memory through the buffer interface on
-     * PyArray_BASE(new) or if that fails from the current new
+     * PyArray_BASE(_new) or if that fails from the current _new
      */
-    if (PyArray_BASE(new) &&
-            PyObject_GetBuffer(PyArray_BASE(new), &view, PyBUF_SIMPLE) >= 0) {
+    if (PyArray_BASE(_new) &&
+            PyObject_GetBuffer(PyArray_BASE(_new), &view, PyBUF_SIMPLE) >= 0) {
         offset = PyArray_BYTES(self) - (char *)view.buf;
         numbytes = view.len + offset;
         PyBuffer_Release(&view);
     }
     else {
         PyErr_Clear();
-        offset_bounds_from_strides(PyArray_ITEMSIZE(new), PyArray_NDIM(new),
-                                   PyArray_DIMS(new), PyArray_STRIDES(new),
+        offset_bounds_from_strides(PyArray_ITEMSIZE(_new), PyArray_NDIM(_new),
+                                   PyArray_DIMS(_new), PyArray_STRIDES(_new),
                                    &lower_offset, &upper_offset);
 
-        offset = PyArray_BYTES(self) - (PyArray_BYTES(new) + lower_offset);
+        offset = PyArray_BYTES(self) - (PyArray_BYTES(_new) + lower_offset);
         numbytes = upper_offset - lower_offset;
     }
 
@@ -753,7 +753,7 @@ static int
 array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
-    PyArrayObject *new;
+    PyArrayObject *_new;
     int retcode;
 
     if (val == NULL) {
@@ -771,14 +771,14 @@ array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
         Py_INCREF(self);
         ret = self;
     }
-    new = (PyArrayObject *)PyArray_FROM_O(val);
-    if (new == NULL) {
+    _new = (PyArrayObject *)PyArray_FROM_O(val);
+    if (_new == NULL) {
         Py_DECREF(ret);
         return -1;
     }
-    retcode = PyArray_MoveInto(ret, new);
+    retcode = PyArray_MoveInto(ret, _new);
     Py_DECREF(ret);
-    Py_DECREF(new);
+    Py_DECREF(_new);
     return retcode;
 }
 
@@ -826,21 +826,21 @@ array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
     }
     if (PyArray_ISCOMPLEX(self)) {
         PyArrayObject *ret;
-        PyArrayObject *new;
+        PyArrayObject *_new;
         int retcode;
 
         ret = _get_part(self, 1);
         if (ret == NULL) {
             return -1;
         }
-        new = (PyArrayObject *)PyArray_FROM_O(val);
-        if (new == NULL) {
+        _new = (PyArrayObject *)PyArray_FROM_O(val);
+        if (_new == NULL) {
             Py_DECREF(ret);
             return -1;
         }
-        retcode = PyArray_MoveInto(ret, new);
+        retcode = PyArray_MoveInto(ret, _new);
         Py_DECREF(ret);
-        Py_DECREF(new);
+        Py_DECREF(_new);
         return retcode;
     }
     else {

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -552,7 +552,7 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     char *dptr;
     int size;
     PyObject *obj = NULL;
-    PyObject *new;
+    PyObject *_new;
     PyArray_CopySwapFunc *copyswap;
 
     if (ind == Py_Ellipsis) {
@@ -673,15 +673,15 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     }
 
     Py_INCREF(indtype);
-    new = PyArray_FromAny(obj, indtype, 0, 0,
+    _new = PyArray_FromAny(obj, indtype, 0, 0,
                       NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
-    if (new == NULL) {
+    if (_new == NULL) {
         goto fail;
     }
     Py_DECREF(indtype);
     Py_DECREF(obj);
-    ret = (PyArrayObject *)iter_subscript_int(self, (PyArrayObject *)new);
-    Py_DECREF(new);
+    ret = (PyArrayObject *)iter_subscript_int(self, (PyArrayObject *)_new);
+    Py_DECREF(_new);
     return (PyObject *)ret;
 
 
@@ -928,13 +928,13 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         }
         /* Check for integer array */
         else if (PyArray_ISINTEGER((PyArrayObject *)obj)) {
-            PyObject *new;
+            PyObject *_new;
             Py_INCREF(indtype);
-            new = PyArray_CheckFromAny(obj, indtype, 0, 0,
+            _new = PyArray_CheckFromAny(obj, indtype, 0, 0,
                            NPY_ARRAY_FORCECAST | NPY_ARRAY_BEHAVED_NS, NULL);
             Py_DECREF(obj);
-            obj = new;
-            if (new == NULL) {
+            obj = _new;
+            if (_new == NULL) {
                 goto finish;
             }
             if (iter_ass_sub_int(self, (PyArrayObject *)obj,
@@ -1047,15 +1047,15 @@ static PyMethodDef iter_methods[] = {
 static PyObject *
 iter_richcompare(PyArrayIterObject *self, PyObject *other, int cmp_op)
 {
-    PyArrayObject *new;
+    PyArrayObject *_new;
     PyObject *ret;
-    new = (PyArrayObject *)iter_array(self, NULL);
-    if (new == NULL) {
+    _new = (PyArrayObject *)iter_array(self, NULL);
+    if (_new == NULL) {
         return NULL;
     }
-    ret = array_richcompare(new, other, cmp_op);
-    PyArray_ResolveWritebackIfCopy(new);
-    Py_DECREF(new);
+    ret = array_richcompare(_new, other, cmp_op);
+    PyArray_ResolveWritebackIfCopy(_new);
+    Py_DECREF(_new);
     return ret;
 }
 

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -125,7 +125,7 @@ _get_transpose(int fancy_ndim, int consec, int ndim, int getmap, npy_intp *dims)
 NPY_NO_EXPORT void
 PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getmap)
 {
-    PyObject *new;
+    PyObject *_new;
     PyArray_Dims permute;
     npy_intp d[NPY_MAXDIMS];
     PyArrayObject *arr;
@@ -145,19 +145,19 @@ PyArray_MapIterSwapAxes(PyArrayMapIterObject *mit, PyArrayObject **ret, int getm
         for (int i = 0; i < mit->nd-PyArray_NDIM(arr); i++) {
             permute.ptr[i] = 1;
         }
-        new = PyArray_Newshape(arr, &permute, NPY_ANYORDER);
+        _new = PyArray_Newshape(arr, &permute, NPY_ANYORDER);
         Py_DECREF(arr);
-        *ret = (PyArrayObject *)new;
-        if (new == NULL) {
+        *ret = (PyArrayObject *)_new;
+        if (_new == NULL) {
             return;
         }
     }
 
     _get_transpose(mit->nd_fancy, mit->consec, mit->nd, getmap, permute.ptr);
 
-    new = PyArray_Transpose(*ret, &permute);
+    _new = PyArray_Transpose(*ret, &permute);
     Py_DECREF(*ret);
-    *ret = (PyArrayObject *)new;
+    *ret = (PyArrayObject *)_new;
 }
 
 static NPY_INLINE void
@@ -2113,7 +2113,7 @@ static int
 _nonzero_indices(PyObject *myBool, PyArrayObject **arrays)
 {
     PyArray_Descr *typecode;
-    PyArrayObject *ba = NULL, *new = NULL;
+    PyArrayObject *ba = NULL, *_new = NULL;
     int nd, j;
     npy_intp size, i, count;
     npy_bool *ptr;
@@ -2144,16 +2144,16 @@ _nonzero_indices(PyObject *myBool, PyArrayObject **arrays)
 
     /* create count-sized index arrays for each dimension */
     for (j = 0; j < nd; j++) {
-        new = (PyArrayObject *)PyArray_NewFromDescr(
+        _new = (PyArrayObject *)PyArray_NewFromDescr(
             &PyArray_Type, PyArray_DescrFromType(NPY_INTP),
             1, &count, NULL, NULL,
             0, NULL);
-        if (new == NULL) {
+        if (_new == NULL) {
             goto fail;
         }
-        arrays[j] = new;
+        arrays[j] = _new;
 
-        dptr[j] = (npy_intp *)PyArray_DATA(new);
+        dptr[j] = (npy_intp *)PyArray_DATA(_new);
         coords[j] = 0;
         dims_m1[j] = PyArray_DIMS(ba)[j]-1;
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -558,12 +558,12 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
         return (PyObject *)self;
     }
     else {
-        PyObject *new;
+        PyObject *_new;
         if ((ret = (PyArrayObject *)PyArray_NewCopy(self,-1)) == NULL) {
             return NULL;
         }
-        new = PyArray_Byteswap(ret, NPY_TRUE);
-        Py_DECREF(new);
+        _new = PyArray_Byteswap(ret, NPY_TRUE);
+        Py_DECREF(_new);
         return (PyObject *)ret;
     }
 }
@@ -1046,10 +1046,10 @@ array_getarray(PyArrayObject *self, PyObject *args)
 
     /* convert to PyArray_Type */
     if (!PyArray_CheckExact(self)) {
-        PyArrayObject *new;
+        PyArrayObject *_new;
 
         Py_INCREF(PyArray_DESCR(self));
-        new = (PyArrayObject *)PyArray_NewFromDescrAndBase(
+        _new = (PyArrayObject *)PyArray_NewFromDescrAndBase(
                 &PyArray_Type,
                 PyArray_DESCR(self),
                 PyArray_NDIM(self),
@@ -1060,10 +1060,10 @@ array_getarray(PyArrayObject *self, PyObject *args)
                 NULL,
                 (PyObject *)self
         );
-        if (new == NULL) {
+        if (_new == NULL) {
             return NULL;
         }
-        self = new;
+        self = _new;
     }
     else {
         Py_INCREF(self);
@@ -1611,18 +1611,18 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
     }
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         int offset, res;
         Py_ssize_t pos = 0;
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+            if (!PyArg_ParseTuple(value, "Oi|O", &_new, &offset,
                                   &title)) {
                 return -1;
             }
-            res = _deepcopy_call(iptr + offset, optr + offset, new,
+            res = _deepcopy_call(iptr + offset, optr + offset, _new,
                                  deepcopy, visit);
             if (res < 0) {
                 return -1;
@@ -2755,17 +2755,17 @@ static PyObject *
 array_newbyteorder(PyArrayObject *self, PyObject *args)
 {
     char endian = NPY_SWAP;
-    PyArray_Descr *new;
+    PyArray_Descr *_new;
 
     if (!PyArg_ParseTuple(args, "|O&:newbyteorder", PyArray_ByteorderConverter,
                           &endian)) {
         return NULL;
     }
-    new = PyArray_DescrNewByteorder(PyArray_DESCR(self), endian);
-    if (!new) {
+    _new = PyArray_DescrNewByteorder(PyArray_DESCR(self), endian);
+    if (!_new) {
         return NULL;
     }
-    return PyArray_View(self, new, NULL);
+    return PyArray_View(self, _new, NULL);
 
 }
 

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -41,7 +41,7 @@ PyArray_Item_INCREF(char *data, PyArray_Descr *descr)
     }
     else if (PyDataType_HASFIELDS(descr)) {
         PyObject *key, *value, *title = NULL;
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         int offset;
         Py_ssize_t pos = 0;
 
@@ -49,11 +49,11 @@ PyArray_Item_INCREF(char *data, PyArray_Descr *descr)
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+            if (!PyArg_ParseTuple(value, "Oi|O", &_new, &offset,
                                   &title)) {
                 return;
             }
-            PyArray_Item_INCREF(data + offset, new);
+            PyArray_Item_INCREF(data + offset, _new);
         }
     }
     else if (PyDataType_HASSUBARRAY(descr)) {
@@ -103,7 +103,7 @@ PyArray_Item_XDECREF(char *data, PyArray_Descr *descr)
     }
     else if (PyDataType_HASFIELDS(descr)) {
             PyObject *key, *value, *title = NULL;
-            PyArray_Descr *new;
+            PyArray_Descr *_new;
             int offset;
             Py_ssize_t pos = 0;
 
@@ -111,11 +111,11 @@ PyArray_Item_XDECREF(char *data, PyArray_Descr *descr)
                 if (NPY_TITLE_KEY(key, value)) {
                     continue;
                 }
-                if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+                if (!PyArg_ParseTuple(value, "Oi|O", &_new, &offset,
                                       &title)) {
                     return;
                 }
-                PyArray_Item_XDECREF(data + offset, new);
+                PyArray_Item_XDECREF(data + offset, _new);
             }
         }
     else if (PyDataType_HASSUBARRAY(descr)) {
@@ -315,7 +315,7 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
     }
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         int offset;
         Py_ssize_t pos = 0;
 
@@ -323,10 +323,10 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "Oi|O", &_new, &offset, &title)) {
                 return;
             }
-            _fillobject(optr + offset, obj, new);
+            _fillobject(optr + offset, obj, _new);
         }
     }
     else if (PyDataType_HASSUBARRAY(dtype)) {

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -466,29 +466,29 @@ PyArray_DescrFromTypeObject(PyObject *type)
 
     /* Do special thing for VOID sub-types */
     if (PyType_IsSubtype((PyTypeObject *)type, &PyVoidArrType_Type)) {
-        PyArray_Descr *new = PyArray_DescrNewFromType(NPY_VOID);
-        if (new == NULL) {
+        PyArray_Descr *_new = PyArray_DescrNewFromType(NPY_VOID);
+        if (_new == NULL) {
             return NULL;
         }
         PyArray_Descr *conv = _arraydescr_try_convert_from_dtype_attr(type);
         if ((PyObject *)conv != Py_NotImplemented) {
             if (conv == NULL) {
-                Py_DECREF(new);
+                Py_DECREF(_new);
                 return NULL;
             }
-            new->fields = conv->fields;
-            Py_XINCREF(new->fields);
-            new->names = conv->names;
-            Py_XINCREF(new->names);
-            new->elsize = conv->elsize;
-            new->subarray = conv->subarray;
+            _new->fields = conv->fields;
+            Py_XINCREF(_new->fields);
+            _new->names = conv->names;
+            Py_XINCREF(_new->names);
+            _new->elsize = conv->elsize;
+            _new->subarray = conv->subarray;
             conv->subarray = NULL;
         }
         Py_DECREF(conv);
-        Py_XDECREF(new->typeobj);
-        new->typeobj = (PyTypeObject *)type;
+        Py_XDECREF(_new->typeobj);
+        _new->typeobj = (PyTypeObject *)type;
         Py_INCREF(type);
-        return new;
+        return _new;
     }
     return _descr_from_subtype(type);
 }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -389,18 +389,18 @@ stringtype_@form@(PyObject *self)
 {
     const npy_char *dptr, *ip;
     Py_ssize_t len;
-    PyObject *new;
+    PyObject *_new;
     PyObject *ret;
 
     ip = PyBytes_AS_STRING(self);
     len = PyBytes_GET_SIZE(self);
     for(dptr = ip + len - 1; len > 0 && *dptr == 0; len--, dptr--);
-    new = PyBytes_FromStringAndSize(ip, len);
-    if (new == NULL) {
+    _new = PyBytes_FromStringAndSize(ip, len);
+    if (_new == NULL) {
         return NULL;
     }
-    ret = PyBytes_Type.tp_@form@(new);
-    Py_DECREF(new);
+    ret = PyBytes_Type.tp_@form@(_new);
+    Py_DECREF(_new);
     return ret;
 }
 /**end repeat**/
@@ -418,7 +418,7 @@ unicodetype_@form@(PyObject *self)
 {
     Py_UCS4 *dptr, *ip;
     Py_ssize_t len;
-    PyObject *new;
+    PyObject *_new;
     PyObject *ret;
 
     /* PyUnicode_READY is called by PyUnicode_GetLength */
@@ -428,13 +428,13 @@ unicodetype_@form@(PyObject *self)
         return NULL;
     }
     for(dptr = ip + len - 1; len > 0 && *dptr == 0; len--, dptr--);
-    new = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, ip, len);
-    if (new == NULL) {
+    _new = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, ip, len);
+    if (_new == NULL) {
         PyMem_Free(ip);
         return NULL;
     }
-    ret = PyUnicode_Type.tp_@form@(new);
-    Py_DECREF(new);
+    ret = PyUnicode_Type.tp_@form@(_new);
+    Py_DECREF(_new);
     PyMem_Free(ip);
     return ret;
 }
@@ -1534,7 +1534,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         /* get the data, copyswap it and pass it to a new Array scalar */
         char *data;
         PyArray_Descr *descr;
-        PyObject *new;
+        PyObject *_new;
         char *newmem;
 
         descr = PyArray_DescrFromScalar(self);
@@ -1548,10 +1548,10 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         else {
             descr->f->copyswap(newmem, data, 1, NULL);
         }
-        new = PyArray_Scalar(newmem, descr, NULL);
+        _new = PyArray_Scalar(newmem, descr, NULL);
         PyObject_Free(newmem);
         Py_DECREF(descr);
-        return new;
+        return _new;
     }
 }
 
@@ -3170,7 +3170,7 @@ static PyObject *
 void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *obj, *arr;
-    PyObject *new = NULL;
+    PyObject *_new = NULL;
 
     static char *kwnames[] = {"", NULL};  /* positional-only */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:void", kwnames, &obj)) {
@@ -3185,13 +3185,13 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             (PyArray_Check(obj) &&
                      PyArray_NDIM((PyArrayObject *)obj)==0 &&
                      PyArray_ISINTEGER((PyArrayObject *)obj))) {
-        new = Py_TYPE(obj)->tp_as_number->nb_int(obj);
+        _new = Py_TYPE(obj)->tp_as_number->nb_int(obj);
     }
-    if (new && PyLong_Check(new)) {
+    if (_new && PyLong_Check(_new)) {
         PyObject *ret;
         char *destptr;
-        npy_ulonglong memu = PyLong_AsUnsignedLongLong(new);
-        Py_DECREF(new);
+        npy_ulonglong memu = PyLong_AsUnsignedLongLong(_new);
+        Py_DECREF(_new);
         if (PyErr_Occurred() || (memu > NPY_MAX_INT)) {
             PyErr_Clear();
             PyErr_Format(PyExc_OverflowError,

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -320,17 +320,17 @@ _putzero(char *optr, PyObject *zero, PyArray_Descr *dtype)
     }
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
-        PyArray_Descr *new;
+        PyArray_Descr *_new;
         int offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "Oi|O", &_new, &offset, &title)) {
                 return;
             }
-            _putzero(optr + offset, zero, new);
+            _putzero(optr + offset, zero, _new);
         }
     }
     else {

--- a/numpy/core/src/multiarray/textreading/readtext.c
+++ b/numpy/core/src/multiarray/textreading/readtext.c
@@ -56,7 +56,8 @@ _readtext_from_stream(stream *s,
     if (num_fields < 0) {
         goto finish;
     }
-    bool homogeneous = num_fields == 1 && ft[0].descr == out_dtype;
+    bool homogeneous;
+    homogeneous = num_fields == 1 && ft[0].descr == out_dtype;
 
     if (!homogeneous && usecols != NULL && num_usecols != num_fields) {
         PyErr_Format(PyExc_TypeError,

--- a/numpy/core/src/multiarray/textreading/rows.c
+++ b/numpy/core/src/multiarray/textreading/rows.c
@@ -57,7 +57,8 @@ create_conv_funcs(
     }
 
     PyObject *key, *value;
-    Py_ssize_t pos = 0;
+    Py_ssize_t pos;
+    pos = 0;
     while (PyDict_Next(converters, &pos, &key, &value)) {
         Py_ssize_t column = PyNumber_AsSsize_t(key, PyExc_IndexError);
         if (column == -1 && PyErr_Occurred()) {
@@ -186,7 +187,8 @@ read_rows(stream *s,
     }
 
     /* Set the actual number of fields if it is already known, otherwise -1 */
-    Py_ssize_t actual_num_fields = -1;
+    Py_ssize_t actual_num_fields;
+    actual_num_fields = -1;
     if (usecols != NULL) {
         assert(homogeneous || num_field_types == num_usecols);
         actual_num_fields = num_usecols;
@@ -208,7 +210,8 @@ read_rows(stream *s,
         }
     }
 
-    Py_ssize_t row_count = 0;  /* number of rows actually processed */
+    Py_ssize_t row_count;
+    row_count = 0;  /* number of rows actually processed */
     while ((max_rows < 0 || row_count < max_rows) && ts_result == 0) {
         ts_result = tokenize(s, &ts, pconfig);
         if (ts_result < 0) {

--- a/numpy/core/src/umath/_scaled_float_dtype.c
+++ b/numpy/core/src/umath/_scaled_float_dtype.c
@@ -151,18 +151,18 @@ static PyArray_SFloatDescr SFloatSingleton = {{
 
 static PyArray_Descr *
 sfloat_scaled_copy(PyArray_SFloatDescr *self, double factor) {
-    PyArray_SFloatDescr *new = PyObject_New(
+    PyArray_SFloatDescr *_new = PyObject_New(
             PyArray_SFloatDescr, (PyTypeObject *)&PyArray_SFloatDType);
-    if (new == NULL) {
+    if (_new == NULL) {
         return NULL;
     }
     /* Don't copy PyObject_HEAD part */
-    memcpy((char *)new + sizeof(PyObject),
+    memcpy((char *)_new + sizeof(PyObject),
             (char *)self + sizeof(PyObject),
             sizeof(PyArray_SFloatDescr) - sizeof(PyObject));
 
-    new->scaling = new->scaling * factor;
-    return (PyArray_Descr *)new;
+    _new->scaling = _new->scaling * factor;
+    return (PyArray_Descr *)_new;
 }
 
 
@@ -691,12 +691,12 @@ promote_to_sfloat(PyUFuncObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *new_dtypes[3])
 {
     for (int i = 0; i < 3; i++) {
-        PyArray_DTypeMeta *new = &PyArray_SFloatDType;
+        PyArray_DTypeMeta *_new = &PyArray_SFloatDType;
         if (signature[i] != NULL) {
-            new = signature[i];
+            _new = signature[i];
         }
-        Py_INCREF(new);
-        new_dtypes[i] = new;
+        Py_INCREF(_new);
+        new_dtypes[i] = _new;
     }
     return 0;
 }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2090,12 +2090,12 @@ NPY_NO_EXPORT void
     // Parenthesis around @PW@ tells clang dead code is intentional
     if (IS_BINARY_REDUCE && (@PW@)) {
         npy_intp n = dimensions[0];
-        @ftype@ * or = ((@ftype@ *)args[0]);
+        @ftype@ * _or = ((@ftype@ *)args[0]);
         @ftype@ * oi = ((@ftype@ *)args[0]) + 1;
         @ftype@ rr, ri;
 
         @TYPE@_pairwise_sum(&rr, &ri, args[1], n * 2, steps[1] / 2);
-        *or @OP@= rr;
+        *_or @OP@= rr;
         *oi @OP@= ri;
         return;
     }

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -739,12 +739,12 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     // Parenthesis around @PW@ tells clang dead code is intentional
     if (IS_BINARY_REDUCE && (@PW@)) {
         npy_intp n = dimensions[0];
-        @ftype@ * or = ((@ftype@ *)args[0]);
+        @ftype@ * _or = ((@ftype@ *)args[0]);
         @ftype@ * oi = ((@ftype@ *)args[0]) + 1;
         @ftype@ rr, ri;
 
         @TYPE@_pairwise_sum(&rr, &ri, args[1], n * 2, steps[1] / 2);
-        *or @OP@= rr;
+        *_or @OP@= rr;
         *oi @OP@= ri;
         return;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4968,15 +4968,15 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
             /* Otherwise, replace the operand with a new array */
             PyArray_Descr *descr = operation_descrs[i];
             Py_INCREF(descr);
-            PyArrayObject *new = (PyArrayObject *)PyArray_NewFromDescr(
+            PyArrayObject *_new = (PyArrayObject *)PyArray_NewFromDescr(
                     &PyArray_Type, descr, 0, NULL, NULL, NULL, 0, NULL);
-            Py_SETREF(operands[i], new);
+            Py_SETREF(operands[i], _new);
             if (operands[i] == NULL) {
                 goto fail;
             }
 
             PyObject *value = PyTuple_GET_ITEM(full_args.in, i);
-            if (PyArray_SETITEM(new, PyArray_BYTES(operands[i]), value) < 0) {
+            if (PyArray_SETITEM(_new, PyArray_BYTES(operands[i]), value) < 0) {
                 goto fail;
             }
         }


### PR DESCRIPTION
## Description

This is a cleanup commit broken out from https://github.com/numpy/numpy/pull/22545. This PR changes all reserved words used for variable names to available symbols by prefixing a `_`.

While not required for C99, it might be useful to be more compatible with C++ compilers in the future. Any way, it doesn't hurt existing code, other than the cosmetic blemish of a preceding `_`.

## How has this been tested?

Compile-tested with gcc and g++. I also ran the following code in my RISC-V VM:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```