### PR TITLE
MAINT: Replace Python3.8 by Python3.9.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # therefore a new base image chose instead to guarantee to
       # have a newer version >= 1.8.10 to avoid warnings
       # that related to the default behaviors or non-exist config options
-      - image: cimg/base:2021.05
+      - image: cimg/python:3.9
 
     working_directory: ~/repo
 
@@ -47,9 +47,10 @@ jobs:
           name: create virtual environment, install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y python3.8 python3.8-dev python3-venv graphviz texlive-fonts-recommended texlive-latex-recommended \
+            #sudo apt-get install -y python3.9 python3.9-dev python3-venv graphviz texlive-fonts-recommended texlive-latex-recommended \
+            sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended \
               texlive-latex-extra latexmk texlive-xetex doxygen
-            python3.8 -m venv venv
+            python3.9 -m venv venv
             . venv/bin/activate
 
       - run:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ defaults:
 
 env:
   DOWNLOAD_OPENBLAS: 1
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.9
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -88,14 +88,14 @@ jobs:
         submodules: recursive
         fetch-depth: 0
     # comes with python3.6
-    - name: Install Python3.8
+    - name: Install Python3.9
       run: |
         sudo apt update
         # for add-apt-repository
         sudo apt install software-properties-common -y
         sudo add-apt-repository ppa:deadsnakes/ppa -y
-        sudo apt install python3.8-dev -y
-        sudo ln -s /usr/bin/python3.8 /usr/bin/pythonx
+        sudo apt install python3.9-dev -y
+        sudo ln -s /usr/bin/python3.9 /usr/bin/pythonx
         pythonx -m pip install --upgrade pip setuptools wheel
         pythonx -m pip install -r test_requirements.txt
     - name: Install Compilers

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -34,10 +34,10 @@ jobs:
           platform: x86_64
           install-dir: 'C:\tools\cygwin'
           packages: >-
-            python38-devel python38-zipp python38-importlib-metadata
-            python38-cython python38-pip python38-wheel python38-cffi
-            python38-pytz python38-setuptools python38-pytest
-            python38-hypothesis liblapack-devel
+            python39-devel python39-zipp python39-importlib-metadata
+            python39-cython python39-pip python39-wheel python39-cffi
+            python39-pytz python39-setuptools python39-pytest
+            python39-hypothesis liblapack-devel
             gcc-fortran gcc-g++ git dash
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@v1
@@ -53,34 +53,34 @@ jobs:
       - name: Verify python version
         # Make sure it's the Cygwin one, not a Windows one
         run: |
-          dash -c "which python3.8; /usr/bin/python3.8 --version -V"
+          dash -c "which python3.9; /usr/bin/python3.9 --version -V"
       - name: Build NumPy wheel
         run: |
-          dash -c "/usr/bin/python3.8 -m pip install 'setuptools<49.2.0' pytest pytz cffi pickle5 importlib_metadata typing_extensions"
-          dash -c "/usr/bin/python3.8 -m pip install -r test_requirements.txt"
-          dash -c "/usr/bin/python3.8 setup.py bdist_wheel"
+          dash -c "/usr/bin/python3.9 -m pip install 'setuptools<49.2.0' pytest pytz cffi pickle5 importlib_metadata typing_extensions"
+          dash -c "/usr/bin/python3.9 -m pip install -r test_requirements.txt"
+          dash -c "/usr/bin/python3.9 setup.py bdist_wheel"
       - name: Install new NumPy
         run: |
-          bash -c "/usr/bin/python3.8 -m pip install dist/numpy-*cp38*.whl"
+          bash -c "/usr/bin/python3.9 -m pip install dist/numpy-*cp39*.whl"
       - name: Rebase NumPy compiled extensions
         run: |
-          dash "tools/rebase_installed_dlls_cygwin.sh" 3.8
+          dash "tools/rebase_installed_dlls_cygwin.sh" 3.9
       - name: Run NumPy test suite
         run: >-
-          dash -c "/usr/bin/python3.8 runtests.py -n -vv"
+          dash -c "/usr/bin/python3.9 runtests.py -n -vv"
       - name: Upload wheel if tests fail
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: numpy-cygwin-wheel
-          path: dist/numpy-*cp38*.whl
+          path: dist/numpy-*cp39*.whl
       - name: Check the extension modules on failure
         if: failure()
         run: |
-          dash -c "/usr/bin/python3.8 -m pip show numpy"
-          dash -c "/usr/bin/python3.8 -m pip show -f numpy | grep .dll"
+          dash -c "/usr/bin/python3.9 -m pip show numpy"
+          dash -c "/usr/bin/python3.9 -m pip show -f numpy | grep .dll"
           dash -c "/bin/tr -d '\r' <tools/list_installed_dll_dependencies_cygwin.sh >list_dlls_unix.sh"
-          dash "list_dlls_unix.sh" 3.8
+          dash "list_dlls_unix.sh" 3.9
       - name: Print installed package versions on failure
         if: failure()
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,7 +81,7 @@ jobs:
         # TODO: uncomment PyPy 3.9 builds once PyPy
         # re-releases a new minor version
         # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
-        python: ["cp38", "cp39", "cp310", "cp311", "pp38"] #, "pp39"]
+        python: ["cp39", "cp310", "cp311", "pp38"]  #, "pp39"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32]
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           # Build sdist on lowest supported Python
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Build sdist
         run: |
           python setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 
 jobs:
   include:
-    - python: "3.8"
+    - python: "3.9"
       os: linux
       arch: ppc64le
       env:
