### PR TITLE
CI: Include x86-simd-sort in submodules in gitpod.Dockerfile

### DIFF
--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -35,7 +35,7 @@ WORKDIR ${WORKSPACE}
 
 # Build numpy to populate the cache used by ccache
 RUN git config --global --add safe.directory /workspace/numpy
-RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml
+RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml numpy/core/src/npysort/x86-simd-sort
 RUN conda activate ${CONDA_ENV} && \ 
     python setup.py build_ext --inplace && \
     ccache -s


### PR DESCRIPTION
I think this should fix the gitpod failure on the main development branch (but I've said that [before](https://github.com/numpy/numpy/pull/23224)!).
