### PR TITLE
ENH: Allow trivial pickling of user DType (classes)

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -145,8 +145,10 @@ def _DType_reconstruct(scalar_type):
 def _DType_reduce(DType):
     # To pickle a DType without having to add top-level names, pickle the
     # scalar type for now (and assume that reconstruction will be possible).
-    if DType is dtype:
-        return "dtype"  # must pickle `np.dtype` as a singleton.
+    if not DType._legacy:
+        # If we don't have a legacy DType, we should have a valid top level
+        # name available, so use it (i.e. `np.dtype` itself!)
+        return DType.__name__
     scalar_type = DType.type  # pickle the scalar type for reconstruction
     return _DType_reconstruct, (scalar_type,)
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -918,6 +918,11 @@ dtypemeta_get_abstract(PyArray_DTypeMeta *self) {
 }
 
 static PyObject *
+dtypemeta_get_legacy(PyArray_DTypeMeta *self) {
+    return PyBool_FromLong(NPY_DT_is_legacy(self));
+}
+
+static PyObject *
 dtypemeta_get_parametric(PyArray_DTypeMeta *self) {
     return PyBool_FromLong(NPY_DT_is_parametric(self));
 }
@@ -927,6 +932,7 @@ dtypemeta_get_parametric(PyArray_DTypeMeta *self) {
  */
 static PyGetSetDef dtypemeta_getset[] = {
         {"_abstract", (getter)dtypemeta_get_abstract, NULL, NULL, NULL},
+        {"_legacy", (getter)dtypemeta_get_legacy, NULL, NULL, NULL},
         {"_parametric", (getter)dtypemeta_get_parametric, NULL, NULL, NULL},
         {NULL, NULL, NULL, NULL, NULL}
 };

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -218,3 +218,16 @@ class TestSFloat:
         assert res.dtype == a.dtype
         expected = np.hypot.reduce(float_equiv, keepdims=True)
         assert res.view(np.float64) * 2 == expected
+
+
+def test_type_pickle():
+    # can't actually unpickle, but we can pickle (if in namespace)
+    import pickle
+
+    np._ScaledFloatTestDType = SF
+
+    s = pickle.dumps(SF)
+    res = pickle.loads(s)
+    assert res is SF
+
+    del np._ScaledFloatTestDType


### PR DESCRIPTION
This also adds a `_legacy` attribute, I am happy to rename it, but I suspect having something like it is useful.

Arguably, the best solution would be to give our DTypes a working module+name, but given that we are not there, this seems easy. We could probably check for `__reduce__`, but I am not certain that wouldn't pre-empt successfully already, so this just restores the default for now.

---

@ngoldbaum this one is for you or Peyton.