### PR TITLE
BUG: Fix refcounting errors found using pytest-leaks

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -393,6 +393,9 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
             PyArray_BYTES(arr), PyArray_STRIDES(arr),
             descr, value);
 
+    if (PyDataType_REFCHK(descr)) {
+        PyArray_Item_XDECREF(value, descr);
+    }
     PyMem_FREE(value_buffer_heap);
     return retcode;
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -6473,7 +6473,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
          /* Explicitly allow int, float, and complex for the "weak" types. */
         else if (descr_obj == (PyObject *)&PyLong_Type) {
             descr = PyArray_DescrFromType(NPY_LONG);
-            Py_INCREF(descr);
             dummy_arrays[i] = (PyArrayObject *)PyArray_Empty(0, NULL, descr, 0);
             if (dummy_arrays[i] == NULL) {
                 goto finish;
@@ -6485,7 +6484,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         }
         else if (descr_obj == (PyObject *)&PyFloat_Type) {
             descr = PyArray_DescrFromType(NPY_DOUBLE);
-            Py_INCREF(descr);
             dummy_arrays[i] = (PyArrayObject *)PyArray_Empty(0, NULL, descr, 0);
             if (dummy_arrays[i] == NULL) {
                 goto finish;
@@ -6497,7 +6495,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         }
         else if (descr_obj == (PyObject *)&PyComplex_Type) {
             descr = PyArray_DescrFromType(NPY_CDOUBLE);
-            Py_INCREF(descr);
             dummy_arrays[i] = (PyArrayObject *)PyArray_Empty(0, NULL, descr, 0);
             if (dummy_arrays[i] == NULL) {
                 goto finish;


### PR DESCRIPTION
These are the clear errors I found based on pytest-leaks.  One day it would be nice to fix up pytest-leaks to better support newer versions of pytest and cleaning up fixtures...