### PR TITLE
BUG: Fixes for numpy.testing.overrides

### DIFF
--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -14,6 +14,7 @@ from ._private import extbuild, decorators as dec
 from ._private.nosetester import (
     run_module_suite, NoseTester as Tester
     )
+from . import overrides
 
 __all__ = _private.utils.__all__ + ['TestCase', 'run_module_suite']
 

--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -16,7 +16,9 @@ from ._private.nosetester import (
     )
 from . import overrides
 
-__all__ = _private.utils.__all__ + ['TestCase', 'run_module_suite']
+__all__ = (
+    _private.utils.__all__ + ['TestCase', 'run_module_suite', 'overrides']
+)
 
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)

--- a/numpy/testing/overrides.py
+++ b/numpy/testing/overrides.py
@@ -21,6 +21,7 @@ def get_overridable_numpy_ufuncs():
     """
     ufuncs = {obj for obj in _umath.__dict__.values()
               if isinstance(obj, _ufunc)}
+    return ufuncs
     
 
 def allows_array_ufunc_override(func):


### PR DESCRIPTION
Followup for #22533. Adds a missing return statement to `get_overridable_numpy_ufuncs` (oops!) and imports `numpy.testing.overrides` into `numpy.testing` so e.g. tab completion on `numpy.testing` works for `overrides`.

This should probably be backported for numpy 1.24.1.