### PR TITLE
BUG: Add missing <type_traits> header.

### DIFF
--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cassert>
 #include <cmath>
+#include <type_traits>
 #include <utility>
 
 


### PR DESCRIPTION
`std::is_scalar` is defined in `type_traits`, which is missing from the includes.

Fixes a compilation failure.