### PR TITLE
Set github workflow permissions to circleci and labeler

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -5,12 +5,17 @@
 name: CircleCI artifact redirector
 
 on: [status]
+
+permissions: read-all
+
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
     if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[circle skip]') && !contains(github.event.head_commit.message, '[skip circle]')  && github.event.context == 'ci/circleci: build'"
     name: Run CircleCI artifacts redirector
     # if: github.repository == 'numpy/numpy'
+    permissions:
+      statuses: write
     steps:
       - name: GitHub Action step
         uses: larsoner/circleci-artifacts-redirector-action@master

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,12 +3,13 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-   pull-requests: write  # to add labels
+permissions: {}
 
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write  # to add labels
     steps:
     - name: Label the PR
       uses: gerrymanoim/pr-prefix-labeler@v3


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes #23293

## Changes

- Set circleci top level permission to `contents: read` and grant `statuses: write` to the job. (Looking at this PR https://github.com/larsoner/circleci-artifacts-redirector-action/issues/33 it seems that it only needs write access to statuses. Since I'm not sure I can test this workflow, I've looked into their documentation to understand it)
- Reduce scope of write permission on labeler.yml