### PR TITLE
Forward declare timespec struct

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -2,6 +2,7 @@
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_COMMON_H_
 
 /* need Python.h for npy_intp, npy_uintp */
+struct timespec;
 #include <Python.h>
 
 /* numpconfig.h is auto-generated */

--- a/numpy/core/src/multiarray/textreading/readtext.c
+++ b/numpy/core/src/multiarray/textreading/readtext.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 #define PY_SSIZE_T_CLEAN
+struct timespec;
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/textreading/stream_pyobject.c
+++ b/numpy/core/src/multiarray/textreading/stream_pyobject.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 #define PY_SSIZE_T_CLEAN
+struct timespec;
 #include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/textreading/stream_pyobject.h
+++ b/numpy/core/src/multiarray/textreading/stream_pyobject.h
@@ -3,6 +3,7 @@
 #define NUMPY_CORE_SRC_MULTIARRAY_TEXTREADING_STREAM_PYOBJECT_H_
 
 #define PY_SSIZE_T_CLEAN
+struct timespec;
 #include <Python.h>
 
 #include "textreading/stream.h"


### PR DESCRIPTION
The Python headers use this as, e.g.:

```
PyAPI_FUNC(int) _PyTime_FromTimespec(_PyTime_t *tp, struct timespec *ts);
```

When GCC sees this, it complains that the definition of `timespec` will not be visible outside of the function declaration. However, `timespec` is defined in `time.h`.

Forward definition is the fix pipewire applied
(https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/230).

Perhaps there is a better way?
