### PR TITLE
TYP, MAINT: Add a missing explicit ``Any`` parameter to the ``npt.ArrayLike`` definition

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 # NOTE: Import `Sequence` from `typing` as we it is needed for a type-alias,
 # not an annotation
+import sys
 from collections.abc import Collection, Callable
 from typing import Any, Sequence, Protocol, Union, TypeVar, runtime_checkable
 from numpy import (
@@ -82,10 +83,16 @@ _DualArrayLike = Union[
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = _DualArrayLike[
-    dtype,
-    Union[bool, int, float, complex, str, bytes],
-]
+if sys.version_info[:2] < (3, 9):
+    ArrayLike = _DualArrayLike[
+        dtype,
+        Union[bool, int, float, complex, str, bytes],
+    ]
+else:
+    ArrayLike = _DualArrayLike[
+        dtype[Any],
+        Union[bool, int, float, complex, str, bytes],
+    ]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`


### PR DESCRIPTION
Backport of #23144.

Closes https://github.com/numpy/numpy/issues/23137

While equivalent to omitting, explicitly setting generic type parameters that you don't care about to `Any` is considered best practice.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
