### PR TITLE
ENH: Faster numpy.load (try/except _filter_header)

### DIFF
--- a/benchmarks/benchmarks/bench_io.py
+++ b/benchmarks/benchmarks/bench_io.py
@@ -1,7 +1,7 @@
-from .common import Benchmark, get_squares
+from .common import Benchmark, get_squares, get_squares_
 
 import numpy as np
-from io import StringIO
+from io import SEEK_SET, StringIO, BytesIO
 
 
 class Copy(Benchmark):
@@ -66,6 +66,15 @@ class Savez(Benchmark):
     def time_vb_savez_squares(self):
         np.savez('tmp.npz', **self.squares)
 
+
+class LoadNpyOverhead(Benchmark):
+    def setup(self):
+        self.buffer = BytesIO()
+        np.save(self.buffer, get_squares_()['float32'])
+
+    def time_loadnpy_overhead(self):
+        self.buffer.seek(0, SEEK_SET)
+        np.load(self.buffer)
 
 class LoadtxtCSVComments(Benchmark):
     # benchmarks for np.loadtxt comment handling

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -640,7 +640,7 @@ def _read_array_header(fp, version, max_header_size=_MAX_HEADER_SIZE):
                     "Reading `.npy` or `.npz` file required additional "
                     "header parsing as it was created on Python 2. Save the "
                     "file again to speed up loading and avoid this warning.",
-                    UserWarning, stacklevel=2)
+                    UserWarning, stacklevel=4)
         else:
             msg = "Cannot parse header: {!r}"
             raise ValueError(msg.format(header)) from e

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -531,7 +531,8 @@ def test_load_padded_dtype(tmpdir, dt):
 def test_python2_python3_interoperability():
     fname = 'win64python2.npy'
     path = os.path.join(os.path.dirname(__file__), 'data', fname)
-    data = np.load(path)
+    with pytest.warns(UserWarning, match="Reading.*this warning\\."):
+        data = np.load(path)
     assert_array_equal(data, np.ones(2))
 
 def test_pickle_python2_python3():


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This pull requests speeds up `numpy.load`. Since `_filter_header` is quite a bottleneck, we only run it if we must. Users will get a warning if they have a legacy Numpy file so that they can save it again for faster loading.

Main discussion and benchmarks see https://github.com/numpy/numpy/issues/22898