### PR TITLE
ENH: Extend chebinterpolate to 2D and 3D

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1811,6 +1811,7 @@ def chebinterpolate(func, deg, args=()):
     Let us find the Chebyshev coefficients (up to 8 degrees) of 
     a function of one variable. This will return an (8+1,) array of
     Chebyshev coefficients.
+
     >>> import numpy.polynomial.chebyshev as cheb
     >>> cheb.chebinterpolate(lambda x: np.tanh(x) + 0.5, 8)
     array([ 5.00000000e-01,  8.11675684e-01, -1.23358114e-16, -5.42457905e-02,
@@ -1818,15 +1819,17 @@ def chebinterpolate(func, deg, args=()):
             -3.45402719e-16])
 
     Likewise, we can do this for a 2-D function with degrees (12, 20)
+
     >>> interp_f = lambda x: x[0] + np.cos(x[1])*np.tanh(x[0])
-    >>> coeffs = chebinterpolate(interp_f, (12, 20))
+    >>> coeffs = cheb.chebinterpolate(interp_f, (12, 20))
     
     We can evaluate the interpolating series on a grid with `chebval2d`.
+
     >>> X = np.linspace(-1, 1, 4)
     >>> Y = np.linspace(-1, 1, 4)
     >>> XY_grid = np.meshgrid(X, Y)
     >>> XY = np.vstack(list(map(np.ravel, XY_grid))).T
