### PR TITLE
ENH: Integrate Optimized Routines for AArch64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "numpy/core/src/umath/svml"]
 	path = numpy/core/src/umath/svml
 	url = https://github.com/numpy/SVML.git
+[submodule "numpy/core/src/umath/optimized-routines"]
+	path = numpy/core/src/umath/optimized-routines
+	url = https://github.com/ARM-software/optimized-routines.git

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -1,3 +1,5 @@
+# Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
 # This file should contain what setup.py + setup_common.py do (WIP)
 #
 # Potential issues to address or keep track of:
@@ -71,6 +73,17 @@ cdata = configuration_data()
 
 cdata.set('NPY_ABI_VERSION', C_ABI_VERSION)
 cdata.set('NPY_API_VERSION', C_API_VERSION)
+
+use_optimized_routines = (
+  host_machine.cpu_family() == 'aarch64' and
+  not get_option('disable-optimized-routines')
+)
+if use_optimized_routines
+  cdata.set10('NPY_CAN_LINK_AOR', true)
+  if not fs.exists('src/umath/optimized-routines')
+    error('Missing the `Optimized Routines` git submodule! Run `git submodule update --init` to fix this.')
+  endif
+endif
 
 use_svml = (
   host_machine.system() == 'linux' and
@@ -779,6 +792,22 @@ src_umath = [
   'src/umath/_scaled_float_dtype.c',
 ]
 
+# Optimized Routines source files. If functionality is migrated to universal intrinsics and
+# the object files are no longer needed, comment out the relevant object files
+# here. Note that this migration is desirable; we then get the performance
+# benefits for all platforms rather than only for AArch64.
+src_optimized_routines = []
+optimized_routines_include = []
+if use_optimized_routines
+  optimized_routines_include += [
+    'src/umath/optimized-routines/math/include/'
+  ]
+  src_optimized_routines += [
+    'src/umath/optimized-routines/math/v_cos.c',
+    'src/umath/optimized-routines/math/v_sin.c',
+  ]
+endif
+
 # SVML object files. If functionality is migrated to universal intrinsics and
 # the object files are no longer needed, comment out the relevant object files
 # here. Note that this migration is desirable; we then get the performance
@@ -845,6 +874,7 @@ py.extension_module('_multiarray_umath',
     src_numpy_api[1],  # __multiarray_api.h
     src_umath_doc_h,
     npy_math_internal_h,
+    src_optimized_routines,
   ],
   objects: svml_objects,
   c_args: c_args_common,
@@ -855,6 +885,7 @@ py.extension_module('_multiarray_umath',
     'src/multiarray',
     'src/npymath',
     'src/umath',
+    optimized_routines_include
   ],
   dependencies: blas,
   link_with: npymath_lib,

--- a/numpy/core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_umath_fp.dispatch.c.src
@@ -1,6 +1,12 @@
 /*@targets
- ** $maxopt baseline avx512_skx
+ ** $maxopt baseline
+ ** avx512_skx
+ ** asimd
  */
+/*
+ * Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ */
+
 #include "numpy/npy_math.h"
 #include "simd/simd.h"
 #include "loops_utils.h"
@@ -8,7 +14,17 @@
 #include "npy_svml.h"
 #include "fast_loop_macros.h"
 
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if NPY_SIMD
+#if defined(NPY_HAVE_ASIMD) && defined(NPY_CAN_LINK_AOR)
+#include <mathlib.h>
+#define _NPY_OPTIMIZED_ROUTINES
+#endif
+#if defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#define _NPY_SVML
+#endif
+#endif
+
+#if defined(_NPY_SVML)
 /**begin repeat
  * #sfx = f32, f64#
  * #func_suffix = f16, 8#
@@ -58,7 +74,9 @@ simd_@func@_@sfx@(const npyv_lanetype_@sfx@ *src, npy_intp ssrc,
 }
 /**end repeat1**/
 /**end repeat**/
+#endif
 
+#if defined(_NPY_OPTIMIZED_ROUTINES) || defined(_NPY_SVML)
 /**begin repeat
  * #func = sin, cos#
  */
@@ -74,7 +92,11 @@ simd_@func@_f64(const double *src, npy_intp ssrc,
         } else {
             x = npyv_loadn_tillz_f64(src, ssrc, len);
         }
+        #if defined(_NPY_OPTIMIZED_ROUTINES)
+        npyv_f64 out = __v_@func@(x);
+        #else
         npyv_f64 out = __svml_@func@8(x);
+        #endif
         if (sdst == 1) {
             npyv_store_till_f64(dst, len, out);
         } else {
@@ -84,7 +106,9 @@ simd_@func@_f64(const double *src, npy_intp ssrc,
     npyv_cleanup();
 }
 /**end repeat**/
+#endif
 
+#if defined(_NPY_SVML)
 /**begin repeat
  * #sfx = f32, f64#
  * #func_suffix = f16, 8#
@@ -92,7 +116,6 @@ simd_@func@_f64(const double *src, npy_intp ssrc,
 /**begin repeat1
  * #func = pow, atan2#
  */
-
 static void
 simd_@func@_@sfx@(const npyv_lanetype_@sfx@ *src1, npy_intp ssrc1,
                   const npyv_lanetype_@sfx@ *src2, npy_intp ssrc2,
@@ -182,7 +205,7 @@ avx512_@func@_f16(const npy_half *src, npy_half *dst, npy_intp len)
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(HALF_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if defined(_NPY_SVML)
     const npy_half *src = (npy_half*)args[0];
           npy_half *dst = (npy_half*)args[1];
     const int lsize = sizeof(src[0]);
@@ -216,7 +239,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(HALF_@func@)
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if defined(_NPY_SVML)
     const @type@ *src = (@type@*)args[0];
           @type@ *dst = (@type@*)args[1];
     const int lsize = sizeof(src[0]);
@@ -252,7 +275,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if defined(_NPY_SVML)
     const @type@ *src1 = (@type@*)args[0];
     const @type@ *src2 = (@type@*)args[1];
           @type@ *dst  = (@type@*)args[2];
@@ -284,7 +307,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(DOUBLE_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if defined(_NPY_SVML) || defined(_NPY_OPTIMIZED_ROUTINES)
     const double *src = (double*)args[0];
           double *dst = (double*)args[1];
     const int lsize = sizeof(src[0]);

--- a/tools/ci/cirrus_general.yml
+++ b/tools/ci/cirrus_general.yml
@@ -1,3 +1,5 @@
+# Copyright 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
     - python -m pip install cibuildwheel==2.12.0
@@ -34,6 +36,7 @@ linux_aarch64_task:
   build_script: |
     apt install -y python3-venv python-is-python3 gfortran libatlas-base-dev libgfortran5 eatmydata
     git fetch origin
+    git submodule update --init
     ./tools/travis-before-install.sh
     which python
     echo $CIRRUS_CHANGE_MESSAGE


### PR DESCRIPTION
Adds the initial support for using the Optimized Routines library to improve performance on AArch64.

`cos` and `sin` are implemented to demonstrate the flow through to the library calls, more will be added in a follow up patch to align with the existing SVML integration.

I've updated both setup.py and meson.build, but I'm unsure which gets triggered when 🤔 

```
16:47:00  -         729±2μs        397±0.4μs     0.54  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 1, 1, 'd')
16:47:00  -        732±10μs          414±6μs     0.56  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 1, 2, 'd')
16:47:00  -        776±20μs         436±10μs     0.56  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 1, 4, 'd')
16:47:00  -         731±2μs        419±0.3μs     0.57  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 2, 1, 'd')
16:47:00  -         732±3μs        439±0.5μs     0.60  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 2, 2, 'd')
16:47:00  -        735±20μs         440±10μs     0.60  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 2, 4, 'd')
16:47:00  -         736±1μs          420±1μs     0.57  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 4, 1, 'd')
16:47:00  -       736±0.7μs          441±1μs     0.60  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 4, 2, 'd')
16:47:00  -         736±2μs          442±2μs     0.60  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 4, 4, 'd')
16:47:00  -         871±5μs        395±0.3μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 1, 1, 'd')
16:47:00  -        876±10μs          413±6μs     0.47  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 1, 2, 'd')
16:47:00  -        928±30μs         436±10μs     0.47  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 1, 4, 'd')
16:47:00  -         871±5μs        417±0.2μs     0.48  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 2, 1, 'd')
16:47:00  -         874±2μs        430±0.2μs     0.49  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 2, 2, 'd')
16:47:00  -        876±20μs         430±10μs     0.49  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 2, 4, 'd')
16:47:00  -         876±4μs          419±1μs     0.48  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 4, 1, 'd')
16:47:00  -         872±2μs          431±2μs     0.49  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 4, 2, 'd')
16:47:00  -         875±6μs          434±2μs     0.50  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 4, 4, 'd')
```


See: https://mail.python.org/archives/list/numpy-discussion@python.org/message/GTHX4TFRUCGQI2VPHEWMEC4GBOAOOH4C/