### PR TITLE
ENH: Refactor deallocation of dtypes with embedded references

### DIFF
--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -334,27 +334,29 @@ fill_arraymethod_from_slots(
     }
 
     /* Check whether the provided loops make sense. */
-    if (meth->strided_loop == NULL) {
+    if ((meth->unaligned_strided_loop == NULL) !=
+            !(meth->flags & NPY_METH_SUPPORTS_UNALIGNED)) {
         PyErr_Format(PyExc_TypeError,
-                "Must provide a strided inner loop function. (method: %s)",
+                "Must provide unaligned strided inner loop for method to "
+                "indicate unaligned support (method: %s)",
                 spec->name);
         return -1;
+    }
+    /* Fill in the blanks: */
+    if (meth->unaligned_contiguous_loop == NULL) {
+        meth->unaligned_contiguous_loop = meth->unaligned_strided_loop;
+    }
+    if (meth->strided_loop == NULL) {
+        meth->strided_loop = meth->unaligned_strided_loop;
     }
     if (meth->contiguous_loop == NULL) {
         meth->contiguous_loop = meth->strided_loop;
     }
-    if (meth->unaligned_contiguous_loop != NULL &&
-            meth->unaligned_strided_loop == NULL) {
+
+    if (meth->strided_loop == NULL) {
         PyErr_Format(PyExc_TypeError,
-                "Must provide unaligned strided inner loop when providing "
-                "a contiguous version. (method: %s)", spec->name);
-        return -1;
-    }
-    if ((meth->unaligned_strided_loop == NULL) !=
-            !(meth->flags & NPY_METH_SUPPORTS_UNALIGNED)) {
-        PyErr_Format(PyExc_TypeError,
-                "Must provide unaligned strided inner loop when providing "
-                "a contiguous version. (method: %s)", spec->name);
+                "Must provide a strided inner loop function. (method: %s)",
+                spec->name);
         return -1;
     }
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -56,6 +56,7 @@ maintainer email:  oliphant.travis@ieee.org
 #include "alloc.h"
 #include "mem_overlap.h"
 #include "numpyos.h"
+#include "refcount.h"
 #include "strfuncs.h"
 
 #include "binop_override.h"
@@ -452,9 +453,9 @@ array_dealloc(PyArrayObject *self)
     }
 
     if ((fa->flags & NPY_ARRAY_OWNDATA) && fa->data) {
-        /* Free internal references if an Object array */
-        if (PyDataType_FLAGCHK(fa->descr, NPY_ITEM_REFCOUNT)) {
-            PyArray_XDECREF(self);
+        /* Free any internal references by clearing the buffer */
+        if (PyDataType_REFCHK(fa->descr)) {
+            PyArray_ClearArray(self);
         }
         if (fa->mem_handler == NULL) {
             char *env = getenv("NUMPY_WARN_IF_NO_MEM_POLICY");

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -149,7 +149,7 @@ PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 {
     PyObject *res;
     if (from == to) {
-        res = NPY_DT_SLOTS(from)->within_dtype_castingimpl;
+        res = (PyObject *)NPY_DT_SLOTS(from)->within_dtype_castingimpl;
     }
     else {
         res = PyDict_GetItemWithError(NPY_DT_SLOTS(from)->castingimpls, (PyObject *)to);
@@ -2415,8 +2415,7 @@ PyArray_AddCastingImplementation(PyBoundArrayMethodObject *meth)
             return -1;
         }
         Py_INCREF(meth->method);
-        NPY_DT_SLOTS(meth->dtypes[0])->within_dtype_castingimpl = (
-                (PyObject *)meth->method);
+        NPY_DT_SLOTS(meth->dtypes[0])->within_dtype_castingimpl = meth->method;
 
         return 0;
     }
@@ -3913,6 +3912,61 @@ PyArray_InitializeObjectToObjectCast(void)
 }
 
 
+static int
+PyArray_InitClearFunctions(void)
+{
+    /*
+     * Initial clearing of objects:
+     */
+    PyArray_DTypeMeta *Object = PyArray_DTypeFromTypeNum(NPY_OBJECT);
+    Py_DECREF(Object);  /* use borrowed */
+    PyArray_DTypeMeta *Void = PyArray_DTypeFromTypeNum(NPY_VOID);
+    Py_DECREF(Void);  /* use borrowed */
+
+    PyArray_DTypeMeta *dtypes[1] = {Object};
+    PyType_Slot slots[] = {
+        {NPY_METH_resolve_descriptors, NULL},  /* must not be used */
+        {NPY_METH_unaligned_strided_loop, &npy_clear_object_strided_loop},
+        {0, NULL}};
+
+    PyArrayMethod_Spec spec = {
+        .name = "object_clear",
+        .nin = 0,
+        .nout = 1,
+        .casting = NPY_NO_CASTING,
+        .flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_SUPPORTS_UNALIGNED,
+        .dtypes = dtypes,
+        .slots = slots,
+    };
+
+    PyBoundArrayMethodObject *bmeth = PyArrayMethod_FromSpec_int(&spec, 1);
+    if (bmeth == NULL) {
+        return -1;
+    }
+    Py_INCREF(bmeth->method);
+    NPY_DT_SLOTS(Object)->clearimpl = bmeth->method;
+    Py_DECREF(bmeth);
+
+    /*
+     * Initialize clearing of structured DTypes.
+     */
+    spec.name = "void_clear";
+    dtypes[0] = Void;
+    slots[1].slot = NPY_METH_get_loop;
+    slots[1].pfunc = &npy_get_clear_void_and_legacy_user_dtype_loop;
+
+    bmeth = PyArrayMethod_FromSpec_int(&spec, 1);
+    if (bmeth == NULL) {
+        return -1;
+    }
+    Py_INCREF(bmeth->method);
+    NPY_DT_SLOTS(Void)->clearimpl = bmeth->method;
+    Py_DECREF(bmeth);
+    return 0;
+}
+
+
+
 NPY_NO_EXPORT int
 PyArray_InitializeCasts()
 {
@@ -3930,6 +3984,9 @@ PyArray_InitializeCasts()
     }
     /* Datetime casts are defined in datetime.c */
     if (PyArray_InitializeDatetimeCasts() < 0) {
+        return -1;
+    }
+    if (PyArray_InitClearFunctions() < 0) {
         return -1;
     }
     return 0;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -3929,12 +3929,16 @@ PyArray_InitClearFunctions(void)
         {NPY_METH_unaligned_strided_loop, &npy_clear_object_strided_loop},
         {0, NULL}};
 
+    NPY_ARRAYMETHOD_FLAGS flags = (
+        NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI |
+        NPY_METH_NO_FLOATINGPOINT_ERRORS);
+
     PyArrayMethod_Spec spec = {
         .name = "object_clear",
         .nin = 0,
         .nout = 1,
         .casting = NPY_NO_CASTING,
-        .flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_SUPPORTS_UNALIGNED,
+        .flags = flags,
         .dtypes = dtypes,
         .slots = slots,
     };

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2501,6 +2501,7 @@ get_clear_fields_transfer_function(int NPY_UNUSED(aligned),
     data->field_count = 0;
 
     _single_field_transfer *field = data->fields;
+    *flags = PyArrayMethod_MINIMAL_FLAGS;
     for (i = 0; i < field_count; ++i) {
         key = PyTuple_GET_ITEM(names, i);
         tup = PyDict_GetItem(src_dtype->fields, key);

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2690,7 +2690,7 @@ npy_clear_object_strided_loop(
     while (N > 0) {
         /* Release the reference in src and set it to NULL */
         NPY_DT_DBG_REFTRACE("dec src ref (null dst)", src_ref);
-        memcpy(&src_ref, src, sizeof(src_ref));
+        memcpy(&src_ref, src, sizeof(PyObject *));
         Py_XDECREF(src_ref);
         memset(src, 0, sizeof(PyObject *));
 

--- a/numpy/core/src/multiarray/dtype_transfer.h
+++ b/numpy/core/src/multiarray/dtype_transfer.h
@@ -146,6 +146,20 @@ object_to_any_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags);
 
+NPY_NO_EXPORT int
+npy_clear_object_strided_loop(
+        PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const *args, const npy_intp *dimensions,
+        const npy_intp *strides, NpyAuxData *NPY_UNUSED(auxdata));
+
+NPY_NO_EXPORT int
+npy_get_clear_void_and_legacy_user_dtype_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int NPY_UNUSED(move_references),
+        const npy_intp *strides,
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
 
 NPY_NO_EXPORT int
 wrap_aligned_transferfunction(

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -1,6 +1,8 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_DTYPEMETA_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_DTYPEMETA_H_
 
+#include "array_method.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,7 +60,13 @@ typedef struct {
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
      */
-    PyObject *within_dtype_castingimpl;
+    PyArrayMethodObject *within_dtype_castingimpl;
+    /*
+     * Implementation which clears a dtype or NULL.  If not given, setting
+     * HASREF on the dtype is invalid.  We only use the loop getting, not
+     * any resolution.
+     */
+    PyArrayMethodObject *clearimpl;
     /*
      * Dictionary of ArrayMethods representing most possible casts
      * (structured and object are exceptions).

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2642,7 +2642,7 @@ PyArray_Nonzero(PyArrayObject *self)
                 }
             }
             /*
-             * Fallback to a branchless strategy to avoid branch misprediction 
+             * Fallback to a branchless strategy to avoid branch misprediction
              * stalls that are very expensive on most modern processors.
              */
             else {

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -2649,7 +2649,7 @@ npyiter_clear_buffers(NpyIter *iter)
             continue;
         }
         int itemsize = dtypes[iop]->elsize;
-        if (PyArray_ClearData(
+        if (PyArray_ClearBuffer(
                 dtypes[iop], *buffers, itemsize, NBF_SIZE(bufferdata), 1) < 0) {
             /* This should never fail; if it does write it out */
             PyErr_WriteUnraisable(NULL);

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -13,6 +13,8 @@
 #include "numpy/arrayscalars.h"
 #include "iterators.h"
 #include "refcount.h"
+#include "dtype_transfer.h"
+#include "lowlevel_strided_loops.h"
 
 #include "npy_config.h"
 
@@ -63,7 +65,7 @@ PyArray_ClearBuffer(
 NPY_NO_EXPORT int
 PyArray_ClearArray(PyArrayObject *arr)
 {
-    assert(PyArray_FLAGS(arr) & NPY_OWNDATA);
+    assert(PyArray_FLAGS(arr) & NPY_ARRAY_OWNDATA);
 
     PyArray_Descr *descr = PyArray_DESCR(arr);
     if (!PyDataType_REFCHK(descr)) {

--- a/numpy/core/src/multiarray/refcount.h
+++ b/numpy/core/src/multiarray/refcount.h
@@ -1,6 +1,27 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_REFCOUNT_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_REFCOUNT_H_
 
+
+NPY_NO_EXPORT int
+PyArray_ClearBuffer(
+        PyArray_Descr *descr, char *data,
+        npy_intp stride, npy_intp size, int aligned);
+
+NPY_NO_EXPORT int
+PyArray_ClearArray(PyArrayOBject *arr);
+
+/*
+ * The following functions worke directly on object or structured dtypes.
+ * Their use is generally incorrect.  In all cases the above functions should
+ * be used.
+ * In some old code, these were (are still) used by copying data first and
+ * calling INCREF in hindsight.  This use is generally incorrect since it
+ * does not translate to user DTypes.
+ * The code should rather use `PyArray_GetStridedCopyFn()` (or copyswapn
+ * as a start, although that probably needs replacement for new DTypes as
+ * well).  (Comment as of NumPy 1.25)
+ */
+
 NPY_NO_EXPORT void
 PyArray_Item_INCREF(char *data, PyArray_Descr *descr);
 

--- a/numpy/core/src/multiarray/refcount.h
+++ b/numpy/core/src/multiarray/refcount.h
@@ -8,7 +8,7 @@ PyArray_ClearBuffer(
         npy_intp stride, npy_intp size, int aligned);
 
 NPY_NO_EXPORT int
-PyArray_ClearArray(PyArrayOBject *arr);
+PyArray_ClearArray(PyArrayObject *arr);
 
 /*
  * The following functions worke directly on object or structured dtypes.

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -20,7 +20,6 @@ maintainer email:  oliphant.travis@ieee.org
   Space Science Telescope Institute
   (J. Todd Miller, Perry Greenfield, Rick White)
 */
-#include "numpy/ndarraytypes.h"
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 


### PR DESCRIPTION
Draft for now, since I want to discuss the approach a bit (I have two).

Basically, this changes it so that we use a `clear` function for each DType rather than the current "specialized" `PyArray_Decref`, which cannot be extended to non-objects.

We already have functions to clear buffers internally in the casting machinery, so this wires them in.  There are two very unrelated questions:

* Should we even bother keeping `PyArray_Decref()` in case someone wants to decref *without* also clearing?  I would still prefer deprecating it, I think.  But maybe we should first expose the new API...  Unless we can just rename the symbol.

* I have *two* different approaches to do this:
  1. This one uses the `ArrayMethod` which is very simple because it fits with our casting setup.  But we don't need `resolve_dtypes` and need to pass a lot of indirections (there is 1 array to operate, so we only need 1 stride, data pointer, etc.)
  2. We could create a new specialized function.  This requires duplicating a bit of the casting setup (for support of structured dtypes) and means a bit more new API.  OTOH, such API might be useful for re-use for a `TRAVERSE` slot, which I presume we need eventually.
  (For some Python implementations, I believe you *must* have a traverse).