-    >>> interpolated_points = chebval2d(x=XY[:,0], y=XY[:,1], c=coeffs)
+    >>> interpolated_points = cheb.chebval2d(x=XY[:,0], y=XY[:,1], c=coeffs)
     >>> true_points = np.array([interp_f(xy) for xy in XY])
     >>> interpolated_points - true_points
     array([ 1.06470865e-07 -1.37010050e-07  1.37010049e-07 -1.06470864e-07
@@ -1836,31 +1839,34 @@ def chebinterpolate(func, deg, args=()):
 
     To interpolate beyond [-1,1] we can use
     `numpy.polynomial.polyutils.mapdomain`.
+
     >>> from numpy.polynomial import polyutils as pu
     >>> real_domain = (0, 2*np.pi)
     >>> cheb_domain = (-1, 1)
     >>> interp_f = lambda x: np.sin(x[0]) + x[0]*np.cos(x[2]) + np.sin(x[1])
     >>> f_mapped = lambda x: interp_f(pu.mapdomain(x, cheb_domain, real_domain))
-    >>> coeffs = chebinterpolate(f_mapped, (20, 20, 20))
+    >>> coeffs = cheb.chebinterpolate(f_mapped, (20, 20, 20))
     
-    Now let's test this on a 3D grid [0, 2*pi]x[0, 2*pi]x[0, 2*pi].
+    Now let's test this on a 3D grid [0, 2*pi]x[0, 2*pi]x[0, 2*pi] to see how well
+    our interpolation works.
+
     >>> X = np.linspace(0, 2*np.pi, 3)
     >>> Y = np.linspace(0, 2*np.pi, 3)
     >>> Z = np.linspace(0, 2*np.pi, 3)
     >>> XYZ_grid = np.meshgrid(X, Y, Z)
     >>> XYZ = np.vstack(list(map(np.ravel, XYZ_grid))).T
     >>> XYZ_cheb = pu.mapdomain(XYZ, real_domain, cheb_domain)
-    >>> interpolated_points = chebval3d(x=XYZ_cheb[:,0], y=XYZ_cheb[:,1], 
+    >>> interpolated_points = cheb.chebval3d(x=XYZ_cheb[:,0], y=XYZ_cheb[:,1], 
     ...                                 z=XYZ_cheb[:,2], c=coeffs)
     >>> true_points = np.array([interp_f(xyz) for xyz in XYZ])
     >>> interpolated_points - true_points
     >>> array([-2.46439697e-16 -1.00035424e-15  5.49706495e-16 -2.39808173e-14
-            1.24344979e-14 -2.13162821e-14 -6.39488462e-14  4.44089210e-14
-            -6.03961325e-14 -7.93826392e-15  1.80697225e-15 -6.27469763e-15
-            -2.53130850e-14  2.26485497e-14 -2.75335310e-14 -6.12843110e-14
-            4.52970994e-14 -5.59552404e-14 -2.89594369e-14  1.26623055e-14
-            -2.93184954e-14 -3.81916720e-14  2.30926389e-14 -3.59712260e-14
-            -8.43769499e-14  6.21724894e-14 -7.99360578e-14])
+                1.24344979e-14 -2.13162821e-14 -6.39488462e-14  4.44089210e-14
+                -6.03961325e-14 -7.93826392e-15  1.80697225e-15 -6.27469763e-15
+                -2.53130850e-14  2.26485497e-14 -2.75335310e-14 -6.12843110e-14
+                4.52970994e-14 -5.59552404e-14 -2.89594369e-14  1.26623055e-14
+                -2.93184954e-14 -3.81916720e-14  2.30926389e-14 -3.59712260e-14
+                -8.43769499e-14  6.21724894e-14 -7.99360578e-14])
 
     Notes
     -----
@@ -1898,7 +1904,7 @@ def chebinterpolate(func, deg, args=()):
 
     if deg.size==1:
         chebnodes = chebpts1(order[0])
-        yfunc = np.asarray(list(map(lambda x: func([x], *args), chebnodes)))
+        yfunc = np.asarray(list(map(lambda x: func(np.asarray([x]), *args), chebnodes)))
         m = chebvander(chebnodes, deg[0])
         c = np.dot(m.T, yfunc).reshape(order)
         c[0] /= order

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1887,71 +1887,84 @@ def chebinterpolate(func, deg, args=()):
     Chebyshev coefficients can be evaluated using 
     `chebval` or `chebval2d` or `chebval3d`.
     """
+
     deg = np.asarray(deg)
 
     # check arguments:
-    if (deg.ndim > 1 or deg.dtype.kind not in 'iu' or deg.size == 0 or
-        deg.size > 3):
+
+    if deg.ndim > 1 or deg.dtype.kind not in "iu" or deg.size == 0 \
+        or deg.size > 3:
         raise TypeError("deg must be an int or 1-D array of ints")
     if np.any(deg) < 0:
         raise ValueError("all values of deg must be >= 0")
 
     # if deg is a scalar, convert it to a 1-D array
+
     if deg.ndim == 0:
         deg = np.asarray([deg])
 
     order = deg + 1
 
-    if deg.size==1:
+    if deg.size == 1:
         chebnodes = chebpts1(order[0])
-        yfunc = np.asarray(list(map(lambda x: func(np.asarray([x]), *args), chebnodes)))
+        yfunc = np.asarray(list(map(lambda x: func(np.asarray([x]),
+                           *args), chebnodes)))
         m = chebvander(chebnodes, deg[0])
         c = np.dot(m.T, yfunc).reshape(order)
         c[0] /= order
-        c[1:] /= 0.5*order
-
+        c[1:] /= 0.5 * order
     elif deg.size == 2:
+
         # create chebyshev nodes in 2d by making a grid out of the 1d nodes
         # chebnodes is an array of shape (order[0]*order[1], 2)
+
         chebnodes_x = chebpts1(order[0])
         chebnodes_y = chebpts1(order[1])
         g = np.meshgrid(chebnodes_x, chebnodes_y)
         chebnodes = np.vstack(list(map(np.ravel, g))).T
 
-        # evaluate the function at the chebyshev nodes and 
+        # evaluate the function at the chebyshev nodes and
         # calculate vandermonde matrix
-        func_val = np.asarray(list(map(lambda x: func(x, *args), chebnodes)))
-        m = chebvander2d(chebnodes[:,0], chebnodes[:,1], deg)
+
+        func_val = np.asarray(list(map(lambda x: func(x, *args),
+                              chebnodes)))
+        m = chebvander2d(chebnodes[:, 0], chebnodes[:, 1], deg)
 
         # calculate the coefficients and apply normalization
+
         c = np.dot(m.T, func_val).reshape(order)
-        c[0,:] /= order[0]
-        c[:,0] /= order[1]
-        c[1:,:] /= 0.5*order[0]
-        c[:,1:] /= 0.5*order[1]
-    
+        c[0, :] /= order[0]
+        c[:, 0] /= order[1]
+        c[1:, :] /= 0.5 * order[0]
+        c[:, 1:] /= 0.5 * order[1]
     elif deg.size == 3:
+
         # create chebyshev nodes in 3d by making a grid out of the 1d nodes
         # chebnodes is an array of shape (order[0]*order[1]*order[2], 3)
+
         chebnodes_x = chebpts1(order[0])
         chebnodes_y = chebpts1(order[1])
         chebnodes_z = chebpts1(order[2])
         g = np.meshgrid(chebnodes_x, chebnodes_y, chebnodes_z)
         chebnodes = np.vstack(list(map(np.ravel, g))).T
 
-        # evaluate the function at the chebyshev nodes and 
+        # evaluate the function at the chebyshev nodes and
         # calculate vandermonde matrix
-        func_val = np.asarray(list(map(lambda x: func(x, *args), chebnodes)))
-        m = chebvander3d(chebnodes[:,0], chebnodes[:,1], chebnodes[:,2], deg)
+
+        func_val = np.asarray(list(map(lambda x: func(x, *args),
+                              chebnodes)))
+        m = chebvander3d(chebnodes[:, 0], chebnodes[:, 1], chebnodes[:,
+                         2], deg)
 
         # calculate the coefficients and apply normalization
+
         c = np.dot(m.T, func_val).reshape(order)
-        c[0,:,:] /= order[0]
-        c[:,0,:] /= order[1]
-        c[:,:,0] /= order[2]
-        c[1:,:,:] /= 0.5*order[0]
-        c[:,1:,:] /= 0.5*order[1]
-        c[:,:,1:] /= 0.5*order[2]
+        c[0, :, :] /= order[0]
+        c[:, 0, :] /= order[1]
+        c[:, :, 0] /= order[2]
+        c[1:, :, :] /= 0.5 * order[0]
+        c[:, 1:, :] /= 0.5 * order[1]
+        c[:, :, 1:] /= 0.5 * order[2]
 
     return c
     

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1844,11 +1844,11 @@ def chebinterpolate(func, deg, args=()):
     >>> real_domain = (0, 2*np.pi)
     >>> cheb_domain = (-1, 1)
     >>> interp_f = lambda x: np.sin(x[0]) + x[0]*np.cos(x[2]) + np.sin(x[1])
-    >>> f_mapped = lambda x: interp_f(pu.mapdomain(x, cheb_domain, real_domain))
+    >>> f_mapped = lambda x: interp_f(pu.mapdomain(x,cheb_domain,real_domain))
     >>> coeffs = cheb.chebinterpolate(f_mapped, (20, 20, 20))
     
-    Now let's test this on a 3D grid [0, 2*pi]x[0, 2*pi]x[0, 2*pi] to see how well
-    our interpolation works.
+    Now let's test this on a 3D grid [0, 2*pi]x[0, 2*pi]x[0, 2*pi] to see 
+    how well our interpolation works.
 
     >>> X = np.linspace(0, 2*np.pi, 3)
     >>> Y = np.linspace(0, 2*np.pi, 3)
@@ -1881,8 +1881,9 @@ def chebinterpolate(func, deg, args=()):
 
     The Chebyshev polynomials are only defined on the range [-1, 1] so the
     provided function will only be interpolated on this domain. To interpolate
-    on a different domain, the function should be rescaled to the range [-1, 1].
-    This can be done for example, via `numpy.polynomial.polyutils.mapdomain`.
+    on a different domain, the function should be rescaled 
+    to the range [-1, 1]. This can be done for example, 
+    via `numpy.polynomial.polyutils.mapdomain`.
 
     Chebyshev coefficients can be evaluated using 
     `chebval` or `chebval2d` or `chebval3d`.

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -486,87 +486,105 @@ class TestInterpolate:
 
     def f(self, x):
         return x * (x - 1) * (x - 2)
-    
+
     def f2d(self, x):
-        return x[0] * (x[1]*x[0] - 1)
+        return x[0] * (x[1] * x[0] - 1)
 
     def f3d(self, x):
-        return x[0] * (x[1]*x[0] - 1) * (x[2]*x[0] - 1)
+        return x[0] * (x[1] * x[0] - 1) * (x[2] * x[0] - 1)
 
     def test_raises(self):
         assert_raises(ValueError, cheb.chebinterpolate, self.f, -1)
-        assert_raises(ValueError, cheb.chebinterpolate, self.f2d, [-1, 2])
-        assert_raises(ValueError, cheb.chebinterpolate, self.f3d, [-1, 2, -3])
-        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [[2,2,3]])
+        assert_raises(ValueError, cheb.chebinterpolate, self.f2d, [-1,
+                      2])
+        assert_raises(ValueError, cheb.chebinterpolate, self.f3d, [-1,
+                      2, -3])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [[2,
+                      2, 3]])
         assert_raises(TypeError, cheb.chebinterpolate, self.f, [])
-        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [5,5,5,5])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [5, 5,
+                      5, 5])
         assert_raises(TypeError, cheb.chebinterpolate, self.f, 10.)
-        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [10., 5])
-        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [2., 3, 3])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [10.,
+                      5])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [2.,
+                      3, 3])
 
     def test_dimensions(self):
         for deg in range(1, 5):
-            assert_(cheb.chebinterpolate(self.f, deg).shape == (deg + 1,))
-        
-        for deg1 in range(1, 5):
-            for deg2 in range(1,5):
-                deg = np.asarray((deg1, deg2))
-                assert_(cheb.chebinterpolate(self.f2d, deg).shape == 
-                        (deg1+1, deg2+1,))
-        
-        for deg1 in range(1, 5):
-            for deg2 in range(1,5):
-                for deg3 in range(1,5):
-                    deg = np.asarray((deg1, deg2, deg3))
-                    assert_(
-                        cheb.chebinterpolate(self.f3d, deg).shape == 
-                        (deg1+1, deg2+1, deg3+1,))
+            assert_(cheb.chebinterpolate(self.f, deg).shape == (deg
+                    + 1, ))
 
+        for deg1 in range(1, 5):
+            for deg2 in range(1, 5):
+                deg = np.asarray((deg1, deg2))
+                assert_(cheb.chebinterpolate(self.f2d, deg).shape
+                        == (deg1 + 1, deg2 + 1))
+
+        for deg1 in range(1, 5):
+            for deg2 in range(1, 5):
+                for deg3 in range(1, 5):
+                    deg = np.asarray((deg1, deg2, deg3))
+                    assert_(cheb.chebinterpolate(self.f3d, deg).shape
+                            == (deg1 + 1, deg2 + 1, deg3 + 1))
 
     def test_approximation(self):
 
         # 1d test
+
         def powx(x, p):
-            return x**p
+            return x ** p
 
         x = np.linspace(-1, 1, 10)
         for deg in range(0, 10):
             for p in range(0, deg + 1):
-                c = cheb.chebinterpolate(powx, deg, (p,))
-                assert_almost_equal(cheb.chebval(x, c), powx(x, p), decimal=12)
+                c = cheb.chebinterpolate(powx, deg, (p, ))
+                assert_almost_equal(cheb.chebval(x, c), powx(x, p),
+                                    decimal=12)
 
         # 2d test
+
         def powx2d(x, p):
-            return (x[0]**p) * (x[1]**p)
+            return x[0] ** p * x[1] ** p
 
         x = np.linspace(-1, 1, 100)
         for deg in range(0, 10):
             for p in range(0, deg + 1):
-                c = cheb.chebinterpolate(powx2d, deg=[deg, deg], args=(p,))
-                interp = [cheb.chebval2d(x, y, c) for x, y in zip(x, x)]
-                true = [powx2d((x, y), p) for x, y in zip(x, x)]
+                c = cheb.chebinterpolate(powx2d, deg=[deg, deg],
+                        args=(p, ))
+                interp = [cheb.chebval2d(x, y, c) for (x, y) in zip(x,
+                          x)]
+                true = [powx2d((x, y), p) for (x, y) in zip(x, x)]
                 assert_almost_equal(interp, true, decimal=12)
 
         # 3d test
+
         def powx3d(x, p):
-            return (x[0]**p) * (x[1]**p) * (x[2]**p)
+            return x[0] ** p * x[1] ** p * x[2] ** p
 
         x = np.linspace(-1, 1, 100)
         for deg in range(0, 10):
             for p in range(0, deg + 1):
-                c = cheb.chebinterpolate(powx3d, deg=[deg, deg, deg], args=(p,))
-                interp = [cheb.chebval3d(x, y, z, c) for x, y, z in zip(x, x, x)]
-                true = [powx3d((x, y, z), p) for x, y, z in zip(x, x, x)]
+                c = cheb.chebinterpolate(powx3d, deg=[deg, deg, deg],
+                        args=(p, ))
+                interp = [cheb.chebval3d(x, y, z, c) for (x, y, z) in
+                          zip(x, x, x)]
+                true = [powx3d((x, y, z), p) for (x, y, z) in zip(x, x,
+                        x)]
                 assert_almost_equal(interp, true, decimal=12)
-        
+
         # a pretty difficult interpolation
+
         def challenging_3d(x):
-            return np.tan(x[0]) + x[0]*np.cos(x[2]) + np.sin(x[1])*np.tanh(x[0])
+            return np.tan(x[0]) + x[0] * np.cos(x[2]) + np.sin(x[1]) \
+                * np.tanh(x[0])
 
         x = np.linspace(-1, 1, 100)
         c = cheb.chebinterpolate(challenging_3d, deg=[30, 20, 20])
-        interp = np.asarray([cheb.chebval3d(x, y, z, c) for x, y, z in zip(x, x, x)])
-        true = np.asarray([challenging_3d([x, y, z]) for x, y, z in zip(x, x, x)])
+        interp = np.asarray([cheb.chebval3d(x, y, z, c) for (x, y,
+                            z) in zip(x, x, x)])
+        true = np.asarray([challenging_3d([x, y, z]) for (x, y, z) in
+                          zip(x, x, x)])
         assert_almost_equal(interp, true, decimal=12)
 
 

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -486,17 +486,46 @@ class TestInterpolate:
 
     def f(self, x):
         return x * (x - 1) * (x - 2)
+    
+    def f2d(self, x):
+        return x[0] * (x[1]*x[0] - 1)
+
+    def f3d(self, x):
+        return x[0] * (x[1]*x[0] - 1) * (x[2]*x[0] - 1)
 
     def test_raises(self):
         assert_raises(ValueError, cheb.chebinterpolate, self.f, -1)
+        assert_raises(ValueError, cheb.chebinterpolate, self.f2d, [-1, 2])
+        assert_raises(ValueError, cheb.chebinterpolate, self.f3d, [-1, 2, -3])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [[2,2,3]])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f, [])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [5,5,5,5])
         assert_raises(TypeError, cheb.chebinterpolate, self.f, 10.)
+        assert_raises(TypeError, cheb.chebinterpolate, self.f2d, [10., 5])
+        assert_raises(TypeError, cheb.chebinterpolate, self.f3d, [2., 3, 3])
 
     def test_dimensions(self):
         for deg in range(1, 5):
             assert_(cheb.chebinterpolate(self.f, deg).shape == (deg + 1,))
+        
+        for deg1 in range(1, 5):
+            for deg2 in range(1,5):
+                deg = np.asarray((deg1, deg2))
+                assert_(cheb.chebinterpolate(self.f2d, deg).shape == 
+                        (deg1+1, deg2+1,))
+        
+        for deg1 in range(1, 5):
+            for deg2 in range(1,5):
+                for deg3 in range(1,5):
+                    deg = np.asarray((deg1, deg2, deg3))
+                    assert_(
+                        cheb.chebinterpolate(self.f3d, deg).shape == 
+                        (deg1+1, deg2+1, deg3+1,))
+
 
     def test_approximation(self):
 
+        # 1d test
         def powx(x, p):
             return x**p
 
@@ -505,6 +534,40 @@ class TestInterpolate:
             for p in range(0, deg + 1):
                 c = cheb.chebinterpolate(powx, deg, (p,))
                 assert_almost_equal(cheb.chebval(x, c), powx(x, p), decimal=12)
+
+        # 2d test
+        def powx2d(x, p):
+            return (x[0]**p) * (x[1]**p)
+
+        x = np.linspace(-1, 1, 100)
+        for deg in range(0, 10):
+            for p in range(0, deg + 1):
+                c = cheb.chebinterpolate(powx2d, deg=[deg, deg], args=(p,))
+                interp = [cheb.chebval2d(x, y, c) for x, y in zip(x, x)]
+                true = [powx2d((x, y), p) for x, y in zip(x, x)]
+                assert_almost_equal(interp, true, decimal=12)
+
+        # 3d test
+        def powx3d(x, p):
+            return (x[0]**p) * (x[1]**p) * (x[2]**p)
+
+        x = np.linspace(-1, 1, 100)
+        for deg in range(0, 10):
+            for p in range(0, deg + 1):
+                c = cheb.chebinterpolate(powx3d, deg=[deg, deg, deg], args=(p,))
+                interp = [cheb.chebval3d(x, y, z, c) for x, y, z in zip(x, x, x)]
+                true = [powx3d((x, y, z), p) for x, y, z in zip(x, x, x)]
+                assert_almost_equal(interp, true, decimal=12)
+        
+        # a pretty difficult interpolation
+        def challenging_3d(x):
+            return np.tan(x[0]) + x[0]*np.cos(x[2]) + np.sin(x[1])*np.tanh(x[0])
+
+        x = np.linspace(-1, 1, 100)
+        c = cheb.chebinterpolate(challenging_3d, deg=[30, 20, 20])
+        interp = np.asarray([cheb.chebval3d(x, y, z, c) for x, y, z in zip(x, x, x)])
+        true = np.asarray([challenging_3d([x, y, z]) for x, y, z in zip(x, x, x)])
+        assert_almost_equal(interp, true, decimal=12)
 
 
 class TestCompanion:


### PR DESCRIPTION
Extended `polynomial.chebyshev.chebinterpolate` to be able to interpolate in two and three dimensions. Also expanded the documentation in more details.

(This is my first pull request, please let me know how I can improve!)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
