### PR TITLE
BUG: Use whole file for encoding checks with ``charset_normalizer``.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,3 +43,4 @@ dependencies:
   # Used in some tests
   - cffi
   - pytz
+  - chardet

--- a/environment.yml
+++ b/environment.yml
@@ -43,4 +43,3 @@ dependencies:
   # Used in some tests
   - cffi
   - pytz
-  - chardet

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -314,6 +314,9 @@ def openhook(filename, mode):
     not available, the function detects only UTF encodings, otherwise,
     ASCII encoding is used as fallback.
     """
+    # Reads in the entire file, shouldn't be a bottleneck
+    # Correctly handles comments or late stage unicode characters
+    # gh-22871
     with open(filename, 'rb') as f:
         raw = f.read()
     if raw.startswith(codecs.BOM_UTF8):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -314,9 +314,8 @@ def openhook(filename, mode):
     not available, the function detects only UTF encodings, otherwise,
     ASCII encoding is used as fallback.
     """
-    bytes = min(32, os.path.getsize(filename))
     with open(filename, 'rb') as f:
-        raw = f.read(bytes)
+        raw = f.read()
     if raw.startswith(codecs.BOM_UTF8):
         encoding = 'UTF-8-SIG'
     elif raw.startswith((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE)):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -148,9 +148,9 @@ import copy
 import platform
 import codecs
 try:
-    import chardet
+    import charset_normalizer
 except ImportError:
-    chardet = None
+    charset_normalizer = None
 
 from . import __version__
 
@@ -309,28 +309,31 @@ _free_f90_start = re.compile(r'[^c*]\s*[^\s\d\t]', re.I).match
 def openhook(filename, mode):
     """Ensures that filename is opened with correct encoding parameter.
 
-    This function uses chardet package, when available, for
-    determining the encoding of the file to be opened. When chardet is
-    not available, the function detects only UTF encodings, otherwise,
-    ASCII encoding is used as fallback.
+    This function uses charset_normalizer package, when available, for
+    determining the encoding of the file to be opened. When charset_normalizer
+    is not available, the function detects only UTF encodings, otherwise, ASCII
+    encoding is used as fallback.
     """
-    # Reads in the entire file, shouldn't be a bottleneck
+    # Reads in the entire file. Robust detection of encoding.
     # Correctly handles comments or late stage unicode characters
     # gh-22871
-    with open(filename, 'rb') as f:
-        raw = f.read()
-    if raw.startswith(codecs.BOM_UTF8):
-        encoding = 'UTF-8-SIG'
-    elif raw.startswith((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE)):
-        encoding = 'UTF-32'
-    elif raw.startswith((codecs.BOM_LE, codecs.BOM_BE)):
-        encoding = 'UTF-16'
+    if charset_normalizer is not None:
+        encoding = charset_normalizer.from_path(filename).best().encoding
     else:
-        if chardet is not None:
-            encoding = chardet.detect(raw)['encoding']
-        else:
-            # hint: install chardet to ensure correct encoding handling
-            encoding = 'ascii'
+        # hint: install charset_normalizer for correct encoding handling
+        # No need to read the whole file for trying with startswith
+        nbytes = min(32, os.path.getsize(filename))
+        with open(filename, 'rb') as fhandle:
+            raw = fhandle.read(nbytes)
+            if raw.startswith(codecs.BOM_UTF8):
+                encoding = 'UTF-8-SIG'
+            elif raw.startswith((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE)):
+                encoding = 'UTF-32'
+            elif raw.startswith((codecs.BOM_LE, codecs.BOM_BE)):
+                encoding = 'UTF-16'
+            else:
+                # Fallback, without charset_normalizer
+                encoding = 'ascii'
     return open(filename, mode, encoding=encoding)
 
 
@@ -396,7 +399,7 @@ def readfortrancode(ffile, dowithline=show, istop=1):
         except UnicodeDecodeError as msg:
             raise Exception(
                 f'readfortrancode: reading {fin.filename()}#{fin.lineno()}'
-                f' failed with\n{msg}.\nIt is likely that installing chardet'
+                f' failed with\n{msg}.\nIt is likely that installing charset_normalizer'
                 ' package will help f2py determine the input file encoding'
                 ' correctly.')
         if not l:

--- a/numpy/f2py/tests/src/crackfortran/unicode_comment.f90
+++ b/numpy/f2py/tests/src/crackfortran/unicode_comment.f90
@@ -1,0 +1,4 @@
+subroutine foo(x)
+  real(8), intent(in) :: x
+  ! Écrit à l'écran la valeur de x
+end subroutine

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,5 +1,6 @@
 import importlib
 import codecs
+import unicodedata
 import pytest
 import numpy as np
 from numpy.f2py.crackfortran import markinnerspaces
@@ -258,11 +259,8 @@ class TestFortranReader(util.F2PyTest):
     def test_input_encoding(self, tmp_path, encoding):
         # gh-635
         f_path = tmp_path / f"input_with_{encoding}_encoding.f90"
-        # explicit BOM is required for UTF8
-        bom = {'utf-8': codecs.BOM_UTF8}.get(encoding, b'')
         with f_path.open('w', encoding=encoding) as ff:
-            ff.write(bom.decode(encoding) +
-                     """
+            ff.write("""
                      subroutine foo()
                      end subroutine foo
                      """)

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -273,8 +273,8 @@ class TestUnicodeComment(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "unicode_comment.f90")]
 
     @pytest.mark.skipif(
-        (importlib.util.find_spec("chardet") is None),
-        reason="test requires chardet which is not installed",
+        (importlib.util.find_spec("charset_normalizer") is None),
+        reason="test requires charset_normalizer which is not installed",
     )
     def test_encoding_comment(self):
         self.module.foo(3)

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,3 +1,4 @@
+import importlib
 import codecs
 import pytest
 import numpy as np
@@ -267,3 +268,13 @@ class TestFortranReader(util.F2PyTest):
                      """)
         mod = crackfortran.crackfortran([str(f_path)])
         assert mod[0]['name'] == 'foo'
+
+class TestUnicodeComment(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "crackfortran", "unicode_comment.f90")]
+
+    @pytest.mark.skipif(
+        (importlib.util.find_spec("chardet") is None),
+        reason="test requires chardet which is not installed",
+    )
+    def test_encoding_comment(self):
+        self.module.foo(3)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,3 +12,5 @@ cffi; python_version < '3.10'
 # NOTE: Keep mypy in sync with environment.yml
 mypy==0.981; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
+# for optional f2py encoding detection
+charset-normalizer


### PR DESCRIPTION
Closes #22871.

The issue is that the current behavior uses only the first `32` bytes. The current variation (reading in the whole file) should be fine, fortran files are rarely large enough for this to be a practical bottleneck (tentatively).

**EDIT**: Now this has a slightly larger changelog

- [x] Switch from `chardet` to `charset_normalizer`
- [x] Rework to keep old behavior (bytes read) without `charset_normalizer`

The rationale here is that if there are encoding errors, attempting to determine the encoding with `startswith` doesn't need more than the old number of bytes anyway.

`charset_normalizer` will use the whole file to check the encoding.