### PR TITLE
ENH: Speedup masked array creation when mask=None

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2871,7 +2871,8 @@ class MaskedArray(ndarray):
             # Case 2. : With a mask in input.
             # If mask is boolean, create an array of True or False
             
-            # If mask is None, cast it to False
+            # if users pass `mask=None` be forgiving here and cast it False
+            # for speed; although the default is `mask=nomask` and can differ.
             if mask is None:
                 mask = False
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2836,9 +2836,6 @@ class MaskedArray(ndarray):
         # Type of the mask
         mdtype = make_mask_descr(_data.dtype)
         
-        if mask is None:
-            mask = False
-
         if mask is nomask:
             # Case 1. : no mask in input.
             # Erase the current mask ?
@@ -2873,6 +2870,11 @@ class MaskedArray(ndarray):
         else:
             # Case 2. : With a mask in input.
             # If mask is boolean, create an array of True or False
+            
+            # If mask is None, cast it to False
+                    if mask is None:
+                        mask = False
+
             if mask is True and mdtype == MaskType:
                 mask = np.ones(_data.shape, dtype=mdtype)
             elif mask is False and mdtype == MaskType:
@@ -2920,6 +2922,7 @@ class MaskedArray(ndarray):
                     else:
                         _data._mask = np.logical_or(mask, _data._mask)
                     _data._sharedmask = False
+        
         # Update fill_value.
         if fill_value is None:
             fill_value = getattr(data, '_fill_value', None)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2835,6 +2835,9 @@ class MaskedArray(ndarray):
         # Process mask.
         # Type of the mask
         mdtype = make_mask_descr(_data.dtype)
+        
+        if mask is None:
+            mask = False
 
         if mask is nomask:
             # Case 1. : no mask in input.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2872,8 +2872,8 @@ class MaskedArray(ndarray):
             # If mask is boolean, create an array of True or False
             
             # If mask is None, cast it to False
-                    if mask is None:
-                        mask = False
+            if mask is None:
+                mask = False
 
             if mask is True and mdtype == MaskType:
                 mask = np.ones(_data.shape, dtype=mdtype)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2835,7 +2835,6 @@ class MaskedArray(ndarray):
         # Process mask.
         # Type of the mask
         mdtype = make_mask_descr(_data.dtype)
-        
         if mask is nomask:
             # Case 1. : no mask in input.
             # Erase the current mask ?

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -214,6 +214,8 @@ class TestMaskedArray:
         assert_(np.may_share_memory(x.mask, y.mask))
         y = array([1, 2, 3], mask=x._mask, copy=True)
         assert_(not np.may_share_memory(x.mask, y.mask))
+        x = array([1, 2, 3], mask=None)
+        assert_equal(x._mask, [False, False, False])
 
     def test_masked_singleton_array_creation_warns(self):
         # The first works, but should not (ideally), there may be no way


### PR DESCRIPTION
Hi mates! This PR Closes #17046. 

The problem was that when calling `mask=None`, the array creation took **seconds** **compared** **to** the **microseconds** needed when calling `mask=False`.

I followed @rgommers instructions/comments for the fix.

I also wrote a succesful time test using the *modified code* which asserts equal time between the two calls, i.e., `mask=False` and `mask=None`. 

```
import timeit

code_with_false_mask = """np.ma.array(np.zeros(int(1e7)), mask=False)"""
code_with_none_mask = """np.ma.array(np.zeros(int(1e7)), mask=None)"""
setup_code = """import numpy as np"""

print(timeit.timeit(stmt=code_with_false_mask,
                    setup=setup_code,
                    number=1))
# 7.131900019885506e-05 seconds

print(timeit.timeit(stmt=code_with_none_mask,
                    setup=setup_code,
                    number=1))
# 7.389999882434495e-05 seconds -- Previously, it needed 2.415097792000779 seconds 
```