### PR TITLE
TST: Add linspace test case for any_step_zero and not _mult_inplace

### DIFF
--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -407,3 +407,12 @@ class TestLinspace:
         y = linspace(-1, 3, num=8, dtype=int)
         t = array([-1, -1, 0, 0, 1, 1, 2, 3], dtype=int)
         assert_array_equal(y, t)
+
+    def test_any_step_zero_and_not_mult_inplace(self):
+        # any_step_zero is True, _mult_inplace is False
+        start = array([0.0, 1.0])
+        stop = array([2.0, 1.0])
+        y = linspace(start, stop, 3)
+        assert_array_equal(y, array([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]))
+    
+


### PR DESCRIPTION
The existing test code misses the following line of `linspace`:
![Screenshot from 2022-12-30 08-23-52](https://user-images.githubusercontent.com/17813788/210083347-0d23b3ab-642e-4d55-be7a-1b70525eba95.png)

The proposed test will cover this line:
![Screenshot from 2022-12-30 08-42-12](https://user-images.githubusercontent.com/17813788/210083447-44f98c69-aff5-4f9c-9ae4-0b6244f17591.png)
