### PR TITLE
MAINT: unify NPY_NO_SIGNAL macros

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -469,7 +469,7 @@ def configuration(parent_package='',top_path=None):
 
             # Signal check
             if is_npy_no_signal():
-                moredefs.append('__NPY_PRIVATE_NO_SIGNAL')
+                moredefs.append('NPY_NO_SIGNAL')
 
             # Windows checks
             if sys.platform == 'win32' or os.name == 'nt':

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4100,7 +4100,7 @@ _vec_string(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kw
     return 0;
 }
 
-#ifndef __NPY_PRIVATE_NO_SIGNAL
+#ifndef NPY_NO_SIGNAL
 
 static NPY_TLS int sigint_buf_init = 0;
 static NPY_TLS NPY_SIGJMP_BUF _NPY_SIGINT_BUF;


### PR DESCRIPTION
Discovered this when working on meson support. There are two macros `__NPY_PRIVATE_NO_SIGNAL` and `NPY_NO_SIGNAL`. They are defined here https://github.com/numpy/numpy/blob/3c2717c9a923926ca197bee88b4c5b646b1b93d3/numpy/core/setup.py#L471-L472

and here https://github.com/numpy/numpy/blob/3c2717c9a923926ca197bee88b4c5b646b1b93d3/numpy/core/setup.py#L577-L578

and used in two places here https://github.com/numpy/numpy/blob/3c2717c9a923926ca197bee88b4c5b646b1b93d3/numpy/core/include/numpy/npy_interrupt.h#L20
and here https://github.com/numpy/numpy/blob/3c2717c9a923926ca197bee88b4c5b646b1b93d3/numpy/core/src/multiarray/multiarraymodule.c#L4103

I didn't dig into the history to figure out where the uses diverged. This PR unifies them to `NPY_NO_SIGNAL`, which is defined on windows.