### PR TITLE
MAINT: Rm meaningless checks in determining typeless data

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1394,10 +1394,6 @@ def _void_scalar_repr(x):
 
 
 _typelessdata = [int_, float_, complex_, bool_]
-if issubclass(intc, int):
-    _typelessdata.append(intc)
-if issubclass(longlong, int):
-    _typelessdata.append(longlong)
 
 
 def dtype_is_implied(dtype):


### PR DESCRIPTION
Cleanup some checks that were only relevant for Python2