### PR TITLE
DOC: fail the CI build and do not deploy if docs are not created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,10 @@ jobs:
             cd doc
             # Don't use -q, show warning summary"
             SPHINXOPTS="-j2 -n" make -e html || echo "ignoring errors for now, see gh-13114"
+            if [[ $(find build/html -type f | wc -l) -lt 1000 ]]; then
+                echo "doc build failed: build/html is empty"
+                exit -1
+            fi
 
       - run:
           name: build neps
@@ -128,11 +132,12 @@ jobs:
             touch doc/build/html/.nojekyll
 
             ./tools/ci/push_docs_to_repo.py doc/build/html \
-                git@github.com:numpy/devdocs.git \
                 --committer "numpy-circleci-bot" \
                 --email "numpy-circleci-bot@nomail" \
                 --message "Docs build of $CIRCLE_SHA1" \
-                --force
+                --count 5 \
+                --force \
+                git@github.com:numpy/devdocs.git
 
       - add_ssh_keys:
           fingerprints:
@@ -153,11 +158,12 @@ jobs:
             touch doc/neps/_build/html/.nojekyll
 
             ./tools/ci/push_docs_to_repo.py doc/neps/_build/html \
-                git@github.com:numpy/neps.git \
                 --committer "numpy-circleci-bot" \
                 --email "numpy-circleci-bot@nomail" \
                 --message "Docs build of $CIRCLE_SHA1" \
-                --force
+                --count 5 \
+                --force \
+                git@github.com:numpy/neps.git \
 
 workflows:
   version: 2

--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -19,6 +19,8 @@ parser.add_argument('--committer', default='numpy-commit-bot',
                     help='Name of the git committer')
 parser.add_argument('--email', default='numpy-commit-bot@nomail',
                     help='Email of the git committer')
+parser.add_argument('--count', default=1, type=int,
+                    help="minimum number of expected files, defaults to 1")
 
 parser.add_argument(
     '--force', action='store_true',
@@ -31,6 +33,11 @@ if not os.path.exists(args.dir):
     print('Content directory does not exist')
     sys.exit(1)
 
+count = len([name for name in os.listdir(args.dir) if os.path.isfile(os.path.join(args.dir, name))])
+
+if count < args.count:
+    print(f"Expected {args.count} top-directory files to upload, got {count}")
+    sys.exit(1)
 
 def run(cmd, stdout=True):
     pipe = None if stdout else subprocess.DEVNULL


### PR DESCRIPTION
Fixes #23063 by
- checking that the sphinx build actually output some files
- refuse to deploy if a minimum count of files is not found