### PR TITLE
BUG: Move `NPY_END_ALLOW_THREADS` to earlier in `from_text`

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3535,6 +3535,8 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
             break;
         }
     }
+    NPY_END_ALLOW_THREADS;
+
     if (num < 0) {
         const size_t nsize = PyArray_MAX(*nread,1)*dtype->elsize;
 
@@ -3551,7 +3553,6 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
             }
         }
     }
-    NPY_END_ALLOW_THREADS;
 
     free(clean_sep);
 


### PR DESCRIPTION
Probably doesn't matter in practice, but saw it while looking a bit at gh-23037.  There is a small chance that it is related.