### PR TITLE
MAINT: Fix some noisy clang suggestions.

### DIFF
--- a/numpy/core/src/npysort/selection.cpp
+++ b/numpy/core/src/npysort/selection.cpp
@@ -423,8 +423,8 @@ static constexpr std::array<arg_map, sizeof...(Tags)>
 make_partition_map(npy::taglist<Tags...>)
 {
     return std::array<arg_map, sizeof...(Tags)>{
-            arg_map{Tags::type_value, &introselect_noarg<Tags>,
-                    &introselect_arg<Tags>}...};
+            arg_map{Tags::type_value, {&introselect_noarg<Tags>},
+                {&introselect_arg<Tags>}}...};
 }
 
 struct partition_t {


### PR DESCRIPTION
The suggestions looks like:
```
numpy/core/src/npysort/selection.cpp:426:39: warning
suggest braces around initialization of subobject [-Wmissing-braces]
        arg_map{Tags::type_value, &introselect_noarg<Tags>,
                                  ^~~~~~~~~~~~~~~~~~~~~~~~
                                  {                       }
```

For the curious, think of these as initializers for the corresponding argument variables. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
