### PR TITLE
API: (cython) remove `long_t` and `ulong_t`

### DIFF
--- a/doc/release/upcoming_changes/22637.compatibility.rst
+++ b/doc/release/upcoming_changes/22637.compatibility.rst
@@ -1,0 +1,15 @@
+Cython ``long_t`` and ``ulong_t`` removed
+-----------------------------------------
+``long_t`` and ``ulong_t`` were aliases for ``longlong_t`` and ``ulonglong_t``
+and confusing (a remainder from of Python 2).  This change may lead to the errors::
+
+     'long_t' is not a type identifier
+     'ulong_t' is not a type identifier
+
+We recommend use of bit-sized types such as ``cnp.int64_t`` or the use of
+``cnp.intp_t`` which is 32 bits on 32 bit systems and 64 bits on 64 bit
+systems (this is most compatible with indexing).
+If C ``long`` is desired, use plain ``long`` or ``npy_long``.
+``cnp.int_t`` is also ``long`` (NumPy's default integer).  However, ``long``
+is 32 bit on 64 bit windows and we may wish to adjust this even in NumPy.
+(Please do not hesitate to contact NumPy developers if you are curious about this.)

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -753,11 +753,9 @@ ctypedef double complex complex128_t
 # The int types are mapped a bit surprising --
 # numpy.int corresponds to 'l' and numpy.long to 'q'
 ctypedef npy_long       int_t
-ctypedef npy_longlong   long_t
 ctypedef npy_longlong   longlong_t
 
 ctypedef npy_ulong      uint_t
-ctypedef npy_ulonglong  ulong_t
 ctypedef npy_ulonglong  ulonglong_t
 
 ctypedef npy_intp       intp_t

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -711,11 +711,9 @@ ctypedef double complex complex128_t
 # The int types are mapped a bit surprising --
 # numpy.int corresponds to 'l' and numpy.long to 'q'
 ctypedef npy_long       int_t
-ctypedef npy_longlong   long_t
 ctypedef npy_longlong   longlong_t
 
 ctypedef npy_ulong      uint_t
-ctypedef npy_ulonglong  ulong_t
 ctypedef npy_ulonglong  ulonglong_t
 
 ctypedef npy_intp       intp_t


### PR DESCRIPTION
They are both very confusing aliases.  Unfortunately, I did not find a way to give a more informative cython compilation error. Thus, I pasted the expected error message in the hope it will be easy to google.

The release notes are long and maybe confusing.  I really want to prepare us for switching the default integer to (probably) `intp` and this could be rather disprutpive for Cython modules if, so I thought it might be good to hint towards that, but maybe that is too much?