### PR TITLE
BUG: Correct types, add missing functions to c_distributions.pxd 

### DIFF
--- a/numpy/random/c_distributions.pxd
+++ b/numpy/random/c_distributions.pxd
@@ -66,7 +66,7 @@ cdef extern from "numpy/random/distributions.h":
     double random_uniform(bitgen_t *bitgen_state, double lower, double range) nogil
     double random_beta(bitgen_t *bitgen_state, double a, double b) nogil
     double random_chisquare(bitgen_t *bitgen_state, double df) nogil
-    float random_f(bitgen_t *bitgen_state, double dfnum, double dfden) nogil
+    double random_f(bitgen_t *bitgen_state, double dfnum, double dfden) nogil
     double random_standard_cauchy(bitgen_t *bitgen_state) nogil
     double random_pareto(bitgen_t *bitgen_state, double a) nogil
     double random_weibull(bitgen_t *bitgen_state, double a) nogil

--- a/numpy/random/c_distributions.pxd
+++ b/numpy/random/c_distributions.pxd
@@ -28,18 +28,24 @@ cdef extern from "numpy/random/distributions.h":
 
     ctypedef s_binomial_t binomial_t
 
+    float random_standard_uniform_f(bitgen_t *bitgen_state) nogil
     double random_standard_uniform(bitgen_t *bitgen_state) nogil
     void random_standard_uniform_fill(bitgen_t* bitgen_state, npy_intp cnt, double *out) nogil
+    void random_standard_uniform_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float *out) nogil
+    
     double random_standard_exponential(bitgen_t *bitgen_state) nogil
-    double random_standard_exponential_f(bitgen_t *bitgen_state) nogil
+    float random_standard_exponential_f(bitgen_t *bitgen_state) nogil
     void random_standard_exponential_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out) nogil
-    void random_standard_exponential_fill_f(bitgen_t *bitgen_state, npy_intp cnt, double *out) nogil
+    void random_standard_exponential_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float *out) nogil
     void random_standard_exponential_inv_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out) nogil
-    void random_standard_exponential_inv_fill_f(bitgen_t *bitgen_state, npy_intp cnt, double *out) nogil
+    void random_standard_exponential_inv_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float *out) nogil
+    
     double random_standard_normal(bitgen_t* bitgen_state) nogil
+    float random_standard_normal_f(bitgen_t *bitgen_state) nogil
     void random_standard_normal_fill(bitgen_t *bitgen_state, npy_intp count, double *out) nogil
     void random_standard_normal_fill_f(bitgen_t *bitgen_state, npy_intp count, float *out) nogil
     double random_standard_gamma(bitgen_t *bitgen_state, double shape) nogil
+    float random_standard_gamma_f(bitgen_t *bitgen_state, float shape) nogil
 
     float random_standard_uniform_f(bitgen_t *bitgen_state) nogil
     void random_standard_uniform_fill_f(bitgen_t* bitgen_state, npy_intp cnt, float *out) nogil
@@ -60,7 +66,7 @@ cdef extern from "numpy/random/distributions.h":
     double random_uniform(bitgen_t *bitgen_state, double lower, double range) nogil
     double random_beta(bitgen_t *bitgen_state, double a, double b) nogil
     double random_chisquare(bitgen_t *bitgen_state, double df) nogil
-    double random_f(bitgen_t *bitgen_state, double dfnum, double dfden) nogil
+    float random_f(bitgen_t *bitgen_state, double dfnum, double dfden) nogil
     double random_standard_cauchy(bitgen_t *bitgen_state) nogil
     double random_pareto(bitgen_t *bitgen_state, double a) nogil
     double random_weibull(bitgen_t *bitgen_state, double a) nogil


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
The Cython declarations in c_distributions.pxd for the npyrandom C API incorrectly marks some types as 'double' instead of 'float' for single-precision random number generator functions. There are also several single-precision functions in the API which were not previously exposed for use in Cython.

This pull request corrects the floating point types in c_distributions.pyx to match distributions.h, and adds missing functions declarations for single-precision random number generators.