### PR TITLE
BUG: Polynomials now copy properly (#22669)

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -499,7 +499,7 @@ class ABCPolyBase(abc.ABC):
         ret['coef'] = self.coef.copy()
         ret['domain'] = self.domain.copy()
         ret['window'] = self.window.copy()
-        ret['symbol'] = self.symbol.copy()
+        ret['symbol'] = self.symbol
         return ret
 
     def __setstate__(self, dict):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -5,6 +5,7 @@ from functools import reduce
 
 import numpy as np
 import numpy.polynomial.polynomial as poly
+from copy import deepcopy
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
     assert_warns, assert_array_equal, assert_raises_regex)
@@ -41,6 +42,10 @@ class TestConstants:
     def test_polyx(self):
         assert_equal(poly.polyx, [0, 1])
 
+    def test_copy(self):
+        x = poly.Polynomial([1, 2, 3])
+        y = deepcopy(x)
+        assert_equal(x, y)
 
 class TestArithmetic:
 

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -5,6 +5,7 @@ from functools import reduce
 
 import numpy as np
 import numpy.polynomial.polynomial as poly
+import pickle
 from copy import deepcopy
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
@@ -45,6 +46,11 @@ class TestConstants:
     def test_copy(self):
         x = poly.Polynomial([1, 2, 3])
         y = deepcopy(x)
+        assert_equal(x, y)
+
+    def test_pickle(self):
+        x = poly.Polynomial([1, 2, 3])
+        y = pickle.loads(pickle.dumps(x))
         assert_equal(x, y)
 
 class TestArithmetic:


### PR DESCRIPTION
Backport of #22670.

On line 502, self.symbol.copy() was called, which
causes an AttributeError, since self.symbol is a
string, so it doesn't have a copy() method. To fix it,
I simply removed the copy() and directly assigned the string.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
