### PR TITLE
MAINT: change circleCI keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "9f:8c:e5:3f:53:40:0b:ee:c9:c3:0f:fd:0f:3c:cc:55"
+            - "45:d8:d1:d6:f7:53:47:c5:d0:9e:35:19:79:e7:ff:24"
 
       -  run:
           name: deploy devdocs
@@ -131,7 +131,7 @@ jobs:
 
       - add_ssh_keys:
           fingerprints:
-            - "11:fb:19:69:80:3a:6d:37:9c:d1:ac:20:17:cd:c8:17"
+            - "df:8b:fb:34:2d:38:7d:49:fc:1b:e8:44:4f:bd:2c:0e"
 
       - run:
           name: select SSH key for neps repo
@@ -139,7 +139,7 @@ jobs:
             cat <<\EOF > ~/.ssh/config
             Host github.com
               IdentitiesOnly yes
-              IdentityFile /home/circleci/.ssh/id_rsa_11fb1969803a6d379cd1ac2017cdc817
+              IdentityFile /home/circleci/.ssh/id_rsa_df8bfb342d387d49fc1be8444fbd2c0e
             EOF
 
       -  run:


### PR DESCRIPTION
Related to https://circleci.com/blog/january-4-2023-security-alert/. People without permissions should not be able to visit the links below, but I want to document what I did.
- Create new keys, delete the old ones from [the ssh keys section](https://app.circleci.com/settings/project/github/numpy/numpy/ssh) of the circleCI numpy/numpy configuration. Also delete "deploy key" that led to this repo numpy/numpy 
- Delete the keys from [the neps settings ](https://github.com/numpy/neps/settings/keys) and [the devdocs settings](https://github.com/numpy/devdocs/settings/keys) and add new public keys from the private keys in the first step
- Delete the deploy permissions for the key that was registered to numpy/numpy, I did not replace it. I think it was part of an older documentation deployment scheme.
- Change the key fingerprints in this PR

cc @tupui 