### PR TITLE
MAINT: Remove the aarch64 python 3.8 wheel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,20 +58,6 @@ jobs:
       arch: arm64
       virt: vm
       env:
-        - CIBW_BUILD: cp38-manylinux_aarch64
-        - EXPECT_CPU_FEATURES: "NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM"
-      install: python3 -m pip install cibuildwheel==2.11.2
-      script: |
-        cibuildwheel --output-dir wheelhouse
-        source ./tools/wheels/upload_wheels.sh
-        set_travis_vars
-        set_upload_vars
-        upload_wheels # Will be skipped if not a push/tag/scheduled build
-    - python: "3.8"
-      os: linux
-      arch: arm64
-      virt: vm
-      env:
         - CIBW_BUILD: cp39-manylinux_aarch64
       install: python3 -m pip install cibuildwheel==2.11.2
       script: |
@@ -110,4 +96,4 @@ before_install:
   - ./tools/travis-before-install.sh
 
 script:
-  - travis_wait 30 ./tools/travis-test.sh
+  - ./tools/travis-test.sh


### PR DESCRIPTION
This is a quick fix for the failing tests on merge. There will be a follow up PR updating other ci infrastucture to Python 3.9

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
