### PR TITLE
MAINT: Do not use temporary struct construct

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2951,9 +2951,11 @@ _strided_to_strided_multistep_cast(
 
         if (castdata->from.func != NULL) {
             npy_intp out_stride = castdata->from.descriptors[1]->elsize;
+            char *const data[2] = {src, castdata->from_buffer};
+            npy_intp strides[2] = {src_stride, out_stride};
             if (castdata->from.func(&castdata->from.context,
-                    (char *[2]){src, castdata->from_buffer}, &block_size,
-                    (npy_intp [2]){src_stride, out_stride},
+                    data, &block_size,
+                    strides,
                     castdata->from.auxdata) != 0) {
                 /* TODO: Internal buffer may require cleanup on error. */
                 return -1;
@@ -2975,18 +2977,22 @@ _strided_to_strided_multistep_cast(
             main_dst_stride = dst_stride;
         }
 
+        char *const data[2] = {main_src, main_dst};
+        npy_intp strides[2] = {main_src_stride, main_dst_stride};
         if (castdata->main.func(&castdata->main.context,
-                (char *[2]){main_src, main_dst}, &block_size,
-                (npy_intp [2]){main_src_stride, main_dst_stride},
+                data, &block_size,
+                strides,
                 castdata->main.auxdata) != 0) {
             /* TODO: Internal buffer may require cleanup on error. */
             return -1;
         }
 
         if (castdata->to.func != NULL) {
+            char *const data[2] = {main_dst, dst};
+            npy_intp strides[2] = {main_dst_stride, dst_stride};
             if (castdata->to.func(&castdata->to.context,
-                    (char *[2]){main_dst, dst}, &block_size,
-                    (npy_intp [2]){main_dst_stride, dst_stride},
+                    data, &block_size,
+                    strides,
                     castdata->to.auxdata) != 0) {
                 return -1;
             }


### PR DESCRIPTION
## Description

The affected code caused a build error when compiling with g++. On closer inspection, this appears to be a bug in C99 also.

## Related PRs

Split out from https://github.com/numpy/numpy/pull/22545.

## How has this been tested?

When compiling with g++, the error was:

```
dtype_transfer.c:2979:28: error: taking address of temporary array
 2979 |                 (char *[2]){main_src, main_dst}, &block_size,
      |                            ^~~~~~~~~~~~~~~~~~~~
```

Compile-tested with gcc and g++. I also ran the following code in my RISC-V VM:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```