### PR TITLE
MAINT: add new simd_qsort files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ tools/swig/test/Array.py
 *.dispatch.h
 # wrapped sources of dispatched targets, e.g. *.dispatch.avx2.c
 *.dispatch.*.c
+*.dispatch.*.cpp
 # _simd module
 numpy/core/src/_simd/_simd.dispatch.c
 numpy/core/src/_simd/_simd_data.inc
@@ -228,9 +229,6 @@ numpy/core/src/umath/loops_hyperbolic.dispatch.c
 numpy/core/src/umath/loops_modulo.dispatch.c
 numpy/core/src/umath/loops_comparison.dispatch.c
 numpy/core/src/umath/loops_unary_complex.dispatch.c
-# npysort module
-numpy/core/src/npysort/x86-qsort.dispatch.c
-numpy/core/src/npysort/x86-qsort.dispatch.*.cpp
 # multiarray module
 numpy/core/src/multiarray/argfunc.dispatch.c
 numpy/core/src/multiarray/arraytypes.h


### PR DESCRIPTION
Building numpy main leaves two new files in my numpy tree that should be in .gitignore:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	numpy/core/src/npysort/simd_qsort.dispatch.avx512_skx.cpp
	numpy/core/src/npysort/simd_qsort_16bit.dispatch.avx512_icl.cpp
```