### PR TITLE
ENH: allow NEP 42 dtypes to work with np.char

### DIFF
--- a/doc/release/upcoming_changes/22863.new_feature.rst
+++ b/doc/release/upcoming_changes/22863.new_feature.rst
@@ -1,7 +1,4 @@
-String dtype instances can be created from the string abstract dtype classes
-----------------------------------------------------------------------------
-It is now possible to create a string dtype instance with a size without
-using the string name of the dtype. For example, ``type(np.dtype('U'))(8)``
-will create a dtype that is equivalent to ``np.dtype('U8')``. This feature
-is most useful when writing generic code dealing with string dtype
-classes.
+String functions in np.char are compatible with NEP 42 custom dtypes
+--------------------------------------------------------------------
+Custom dtypes that represent unicode strings or byte strings can now be
+passed to the string functions in np.char.

--- a/doc/release/upcoming_changes/22963.new_feature.rst
+++ b/doc/release/upcoming_changes/22963.new_feature.rst
@@ -1,0 +1,7 @@
+String dtype instances can be created from the string abstract dtype classes
+----------------------------------------------------------------------------
+It is now possible to create a string dtype instance with a size without
+using the string name of the dtype. For example, ``type(np.dtype('U'))(8)``
+will create a dtype that is equivalent to ``np.dtype('U8')``. This feature
+is most useful when writing generic code dealing with string dtype
+classes.

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1925,7 +1925,8 @@ def isdecimal(a):
 
     """ 
     if not _is_unicode(a):
-        raise TypeError("isdecimal is only available for Unicode strings and arrays")
+        raise TypeError(
+            "isdecimal is only available for Unicode strings and arrays")
     return _vec_string(a, bool_, 'isdecimal')
 
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -375,7 +375,7 @@ def multiply(a, i):
         raise ValueError("Can only multiply by integers")
     out_size = _get_num_chars(a_arr) * max(int(i_arr.max()), 0)
     return _vec_string(
-        a_arr, (a_arr.dtype.type, out_size), '__mul__', (i_arr,))
+        a_arr, type(a_arr.dtype)(out_size), '__mul__', (i_arr,))
 
 
 def _mod_dispatcher(a, values):
@@ -503,7 +503,7 @@ def center(a, width, fillchar=' '):
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
-        a_arr, (a_arr.dtype.type, size), 'center', (width_arr, fillchar))
+        a_arr, type(a_arr.dtype)(size), 'center', (width_arr, fillchar))
 
 
 def _count_dispatcher(a, sub, start=None, end=None):
@@ -1088,7 +1088,7 @@ def ljust(a, width, fillchar=' '):
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
-        a_arr, (a_arr.dtype.type, size), 'ljust', (width_arr, fillchar))
+        a_arr, type(a_arr.dtype)(size), 'ljust', (width_arr, fillchar))
 
 
 @array_function_dispatch(_unary_op_dispatcher)
@@ -1367,7 +1367,7 @@ def rjust(a, width, fillchar=' '):
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
-        a_arr, (a_arr.dtype.type, size), 'rjust', (width_arr, fillchar))
+        a_arr, type(a_arr.dtype)(size), 'rjust', (width_arr, fillchar))
 
 
 @array_function_dispatch(_partition_dispatcher)
@@ -1833,7 +1833,7 @@ def zfill(a, width):
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
     return _vec_string(
-        a_arr, (a_arr.dtype.type, size), 'zfill', (width_arr,))
+        a_arr, type(a_arr.dtype)(size), 'zfill', (width_arr,))
 
 
 @array_function_dispatch(_unary_op_dispatcher)

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -51,13 +51,17 @@ def _use_unicode(*args):
     Helper function for determining the output type of some string
     operations.
 
-    For an operation on two ndarrays, if at least one is unicode, the
-    result should be unicode.
+    For an operation on two ndarrays, if at least one is a dtype with a
+    scalar that subclasses str or bytes, the result should be that
+    dtype. Otherwise, if at least one is unicode, the result should be
+    unicode.
     """
     for x in args:
-        if (isinstance(x, str) or
-                issubclass(numpy.asarray(x).dtype.type, unicode_)):
+        scalar_type = numpy.asarray(x).dtype.type
+        if (isinstance(x, str) or issubclass(scalar_type, unicode_)):
             return unicode_
