### PR TITLE
MAINT: Further removal of PyArray_Item_INCREF use

### DIFF
--- a/benchmarks/benchmarks/bench_itemselection.py
+++ b/benchmarks/benchmarks/bench_itemselection.py
@@ -21,7 +21,7 @@ class Take(Benchmark):
 class PutMask(Benchmark):
     params = [
         [True, False],
-        TYPES1]
+        TYPES1 + ["O", "i,O"]]
     param_names = ["values_is_scalar", "dtype"]
 
     def setup(self, values_is_scalar, dtype):
@@ -41,3 +41,21 @@ class PutMask(Benchmark):
     def time_sparse(self, values_is_scalar, dtype):
         np.putmask(self.arr, self.sparse_mask, self.vals)
 
+
+class Put(Benchmark):
+    params = [
+        [True, False],
+        TYPES1 + ["O", "i,O"]]
+    param_names = ["values_is_scalar", "dtype"]
+
+    def setup(self, values_is_scalar, dtype):
+        if values_is_scalar:
+            self.vals = np.array(1., dtype=dtype)
+        else:
+            self.vals = np.ones(1000, dtype=dtype)
+
+        self.arr = np.ones(1000, dtype=dtype)
+        self.indx = np.arange(1000, dtype=np.intp)
+
+    def time(self, values_is_scalar, dtype):
+        np.put(self.arr, self.indx, self.vals)

--- a/benchmarks/benchmarks/bench_itemselection.py
+++ b/benchmarks/benchmarks/bench_itemselection.py
@@ -57,5 +57,5 @@ class Put(Benchmark):
         self.arr = np.ones(1000, dtype=dtype)
         self.indx = np.arange(1000, dtype=np.intp)
 
-    def time(self, values_is_scalar, dtype):
+    def time_ordered(self, values_is_scalar, dtype):
         np.put(self.arr, self.indx, self.vals)

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -436,7 +436,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
             for (i = 0; i < ni; i++) {
                 src = PyArray_BYTES(values) + itemsize*(i % nv);
                 tmp = ((npy_intp *)(PyArray_DATA(indices)))[i];
-                if (check_and_adjust_index(&tmp, max_item, 0, NULL) < 0) {
+                if (check_and_adjust_index(&tmp, max_item, 0, _save) < 0) {
                     goto fail;
                 }
                 char *data[2] = {src, dest + tmp*itemsize};

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 import numpy as np
 from numpy.testing import (
     assert_, assert_raises, assert_array_equal, HAS_REFCOUNT
@@ -84,3 +86,59 @@ class TestTake:
 
         b = np.array([0, 1, 2, 3, 4, 5])
         assert_array_equal(a, b)
+
+
+class TestPutMask:
+    @pytest.mark.parametrize("dtype", list(np.typecodes["All"]) + ["i,O"])
+    def test_simple(self, dtype):
+        if dtype.lower() == "m":
+            dtype += "8[ns]"
+
+        # putmask is weird and doesn't care about value length (even shorter)
+        vals = np.arange(1001).astype(dtype=dtype)
+
+        mask = np.random.randint(2, size=1000).astype(bool)
+        # Use vals.dtype in case of flexible dtype (i.e. string)
+        arr = np.zeros(1000, dtype=vals.dtype)
+        zeros = arr.copy()
+
+        np.putmask(arr, mask, vals)
+        assert_array_equal(arr[mask], vals[:len(mask)][mask])
+        assert_array_equal(arr[~mask], zeros[~mask])
+
+
+class TestPut:
+    @pytest.mark.parametrize("dtype", list(np.typecodes["All"])[1:] + ["i,O"])
+    @pytest.mark.parametrize("mode", ["raise", "wrap", "clip"])
+    def test_simple(self, dtype, mode):
+        if dtype.lower() == "m":
+            dtype += "8[ns]"
+
+        # put is weird and doesn't care about value length (even shorter)
+        vals = np.arange(1001).astype(dtype=dtype)
+
+        # Use vals.dtype in case of flexible dtype (i.e. string)
+        arr = np.zeros(1000, dtype=vals.dtype)
+        zeros = arr.copy()
+
+        if mode == "clip":
+            # Special because 0 and -1 value are "reserved" for clip test
+            indx = np.random.permutation(len(arr) - 2)[:-500] + 1
+
+            indx[-1] = 0
+            indx[-2] = len(arr) - 1
+            indx_put = indx.copy()
+            indx_put[-1] = -1389
+            indx_put[-2] = 1321
+        else:
+            # Avoid duplicates (for simplicity) and fill half only
+            indx = np.random.permutation(len(arr) - 3)[:-500]
+            indx_put = indx
+            if mode == "wrap":
+                indx_put = indx_put + len(arr)
+
+        np.put(arr, indx_put, vals, mode=mode)
+        assert_array_equal(arr[indx], vals[:len(indx)])
+        untouched = np.ones(len(arr), dtype=bool)
+        untouched[indx] = False
+        assert_array_equal(arr[untouched], zeros[:untouched.sum()])


### PR DESCRIPTION
This follows the same pattern as gh-23248 for put and putmask.  (There are a few more, but the pattern should be a bit less common.)

One benchmark gets slower, because it ends up doing no copy at all, but now has to do the setup work anyway, the "dense" is massively faster for the same reason of course:
```
       before           after         ratio
     [b657a75c]       [3a33b4c2]
     <main>           <further-removals>
+        1.40±0μs      1.69±0.01μs     1.21  bench_itemselection.PutMask.time_sparse(False, 'i,O')
+     1.40±0.01μs         1.69±0μs     1.21  bench_itemselection.PutMask.time_sparse(True, 'i,O')
-        5.54±0μs      4.36±0.01μs     0.79  bench_itemselection.PutMask.time_dense(True, 'O')
-     5.63±0.09μs         4.35±0μs     0.77  bench_itemselection.PutMask.time_dense(False, 'O')
-     6.08±0.04μs         4.57±0μs     0.75  bench_itemselection.Put.time_ordered(False, 'O')
-     6.40±0.08μs       4.61±0.2μs     0.72  bench_itemselection.Put.time_ordered(True, 'O')
-         175±4μs      11.3±0.01μs     0.06  bench_itemselection.Put.time_ordered(False, 'i,O')
-         183±3μs       11.7±0.3μs     0.06  bench_itemselection.Put.time_ordered(True, 'i,O')
-       176±0.2μs      10.4±0.02μs     0.06  bench_itemselection.PutMask.time_dense(True, 'i,O')
-         178±3μs      10.4±0.01μs     0.06  bench_itemselection.PutMask.time_dense(False, 'i,O')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.
```