### PR TITLE
BLD: fix build warning about `backtrace` implicit definition

### DIFF
--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -7,6 +7,10 @@
 #include "npy_config.h"
 #include "numpy/arrayobject.h"
 
+#if defined HAVE_BACKTRACE
+#include <execinfo.h>
+#endif
+
 #define NPY_NUMBER_MAX(a, b) ((a) > (b) ? (a) : (b))
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 


### PR DESCRIPTION
The exact warning was:

```
[1/3] Compiling C object numpy/core/_multi...nux-gnu.so.p/src_multiarray_temp_elide.c.o
../numpy/core/src/multiarray/temp_elide.c: In function 'check_callers':
../numpy/core/src/multiarray/temp_elide.c:154:13: warning: implicit declaration of function 'backtrace' [-Wimplicit-function-declaration]
  154 |     nptrs = backtrace(buffer, NPY_MAX_STACKSIZE);
      |             ^~~~~~~~~
```