### PR TITLE
BLD: add a meson windows build

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -1,10 +1,6 @@
 name: Test Meson build (Linux)
 
 on:
-  push:
-    branches:
-      - main
-      - maintenance/**
   pull_request:
     branches:
       - main
@@ -26,7 +22,7 @@ permissions:
 
 jobs:
   meson_devpy:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -194,7 +194,7 @@ jobs:
           python -m pip install dist/*.gz
           pip install -r test_requirements.txt
           cd .. # Can't import numpy within numpy src directory
-          python -c "import numpy; print(numpy.__version__); numpy.test();"
+          python -c "import numpy, sys; print(numpy.__version__); sys.exit(numpy.test() is False)"
 
       - name: Check README rendering for PyPI
         run: |

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -1,10 +1,6 @@
 name: Test Meson build (Windows)
 
 on:
-  push:
-    branches:
-      - main
-      - maintenance/**
   pull_request:
     branches:
       - main
@@ -24,7 +20,7 @@ jobs:
   meson:
     name: Meson windows build/test
     runs-on: windows-2019
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -68,7 +68,7 @@ jobs:
           $ob_path = "C:/opt/64/bin/"
           cp $ob_path/*.dll $libs_path
           # Write _distributor_init.py to load .libs DLLs.
-          python tools\openblas_support.py --write-init $numpy_path
+          python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
 
       - name: prep-test
         run: |

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -20,64 +20,69 @@ jobs:
   meson:
     name: Meson windows build/test
     runs-on: windows-2019
-    if: "github.repository == 'numpy/numpy'"
+    # if: "github.repository == 'numpy/numpy'"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        run: |
-          pip install -r build_requirements.txt
-      - name: openblas-libs
-        run: |
-          # Download and install pre-built OpenBLAS library
-          # with 32-bit interfaces
-          # Unpack it in the pkg-config hardcoded path
-          choco install unzip -y
-          choco install wget -y
-          choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-          wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
-          unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
-          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
-      - name: meson-configure
-        run: |
-          meson setup build --prefix=$PWD\build-install -Ddebug=false --optimization 2 --vsenv 
-      - name: meson-build
-        run: |
-          meson compile -C build -v
+    - name: Install dependencies
+      run: |
+        pip install -r build_requirements.txt
+    - name: openblas-libs
+      run: |
+        # Download and install pre-built OpenBLAS library
+        # with 32-bit interfaces
+        # Unpack it in the pkg-config hardcoded path
+        choco install unzip -y
+        choco install wget -y
+        choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+        wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+        unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+        echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+    - name: meson-configure
+      run: |
+        meson setup build --prefix=$PWD\build-install -Ddebug=false --optimization 2 --vsenv 
+    - name: meson-build
+      run: |
+        meson compile -C build -v
 
-      - name: meson-install
-        run: |
-          cd build
-          meson install --no-rebuild
-      - name: build-path
-        run: |
-          echo "installed_path=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
-      - name: post-install
-        run: |
-          $numpy_path = "${env:installed_path}\numpy"
-          $libs_path = "${numpy_path}\.libs"
-          mkdir ${libs_path}
-          $ob_path = "C:/opt/64/bin/"
-          cp $ob_path/*.dll $libs_path
-          # Write _distributor_init.py to load .libs DLLs.
-          python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
+    - name: meson-install
+      run: |
+        cd build
+        meson install --no-rebuild
+    - name: build-path
+      run: |
+        echo "installed_path=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
+    - name: post-install
+      run: |
+        $numpy_path = "${env:installed_path}\numpy"
+        $libs_path = "${numpy_path}\.libs"
+        mkdir ${libs_path}
+        $ob_path = "C:/opt/64/bin/"
+        cp $ob_path/*.dll $libs_path
+        # Write _distributor_init.py to load .libs DLLs.
+        python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
 
-      - name: prep-test
-        run: |
-          echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
-          python -m pip install -r test_requirements.txt
-          python -m pip install threadpoolctl
-      - name: test
-        run: |
-          mkdir tmp
-          cd tmp
-          python -c"import numpy; print(numpy.show_runtime())"
-          python -c "import numpy; numpy.test(verbose=3)"
+    - name: prep-test
+      run: |
+        echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
+        python -m pip install -r test_requirements.txt
+        python -m pip install threadpoolctl
+
+    - name: test
+      run: |
+        mkdir tmp
+        cd tmp
+        echo "============================================"
+        python -c "import numpy; print(numpy.show_runtime())"
+        echo "============================================"
+        echo "LASTEXITCODE is '$LASTEXITCODE'"
+        python -c "import numpy, sys; sys.exit(numpy.test(verbose=3) is False)"
+        echo "LASTEXITCODE is '$LASTEXITCODE'"

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -1,0 +1,86 @@
+name: Test Meson build (Windows)
+
+on:
+  push:
+    branches:
+      - main
+      - maintenance/**
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+
+env:
+  PYTHON_VERSION: 3.11
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  meson:
+    name: Meson windows build/test
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          pip install -r build_requirements.txt
+      - name: openblas-libs
+        run: |
+          # Download and install pre-built OpenBLAS library
+          # with 32-bit interfaces
+          # Unpack it in the pkg-config hardcoded path
+          choco install unzip -y
+          choco install wget -y
+          choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+          wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+          unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
+          echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+      - name: meson-configure
+        run: |
+          meson setup build --prefix=$PWD\build-install -Ddebug=false --optimization 2 --vsenv 
+      - name: meson-build
+        run: |
+          meson compile -C build -v
+
+      - name: meson-install
+        run: |
+          cd build
+          meson install --no-rebuild
+      - name: build-path
+        run: |
+          echo "installed_path=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
+      - name: post-install
+        run: |
+          $numpy_path = "${env:installed_path}\numpy"
+          $libs_path = "${numpy_path}\.libs"
+          mkdir ${libs_path}
+          $ob_path = "C:/opt/64/bin/"
+          cp $ob_path/*.dll $libs_path
+          # Write _distributor_init.py to load .libs DLLs.
+          python tools\openblas_support.py --write-init $numpy_path
+
+      - name: prep-test
+        run: |
+          echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
+          python -m pip install -r test_requirements.txt
+          python -m pip install threadpoolctl
+      - name: test
+        run: |
+          mkdir tmp
+          cd tmp
+          python -c"import numpy; print(numpy.show_runtime())"
+          python -c "import numpy; numpy.test(verbose=3)"

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -24,6 +24,7 @@ jobs:
   meson:
     name: Meson windows build/test
     runs-on: windows-2019
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Testing:
 
 NumPy requires `pytest` and `hypothesis`.  Tests can then be run after installation with:
 
-    python -c 'import numpy; numpy.test()'
+    python -c "import numpy, sys; sys.exit(numpy.test() is False)"
 
 Code of Conduct
 ----------------------

--- a/building_with_meson.md
+++ b/building_with_meson.md
@@ -9,8 +9,14 @@ into a problem._
 
 **Install build tools:** Use one of:
 
-- `mamba create -f environment.yml
-- `pip install -r build_requirements.txt  # also make sure you have pkg-config and the usual system dependencies for NumPy`
+- `mamba env create -f environment.yml && mamba activate numpy-dev
+
+- `python -m pip install -r build_requirements.txt
+  # also make sure you have pkg-config and the usual system dependencies for
+  # NumPy`
+
+Then install devpy:
+- `python -m pip install git+https://github.com/scientific-python/devpy`
 
 **Compile and install:** `./dev.py build`
 

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,9 @@ dependencies:
   - setuptools=59.2.0
   - meson >= 0.64.0
   - ninja
-  - pkg-config  # note: not available on Windows, comment out this line
+  - pkg-config
   - meson-python
+  - pip   # so you can use pip to install devpy
   # For testing
   - pytest
   - pytest-cov

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -112,9 +112,6 @@ from .exceptions import (
     ComplexWarning, ModuleDeprecationWarning, VisibleDeprecationWarning,
     TooHardError, AxisError)
 
-# Allow distributors to run custom init code before importing numpy.core
-from . import _distributor_init
-
 # We first need to detect if we're being called as part of the numpy setup
 # procedure itself in a reliable manner.
 try:
@@ -125,6 +122,9 @@ except NameError:
 if __NUMPY_SETUP__:
     sys.stderr.write('Running from numpy source directory.\n')
 else:
+    # Allow distributors to run custom init code before importing numpy.core
+    from . import _distributor_init
+
     try:
         from numpy.__config__ import show as show_config
     except ImportError as e:

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -112,6 +112,9 @@ from .exceptions import (
     ComplexWarning, ModuleDeprecationWarning, VisibleDeprecationWarning,
     TooHardError, AxisError)
 
+# Allow distributors to run custom init code before importing numpy.core
+from . import _distributor_init
+
 # We first need to detect if we're being called as part of the numpy setup
 # procedure itself in a reliable manner.
 try:
@@ -136,9 +139,6 @@ else:
 
     # mapping of {name: (value, deprecation_msg)}
     __deprecated_attrs__ = {}
-
-    # Allow distributors to run custom init code
-    from . import _distributor_init
 
     from . import core
     from .core import *

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -173,6 +173,8 @@ static inline int PyInt_Check(PyObject *op) {
  */
 #if defined _MSC_VER && _MSC_VER >= 1900
 
