### PR TITLE
ENH: add support for fujitsu C/C++ compiler and SSL2 to numpy.

### DIFF
--- a/doc/release/upcoming_changes/22982.new_feature.rst
+++ b/doc/release/upcoming_changes/22982.new_feature.rst
@@ -1,0 +1,13 @@
+Fujitsu C/C++ compiler is now supported
+----------------------------------------------
+Support for Fujitsu compiler has been added.
+To build with Fujitsu compiler, run:
+
+    python setup.py build -c fujitsu
+
+
+SSL2 is now supported
+-----------------------------------
+Support for SSL2 has been added. SSL2 is a library that provides OpenBLAS compatible GEMM functions.
+To enable SSL2, it need to edit site.cfg and build with Fujitsu compiler.
+See site.cfg.example.

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -77,7 +77,7 @@
     #elif defined(__ARMEL__) || defined(__AARCH64EL__) || defined(_M_ARM64)
         #if defined(__ARM_32BIT_STATE)
             #define NPY_CPU_ARMEL_AARCH32
-        #elif defined(__ARM_64BIT_STATE) || defined(_M_ARM64)
+        #elif defined(__ARM_64BIT_STATE) || defined(_M_ARM64) || defined(__AARCH64EL__)
             #define NPY_CPU_ARMEL_AARCH64
         #else
             #define NPY_CPU_ARMEL

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -28,7 +28,7 @@ from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
     assert_allclose, IS_PYPY, IS_PYSTON, HAS_REFCOUNT, assert_array_less,
-    runstring, temppath, suppress_warnings, break_cycles,
+    runstring, temppath, suppress_warnings, break_cycles, _SUPPORTS_SVE,
     )
 from numpy.testing._private.utils import requires_memory, _no_tracing
 from numpy.core.tests._locales import CommaDecimalPointLocale
@@ -9857,6 +9857,7 @@ class TestViewDtype:
         assert_array_equal(x.view('<i2'), expected)
 
 
+@pytest.mark.xfail(_SUPPORTS_SVE, reason="gh-22982")
 # Test various array sizes that hit different code paths in quicksort-avx512
 @pytest.mark.parametrize("N", [8, 16, 24, 32, 48, 64, 96, 128, 151, 191,
                                256, 383, 512, 1023, 2047])

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_almost_equal,
     assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
-    assert_warns,
+    assert_warns, _SUPPORTS_SVE,
     )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -146,6 +146,7 @@ def test_int_float_promotion_truediv(fscalar):
 
 
 class TestBaseMath:
