### PR TITLE
BUG: savez raises exception for masked arrays

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -47,7 +47,9 @@ def asstr(s):
     return str(s)
 
 def isfileobj(f):
-    return isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter))
+    import zipfile
+    return isinstance(f, (zipfile._ZipWriteFile, io.FileIO,
+                          io.BufferedReader, io.BufferedWriter))
 
 def open_latin1(filename, mode='r'):
     return open(filename, mode=mode, encoding='iso-8859-1')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1001,7 +1001,7 @@ class TestMaskedArray:
         with pytest.raises(NotImplementedError, match=exc_text) as e_info:
             np.save('abc', mx1)
 
-        with pytest.raises(NotImplementError, match=exc_text) as e_info:
+        with pytest.raises(NotImplementedError, match=exc_text) as e_info:
             np.savez('abc', mx1)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -998,7 +998,7 @@ class TestMaskedArray:
         # make sure save and savez return exception for masked arrays
         mx1 = masked_array([1.], mask=[True])
         exc_text = 'fromfile() not yet implemented for a MaskedArray'
-        with pytest.raises(NotImplementError, match=exc_text) as e_info:
+        with pytest.raises(NotImplementedError, match=exc_text) as e_info:
             np.save('abc', mx1)
 
         with pytest.raises(NotImplementError, match=exc_text) as e_info:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -993,6 +993,18 @@ class TestMaskedArray:
         mx[1].data[0] = 0.
         assert_(mx2[0] == 0.)
 
+    def test_saving_exception(self):
+
+        # make sure save and savez return exception for masked arrays
+        mx1 = masked_array([1.], mask=[True])
+        exc_text = 'fromfile() not yet implemented for a MaskedArray'
+        with pytest.raises(NotImplementError, match=exc_text) as e_info:
+            np.save('abc', mx1)
+
+        with pytest.raises(NotImplementError, match=exc_text) as e_info:
+            np.savez('abc', mx1)
+
+
 
 class TestMaskedArrayArithmetic:
     # Base test class for MaskedArrays.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -997,7 +997,7 @@ class TestMaskedArray:
 
         # make sure save and savez return exception for masked arrays
         mx1 = masked_array([1.], mask=[True])
-        exc_text = 'MaskedArray.tofile() not implemented yet.'
+        exc_text = r'MaskedArray\.tofile\(\) not implemented yet.'
         with pytest.raises(NotImplementedError, match=exc_text) as e_info:
             np.save('abc', mx1)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -997,7 +997,7 @@ class TestMaskedArray:
 
         # make sure save and savez return exception for masked arrays
         mx1 = masked_array([1.], mask=[True])
-        exc_text = 'fromfile() not yet implemented for a MaskedArray'
+        exc_text = 'MaskedArray.tofile() not implemented yet.'
         with pytest.raises(NotImplementedError, match=exc_text) as e_info:
             np.save('abc', mx1)
 


### PR DESCRIPTION
Resolves #18134
savez() now raises an exception for a masked array, like save() already did.
Tests were added for both functions to test the exception being raised in case a masked array is passed as argument. 
