### PR TITLE
BLD: fix cirrus wheel upload triggers

### DIFF
--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -69,13 +69,16 @@ wheels_upload_task:
     export IS_PUSH="false"
 
     # cron job
-    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
+    if [[ "$CIRRUS_CRON" == "weekly" ]]; then
       export IS_SCHEDULE_DISPATCH="true"
     fi
 
     if [[ "$CIRRUS_TAG" == "v*" ]]; then
       export IS_PUSH="true"    
     fi
+    if [[ "$CIRRUS_BUILD_SOURCE" == "api" && "$CIRRUS_COMMIT_MESSAGE" == "API build for null" ]]; then      export IS_SCHEDULE_DISPATCH="true"
+    fi
+
 
     # The name of the zip file is derived from the `wheels_artifact` line.
     # If you change the artifact line to `myfile_artifact` then it would be
@@ -85,6 +88,6 @@ wheels_upload_task:
     unzip wheels.zip
     
     source ./tools/wheels/upload_wheels.sh
-    set_travis_vars
+    # set_travis_vars
     set_upload_vars
     upload_wheels # Will be skipped if not a push/tag/scheduled build

--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -1,22 +1,13 @@
 set_travis_vars() {
     # Set env vars
     echo "TRAVIS_EVENT_TYPE is $TRAVIS_EVENT_TYPE"
-    echo CIRRUS_TASK_NAME is "$CIRRUS_TASK_NAME"
     echo "TRAVIS_TAG is $TRAVIS_TAG"
-    echo "CIRRUS_TAG is $CIRRUS_TAG"
-    echo "CIRRUS_API_CREATED is $CIRRUS_API_CREATED"
-    echo "CIRRUS_PR is $CIRRUS_PR"
     if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_TAG" == v* ]]; then
-      IS_PUSH="true"
-    elif [[ "$CIRRUS_PR" == "" && "$CIRRUS_TAG" == v* ]]; then
       IS_PUSH="true"
     else
       IS_PUSH="false"
     fi
     if [[ "$TRAVIS_EVENT_TYPE" == "cron"  || -v CIRRUS_CRON ]]; then
-      IS_SCHEDULE_DISPATCH="true"
-    elif [[ "$TRAVIS_EVENT_TYPE" == "api"  || "$CIRRUS_API_CREATED" == "true" ]]; then
-      # Manual CI run, so upload
       IS_SCHEDULE_DISPATCH="true"
     else
       IS_SCHEDULE_DISPATCH="false"

--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -7,7 +7,7 @@ set_travis_vars() {
     else
       IS_PUSH="false"
     fi
-    if [[ "$TRAVIS_EVENT_TYPE" == "cron"  || -v CIRRUS_CRON ]]; then
+    if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
       IS_SCHEDULE_DISPATCH="true"
     else
       IS_SCHEDULE_DISPATCH="false"
@@ -34,7 +34,7 @@ set_upload_vars() {
 upload_wheels() {
     echo ${PWD}
     if [[ ${ANACONDA_UPLOAD} == true ]]; then
-        if [ -z ${TOKEN} ]; then
+        if [[ -z ${TOKEN} ]]; then
             echo no token set, not uploading
         else
             python -m pip install \


### PR DESCRIPTION
Adopt [the comments](https://github.com/numpy/numpy/pull/22650#issuecomment-1330159211) from @andyfaff:
- totally separate between travis and cirrus upload triggers
- use the cirrus triggers in the main CI runner file
- add a trigger for manual builds, as per the comment

@andyfaff: thoughts?