### PR TITLE
DOC:fix type in bitwise_ior

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -667,7 +667,7 @@ add_newdoc('numpy.core.umath', 'bitwise_or',
     --------
     The number 13 has the binary representation ``00001101``. Likewise,
     16 is represented by ``00010000``.  The bit-wise OR of 13 and 16 is
-    then ``000111011``, or 29:
+    then ``00011101``, or 29:
 
     >>> np.bitwise_or(13, 16)
     29


### PR DESCRIPTION
Issue with current documentation:
https://numpy.org/doc/stable/reference/generated/numpy.bitwise_or.html

The number 13 has the binary representation 00001101. Likewise, 16 is represented by 00010000. The bit-wise OR of 13 and 16 is then 000111011, or 29:

should be 00011101 instead

for Issue: https://github.com/numpy/numpy/issues/23086
