### PR TITLE
BUG: masked array proper deepcopies

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6310,9 +6310,8 @@ class MaskedArray(ndarray):
         # deepcopy() directly for arrays of object type that may
         # contain compound types--you cannot depend on normal
         # copy semantics to do the right thing here
-        if self.dtype.type is np.object_:
-            for idx, _ in enumerate(copied):
-                copied[idx] = deepcopy(copied[idx])
+        if self.dtype.hasobject:
+            copied = deepcopy(self._data)
         return copied
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6311,7 +6311,7 @@ class MaskedArray(ndarray):
         # contain compound types--you cannot depend on normal
         # copy semantics to do the right thing here
         if self.dtype.hasobject:
-            copied._data[:] = deepcopy(copied._data)
+            copied._data[...] = deepcopy(copied._data)
         return copied
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6311,7 +6311,7 @@ class MaskedArray(ndarray):
         # contain compound types--you cannot depend on normal
         # copy semantics to do the right thing here
         if self.dtype.hasobject:
-            copied = deepcopy(self._data)
+            copied._data[:] = deepcopy(copied._data)
         return copied
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2870,7 +2870,13 @@ class MaskedArray(ndarray):
                     _data._mask = _data._mask.copy()
                     # Reset the shape of the original mask
                     if getmask(data) is not nomask:
-                        data._mask.shape = data.shape
+                        # gh-21022 encounters an issue here
+                        # because data._mask.shape is not writeable, but
+                        # the op was also pointless in that case, because
+                        # the shapes were the same, so we can at least
+                        # avoid that path
+                        if data._mask.shape != data.shape:
+                            data._mask.shape = data.shape
         else:
             # Case 2. : With a mask in input.
             # If mask is boolean, create an array of True or False
@@ -6300,6 +6306,13 @@ class MaskedArray(ndarray):
         memo[id(self)] = copied
         for (k, v) in self.__dict__.items():
             copied.__dict__[k] = deepcopy(v, memo)
+        # as clearly documented for np.copy(), you need to use
+        # deepcopy() directly for arrays of object type that may
+        # contain compound types--you cannot depend on normal
+        # copy semantics to do the right thing here
+        if self.dtype.type is np.object_:
+            for idx, _ in enumerate(copied):
+                copied[idx] = deepcopy(copied[idx])
         return copied
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5607,3 +5607,11 @@ def test_deepcopy_2d_obj():
     assert_equal(deepcopy._mask, source._mask)
     deepcopy._mask[0, 0] = 1
     assert source._mask[0, 0] == 0
+
+
+def test_deepcopy_0d_obj():
+    source = np.ma.array(0, mask=[0], dtype=object)
+    deepcopy = copy.deepcopy(source)
+    deepcopy[...] = 17
+    assert_equal(source, 0)
+    assert_equal(deepcopy, 17)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -8,6 +8,7 @@ __author__ = "Pierre GF Gerard-Marchant"
 
 import sys
 import warnings
+import copy
 import operator
 import itertools
 import textwrap
@@ -5570,3 +5571,22 @@ note
 original note"""
 
     assert_equal(np.ma.core.doc_note(method.__doc__, "note"), expected_doc)
+
+
+def test_gh_22556():
+    source = np.ma.array([0, [0, 1, 2]], dtype=object)
+    deepcopy = copy.deepcopy(source)
+    deepcopy[1].append('this should not appear in source')
+    assert len(source[1]) == 3
+
+
+def test_gh_21022():
+    # testing for absence of reported error
+    source = np.ma.masked_array(data=[-1, -1], mask=True, dtype=np.float64)
+    axis = np.array(0)
+    result = np.prod(source, axis=axis, keepdims=False)
+    result = np.ma.masked_array(result,
+                                mask=np.ones(result.shape, dtype=np.bool_))
+    array = np.ma.masked_array(data=-1, mask=True, dtype=np.float64)
+    copy.deepcopy(array)
+    copy.deepcopy(result)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5604,3 +5604,6 @@ def test_deepcopy_2d_obj():
     deepcopy[2, 0].extend(['this should not appear in source', 3])
     assert len(source[2, 0]) == 2
     assert len(deepcopy[2, 0]) == 4
+    assert_equal(deepcopy._mask, source._mask)
+    deepcopy._mask[0, 0] = 1
+    assert source._mask[0, 0] == 0

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5590,3 +5590,17 @@ def test_gh_21022():
     array = np.ma.masked_array(data=-1, mask=True, dtype=np.float64)
     copy.deepcopy(array)
     copy.deepcopy(result)
+
+
+def test_deepcopy_2d_obj():
+    source = np.ma.array([[0, "dog"],
+                          [1, 1],
+                          [[1, 2], "cat"]],
+                        mask=[[0, 1],
+                              [0, 0],
+                              [0, 0]],
+                        dtype=object)
+    deepcopy = copy.deepcopy(source)
+    deepcopy[2, 0].extend(['this should not appear in source', 3])
+    assert len(source[2, 0]) == 2
+    assert len(deepcopy[2, 0]) == 4


### PR DESCRIPTION
Fixes #22556
Fixes #21022

* add regression test and fix for gh-22556, where we were relying on the array `copy` arg to deepcopy a compound object type; I thought about performance issues here, but if you are already in the land of `object` and you are explicitly opting in to `deepcopy`, it seems like performance might be wishful thinking anyway

* add regression test and fix for gh-21022--this one was weirder but seems possible to sidestep by not trying to assign a shape of `()` to something that already has shape `()` and a non-writeable `shape` attribute