### PR TITLE
DOC: Fix typo in NEP-19

### DIFF
--- a/doc/neps/nep-0019-rng-policy.rst
+++ b/doc/neps/nep-0019-rng-policy.rst
@@ -17,7 +17,7 @@ Abstract
 For the past decade, NumPy has had a strict backwards compatibility policy for
 the number stream of all of its random number distributions.  Unlike other
 numerical components in ``numpy``, which are usually allowed to return
-different when results when they are modified if they remain correct, we have
+different results when modified if the results remain correct, we have
 obligated the random number distributions to always produce the exact same
 numbers in every version.  The objective of our stream-compatibility guarantee
 was to provide exact reproducibility for simulations across numpy versions in


### PR DESCRIPTION
@rkern

One could also go with

> Unlike other numerical components in ``numpy``, which, when modified, are allowed to return different results if these remain correct, we have obligated the random number distributions to consistently produce the exact same numbers in every version. 
