### PR TITLE
BUG: Quantile function on complex number now throws an error (#22652)

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4182,8 +4182,8 @@ def percentile(a,
             method, interpolation, "percentile")
 
     a = np.asanyarray(a)
-    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-        raise ValueError("a must be an array of real numbers")
+    if a.dtype.kind == "c":
+        raise TypeError("a must be an array of real numbers")
 
     q = np.true_divide(q, 100)
     q = asanyarray(q)  # undo any decay that the ufunc performed (see gh-13105)
@@ -4443,8 +4443,8 @@ def quantile(a,
             method, interpolation, "quantile")
 
     a = np.asanyarray(a)
-    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-        raise ValueError("a must be an array of real numbers")
+    if a.dtype.kind == "c":
+        raise TypeError("a must be an array of real numbers")
 
     q = np.asanyarray(q)
     if not _quantile_is_valid(q):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3916,7 +3916,7 @@ def percentile(a,
 
     Parameters
     ----------
-    a : array_like
+    a : array_like of real numbers
         Input array or object that can be converted to an array.
     q : array_like of float
         Percentile or sequence of percentiles to compute, which must be between
@@ -4180,6 +4180,11 @@ def percentile(a,
     if interpolation is not None:
         method = _check_interpolation_as_method(
             method, interpolation, "percentile")
+
+    a = np.asanyarray(a)
+    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+        raise ValueError("a must be an array of real numbers")
+
     q = np.true_divide(q, 100)
     q = asanyarray(q)  # undo any decay that the ufunc performed (see gh-13105)
     if not _quantile_is_valid(q):
@@ -4210,7 +4215,7 @@ def quantile(a,
 
     Parameters
     ----------
-    a : array_like
+    a : array_like of real numbers
         Input array or object that can be converted to an array.
     q : array_like of float
         Quantile or sequence of quantiles to compute, which must be between
@@ -4436,6 +4441,10 @@ def quantile(a,
     if interpolation is not None:
         method = _check_interpolation_as_method(
             method, interpolation, "quantile")
+
+    a = np.asanyarray(a)
+    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+        raise ValueError("a must be an array of real numbers")
 
     q = np.asanyarray(q)
     if not _quantile_is_valid(q):

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1376,6 +1376,9 @@ def nanpercentile(
             method, interpolation, "nanpercentile")
 
     a = np.asanyarray(a)
+    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+        raise ValueError("a must be an array of real numbers")
+
     q = np.true_divide(q, 100.0)
     # undo any decay that the ufunc performed (see gh-13105)
     q = np.asanyarray(q)
@@ -1530,11 +1533,15 @@ def nanquantile(
        The American Statistician, 50(4), pp. 361-365, 1996
 
     """
+
     if interpolation is not None:
         method = function_base._check_interpolation_as_method(
             method, interpolation, "nanquantile")
 
     a = np.asanyarray(a)
+    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+        raise ValueError("a must be an array of real numbers")
+
     q = np.asanyarray(q)
     if not function_base._quantile_is_valid(q):
         raise ValueError("Quantiles must be in the range [0, 1]")

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1376,8 +1376,8 @@ def nanpercentile(
             method, interpolation, "nanpercentile")
 
     a = np.asanyarray(a)
-    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-        raise ValueError("a must be an array of real numbers")
+    if a.dtype.kind == "c":
+        raise TypeError("a must be an array of real numbers")
 
     q = np.true_divide(q, 100.0)
     # undo any decay that the ufunc performed (see gh-13105)
@@ -1539,8 +1539,8 @@ def nanquantile(
             method, interpolation, "nanquantile")
 
     a = np.asanyarray(a)
-    if a.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-        raise ValueError("a must be an array of real numbers")
+    if a.dtype.kind == "c":
+        raise TypeError("a must be an array of real numbers")
 
     q = np.asanyarray(q)
     if not function_base._quantile_is_valid(q):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2974,11 +2974,11 @@ class TestPercentile:
 
     def test_complex(self):
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
-        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+        assert_raises(TypeError, np.percentile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
-        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+        assert_raises(TypeError, np.percentile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
-        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+        assert_raises(TypeError, np.percentile, arr_c, 0.5)
 
     def test_2D(self):
         x = np.array([[1, 1, 1],
@@ -3498,11 +3498,11 @@ class TestQuantile:
     def test_complex(self):
         #See gh-22652
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
-        assert_raises(ValueError, np.quantile, arr_c, 0.5)
+        assert_raises(TypeError, np.quantile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
-        assert_raises(ValueError, np.quantile, arr_c, 0.5)
+        assert_raises(TypeError, np.quantile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
-        assert_raises(ValueError, np.quantile, arr_c, 0.5)
+        assert_raises(TypeError, np.quantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):
         # this is worth retesting, because quantile does not make a copy

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2972,6 +2972,14 @@ class TestPercentile:
         o = np.ones((1,))
         np.percentile(d, 5, None, o, False, 'linear')
 
+    def test_complex(self):
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        assert_raises(ValueError, np.percentile, arr_c, 0.5)
+
     def test_2D(self):
         x = np.array([[1, 1, 1],
                       [1, 1, 1],
@@ -2980,7 +2988,7 @@ class TestPercentile:
                       [1, 1, 1]])
         assert_array_equal(np.percentile(x, 50, axis=0), [1, 1, 1])
 
-    @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])
+    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
     def test_linear_nan_1D(self, dtype):
         # METHOD 1 of H&F
         arr = np.asarray([15.0, np.NAN, 35.0, 40.0, 50.0], dtype=dtype)
@@ -2997,9 +3005,6 @@ class TestPercentile:
                            (np.float32, np.float32),
                            (np.float64, np.float64),
                            (np.longdouble, np.longdouble),
-                           (np.complex64, np.complex64),
-                           (np.complex128, np.complex128),
-                           (np.clongdouble, np.clongdouble),
                            (np.dtype("O"), np.float64)]
 
     @pytest.mark.parametrize(["input_dtype", "expected_dtype"], H_F_TYPE_CODES)
@@ -3039,7 +3044,7 @@ class TestPercentile:
             np.testing.assert_equal(np.asarray(actual).dtype,
                                     np.dtype(expected_dtype))
 
-    TYPE_CODES = np.typecodes["AllInteger"] + np.typecodes["AllFloat"] + "O"
+    TYPE_CODES = np.typecodes["AllInteger"] + np.typecodes["Float"] + "O"
 
     @pytest.mark.parametrize("dtype", TYPE_CODES)
     def test_lower_higher(self, dtype):
@@ -3048,7 +3053,7 @@ class TestPercentile:
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50,
                                    method='higher'), 5)
 
-    @pytest.mark.parametrize("dtype", TYPE_CODES)
+    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
     def test_midpoint(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51,
                                    method='midpoint'), 4.5)
@@ -3059,7 +3064,7 @@ class TestPercentile:
         assert_equal(np.percentile(np.arange(11, dtype=dtype), 50,
                                    method='midpoint'), 5)
 
-    @pytest.mark.parametrize("dtype", TYPE_CODES)
+    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
     def test_nearest(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51,
                                    method='nearest'), 5)
@@ -3489,6 +3494,15 @@ class TestQuantile:
         # repeat with integral input but fractional quantile
         x = np.arange(8)
         assert_equal(np.quantile(x, Fraction(1, 2)), Fraction(7, 2))
+
+    def test_complex(self):
+        #See gh-22652
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        assert_raises(ValueError, np.quantile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        assert_raises(ValueError, np.quantile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        assert_raises(ValueError, np.quantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):
         # this is worth retesting, because quantile does not make a copy

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2973,11 +2973,11 @@ class TestPercentile:
         np.percentile(d, 5, None, o, False, 'linear')
 
     def test_complex(self):
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('G'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('D'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='D')
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('F'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='F')
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
 
     def test_2D(self):
@@ -3497,11 +3497,11 @@ class TestQuantile:
 
     def test_complex(self):
         #See gh-22652
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('G'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('D'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='D')
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('F'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='F')
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3053,7 +3053,7 @@ class TestPercentile:
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 50,
                                    method='higher'), 5)
 
-    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
+    @pytest.mark.parametrize("dtype", TYPE_CODES)
     def test_midpoint(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51,
                                    method='midpoint'), 4.5)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3064,7 +3064,7 @@ class TestPercentile:
         assert_equal(np.percentile(np.arange(11, dtype=dtype), 50,
                                    method='midpoint'), 5)
 
-    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
+    @pytest.mark.parametrize("dtype", TYPE_CODES)
     def test_nearest(self, dtype):
         assert_equal(np.percentile(np.arange(10, dtype=dtype), 51,
                                    method='nearest'), 5)
@@ -3497,11 +3497,11 @@ class TestQuantile:
 
     def test_complex(self):
         #See gh-22652
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('G'))
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('D'))
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('F'))
         assert_raises(TypeError, np.quantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2973,11 +2973,11 @@ class TestPercentile:
         np.percentile(d, 5, None, o, False, 'linear')
 
     def test_complex(self):
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('G'))
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('D'))
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('F'))
         assert_raises(TypeError, np.percentile, arr_c, 0.5)
 
     def test_2D(self):

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1007,11 +1007,11 @@ class TestNanFunctions_Percentile:
         assert_almost_equal(res, tgt)
 
     def test_complex(self):
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')
         assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='D')
         assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='F')
         assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
 
     def test_result_values(self):
@@ -1119,11 +1119,11 @@ class TestNanFunctions_Quantile:
         assert_equal(np.nanquantile(x, 0.5), 1.75)
 
     def test_complex(self):
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='G')
         assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='D')
         assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
-        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype='F')
         assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -403,9 +403,9 @@ class TestNanFunctions_NumberTypes:
     )
     def test_nanfunc_q(self, mat, dtype, nanfunc, func):
         mat = mat.astype(dtype)
-        if mat.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-            assert_raises(ValueError, func, mat, q=1)
-            assert_raises(ValueError, nanfunc, mat, q=1)
+        if mat.dtype.kind == "c":
+            assert_raises(TypeError, func, mat, q=1)
+            assert_raises(TypeError, nanfunc, mat, q=1)
 
         else:
             tgt = func(mat, q=1)
@@ -1008,11 +1008,11 @@ class TestNanFunctions_Percentile:
 
     def test_complex(self):
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
-        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
-        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
-        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanpercentile, arr_c, 0.5)
 
     def test_result_values(self):
         tgt = [np.percentile(d, 28) for d in _rdat]
@@ -1120,11 +1120,11 @@ class TestNanFunctions_Quantile:
 
     def test_complex(self):
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
-        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
-        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
         arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
-        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+        assert_raises(TypeError, np.nanquantile, arr_c, 0.5)
 
     def test_no_p_overwrite(self):
         # this is worth retesting, because quantile does not make a copy

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -403,14 +403,20 @@ class TestNanFunctions_NumberTypes:
     )
     def test_nanfunc_q(self, mat, dtype, nanfunc, func):
         mat = mat.astype(dtype)
-        tgt = func(mat, q=1)
-        out = nanfunc(mat, q=1)
+        if mat.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+            assert_raises(ValueError, func, mat, q=1)
+            assert_raises(ValueError, nanfunc, mat, q=1)
 
-        assert_almost_equal(out, tgt)
-        if dtype == "O":
-            assert type(out) is type(tgt)
         else:
-            assert out.dtype == tgt.dtype
+            tgt = func(mat, q=1)
+            out = nanfunc(mat, q=1)
+
+            assert_almost_equal(out, tgt)
+
+            if dtype == "O":
+                assert type(out) is type(tgt)
+            else:
+                assert out.dtype == tgt.dtype
 
     @pytest.mark.parametrize(
         "nanfunc,func",
@@ -1000,6 +1006,14 @@ class TestNanFunctions_Percentile:
         assert_almost_equal(res, resout)
         assert_almost_equal(res, tgt)
 
+    def test_complex(self):
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        assert_raises(ValueError, np.nanpercentile, arr_c, 0.5)
+
     def test_result_values(self):
         tgt = [np.percentile(d, 28) for d in _rdat]
         res = np.nanpercentile(_ndat, 28, axis=1)
@@ -1010,7 +1024,7 @@ class TestNanFunctions_Percentile:
         assert_almost_equal(res, tgt)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
-    @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])
+    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
     @pytest.mark.parametrize("array", [
         np.array(np.nan),
         np.full((3, 3), np.nan),
@@ -1104,6 +1118,14 @@ class TestNanFunctions_Quantile:
         assert_equal(np.nanquantile(x, 1), 3.5)
         assert_equal(np.nanquantile(x, 0.5), 1.75)
 
+    def test_complex(self):
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex256'))
+        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex128'))
+        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+        arr_c = np.array([0.5+3.0j, 2.1+0.5j, 1.6+2.3j], dtype=np.dtype('complex64'))
+        assert_raises(ValueError, np.nanquantile, arr_c, 0.5)
+
     def test_no_p_overwrite(self):
         # this is worth retesting, because quantile does not make a copy
         p0 = np.array([0, 0.75, 0.25, 0.5, 1.0])
@@ -1117,7 +1139,7 @@ class TestNanFunctions_Quantile:
         assert_array_equal(p, p0)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
-    @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])
+    @pytest.mark.parametrize("dtype", np.typecodes["Float"])
     @pytest.mark.parametrize("array", [
         np.array(np.nan),
         np.full((3, 3), np.nan),


### PR DESCRIPTION
Since percentile is more or less identical to quantile, I also made it throw an error if it receives a complex input. I also made nanquantile and nanpercentile throw errors as well.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
