### PR TITLE
BUG: Fix some valgrind errors (and probably harmless warnings)

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1766,7 +1766,8 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     }
 
     if (cache == NULL && newtype != NULL &&
-            PyDataType_ISSIGNED(newtype) && PyArray_IsScalar(op, Generic)) {
+            PyDataType_ISSIGNED(dtype) &&
+            PyArray_IsScalar(op, Generic)) {
         assert(ndim == 0);
         /*
          * This is an (possible) inconsistency where:
@@ -3242,7 +3243,7 @@ _calc_length(PyObject *start, PyObject *stop, PyObject *step, PyObject **next, i
 NPY_NO_EXPORT PyObject *
 PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr *dtype)
 {
-    PyArrayObject *range;
+    PyArrayObject *range = NULL;
     PyArray_ArrFuncs *funcs;
     PyObject *next = NULL;
     PyArray_Descr *native = NULL;
@@ -3402,6 +3403,7 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     Py_XDECREF(stop);
     Py_XDECREF(step);
     Py_XDECREF(next);
+    Py_XDECREF(range);
     return NULL;
 }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3239,6 +3239,9 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (descr == NULL) {
         /* Use the "size-less" void dtype to discover the size. */
         descr = PyArray_DescrNewFromType(NPY_VOID);
+        if (descr == NULL) {
+            return NULL;
+        }
     }
     else if (descr->type_num != NPY_VOID || PyDataType_HASSUBARRAY(descr)) {
         /* we reject subarrays, since subarray scalars do not exist. */
@@ -3246,10 +3249,8 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 "void: descr must be a `void` dtype that is not "
                 "a subarray dtype (structured or unstructured). "
                 "Got '%.100R'.", descr);
+        Py_DECREF(descr);
         return NULL;
-    }
-    else {
-        Py_INCREF(descr);
     }
 
     arr = PyArray_FromAny(obj, descr, 0, 0, NPY_ARRAY_FORCECAST, NULL);


### PR DESCRIPTION
Backport of #22724.

Small refcounting fixups found using valgrind. More may be coming, but probably no point in waiting with these.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
