### PR TITLE
MAINT, BLD: Update wheel and GitPython versions.

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.10.0
 Cython>=0.29.30,<3.0
-wheel==0.37.0
+wheel==0.38.1
 ninja
 git+https://github.com/scientific-python/devpy

--- a/linter_requirements.txt
+++ b/linter_requirements.txt
@@ -1,2 +1,2 @@
 pycodestyle==2.8.0
-GitPython==3.1.13
+GitPython>=3.1.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.11.0) - it's
     # likely to be removed as a dependency in meson-python 0.12.0.
-    "wheel==0.37.0",
+    "wheel==0.38.1",
     "Cython>=0.29.30,<3.0",
 #    "meson-python>=0.10.0",
 ]

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -7,7 +7,7 @@ beautifulsoup4
 
 # changelog.py
 pygithub
-gitpython
+gitpython>=3.1.30
 
 # uploading wheels
 twine

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.29.30,<3.0
-wheel==0.37.0
+wheel==0.38.1
 setuptools==59.2.0
 hypothesis==6.24.1
 pytest==6.2.5


### PR DESCRIPTION
This is motivated by Dependabot security alerts.

I don't recall if we need the wheel pin to 1.37.1, but suspect it was on account of 1.38.0 being buggy.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
