### PR TITLE
DOC: Add a note to the documentation of the rot90

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -193,6 +193,8 @@ def rot90(m, k=1, axes=(0, 1)):
     ``rot90(m, k=1, axes=(1,0))`` is equivalent to
     ``rot90(m, k=-1, axes=(0,1))``
 
+    ``rot90(m, k=1, axes=(0,1))`` will rotate the array by 90 degrees in the counter-clockwise direction
+
     Examples
     --------
     >>> m = np.array([[1,2],[3,4]], int)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -162,6 +162,9 @@ def rot90(m, k=1, axes=(0, 1)):
 
     Rotation direction is from the first towards the second axis.
 
+    This means for a 2D array with the default k and axes, the 
+    rotation will be counterclockwise.
+
     Parameters
     ----------
     m : array_like
@@ -192,9 +195,6 @@ def rot90(m, k=1, axes=(0, 1)):
 
     ``rot90(m, k=1, axes=(1,0))`` is equivalent to
     ``rot90(m, k=-1, axes=(0,1))``
-
-    ``rot90(m, k=1, axes=(0,1))`` will rotate the array by 90 degrees in the
-    counter-clockwise direction
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -161,8 +161,7 @@ def rot90(m, k=1, axes=(0, 1)):
     Rotate an array by 90 degrees in the plane specified by axes.
 
     Rotation direction is from the first towards the second axis.
-
-    This means for a 2D array with the default k and axes, the 
+    This means for a 2D array with the default `k` and `axes`, the
     rotation will be counterclockwise.
 
     Parameters

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -193,7 +193,8 @@ def rot90(m, k=1, axes=(0, 1)):
     ``rot90(m, k=1, axes=(1,0))`` is equivalent to
     ``rot90(m, k=-1, axes=(0,1))``
 
-    ``rot90(m, k=1, axes=(0,1))`` will rotate the array by 90 degrees in the counter-clockwise direction
+    ``rot90(m, k=1, axes=(0,1))`` will rotate the array by 90 degrees in the
+    counter-clockwise direction
 
     Examples
     --------


### PR DESCRIPTION
The note added indicates that rotation is counter clockwise with the default argumemnts.

Opening this as a PR was suggested when this was raised as an issue here: https://github.com/numpy/numpy/issues/22873

I have added this as another line on the note as I found the "counter-clockwise" description in the 1.9 documentation more helpful than the current one.