### PR TITLE
BLD: revert function() -> #define for 3 npymath functions

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -184,21 +184,28 @@ NPY_INPLACE double npy_atan2(double x, double y);
 #define npy_fmod fmod
 #define npy_floor floor
 #define npy_expm1 expm1
-#define npy_log1p log1p
 #define npy_acosh acosh
-#define npy_asinh asinh
 #define npy_atanh atanh
 #define npy_rint rint
 #define npy_trunc trunc
 #define npy_exp2 exp2
 #define npy_frexp frexp
 #define npy_ldexp ldexp
-#define npy_copysign copysign
 #define npy_exp exp
 #define npy_sqrt sqrt
 #define npy_pow pow
 #define npy_modf modf
 
+#if defined(__arm64__) && defined(__APPLE__)
+/* due to a build problem with scipy, export these as functions */
+NPY_INPLACE double npy_asinh(double x);
+NPY_INPLACE double npy_copysign(double y, double x);
+NPY_INPLACE double npy_log1p(double x);
+#else
+#define npy_asinh asinh
+#define npy_copysign copysign
+#define npy_log1p log1p
+#endif
 double npy_nextafter(double x, double y);
 double npy_spacing(double x);
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -770,7 +770,11 @@ def configuration(parent_package='',top_path=None):
                        # join('src', 'npymath', 'ieee754.cpp'),
                        join('src', 'npymath', 'ieee754.c.src'),
                        join('src', 'npymath', 'npy_math_complex.c.src'),
-                       join('src', 'npymath', 'halffloat.c')
+                       join('src', 'npymath', 'halffloat.c'),
+                       # Remove this once scipy macos arm64 build correctly
+                       # links to the arm64 npymath library,
+                       # see gh-22673
+                       join('src', 'npymath', 'arm64_exports.c'),
                        ]
 
     config.add_installed_library('npymath',

--- a/numpy/core/src/npymath/arm64_exports.c
+++ b/numpy/core/src/npymath/arm64_exports.c
@@ -1,0 +1,23 @@
+#if defined(__arm64__) && defined(__APPLE__)
+
+#include <math.h>
+/* 
+ * Export these for scipy, since the SciPy build for macos arm64
+ * downloads the macos x86_64 NumPy, and does not error when the
+ * linker fails to use npymathlib.a. Importing numpy will expose
+ * these external functions
+ * See https://github.com/numpy/numpy/issues/22673#issuecomment-1327520055
+ */
+
+double npy_asinh(double x) {
+    return asinh(x);
+}
+
+double npy_copysign(double y, double x) {
+    return copysign(y, x);
+}
+
+double npy_log1p(double x) {
+    return log1p(x);
+}
+#endif


### PR DESCRIPTION
Backport of #22679.

It turns out scipy is cross-compiling for macos-arm64 on macos-x86_64 hardware, and using the numpy macos-x86_64 wheel to get `libnpymath.a` This causes a linker warning but not an error. At runtime, when using NumPy 1.24, importing `scipy.special` fails because functions are missing: we changed the external functions to defines when refactoring npymath.

This PR exports the missing functions. Closes #22673. Going forward, SciPy should fix its build, but that is too late for the released wheels.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
