### PR TITLE
DEP: Finalize the non-sequence stacking deprecation

### DIFF
--- a/doc/release/upcoming_changes/23019.expired.rst
+++ b/doc/release/upcoming_changes/23019.expired.rst
@@ -1,0 +1,2 @@
+* A sequence must now be passed into the stacking family of functions
+  (``stack``, ``vstack``, ``hstack``, ``dstack`` and ``column_stack``).

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -204,19 +204,15 @@ def atleast_3d(*arys):
         return res
 
 
-def _arrays_for_stack_dispatcher(arrays, stacklevel=4):
-    if not hasattr(arrays, '__getitem__') and hasattr(arrays, '__iter__'):
-        warnings.warn('arrays to stack must be passed as a "sequence" type '
-                      'such as list or tuple. Support for non-sequence '
-                      'iterables such as generators is deprecated as of '
-                      'NumPy 1.16 and will raise an error in the future.',
-                      FutureWarning, stacklevel=stacklevel)
-        return ()
-    return arrays
+def _arrays_for_stack_dispatcher(arrays):
+    if not hasattr(arrays, "__getitem__"):
+        raise TypeError('arrays to stack must be passed as a "sequence" type '
+                        'such as list or tuple.')
+
+    return tuple(arrays)
 
 
-def _vhstack_dispatcher(tup, *, 
-                        dtype=None, casting=None):
+def _vhstack_dispatcher(tup, *, dtype=None, casting=None):
     return _arrays_for_stack_dispatcher(tup)
 
 
@@ -288,8 +284,8 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
 
     """
     if not overrides.ARRAY_FUNCTION_ENABLED:
-        # raise warning if necessary
-        _arrays_for_stack_dispatcher(tup, stacklevel=2)
+        # reject non-sequences (and make tuple)
+        tup = _arrays_for_stack_dispatcher(tup)
     arrs = atleast_2d(*tup)
     if not isinstance(arrs, list):
         arrs = [arrs]
@@ -357,8 +353,8 @@ def hstack(tup, *, dtype=None, casting="same_kind"):
 
     """
     if not overrides.ARRAY_FUNCTION_ENABLED:
-        # raise warning if necessary
-        _arrays_for_stack_dispatcher(tup, stacklevel=2)
+        # reject non-sequences (and make tuple)
+        tup = _arrays_for_stack_dispatcher(tup)
 
     arrs = atleast_1d(*tup)
     if not isinstance(arrs, list):
@@ -372,7 +368,7 @@ def hstack(tup, *, dtype=None, casting="same_kind"):
 
 def _stack_dispatcher(arrays, axis=None, out=None, *,
                       dtype=None, casting=None):
-    arrays = _arrays_for_stack_dispatcher(arrays, stacklevel=6)
+    arrays = _arrays_for_stack_dispatcher(arrays)
     if out is not None:
         # optimize for the typical case where only arrays is provided
         arrays = list(arrays)
@@ -452,8 +448,8 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
 
     """
     if not overrides.ARRAY_FUNCTION_ENABLED:
-        # raise warning if necessary
-        _arrays_for_stack_dispatcher(arrays, stacklevel=2)
+        # reject non-sequences (and make tuple)
+        arrays = _arrays_for_stack_dispatcher(arrays)
 
     arrays = [asanyarray(arr) for arr in arrays]
     if not arrays:

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -152,9 +152,9 @@ class TestHstack:
         assert_array_equal(res, desired)
 
     def test_generator(self):
-        with assert_warns(FutureWarning):
+        with pytest.raises(TypeError, match="arrays to stack must be"):
             hstack((np.arange(3) for _ in range(2)))
-        with assert_warns(FutureWarning):
+        with pytest.raises(TypeError, match="arrays to stack must be"):
             hstack(map(lambda x: x, np.ones((3, 2))))
 
     def test_casting_and_dtype(self):
@@ -207,7 +207,7 @@ class TestVstack:
         assert_array_equal(res, desired)
 
     def test_generator(self):
-        with assert_warns(FutureWarning):
+        with pytest.raises(TypeError, match="arrays to stack must be"):
             vstack((np.arange(3) for _ in range(2)))
 
     def test_casting_and_dtype(self):
@@ -472,10 +472,11 @@ def test_stack():
                         stack, [np.zeros((3, 3)), np.zeros(3)], axis=1)
     assert_raises_regex(ValueError, 'must have the same shape',
                         stack, [np.arange(2), np.arange(3)])
-    # generator is deprecated
-    with assert_warns(FutureWarning):
-        result = stack((x for x in range(3)))
-    assert_array_equal(result, np.array([0, 1, 2]))
+
+    # do not accept generators
+    with pytest.raises(TypeError, match="arrays to stack must be"):
+        stack((x for x in range(3)))
+
     #casting and dtype test
     a = np.array([1, 2, 3])
     b = np.array([2.5, 3.5, 4.5])

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -644,8 +644,8 @@ def column_stack(tup):
 
     """
     if not overrides.ARRAY_FUNCTION_ENABLED:
-        # raise warning if necessary
-        _arrays_for_stack_dispatcher(tup, stacklevel=2)
+        # reject non-sequences (and make tuple)
+        tup = _arrays_for_stack_dispatcher(tup)
 
     arrays = []
     for v in tup:
@@ -714,8 +714,8 @@ def dstack(tup):
 
     """
     if not overrides.ARRAY_FUNCTION_ENABLED:
-        # raise warning if necessary
-        _arrays_for_stack_dispatcher(tup, stacklevel=2)
+        # reject non-sequences (and make tuple)
+        tup = _arrays_for_stack_dispatcher(tup)
 
     arrs = atleast_3d(*tup)
     if not isinstance(arrs, list):

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -492,7 +492,7 @@ class TestColumnStack:
         assert_equal(actual, expected)
 
     def test_generator(self):
-        with assert_warns(FutureWarning):
+        with pytest.raises(TypeError, match="arrays to stack must be"):
             column_stack((np.arange(3) for _ in range(2)))
 
 
@@ -529,7 +529,7 @@ class TestDstack:
         assert_array_equal(res, desired)
 
     def test_generator(self):
-        with assert_warns(FutureWarning):
+        with pytest.raises(TypeError, match="arrays to stack must be"):
             dstack((np.arange(3) for _ in range(2)))
 
 


### PR DESCRIPTION
The `__array_function__` API currently will exhaust iterators so we cannot accept sequences reasonably.  Checking for `__getitem__` is presumably enough to reject that (and was what the deprecation used).

Future changes could allow this again, although it is not a useful API anyway, since we have to materialize the iterable in any case.