### PR TITLE
BLD: Build PyPy 3.9 wheels.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,9 +78,6 @@ jobs:
           - [macos-12, macosx_*]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
-        # TODO: uncomment PyPy 3.9 builds once PyPy
-        # re-releases a new minor version
-        # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
         python: ["cp39", "cp310", "cp311", "pp39"]
         exclude:
           # Don't build PyPy 32-bit windows

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,7 +81,7 @@ jobs:
         # TODO: uncomment PyPy 3.9 builds once PyPy
         # re-releases a new minor version
         # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
-        python: ["cp39", "cp310", "cp311", "pp38"]  #, "pp39"]
+        python: ["cp39", "cp310", "cp311", "pp39"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32]


### PR DESCRIPTION
NumPy is dropping Python 3.8 for the 1.25.x release cycle. This updates PyPy to 3.9 in order to be consistant with that.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
