### PR TITLE
MAINT: Rename symbols in textreading/ that may clash when statically linked.

### DIFF
--- a/numpy/core/src/multiarray/textreading/conversions.c
+++ b/numpy/core/src/multiarray/textreading/conversions.c
@@ -19,7 +19,7 @@
  * Coercion to boolean is done via integer right now.
  */
 NPY_NO_EXPORT int
-to_bool(PyArray_Descr *NPY_UNUSED(descr),
+npy_to_bool(PyArray_Descr *NPY_UNUSED(descr),
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(pconfig))
 {
@@ -110,7 +110,7 @@ double_from_ucs4(
 
 
 NPY_NO_EXPORT int
-to_float(PyArray_Descr *descr,
+npy_to_float(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(pconfig))
 {
@@ -133,7 +133,7 @@ to_float(PyArray_Descr *descr,
 
 
 NPY_NO_EXPORT int
-to_double(PyArray_Descr *descr,
+npy_to_double(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(pconfig))
 {
@@ -228,7 +228,7 @@ to_complex_int(
 
 
 NPY_NO_EXPORT int
-to_cfloat(PyArray_Descr *descr,
+npy_to_cfloat(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig)
 {
@@ -253,7 +253,7 @@ to_cfloat(PyArray_Descr *descr,
 
 
 NPY_NO_EXPORT int
-to_cdouble(PyArray_Descr *descr,
+npy_to_cdouble(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig)
 {
@@ -280,7 +280,7 @@ to_cdouble(PyArray_Descr *descr,
  * String and unicode conversion functions.
  */
 NPY_NO_EXPORT int
-to_string(PyArray_Descr *descr,
+npy_to_string(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(unused))
 {
@@ -309,7 +309,7 @@ to_string(PyArray_Descr *descr,
 
 
 NPY_NO_EXPORT int
-to_unicode(PyArray_Descr *descr,
+npy_to_unicode(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(unused))
 {
@@ -362,7 +362,7 @@ call_converter_function(
 
 
 NPY_NO_EXPORT int
-to_generic_with_converter(PyArray_Descr *descr,
+npy_to_generic_with_converter(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *config, PyObject *func)
 {
@@ -387,9 +387,9 @@ to_generic_with_converter(PyArray_Descr *descr,
 
 
 NPY_NO_EXPORT int
-to_generic(PyArray_Descr *descr,
+npy_to_generic(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *config)
 {
-    return to_generic_with_converter(descr, str, end, dataptr, config, NULL);
+    return npy_to_generic_with_converter(descr, str, end, dataptr, config, NULL);
 }

--- a/numpy/core/src/multiarray/textreading/conversions.h
+++ b/numpy/core/src/multiarray/textreading/conversions.h
@@ -10,47 +10,47 @@
 #include "textreading/parser_config.h"
 
 NPY_NO_EXPORT int
-to_bool(PyArray_Descr *descr,
+npy_to_bool(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
 NPY_NO_EXPORT int
-to_float(PyArray_Descr *descr,
+npy_to_float(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
 NPY_NO_EXPORT int
-to_double(PyArray_Descr *descr,
+npy_to_double(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
 NPY_NO_EXPORT int
-to_cfloat(PyArray_Descr *descr,
+npy_to_cfloat(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
 NPY_NO_EXPORT int
-to_cdouble(PyArray_Descr *descr,
+npy_to_cdouble(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
 NPY_NO_EXPORT int
-to_string(PyArray_Descr *descr,
+npy_to_string(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *unused);
 
 NPY_NO_EXPORT int
-to_unicode(PyArray_Descr *descr,
+npy_to_unicode(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *unused);
 
 NPY_NO_EXPORT int
-to_generic_with_converter(PyArray_Descr *descr,
+npy_to_generic_with_converter(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *unused, PyObject *func);
 
 NPY_NO_EXPORT int
-to_generic(PyArray_Descr *descr,
+npy_to_generic(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 

--- a/numpy/core/src/multiarray/textreading/field_types.c
+++ b/numpy/core/src/multiarray/textreading/field_types.c
@@ -35,18 +35,18 @@ static set_from_ucs4_function *
 get_from_ucs4_function(PyArray_Descr *descr)
 {
     if (descr->type_num == NPY_BOOL) {
-        return &to_bool;
+        return &npy_to_bool;
     }
     else if (PyDataType_ISSIGNED(descr)) {
         switch (descr->elsize) {
             case 1:
-                return &to_int8;
+                return &npy_to_int8;
             case 2:
-                return &to_int16;
+                return &npy_to_int16;
             case 4:
-                return &to_int32;
+                return &npy_to_int32;
             case 8:
-                return &to_int64;
+                return &npy_to_int64;
             default:
                 assert(0);
         }
@@ -54,36 +54,36 @@ get_from_ucs4_function(PyArray_Descr *descr)
     else if (PyDataType_ISUNSIGNED(descr)) {
         switch (descr->elsize) {
             case 1:
-                return &to_uint8;
+                return &npy_to_uint8;
             case 2:
-                return &to_uint16;
+                return &npy_to_uint16;
             case 4:
-                return &to_uint32;
+                return &npy_to_uint32;
             case 8:
-                return &to_uint64;
+                return &npy_to_uint64;
             default:
                 assert(0);
         }
     }
     else if (descr->type_num == NPY_FLOAT) {
-        return &to_float;
+        return &npy_to_float;
     }
     else if (descr->type_num == NPY_DOUBLE) {
-        return &to_double;
+        return &npy_to_double;
     }
     else if (descr->type_num == NPY_CFLOAT) {
-        return &to_cfloat;
+        return &npy_to_cfloat;
     }
     else if (descr->type_num == NPY_CDOUBLE) {
-        return &to_cdouble;
+        return &npy_to_cdouble;
     }
     else if (descr->type_num == NPY_STRING) {
-        return &to_string;
+        return &npy_to_string;
     }
     else if (descr->type_num == NPY_UNICODE) {
-        return &to_unicode;
+        return &npy_to_unicode;
     }
-    return &to_generic;
+    return &npy_to_generic;
 }
 
 

--- a/numpy/core/src/multiarray/textreading/rows.c
+++ b/numpy/core/src/multiarray/textreading/rows.c
@@ -181,7 +181,7 @@ read_rows(stream *s,
 
     int ts_result = 0;
     tokenizer_state ts;
-    if (tokenizer_init(&ts, pconfig) < 0) {
+    if (npy_tokenizer_init(&ts, pconfig) < 0) {
         goto error;
     }
 
@@ -198,7 +198,7 @@ read_rows(stream *s,
 
     for (Py_ssize_t i = 0; i < skiplines; i++) {
         ts.state = TOKENIZE_GOTO_LINE_END;
-        ts_result = tokenize(s, &ts, pconfig);
+        ts_result = npy_tokenize(s, &ts, pconfig);
         if (ts_result < 0) {
             goto error;
         }
@@ -210,7 +210,7 @@ read_rows(stream *s,
 
     Py_ssize_t row_count = 0;  /* number of rows actually processed */
     while ((max_rows < 0 || row_count < max_rows) && ts_result == 0) {
-        ts_result = tokenize(s, &ts, pconfig);
+        ts_result = npy_tokenize(s, &ts, pconfig);
         if (ts_result < 0) {
             goto error;
         }
@@ -402,7 +402,7 @@ read_rows(stream *s,
                         str, end, item_ptr, pconfig);
             }
             else {
-                parser_res = to_generic_with_converter(field_types[f].descr,
+                parser_res = npy_to_generic_with_converter(field_types[f].descr,
                         str, end, item_ptr, pconfig, conv_funcs[i]);
             }
 
@@ -431,7 +431,7 @@ read_rows(stream *s,
         data_ptr += row_size;
     }
 
-    tokenizer_clear(&ts);
+    npy_tokenizer_clear(&ts);
     if (conv_funcs != NULL) {
         for (Py_ssize_t i = 0; i < actual_num_fields; i++) {
             Py_XDECREF(conv_funcs[i]);
@@ -485,7 +485,7 @@ read_rows(stream *s,
         }
         PyMem_FREE(conv_funcs);
     }
-    tokenizer_clear(&ts);
+    npy_tokenizer_clear(&ts);
     Py_XDECREF(data_array);
     return NULL;
 }

--- a/numpy/core/src/multiarray/textreading/str_to_int.c
+++ b/numpy/core/src/multiarray/textreading/str_to_int.c
@@ -23,7 +23,7 @@ const char *deprecation_msg = (
 
 #define DECLARE_TO_INT(intw, INT_MIN, INT_MAX, byteswap_unaligned)          \
     NPY_NO_EXPORT int                                                       \
-    to_##intw(PyArray_Descr *descr,                                         \
+    npy_to_##intw(PyArray_Descr *descr,                                     \
             const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,          \
             parser_config *pconfig)                                         \
     {                                                                       \
@@ -36,7 +36,7 @@ const char *deprecation_msg = (
             double fval;                                                    \
             PyArray_Descr *d_descr = PyArray_DescrFromType(NPY_DOUBLE);     \
             Py_DECREF(d_descr);  /* borrowed */                             \
-            if (to_double(d_descr, str, end, (char *)&fval, pconfig) < 0) { \
+            if (npy_to_double(d_descr, str, end, (char *)&fval, pconfig) < 0) { \
                 return -1;                                                  \
             }                                                               \
             if (!pconfig->gave_int_via_float_warning) {                     \
@@ -61,7 +61,7 @@ const char *deprecation_msg = (
 
 #define DECLARE_TO_UINT(uintw, UINT_MAX, byteswap_unaligned)                \
     NPY_NO_EXPORT int                                                       \
-    to_##uintw(PyArray_Descr *descr,                                        \
+    npy_to_##uintw(PyArray_Descr *descr,                                    \
             const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,          \
             parser_config *pconfig)                                         \
     {                                                                       \
@@ -74,7 +74,7 @@ const char *deprecation_msg = (
             double fval;                                                    \
             PyArray_Descr *d_descr = PyArray_DescrFromType(NPY_DOUBLE);     \
             Py_DECREF(d_descr);  /* borrowed */                             \
-            if (to_double(d_descr, str, end, (char *)&fval, pconfig) < 0) { \
+            if (npy_to_double(d_descr, str, end, (char *)&fval, pconfig) < 0) { \
                 return -1;                                                  \
             }                                                               \
             if (!pconfig->gave_int_via_float_warning) {                     \

--- a/numpy/core/src/multiarray/textreading/str_to_int.h
+++ b/numpy/core/src/multiarray/textreading/str_to_int.h
@@ -157,7 +157,7 @@ str_to_uint64(
 
 #define DECLARE_TO_INT_PROTOTYPE(intw)                                  \
     NPY_NO_EXPORT int                                                   \
-    to_##intw(PyArray_Descr *descr,                                     \
+    npy_to_##intw(PyArray_Descr *descr,                                     \
             const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,      \
             parser_config *pconfig);
 

--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -284,7 +284,7 @@ tokenizer_core(tokenizer_state *ts, parser_config *const config)
  * unicode flavors UCS1, UCS2, and UCS4 as a worthwhile optimization.
  */
 NPY_NO_EXPORT int
-tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
+npy_tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
 {
     assert(ts->fields_size >= 2);
     assert(ts->field_buffer_length >= 2*sizeof(Py_UCS4));
@@ -402,7 +402,7 @@ tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
 
 
 NPY_NO_EXPORT void
-tokenizer_clear(tokenizer_state *ts)
+npy_tokenizer_clear(tokenizer_state *ts)
 {
     PyMem_FREE(ts->field_buffer);
     ts->field_buffer = nullptr;
@@ -420,7 +420,7 @@ tokenizer_clear(tokenizer_state *ts)
  * tokenizing.
  */
 NPY_NO_EXPORT int
-tokenizer_init(tokenizer_state *ts, parser_config *config)
+npy_tokenizer_init(tokenizer_state *ts, parser_config *config)
 {
     /* State and buf_state could be moved into tokenize if we go by row */
     ts->buf_state = BUFFER_MAY_CONTAIN_NEWLINE;

--- a/numpy/core/src/multiarray/textreading/tokenize.h
+++ b/numpy/core/src/multiarray/textreading/tokenize.h
@@ -70,14 +70,14 @@ typedef struct {
 
 
 NPY_NO_EXPORT void
-tokenizer_clear(tokenizer_state *ts);
+npy_tokenizer_clear(tokenizer_state *ts);
 
 
 NPY_NO_EXPORT int
-tokenizer_init(tokenizer_state *ts, parser_config *config);
+npy_tokenizer_init(tokenizer_state *ts, parser_config *config);
 
 NPY_NO_EXPORT int
-tokenize(stream *s, tokenizer_state *ts, parser_config *const config);
+npy_tokenize(stream *s, tokenizer_state *ts, parser_config *const config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Backport of #22646.

While it is not the standard way NumPy is built, some users build and link NumPy statically together with other modules. In this case generic names like `tokenize` or `to_float` can clash with similar symbols from other modules. We can defend against this either by using a C++ namespace or by prefixing symbols likely to clash with a prefix like `npy_`.

Internally, Google builds NumPy and indeed most Python programs statically linked, and this PR fixes symbol clashes we found between NumPy and Google's codebase. While static linking is rare, this change seems like an improvement regardless.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
