### PR TITLE
BUG: Use raw strings for paths `__config__.py.in`

### DIFF
--- a/numpy/__config__.py.in
+++ b/numpy/__config__.py.in
@@ -21,10 +21,8 @@ def _cleanup(d):
     Removes empty values in a `dict` recursively
     This ensures we remove values that Meson could not provide to CONFIG
     """
-    if type(d) is dict:
-        return dict(
-            (k, _cleanup(v)) for k, v in d.items() if v and _cleanup(v)
-        )
+    if isinstance(d, dict):
+        return {k: _cleanup(v) for k, v in d.items() if v and _cleanup(v)}
     else:
         return d
 
@@ -64,45 +62,41 @@ CONFIG = _cleanup(
                 "endian": "@BUILD_CPU_ENDIAN@",
                 "system": "@BUILD_CPU_SYSTEM@",
             },
-            "cross-compiled": "@CROSS_COMPILED@",
+            "cross-compiled": bool("@CROSS_COMPILED@".lower().replace("false", "")),
         },
         "Build Dependencies": {
             "blas": {
                 "name": "@BLAS_NAME@",
-                "found": "@BLAS_FOUND@",
+                "found": bool("@BLAS_FOUND@".lower().replace("false", "")),
                 "version": "@BLAS_VERSION@",
                 "detection method": "@BLAS_TYPE_NAME@",
-                "include directory": "@BLAS_INCLUDEDIR@",
-                "lib directory": "@BLAS_LIBDIR@",
+                "include directory": r"@BLAS_INCLUDEDIR@",
+                "lib directory": r"@BLAS_LIBDIR@",
                 "openblas configuration": "@BLAS_OPENBLAS_CONFIG@",
-                "pc file directory": "@BLAS_PCFILEDIR@",
+                "pc file directory": r"@BLAS_PCFILEDIR@",
             },
             "lapack": {
                 "name": "@LAPACK_NAME@",
-                "found": "@LAPACK_FOUND@",
+                "found": bool("@LAPACK_FOUND@".lower().replace("false", "")),
                 "version": "@LAPACK_VERSION@",
                 "detection method": "@LAPACK_TYPE_NAME@",
-                "include directory": "@LAPACK_INCLUDEDIR@",
-                "lib directory": "@LAPACK_LIBDIR@",
+                "include directory": r"@LAPACK_INCLUDEDIR@",
+                "lib directory": r"@LAPACK_LIBDIR@",
                 "openblas configuration": "@LAPACK_OPENBLAS_CONFIG@",
-                "pc file directory": "@LAPACK_PCFILEDIR@",
+                "pc file directory": r"@LAPACK_PCFILEDIR@",
             },
         },
         "Python Information": {
-            "path": "@PYTHON_PATH@",
+            "path": r"@PYTHON_PATH@",
             "version": "@PYTHON_VERSION@",
         },
         "SIMD Extensions": {
             "baseline": __cpu_baseline__,
             "found": [
-                feature
-                for feature in __cpu_dispatch__
-                if __cpu_features__[feature]
+                feature for feature in __cpu_dispatch__ if __cpu_features__[feature]
             ],
             "not found": [
-                feature
-                for feature in __cpu_dispatch__
-                if not __cpu_features__[feature]
+                feature for feature in __cpu_dispatch__ if not __cpu_features__[feature]
             ],
         },
     }


### PR DESCRIPTION
### Changes

* `\U` leads to strings being treated as unicode, hence we escape it with raw strings
* Changed bool parameters to real bools instead of string `"True"` and `"False"`
* Small refactor in `_cleanup` to make it consistent with SciPy

Taken from https://github.com/scipy/scipy/pull/17936/

related: #23165