### PR TITLE
MAINT: remove unused API documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,6 @@ numpy/core/include/numpy/__ufunc_api.c
 numpy/core/include/numpy/__umath_generated.c
 numpy/core/include/numpy/_umath_doc_generated.h
 numpy/core/include/numpy/config.h
-numpy/core/include/numpy/multiarray_api.txt
-numpy/core/include/numpy/ufunc_api.txt
 numpy/core/lib/
 numpy/core/src/common/npy_sort.h
 numpy/core/src/common/templ_common.h

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -11,7 +11,6 @@ import io
 import os
 import re
 import sys
-import textwrap
 import importlib.util
 
 from os.path import join
@@ -130,21 +129,6 @@ class Function:
         else:
             doccomment = ''
         return '%s%s %s(%s)' % (doccomment, self.return_type, self.name, argstr)
-
-    def to_ReST(self):
-        lines = ['::', '', '  ' + self.return_type]
-        argstr = ',\000'.join([self._format_arg(*a) for a in self.args])
-        name = '  %s' % (self.name,)
-        s = textwrap.wrap('(%s)' % (argstr,), width=72,
-                          initial_indent=name,
-                          subsequent_indent=' ' * (len(name)+1),
-                          break_long_words=False)
-        for l in s:
-            lines.append(l.replace('\000', ' ').rstrip())
-        lines.append('')
-        if self.doc:
-            lines.append(textwrap.dedent(self.doc))
-        return '\n'.join(lines)
 
     def api_hash(self):
         m = hashlib.md5()

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -141,19 +141,12 @@ void *PyArray_API[] = {
 };
 """
 
-c_api_header = """
-===========
-NumPy C-API
-===========
-"""
-
 def generate_api(output_dir, force=False):
     basename = 'multiarray_api'
 
     h_file = os.path.join(output_dir, '__%s.h' % basename)
     c_file = os.path.join(output_dir, '__%s.c' % basename)
-    d_file = os.path.join(output_dir, '%s.txt' % basename)
-    targets = (h_file, c_file, d_file)
+    targets = (h_file, c_file)
 
     sources = numpy_api.multiarray_api
 
@@ -167,7 +160,6 @@ def generate_api(output_dir, force=False):
 def do_generate_api(targets, sources):
     header_file = targets[0]
     c_file = targets[1]
-    doc_file = targets[2]
 
     global_vars = sources[0]
     scalar_bool_values = sources[1]
@@ -235,13 +227,6 @@ def do_generate_api(targets, sources):
     # Write to c-code
     s = c_template % ',\n'.join(init_list)
     genapi.write_file(c_file, s)
-
-    # write to documentation
-    s = c_api_header
-    for func in numpyapi_list:
-        s += func.to_ReST()
-        s += '\n\n'
-    genapi.write_file(doc_file, s)
 
     return targets
 

--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -122,8 +122,7 @@ def generate_api(output_dir, force=False):
 
     h_file = os.path.join(output_dir, '__%s.h' % basename)
     c_file = os.path.join(output_dir, '__%s.c' % basename)
-    d_file = os.path.join(output_dir, '%s.txt' % basename)
-    targets = (h_file, c_file, d_file)
+    targets = (h_file, c_file)
 
     sources = ['ufunc_api_order.txt']
 
@@ -137,7 +136,6 @@ def generate_api(output_dir, force=False):
 def do_generate_api(targets, sources):
     header_file = targets[0]
     c_file = targets[1]
-    doc_file = targets[2]
 
     ufunc_api_index = genapi.merge_api_dicts((
             numpy_api.ufunc_funcs_api,
@@ -178,17 +176,6 @@ def do_generate_api(targets, sources):
     # Write to c-code
     s = c_template % ',\n'.join(init_list)
     genapi.write_file(c_file, s)
-
-    # Write to documentation
-    s = '''
-=================
-NumPy Ufunc C-API
-=================
-'''
-    for func in ufunc_api_list:
-        s += func.to_ReST()
-        s += '\n\n'
-    genapi.write_file(doc_file, s)
 
     return targets
 

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -537,7 +537,7 @@ src_umath_doc_h = custom_target('_umath_doc_generated',
 )
 
 src_numpy_api = custom_target('__multiarray_api',
-  output : ['__multiarray_api.c', '__multiarray_api.h', 'multiarray_api.txt'],
+  output : ['__multiarray_api.c', '__multiarray_api.h'],
   input : 'code_generators/generate_numpy_api.py',
   command: [py, '@INPUT@', '-o', '@OUTDIR@', '--ignore', src_umath_api_c],
   install: true,  # NOTE: setup.py build installs all, but just need .h?
@@ -545,7 +545,7 @@ src_numpy_api = custom_target('__multiarray_api',
 )
 
 src_ufunc_api = custom_target('__ufunc_api',
-  output : ['__ufunc_api.c', '__ufunc_api.h', 'ufunc_api.txt'],
+  output : ['__ufunc_api.c', '__ufunc_api.h'],
   input : 'code_generators/generate_ufunc_api.py',
   command: [py, '@INPUT@', '-o', '@OUTDIR@'],
   install: true,  # NOTE: setup.py build installs all, but just need .h?

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -630,11 +630,11 @@ def configuration(parent_package='',top_path=None):
             try:
                 m = __import__(module_name)
                 log.info('executing %s', script)
-                h_file, c_file, doc_file = m.generate_api(os.path.join(build_dir, header_dir))
+                h_file, c_file = m.generate_api(os.path.join(build_dir, header_dir))
             finally:
                 del sys.path[0]
             config.add_data_files((header_dir, h_file),
-                                  (header_dir, doc_file))
+                                 )
             return (h_file,)
         return generate_api
 


### PR DESCRIPTION
Closes #22768 by removing the unused documentation generation. These days we would prefer a workflow that uses doxygen anyway.