### PR TITLE
DOC: Fix matplotlib error in documentation

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -754,7 +754,7 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     >>> xcenters = (xedges[:-1] + xedges[1:]) / 2
     >>> ycenters = (yedges[:-1] + yedges[1:]) / 2
     >>> im.set_data(xcenters, ycenters, H)
-    >>> ax.images.append(im)
+    >>> ax.add_image(im)
     >>> plt.show()
 
     It is also possible to construct a 2-D histogram without specifying bin


### PR DESCRIPTION
As noted by Kyle Sunden, this was deprecated and has been removed, using the method is the correct way of doing it in newer matplotlib.

Closes gh-23209

Co-authored-by: Kyle Sunden <ksunden@users.noreply.github.com>

---

Lets unbreak CI.  @charris it was intentional that you put the other fixup into the maintenance branch?