### PR TITLE
MAINT: check user-defined dtype has an ensure_canonical implementation

### DIFF
--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -209,6 +209,12 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
+    if (NPY_DT_SLOTS(DType)->ensure_canonical == NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "A DType must provide an ensure_canonical implementation.");
+        return -1;
+    }
+
     /*
      * Now that the spec is read we can check that all required functions were
      * defined by the user.


### PR DESCRIPTION
I've been working with @peytondmurray and @seberg on user-defined dtypes using the experimental dtype API.

I hit some memory corruption yesterday trying to get casting from my dtype to `float64` working and Sebastian tells me the ultimate cause is my dtype didn't have an `ensure_canonical` implementation, causing reference counting errors.

At sebastian's suggestion I've added an explicit check that user-defined dtypes have an `ensure_canonical` slot.

I could also probably add a default implementation that just does `Py_INCREF(self)` too, I'm not sure if that would be nicer for dtype authors.