### PR TITLE
MAINT: Move export for scipy arm64 helper into main module

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -184,29 +184,21 @@ NPY_INPLACE double npy_atan2(double x, double y);
 #define npy_fmod fmod
 #define npy_floor floor
 #define npy_expm1 expm1
+#define npy_log1p log1p
 #define npy_acosh acosh
+#define npy_asinh asinh
 #define npy_atanh atanh
 #define npy_rint rint
 #define npy_trunc trunc
 #define npy_exp2 exp2
 #define npy_frexp frexp
 #define npy_ldexp ldexp
+#define npy_copysign copysign
 #define npy_exp exp
 #define npy_sqrt sqrt
 #define npy_pow pow
 #define npy_modf modf
 #define npy_nextafter nextafter
-
-#if defined(__arm64__) && defined(__APPLE__)
-/* due to a build problem with scipy, export these as functions */
-NPY_INPLACE double npy_asinh(double x);
-NPY_INPLACE double npy_copysign(double y, double x);
-NPY_INPLACE double npy_log1p(double x);
-#else
-#define npy_asinh asinh
-#define npy_copysign copysign
-#define npy_log1p log1p
-#endif
 
 double npy_spacing(double x);
 

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -466,9 +466,6 @@ npymath_sources = [
   npy_math_internal_h,
   'src/npymath/halffloat.c',
   'src/npymath/npy_math.c',
-  # Remove this `arm64_exports.c` file once scipy macos arm64 build correctly
-  # links to the arm64 npymath library, see gh-22673
-  'src/npymath/arm64_exports.c',
 ]
 npymath_lib = static_library('npymath',
   npymath_sources,
@@ -739,6 +736,9 @@ src_multiarray = [
   'src/multiarray/textreading/stream_pyobject.c',
   'src/multiarray/textreading/str_to_int.c',
   'src/multiarray/textreading/tokenize.cpp',
+  # Remove this `arm64_exports.c` file once scipy macos arm64 build correctly
+  # links to the arm64 npymath library, see gh-22673
+  'src/npymath/arm64_exports.c',
 ]
 
 src_umath = [

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -729,10 +729,6 @@ def configuration(parent_package='',top_path=None):
                        join('src', 'npymath', 'ieee754.c.src'),
                        join('src', 'npymath', 'npy_math_complex.c.src'),
                        join('src', 'npymath', 'halffloat.c'),
-                       # Remove this once scipy macos arm64 build correctly
-                       # links to the arm64 npymath library,
-                       # see gh-22673
-                       join('src', 'npymath', 'arm64_exports.c'),
                        ]
 
     config.add_installed_library('npymath',
@@ -964,6 +960,10 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'textreading', 'stream_pyobject.c'),
             join('src', 'multiarray', 'textreading', 'str_to_int.c'),
             join('src', 'multiarray', 'textreading', 'tokenize.cpp'),
+            # Remove this once scipy macos arm64 build correctly
+            # links to the arm64 npymath library,
+            # see gh-22673
+            join('src', 'npymath', 'arm64_exports.c'),
             ]
 
     #######################################################################

--- a/numpy/core/src/npymath/arm64_exports.c
+++ b/numpy/core/src/npymath/arm64_exports.c
@@ -1,12 +1,14 @@
 #if defined(__arm64__) && defined(__APPLE__)
 
 #include <math.h>
-/* 
+/*
  * Export these for scipy, since the SciPy build for macos arm64
  * downloads the macos x86_64 NumPy, and does not error when the
  * linker fails to use npymathlib.a. Importing numpy will expose
  * these external functions
  * See https://github.com/numpy/numpy/issues/22673#issuecomment-1327520055
+ *
+ * This file is actually compiled as part of the main module.
  */
 
 double npy_asinh(double x) {
@@ -20,4 +22,9 @@ double npy_copysign(double y, double x) {
 double npy_log1p(double x) {
     return log1p(x);
 }
+
+double npy_nextafter(double x, double y) {
+    return nextafter(x, y);
+}
+
 #endif


### PR DESCRIPTION
This is a follow up to gh-22679 which addressed gh-22673.

The main thing is that we want the functions to be available after importing NumPy, so they need to be part of multiarray. However, `npymath` is a static library, so the symbols are not really exported there.  The former PR did actually work in practice but this seems like it is technically the right place?

~For some reason,~ I had to add nextafter to be able to do:

    from scipy.spatial.distance import euclidean

with the SciPy 1.9.3 wheels.  SciPy test collection works with this for the 1.9.3 wheel, so this should be all the symbols hopefully.

---

@mattip this was what I figured to solve the internal linking warnings that I have been seeing now.  Does this make sense to you?

Maybe it also doesn't matter, since we should pull the whole hack out soon enough.