### PR TITLE
TST: Add fixture to avoid issue with randomizing test order.

### DIFF
--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -478,6 +478,10 @@ class TestPrintOptions:
     are too small or too large.
     """
 
+    @pytest.fixture(scope='class', autouse=True)
+    def use_ascii(self):
+        poly.set_default_printstyle('ascii')
+
     def test_str(self):
         p = poly.Polynomial([1/2, 1/7, 1/7*10**8, 1/7*10**9])
         assert_equal(str(p), '0.5 + 0.14285714 x + 14285714.28571429 x**2 '


### PR DESCRIPTION
Adds a missing test fixture to prevent cross-talk between polynomial printing test classes when the test order is randomized with `pytest-randomly`.

Addresses the immediate issue #22825 though there is another, deeper issue with polynomial printing thread safety. Therefore #22825 should either be left open or a follow-up issue opened.