### PR TITLE
Cleanup: Redefinition of static variables

### DIFF
--- a/numpy/core/src/umath/_rational_tests.c
+++ b/numpy/core/src/umath/_rational_tests.c
@@ -365,7 +365,7 @@ typedef struct {
     rational r;
 } PyRational;
 
-static PyTypeObject PyRational_Type;
+extern PyTypeObject PyRational_Type;
 
 static NPY_INLINE int
 PyRational_Check(PyObject* object) {

--- a/numpy/core/src/umath/_scaled_float_dtype.c
+++ b/numpy/core/src/umath/_scaled_float_dtype.c
@@ -31,8 +31,8 @@ typedef struct {
     double scaling;
 } PyArray_SFloatDescr;
 
-static PyArray_DTypeMeta PyArray_SFloatDType;
-static PyArray_SFloatDescr SFloatSingleton;
+extern PyArray_DTypeMeta PyArray_SFloatDType;
+extern PyArray_SFloatDescr SFloatSingleton;
 
 
 static int


### PR DESCRIPTION
## Description

This PR is split out from https://github.com/numpy/numpy/pull/22545. When compiling with g++, I received an error because `static` was used to forward-declare variables instead of `extern`. It seems like extern is more appropriate for these variables and it fixes the C++ compiler error.

## How has this been tested?

Before the commit, the error when compiling with g++ was:

```
numpy/core/src/umath/_scaled_float_dtype.c:139:28: error: redefinition of 'PyArray_SFloatDescr SFloatSingleton'
  139 | static PyArray_SFloatDescr SFloatSingleton = {{
      |                            ^~~~~~~~~~~~~~~
```

After the commit, numpy was compile-tested with gcc and g++. I also ran the following code in my RISC-V VM:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```