### PR TITLE
DOC: Fix gh-22990 by correcting docstring of result_type

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -714,7 +714,7 @@ def result_type(*arrays_and_dtypes):
     the data types are combined with :func:`promote_types`
     to produce the return value.
 
-    Otherwise, `min_scalar_type` is called on each array, and
+    Otherwise, `min_scalar_type` is called on each scalar, and
     the resulting data types are all combined with :func:`promote_types`
     to produce the return value.
 


### PR DESCRIPTION
Closes #22990 

This PR corrects doc-string of `numpy.result_type` in description of its specific logic. The docstring currently says that `numpy.min_scalar_type` is applied to arguments of type arrays, but should state that `min_scalar_type` is applied to scalar arguments instead.

