### PR TITLE
BUG: fix broken numpy.distutils Fortran handling

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -67,7 +67,7 @@ jobs:
           dash "tools/rebase_installed_dlls_cygwin.sh" 3.9
       - name: Run NumPy test suite
         run: >-
-          dash -c "/usr/bin/python3.9 runtests.py -n -vv"
+          dash -c "/usr/bin/python3.9 runtests.py -n"
       - name: Upload wheel if tests fail
         uses: actions/upload-artifact@v3
         if: failure()

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -5,6 +5,7 @@ import shlex
 import time
 import subprocess
 from copy import copy
+from pathlib import Path
 from distutils import ccompiler
 from distutils.ccompiler import (
     compiler_class, gen_lib_options, get_default_compiler, new_compiler,
@@ -279,7 +280,8 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
 
     if not sources:
         return []
-    from numpy.distutils.fcompiler import (FCompiler, is_f_file,
+    from numpy.distutils.fcompiler import (FCompiler,
+                                           FORTRAN_COMMON_FIXED_EXTENSIONS,
                                            has_f90_header)
     if isinstance(self, FCompiler):
         display = []
@@ -338,7 +340,7 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
                 if self.compiler_type=='absoft':
                     obj = cyg2win32(obj)
                     src = cyg2win32(src)
-                if Path(src).suffix.lower() in COMMON_FIXED_EXTENSIONS \
+                if Path(src).suffix.lower() in FORTRAN_COMMON_FIXED_EXTENSIONS \
                    and not has_f90_header(src):
                     f77_objects.append((obj, (src, ext)))
                 else:

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -19,6 +19,7 @@ __all__ = ['FCompiler', 'new_fcompiler', 'show_fcompilers',
 import os
 import sys
 import re
+from pathlib import Path
 
 from distutils.sysconfig import get_python_lib
 from distutils.fancy_getopt import FancyGetopt
@@ -36,6 +37,10 @@ from numpy.distutils import _shell_utils
 from .environment import EnvironmentConfig
 
 __metaclass__ = type
+
+
+FORTRAN_COMMON_FIXED_EXTENSIONS = ['.for', '.ftn', '.f77', '.f']
+
 
 class CompilerNotFound(Exception):
     pass
@@ -571,7 +576,7 @@ class FCompiler(CCompiler):
     def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
         """Compile 'src' to product 'obj'."""
         src_flags = {}
-        if Path(src).suffix.lower() in COMMON_FIXED_EXTENSIONS \
+        if Path(src).suffix.lower() in FORTRAN_COMMON_FIXED_EXTENSIONS \
            and not has_f90_header(src):
             flavor = ':f77'
             compiler = self.compiler_f77
@@ -971,7 +976,6 @@ def dummy_fortran_file():
     return name[:-2]
 
 
-is_f_file = re.compile(r'.*\.(for|ftn|f77|f)\Z', re.I).match
 _has_f_header = re.compile(r'-\*-\s*fortran\s*-\*-', re.I).search
 _has_f90_header = re.compile(r'-\*-\s*f90\s*-\*-', re.I).search
 _has_fix_header = re.compile(r'-\*-\s*fix\s*-\*-', re.I).search


### PR DESCRIPTION
The `Path` and `COMMON_FIXED_EXTENSIONS` variables were not defined at all. This code is untested, and SciPy doesn't build with NumPy `main` before this fix. The issue was introduced a few days ago in gh-22885.