### PR TITLE
MAINT: remove 'six' dependency from pyinstaller

### DIFF
--- a/numpy/_pyinstaller/hook-numpy.py
+++ b/numpy/_pyinstaller/hook-numpy.py
@@ -23,8 +23,6 @@ if is_pure_conda:
 # Submodules PyInstaller cannot detect (probably because they are only imported
 # by extension modules, which PyInstaller cannot read).
 hiddenimports = ['numpy.core._dtype_ctypes']
-if is_conda:
-    hiddenimports.append("six")
 
 # Remove testing and building code and packages that are referenced throughout
 # NumPy but are not really dependencies.


### PR DESCRIPTION
We dropped the dependency on "six" in [NumPy 1.19](https://github.com/numpy/numpy/pull/15358), this was added afterward. It was added in #20745 by @bwoodsend, maybe they can comment if it is still needed?