### PR TITLE
ENH: Avoid use of item XINCREF and DECREF in fasttake

### DIFF
--- a/benchmarks/benchmarks/bench_itemselection.py
+++ b/benchmarks/benchmarks/bench_itemselection.py
@@ -7,7 +7,7 @@ class Take(Benchmark):
     params = [
         [(1000, 1), (1000, 2), (2, 1000, 1), (1000, 3)],
         ["raise", "wrap", "clip"],
-        TYPES1]
+        TYPES1 + ["O", "i,O"]]
     param_names = ["shape", "mode", "dtype"]
 
     def setup(self, shape, mode, dtype):

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -79,12 +79,11 @@ npy_fasttake_impl(
                             NPY_END_THREADS;
                             goto fail;
                         }
-                        dest += itemsize * nelem;
                     }
                     else {
                         memcpy(dest, tmp_src, chunk);
-                        dest += chunk;
                     }
+                    dest += chunk;
                 }
                 src += chunk*max_item;
             }
@@ -113,12 +112,11 @@ npy_fasttake_impl(
                             NPY_END_THREADS;
                             goto fail;
                         }
-                        dest += itemsize * nelem;
                     }
                     else {
                         memcpy(dest, tmp_src, chunk);
-                        dest += chunk;
                     }
+                    dest += chunk;
                 }
                 src += chunk*max_item;
             }
@@ -143,12 +141,11 @@ npy_fasttake_impl(
                             NPY_END_THREADS;
                             goto fail;
                         }
-                        dest += itemsize * nelem;
                     }
                     else {
                         memcpy(dest, tmp_src, chunk);
-                        dest += chunk;
                     }
+                    dest += chunk;
                 }
                 src += chunk*max_item;
             }

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -17,6 +17,7 @@
 
 #include "multiarraymodule.h"
 #include "common.h"
+#include "dtype_transfer.h"
 #include "arrayobject.h"
 #include "ctors.h"
 #include "lowlevel_strided_loops.h"
