### PR TITLE
MAINT, CI: Update Ubuntu 18.04 to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,8 +80,8 @@ jobs:
 
   old_gcc:
     needs: [smoke_test]
-    # provides GCC 6, 7, 8
-    runs-on: ubuntu-18.04
+    # provides GCC  7, 8
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -99,14 +99,7 @@ jobs:
         pythonx -m pip install --upgrade pip setuptools wheel
         pythonx -m pip install -r test_requirements.txt
     - name: Install Compilers
-      run: sudo apt install g++-6 g++-7 g++-8 -y
-    - name: Build gcc-6
-      run: |
-        export CC=/usr/bin/gcc-6
-        export CXX=/usr/bin/g++-6
-        pythonx setup.py install --user
-    - name: Runtests gcc-6
-      run: pythonx runtests.py -n
+      run: sudo apt install g++-7 g++-8 -y
     - name: Build gcc-7
       run: |
         export CC=/usr/bin/gcc-7
@@ -199,11 +192,14 @@ jobs:
 
   full:
     needs: [smoke_test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       USE_WHEEL: 1
       RUN_FULL_TESTS: 1
-      RUN_COVERAGE: 1
+      # The coverage option fails with internal compiler error
+      # in coverage.c with Ubunto 20.04. That problem is fixed
+      # in 22.04, but there are other, new errors.
+      #RUN_COVERAGE: 1
       INSTALL_PICKLE5: 1
     steps:
     - uses: actions/checkout@v3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
   - job: Lint
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - task: UsePythonVersion@0
       inputs:

--- a/doc/release/upcoming_changes/22598.compatibility.rst
+++ b/doc/release/upcoming_changes/22598.compatibility.rst
@@ -1,0 +1,5 @@
+NumPy builds are no longer tested on GCC-6
+------------------------------------------
+Ubuntu 18.04 is deprecated for GitHub actions and GCC-6 is not available on
+Ubuntu 20.04, so builds using that compiler are no longer tested. We still test
+builds using GCC-7 and GCC-8.


### PR DESCRIPTION
Github actions will drop support for 18.04 April 1, 2023. There are now sporadic test cancelations due to warning brownouts, and the NumPy 1.24.x release will overlap that date, so increase the Ubuntu version.

The main change here is that there is no support for gcc-6 in Ubuntu 20.04, so testing with that version is dropped.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
