### PR TITLE
BUG: Use whole file for encoding checks with ``charset_normalizer``. 

### DIFF
--- a/numpy/f2py/tests/src/crackfortran/unicode_comment.f90
+++ b/numpy/f2py/tests/src/crackfortran/unicode_comment.f90
@@ -1,0 +1,4 @@
+subroutine foo(x)
+  real(8), intent(in) :: x
+  ! Écrit à l'écran la valeur de x
+end subroutine

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,3 +12,5 @@ cffi; python_version < '3.10'
 # NOTE: Keep mypy in sync with environment.yml
 mypy==0.981; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
+# for optional f2py encoding detection
+charset-normalizer


### PR DESCRIPTION
Backport or #22872.

* BUG: Use whole file for encoding checks [f2py]

* DOC: Add a code comment

Co-authored-by: melissawm <melissawm@gmail.com>

* TST: Add a conditional unicode f2py test

* MAINT: Add chardet as a test requirement

* ENH: Cleanup and switch f2py to charset_normalizer

* MAINT: Remove chardet for charset_normalizer

* TST: Simplify UTF-8 encoding [f2py]

Co-authored-by: melissawm <melissawm@gmail.com>

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
