### PR TITLE
ENH: Add slots to NDArrayOperatorsMixin allowing them in subclasses

### DIFF
--- a/doc/release/upcoming_changes/23113.improvement.rst
+++ b/doc/release/upcoming_changes/23113.improvement.rst
@@ -1,0 +1,3 @@
+- The ``NDArrayOperatorsMixin`` class now specifies that it contains no
+  ``__slots__`` ensureing that subclasses can now make use of this feature in
+  Python.

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -133,6 +133,7 @@ class NDArrayOperatorsMixin:
 
     .. versionadded:: 1.13
     """
+    __slots__ = ()
     # Like np.ndarray, this mixin class implements "Option 1" from the ufunc
     # overrides NEP.
 

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -154,6 +154,7 @@ class WrappedArray(NDArrayOperatorsMixin):
     ufunc deferrals are commutative.
     See: https://github.com/numpy/numpy/issues/15200)
     """
+    __slots__ = ('_array', 'attrs')
     __array_priority__ = 20
 
     def __init__(self, array, **attrs):
@@ -448,3 +449,12 @@ class TestClassWrapping:
         assert_(isinstance(np.divide(wm, m2), WrappedArray))
         assert_(isinstance(np.divide(m2, wm), WrappedArray))
         assert_equal(np.divide(m2, wm), np.divide(wm, m2))
+
+    def test_mixins_have_slots(self):
+        mixin = NDArrayOperatorsMixin()
+        # Should raise an error
+        assert_raises(AttributeError, mixin.__setattr__, "not_a_real_attr", 1)
+
+        m = np.ma.masked_array([1, 3, 5], mask=[False, True, False])
+        wm = WrappedArray(m)
+        assert_raises(AttributeError, wm.__setattr__, "not_an_attr", 2)


### PR DESCRIPTION
I use the mixins in a few different file backed arrays.

However, the lack of slots make it difficult for me to use slots.

I mostly use slots to ensure that performance optimized code doesn't create unecessary references to large chunks of memory.

If all parent classes do not have `__slots__` defined, I think that Python (3.9) just ignores `__slots__` alltogether.

Thank you for considering.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
