### PR TITLE
TST: ignore more np.distutils.log imports

### DIFF
--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -353,6 +353,8 @@ def test_all_modules_are_expected():
 SKIP_LIST_2 = [
     'numpy.math',
     'numpy.distutils.log.sys',
+    'numpy.distutils.log.logging',
+    'numpy.distutils.log.warnings',
     'numpy.doc.constants.re',
     'numpy.doc.constants.textwrap',
     'numpy.lib.emath',


### PR DESCRIPTION
Ignore two more modules from np.distutils.log found by test_public_api.py::test_all_modules_are_expected_2
Closes #22827