### PR TITLE
DOC: Mention numpy types in `isnat` error message

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -650,7 +650,7 @@ PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
 {
     if (!PyTypeNum_ISDATETIME(PyArray_DESCR(operands[0])->type_num)) {
         PyErr_SetString(PyExc_TypeError,
-                "ufunc 'isnat' is only defined for datetime and timedelta.");
+                "ufunc 'isnat' is only defined for numpy.datetime64 and numpy.timedelta64.");
         return -1;
     }
 

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -650,7 +650,7 @@ PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
 {
     if (!PyTypeNum_ISDATETIME(PyArray_DESCR(operands[0])->type_num)) {
         PyErr_SetString(PyExc_TypeError,
-                "ufunc 'isnat' is only defined for 'numpy.datetime64' and 'numpy.timedelta64'.");
+                "ufunc 'isnat' is only defined for np.datetime64 and np.timedelta64.");
         return -1;
     }
 

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -650,7 +650,7 @@ PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
 {
     if (!PyTypeNum_ISDATETIME(PyArray_DESCR(operands[0])->type_num)) {
         PyErr_SetString(PyExc_TypeError,
-                "ufunc 'isnat' is only defined for numpy.datetime64 and numpy.timedelta64.");
+                "ufunc 'isnat' is only defined for 'numpy.datetime64' and 'numpy.timedelta64'.");
         return -1;
     }
 


### PR DESCRIPTION
Enhance error message of `isnat` function with proper types instead of previous ambigous message.

closes gh-22570

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
