### PR TITLE
DOC: add information about disabling SIMD for crashes

### DIFF
--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -6,9 +6,9 @@
    to this page.
 
 
-***************************
-Troubleshooting ImportError
-***************************
+***************
+Troubleshooting
+***************
 
 .. note::
 
@@ -183,3 +183,65 @@ that usually works is to upgrade the NumPy version::
 
     pip install numpy --upgrade
 
+Segfaults or crashes
+====================
+
+NumPy tries to use advanced CPU features (SIMD) to speed up operations. If you
+are getting an "illegal instruction" error or a segfault, one cause could be
+that the environment claims it can support one or more of these features but
+actually cannot. This can happen inside a docker image or a VM (qemu, VMWare,
+...)
+
+You can use the output of ``np.show_runtime()`` to show which SIMD features are
+detected. For instance::
+
+    >>> np.show_runtime()
+    WARNING: `threadpoolctl` not found in system! Install it by `pip install \
+    threadpoolctl`. Once installed, try `np.show_runtime` again for more detailed
+    build information
+    [{'simd_extensions': {'baseline': ['SSE', 'SSE2', 'SSE3'],
+                          'found': ['SSSE3',
+                                    'SSE41',
+                                    'POPCNT',
+                                    'SSE42',
+                                    'AVX',
+                                    'F16C',
+                                    'FMA3',
+                                    'AVX2'],
+                          'not_found': ['AVX512F',
+                                        'AVX512CD',
+                                        'AVX512_KNL',
+                                        'AVX512_KNM',
+                                        'AVX512_SKX',
+                                        'AVX512_CLX',
+                                        'AVX512_CNL',
+                                        'AVX512_ICL']}}]
+
+In this case, it shows AVX2 and FMA3 under the ``found`` section, so you can
+try disabling them by setting ``NPY_DISABLE_CPU_FEATURES="AVX2,FMA3"`` in your
+environment before running python (for cmd.exe on windows)::
+
+    >SET NPY_DISABLE_CPU_FEATURES="AVX2,FMA3"
+    >python <myprogram.py>
+
+By installing threadpoolctl ``np.show_runtime()`` will show additional information::
+
+    ...
+    {'architecture': 'Zen',
+      'filepath': '/tmp/venv3/lib/python3.9/site-packages/numpy.libs/libopenblas64_p-r0-15028c96.3.21.so',
+      'internal_api': 'openblas',
+      'num_threads': 24,
+      'prefix': 'libopenblas',
+      'threading_layer': 'pthreads',
+      'user_api': 'blas',
+      'version': '0.3.21'}]
+
+If you use the wheel from PyPI, it contains code from the OpenBLAS project to
+speed up matrix operations. This code too can try to use SIMD instructions. It
+has a different mechanism for choosing which to use, based on a CPU
+architecture, You can override this architecture by setting
+``OPENBLAS_CORETYPE``: a minimal value for ``x86_64`` is
+``OPENBLAS_CORETYPE=Haswell``.  This too needs to be set before running your
+python (this time for posix)::
+
+    $ OPENBLAS_CORETYPE=Haswell python <myprogram.py>


### PR DESCRIPTION
We get around one issue a year where running NumPy inside a VM crashes, so I added a section on troubleshooting crashes from a user perspective. This came from a comment in #22979