### PR TITLE
BENCH: Init benchmarks for xp (array_api)

### DIFF
--- a/benchmarks/benchmarks/bench_xp.py
+++ b/benchmarks/benchmarks/bench_xp.py
@@ -1,0 +1,34 @@
+from .common import Benchmark
+
+import numpy as np
+import numpy.array_api as xp
+
+# https://data-apis.org/array-api/latest/API_specification/data_types.html
+XP_TYPES = {
+    'bool' : xp.bool,
+    'int8' : xp.int8,
+    'int16' : xp.int16,
+    'int32' : xp.int32,
+    'int64' : xp.int64,
+    'uint8' : xp.uint8,
+    'uint16' : xp.uint16,
+    'uint32' : xp.uint32,
+    'uint64' : xp.uint64,
+    'float32' : xp.float32,
+    'float64' : xp.float64,
+    # 'complex64' : xp.complex64,
+    # 'complex128' : xp.complex128
+}
+
+class XP_Creation(Benchmark):
+    param_names=['xpdtype']
+    params = XP_TYPES.keys()
+
+    def setup(self, args):
+        self.d = xp.asarray(np.array([1, 2, 3]))
+
+    def time_xp_linspace_scalar(self, args):
+        xp.linspace(0, 10, 2)
+
+    def time_xp_linspace_array(self, args):
+        xp.linspace(self.d, 10, 10)


### PR DESCRIPTION
This is part of an attempt to have better regression detection for `numpy`. Not sure how useful it is to test all of the `array_api` space because they mostly call the underlying `numpy` function and then use `asarray`. This means a lot of them are covered already, but this might be a futureproofing exercise in case the implementation changes.