### PR TITLE
BUG: fix for f2py string scalars (#23194)

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -342,9 +342,9 @@ def getstrlength(var):
 def getarrdims(a, var, verbose=0):
     ret = {}
     if isstring(var) and not isarray(var):
-        ret['dims'] = getstrlength(var)
-        ret['size'] = ret['dims']
-        ret['rank'] = '1'
+        ret['size'] = getstrlength(var)
+        ret['rank'] = '0'
+        ret['dims'] = ''
     elif isscalar(var):
         ret['size'] = '1'
         ret['rank'] = '0'

--- a/numpy/f2py/tests/src/string/scalar_string.f90
+++ b/numpy/f2py/tests/src/string/scalar_string.f90
@@ -1,0 +1,7 @@
+MODULE string_test
+
+  character(len=8) :: string
+
+  character(len=12), dimension(5,7) :: strarr
+
+END MODULE string_test

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -568,3 +568,23 @@ class TestMiscCharacter(util.F2PyTest):
         assert_equal(len(a), 2)
 
         assert_raises(Exception, lambda: f(b'c'))
+
+
+class TestStringScalarArr(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "string", "scalar_string.f90")]
+
+    @pytest.mark.slow
+    def test_char(self):
+        out = self.module.string_test.string
+        expected = ()
+        assert out.shape == expected
+        expected = '|S8'
+        assert out.dtype == expected
+
+    @pytest.mark.slow
+    def test_char_arr(self):
+        out = self.module.string_test.strarr
+        expected = (5,7)
+        assert out.shape == expected
+        expected = '|S12'
+        assert out.dtype == expected


### PR DESCRIPTION
Backport of #23194.

Closes  #23192

in previous version, any string scalar was converted to a string array of dimension len, i.e., a definition
```fortran
character(len=N) :: X
```
 effectively became
```fortran
character(len=NNN), dimension(NNN) :: X
```
from the point of few of the numpy (python) interface:
```python
X.shape == (NNN,)
X.dtype == '|SNNN'
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
