### PR TITLE
DEP: Next step in scalar type alias deprecations/futurewarnings

### DIFF
--- a/doc/release/upcoming_changes/22607.deprecation.rst
+++ b/doc/release/upcoming_changes/22607.deprecation.rst
@@ -1,0 +1,5 @@
+``np.str0`` and similar are now deprecated
+------------------------------------------
+The scalar type aliases ending in a 0 bit size: ``np.object0``, ``np.str0``,
+``np.bytes0``, ``np.void0``, ``np.int0``, ``np.uint0`` as well as ``np.bool8``
+are now deprecated and will eventually be removed.

--- a/doc/release/upcoming_changes/22607.expired.rst
+++ b/doc/release/upcoming_changes/22607.expired.rst
@@ -1,0 +1,4 @@
+* The deprecation for the aliases ``np.object``, ``np.bool``, ``np.float``,
+  ``np.complex``, ``np.str``, and ``np.int`` is expired (introduces NumPy 1.20).
+  Some of these will now give a FutureWarning in addition to raising an error
+  since they will be mapped to the NumPy scalars in the future.

--- a/doc/source/reference/routines.dtype.rst
+++ b/doc/source/reference/routines.dtype.rst
@@ -30,7 +30,6 @@ Data type information
 
    finfo
    iinfo
-   MachAr
 
 Data type testing
 -----------------

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -159,7 +159,7 @@ else:
     _msg = (
         "`np.{n}` is a deprecated alias for `{an}`.  (Deprecated NumPy 1.24)")
 
-    # Some of these are awkard (since `np.str` may be preferable in the long
+    # Some of these are awkward (since `np.str` may be preferable in the long
     # term), but overall the names ending in 0 seem undesireable
     _type_info = [
         ("bool8", bool_, "np.bool_"),
@@ -173,8 +173,10 @@ else:
             "`object` can be used instead.  (Deprecated NumPy 1.24)")]
 
     # Some of these could be defined right away, but most were aliases to
-    # the Python objects before.  When defined, these should possibly not
-    # be added to `__all__` to avoid import with `from numpy import *`.
+    # the Python objects and only removed in NumPy 1.24.  Defining them should
+    # probably wait for NumPy 1.26 or 2.0.
+    # When defined, these should possibly not be added to `__all__` to avoid
+    # import with `from numpy import *`.
     __future_scalars__ = {"bool", "long", "ulong", "str", "bytes", "object"}
 
     __deprecated_attrs__.update({

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -262,9 +262,9 @@ else:
             # And future warnings for those that will change, but also give
             # the AttributeError
             warnings.warn(
-                "In the future the attribute `%s` will be defined as the "
+                f"In the future `np.{attr}` will be defined as the "
                 "corresponding NumPy scalar.  (This may have returned Python "
-                "scalars in past versions.", FutureWarning)
+                "scalars in past versions.", FutureWarning, stacklevel=2)
 
         # Importing Tester requires importing all of UnitTest which is not a
         # cheap import Since it is mainly used in test suits, we lazy import it

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2744,8 +2744,6 @@ class bool_(generic):
     __gt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
     __ge__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
 
-bool8 = bool_
-
 class object_(generic):
     def __init__(self, value: object = ..., /) -> None: ...
     @property
@@ -2757,8 +2755,6 @@ class object_(generic):
     def __int__(self) -> int: ...
     def __float__(self) -> float: ...
     def __complex__(self) -> complex: ...
-
-object0 = object_
 
 # The `datetime64` constructors requires an object with the three attributes below,
 # and thus supports datetime duck typing
@@ -2882,7 +2878,6 @@ byte = signedinteger[_NBitByte]
 short = signedinteger[_NBitShort]
 intc = signedinteger[_NBitIntC]
 intp = signedinteger[_NBitIntP]
-int0 = signedinteger[_NBitIntP]
 int_ = signedinteger[_NBitInt]
 longlong = signedinteger[_NBitLongLong]
 
@@ -2964,7 +2959,6 @@ ubyte = unsignedinteger[_NBitByte]
 ushort = unsignedinteger[_NBitShort]
 uintc = unsignedinteger[_NBitIntC]
 uintp = unsignedinteger[_NBitIntP]
-uint0 = unsignedinteger[_NBitIntP]
 uint = unsignedinteger[_NBitInt]
 ulonglong = unsignedinteger[_NBitLongLong]
 
@@ -3089,8 +3083,6 @@ class void(flexible):
         value: ArrayLike,
     ) -> None: ...
 
