### PR TITLE
DEP: Finalize `+arr` returning a copy e.g. for string arrays

### DIFF
--- a/doc/release/upcoming_changes/22998.expired.rst
+++ b/doc/release/upcoming_changes/22998.expired.rst
@@ -1,0 +1,2 @@
+* ``+arr`` will now raise an error when the dtype is not
+  numeric (and positive is undefined).

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -539,47 +539,10 @@ array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
 static PyObject *
 array_positive(PyArrayObject *m1)
 {
-    /*
-     * For backwards compatibility, where + just implied a copy,
-     * we cannot just call n_ops.positive.  Instead, we do the following
-     * 1. Try n_ops.positive
-     * 2. If we get an exception, check whether __array_ufunc__ is
-     *    overridden; if so, we live in the future and we allow the
-     *    TypeError to be passed on.
-     * 3. If not, give a deprecation warning and return a copy.
-     */
-    PyObject *value;
     if (can_elide_temp_unary(m1)) {
-        value = PyArray_GenericInplaceUnaryFunction(m1, n_ops.positive);
+        return PyArray_GenericInplaceUnaryFunction(m1, n_ops.positive);
     }
-    else {
-        value = PyArray_GenericUnaryFunction(m1, n_ops.positive);
-    }
-    if (value == NULL) {
-        /*
-         * We first fetch the error, as it needs to be clear to check
-         * for the override.  When the deprecation is removed,
-         * this whole stanza can be deleted.
-         */
-        PyObject *exc, *val, *tb;
-        PyErr_Fetch(&exc, &val, &tb);
-        if (PyUFunc_HasOverride((PyObject *)m1)) {
-            PyErr_Restore(exc, val, tb);
-            return NULL;
-        }
-        Py_XDECREF(exc);
-        Py_XDECREF(val);
-        Py_XDECREF(tb);
-
-        /* 2018-06-28, 1.16.0 */
-        if (DEPRECATE("Applying '+' to a non-numerical array is "
-                      "ill-defined. Returning a copy, but in the future "
-                      "this will error.") < 0) {
-            return NULL;
-        }
-        value = PyArray_Return((PyArrayObject *)PyArray_Copy(m1));
-    }
-    return value;
+    return PyArray_GenericUnaryFunction(m1, n_ops.positive);
 }
 
 static PyObject *

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -310,12 +310,6 @@ class TestGeneratorSum(_DeprecationTestCase):
         self.assert_deprecated(np.sum, args=((i for i in range(5)),))
 
 
-class TestPositiveOnNonNumerical(_DeprecationTestCase):
-    # 2018-06-28, 1.16.0
-    def test_positive_on_non_number(self):
-        self.assert_deprecated(operator.pos, args=(np.array('foo'),))
-
-
 class TestFromstring(_DeprecationTestCase):
     # 2017-10-19, 1.14
     def test_fromstring(self):


### PR DESCRIPTION
This was deprecated 4-5 years ago in NumPy 1.16.  Pandas stumbled over it cleaning up their warning filters, so I decided to just expire it.