### PR TITLE
DOC, ENH: Improve docstring of real_if_close

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -2,7 +2,6 @@
 
 """
 import functools
-import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'isreal', 'nan_to_num', 'real', 'real_if_close',
@@ -12,7 +11,7 @@ __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
 from .._utils import set_module
 import numpy.core.numeric as _nx
 from numpy.core.numeric import asarray, asanyarray, isnan, zeros
-from numpy.core import overrides
+from numpy.core import overrides, getlimits
 from .ufunclike import isneginf, isposinf
 
 
@@ -541,7 +540,8 @@ def real_if_close(a, tol=100):
         Input array.
     tol : float
         Tolerance in machine epsilons for the complex part of the elements
-        in the array.
+        in the array. If the tolerance is <=1, then the absolute tolerance
+        is used.
 
     Returns
     -------
@@ -574,8 +574,7 @@ def real_if_close(a, tol=100):
     a = asanyarray(a)
     if not issubclass(a.dtype.type, _nx.complexfloating):
         return a
-    if tol > 1:
-        from numpy.core import getlimits
+    if tol > 1:        
         f = getlimits.finfo(a.dtype.type)
         tol = f.eps * tol
     if _nx.all(_nx.absolute(a.imag) < tol):

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -572,10 +572,11 @@ def real_if_close(a, tol=100):
 
     """
     a = asanyarray(a)
-    if not issubclass(a.dtype.type, _nx.complexfloating):
+    type_ = a.dtype.type
+    if not issubclass(type_, _nx.complexfloating):
         return a
-    if tol > 1:        
-        f = getlimits.finfo(a.dtype.type)
+    if tol > 1:
+        f = getlimits.finfo(type_)
         tol = f.eps * tol
     if _nx.all(_nx.absolute(a.imag) < tol):
         a = a.real


### PR DESCRIPTION
* The docstring of `real_if_close`  did not mention that if `tol<=1`  the tolerance does not specify the number of epsilons, but the absolute tolerance.
* Improve overhead for the common case by factoring out the `dtype`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
