### PR TITLE
BUG: Handle arrays in `conf_data`

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -163,7 +163,7 @@ foreach name, compiler : compilers
   conf_data.set(name + '_COMP', compiler.get_id())
   conf_data.set(name + '_COMP_LINKER_ID', compiler.get_linker_id())
   conf_data.set(name + '_COMP_VERSION', compiler.version())
-  conf_data.set(name + '_COMP_CMD_ARRAY', compiler.cmd_array())
+  conf_data.set(name + '_COMP_CMD_ARRAY', ', '.join(compiler.cmd_array()))
 endforeach
 
 # Machines CPU and system information


### PR DESCRIPTION
### What's the bug?
* `configuration_data` does not support `lists` as the data argument
* ref: https://mesonbuild.com/Reference-manual_functions.html#arguments12
* Hence, it expands the list leading to more than 2 args if we have more elements

Found this after I installed `ccache` when I was porting this to SciPy

### Error before fix:
```
numpy/meson.build:167:12: ERROR: configuration_data.set takes exactly 2 arguments, but got 3.
```

### Output after fix
```
In [6]: np.show_config(mode='dicts')['Compilers']['c++']['commands']
Out[6]: 'ccache, c++'
```

Part of: https://github.com/numpy/numpy/pull/22769