### PR TITLE
DOC: Add details on benchmarking versions with ASV

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -22,6 +22,9 @@ By default, `asv` ships with support for anaconda and virtualenv::
     pip install asv
     pip install virtualenv
 
+After contributing new benchmarks, you should test them locally before
+submitting a pull request.
+
 To run all benchmarks, navigate to the root NumPy directory at
 the command line and execute::
 
@@ -32,6 +35,14 @@ test suite. This builds NumPy and runs  all available benchmarks
 defined in ``benchmarks/``. (Note: this could take a while. Each
 benchmark is run multiple times to measure the distribution in
 execution times.)
+
+For **testing** benchmarks locally, it may be better to run these without
+replications::
+
+    cd benchmarks/
+    asv run -n -e --python=same -q -b $REGEXP
+
+Where the regular expression used to match benchmarks is stored in ``$REGEXP``.
 
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -78,12 +78,11 @@ To benchmark or visualize only releases on different machines locally, the tags 
     # Get commits for tags
     # delete tag_commits.txt before re-runs
     for gtag in $(git tag --list --sort taggerdate | grep "^v"); do
-    git log $gtag --oneline -n1 --decorate=no | awk -v gtg="$gtag" '{print $1, gtg;}' >> tag_commits.txt
+    git log $gtag --oneline -n1 --decorate=no | awk '{print $1;}' >> tag_commits.txt
     done
-    # Take last 20
-    for commitLine in $(tail --lines=20 tag_commits.txt); do
-    asv run $(echo $commitLine | awk '{print $1}')^!
-    done
+    # Use the last 20
+    tail --lines=20 tag_commits.txt > 20_vers.txt
+    asv run HASHFILE:20_vers.txt
     # Publish and view
     asv publish
     asv preview

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -43,7 +43,8 @@ replications::
     export REGEXP="bench.*Ufunc"
     asv run --dry-run --show-stderr --python=same --quick -b $REGEXP
 
-Where the regular expression used to match benchmarks is stored in ``$REGEXP``, and `--quick` is used to avoid repititions.
+Where the regular expression used to match benchmarks is stored in ``$REGEXP``,
+and `--quick` is used to avoid repetitions.
 
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -22,9 +22,6 @@ By default, `asv` ships with support for anaconda and virtualenv::
     pip install asv
     pip install virtualenv
 
-After contributing new benchmarks, you should test them locally
-before submitting a pull request.
-
 To run all benchmarks, navigate to the root NumPy directory at
 the command line and execute::
 
@@ -87,7 +84,9 @@ To benchmark or visualize only releases on different machines locally, the tags 
     asv publish
     asv preview
 
-Note that this can still be a significant time commitment. Do not open pull requests to the main repository with these results.
+For details on contributing these, see the `benchmark results repository`_.
+
+.. _benchmark results repository: https://github.com/HaoZeke/asv-numpy
 
 Writing benchmarks
 ------------------

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -40,9 +40,10 @@ For **testing** benchmarks locally, it may be better to run these without
 replications::
 
     cd benchmarks/
-    asv run -n -e --python=same -q -b $REGEXP
+    export REGEXP="bench.*Ufunc"
+    asv run --dry-run --show-stderr --python=same --quick -b $REGEXP
 
-Where the regular expression used to match benchmarks is stored in ``$REGEXP``.
+Where the regular expression used to match benchmarks is stored in ``$REGEXP``, and `--quick` is used to avoid repititions.
 
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -69,6 +69,26 @@ Command-line help is available as usual via ``asv --help`` and
 
 .. _ASV documentation: https://asv.readthedocs.io/
 
+Benchmarking versions
+---------------------
+
+To benchmark or visualize only releases on different machines locally, the tags with their commits can be generated, before being run with ``asv``, that is::
+
+    cd benchmarks
+    # Get commits for tags
+    # delete tag_commits.txt before re-runs
+    for gtag in $(git tag --list --sort taggerdate | grep "^v"); do
+    git log $gtag --oneline -n1 --decorate=no | awk -v gtg="$gtag" '{print $1, gtg;}' >> tag_commits.txt
+    done
+    # Take last 20
+    for commitLine in $(tail --lines=20 tag_commits.txt); do
+    asv run $(echo $commitLine | awk '{print $1}')^!
+    done
+    # Publish and view
+    asv publish
+    asv preview
+
+Note that this can still be a significant time commitment. Do not open pull requests to the main repository with these results.
 
 Writing benchmarks
 ------------------


### PR DESCRIPTION
These may be better off in part of the rendered documentation. Also machine data could be stored in a separate repo under the `numpy/` space.