### PR TITLE
BLD: CIRRUS_TAG redux

### DIFF
--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -80,7 +80,7 @@ wheels_upload_task:
 
     # only upload wheels to staging if it's a tag beginning with 'v' and you're
     # on a maintenance branch
-    if [[ "$CIRRUS_TAG" == v* ]] && [[ "$CIRRUS_BRANCH" == maintenance* ]]; then
+    if [[ "$CIRRUS_TAG" == v* ]] && [[ $CIRRUS_TAG != *"dev0"* ]]; then
       export IS_PUSH="true"    
     fi
 


### PR DESCRIPTION
Another attempt to close #22730.

In this PR if the tag name begins with `v` and doesn't contain `dev0` then it will get uploaded to staging.