### PR TITLE
ENH: Create string dtype instances from the abstract dtype

### DIFF
--- a/doc/release/upcoming_changes/22863.new_feature.rst
+++ b/doc/release/upcoming_changes/22863.new_feature.rst
@@ -1,0 +1,7 @@
+String dtype instances can be created from the string abstract dtype classes
+----------------------------------------------------------------------------
+It is now possible to create a string dtype instance with a size without
+using the string name of the dtype. For example, ``type(np.dtype('U'))(8)``
+will create a dtype that is equivalent to ``np.dtype('U8')``. This feature
+is most useful when writing generic code dealing with string dtype
+classes.

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -136,15 +136,17 @@ string_unicode_new(PyArray_DTypeMeta *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
+    if (size < 0) {
+        PyErr_Format(PyExc_TypeError,
+                     "Strings cannot have a negative size but a size of "
+                     "%"NPY_INTP_FMT" was given", size);
+        return NULL;
+    }
+
     PyArray_Descr *res = PyArray_DescrNewFromType(self->type_num);
 
     if (res == NULL) {
         return NULL;
-    }
-
-    if (size > NPY_MAX_INT) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Strings too large to store inside array.");
     }
 
     if (self->type_num == NPY_UNICODE) {
@@ -153,7 +155,14 @@ string_unicode_new(PyArray_DTypeMeta *self, PyObject *args, PyObject *kwargs)
             PyErr_SetString(
                 PyExc_TypeError,
                 "Strings too large to store inside array.");
+            return NULL;
         }
+    }
+
+    if (size > NPY_MAX_INT) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Strings too large to store inside array.");
+        return NULL;
     }
 
     res->elsize = (int)size;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -137,7 +137,7 @@ string_unicode_new(PyArray_DTypeMeta *self, PyObject *args, PyObject *kwargs)
     }
 
     if (size < 0) {
-        PyErr_Format(PyExc_TypeError,
+        PyErr_Format(PyExc_ValueError,
                      "Strings cannot have a negative size but a size of "
                      "%"NPY_INTP_FMT" was given", size);
         return NULL;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -18,6 +18,8 @@
 #include "scalartypes.h"
 #include "convert_datatype.h"
 #include "usertypes.h"
+#include "conversion_utils.h"
+#include "templ_common.h"
 
 #include <assert.h>
 
@@ -122,6 +124,41 @@ legacy_dtype_default_new(PyArray_DTypeMeta *self,
     return (PyObject *)self->singleton;
 }
 
+static PyObject *
+string_unicode_new(PyArray_DTypeMeta *self, PyObject *args, PyObject *kwargs)
+{
+    npy_intp size;
+
+    static char *kwlist[] = {"", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&", kwlist,
+                                     PyArray_IntpFromPyIntConverter, &size)) {
+        return NULL;
+    }
+
+    PyArray_Descr *res = PyArray_DescrNewFromType(self->type_num);
+
+    if (res == NULL) {
+        return NULL;
+    }
+
+    if (size > NPY_MAX_INT) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Strings too large to store inside array.");
+    }
+
+    if (self->type_num == NPY_UNICODE) {
+        // unicode strings are 4 bytes per character
+        if (npy_mul_sizes_with_overflow(&size, size, 4)) {
+            PyErr_SetString(
+                PyExc_TypeError,
+                "Strings too large to store inside array.");
+        }
+    }
+
+    res->elsize = (int)size;
+    return (PyObject *)res;
+}
 
 static PyArray_Descr *
 nonparametric_discover_descr_from_pyobject(
@@ -151,7 +188,7 @@ string_discover_descr_from_pyobject(
         }
         if (itemsize > NPY_MAX_INT) {
             PyErr_SetString(PyExc_TypeError,
-                    "string to large to store inside array.");
+                    "string too large to store inside array.");
         }
         PyArray_Descr *res = PyArray_DescrNewFromType(cls->type_num);
         if (res == NULL) {
@@ -849,6 +886,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr)
                     string_discover_descr_from_pyobject);
             dt_slots->common_dtype = string_unicode_common_dtype;
             dt_slots->common_instance = string_unicode_common_instance;
+            ((PyTypeObject*)dtype_class)->tp_new = (newfunc)string_unicode_new;
         }
     }
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -207,6 +207,17 @@ class TestBuiltin:
         assert dtype.type is scalar_type
         assert dtype.itemsize == 8*char_size
 
+    def test_create_invalid_string_errors(self):
+        one_too_big = np.iinfo(np.intc).max + 1
+        with pytest.raises(TypeError):
+            type(np.dtype("U"))(one_too_big // 4)
+
+        with pytest.raises(TypeError):
+            type(np.dtype("U"))(one_too_big)
+
+        with pytest.raises(TypeError):
+            type(np.dtype("U"))(-1)
+
 
 class TestRecord:
     def test_equivalent_record(self):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -212,11 +212,15 @@ class TestBuiltin:
         with pytest.raises(TypeError):
             type(np.dtype("U"))(one_too_big // 4)
 
+        with pytest.raises(TypeError):
+            # Code coverage for very large numbers:
+            type(np.dtype("U"))(np.iinfo(np.intp).max // 4 + 1)
+
         if one_too_big < sys.maxsize:
             with pytest.raises(TypeError):
                 type(np.dtype("S"))(one_too_big)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             type(np.dtype("U"))(-1)
 
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -207,9 +207,6 @@ class TestBuiltin:
         assert dtype.type is scalar_type
         assert dtype.itemsize == 8*char_size
 
-        with pytest.raises(TypeError):
-            dtype_class(8, foobar=False)
-
 
 class TestRecord:
     def test_equivalent_record(self):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -195,6 +195,21 @@ class TestBuiltin:
         # This is an safe cast (not equiv) due to the different names:
         assert np.can_cast(x, y, casting="safe")
 
+    @pytest.mark.parametrize(
+        ["type_char", "char_size", "scalar_type"],
+        [["U", 4, np.str_],
+         ["S", 1, np.bytes_]])
+    def test_create_string_dtypes_directly(
+            self, type_char, char_size, scalar_type):
+        dtype_class = type(np.dtype(type_char))
+
+        dtype = dtype_class(8)
+        assert dtype.type is scalar_type
+        assert dtype.itemsize == 8*char_size
+
+        with pytest.raises(TypeError):
+            dtype_class(8, foobar=False)
+
 
 class TestRecord:
     def test_equivalent_record(self):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -212,8 +212,9 @@ class TestBuiltin:
         with pytest.raises(TypeError):
             type(np.dtype("U"))(one_too_big // 4)
 
-        with pytest.raises(TypeError):
-            type(np.dtype("U"))(one_too_big)
+        if one_too_big < sys.maxsize:
+            with pytest.raises(TypeError):
+                type(np.dtype("S"))(one_too_big)
 
         with pytest.raises(TypeError):
             type(np.dtype("U"))(-1)


### PR DESCRIPTION
Following up from https://github.com/numpy/numpy/pull/22863#issuecomment-1369251624, this makes it possible to create string dtype instances from an abstract string `DTypeMeta`.

Should I support any additional arguments or keywords to `__new__` besides `size`? Possibly `byteorder`?

Should this be documented somewhere? If so, where?