### PR TITLE
MAINT: elaborate on error message for unaligned casting spec

### DIFF
--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -353,8 +353,9 @@ fill_arraymethod_from_slots(
     if ((meth->unaligned_strided_loop == NULL) !=
             !(meth->flags & NPY_METH_SUPPORTS_UNALIGNED)) {
         PyErr_Format(PyExc_TypeError,
-                "Must provide unaligned strided inner loop when providing "
-                "a contiguous version. (method: %s)", spec->name);
+                "Must provide unaligned strided inner loop when casting spec "
+                "has the NPY_METH_SUPPORTS_UNALIGNED flag. "
+                "(method: %s)", spec->name);
         return -1;
     }
 


### PR DESCRIPTION
The current error message is copy/pasted from the case directly above and is not quite right for this case. I've updated the message to be more accurate about what is actually going wrong.