### PR TITLE
API: Allow SciPy to get away with assuming `trapz` is a Python function

### DIFF
--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -723,3 +723,24 @@ def test_function_like():
     bound = np.mean.__get__(MyClass)  # classmethod
     with pytest.raises(TypeError, match="unsupported operand type"):
         bound()
+
+
+def test_scipy_trapz_support_shim():
+    # SciPy 1.10 and earlier "clone" trapz in this way, so we have a
+    # support shim in place: https://github.com/scipy/scipy/issues/17811
+    # That should be removed eventually.  This test copies what SciPy does.
+    # Hopefully removable 1 year after SciPy 1.11; shim added to NumPy 1.25.
+    import types
+    import functools
+
+    def _copy_func(f):
+        # Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)
+        g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
+                            argdefs=f.__defaults__, closure=f.__closure__)
+        g = functools.update_wrapper(g, f)
+        g.__kwdefaults__ = f.__kwdefaults__
+        return g
+
+    trapezoid = _copy_func(np.trapz)
+
+    assert np.trapz([1, 2]) == trapezoid([1, 2])

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4912,6 +4912,25 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     return ret
 
 
+if overrides.ARRAY_FUNCTION_ENABLED:
+    # If array-function is enabled (normal), we wrap everything into a C
+    # callable, which has no __code__ or other attributes normal Python funcs
+    # have.  SciPy however, tries to "clone" `trapz` into a new Python function
+    # which requires `__code__` and a few other attributes.
+    # So we create a dummy clone and copy over its attributes allowing
+    # SciPy <= 1.10 to work: https://github.com/scipy/scipy/issues/17811
+    assert not hasattr(trapz, "__code__")
+
+    def _fake_trapz(y, x=None, dx=1.0, axis=-1):
+        return trapz(y, x=x, dx=dx, axis=axis)
+
+    trapz.__code__ = _fake_trapz.__code__
+    trapz.__globals__ = _fake_trapz.__globals__
+    trapz.__defaults__ = _fake_trapz.__defaults__
+    trapz.__closure__ = _fake_trapz.__closure__
+    trapz.__kwdefaults__ = _fake_trapz.__kwdefaults__
+
+
 def _meshgrid_dispatcher(*xi, copy=None, sparse=None, indexing=None):
     return xi
 


### PR DESCRIPTION
This wraps `trapz` into a proper python function, I could also just copy over all the relevant attributes.  In case we change things so that `trapz` is a Python function anyway, the assert would fail.

EDIT: Changed the approach to just copy over the stuff that SciPy needs to "clone" the function.