### PR TITLE
DOC: Clarify relationship between row_stack and vstack.

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -234,6 +234,8 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
     and r/g/b channels (third axis). The functions `concatenate`, `stack` and
     `block` provide more general stacking and concatenation operations.
 
+    ``np.row_stack`` is an alias for `vstack`. They are the same function.
+
     Parameters
     ----------
     tup : sequence of ndarrays


### PR DESCRIPTION
`row_stack` is a second name bound to the `vstack` function:

https://github.com/numpy/numpy/blob/fbe1b65f5f66ca5a416b23194577a1ed5a4cf1bd/numpy/lib/shape_base.py#L605

This PR clarifies the relationship between the two functions in the `vstack` docstring. References to `row_stack` are intentionally non-linkable to prevent issues with broken sphinx links with aliases.

Closes #21278 