### PR TITLE
ENH: Support export PyArray_API and PyUFunc_API from shared libraries

### DIFF
--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -482,28 +482,20 @@ Importing the API
 
 .. c:macro:: PY_UFUNC_UNIQUE_SYMBOL
 
+.. c:macro:: PY_UFUNC_ATTRIBUTE
+
 .. c:macro:: NO_IMPORT_UFUNC
 
 .. c:function:: void import_ufunc(void)
 
-    These are the constants and functions for accessing the ufunc
+    These are the macros and functions for accessing the ufunc
     C-API from extension modules in precisely the same way as the
     array C-API can be accessed. The ``import_ufunc`` () function must
     always be called (in the initialization subroutine of the
-    extension module). If your extension module is in one file then
-    that is all that is required. The other two constants are useful
-    if your extension module makes use of multiple files. In that
-    case, define :c:data:`PY_UFUNC_UNIQUE_SYMBOL` to something unique to
-    your code and then in source files that do not contain the module
-    initialization function but still need access to the UFUNC API,
-    define :c:data:`PY_UFUNC_UNIQUE_SYMBOL` to the same name used previously
-    and also define :c:data:`NO_IMPORT_UFUNC`.
+    extension module).
 
-    The C-API is actually an array of function pointers. This array is
-    created (and pointed to by a global variable) by import_ufunc. The
-    global variable is either statically defined or allowed to be seen
-    by other files depending on the state of
-    :c:data:`PY_UFUNC_UNIQUE_SYMBOL` and :c:data:`NO_IMPORT_UFUNC`.
+    To understand how these macros work together, please refer to
+    :c:func:`import_array`.
 
 .. index::
    pair: ufunc; C-API

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -29,11 +29,15 @@ extern NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[2];
 #define PyArray_API PY_ARRAY_UNIQUE_SYMBOL
 #endif
 
+#ifndef PY_ARRAY_ATTRIBUTE
+#define PY_ARRAY_ATTRIBUTE
+#endif
+
 #if defined(NO_IMPORT) || defined(NO_IMPORT_ARRAY)
-extern void **PyArray_API;
+extern PY_ARRAY_ATTRIBUTE void **PyArray_API;
 #else
 #if defined(PY_ARRAY_UNIQUE_SYMBOL)
-void **PyArray_API;
+PY_ARRAY_ATTRIBUTE void **PyArray_API;
 #else
 static void **PyArray_API=NULL;
 #endif

--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -18,11 +18,15 @@ extern NPY_NO_EXPORT PyTypeObject PyUFunc_Type;
 #define PyUFunc_API PY_UFUNC_UNIQUE_SYMBOL
 #endif
 
+#ifndef PY_UFUNC_ATTRIBUTE
+#define PY_UFUNC_ATTRIBUTE
+#endif
+
 #if defined(NO_IMPORT) || defined(NO_IMPORT_UFUNC)
-extern void **PyUFunc_API;
+extern PY_UFUNC_ATTRIBUTE void **PyUFunc_API;
 #else
 #if defined(PY_UFUNC_UNIQUE_SYMBOL)
-void **PyUFunc_API;
+PY_UFUNC_ATTRIBUTE void **PyUFunc_API;
 #else
 static void **PyUFunc_API=NULL;
 #endif


### PR DESCRIPTION
Currently, if multiple extension modules share same initialization, and the code is insde a **shared library**. e.g. [`boost::python::numpy::initialize()`](https://github.com/boostorg/python/blob/47d5bc76f69e20625214381c930a2fad5765e2b3/src/numpy/numpy.cpp#L26), we have to `import_array()` again for each module:
```cpp
boost::python::numpy::initialize();
import_array();
```

This PR adds two macros: `PY_ARRAY_ATTRIBUTE` and `PY_UFUNC_ATTRIBUTE`. To address the issue above, just add the following macro definitions to every compilation unit of every extension module:
```cpp
#define NO_IMPORT_ARRAY
#define PY_ARRAY_UNIQUE_SYMBOL the_same_array_symbol_as_in_initialization_library
#define PY_ARRAY_ATTRIBUTE __attribute__((visibility("default")))   // __declspec(dllexport) for Windows

#define NO_IMPORT_UFUNC
#define PY_UFUNC_UNIQUE_SYMBOL the_same_ufunc_symbol_as_in_initialization_library
#define PY_UFUNC_ATTRIBUTE __attribute__((visibility("default")))   // __declspec(dllexport) for Windows
```



