### PR TITLE
TST: Fixup string cast test to not use `tiny`

### DIFF
--- a/numpy/core/tests/test_strings.py
+++ b/numpy/core/tests/test_strings.py
@@ -90,8 +90,8 @@ def test_string_comparisons_empty(op, ufunc, sym, dtypes):
 def test_float_to_string_cast(str_dt, float_dt):
     float_dt = np.dtype(float_dt)
     fi = np.finfo(float_dt)
-    arr = np.array([np.nan, np.inf, -np.inf, fi.max, fi.tiny], dtype=float_dt)
-    expected = ["nan", "inf", "-inf", repr(fi.max), repr(fi.tiny)]
+    arr = np.array([np.nan, np.inf, -np.inf, fi.max, fi.min], dtype=float_dt)
+    expected = ["nan", "inf", "-inf", repr(fi.max), repr(fi.min)]
     if float_dt.kind == 'c':
         expected = [f"({r}+0j)" for r in expected]
 


### PR DESCRIPTION
There is not much value in these values anyway probably, but tiny isn't reliably for double-double (maybe it should be, but that is a different issue).

Fixup for gh-22855 and gh-22868