### PR TITLE
CI: Bump debug test to ubuntu-latest/22.04 rather than 20.04

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -177,7 +177,7 @@ jobs:
 
   debug:
     needs: [smoke_test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       USE_DEBUG: 1
     steps:
@@ -326,8 +326,8 @@ jobs:
 
   armv7_simd_test:
     needs: [smoke_test]
-    # make sure this (20.04) matches the base docker image (focal) below
-    runs-on: ubuntu-20.04
+    # make sure this matches the base docker image below
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -343,10 +343,10 @@ jobs:
         sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 
         # Keep the `test_requirements.txt` dependency-subset synced
-        docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:focal /bin/bash -c "
+        docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:22.04 /bin/bash -c "
           apt update &&
-          apt install -y git python3 python3-dev python3-pip &&
-          pip3 install cython==0.29.30 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 'typing_extensions>=4.2.0' &&
+          apt install -y git python3 python3-dev python3-pip  &&
+          python3 -m pip install cython==0.29.30 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 'typing_extensions>=4.2.0' &&
           ln -s /host/lib64 /lib64 &&
           ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&
           ln -s /host/usr/arm-linux-gnueabihf /usr/arm-linux-gnueabihf &&


### PR DESCRIPTION
This bumps the `armv7_simd_test` and `debug` one to use newer python versions as they were still on 3.8.

---

Removes the remaining Python 3.8 jobs, I think both are on 3.10 after this (which seems fine).  @seiko2plus do the simd job changes make sense?

(This is split out from gh-23020)