### PR TITLE
BUILD: use GITHUB_REF_NAME in musllinux merge CI run [skip ci], add more conditions to CI runs

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   cygwin_build_test:
     runs-on: windows-latest
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-wasm-emscripten:
     runs-on: ubuntu-22.04
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     env:
       PYODIDE_VERSION: 0.22.0a3
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   meson_devpy:
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -39,7 +39,7 @@ jobs:
         git config --global --add safe.directory $PWD 
         
         if [ $GITHUB_EVENT_NAME != pull_request ]; then
-            git clone --recursive --branch=$GITHUB_REF https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
+            git clone --recursive --branch=$GITHUB_REF_NAME https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
             git reset --hard $GITHUB_SHA
         else        
             git clone --recursive https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:


### PR DESCRIPTION
CI runs of musllinux have [been failing](https://github.com/numpy/numpy/actions/workflows/linux_musl.yml) to clone the repo after merges:
```
fatal: Remote branch refs/heads/main not found in upstream origin
```

That value comes from [`$GITHUB_REF`](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables). I think it should be `$GITHUB_REF_NAME` (i.e. `main`) instead. This will only affect merging after PR approval, so I am skipping CI.

Also add the `[skip ci]` conditional stanza to workflows where it was missing, found by `grep -L "skip ci"`