+#include <stdlib.h>
+
 extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #define NPY_BEGIN_SUPPRESS_IPH { _invalid_parameter_handler _Py_old_handler = \
     _set_thread_local_invalid_parameter_handler(_Py_silent_invalid_parameter_handler);

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -167,6 +167,24 @@ static inline int PyInt_Check(PyObject *op) {
 
 #endif /* NPY_PY3K */
 
+/*
+ * Macros to protect CRT calls against instant termination when passed an
+ * invalid parameter (issue23524).
+ */
+#if defined _MSC_VER && _MSC_VER >= 1900
+
+extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
+#define NPY_BEGIN_SUPPRESS_IPH { _invalid_parameter_handler _Py_old_handler = \
+    _set_thread_local_invalid_parameter_handler(_Py_silent_invalid_parameter_handler);
+#define NPY_END_SUPPRESS_IPH _set_thread_local_invalid_parameter_handler(_Py_old_handler); }
+
+#else
+
+#define NPY_BEGIN_SUPPRESS_IPH
+#define NPY_END_SUPPRESS_IPH
+
+#endif /* _MSC_VER >= 1900 */
+
 
 static inline void
 PyUnicode_ConcatAndDel(PyObject **left, PyObject *right)
@@ -242,13 +260,17 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
 
     /* Convert to FILE* handle */
 #ifdef _WIN32
+    NPY_BEGIN_SUPPRESS_IPH
     handle = _fdopen(fd2, mode);
+    NPY_END_SUPPRESS_IPH
 #else
     handle = fdopen(fd2, mode);
 #endif
     if (handle == NULL) {
         PyErr_SetString(PyExc_IOError,
-                        "Getting a FILE* from a Python file object failed");
+                        "Getting a FILE* from a Python file object via "
+                        "_fdopen failed. If you built NumPy, you probably "
+                        "linked with the wrong debug/release runtime");
         return NULL;
     }
 

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -169,7 +169,7 @@ static inline int PyInt_Check(PyObject *op) {
 
 /*
  * Macros to protect CRT calls against instant termination when passed an
- * invalid parameter (issue23524).
+ * invalid parameter (https://bugs.python.org/issue23524).
  */
 #if defined _MSC_VER && _MSC_VER >= 1900
 

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -109,11 +109,19 @@ cdata.set('NPY_SIZEOF_PY_LONG_LONG',
 if cc.has_header('complex.h')
   cdata.set10('HAVE_COMPLEX_H', true)
   cdata.set10('NPY_USE_C99_COMPLEX', true)
-  complex_types_to_check = [
-    ['NPY_HAVE_COMPLEX_FLOAT', 'NPY_SIZEOF_COMPLEX_FLOAT', 'complex float', 'float'],
-    ['NPY_HAVE_COMPLEX_DOUBLE', 'NPY_SIZEOF_COMPLEX_DOUBLE', 'complex double', 'double'],
-    ['NPY_HAVE_COMPLEX_LONG_DOUBLE', 'NPY_SIZEOF_COMPLEX_LONGDOUBLE', 'complex long double', 'long double'],
-  ]
+  if cc.get_id() == 'msvc'
+    complex_types_to_check = [
+      ['NPY_HAVE_COMPLEX_FLOAT', 'NPY_SIZEOF_COMPLEX_FLOAT', '_Fcomplex', 'float'],
+      ['NPY_HAVE_COMPLEX_DOUBLE', 'NPY_SIZEOF_COMPLEX_DOUBLE', '_Dcomplex', 'double'],
+      ['NPY_HAVE_COMPLEX_LONG_DOUBLE', 'NPY_SIZEOF_COMPLEX_LONGDOUBLE', '_Lcomplex', 'long double'],
+    ]
+  else
+    complex_types_to_check = [
+      ['NPY_HAVE_COMPLEX_FLOAT', 'NPY_SIZEOF_COMPLEX_FLOAT', 'complex float', 'float'],
+      ['NPY_HAVE_COMPLEX_DOUBLE', 'NPY_SIZEOF_COMPLEX_DOUBLE', 'complex double', 'double'],
+      ['NPY_HAVE_COMPLEX_LONG_DOUBLE', 'NPY_SIZEOF_COMPLEX_LONGDOUBLE', 'complex long double', 'long double'],
+    ]
+  endif
   foreach symbol_type: complex_types_to_check
     if cc.has_type(symbol_type[2], prefix: '#include <complex.h>')
       cdata.set10(symbol_type[0], true)
@@ -250,7 +258,9 @@ else
   # function is not available in CI. For the latter there is a fallback path,
   # but that is broken because we don't have the exact long double
   # representation checks.
-  cdata.set10('HAVE_STRTOLD_L', false)
+  if cc.get_id() != 'msvc'
+    cdata.set10('HAVE_STRTOLD_L', false)
+  endif
 endif
 
 # Other optional functions
@@ -451,7 +461,7 @@ if cc.get_id() == 'msvc'
   # libnpymath and libnpyrandom)
   if cc.has_argument('-d2VolatileMetadata-')
      staticlib_cflags +=  '-d2VolatileMetadata-'
-   endif
+  endif
 endif
 # TODO: change to "feature" option in meson_options.txt? See
 # https://mesonbuild.com/Build-options.html#build-options

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -589,13 +589,11 @@ c_args_common = [
 ]
 
 # Same as NPY_CXX_FLAGS (TODO: extend for what ccompiler_opt adds)
-if cc.get_id() == 'msvc'
-  cpp_args_common = c_args_common + [
-    '-D__STDC_VERSION__=0',  # for compatibility with C headers
-  ]
-else
-  cpp_args_common = c_args_common + [
-    '-D__STDC_VERSION__=0',  # for compatibility with C headers
+cpp_args_common = c_args_common + [
+  '-D__STDC_VERSION__=0',  # for compatibility with C headers
+]
+if cc.get_id() != 'msvc'
+  cpp_args_common += [
     '-fno-exceptions',  # no exception support
     '-fno-rtti',  # no runtime type information
   ]

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -589,11 +589,17 @@ c_args_common = [
 ]
 
 # Same as NPY_CXX_FLAGS (TODO: extend for what ccompiler_opt adds)
-cpp_args_common = c_args_common + [
-  '-D__STDC_VERSION__=0',  # for compatibility with C headers
-  '-fno-exceptions',  # no exception support
-  '-fno-rtti',  # no runtime type information
-]
+if cc.get_id() == 'msvc'
+  cpp_args_common = c_args_common + [
+    '-D__STDC_VERSION__=0',  # for compatibility with C headers
+  ]
+else
+  cpp_args_common = c_args_common + [
+    '-D__STDC_VERSION__=0',  # for compatibility with C headers
+    '-fno-exceptions',  # no exception support
+    '-fno-rtti',  # no runtime type information
+  ]
+endif
 
 # Other submodules depend on generated headers and include directories from
 # core, wrap those up into a reusable dependency. Also useful for some test

--- a/numpy/core/src/common/numpyos.c
+++ b/numpy/core/src/common/numpyos.c
@@ -779,3 +779,25 @@ NumPyOS_strtoull(const char *str, char **endptr, int base)
     return strtoull(str, endptr, base);
 }
 
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+
+#if _MSC_VER >= 1900
+/* npy3k_compat.h uses this function in the _Py_BEGIN/END_SUPPRESS_IPH
+ * macros. It does not need to be defined when building using MSVC
+ * earlier than 14.0 (_MSC_VER == 1900).
+ */
+
+static void __cdecl _silent_invalid_parameter_handler(
+    wchar_t const* expression,
+    wchar_t const* function,
+    wchar_t const* file,
+    unsigned int line,
+    uintptr_t pReserved) { }
+
+_invalid_parameter_handler _Py_silent_invalid_parameter_handler = _silent_invalid_parameter_handler;
+
+#endif
+
+#endif

--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -290,7 +290,7 @@ NPY_NO_EXPORT int
 npy_tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
 {
     assert(ts->fields_size >= 2);
-    assert(ts->field_buffer_length >= 2*(ssize_t)sizeof(Py_UCS4));
+    assert(ts->field_buffer_length >= 2*(Py_ssize_t)sizeof(Py_UCS4));
 
     int finished_reading_file = 0;
 

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -30,9 +30,6 @@ if is_windows
     endif
   endif
 endif
-if is_msvc
-  add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
-endif
 
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,
 # lseek -> lseek64, etc.)

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -31,7 +31,7 @@ if is_windows
   endif
 endif
 if is_msvc
-      add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
+  add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
 endif
 
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,
@@ -81,6 +81,9 @@ dependency_map = {
 have_blas = blas.found() # TODO: and blas.has_cblas()
 have_lapack = lapack.found()
 if have_blas
+  # TODO: this is a shortcut - it needs to be checked rather than used
+  # unconditionally, and then added to the extension modules that need the
+  # macro, rather than as a project argument.
   add_project_arguments('-DHAVE_CBLAS', language: ['c', 'cpp'])
 endif
 

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -10,6 +10,7 @@ endif
 # Platform detection
 is_windows = host_machine.system() == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
+is_msvc = is_windows and cc.get_id() == 'msvc'
 
 if is_windows
   # For mingw-w64, link statically against the UCRT.

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -30,6 +30,9 @@ if is_windows
     endif
   endif
 endif
+if is_msvc
+      add_project_arguments('-DNDEBUG', language: ['c', 'cpp'])
+endif
 
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,
 # lseek -> lseek64, etc.)
@@ -77,6 +80,9 @@ dependency_map = {
 # TODO: add ILP64 support
 have_blas = blas.found() # TODO: and blas.has_cblas()
 have_lapack = lapack.found()
+if have_blas
+  add_project_arguments('-DHAVE_CBLAS', language: ['c', 'cpp'])
+endif
 
 # Copy the main __init__.py|pxd files to the build dir (needed for Cython)
 __init__py = fs.copyfile('__init__.py')

--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -66,7 +66,7 @@ random_pyx_sources = [
       fs.copyfile('mtrand.pyx'),
       'src/distributions/distributions.c',
       'src/legacy/legacy-distributions.c'
-    ], ['-DNPY_RANDOM_LEGACY=1'], npymath_lib,
+    ], ['-DNP_RANDOM_LEGACY=1'], npymath_lib,
   ],
 ]
 foreach gen: random_pyx_sources

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -471,6 +471,10 @@ def test_api_importable():
 
 
 @pytest.mark.xfail(
+    hasattr(np.__config__, "_built_with_meson"),
+    reason = "Meson does not yet support entry points via pyproject.toml",
+)
+@pytest.mark.xfail(
     sysconfig.get_config_var("Py_DEBUG") is not None,
     reason=(
         "NumPy possibly built with `USE_DEBUG=True ./tools/travis-test.sh`, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ requires = [
 #'f2py3 = numpy.f2py.f2py2e:main'
 #'f2py3.MINOR_VERSION = numpy.f2py.f2py2e:main'
 #
+# When enabling this stanza, make sure to remove the meson-specific xfail from
+# numpy/tests/test_public_api.py
 #[project.entry-points]
 #'array_api': 'numpy = numpy.array_api'
 #'pyinstaller40': 'hook-dirs = numpy:_pyinstaller_hooks_dir'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -232,36 +232,13 @@ def make_init(dirname):
     with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
         fid.write(textwrap.dedent("""
             '''
-            Helper to preload windows dlls to prevent dll not found errors.
-            Once a DLL is preloaded, its namespace is made available to any
-            subsequent DLL. This file originated in the numpy-wheels repo,
-            and is created as part of the scripts that build the wheel.
+            Helper to add the path to the openblas dll to the dll search space
             '''
             import os
-            import glob
-            if os.name == 'nt':
-                # convention for storing / loading the DLL from
-                # numpy/.libs/, if present
-                try:
-                    from ctypes import WinDLL
-                    basedir = os.path.dirname(__file__)
-                except:
-                    pass
-                else:
-                    libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
-                    DLL_filenames = []
-                    if os.path.isdir(libs_dir):
-                        for filename in glob.glob(os.path.join(libs_dir,
-                                                               '*openblas*dll')):
-                            # NOTE: would it change behavior to load ALL
-                            # DLLs at this path vs. the name restriction?
-                            WinDLL(os.path.abspath(filename))
-                            DLL_filenames.append(filename)
-                    if len(DLL_filenames) > 1:
-                        import warnings
-                        warnings.warn("loaded more than 1 DLL from .libs:"
-                                      "\\n%s" % "\\n".join(DLL_filenames),
-                                      stacklevel=1)
+            import sys
+            extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
+            if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
+                os.add_dll_directory(extra_dll_dir)
     """))
 
 
@@ -343,9 +320,14 @@ if __name__ == '__main__':
     parser.add_argument('--check_version', nargs='?', default='',
                         help='Check provided OpenBLAS version string '
                              'against available OpenBLAS')
+    parser.add_argument('--write-init', nargs=1,
+                        metavar='OUT_SCIPY_DIR',
+                        help='Write distribution init to named dir')
     args = parser.parse_args()
     if args.check_version != '':
         test_version(args.check_version)
+    elif args.write_init:
+        make_init(args.write_init[0])
     elif args.test is None:
         print(setup_openblas())
     else:


### PR DESCRIPTION
Add a meson build for windows. Eventually, we should extend this to replace the azure windows builds. In addition to the new github workflow this:
- Tweaks the meson.md instructions and the conda environment
- Changes imports to import `_distributor_init` before the c-extensions
- ~Changes `tools/openblas_support.py` to generate the `_distributor_init` and use `os.add_dll_directory()` to enable loading OpenBLAS~ (reverted this since it does not work with conda)
- Uses the `openblas*.dll` packaged by `MacPython/openblas-libs` instead of repackaging the `openblas.a`. No mingw is needed for building and packaging NumPy. It is needed for f2py, until we find a better fortran compiler.
- Wrap `_fdopen` in an [invalid parameter handler](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/set-invalid-parameter-handler-set-thread-local-invalid-parameter-handler?view=msvc-170). Without it, linking to the wrong runtime can cause the process to silently exit. Now when `_fdopen` fails, a helpful error message will be emitted.