### PR TITLE
BUG/ENH: Fix fast index loops for 1-el array / allow scalar value

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5915,7 +5915,12 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
         steps[2] = 0;
     } else {
         args[2] = (char *)PyArray_DATA(op2_array);
-        steps[2] = PyArray_STRIDE(op2_array, 0);
+        if (PyArray_NDIM(op2_array) == 0
+            || PyArray_DIM(op2_array, 0) <= 1) {
+            steps[2] = 0;
+        } else {
+            steps[2] = PyArray_STRIDE(op2_array, 0);
+        }
     }
 
     npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
@@ -6435,7 +6440,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
          */
         if ((ufuncimpl->contiguous_indexed_loop != NULL) &&
                 (PyArray_NDIM(op1_array) == 1)  &&
-                (op2_array == NULL || PyArray_NDIM(op2_array) == 1) &&
+                (op2_array == NULL || PyArray_NDIM(op2_array) <= 1) &&
                 (iter->subspace_iter == NULL) && (iter->numiter == 1)) {
             res = trivial_at_loop(ufuncimpl, flags, iter, op1_array,
                         op2_array, &context);

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2045,6 +2045,15 @@ class TestUfunc:
         np.add.at(arr, index, values)
         assert arr[0] == len(values)
 
+    @pytest.mark.parametrize("value", [
+        np.ones(1), np.ones(()), np.float64(1.), 1.])
+    def test_ufunc_at_scalar_value_fastpath(self, value):
+        arr = np.zeros(1000)
+        # index must be cast, which may be buffered in chunks:
+        index = np.repeat(np.arange(1000), 2)
+        np.add.at(arr, index, value)
+        assert_array_equal(arr, np.full_like(arr, 2 * value))
+
     def test_ufunc_at_multiD(self):
         a = np.arange(9).reshape(3, 3)
         b = np.array([[100, 100, 100], [200, 200, 200], [300, 300, 300]])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fixes #23178 and also ensures that regular scalar values take the fast path for the index loops (like `np.add.at`).

EDIT: new timings:
```
In [2]: import numpy as np; c = np.zeros(1000, complex); r = c.view(float); i = np.repeat(np.arange(999, 1, -1, dtype=np.intp), 100); np.__version__
Out[2]: '1.25.0.dev0+597.gc4c0bbd36'

In [3]: %timeit np.add.at(r, i, np.ones(1))
324 µs ± 3.97 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [4]: %timeit np.add.at(r, i, np.ones(()))
324 µs ± 2.88 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [5]: %timeit np.add.at(r, i, 1.)
317 µs ± 690 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [6]: %timeit np.add.at(r, i, 1)
8.55 ms ± 39.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
Last one is slow because of the need for casting (maybe can be special-cased too, but for another time!)

EDIT2: for comparison on the same machine,
```
In [3]: %timeit np.bincount(i)
264 µs ± 1.48 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```