### PR TITLE
BUG: fix unexpected return of np.pad with mode=wrap

### DIFF
--- a/doc/release/upcoming_changes/22575.compatibility.rst
+++ b/doc/release/upcoming_changes/22575.compatibility.rst
@@ -1,8 +1,8 @@
 ``np.pad`` with ``mode=wrap`` pads with strict multiples of original data
 -------------------------------------------------------------------------
 
-Codes based on earlier version of ``pad`` with ``wrap`` will 
-break when padding size is larger than initial array.
+Code based on earlier version of ``pad`` that uses  ``mode="wrap"`` will return
+different results when the padding size is larger than initial array.
 
 ``np.pad`` with ``mode=wrap`` now always fills the space with 
 strict multiples of original data even if the padding size is larger than the

--- a/doc/release/upcoming_changes/22575.compatibility.rst
+++ b/doc/release/upcoming_changes/22575.compatibility.rst
@@ -1,0 +1,8 @@
+``np.pad`` with ``mode=wrap`` now returns expected results
+----------------------------------------------------------
+
+Codes based on earlier version of ``pad`` with ``wrap`` will 
+break when padding size is larger than initial array.
+
+``np.pad`` with ``mode=wrap`` now always fills the space with 
+strict loops of original data, as expected.

--- a/doc/release/upcoming_changes/22575.compatibility.rst
+++ b/doc/release/upcoming_changes/22575.compatibility.rst
@@ -1,5 +1,5 @@
-``np.pad`` with ``mode=wrap`` now returns expected results
-----------------------------------------------------------
+``np.pad`` with ``mode=wrap`` pads with strict multiples of original data
+-------------------------------------------------------------------------
 
 Codes based on earlier version of ``pad`` with ``wrap`` will 
 break when padding size is larger than initial array.

--- a/doc/release/upcoming_changes/22575.compatibility.rst
+++ b/doc/release/upcoming_changes/22575.compatibility.rst
@@ -5,4 +5,5 @@ Codes based on earlier version of ``pad`` with ``wrap`` will
 break when padding size is larger than initial array.
 
 ``np.pad`` with ``mode=wrap`` now always fills the space with 
-strict loops of original data, as expected.
+strict multiples of original data even if the padding size is larger than the
+initial array.

--- a/doc/release/upcoming_changes/22575.improvement.rst
+++ b/doc/release/upcoming_changes/22575.improvement.rst
@@ -1,5 +1,0 @@
-``np.pad`` with ``mode=wrap`` now returns expected results
-----------------------------------------------------------
-
-``np.pad`` with ``mode=wrap`` now always fills padding with 
-strict loops of original data.

--- a/doc/release/upcoming_changes/22575.improvement.rst
+++ b/doc/release/upcoming_changes/22575.improvement.rst
@@ -1,0 +1,5 @@
+``np.pad`` with ``mode=wrap`` now returns expected results
+----------------------------------------------------------
+
+``np.pad`` with ``mode=wrap`` now always fills padding with 
+strict loops of original data.

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -437,7 +437,7 @@ def _set_wrap_both(padded, axis, width_pair, original_period):
         # First slice chunk from right side of the non-pad area.
         # Use min(period, right_pad) to ensure that chunk is not larger than
         # pad area.
-        slice_start = - right_pad - period
+        slice_start = -right_pad - period
         slice_end = slice_start + min(period, right_pad)
         left_slice = _slice_at_axis(slice(slice_start, slice_end), axis)
         left_chunk = padded[left_slice]

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -378,80 +378,7 @@ def _set_reflect_both(padded, axis, width_pair, method, include_edge=False):
     return left_pad, right_pad
 
 
