### PR TITLE
MAINT: Match arguments of constant in `isless()`

### DIFF
--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -567,7 +567,7 @@ npy_divmod@c@(@type@ a, @type@ b, @type@ *modulus)
 
     /* adjust fmod result to conform to Python convention of remainder */
     if (mod) {
-        if (isless(b, 0) != isless(mod, 0)) {
+        if (isless(b, (@type@)0) != isless(mod, (@type@)0)) {
             mod += b;
             div -= 1.0@c@;
         }


### PR DESCRIPTION
## Description

This is a cleanup commit broken out from https://github.com/numpy/numpy/pull/22545. When compiling with g++, argument types can't be deduced. An explicit cast solves that.

## How has this been tested?

Before the patch, on g++:

```
npy_math_internal.h.src:570:24: error: no matching function for call to 'isless(npy_float&, int)'
  570 |         if (isless(b, 0) != isless(mod, 0)) {
      |                  
```

After the patch, compile-tested with gcc and g++. I also ran the following code in my RISC-V VM:

```python
import numpy as np
print(np.sqrt(2))
```

output:

```
1.4142135623730951
```