### PR TITLE
DOC: Rm round_ from the autosummary for rounding

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -40,7 +40,6 @@ Rounding
    :toctree: generated/
 
    around
-   round_
    rint
    fix
    floor


### PR DESCRIPTION
Remove round_ from the autosummary of the suggested functions for rounding as it is a disrecommended backwards-compatibility alias of np.round and np.around. Refer to https://github.com/numpy/numpy/pull/21853#discussion_r906834026 and https://github.com/numpy/numpy/pull/22527#pullrequestreview-1177670866 for more context.
