### PR TITLE
DOC: memmap doc does not mention an exception regarding 'mode' and 'shape' #22643

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -64,7 +64,7 @@ class memmap(ndarray):
         |      | changes are not saved to disk.  The file on disk is         |
         |      | read-only.                                                  |
         +------+-------------------------------------------------------------+
-
+        if the file is opened in  `mode == 'r'`` and ``mode == 'w'`` you must specify the shape.
         Default is 'r+'.
     offset : int, optional
         In the file, array data starts at this offset. Since `offset` is

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -75,7 +75,7 @@ class memmap(ndarray):
         the file, even if ``filename`` is a file pointer ``fp`` and
         ``fp.tell() != 0``.
     shape : tuple, optional
-        The desired shape of the array. If ``mode == 'r'`` and the number
+        The desired shape of the array. If ``mode == 'r'`` and ``mode == 'w'`` and the number
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
         will be 1-D with the number of elements determined by file size

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -64,7 +64,7 @@ class memmap(ndarray):
         |      | changes are not saved to disk.  The file on disk is         |
         |      | read-only.                                                  |
         +------+-------------------------------------------------------------+
-        if the file is opened in  `mode == 'r'`` and ``mode == 'w'`` you must specify the shape.
+        if the file is opened in  `mode == 'r'`` and ``mode == 'w+'`` you must specify the shape.
         Default is 'r+'.
     offset : int, optional
         In the file, array data starts at this offset. Since `offset` is
@@ -75,11 +75,11 @@ class memmap(ndarray):
         the file, even if ``filename`` is a file pointer ``fp`` and
         ``fp.tell() != 0``.
     shape : tuple, optional
-        The desired shape of the array. If ``mode == 'r'`` and ``mode == 'w'`` and the number
+        The desired shape of the array. If ``mode == 'r'``  and the number
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
         will be 1-D with the number of elements determined by file size
-        and data-type.
+        and data-type.If``mode == 'w+'`` you must specify `shape`.
     order : {'C', 'F'}, optional
         Specify the order of the ndarray memory layout:
         :term:`row-major`, C-style or :term:`column-major`,

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -64,7 +64,7 @@ class memmap(ndarray):
         |      | changes are not saved to disk.  The file on disk is         |
         |      | read-only.                                                  |
         +------+-------------------------------------------------------------+
-        if the file is opened in  `mode == 'r'`` and ``mode == 'w+'`` you must specify the shape.
+        If thh file is opened in ``mode == 'w+'`` you must specify shape.
         Default is 'r+'.
     offset : int, optional
         In the file, array data starts at this offset. Since `offset` is


### PR DESCRIPTION
See #22643 
"shape must be given if mode == 'w+'"
and appended
"If mode == 'w+' then shape must also be specified."
to the description of the parameter shape in line 82
and appended to mode paramenter .


