### PR TITLE
DOC: Remove Gitpod as a local build option for users

### DIFF
--- a/doc/source/dev/howto_build_docs.rst
+++ b/doc/source/dev/howto_build_docs.rst
@@ -44,7 +44,8 @@ NumPy
 
 Since large parts of the main documentation are obtained from NumPy via
 ``import numpy`` and examining the docstrings, you will need to first
-:ref:`build <building-from-source>` and install it so that the correct version is imported.
+:ref:`build <development-environment>` and install it so that the correct version is
+imported.
 NumPy has to be re-built and re-installed every time you fetch the latest version of the
 repository, before generating the documentation. This ensures that the NumPy version and
 the git repository version are in sync.

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -3,8 +3,8 @@
 Building from source
 ====================
 
-Building locally on your machine gives you
-more granular control. If you are a MacOS or Linux user familiar with using the
+Building locally on your machine gives you complete control over build options.
+If you are a MacOS or Linux user familiar with using the
 command line, you can continue with building NumPy locally by following the
 instructions below.
 

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -3,30 +3,13 @@
 Building from source
 ====================
 
-There are two options for building NumPy- building with Gitpod or locally from
-source. Your choice depends on your operating system and familiarity with the
-command line.
-
-Gitpod
-------
-
-Gitpod is an open-source platform that automatically creates
-the correct development environment right in your browser, reducing the need to
-install local development environments and deal with incompatible dependencies.
-
-If you are a Windows user, unfamiliar with using the command line or building
-NumPy for the first time, it is often faster to build with Gitpod. Here are the
-in-depth instructions for building NumPy with `building NumPy with Gitpod`_.
-
-.. _building NumPy with Gitpod: https://numpy.org/devdocs/dev/development_gitpod.html
-
-Building locally
-----------------
-
 Building locally on your machine gives you
 more granular control. If you are a MacOS or Linux user familiar with using the
 command line, you can continue with building NumPy locally by following the
 instructions below.
+
+.. note:: If you want to build NumPy for development purposes, please refer to 
+   :ref:`development-environment` for additional information.
 
 ..
   This page is referenced from numpy/numpy/__init__.py. Please keep its


### PR DESCRIPTION
The user-facing doc for building NumPy - [Building from source](https://numpy.org/devdocs/user/building.html) currently mentions Gitpod as a build environment option, which is incorrect. Gitpod is only useful for development purposes. 

*Changes:*
1. Removed the subsection on Gitpod and added a note for contributors to refer to [Setting up and using your development environment](https://numpy.org/devdocs/dev/development_environment.html).
2.  Fixed the link to direct users to the correct doc for building API docs.