### PR TITLE
MAINT: (array-coercion) Silence invalid read warning in some gcc versions

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -552,8 +552,8 @@ PyArray_Pack(PyArray_Descr *descr, char *item, PyObject *value)
 
 static int
 update_shape(int curr_ndim, int *max_ndim,
-             npy_intp out_shape[NPY_MAXDIMS], int new_ndim,
-             const npy_intp new_shape[NPY_MAXDIMS], npy_bool sequence,
+             npy_intp out_shape[], int new_ndim,
+             const npy_intp new_shape[], npy_bool sequence,
              enum _dtype_discovery_flags *flags)
 {
     int success = 0;  /* unsuccessful if array is ragged */


### PR DESCRIPTION
The warnings are harmless and seem to be caused by the "hint" that the shape cannot be larger than that area.  But some compiler versions seem to check that the function call is always correct based on the signature.

That probably makes sense, so just remove that "size hint" which is maybe even technically incorrect (the compiler is not allowed to read more as an optimization).

---

@charris this should fix the other warning~s~, but my local setup doesn't seem to have the gcc version that shows this anymore, so I did not test it.