### PR TITLE
DOC: Remove traces of interrupt handling utilities

### DIFF
--- a/doc/source/reference/c-api/config.rst
+++ b/doc/source/reference/c-api/config.rst
@@ -118,14 +118,3 @@ Compiler directives
 .. c:macro:: NPY_LIKELY
 .. c:macro:: NPY_UNLIKELY
 .. c:macro:: NPY_UNUSED
-
-
-Interrupt Handling
-------------------
-
-.. c:macro:: NPY_INTERRUPT_H
-.. c:macro:: NPY_SIGSETJMP
-.. c:macro:: NPY_SIGLONGJMP
-.. c:macro:: NPY_SIGJMP_BUF
-.. c:macro:: NPY_SIGINT_ON
-.. c:macro:: NPY_SIGINT_OFF


### PR DESCRIPTION
We do not use these in NumPy anymore, and at this point the whole `npy_interrupt.h` header only exists in case someone is using it out there.
We may wish to just remove it at some point, vendoring the header is simple enough after all (and no known downstream usage exists).

See also gh-7545, gh-12541