### PR TITLE
BUG: Do not use getdata() in np.ma.masked_invalid

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2310,7 +2310,7 @@ def masked_values(x, value, rtol=1e-5, atol=1e-8, copy=True, shrink=True):
                  mask=False,
            fill_value=2.1)
 
-    Unlike `masked_equal`, `masked_values` can perform approximate equalities. 
+    Unlike `masked_equal`, `masked_values` can perform approximate equalities.
 
     >>> ma.masked_values(x, 2.1, atol=1e-1)
     masked_array(data=[1.0, 1.1, --, 1.1, 3.0],
@@ -2356,8 +2356,8 @@ def masked_invalid(a, copy=True):
            fill_value=1e+20)
 
     """
-
-    return masked_where(~(np.isfinite(getdata(a))), a, copy=copy)
+    a = np.array(a, copy=False, subok=True)
+    return masked_where(~(np.isfinite(a)), a, copy=copy)
 
 ###############################################################################
 #                            Printing options                                 #
@@ -2869,7 +2869,7 @@ class MaskedArray(ndarray):
         else:
             # Case 2. : With a mask in input.
             # If mask is boolean, create an array of True or False
-            
+
             # if users pass `mask=None` be forgiving here and cast it False
             # for speed; although the default is `mask=nomask` and can differ.
             if mask is None:
@@ -2922,7 +2922,7 @@ class MaskedArray(ndarray):
                     else:
                         _data._mask = np.logical_or(mask, _data._mask)
                     _data._sharedmask = False
-        
+
         # Update fill_value.
         if fill_value is None:
             fill_value = getattr(data, '_fill_value', None)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4507,6 +4507,20 @@ class TestMaskedArrayFunctions:
                            match="not supported for the input types"):
             np.ma.masked_invalid(a)
 
+    def test_masked_invalid_pandas(self):
+        # getdata() used to be bad for pandas series due to its _data
+        # attribute.  This test is a regression test mainly and may be
+        # removed if getdata() is adjusted.
+        class Series():
+            _data = "nonsense"
+
+            def __array__(self):
+                return np.array([5, np.nan, np.inf])
+
+        arr = np.ma.masked_invalid(Series())
+        assert_array_equal(arr._data, np.array(Series()))
+        assert_array_equal(arr._mask, [False, True, True])
+
     def test_choose(self):
         # Test choose
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],


### PR DESCRIPTION
This is the minimal solution to fix gh-22826 with as little change as possible.
We should fix `getdata()` but I don't want to do that in a bug-fix release really.

IMO the alternative is to revert gh-22046 which would also revert the behavior noticed in gh-22720  (which seems less harmful though).

Closes gh-22826
