### PR TITLE
DOC memmap #22643

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -59,6 +59,7 @@ class memmap(ndarray):
         | 'r+' | Open existing file for reading and writing.                 |
         +------+-------------------------------------------------------------+
         | 'w+' | Create or overwrite existing file for reading and writing.  |
+        |      | If ``mode == 'w+'`` then shape must also be specified.      |
         +------+-------------------------------------------------------------+
         | 'c'  | Copy-on-write: assignments affect data in memory, but       |
         |      | changes are not saved to disk.  The file on disk is         |
@@ -79,7 +80,7 @@ class memmap(ndarray):
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
         will be 1-D with the number of elements determined by file size
-        and data-type. If ``mode == 'w+'`` then shape must also be specified.
+        and data-type. 
     order : {'C', 'F'}, optional
         Specify the order of the ndarray memory layout:
         :term:`row-major`, C-style or :term:`column-major`,

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -79,7 +79,7 @@ class memmap(ndarray):
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
         will be 1-D with the number of elements determined by file size
-        and data-type.
+        and data-type. If ``mode == 'w+'`` then shape must also be specified.
     order : {'C', 'F'}, optional
         Specify the order of the ndarray memory layout:
         :term:`row-major`, C-style or :term:`column-major`,
@@ -220,7 +220,7 @@ class memmap(ndarray):
                 ) from None
 
         if mode == 'w+' and shape is None:
-            raise ValueError("shape must be given")
+            raise ValueError("shape must be given if mode == 'w+'")
 
         if hasattr(filename, 'read'):
             f_ctx = nullcontext(filename)

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -59,7 +59,7 @@ class memmap(ndarray):
         | 'r+' | Open existing file for reading and writing.                 |
         +------+-------------------------------------------------------------+
         | 'w+' | Create or overwrite existing file for reading and writing.  |
-        |      | If ``mode == 'w+'`` then shape must also be specified.      |
+        |      | If ``mode == 'w+'`` then `shape` must also be specified.    |
         +------+-------------------------------------------------------------+
         | 'c'  | Copy-on-write: assignments affect data in memory, but       |
         |      | changes are not saved to disk.  The file on disk is         |
@@ -80,7 +80,7 @@ class memmap(ndarray):
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
         will be 1-D with the number of elements determined by file size
-        and data-type. 
+        and data-type.
     order : {'C', 'F'}, optional
         Specify the order of the ndarray memory layout:
         :term:`row-major`, C-style or :term:`column-major`,


### PR DESCRIPTION
See #22643. Have changed error message on line 223 to 
"shape must be given if mode == 'w+'" 
and appended 
"If ``mode == 'w+'`` then shape must also be specified." 
to the description of the parameter *mode* in line 62

Closes #22643 