### PR TITLE
TST: Ignore nan-warnings in randomized nanfunction `out=` tests

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -824,6 +824,7 @@ class TestNanFunctions_Median:
             (-3, -1),
         ]
     )
+    @pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
     def test_keepdims_out(self, axis):
         d = np.ones((3, 5, 7, 11))
         # Randomly set some elements to NaN:
@@ -1027,6 +1028,7 @@ class TestNanFunctions_Percentile:
             (-3, -1),
         ]
     )
+    @pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
     def test_keepdims_out(self, q, axis):
         d = np.ones((3, 5, 7, 11))
         # Randomly set some elements to NaN:


### PR DESCRIPTION
The tests randomize the nan pattern and thus can run into these (additional) warnings, so ignore them.
(Could also fix the random seed, but this should do)

Closes gh-22835

--

Checked briefly manually that it suppresses the warnings if everything is NaN.
