### PR TITLE
BLD: Build wheels with cibuildwheel 2.12.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,7 +111,7 @@ jobs:
       - name: setup rtools for 32-bit
         run: |
           echo "PLAT=i686" >> $env:GITHUB_ENV
-          echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
+          #echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
           echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           gfortran --version
         if: ${{ matrix.buildplat[1] == 'win32' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.11.3
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,13 +111,12 @@ jobs:
       - name: setup rtools for 32-bit
         run: |
           echo "PLAT=i686" >> $env:GITHUB_ENV
-          #echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
           echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           gfortran --version
         if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,7 +116,7 @@ jobs:
         if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/numpy/core/src/common/simd/neon/operators.h
+++ b/numpy/core/src/common/simd/neon/operators.h
@@ -249,9 +249,9 @@ NPY_FINLINE npyv_b32 npyv_notnan_f32(npyv_f32 a)
  */
     npyv_b32 ret;
     #if NPY_SIMD_F64
-        asm ("fcmeq %0.4s, %1.4s, %1.4s" : "=w" (ret) : "w" (a));
+        __asm("fcmeq %0.4s, %1.4s, %1.4s" : "=w" (ret) : "w" (a));
     #else
-        asm ("vceq.f32 %q0, %q1, %q1" : "=w" (ret) : "w" (a));
+        __asm("vceq.f32 %q0, %q1, %q1" : "=w" (ret) : "w" (a));
     #endif
     return ret;
 #else
@@ -263,7 +263,7 @@ NPY_FINLINE npyv_b32 npyv_notnan_f32(npyv_f32 a)
     {
     #if defined(__clang__)
         npyv_b64 ret;
-        asm ("fcmeq %0.2d, %1.2d, %1.2d" : "=w" (ret) : "w" (a));
+        __asm("fcmeq %0.2d, %1.2d, %1.2d" : "=w" (ret) : "w" (a));
         return ret;
     #else
         return vceqq_f64(a, a);

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -440,6 +440,7 @@ def _build_import_library_x86():
     from numpy.distutils import lib2def
 
     def_name = "python%d%d.def" % tuple(sys.version_info[:2])
+    os.makedirs(os.path.join(sys.prefix, 'libs'), exist_ok=True)
     def_file = os.path.join(sys.prefix, 'libs', def_name)
     nm_output = lib2def.getnm(
             lib2def.DEFAULT_NM + [lib_file], shell=False)

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -440,7 +440,6 @@ def _build_import_library_x86():
     from numpy.distutils import lib2def
 
     def_name = "python%d%d.def" % tuple(sys.version_info[:2])
-    os.makedirs(os.path.join(sys.prefix, 'libs'), exist_ok=True)
     def_file = os.path.join(sys.prefix, 'libs', def_name)
     nm_output = lib2def.getnm(
             lib2def.DEFAULT_NM + [lib_file], shell=False)

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.4
+    - python -m pip install cibuildwheel==2.12.0
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.2
+    - python -m pip install cibuildwheel==2.11.4
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.3
+    - python -m pip install cibuildwheel==2.11.4
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.4
+    - python -m pip install cibuildwheel==2.11.3
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:


### PR DESCRIPTION
The 2.11.4 version of cibuildwheel was failing on 32 bit windows. This is to check that and provide an error log that can be linked to in a cibuildwheel issue.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
