### PR TITLE
DOC: Remove dangling deprecation warning

### DIFF
--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -294,10 +294,6 @@ basic slicing that returns a :term:`view`).
    the former will trigger advanced indexing. Be sure to understand
    why this occurs.
 
-   Also recognize that ``x[[1, 2, 3]]`` will trigger advanced indexing,
-   whereas due to the deprecated Numeric compatibility mentioned above,
-   ``x[[1, 2, slice(None)]]`` will trigger basic slicing.
-
 Integer array indexing
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The referenced deprecation is no longer mentioned elsewhere on the page, and in any case this usage is no longer supported.
Addresses issue https://github.com/numpy/numpy/issues/22706
[skip ci]

Closes gh-22706
