### PR TITLE
BUG: fix issue with broken assert statement in `templ_common.h.src`

### DIFF
--- a/numpy/core/src/common/templ_common.h.src
+++ b/numpy/core/src/common/templ_common.h.src
@@ -4,6 +4,7 @@
 /* utility functions that profit from templates */
 
 #include "numpy/npy_common.h"
+#include <assert.h>
 
 /**begin repeat
  *  #name = int, uint, long, ulong,
@@ -57,8 +58,8 @@ npy_mul_sizes_with_overflow (npy_intp * r, npy_intp a, npy_intp b)
 #ifdef HAVE___BUILTIN_MUL_OVERFLOW
     return __builtin_mul_overflow(a, b, r);
 #else
-
-    assert(a >= 0 && b >= 0, "this function only supports non-negative numbers");
+    /* this function only supports non-negative numbers */
+    assert(a >= 0 && b >= 0);
     const npy_intp half_sz = ((npy_intp)1 << ((sizeof(a) * 8 - 1 ) / 2));
 
     *r = a * b;


### PR DESCRIPTION
`assert()` only takes one argument. This was recently introduced, in commit 4156ae260 (gh-21793).

It looks like this code is not exercised in CI. I only stumbled over it because I'm working with an incomplete config header, so `HAVE___BUILTIN_MUL_OVERFLOW` was not defined.

Full error:
```
In file included from ../numpy/core/src/common/npy_hashtable.c:15:
../numpy/core/src/common/templ_common.h.src: In function 'npy_mul_sizes_with_overflow':
../numpy/core/src/common/templ_common.h.src:61:80: error: macro "assert" passed 2 arguments, but takes just 1
   61 |     assert(a >= 0 && b >= 0, "this function only supports non-negative numbers");
      |                                                                                ^
In file included from /home/rgommers/mambaforge/envs/numpy-dev/include/python3.9/Python.h:48,
                 from ../numpy/core/include/numpy/npy_common.h:5,
                 from ../numpy/core/src/common/templ_common.h.src:6,
                 from ../numpy/core/src/common/npy_hashtable.c:15:
/home/rgommers/mambaforge/envs/numpy-dev/x86_64-conda-linux-gnu/sysroot/usr/include/assert.h:52: note: macro "assert" defined here
   52 | # define assert(expr)  (__ASSERT_VOID_CAST (0))
      | 
In file included from ../numpy/core/src/common/npy_hashtable.c:15:
../numpy/core/src/common/templ_common.h.src:61:5: error: 'assert' undeclared (first use in this function)
   61 |     assert(a >= 0 && b >= 0, "this function only supports non-negative numbers");
      |     ^~~~~~
In file included from ../numpy/core/src/common/npy_hashtable.c:15:
../numpy/core/src/common/templ_common.h.src:7:1: note: 'assert' is defined in header '<assert.h>'; did you forget to '#include <assert.h>'?
    6 | #include "numpy/npy_common.h"
  +++ |+#include <assert.h>
    7 | 
In file included from ../numpy/core/src/common/npy_hashtable.c:15:
../numpy/core/src/common/templ_common.h.src:61:5: note: each undeclared identifier is reported only once for each function it appears in
   61 |     assert(a >= 0 && b >= 0, "this function only supports non-negative numbers");
      |     ^~~~~~
```