### PR TITLE
CI: clean up GHA boilerplate for `[skip github]`

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   lint:
-    if: "github.repository == 'numpy/numpy' && github.ref != 'refs/heads/main' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -42,7 +42,7 @@ jobs:
         python tools/linter.py --branch origin/${{ github.base_ref }}
 
   smoke_test:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     runs-on: ubuntu-latest
     env:
       WITHOUT_SIMD: 1

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   cygwin_build_test:
     runs-on: windows-latest
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build base Docker image
     runs-on: ubuntu-latest
     environment: numpy-dev
-    if: "github.repository_owner == 'numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository_owner == 'numpy'"
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-wasm-emscripten:
     runs-on: ubuntu-22.04
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     env:
       PYODIDE_VERSION: 0.22.1
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build Gitpod Docker image
     runs-on: ubuntu-latest
     environment: numpy-dev
-    if: "github.repository_owner == 'numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository_owner == 'numpy'"
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -200,8 +200,7 @@ sequences. In such cases you may explicitly skip CI by including one of these
 fragments in your commit message:
 
 * ``[skip ci]``: skip all CI
-* ``[skip github]``: skip GitHub Actions "build numpy and run tests" jobs
-* ``[skip actions]``: skip all GitHub Actions
+* ``[skip actions]``: skip GitHub Actions jobs
 * ``[skip travis]``: skip TravisCI jobs
 * ``[skip azp]``: skip Azure jobs
 * ``[skip circle]``: skip CircleCI jobs


### PR DESCRIPTION
GitHub has had builtin support for this for quite a while now, via `skip actions`. So we no longer need this. It's left only in the one Meson job; that line is already taken care of in gh-23165.

[skip cirrus] [skip circle] [skip azp] [skip travis]