### PR TITLE
WIP: NEP 50 related cleanups to tests and codes

### DIFF
--- a/numpy/core/src/multiarray/abstractdtypes.h
+++ b/numpy/core/src/multiarray/abstractdtypes.h
@@ -58,7 +58,8 @@ npy_mark_tmp_array_if_pyscalar(
         }
         return 1;
     }
-    else if (PyComplex_Check(obj) && PyArray_TYPE(arr) == NPY_CDOUBLE) {
+    else if (PyComplex_Check(obj) && !PyArray_IsScalar(obj, CDouble)
+             && PyArray_TYPE(arr) == NPY_CDOUBLE) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_COMPLEX;
         if (dtype != NULL) {
             Py_INCREF(&PyArray_PyComplexAbstractDType);

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -2342,10 +2342,12 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
         }
 
         mps[i] = (PyArrayObject *)PyArray_FROM_O(tmp);
-        Py_DECREF(tmp);
         if (mps[i] == NULL) {
+            Py_DECREF(tmp);
             goto fail;
         }
+        npy_mark_tmp_array_if_pyscalar(tmp, mps[i], NULL);
+        Py_DECREF(tmp);
     }
 
     common_descr = PyArray_ResultType(n, mps, 0, NULL);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -712,6 +712,7 @@ PyArray_ConcatenateInto(PyObject *op,
             narrays = iarrays;
             goto fail;
         }
