### PR TITLE
BLD: Help raspian arm + clang 13 about `__builtin_mul_overflow`

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -315,7 +315,8 @@ optional_intrinsics = [
   ['__builtin_bswap32', '5u', [], []],
   ['__builtin_bswap64', '5u', [], []],
   ['__builtin_expect', '5, 0', [], []],
-  ['__builtin_mul_overflow', '5, 5, (int*)5', [], []],
+  # Test `long long` for arm+clang 13 (gh-22811, but we use all versions):
+  ['__builtin_mul_overflow', '(long long)5, 5, (int*)5', [], []],
 ]
 if host_machine.cpu_family() in ['x86', 'x86_64']
  optional_intrinsics += [

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -129,7 +129,7 @@ MANDATORY_FUNCS = [
     "floor", "ceil", "sqrt", "log10", "log", "exp", "asin",
     "acos", "atan", "fmod", 'modf', 'frexp', 'ldexp',
     "expm1", "log1p", "acosh", "asinh", "atanh",
-    "rint", "trunc", "exp2", 
+    "rint", "trunc", "exp2",
     "copysign", "nextafter", "strtoll", "strtoull", "cbrt",
     "log2", "pow", "hypot", "atan2",
     "csin", "csinh", "ccos", "ccosh", "ctan", "ctanh",
@@ -178,7 +178,9 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        ("__builtin_bswap32", '5u'),
                        ("__builtin_bswap64", '5u'),
                        ("__builtin_expect", '5, 0'),
-                       ("__builtin_mul_overflow", '5, 5, (int*)5'),
+                       # Test `long long` for arm+clang 13 (gh-22811,
+                       # but we use all versions of __builtin_mul_overflow):
+                       ("__builtin_mul_overflow", '(long long)5, 5, (int*)5'),
                        # MMX only needed for icc, but some clangs don't have it
                        ("_m_from_int64", '0', "emmintrin.h"),
                        ("_mm_load_ps", '(float*)0', "xmmintrin.h"),  # SSE


### PR DESCRIPTION
It seems on raspian arm with clang 13 `__builtin_mul_overflow` is defined for `int` but doesn't work for `ptrdiff_t` (and maybe others). This checks for `long long` instead of int, which was reported to work-around the issue.

Closes gh-22811

---

@rgommers based on the comments in the issue, is this worth a shot/helpful?