### PR TITLE
MAINT: remove `NPY_RESTRICT` in favor of C99 `restrict`

### DIFF
--- a/numpy/fft/_pocketfft.c
+++ b/numpy/fft/_pocketfft.c
@@ -22,8 +22,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define restrict NPY_RESTRICT
-
 #define RALLOC(type,num) \
   ((type *)malloc((num)*sizeof(type)))
 #define DEALLOC(ptr) \


### PR DESCRIPTION
This saves doing an expensive configure-time check that does not seem needed. Let's see if CI is happy with this - I assume it's implemented universally now.

EDIT: I'll note that while this is the only use in code, I left the private entry in `config.h` alone. I'll just not reimplement that check in the Meson build.