### PR TITLE
MAINT: pin ubuntu and python for emscripten

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-wasm-emscripten:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'numpy/numpy'
     env:
       PYODIDE_VERSION: 0.22.0a3
@@ -26,7 +26,7 @@ jobs:
       # The appropriate versions can be found in the Pyodide repodata.json
       # "info" field, or in Makefile.envs:
       # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
-      PYTHON_VERSION: 3.10.2
+      PYTHON_VERSION: 3.10.7
       EMSCRIPTEN_VERSION: 3.1.24
       NODE_VERSION: 18
     steps:


### PR DESCRIPTION
The emscripten CI run has been failing since CPython3.10.2 is not available on `ubuntu-latest`. This PR pins to `ubuntu-22.04` and cpython 3.10.7 (the latest available).

xref [this comment](https://github.com/numpy/numpy/pull/21895#issuecomment-1327000890) 