### PR TITLE
BUG: fix unexpected return of np.pad with mode=wrap

### DIFF
--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1121,6 +1121,11 @@ class TestWrap:
         a = np.pad([1, 2, 3], 4, 'wrap')
         b = np.array([3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
         assert_array_equal(a, b)
+    
+    def test_check_03(self):
+        a = np.pad([1, 2, 3], (1,4), 'wrap')
+        b = np.array([3, 1, 2, 3, 1, 2, 3, 1])
+        assert_array_equal(a, b)
 
     def test_pad_with_zero(self):
         a = np.ones((3, 5))

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1123,7 +1123,7 @@ class TestWrap:
         assert_array_equal(a, b)
     
     def test_check_03(self):
-        a = np.pad([1, 2, 3], (1,4), 'wrap')
+        a = np.pad([1, 2, 3], (1, 4), 'wrap')
         b = np.array([3, 1, 2, 3, 1, 2, 3, 1])
         assert_array_equal(a, b)
 


### PR DESCRIPTION
`np.pad` with `mode="wrap"` returns unexpected result that original data is not strictly looped in padding. This may happen in some occassions when padding widths in the same dimension are unbalanced (see added testcase in `test_arraypad.py` and the related issue). The reason is the function `pad` makes iterative calls of `_set_wrap_both()` in the above situation, yet `period` for padding is not correctly computed in each iteration.

The bug is fixed by guaranteeing that `period` is always a multiple of original data size, and also be the possible maximum for computation efficiency.


Closes [#22464](https://github.com/numpy/numpy/issues/22464#issue-1417891134)