### PR TITLE
BLD: refactor distributor_init to use add_dll_directory

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -232,38 +232,14 @@ def make_init(dirname):
     with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
         fid.write(textwrap.dedent("""
             '''
-            Helper to preload windows dlls to prevent dll not found errors.
-            Once a DLL is preloaded, its namespace is made available to any
-            subsequent DLL. This file originated in the numpy-wheels repo,
-            and is created as part of the scripts that build the wheel.
+            Helper to add the path to the openblas dll to the dll search space
             '''
             import os
-            import glob
-            if os.name == 'nt':
-                # convention for storing / loading the DLL from
-                # numpy/.libs/, if present
-                try:
-                    from ctypes import WinDLL
-                    basedir = os.path.dirname(__file__)
-                except:
-                    pass
-                else:
-                    libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
-                    DLL_filenames = []
-                    if os.path.isdir(libs_dir):
-                        for filename in glob.glob(os.path.join(libs_dir,
-                                                               '*openblas*dll')):
-                            # NOTE: would it change behavior to load ALL
-                            # DLLs at this path vs. the name restriction?
-                            WinDLL(os.path.abspath(filename))
-                            DLL_filenames.append(filename)
-                    if len(DLL_filenames) > 1:
-                        import warnings
-                        warnings.warn("loaded more than 1 DLL from .libs:"
-                                      "\\n%s" % "\\n".join(DLL_filenames),
-                                      stacklevel=1)
-    """))
-
+            import sys
+            extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
+            if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
+                os.add_dll_directory(extra_dll_dir)
+        """))
 
 def test_setup(plats):
     '''
@@ -343,11 +319,16 @@ if __name__ == '__main__':
     parser.add_argument('--check_version', nargs='?', default='',
                         help='Check provided OpenBLAS version string '
                              'against available OpenBLAS')
+    parser.add_argument('--write-init', nargs=1,
+                        metavar='OUT_SCIPY_DIR',
+                        help='Write distribution init to named dir')
     args = parser.parse_args()
     if args.check_version != '':
         test_version(args.check_version)
     elif args.test is None:
         print(setup_openblas())
+    elif args.write_init:
+        make_init(args.write_init[0])
     else:
         if len(args.test) == 0 or 'all' in args.test:
             test_setup(SUPPORTED_PLATFORMS)


### PR DESCRIPTION
Refactored from #23165 

Windows does not have an RPATH mechanism to add a relative search directory to a dll's search for supporting libraries [0]. Before Python3.8, we would modify the PATH on windows so it could find the OpenBLAS dll packaged into `<site-packages>/numpy/.libs`. On Python3.8, the use of PATH was changed to use `add_dll_directory()`, so the mechanism was changed to preload the DLL using `dlopen`, which works on any version of python but 
- is not very clean
- requires ctypes, which may not be compiled into python

This PR refactors the code to use `add_dll_directory`, since all supported versions of python have it. It also adds a command-line interface to the funtions, that is used in the windows meson build.

[0] [machomachomangler](https://github.com/njsmith/machomachomangler#pe-features) might be able to help here, but that is a bigger refactor.