### PR TITLE
CI: Ensure submodules are initialized on MacOS CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,9 @@ stages:
             NPY_USE_BLAS_ILP64: '1'
             USE_OPENBLAS: '1'
     steps:
+    - script: |
+        git submodule update --init
+      displayName: 'Fetch submodules'
     # the @0 refers to the (major) version of the *task* on Microsoft's
     # end, not the order in the build matrix nor anything to do
     # with version of Python selected


### PR DESCRIPTION
For some reason this didn't show up on the original PR or was missed but is now making CI fail after the sorting merge.