### PR TITLE
MAINT: Fix Fortran order flag use (using bool rather than enum)

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -305,7 +305,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
     PyArrayIterObject *it;
 
     if (order == NPY_ANYORDER)
-        order = PyArray_ISFORTRAN(self);
+        order = PyArray_ISFORTRAN(self) ? NPY_FORTRANORDER : NPY_CORDER;
 
     /*        if (PyArray_TYPE(self) == NPY_OBJECT) {
               PyErr_SetString(PyExc_ValueError, "a string for the data" \

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -211,7 +211,7 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
     int flags;
 
     if (order == NPY_ANYORDER) {
-        order = PyArray_ISFORTRAN(self);
+        order = PyArray_ISFORTRAN(self) ? NPY_FORTRANORDER : NPY_CORDER;
     }
     else if (order == NPY_KEEPORDER) {
         PyErr_SetString(PyExc_ValueError,


### PR DESCRIPTION
## Description

True is `1` and false is `0` in the C99 the standard (I think). But in order to work with additional standards, it might be required that `true` is not always 1. Therefore, instead of the unsafe cast from bool to enum, we should use a trinary statement and select the correct enum value.

## Related PRs

Split out from https://github.com/numpy/numpy/pull/22545

## How has this been tested?

Compile-tested with gcc and g++. I also ran the following code in my RISC-V VM:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```