### PR TITLE
TST: Mark F2PY tests as XFail on Cygwin

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -75,11 +75,15 @@ jobs:
           name: numpy-cygwin-wheel
           path: dist/numpy-*cp39*.whl
       - name: Check the extension modules on failure
+        timeout-minutes: 30
+        # Cygcheck has been hanging for some reason.
+        # Catch it if it does.
+        shell: "C:\\tools\\cygwin\\bin\\bash.exe -eo pipefail -o igncr {0}"
         if: failure()
         run: |
-          dash -c "/usr/bin/python3.9 -m pip show numpy"
-          dash -c "/usr/bin/python3.9 -m pip show -f numpy | grep .dll"
-          dash -c "/bin/tr -d '\r' <tools/list_installed_dll_dependencies_cygwin.sh >list_dlls_unix.sh"
+          /usr/bin/python3.9 -m pip show numpy
+          /usr/bin/python3.9 -m pip show -f numpy | grep .dll
+          /bin/tr -d '\r' <tools/list_installed_dll_dependencies_cygwin.sh >list_dlls_unix.sh
           dash "list_dlls_unix.sh" 3.9
       - name: Print installed package versions on failure
         if: failure()

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -7,7 +7,8 @@ from numpy.f2py import crackfortran
 from numpy.testing import IS_WASM
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -1,9 +1,14 @@
 from pathlib import Path
 import pytest
+import sys
 import textwrap
 from . import util
 from numpy.f2py import crackfortran
 from numpy.testing import IS_WASM
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -12,7 +12,8 @@ from . import util
 
 wrap = None
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 # Extend core typeinfo with CHARACTER to test dtype('c')

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -11,6 +11,9 @@ from numpy.core.multiarray import typeinfo as _typeinfo
 from . import util
 
 wrap = None
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 # Extend core typeinfo with CHARACTER to test dtype('c')
 _ti = _typeinfo['STRING']

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -1,8 +1,13 @@
 import os
 import pytest
+import sys
 import tempfile
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestAssumedShapeSumExample(util.F2PyTest):

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -6,7 +6,8 @@ import tempfile
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -4,6 +4,10 @@ from . import util
 
 from numpy.testing import IS_PYPY
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestBlockDocString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "block_docstring", "foo.f")]

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -5,7 +5,8 @@ from . import util
 from numpy.testing import IS_PYPY
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -10,6 +10,10 @@ import numpy as np
 from numpy.testing import IS_PYPY
 from . import util
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,7 +11,8 @@ from numpy.testing import IS_PYPY
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -6,7 +6,8 @@ import numpy as np
 from numpy.f2py.tests import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -1,8 +1,13 @@
+import sys
 import pytest
 import textwrap
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 import numpy as np
 from numpy.f2py.tests import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestCharacterString(util.F2PyTest):

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -5,6 +5,10 @@ import pytest
 import numpy as np
 from . import util
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestCommonBlock(util.F2PyTest):
     sources = [util.getpath("tests", "src", "common", "block.f")]

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -6,7 +6,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -95,6 +95,17 @@ def test_f2py_init_compile_failure():
     # verify an appropriate integer status value returned by
     # f2py.compile() when invalid Fortran is provided
     ret_val = numpy.f2py.compile(b"invalid")
+
+    if (
+            sys.platform == "cygwin"
+            and ret_val == 127
+            and numpy.f2py._compile_has_blockingioerror
+    ):
+        pytest.xfail(
+            "Likely a fork() failure\n"
+            "stderr should mention child_info_fork::abort"
+        )
+
     assert ret_val == 1
 
 
@@ -129,4 +140,15 @@ def test_compile_from_strings(tmpdir, fsource):
         ret_val = numpy.f2py.compile(fsource,
                                      modulename="test_compile_from_strings",
                                      extension=".f90")
+
+        if (
+                sys.platform == "cygwin"
+                and ret_val == 127
+                and numpy.f2py._compile_has_blockingioerror
+        ):
+            pytest.xfail(
+                "Likely a fork() failure\n"
+                "stderr should mention child_info_fork::abort"
+            )
+
         assert ret_val == 0

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -11,6 +11,10 @@ import numpy.f2py
 
 from . import util
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 def setup_module():
     if not util.has_c_compiler():

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -63,10 +63,14 @@ def test_f2py_init_compile(extra_args):
                                          extra_args=extra_args,
                                          source_fn=source_fn)
 
