### PR TITLE
DEV: Fix shell configuration in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,3 @@
-// For format details, see https://aka.ms/devcontainer.json
 {
 	// Conda requires lots of memory to resolve our environment
 	"hostRequirements": {
@@ -9,7 +8,9 @@
 	"image": "mcr.microsoft.com/devcontainers/universal:2",
 	"features": {},
 
-	"postCreateCommand": "./.devcontainer/setup.sh",
+	"onCreateCommand": ".devcontainer/setup.sh",
+	"postCreateCommand": "",
+
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-conda env create -f environment.yml
 conda init --all
+conda env create -f environment.yml
 
 git submodule update --init


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR moves our repo setup to `onCreateCommand` from `postCreateCommand` in order to resolve a race condition between `conda init` and the default shell in VS Code. You can test this new `devcontainer.json` by creating a codespace for my fork/branch: https://github.com/codespaces/new?hide_repo_select=true&ref=jungaretti%2Fupdate-devcontainer&repo=576410652

`postCreateCommand` doesn't block interaction with your codespace. You can use other terminals and move around editors while it runs. On the other hand, `onCreateCommand` runs before you interact with your codespace. You won't be able to open a terminal until it finishes. `onCreateCommand` is a better choice for running our setup script because we need to run `conda init` before using the terminal.

<img width="1512" alt="Setting up your codespace" src="https://user-images.githubusercontent.com/19893438/214150074-eb37226d-48aa-4eba-bf90-677e3dd1c42e.png">