### PR TITLE
API: expose traversal typedefs and `get_clear_loop` slot

### DIFF
--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -140,10 +140,6 @@ typedef struct {
 #define NPY_METH_unaligned_contiguous_loop 7
 #define NPY_METH_contiguous_indexed_loop 8
 
-/* other slots are in order, so note last one (internal use!) */
-#define _NPY_NUM_DTYPE_SLOTS 8
-#define _NPY_NUM_DTYPE_PYARRAY_ARRFUNC_SLOTS 22 + (1 << 10)
-
 /*
  * The resolve descriptors function, must be able to handle NULL values for
  * all output (but not input) `given_descrs` and fill `loop_descrs`.
@@ -266,7 +262,15 @@ typedef int translate_loop_descrs_func(int nin, int nout,
 #define NPY_DT_PARAMETRIC 1 << 2
 #define NPY_DT_NUMERIC 1 << 3
 
+/*
+ * These correspond to slots in the NPY_DType_Slots struct and must
+ * be in the same order as the members of that struct. If new slots
+ * get added or old slots get removed NPY_NUM_DTYPE_SLOTS must also
+ * be updated
+ */
+
 #define NPY_DT_discover_descr_from_pyobject 1
+// this slot is considered private because its API hasn't beed decided
 #define _NPY_DT_is_known_scalar_type 2
 #define NPY_DT_default_descr 3
 #define NPY_DT_common_dtype 4
@@ -281,38 +285,42 @@ typedef int translate_loop_descrs_func(int nin, int nout,
 // `legacy_setitem_using_DType`, respectively. This functionality is
 // only supported for basic NumPy DTypes.
 
+
+// used to separate dtype slots from arrfuncs slots
+// intended only for internal use but defined here for clarity
+#define _NPY_DT_ARRFUNCS_OFFSET (1 << 10)
+
 // Cast is disabled
-// #define NPY_DT_PyArray_ArrFuncs_cast 0 + (1 << 10)
+// #define NPY_DT_PyArray_ArrFuncs_cast 0 + _NPY_DT_ARRFUNCS_OFFSET
 
-#define NPY_DT_PyArray_ArrFuncs_getitem 1 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_setitem 2 + (1 << 10)
+#define NPY_DT_PyArray_ArrFuncs_getitem 1 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_setitem 2 + _NPY_DT_ARRFUNCS_OFFSET
 
-#define NPY_DT_PyArray_ArrFuncs_copyswapn 3 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_copyswap 4 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_compare 5 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_argmax 6 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_dotfunc 7 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_scanfunc 8 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_fromstr 9 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_nonzero 10 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_fill 11 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_fillwithscalar 12 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_sort 13 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_argsort 14 + (1 << 10)
+#define NPY_DT_PyArray_ArrFuncs_copyswapn 3 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_copyswap 4 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_compare 5 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_argmax 6 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_dotfunc 7 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_scanfunc 8 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_fromstr 9 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_nonzero 10 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_fill 11 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_fillwithscalar 12 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_sort 13 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_argsort 14 + _NPY_DT_ARRFUNCS_OFFSET
 
 // Casting related slots are disabled. See
 // https://github.com/numpy/numpy/pull/23173#discussion_r1101098163
-// #define NPY_DT_PyArray_ArrFuncs_castdict 15 + (1 << 10)
-// #define NPY_DT_PyArray_ArrFuncs_scalarkind 16 + (1 << 10)
-// #define NPY_DT_PyArray_ArrFuncs_cancastscalarkindto 17 + (1 << 10)
-// #define NPY_DT_PyArray_ArrFuncs_cancastto 18 + (1 << 10)
+// #define NPY_DT_PyArray_ArrFuncs_castdict 15 + _NPY_DT_ARRFUNCS_OFFSET
+// #define NPY_DT_PyArray_ArrFuncs_scalarkind 16 + _NPY_DT_ARRFUNCS_OFFSET
+// #define NPY_DT_PyArray_ArrFuncs_cancastscalarkindto 17 + _NPY_DT_ARRFUNCS_OFFSET
+// #define NPY_DT_PyArray_ArrFuncs_cancastto 18 + _NPY_DT_ARRFUNCS_OFFSET
 
 // These are deprecated in NumPy 1.19, so are disabled here.
-// #define NPY_DT_PyArray_ArrFuncs_fastclip 19 + (1 << 10)
-// #define NPY_DT_PyArray_ArrFuncs_fastputmask 20 + (1 << 10)
-// #define NPY_DT_PyArray_ArrFuncs_fasttake 21 + (1 << 10)
-#define NPY_DT_PyArray_ArrFuncs_argmin 22 + (1 << 10)
-
+// #define NPY_DT_PyArray_ArrFuncs_fastclip 19 + _NPY_DT_ARRFUNCS_OFFSET
+// #define NPY_DT_PyArray_ArrFuncs_fastputmask 20 + _NPY_DT_ARRFUNCS_OFFSET
+// #define NPY_DT_PyArray_ArrFuncs_fasttake 21 + _NPY_DT_ARRFUNCS_OFFSET
+#define NPY_DT_PyArray_ArrFuncs_argmin 22 + _NPY_DT_ARRFUNCS_OFFSET
 
 // TODO: These slots probably still need some thought, and/or a way to "grow"?
 typedef struct {

--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -261,8 +261,7 @@ typedef int translate_loop_descrs_func(int nin, int nout,
  * NPY_DT_get_clear_loop, api hook, particularly for arrays storing embedded
  * references to python objects or heap-allocated data. If you define a dtype
  * that uses embedded references, the NPY_ITEM_REFCOUNT flag must be set on the
- * dtype instance. If the embedded references are to heap-allocated data and not
- * python objects, the `NPY_ITEM_IS_POINTER` flag must additionally be set.
+ * dtype instance.
  *
  * The `void *traverse_context` is passed in because we may need to pass in
  * Intepreter state or similar in the futurem, but we don't want to pass in

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1076,11 +1076,32 @@ PyArray_NewLikeArrayWithShape(PyArrayObject *prototype, NPY_ORDER order,
     }
 
     /* Logic shared by `empty`, `empty_like`, and `ndarray.__new__` */
-    if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)ret))) {
-        PyArray_FillObjectArray((PyArrayObject *)ret, Py_None);
-        if (PyErr_Occurred()) {
-            Py_DECREF(ret);
-            return NULL;
+    PyArray_Descr* descr = PyArray_DESCR((PyArrayObject *)ret);
+    if (PyDataType_REFCHK(descr)) {
+        if (NPY_DT_is_legacy(NPY_DTYPE(dtype))) {
+            PyArray_FillObjectArray((PyArrayObject *)ret, Py_None);
+            if (PyErr_Occurred()) {
+                Py_DECREF(ret);
+                return NULL;
+            }
+        }
+        else {
+            // Currently we assume all non-legacy dtypes that have with the
+            // NPY_ITEM_REFCOUNT flag either represent heap-allocated dtypes or
+            // represent python objects. In the latter case the dtype is
+            // responsible for managing initialization and reference counts. In
+            // both cases initializing to NULL makes sense.
+            //
+            // In the future we might adjust this and have separate logic for
+            // new dtypes that hold heap-allocated data and new dtypes that hold
+            // python objects, particularly if we want to allow releasing the
+            // GIL in the former case.
+            char *optr = PyArray_DATA((PyArrayObject*)ret);
+            npy_intp n = PyArray_SIZE((PyArrayObject*)ret);
+            for (npy_intp i = 0; i < n; i++) {
+                optr = NULL;
+                optr += descr->elsize;
+            }
         }
     }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1086,16 +1086,11 @@ PyArray_NewLikeArrayWithShape(PyArrayObject *prototype, NPY_ORDER order,
             }
         }
         else {
-            // Currently we assume all non-legacy dtypes that have with the
-            // NPY_ITEM_REFCOUNT flag either represent heap-allocated dtypes or
-            // represent python objects. In the latter case the dtype is
-            // responsible for managing initialization and reference counts. In
-            // both cases initializing to NULL makes sense.
-            //
-            // In the future we might adjust this and have separate logic for
-            // new dtypes that hold heap-allocated data and new dtypes that hold
-            // python objects, particularly if we want to allow releasing the
-            // GIL in the former case.
+            // Currently we assume all non-legacy dtypes with the
+            // NPY_ITEM_REFCOUNT flag either hold heap-allocated data or hold
+            // python objects. In the latter case the dtype is responsible for
+            // managing initialization and reference counts. In both cases
+            // initializing to NULL makes sense.
             char *optr = PyArray_DATA((PyArrayObject*)ret);
             npy_intp n = PyArray_SIZE((PyArrayObject*)ret);
             for (npy_intp i = 0; i < n; i++) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1076,27 +1076,11 @@ PyArray_NewLikeArrayWithShape(PyArrayObject *prototype, NPY_ORDER order,
     }
 
     /* Logic shared by `empty`, `empty_like`, and `ndarray.__new__` */
-    PyArray_Descr* descr = PyArray_DESCR((PyArrayObject *)ret);
-    if (PyDataType_REFCHK(descr)) {
-        if (NPY_DT_is_legacy(NPY_DTYPE(dtype))) {
-            PyArray_FillObjectArray((PyArrayObject *)ret, Py_None);
-            if (PyErr_Occurred()) {
-                Py_DECREF(ret);
-                return NULL;
-            }
-        }
-        else {
-            // Currently we assume all non-legacy dtypes with the
-            // NPY_ITEM_REFCOUNT flag either hold heap-allocated data or hold
-            // python objects. In the latter case the dtype is responsible for
-            // managing initialization and reference counts. In both cases
-            // initializing to NULL makes sense.
-            char *optr = PyArray_DATA((PyArrayObject*)ret);
-            npy_intp n = PyArray_SIZE((PyArrayObject*)ret);
-            for (npy_intp i = 0; i < n; i++) {
-                optr = NULL;
-                optr += descr->elsize;
-            }
+    if (PyDataType_REFCHK(PyArray_DESCR((PyArrayObject *)ret))) {
+        PyArray_FillObjectArray((PyArrayObject *)ret, Py_None);
+        if (PyErr_Occurred()) {
+            Py_DECREF(ret);
+            return NULL;
         }
     }
 

--- a/numpy/core/src/multiarray/dtype_traversal.h
+++ b/numpy/core/src/multiarray/dtype_traversal.h
@@ -3,30 +3,6 @@
 
 #include "array_method.h"
 
-/*
- * A traverse loop working on a single array. This is similar to the general
- * strided-loop function.
- * Using a `void *traverse_context`, because I we may need to pass in
- * Intepreter state or similar in the future.  But I don't want to pass in
- * a full context (with pointers to dtypes, method, caller which all make
- * no sense for a traverse function).
- *
- * We assume for now that this context can be just passed through in the
- * the future (for structured dtypes).
- */
-typedef int (traverse_loop_function)(
-        void *traverse_context, PyArray_Descr *descr, char *data,
-        npy_intp size, npy_intp stride, NpyAuxData *auxdata);
-
-
-/* Simplified get_loop function specific to dtype traversal */
-typedef int (get_traverse_loop_function)(
-        void *traverse_context, PyArray_Descr *descr,
-        int aligned, npy_intp fixed_stride,
-        traverse_loop_function **out_loop, NpyAuxData **out_auxdata,
-        NPY_ARRAYMETHOD_FLAGS *flags);
-
-
 /* NumPy DType clear (object DECREF + NULLing) implementations */
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -29,11 +29,6 @@ typedef struct {
     setitemfunction *setitem;
     getitemfunction *getitem;
     /*
-     * The casting implementation (ArrayMethod) to convert between two
-     * instances of this DType, stored explicitly for fast access:
-     */
-    PyArrayMethodObject *within_dtype_castingimpl;
-    /*
      * Either NULL or fetches a clearing function.  Clearing means deallocating
      * any referenced data and setting it to a safe state.  For Python objects
      * this means using `Py_CLEAR` which is equivalent to `Py_DECREF` and
@@ -46,6 +41,11 @@ typedef struct {
      * Python objects.
      */
     get_traverse_loop_function *get_clear_loop;
+    /*
+     * The casting implementation (ArrayMethod) to convert between two
+     * instances of this DType, stored explicitly for fast access:
+     */
+    PyArrayMethodObject *within_dtype_castingimpl;
     /*
      * Dictionary of ArrayMethods representing most possible casts
      * (structured and object are exceptions).
@@ -60,6 +60,13 @@ typedef struct {
      */
     PyArray_ArrFuncs f;
 } NPY_DType_Slots;
+
+// This must be updated if new slots before within_dtype_castingimpl
+// are added
+#define NPY_NUM_DTYPE_SLOTS 9
+#define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
+#define NPY_DT_MAX_ARRFUNCS_SLOT \
+  NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET
 
 
 #define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -172,10 +172,10 @@ PyArrayInitDTypeMeta_FromSpec(
         if (slot == 0) {
             break;
         }
-        if ((slot > NPY_DT_MAX_ARRFUNCS_SLOT) ||
-            (slot < 0) ||
+        if ((slot < 0) ||
             ((slot > NPY_NUM_DTYPE_SLOTS) &&
-             (slot < _NPY_DT_ARRFUNCS_OFFSET))) {
+             (slot <= _NPY_DT_ARRFUNCS_OFFSET)) ||
+            (slot > NPY_DT_MAX_ARRFUNCS_SLOT)) {
             PyErr_Format(PyExc_RuntimeError,
                     "Invalid slot with value %d passed in.", slot);
             return -1;
@@ -194,7 +194,7 @@ PyArrayInitDTypeMeta_FromSpec(
         }
         else {
             int f_slot = slot - _NPY_DT_ARRFUNCS_OFFSET;
-            if (1 <= f_slot && f_slot <= 22) {
+            if (1 <= f_slot && f_slot <= NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS) {
                 switch (f_slot) {
                     case 1:
                         NPY_DT_SLOTS(DType)->f.getitem = pfunc;

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -171,17 +171,21 @@ PyArrayInitDTypeMeta_FromSpec(
         if (slot == 0) {
             break;
         }
-        if (slot > _NPY_NUM_DTYPE_PYARRAY_ARRFUNC_SLOTS || slot < 0) {
+        if ((slot > NPY_DT_MAX_ARRFUNCS_SLOT) ||
+            (slot < 0) ||
+            ((slot > NPY_NUM_DTYPE_SLOTS) &&
+             (slot < _NPY_DT_ARRFUNCS_OFFSET))) {
             PyErr_Format(PyExc_RuntimeError,
                     "Invalid slot with value %d passed in.", slot);
             return -1;
         }
         /*
-         * It is up to the user to get this right, and slots are sorted
-         * exactly like they are stored right now:
+         * It is up to the user to get this right, the slots in the public API
+         * are sorted exactly like they are stored in the NPY_DT_Slots struct
+         * right now:
          */
-        if (slot <= _NPY_NUM_DTYPE_SLOTS) {
-            // slot > 8 are PyArray_ArrFuncs
+        if (slot <= NPY_NUM_DTYPE_SLOTS) {
+            // slot > NPY_NUM_DTYPE_SLOTS are PyArray_ArrFuncs
             void **current = (void **)(&(
                     NPY_DT_SLOTS(DType)->discover_descr_from_pyobject));
             current += slot - 1;

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -161,6 +161,7 @@ PyArrayInitDTypeMeta_FromSpec(
     NPY_DT_SLOTS(DType)->common_instance = NULL;
     NPY_DT_SLOTS(DType)->setitem = NULL;
     NPY_DT_SLOTS(DType)->getitem = NULL;
+    NPY_DT_SLOTS(DType)->get_clear_loop = NULL;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
     PyType_Slot *spec_slot = spec->slots;
@@ -192,8 +193,7 @@ PyArrayInitDTypeMeta_FromSpec(
             *current = pfunc;
         }
         else {
-            // Remove PyArray_ArrFuncs offset
-            int f_slot = slot - (1 << 10);
+            int f_slot = slot - _NPY_DT_ARRFUNCS_OFFSET;
             if (1 <= f_slot && f_slot <= 22) {
                 switch (f_slot) {
                     case 1:
@@ -294,6 +294,7 @@ PyArrayInitDTypeMeta_FromSpec(
             return -1;
         }
     }
+
     /* invalid type num. Ideally, we get away with it! */
     DType->type_num = -1;
 

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -444,7 +444,12 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
             optr += inner_elsize;
         }
     }
-    else {
+    else if (PyDataType_FLAGCHK(dtype, NPY_ITEM_IS_POINTER))
+    {
+        optr = NULL;
+    }
+    else
+    {
         /* This path should not be reachable. */
         assert(0);
     }

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -444,12 +444,7 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
             optr += inner_elsize;
         }
     }
-    else if (PyDataType_FLAGCHK(dtype, NPY_ITEM_IS_POINTER))
-    {
-        optr = NULL;
-    }
-    else
-    {
+    else {
         /* This path should not be reachable. */
         assert(0);
     }


### PR DESCRIPTION
This is a followup to #22924, to publicly expose the new `get_clear_loop` slot that was added in that PR.

Since I had to touch the dtype slots, I also took the opportunity to clean up some of the logic from #23173, which is in the first commit.

I added some additional comments to help document how to use the array traversal loops and edited what was already there. As a warning, since I moved the typedefs to another file, it's not obvious in the diff what changed in the comments.

I'll be opening a separate PR in the numpy-user-dtypes repo with a usage of this new public API for `stringdtype`.