### PR TITLE
BUG: assert_array_almost_equal_nulp longdouble

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1794,6 +1794,9 @@ def integer_repr(x):
         return _integer_repr(x, np.int32, np.int32(-2**31))
     elif x.dtype == np.float64:
         return _integer_repr(x, np.int64, np.int64(-2**63))
+    elif x.dtype == np.longdouble:
+        bits = np.finfo(np.longdouble).bits
+        return _integer_repr(x, np.longdouble, np.longdouble(-2**(bits - 1)))
     else:
         raise ValueError(f'Unsupported dtype {x.dtype}')
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -15,6 +15,7 @@ from numpy.testing import (
     tempdir, temppath, assert_no_gc_cycles, HAS_REFCOUNT
     )
 from numpy.core.overrides import ARRAY_FUNCTION_ENABLED
+import pytest
 
 
 class _GenericTest:
@@ -970,13 +971,17 @@ class TestAssertAllclose:
 
 class TestArrayAlmostEqualNulp:
 
-    def test_gh_21520(self):
-        x0 = np.longdouble(1.0)
-        x1 = np.nextafter(x0, np.longdouble(2.0))
-        x2 = np.nextafter(x1, np.longdouble(2.0))
+    @pytest.mark.parametrize("val", [
+        1.0, 2**60, 2**60 + 1,
+        2**80,
+        ])
+    def test_gh_21520(self, val):
+        x0 = np.longdouble(val)
+        x1 = np.nextafter(x0, np.inf)
+        x2 = np.nextafter(x1, np.inf)
         with pytest.raises(AssertionError, match="1 ULP"):
             assert_array_almost_equal_nulp(x0, x2)
-
+        assert_array_almost_equal_nulp(x0, x2, 2)
 
     def test_float64_pass(self):
         # The number of units of least precision

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -970,6 +970,14 @@ class TestAssertAllclose:
 
 class TestArrayAlmostEqualNulp:
 
+    def test_gh_21520(self):
+        x0 = np.longdouble(1.0)
+        x1 = np.nextafter(x0, np.longdouble(2.0))
+        x2 = np.nextafter(x1, np.longdouble(2.0))
+        with pytest.raises(AssertionError, match="1 ULP"):
+            assert_array_almost_equal_nulp(x0, x2)
+
+
     def test_float64_pass(self):
         # The number of units of least precision
         # In this case, use a few places above the lowest level (ie nulp=1)


### PR DESCRIPTION
Fixes #21520

* allow `assert_array_almost_equal_nulp` to properly handle `np.longdouble` + regression test