@@ -39,7 +40,26 @@ npy_fasttake_impl(
         PyArray_Descr *dtype, int axis)
 {
     NPY_BEGIN_THREADS_DEF;
-    NPY_BEGIN_THREADS_DESCR(dtype);
+
+    NPY_cast_info cast_info;
+    NPY_ARRAYMETHOD_FLAGS flags;
+    NPY_cast_info_init(&cast_info);
+
+    if (!needs_refcounting) {
+        /* if "refcounting" is not needed memcpy is safe for a simple copy  */
+        NPY_BEGIN_THREADS;
+    }
+    else {
+        if (PyArray_GetDTypeTransferFunction(
+                1, itemsize, itemsize, dtype, dtype, 0,
+                &cast_info, &flags) < 0) {
+            return -1;
+        }
+        if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+            NPY_BEGIN_THREADS;
+        }
+    }
+
     switch (clipmode) {
         case NPY_RAISE:
             for (npy_intp i = 0; i < n; i++) {
@@ -47,20 +67,22 @@ npy_fasttake_impl(
                     npy_intp tmp = indices[j];
                     if (check_and_adjust_index(&tmp, max_item, axis,
                                                _save) < 0) {
-                        return -1;
+                        goto fail;
                     }
                     char *tmp_src = src + tmp * chunk;
                     if (needs_refcounting) {
-                        for (npy_intp k = 0; k < nelem; k++) {
-                            PyArray_Item_INCREF(tmp_src, dtype);
-                            PyArray_Item_XDECREF(dest, dtype);
-                            memmove(dest, tmp_src, itemsize);
-                            dest += itemsize;
-                            tmp_src += itemsize;
+                        char *data[2] = {tmp_src, dest};
+                        npy_intp strides[2] = {itemsize, itemsize};
+                        if (cast_info.func(
+                                &cast_info.context, data, &nelem, strides,
+                                cast_info.auxdata) < 0) {
+                            NPY_END_THREADS;
+                            goto fail;
                         }
+                        dest += itemsize * nelem;
                     }
                     else {
-                        memmove(dest, tmp_src, chunk);
+                        memcpy(dest, tmp_src, chunk);
                         dest += chunk;
                     }
                 }
@@ -83,16 +105,18 @@ npy_fasttake_impl(
                     }
                     char *tmp_src = src + tmp * chunk;
                     if (needs_refcounting) {
-                        for (npy_intp k = 0; k < nelem; k++) {
-                            PyArray_Item_INCREF(tmp_src, dtype);
-                            PyArray_Item_XDECREF(dest, dtype);
-                            memmove(dest, tmp_src, itemsize);
-                            dest += itemsize;
-                            tmp_src += itemsize;
+                        char *data[2] = {tmp_src, dest};
+                        npy_intp strides[2] = {itemsize, itemsize};
+                        if (cast_info.func(
+                                &cast_info.context, data, &nelem, strides,
+                                cast_info.auxdata) < 0) {
+                            NPY_END_THREADS;
+                            goto fail;
                         }
+                        dest += itemsize * nelem;
                     }
                     else {
-                        memmove(dest, tmp_src, chunk);
+                        memcpy(dest, tmp_src, chunk);
                         dest += chunk;
                     }
                 }
@@ -111,16 +135,18 @@ npy_fasttake_impl(
                     }
                     char *tmp_src = src + tmp * chunk;
                     if (needs_refcounting) {
-                        for (npy_intp k = 0; k < nelem; k++) {
-                            PyArray_Item_INCREF(tmp_src, dtype);
-                            PyArray_Item_XDECREF(dest, dtype);
-                            memmove(dest, tmp_src, itemsize);
-                            dest += itemsize;
-                            tmp_src += itemsize;
+                        char *data[2] = {tmp_src, dest};
+                        npy_intp strides[2] = {itemsize, itemsize};
+                        if (cast_info.func(
+                                &cast_info.context, data, &nelem, strides,
+                                cast_info.auxdata) < 0) {
+                            NPY_END_THREADS;
+                            goto fail;
                         }
+                        dest += itemsize * nelem;
                     }
                     else {
-                        memmove(dest, tmp_src, chunk);
+                        memcpy(dest, tmp_src, chunk);
                         dest += chunk;
                     }
                 }
@@ -130,7 +156,13 @@ npy_fasttake_impl(
     }
 
     NPY_END_THREADS;
+    NPY_cast_info_xfree(&cast_info);
     return 0;
+
+  fail:
+    /* NPY_END_THREADS already ensured. */
+    NPY_cast_info_xfree(&cast_info);
+    return -1;
 }
 
 


### PR DESCRIPTION
Rather, use the cast function directly when the copy is not trivial (which we know based on it not passing REFCHK, if that passes we assume memcpy is fine).

Also uses memcpy, since no overlap is possible here.


(There is a tests that covers these paths.)

---

This is a followup (in a sense) to the reference counting cleanup.  The functions `PyArray_Item_INCREF` and `PyArray_Item_XDECREF` should be considered deprecated (or plain wrong) now.

Thus, here is a blueprint of now to fix fasttake (and others would have to follow up on that).  `copyswap` would be another solution, but I want to see if we can't get away with this (here we can, its much faster, but it is plausible that copyswap would be even faster, since it is a single item).

---

Benchmark result, just to proof that the old stuff was anyway ridiculous for structured arrays:

```
       before           after         ratio
     [af9f6568]       [38d52100]
     <main>           <fast-take-no-refcnt>
-        8.03±0μs      5.00±0.01μs     0.62  bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'O')
-     8.03±0.02μs      5.00±0.06μs     0.62  bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'O')
-     15.7±0.01μs       9.67±0.1μs     0.61  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'O')
-     15.7±0.01μs      9.62±0.01μs     0.61  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'wrap', 'O')
-     15.7±0.01μs      9.46±0.01μs     0.60  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'O')
-      8.29±0.3μs      4.97±0.04μs     0.60  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'O')
-     15.1±0.02μs      8.70±0.08μs     0.58  bench_itemselection.Take.time_contiguous((1000, 2), 'wrap', 'O')
-     22.2±0.04μs         12.8±0μs     0.58  bench_itemselection.Take.time_contiguous((1000, 3), 'raise', 'O')
-     22.1±0.04μs      12.7±0.01μs     0.58  bench_itemselection.Take.time_contiguous((1000, 3), 'wrap', 'O')
-     22.2±0.02μs      12.7±0.03μs     0.58  bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'O')
-     15.1±0.01μs      8.67±0.02μs     0.57  bench_itemselection.Take.time_contiguous((1000, 2), 'clip', 'O')
-     15.1±0.01μs      8.65±0.02μs     0.57  bench_itemselection.Take.time_contiguous((1000, 2), 'raise', 'O')
-       177±0.4μs      12.9±0.02μs     0.07  bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'i,O')
-         178±1μs       12.9±0.2μs     0.07  bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'i,O')
-         353±1μs       25.4±0.2μs     0.07  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'i,O')
-       189±0.7μs       13.6±0.4μs     0.07  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'i,O')
-         355±1μs      25.0±0.04μs     0.07  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'wrap', 'i,O')
-       356±0.4μs      25.0±0.04μs     0.07  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'i,O')
-         352±2μs       20.9±0.3μs     0.06  bench_itemselection.Take.time_contiguous((1000, 2), 'wrap', 'i,O')
-       356±0.6μs      20.9±0.07μs     0.06  bench_itemselection.Take.time_contiguous((1000, 2), 'clip', 'i,O')
-         357±3μs      20.9±0.03μs     0.06  bench_itemselection.Take.time_contiguous((1000, 2), 'raise', 'i,O')
-         528±2μs       27.7±0.2μs     0.05  bench_itemselection.Take.time_contiguous((1000, 3), 'wrap', 'i,O')
-         533±2μs      27.6±0.07μs     0.05  bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'i,O')
-         532±2μs      27.5±0.04μs     0.05  bench_itemselection.Take.time_contiguous((1000, 3), 'raise', 'i,O')
```