### PR TITLE
TYP,MAINT: Add a missing explicit ``Any`` parameter to the ``npt.ArrayLike`` definition

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -83,7 +83,7 @@ _DualArrayLike = Union[
 #
 # https://github.com/python/typing/issues/593
 ArrayLike = _DualArrayLike[
-    dtype,
+    dtype[Any],
     Union[bool, int, float, complex, str, bytes],
 ]
 


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/23137

While equivalent to omitting, explicitly setting generic type parameters that you don't care about to `Any` is considered best practice.