### PR TITLE
BLD: remove redundant definition of npy_nextafter [wheel build]

### DIFF
--- a/numpy/core/src/npymath/arm64_exports.c
+++ b/numpy/core/src/npymath/arm64_exports.c
@@ -23,8 +23,4 @@ double npy_log1p(double x) {
     return log1p(x);
 }
 
-double npy_nextafter(double x, double y) {
-    return nextafter(x, y);
-}
-
 #endif


### PR DESCRIPTION
Fixes the failure from #22972 which added a redundant definition. This was improperly backported from main in that PR. On the release branch the definition still exists in `ieee754.cpp`