### PR TITLE
BUG, SIMD: Fix rounding large numbers on SSE2

### DIFF
--- a/numpy/core/tests/test_simd.py
+++ b/numpy/core/tests/test_simd.py
@@ -437,6 +437,16 @@ class _SIMD_FP(_Test_Utility):
                 _round = intrin(data)
                 assert _round == data_round
 
+        # test large numbers
+        for i in (
+            1.1529215045988576e+18, 4.6116860183954304e+18,
+            5.902958103546122e+20, 2.3611832414184488e+21
+        ):
+            x = self.setall(i)
+            y = intrin(x)
+            data_round = [func(n) for n in x]
+            assert y == data_round
+
         # signed zero
         if intrin_name == "floor":
             data_szero = (-0.0,)


### PR DESCRIPTION
closes #22170 

  Before SSE41, there were no native instructions for rounding
  operations on double precision. We usually emulate it by assuming
  that the `MXCR` register is set to rounding, adding a
  large number `2^52` to `X` and then subtracting it back to
  eliminate any excess precision as long as `|X|` is less than `2^52`
  otherwise returns `X.`

  The current emulated intrinsics `npyv_[rint, floor, ceil, trunc]_f64`
  was not checking whether `|x|` equal or large `2^52` which leads
  to losing accuracy on large numbers.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
