### PR TITLE
DOC: Clarify ``where`` docs

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -345,7 +345,7 @@ def inner(a, b):
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.where)
 def where(condition, x=None, y=None):
     """
-    where(condition, [x, y], /)
+    where(condition, x=None, y=None)
 
     Return elements chosen from `x` or `y` depending on `condition`.
 


### PR DESCRIPTION
DOC: x=None, y=None instead of [x,y]/ in numpy.where()

x and y are optional variables. [x,y]/ is Backus-Naur Form to show optional arguments, but the [] operator is used so frequently in lists and as an accessor that to a programmer unfamiliar with this form becomes ambiguous. Writing that x and y default to None is more explicit and is easily readable without assuming knowledge of 1970's documentation standards.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
