### PR TITLE
BLD: Bump PyPy wheel to 3.9 and upgrade cibuildwheel to latest

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,14 +78,9 @@ jobs:
           - [macos-12, macosx_*]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
-        # TODO: uncomment PyPy 3.9 builds once PyPy
-        # re-releases a new minor version
-        # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
-        python: ["cp39", "cp310", "cp311", "pp38"]  #, "pp39"]
+        python: ["cp39", "cp310", "cp311", "pp39"]
         exclude:
           # Don't build PyPy 32-bit windows
-          - buildplat: [windows-2019, win32]
-            python: "pp38"
           - buildplat: [windows-2019, win32]
             python: "pp39"
     env:
@@ -117,7 +112,7 @@ jobs:
         if: ${{ matrix.buildplat[1] == 'win32' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

I realized that https://github.com/numpy/numpy/pull/22921 exists after creating this, but maybe bumping both PyPy to 3.9 (which was the main purpose of this) and cibuildwheel solves it...

(As I assume that you drop 3.8 for next release?)
