### PR TITLE
BUG: fix for f2py string scalars

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -342,9 +342,9 @@ def getstrlength(var):
 def getarrdims(a, var, verbose=0):
     ret = {}
     if isstring(var) and not isarray(var):
-        ret['dims'] = getstrlength(var)
-        ret['size'] = ret['dims']
-        ret['rank'] = '1'
+        ret['size'] = getstrlength(var)
+        ret['rank'] = '0'
+        ret['dims'] = ''
     elif isscalar(var):
         ret['size'] = '1'
         ret['rank'] = '0'

--- a/numpy/f2py/tests/src/string/scalar_string.f90
+++ b/numpy/f2py/tests/src/string/scalar_string.f90
@@ -2,4 +2,6 @@ MODULE string_test
 
   character(len=8) :: string
 
+  character(len=12), dimension(5,7) :: strarr
+
 END MODULE string_test

--- a/numpy/f2py/tests/src/string/scalar_string.f90
+++ b/numpy/f2py/tests/src/string/scalar_string.f90
@@ -1,0 +1,5 @@
+MODULE string_test
+
+  character(len=8) :: string
+
+END MODULE string_test

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -571,7 +571,7 @@ class TestMiscCharacter(util.F2PyTest):
         assert_raises(Exception, lambda: f(b'c'))
 
 
-class TestStringScalar(util.F2PyTest):
+class TestStringScalarArr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "scalar_string.f90")]
 
     @pytest.mark.slow
@@ -580,4 +580,12 @@ class TestStringScalar(util.F2PyTest):
         expected = ()
         assert out.shape == expected
         expected = '|S8'
+        assert out.dtype == expected
+
+    @pytest.mark.slow
+    def test_char_arr(self):
+        out = self.module.string_test.strarr
+        expected = (5,7)
+        assert out.shape == expected
+        expected = '|S12'
         assert out.dtype == expected

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -569,3 +569,15 @@ class TestMiscCharacter(util.F2PyTest):
         assert_equal(len(a), 2)
 
         assert_raises(Exception, lambda: f(b'c'))
+
+
+class TestStringScalar(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "string", "scalar_string.f90")]
+
+    @pytest.mark.slow
+    def test_char(self):
+        out = self.module.string_test.string
+        expected = ()
+        assert out.shape == expected
+        expected = '|S8'
+        assert out.dtype == expected

--- a/numpy/testing/overrides.py
+++ b/numpy/testing/overrides.py
@@ -25,7 +25,7 @@ def get_overridable_numpy_ufuncs():
     
 
 def allows_array_ufunc_override(func):
-    """Determine if a function can be overriden via `__array_ufunc__`
+    """Determine if a function can be overridden via `__array_ufunc__`
 
     Parameters
     ----------
@@ -67,7 +67,7 @@ def get_overridable_numpy_array_functions():
     return _array_functions.copy()
 
 def allows_array_function_override(func):
-    """Determine if a Numpy function can be overriden via `__array_function__`
+    """Determine if a Numpy function can be overridden via `__array_function__`
 
     Parameters
     ----------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
proposed fix for #23192

in previous version, any string scalar was converted to a string array of dimension len, i.e., a definition
```fortran
character(len=N) :: X
```
 effectively became
```fortran
character(len=NNN), dimension(NNN) :: X
```
from the point of few of the numpy (python) interface:
```python
X.shape == (NNN,)
X.dtype == '|SNNN'
```