### PR TITLE
CI: Increase travis timeout to 30 minutes (2).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
         - EXPECT_CPU_FEATURES: "NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM"
       install: python3 -m pip install cibuildwheel==2.11.2
       script: |
-        travis_wait cibuildwheel --output-dir wheelhouse
+        cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
         set_travis_vars
         set_upload_vars
@@ -110,4 +110,4 @@ before_install:
   - ./tools/travis-before-install.sh
 
 script:
-  - ./tools/travis-test.sh
+  - travis_wait 30 ./tools/travis-test.sh


### PR DESCRIPTION
This is an attempted fix for the Python 3.8 aarch64 builds that are timing out when merged to master.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
