### PR TITLE
TST: Skip when numba/numpy compat issues cause SystemError

### DIFF
--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -23,7 +23,8 @@ try:
         # numba issue gh-4733
         warnings.filterwarnings('always', '', DeprecationWarning)
         import numba
-except ImportError:
+except (ImportError, SystemError):
+    # Certain numpy/numba versions trigger a SystemError due to a numba bug
     numba = None
 
 try:


### PR DESCRIPTION
numba is a bit buggy when wrapping ufuncs, so what should be nothing is (on non dev versions) a SystemError and not even an ImportError.

So simply catch those too, since it can be a confusing error during dev otherwise.

EDIT: To be clear, the bug should be fixed on numba dev versions.