### PR TITLE
MAINT: change labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,18 +1,18 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [created]
+    types: [opened]
 
-permissions: {}
-   contents: write  # to add labels
+permissions:
+   pull-requests: write  # to add labels
 
 jobs:
-  label_pull_request by the PR label:
+  pr-labeler:
     runs-on: ubuntu-latest
     steps:
     - name: Label the PR
       uses: gerrymanoim/pr-prefix-labeler@v3
       continue-on-error: true
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.repository == 'numpy/numpy'


### PR DESCRIPTION
 The PR labeler has been disabled for a while. This PR makes it possible to re-enable it:
- properly set permissions for the job
- fix invalid yaml introduced in #22816
- trigger the job on PR open. That seems like the best option from [the possibilities](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request). `created` is not one of the options.

I tested this on my fork.