### PR TITLE
MAINT: use pypy3.9 in testing

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11-dev"]
+        python-version: ["3.9", "3.10", "3.11-dev", "pypy3.9-v7.3.11"]
     env:
       EXPECT_CPU_FEATURES: "SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL"
     steps:
@@ -307,19 +307,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-    - uses: ./.github/actions
-
-  pypy38:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@v4
-      with:
-        python-version: pypy-3.8-v7.3.9
     - uses: ./.github/actions
 
   sdist:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,10 +278,8 @@ stages:
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
 
-          # Not sure how the PyPy version is set here
-          # It is set in azure-steps-windows.ym
-          PyPy38-64bit-fast:
-            PYTHON_VERSION: 'PyPy'
+          PyPy39-64bit-fast:
+            PYTHON_VERSION: 'pypy3.9'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -4,26 +4,6 @@ steps:
     versionSpec: $(PYTHON_VERSION)
     addToPath: true
     architecture: $(PYTHON_ARCH)
-  condition: not(contains(variables['PYTHON_VERSION'], 'PyPy'))
-- powershell: |
-    # UsePythonVersion only supports pypy3.6, we need 3.8
-    # https://github.com/microsoft/azure-pipelines-tasks/pull/15553
-    $url = "https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip"
-    $output = "pypy.zip"
-    $wc = New-Object System.Net.WebClient
-    $wc.DownloadFile($url, $output)
-    echo "downloaded $url to $output"
-    mkdir pypy3
-    Expand-Archive $output -DestinationPath pypy3
-    # move pypy3/pypy-c-*/* pypy3
-    move pypy3/pypy*/* pypy3
-    $pypypath = Join-Path (Get-Item .).FullName pypy3
-    $env:Path = $pypypath + ";" + $env:Path
-    setx PATH $env:Path
-    python -mensurepip
-    echo "##vso[task.prependpath]$pypypath"
-  condition: contains(variables['PYTHON_VERSION'], 'PyPy')
-  displayName: "Install PyPy3.8 "
 
 - script: python -m pip install --upgrade pip wheel
   displayName: 'Install tools'

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -8,7 +8,6 @@ Support code for building Python extensions on Windows.
 
 """
 import os
-import platform
 import sys
 import subprocess
 import re
@@ -203,11 +202,14 @@ def find_python_dll():
 
     # search in the file system for possible candidates
     major_version, minor_version = tuple(sys.version_info[:2])
-    implementation = platform.python_implementation()
-    if implementation == 'CPython':
+    implementation = sys.implementation.name
+    if implementation == 'cpython':
         dllname = f'python{major_version}{minor_version}.dll'
-    elif implementation == 'PyPy':
-        dllname = f'libpypy{major_version}-c.dll'
+    elif implementation == 'pypy':
+        if sys.version_info >= (3, 9):
+            dllname = f'libpypy{major_version}.{minor_version}-c.dll'
+        else:
+            dllname = f'libpypy{major_version}-c.dll'
     else:
         dllname = f'Unknown platform {implementation}' 
     print("Looking for %s" % dllname)


### PR DESCRIPTION
Use pypy3.9 for testing on linux, windows via the CI provider matrix.

Also fix the `find_dll` heuristics in mingw compilation. It is too bad windows does not implement `sysconfig.get_config_var("LDLIBRARY")` which would allow the interpreter to self-report.

cibuildwheel does not yet fully support pypy3.9, so that will come later.