### PR TITLE
BUG: Fix infinite recursion in longdouble/large integer scalar ops

### DIFF
--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1004,7 +1004,7 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
         if (overflow) {
             /* handle as if "unsafe" */
             if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
-                return PROMOTION_REQUIRED;
+                return OTHER_IS_UNKNOWN_OBJECT;
             }
             return CONVERT_PYSCALAR;
         }

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -860,27 +860,29 @@ def test_operator_scalars(op, type1, type2):
 
 
 @pytest.mark.parametrize("op", reasonable_operators_for_scalars)
-def test_longdouble_inf_loop(op):
+@pytest.mark.parametrize("val", [None, 2**64])
+def test_longdouble_inf_loop(op, val):
+    # Note: The 2**64 value will pass once NEP 50 is adopted.
     try:
-        op(np.longdouble(3), None)
+        op(np.longdouble(3), val)
     except TypeError:
         pass
     try:
-        op(None, np.longdouble(3))
+        op(val, np.longdouble(3))
     except TypeError:
         pass
 
 
 @pytest.mark.parametrize("op", reasonable_operators_for_scalars)
-def test_clongdouble_inf_loop(op):
-    if op in {operator.mod} and False:
-        pytest.xfail("The modulo operator is known to be broken")
+@pytest.mark.parametrize("val", [None, 2**64])
+def test_clongdouble_inf_loop(op, val):
+    # Note: The 2**64 value will pass once NEP 50 is adopted.
     try:
-        op(np.clongdouble(3), None)
+        op(np.clongdouble(3), val)
     except TypeError:
         pass
     try:
-        op(None, np.longdouble(3))
+        op(val, np.longdouble(3))
     except TypeError:
         pass
 


### PR DESCRIPTION
Backport of #22789.

A small bug snuck in when implementing NEP 50 weak-scalar logic, and unfortunately the tests didn't cover that specific path :/.

closes gh-22787

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
