### PR TITLE
BLD: use conda to install anaconda-client for upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -122,6 +122,16 @@ jobs:
           name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          # for installation of anaconda-client, required for upload to
+          # anaconda.org
+          # default (and activated) environment name is test
+          # Note that this step is *after* specific pythons have been used to
+          # build and test the wheel
+          auto-update-conda: true
+          python-version: "3.10"
+
       - name: Upload wheels
         if: success()
         shell: bash
@@ -129,6 +139,7 @@ jobs:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
+          conda install -y anaconda-client
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # trigger an upload to
@@ -138,6 +149,7 @@ jobs:
           # https://anaconda.org/multibuild-wheels-staging/numpy
           # The tokens were originally generated at anaconda.org
           upload_wheels
+
   build_sdist:
     name: Build sdist
     needs: get_commit_message
@@ -190,6 +202,16 @@ jobs:
           name: sdist
           path: ./dist/*
 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          # for installation of anaconda-client, required for upload to
+          # anaconda.org
+          # default (and activated) environment name is test
+          # Note that this step is *after* specific pythons have been used to
+          # build and test
+          auto-update-conda: true
+          python-version: "3.10"
+
       - name: Upload sdist
         if: success()
         shell: bash
@@ -197,6 +219,7 @@ jobs:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
+          conda install -y anaconda-client
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # trigger an upload to

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -166,7 +166,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-      IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      # commented out so the sdist doesn't upload to nightly
+      # IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout numpy
         uses: actions/checkout@v3
@@ -219,7 +220,8 @@ jobs:
         shell: bash -el {0}
         env:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
-          NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
+          # commented out so the sdist doesn't upload to nightly
+          # NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
           conda install -y anaconda-client
           source tools/wheels/upload_wheels.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -134,7 +134,9 @@ jobs:
 
       - name: Upload wheels
         if: success()
-        shell: bash
+        shell: bash -el {0}
+        # see https://github.com/marketplace/actions/setup-miniconda for why
+        # `-el {0}` is required.
         env:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
@@ -214,7 +216,7 @@ jobs:
 
       - name: Upload sdist
         if: success()
-        shell: bash
+        shell: bash -el {0}
         env:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -62,9 +62,17 @@ wheels_upload_task:
     NUMPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[!196422e6c3419a3b1d79815e1026094a215cb0f346fe34ed0f9d3ca1c19339df7398d04556491b1e0420fc1fe3713289!]
 
   upload_script: |
-    apt-get install -y python3-venv python-is-python3 curl
+    apt-get update
+    apt-get install -y curl wget
     export IS_SCHEDULE_DISPATCH="false"
     export IS_PUSH="false"
+
+    # install miniconda for uploading to anaconda
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    bash miniconda.sh -b -p ~/miniconda3
+    ~/miniconda3/bin/conda init bash
+    source ~/miniconda3/bin/activate
+    conda install -y anaconda-client
 
     # cron job
     if [[ "$CIRRUS_CRON" == "weekly" ]]; then

--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -37,8 +37,6 @@ upload_wheels() {
         if [[ -z ${TOKEN} ]]; then
             echo no token set, not uploading
         else
-            python -m pip install \
-            git+https://github.com/Anaconda-Platform/anaconda-client.git@be1e14936a8e947da94d026c990715f0596d7043
             # sdists are located under dist folder when built through setup.py
             if compgen -G "./dist/*.gz"; then
                 echo "Found sdist"


### PR DESCRIPTION
Issue #21874 wishes to use conda to install anaconda-client, rather than using Python to install an older pinned version. The newer version has dependencies that can only be met with conda.

This PR:

- installs conda into the wheel building CI runs, after the wheels have been built and tested with their own specific Python
- conda is then used to install `anaconda` for the upload.

This PR closes #21874.