+        elif (issubclass(scalar_type, (str, bytes))):
+            return x.dtype
     return string_
 
 def _to_string_or_unicode_array(result):

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -76,15 +76,16 @@ def _is_unicode(arr):
     return False
 
 
-def _to_string_or_unicode_array(result, output_dtype_class=None):
+def _to_string_or_unicode_array(result, output_dtype_like=None):
     """
     Helper function to cast a result back into an array
     with the appropriate dtype if an object array must be used
     as an intermediary.
     """
     ret = numpy.asarray(result.tolist())
-    if output_dtype_class is not None:
-        return ret.astype(output_dtype_class(_get_num_chars(ret)))
+    dtype = getattr(output_dtype_like, 'dtype', None)
+    if dtype is not None:
+        return ret.astype(type(dtype)(_get_num_chars(ret)))
     return ret
 
 
@@ -424,7 +425,7 @@ def mod(a, values):
 
     """
     return _to_string_or_unicode_array(
-        _vec_string(a, object_, '__mod__', (values,)), type(a.dtype))
+        _vec_string(a, object_, '__mod__', (values,)), a)
 
 
 @array_function_dispatch(_unary_op_dispatcher)
@@ -744,9 +745,7 @@ def expandtabs(a, tabsize=8):
 
     """
     return _to_string_or_unicode_array(
-        _vec_string(a, object_, 'expandtabs', (tabsize,)),
-        type(a.dtype)
-    )
+        _vec_string(a, object_, 'expandtabs', (tabsize,)), a)
 
 
 @array_function_dispatch(_count_dispatcher)
@@ -1066,7 +1065,7 @@ def join(sep, seq):
 
     """
     return _to_string_or_unicode_array(
-        _vec_string(sep, object_, 'join', (seq,)), type(seq.dtype))
+        _vec_string(sep, object_, 'join', (seq,)), seq)
 
 
 
@@ -1241,7 +1240,7 @@ def partition(a, sep):
 
     """
     return _to_string_or_unicode_array(
-        _vec_string(a, object_, 'partition', (sep,)), type(a.dtype))
+        _vec_string(a, object_, 'partition', (sep,)), a)
 
 
 def _replace_dispatcher(a, old, new, count=None):
@@ -1286,10 +1285,7 @@ def replace(a, old, new, count=None):
     array(['The dwash was fresh', 'Thwas was it'], dtype='<U19')
     """
     return _to_string_or_unicode_array(
-        _vec_string(
-            a, object_, 'replace', [old, new] + _clean_args(count)),
-        type(a.dtype)
-    )
+        _vec_string(a, object_, 'replace', [old, new] + _clean_args(count)), a)
 
 
 @array_function_dispatch(_count_dispatcher)
@@ -1424,7 +1420,7 @@ def rpartition(a, sep):
 
     """
     return _to_string_or_unicode_array(
-        _vec_string(a, object_, 'rpartition', (sep,)), type(a.dtype))
+        _vec_string(a, object_, 'rpartition', (sep,)), a)
 
 
 def _split_dispatcher(a, sep=None, maxsplit=None):

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -59,10 +59,10 @@ def _use_unicode(*args):
     for x in args:
         scalar_type = numpy.asarray(x).dtype.type
         if (isinstance(x, str) or issubclass(scalar_type, unicode_)):
-            return unicode_
+            return numpy.dtype(unicode_)
         elif (issubclass(scalar_type, (str, bytes))):
             return x.dtype
-    return string_
+    return numpy.dtype(string_)
 
 
 def _is_unicode(arr):
@@ -342,7 +342,7 @@ def add(x1, x2):
     arr2 = numpy.asarray(x2)
     out_size = _get_num_chars(arr1) + _get_num_chars(arr2)
     dtype = _use_unicode(arr1, arr2)
