### PR TITLE
CI: undo permissions in circleci artifact redirector.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -4,16 +4,11 @@
 
 name: CircleCI artifact redirector
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
-    permissions:
-      pull-requests: write
     # if: github.repository == 'numpy/numpy'
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
Temporary fix to recover the circleci artifact redirector in the workflow summary for PRs.

The long-term fix is to figure out which permissions are necessary for the action; in the meantime this restores the desired behavior.