### PR TITLE
MAINT: Add `np._utils` to meson

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -120,6 +120,7 @@ tempita = generator(tempita_cli,
 pure_subdirs = [
   '_pyinstaller',
   '_typing',
+  '_utils',
   'array_api',
   'compat',
   'distutils',


### PR DESCRIPTION
Odd PR timing/based on an older branch or seems to have hid, this necessary addition when adding `_util`.
(Or we just missed it next to a lint failure)