### PR TITLE
MAINT: check if PyArrayDTypeMeta_Spec->casts is set

### DIFF
--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -258,6 +258,14 @@ PyArrayInitDTypeMeta_FromSpec(
     /*
      * And now, register all the casts that are currently defined!
      */
+    if (spec->casts == NULL) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "DType must at least provide a function to cast (or just copy) "
+            "between its own instances!");
+        return -1;
+    }
+
     PyArrayMethod_Spec **next_meth_spec = spec->casts;
     while (1) {
         PyArrayMethod_Spec *meth_spec = *next_meth_spec;


### PR DESCRIPTION
If someone writes a dtype and doesn't fill in `casts`, dereferencing `next_meth_spec` below causes a seg fault. This adds an error (and hopefully helpful error message) to avoid that case.