-    return _vec_string(arr1, (dtype, out_size), '__add__', (arr2,))
+    return _vec_string(arr1, type(dtype)(out_size), '__add__', (arr2,))
 
 
 def _multiply_dispatcher(a, i):

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -57,8 +57,10 @@ def _use_unicode(*args):
     unicode.
     """
     for x in args:
+        if isinstance(x, str):
+            return numpy.dtype(unicode_)
         scalar_type = numpy.asarray(x).dtype.type
-        if (isinstance(x, str) or issubclass(scalar_type, unicode_)):
+        if isinstance(scalar_type, unicode_):
             return numpy.dtype(unicode_)
         elif (issubclass(scalar_type, (str, bytes))):
             return x.dtype
@@ -70,8 +72,8 @@ def _is_unicode(arr):
     represents a unicode string, otherwise returns False.
 
     """
-    scalar_type = numpy.asarray(arr).dtype.type
-    if isinstance(arr, str) or issubclass(scalar_type, (unicode_, str)):
+    if (isinstance(arr, str) or
+            issubclass(numpy.asarray(arr).dtype.type, (unicode_, str))):
         return True
     return False
 
@@ -85,7 +87,7 @@ def _to_string_or_unicode_array(result, output_dtype_like=None):
     ret = numpy.asarray(result.tolist())
     dtype = getattr(output_dtype_like, 'dtype', None)
     if dtype is not None:
-        return ret.astype(type(dtype)(_get_num_chars(ret)))
+        return ret.astype(type(dtype)(_get_num_chars(ret)), copy=False)
     return ret
 
 