+        npy_mark_tmp_array_if_pyscalar(item, arrays[iarrays], NULL);
     }
 
     if (axis >= NPY_MAXDIMS) {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1423,6 +1423,8 @@ class TestPromotion:
         expected_dtype = np.result_type(np.array(val).dtype, np.array(0).dtype)
         assert np.result_type(val, 0) == expected_dtype
         # For completeness sake, also check with a NumPy scalar as second arg:
+        if np._get_promotion_state() == "legacy":
+            expected_dtype = np.int8  # the int8 will win out, no matter what
         assert np.result_type(val, np.int8(0)) == expected_dtype
 
     @pytest.mark.parametrize(["other", "expected"],

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4975,8 +4975,13 @@ class TestClip:
 
             self._clip_type(
                 'uint', 1024, 0, 0, inplace=inplace)
-            self._clip_type(
-                'uint', 1024, -120, 100, inplace=inplace, expected_min=0)
+            if np._get_promotion_state() == "weak":
+                with pytest.raises(OverFlowError, match="Python integer -120"):
+                    self._clip_type(
+                        'uint', 1024, -120, 100, inplace=inplace)
+            else:
+                self._clip_type(
+                    'uint', 1024, -120, 100, inplace=inplace, expected_min=0)
 
     def test_record_array(self):
         rec = np.array([(-5, 2.0, 3.0), (5.0, 4.0, 3.0)],
@@ -7315,6 +7320,8 @@ class TestChoose:
          (1., np.float32(3)),
          (1., np.array([3], dtype=np.float32))],)
     def test_output_dtype(self, ops):
+        # TODO: Test changes with weak promotion, as it seems to call asarray()
+        #       on the integer argument (thus "upcasting").
         expected_dt = np.result_type(*ops)
         assert(np.choose([0], ops).dtype == expected_dt)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3063,9 +3063,9 @@ def bartlett(M):
 
     """
     if M < 1:
-        return array([], dtype=np.result_type(M, 0.0))
+        return array([], dtype=np.result_type(M, np.float64))
     if M == 1:
-        return ones(1, dtype=np.result_type(M, 0.0))
+        return ones(1, dtype=np.result_type(M, np.float64))
     n = arange(1-M, M, 2)
     return where(less_equal(n, 0), 1 + n/(M-1), 1 - n/(M-1))
 
@@ -3167,9 +3167,9 @@ def hanning(M):
 
     """
     if M < 1:
-        return array([], dtype=np.result_type(M, 0.0))
+        return array([], dtype=np.result_type(M, np.float64))
     if M == 1:
-        return ones(1, dtype=np.result_type(M, 0.0))
+        return ones(1, dtype=np.result_type(M, np.float64))
     n = arange(1-M, M, 2)
     return 0.5 + 0.5*cos(pi*n/(M-1))
 
@@ -3267,9 +3267,9 @@ def hamming(M):
 
     """
     if M < 1:
-        return array([], dtype=np.result_type(M, 0.0))
+        return array([], dtype=np.result_type(M, np.float64))
     if M == 1:
-        return ones(1, dtype=np.result_type(M, 0.0))
+        return ones(1, dtype=np.result_type(M, np.float64))
     n = arange(1-M, M, 2)
     return 0.54 + 0.46*cos(pi*n/(M-1))
 


### PR DESCRIPTION
The aim is to make at least the normal tests pass with NEP 50 eventually.  But there is a lot going on here, so thought I would open a PR and hope others find interest in what changes are needed.

<details> <summary>  As of starting this, the following (non slow) test failures exist, many easy, some may also go back to arange being weird </summary>

```
============================================================================================= short test summary info ==============================================================================================
FAILED numpy/core/tests/test_dtype.py::TestPromotion::test_python_integer_promotion[2] - AssertionError: assert dtype('int8') == dtype('int64')
FAILED numpy/core/tests/test_dtype.py::TestPromotion::test_python_integer_promotion[4294967296] - AssertionError: assert dtype('int8') == dtype('int64')
FAILED numpy/core/tests/test_dtype.py::TestPromotion::test_python_integer_promotion[9223372036854775808] - AssertionError: assert dtype('int64') == dtype('float64')
FAILED numpy/core/tests/test_dtype.py::TestPromotion::test_python_integer_promotion[18446744073709551616] - AssertionError: assert dtype('int64') == dtype('O')
FAILED numpy/core/tests/test_dtype.py::TestPromotion::test_python_integer_promotion[200] - AssertionError: assert dtype('int8') == dtype('int64')
FAILED numpy/core/tests/test_getlimits.py::TestIinfo::test_basic - OverflowError: Python int too large to convert to C long
FAILED numpy/core/tests/test_getlimits.py::TestIinfo::test_unsigned_max - OverflowError: Python int too large to convert to C long
FAILED numpy/core/tests/test_multiarray.py::TestTemporaryElide::test_temporary_with_cast - OverflowError: Python int too large to convert to C long
FAILED numpy/core/tests/test_multiarray.py::TestClip::test_basic - NameError: name 'OverFlowError' is not defined
FAILED numpy/core/tests/test_multiarray.py::TestConversion::test_array_scalar_relational_operation - OverflowError: Python integer -1 out of bounds for uint8
FAILED numpy/core/tests/test_multiarray.py::TestWhere::test_exotic - AssertionError: 
FAILED numpy/core/tests/test_nditer.py::test_iter_common_dtype - AssertionError: 
FAILED numpy/core/tests/test_nditer.py::test_iter_allocate_output_types_promotion - AssertionError: 
FAILED numpy/core/tests/test_numeric.py::TestTypes::test_coercion - AssertionError: 
FAILED numpy/core/tests/test_numeric.py::TestTypes::test_result_type - AssertionError: 
FAILED numpy/core/tests/test_numeric.py::TestTypes::test_can_cast_values - AssertionError
FAILED numpy/core/tests/test_numeric.py::TestClip::test_clip_problem_cases[arr0-0--18446744073709551615-exp0] - OverflowError: Python int too large to convert to C long
FAILED numpy/core/tests/test_regression.py::TestRegression::test_uint_int_conversion - OverflowError: Python int too large to convert to C long
FAILED numpy/core/tests/test_scalar_ctors.py::TestFromInt::test_uint64_from_negative - OverflowError: Python integer -2 out of bounds for uint64
FAILED numpy/core/tests/test_scalarmath.py::TestConversion::test_iinfo_long_values - OverflowError: Python integer 128 out of bounds for int8
FAILED numpy/core/tests/test_scalarmath.py::TestConversion::test_numpy_scalar_relational_operators - OverflowError: Python integer -1 out of bounds for uint8
FAILED numpy/core/tests/test_scalarmath.py::test_longdouble_inf_loop[18446744073709551616-pow] - RuntimeWarning: overflow encountered in scalar power
FAILED numpy/core/tests/test_scalarmath.py::test_clongdouble_inf_loop[18446744073709551616-pow] - RuntimeWarning: overflow encountered in scalar power
FAILED numpy/core/tests/test_ufunc.py::TestUfunc::test_use_output_signature_for_all_arguments - Failed: DID NOT RAISE <class 'TypeError'>
FAILED numpy/core/tests/test_ufunc.py::TestUfunc::test_ufunc_custom_out - AssertionError: TypeError not raised
FAILED numpy/core/tests/test_umath.py::TestRationalFunctions::test_builtin_long - OverflowError: Python int too large to convert to C long
FAILED numpy/f2py/tests/test_kind.py::TestKind::test_all - AssertionError: selectedrealkind(16): expected 10 but got 16
FAILED numpy/lib/tests/test_function_base.py::TestSelect::test_return_dtype - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-B] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-H] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-I] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-L] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-Q] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hanning[10-P] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-B] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-H] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-I] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-L] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-Q] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_hamming[10-P] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-B] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-H] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-I] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-L] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-Q] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_bartlett[10-P] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[0-e] - AssertionError: assert dtype('float16') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[0-f] - AssertionError: assert dtype('float32') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[1-e] - AssertionError: assert dtype('float16') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[1-f] - AssertionError: assert dtype('float32') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-B] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-H] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-I] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-L] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-Q] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_blackman[10-P] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-B] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-H] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-I] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-L] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-Q] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[0-P] - RuntimeWarning: overflow encountered in scalar subtract
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[1-e] - AssertionError: assert dtype('float16') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestFilterwindows::test_kaiser[1-f] - AssertionError: assert dtype('float32') == dtype('float64')
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[averaged_inverted_cdf-27.5-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[averaged_inverted_cdf-27.5-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[interpolated_inverted_cdf-20-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[interpolated_inverted_cdf-20-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[hazen-27.5-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[hazen-27.5-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[weibull-26-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[weibull-26-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[linear-29-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[linear-29-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[median_unbiased-27-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[median_unbiased-27-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[normal_unbiased-27.125-float16-float16] - AssertionError: 
FAILED numpy/lib/tests/test_function_base.py::TestPercentile::test_linear_interpolation[normal_unbiased-27.125-float32-float32] - AssertionError: 
FAILED numpy/lib/tests/test_histograms.py::TestHistogram::test_no_side_effects - OverflowError: Python integer -10 out of bounds for uint64
FAILED numpy/lib/tests/test_histograms.py::TestHistogram::test_precision - AssertionError: 
FAILED numpy/lib/tests/test_histograms.py::TestHistogramOptimBinNums::test_simple_range - OverflowError: Python integer -20 out of bounds for uint64
FAILED numpy/lib/tests/test_index_tricks.py::TestGrid::test_accepts_npfloating - AssertionError
FAILED numpy/linalg/tests/test_linalg.py::TestDet::test_types[complex64] - RuntimeWarning: divide by zero encountered in det
FAILED numpy/linalg/tests/test_linalg.py::TestDet::test_types[complex128] - RuntimeWarning: divide by zero encountered in det
FAILED numpy/random/tests/test_direct.py::TestPhilox::test_raw - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_direct.py::TestPCG64DXSM::test_raw - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_direct.py::TestSFC64::test_raw - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_bounds_checking[True] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_bounds_checking_array[True] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_rng_zero_and_extremes[True] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_rng_zero_and_extremes_array[True] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_int64_uint64_broadcast_exceptions[True] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestSingleEltArrayInput::test_integers[True] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_bounds_checking[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_bounds_checking_array[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_rng_zero_and_extremes[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_rng_zero_and_extremes_array[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_full_range_array[False] - AssertionError: No error should have been raised, but one was with the following message:
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_scalar_array_equiv[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_repeatability_broadcasting[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_int64_uint64_broadcast_exceptions[False] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_generator_mt19937.py::TestIntegers::test_respect_dtype_array[False] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_generator_mt19937.py::TestSingleEltArrayInput::test_integers[False] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_random.py::TestSingleEltArrayInput::test_randint - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestMT19937::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestMT19937::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPhilox::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPhilox::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestSFC64::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestSFC64::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPCG64::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPCG64::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPCG64DXSM::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestPCG64DXSM::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestDefaultRNG::test_integers_broadcast[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestDefaultRNG::test_integers_broadcast_errors[int64] - OverflowError: Python integer -9223372036854775808 out of bounds for uint64
FAILED numpy/random/tests/test_smoke.py::TestMT19937::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestPhilox::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestSFC64::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestPCG64::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestPCG64DXSM::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
FAILED numpy/random/tests/test_smoke.py::TestDefaultRNG::test_integers_numpy[uint64] - OverflowError: Python int too large to convert to C long
122 failed, 25148 passed, 199 skipped, 1307 deselected, 42 xfailed, 6 xpassed in 124.17s (0:02:04)
```