### PR TITLE
TST: Ignore nan-warnings in randomized out tests

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -818,6 +818,7 @@ class TestNanFunctions_Median:
             (-3, -1),
         ]
     )
+    @pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
     def test_keepdims_out(self, axis):
         d = np.ones((3, 5, 7, 11))
         # Randomly set some elements to NaN:
@@ -1021,6 +1022,7 @@ class TestNanFunctions_Percentile:
             (-3, -1),
         ]
     )
+    @pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
     def test_keepdims_out(self, q, axis):
         d = np.ones((3, 5, 7, 11))
         # Randomly set some elements to NaN:


### PR DESCRIPTION
Backport of #22869.

The tests randomize the nan pattern and thus can run into these (additional) warnings, so ignore them.
(Could also fix the random seed, but this should do)

Closes gh-22835

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
