### PR TITLE
DOC: Fix matplotlib error in documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,7 +194,7 @@ stages:
 
     # wait until after dev build of NumPy to pip
     # install matplotlib to avoid pip install of older numpy
-    - script: python -m pip install matplotlib==3.6.3
+    - script: python -m pip install matplotlib
       displayName: 'Install matplotlib before refguide run'
 
     - script: python runtests.py -g --refguide-check

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -5,7 +5,7 @@ pydata-sphinx-theme==0.9.0
 sphinx-design
 ipython!=8.1.0
 scipy
-matplotlib==3.6.3
+matplotlib
 pandas
 breathe
 

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -766,7 +766,7 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     >>> xcenters = (xedges[:-1] + xedges[1:]) / 2
     >>> ycenters = (yedges[:-1] + yedges[1:]) / 2
     >>> im.set_data(xcenters, ycenters, H)
-    >>> ax.images.append(im)
+    >>> ax.add_image(im)
     >>> plt.show()
 
     It is also possible to construct a 2-D histogram without specifying bin


### PR DESCRIPTION
Backport of #23212

As noted by Kyle Sunden, this was deprecated and has been removed, using the method is the correct way of doing it in newer matplotlib.

Closes gh-23209

Co-authored-by: Kyle Sunden ksunden@users.noreply.github.com

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