-            if sys.platform == "cygwin" and ret_val == 127:
+            if (
+                    sys.platform == "cygwin"
+                    and ret_val == 127
+                    and numpy.f2py._compile_has_blockingioerror
+            ):
                 pytest.xfail(
                     "Likely a fork() failure\n"
-                    "stderr will likely mention child_info_fork::abort"
+                    "stderr should mention child_info_fork::abort"
                 )
 
             # check for compile success return value

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -12,7 +12,8 @@ import numpy.f2py
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -63,6 +63,12 @@ def test_f2py_init_compile(extra_args):
                                          extra_args=extra_args,
                                          source_fn=source_fn)
 
+            if sys.platform == "cygwin" and ret_val == 127:
+                pytest.xfail(
+                    "Likely a fork() failure\n"
+                    "stderr will likely mention child_info_fork::abort"
+                )
+
             # check for compile success return value
             assert ret_val == 0
 

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -10,7 +10,8 @@ from numpy.f2py import crackfortran
 import textwrap
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,5 +1,6 @@
 import importlib
 import codecs
+import sys
 import unicodedata
 import pytest
 import numpy as np
@@ -7,6 +8,10 @@ from numpy.f2py.crackfortran import markinnerspaces
 from . import util
 from numpy.f2py import crackfortran
 import textwrap
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestNoSpace(util.F2PyTest):

--- a/numpy/f2py/tests/test_docs.py
+++ b/numpy/f2py/tests/test_docs.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
@@ -14,10 +15,21 @@ def get_docdir():
         'doc', 'source', 'f2py', 'code'))
 
 
