### PR TITLE
API: Raise EOFError when trying to load past the end of a `.npy` file

### DIFF
--- a/doc/release/upcoming_changes/23105.compatibility.rst
+++ b/doc/release/upcoming_changes/23105.compatibility.rst
@@ -1,5 +1,5 @@
 * When loading data from a file handle using ``np.load``,
   if the handle is at the end of file, as can happen when reading
   multiple arrays by calling ``np.load`` repeatedly, numpy previously
-  raised `ValueError` if `allow_pickle=False`, and `OSError` if
-  `allow_pickle=True. Now it raises `EOFError` instead, in both cases.
+  raised ``ValueError`` if ``allow_pickle=False``, and ``OSError`` if
+  ``allow_pickle=True``. Now it raises ``EOFError`` instead, in both cases.

--- a/doc/release/upcoming_changes/23105.compatibility.rst
+++ b/doc/release/upcoming_changes/23105.compatibility.rst
@@ -1,0 +1,5 @@
+* When loading data from a file handle using ``np.load``,
+  if the handle is at the end of file, as can happen when reading
+  multiple arrays by calling ``np.load`` repeatedly, numpy previously
+  raised `ValueError` if `allow_pickle=False`, and `OSError` if
+  `allow_pickle=True. Now it raises `EOFError` instead, in both cases.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -328,8 +328,8 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
     ValueError
         The file contains an object array, but ``allow_pickle=False`` given.
     EOFError
-        If the input file is empty or, when calling `np.load` multiple times
-        on the same file, if all data has already been read
+        When calling `np.load` multiple times on the same file handle,
+        if all data has already been read
 
     See Also
     --------
@@ -413,12 +413,12 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         _ZIP_SUFFIX = b'PK\x05\x06' # empty zip files start with this
         N = len(format.MAGIC_PREFIX)
         magic = fid.read(N)
+        if not magic:
+            raise EOFError("No data left in file")
         # If the file size is less than N, we need to make sure not
         # to seek past the beginning of the file
         fid.seek(-min(N, len(magic)), 1)  # back-up
-        if not magic:
-            raise EOFError()
-        elif magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
+        if magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
             # zip-file (assume .npz)
             # Potentially transfer file ownership to NpzFile
             stack.pop_all()

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -328,7 +328,7 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
     ValueError
         The file contains an object array, but ``allow_pickle=False`` given.
     EOFError
-        When calling `np.load` multiple times on the same file handle,
+        When calling ``np.load`` multiple times on the same file handle,
         if all data has already been read
 
     See Also

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -327,6 +327,9 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         If ``allow_pickle=True``, but the file cannot be loaded as a pickle.
     ValueError
         The file contains an object array, but ``allow_pickle=False`` given.
+    EOFError
+        If the input file is empty or, when calling `np.load` multiple times
+        on the same file, if all data has already been read
 
     See Also
     --------
@@ -413,7 +416,9 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         # If the file size is less than N, we need to make sure not
         # to seek past the beginning of the file
         fid.seek(-min(N, len(magic)), 1)  # back-up
-        if magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
+        if not magic:
+            raise EOFError()
+        elif magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
             # zip-file (assume .npz)
             # Potentially transfer file ownership to NpzFile
             stack.pop_all()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2737,3 +2737,13 @@ def test_load_refcount():
     with assert_no_gc_cycles():
         x = np.loadtxt(TextIO("0 1 2 3"), dtype=dt)
         assert_equal(x, np.array([((0, 1), (2, 3))], dtype=dt))
+
+def test_load_multiple_arrays_until_eof():
+    f = BytesIO()
+    np.save(f, 1)
+    np.save(f, 2)
+    f.seek(0)
+    assert np.load(f) == 1
+    assert np.load(f) == 2
+    with pytest.raises(EOFError):
+        np.load(f)


### PR DESCRIPTION
Currently, the following code:
```
import numpy as np
with open('foo.npy', 'wb') as f:
    for i in range(np.random.randint(10)):
        np.save(f, 1)

with open('foo.npy', 'rb') as f:
    while True:
        np.load(f)
```
Will raise:
```
ValueError: Cannot load file containing pickled data when allow_pickle=False
```
While there is no pickled data in the file.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
