### PR TITLE
BUG: Fix fill violating read-only flag.

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -370,7 +370,6 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
      *
      * (The longlong here should help with alignment.)
      */
-
     npy_longlong value_buffer_stack[4] = {0};
     char *value_buffer_heap = NULL;
     char *value = (char *)value_buffer_stack;

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -359,6 +359,11 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
 NPY_NO_EXPORT int
 PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
 {
+
+    if (PyArray_FailUnlessWriteable(arr, "assignment destination") < 0) {
+        return -1;
+    }
+
     /*
      * If we knew that the output array has at least one element, we would
      * not actually need a helping buffer, we always null it, just in case.
@@ -366,9 +371,6 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
      * (The longlong here should help with alignment.)
      */
 
-    if (PyArray_FailUnlessWriteable(arr, "assignment destination") < 0) {
-        return -1;
-    }
     npy_longlong value_buffer_stack[4] = {0};
     char *value_buffer_heap = NULL;
     char *value = (char *)value_buffer_stack;

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -365,6 +365,10 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
      *
      * (The longlong here should help with alignment.)
      */
+
+    if (PyArray_FailUnlessWriteable(arr, "assignment destination") < 0) {
+        return -1;
+    }
     npy_longlong value_buffer_stack[4] = {0};
     char *value_buffer_heap = NULL;
     char *value = (char *)value_buffer_stack;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -407,7 +407,7 @@ class TestAttributes:
         # gh-22922
         a = np.zeros(11)
         a.setflags(write=False)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=".*read-only"):
             a.fill(0)
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -403,6 +403,13 @@ class TestAttributes:
         assert_array_equal(x['a'], [3.5, 3.5])
         assert_array_equal(x['b'], [-2, -2])
 
+    def test_fill_readonly(self):
+        # gh-22922
+        a = np.zeros(11)
+        a.setflags(write=False)
+        with pytest.raises(ValueError):
+            a.fill(0)
+
 
 class TestArrayConstruction:
     def test_array(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -323,6 +323,13 @@ class TestRegression:
         assert_raises(ValueError, bfa)
         assert_raises(ValueError, bfb)
 
+    def test_fill_readonly(self):
+        # Ticket #22922
+        with pytest.raises(ValueError):
+            a = np.zeros(11)
+            a.setflags(write=False)
+            a.fill(0)
+
     @pytest.mark.xfail(IS_WASM, reason="not sure why")
     @pytest.mark.parametrize("index",
             [np.ones(10, dtype=bool), np.arange(10)],

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -323,13 +323,6 @@ class TestRegression:
         assert_raises(ValueError, bfa)
         assert_raises(ValueError, bfb)
 
-    def test_fill_readonly(self):
-        # Ticket #22922
-        with pytest.raises(ValueError):
-            a = np.zeros(11)
-            a.setflags(write=False)
-            a.fill(0)
-
     @pytest.mark.xfail(IS_WASM, reason="not sure why")
     @pytest.mark.parametrize("index",
             [np.ones(10, dtype=bool), np.arange(10)],


### PR DESCRIPTION
- See #22922
- `PyArray_FillWithScalar` checks if destination is writeable before attempting to fill it
- A relevant test is added as a method of `TestRegression`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
