### PR TITLE
BUILD: add a windows meson CI job

### DIFF
--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -39,14 +39,14 @@ jobs:
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library
-          # Built with mingw-w64, -ucrt -static.
-          # https://github.com/matthew-brett/openblas-libs/blob/ucrt-build/build_openblas.ps1
+          # with 32-bit interfaces
+          # Unpack it in the pkg-config hardcoded path
           choco install unzip -y
           choco install wget -y
           choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-          wget https://github.com/scipy/scipy-ci-artifacts/raw/main/openblas_32_if.zip
-          unzip -d c:\ openblas_32_if.zip
-          echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+          wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+          unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
       - name: meson-configure
         run: |
           meson setup build --prefix=$PWD\build --buildtype plain --vsenv
@@ -77,4 +77,4 @@ jobs:
         run: |
           mkdir tmp
           cd tmp
-          python -c 'import numpy; numpy.test(verbose=3)'
+          python -c "import numpy; numpy.test(verbose=3)"

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -65,7 +65,7 @@ jobs:
           $numpy_path = "${env:installed_path}\numpy"
           $libs_path = "${numpy_path}\.libs"
           mkdir ${libs_path}
-          $ob_path = (pkg-config --variable libdir openblas) -replace "lib", "bin"
+          $ob_path = "C:/opt/64/lib/"
           cp $ob_path/*.dll $libs_path
           # Write _distributor_init.py to scipy dir to load .libs DLLs.
           & python tools\openblas_support.py --write-init $numpy_path

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -65,10 +65,15 @@ jobs:
           $numpy_path = "${env:installed_path}\numpy"
           $libs_path = "${numpy_path}\.libs"
           mkdir ${libs_path}
-          $ob_path = "C:/opt/64/lib/"
+          $ob_path = "C:/opt/64/bin/"
+          echo "listing $ob_path"
+          dir $ob_path
+          echo "copying dll to $libs_path"
           cp $ob_path/*.dll $libs_path
-          # Write _distributor_init.py to scipy dir to load .libs DLLs.
-          & python tools\openblas_support.py --write-init $numpy_path
+          echo "listing $libs_path"
+          # Write _distributor_init.py to load .libs DLLs.
+          python tools\openblas_support.py --write-init $numpy_path
+          echo "ran python tools\openblas_support.py --write-init"
       - name: prep-test
         run: |
           echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -53,7 +53,7 @@ jobs:
           meson setup build --prefix=$PWD\build
       - name: meson-build
         run: |
-          ninja -j 2 -C build
+          ninja -v -j 2 -C build
       - name: meson-install
         run: |
           cd build
@@ -78,4 +78,4 @@ jobs:
         run: |
           mkdir tmp
           cd tmp
-          python -c 'import numpy; numpy.test(verbose=2)'
+          python -c 'import numpy; numpy.test(verbose=3)'

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -43,6 +43,7 @@ jobs:
           # https://github.com/matthew-brett/openblas-libs/blob/ucrt-build/build_openblas.ps1
           choco install unzip -y
           choco install wget -y
+          choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
           wget https://github.com/scipy/scipy-ci-artifacts/raw/main/openblas_32_if.zip
           unzip -d c:\ openblas_32_if.zip
           echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -48,7 +48,7 @@ jobs:
           echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
       - name: meson-configure
         run: |
-          meson setup build -DHAVE_CBLAS=1 --prefix=$PWD\build --buildtype plain --vsenv
+          meson setup build --prefix=$PWD\build --buildtype plain --vsenv
       - name: meson-build
         run: |
           ninja -v -j 2 -C build

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          branch: meson
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -49,8 +48,7 @@ jobs:
           echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
       - name: meson-configure
         run: |
-          
-          meson setup build --prefix=$PWD\build
+          meson setup build -DHAVE_CBLAS=1 --prefix=$PWD\build --buildtype plain --vsenv
       - name: meson-build
         run: |
           ninja -v -j 2 -C build

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -25,10 +25,15 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          branch: meson
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Activate Developer Command Prompt (MSVC)
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install dependencies
         run: |
           pip install -r build_requirements.txt
@@ -44,6 +49,7 @@ jobs:
           echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
       - name: meson-configure
         run: |
+          
           meson setup build --prefix=$PWD\build
       - name: meson-build
         run: |

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -1,0 +1,75 @@
+name: Test Meson build (Windows)
+
+on:
+  push:
+    branches:
+      - meson
+
+env:
+  PYTHON_VERSION: 3.11
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  meson:
+    name: Meson windows build/test
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          pip install -r build_requirements.txt
+      - name: openblas-libs
+        run: |
+          # Download and install pre-built OpenBLAS library
+          # Built with mingw-w64, -ucrt -static.
+          # https://github.com/matthew-brett/openblas-libs/blob/ucrt-build/build_openblas.ps1
+          choco install unzip -y
+          choco install wget -y
+          wget https://github.com/scipy/scipy-ci-artifacts/raw/main/openblas_32_if.zip
+          unzip -d c:\ openblas_32_if.zip
+          echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+      - name: meson-configure
+        run: |
+          meson setup build --prefix=$PWD\build
+      - name: meson-build
+        run: |
+          ninja -j 2 -C build
+      - name: meson-install
+        run: |
+          cd build
+          meson install
+      - name: build-path
+        run: |
+          echo "installed_path=$PWD\build\Lib\site-packages" >> $env:GITHUB_ENV
+      - name: post-install
+        run: |
+          $numpy_path = "${env:installed_path}\numpy"
+          $libs_path = "${numpy_path}\.libs"
+          mkdir ${libs_path}
+          $ob_path = (pkg-config --variable libdir openblas) -replace "lib", "bin"
+          cp $ob_path/*.dll $libs_path
+          # Write _distributor_init.py to scipy dir to load .libs DLLs.
+          & python tools\openblas_support.py --write-init $numpy_path
+      - name: prep-test
+        run: |
+          echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
+          python -m pip install -r test_requirements.txt
+      - name: test
+        run: |
+          mkdir tmp
+          cd tmp
+          python -c 'import numpy; numpy.test(verbose=2)'

--- a/numpy/__config__.py.in
+++ b/numpy/__config__.py.in
@@ -8,6 +8,7 @@ import sys
 extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
 
 if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
+    print(f"in __config__, using {extra_dll_dir=}")
     os.add_dll_directory(extra_dll_dir)
 
 blas_armpl_info={}

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -32,6 +32,7 @@ if is_windows
 endif
 if is_msvc
       add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
+      add_project_arguments('-O2', language: ['c', 'cpp'])
 endif
 
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -76,6 +76,9 @@ lapack = dependency(lapack_name, required: false)
 # TODO: add ILP64 support
 have_blas = blas.found() # TODO: and blas.has_cblas()
 have_lapack = lapack.found()
+if have_blas
+  add_project_arguments('-DHAVE_CBLAS', language: ['c', 'cpp'])
+endif
 
 
 # TODO: generate __config__.py (see scipy/meson.build)

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -32,7 +32,7 @@ if is_windows
 endif
 if is_msvc
       add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
-      add_project_arguments('-O2', language: ['c', 'cpp'])
+      add_project_arguments('-Ox', language: ['c', 'cpp'])
 endif
 
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -320,10 +320,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.check_version != '':
         test_version(args.check_version)
-    elif args.test is None:
-        print(setup_openblas())
     elif args.write_init:
         make_init(args.write_init[0])
+    elif args.test is None:
+        print(setup_openblas())
     else:
         if len(args.test) == 0 or 'all' in args.test:
             test_setup(SUPPORTED_PLATFORMS)

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -213,6 +213,7 @@ def make_init(dirname):
             if os.name == 'nt':
                 # convention for storing / loading the DLL from
                 # numpy/.libs/, if present
+                DLL_filenames = []
                 try:
                     from ctypes import WinDLL
                     basedir = os.path.dirname(__file__)
@@ -220,7 +221,7 @@ def make_init(dirname):
                     pass
                 else:
                     libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
-                    DLL_filenames = []
+                    print(f"looking in {libs_dir} for dlls to preload")
                     if os.path.isdir(libs_dir):
                         for filename in glob.glob(os.path.join(libs_dir,
                                                                '*openblas*dll')):
@@ -233,6 +234,7 @@ def make_init(dirname):
                         warnings.warn("loaded more than 1 DLL from .libs:"
                                       "\\n%s" % "\\n".join(DLL_filenames),
                                       stacklevel=1)
+                print("loaded", DLL_filenames)
     """))
 
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -314,11 +314,16 @@ if __name__ == '__main__':
     parser.add_argument('--check_version', nargs='?', default='',
                         help='Check provided OpenBLAS version string '
                              'against available OpenBLAS')
+    parser.add_argument('--write-init', nargs=1,
+                        metavar='OUT_SCIPY_DIR',
+                        help='Write distribution init to named dir')
     args = parser.parse_args()
     if args.check_version != '':
         test_version(args.check_version)
     elif args.test is None:
         print(setup_openblas())
+    elif args.write_init:
+        make_init(args.write_init[0])
     else:
         if len(args.test) == 0 or 'all' in args.test:
             test_setup(SUPPORTED_PLATFORMS)


### PR DESCRIPTION
Using the scipy run as a template, add a windows meson CI run.

Replaces #23027

Does not use dev.py, that can be done in a subsequent PR.