### PR TITLE
BLD: add workaround in setup.py for newer setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -463,6 +463,8 @@ def setup_package():
     else:
         #from numpy.distutils.core import setup
         from setuptools import setup
+        # workaround for broken --no-build-isolation with newer setuptools, see gh-21288
+        metadata["packages"] = []
 
     try:
         setup(**metadata)

--- a/setup.py
+++ b/setup.py
@@ -463,7 +463,8 @@ def setup_package():
     else:
         #from numpy.distutils.core import setup
         from setuptools import setup
-        # workaround for broken --no-build-isolation with newer setuptools, see gh-21288
+        # workaround for broken --no-build-isolation with newer setuptools,
+        # see gh-21288
         metadata["packages"] = []
 
     try:


### PR DESCRIPTION
(cherry picked from commit bf148bf9cd1e5cde05353bfdbe11124523555f5c)

This backports the relevant part of gh-22687.