### PR TITLE
MAINT: Pin matplotlib to version 3.6.3 for refguide checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,7 +194,7 @@ stages:
 
     # wait until after dev build of NumPy to pip
     # install matplotlib to avoid pip install of older numpy
-    - script: python -m pip install matplotlib
+    - script: python -m pip install matplotlib==3.6.3
       displayName: 'Install matplotlib before refguide run'
 
     - script: python runtests.py -g --refguide-check

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -5,7 +5,7 @@ pydata-sphinx-theme==0.9.0
 sphinx-design
 ipython!=8.1.0
 scipy
-matplotlib
+matplotlib==3.6.3
 pandas
 breathe
 


### PR DESCRIPTION
The refguide tests have started failing and there was a new Matplotlib released four hours ago. Try pinning it to v3.6.3.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
