### PR TITLE
CI: Make benchmark asv run quick to only check that benchmarks work

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -143,7 +143,7 @@ EOF
   fi
 
   if [ -n "$CHECK_BLAS" ]; then
-    $PYTHON -m pip install threadpoolctl 
+    $PYTHON -m pip install threadpoolctl
     $PYTHON ../tools/openblas_support.py --check_version
   fi
 
@@ -181,7 +181,7 @@ EOF
     pushd ../benchmarks
     $PYTHON `which asv` check --python=same
     $PYTHON `which asv` machine --machine travis
-    $PYTHON `which asv` dev 2>&1| tee asv-output.log
+    $PYTHON `which asv` dev -q 2>&1| tee asv-output.log
     if grep -q Traceback asv-output.log; then
       echo "Some benchmarks have errors!"
       exit 1


### PR DESCRIPTION
This means that benchmark results are effectively useless but I do not think we use them anyway right now.
IT could be useful to have an asv running as a chron job with an in depth test.  (or maybe also on request for a given PR?)