### PR TITLE
MAINT: allow unsized NEP 42 user-defined dtypes

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -1395,8 +1395,13 @@ PyArray_DiscoverDTypeAndShape(
  * @return 1 if this is not a concrete dtype instance 0 otherwise
  */
 static int
-descr_is_legacy_parametric_instance(PyArray_Descr *descr)
+descr_is_legacy_parametric_instance(PyArray_Descr *descr,
+                                    PyArray_DTypeMeta *DType)
 {
+    if (!NPY_DT_is_legacy(DType)) {
+        return 0;
+    }
+
     if (PyDataType_ISUNSIZED(descr)) {
         return 1;
     }
@@ -1440,7 +1445,8 @@ PyArray_ExtractDTypeAndDescriptor(PyObject *dtype,
                     (PyTypeObject *)&PyArrayDTypeMeta_Type)) {
             *out_DType = NPY_DTYPE(dtype);
             Py_INCREF(*out_DType);
-            if (!descr_is_legacy_parametric_instance((PyArray_Descr *)dtype)) {
+            if (!descr_is_legacy_parametric_instance((PyArray_Descr *)dtype,
+                                                     *out_DType)) {
                 *out_descr = (PyArray_Descr *)dtype;
                 Py_INCREF(*out_descr);
             }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "ctors.h"
 #include "convert_datatype.h"
+#include "dtypemeta.h"
 #include "shape.h"
 #include "npy_buffer.h"
 #include "lowlevel_strided_loops.h"
@@ -664,7 +665,8 @@ PyArray_NewFromDescr_int(
     /* Check datatype element size */
     nbytes = descr->elsize;
     if (PyDataType_ISUNSIZED(descr)) {
-        if (!PyDataType_ISFLEXIBLE(descr)) {
+        if (!PyDataType_ISFLEXIBLE(descr) &&
+            NPY_DT_is_legacy(NPY_DTYPE(descr))) {
             PyErr_SetString(PyExc_TypeError, "Empty data-type");
             Py_DECREF(descr);
             return NULL;


### PR DESCRIPTION
Currently unsized user-defined dtypes are not allowed. This relaxes that restriction by updating the code paths that check for an unsized dtype to also check if the dtype is legacy or not.

For the check in `PyArray_NewFromDescr_int`, I had to directly check if `type_num == -1` (currently true for all NEP 42 user-defined dtypes), since there isn't a e.g. `PyDataType_ISNEWUSERDEFINED` macro that does this check. Is there a better way to do this check that might be less brittle? Should I just add a macro that does this check?

Adding tests for this would require adding a new dtype that can be unsized, which seemed beyond the scope of just this fix. This was motivated by [`asciidtype`](https://github.com/numpy/numpy-user-dtypes/tree/main/asciidtype), which can be unsized when its `size` parameter is zero.