### PR TITLE
BUG: Ensure correct loop order in sin, cos, and arctan2

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -4027,6 +4027,14 @@ class TestComplexFunctions:
             check(func, pts, 1j)
             check(func, pts, 1+1j)
 
+    @np.errstate(all="ignore")
+    def test_promotion_corner_cases(self):
+        for func in self.funcs:
+            assert func(np.float16(1)).dtype == np.float16
+            # Integer to low precision float promotion is a dubious choice:
+            assert func(np.uint8(1)).dtype == np.float16
+            assert func(np.int16(1)).dtype == np.float32
+
 
 class TestAttributes:
     def test_attributes(self):


### PR DESCRIPTION
These were incorrect afer being vectorized.  The commit additional tests these (not arctan2 admittedly) and adds a check to generate_umath to make it a bit less likely that future additions add this type of thing.

Note that the check allows duplicated loops so long they are correctly ordered the *first* time.  This makes results correct, but duplicated loops are not nice anyways and it would be nice to remove them.

We could drop them manually in hindsight even?  In any case, that should not be backported, so it is not includedhere.

Closes gh-22984