### PR TITLE
DOC: (LaTeX) fix 'fontenc' key for usage with xelatex

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -248,7 +248,6 @@ latex_documents = [
 #latex_use_parts = False
 
 latex_elements = {
-    'fontenc': r'\usepackage[LGR,T1]{fontenc}'
 }
 
 # Additional stuff for the LaTeX preamble.


### PR DESCRIPTION
Sphinx documentation says

    Do not use this key for a latex_engine other than 'pdflatex'.

https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting

The ``'fontenc': r'\usepackage[LGR,T1]{fontenc}'`` was useful with pdflatex for support of occasional Greek.  But with `xelatex` and the FreeFont which is used by default by Sphinx with it, the Greek script is already supported.

EDIT: besides overriding this key causes Sphinx not to do some special `xelatex` set-up related to some ligatures and curly quotes problems:
> Changed in version 2.3.0: 'xelatex' executes \defaultfontfeatures[\rmfamily,\sffamily]{} in order to avoid contractions of -- into en-dash or transforms of straight quotes into curly ones in PDF (in non-literal text paragraphs) despite [smartquotes](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes) being set to False.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

I tested build of both `numpy-ref.pdf` and `numpy-user.pdf` at  v1.24.1 and current Sphinx `6.1.0`, and reported the few problems at #22930.  See in particular https://github.com/numpy/numpy/issues/22930#issuecomment-1372144253 for a fix of the missing Chinese glyphs, unfortunately I may have only a partial LaTeX installation so had to use a system font, so I do not know how to present it as a PR (I do not know if PDF build is expected to work on everybody's system).  Besides, `xelatex + fontspec` have diverse manners of finding fonts, depending on system.