### PR TITLE
CI: Add PR write permissions to artifact redirector.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -10,6 +10,8 @@ jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
+    permissions:
+      pull-requests: write
     # if: github.repository == 'numpy/numpy'
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
Re-enable the circleci artifact redirector action which was disabled when permissions were added to the workflow. Note: permissions added at the job level rather than the workflow level reflecting recommended security practices.

I'm not exactly sure which permissions are required, @larsoner any ideas here? The github docs on workflow permissions are [here](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs).