### PR TITLE
BENCH: Add a test for masked array creations

### DIFF
--- a/benchmarks/benchmarks/bench_ma.py
+++ b/benchmarks/benchmarks/bench_ma.py
@@ -17,6 +17,14 @@ class MA(Benchmark):
     def time_masked_array_l100_t100(self):
         np.ma.masked_array(self.l100, self.t100)
 
+class MACreation(Benchmark):
+    param_names = ['data', 'mask']
+    params = [[10, 100, 1000],
+              [True, False, None]]
+
+    def time_ma_creations(self, data, mask):
+        np.ma.array(data=np.zeros(int(data)), mask=mask)
+
 
 class Indexing(Benchmark):
     param_names = ['masked', 'ndim', 'size']


### PR DESCRIPTION
Part of the NumPy PyData Global 2022 Sprint. Companion to https://github.com/numpy/numpy/pull/22725, and partially addresses https://github.com/numpy/numpy/issues/17046.

This clearly demonstrates the speed issue present before:

```
[100.00%] ··· ====== ============= ============= ============
              --                       mask                  
              ------ ----------------------------------------
               data       True         False         None    
              ====== ============= ============= ============
                10    7.72±0.05μs   5.89±0.09μs   13.7±0.2μs 
               100     7.82±0.1μs   5.99±0.08μs   32.1±0.1μs 
               1000    8.25±0.1μs    6.43±0.3μs   198±0.7μs  
              ====== ============= ============= ============
```

After #22725, `False` and `None` have the same (statistically close enough) timing data:

```
[100.00%] ··· ====== ============= ============= =============
              --                        mask                  
              ------ -----------------------------------------
               data       True         False          None    
              ====== ============= ============= =============
                10     7.70±0.3μs   5.91±0.08μs   6.08±0.07μs 
               100     8.34±0.3μs    6.17±0.3μs   5.91±0.04μs 
               1000   8.51±0.05μs   6.52±0.02μs    6.55±0.5μs 
              ====== ============= ============= =============
```