### PR TITLE
TYP,MAINT: Add a missing explicit Any parameter to scalars

### DIFF
--- a/numpy/_typing/_scalars.py
+++ b/numpy/_typing/_scalars.py
@@ -10,13 +10,13 @@ _CharLike_co = Union[str, bytes]
 # The 6 `<X>Like_co` type-aliases below represent all scalars that can be
 # coerced into `<X>` (with the casting rule `same_kind`)
 _BoolLike_co = Union[bool, np.bool_]
-_UIntLike_co = Union[_BoolLike_co, np.unsignedinteger]
-_IntLike_co = Union[_BoolLike_co, int, np.integer]
-_FloatLike_co = Union[_IntLike_co, float, np.floating]
-_ComplexLike_co = Union[_FloatLike_co, complex, np.complexfloating]
+_UIntLike_co = Union[_BoolLike_co, np.unsignedinteger[Any]]
+_IntLike_co = Union[_BoolLike_co, int, np.integer[Any]]
+_FloatLike_co = Union[_IntLike_co, float, np.floating[Any]]
+_ComplexLike_co = Union[_FloatLike_co, complex, np.complexfloating[Any, Any]]
 _TD64Like_co = Union[_IntLike_co, np.timedelta64]
 
-_NumberLike_co = Union[int, float, complex, np.number, np.bool_]
+_NumberLike_co = Union[int, float, complex, np.number[Any], np.bool_]
 _ScalarLike_co = Union[
     int,
     float,


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
**Related** to #23137

**Context**
Where are on the way to add typings in our codebase, we make extensive usage of _numpy_ and we would be able to set pyright as strict as possible.

We came across with this because many function depend on definitions this pr changes.

**This pr**:
 I took the freedom of doing the same as in #23144, adding `Any` to generics for the parameters we don't care about.

**Note** 
As @BvB93 pointed out backporting this depends on a Python >= 3.9 feature

**Example**
```python
# arange.py
# pyright: strict
import numpy as np

arr = np.arange(10, dtype=np.float64)
print(arr)
```

```
❯ pip install -U pyright
❯ pyright arange.py
# will reportUnknownMemberType
```
