### PR TITLE
NEP: add a paragraph about accredidation for sponsored work

### DIFF
--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -109,7 +109,7 @@ partners, and any other entities and individuals who provided $5,000 or more of
 financial or in-kind support. This page will include relevant details of
 support (dates, amounts, names, and purpose); no logos will be used on this
 page. Such support, if provided for a specific enhancements or fix, may be
-acknowledged in the appropriate release note snippet.  The rationale for the
+acknowledged in the appropriate release note snippet. The rationale for the
 $5,000 minimum level is to keep the amount of work maintaining the page
 reasonable; the level is the equivalent of, e.g., one GSoC or a person-week's
 worth of engineering time in a Western country, which seems like a reasonable

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -113,6 +113,11 @@ maintaining the page reasonable; the level is the equivalent of, e.g., one GSoC
 or a person-week's worth of engineering time in a Western country, which seems
 like a reasonable lower limit.
 
+Additionally, accredidation for smaller focused support in implementing
+specific ehancements or fixes may be attributed in the release notes for that
+contribution. In this case the accredidation will take the form of something
+like "Thanks to <name and url> for sponsoring this work" in the appropriate
+release note blurb.
 
 Implementation
 --------------

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -109,12 +109,11 @@ partners, and any other entities and individuals who provided $5,000 or more of
 financial or in-kind support. This page will include relevant details of
 support (dates, amounts, names, and purpose); no logos will be used on this
 page. Such support, if provided for a specific enhancements or fix, may be
-acknowledged in the release notes, through a "Thanks to
-``sponsor-name-and-url`` for sponsoring this work" in the appropriate release
-note snippet.  The rationale for the $5,000 minimum level is to keep the amount
-of work maintaining the page reasonable; the level is the equivalent of, e.g.,
-one GSoC or a person-week's worth of engineering time in a Western country,
-which seems like a reasonable lower limit.
+acknowledged in the appropriate release note snippet.  The rationale for the
+$5,000 minimum level is to keep the amount of work maintaining the page
+reasonable; the level is the equivalent of, e.g., one GSoC or a person-week's
+worth of engineering time in a Western country, which seems like a reasonable
+lower limit.
 
 Implementation
 --------------

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -108,16 +108,13 @@ About page) will be added to acknowledge all current and previous sponsors,
 partners, and any other entities and individuals who provided $5,000 or more of
 financial or in-kind support. This page will include relevant details of
 support (dates, amounts, names, and purpose); no logos will be used on this
-page. The rationale for the $5,000 minimum level is to keep the amount of work
-maintaining the page reasonable; the level is the equivalent of, e.g., one GSoC
-or a person-week's worth of engineering time in a Western country, which seems
-like a reasonable lower limit.
-
-Additionally, accredidation for smaller focused support in implementing
-specific ehancements or fixes may be attributed in the release notes for that
-contribution. In this case the accredidation will take the form of something
-like "Thanks to <name and url> for sponsoring this work" in the appropriate
-release note blurb.
+page. Such support, if provided for a specific enhancements or fix, may be
+acknowledged in the release notes, through a "Thanks to
+``sponsor-name-and-url`` for sponsoring this work" in the appropriate release
+note snippet.  The rationale for the $5,000 minimum level is to keep the amount
+of work maintaining the page reasonable; the level is the equivalent of, e.g.,
+one GSoC or a person-week's worth of engineering time in a Western country,
+which seems like a reasonable lower limit.
 
 Implementation
 --------------
@@ -132,7 +129,6 @@ The following content changes need to be made:
   eligibility requirements and benefits.
 - Update https://numpy.org/about with details on how to get in touch with the
   NumPy project about sponsorship related matters (see next section).
-
 
 NumPy Funding Team
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Our sponsorship NEP did not mention the possibility of mentioning sponsored work in a release note blurb. I suggest we add this so we can give credit where credit is due. The fact that it must be enough work to appear in a release note will hopefully set a lower bound for such contributions.