### PR TITLE
BUG: Fix integer overflow in in1d for mixed integer dtypes #22877

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -652,14 +652,14 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         #  1. Assert memory usage is not too large
         below_memory_constraint = ar2_range <= 6 * (ar1.size + ar2.size)
         #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
-        range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
+        range_safe_from_overflow = ar2_range <= np.iinfo(ar2.dtype).max
         #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
         if ar1.size > 0:
             ar1_min = np.min(ar1)
             ar1_max = np.max(ar1)
             range_safe_from_overflow &= all((
-                int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max,
-                int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
+                int(ar1_max) - int(ar2_min) <= np.iinfo(ar1.dtype).max,
+                int(ar1_min) - int(ar2_min) >= np.iinfo(ar1.dtype).min
             ))
 
         # Optimal performance is for approximately

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -643,8 +643,6 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         if ar2.dtype == bool:
             ar2 = ar2.astype(np.uint8)
 
-        ar1_min = np.min(ar1)
-        ar1_max = np.max(ar1)
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
 
@@ -656,10 +654,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
         range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
         #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
-        range_safe_from_overflow &= all((
-            int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max,
-            int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
-        ))
+        if ar1.size > 0:
+            ar1_min = np.min(ar1)
+            ar1_max = np.max(ar1)
+            range_safe_from_overflow &= all((
+                int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max,
+                int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
+            ))
 
         # Optimal performance is for approximately
         # log10(size) > (log10(range) - 2.27) / 0.927.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -656,8 +656,10 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
         range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
         #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
-        range_safe_from_overflow &= int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max
-        range_safe_from_overflow &= int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
+        range_safe_from_overflow &= all((
+            int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max,
+            int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
+        ))
 
         # Optimal performance is for approximately
         # log10(size) > (log10(range) - 2.27) / 0.927.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -657,9 +657,15 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         if ar1.size > 0:
             ar1_min = np.min(ar1)
             ar1_max = np.max(ar1)
+
+            # After masking, the range of ar1 is guaranteed to be
+            # within the range of ar2:
+            ar1_upper = min(int(ar1_max), int(ar2_max))
+            ar1_lower = max(int(ar1_min), int(ar2_min))
+
             range_safe_from_overflow &= all((
-                int(ar1_max) - int(ar2_min) <= np.iinfo(ar1.dtype).max,
-                int(ar1_min) - int(ar2_min) >= np.iinfo(ar1.dtype).min
+                ar1_upper - int(ar2_min) <= np.iinfo(ar1.dtype).max,
+                ar1_lower - int(ar2_min) >= np.iinfo(ar1.dtype).min
             ))
 
         # Optimal performance is for approximately

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -656,8 +656,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
         range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
         #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
-        range_safe_from_overflow &= ar1_max - ar2_min < np.iinfo(ar1.dtype).max
-        range_safe_from_overflow &= ar1_min - ar2_min > np.iinfo(ar1.dtype).min
+        range_safe_from_overflow &= int(ar1_max) - int(ar2_min) < np.iinfo(ar1.dtype).max
+        range_safe_from_overflow &= int(ar1_min) - int(ar2_min) > np.iinfo(ar1.dtype).min
 
         # Optimal performance is for approximately
         # log10(size) > (log10(range) - 2.27) / 0.927.

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -425,7 +425,8 @@ class TestSetOps:
             (np.int16, np.uint8),
         ]
     )
-    def test_in1d_mixed_dtype(self, dtype1, dtype2):
+    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    def test_in1d_mixed_dtype(self, dtype1, dtype2, kind):
         """Test that in1d works as expected for mixed dtype input."""
         is_dtype2_signed = np.issubdtype(dtype2, np.signedinteger)
         ar1 = np.array([0, 0, 1, 1], dtype=dtype1)
@@ -436,7 +437,17 @@ class TestSetOps:
             ar2 = np.array([127, 0, 255], dtype=dtype2)
 
         expected = np.array([True, True, False, False])
-        assert_array_equal(in1d(ar1, ar2), expected)
+
+        expect_failure = kind == "table" and any((
+            dtype1 == np.int8 and dtype2 == np.int16,
+            dtype1 == np.int16 and dtype2 == np.int8
+        ))
+
+        if expect_failure:
+            with pytest.raises(RuntimeError, match="exceed the maximum"):
+                in1d(ar1, ar2, kind=kind)
+        else:
+            assert_array_equal(in1d(ar1, ar2, kind=kind), expected)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_in1d_mixed_boolean(self, kind):

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -443,8 +443,8 @@ class TestSetOps:
         """Test that in1d works as expected for bool/int input."""
         for dtype in np.typecodes["AllInteger"]:
             a = np.array([True, False, False], dtype=bool)
-            b = np.array([1, 1, 1, 1], dtype=dtype)
-            expected = np.array([True, False, False], dtype=bool)
+            b = np.array([0, 0, 0, 0], dtype=dtype)
+            expected = np.array([False, True, True], dtype=bool)
             assert_array_equal(in1d(a, b, kind=kind), expected)
 
             a, b = b, a

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -414,6 +414,30 @@ class TestSetOps:
         with pytest.raises(ValueError):
             in1d(a, b, kind="table")
 
+    @pytest.mark.parametrize(
+        "dtype1,dtype2",
+        [
+            (np.int8, np.int16),
+            (np.int16, np.int8),
+            (np.uint8, np.uint16),
+            (np.uint16, np.uint8),
+            (np.uint8, np.int16),
+            (np.int16, np.uint8),
+        ]
+    )
+    def test_in1d_mixed_dtype(self, dtype1, dtype2):
+        """Test that in1d works as expected for mixed dtype input."""
+        is_dtype2_signed = np.issubdtype(dtype2, np.signedinteger)
+        ar1 = np.array([0, 0, 1, 1], dtype=dtype1)
+
+        if is_dtype2_signed:
+            ar2 = np.array([-128, 0, 127], dtype=dtype2)
+        else:
+            ar2 = np.array([127, 0, 255], dtype=dtype2)
+
+        expected = np.array([True, True, False, False])
+        assert_array_equal(in1d(ar1, ar2), expected)
+
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_in1d_mixed_boolean(self, kind):
         """Test that in1d works as expected for bool/int input."""


### PR DESCRIPTION
This fixes #22877 raised by @TonyXiang8787. The bug, introduced by #12065, results in integer overflows occurring in the following line: https://github.com/numpy/numpy/blob/2b9851ba4f8cc436266d913eb5db75fc702e1eed/numpy/lib/arraysetops.py#L683-L684 when mixed dtype input was passed to `in1d`.

The fix is to simply test for these in advance of the `kind='table'` method being used:

```python
        #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
        range_safe_from_overflow = ar2_range <= np.iinfo(ar2.dtype).max
        #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
        range_safe_from_overflow &= int(ar1_max) - int(ar2_min) <= np.iinfo(ar1.dtype).max
        range_safe_from_overflow &= int(ar1_min) - int(ar2_min) >= np.iinfo(ar1.dtype).min
```

I also added some unittests to evaluate this behavior.

cc @seberg 