### PR TITLE
BUG: Fix for npyv__trunc_s32_f32 (VXE)

### DIFF
--- a/numpy/core/src/common/simd/vec/conversion.h
+++ b/numpy/core/src/common/simd/vec/conversion.h
@@ -170,7 +170,8 @@ npyv_pack_b8_b64(npyv_b64 a, npyv_b64 b, npyv_b64 c, npyv_b64 d,
     #ifdef NPY_HAVE_VXE2
         return vec_signed(a);
     #elif defined(NPY_HAVE_VXE)
-        return vec_packs(vec_signed(npyv_doublee(a)), vec_signed(npyv_doublee(vec_mergel(a, a))));
+        return vec_packs(vec_signed(__builtin_s390_vflls(vec_mergeh(a,a))),
+            vec_signed(__builtin_s390_vflls(vec_mergel(a, a))));
     // VSX
     #elif defined(__IBMC__)
         return vec_cts(a, 0);

--- a/numpy/core/src/common/simd/vec/conversion.h
+++ b/numpy/core/src/common/simd/vec/conversion.h
@@ -170,8 +170,8 @@ npyv_pack_b8_b64(npyv_b64 a, npyv_b64 b, npyv_b64 c, npyv_b64 d,
     #ifdef NPY_HAVE_VXE2
         return vec_signed(a);
     #elif defined(NPY_HAVE_VXE)
-        return vec_packs(vec_signed(__builtin_s390_vflls(vec_mergeh(a,a))),
-            vec_signed(__builtin_s390_vflls(vec_mergel(a, a))));
+        return vec_packs(vec_signed(npyv_doublee(vec_mergeh(a,a))),
+            vec_signed(npyv_doublee(vec_mergel(a, a))));
     // VSX
     #elif defined(__IBMC__)
         return vec_cts(a, 0);


### PR DESCRIPTION
np.sin(), np.cos() are giving erroneous result for float32 (VXE). 
This PR is fixing ` npyv__trunc_s32_f32(npyv_f32 a)` to resolve the issue.

np.sin() reproduce (without fix)
```python
>>> c = np.array( [-25.091976, 90.14286], dtype=np.float32)
>>> np.sin(c)
array([0.04075377, 0.5707917 ], dtype=float32)
>>> 

>>> c = np.array( [90.14286], dtype=np.float32)
>>> np.sin(c)
array([0.8210949], dtype=float32)
>>>

>>> c = np.array( [-25.091976,  90.14286,   46.39879], dtype=np.float32)
>>> np.sin(c)
array([ 0.04075377, -0.5707917 ,  0.6632113 ], dtype=float32)  
```
After the fix: 

```python

>>> import numpy as np
>>> c = np.array( [-25.091976, 90.14286], dtype=np.float32)
>>> np.sin(c)
array([0.04075377, 0.8210949 ], dtype=float32)

>>> c = np.array( [90.14286], dtype=np.float32)
>>> np.sin(c)
array([0.8210949], dtype=float32)

>>> c = np.array( [-25.091976,  90.14286,   46.39879], dtype=np.float32)
>>> np.sin(c)
array([0.04075377, 0.8210949 , 0.6632113 ], dtype=float32)
>>>
```
Test failure without fix - 
```python
FAILED ../../core/tests/test_umath.py::TestAVXFloat32Transcendental::test_sincos_float32 - AssertionError: Arrays are not almost equal up to 2 ULP (max difference is 2.13071e+09 ULP)
FAILED ../../core/tests/test_umath.py::TestAVXFloat32Transcendental::test_strided_float32 - AssertionError: X and Y are not equal to 2 ULP (max is 6.79208e+06)
FAILED ../../core/tests/test_umath_accuracy.py::TestAccuracy::test_validate_fp16_transcendentals[cos] - AssertionError: Arrays are not almost equal up to 1 ULP (max difference is 30720 ULP)
FAILED ../../core/tests/test_umath_accuracy.py::TestAccuracy::test_validate_fp16_transcendentals[sin] - AssertionE
```

 cc @Andreas-Krebbel @potula-chandra @andrewsi-z 