### PR TITLE
BLD: redo delocate, update labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,19 +1,18 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
+    types: [created]
 
 permissions: {}
+   contents: write  # to add labels
 
 jobs:
-  pr-labeler:
-    permissions:
-      contents: read  #  to read a configuration file
-      pull-requests: write  #  to add labels to pull requests
-
+  label_pull_request by the PR label:
     runs-on: ubuntu-latest
     steps:
     - name: Label the PR
       uses: gerrymanoim/pr-prefix-labeler@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      if: github.repository == 'numpy/numpy'

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -42,6 +42,5 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     fi
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
-    # Try a newer version of delocate that knows about /usr/local/lib
-    pip install git+https://github.com/matthew-brett/delocate@2b10a14b
+    pip install "delocate==0.10.4"
 fi


### PR DESCRIPTION
Redo #22814 since the project made an official release

Redo the labeler CI run. Note we use a very different logic than SciPy: they label PRs by the files changed, we use the commit message. 