### PR TITLE
DOC: update release blurb

### DIFF
--- a/doc/release/upcoming_changes/23136.performance.rst
+++ b/doc/release/upcoming_changes/23136.performance.rst
@@ -8,7 +8,8 @@ Generic ``ufunc.at`` can be up to 9x faster. The conditions for this speedup:
 If ufuncs with appropriate indexed loops on 1d arguments with the above
 conditions, ``ufunc.at`` can be up to 60x faster (an additional 7x speedup).
 Appropriate indexed loops have been added to ``add``, ``subtract``,
-``multiply``, ``divide`` (and ``floor_divide``)
+``multiply``, ``floor_divide``, ``maximum``, ``minimum``, ``fmax``, and
+``fmin``.
 
 The internal logic is similar to the logic used for regular ufuncs, which also
 have fast paths.


### PR DESCRIPTION
Update release blurb after #23177

The original pull request had a typo: the indexed loops were only added for `floor_divide`, not for `divide`.