### PR TITLE
DOC: Improved nbytes description

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2706,8 +2706,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('nbytes',
     See Also
     --------
     sys.getsizeof
-        Memory consumed by the object itself
-        without parents in case view.
+        Memory consumed by the object itself without parents in case view.
         This does include memory consumed by non-element attributes.
 
     Examples

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2702,6 +2702,13 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('nbytes',
     -----
     Does not include memory consumed by non-element attributes of the
     array object.
+    
+    See Also
+    --------
+    sys.getsizeof
+        Memory consumed by the object itself
+        without parents in case view.
+        This does include memory consumed by non-element attributes.
 
     Examples
     --------


### PR DESCRIPTION
closes #22925 
The doc description for `numpy,ndarray.nbytes` might be misleading.
Added `see also` section to `numpy,ndarray.nbytes`.