@@ -37,7 +37,7 @@ jobs:
        # VSX4 still not supported by ubuntu/gcc-11
        - EXPECT_CPU_FEATURES="VSX VSX2 VSX3"
 
-    - python: "3.8"
+    - python: "3.9"
       os: linux
       arch: s390x
       # fixes VX assembler ambiguous errors

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,14 +49,16 @@ stages:
             if ! `gcc 2>/dev/null`; then
                 sudo apt install gcc
             fi
-            sudo apt install python3
-            sudo apt install python3-dev
+            sudo add-apt-repository ppa:deadsnakes/ppa -y
+            sudo apt install python3.9
+            sudo apt install python3.9-dev
+            sudo apt install python3.9-distutils
             # python3 has no setuptools, so install one to get us going
-            python3 -m pip install --user --upgrade pip 'setuptools<49.2.0'
-            python3 -m pip install --user -r test_requirements.txt
+            python3.9 -m pip install --user --upgrade pip 'setuptools<49.2.0'
+            python3.9 -m pip install --user -r test_requirements.txt
       displayName: 'install python/requirements'
     - script: |
-            python3 runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
+            python3.9 runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
             --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
       displayName: 'Run native baseline Build / Tests'
     - task: PublishTestResults@2
@@ -78,7 +80,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.9'
         addToPath: true
         architecture: 'x64'
     - script: >-
@@ -91,7 +93,7 @@ stages:
       displayName: 'Run Lint Checks'
       failOnStderr: true
 
-  - job: Linux_Python_38_32bit_full_with_asserts
+  - job: Linux_Python_39_32bit_full_with_asserts
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
@@ -104,7 +106,7 @@ stages:
             /bin/bash -xc " \
             git config --global --add safe.directory /numpy && \
             cd /numpy && \
-            /opt/python/cp38-cp38/bin/python -mvenv venv && \
+            /opt/python/cp39-cp39/bin/python -mvenv venv && \
             source venv/bin/activate && \
             target=\$(python3 tools/openblas_support.py) && \
             cp -r \$target/lib/* /usr/lib && \
@@ -121,7 +123,7 @@ stages:
       inputs:
         testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python 3.8-32 bit full Linux'
+        testRunTitle: 'Publish test results for Python 3.9-32 bit full Linux'
 
 
   - job: macOS
@@ -130,11 +132,11 @@ stages:
     strategy:
       maxParallel: 3
       matrix:
-          Python38:
-            PYTHON_VERSION: '3.8'
+          Python39:
+            PYTHON_VERSION: '3.9'
             USE_OPENBLAS: '1'
-          Python38-ILP64:
-            PYTHON_VERSION: '3.8'
+          Python39-ILP64:
+            PYTHON_VERSION: '3.9'
             NPY_USE_BLAS_ILP64: '1'
             USE_OPENBLAS: '1'
     steps:
@@ -234,7 +236,7 @@ stages:
       inputs:
         testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python 3.8 64-bit full Mac OS'
+        testRunTitle: 'Publish test results for Python 3.9 64-bit full Mac OS'
 
 
   - job: Windows
@@ -243,16 +245,6 @@ stages:
     strategy:
       maxParallel: 6
       matrix:
-          Python38-32bit-fast:
-            PYTHON_VERSION: '3.8'
-            PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
-            BITS: 32
-          Python38-64bit-full:
-            PYTHON_VERSION: '3.8'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: full
-            BITS: 64
           Python39-32bit-fast:
             PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x86'
@@ -263,7 +255,31 @@ stages:
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64
+          Python310-32bit-fast:
+            PYTHON_VERSION: '3.10'
+            PYTHON_ARCH: 'x86'
+            TEST_MODE: fast
+            BITS: 32
+          Python310-64bit-full:
+            PYTHON_VERSION: '3.10'
+            PYTHON_ARCH: 'x64'
+            TEST_MODE: full
+            BITS: 64
             NPY_USE_BLAS_ILP64: '1'
+          Python311-32bit-fast:
+            PYTHON_VERSION: '3.11'
+            PYTHON_ARCH: 'x86'
+            TEST_MODE: fast
+            BITS: 32
+          Python311-64bit-full:
+            PYTHON_VERSION: '3.11'
+            PYTHON_ARCH: 'x64'
+            TEST_MODE: full
+            BITS: 64
+            NPY_USE_BLAS_ILP64: '1'
+
+          # Not sure how the PyPy version is set here
+          # It is set in azure-steps-windows.ym
           PyPy38-64bit-fast:
             PYTHON_VERSION: 'PyPy'
             PYTHON_ARCH: 'x64'

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -24,10 +24,8 @@ linux_aarch64_task:
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
     - env:
-        CIBW_BUILD: cp38-*
-        EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
-    - env:
         CIBW_BUILD: cp39-*
+        EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
     - env:
         CIBW_BUILD: cp310-*
     - env:


### PR DESCRIPTION
We will drop Python3.8 in NumPy 1.25. This PR  updates the ci tests and wheel builds to use 3.9.

A few observations in getting this working:

- PyPy 3.9 isn't ready, it fails some tests, it is left at 3.8.
- The latest cibuildwheel@v2.11.4 fails on 32 bit Windows, cibuildwheel@2.11.2 works.

The failing PyPy 3.9 tests aren't terrible, we could skip them, but I would rather not at this point.

After this goes in, I'll make another PR using cibuildwheel@v2.11.4 to generate errors so I can report them upstream. We will need this fixed so that later versions with Python 3.12 will work when we begin to support it.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
