### PR TITLE
TYP: Spelling alignment for array flag literal 

### DIFF
--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -971,7 +971,7 @@ _GetItemKeys = L[
 ]
 _SetItemKeys = L[
     "A", "ALIGNED",
-    "W", "WRITABLE",
+    "W", "WRITEABLE",
     "X", "WRITEBACKIFCOPY",
 ]
 


### PR DESCRIPTION
Backport of #22447.

The documentation for array flags and _GetItemKeys in numpy/core/multiarray.pyi use the spelling WRITEABLE while _SetItemKeys in numpy/core/multiarray.pyi uses WRITABLE. This PR adds an E.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