-void0 = void
-
 class character(flexible):  # type: ignore
     def __int__(self) -> int: ...
     def __float__(self) -> float: ...
@@ -3111,7 +3103,6 @@ class bytes_(character, bytes):
     def tolist(self) -> bytes: ...
 
 string_ = bytes_
-bytes0 = bytes_
 
 class str_(character, str):
     @overload
@@ -3126,7 +3117,6 @@ class str_(character, str):
     def tolist(self) -> str: ...
 
 unicode_ = str_
-str0 = str_
 
 #
 # Constants

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -107,13 +107,15 @@ def _add_aliases():
         if name in ('longdouble', 'clongdouble') and myname in allTypes:
             continue
 
-        allTypes[myname] = info.type
-
-        # add mapping for both the bit name and the numarray name
-        sctypeDict[myname] = info.type
+        # Add to the main namespace if desired:
+        if bit != 0 and base != "bool":
+            allTypes[myname] = info.type
 
         # add forward, reverse, and string mapping to numarray
         sctypeDict[char] = info.type
+
+        # add mapping for both the bit name
+        sctypeDict[myname] = info.type
 
 
 _add_aliases()
@@ -148,8 +150,6 @@ void = allTypes['void']
 #
 def _set_up_aliases():
     type_pairs = [('complex_', 'cdouble'),
-                  ('int0', 'intp'),
-                  ('uint0', 'uintp'),
                   ('single', 'float'),
                   ('csingle', 'cfloat'),
                   ('singlecomplex', 'cfloat'),

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -47,14 +47,14 @@ Exported symbols include:
      |   |   |     byte
      |   |   |     short
      |   |   |     intc
-     |   |   |     intp            int0
+     |   |   |     intp
      |   |   |     int_
      |   |   |     longlong
      |   |   \\-> unsignedinteger  (uintxx)     (kind=u)
      |   |         ubyte
      |   |         ushort
      |   |         uintc
-     |   |         uintp           uint0
+     |   |         uintp
      |   |         uint_
      |   |         ulonglong
      |   +-> inexact

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1169,7 +1169,8 @@ class TestDeprecatedGlobals(_DeprecationTestCase):
 def test_future_scalar_attributes(name):
     # FutureWarning added 2022-11-17, NumPy 1.24,
     assert name not in dir(np)  # we may want to not add them
-    with pytest.warns(FutureWarning):
+    with pytest.warns(FutureWarning,
+            match=f"In the future .*{name}"):
         assert not hasattr(np, name)
 
     # Unfortunately, they are currently still valid via `np.dtype()`

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -583,25 +583,6 @@ class TestNonExactMatchDeprecation(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.searchsorted(arr[0], 4, side='Random'))
 
 
-class TestDeprecatedGlobals(_DeprecationTestCase):
-    # 2020-06-06
-    def test_type_aliases(self):
-        # from builtins
-        self.assert_deprecated(lambda: np.bool(True))
-        self.assert_deprecated(lambda: np.int(1))
-        self.assert_deprecated(lambda: np.float(1))
-        self.assert_deprecated(lambda: np.complex(1))
-        self.assert_deprecated(lambda: np.object())
-        self.assert_deprecated(lambda: np.str('abc'))
-
-        # from np.compat
-        self.assert_deprecated(lambda: np.long(1))
-        self.assert_deprecated(lambda: np.unicode('abc'))
-
-        # from np.core.numerictypes
-        self.assert_deprecated(lambda: np.typeDict)
-
-
 class TestMatrixInOuter(_DeprecationTestCase):
     # 2020-05-13 NumPy 1.20.0
     message = (r"add.outer\(\) was passed a numpy matrix as "
@@ -1046,9 +1027,6 @@ class TestMachAr(_DeprecationTestCase):
     # Deprecated 2021-10-19, NumPy 1.22
     warning_cls = DeprecationWarning
 
-    def test_deprecated(self):
-        self.assert_deprecated(lambda: np.MachAr)
-
     def test_deprecated_module(self):
         self.assert_deprecated(lambda: getattr(np.core, "machar"))
 
@@ -1172,3 +1150,28 @@ class TestPyIntConversion(_DeprecationTestCase):
                         lambda: creation_func(info.max + 1, dtype))
             except OverflowError:
                 pass  # OverflowErrors always happened also before and are OK.
+
+
+class TestDeprecatedGlobals(_DeprecationTestCase):
+    # Deprecated 2022-11-17, NumPy 1.24
+    def test_type_aliases(self):
+        # from builtins
+        self.assert_deprecated(lambda: np.bool8)
+        self.assert_deprecated(lambda: np.int0)
+        self.assert_deprecated(lambda: np.uint0)
+        self.assert_deprecated(lambda: np.bytes0)
+        self.assert_deprecated(lambda: np.str0)
+        self.assert_deprecated(lambda: np.object0)
+
+
+@pytest.mark.parametrize("name",
+        ["bool", "long", "ulong", "str", "bytes", "object"])
+def test_future_scalar_attributes(name):
+    # FutureWarning added 2022-11-17, NumPy 1.24,
+    assert name not in dir(np)  # we may want to not add them
+    with pytest.warns(FutureWarning):
+        assert not hasattr(np, name)
+
+    # Unfortunately, they are currently still valid via `np.dtype()`
+    np.dtype(name)
+    name in np.sctypeDict

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -443,8 +443,9 @@ class TestSctypeDict:
         # alias for np.int_, but np.long is not supported for historical
         # reasons (gh-21063)
         assert_(np.sctypeDict['ulong'] is np.uint)
-        assert_(not hasattr(np, 'ulong'))
-
+        with pytest.warns(FutureWarning):
+            # We will probably allow this in the future:
+            assert not hasattr(np, 'ulong')
 
 class TestBitName:
     def test_abstract(self):

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -173,18 +173,12 @@ c16.byteswap()
 c16.transpose()
 
 # Aliases
-np.str0()
-np.bool8()
-np.bytes0()
 np.string_()
-np.object0()
-np.void0(0)
 
 np.byte()
 np.short()
 np.intc()
 np.intp()
-np.int0()
 np.int_()
 np.longlong()
 
@@ -192,7 +186,6 @@ np.ubyte()
 np.ushort()
 np.uintc()
 np.uintp()
-np.uint0()
 np.uint()
 np.ulonglong()
 

--- a/numpy/typing/tests/data/reveal/scalars.pyi
+++ b/numpy/typing/tests/data/reveal/scalars.pyi
@@ -35,7 +35,6 @@ reveal_type(c8.real)  # E: {float32}
 reveal_type(c16.imag)  # E: {float64}
 
 reveal_type(np.unicode_('foo'))  # E: str_
-reveal_type(np.str0('foo'))  # E: str_
 
 reveal_type(V[0])  # E: Any
 reveal_type(V["field1"])  # E: Any
@@ -44,18 +43,12 @@ V[0] = 5
 
 # Aliases
 reveal_type(np.unicode_())  # E: str_
-reveal_type(np.str0())  # E: str_
-reveal_type(np.bool8())  # E: bool_
-reveal_type(np.bytes0())  # E: bytes_
 reveal_type(np.string_())  # E: bytes_
-reveal_type(np.object0())  # E: object_
-reveal_type(np.void0(0))  # E: void
 
 reveal_type(np.byte())  # E: {byte}
 reveal_type(np.short())  # E: {short}
 reveal_type(np.intc())  # E: {intc}
 reveal_type(np.intp())  # E: {intp}
-reveal_type(np.int0())  # E: {intp}
 reveal_type(np.int_())  # E: {int_}
 reveal_type(np.longlong())  # E: {longlong}
 
@@ -63,7 +56,6 @@ reveal_type(np.ubyte())  # E: {ubyte}
 reveal_type(np.ushort())  # E: {ushort}
 reveal_type(np.uintc())  # E: {uintc}
 reveal_type(np.uintp())  # E: {uintp}
-reveal_type(np.uint0())  # E: {uintp}
 reveal_type(np.uint())  # E: {uint}
 reveal_type(np.ulonglong())  # E: {ulonglong}
 


### PR DESCRIPTION
Finalizes the scalar type alias deprecations making them an error.
However, at the same time adds a `FutureWarning` that new aliases
will be introduced in the future.
(They would eventually be preferred over the `str_`, etc. version.)

It may make sense, that this FutureWarning is already propelled soon
since it interacts with things such as changing the representation of
strings to `np.str_("")` if the preferred alias becomes `np.str`.

It also introduces a new deprecation to remove the 0 sized bit-aliases
and the bitsize `bool8` alias.  (Unfortunately, these are here still allowed
as part of the `np.sctypeDict`).

xref gh-22021