### PR TITLE
Add append and update keywords to savez

### DIFF
--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -133,6 +133,8 @@ from numpy.lib.npyio import (
     save as save,
     savez as savez,
     savez_compressed as savez_compressed,
+    updatez as updatez,
+    updatez_compressed as updatez_compressed,
     packbits as packbits,
     unpackbits as unpackbits,
     fromregex as fromregex,

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -127,6 +127,18 @@ def savez_compressed(
     **kwds: ArrayLike,
 ) -> None: ...
 
+def updatez(
+    file: str,
+    *args: ArrayLike,
+    **kwds: ArrayLike,
+) -> None: ...
+
+def updatez_compressed(
+    file: str,
+    *args: ArrayLike,
+    **kwds: ArrayLike,
+) -> None: ...
+
 # File-like objects only have to implement `__iter__` and,
 # optionally, `encoding`
 @overload

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2722,14 +2722,15 @@ def test_npzfile_dict():
 
 
 def test_npzfile_append():
-    x = np.zeros((3, 3))
+    x = np.zeros((2, 2))
     y = np.zeros((3, 3))
+    append_array = np.zeros((6, 6))
     savez_list = [np.savez, np.savez_compressed]
 
     # filename
 
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_append_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_append_", suffix=".npz") as tmp:
             savez(tmp, x=x)
             savez(tmp, y=y, append=True)
             l = np.load(tmp)
@@ -2740,7 +2741,7 @@ def test_npzfile_append():
 
     # append during file creation
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_append_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_append_", suffix=".npz") as tmp:
             savez(tmp, x=x, append=True)
             savez(tmp, y=y, append=True)
             l = np.load(tmp)
@@ -2751,15 +2752,28 @@ def test_npzfile_append():
 
     # error because same array
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_append_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_append_", suffix=".npz") as tmp:
             savez(tmp, x=x)
             assert_raises(ValueError, savez, tmp, x=x, append=True)
+
+    # append is array, i.e. new file
+    for savez in savez_list:
+        with temppath(prefix="np_test_npzfile_append_", suffix=".npz") as tmp:
+            savez(tmp, x=x)
+            savez(tmp, y=y, append=append_array)
+            l = np.load(tmp)
+            assert_('x' not in l.keys())
+            assert_('y' in l.keys())
+            assert_('append' in l.keys())
+            assert_equal(y, l['y'])
+            assert_equal(append_array, l['append'])
 
     # path-like object
 
     for savez in savez_list:
         tmp = BytesIO()
         savez(tmp, x=x)
+        tmp.seek(0)
         savez(tmp, y=y, append=True)
         tmp.seek(0)
         l = np.load(tmp)
@@ -2772,6 +2786,7 @@ def test_npzfile_append():
     for savez in savez_list:
         tmp = BytesIO()
         savez(tmp, x=x, append=True)
+        tmp.seek(0)
         savez(tmp, y=y, append=True)
         tmp.seek(0)
         l = np.load(tmp)
@@ -2786,11 +2801,27 @@ def test_npzfile_append():
         savez(tmp, x=x)
         assert_raises(ValueError, savez, tmp, x=x, append=True)
 
+    # append is array, i.e. new file
+    for savez in savez_list:
+        tmp = BytesIO()
+        savez(tmp, x=x)
+        tmp.seek(0)
+        savez(tmp, y=y, append=append_array)
+        tmp.seek(0)
+        l = np.load(tmp)
+        assert_('x' not in l.keys())
+        assert_('y' in l.keys())
+        assert_('append' in l.keys())
+        assert_equal(y, l['y'])
+        assert_equal(append_array, l['append'])
+
 
 def test_npzfile_update():
-    x = np.zeros((3, 3))
+    x = np.zeros((2, 2))
     y = np.zeros((3, 3))
-    xnew = np.zeros((6, 6))
+    xnew = np.zeros((4, 4))
+    append_array = np.zeros((6, 6))
+    update_array = np.zeros((9, 9))
     savez_list = [np.savez, np.savez_compressed]
 
     # path-like object
@@ -2803,7 +2834,7 @@ def test_npzfile_update():
     # filename
 
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_update_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
             savez(tmp, x=x)
             l = np.load(tmp)
             assert_('x' in l.keys())
@@ -2817,7 +2848,7 @@ def test_npzfile_update():
 
     # update during file creation
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_update_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
             savez(tmp, x=x, update=True)
             l = np.load(tmp)
             assert_('x' in l.keys())
@@ -2831,7 +2862,7 @@ def test_npzfile_update():
 
     # update but only append
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_update_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
             savez(tmp, x=x)
             l = np.load(tmp)
             assert_('x' in l.keys())
@@ -2845,7 +2876,7 @@ def test_npzfile_update():
 
     # update and append keyword
     for savez in savez_list:
-        with temppath(prefix="numpy_test_npzfile_update_", suffix=".npz") as tmp:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
             savez(tmp, x=x)
             l = np.load(tmp)
             assert_('x' in l.keys())
@@ -2856,6 +2887,55 @@ def test_npzfile_update():
             assert_('y' in l.keys())
             assert_equal(xnew, l['x'])
             assert_equal(y, l['y'])
+
+    # append is array
+    for savez in savez_list:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
+            savez(tmp, x=x)
+            l = np.load(tmp)
+            assert_('x' in l.keys())
+            assert_equal(x, l['x'])
+            savez(tmp, x=xnew, y=y, update=True, append=append_array)
+            l = np.load(tmp)
+            assert_('x' in l.keys())
+            assert_('y' in l.keys())
+            assert_('append' in l.keys())
+            assert_equal(xnew, l['x'])
+            assert_equal(y, l['y'])
+            assert_equal(append_array, l['append'])
+
+    # update is array, i.e. appended
+    for savez in savez_list:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
+            savez(tmp, x=x)
+            l = np.load(tmp)
+            assert_('x' in l.keys())
+            assert_equal(x, l['x'])
+            savez(tmp, y=y, update=update_array, append=True)
+            l = np.load(tmp)
+            assert_('x' in l.keys())
+            assert_('y' in l.keys())
+            assert_('update' in l.keys())
+            assert_equal(x, l['x'])
+            assert_equal(y, l['y'])
+            assert_equal(update_array, l['update'])
+
+    # append and update are arrays, i.e. new file
+    for savez in savez_list:
+        with temppath(prefix="np_test_npzfile_update_", suffix=".npz") as tmp:
+            savez(tmp, x=x)
+            l = np.load(tmp)
+            assert_('x' in l.keys())
+            assert_equal(x, l['x'])
+            savez(tmp, y=y, update=update_array, append=append_array)
+            l = np.load(tmp)
+            assert_('x' not in l.keys())
+            assert_('y' in l.keys())
+            assert_('append' in l.keys())
+            assert_('update' in l.keys())
+            assert_equal(y, l['y'])
+            assert_equal(append_array, l['append'])
+            assert_equal(update_array, l['update'])
 
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")


### PR DESCRIPTION
This PR adds the keywords append and update to numpy.savez and numpy.savez_compressed.

I like to store results of lengthy calculations into files such as numpy's npz-files and use these in plotting scripts, which run very often to be refined, etc. If I have to redo some of the calculations but not all, then only some of the results in the output files need updating.

So I implemented that one can simply append new arrays to existing npz-files and also that one can update arrays in existing npz-files. The latter uses a temporary file, just as the zip-utility with -u. Python also only allows 'r', 'w', 'a', and 'x' with zipfile.ZipFile.

I am a first time contributor. I do not know the dispatch mechanism. So I followed how it is done in the save function with the _save_dispatcher.

I added tests. However, `python runtests.py --coverage` gave already 18 times the same error:
`E               AssertionError: Got warnings: [<warnings.WarningMessage object at 0x1a93b92d0>]
`
in `numpy/core/tests/test_umath.py::TestSpecialFloats::test_unary_spurious_fpexception`
before starting the PR. This is still the case.

<!--
*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
