### PR TITLE
BLD: use newer version of delocate

### DIFF
--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -43,5 +43,5 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
     # Try a newer version of delocate that knows about /usr/local/lib
-    pip install git+https://github.com/isuruf/delocate@search_usr_local#egg=delocate
+    pip install git+https://github.com/matthew-brett/delocate@2b10a14b
 fi


### PR DESCRIPTION
Fix wheel building on macOS. The branch on the fork was merged and deleted, so use the upstream library at a known commit. Once delocate makes an official release this should change to a pypi download.

xref #22813. 