### PR TITLE
BUG: fix ma.diff skipping the mask when using append/prepend

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1434,7 +1434,7 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
         combined.append(append)
 
     if len(combined) > 1:
-        a = np.concatenate(combined, axis)
+        a = np.ma.concatenate(combined, axis)
 
     slice1 = [slice(None)] * nd
     slice2 = [slice(None)] * nd

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1868,7 +1868,7 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, control.mask)
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
-    def test_diff_with_prepend():
+    def test_diff_with_prepend(self):
         # GH 22465
         a = np.ma.masked_equal([[2, -1, 10], [5, 2, -1]], value=2)
 
@@ -1876,7 +1876,7 @@ class TestMaskedArrayArithmetic:
         b = np.ma.diff(a, prepend=prep, axis=0)
         assert b.mask.any()
 
-    def test_diff_with_append():
+    def test_diff_with_append(self):
         # GH 22465
         a = np.ma.masked_equal([[2, -1, 10], [5, 2, -1]], value=2)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1868,6 +1868,22 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, control.mask)
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
+    def test_diff_with_prepend():
+        # GH 22465
+        a = np.ma.masked_equal([[2, -1, 10], [5, 2, -1]], value=2)
+
+        prep = np.array([[2, 1, 10]])
+        b = np.ma.diff(a, prepend=prep, axis=0)
+        assert b.mask.any()
+
+    def test_diff_with_append():
+        # GH 22465
+        a = np.ma.masked_equal([[2, -1, 10], [5, 2, -1]], value=2)
+
+        app = np.array([[2, 1, 10]])
+        b = np.ma.diff(a, append=app, axis=0)
+        assert b.mask.any()
+
 
 class TestMaskedArrayAttributes:
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes https://github.com/numpy/numpy/issues/22465.

The issue is easily fixed by using `np.ma.concatenate` instead of `np.concatenate` (see changes). 

The problem is that `np.ma.diff` is generated from `np.diff`, so I had to to modify the original: now, all calls to `np.diff` will call the underlying `np.ma.concatenate`.

The solution to this would be to copy the function `np.diff` to the _ma_ module and apply my changes there, so that the original function remains untouched.
