### PR TITLE
API: Hide exceptions from the main namespace

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -107,8 +107,7 @@ import sys
 import warnings
 
 from ._globals import _NoValue, _CopyMode
-from . import exceptions
-# Note that the following names are imported explicitly for backcompat:
+# These exceptions were moved in 1.25 and are hidden from __dir__()
 from .exceptions import (
     ComplexWarning, ModuleDeprecationWarning, VisibleDeprecationWarning,
     TooHardError, AxisError)
@@ -144,6 +143,7 @@ else:
     from . import core
     from .core import *
     from . import compat
+    from . import exceptions
     from . import lib
     # NOTE: to be revisited following future namespace cleanup.
     # See gh-14454 and gh-15672 for discussion.
@@ -291,6 +291,9 @@ else:
         public_symbols = globals().keys() | {'Tester', 'testing'}
         public_symbols -= {
             "core", "matrixlib",
+            # These were moved in 1.25 and may be deprecated eventually:
+            "ModuleDeprecationWarning", "VisibleDeprecationWarning",
+            "ComplexWarning", "TooHardError", "AxisError"
         }
         return list(public_symbols)
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1122,7 +1122,7 @@ def copyto(dst, src, casting=None, where=None):
     >>> A
     array([[4, 5, 6],
            [7, 8, 9]])
-       
+
     """
     return (dst, src, where)
 
@@ -1345,7 +1345,7 @@ def shares_memory(a, b, max_work=None):
 
     Raises
     ------
-    numpy.TooHardError
+    numpy.exceptions.TooHardError
         Exceeded max_work.
 
     Returns
@@ -1379,7 +1379,7 @@ def shares_memory(a, b, max_work=None):
     >>> np.shares_memory(x1, x2, max_work=1000)
     Traceback (most recent call last):
     ...
-    numpy.TooHardError: Exceeded max_work
+    numpy.exceptions.TooHardError: Exceeded max_work
 
     Running ``np.shares_memory(x1, x2)`` without `max_work` set takes
     around 1 minute for this case. It is possible to find problems

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -35,7 +35,7 @@ Exceptions
 from ._utils import set_module as _set_module
 
 __all__ = [
-    "ComplexWarning", "VisibleDeprecationWarning",
+    "ComplexWarning", "VisibleDeprecationWarning", "ModuleDeprecationWarning",
     "TooHardError", "AxisError", "DTypePromotionError"]
 
 
@@ -52,7 +52,6 @@ _is_loaded = True
 #       This then also means that the typing stubs should be moved!
 
 
-@_set_module('numpy')
 class ComplexWarning(RuntimeWarning):
     """
     The warning raised when casting a complex dtype to a real dtype.
@@ -63,7 +62,7 @@ class ComplexWarning(RuntimeWarning):
     """
     pass
 
-@_set_module("numpy")
+
 class ModuleDeprecationWarning(DeprecationWarning):
     """Module deprecation warning.
 
@@ -80,7 +79,6 @@ class ModuleDeprecationWarning(DeprecationWarning):
     """
 
 
-@_set_module("numpy")
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning.
 
@@ -92,7 +90,6 @@ class VisibleDeprecationWarning(UserWarning):
 
 
 # Exception used in shares_memory()
-@_set_module('numpy')
 class TooHardError(RuntimeError):
     """max_work was exceeded.
 
@@ -106,7 +103,6 @@ class TooHardError(RuntimeError):
     pass
 
 
-@_set_module('numpy')
 class AxisError(ValueError, IndexError):
     """Axis supplied was invalid.
 

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -146,14 +146,14 @@ class AxisError(ValueError, IndexError):
     >>> np.cumsum(array_1d, axis=1)
     Traceback (most recent call last):
       ...
-    numpy.AxisError: axis 1 is out of bounds for array of dimension 1
+    numpy.exceptions.AxisError: axis 1 is out of bounds for array of dimension 1
 
     Negative axes are preserved:
 
     >>> np.cumsum(array_1d, axis=-2)
     Traceback (most recent call last):
       ...
-    numpy.AxisError: axis -2 is out of bounds for array of dimension 1
+    numpy.exceptions.AxisError: axis -2 is out of bounds for array of dimension 1
 
     The class constructor generally takes the axis and arrays'
     dimensionality as arguments:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4745,7 +4745,7 @@ cdef class Generator:
         >>> rng.permutation("abc")
         Traceback (most recent call last):
             ...
-        numpy.AxisError: axis 0 is out of bounds for array of dimension 0
+        numpy.exceptions.AxisError: axis 0 is out of bounds for array of dimension 0
 
         >>> arr = np.arange(9).reshape((3, 3))
         >>> rng.permutation(arr, axis=1)

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -505,3 +505,17 @@ def test_array_api_entry_point():
         "does not point to our Array API implementation"
     )
     assert xp is numpy.array_api, msg
+
+
+@pytest.mark.parametrize("name", [
+        'ModuleDeprecationWarning', 'VisibleDeprecationWarning',
+        'ComplexWarning', 'TooHardError', 'AxisError'])
+def test_moved_exceptions(name):
+    # These were moved to the exceptions namespace, but currently still
+    # available
+    assert name in np.__all__
+    assert name not in np.__dir__()
+    # Fetching works, but __module__ is set correctly:
+    assert getattr(np, name).__module__ == "numpy.exceptions"
+    assert name in np.exceptions.__all__
+    getattr(np.exceptions, name)


### PR DESCRIPTION
I wasn't sure if we should already start deprecating the exceptions so opted to follow up with only hiding them from `__dir__()` but still having them in `__all__` and available.

This also changes their module to `numpy.exceptions`, which matters because that is how they will be pickled (it would not be possible to unpickle such an exception in an older NumPy version).

Due to pickling, we could put off changing the module.