### PR TITLE
MAINT: Add debug information to ufunc wrapping error

### DIFF
--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -268,8 +268,9 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
         break;
     }
     if (wrapped_meth == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                "Did not find the to-be-wrapped loop in the ufunc.");
+        PyErr_Format(PyExc_TypeError,
+                "Did not find the to-be-wrapped loop in the ufunc with given "
+                "DTypes. Received wrapping types: %S", wrapped_dt_tuple);
         goto finish;
     }
 


### PR DESCRIPTION
I spent 20 minutes or so debugging why my usage of `PyUFunc_AddWrappingLoop` was failing. It would have saved me some time if the error message printed out the wrapped dtypes, since I had set them incorrectly.