### PR TITLE
CI: fix CIRRUS_TAG check when tagging. Closes #22730.

### DIFF
--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -73,12 +73,16 @@ wheels_upload_task:
       export IS_SCHEDULE_DISPATCH="true"
     fi
 
-    if [[ "$CIRRUS_TAG" == "v*" ]]; then
-      export IS_PUSH="true"
-    fi
-    if [[ "$CIRRUS_BUILD_SOURCE" == "api" && "$CIRRUS_COMMIT_MESSAGE" == "API build for null" ]]; then      export IS_SCHEDULE_DISPATCH="true"
+    # a manual build was started
+    if [[ "$CIRRUS_BUILD_SOURCE" == "api" && "$CIRRUS_COMMIT_MESSAGE" == "API build for null" ]]; then
+      export IS_SCHEDULE_DISPATCH="true"
     fi
 
+    # only upload wheels to staging if it's a tag beginning with 'v' and you're
+    # on a maintenance branch
+    if [[ "$CIRRUS_TAG" == v* ]] && [[ "$CIRRUS_BRANCH" == maintenance* ]]; then
+      export IS_PUSH="true"
+    fi
 
     # The name of the zip file is derived from the `wheels_artifact` line.
     # If you change the artifact line to `myfile_artifact` then it would be
@@ -88,6 +92,8 @@ wheels_upload_task:
     unzip wheels.zip
 
     source ./tools/wheels/upload_wheels.sh
-    # set_travis_vars
+    # IS_PUSH takes precedence over IS_SCHEDULE_DISPATCH
     set_upload_vars
-    upload_wheels # Will be skipped if not a push/tag/scheduled build
+
+    # Will be skipped if not a push/tag/scheduled build
+    upload_wheels


### PR DESCRIPTION
Backport of #22752.

Closes #22730.

* CI: fix CIRRUS_TAG check when tagging

* CI: cirrus upload on tag+maintenance

* MAINT: Break a long line.

Co-authored-by: Charles Harris <charlesr.harris@gmail.com>

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
