### PR TITLE
ENH: Missing operator++() for enum type

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1060,7 +1060,7 @@ get_datetime_units_factor(NPY_DATETIMEUNIT bigbase, NPY_DATETIMEUNIT littlebase)
         if (factor&0xff00000000000000ULL) {
             return 0;
         }
-        ++unit;
+        unit = unit + 1;
     }
     return factor;
 }


### PR DESCRIPTION
## Description

This is a cleanup commit broken out from https://github.com/numpy/numpy/pull/22545. When compiling with a c++ standard, the ++ operator is undefined for enum types. However, the standard is flexible enough to support general `+ 1` incrementation.

## How has this been tested?

When compiling with g++, the error was:

```
datetime.c:1063:9: error: no match for 'operator++' (operand type is 'NPY_DATETIMEUNIT')
  1063 |         ++unit;
       |         ^~~~~~
```

After applying the change, I ran the following code in my RISC-V Cartesi machine:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```