### PR TITLE
BUG: Allow no-op clearing of void dtypes

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -455,7 +455,9 @@ array_dealloc(PyArrayObject *self)
     if ((fa->flags & NPY_ARRAY_OWNDATA) && fa->data) {
         /* Free any internal references */
         if (PyDataType_REFCHK(fa->descr)) {
-            PyArray_ClearArray(self);
+            if (PyArray_ClearArray(self) < 0) {
+                PyErr_WriteUnraisable(NULL);
+            }
         }
         if (fa->mem_handler == NULL) {
             char *env = getenv("NUMPY_WARN_IF_NO_MEM_POLICY");

--- a/numpy/core/src/multiarray/dtype_traversal.c
+++ b/numpy/core/src/multiarray/dtype_traversal.c
@@ -454,10 +454,21 @@ npy_get_clear_void_and_legacy_user_dtype_loop(
         }
         return 0;
     }
+    else if (dtype->type_num == NPY_VOID) {
+        /* 
+         * Void dtypes can have "ghosts" of objects marking the dtype because
+         * holes (or the raw bytes if fields are gone) may include objects.
+         * Paths that need those flags should probably be considered incorrect.
+         * But as long as this can happen (a V8 that indicates references)
+         * we need to make it a no-op here.
+         */
+        *out_func = &clear_no_op;
+        return 0;
+    }
 
     PyErr_Format(PyExc_RuntimeError,
             "Internal error, tried to fetch clear function for the "
-            "user dtype '%s' without fields or subarray (legacy support).",
+            "user dtype '%S' without fields or subarray (legacy support).",
             dtype);
     return -1;
 }

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -551,6 +551,14 @@ class TestRecord:
         assert_equal(np.zeros((1, 2), dtype=[]) == a,
                      np.ones((1, 2), dtype=bool))
 
+    def test_nonstructured_with_object(self):
+        # See gh-23277, the dtype here thinks it contain objects, if the
+        # assert about that fails, the test becomes meaningless (which is OK)
+        arr = np.recarray((0,), dtype="O") 
+        assert arr.dtype.names is None  # no fields
+        assert arr.dtype.hasobject  # but claims to contain objects
+        del arr  # the deletion failed previously.
+
 
 class TestSubarray:
     def test_single_subarray(self):


### PR DESCRIPTION
Some void dtypes think they contain objects but don't.  Instead of playing whack-a-mole to see if that can be fixed, simply make the clearing a no-op here for them.
User dtypes are weirder, it should be OK to pass through.

Fixes the error message and use write-unraisable.

Closes gh-23277