### PR TITLE
BUG: fix type in resolve_descriptors_function typedef

### DIFF
--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -289,7 +289,7 @@ typedef NPY_CASTING (resolve_descriptors_function)(
         /* "method" is currently opaque (necessary e.g. to wrap Python) */
         PyObject *method,
         /* DTypes the method was created for */
-        PyObject **dtypes,
+        PyArray_DTypeMeta **dtypes,
         /* Input descriptors (instances).  Outputs may be NULL. */
         PyArray_Descr **given_descrs,
         /* Exact loop descriptors to use, must not hold references on error */


### PR DESCRIPTION
Currently this typedef differs from the "real" typedef in `array_method.h`: https://github.com/numpy/numpy/blob/930addb6dace3988268112ab56fe638d2941a7c3/numpy/core/src/multiarray/array_method.h#L90-L95 

This PR fixes it to match.