-pytestmark = pytest.mark.skipif(
-    not os.path.isdir(get_docdir()),
-    reason=('Could not find f2py documentation sources'
-            f' ({get_docdir()} does not exists)'))
+# Syntax borrowed from here:
+# https://docs.pytest.org/en/7.1.x/reference/reference.html#globalvar-pytestmark
+# https://docs.pytest.org/en/7.1.x/example/markers.html#marking-whole-classes-or-modules
+pytestmark = [
+    pytest.mark.skipif(
+        not os.path.isdir(get_docdir()),
+        reason=('Could not find f2py documentation sources'
+                f' ({get_docdir()} does not exists)')
+    ),
+    pytest.mark.xfail(
+        sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+        raises=BlockingIOError
+    )
+]
+
 
 
 def _path(*a):

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -5,7 +5,8 @@ from . import util
 import numpy as np
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -1,5 +1,13 @@
+import sys
+import pytest
+
 from . import util
 import numpy as np
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestF2Cmap(util.F2PyTest):
     sources = [

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -8,7 +8,8 @@ from . import util
 from numpy.f2py.f2py2e import main as f2pycli
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 #########################

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -7,6 +7,10 @@ import pytest
 from . import util
 from numpy.f2py.f2py2e import main as f2pycli
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 #########################
 # CLI utils and classes #
 #########################

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -9,7 +9,8 @@ from numpy.f2py.crackfortran import (
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 from numpy.f2py.crackfortran import (
@@ -6,6 +7,10 @@ from numpy.f2py.crackfortran import (
     _selected_real_kind_func as selected_real_kind,
 )
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestKind(util.F2PyTest):

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -1,9 +1,14 @@
 import os
+import sys
 import textwrap
 import pytest
 
 from numpy.testing import IS_PYPY
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestMixed(util.F2PyTest):

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -7,7 +7,8 @@ from numpy.testing import IS_PYPY
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_module_doc.py
+++ b/numpy/f2py/tests/test_module_doc.py
@@ -6,6 +6,10 @@ import textwrap
 from . import util
 from numpy.testing import IS_PYPY
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestModuleDocString(util.F2PyTest):
     sources = [

--- a/numpy/f2py/tests/test_module_doc.py
+++ b/numpy/f2py/tests/test_module_doc.py
@@ -7,7 +7,8 @@ from . import util
 from numpy.testing import IS_PYPY
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -1,9 +1,14 @@
 import os
+import sys
 import pytest
 
 import numpy as np
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestParameters(util.F2PyTest):

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -7,7 +7,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -6,6 +6,10 @@ import pytest
 
 from . import util
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
+
 
 class TestQuotedCharacter(util.F2PyTest):
     sources = [util.getpath("tests", "src", "quoted_character", "foo.f")]

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -7,7 +7,8 @@ import pytest
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -1,9 +1,14 @@
 import os
+import sys
 import pytest
 
 import numpy as np
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestIntentInOut(util.F2PyTest):

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -7,7 +7,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 from numpy import array
@@ -5,6 +6,10 @@ from . import util
 import platform
 
 IS_S390X = platform.machine() == "s390x"
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestReturnCharacter(util.F2PyTest):

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -8,7 +8,8 @@ import platform
 IS_S390X = platform.machine() == "s390x"
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -6,7 +6,8 @@ from numpy import array
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -1,7 +1,13 @@
+import sys
+
 import pytest
 
 from numpy import array
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestReturnComplex(util.F2PyTest):

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -5,7 +5,8 @@ from numpy import array
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -1,7 +1,12 @@
+import sys
 import pytest
 
 from numpy import array
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestReturnInteger(util.F2PyTest):

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -5,7 +5,8 @@ from numpy import array
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -1,7 +1,12 @@
+import sys
 import pytest
 
 from numpy import array
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestReturnLogical(util.F2PyTest):

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -7,7 +7,8 @@ from numpy import array
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -1,9 +1,14 @@
 import platform
+import sys
 import pytest
 import numpy as np
 
 from numpy import array
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestReturnReal(util.F2PyTest):

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -1,8 +1,13 @@
 import platform
+import sys
 import pytest
 import numpy as np
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 @pytest.mark.skipif(

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -6,7 +6,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -1,8 +1,13 @@
 import os
+import sys
 import pytest
 import numpy as np
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestSizeSumExample(util.F2PyTest):

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -6,7 +6,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -1,8 +1,13 @@
 import os
+import sys
 import pytest
 import textwrap
 import numpy as np
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestString(util.F2PyTest):

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -6,7 +6,8 @@ import numpy as np
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_symbolic.py
+++ b/numpy/f2py/tests/test_symbolic.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 from numpy.f2py.symbolic import (
@@ -30,6 +31,10 @@ from numpy.f2py.symbolic import (
     as_ge,
 )
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 
 class TestSymbolic(util.F2PyTest):

--- a/numpy/f2py/tests/test_symbolic.py
+++ b/numpy/f2py/tests/test_symbolic.py
@@ -33,7 +33,8 @@ from numpy.f2py.symbolic import (
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -5,7 +5,8 @@ import pytest
 from . import util
 
 pytestmark = pytest.mark.xfail(
-    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
 )
 
 class TestValueAttr(util.F2PyTest):

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -1,7 +1,12 @@
 import os
+import sys
 import pytest
 
 from . import util
+
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin", raises=BlockingIOError
+)
 
 class TestValueAttr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "value_attrspec", "gh21665.f90")]

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -63,6 +63,10 @@ def test_numpy_namespace():
 
 
 @pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+@pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
+)
 @pytest.mark.parametrize('name', ['testing'])
 def test_import_lazy_import(name):
     """Make sure we can actually use the modules we lazy load.

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -45,6 +45,10 @@ def test_novalue():
 
 
 @pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+@pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
+)
 def test_full_reimport():
     """At the time of writing this, it is *not* truly supported, but
     apparently enough users rely on it, for it to be an annoying change

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -11,6 +11,11 @@ import subprocess
 import numpy as np
 from numpy.testing import assert_equal, IS_WASM
 
+pytestmark = pytest.mark.xfail(
+    sys.platform == "cygwin", reason="Random fork() failures on Cygwin",
+    raises=BlockingIOError
+)
+
 is_inplace = isfile(pathjoin(dirname(np.__file__),  '..', 'setup.py'))
 
 


### PR DESCRIPTION
More compiled extension modules means higher chances for fork() failure, as does more compilation of extension modules. This should still let actual test failures through, when they happen.

Replaces #23073
Fixes #23070?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
