### PR TITLE
DOC: remove old LaTeX hack if Sphinx is at 5.0.0 or later (fix #22941)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -253,19 +253,25 @@ latex_elements = {
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r'''
 % In the parameters section, place a newline after the Parameters
-% header
-\usepackage{xcolor}
+% header.  This is default with Sphinx 5.0.0+, so no need for
+% the old hack then.
+% Unfortunately sphinx.sty 5.0.0 did not bump its version date
+% hence some complications here:  we first check if Sphinx is
+% at 4.0.0+ so sphinxpackagefootnote.sty exists then check
+% the latter date which was bumped to 2022/02/12 at Sphinx 5.0.0.
+\makeatletter
+\if1\@ifpackagelater{sphinx}{2021/01/27}% later = at least
+    {\@ifpackagelater{sphinxpackagefootnote}{2022/02/12}01}%
+    {1}%
+% this until next \fi gets executed if and only if Sphinx < 5.0.0
 \usepackage{expdlist}
 \let\latexdescription=\description
 \def\description{\latexdescription{}{} \breaklabel}
 % but expdlist old LaTeX package requires fixes:
 % 1) remove extra space
 \usepackage{etoolbox}
-\makeatletter
 \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
-\makeatother
 % 2) fix bug in expdlist's way of breaking the line after long item label
-\makeatletter
 \def\breaklabel{%
     \def\@breaklabel{%
         \leavevmode\par
@@ -273,6 +279,7 @@ latex_elements['preamble'] = r'''
         \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
     }%
 }
+\fi
 \makeatother
 
 % Make Examples/etc section headers smaller and more compact

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -279,7 +279,7 @@ latex_elements['preamble'] = r'''
         \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
     }%
 }
-\fi
+\fi  % sphinx < 5.0.0
 \makeatother
 
 % Make Examples/etc section headers smaller and more compact

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -256,14 +256,12 @@ latex_elements['preamble'] = r'''
 % header.  This is default with Sphinx 5.0.0+, so no need for
 % the old hack then.
 % Unfortunately sphinx.sty 5.0.0 did not bump its version date
-% hence some complications here:  we first check if Sphinx is
-% at 4.0.0+ so sphinxpackagefootnote.sty exists then check
-% the latter date which was bumped to 2022/02/12 at Sphinx 5.0.0.
+% so we check rather sphinxpackagefootnote.sty (which exists
+% since Sphinx 4.0.0).
 \makeatletter
-\if1\@ifpackagelater{sphinx}{2021/01/27}% later = at least
-    {\@ifpackagelater{sphinxpackagefootnote}{2022/02/12}01}%
-    {1}%
-% this until next \fi gets executed if and only if Sphinx < 5.0.0
+\@ifpackagelater{sphinxpackagefootnote}{2022/02/12}
+    {}% Sphinx >= 5.0.0, nothing to do
+    {%
 \usepackage{expdlist}
 \let\latexdescription=\description
 \def\description{\latexdescription{}{} \breaklabel}
@@ -279,7 +277,7 @@ latex_elements['preamble'] = r'''
         \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
     }%
 }
-\fi  % sphinx < 5.0.0
+    }% Sphinx < 5.0.0 (and assumed >= 4.0.0)
 \makeatother
 
 % Make Examples/etc section headers smaller and more compact


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This removes an old LaTeX hack if Sphinx is at 5.0.0+.  The hack served to insert a newline after each parameter name before its description and is unneeded as Sphinx 5+ does it (otherwise) and it now causes extra vertical whitespace.

If one day in future NumPy pins Sphinx to be at least 5.0.0, the whole thing will become removable.

Closes #22941

EDIT: this also removes `\usepackage{xcolor}`.  Sphinx for many many years uses `xcolor` if it is available.