### PR TITLE
DOC: Fixup docs after the code removal

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,7 +163,6 @@ def setup(app):
 # If we deemed it desirable, we could in future make these real modules, which
 # would make `from numpy.char import split` work.
 sys.modules['numpy.char'] = numpy.char
-sys.modules['numpy.testing.dec'] = numpy.testing.dec
 
 # -----------------------------------------------------------------------------
 # HTML output

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -51,11 +51,6 @@ Decorators
 .. autosummary::
    :toctree: generated/
 
-   dec.deprecated
-   dec.knownfailureif
-   dec.setastest
-   dec.skipif
-   dec.slow
    decorate_methods
 
 Test Running
@@ -63,10 +58,8 @@ Test Running
 .. autosummary::
    :toctree: generated/
 
-   Tester
    clear_and_catch_warnings
    measure
-   run_module_suite
    rundocs
    suppress_warnings
 


### PR DESCRIPTION
CircleCI is currently not set up to fail when docs fail, so this slipped through the cracks.
It may be that the testing docs should get a bit more changes then just removing these things.