### PR TITLE
DOC: Add notation for skipping Cirrus to dev docs.

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -205,6 +205,7 @@ fragments in your commit message:
 * ``[skip travis]``: skip TravisCI jobs
 * ``[skip azp]``: skip Azure jobs
 * ``[skip circle]``: skip CircleCI jobs
+* ``[skip cirrus]``: skip Cirrus jobs
 
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This feature is implemented in `.cirrus.star`.