### PR TITLE
MAINT, CI: Enable coverage checking.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -192,14 +192,11 @@ jobs:
 
   full:
     needs: [smoke_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       USE_WHEEL: 1
       RUN_FULL_TESTS: 1
-      # The coverage option fails with internal compiler error
-      # in coverage.c with Ubunto 20.04. That problem is fixed
-      # in 22.04, but there are other, new errors.
-      #RUN_COVERAGE: 1
+      RUN_COVERAGE: 1
       INSTALL_PICKLE5: 1
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Coverage checking was disabled for the "full" test because of internal compiler errors with the gcc supplied by Ubuntu-20.04. That problem is fixed in Ubuntu-22.04, but there were unrelated warnings. Those warnings are now fixed, so re-enable coverage checking.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
