### PR TITLE
BUG: Ensure arguments to npy_floatstatus_..._barrier() can be dereferenced

### DIFF
--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -130,7 +130,7 @@ raw_array_assign_array(int ndim, npy_intp const *shape,
     }
 
     if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
-        npy_clear_floatstatus_barrier(src_data);
+        npy_clear_floatstatus_barrier((char*)&src_data);
     }
     if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
         NPY_BEGIN_THREADS;
@@ -153,7 +153,7 @@ raw_array_assign_array(int ndim, npy_intp const *shape,
     NPY_cast_info_xfree(&cast_info);
 
     if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
-        int fpes = npy_get_floatstatus_barrier(src_data);
+        int fpes = npy_get_floatstatus_barrier((char*)&src_data);
         if (fpes && PyUFunc_GiveFloatingpointErrors("cast", fpes) < 0) {
             return -1;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2834,7 +2834,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
     }
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
-        int fpes = npy_get_floatstatus_barrier((char *)src_iter);
+        int fpes = npy_get_floatstatus_barrier((char *)&src_iter);
         if (fpes && PyUFunc_GiveFloatingpointErrors("cast", fpes) < 0) {
             return -1;
         }


### PR DESCRIPTION
The argument to these functions is dereferenced, even if the value is thrown away. AddressSanitizer reports an error on the dereference for these functions when running the NumPy test suite.
* In the case of `ctors.c` this is a use after free.
* In the case of `array_assign_array.c` this is an out-of-bounds heap access.

Since I don't think it matters exactly *which* pointer we choose for the `floatstatus` code, changed to use another level of indirection. It's unclear to me whether this is a legal fix or not, or whether we need to work harder to find a valid pointer that points within one of the arrays. This depends deeply on the semantics of `volatile` in C and I'm not 100% sure.

This change would need to be backported to the 1.24.x branch.