### PR TITLE
MAINT: Move unused import into hook for pyinstaller

### DIFF
--- a/numpy/_pyinstaller/hook-numpy.py
+++ b/numpy/_pyinstaller/hook-numpy.py
@@ -20,9 +20,9 @@ if is_pure_conda:
     from PyInstaller.utils.hooks import conda_support
     datas = conda_support.collect_dynamic_libs("numpy", dependencies=True)
 
-# Submodules PyInstaller cannot detect (probably because they are only imported
-# by extension modules, which PyInstaller cannot read).
-hiddenimports = ['numpy.core._dtype_ctypes']
+# Submodules PyInstaller cannot detect.  `_dtype_ctypes` is only imported
+# from C and `_multiarray_tests` is used in tests (which are not packed).
+hiddenimports = ['numpy.core._dtype_ctypes', 'numpy.core._multiarray_tests']
 
 # Remove testing and building code and packages that are referenced throughout
 # NumPy but are not really dependencies.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -11,7 +11,7 @@ NOTE: Many of the methods of ndarray have corresponding functions.
 
 from numpy.core.function_base import add_newdoc
 from numpy.core.overrides import array_function_like_doc
-import numpy.core._multiarray_tests
+
 
 ###############################################################################
 #


### PR DESCRIPTION
pyinstaller should pack it to allow running the tests, but doesn't pack the tests themselves and thus doesn't find the `import` statements that use `numpy.core._multiarray_tests`.

This makes sure that pyinstaller will ship `numpy.core._multiarray_tests` in any case.
