### PR TITLE
MAINT: Remove distutils usage in travis-test.sh.

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -33,7 +33,7 @@ werrors="$werrors -Werror=implicit-function-declaration"
 setup_base()
 {
   # use default python flags but remove sign-compare
-  sysflags="$($PYTHON -c "from distutils import sysconfig; \
+  sysflags="$($PYTHON -c "import sysconfig; \
     print (sysconfig.get_config_var('CFLAGS'))")"
   export CFLAGS="$sysflags $werrors -Wlogical-op -Wno-sign-compare"
 


### PR DESCRIPTION
`distutils` module was removed in Python 3.12.

I wasn't sure what to do with the other usage of `disutils`, but I think it's worth removing `distutils` from `travis-test.sh`, as it should allow for testing with Python 3.12 (see #22926).