### PR TITLE
BLD: fix issue in npymath on macOS arm64 in the Meson build

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -461,6 +461,9 @@ npymath_sources = [
   npy_math_internal_h,
   'src/npymath/halffloat.c',
   'src/npymath/npy_math.c',
+  # Remove this `arm64_exports.c` file once scipy macos arm64 build correctly
+  # links to the arm64 npymath library, see gh-22673
+  'src/npymath/arm64_exports.c',
 ]
 npymath_lib = static_library('npymath',
   npymath_sources,


### PR DESCRIPTION
This was due to a cross-merge conflict. gh-22679 added a new file to the setup.py build, while the Meson build got merged. It's a file that only does anything on arm64 macOS, hence it wasn't noticed in CI.

Addresses a "missing `npy_asinh`" problem discussed in gh-22796

[skip azp]
[skip circle]
[skip cirrus]