### PR TITLE
DOC: update discussion in dtypes docs that references Python 2

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -264,7 +264,7 @@ Array-protocol type strings (see :ref:`arrays.interface`)
    .. admonition:: Note on string types
 
     For backward compatibility with existing code originally written to support
-    Python 2 ``S`` and ``a`` typestrings are zero-terminated bytes and
+    Python 2, ``S`` and ``a`` typestrings are zero-terminated bytes and
     `numpy.string_` continues to alias `numpy.bytes_`. For unicode strings,
     use ``U``, `numpy.str_`, or `numpy.unicode_`.  For signed bytes that do not
     need zero-termination ``b`` or ``i1`` can be used.

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -189,8 +189,8 @@ Built-in Python types
     ================  ===============
 
     Note that ``str`` corresponds to UCS4 encoded unicode strings, while
-    ``string`` is an alias to ``bytes_``. The name `np.unicode_` is also
-    available as an alias to `np.str_`, see :ref:`Note on string
+    ``string`` is an alias to ``bytes_``. The name ``np.unicode_`` is also
+    available as an alias to ``np.str_``, see :ref:`Note on string
     types<string-dtype-note>`.
 
     .. admonition:: Example

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -188,10 +188,10 @@ Built-in Python types
     (all others)      :class:`object_`
     ================  ===============
 
-    Note that ``str`` refers to either null terminated bytes or unicode strings
-    depending on the Python version. In code targeting both Python 2 and 3
-    ``np.unicode_`` should be used as a dtype for strings.
-    See :ref:`Note on string types<string-dtype-note>`.
+    Note that ``str`` corresponds to UCS4 encoded unicode strings, while
+    ``string`` is an alias to ``bytes_``. The name `np.unicode_` is also
+    available as an alias to `np.str_`, see :ref:`Note on string
+    types<string-dtype-note>`.
 
     .. admonition:: Example
 
@@ -263,11 +263,11 @@ Array-protocol type strings (see :ref:`arrays.interface`)
 
    .. admonition:: Note on string types
 
-    For backward compatibility with Python 2 the ``S`` and ``a`` typestrings
-    remain zero-terminated bytes and `numpy.string_` continues to alias
-    `numpy.bytes_`. To use actual strings in Python 3 use ``U`` or `numpy.str_`.
-    For signed bytes that do not need zero-termination ``b`` or ``i1`` can be
-    used.
+    For backward compatibility with existing code originally written to support
+    Python 2 ``S`` and ``a`` typestrings are zero-terminated bytes and
+    `numpy.string_` continues to alias `numpy.bytes_`. For unicode strings,
+    use ``U``, `numpy.str_`, or `numpy.unicode_`.  For signed bytes that do not
+    need zero-termination ``b`` or ``i1`` can be used.
 
 String with comma-separated fields
    A short-hand notation for specifying the format of a structured data type is


### PR DESCRIPTION
This updates the discussion of string dtypes to no longer focus on compatibility with Python 2 and instead document the naming subtleties. I also added a mention that unicode dtypes are UCS4 encoded.