### PR TITLE
CI: Fix CircleCI ssh key missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,8 @@ jobs:
   deploy:
     <<: *defaults
     steps:
+      - checkout
+
       - attach_workspace:
           at: ~/repo
 


### PR DESCRIPTION
cc @seberg 

Apparently the ssh logic is getting initialised by CircleCI during the checkout step. We missed it as in SciPy the whole home is persisted to the workspace.