### PR TITLE
ENH: add initial and out parameters to bincount

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -889,16 +889,17 @@ def vdot(a, b):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.bincount)
-def bincount(x, weights=None, minlength=None):
+def bincount(x, weights=None, minlength=None, initial=None, out=None):
     """
-    bincount(x, /, weights=None, minlength=0)
+    bincount(x, /, weights=None, minlength=0, initial=None, out=None)
 
     Count number of occurrences of each value in array of non-negative ints.
 
     The number of bins (of size 1) is one larger than the largest value in
     `x`. If `minlength` is specified, there will be at least this number
     of bins in the output array (though it will be longer if necessary,
-    depending on the contents of `x`).
+    depending on the contents of `x`). If `out` is specified, its size must
+    be large enough to contain all of the bins.
     Each bin gives the number of occurrences of its index value in `x`.
     If `weights` is specified the input array is weighted by it, i.e. if a
     value ``n`` is found at position ``i``, ``out[n] += weight[i]`` instead
@@ -912,6 +913,13 @@ def bincount(x, weights=None, minlength=None):
         Weights, array of the same shape as `x`.
     minlength : int, optional
         A minimum number of bins for the output array.
+    initial: ndarray, 1 dimension, optional
+        Array of initial values for each bin. It must have the same shape and
+        buffer length as the expected output
+    out: ndarray, 1 dimenion, optional
+        Alternative output array in which to place the result. It must have the
+        same shape and buffer length as the expected output but the type will
+        be cast when safe.
 
         .. versionadded:: 1.6.0
 
@@ -919,15 +927,18 @@ def bincount(x, weights=None, minlength=None):
     -------
     out : ndarray of ints
         The result of binning the input array.
-        The length of `out` is equal to ``np.amax(x)+1``.
+        The length of `out` is equal to ``max(minlength, np.amax(x)+1)``.
 
     Raises
     ------
     ValueError
         If the input is not 1-dimensional, or contains elements with negative
-        values, or if `minlength` is negative.
+        values, or if `minlength` is negative, or initial or out do not have
+        sufficient sizes, or initial and out have different sizes.
     TypeError
-        If the type of the input is float or complex.
+        If the type of the input is float or complex, or `minlength` cannot be
+        converted to int, or `initial` or `out` cannot be safely converted to 
+        the expected type.
 
     See Also
     --------

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -417,6 +417,8 @@ def bincount(
     /,
     weights: None | ArrayLike = ...,
     minlength: SupportsIndex = ...,
+    initial: None | NDArray[Any] = ...,
+    out: None | NDArray[Any] = ...,
 ) -> NDArray[intp]: ...
 
 def copyto(


### PR DESCRIPTION
This PR adds optional parameters `initial` and `out` to `np.bincount`, mostly based on discussion in #22471 and a prior attempt at this #9424. 
- `initial` is used to set the initial values for the output array.
- `out` is an alternative output parameter.  if `initial is out`, then `np.bincount` will reuse and directly accumulate onto `out`. (this allows `bincount` to reuse `out` across multiple calls, rather than overwriting it.)

It's a bit niche, but a feature like this has been requested several times in the past. Including these: #22471, #8495, #9424. It's sort of a faster alternative to `np.add.at`.

The intended use case is essentially to do bincounts over large chunks of data:
~~~~
high_res_map = np.zeros(10000**2)
for indices, quantities in next_big_chunk_of_data():
    np.bincount(indices, quantities, initial=high_res_map, out=high_res_map)
~~~~

This is my first time trying to contribute to Numpy, so apologies in advance if I've missed something. Of course, I am happy to make any changes / improvements :-)
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
