### PR TITLE
MAINT: Remove two TODO notes that got outdated

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1003,12 +1003,11 @@ class TestDateTime:
                      casting='unsafe'))
 
         # Shouldn't be able to compare datetime and timedelta
-        # TODO: Changing to 'same_kind' or 'safe' casting in the ufuncs by
-        #       default is needed to properly catch this kind of thing...
         a = np.array('2012-12-21', dtype='M8[D]')
         b = np.array(3, dtype='m8[D]')
-        #assert_raises(TypeError, np.less, a, b)
-        assert_raises(TypeError, np.less, a, b, casting='same_kind')
+        assert_raises(TypeError, np.less, a, b)
+        # not even if "unsafe"
+        assert_raises(TypeError, np.less, a, b, casting='unsafe')
 
     def test_datetime_like(self):
         a = np.array([3], dtype='m8[4D]')

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -32,8 +32,6 @@ Exceptions
 """
 
 
-from ._utils import set_module as _set_module
-
 __all__ = [
     "ComplexWarning", "VisibleDeprecationWarning", "ModuleDeprecationWarning",
     "TooHardError", "AxisError", "DTypePromotionError"]
@@ -44,12 +42,6 @@ __all__ = [
 if '_is_loaded' in globals():
     raise RuntimeError('Reloading numpy._globals is not allowed')
 _is_loaded = True
-
-
-# TODO: One day, we should remove the _set_module here before removing them
-#       fully.  Not doing it now, just to allow unpickling to work on older
-#       versions for a bit.  (Module exists since NumPy 1.25.)
-#       This then also means that the typing stubs should be moved!
 
 
 class ComplexWarning(RuntimeWarning):


### PR DESCRIPTION
The first one should have been removed in gh-22735, the second an even more random find.