+    @pytest.mark.xfail(_SUPPORTS_SVE, reason="gh-22982")
     def test_blocked(self):
         # test alignments offsets for simd instructions
         # alignments for vz + 2 * (vs - 1) + 1

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -589,6 +589,8 @@ class TestDivision:
         assert_equal(np.signbit(x//1), 0)
         assert_equal(np.signbit((-x)//1), 1)
 
+    @pytest.mark.skipif(hasattr(np.__config__, "blas_ssl2_info"),
+            reason="gh-22982")
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     @pytest.mark.parametrize('dtype', np.typecodes['Float'])
     def test_floor_division_errors(self, dtype):
@@ -731,6 +733,8 @@ class TestRemainder:
             # inf / 0 does not set any flags, only the modulo creates a NaN
             np.divmod(finf, fzero)
 
+    @pytest.mark.skipif(hasattr(np.__config__, "blas_ssl2_info"),
+            reason="gh-22982")
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     @pytest.mark.xfail(sys.platform.startswith("darwin"),
            reason="MacOS seems to not give the correct 'invalid' warning for "

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -720,6 +720,8 @@ compiler_class['pathcc'] = ('pathccompiler', 'PathScaleCCompiler',
                             "PathScale Compiler for SiCortex-based applications")
 compiler_class['arm'] = ('armccompiler', 'ArmCCompiler',
                             "Arm C Compiler")
+compiler_class['fujitsu'] = ('fujitsuccompiler', 'FujitsuCCompiler',
+                            "Fujitsu C Compiler")
 
 ccompiler._default_compilers += (('linux.*', 'intel'),
                                  ('linux.*', 'intele'),

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -229,6 +229,11 @@ class _Config:
             native = None,
             opt = '/O2',
             werror = '/WX',
+        ),
+        fcc = dict(
+            native = '-mcpu=a64fx',
+            opt = None,
+            werror = None,
         )
     )
     conf_min_features = dict(
@@ -338,7 +343,7 @@ class _Config:
             return {}
 
         on_x86 = self.cc_on_x86 or self.cc_on_x64
-        is_unix = self.cc_is_gcc or self.cc_is_clang
+        is_unix = self.cc_is_gcc or self.cc_is_clang or self.cc_is_fcc
 
         if on_x86 and is_unix: return dict(
             SSE    = dict(flags="-msse"),
@@ -979,12 +984,14 @@ class _CCompiler:
             ("cc_is_iccw",     ".*(intelw|intelemw|iccw).*", ""),
             ("cc_is_icc",      ".*(intel|icc).*", ""),  # intel unix like
             ("cc_is_msvc",     ".*msvc.*", ""),
+            ("cc_is_fcc",     ".*fcc.*", ""),
             # undefined compiler will be treat it as gcc
             ("cc_is_nocc",     "", ""),
         )
         detect_args = (
            ("cc_has_debug",  ".*(O0|Od|ggdb|coverage|debug:full).*", ""),
-           ("cc_has_native", ".*(-march=native|-xHost|/QxHost).*", ""),
+           ("cc_has_native", 
+                ".*(-march=native|-xHost|/QxHost|-mcpu=a64fx).*", ""),
            # in case if the class run with -DNPY_DISABLE_OPTIMIZATION
            ("cc_noopt", ".*DISABLE_OPT.*", ""),
         )
@@ -1045,7 +1052,7 @@ class _CCompiler:
                 break
 
         self.cc_name = "unknown"
-        for name in ("gcc", "clang", "iccw", "icc", "msvc"):
+        for name in ("gcc", "clang", "iccw", "icc", "msvc", "fcc"):
             if getattr(self, "cc_is_" + name):
                 self.cc_name = name
                 break

--- a/numpy/distutils/fujitsuccompiler.py
+++ b/numpy/distutils/fujitsuccompiler.py
@@ -1,0 +1,28 @@
+from distutils.unixccompiler import UnixCCompiler
+
+class FujitsuCCompiler(UnixCCompiler):
+
+    """
+    Fujitsu compiler.
+    """
+
+    compiler_type = 'fujitsu'
+    cc_exe = 'fcc'
+    cxx_exe = 'FCC'
+
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        UnixCCompiler.__init__(self, verbose, dry_run, force)
+        cc_compiler = self.cc_exe
+        cxx_compiler = self.cxx_exe
+        self.set_executables(
+            compiler=cc_compiler +
+            ' -O3 -Nclang -fPIC',
+            compiler_so=cc_compiler +
+            ' -O3 -Nclang -fPIC',
+            compiler_cxx=cxx_compiler +
+            ' -O3 -Nclang -fPIC',
+            linker_exe=cc_compiler +
+            ' -lfj90i -lfj90f -lfjsrcinfo -lelf -shared',
+            linker_so=cc_compiler +
+            ' -lfj90i -lfj90f -lfjsrcinfo -lelf -shared'
+            )

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -62,6 +62,7 @@ Currently, the following classes are available, along with their section names:
     blas_ilp64_plain_opt_info:ALL      # usage recommended (general ILP64 BLAS, no symbol suffix)
     blas_info:blas
     blas_mkl_info:mkl
+    blas_ssl2_info:ssl2
     blas_opt_info:ALL                  # usage recommended
     blas_src_info:blas_src
     blis_info:blis
@@ -93,9 +94,11 @@ Currently, the following classes are available, along with their section names:
     lapack_ilp64_plain_opt_info:ALL    # usage recommended (general ILP64 LAPACK, no symbol suffix)
     lapack_info:lapack
     lapack_mkl_info:mkl
+    lapack_ssl2_info:ssl2
     lapack_opt_info:ALL                # usage recommended
     lapack_src_info:lapack_src
     mkl_info:mkl
+    ssl2_info:ssl2
     numarray_info:numarray
     numerix_info:numerix
     numpy_info:numpy
@@ -519,6 +522,7 @@ def get_info(name, notfound_action=0):
           'lapack_atlas_3_10_threads': lapack_atlas_3_10_threads_info,  # ditto
           'flame': flame_info,          # use lapack_opt instead
           'mkl': mkl_info,
+          'ssl2': ssl2_info,
           # openblas which may or may not have embedded lapack
           'openblas': openblas_info,          # use blas_opt instead
           # openblas with embedded lapack
@@ -527,6 +531,8 @@ def get_info(name, notfound_action=0):
           'blis': blis_info,                  # use blas_opt instead
           'lapack_mkl': lapack_mkl_info,      # use lapack_opt instead
           'blas_mkl': blas_mkl_info,          # use blas_opt instead
+          'lapack_ssl2': lapack_ssl2_info,      
+          'blas_ssl2': blas_ssl2_info,          
           'accelerate': accelerate_info,      # use blas_opt instead
           'openblas64_': openblas64__info,
           'openblas64__lapack': openblas64__lapack_info,
@@ -1325,6 +1331,34 @@ class blas_mkl_info(mkl_info):
     pass
 
 
+class ssl2_info(system_info):
+    section = 'ssl2'
+    dir_env_var = 'SSL2_DIR'
+    _lib_ssl2 = ['fjlapacksve']
+
+    def calc_info(self):
+        lib_dirs = self.get_lib_dirs()
+        incl_dirs = self.get_include_dirs()
+        ssl2_libs = self.get_libs('ssl2_libs', self._lib_ssl2)
+        info = self.check_libs2(lib_dirs, ssl2_libs)
+        if info is None:
+            return
+        dict_append(info,
+                    define_macros=[('HAVE_CBLAS', None),
+                                   ('HAVE_SSL2', 1)],
+                    include_dirs=incl_dirs,)
+        self.set_info(**info)
+
+
+class lapack_ssl2_info(ssl2_info):
+    pass
+
+
+class blas_ssl2_info(ssl2_info):
+    pass
+
+
+
 class armpl_info(system_info):
     section = 'armpl'
     dir_env_var = 'ARMPL_DIR'
@@ -1787,7 +1821,7 @@ class lapack_opt_info(system_info):
     notfounderror = LapackNotFoundError
 
     # List of all known LAPACK libraries, in the default order
-    lapack_order = ['armpl', 'mkl', 'openblas', 'flame',
+    lapack_order = ['armpl', 'mkl', 'ssl2', 'openblas', 'flame',
                     'accelerate', 'atlas', 'lapack']
     order_env_var_name = 'NPY_LAPACK_ORDER'
     
@@ -1800,6 +1834,13 @@ class lapack_opt_info(system_info):
 
     def _calc_info_mkl(self):
         info = get_info('lapack_mkl')
+        if info:
+            self.set_info(**info)
+            return True
+        return False
+
+    def _calc_info_ssl2(self):
+        info = get_info('lapack_ssl2')
         if info:
             self.set_info(**info)
             return True
@@ -1971,7 +2012,7 @@ class blas_opt_info(system_info):
     notfounderror = BlasNotFoundError
     # List of all known BLAS libraries, in the default order
 
-    blas_order = ['armpl', 'mkl', 'blis', 'openblas',
+    blas_order = ['armpl', 'mkl', 'ssl2', 'blis', 'openblas',
                   'accelerate', 'atlas', 'blas']
     order_env_var_name = 'NPY_BLAS_ORDER'
     
@@ -1984,6 +2025,13 @@ class blas_opt_info(system_info):
 
     def _calc_info_mkl(self):
         info = get_info('blas_mkl')
+        if info:
+            self.set_info(**info)
+            return True
+        return False
+
+    def _calc_info_ssl2(self):
+        info = get_info('blas_ssl2')
         if info:
             self.set_info(**info)
             return True

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -31,7 +31,7 @@ arch_compilers = dict(
     ppc64 = ("gcc", "clang"),
     ppc64le = ("gcc", "clang"),
     armhf = ("gcc", "clang"),
-    aarch64 = ("gcc", "clang"),
+    aarch64 = ("gcc", "clang", "fcc"),
     s390x = ("gcc", "clang"),
     noarch = ("gcc",)
 )
@@ -422,8 +422,8 @@ class _Test_CCompilerOpt:
         # when option "native" is activated through the args
         try:
             self.expect("native",
-                trap_flags=".*(-march=native|-xHost|/QxHost).*",
-                x86=".*", ppc64=".*", armhf=".*", s390x=".*"
+                trap_flags=".*(-march=native|-xHost|/QxHost|-mcpu=a64fx).*",
+                x86=".*", ppc64=".*", armhf=".*", s390x=".*", aarch64=".*",
             )
             if self.march() != "unknown":
                 raise AssertionError(

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -37,7 +37,7 @@ __all__ = [
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
         'HAS_REFCOUNT', "IS_WASM", 'suppress_warnings', 'assert_array_compare',
         'assert_no_gc_cycles', 'break_cycles', 'HAS_LAPACK64', 'IS_PYSTON',
-        '_OLD_PROMOTION', 'IS_MUSL'
+        '_OLD_PROMOTION', 'IS_MUSL', '_SUPPORTS_SVE'
         ]
 
 
@@ -1297,6 +1297,22 @@ def rundocs(filename=None, raise_on_error=True):
         raise AssertionError("Some doctests failed:\n%s" % "\n".join(msg))
 
 
+def check_support_sve():
+    """
+    gh-22982
+    """
+    
+    import subprocess
+    cmd = 'lscpu'
+    try:
+        return "sve" in (subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            shell=True).communicate()[0]).decode('utf-8')
+    except OSError:
+        return False
+
+
+_SUPPORTS_SVE = check_support_sve()
+
 #
 # assert_raises and assert_raises_regex are taken from unittest.
 #
@@ -2548,3 +2564,4 @@ def _get_glibc_version():
 
 _glibcver = _get_glibc_version()
 _glibc_older_than = lambda x: (_glibcver != '0.0' and _glibcver < x)
+

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -194,6 +194,7 @@ PRIVATE_BUT_PRESENT_MODULES = ['numpy.' + s for s in [
     "core.umath",
     "core.umath_tests",
     "distutils.armccompiler",
+    "distutils.fujitsuccompiler",
     "distutils.ccompiler",
     'distutils.ccompiler_opt',
     "distutils.command",

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -252,3 +252,11 @@
 #[djbfft]
 #include_dirs = /usr/local/djbfft/include
 #library_dirs = /usr/local/djbfft/lib
+
+# SSL2
+# ----
+#
+# [ssl2]
+# library_dirs = /opt/FJSVstclanga/v1.1.0/lib64
+# include_dirs = /opt/FJSVstclanga/v1.1.0/clang-comp/include
+# extra_link_args = -SSL2BLAMP


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This is my first pull request, so please let me know if there is anything missing.

I added an implementation for the Fujitsu C/C++ compiler (fcc/FCC) and the SSL2 library. 

To build with the Fujitsu compiler, please build as follows:
```
$ python setup.py build -c fujitsu install
```
SSL2 is a library that provides OpenBLAS compatible GEMM functions. SSL2 in Fujitsu Compiler  is the library in the same position as MKL in Intel Compiler.
To use SSL2, please edit site.cfg. I changed system_info.py based on mkl implementation.
The regression test was run the following command:.
```
$ python runtests.py
```
Because I didn't know how to specify a compiler in runtests.py, I modified the implementation to use the Fujitsu compiler and ran the tests.
Tests passed other than version check.