### PR TITLE
BUG: Do not use getdata() in np.ma.masked_invalid

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2356,8 +2356,8 @@ def masked_invalid(a, copy=True):
            fill_value=1e+20)
 
     """
-
-    return masked_where(~(np.isfinite(getdata(a))), a, copy=copy)
+    a = np.array(a, copy=False, subok=True)
+    return masked_where(~(np.isfinite(a)), a, copy=copy)
 
 ###############################################################################
 #                            Printing options                                 #

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4505,6 +4505,20 @@ class TestMaskedArrayFunctions:
                            match="not supported for the input types"):
             np.ma.masked_invalid(a)
 
+    def test_masked_invalid_pandas(self):
+        # getdata() used to be bad for pandas series due to its _data
+        # attribute.  This test is a regression test mainly and may be
+        # removed if getdata() is adjusted.
+        class Series():
+            _data = "nonsense"
+
+            def __array__(self):
+                return np.array([5, np.nan, np.inf])
+
+        arr = np.ma.masked_invalid(Series())
+        assert_array_equal(arr._data, np.array(Series()))
+        assert_array_equal(arr._mask, [False, True, True])
+
     def test_choose(self):
         # Test choose
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],


### PR DESCRIPTION
Backport of #22838.

This is the minimal solution to fix gh-22826 with as little change as possible.
We should fix `getdata()` but I don't want to do that in a bug-fix release really.

IMO the alternative is to revert gh-22046 which would also revert the behavior noticed in gh-22720  (which seems less harmful though).

Closes gh-22826

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
