### PR TITLE
BUG: ma.getdata can return an object that is not an ndarray subtype

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -712,6 +712,8 @@ def getdata(a, subok=True):
     """
     try:
         data = a._data
+        if not issubclass(type(data), np.ndarray):
+            data =  np.array(a, copy=False, subok=subok)
     except AttributeError:
         data = np.array(a, copy=False, subok=subok)
     if not subok:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -713,7 +713,7 @@ def getdata(a, subok=True):
     try:
         data = a._data
         if not issubclass(type(data), np.ndarray):
-            data =  np.array(a, copy=False, subok=subok)
+            data = np.array(a, copy=False, subok=subok)
     except AttributeError:
         data = np.array(a, copy=False, subok=subok)
     if not subok:


### PR DESCRIPTION
`getdata()` is supposed to "Return the data of a masked array as an ndarray." It does that by taking:
```
data = a._data
```
and if the member `_data` does not exist, it uses:
```
data = np.array(a, copy=False, subok=subok)
```
In some (rare) cases, the member `_data` exists, but does not point towards an ndarray. In those cases, the result of `getdata()` is not an ndarray as expected, and the functions that use `getdata()` fail (e.g. `masked_invalid()` raises an exception). 

I suggest adding a test after `data = a._data` to check that the result is a subtype of `ndarray` as expected.