### PR TITLE
CI: reduce CI load - two fewer Azure Windows jobs, and no GHA jobs on merge

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,10 +1,6 @@
 name: Build_Test
 
 on:
-  push:
-    branches:
-      - main
-      - maintenance/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -3,10 +3,6 @@
 # if: github.repository == 'numpy/numpy'
 name: Test on Cygwin
 on:
-  push:
-    branches:
-      - main
-      - maintenance/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -1,10 +1,6 @@
 name: Test musllinux_x86_64
 
 on:
-  push:
-    branches:
-      - main
-      - maintenance/**
   pull_request:
     branches:
       - main

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,29 +243,18 @@ stages:
     pool:
       vmImage: 'windows-2019'
     strategy:
-      maxParallel: 6
+      maxParallel: 5
       matrix:
-          Python39-32bit-fast:
+          Python39-32bit-full:
             PYTHON_VERSION: '3.9'
             PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
-            BITS: 32
-          Python39-64bit-full:
-            PYTHON_VERSION: '3.9'
-            PYTHON_ARCH: 'x64'
             TEST_MODE: full
-            BITS: 64
-          Python310-32bit-fast:
-            PYTHON_VERSION: '3.10'
-            PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
             BITS: 32
-          Python310-64bit-full:
+          Python310-64bit-fast:
             PYTHON_VERSION: '3.10'
             PYTHON_ARCH: 'x64'
-            TEST_MODE: full
+            TEST_MODE: fast
             BITS: 64
-            NPY_USE_BLAS_ILP64: '1'
           Python311-32bit-fast:
             PYTHON_VERSION: '3.11'
             PYTHON_ARCH: 'x86'

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -157,7 +157,24 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             NPY_BEGIN_ALLOW_THREADS;
 
 #if defined (_MSC_VER) && defined(_WIN64)
-            /* Workaround Win64 fwrite() bug. Ticket #1660 */
+            /* Workaround Win64 fwrite() bug. Issue gh-2556
+             * If you touch this code, please run this test which is so slow
+             * it was removed from the test suite
+             *
+             * fourgbplus = 2**32 + 2**16
+             * testbytes = np.arange(8, dtype=np.int8)
+             * n = len(testbytes)
+             * flike = tempfile.NamedTemporaryFile()
+             * f = flike.file
+             * np.tile(testbytes, fourgbplus // testbytes.nbytes).tofile(f)
+             * flike.seek(0)
+             * a = np.fromfile(f, dtype=np.int8)
+             * flike.close()
+             * assert_(len(a) == fourgbplus)
+             * # check only start and end for speed:
+             * assert_((a[:n] == testbytes).all())
+             * assert_((a[-n:] == testbytes).all())
+             */
             {
                 npy_intp maxsize = 2147483648 / PyArray_DESCR(self)->elsize;
                 npy_intp chunksize;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5552,33 +5552,6 @@ class TestIO:
             tmp_filename,
             dtype='<f4')
 
-    @pytest.mark.slow  # takes > 1 minute on mechanical hard drive
-    def test_big_binary(self):
-        """Test workarounds for 32-bit limit for MSVC fwrite, fseek, and ftell
-
-        These normally would hang doing something like this.
-        See : https://github.com/numpy/numpy/issues/2256
-        """
-        if sys.platform != 'win32' or '[GCC ' in sys.version:
-            return
-        try:
-            # before workarounds, only up to 2**32-1 worked
-            fourgbplus = 2**32 + 2**16
-            testbytes = np.arange(8, dtype=np.int8)
-            n = len(testbytes)
-            flike = tempfile.NamedTemporaryFile()
-            f = flike.file
-            np.tile(testbytes, fourgbplus // testbytes.nbytes).tofile(f)
-            flike.seek(0)
-            a = np.fromfile(f, dtype=np.int8)
-            flike.close()
-            assert_(len(a) == fourgbplus)
-            # check only start and end for speed:
-            assert_((a[:n] == testbytes).all())
-            assert_((a[-n:] == testbytes).all())
-        except (MemoryError, ValueError):
-            pass
-
     def test_string(self, tmp_filename):
         self._check_from(b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, sep=',')
 


### PR DESCRIPTION
As discussed in the community meeting just now, we have a large CI matrix and some of it doesn't really add much. In the future we'd like to see about getting rid of Azure as much as possible, since it's the most cumbersome system to work with. For now, cull jobs that are not adding value.