-def _set_wrap_both(padded, axis, width_pair):
-    """
-    Pad `axis` of `arr` with wrapped values.
-
-    Parameters
-    ----------
-    padded : ndarray
-        Input array of arbitrary shape.
-    axis : int
-        Axis along which to pad `arr`.
-    width_pair : (int, int)
-        Pair of widths that mark the pad area on both sides in the given
-        dimension.
-
-    Returns
-    -------
-    pad_amt : tuple of ints, length 2
-        New index positions of padding to do along the `axis`. If these are
-        both 0, padding is done in this dimension.
-    """
-    left_pad, right_pad = width_pair
-    period = padded.shape[axis] - right_pad - left_pad
-
-    # If the current dimension of `arr` doesn't contain enough valid values
-    # (not part of the undefined pad area) we need to pad multiple times.
-    # Each time the pad area shrinks on both sides which is communicated with
-    # these variables.
-    new_left_pad = 0
-    new_right_pad = 0
-
-    if left_pad > 0:
-        # Pad with wrapped values on left side
-        # First slice chunk from right side of the non-pad area.
-        # Use min(period, left_pad) to ensure that chunk is not larger than
-        # pad area
-        right_slice = _slice_at_axis(
-            slice(-right_pad - min(period, left_pad),
-                  -right_pad if right_pad != 0 else None),
-            axis
-        )
-        right_chunk = padded[right_slice]
-
-        if left_pad > period:
-            # Chunk is smaller than pad area
-            pad_area = _slice_at_axis(slice(left_pad - period, left_pad), axis)
-            new_left_pad = left_pad - period
-        else:
-            # Chunk matches pad area
-            pad_area = _slice_at_axis(slice(None, left_pad), axis)
-        padded[pad_area] = right_chunk
-
-    if right_pad > 0:
-        # Pad with wrapped values on right side
-        # First slice chunk from left side of the non-pad area.
-        # Use min(period, right_pad) to ensure that chunk is not larger than
-        # pad area
-        left_slice = _slice_at_axis(
-            slice(left_pad, left_pad + min(period, right_pad),), axis)
-        left_chunk = padded[left_slice]
-
-        if right_pad > period:
-            # Chunk is smaller than pad area
-            pad_area = _slice_at_axis(
-                slice(-right_pad, -right_pad + period), axis)
-            new_right_pad = right_pad - period
-        else:
-            # Chunk matches pad area
-            pad_area = _slice_at_axis(slice(-right_pad, None), axis)
-        padded[pad_area] = left_chunk
-
-    return new_left_pad, new_right_pad
-
-
-def _set_wrapmod_both(padded, axis, width_pair, original_period):
+def _set_wrap_both(padded, axis, width_pair, original_period):
     """
     Pad `axis` of `arr` with wrapped values.
 
@@ -943,22 +870,12 @@ def pad(array, pad_width, mode='constant', **kwargs):
     elif mode == "wrap":
         for axis, (left_index, right_index) in zip(axes, pad_width):
             roi = _view_roi(padded, original_area_slice, axis)
-            while left_index > 0 or right_index > 0:
-                # Iteratively pad until dimension is filled with wrapped
-                # values. This is necessary if the pad area is larger than
-                # the length of the original values in the current dimension.
-                left_index, right_index = _set_wrap_both(
-                    roi, axis, (left_index, right_index))
-
-    elif mode == "wrapmod":
-        for axis, (left_index, right_index) in zip(axes, pad_width):
-            roi = _view_roi(padded, original_area_slice, axis)
             original_period = padded.shape[axis] - right_index - left_index
             while left_index > 0 or right_index > 0:
                 # Iteratively pad until dimension is filled with wrapped
                 # values. This is necessary if the pad area is larger than
                 # the length of the original values in the current dimension.
-                left_index, right_index = _set_wrapmod_both(
+                left_index, right_index = _set_wrap_both(
                     roi, axis, (left_index, right_index), original_period)
 
     return padded

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1123,8 +1123,18 @@ class TestWrap:
         assert_array_equal(a, b)
     
     def test_check_03(self):
-        a = np.pad([1, 2, 3], (1, 4), 'wrap')
-        b = np.array([3, 1, 2, 3, 1, 2, 3, 1])
+        a = np.arange(9, dtype=float).reshape(3, 3)
+        a = np.pad(a, [(2, 4), (1, 1)], mode='wrap')
+        b = np.array([
+            [5, 3, 4, 5, 3],
+            [8, 6, 7, 8, 6],
+            [2, 0, 1, 2, 0],
+            [5, 3, 4, 5, 3],
+            [8, 6, 7, 8, 6],
+            [2, 0, 1, 2, 0],
+            [5, 3, 4, 5, 3],
+            [8, 6, 7, 8, 6],
+            [2, 0, 1, 2, 0]])
         assert_array_equal(a, b)
 
     def test_pad_with_zero(self):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1121,6 +1121,11 @@ class TestWrap:
         a = np.pad([1, 2, 3], 4, 'wrap')
         b = np.array([3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
         assert_array_equal(a, b)
+    
+    def test_check_03(self):
+        a = np.pad([1, 2, 3], (1,4), 'wrap')
+        b = np.array([3, 1, 2, 3, 1, 2, 3, 1])
+        assert_array_equal(a, b)
 
     def test_pad_with_zero(self):
         a = np.ones((3, 5))

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1121,21 +1121,6 @@ class TestWrap:
         a = np.pad([1, 2, 3], 4, 'wrap')
         b = np.array([3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
         assert_array_equal(a, b)
-    
-    def test_check_03(self):
-        a = np.arange(9, dtype=float).reshape(3, 3)
-        a = np.pad(a, [(2, 4), (1, 1)], mode='wrap')
-        b = np.array([
-            [5, 3, 4, 5, 3],
-            [8, 6, 7, 8, 6],
-            [2, 0, 1, 2, 0],
-            [5, 3, 4, 5, 3],
-            [8, 6, 7, 8, 6],
-            [2, 0, 1, 2, 0],
-            [5, 3, 4, 5, 3],
-            [8, 6, 7, 8, 6],
-            [2, 0, 1, 2, 0]])
-        assert_array_equal(a, b)
 
     def test_pad_with_zero(self):
         a = np.ones((3, 5))
@@ -1154,6 +1139,24 @@ class TestWrap:
         a = np.arange(5)
         b = np.pad(a, (0, 12), mode="wrap")
         assert_array_equal(np.r_[a, a, a, a][:-3], b)
+    
+    def test_repeated_wrapping_with_mod(self):
+        """
+        Check wrapping on each side individually if the wrapped area is longer
+        than the original array.
+        Assert that 'wrapmod' pads only with multiples of the original area.
+        """
+        a = np.arange(4).reshape(2, 2)
+        a = np.pad(a, [(1, 3), (3, 1)], mode='wrapmod')
+        b = np.array(
+            [[3, 2, 3, 2, 3, 2],
+             [1, 0, 1, 0, 1, 0],
+             [3, 2, 3, 2, 3, 2],
+             [1, 0, 1, 0, 1, 0],
+             [3, 2, 3, 2, 3, 2],
+             [1, 0, 1, 0, 1, 0]]
+        )
+        assert_array_equal(a, b)
 
 
 class TestEdge:

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1123,7 +1123,7 @@ class TestWrap:
         assert_array_equal(a, b)
     
     def test_check_03(self):
-        a = np.pad([1, 2, 3], (1,4), 'wrap')
+        a = np.pad([1, 2, 3], (1, 4), 'wrap')
         b = np.array([3, 1, 2, 3, 1, 2, 3, 1])
         assert_array_equal(a, b)
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1140,14 +1140,13 @@ class TestWrap:
         b = np.pad(a, (0, 12), mode="wrap")
         assert_array_equal(np.r_[a, a, a, a][:-3], b)
     
-    def test_repeated_wrapping_with_mod(self):
+    def test_repeated_wrapping_multiple_origin(self):
         """
-        Check wrapping on each side individually if the wrapped area is longer
-        than the original array.
-        Assert that 'wrapmod' pads only with multiples of the original area.
+        Assert that 'wrap' pads only with multiples of the original area if
+        the pad width is larger than the original array.
         """
         a = np.arange(4).reshape(2, 2)
-        a = np.pad(a, [(1, 3), (3, 1)], mode='wrapmod')
+        a = np.pad(a, [(1, 3), (3, 1)], mode='wrap')
         b = np.array(
             [[3, 2, 3, 2, 3, 2],
              [1, 0, 1, 0, 1, 0],


### PR DESCRIPTION
`np.pad` with `mode="wrap"` returns unexpected result that original data is not strictly looped in padding. This may happen in some occassions when padding widths in the same dimension are unbalanced (see added testcase in `test_arraypad.py` and the related issue). The reason is the function `pad` makes iterative calls of `_set_wrap_both()` in the above situation, yet `period` for padding is not correctly computed in each iteration.

The bug is fixed by guaranteeing that `period` is always a multiple of original data size, and also be the possible maximum for computation efficiency.


Closes [#22464](https://github.com/numpy/numpy/issues/22464#issue-1417891134)