### PR TITLE
DOC: Add instruction to do `git pull`

### DIFF
--- a/doc/source/dev/gitwash/development_setup.rst
+++ b/doc/source/dev/gitwash/development_setup.rst
@@ -107,6 +107,10 @@ Make the local copy
 
     git submodule update --init
 
+#. Pull from upstream to get latest tag information: ::
+
+    git pull
+
 ******************************************************************************
 Look it over
 ******************************************************************************


### PR DESCRIPTION
### DOC: Add instruction to do `git pull`

Without `git pull` after the above steps, we face this issue which leads to issues in building docs:
```py
In [1]: np.__version__                                                                           
Out[1]: '0.3.0+30212.gfb4c96306'   
```

After doing a `git pull` (assuming `main` refs to upstream) and build:
```py
In [1]: np.__version__
Out[1]: '1.25.0.dev0+109.gcfad62fd7'

```