@@ -1923,7 +1925,7 @@ def isdecimal(a):
 
     """ 
     if not _is_unicode(a):
-        raise TypeError("isnumeric is only available for Unicode strings and arrays")
+        raise TypeError("isdecimal is only available for Unicode strings and arrays")
     return _vec_string(a, bool_, 'isdecimal')
 
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1468,23 +1468,6 @@ _convert_from_type(PyObject *obj) {
         Py_DECREF(ret);
 
         /*
-         * Handle scalars associated with NEP-42 dtypes
-         */
-
-        if (PyObject_HasAttrString((PyObject *) typ,
-                                   "__associated_array_dtype__")) {
-            PyObject * array_dtype = PyObject_GetAttrString(
-                (PyObject *)typ, "__associated_array_dtype__");
-
-            if (array_dtype != NULL) {
-                ret = ((PyArray_DTypeMeta *)array_dtype)->singleton;
-                Py_INCREF(ret);
-                Py_DECREF(array_dtype);
-                return ret;
-            }
-        }
-
-        /*
          * All other classes are treated as object. This can be convenient
          * to convey an intention of using it for a specific python type
          * and possibly allow converting to a new type-specific dtype in the future. It may make sense to

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -262,24 +262,7 @@ _convert_from_tuple(PyObject *obj, int align)
     /*
      * We get here if _try_convert_from_inherit_tuple failed without crashing
      */
-    if (NPY_DT_is_user_defined(type)) {
-        /* interpret next item as a typesize */
-        PyObject* itemsize = PyTuple_GET_ITEM(obj, 1);
-
-        PyArray_DTypeMeta* DType = NPY_DTYPE(type);
-
-        PyObject *res = PyObject_CallFunctionObjArgs(
-            (PyObject *)DType, itemsize, NULL);
-
-        Py_DECREF(type);
-
-        if (res == NULL) {
-            return NULL;
-        }
-
-        return (PyArray_Descr *)res;
-    }
-    else if (PyDataType_ISUNSIZED(type)) {
+    if (PyDataType_ISUNSIZED(type)) {
         /* interpret next item as a typesize */
         int itemsize = PyArray_PyIntAsInt(PyTuple_GET_ITEM(obj,1));
 

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -81,6 +81,7 @@ typedef struct {
 #define NPY_DT_is_legacy(dtype) (((dtype)->flags & NPY_DT_LEGACY) != 0)
 #define NPY_DT_is_abstract(dtype) (((dtype)->flags & NPY_DT_ABSTRACT) != 0)
 #define NPY_DT_is_parametric(dtype) (((dtype)->flags & NPY_DT_PARAMETRIC) != 0)
+#define NPY_DT_is_user_defined(dtype) (((dtype)->type_num == -1))
 
 /*
  * Macros for convenient classmethod calls, since these require

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4061,15 +4061,13 @@ _vec_string(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kw
         method = PyObject_GetAttr((PyObject *)&PyUnicode_Type, method_name);
     }
     else if (NPY_DT_is_user_defined(PyArray_DESCR(char_array))) {
-        PyArray_DTypeMeta* DType = NPY_DTYPE(PyArray_DESCR(char_array));
-        PyTypeObject* scalar_type = DType->scalar_type;
-        PyObject* allowed_scalar_types = PyTuple_Pack(2, (PyObject*)&PyBytes_Type, (PyObject*)&PyUnicode_Type);
-        int is_sub = PyObject_IsSubclass(
-            (PyObject*)scalar_type, allowed_scalar_types);
-        Py_DECREF(allowed_scalar_types);
+        PyTypeObject* scalar_type = NPY_DTYPE(PyArray_DESCR(char_array))->scalar_type;;
+        int is_sub = (PyObject_IsSubType(scalar_type, &PyBytes_Type) ||
+                      PyObject_IsSubType(scalar_type, &PyUnicode_Type));
         if (is_sub == 1) {
             method = PyObject_GetAttr((PyObject*)scalar_type, method_name);
-        } else {
+        } else
+        {
             PyErr_SetString(PyExc_TypeError,
                 "string operations are only allowed for dtypes with a "
                 "scalar type that subclasses str or bytes.");

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3878,32 +3878,14 @@ compare_chararrays(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
         Py_DECREF(newarr);
         return NULL;
     }
-    int is_user_string_newarr = _is_user_defined_string_array(newarr);
-    int is_user_string_newoth = _is_user_defined_string_array(newoth);
-    if ((PyArray_ISSTRING(newarr) || (is_user_string_newarr == 1)) &&
-        (PyArray_ISSTRING(newoth) || (is_user_string_newoth == 1)))
-    {
+    if ((PyArray_ISSTRING(newarr) &&  (PyArray_ISSTRING(newoth)) {
         res = _umath_strings_richcompare(newarr, newoth, cmp_op, rstrip != 0);
     }
     else {
-        if ((is_user_string_newarr == -1) || (is_user_string_newoth == -1))
-        {
-            PyErr_SetString(PyExc_TypeError,
-                    "comparison of non-string arrays");
-            Py_DECREF(newarr);
-            Py_DECREF(newoth);
-            return NULL;
-        }
-        else if ((is_user_string_newarr == 0) || (is_user_string_newoth == 0))
-        {
-            PyErr_SetString(
-                PyExc_TypeError,
-                "string comparisons are only allowed for dtypes with a "
-                "scalar type that are subtypes of str or bytes.");
-            Py_DECREF(newarr);
-            Py_DECREF(newoth);
-            return NULL;
-        }
+        PyErr_SetString(
+            PyExc_TypeError,
+            "comparison of non-string arrays");
+        return NULL;
     }
     Py_DECREF(newarr);
     Py_DECREF(newoth);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4060,6 +4060,22 @@ _vec_string(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kw
     else if (PyArray_TYPE(char_array) == NPY_UNICODE) {
         method = PyObject_GetAttr((PyObject *)&PyUnicode_Type, method_name);
     }
+    else if (NPY_DT_is_user_defined(PyArray_DESCR(char_array))) {
+        PyArray_DTypeMeta* DType = NPY_DTYPE(PyArray_DESCR(char_array));
+        PyTypeObject* scalar_type = DType->scalar_type;
+        PyObject* allowed_scalar_types = PyTuple_Pack(2, (PyObject*)&PyBytes_Type, (PyObject*)&PyUnicode_Type);
+        int is_sub = PyObject_IsSubclass(
+            (PyObject*)scalar_type, allowed_scalar_types);
+        Py_DECREF(allowed_scalar_types);
+        if (is_sub == 1) {
+            method = PyObject_GetAttr((PyObject*)scalar_type, method_name);
+        } else {
+            PyErr_SetString(PyExc_TypeError,
+                "string operations are only allowed for dtypes with a "
+                "scalar type that subclasses str or bytes.");
+            goto err;
+        }
+    }
     else {
         PyErr_SetString(PyExc_TypeError,
                 "string operation on non-string array");

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3791,16 +3791,13 @@ format_longfloat(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
  */
 static int _is_user_defined_string_array(PyArrayObject* array)
 {
-    if (NPY_DT_is_user_defined(PyArray_DESCR(array)))
-    {
+    if (NPY_DT_is_user_defined(PyArray_DESCR(array))) {
         PyTypeObject* scalar_type = NPY_DTYPE(PyArray_DESCR(array))->scalar_type;
         if (PyType_IsSubtype(scalar_type, &PyBytes_Type) ||
-            PyType_IsSubtype(scalar_type, &PyUnicode_Type))
-        {
+            PyType_IsSubtype(scalar_type, &PyUnicode_Type)) {
             return 1;
         }
-        else
-        {
+        else {
             PyErr_SetString(
                 PyExc_TypeError,
                 "string comparisons are only allowed for dtypes with a "
@@ -3808,8 +3805,7 @@ static int _is_user_defined_string_array(PyArrayObject* array)
             return 0;
         }
     }
-    else
-    {
+    else {
         PyErr_SetString(
             PyExc_TypeError,
             "string operation on non-string array");
@@ -4101,8 +4097,7 @@ _vec_string(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kw
                 NPY_DTYPE(PyArray_DESCR(char_array))->scalar_type;
             method = PyObject_GetAttr((PyObject*)scalar_type, method_name);
         }
-        else
-        {
+        else {
             Py_DECREF(type);
             goto err;
         }

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 from numpy.core.multiarray import _vec_string
 from numpy.testing import (
@@ -670,3 +672,15 @@ def test_empty_indexing():
     # empty chararray instead of a chararray with a single empty string in it.
     s = np.chararray((4,))
     assert_(s[[]].size == 0)
+
+
+@pytest.mark.parametrize(["dt1", "dt2"],
+        [("S", "U"), ("U", "S"), ("S", "O"), ("U", "O"),
+         ("S", "d"), ("S", "V")])
+def test_add_types(dt1, dt2):
+    arr1 = np.array([1234234], dtype=dt1)
+    # If the following fails, e.g. use a number and test "V" explicitly
+    arr2 = np.array([b"423"], dtype=dt2)
+    with pytest.raises(TypeError,
+            match=f".*same dtype kind.*{arr1.dtype}.*{arr2.dtype}"):
+        np.char.add(arr1, arr2)


### PR DESCRIPTION
This makes it possible for new-style NEP 42 string dtypes like [ASCIIDType](https://github.com/numpy/numpy-user-dtypes/tree/main/asciidtype) to work with the functions in `np.char`.

It will only work with dtypes with a scalar that subclasses `str` or `bytes`. I also assume that you can create instances of the user dtype from python like `dtype_instance = CustomDType(size_in_bytes)`. This is a pretty big assumption about the API of the dtype, I'm not sure offhand how I can do this more portably or more safely.

I also added a new macro, `NPY_DT_is_user_defined`, which checks `dtype->type_num == -1`, which is currently true for all custom dtypes using the experimental dtype API. This new macro is needed because `NPY_DT_is_legacy` will return false for np.void.

I don't know how I can add tests to numpy for this change without adding a custom string dtype. So far I've tested this locally using `asciidtype`.

I've included some more detail on how I'm testing this below:

<details>

To test this out, you'll need to install asciidtype (using [an unmerged PR for asciidtype](https://github.com/numpy/numpy-user-dtypes/pull/17)) and run a script like the following:

```python
import os

os.environ["NUMPY_EXPERIMENTAL_DTYPE_API"] = "1"

import numpy as np
from asciidtype import ASCIIDType

dtype = ASCIIDType(5)

arr = np.array(["this", "is", "an", "array"], dtype=dtype)

print(repr(np.char.add(arr, arr)))
print(repr(np.char.multiply(arr, 3)))
print(repr(np.char.capitalize(arr)))
print(repr(np.char.endswith(arr, "is")))
```

you should get the following output:

```
array(['thisthis', 'isis', 'anan', 'arrayarray'], dtype=ASCIIDType(10))
array(['thisthisthis', 'isisis', 'ananan', 'arrayarrayarray'],
      dtype=ASCIIDType(15))
array(['This', 'Is', 'An', 'Array'], dtype=ASCIIDType(5))
array([ True,  True, False, False])

```

</details>