### PR TITLE
BUG: Use _Alignof to compute alignment.

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -225,7 +225,13 @@ MyPyLong_AsUnsigned@Type@(PyObject *obj)
  *****************************************************************************
  */
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#include <stdalign.h>
+#define _ALIGN(type) _Alignof(type)
+#else
 #define _ALIGN(type) offsetof(struct {char c; type v;}, v)
+#endif
+
 /*
  * Disable harmless compiler warning "4116: unnamed type definition in
  * parentheses" which is caused by the _ALIGN macro.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -178,7 +178,13 @@ check_and_adjust_axis(int *axis, int ndim)
 }
 
 /* used for some alignment checks */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#include <stdalign.h>
+#define _ALIGN(type) _Alignof(type)
+#else
 #define _ALIGN(type) offsetof(struct {char c; type v;}, v)
+#endif
+
 #define _UINT_ALIGN(type) npy_uint_alignment(sizeof(type))
 /*
  * Disable harmless compiler warning "4116: unnamed type definition in


### PR DESCRIPTION
It is undefined behavior to have a type declaration inside `offsetof`, see:
https://github.com/llvm/llvm-project/commit/e327b52766ed497e4779f4e652b9ad237dfda8e6

This code will fail to compile under upcoming versions of clang.

If we have a C11-compliant compiler, use `_Alignof` instead.