### PR TITLE
BUG: Ensure string aliases `"int0"`, etc. remain valid for now

### DIFF
--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -233,7 +233,8 @@ _set_array_types()
 
 # Add additional strings to the sctypeDict
 _toadd = ['int', 'float', 'complex', 'bool', 'object',
-          'str', 'bytes', ('a', 'bytes_')]
+          'str', 'bytes', ('a', 'bytes_'),
+          ('int0', 'intp'), ('uint0', 'uintp')]
 
 for name in _toadd:
     if isinstance(name, tuple):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -126,6 +126,15 @@ class TestBuiltin:
         with assert_raises(TypeError):
             np.dtype(dtype)
 
+    def test_remaining_dtypes_with_bad_bytesize(self):
+        # These should probably deprecated as well, the np.<name> aliases were
+        assert np.dtype("int0") is np.dtype("intp")
+        assert np.dtype("uint0") is np.dtype("uintp")
+        assert np.dtype("bool8") is np.dtype("bool")
+        assert np.dtype("bytes0") is np.dtype("bytes")
+        assert np.dtype("str0") is np.dtype("str")
+        assert np.dtype("object0") is np.dtype("object")
+
     @pytest.mark.parametrize(
         'value',
         ['m8', 'M8', 'datetime64', 'timedelta64',

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -127,7 +127,7 @@ class TestBuiltin:
             np.dtype(dtype)
 
     def test_remaining_dtypes_with_bad_bytesize(self):
-        # These should probably deprecated as well, the np.<name> aliases were
+        # The np.<name> aliases were deprecated, these probably should be too 
         assert np.dtype("int0") is np.dtype("intp")
         assert np.dtype("uint0") is np.dtype("uintp")
         assert np.dtype("bool8") is np.dtype("bool")


### PR DESCRIPTION
int0 and uint0 were accidentally dropped, the others just added as a test.
We did successfully remove many Numeric types before, so these could probably be deprecated (it is a bit more annoying to do).

These could probably just be removed, ~even scipy only noticed it in a single test~ scikit-learn only noticed it in a single test (scipy probably not at all)..  But maybe not in 1.24

Closes gh-22672