### PR TITLE
BLD: revert adding PEP 621 metadata, it confuses setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-# Uncomment this line in order to build with Meson by default
+# Uncomment this line, the `meson-python` requires line, and the [project] and
+# [project.urls] tables below in order to build with Meson by default
 #build-backend = "mesonpy"
 requires = [
     # setuptools, wheel and Cython are needed for the setup.py based build
@@ -9,56 +10,69 @@ requires = [
     # likely to be removed as a dependency in meson-python 0.12.0.
     "wheel==0.37.0",
     "Cython>=0.29.30,<3.0",
-    "meson-python>=0.10.0",
+#    "meson-python>=0.10.0",
 ]
 
-[project]
-name = "numpy"
-
-# Using https://peps.python.org/pep-0639/
-# which is still in draft
-license = {text = "BSD-3-Clause"}
-license-files.paths = [
-    "LICENSE.txt",
-    "LICENSES_bundles.txt"
-]
-
-description = "Fundamental package for array computing in Python"
-maintainers = [
-    {name = "NumPy Developers", email="numpy-discussion@python.org"},
-]
-requires-python = ">=3.8"
-readme = "README.md"
-classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Science/Research',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: BSD License',
-    'Programming Language :: C',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: Implementation :: CPython',
-    'Topic :: Software Development',
-    'Topic :: Scientific/Engineering',
-    'Typing :: Typed',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: POSIX',
-    'Operating System :: Unix',
-    'Operating System :: MacOS',
-]
-dynamic = ["version"]
-
-[project.urls]
-homepage = "https://numpy.org"
-documentation = "https://numpy.org/doc/"
-source = "https://github.com/numpy/numpy"
-download = "https://pypi.org/project/numpy/#files"
-tracker = "https://github.com/numpy/numpy/issues"
+#[project]
+#name = "numpy"
+#
+## Using https://peps.python.org/pep-0639/
+## which is still in draft
+#license = {text = "BSD-3-Clause"}
+## Note: needed for Meson, but setuptools errors on it. Uncomment once Meson is default.
+##license-files.paths = [
+##    "LICENSE.txt",
+##    "LICENSES_bundles.txt"
+##]
+#
+#description = "Fundamental package for array computing in Python"
+#authors = [{name = "Travis E. Oliphant et al."}]
+#maintainers = [
+#    {name = "NumPy Developers", email="numpy-discussion@python.org"},
+#]
+#requires-python = ">=3.8"
+#readme = "README.md"
+#classifiers = [
+#    'Development Status :: 5 - Production/Stable',
+#    'Intended Audience :: Science/Research',
+#    'Intended Audience :: Developers',
+#    'License :: OSI Approved :: BSD License',
+#    'Programming Language :: C',
+#    'Programming Language :: Python',
+#    'Programming Language :: Python :: 3',
+#    'Programming Language :: Python :: 3.8',
+#    'Programming Language :: Python :: 3.9',
+#    'Programming Language :: Python :: 3.10',
+#    'Programming Language :: Python :: 3.11',
+#    'Programming Language :: Python :: 3 :: Only',
+#    'Programming Language :: Python :: Implementation :: CPython',
+#    'Topic :: Software Development',
+#    'Topic :: Scientific/Engineering',
+#    'Typing :: Typed',
+#    'Operating System :: Microsoft :: Windows',
+#    'Operating System :: POSIX',
+#    'Operating System :: Unix',
+#    'Operating System :: MacOS',
+#]
+#dynamic = ["version", "scripts"]
+#
+#[project.scripts]
+## Note: this is currently dynamic, see setup.py. Can we get rid of that?
+##       see commit f22a33b71 for rationale for dynamic behavior
+#'f2py = numpy.f2py.f2py2e:main'
+#'f2py3 = numpy.f2py.f2py2e:main'
+#'f2py3.MINOR_VERSION = numpy.f2py.f2py2e:main'
+#
+#[project.entry-points]
+#'array_api': 'numpy = numpy.array_api'
+#'pyinstaller40': 'hook-dirs = numpy:_pyinstaller_hooks_dir'
+#
+#[project.urls]
+#homepage = "https://numpy.org"
+#documentation = "https://numpy.org/doc/"
+#source = "https://github.com/numpy/numpy"
+#download = "https://pypi.org/project/numpy/#files"
+#tracker = "https://github.com/numpy/numpy/issues"
 
 [tool.towncrier]
     # Do no set this since it is hard to import numpy inside the source directory

--- a/setup.py
+++ b/setup.py
@@ -463,6 +463,8 @@ def setup_package():
     else:
         #from numpy.distutils.core import setup
         from setuptools import setup
+        # workaround for broken --no-build-isolation with newer setuptools, see gh-21288
+        metadata["packages"] = []
 
     try:
         setup(**metadata)

--- a/setup.py
+++ b/setup.py
@@ -463,7 +463,8 @@ def setup_package():
     else:
         #from numpy.distutils.core import setup
         from setuptools import setup
-        # workaround for broken --no-build-isolation with newer setuptools, see gh-21288
+        # workaround for broken --no-build-isolation with newer setuptools,
+        # see gh-21288
         metadata["packages"] = []
 
     try:


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/22663/files#r1034053192.

The one `setup.py` tweak is to even make it possible to test newer `setuptools` versions without build isolation (applies fix suggested in gh-21288).