### PR TITLE
ENH: show dtype in array repr when endianness is non-native

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1428,6 +1428,9 @@ def dtype_is_implied(dtype):
     # not just void types can be structured, and names are not part of the repr
     if dtype.names is not None:
         return False
+    
+    if dtype.byteorder != '=' and dtype.itemsize != 1:
+        return False # should care about endianness *unless size is 1* (e.g., int8, bool)
 
     return dtype.type in _typelessdata
 
@@ -1453,10 +1456,13 @@ def dtype_short_repr(dtype):
         return "'%s'" % str(dtype)
 
     typename = dtype.name
+    if dtype.itemsize != 1 and dtype.byteorder != '=':
+        # deal with cases like dtype('<u2') that are identical to an established dtype
+        # (in this case uint16) except that they have a different endianness.
+        return repr(dtype.descr[0][1])
     # quote typenames which can't be represented as python variable names
     if typename and not (typename[0].isalpha() and typename.isalnum()):
         typename = repr(typename)
-
     return typename
 
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -3,18 +3,10 @@
 $Id: arrayprint.py,v 1.9 2005/09/13 13:58:44 teoliphant Exp $
 
 """
-__all__ = [
-    "array2string",
-    "array_str",
-    "array_repr",
-    "set_string_function",
-    "set_printoptions",
-    "get_printoptions",
-    "printoptions",
-    "format_float_positional",
-    "format_float_scientific",
-]
-__docformat__ = "restructuredtext"
+__all__ = ["array2string", "array_str", "array_repr", "set_string_function",
+           "set_printoptions", "get_printoptions", "printoptions",
+           "format_float_positional", "format_float_scientific"]
+__docformat__ = 'restructuredtext'
 
 #
 # Written by Konrad Hinsen <hinsenk@ere.umontreal.ca>
@@ -33,64 +25,45 @@ __docformat__ = "restructuredtext"
 import functools
 import numbers
 import sys
-
 try:
     from _thread import get_ident
 except ImportError:
     from _dummy_thread import get_ident
 
-import contextlib
+import numpy as np
+from . import numerictypes as _nt
+from .umath import absolute, isinf, isfinite, isnat
+from . import multiarray
+from .multiarray import (array, dragon4_positional, dragon4_scientific,
+                         datetime_as_string, datetime_data, ndarray,
+                         set_legacy_print_mode)
+from .fromnumeric import any
+from .numeric import concatenate, asarray, errstate
+from .numerictypes import (longlong, intc, int_, float_, complex_, bool_,
+                           flexible)
+from .overrides import array_function_dispatch, set_module
 import operator
 import warnings
-
-import numpy as np
-
-from . import multiarray, numerictypes as _nt
-from .fromnumeric import any
-from .multiarray import (
-    array,
-    datetime_as_string,
-    datetime_data,
-    dragon4_positional,
-    dragon4_scientific,
-    ndarray,
-    set_legacy_print_mode,
-)
-from .numeric import asarray, concatenate, errstate
-from .numerictypes import bool_, complex_, flexible, float_, int_
-from .overrides import array_function_dispatch, set_module
-from .umath import absolute, isfinite, isinf, isnat
+import contextlib
 
 _format_options = {
-    "edgeitems": 3,  # repr N leading and trailing items of each dimension
-    "threshold": 1000,  # total items > triggers array summarization
-    "floatmode": "maxprec",
-    "precision": 8,  # precision of floating point representations
-    "suppress": False,  # suppress printing small floating values in exp format
-    "linewidth": 75,
-    "nanstr": "nan",
-    "infstr": "inf",
-    "sign": "-",
-    "formatter": None,
+    'edgeitems': 3,  # repr N leading and trailing items of each dimension
+    'threshold': 1000,  # total items > triggers array summarization
+    'floatmode': 'maxprec',
+    'precision': 8,  # precision of floating point representations
+    'suppress': False,  # suppress printing small floating values in exp format
+    'linewidth': 75,
+    'nanstr': 'nan',
+    'infstr': 'inf',
+    'sign': '-',
+    'formatter': None,
     # Internally stored as an int to simplify comparisons; converted from/to
     # str/False on the way in/out.
-    "legacy": sys.maxsize,
-}
+    'legacy': sys.maxsize}
 
-
-def _make_options_dict(
-    precision=None,
-    threshold=None,
-    edgeitems=None,
-    linewidth=None,
-    suppress=None,
-    nanstr=None,
-    infstr=None,
-    sign=None,
-    formatter=None,
-    floatmode=None,
-    legacy=None,
-):
+def _make_options_dict(precision=None, threshold=None, edgeitems=None,
+                       linewidth=None, suppress=None, nanstr=None, infstr=None,
+                       sign=None, formatter=None, floatmode=None, legacy=None):
     """
     Make a dictionary out of the non-None arguments, plus conversion of
     *legacy* and sanity checks.
@@ -99,67 +72,51 @@ def _make_options_dict(
     options = {k: v for k, v in locals().items() if v is not None}
 
     if suppress is not None:
-        options["suppress"] = bool(suppress)
+        options['suppress'] = bool(suppress)
 
-    modes = ["fixed", "unique", "maxprec", "maxprec_equal"]
+    modes = ['fixed', 'unique', 'maxprec', 'maxprec_equal']
     if floatmode not in modes + [None]:
-        raise ValueError(
-            "floatmode option must be one of " + ", ".join(f'"{m}"' for m in modes)
-        )
+        raise ValueError("floatmode option must be one of " +
+                         ", ".join('"{}"'.format(m) for m in modes))
 
-    if sign not in [None, "-", "+", " "]:
+    if sign not in [None, '-', '+', ' ']:
         raise ValueError("sign option must be one of ' ', '+', or '-'")
 
     if legacy == False:
-        options["legacy"] = sys.maxsize
-    elif legacy == "1.13":
-        options["legacy"] = 113
-    elif legacy == "1.21":
-        options["legacy"] = 121
+        options['legacy'] = sys.maxsize
+    elif legacy == '1.13':
+        options['legacy'] = 113
+    elif legacy == '1.21':
+        options['legacy'] = 121
     elif legacy is None:
         pass  # OK, do nothing.
     else:
         warnings.warn(
             "legacy printing option can currently only be '1.13', '1.21', or "
-            "`False`",
-            stacklevel=3,
-        )
+            "`False`", stacklevel=3)
 
     if threshold is not None:
         # forbid the bad threshold arg suggested by stack overflow, gh-12351
         if not isinstance(threshold, numbers.Number):
             raise TypeError("threshold must be numeric")
         if np.isnan(threshold):
-            raise ValueError(
-                "threshold must be non-NAN, try "
-                "sys.maxsize for untruncated representation"
-            )
+            raise ValueError("threshold must be non-NAN, try "
+                             "sys.maxsize for untruncated representation")
 
     if precision is not None:
         # forbid the bad precision arg as suggested by issue #18254
         try:
-            options["precision"] = operator.index(precision)
+            options['precision'] = operator.index(precision)
         except TypeError as e:
-            raise TypeError("precision must be an integer") from e
+            raise TypeError('precision must be an integer') from e
 
     return options
 
 
-@set_module("numpy")
-def set_printoptions(
-    precision=None,
-    threshold=None,
-    edgeitems=None,
-    linewidth=None,
-    suppress=None,
-    nanstr=None,
-    infstr=None,
-    formatter=None,
-    sign=None,
-    floatmode=None,
-    *,
-    legacy=None,
-):
+@set_module('numpy')
+def set_printoptions(precision=None, threshold=None, edgeitems=None,
+                     linewidth=None, suppress=None, nanstr=None, infstr=None,
+                     formatter=None, sign=None, floatmode=None, *, legacy=None):
     """
     Set printing options.
 
@@ -317,35 +274,25 @@ def set_printoptions(
     array([ 0.  ,  1.11,  2.22, ...,  7.78,  8.89, 10.  ])
 
     """
-    opt = _make_options_dict(
-        precision,
-        threshold,
-        edgeitems,
-        linewidth,
-        suppress,
-        nanstr,
-        infstr,
-        sign,
-        formatter,
-        floatmode,
-        legacy,
-    )
+    opt = _make_options_dict(precision, threshold, edgeitems, linewidth,
+                             suppress, nanstr, infstr, sign, formatter,
+                             floatmode, legacy)
     # formatter is always reset
-    opt["formatter"] = formatter
+    opt['formatter'] = formatter
     _format_options.update(opt)
 
     # set the C variable for legacy mode
-    if _format_options["legacy"] == 113:
+    if _format_options['legacy'] == 113:
         set_legacy_print_mode(113)
         # reset the sign option in legacy mode to avoid confusion
-        _format_options["sign"] = "-"
-    elif _format_options["legacy"] == 121:
+        _format_options['sign'] = '-'
+    elif _format_options['legacy'] == 121:
         set_legacy_print_mode(121)
-    elif _format_options["legacy"] == sys.maxsize:
+    elif _format_options['legacy'] == sys.maxsize:
         set_legacy_print_mode(0)
 
 
-@set_module("numpy")
+@set_module('numpy')
 def get_printoptions():
     """
     Return the current print options.
@@ -373,20 +320,18 @@ def get_printoptions():
 
     """
     opts = _format_options.copy()
-    opts["legacy"] = {
-        113: "1.13",
-        121: "1.21",
-        sys.maxsize: False,
-    }[opts["legacy"]]
+    opts['legacy'] = {
+        113: '1.13', 121: '1.21', sys.maxsize: False,
+    }[opts['legacy']]
     return opts
 
 
 def _get_legacy_print_mode():
     """Return the legacy print mode as an int."""
-    return _format_options["legacy"]
+    return _format_options['legacy']
 
 
-@set_module("numpy")
+@set_module('numpy')
 @contextlib.contextmanager
 def printoptions(*args, **kwargs):
     """Context manager for setting print options.
@@ -432,62 +377,50 @@ def _leading_trailing(a, edgeitems, index=()):
     if axis == a.ndim:
         return a[index]
 
-    if a.shape[axis] > 2 * edgeitems:
-        return concatenate(
-            (
-                _leading_trailing(a, edgeitems, index + np.index_exp[:edgeitems]),
-                _leading_trailing(a, edgeitems, index + np.index_exp[-edgeitems:]),
-            ),
-            axis=axis,
-        )
+    if a.shape[axis] > 2*edgeitems:
+        return concatenate((
+            _leading_trailing(a, edgeitems, index + np.index_exp[ :edgeitems]),
+            _leading_trailing(a, edgeitems, index + np.index_exp[-edgeitems:])
+        ), axis=axis)
     else:
         return _leading_trailing(a, edgeitems, index + np.index_exp[:])
 
 
 def _object_format(o):
-    """Object arrays containing lists should be printed unambiguously"""
+    """ Object arrays containing lists should be printed unambiguously """
     if type(o) is list:
-        fmt = "list({!r})"
+        fmt = 'list({!r})'
     else:
-        fmt = "{!r}"
+        fmt = '{!r}'
     return fmt.format(o)
-
 
 def repr_format(x):
     return repr(x)
 
-
 def str_format(x):
     return str(x)
 
-
-def _get_formatdict(
-    data, *, precision, floatmode, suppress, sign, legacy, formatter, **kwargs
-):
+def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
+                    formatter, **kwargs):
     # note: extra arguments in kwargs are ignored
 
     # wrapped in lambdas to avoid taking a code path with the wrong type of data
     formatdict = {
-        "bool": lambda: BoolFormat(data),
-        "int": lambda: IntegerFormat(data),
-        "float": lambda: FloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy
-        ),
-        "longfloat": lambda: FloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy
-        ),
-        "complexfloat": lambda: ComplexFloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy
-        ),
-        "longcomplexfloat": lambda: ComplexFloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy
-        ),
-        "datetime": lambda: DatetimeFormat(data, legacy=legacy),
-        "timedelta": lambda: TimedeltaFormat(data),
-        "object": lambda: _object_format,
-        "void": lambda: str_format,
-        "numpystr": lambda: repr_format,
-    }
+        'bool': lambda: BoolFormat(data),
+        'int': lambda: IntegerFormat(data),
+        'float': lambda: FloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy),
+        'longfloat': lambda: FloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy),
+        'complexfloat': lambda: ComplexFloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy),
+        'longcomplexfloat': lambda: ComplexFloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy),
+        'datetime': lambda: DatetimeFormat(data, legacy=legacy),
+        'timedelta': lambda: TimedeltaFormat(data),
+        'object': lambda: _object_format,
+        'void': lambda: str_format,
+        'numpystr': lambda: repr_format}
 
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
@@ -496,26 +429,25 @@ def _get_formatdict(
 
     if formatter is not None:
         fkeys = [k for k in formatter.keys() if formatter[k] is not None]
-        if "all" in fkeys:
+        if 'all' in fkeys:
             for key in formatdict.keys():
-                formatdict[key] = indirect(formatter["all"])
-        if "int_kind" in fkeys:
-            for key in ["int"]:
-                formatdict[key] = indirect(formatter["int_kind"])
-        if "float_kind" in fkeys:
-            for key in ["float", "longfloat"]:
-                formatdict[key] = indirect(formatter["float_kind"])
-        if "complex_kind" in fkeys:
-            for key in ["complexfloat", "longcomplexfloat"]:
-                formatdict[key] = indirect(formatter["complex_kind"])
-        if "str_kind" in fkeys:
-            formatdict["numpystr"] = indirect(formatter["str_kind"])
+                formatdict[key] = indirect(formatter['all'])
+        if 'int_kind' in fkeys:
+            for key in ['int']:
+                formatdict[key] = indirect(formatter['int_kind'])
+        if 'float_kind' in fkeys:
+            for key in ['float', 'longfloat']:
+                formatdict[key] = indirect(formatter['float_kind'])
+        if 'complex_kind' in fkeys:
+            for key in ['complexfloat', 'longcomplexfloat']:
+                formatdict[key] = indirect(formatter['complex_kind'])
+        if 'str_kind' in fkeys:
+            formatdict['numpystr'] = indirect(formatter['str_kind'])
         for key in formatdict.keys():
             if key in fkeys:
                 formatdict[key] = indirect(formatter[key])
 
     return formatdict
-
 
 def _get_format_function(data, **options):
     """
@@ -527,38 +459,38 @@ def _get_format_function(data, **options):
     if dtypeobj is None:
         return formatdict["numpystr"]()
     elif issubclass(dtypeobj, _nt.bool_):
-        return formatdict["bool"]()
+        return formatdict['bool']()
     elif issubclass(dtypeobj, _nt.integer):
         if issubclass(dtypeobj, _nt.timedelta64):
-            return formatdict["timedelta"]()
+            return formatdict['timedelta']()
         else:
-            return formatdict["int"]()
+            return formatdict['int']()
     elif issubclass(dtypeobj, _nt.floating):
         if issubclass(dtypeobj, _nt.longfloat):
-            return formatdict["longfloat"]()
+            return formatdict['longfloat']()
         else:
-            return formatdict["float"]()
+            return formatdict['float']()
     elif issubclass(dtypeobj, _nt.complexfloating):
         if issubclass(dtypeobj, _nt.clongfloat):
-            return formatdict["longcomplexfloat"]()
+            return formatdict['longcomplexfloat']()
         else:
-            return formatdict["complexfloat"]()
+            return formatdict['complexfloat']()
     elif issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
-        return formatdict["numpystr"]()
+        return formatdict['numpystr']()
     elif issubclass(dtypeobj, _nt.datetime64):
-        return formatdict["datetime"]()
+        return formatdict['datetime']()
     elif issubclass(dtypeobj, _nt.object_):
-        return formatdict["object"]()
+        return formatdict['object']()
     elif issubclass(dtypeobj, _nt.void):
         if dtype_.names is not None:
             return StructuredVoidFormat.from_data(data, **options)
         else:
-            return formatdict["void"]()
+            return formatdict['void']()
     else:
-        return formatdict["numpystr"]()
+        return formatdict['numpystr']()
 
 
-def _recursive_guard(fillvalue="..."):
+def _recursive_guard(fillvalue='...'):
     """
     Like the python 3.2 reprlib.recursive_repr, but forwards *args and **kwargs
 
@@ -589,7 +521,7 @@ def _recursive_guard(fillvalue="..."):
 
 # gracefully handle recursive calls, when object arrays contain themselves
 @_recursive_guard()
-def _array2string(a, options, separator=" ", prefix=""):
+def _array2string(a, options, separator=' ', prefix=""):
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in
     # _formatArray with subclasses which return 0d arrays in place of scalars
@@ -597,9 +529,9 @@ def _array2string(a, options, separator=" ", prefix=""):
     if a.shape == ():
         a = data
 
-    if a.size > options["threshold"]:
+    if a.size > options['threshold']:
         summary_insert = "..."
-        data = _leading_trailing(data, options["edgeitems"])
+        data = _leading_trailing(data, options['edgeitems'])
     else:
         summary_insert = ""
 
@@ -609,59 +541,29 @@ def _array2string(a, options, separator=" ", prefix=""):
     # skip over "["
     next_line_prefix = " "
     # skip over array(
-    next_line_prefix += " " * len(prefix)
+    next_line_prefix += " "*len(prefix)
 
-    lst = _formatArray(
-        a,
-        format_function,
-        options["linewidth"],
-        next_line_prefix,
-        separator,
-        options["edgeitems"],
-        summary_insert,
-        options["legacy"],
-    )
+    lst = _formatArray(a, format_function, options['linewidth'],
+                       next_line_prefix, separator, options['edgeitems'],
+                       summary_insert, options['legacy'])
     return lst
 
 
 def _array2string_dispatcher(
-    a,
-    max_line_width=None,
-    precision=None,
-    suppress_small=None,
-    separator=None,
-    prefix=None,
-    style=None,
-    formatter=None,
-    threshold=None,
-    edgeitems=None,
-    sign=None,
-    floatmode=None,
-    suffix=None,
-    *,
-    legacy=None,
-):
+        a, max_line_width=None, precision=None,
+        suppress_small=None, separator=None, prefix=None,
+        style=None, formatter=None, threshold=None,
+        edgeitems=None, sign=None, floatmode=None, suffix=None,
+        *, legacy=None):
     return (a,)
 
 
-@array_function_dispatch(_array2string_dispatcher, module="numpy")
-def array2string(
-    a,
-    max_line_width=None,
-    precision=None,
-    suppress_small=None,
-    separator=" ",
-    prefix="",
-    style=np._NoValue,
-    formatter=None,
-    threshold=None,
-    edgeitems=None,
-    sign=None,
-    floatmode=None,
-    suffix="",
-    *,
-    legacy=None,
-):
+@array_function_dispatch(_array2string_dispatcher, module='numpy')
+def array2string(a, max_line_width=None, precision=None,
+                 suppress_small=None, separator=' ', prefix="",
+                 style=np._NoValue, formatter=None, threshold=None,
+                 edgeitems=None, sign=None, floatmode=None, suffix="",
+                 *, legacy=None):
     """
     Return a string representation of an array.
 
@@ -806,23 +708,13 @@ def array2string(
 
     """
 
-    overrides = _make_options_dict(
-        precision,
-        threshold,
-        edgeitems,
-        max_line_width,
-        suppress_small,
-        None,
-        None,
-        sign,
-        formatter,
-        floatmode,
-        legacy,
-    )
+    overrides = _make_options_dict(precision, threshold, edgeitems,
+                                   max_line_width, suppress_small, None, None,
+                                   sign, formatter, floatmode, legacy)
     options = _format_options.copy()
     options.update(overrides)
 
-    if options["legacy"] <= 113:
+    if options['legacy'] <= 113:
         if style is np._NoValue:
             style = repr
 
@@ -830,15 +722,12 @@ def array2string(
             return style(a.item())
     elif style is not np._NoValue:
         # Deprecation 11-9-2017  v1.14
-        warnings.warn(
-            "'style' argument is deprecated and no longer functional"
-            " except in 1.13 'legacy' mode",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        warnings.warn("'style' argument is deprecated and no longer functional"
+                      " except in 1.13 'legacy' mode",
+                      DeprecationWarning, stacklevel=2)
 
-    if options["legacy"] > 113:
-        options["linewidth"] -= len(suffix)
+    if options['legacy'] > 113:
+        options['linewidth'] -= len(suffix)
 
     # treat as a null array if any of shape elements == 0
     if a.size == 0:
@@ -870,34 +759,26 @@ def _extendLine_pretty(s, line, word, line_width, next_line_prefix, legacy):
         return _extendLine(s, line, word, line_width, next_line_prefix, legacy)
 
     max_word_length = max(len(word) for word in words)
-    if len(line) + max_word_length > line_width and len(line) > len(next_line_prefix):
-        s += line.rstrip() + "\n"
+    if (len(line) + max_word_length > line_width and
+            len(line) > len(next_line_prefix)):
+        s += line.rstrip() + '\n'
         line = next_line_prefix + words[0]
         indent = next_line_prefix
     else:
-        indent = len(line) * " "
+        indent = len(line)*' '
         line += words[0]
 
     for word in words[1::]:
-        s += line.rstrip() + "\n"
+        s += line.rstrip() + '\n'
         line = indent + word
 
     suffix_length = max_word_length - len(words[-1])
-    line += suffix_length * " "
+    line += suffix_length*' '
 
     return s, line
 
-
-def _formatArray(
-    a,
-    format_function,
-    line_width,
-    next_line_prefix,
-    separator,
-    edge_items,
-    summary_insert,
-    legacy,
-):
+def _formatArray(a, format_function, line_width, next_line_prefix,
+                 separator, edge_items, summary_insert, legacy):
     """formatArray is designed for two modes of operation:
 
     1. Full output
@@ -905,7 +786,6 @@ def _formatArray(
     2. Summarized output
 
     """
-
     def recurser(index, hanging_indent, curr_width):
         """
         By using this local function, we don't need to recurse with all the
@@ -920,14 +800,14 @@ def _formatArray(
 
         # when recursing, add a space to align with the [ added, and reduce the
         # length of the line by 1
-        next_hanging_indent = hanging_indent + " "
+        next_hanging_indent = hanging_indent + ' '
         if legacy <= 113:
             next_width = curr_width
         else:
-            next_width = curr_width - len("]")
+            next_width = curr_width - len(']')
 
         a_len = a.shape[axis]
-        show_summary = summary_insert and 2 * edge_items < a_len
+        show_summary = summary_insert and 2*edge_items < a_len
         if show_summary:
             leading_items = edge_items
             trailing_items = edge_items
@@ -936,7 +816,7 @@ def _formatArray(
             trailing_items = a_len
 
         # stringify the array with the hanging indent on the first line too
-        s = ""
+        s = ''
 
         # last axis (rows) - wrap elements if they would not fit on one line
         if axes_left == 1:
@@ -944,20 +824,18 @@ def _formatArray(
             if legacy <= 113:
                 elem_width = curr_width - len(separator.rstrip())
             else:
-                elem_width = curr_width - max(len(separator.rstrip()), len("]"))
+                elem_width = curr_width - max(len(separator.rstrip()), len(']'))
 
             line = hanging_indent
             for i in range(leading_items):
                 word = recurser(index + (i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
-                    s, line, word, elem_width, hanging_indent, legacy
-                )
+                    s, line, word, elem_width, hanging_indent, legacy)
                 line += separator
 
             if show_summary:
                 s, line = _extendLine(
-                    s, line, summary_insert, elem_width, hanging_indent, legacy
-                )
+                    s, line, summary_insert, elem_width, hanging_indent, legacy)
                 if legacy <= 113:
                     line += ", "
                 else:
@@ -966,8 +844,7 @@ def _formatArray(
             for i in range(trailing_items, 1, -1):
                 word = recurser(index + (-i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
-                    s, line, word, elem_width, hanging_indent, legacy
-                )
+                    s, line, word, elem_width, hanging_indent, legacy)
                 line += separator
 
             if legacy <= 113:
@@ -975,15 +852,14 @@ def _formatArray(
                 elem_width = curr_width
             word = recurser(index + (-1,), next_hanging_indent, next_width)
             s, line = _extendLine_pretty(
-                s, line, word, elem_width, hanging_indent, legacy
-            )
+                s, line, word, elem_width, hanging_indent, legacy)
 
             s += line
 
         # other axes - insert newlines between rows
         else:
-            s = ""
-            line_sep = separator.rstrip() + "\n" * (axes_left - 1)
+            s = ''
+            line_sep = separator.rstrip() + '\n'*(axes_left - 1)
 
             for i in range(leading_items):
                 nested = recurser(index + (i,), next_hanging_indent, next_width)
@@ -997,59 +873,56 @@ def _formatArray(
                     s += hanging_indent + summary_insert + line_sep
 
             for i in range(trailing_items, 1, -1):
-                nested = recurser(index + (-i,), next_hanging_indent, next_width)
+                nested = recurser(index + (-i,), next_hanging_indent,
+                                  next_width)
                 s += hanging_indent + nested + line_sep
 
             nested = recurser(index + (-1,), next_hanging_indent, next_width)
             s += hanging_indent + nested
 
         # remove the hanging indent, and wrap in []
-        s = "[" + s[len(hanging_indent) :] + "]"
+        s = '[' + s[len(hanging_indent):] + ']'
         return s
 
     try:
         # invoke the recursive part with an initial index and prefix
-        return recurser(
-            index=(), hanging_indent=next_line_prefix, curr_width=line_width
-        )
+        return recurser(index=(),
+                        hanging_indent=next_line_prefix,
+                        curr_width=line_width)
     finally:
         # recursive closures have a cyclic reference to themselves, which
         # requires gc to collect (gh-10620). To avoid this problem, for
         # performance and PyPy friendliness, we break the cycle:
         recurser = None
 
-
 def _none_or_positive_arg(x, name):
     if x is None:
         return -1
     if x < 0:
-        raise ValueError(f"{name} must be >= 0")
+        raise ValueError("{} must be >= 0".format(name))
     return x
 
-
 class FloatingFormat:
-    """Formatter for subtypes of np.floating"""
-
-    def __init__(
-        self, data, precision, floatmode, suppress_small, sign=False, *, legacy=None
-    ):
+    """ Formatter for subtypes of np.floating """
+    def __init__(self, data, precision, floatmode, suppress_small, sign=False,
+                 *, legacy=None):
         # for backcompatibility, accept bools
         if isinstance(sign, bool):
-            sign = "+" if sign else "-"
+            sign = '+' if sign else '-'
 
         self._legacy = legacy
         if self._legacy <= 113:
             # when not 0d, legacy does not support '-'
-            if data.shape != () and sign == "-":
-                sign = " "
+            if data.shape != () and sign == '-':
+                sign = ' '
 
         self.floatmode = floatmode
-        if floatmode == "unique":
+        if floatmode == 'unique':
             self.precision = None
         else:
             self.precision = precision
 
-        self.precision = _none_or_positive_arg(self.precision, "precision")
+        self.precision = _none_or_positive_arg(self.precision, 'precision')
 
         self.suppress_small = suppress_small
         self.sign = sign
@@ -1067,40 +940,31 @@ class FloatingFormat:
         if len(abs_non_zero) != 0:
             max_val = np.max(abs_non_zero)
             min_val = np.min(abs_non_zero)
-            with errstate(over="ignore"):  # division can overflow
-                if max_val >= 1.0e8 or (
-                    not self.suppress_small
-                    and (min_val < 0.0001 or max_val / min_val > 1000.0)
-                ):
+            with errstate(over='ignore'):  # division can overflow
+                if max_val >= 1.e8 or (not self.suppress_small and
+                        (min_val < 0.0001 or max_val/min_val > 1000.)):
                     self.exp_format = True
 
         # do a first pass of printing all the numbers, to determine sizes
         if len(finite_vals) == 0:
             self.pad_left = 0
             self.pad_right = 0
-            self.trim = "."
+            self.trim = '.'
             self.exp_size = -1
             self.unique = True
             self.min_digits = None
         elif self.exp_format:
-            trim, unique = ".", True
-            if self.floatmode == "fixed" or self._legacy <= 113:
-                trim, unique = "k", False
-            strs = (
-                dragon4_scientific(
-                    x,
-                    precision=self.precision,
-                    unique=unique,
-                    trim=trim,
-                    sign=self.sign == "+",
-                )
-                for x in finite_vals
-            )
-            frac_strs, _, exp_strs = zip(*(s.partition("e") for s in strs))
-            int_part, frac_part = zip(*(s.split(".") for s in frac_strs))
+            trim, unique = '.', True
+            if self.floatmode == 'fixed' or self._legacy <= 113:
+                trim, unique = 'k', False
+            strs = (dragon4_scientific(x, precision=self.precision,
+                               unique=unique, trim=trim, sign=self.sign == '+')
+                    for x in finite_vals)
+            frac_strs, _, exp_strs = zip(*(s.partition('e') for s in strs))
+            int_part, frac_part = zip(*(s.split('.') for s in frac_strs))
             self.exp_size = max(len(s) for s in exp_strs) - 1
 
-            self.trim = "k"
+            self.trim = 'k'
             self.precision = max(len(s) for s in frac_part)
             self.min_digits = self.precision
             self.unique = unique
@@ -1114,96 +978,79 @@ class FloatingFormat:
             # pad_right is only needed for nan length calculation
             self.pad_right = self.exp_size + 2 + self.precision
         else:
-            trim, unique = ".", True
-            if self.floatmode == "fixed":
-                trim, unique = "k", False
-            strs = (
-                dragon4_positional(
-                    x,
-                    precision=self.precision,
-                    fractional=True,
-                    unique=unique,
-                    trim=trim,
-                    sign=self.sign == "+",
-                )
-                for x in finite_vals
-            )
-            int_part, frac_part = zip(*(s.split(".") for s in strs))
+            trim, unique = '.', True
+            if self.floatmode == 'fixed':
+                trim, unique = 'k', False
+            strs = (dragon4_positional(x, precision=self.precision,
+                                       fractional=True,
+                                       unique=unique, trim=trim,
+                                       sign=self.sign == '+')
+                    for x in finite_vals)
+            int_part, frac_part = zip(*(s.split('.') for s in strs))
             if self._legacy <= 113:
-                self.pad_left = 1 + max(len(s.lstrip("-+")) for s in int_part)
+                self.pad_left = 1 + max(len(s.lstrip('-+')) for s in int_part)
             else:
                 self.pad_left = max(len(s) for s in int_part)
             self.pad_right = max(len(s) for s in frac_part)
             self.exp_size = -1
             self.unique = unique
 
-            if self.floatmode in ["fixed", "maxprec_equal"]:
+            if self.floatmode in ['fixed', 'maxprec_equal']:
                 self.precision = self.min_digits = self.pad_right
-                self.trim = "k"
+                self.trim = 'k'
             else:
-                self.trim = "."
+                self.trim = '.'
                 self.min_digits = 0
 
         if self._legacy > 113:
             # account for sign = ' ' by adding one to pad_left
-            if self.sign == " " and not any(np.signbit(finite_vals)):
+            if self.sign == ' ' and not any(np.signbit(finite_vals)):
                 self.pad_left += 1
 
         # if there are non-finite values, may need to increase pad_left
         if data.size != finite_vals.size:
-            neginf = self.sign != "-" or any(data[isinf(data)] < 0)
-            nanlen = len(_format_options["nanstr"])
-            inflen = len(_format_options["infstr"]) + neginf
+            neginf = self.sign != '-' or any(data[isinf(data)] < 0)
+            nanlen = len(_format_options['nanstr'])
+            inflen = len(_format_options['infstr']) + neginf
             offset = self.pad_right + 1  # +1 for decimal pt
             self.pad_left = max(self.pad_left, nanlen - offset, inflen - offset)
 
     def __call__(self, x):
         if not np.isfinite(x):
-            with errstate(invalid="ignore"):
+            with errstate(invalid='ignore'):
                 if np.isnan(x):
-                    sign = "+" if self.sign == "+" else ""
-                    ret = sign + _format_options["nanstr"]
+                    sign = '+' if self.sign == '+' else ''
+                    ret = sign + _format_options['nanstr']
                 else:  # isinf
-                    sign = "-" if x < 0 else "+" if self.sign == "+" else ""
-                    ret = sign + _format_options["infstr"]
-                return " " * (self.pad_left + self.pad_right + 1 - len(ret)) + ret
+                    sign = '-' if x < 0 else '+' if self.sign == '+' else ''
+                    ret = sign + _format_options['infstr']
+                return ' '*(self.pad_left + self.pad_right + 1 - len(ret)) + ret
 
         if self.exp_format:
-            return dragon4_scientific(
-                x,
-                precision=self.precision,
-                min_digits=self.min_digits,
-                unique=self.unique,
-                trim=self.trim,
-                sign=self.sign == "+",
-                pad_left=self.pad_left,
-                exp_digits=self.exp_size,
-            )
+            return dragon4_scientific(x,
+                                      precision=self.precision,
+                                      min_digits=self.min_digits,
+                                      unique=self.unique,
+                                      trim=self.trim,
+                                      sign=self.sign == '+',
+                                      pad_left=self.pad_left,
+                                      exp_digits=self.exp_size)
         else:
-            return dragon4_positional(
-                x,
-                precision=self.precision,
-                min_digits=self.min_digits,
-                unique=self.unique,
-                fractional=True,
-                trim=self.trim,
-                sign=self.sign == "+",
-                pad_left=self.pad_left,
-                pad_right=self.pad_right,
-            )
+            return dragon4_positional(x,
+                                      precision=self.precision,
+                                      min_digits=self.min_digits,
+                                      unique=self.unique,
+                                      fractional=True,
+                                      trim=self.trim,
+                                      sign=self.sign == '+',
+                                      pad_left=self.pad_left,
+                                      pad_right=self.pad_right)
 
 
-@set_module("numpy")
-def format_float_scientific(
-    x,
-    precision=None,
-    unique=True,
-    trim="k",
-    sign=False,
-    pad_left=None,
-    exp_digits=None,
-    min_digits=None,
-):
+@set_module('numpy')
+def format_float_scientific(x, precision=None, unique=True, trim='k',
+                            sign=False, pad_left=None, exp_digits=None,
+                            min_digits=None):
     """
     Format a floating-point scalar as a decimal string in scientific notation.
 
@@ -1249,7 +1096,7 @@ def format_float_scientific(
         identify the value may be printed and rounded unbiased.
 
         -- versionadded:: 1.21.0
-
+        
     Returns
     -------
     rep : string
@@ -1269,36 +1116,21 @@ def format_float_scientific(
     >>> np.format_float_scientific(s, exp_digits=4)
     '1.23e+0024'
     """
-    precision = _none_or_positive_arg(precision, "precision")
-    pad_left = _none_or_positive_arg(pad_left, "pad_left")
-    exp_digits = _none_or_positive_arg(exp_digits, "exp_digits")
-    min_digits = _none_or_positive_arg(min_digits, "min_digits")
+    precision = _none_or_positive_arg(precision, 'precision')
+    pad_left = _none_or_positive_arg(pad_left, 'pad_left')
+    exp_digits = _none_or_positive_arg(exp_digits, 'exp_digits')
+    min_digits = _none_or_positive_arg(min_digits, 'min_digits')
     if min_digits > 0 and precision > 0 and min_digits > precision:
         raise ValueError("min_digits must be less than or equal to precision")
-    return dragon4_scientific(
-        x,
-        precision=precision,
-        unique=unique,
-        trim=trim,
-        sign=sign,
-        pad_left=pad_left,
-        exp_digits=exp_digits,
-        min_digits=min_digits,
-    )
+    return dragon4_scientific(x, precision=precision, unique=unique,
+                              trim=trim, sign=sign, pad_left=pad_left,
+                              exp_digits=exp_digits, min_digits=min_digits)
 
 
-@set_module("numpy")
-def format_float_positional(
-    x,
-    precision=None,
-    unique=True,
-    fractional=True,
-    trim="k",
-    sign=False,
-    pad_left=None,
-    pad_right=None,
-    min_digits=None,
-):
+@set_module('numpy')
+def format_float_positional(x, precision=None, unique=True,
+                            fractional=True, trim='k', sign=False,
+                            pad_left=None, pad_right=None, min_digits=None):
     """
     Format a floating-point scalar as a decimal string in positional notation.
 
@@ -1349,7 +1181,7 @@ def format_float_positional(
         Minimum number of digits to print. Only has an effect if `unique=True`
         in which case additional digits past those necessary to uniquely
         identify the value may be printed, rounding the last additional digit.
-
+        
         -- versionadded:: 1.21.0
 
     Returns
@@ -1372,34 +1204,29 @@ def format_float_positional(
     >>> np.format_float_positional(np.float16(0.3), unique=False, precision=10)
     '0.3000488281'
     """
-    precision = _none_or_positive_arg(precision, "precision")
-    pad_left = _none_or_positive_arg(pad_left, "pad_left")
-    pad_right = _none_or_positive_arg(pad_right, "pad_right")
-    min_digits = _none_or_positive_arg(min_digits, "min_digits")
+    precision = _none_or_positive_arg(precision, 'precision')
+    pad_left = _none_or_positive_arg(pad_left, 'pad_left')
+    pad_right = _none_or_positive_arg(pad_right, 'pad_right')
+    min_digits = _none_or_positive_arg(min_digits, 'min_digits')
     if not fractional and precision == 0:
-        raise ValueError("precision must be greater than 0 if " "fractional=False")
+        raise ValueError("precision must be greater than 0 if "
+                         "fractional=False")
     if min_digits > 0 and precision > 0 and min_digits > precision:
         raise ValueError("min_digits must be less than or equal to precision")
-    return dragon4_positional(
-        x,
-        precision=precision,
-        unique=unique,
-        fractional=fractional,
-        trim=trim,
-        sign=sign,
-        pad_left=pad_left,
-        pad_right=pad_right,
-        min_digits=min_digits,
-    )
+    return dragon4_positional(x, precision=precision, unique=unique,
+                              fractional=fractional, trim=trim,
+                              sign=sign, pad_left=pad_left,
+                              pad_right=pad_right, min_digits=min_digits)
 
 
 class IntegerFormat:
     def __init__(self, data):
         if data.size > 0:
-            max_str_len = max(len(str(np.max(data))), len(str(np.min(data))))
+            max_str_len = max(len(str(np.max(data))),
+                              len(str(np.min(data))))
         else:
             max_str_len = 0
-        self.format = f"%{max_str_len}d"
+        self.format = '%{}d'.format(max_str_len)
 
     def __call__(self, x):
         return self.format % x
@@ -1409,32 +1236,32 @@ class BoolFormat:
     def __init__(self, data, **kwargs):
         # add an extra space so " True" and "False" have the same length and
         # array elements align nicely when printed, except in 0d arrays
-        self.truestr = " True" if data.shape != () else "True"
+        self.truestr = ' True' if data.shape != () else 'True'
 
     def __call__(self, x):
         return self.truestr if x else "False"
 
 
 class ComplexFloatingFormat:
-    """Formatter for subtypes of np.complexfloating"""
-
-    def __init__(
-        self, x, precision, floatmode, suppress_small, sign=False, *, legacy=None
-    ):
+    """ Formatter for subtypes of np.complexfloating """
+    def __init__(self, x, precision, floatmode, suppress_small,
+                 sign=False, *, legacy=None):
         # for backcompatibility, accept bools
         if isinstance(sign, bool):
-            sign = "+" if sign else "-"
+            sign = '+' if sign else '-'
 
         floatmode_real = floatmode_imag = floatmode
         if legacy <= 113:
-            floatmode_real = "maxprec_equal"
-            floatmode_imag = "maxprec"
+            floatmode_real = 'maxprec_equal'
+            floatmode_imag = 'maxprec'
 
         self.real_format = FloatingFormat(
-            x.real, precision, floatmode_real, suppress_small, sign=sign, legacy=legacy
+            x.real, precision, floatmode_real, suppress_small,
+            sign=sign, legacy=legacy
         )
         self.imag_format = FloatingFormat(
-            x.imag, precision, floatmode_imag, suppress_small, sign="+", legacy=legacy
+            x.imag, precision, floatmode_imag, suppress_small,
+            sign='+', legacy=legacy
         )
 
     def __call__(self, x):
@@ -1443,7 +1270,7 @@ class ComplexFloatingFormat:
 
         # add the 'j' before the terminal whitespace in i
         sp = len(i.rstrip())
-        i = i[:sp] + "j" + i[sp:]
+        i = i[:sp] + 'j' + i[sp:]
 
         return r + i
 
@@ -1453,16 +1280,14 @@ class _TimelikeFormat:
         non_nat = data[~isnat(data)]
         if len(non_nat) > 0:
             # Max str length of non-NaT elements
-            max_str_len = max(
-                len(self._format_non_nat(np.max(non_nat))),
-                len(self._format_non_nat(np.min(non_nat))),
-            )
+            max_str_len = max(len(self._format_non_nat(np.max(non_nat))),
+                              len(self._format_non_nat(np.min(non_nat))))
         else:
             max_str_len = 0
         if len(non_nat) < data.size:
             # data contains a NaT
             max_str_len = max(max_str_len, 5)
-        self._format = f"%{max_str_len}s"
+        self._format = '%{}s'.format(max_str_len)
         self._nat = "'NaT'".rjust(max_str_len)
 
     def _format_non_nat(self, x):
@@ -1477,16 +1302,17 @@ class _TimelikeFormat:
 
 
 class DatetimeFormat(_TimelikeFormat):
-    def __init__(self, x, unit=None, timezone=None, casting="same_kind", legacy=False):
+    def __init__(self, x, unit=None, timezone=None, casting='same_kind',
+                 legacy=False):
         # Get the unit from the dtype
         if unit is None:
-            if x.dtype.kind == "M":
+            if x.dtype.kind == 'M':
                 unit = datetime_data(x.dtype)[0]
             else:
-                unit = "s"
+                unit = 's'
 
         if timezone is None:
-            timezone = "naive"
+            timezone = 'naive'
         self.timezone = timezone
         self.unit = unit
         self.casting = casting
@@ -1501,14 +1327,15 @@ class DatetimeFormat(_TimelikeFormat):
         return super().__call__(x)
 
     def _format_non_nat(self, x):
-        return "'%s'" % datetime_as_string(
-            x, unit=self.unit, timezone=self.timezone, casting=self.casting
-        )
+        return "'%s'" % datetime_as_string(x,
+                                    unit=self.unit,
+                                    timezone=self.timezone,
+                                    casting=self.casting)
 
 
 class TimedeltaFormat(_TimelikeFormat):
     def _format_non_nat(self, x):
-        return str(x.astype("i8"))
+        return str(x.astype('i8'))
 
 
 class SubArrayFormat:
@@ -1529,7 +1356,6 @@ class StructuredVoidFormat:
     as alias scalars lose their field information, and the implementation
     relies upon np.void.__getitem__.
     """
-
     def __init__(self, format_functions):
         self.format_functions = format_functions
 
@@ -1553,7 +1379,7 @@ class StructuredVoidFormat:
             for field, format_function in zip(x, self.format_functions)
         ]
         if len(str_fields) == 1:
-            return f"({str_fields[0]},)"
+            return "({},)".format(str_fields[0])
         else:
             return "({})".format(", ".join(str_fields))
 
@@ -1596,16 +1422,15 @@ def dtype_is_implied(dtype):
     array([1, 2, 3], dtype=int8)
     """
     dtype = np.dtype(dtype)
-    if _format_options["legacy"] <= 113 and dtype.type == bool_:
+    if _format_options['legacy'] <= 113 and dtype.type == bool_:
         return False
 
     # not just void types can be structured, and names are not part of the repr
     if dtype.names is not None:
         return False
-
+    
     if not dtype.isnative:
-        # should care about endianness *unless size is 1* (e.g., int8, bool)
-        return False
+        return False # should care about endianness *unless size is 1* (e.g., int8, bool)
 
     return dtype.type in _typelessdata
 
@@ -1642,15 +1467,11 @@ def dtype_short_repr(dtype):
 
 
 def _array_repr_implementation(
-    arr,
-    max_line_width=None,
-    precision=None,
-    suppress_small=None,
-    array2string=array2string,
-):
+        arr, max_line_width=None, precision=None, suppress_small=None,
+        array2string=array2string):
     """Internal version of array_repr() that allows overriding array2string."""
     if max_line_width is None:
-        max_line_width = _format_options["linewidth"]
+        max_line_width = _format_options['linewidth']
 
     if type(arr) is not ndarray:
         class_name = type(arr).__name__
@@ -1662,43 +1483,42 @@ def _array_repr_implementation(
     prefix = class_name + "("
     suffix = ")" if skipdtype else ","
 
-    if _format_options["legacy"] <= 113 and arr.shape == () and not arr.dtype.names:
+    if (_format_options['legacy'] <= 113 and
+            arr.shape == () and not arr.dtype.names):
         lst = repr(arr.item())
     elif arr.size > 0 or arr.shape == (0,):
-        lst = array2string(
-            arr, max_line_width, precision, suppress_small, ", ", prefix, suffix=suffix
-        )
+        lst = array2string(arr, max_line_width, precision, suppress_small,
+                           ', ', prefix, suffix=suffix)
     else:  # show zero-length shape unless it is (0,)
-        lst = f"[], shape={repr(arr.shape)}"
+        lst = "[], shape=%s" % (repr(arr.shape),)
 
     arr_str = prefix + lst + suffix
 
     if skipdtype:
         return arr_str
 
-    dtype_str = f"dtype={dtype_short_repr(arr.dtype)})"
+    dtype_str = "dtype={})".format(dtype_short_repr(arr.dtype))
 
     # compute whether we should put dtype on a new line: Do so if adding the
     # dtype would extend the last line past max_line_width.
     # Note: This line gives the correct result even when rfind returns -1.
-    last_line_len = len(arr_str) - (arr_str.rfind("\n") + 1)
+    last_line_len = len(arr_str) - (arr_str.rfind('\n') + 1)
     spacer = " "
-    if _format_options["legacy"] <= 113:
+    if _format_options['legacy'] <= 113:
         if issubclass(arr.dtype.type, flexible):
-            spacer = "\n" + " " * len(class_name + "(")
+            spacer = '\n' + ' '*len(class_name + "(")
     elif last_line_len + len(dtype_str) + 1 > max_line_width:
-        spacer = "\n" + " " * len(class_name + "(")
+        spacer = '\n' + ' '*len(class_name + "(")
 
     return arr_str + spacer + dtype_str
 
 
 def _array_repr_dispatcher(
-    arr, max_line_width=None, precision=None, suppress_small=None
-):
+        arr, max_line_width=None, precision=None, suppress_small=None):
     return (arr,)
 
 
-@array_function_dispatch(_array_repr_dispatcher, module="numpy")
+@array_function_dispatch(_array_repr_dispatcher, module='numpy')
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1743,7 +1563,8 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     'array([0.000001,  0.      ,  2.      ,  3.      ])'
 
     """
-    return _array_repr_implementation(arr, max_line_width, precision, suppress_small)
+    return _array_repr_implementation(
+        arr, max_line_width, precision, suppress_small)
 
 
 @_recursive_guard()
@@ -1754,14 +1575,11 @@ def _guarded_repr_or_str(v):
 
 
 def _array_str_implementation(
-    a,
-    max_line_width=None,
-    precision=None,
-    suppress_small=None,
-    array2string=array2string,
-):
+        a, max_line_width=None, precision=None, suppress_small=None,
+        array2string=array2string):
     """Internal version of array_str() that allows overriding array2string."""
-    if _format_options["legacy"] <= 113 and a.shape == () and not a.dtype.names:
+    if (_format_options['legacy'] <= 113 and
+            a.shape == () and not a.dtype.names):
         return str(a.item())
 
     # the str of 0d arrays is a special case: It should appear like a scalar,
@@ -1773,14 +1591,15 @@ def _array_str_implementation(
         # ndarray's getindex. Also guard against recursive 0d object arrays.
         return _guarded_repr_or_str(np.ndarray.__getitem__(a, ()))
 
-    return array2string(a, max_line_width, precision, suppress_small, " ", "")
+    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
 
 
-def _array_str_dispatcher(a, max_line_width=None, precision=None, suppress_small=None):
+def _array_str_dispatcher(
+        a, max_line_width=None, precision=None, suppress_small=None):
     return (a,)
 
 
-@array_function_dispatch(_array_str_dispatcher, module="numpy")
+@array_function_dispatch(_array_str_dispatcher, module='numpy')
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     """
     Return a string representation of the data in an array.
@@ -1816,17 +1635,16 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return _array_str_implementation(a, max_line_width, precision, suppress_small)
+    return _array_str_implementation(
+        a, max_line_width, precision, suppress_small)
 
 
 # needed if __array_function__ is disabled
-_array2string_impl = getattr(array2string, "__wrapped__", array2string)
-_default_array_str = functools.partial(
-    _array_str_implementation, array2string=_array2string_impl
-)
-_default_array_repr = functools.partial(
-    _array_repr_implementation, array2string=_array2string_impl
-)
+_array2string_impl = getattr(array2string, '__wrapped__', array2string)
+_default_array_str = functools.partial(_array_str_implementation,
+                                       array2string=_array2string_impl)
+_default_array_repr = functools.partial(_array_repr_implementation,
+                                        array2string=_array2string_impl)
 
 
 def set_string_function(f, repr=True):

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -31,6 +31,7 @@ except ImportError:
     from _dummy_thread import get_ident
 
 import numpy as np
+from ._dtype import _construction_repr
 from . import numerictypes as _nt
 from .umath import absolute, isinf, isfinite, isnat
 from . import multiarray
@@ -1461,7 +1462,7 @@ def dtype_short_repr(dtype):
         # deal with cases like dtype('<u2') that are identical to an
         # established dtype (in this case uint16)
         # except that they have a different endianness.
-        return repr(dtype.descr[0][1])
+        return _construction_repr(dtype)
     # quote typenames which can't be represented as python variable names
     if typename and not (typename[0].isalpha() and typename.isalnum()):
         typename = repr(typename)

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1429,7 +1429,7 @@ def dtype_is_implied(dtype):
     if dtype.names is not None:
         return False
     
-    if dtype.byteorder != '=' and dtype.itemsize != 1:
+    if not dtype.isnative:
         return False # should care about endianness *unless size is 1* (e.g., int8, bool)
 
     return dtype.type in _typelessdata
@@ -1456,7 +1456,7 @@ def dtype_short_repr(dtype):
         return "'%s'" % str(dtype)
 
     typename = dtype.name
-    if dtype.itemsize != 1 and dtype.byteorder != '=':
+    if not dtype.isnative:
         # deal with cases like dtype('<u2') that are identical to an established dtype
         # (in this case uint16) except that they have a different endianness.
         return repr(dtype.descr[0][1])

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -3,10 +3,18 @@
 $Id: arrayprint.py,v 1.9 2005/09/13 13:58:44 teoliphant Exp $
 
 """
-__all__ = ["array2string", "array_str", "array_repr", "set_string_function",
-           "set_printoptions", "get_printoptions", "printoptions",
-           "format_float_positional", "format_float_scientific"]
-__docformat__ = 'restructuredtext'
+__all__ = [
+    "array2string",
+    "array_str",
+    "array_repr",
+    "set_string_function",
+    "set_printoptions",
+    "get_printoptions",
+    "printoptions",
+    "format_float_positional",
+    "format_float_scientific",
+]
+__docformat__ = "restructuredtext"
 
 #
 # Written by Konrad Hinsen <hinsenk@ere.umontreal.ca>
@@ -25,45 +33,64 @@ __docformat__ = 'restructuredtext'
 import functools
 import numbers
 import sys
+
 try:
     from _thread import get_ident
 except ImportError:
     from _dummy_thread import get_ident
 
-import numpy as np
-from . import numerictypes as _nt
-from .umath import absolute, isinf, isfinite, isnat
-from . import multiarray
-from .multiarray import (array, dragon4_positional, dragon4_scientific,
-                         datetime_as_string, datetime_data, ndarray,
-                         set_legacy_print_mode)
-from .fromnumeric import any
-from .numeric import concatenate, asarray, errstate
-from .numerictypes import (longlong, intc, int_, float_, complex_, bool_,
-                           flexible)
-from .overrides import array_function_dispatch, set_module
+import contextlib
 import operator
 import warnings
-import contextlib
+
+import numpy as np
+
+from . import multiarray, numerictypes as _nt
+from .fromnumeric import any
+from .multiarray import (
+    array,
+    datetime_as_string,
+    datetime_data,
+    dragon4_positional,
+    dragon4_scientific,
+    ndarray,
+    set_legacy_print_mode,
+)
+from .numeric import asarray, concatenate, errstate
+from .numerictypes import bool_, complex_, flexible, float_, int_
+from .overrides import array_function_dispatch, set_module
+from .umath import absolute, isfinite, isinf, isnat
 
 _format_options = {
-    'edgeitems': 3,  # repr N leading and trailing items of each dimension
-    'threshold': 1000,  # total items > triggers array summarization
-    'floatmode': 'maxprec',
-    'precision': 8,  # precision of floating point representations
-    'suppress': False,  # suppress printing small floating values in exp format
-    'linewidth': 75,
-    'nanstr': 'nan',
-    'infstr': 'inf',
-    'sign': '-',
-    'formatter': None,
+    "edgeitems": 3,  # repr N leading and trailing items of each dimension
+    "threshold": 1000,  # total items > triggers array summarization
+    "floatmode": "maxprec",
+    "precision": 8,  # precision of floating point representations
+    "suppress": False,  # suppress printing small floating values in exp format
+    "linewidth": 75,
+    "nanstr": "nan",
+    "infstr": "inf",
+    "sign": "-",
+    "formatter": None,
     # Internally stored as an int to simplify comparisons; converted from/to
     # str/False on the way in/out.
-    'legacy': sys.maxsize}
+    "legacy": sys.maxsize,
+}
 
-def _make_options_dict(precision=None, threshold=None, edgeitems=None,
-                       linewidth=None, suppress=None, nanstr=None, infstr=None,
-                       sign=None, formatter=None, floatmode=None, legacy=None):
+
+def _make_options_dict(
+    precision=None,
+    threshold=None,
+    edgeitems=None,
+    linewidth=None,
+    suppress=None,
+    nanstr=None,
+    infstr=None,
+    sign=None,
+    formatter=None,
+    floatmode=None,
+    legacy=None,
+):
     """
     Make a dictionary out of the non-None arguments, plus conversion of
     *legacy* and sanity checks.
@@ -72,51 +99,67 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     options = {k: v for k, v in locals().items() if v is not None}
 
     if suppress is not None:
-        options['suppress'] = bool(suppress)
+        options["suppress"] = bool(suppress)
 
-    modes = ['fixed', 'unique', 'maxprec', 'maxprec_equal']
+    modes = ["fixed", "unique", "maxprec", "maxprec_equal"]
     if floatmode not in modes + [None]:
-        raise ValueError("floatmode option must be one of " +
-                         ", ".join('"{}"'.format(m) for m in modes))
+        raise ValueError(
+            "floatmode option must be one of " + ", ".join(f'"{m}"' for m in modes)
+        )
 
-    if sign not in [None, '-', '+', ' ']:
+    if sign not in [None, "-", "+", " "]:
         raise ValueError("sign option must be one of ' ', '+', or '-'")
 
     if legacy == False:
-        options['legacy'] = sys.maxsize
-    elif legacy == '1.13':
-        options['legacy'] = 113
-    elif legacy == '1.21':
-        options['legacy'] = 121
+        options["legacy"] = sys.maxsize
+    elif legacy == "1.13":
+        options["legacy"] = 113
+    elif legacy == "1.21":
+        options["legacy"] = 121
     elif legacy is None:
         pass  # OK, do nothing.
     else:
         warnings.warn(
             "legacy printing option can currently only be '1.13', '1.21', or "
-            "`False`", stacklevel=3)
+            "`False`",
+            stacklevel=3,
+        )
 
     if threshold is not None:
         # forbid the bad threshold arg suggested by stack overflow, gh-12351
         if not isinstance(threshold, numbers.Number):
             raise TypeError("threshold must be numeric")
         if np.isnan(threshold):
-            raise ValueError("threshold must be non-NAN, try "
-                             "sys.maxsize for untruncated representation")
+            raise ValueError(
+                "threshold must be non-NAN, try "
+                "sys.maxsize for untruncated representation"
+            )
 
     if precision is not None:
         # forbid the bad precision arg as suggested by issue #18254
         try:
-            options['precision'] = operator.index(precision)
+            options["precision"] = operator.index(precision)
         except TypeError as e:
-            raise TypeError('precision must be an integer') from e
+            raise TypeError("precision must be an integer") from e
 
     return options
 
 
-@set_module('numpy')
-def set_printoptions(precision=None, threshold=None, edgeitems=None,
-                     linewidth=None, suppress=None, nanstr=None, infstr=None,
-                     formatter=None, sign=None, floatmode=None, *, legacy=None):
+@set_module("numpy")
+def set_printoptions(
+    precision=None,
+    threshold=None,
+    edgeitems=None,
+    linewidth=None,
+    suppress=None,
+    nanstr=None,
+    infstr=None,
+    formatter=None,
+    sign=None,
+    floatmode=None,
+    *,
+    legacy=None,
+):
     """
     Set printing options.
 
@@ -274,25 +317,35 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     array([ 0.  ,  1.11,  2.22, ...,  7.78,  8.89, 10.  ])
 
     """
-    opt = _make_options_dict(precision, threshold, edgeitems, linewidth,
-                             suppress, nanstr, infstr, sign, formatter,
-                             floatmode, legacy)
+    opt = _make_options_dict(
+        precision,
+        threshold,
+        edgeitems,
+        linewidth,
+        suppress,
+        nanstr,
+        infstr,
+        sign,
+        formatter,
+        floatmode,
+        legacy,
+    )
     # formatter is always reset
-    opt['formatter'] = formatter
+    opt["formatter"] = formatter
     _format_options.update(opt)
 
     # set the C variable for legacy mode
-    if _format_options['legacy'] == 113:
+    if _format_options["legacy"] == 113:
         set_legacy_print_mode(113)
         # reset the sign option in legacy mode to avoid confusion
-        _format_options['sign'] = '-'
-    elif _format_options['legacy'] == 121:
+        _format_options["sign"] = "-"
+    elif _format_options["legacy"] == 121:
         set_legacy_print_mode(121)
-    elif _format_options['legacy'] == sys.maxsize:
+    elif _format_options["legacy"] == sys.maxsize:
         set_legacy_print_mode(0)
 
 
-@set_module('numpy')
+@set_module("numpy")
 def get_printoptions():
     """
     Return the current print options.
@@ -320,18 +373,20 @@ def get_printoptions():
 
     """
     opts = _format_options.copy()
-    opts['legacy'] = {
-        113: '1.13', 121: '1.21', sys.maxsize: False,
-    }[opts['legacy']]
+    opts["legacy"] = {
+        113: "1.13",
+        121: "1.21",
+        sys.maxsize: False,
+    }[opts["legacy"]]
     return opts
 
 
 def _get_legacy_print_mode():
     """Return the legacy print mode as an int."""
-    return _format_options['legacy']
+    return _format_options["legacy"]
 
 
-@set_module('numpy')
+@set_module("numpy")
 @contextlib.contextmanager
 def printoptions(*args, **kwargs):
     """Context manager for setting print options.
@@ -377,50 +432,62 @@ def _leading_trailing(a, edgeitems, index=()):
     if axis == a.ndim:
         return a[index]
 
-    if a.shape[axis] > 2*edgeitems:
-        return concatenate((
-            _leading_trailing(a, edgeitems, index + np.index_exp[ :edgeitems]),
-            _leading_trailing(a, edgeitems, index + np.index_exp[-edgeitems:])
-        ), axis=axis)
+    if a.shape[axis] > 2 * edgeitems:
+        return concatenate(
+            (
+                _leading_trailing(a, edgeitems, index + np.index_exp[:edgeitems]),
+                _leading_trailing(a, edgeitems, index + np.index_exp[-edgeitems:]),
+            ),
+            axis=axis,
+        )
     else:
         return _leading_trailing(a, edgeitems, index + np.index_exp[:])
 
 
 def _object_format(o):
-    """ Object arrays containing lists should be printed unambiguously """
+    """Object arrays containing lists should be printed unambiguously"""
     if type(o) is list:
-        fmt = 'list({!r})'
+        fmt = "list({!r})"
     else:
-        fmt = '{!r}'
+        fmt = "{!r}"
     return fmt.format(o)
+
 
 def repr_format(x):
     return repr(x)
 
+
 def str_format(x):
     return str(x)
 
-def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
-                    formatter, **kwargs):
+
+def _get_formatdict(
+    data, *, precision, floatmode, suppress, sign, legacy, formatter, **kwargs
+):
     # note: extra arguments in kwargs are ignored
 
     # wrapped in lambdas to avoid taking a code path with the wrong type of data
     formatdict = {
-        'bool': lambda: BoolFormat(data),
-        'int': lambda: IntegerFormat(data),
-        'float': lambda: FloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy),
-        'longfloat': lambda: FloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy),
-        'complexfloat': lambda: ComplexFloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy),
-        'longcomplexfloat': lambda: ComplexFloatingFormat(
-            data, precision, floatmode, suppress, sign, legacy=legacy),
-        'datetime': lambda: DatetimeFormat(data, legacy=legacy),
-        'timedelta': lambda: TimedeltaFormat(data),
-        'object': lambda: _object_format,
-        'void': lambda: str_format,
-        'numpystr': lambda: repr_format}
+        "bool": lambda: BoolFormat(data),
+        "int": lambda: IntegerFormat(data),
+        "float": lambda: FloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy
+        ),
+        "longfloat": lambda: FloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy
+        ),
+        "complexfloat": lambda: ComplexFloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy
+        ),
+        "longcomplexfloat": lambda: ComplexFloatingFormat(
+            data, precision, floatmode, suppress, sign, legacy=legacy
+        ),
+        "datetime": lambda: DatetimeFormat(data, legacy=legacy),
+        "timedelta": lambda: TimedeltaFormat(data),
+        "object": lambda: _object_format,
+        "void": lambda: str_format,
+        "numpystr": lambda: repr_format,
+    }
 
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
@@ -429,25 +496,26 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
 
     if formatter is not None:
         fkeys = [k for k in formatter.keys() if formatter[k] is not None]
-        if 'all' in fkeys:
+        if "all" in fkeys:
             for key in formatdict.keys():
-                formatdict[key] = indirect(formatter['all'])
-        if 'int_kind' in fkeys:
-            for key in ['int']:
-                formatdict[key] = indirect(formatter['int_kind'])
-        if 'float_kind' in fkeys:
-            for key in ['float', 'longfloat']:
-                formatdict[key] = indirect(formatter['float_kind'])
-        if 'complex_kind' in fkeys:
-            for key in ['complexfloat', 'longcomplexfloat']:
-                formatdict[key] = indirect(formatter['complex_kind'])
-        if 'str_kind' in fkeys:
-            formatdict['numpystr'] = indirect(formatter['str_kind'])
+                formatdict[key] = indirect(formatter["all"])
+        if "int_kind" in fkeys:
+            for key in ["int"]:
+                formatdict[key] = indirect(formatter["int_kind"])
+        if "float_kind" in fkeys:
+            for key in ["float", "longfloat"]:
+                formatdict[key] = indirect(formatter["float_kind"])
+        if "complex_kind" in fkeys:
+            for key in ["complexfloat", "longcomplexfloat"]:
+                formatdict[key] = indirect(formatter["complex_kind"])
+        if "str_kind" in fkeys:
+            formatdict["numpystr"] = indirect(formatter["str_kind"])
         for key in formatdict.keys():
             if key in fkeys:
                 formatdict[key] = indirect(formatter[key])
 
     return formatdict
+
 
 def _get_format_function(data, **options):
     """
@@ -459,38 +527,38 @@ def _get_format_function(data, **options):
     if dtypeobj is None:
         return formatdict["numpystr"]()
     elif issubclass(dtypeobj, _nt.bool_):
-        return formatdict['bool']()
+        return formatdict["bool"]()
     elif issubclass(dtypeobj, _nt.integer):
         if issubclass(dtypeobj, _nt.timedelta64):
-            return formatdict['timedelta']()
+            return formatdict["timedelta"]()
         else:
-            return formatdict['int']()
+            return formatdict["int"]()
     elif issubclass(dtypeobj, _nt.floating):
         if issubclass(dtypeobj, _nt.longfloat):
-            return formatdict['longfloat']()
+            return formatdict["longfloat"]()
         else:
-            return formatdict['float']()
+            return formatdict["float"]()
     elif issubclass(dtypeobj, _nt.complexfloating):
         if issubclass(dtypeobj, _nt.clongfloat):
-            return formatdict['longcomplexfloat']()
+            return formatdict["longcomplexfloat"]()
         else:
-            return formatdict['complexfloat']()
+            return formatdict["complexfloat"]()
     elif issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
-        return formatdict['numpystr']()
+        return formatdict["numpystr"]()
     elif issubclass(dtypeobj, _nt.datetime64):
-        return formatdict['datetime']()
+        return formatdict["datetime"]()
     elif issubclass(dtypeobj, _nt.object_):
-        return formatdict['object']()
+        return formatdict["object"]()
     elif issubclass(dtypeobj, _nt.void):
         if dtype_.names is not None:
             return StructuredVoidFormat.from_data(data, **options)
         else:
-            return formatdict['void']()
+            return formatdict["void"]()
     else:
-        return formatdict['numpystr']()
+        return formatdict["numpystr"]()
 
 
-def _recursive_guard(fillvalue='...'):
+def _recursive_guard(fillvalue="..."):
     """
     Like the python 3.2 reprlib.recursive_repr, but forwards *args and **kwargs
 
@@ -521,7 +589,7 @@ def _recursive_guard(fillvalue='...'):
 
 # gracefully handle recursive calls, when object arrays contain themselves
 @_recursive_guard()
-def _array2string(a, options, separator=' ', prefix=""):
+def _array2string(a, options, separator=" ", prefix=""):
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in
     # _formatArray with subclasses which return 0d arrays in place of scalars
@@ -529,9 +597,9 @@ def _array2string(a, options, separator=' ', prefix=""):
     if a.shape == ():
         a = data
 
-    if a.size > options['threshold']:
+    if a.size > options["threshold"]:
         summary_insert = "..."
-        data = _leading_trailing(data, options['edgeitems'])
+        data = _leading_trailing(data, options["edgeitems"])
     else:
         summary_insert = ""
 
@@ -541,29 +609,59 @@ def _array2string(a, options, separator=' ', prefix=""):
     # skip over "["
     next_line_prefix = " "
     # skip over array(
-    next_line_prefix += " "*len(prefix)
+    next_line_prefix += " " * len(prefix)
 
-    lst = _formatArray(a, format_function, options['linewidth'],
-                       next_line_prefix, separator, options['edgeitems'],
-                       summary_insert, options['legacy'])
+    lst = _formatArray(
+        a,
+        format_function,
+        options["linewidth"],
+        next_line_prefix,
+        separator,
+        options["edgeitems"],
+        summary_insert,
+        options["legacy"],
+    )
     return lst
 
 
 def _array2string_dispatcher(
-        a, max_line_width=None, precision=None,
-        suppress_small=None, separator=None, prefix=None,
-        style=None, formatter=None, threshold=None,
-        edgeitems=None, sign=None, floatmode=None, suffix=None,
-        *, legacy=None):
+    a,
+    max_line_width=None,
+    precision=None,
+    suppress_small=None,
+    separator=None,
+    prefix=None,
+    style=None,
+    formatter=None,
+    threshold=None,
+    edgeitems=None,
+    sign=None,
+    floatmode=None,
+    suffix=None,
+    *,
+    legacy=None,
+):
     return (a,)
 
 
-@array_function_dispatch(_array2string_dispatcher, module='numpy')
-def array2string(a, max_line_width=None, precision=None,
-                 suppress_small=None, separator=' ', prefix="",
-                 style=np._NoValue, formatter=None, threshold=None,
-                 edgeitems=None, sign=None, floatmode=None, suffix="",
-                 *, legacy=None):
+@array_function_dispatch(_array2string_dispatcher, module="numpy")
+def array2string(
+    a,
+    max_line_width=None,
+    precision=None,
+    suppress_small=None,
+    separator=" ",
+    prefix="",
+    style=np._NoValue,
+    formatter=None,
+    threshold=None,
+    edgeitems=None,
+    sign=None,
+    floatmode=None,
+    suffix="",
+    *,
+    legacy=None,
+):
     """
     Return a string representation of an array.
 
@@ -708,13 +806,23 @@ def array2string(a, max_line_width=None, precision=None,
 
     """
 
-    overrides = _make_options_dict(precision, threshold, edgeitems,
-                                   max_line_width, suppress_small, None, None,
-                                   sign, formatter, floatmode, legacy)
+    overrides = _make_options_dict(
+        precision,
+        threshold,
+        edgeitems,
+        max_line_width,
+        suppress_small,
+        None,
+        None,
+        sign,
+        formatter,
+        floatmode,
+        legacy,
+    )
     options = _format_options.copy()
     options.update(overrides)
 
-    if options['legacy'] <= 113:
+    if options["legacy"] <= 113:
         if style is np._NoValue:
             style = repr
 
@@ -722,12 +830,15 @@ def array2string(a, max_line_width=None, precision=None,
             return style(a.item())
     elif style is not np._NoValue:
         # Deprecation 11-9-2017  v1.14
-        warnings.warn("'style' argument is deprecated and no longer functional"
-                      " except in 1.13 'legacy' mode",
-                      DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "'style' argument is deprecated and no longer functional"
+            " except in 1.13 'legacy' mode",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-    if options['legacy'] > 113:
-        options['linewidth'] -= len(suffix)
+    if options["legacy"] > 113:
+        options["linewidth"] -= len(suffix)
 
     # treat as a null array if any of shape elements == 0
     if a.size == 0:
@@ -759,26 +870,34 @@ def _extendLine_pretty(s, line, word, line_width, next_line_prefix, legacy):
         return _extendLine(s, line, word, line_width, next_line_prefix, legacy)
 
     max_word_length = max(len(word) for word in words)
-    if (len(line) + max_word_length > line_width and
-            len(line) > len(next_line_prefix)):
-        s += line.rstrip() + '\n'
+    if len(line) + max_word_length > line_width and len(line) > len(next_line_prefix):
+        s += line.rstrip() + "\n"
         line = next_line_prefix + words[0]
         indent = next_line_prefix
     else:
-        indent = len(line)*' '
+        indent = len(line) * " "
         line += words[0]
 
     for word in words[1::]:
-        s += line.rstrip() + '\n'
+        s += line.rstrip() + "\n"
         line = indent + word
 
     suffix_length = max_word_length - len(words[-1])
-    line += suffix_length*' '
+    line += suffix_length * " "
 
     return s, line
 
-def _formatArray(a, format_function, line_width, next_line_prefix,
-                 separator, edge_items, summary_insert, legacy):
+
+def _formatArray(
+    a,
+    format_function,
+    line_width,
+    next_line_prefix,
+    separator,
+    edge_items,
+    summary_insert,
+    legacy,
+):
     """formatArray is designed for two modes of operation:
 
     1. Full output
@@ -786,6 +905,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
     2. Summarized output
 
     """
+
     def recurser(index, hanging_indent, curr_width):
         """
         By using this local function, we don't need to recurse with all the
@@ -800,14 +920,14 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
 
         # when recursing, add a space to align with the [ added, and reduce the
         # length of the line by 1
-        next_hanging_indent = hanging_indent + ' '
+        next_hanging_indent = hanging_indent + " "
         if legacy <= 113:
             next_width = curr_width
         else:
-            next_width = curr_width - len(']')
+            next_width = curr_width - len("]")
 
         a_len = a.shape[axis]
-        show_summary = summary_insert and 2*edge_items < a_len
+        show_summary = summary_insert and 2 * edge_items < a_len
         if show_summary:
             leading_items = edge_items
             trailing_items = edge_items
@@ -816,7 +936,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             trailing_items = a_len
 
         # stringify the array with the hanging indent on the first line too
-        s = ''
+        s = ""
 
         # last axis (rows) - wrap elements if they would not fit on one line
         if axes_left == 1:
@@ -824,18 +944,20 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             if legacy <= 113:
                 elem_width = curr_width - len(separator.rstrip())
             else:
-                elem_width = curr_width - max(len(separator.rstrip()), len(']'))
+                elem_width = curr_width - max(len(separator.rstrip()), len("]"))
 
             line = hanging_indent
             for i in range(leading_items):
                 word = recurser(index + (i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
-                    s, line, word, elem_width, hanging_indent, legacy)
+                    s, line, word, elem_width, hanging_indent, legacy
+                )
                 line += separator
 
             if show_summary:
                 s, line = _extendLine(
-                    s, line, summary_insert, elem_width, hanging_indent, legacy)
+                    s, line, summary_insert, elem_width, hanging_indent, legacy
+                )
                 if legacy <= 113:
                     line += ", "
                 else:
@@ -844,7 +966,8 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             for i in range(trailing_items, 1, -1):
                 word = recurser(index + (-i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
-                    s, line, word, elem_width, hanging_indent, legacy)
+                    s, line, word, elem_width, hanging_indent, legacy
+                )
                 line += separator
 
             if legacy <= 113:
@@ -852,14 +975,15 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                 elem_width = curr_width
             word = recurser(index + (-1,), next_hanging_indent, next_width)
             s, line = _extendLine_pretty(
-                s, line, word, elem_width, hanging_indent, legacy)
+                s, line, word, elem_width, hanging_indent, legacy
+            )
 
             s += line
 
         # other axes - insert newlines between rows
         else:
-            s = ''
-            line_sep = separator.rstrip() + '\n'*(axes_left - 1)
+            s = ""
+            line_sep = separator.rstrip() + "\n" * (axes_left - 1)
 
             for i in range(leading_items):
                 nested = recurser(index + (i,), next_hanging_indent, next_width)
@@ -873,56 +997,59 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                     s += hanging_indent + summary_insert + line_sep
 
             for i in range(trailing_items, 1, -1):
-                nested = recurser(index + (-i,), next_hanging_indent,
-                                  next_width)
+                nested = recurser(index + (-i,), next_hanging_indent, next_width)
                 s += hanging_indent + nested + line_sep
 
             nested = recurser(index + (-1,), next_hanging_indent, next_width)
             s += hanging_indent + nested
 
         # remove the hanging indent, and wrap in []
-        s = '[' + s[len(hanging_indent):] + ']'
+        s = "[" + s[len(hanging_indent) :] + "]"
         return s
 
     try:
         # invoke the recursive part with an initial index and prefix
-        return recurser(index=(),
-                        hanging_indent=next_line_prefix,
-                        curr_width=line_width)
+        return recurser(
+            index=(), hanging_indent=next_line_prefix, curr_width=line_width
+        )
     finally:
         # recursive closures have a cyclic reference to themselves, which
         # requires gc to collect (gh-10620). To avoid this problem, for
         # performance and PyPy friendliness, we break the cycle:
         recurser = None
 
+
 def _none_or_positive_arg(x, name):
     if x is None:
         return -1
     if x < 0:
-        raise ValueError("{} must be >= 0".format(name))
+        raise ValueError(f"{name} must be >= 0")
     return x
 
+
 class FloatingFormat:
-    """ Formatter for subtypes of np.floating """
-    def __init__(self, data, precision, floatmode, suppress_small, sign=False,
-                 *, legacy=None):
+    """Formatter for subtypes of np.floating"""
+
+    def __init__(
+        self, data, precision, floatmode, suppress_small, sign=False, *, legacy=None
+    ):
         # for backcompatibility, accept bools
         if isinstance(sign, bool):
-            sign = '+' if sign else '-'
+            sign = "+" if sign else "-"
 
         self._legacy = legacy
         if self._legacy <= 113:
             # when not 0d, legacy does not support '-'
-            if data.shape != () and sign == '-':
-                sign = ' '
+            if data.shape != () and sign == "-":
+                sign = " "
 
         self.floatmode = floatmode
-        if floatmode == 'unique':
+        if floatmode == "unique":
             self.precision = None
         else:
             self.precision = precision
 
-        self.precision = _none_or_positive_arg(self.precision, 'precision')
+        self.precision = _none_or_positive_arg(self.precision, "precision")
 
         self.suppress_small = suppress_small
         self.sign = sign
@@ -940,31 +1067,40 @@ class FloatingFormat:
         if len(abs_non_zero) != 0:
             max_val = np.max(abs_non_zero)
             min_val = np.min(abs_non_zero)
-            with errstate(over='ignore'):  # division can overflow
-                if max_val >= 1.e8 or (not self.suppress_small and
-                        (min_val < 0.0001 or max_val/min_val > 1000.)):
+            with errstate(over="ignore"):  # division can overflow
+                if max_val >= 1.0e8 or (
+                    not self.suppress_small
+                    and (min_val < 0.0001 or max_val / min_val > 1000.0)
+                ):
                     self.exp_format = True
 
         # do a first pass of printing all the numbers, to determine sizes
         if len(finite_vals) == 0:
             self.pad_left = 0
             self.pad_right = 0
-            self.trim = '.'
+            self.trim = "."
             self.exp_size = -1
             self.unique = True
             self.min_digits = None
         elif self.exp_format:
-            trim, unique = '.', True
-            if self.floatmode == 'fixed' or self._legacy <= 113:
-                trim, unique = 'k', False
-            strs = (dragon4_scientific(x, precision=self.precision,
-                               unique=unique, trim=trim, sign=self.sign == '+')
-                    for x in finite_vals)
-            frac_strs, _, exp_strs = zip(*(s.partition('e') for s in strs))
-            int_part, frac_part = zip(*(s.split('.') for s in frac_strs))
+            trim, unique = ".", True
+            if self.floatmode == "fixed" or self._legacy <= 113:
+                trim, unique = "k", False
+            strs = (
+                dragon4_scientific(
+                    x,
+                    precision=self.precision,
+                    unique=unique,
+                    trim=trim,
+                    sign=self.sign == "+",
+                )
+                for x in finite_vals
+            )
+            frac_strs, _, exp_strs = zip(*(s.partition("e") for s in strs))
+            int_part, frac_part = zip(*(s.split(".") for s in frac_strs))
             self.exp_size = max(len(s) for s in exp_strs) - 1
 
-            self.trim = 'k'
+            self.trim = "k"
             self.precision = max(len(s) for s in frac_part)
             self.min_digits = self.precision
             self.unique = unique
@@ -978,79 +1114,96 @@ class FloatingFormat:
             # pad_right is only needed for nan length calculation
             self.pad_right = self.exp_size + 2 + self.precision
         else:
-            trim, unique = '.', True
-            if self.floatmode == 'fixed':
-                trim, unique = 'k', False
-            strs = (dragon4_positional(x, precision=self.precision,
-                                       fractional=True,
-                                       unique=unique, trim=trim,
-                                       sign=self.sign == '+')
-                    for x in finite_vals)
-            int_part, frac_part = zip(*(s.split('.') for s in strs))
+            trim, unique = ".", True
+            if self.floatmode == "fixed":
+                trim, unique = "k", False
+            strs = (
+                dragon4_positional(
+                    x,
+                    precision=self.precision,
+                    fractional=True,
+                    unique=unique,
+                    trim=trim,
+                    sign=self.sign == "+",
+                )
+                for x in finite_vals
+            )
+            int_part, frac_part = zip(*(s.split(".") for s in strs))
             if self._legacy <= 113:
-                self.pad_left = 1 + max(len(s.lstrip('-+')) for s in int_part)
+                self.pad_left = 1 + max(len(s.lstrip("-+")) for s in int_part)
             else:
                 self.pad_left = max(len(s) for s in int_part)
             self.pad_right = max(len(s) for s in frac_part)
             self.exp_size = -1
             self.unique = unique
 
-            if self.floatmode in ['fixed', 'maxprec_equal']:
+            if self.floatmode in ["fixed", "maxprec_equal"]:
                 self.precision = self.min_digits = self.pad_right
-                self.trim = 'k'
+                self.trim = "k"
             else:
-                self.trim = '.'
+                self.trim = "."
                 self.min_digits = 0
 
         if self._legacy > 113:
             # account for sign = ' ' by adding one to pad_left
-            if self.sign == ' ' and not any(np.signbit(finite_vals)):
+            if self.sign == " " and not any(np.signbit(finite_vals)):
                 self.pad_left += 1
 
         # if there are non-finite values, may need to increase pad_left
         if data.size != finite_vals.size:
-            neginf = self.sign != '-' or any(data[isinf(data)] < 0)
-            nanlen = len(_format_options['nanstr'])
-            inflen = len(_format_options['infstr']) + neginf
+            neginf = self.sign != "-" or any(data[isinf(data)] < 0)
+            nanlen = len(_format_options["nanstr"])
+            inflen = len(_format_options["infstr"]) + neginf
             offset = self.pad_right + 1  # +1 for decimal pt
             self.pad_left = max(self.pad_left, nanlen - offset, inflen - offset)
 
     def __call__(self, x):
         if not np.isfinite(x):
-            with errstate(invalid='ignore'):
+            with errstate(invalid="ignore"):
                 if np.isnan(x):
-                    sign = '+' if self.sign == '+' else ''
-                    ret = sign + _format_options['nanstr']
+                    sign = "+" if self.sign == "+" else ""
+                    ret = sign + _format_options["nanstr"]
                 else:  # isinf
-                    sign = '-' if x < 0 else '+' if self.sign == '+' else ''
-                    ret = sign + _format_options['infstr']
-                return ' '*(self.pad_left + self.pad_right + 1 - len(ret)) + ret
+                    sign = "-" if x < 0 else "+" if self.sign == "+" else ""
+                    ret = sign + _format_options["infstr"]
+                return " " * (self.pad_left + self.pad_right + 1 - len(ret)) + ret
 
         if self.exp_format:
-            return dragon4_scientific(x,
-                                      precision=self.precision,
-                                      min_digits=self.min_digits,
-                                      unique=self.unique,
-                                      trim=self.trim,
-                                      sign=self.sign == '+',
-                                      pad_left=self.pad_left,
-                                      exp_digits=self.exp_size)
+            return dragon4_scientific(
+                x,
+                precision=self.precision,
+                min_digits=self.min_digits,
+                unique=self.unique,
+                trim=self.trim,
+                sign=self.sign == "+",
+                pad_left=self.pad_left,
+                exp_digits=self.exp_size,
+            )
         else:
-            return dragon4_positional(x,
-                                      precision=self.precision,
-                                      min_digits=self.min_digits,
-                                      unique=self.unique,
-                                      fractional=True,
-                                      trim=self.trim,
-                                      sign=self.sign == '+',
-                                      pad_left=self.pad_left,
-                                      pad_right=self.pad_right)
+            return dragon4_positional(
+                x,
+                precision=self.precision,
+                min_digits=self.min_digits,
+                unique=self.unique,
+                fractional=True,
+                trim=self.trim,
+                sign=self.sign == "+",
+                pad_left=self.pad_left,
+                pad_right=self.pad_right,
+            )
 
 
-@set_module('numpy')
-def format_float_scientific(x, precision=None, unique=True, trim='k',
-                            sign=False, pad_left=None, exp_digits=None,
-                            min_digits=None):
+@set_module("numpy")
+def format_float_scientific(
+    x,
+    precision=None,
+    unique=True,
+    trim="k",
+    sign=False,
+    pad_left=None,
+    exp_digits=None,
+    min_digits=None,
+):
     """
     Format a floating-point scalar as a decimal string in scientific notation.
 
@@ -1096,7 +1249,7 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
         identify the value may be printed and rounded unbiased.
 
         -- versionadded:: 1.21.0
-        
+
     Returns
     -------
     rep : string
@@ -1116,21 +1269,36 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
     >>> np.format_float_scientific(s, exp_digits=4)
     '1.23e+0024'
     """
-    precision = _none_or_positive_arg(precision, 'precision')
-    pad_left = _none_or_positive_arg(pad_left, 'pad_left')
-    exp_digits = _none_or_positive_arg(exp_digits, 'exp_digits')
-    min_digits = _none_or_positive_arg(min_digits, 'min_digits')
+    precision = _none_or_positive_arg(precision, "precision")
+    pad_left = _none_or_positive_arg(pad_left, "pad_left")
+    exp_digits = _none_or_positive_arg(exp_digits, "exp_digits")
+    min_digits = _none_or_positive_arg(min_digits, "min_digits")
     if min_digits > 0 and precision > 0 and min_digits > precision:
         raise ValueError("min_digits must be less than or equal to precision")
-    return dragon4_scientific(x, precision=precision, unique=unique,
-                              trim=trim, sign=sign, pad_left=pad_left,
-                              exp_digits=exp_digits, min_digits=min_digits)
+    return dragon4_scientific(
+        x,
+        precision=precision,
+        unique=unique,
+        trim=trim,
+        sign=sign,
+        pad_left=pad_left,
+        exp_digits=exp_digits,
+        min_digits=min_digits,
+    )
 
 
-@set_module('numpy')
-def format_float_positional(x, precision=None, unique=True,
-                            fractional=True, trim='k', sign=False,
-                            pad_left=None, pad_right=None, min_digits=None):
+@set_module("numpy")
+def format_float_positional(
+    x,
+    precision=None,
+    unique=True,
+    fractional=True,
+    trim="k",
+    sign=False,
+    pad_left=None,
+    pad_right=None,
+    min_digits=None,
+):
     """
     Format a floating-point scalar as a decimal string in positional notation.
 
@@ -1181,7 +1349,7 @@ def format_float_positional(x, precision=None, unique=True,
         Minimum number of digits to print. Only has an effect if `unique=True`
         in which case additional digits past those necessary to uniquely
         identify the value may be printed, rounding the last additional digit.
-        
+
         -- versionadded:: 1.21.0
 
     Returns
@@ -1204,29 +1372,34 @@ def format_float_positional(x, precision=None, unique=True,
     >>> np.format_float_positional(np.float16(0.3), unique=False, precision=10)
     '0.3000488281'
     """
-    precision = _none_or_positive_arg(precision, 'precision')
-    pad_left = _none_or_positive_arg(pad_left, 'pad_left')
-    pad_right = _none_or_positive_arg(pad_right, 'pad_right')
-    min_digits = _none_or_positive_arg(min_digits, 'min_digits')
+    precision = _none_or_positive_arg(precision, "precision")
+    pad_left = _none_or_positive_arg(pad_left, "pad_left")
+    pad_right = _none_or_positive_arg(pad_right, "pad_right")
+    min_digits = _none_or_positive_arg(min_digits, "min_digits")
     if not fractional and precision == 0:
-        raise ValueError("precision must be greater than 0 if "
-                         "fractional=False")
+        raise ValueError("precision must be greater than 0 if " "fractional=False")
     if min_digits > 0 and precision > 0 and min_digits > precision:
         raise ValueError("min_digits must be less than or equal to precision")
-    return dragon4_positional(x, precision=precision, unique=unique,
-                              fractional=fractional, trim=trim,
-                              sign=sign, pad_left=pad_left,
-                              pad_right=pad_right, min_digits=min_digits)
+    return dragon4_positional(
+        x,
+        precision=precision,
+        unique=unique,
+        fractional=fractional,
+        trim=trim,
+        sign=sign,
+        pad_left=pad_left,
+        pad_right=pad_right,
+        min_digits=min_digits,
+    )
 
 
 class IntegerFormat:
     def __init__(self, data):
         if data.size > 0:
-            max_str_len = max(len(str(np.max(data))),
-                              len(str(np.min(data))))
+            max_str_len = max(len(str(np.max(data))), len(str(np.min(data))))
         else:
             max_str_len = 0
-        self.format = '%{}d'.format(max_str_len)
+        self.format = f"%{max_str_len}d"
 
     def __call__(self, x):
         return self.format % x
@@ -1236,32 +1409,32 @@ class BoolFormat:
     def __init__(self, data, **kwargs):
         # add an extra space so " True" and "False" have the same length and
         # array elements align nicely when printed, except in 0d arrays
-        self.truestr = ' True' if data.shape != () else 'True'
+        self.truestr = " True" if data.shape != () else "True"
 
     def __call__(self, x):
         return self.truestr if x else "False"
 
 
 class ComplexFloatingFormat:
-    """ Formatter for subtypes of np.complexfloating """
-    def __init__(self, x, precision, floatmode, suppress_small,
-                 sign=False, *, legacy=None):
+    """Formatter for subtypes of np.complexfloating"""
+
+    def __init__(
+        self, x, precision, floatmode, suppress_small, sign=False, *, legacy=None
+    ):
         # for backcompatibility, accept bools
         if isinstance(sign, bool):
-            sign = '+' if sign else '-'
+            sign = "+" if sign else "-"
 
         floatmode_real = floatmode_imag = floatmode
         if legacy <= 113:
-            floatmode_real = 'maxprec_equal'
-            floatmode_imag = 'maxprec'
+            floatmode_real = "maxprec_equal"
+            floatmode_imag = "maxprec"
 
         self.real_format = FloatingFormat(
-            x.real, precision, floatmode_real, suppress_small,
-            sign=sign, legacy=legacy
+            x.real, precision, floatmode_real, suppress_small, sign=sign, legacy=legacy
         )
         self.imag_format = FloatingFormat(
-            x.imag, precision, floatmode_imag, suppress_small,
-            sign='+', legacy=legacy
+            x.imag, precision, floatmode_imag, suppress_small, sign="+", legacy=legacy
         )
 
     def __call__(self, x):
@@ -1270,7 +1443,7 @@ class ComplexFloatingFormat:
 
         # add the 'j' before the terminal whitespace in i
         sp = len(i.rstrip())
-        i = i[:sp] + 'j' + i[sp:]
+        i = i[:sp] + "j" + i[sp:]
 
         return r + i
 
@@ -1280,14 +1453,16 @@ class _TimelikeFormat:
         non_nat = data[~isnat(data)]
         if len(non_nat) > 0:
             # Max str length of non-NaT elements
-            max_str_len = max(len(self._format_non_nat(np.max(non_nat))),
-                              len(self._format_non_nat(np.min(non_nat))))
+            max_str_len = max(
+                len(self._format_non_nat(np.max(non_nat))),
+                len(self._format_non_nat(np.min(non_nat))),
+            )
         else:
             max_str_len = 0
         if len(non_nat) < data.size:
             # data contains a NaT
             max_str_len = max(max_str_len, 5)
-        self._format = '%{}s'.format(max_str_len)
+        self._format = f"%{max_str_len}s"
         self._nat = "'NaT'".rjust(max_str_len)
 
     def _format_non_nat(self, x):
@@ -1302,17 +1477,16 @@ class _TimelikeFormat:
 
 
 class DatetimeFormat(_TimelikeFormat):
-    def __init__(self, x, unit=None, timezone=None, casting='same_kind',
-                 legacy=False):
+    def __init__(self, x, unit=None, timezone=None, casting="same_kind", legacy=False):
         # Get the unit from the dtype
         if unit is None:
-            if x.dtype.kind == 'M':
+            if x.dtype.kind == "M":
                 unit = datetime_data(x.dtype)[0]
             else:
-                unit = 's'
+                unit = "s"
 
         if timezone is None:
-            timezone = 'naive'
+            timezone = "naive"
         self.timezone = timezone
         self.unit = unit
         self.casting = casting
@@ -1327,15 +1501,14 @@ class DatetimeFormat(_TimelikeFormat):
         return super().__call__(x)
 
     def _format_non_nat(self, x):
-        return "'%s'" % datetime_as_string(x,
-                                    unit=self.unit,
-                                    timezone=self.timezone,
-                                    casting=self.casting)
+        return "'%s'" % datetime_as_string(
+            x, unit=self.unit, timezone=self.timezone, casting=self.casting
+        )
 
 
 class TimedeltaFormat(_TimelikeFormat):
     def _format_non_nat(self, x):
-        return str(x.astype('i8'))
+        return str(x.astype("i8"))
 
 
 class SubArrayFormat:
@@ -1356,6 +1529,7 @@ class StructuredVoidFormat:
     as alias scalars lose their field information, and the implementation
     relies upon np.void.__getitem__.
     """
+
     def __init__(self, format_functions):
         self.format_functions = format_functions
 
@@ -1379,7 +1553,7 @@ class StructuredVoidFormat:
             for field, format_function in zip(x, self.format_functions)
         ]
         if len(str_fields) == 1:
-            return "({},)".format(str_fields[0])
+            return f"({str_fields[0]},)"
         else:
             return "({})".format(", ".join(str_fields))
 
@@ -1422,15 +1596,16 @@ def dtype_is_implied(dtype):
     array([1, 2, 3], dtype=int8)
     """
     dtype = np.dtype(dtype)
-    if _format_options['legacy'] <= 113 and dtype.type == bool_:
+    if _format_options["legacy"] <= 113 and dtype.type == bool_:
         return False
 
     # not just void types can be structured, and names are not part of the repr
     if dtype.names is not None:
         return False
-    
+
     if not dtype.isnative:
-        return False # should care about endianness *unless size is 1* (e.g., int8, bool)
+        # should care about endianness *unless size is 1* (e.g., int8, bool)
+        return False
 
     return dtype.type in _typelessdata
 
@@ -1467,11 +1642,15 @@ def dtype_short_repr(dtype):
 
 
 def _array_repr_implementation(
-        arr, max_line_width=None, precision=None, suppress_small=None,
-        array2string=array2string):
+    arr,
+    max_line_width=None,
+    precision=None,
+    suppress_small=None,
+    array2string=array2string,
+):
     """Internal version of array_repr() that allows overriding array2string."""
     if max_line_width is None:
-        max_line_width = _format_options['linewidth']
+        max_line_width = _format_options["linewidth"]
 
     if type(arr) is not ndarray:
         class_name = type(arr).__name__
@@ -1483,42 +1662,43 @@ def _array_repr_implementation(
     prefix = class_name + "("
     suffix = ")" if skipdtype else ","
 
-    if (_format_options['legacy'] <= 113 and
-            arr.shape == () and not arr.dtype.names):
+    if _format_options["legacy"] <= 113 and arr.shape == () and not arr.dtype.names:
         lst = repr(arr.item())
     elif arr.size > 0 or arr.shape == (0,):
-        lst = array2string(arr, max_line_width, precision, suppress_small,
-                           ', ', prefix, suffix=suffix)
+        lst = array2string(
+            arr, max_line_width, precision, suppress_small, ", ", prefix, suffix=suffix
+        )
     else:  # show zero-length shape unless it is (0,)
-        lst = "[], shape=%s" % (repr(arr.shape),)
+        lst = f"[], shape={repr(arr.shape)}"
 
     arr_str = prefix + lst + suffix
 
     if skipdtype:
         return arr_str
 
-    dtype_str = "dtype={})".format(dtype_short_repr(arr.dtype))
+    dtype_str = f"dtype={dtype_short_repr(arr.dtype)})"
 
     # compute whether we should put dtype on a new line: Do so if adding the
     # dtype would extend the last line past max_line_width.
     # Note: This line gives the correct result even when rfind returns -1.
-    last_line_len = len(arr_str) - (arr_str.rfind('\n') + 1)
+    last_line_len = len(arr_str) - (arr_str.rfind("\n") + 1)
     spacer = " "
-    if _format_options['legacy'] <= 113:
+    if _format_options["legacy"] <= 113:
         if issubclass(arr.dtype.type, flexible):
-            spacer = '\n' + ' '*len(class_name + "(")
+            spacer = "\n" + " " * len(class_name + "(")
     elif last_line_len + len(dtype_str) + 1 > max_line_width:
-        spacer = '\n' + ' '*len(class_name + "(")
+        spacer = "\n" + " " * len(class_name + "(")
 
     return arr_str + spacer + dtype_str
 
 
 def _array_repr_dispatcher(
-        arr, max_line_width=None, precision=None, suppress_small=None):
+    arr, max_line_width=None, precision=None, suppress_small=None
+):
     return (arr,)
 
 
-@array_function_dispatch(_array_repr_dispatcher, module='numpy')
+@array_function_dispatch(_array_repr_dispatcher, module="numpy")
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1563,8 +1743,7 @@ def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     'array([0.000001,  0.      ,  2.      ,  3.      ])'
 
     """
-    return _array_repr_implementation(
-        arr, max_line_width, precision, suppress_small)
+    return _array_repr_implementation(arr, max_line_width, precision, suppress_small)
 
 
 @_recursive_guard()
@@ -1575,11 +1754,14 @@ def _guarded_repr_or_str(v):
 
 
 def _array_str_implementation(
-        a, max_line_width=None, precision=None, suppress_small=None,
-        array2string=array2string):
+    a,
+    max_line_width=None,
+    precision=None,
+    suppress_small=None,
+    array2string=array2string,
+):
     """Internal version of array_str() that allows overriding array2string."""
-    if (_format_options['legacy'] <= 113 and
-            a.shape == () and not a.dtype.names):
+    if _format_options["legacy"] <= 113 and a.shape == () and not a.dtype.names:
         return str(a.item())
 
     # the str of 0d arrays is a special case: It should appear like a scalar,
@@ -1591,15 +1773,14 @@ def _array_str_implementation(
         # ndarray's getindex. Also guard against recursive 0d object arrays.
         return _guarded_repr_or_str(np.ndarray.__getitem__(a, ()))
 
-    return array2string(a, max_line_width, precision, suppress_small, ' ', "")
+    return array2string(a, max_line_width, precision, suppress_small, " ", "")
 
 
-def _array_str_dispatcher(
-        a, max_line_width=None, precision=None, suppress_small=None):
+def _array_str_dispatcher(a, max_line_width=None, precision=None, suppress_small=None):
     return (a,)
 
 
-@array_function_dispatch(_array_str_dispatcher, module='numpy')
+@array_function_dispatch(_array_str_dispatcher, module="numpy")
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     """
     Return a string representation of the data in an array.
@@ -1635,16 +1816,17 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     '[0 1 2]'
 
     """
-    return _array_str_implementation(
-        a, max_line_width, precision, suppress_small)
+    return _array_str_implementation(a, max_line_width, precision, suppress_small)
 
 
 # needed if __array_function__ is disabled
-_array2string_impl = getattr(array2string, '__wrapped__', array2string)
-_default_array_str = functools.partial(_array_str_implementation,
-                                       array2string=_array2string_impl)
-_default_array_repr = functools.partial(_array_repr_implementation,
-                                        array2string=_array2string_impl)
+_array2string_impl = getattr(array2string, "__wrapped__", array2string)
+_default_array_str = functools.partial(
+    _array_str_implementation, array2string=_array2string_impl
+)
+_default_array_repr = functools.partial(
+    _array_repr_implementation, array2string=_array2string_impl
+)
 
 
 def set_string_function(f, repr=True):

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1429,8 +1429,9 @@ def dtype_is_implied(dtype):
     if dtype.names is not None:
         return False
     
+    # should care about endianness *unless size is 1* (e.g., int8, bool)
     if not dtype.isnative:
-        return False # should care about endianness *unless size is 1* (e.g., int8, bool)
+        return False
 
     return dtype.type in _typelessdata
 
@@ -1457,8 +1458,9 @@ def dtype_short_repr(dtype):
 
     typename = dtype.name
     if not dtype.isnative:
-        # deal with cases like dtype('<u2') that are identical to an established dtype
-        # (in this case uint16) except that they have a different endianness.
+        # deal with cases like dtype('<u2') that are identical to an
+        # established dtype (in this case uint16)
+        # except that they have a different endianness.
         return repr(dtype.descr[0][1])
     # quote typenames which can't be represented as python variable names
     if typename and not (typename[0].isalpha() and typename.isalnum()):

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -31,7 +31,6 @@ except ImportError:
     from _dummy_thread import get_ident
 
 import numpy as np
-from ._dtype import _construction_repr
 from . import numerictypes as _nt
 from .umath import absolute, isinf, isfinite, isnat
 from . import multiarray
@@ -1462,7 +1461,7 @@ def dtype_short_repr(dtype):
         # deal with cases like dtype('<u2') that are identical to an
         # established dtype (in this case uint16)
         # except that they have a different endianness.
-        return _construction_repr(dtype)
+        return "'%s'" % str(dtype)
     # quote typenames which can't be represented as python variable names
     if typename and not (typename[0].isalpha() and typename.isalnum()):
         typename = repr(typename)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -816,6 +816,8 @@ class TestPrintOptions:
             ('float16', '>e'),
             ('float32', '>f'),
             ('float64', '>d'),
+            ('<U', '>U'), # string
+            ('<U1', '>U1'), # 4-byte width string
         ]
         for little_end, big_end in dtype_combos:
             big_dtype = np.dtype(big_end)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,40 +1,44 @@
-import sys
 import gc
-from hypothesis import given
-from hypothesis.extra import numpy as hynp
-import pytest
+import sys
+import textwrap
 
 import numpy as np
-from numpy.testing import (
-    assert_, assert_equal, assert_raises, assert_warns, HAS_REFCOUNT,
-    assert_raises_regex,
-    )
+import pytest
+from hypothesis import given
+from hypothesis.extra import numpy as hynp
 from numpy.core.arrayprint import _typelessdata
-import textwrap
+from numpy.testing import (
+    HAS_REFCOUNT,
+    assert_,
+    assert_equal,
+    assert_raises,
+    assert_raises_regex,
+    assert_warns,
+)
+
 
 class TestArrayRepr:
     def test_nan_inf(self):
         x = np.array([np.nan, np.inf])
-        assert_equal(repr(x), 'array([nan, inf])')
+        assert_equal(repr(x), "array([nan, inf])")
 
     def test_subclass(self):
-        class sub(np.ndarray): pass
+        class sub(np.ndarray):
+            pass
 
         # one dimensional
         x1d = np.array([1, 2]).view(sub)
-        assert_equal(repr(x1d), 'sub([1, 2])')
+        assert_equal(repr(x1d), "sub([1, 2])")
 
         # two dimensional
         x2d = np.array([[1, 2], [3, 4]]).view(sub)
-        assert_equal(repr(x2d),
-            'sub([[1, 2],\n'
-            '     [3, 4]])')
+        assert_equal(repr(x2d), "sub([[1, 2],\n" "     [3, 4]])")
 
         # two dimensional with flexible dtype
-        xstruct = np.ones((2,2), dtype=[('a', '<i4')]).view(sub)
-        assert_equal(repr(xstruct),
-            "sub([[(1,), (1,)],\n"
-            "     [(1,), (1,)]], dtype=[('a', '<i4')])"
+        xstruct = np.ones((2, 2), dtype=[("a", "<i4")]).view(sub)
+        assert_equal(
+            repr(xstruct),
+            "sub([[(1,), (1,)],\n" "     [(1,), (1,)]], dtype=[('a', '<i4')])",
         )
 
     @pytest.mark.xfail(reason="See gh-10544")
@@ -50,13 +54,14 @@ class TestArrayRepr:
 
         # test that object + subclass is OK:
         x = sub([None, None])
-        assert_equal(repr(x), 'sub([None, None], dtype=object)')
-        assert_equal(str(x), '[None None]')
+        assert_equal(repr(x), "sub([None, None], dtype=object)")
+        assert_equal(str(x), "[None None]")
 
         x = sub([None, sub([None, None])])
-        assert_equal(repr(x),
-            'sub([None, sub([None, None], dtype=object)], dtype=object)')
-        assert_equal(str(x), '[None sub([None, None], dtype=object)]')
+        assert_equal(
+            repr(x), "sub([None, sub([None, None], dtype=object)], dtype=object)"
+        )
+        assert_equal(str(x), "[None sub([None, None], dtype=object)]")
 
     def test_0d_object_subclass(self):
         # make sure that subclasses which return 0ds instead
@@ -71,32 +76,33 @@ class TestArrayRepr:
                 return sub(ret)
 
         x = sub(1)
-        assert_equal(repr(x), 'sub(1)')
-        assert_equal(str(x), '1')
+        assert_equal(repr(x), "sub(1)")
+        assert_equal(str(x), "1")
 
         x = sub([1, 1])
-        assert_equal(repr(x), 'sub([1, 1])')
-        assert_equal(str(x), '[1 1]')
+        assert_equal(repr(x), "sub([1, 1])")
+        assert_equal(str(x), "[1 1]")
 
         # check it works properly with object arrays too
         x = sub(None)
-        assert_equal(repr(x), 'sub(None, dtype=object)')
-        assert_equal(str(x), 'None')
+        assert_equal(repr(x), "sub(None, dtype=object)")
+        assert_equal(str(x), "None")
 
         # plus recursive object arrays (even depth > 1)
         y = sub(None)
         x[()] = y
         y[()] = x
-        assert_equal(repr(x),
-            'sub(sub(sub(..., dtype=object), dtype=object), dtype=object)')
-        assert_equal(str(x), '...')
+        assert_equal(
+            repr(x), "sub(sub(sub(..., dtype=object), dtype=object), dtype=object)"
+        )
+        assert_equal(str(x), "...")
         x[()] = 0  # resolve circular references for garbage collector
 
         # nested 0d-subclass-object
         x = sub(None)
         x[()] = sub(None)
-        assert_equal(repr(x), 'sub(sub(None, dtype=object), dtype=object)')
-        assert_equal(str(x), 'None')
+        assert_equal(repr(x), "sub(sub(None, dtype=object), dtype=object)")
+        assert_equal(str(x), "None")
 
         # gh-10663
         class DuckCounter(np.ndarray):
@@ -107,13 +113,13 @@ class TestArrayRepr:
                 return result
 
             def to_string(self):
-                return {0: 'zero', 1: 'one', 2: 'two'}.get(self.item(), 'many')
+                return {0: "zero", 1: "one", 2: "two"}.get(self.item(), "many")
 
             def __str__(self):
                 if self.shape == ():
                     return self.to_string()
                 else:
-                    fmt = {'all': lambda x: x.to_string()}
+                    fmt = {"all": lambda x: x.to_string()}
                     return np.array2string(self, formatter=fmt)
 
         dc = np.arange(5).view(DuckCounter)
@@ -123,22 +129,24 @@ class TestArrayRepr:
     def test_self_containing(self):
         arr0d = np.array(None)
         arr0d[()] = arr0d
-        assert_equal(repr(arr0d),
-            'array(array(..., dtype=object), dtype=object)')
+        assert_equal(repr(arr0d), "array(array(..., dtype=object), dtype=object)")
         arr0d[()] = 0  # resolve recursion for garbage collector
 
         arr1d = np.array([None, None])
         arr1d[1] = arr1d
-        assert_equal(repr(arr1d),
-            'array([None, array(..., dtype=object)], dtype=object)')
+        assert_equal(
+            repr(arr1d), "array([None, array(..., dtype=object)], dtype=object)"
+        )
         arr1d[1] = 0  # resolve recursion for garbage collector
 
         first = np.array(None)
         second = np.array(None)
         first[()] = second
         second[()] = first
-        assert_equal(repr(first),
-            'array(array(array(..., dtype=object), dtype=object), dtype=object)')
+        assert_equal(
+            repr(first),
+            "array(array(array(..., dtype=object), dtype=object), dtype=object)",
+        )
         first[()] = 0  # resolve circular references for garbage collector
 
     def test_containing_list(self):
@@ -146,18 +154,17 @@ class TestArrayRepr:
         arr1d = np.array([None, None])
         arr1d[0] = [1, 2]
         arr1d[1] = [3]
-        assert_equal(repr(arr1d),
-            'array([list([1, 2]), list([3])], dtype=object)')
+        assert_equal(repr(arr1d), "array([list([1, 2]), list([3])], dtype=object)")
 
     def test_void_scalar_recursion(self):
         # gh-9345
-        repr(np.void(b'test'))  # RecursionError ?
+        repr(np.void(b"test"))  # RecursionError ?
 
     def test_fieldless_structured(self):
         # gh-10366
         no_fields = np.dtype([])
         arr_no_fields = np.empty(4, dtype=no_fields)
-        assert_equal(repr(arr_no_fields), 'array([(), (), (), ()], dtype=[])')
+        assert_equal(repr(arr_no_fields), "array([(), (), (), ()], dtype=[])")
 
 
 class TestComplexArray:
@@ -167,115 +174,195 @@ class TestComplexArray:
         dtypes = [np.complex64, np.cdouble, np.clongdouble]
         actual = [str(np.array([c], dt)) for c in cvals for dt in dtypes]
         wanted = [
-            '[0.+0.j]',    '[0.+0.j]',    '[0.+0.j]',
-            '[0.+1.j]',    '[0.+1.j]',    '[0.+1.j]',
-            '[0.-1.j]',    '[0.-1.j]',    '[0.-1.j]',
-            '[0.+infj]',   '[0.+infj]',   '[0.+infj]',
-            '[0.-infj]',   '[0.-infj]',   '[0.-infj]',
-            '[0.+nanj]',   '[0.+nanj]',   '[0.+nanj]',
-            '[1.+0.j]',    '[1.+0.j]',    '[1.+0.j]',
-            '[1.+1.j]',    '[1.+1.j]',    '[1.+1.j]',
-            '[1.-1.j]',    '[1.-1.j]',    '[1.-1.j]',
-            '[1.+infj]',   '[1.+infj]',   '[1.+infj]',
-            '[1.-infj]',   '[1.-infj]',   '[1.-infj]',
-            '[1.+nanj]',   '[1.+nanj]',   '[1.+nanj]',
-            '[-1.+0.j]',   '[-1.+0.j]',   '[-1.+0.j]',
-            '[-1.+1.j]',   '[-1.+1.j]',   '[-1.+1.j]',
-            '[-1.-1.j]',   '[-1.-1.j]',   '[-1.-1.j]',
-            '[-1.+infj]',  '[-1.+infj]',  '[-1.+infj]',
-            '[-1.-infj]',  '[-1.-infj]',  '[-1.-infj]',
-            '[-1.+nanj]',  '[-1.+nanj]',  '[-1.+nanj]',
-            '[inf+0.j]',   '[inf+0.j]',   '[inf+0.j]',
-            '[inf+1.j]',   '[inf+1.j]',   '[inf+1.j]',
-            '[inf-1.j]',   '[inf-1.j]',   '[inf-1.j]',
-            '[inf+infj]',  '[inf+infj]',  '[inf+infj]',
-            '[inf-infj]',  '[inf-infj]',  '[inf-infj]',
-            '[inf+nanj]',  '[inf+nanj]',  '[inf+nanj]',
-            '[-inf+0.j]',  '[-inf+0.j]',  '[-inf+0.j]',
-            '[-inf+1.j]',  '[-inf+1.j]',  '[-inf+1.j]',
-            '[-inf-1.j]',  '[-inf-1.j]',  '[-inf-1.j]',
-            '[-inf+infj]', '[-inf+infj]', '[-inf+infj]',
-            '[-inf-infj]', '[-inf-infj]', '[-inf-infj]',
-            '[-inf+nanj]', '[-inf+nanj]', '[-inf+nanj]',
-            '[nan+0.j]',   '[nan+0.j]',   '[nan+0.j]',
-            '[nan+1.j]',   '[nan+1.j]',   '[nan+1.j]',
-            '[nan-1.j]',   '[nan-1.j]',   '[nan-1.j]',
-            '[nan+infj]',  '[nan+infj]',  '[nan+infj]',
-            '[nan-infj]',  '[nan-infj]',  '[nan-infj]',
-            '[nan+nanj]',  '[nan+nanj]',  '[nan+nanj]']
+            "[0.+0.j]",
+            "[0.+0.j]",
+            "[0.+0.j]",
+            "[0.+1.j]",
+            "[0.+1.j]",
+            "[0.+1.j]",
+            "[0.-1.j]",
+            "[0.-1.j]",
+            "[0.-1.j]",
+            "[0.+infj]",
+            "[0.+infj]",
+            "[0.+infj]",
+            "[0.-infj]",
+            "[0.-infj]",
+            "[0.-infj]",
+            "[0.+nanj]",
+            "[0.+nanj]",
+            "[0.+nanj]",
+            "[1.+0.j]",
+            "[1.+0.j]",
+            "[1.+0.j]",
+            "[1.+1.j]",
+            "[1.+1.j]",
+            "[1.+1.j]",
+            "[1.-1.j]",
+            "[1.-1.j]",
+            "[1.-1.j]",
+            "[1.+infj]",
+            "[1.+infj]",
+            "[1.+infj]",
+            "[1.-infj]",
+            "[1.-infj]",
+            "[1.-infj]",
+            "[1.+nanj]",
+            "[1.+nanj]",
+            "[1.+nanj]",
+            "[-1.+0.j]",
+            "[-1.+0.j]",
+            "[-1.+0.j]",
+            "[-1.+1.j]",
+            "[-1.+1.j]",
+            "[-1.+1.j]",
+            "[-1.-1.j]",
+            "[-1.-1.j]",
+            "[-1.-1.j]",
+            "[-1.+infj]",
+            "[-1.+infj]",
+            "[-1.+infj]",
+            "[-1.-infj]",
+            "[-1.-infj]",
+            "[-1.-infj]",
+            "[-1.+nanj]",
+            "[-1.+nanj]",
+            "[-1.+nanj]",
+            "[inf+0.j]",
+            "[inf+0.j]",
+            "[inf+0.j]",
+            "[inf+1.j]",
+            "[inf+1.j]",
+            "[inf+1.j]",
+            "[inf-1.j]",
+            "[inf-1.j]",
+            "[inf-1.j]",
+            "[inf+infj]",
+            "[inf+infj]",
+            "[inf+infj]",
+            "[inf-infj]",
+            "[inf-infj]",
+            "[inf-infj]",
+            "[inf+nanj]",
+            "[inf+nanj]",
+            "[inf+nanj]",
+            "[-inf+0.j]",
+            "[-inf+0.j]",
+            "[-inf+0.j]",
+            "[-inf+1.j]",
+            "[-inf+1.j]",
+            "[-inf+1.j]",
+            "[-inf-1.j]",
+            "[-inf-1.j]",
+            "[-inf-1.j]",
+            "[-inf+infj]",
+            "[-inf+infj]",
+            "[-inf+infj]",
+            "[-inf-infj]",
+            "[-inf-infj]",
+            "[-inf-infj]",
+            "[-inf+nanj]",
+            "[-inf+nanj]",
+            "[-inf+nanj]",
+            "[nan+0.j]",
+            "[nan+0.j]",
+            "[nan+0.j]",
+            "[nan+1.j]",
+            "[nan+1.j]",
+            "[nan+1.j]",
+            "[nan-1.j]",
+            "[nan-1.j]",
+            "[nan-1.j]",
+            "[nan+infj]",
+            "[nan+infj]",
+            "[nan+infj]",
+            "[nan-infj]",
+            "[nan-infj]",
+            "[nan-infj]",
+            "[nan+nanj]",
+            "[nan+nanj]",
+            "[nan+nanj]",
+        ]
 
         for res, val in zip(actual, wanted):
             assert_equal(res, val)
+
 
 class TestArray2String:
     def test_basic(self):
         """Basic test of array2string."""
         a = np.arange(3)
-        assert_(np.array2string(a) == '[0 1 2]')
-        assert_(np.array2string(a, max_line_width=4, legacy='1.13') == '[0 1\n 2]')
-        assert_(np.array2string(a, max_line_width=4) == '[0\n 1\n 2]')
+        assert_(np.array2string(a) == "[0 1 2]")
+        assert_(np.array2string(a, max_line_width=4, legacy="1.13") == "[0 1\n 2]")
+        assert_(np.array2string(a, max_line_width=4) == "[0\n 1\n 2]")
 
     def test_unexpected_kwarg(self):
         # ensure than an appropriate TypeError
         # is raised when array2string receives
         # an unexpected kwarg
 
-        with assert_raises_regex(TypeError, 'nonsense'):
-            np.array2string(np.array([1, 2, 3]),
-                            nonsense=None)
+        with assert_raises_regex(TypeError, "nonsense"):
+            np.array2string(np.array([1, 2, 3]), nonsense=None)
 
     def test_format_function(self):
         """Test custom format function for each element in array."""
+
         def _format_function(x):
             if np.abs(x) < 1:
-                return '.'
+                return "."
             elif np.abs(x) < 2:
-                return 'o'
+                return "o"
             else:
-                return 'O'
+                return "O"
 
         x = np.arange(3)
         x_hex = "[0x0 0x1 0x2]"
         x_oct = "[0o0 0o1 0o2]"
-        assert_(np.array2string(x, formatter={'all':_format_function}) ==
-                "[. o O]")
-        assert_(np.array2string(x, formatter={'int_kind':_format_function}) ==
-                "[. o O]")
-        assert_(np.array2string(x, formatter={'all':lambda x: "%.4f" % x}) ==
-                "[0.0000 1.0000 2.0000]")
-        assert_equal(np.array2string(x, formatter={'int':lambda x: hex(x)}),
-                x_hex)
-        assert_equal(np.array2string(x, formatter={'int':lambda x: oct(x)}),
-                x_oct)
+        assert_(np.array2string(x, formatter={"all": _format_function}) == "[. o O]")
+        assert_(
+            np.array2string(x, formatter={"int_kind": _format_function}) == "[. o O]"
+        )
+        assert_(
+            np.array2string(x, formatter={"all": lambda x: "%.4f" % x})
+            == "[0.0000 1.0000 2.0000]"
+        )
+        assert_equal(np.array2string(x, formatter={"int": lambda x: hex(x)}), x_hex)
+        assert_equal(np.array2string(x, formatter={"int": lambda x: oct(x)}), x_oct)
 
-        x = np.arange(3.)
-        assert_(np.array2string(x, formatter={'float_kind':lambda x: "%.2f" % x}) ==
-                "[0.00 1.00 2.00]")
-        assert_(np.array2string(x, formatter={'float':lambda x: "%.2f" % x}) ==
-                "[0.00 1.00 2.00]")
+        x = np.arange(3.0)
+        assert_(
+            np.array2string(x, formatter={"float_kind": lambda x: "%.2f" % x})
+            == "[0.00 1.00 2.00]"
+        )
+        assert_(
+            np.array2string(x, formatter={"float": lambda x: "%.2f" % x})
+            == "[0.00 1.00 2.00]"
+        )
 
-        s = np.array(['abc', 'def'])
-        assert_(np.array2string(s, formatter={'numpystr':lambda s: s*2}) ==
-                '[abcabc defdef]')
-
+        s = np.array(["abc", "def"])
+        assert_(
+            np.array2string(s, formatter={"numpystr": lambda s: s * 2})
+            == "[abcabc defdef]"
+        )
 
     def test_structure_format(self):
-        dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
-        x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)
-        assert_equal(np.array2string(x),
-                "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
+        dt = np.dtype([("name", np.str_, 16), ("grades", np.float64, (2,))])
+        x = np.array([("Sarah", (8.0, 7.0)), ("John", (6.0, 7.0))], dtype=dt)
+        assert_equal(np.array2string(x), "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
 
-        np.set_printoptions(legacy='1.13')
+        np.set_printoptions(legacy="1.13")
         try:
             # for issue #5692
             A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
-            A[5:].fill(np.datetime64('NaT'))
+            A[5:].fill(np.datetime64("NaT"))
             assert_equal(
                 np.array2string(A),
-                textwrap.dedent("""\
+                textwrap.dedent(
+                    """\
                 [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
                  ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('NaT',) ('NaT',)
-                 ('NaT',) ('NaT',) ('NaT',)]""")
+                 ('NaT',) ('NaT',) ('NaT',)]"""
+                ),
             )
         finally:
             np.set_printoptions(legacy=False)
@@ -283,46 +370,56 @@ class TestArray2String:
         # same again, but with non-legacy behavior
         assert_equal(
             np.array2string(A),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
              ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
              ('1970-01-01T00:00:00',) (                'NaT',)
              (                'NaT',) (                'NaT',)
-             (                'NaT',) (                'NaT',)]""")
+             (                'NaT',) (                'NaT',)]"""
+            ),
         )
 
         # and again, with timedeltas
         A = np.full(10, 123456, dtype=[("A", "m8[s]")])
-        A[5:].fill(np.datetime64('NaT'))
+        A[5:].fill(np.datetime64("NaT"))
         assert_equal(
             np.array2string(A),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             [(123456,) (123456,) (123456,) (123456,) (123456,) ( 'NaT',) ( 'NaT',)
-             ( 'NaT',) ( 'NaT',) ( 'NaT',)]""")
+             ( 'NaT',) ( 'NaT',) ( 'NaT',)]"""
+            ),
         )
 
         # See #8160
-        struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[('B', 'i4', 2)])
-        assert_equal(np.array2string(struct_int),
-                "[([  1,  -1],) ([123,   1],)]")
-        struct_2dint = np.array([([[0, 1], [2, 3]],), ([[12, 0], [0, 0]],)],
-                dtype=[('B', 'i4', (2, 2))])
-        assert_equal(np.array2string(struct_2dint),
-                "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]")
+        struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[("B", "i4", 2)])
+        assert_equal(np.array2string(struct_int), "[([  1,  -1],) ([123,   1],)]")
+        struct_2dint = np.array(
+            [([[0, 1], [2, 3]],), ([[12, 0], [0, 0]],)], dtype=[("B", "i4", (2, 2))]
+        )
+        assert_equal(
+            np.array2string(struct_2dint),
+            "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]",
+        )
 
         # See #8172
-        array_scalar = np.array(
-                (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))
+        array_scalar = np.array((1.0, 2.1234567890123456789, 3.0), dtype=("f8,f8,f8"))
         assert_equal(np.array2string(array_scalar), "(1., 2.12345679, 3.)")
 
     def test_unstructured_void_repr(self):
-        a = np.array([27, 91, 50, 75,  7, 65, 10,  8,
-                      27, 91, 51, 49,109, 82,101,100], dtype='u1').view('V8')
+        a = np.array(
+            [27, 91, 50, 75, 7, 65, 10, 8, 27, 91, 51, 49, 109, 82, 101, 100],
+            dtype="u1",
+        ).view("V8")
         assert_equal(repr(a[0]), r"void(b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08')")
         assert_equal(str(a[0]), r"b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'")
-        assert_equal(repr(a),
-            r"array([b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'," "\n"
-            r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64'], dtype='|V8')")
+        assert_equal(
+            repr(a),
+            r"array([b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08',"
+            "\n"
+            r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64'], dtype='|V8')",
+        )
 
         assert_equal(eval(repr(a), vars(np)), a)
         assert_equal(eval(repr(a[0]), vars(np)), a[0])
@@ -330,27 +427,28 @@ class TestArray2String:
     def test_edgeitems_kwarg(self):
         # previously the global print options would be taken over the kwarg
         arr = np.zeros(3, int)
-        assert_equal(
-            np.array2string(arr, edgeitems=1, threshold=0),
-            "[0 ... 0]"
-        )
+        assert_equal(np.array2string(arr, edgeitems=1, threshold=0), "[0 ... 0]")
 
     def test_summarize_1d(self):
         A = np.arange(1001)
-        strA = '[   0    1    2 ...  998  999 1000]'
+        strA = "[   0    1    2 ...  998  999 1000]"
         assert_equal(str(A), strA)
 
-        reprA = 'array([   0,    1,    2, ...,  998,  999, 1000])'
+        reprA = "array([   0,    1,    2, ...,  998,  999, 1000])"
         assert_equal(repr(A), reprA)
 
     def test_summarize_2d(self):
         A = np.arange(1002).reshape(2, 501)
-        strA = '[[   0    1    2 ...  498  499  500]\n' \
-               ' [ 501  502  503 ...  999 1000 1001]]'
+        strA = (
+            "[[   0    1    2 ...  498  499  500]\n"
+            " [ 501  502  503 ...  999 1000 1001]]"
+        )
         assert_equal(str(A), strA)
 
-        reprA = 'array([[   0,    1,    2, ...,  498,  499,  500],\n' \
-                '       [ 501,  502,  503, ...,  999, 1000, 1001]])'
+        reprA = (
+            "array([[   0,    1,    2, ...,  498,  499,  500],\n"
+            "       [ 501,  502,  503, ...,  999, 1000, 1001]])"
+        )
         assert_equal(repr(A), reprA)
 
     def test_linewidth(self):
@@ -359,41 +457,28 @@ class TestArray2String:
         def make_str(a, width, **kw):
             return np.array2string(a, separator="", max_line_width=width, **kw)
 
-        assert_equal(make_str(a, 8, legacy='1.13'), '[111111]')
-        assert_equal(make_str(a, 7, legacy='1.13'), '[111111]')
-        assert_equal(make_str(a, 5, legacy='1.13'), '[1111\n'
-                                                    ' 11]')
+        assert_equal(make_str(a, 8, legacy="1.13"), "[111111]")
+        assert_equal(make_str(a, 7, legacy="1.13"), "[111111]")
+        assert_equal(make_str(a, 5, legacy="1.13"), "[1111\n" " 11]")
 
-        assert_equal(make_str(a, 8), '[111111]')
-        assert_equal(make_str(a, 7), '[11111\n'
-                                     ' 1]')
-        assert_equal(make_str(a, 5), '[111\n'
-                                     ' 111]')
+        assert_equal(make_str(a, 8), "[111111]")
+        assert_equal(make_str(a, 7), "[11111\n" " 1]")
+        assert_equal(make_str(a, 5), "[111\n" " 111]")
 
-        b = a[None,None,:]
+        b = a[None, None, :]
 
-        assert_equal(make_str(b, 12, legacy='1.13'), '[[[111111]]]')
-        assert_equal(make_str(b,  9, legacy='1.13'), '[[[111111]]]')
-        assert_equal(make_str(b,  8, legacy='1.13'), '[[[11111\n'
-                                                     '   1]]]')
+        assert_equal(make_str(b, 12, legacy="1.13"), "[[[111111]]]")
+        assert_equal(make_str(b, 9, legacy="1.13"), "[[[111111]]]")
+        assert_equal(make_str(b, 8, legacy="1.13"), "[[[11111\n" "   1]]]")
 
-        assert_equal(make_str(b, 12), '[[[111111]]]')
-        assert_equal(make_str(b,  9), '[[[111\n'
-                                      '   111]]]')
-        assert_equal(make_str(b,  8), '[[[11\n'
-                                      '   11\n'
-                                      '   11]]]')
+        assert_equal(make_str(b, 12), "[[[111111]]]")
+        assert_equal(make_str(b, 9), "[[[111\n" "   111]]]")
+        assert_equal(make_str(b, 8), "[[[11\n" "   11\n" "   11]]]")
 
     def test_wide_element(self):
-        a = np.array(['xxxxx'])
-        assert_equal(
-            np.array2string(a, max_line_width=5),
-            "['xxxxx']"
-        )
-        assert_equal(
-            np.array2string(a, max_line_width=5, legacy='1.13'),
-            "[ 'xxxxx']"
-        )
+        a = np.array(["xxxxx"])
+        assert_equal(np.array2string(a, max_line_width=5), "['xxxxx']")
+        assert_equal(np.array2string(a, max_line_width=5, legacy="1.13"), "[ 'xxxxx']")
 
     def test_multiline_repr(self):
         class MultiLine:
@@ -404,26 +489,18 @@ class TestArray2String:
 
         assert_equal(
             np.array2string(a),
-            '[[None Line 1\n'
-            '       Line 2]\n'
-            ' [Line 1\n'
-            '  Line 2 None]]'
+            "[[None Line 1\n" "       Line 2]\n" " [Line 1\n" "  Line 2 None]]",
         )
         assert_equal(
             np.array2string(a, max_line_width=5),
-            '[[None\n'
-            '  Line 1\n'
-            '  Line 2]\n'
-            ' [Line 1\n'
-            '  Line 2\n'
-            '  None]]'
+            "[[None\n" "  Line 1\n" "  Line 2]\n" " [Line 1\n" "  Line 2\n" "  None]]",
         )
         assert_equal(
             repr(a),
-            'array([[None, Line 1\n'
-            '              Line 2],\n'
-            '       [Line 1\n'
-            '        Line 2, None]], dtype=object)'
+            "array([[None, Line 1\n"
+            "              Line 2],\n"
+            "       [Line 1\n"
+            "        Line 2, None]], dtype=object)",
         )
 
         class MultiLineLong:
@@ -433,24 +510,24 @@ class TestArray2String:
         a = np.array([[None, MultiLineLong()], [MultiLineLong(), None]])
         assert_equal(
             repr(a),
-            'array([[None, Line 1\n'
-            '              LooooooooooongestLine2\n'
-            '              LongerLine 3          ],\n'
-            '       [Line 1\n'
-            '        LooooooooooongestLine2\n'
-            '        LongerLine 3          , None]], dtype=object)'
+            "array([[None, Line 1\n"
+            "              LooooooooooongestLine2\n"
+            "              LongerLine 3          ],\n"
+            "       [Line 1\n"
+            "        LooooooooooongestLine2\n"
+            "        LongerLine 3          , None]], dtype=object)",
         )
         assert_equal(
             np.array_repr(a, 20),
-            'array([[None,\n'
-            '        Line 1\n'
-            '        LooooooooooongestLine2\n'
-            '        LongerLine 3          ],\n'
-            '       [Line 1\n'
-            '        LooooooooooongestLine2\n'
-            '        LongerLine 3          ,\n'
-            '        None]],\n'
-            '      dtype=object)'
+            "array([[None,\n"
+            "        Line 1\n"
+            "        LooooooooooongestLine2\n"
+            "        LongerLine 3          ],\n"
+            "       [Line 1\n"
+            "        LooooooooooongestLine2\n"
+            "        LongerLine 3          ,\n"
+            "        None]],\n"
+            "      dtype=object)",
         )
 
     def test_nested_array_repr(self):
@@ -461,13 +538,13 @@ class TestArray2String:
         a[1, 1] = np.ones((3, 1))
         assert_equal(
             repr(a),
-            'array([[array([[1., 0.],\n'
-            '               [0., 1.]]), array([[1., 0., 0.],\n'
-            '                                  [0., 1., 0.],\n'
-            '                                  [0., 0., 1.]])],\n'
-            '       [None, array([[1.],\n'
-            '                     [1.],\n'
-            '                     [1.]])]], dtype=object)'
+            "array([[array([[1., 0.],\n"
+            "               [0., 1.]]), array([[1., 0., 0.],\n"
+            "                                  [0., 1., 0.],\n"
+            "                                  [0., 0., 1.]])],\n"
+            "       [None, array([[1.],\n"
+            "                     [1.],\n"
+            "                     [1.]])]], dtype=object)",
         )
 
     @given(hynp.from_dtype(np.dtype("U")))
@@ -496,6 +573,7 @@ class TestArray2String:
         gc.enable()
         assert_(r1 == r2)
 
+
 class TestPrintOptions:
     """Test getting and setting global print options."""
 
@@ -514,310 +592,371 @@ class TestPrintOptions:
     def test_precision_zero(self):
         np.set_printoptions(precision=0)
         for values, string in (
-                ([0.], "0."), ([.3], "0."), ([-.3], "-0."), ([.7], "1."),
-                ([1.5], "2."), ([-1.5], "-2."), ([-15.34], "-15."),
-                ([100.], "100."), ([.2, -1, 122.51], "  0.,  -1., 123."),
-                ([0], "0"), ([-12], "-12"), ([complex(.3, -.7)], "0.-1.j")):
+            ([0.0], "0."),
+            ([0.3], "0."),
+            ([-0.3], "-0."),
+            ([0.7], "1."),
+            ([1.5], "2."),
+            ([-1.5], "-2."),
+            ([-15.34], "-15."),
+            ([100.0], "100."),
+            ([0.2, -1, 122.51], "  0.,  -1., 123."),
+            ([0], "0"),
+            ([-12], "-12"),
+            ([complex(0.3, -0.7)], "0.-1.j"),
+        ):
             x = np.array(values)
             assert_equal(repr(x), "array([%s])" % string)
 
     def test_formatter(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
+        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
 
     def test_formatter_reset(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
+        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'int':None})
+        np.set_printoptions(formatter={"int": None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
+        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'all':None})
+        np.set_printoptions(formatter={"all": None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={'int':lambda x: str(x-1)})
+        np.set_printoptions(formatter={"int": lambda x: str(x - 1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={'int_kind':None})
+        np.set_printoptions(formatter={"int_kind": None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        x = np.arange(3.)
-        np.set_printoptions(formatter={'float':lambda x: str(x-1)})
+        x = np.arange(3.0)
+        np.set_printoptions(formatter={"float": lambda x: str(x - 1)})
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
-        np.set_printoptions(formatter={'float_kind':None})
+        np.set_printoptions(formatter={"float_kind": None})
         assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
-        assert_equal(str(np.array('café', '<U4')), 'café')
+        assert_equal(str(np.array("café", "<U4")), "café")
 
-        assert_equal(repr(np.array('café', '<U4')),
-                     "array('café', dtype='<U4')")
-        assert_equal(str(np.array('test', np.str_)), 'test')
+        assert_equal(repr(np.array("café", "<U4")), "array('café', dtype='<U4')")
+        assert_equal(str(np.array("test", np.str_)), "test")
 
-        a = np.zeros(1, dtype=[('a', '<i4', (3,))])
-        assert_equal(str(a[0]), '([0, 0, 0],)')
+        a = np.zeros(1, dtype=[("a", "<i4", (3,))])
+        assert_equal(str(a[0]), "([0, 0, 0],)")
 
-        assert_equal(repr(np.datetime64('2005-02-25')[...]),
-                     "array('2005-02-25', dtype='datetime64[D]')")
+        assert_equal(
+            repr(np.datetime64("2005-02-25")[...]),
+            "array('2005-02-25', dtype='datetime64[D]')",
+        )
 
-        assert_equal(repr(np.timedelta64('10', 'Y')[...]),
-                     "array(10, dtype='timedelta64[Y]')")
+        assert_equal(
+            repr(np.timedelta64("10", "Y")[...]), "array(10, dtype='timedelta64[Y]')"
+        )
 
         # repr of 0d arrays is affected by printoptions
         x = np.array(1)
-        np.set_printoptions(formatter={'all':lambda x: "test"})
+        np.set_printoptions(formatter={"all": lambda x: "test"})
         assert_equal(repr(x), "array(test)")
         # str is unaffected
         assert_equal(str(x), "1")
 
         # check `style` arg raises
-        assert_warns(DeprecationWarning, np.array2string,
-                                         np.array(1.), style=repr)
+        assert_warns(DeprecationWarning, np.array2string, np.array(1.0), style=repr)
         # but not in legacy mode
-        np.array2string(np.array(1.), style=repr, legacy='1.13')
+        np.array2string(np.array(1.0), style=repr, legacy="1.13")
         # gh-10934 style was broken in legacy mode, check it works
-        np.array2string(np.array(1.), legacy='1.13')
+        np.array2string(np.array(1.0), legacy="1.13")
 
     def test_float_spacing(self):
-        x = np.array([1., 2., 3.])
-        y = np.array([1., 2., -10.])
-        z = np.array([100., 2., -1.])
-        w = np.array([-100., 2., 1.])
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1.0, 2.0, -10.0])
+        z = np.array([100.0, 2.0, -1.0])
+        w = np.array([-100.0, 2.0, 1.0])
 
-        assert_equal(repr(x), 'array([1., 2., 3.])')
-        assert_equal(repr(y), 'array([  1.,   2., -10.])')
-        assert_equal(repr(np.array(y[0])), 'array(1.)')
-        assert_equal(repr(np.array(y[-1])), 'array(-10.)')
-        assert_equal(repr(z), 'array([100.,   2.,  -1.])')
-        assert_equal(repr(w), 'array([-100.,    2.,    1.])')
+        assert_equal(repr(x), "array([1., 2., 3.])")
+        assert_equal(repr(y), "array([  1.,   2., -10.])")
+        assert_equal(repr(np.array(y[0])), "array(1.)")
+        assert_equal(repr(np.array(y[-1])), "array(-10.)")
+        assert_equal(repr(z), "array([100.,   2.,  -1.])")
+        assert_equal(repr(w), "array([-100.,    2.,    1.])")
 
-        assert_equal(repr(np.array([np.nan, np.inf])), 'array([nan, inf])')
-        assert_equal(repr(np.array([np.nan, -np.inf])), 'array([ nan, -inf])')
+        assert_equal(repr(np.array([np.nan, np.inf])), "array([nan, inf])")
+        assert_equal(repr(np.array([np.nan, -np.inf])), "array([ nan, -inf])")
 
         x = np.array([np.inf, 100000, 1.1234])
         y = np.array([np.inf, 100000, -1.1234])
         z = np.array([np.inf, 1.1234, -1e120])
         np.set_printoptions(precision=2)
-        assert_equal(repr(x), 'array([     inf, 1.00e+05, 1.12e+00])')
-        assert_equal(repr(y), 'array([      inf,  1.00e+05, -1.12e+00])')
-        assert_equal(repr(z), 'array([       inf,  1.12e+000, -1.00e+120])')
+        assert_equal(repr(x), "array([     inf, 1.00e+05, 1.12e+00])")
+        assert_equal(repr(y), "array([      inf,  1.00e+05, -1.12e+00])")
+        assert_equal(repr(z), "array([       inf,  1.12e+000, -1.00e+120])")
 
     def test_bool_spacing(self):
-        assert_equal(repr(np.array([True,  True])),
-                     'array([ True,  True])')
-        assert_equal(repr(np.array([True, False])),
-                     'array([ True, False])')
-        assert_equal(repr(np.array([True])),
-                     'array([ True])')
-        assert_equal(repr(np.array(True)),
-                     'array(True)')
-        assert_equal(repr(np.array(False)),
-                     'array(False)')
+        assert_equal(repr(np.array([True, True])), "array([ True,  True])")
+        assert_equal(repr(np.array([True, False])), "array([ True, False])")
+        assert_equal(repr(np.array([True])), "array([ True])")
+        assert_equal(repr(np.array(True)), "array(True)")
+        assert_equal(repr(np.array(False)), "array(False)")
 
     def test_sign_spacing(self):
-        a = np.arange(4.)
+        a = np.arange(4.0)
         b = np.array([1.234e9])
-        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
+        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype="c16")
 
-        assert_equal(repr(a), 'array([0., 1., 2., 3.])')
-        assert_equal(repr(np.array(1.)), 'array(1.)')
-        assert_equal(repr(b), 'array([1.234e+09])')
-        assert_equal(repr(np.array([0.])), 'array([0.])')
-        assert_equal(repr(c),
-            "array([1.        +1.j        , 1.12345679+1.12345679j])")
-        assert_equal(repr(np.array([0., -0.])), 'array([ 0., -0.])')
+        assert_equal(repr(a), "array([0., 1., 2., 3.])")
+        assert_equal(repr(np.array(1.0)), "array(1.)")
+        assert_equal(repr(b), "array([1.234e+09])")
+        assert_equal(repr(np.array([0.0])), "array([0.])")
+        assert_equal(repr(c), "array([1.        +1.j        , 1.12345679+1.12345679j])")
+        assert_equal(repr(np.array([0.0, -0.0])), "array([ 0., -0.])")
 
-        np.set_printoptions(sign=' ')
-        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
-        assert_equal(repr(np.array(1.)), 'array( 1.)')
-        assert_equal(repr(b), 'array([ 1.234e+09])')
-        assert_equal(repr(c),
-            "array([ 1.        +1.j        ,  1.12345679+1.12345679j])")
-        assert_equal(repr(np.array([0., -0.])), 'array([ 0., -0.])')
+        np.set_printoptions(sign=" ")
+        assert_equal(repr(a), "array([ 0.,  1.,  2.,  3.])")
+        assert_equal(repr(np.array(1.0)), "array( 1.)")
+        assert_equal(repr(b), "array([ 1.234e+09])")
+        assert_equal(
+            repr(c), "array([ 1.        +1.j        ,  1.12345679+1.12345679j])"
+        )
+        assert_equal(repr(np.array([0.0, -0.0])), "array([ 0., -0.])")
 
-        np.set_printoptions(sign='+')
-        assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
-        assert_equal(repr(np.array(1.)), 'array(+1.)')
-        assert_equal(repr(b), 'array([+1.234e+09])')
-        assert_equal(repr(c),
-            "array([+1.        +1.j        , +1.12345679+1.12345679j])")
+        np.set_printoptions(sign="+")
+        assert_equal(repr(a), "array([+0., +1., +2., +3.])")
+        assert_equal(repr(np.array(1.0)), "array(+1.)")
+        assert_equal(repr(b), "array([+1.234e+09])")
+        assert_equal(
+            repr(c), "array([+1.        +1.j        , +1.12345679+1.12345679j])"
+        )
 
-        np.set_printoptions(legacy='1.13')
-        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
-        assert_equal(repr(b),  'array([  1.23400000e+09])')
-        assert_equal(repr(-b), 'array([ -1.23400000e+09])')
-        assert_equal(repr(np.array(1.)), 'array(1.0)')
-        assert_equal(repr(np.array([0.])), 'array([ 0.])')
-        assert_equal(repr(c),
-            "array([ 1.00000000+1.j        ,  1.12345679+1.12345679j])")
+        np.set_printoptions(legacy="1.13")
+        assert_equal(repr(a), "array([ 0.,  1.,  2.,  3.])")
+        assert_equal(repr(b), "array([  1.23400000e+09])")
+        assert_equal(repr(-b), "array([ -1.23400000e+09])")
+        assert_equal(repr(np.array(1.0)), "array(1.0)")
+        assert_equal(repr(np.array([0.0])), "array([ 0.])")
+        assert_equal(
+            repr(c), "array([ 1.00000000+1.j        ,  1.12345679+1.12345679j])"
+        )
         # gh-10383
-        assert_equal(str(np.array([-1., 10])), "[ -1.  10.]")
+        assert_equal(str(np.array([-1.0, 10])), "[ -1.  10.]")
 
         assert_raises(TypeError, np.set_printoptions, wrongarg=True)
 
     def test_float_overflow_nowarn(self):
         # make sure internal computations in FloatingFormat don't
         # warn about overflow
-        repr(np.array([1e4, 0.1], dtype='f2'))
+        repr(np.array([1e4, 0.1], dtype="f2"))
 
     def test_sign_spacing_structured(self):
-        a = np.ones(2, dtype='<f,<f')
-        assert_equal(repr(a),
-            "array([(1., 1.), (1., 1.)], dtype=[('f0', '<f4'), ('f1', '<f4')])")
+        a = np.ones(2, dtype="<f,<f")
+        assert_equal(
+            repr(a), "array([(1., 1.), (1., 1.)], dtype=[('f0', '<f4'), ('f1', '<f4')])"
+        )
         assert_equal(repr(a[0]), "(1., 1.)")
 
     def test_floatmode(self):
-        x = np.array([0.6104, 0.922, 0.457, 0.0906, 0.3733, 0.007244,
-                      0.5933, 0.947, 0.2383, 0.4226], dtype=np.float16)
-        y = np.array([0.2918820979355541, 0.5064172631089138,
-                      0.2848750619642916, 0.4342965294660567,
-                      0.7326538397312751, 0.3459503329096204,
-                      0.0862072768214508, 0.39112753029631175],
-                      dtype=np.float64)
-        z = np.arange(6, dtype=np.float16)/10
-        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
+        x = np.array(
+            [
+                0.6104,
+                0.922,
+                0.457,
+                0.0906,
+                0.3733,
+                0.007244,
+                0.5933,
+                0.947,
+                0.2383,
+                0.4226,
+            ],
+            dtype=np.float16,
+        )
+        y = np.array(
+            [
+                0.2918820979355541,
+                0.5064172631089138,
+                0.2848750619642916,
+                0.4342965294660567,
+                0.7326538397312751,
+                0.3459503329096204,
+                0.0862072768214508,
+                0.39112753029631175,
+            ],
+            dtype=np.float64,
+        )
+        z = np.arange(6, dtype=np.float16) / 10
+        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype="c16")
 
         # also make sure 1e23 is right (is between two fp numbers)
-        w = np.array(['1e{}'.format(i) for i in range(25)], dtype=np.float64)
+        w = np.array([f"1e{i}" for i in range(25)], dtype=np.float64)
         # note: we construct w from the strings `1eXX` instead of doing
         # `10.**arange(24)` because it turns out the two are not equivalent in
         # python. On some architectures `1e23 != 10.**23`.
         wp = np.array([1.234e1, 1e2, 1e123])
 
         # unique mode
-        np.set_printoptions(floatmode='unique')
-        assert_equal(repr(x),
+        np.set_printoptions(floatmode="unique")
+        assert_equal(
+            repr(x),
             "array([0.6104  , 0.922   , 0.457   , 0.0906  , 0.3733  , 0.007244,\n"
-            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)")
-        assert_equal(repr(y),
+            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)",
+        )
+        assert_equal(
+            repr(y),
             "array([0.2918820979355541 , 0.5064172631089138 , 0.2848750619642916 ,\n"
             "       0.4342965294660567 , 0.7326538397312751 , 0.3459503329096204 ,\n"
-            "       0.0862072768214508 , 0.39112753029631175])")
-        assert_equal(repr(z),
-            "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(repr(w),
+            "       0.0862072768214508 , 0.39112753029631175])",
+        )
+        assert_equal(repr(z), "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(
+            repr(w),
             "array([1.e+00, 1.e+01, 1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06, 1.e+07,\n"
             "       1.e+08, 1.e+09, 1.e+10, 1.e+11, 1.e+12, 1.e+13, 1.e+14, 1.e+15,\n"
             "       1.e+16, 1.e+17, 1.e+18, 1.e+19, 1.e+20, 1.e+21, 1.e+22, 1.e+23,\n"
-            "       1.e+24])")
+            "       1.e+24])",
+        )
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(repr(c),
-            "array([1.         +1.j         , 1.123456789+1.123456789j])")
+        assert_equal(
+            repr(c), "array([1.         +1.j         , 1.123456789+1.123456789j])"
+        )
 
         # maxprec mode, precision=8
-        np.set_printoptions(floatmode='maxprec', precision=8)
-        assert_equal(repr(x),
+        np.set_printoptions(floatmode="maxprec", precision=8)
+        assert_equal(
+            repr(x),
             "array([0.6104  , 0.922   , 0.457   , 0.0906  , 0.3733  , 0.007244,\n"
-            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)")
-        assert_equal(repr(y),
+            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)",
+        )
+        assert_equal(
+            repr(y),
             "array([0.2918821 , 0.50641726, 0.28487506, 0.43429653, 0.73265384,\n"
-            "       0.34595033, 0.08620728, 0.39112753])")
-        assert_equal(repr(z),
-            "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(repr(w[::5]),
-            "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
+            "       0.34595033, 0.08620728, 0.39112753])",
+        )
+        assert_equal(repr(z), "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(repr(w[::5]), "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(repr(c),
-            "array([1.        +1.j        , 1.12345679+1.12345679j])")
+        assert_equal(repr(c), "array([1.        +1.j        , 1.12345679+1.12345679j])")
 
         # fixed mode, precision=4
-        np.set_printoptions(floatmode='fixed', precision=4)
-        assert_equal(repr(x),
+        np.set_printoptions(floatmode="fixed", precision=4)
+        assert_equal(
+            repr(x),
             "array([0.6104, 0.9219, 0.4570, 0.0906, 0.3733, 0.0072, 0.5933, 0.9468,\n"
-            "       0.2383, 0.4226], dtype=float16)")
-        assert_equal(repr(y),
-            "array([0.2919, 0.5064, 0.2849, 0.4343, 0.7327, 0.3460, 0.0862, 0.3911])")
-        assert_equal(repr(z),
-            "array([0.0000, 0.1000, 0.2000, 0.3000, 0.3999, 0.5000], dtype=float16)")
-        assert_equal(repr(w[::5]),
-            "array([1.0000e+00, 1.0000e+05, 1.0000e+10, 1.0000e+15, 1.0000e+20])")
+            "       0.2383, 0.4226], dtype=float16)",
+        )
+        assert_equal(
+            repr(y),
+            "array([0.2919, 0.5064, 0.2849, 0.4343, 0.7327, 0.3460, 0.0862, 0.3911])",
+        )
+        assert_equal(
+            repr(z),
+            "array([0.0000, 0.1000, 0.2000, 0.3000, 0.3999, 0.5000], dtype=float16)",
+        )
+        assert_equal(
+            repr(w[::5]),
+            "array([1.0000e+00, 1.0000e+05, 1.0000e+10, 1.0000e+15, 1.0000e+20])",
+        )
         assert_equal(repr(wp), "array([1.2340e+001, 1.0000e+002, 1.0000e+123])")
         assert_equal(repr(np.zeros(3)), "array([0.0000, 0.0000, 0.0000])")
-        assert_equal(repr(c),
-            "array([1.0000+1.0000j, 1.1235+1.1235j])")
+        assert_equal(repr(c), "array([1.0000+1.0000j, 1.1235+1.1235j])")
         # for larger precision, representation error becomes more apparent:
-        np.set_printoptions(floatmode='fixed', precision=8)
-        assert_equal(repr(z),
+        np.set_printoptions(floatmode="fixed", precision=8)
+        assert_equal(
+            repr(z),
             "array([0.00000000, 0.09997559, 0.19995117, 0.30004883, 0.39990234,\n"
-            "       0.50000000], dtype=float16)")
+            "       0.50000000], dtype=float16)",
+        )
 
         # maxprec_equal  mode, precision=8
-        np.set_printoptions(floatmode='maxprec_equal', precision=8)
-        assert_equal(repr(x),
+        np.set_printoptions(floatmode="maxprec_equal", precision=8)
+        assert_equal(
+            repr(x),
             "array([0.610352, 0.921875, 0.457031, 0.090576, 0.373291, 0.007244,\n"
-            "       0.593262, 0.946777, 0.238281, 0.422607], dtype=float16)")
-        assert_equal(repr(y),
+            "       0.593262, 0.946777, 0.238281, 0.422607], dtype=float16)",
+        )
+        assert_equal(
+            repr(y),
             "array([0.29188210, 0.50641726, 0.28487506, 0.43429653, 0.73265384,\n"
-            "       0.34595033, 0.08620728, 0.39112753])")
-        assert_equal(repr(z),
-            "array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(repr(w[::5]),
-            "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
+            "       0.34595033, 0.08620728, 0.39112753])",
+        )
+        assert_equal(repr(z), "array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(repr(w[::5]), "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(repr(c),
-            "array([1.00000000+1.00000000j, 1.12345679+1.12345679j])")
+        assert_equal(repr(c), "array([1.00000000+1.00000000j, 1.12345679+1.12345679j])")
 
         # test unique special case (gh-18609)
-        a = np.float64.fromhex('-1p-97')
-        assert_equal(np.float64(np.array2string(a, floatmode='unique')), a)
+        a = np.float64.fromhex("-1p-97")
+        assert_equal(np.float64(np.array2string(a, floatmode="unique")), a)
 
     def test_legacy_mode_scalars(self):
         # in legacy mode, str of floats get truncated, and complex scalars
         # use * for non-finite imaginary part
-        np.set_printoptions(legacy='1.13')
-        assert_equal(str(np.float64(1.123456789123456789)), '1.12345678912')
-        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nan*j)')
+        np.set_printoptions(legacy="1.13")
+        assert_equal(str(np.float64(1.123456789123456789)), "1.12345678912")
+        assert_equal(str(np.complex128(complex(1, np.nan))), "(1+nan*j)")
 
         np.set_printoptions(legacy=False)
-        assert_equal(str(np.float64(1.123456789123456789)),
-                     '1.1234567891234568')
-        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nanj)')
+        assert_equal(str(np.float64(1.123456789123456789)), "1.1234567891234568")
+        assert_equal(str(np.complex128(complex(1, np.nan))), "(1+nanj)")
 
     def test_legacy_stray_comma(self):
-        np.set_printoptions(legacy='1.13')
-        assert_equal(str(np.arange(10000)), '[   0    1    2 ..., 9997 9998 9999]')
+        np.set_printoptions(legacy="1.13")
+        assert_equal(str(np.arange(10000)), "[   0    1    2 ..., 9997 9998 9999]")
 
         np.set_printoptions(legacy=False)
-        assert_equal(str(np.arange(10000)), '[   0    1    2 ... 9997 9998 9999]')
+        assert_equal(str(np.arange(10000)), "[   0    1    2 ... 9997 9998 9999]")
 
     def test_dtype_linewidth_wrapping(self):
         np.set_printoptions(linewidth=75)
-        assert_equal(repr(np.arange(10,20., dtype='f4')),
-            "array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19.], dtype=float32)")
-        assert_equal(repr(np.arange(10,23., dtype='f4')), textwrap.dedent("""\
+        assert_equal(
+            repr(np.arange(10, 20.0, dtype="f4")),
+            "array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19.], dtype=float32)",
+        )
+        assert_equal(
+            repr(np.arange(10, 23.0, dtype="f4")),
+            textwrap.dedent(
+                """\
             array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22.],
-                  dtype=float32)"""))
+                  dtype=float32)"""
+            ),
+        )
 
-        styp = '<U4'
-        assert_equal(repr(np.ones(3, dtype=styp)),
-            "array(['1', '1', '1'], dtype='{}')".format(styp))
-        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
+        styp = "<U4"
+        assert_equal(
+            repr(np.ones(3, dtype=styp)),
+            f"array(['1', '1', '1'], dtype='{styp}')",
+        )
+        assert_equal(
+            repr(np.ones(12, dtype=styp)),
+            textwrap.dedent(
+                """\
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
-                  dtype='{}')""".format(styp)))
+                  dtype='{}')""".format(
+                    styp
+                )
+            ),
+        )
 
     def test_dtype_endianness_repr(self):
-        '''
-        there was an issue where 
+        """
+        there was an issue where
         repr(array([0], dtype='<u2')) and repr(array([0], dtype='>u2')) both returned the same thing:
         array([0], dtype=uint16)
         even though their dtypes have different endianness.
-        '''
-        dtype_combos = [ # little-endian first, big-endian second
-            ('bool', 'bool'),
-            ('uint8', 'u1'),
-            ('uint16', '>u2'),
-            ('uint32', '>u4'),
-            ('uint64', '>u8'),
-            ('int16', '>i2'),
-            ('int32', '>i4'),
-            ('int64', '>i8'),
-            ('float16', '>e'),
-            ('float32', '>f'),
-            ('float64', '>d'),
-            ('<U', '>U'), # string
-            ('<U1', '>U1'), # 4-byte width string
+        """
+        dtype_combos = [  # little-endian first, big-endian second
+            ("bool", "bool"),
+            ("uint8", "u1"),
+            ("uint16", ">u2"),
+            ("uint32", ">u4"),
+            ("uint64", ">u8"),
+            ("int16", ">i2"),
+            ("int32", ">i4"),
+            ("int64", ">i8"),
+            ("float16", ">e"),
+            ("float32", ">f"),
+            ("float64", ">d"),
+            ("<U", ">U"),  # string
+            ("<U1", ">U1"),  # 4-byte width string
         ]
         for little_end, big_end in dtype_combos:
             big_dtype = np.dtype(big_end)
@@ -825,30 +964,42 @@ class TestPrintOptions:
             big_end_repr = repr(np.array([1], big_dtype))
             little_end_repr = repr(np.array([1], little_dtype))
             # preserve the sensible default of only showing dtype if nonstandard
-            assert_(not ('dtype' in big_end_repr and big_dtype in _typelessdata),
-                    ('if a type has default size and endianness (e.g., int32, bool, float64) '
-                    'should not show dtype, but it does'))
+            assert_(
+                not ("dtype" in big_end_repr and big_dtype in _typelessdata),
+                (
+                    "if a type has default size and endianness (e.g., int32, bool, float64) "
+                    "should not show dtype, but it does"
+                ),
+            )
             # only show difference if > 1 byte
-            assert_(not (big_end_repr == little_end_repr and big_dtype.itemsize > 1),
-                    ('expected little endian repr != big endian repr, '
-                    f'but {little_end_repr = }, {big_end_repr = }'))
+            assert_(
+                not (big_end_repr == little_end_repr and big_dtype.itemsize > 1),
+                (
+                    "expected little endian repr != big endian repr, "
+                    f"but {little_end_repr = }, {big_end_repr = }"
+                ),
+            )
 
     def test_linewidth_repr(self):
         a = np.full(7, fill_value=2)
         np.set_printoptions(linewidth=17)
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([2, 2, 2,
                    2, 2, 2,
-                   2])""")
+                   2])"""
+            ),
         )
-        np.set_printoptions(linewidth=17, legacy='1.13')
+        np.set_printoptions(linewidth=17, legacy="1.13")
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([2, 2, 2,
-                   2, 2, 2, 2])""")
+                   2, 2, 2, 2])"""
+            ),
         )
 
         a = np.full(8, fill_value=2)
@@ -856,18 +1007,22 @@ class TestPrintOptions:
         np.set_printoptions(linewidth=18, legacy=False)
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([2, 2, 2,
                    2, 2, 2,
-                   2, 2])""")
+                   2, 2])"""
+            ),
         )
 
-        np.set_printoptions(linewidth=18, legacy='1.13')
+        np.set_printoptions(linewidth=18, legacy="1.13")
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([2, 2, 2, 2,
-                   2, 2, 2, 2])""")
+                   2, 2, 2, 2])"""
+            ),
         )
 
     def test_linewidth_str(self):
@@ -875,17 +1030,21 @@ class TestPrintOptions:
         np.set_printoptions(linewidth=18)
         assert_equal(
             str(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             [2 2 2 2 2 2 2 2
              2 2 2 2 2 2 2 2
-             2 2]""")
+             2 2]"""
+            ),
         )
-        np.set_printoptions(linewidth=18, legacy='1.13')
+        np.set_printoptions(linewidth=18, legacy="1.13")
         assert_equal(
             str(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             [2 2 2 2 2 2 2 2 2
-             2 2 2 2 2 2 2 2 2]""")
+             2 2 2 2 2 2 2 2 2]"""
+            ),
         )
 
     def test_edgeitems(self):
@@ -893,7 +1052,8 @@ class TestPrintOptions:
         a = np.arange(27).reshape((3, 3, 3))
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([[[ 0, ...,  2],
                     ...,
                     [ 6, ...,  8]],
@@ -902,13 +1062,15 @@ class TestPrintOptions:
 
                    [[18, ..., 20],
                     ...,
-                    [24, ..., 26]]])""")
+                    [24, ..., 26]]])"""
+            ),
         )
 
         b = np.zeros((3, 3, 1, 1))
         assert_equal(
             repr(b),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([[[[0.]],
 
                     ...,
@@ -923,15 +1085,17 @@ class TestPrintOptions:
 
                     ...,
 
-                    [[0.]]]])""")
+                    [[0.]]]])"""
+            ),
         )
 
         # 1.13 had extra trailing spaces, and was missing newlines
-        np.set_printoptions(legacy='1.13')
+        np.set_printoptions(legacy="1.13")
 
         assert_equal(
             repr(a),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([[[ 0, ...,  2],
                     ..., 
                     [ 6, ...,  8]],
@@ -939,12 +1103,14 @@ class TestPrintOptions:
                    ..., 
                    [[18, ..., 20],
                     ..., 
-                    [24, ..., 26]]])""")
+                    [24, ..., 26]]])"""
+            ),
         )
 
         assert_equal(
             repr(b),
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             array([[[[ 0.]],
 
                     ..., 
@@ -955,20 +1121,22 @@ class TestPrintOptions:
                    [[[ 0.]],
 
                     ..., 
-                    [[ 0.]]]])""")
+                    [[ 0.]]]])"""
+            ),
         )
 
     def test_bad_args(self):
-        assert_raises(ValueError, np.set_printoptions, threshold=float('nan'))
-        assert_raises(TypeError, np.set_printoptions, threshold='1')
-        assert_raises(TypeError, np.set_printoptions, threshold=b'1')
+        assert_raises(ValueError, np.set_printoptions, threshold=float("nan"))
+        assert_raises(TypeError, np.set_printoptions, threshold="1")
+        assert_raises(TypeError, np.set_printoptions, threshold=b"1")
 
-        assert_raises(TypeError, np.set_printoptions, precision='1')
+        assert_raises(TypeError, np.set_printoptions, precision="1")
         assert_raises(TypeError, np.set_printoptions, precision=1.5)
+
 
 def test_unicode_object_array():
     expected = "array(['é'], dtype=object)"
-    x = np.array(['\xe9'], dtype=object)
+    x = np.array(["\xe9"], dtype=object)
     assert_equal(repr(x), expected)
 
 
@@ -977,13 +1145,14 @@ class TestContextManager:
         # test that context manager actually works
         with np.printoptions(precision=2):
             s = str(np.array([2.0]) / 3)
-        assert_equal(s, '[0.67]')
+        assert_equal(s, "[0.67]")
 
     def test_ctx_mgr_restores(self):
         # test that print options are actually restrored
         opts = np.get_printoptions()
-        with np.printoptions(precision=opts['precision'] - 1,
-                             linewidth=opts['linewidth'] - 4):
+        with np.printoptions(
+            precision=opts["precision"] - 1, linewidth=opts["linewidth"] - 4
+        ):
             pass
         assert_equal(np.get_printoptions(), opts)
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,44 +1,40 @@
-import gc
 import sys
-import textwrap
-
-import numpy as np
-import pytest
+import gc
 from hypothesis import given
 from hypothesis.extra import numpy as hynp
-from numpy.core.arrayprint import _typelessdata
-from numpy.testing import (
-    HAS_REFCOUNT,
-    assert_,
-    assert_equal,
-    assert_raises,
-    assert_raises_regex,
-    assert_warns,
-)
+import pytest
 
+import numpy as np
+from numpy.testing import (
+    assert_, assert_equal, assert_raises, assert_warns, HAS_REFCOUNT,
+    assert_raises_regex,
+    )
+from numpy.core.arrayprint import _typelessdata
+import textwrap
 
 class TestArrayRepr:
     def test_nan_inf(self):
         x = np.array([np.nan, np.inf])
-        assert_equal(repr(x), "array([nan, inf])")
+        assert_equal(repr(x), 'array([nan, inf])')
 
     def test_subclass(self):
-        class sub(np.ndarray):
-            pass
+        class sub(np.ndarray): pass
 
         # one dimensional
         x1d = np.array([1, 2]).view(sub)
-        assert_equal(repr(x1d), "sub([1, 2])")
+        assert_equal(repr(x1d), 'sub([1, 2])')
 
         # two dimensional
         x2d = np.array([[1, 2], [3, 4]]).view(sub)
-        assert_equal(repr(x2d), "sub([[1, 2],\n" "     [3, 4]])")
+        assert_equal(repr(x2d),
+            'sub([[1, 2],\n'
+            '     [3, 4]])')
 
         # two dimensional with flexible dtype
-        xstruct = np.ones((2, 2), dtype=[("a", "<i4")]).view(sub)
-        assert_equal(
-            repr(xstruct),
-            "sub([[(1,), (1,)],\n" "     [(1,), (1,)]], dtype=[('a', '<i4')])",
+        xstruct = np.ones((2,2), dtype=[('a', '<i4')]).view(sub)
+        assert_equal(repr(xstruct),
+            "sub([[(1,), (1,)],\n"
+            "     [(1,), (1,)]], dtype=[('a', '<i4')])"
         )
 
     @pytest.mark.xfail(reason="See gh-10544")
@@ -54,14 +50,13 @@ class TestArrayRepr:
 
         # test that object + subclass is OK:
         x = sub([None, None])
-        assert_equal(repr(x), "sub([None, None], dtype=object)")
-        assert_equal(str(x), "[None None]")
+        assert_equal(repr(x), 'sub([None, None], dtype=object)')
+        assert_equal(str(x), '[None None]')
 
         x = sub([None, sub([None, None])])
-        assert_equal(
-            repr(x), "sub([None, sub([None, None], dtype=object)], dtype=object)"
-        )
-        assert_equal(str(x), "[None sub([None, None], dtype=object)]")
+        assert_equal(repr(x),
+            'sub([None, sub([None, None], dtype=object)], dtype=object)')
+        assert_equal(str(x), '[None sub([None, None], dtype=object)]')
 
     def test_0d_object_subclass(self):
         # make sure that subclasses which return 0ds instead
@@ -76,33 +71,32 @@ class TestArrayRepr:
                 return sub(ret)
 
         x = sub(1)
-        assert_equal(repr(x), "sub(1)")
-        assert_equal(str(x), "1")
+        assert_equal(repr(x), 'sub(1)')
+        assert_equal(str(x), '1')
 
         x = sub([1, 1])
-        assert_equal(repr(x), "sub([1, 1])")
-        assert_equal(str(x), "[1 1]")
+        assert_equal(repr(x), 'sub([1, 1])')
+        assert_equal(str(x), '[1 1]')
 
         # check it works properly with object arrays too
         x = sub(None)
-        assert_equal(repr(x), "sub(None, dtype=object)")
-        assert_equal(str(x), "None")
+        assert_equal(repr(x), 'sub(None, dtype=object)')
+        assert_equal(str(x), 'None')
 
         # plus recursive object arrays (even depth > 1)
         y = sub(None)
         x[()] = y
         y[()] = x
-        assert_equal(
-            repr(x), "sub(sub(sub(..., dtype=object), dtype=object), dtype=object)"
-        )
-        assert_equal(str(x), "...")
+        assert_equal(repr(x),
+            'sub(sub(sub(..., dtype=object), dtype=object), dtype=object)')
+        assert_equal(str(x), '...')
         x[()] = 0  # resolve circular references for garbage collector
 
         # nested 0d-subclass-object
         x = sub(None)
         x[()] = sub(None)
-        assert_equal(repr(x), "sub(sub(None, dtype=object), dtype=object)")
-        assert_equal(str(x), "None")
+        assert_equal(repr(x), 'sub(sub(None, dtype=object), dtype=object)')
+        assert_equal(str(x), 'None')
 
         # gh-10663
         class DuckCounter(np.ndarray):
@@ -113,13 +107,13 @@ class TestArrayRepr:
                 return result
 
             def to_string(self):
-                return {0: "zero", 1: "one", 2: "two"}.get(self.item(), "many")
+                return {0: 'zero', 1: 'one', 2: 'two'}.get(self.item(), 'many')
 
             def __str__(self):
                 if self.shape == ():
                     return self.to_string()
                 else:
-                    fmt = {"all": lambda x: x.to_string()}
+                    fmt = {'all': lambda x: x.to_string()}
                     return np.array2string(self, formatter=fmt)
 
         dc = np.arange(5).view(DuckCounter)
@@ -129,24 +123,22 @@ class TestArrayRepr:
     def test_self_containing(self):
         arr0d = np.array(None)
         arr0d[()] = arr0d
-        assert_equal(repr(arr0d), "array(array(..., dtype=object), dtype=object)")
+        assert_equal(repr(arr0d),
+            'array(array(..., dtype=object), dtype=object)')
         arr0d[()] = 0  # resolve recursion for garbage collector
 
         arr1d = np.array([None, None])
         arr1d[1] = arr1d
-        assert_equal(
-            repr(arr1d), "array([None, array(..., dtype=object)], dtype=object)"
-        )
+        assert_equal(repr(arr1d),
+            'array([None, array(..., dtype=object)], dtype=object)')
         arr1d[1] = 0  # resolve recursion for garbage collector
 
         first = np.array(None)
         second = np.array(None)
         first[()] = second
         second[()] = first
-        assert_equal(
-            repr(first),
-            "array(array(array(..., dtype=object), dtype=object), dtype=object)",
-        )
+        assert_equal(repr(first),
+            'array(array(array(..., dtype=object), dtype=object), dtype=object)')
         first[()] = 0  # resolve circular references for garbage collector
 
     def test_containing_list(self):
@@ -154,17 +146,18 @@ class TestArrayRepr:
         arr1d = np.array([None, None])
         arr1d[0] = [1, 2]
         arr1d[1] = [3]
-        assert_equal(repr(arr1d), "array([list([1, 2]), list([3])], dtype=object)")
+        assert_equal(repr(arr1d),
+            'array([list([1, 2]), list([3])], dtype=object)')
 
     def test_void_scalar_recursion(self):
         # gh-9345
-        repr(np.void(b"test"))  # RecursionError ?
+        repr(np.void(b'test'))  # RecursionError ?
 
     def test_fieldless_structured(self):
         # gh-10366
         no_fields = np.dtype([])
         arr_no_fields = np.empty(4, dtype=no_fields)
-        assert_equal(repr(arr_no_fields), "array([(), (), (), ()], dtype=[])")
+        assert_equal(repr(arr_no_fields), 'array([(), (), (), ()], dtype=[])')
 
 
 class TestComplexArray:
@@ -174,195 +167,115 @@ class TestComplexArray:
         dtypes = [np.complex64, np.cdouble, np.clongdouble]
         actual = [str(np.array([c], dt)) for c in cvals for dt in dtypes]
         wanted = [
-            "[0.+0.j]",
-            "[0.+0.j]",
-            "[0.+0.j]",
-            "[0.+1.j]",
-            "[0.+1.j]",
-            "[0.+1.j]",
-            "[0.-1.j]",
-            "[0.-1.j]",
-            "[0.-1.j]",
-            "[0.+infj]",
-            "[0.+infj]",
-            "[0.+infj]",
-            "[0.-infj]",
-            "[0.-infj]",
-            "[0.-infj]",
-            "[0.+nanj]",
-            "[0.+nanj]",
-            "[0.+nanj]",
-            "[1.+0.j]",
-            "[1.+0.j]",
-            "[1.+0.j]",
-            "[1.+1.j]",
-            "[1.+1.j]",
-            "[1.+1.j]",
-            "[1.-1.j]",
-            "[1.-1.j]",
-            "[1.-1.j]",
-            "[1.+infj]",
-            "[1.+infj]",
-            "[1.+infj]",
-            "[1.-infj]",
-            "[1.-infj]",
-            "[1.-infj]",
-            "[1.+nanj]",
-            "[1.+nanj]",
-            "[1.+nanj]",
-            "[-1.+0.j]",
-            "[-1.+0.j]",
-            "[-1.+0.j]",
-            "[-1.+1.j]",
-            "[-1.+1.j]",
-            "[-1.+1.j]",
-            "[-1.-1.j]",
-            "[-1.-1.j]",
-            "[-1.-1.j]",
-            "[-1.+infj]",
-            "[-1.+infj]",
-            "[-1.+infj]",
-            "[-1.-infj]",
-            "[-1.-infj]",
-            "[-1.-infj]",
-            "[-1.+nanj]",
-            "[-1.+nanj]",
-            "[-1.+nanj]",
-            "[inf+0.j]",
-            "[inf+0.j]",
-            "[inf+0.j]",
-            "[inf+1.j]",
-            "[inf+1.j]",
-            "[inf+1.j]",
-            "[inf-1.j]",
-            "[inf-1.j]",
-            "[inf-1.j]",
-            "[inf+infj]",
-            "[inf+infj]",
-            "[inf+infj]",
-            "[inf-infj]",
-            "[inf-infj]",
-            "[inf-infj]",
-            "[inf+nanj]",
-            "[inf+nanj]",
-            "[inf+nanj]",
-            "[-inf+0.j]",
-            "[-inf+0.j]",
-            "[-inf+0.j]",
-            "[-inf+1.j]",
-            "[-inf+1.j]",
-            "[-inf+1.j]",
-            "[-inf-1.j]",
-            "[-inf-1.j]",
-            "[-inf-1.j]",
-            "[-inf+infj]",
-            "[-inf+infj]",
-            "[-inf+infj]",
-            "[-inf-infj]",
-            "[-inf-infj]",
-            "[-inf-infj]",
-            "[-inf+nanj]",
-            "[-inf+nanj]",
-            "[-inf+nanj]",
-            "[nan+0.j]",
-            "[nan+0.j]",
-            "[nan+0.j]",
-            "[nan+1.j]",
-            "[nan+1.j]",
-            "[nan+1.j]",
-            "[nan-1.j]",
-            "[nan-1.j]",
-            "[nan-1.j]",
-            "[nan+infj]",
-            "[nan+infj]",
-            "[nan+infj]",
-            "[nan-infj]",
-            "[nan-infj]",
-            "[nan-infj]",
-            "[nan+nanj]",
-            "[nan+nanj]",
-            "[nan+nanj]",
-        ]
+            '[0.+0.j]',    '[0.+0.j]',    '[0.+0.j]',
+            '[0.+1.j]',    '[0.+1.j]',    '[0.+1.j]',
+            '[0.-1.j]',    '[0.-1.j]',    '[0.-1.j]',
+            '[0.+infj]',   '[0.+infj]',   '[0.+infj]',
+            '[0.-infj]',   '[0.-infj]',   '[0.-infj]',
+            '[0.+nanj]',   '[0.+nanj]',   '[0.+nanj]',
+            '[1.+0.j]',    '[1.+0.j]',    '[1.+0.j]',
+            '[1.+1.j]',    '[1.+1.j]',    '[1.+1.j]',
+            '[1.-1.j]',    '[1.-1.j]',    '[1.-1.j]',
+            '[1.+infj]',   '[1.+infj]',   '[1.+infj]',
+            '[1.-infj]',   '[1.-infj]',   '[1.-infj]',
+            '[1.+nanj]',   '[1.+nanj]',   '[1.+nanj]',
+            '[-1.+0.j]',   '[-1.+0.j]',   '[-1.+0.j]',
+            '[-1.+1.j]',   '[-1.+1.j]',   '[-1.+1.j]',
+            '[-1.-1.j]',   '[-1.-1.j]',   '[-1.-1.j]',
+            '[-1.+infj]',  '[-1.+infj]',  '[-1.+infj]',
+            '[-1.-infj]',  '[-1.-infj]',  '[-1.-infj]',
+            '[-1.+nanj]',  '[-1.+nanj]',  '[-1.+nanj]',
+            '[inf+0.j]',   '[inf+0.j]',   '[inf+0.j]',
+            '[inf+1.j]',   '[inf+1.j]',   '[inf+1.j]',
+            '[inf-1.j]',   '[inf-1.j]',   '[inf-1.j]',
+            '[inf+infj]',  '[inf+infj]',  '[inf+infj]',
+            '[inf-infj]',  '[inf-infj]',  '[inf-infj]',
+            '[inf+nanj]',  '[inf+nanj]',  '[inf+nanj]',
+            '[-inf+0.j]',  '[-inf+0.j]',  '[-inf+0.j]',
+            '[-inf+1.j]',  '[-inf+1.j]',  '[-inf+1.j]',
+            '[-inf-1.j]',  '[-inf-1.j]',  '[-inf-1.j]',
+            '[-inf+infj]', '[-inf+infj]', '[-inf+infj]',
+            '[-inf-infj]', '[-inf-infj]', '[-inf-infj]',
+            '[-inf+nanj]', '[-inf+nanj]', '[-inf+nanj]',
+            '[nan+0.j]',   '[nan+0.j]',   '[nan+0.j]',
+            '[nan+1.j]',   '[nan+1.j]',   '[nan+1.j]',
+            '[nan-1.j]',   '[nan-1.j]',   '[nan-1.j]',
+            '[nan+infj]',  '[nan+infj]',  '[nan+infj]',
+            '[nan-infj]',  '[nan-infj]',  '[nan-infj]',
+            '[nan+nanj]',  '[nan+nanj]',  '[nan+nanj]']
 
         for res, val in zip(actual, wanted):
             assert_equal(res, val)
-
 
 class TestArray2String:
     def test_basic(self):
         """Basic test of array2string."""
         a = np.arange(3)
-        assert_(np.array2string(a) == "[0 1 2]")
-        assert_(np.array2string(a, max_line_width=4, legacy="1.13") == "[0 1\n 2]")
-        assert_(np.array2string(a, max_line_width=4) == "[0\n 1\n 2]")
+        assert_(np.array2string(a) == '[0 1 2]')
+        assert_(np.array2string(a, max_line_width=4, legacy='1.13') == '[0 1\n 2]')
+        assert_(np.array2string(a, max_line_width=4) == '[0\n 1\n 2]')
 
     def test_unexpected_kwarg(self):
         # ensure than an appropriate TypeError
         # is raised when array2string receives
         # an unexpected kwarg
 
-        with assert_raises_regex(TypeError, "nonsense"):
-            np.array2string(np.array([1, 2, 3]), nonsense=None)
+        with assert_raises_regex(TypeError, 'nonsense'):
+            np.array2string(np.array([1, 2, 3]),
+                            nonsense=None)
 
     def test_format_function(self):
         """Test custom format function for each element in array."""
-
         def _format_function(x):
             if np.abs(x) < 1:
-                return "."
+                return '.'
             elif np.abs(x) < 2:
-                return "o"
+                return 'o'
             else:
-                return "O"
+                return 'O'
 
         x = np.arange(3)
         x_hex = "[0x0 0x1 0x2]"
         x_oct = "[0o0 0o1 0o2]"
-        assert_(np.array2string(x, formatter={"all": _format_function}) == "[. o O]")
-        assert_(
-            np.array2string(x, formatter={"int_kind": _format_function}) == "[. o O]"
-        )
-        assert_(
-            np.array2string(x, formatter={"all": lambda x: "%.4f" % x})
-            == "[0.0000 1.0000 2.0000]"
-        )
-        assert_equal(np.array2string(x, formatter={"int": lambda x: hex(x)}), x_hex)
-        assert_equal(np.array2string(x, formatter={"int": lambda x: oct(x)}), x_oct)
+        assert_(np.array2string(x, formatter={'all':_format_function}) ==
+                "[. o O]")
+        assert_(np.array2string(x, formatter={'int_kind':_format_function}) ==
+                "[. o O]")
+        assert_(np.array2string(x, formatter={'all':lambda x: "%.4f" % x}) ==
+                "[0.0000 1.0000 2.0000]")
+        assert_equal(np.array2string(x, formatter={'int':lambda x: hex(x)}),
+                x_hex)
+        assert_equal(np.array2string(x, formatter={'int':lambda x: oct(x)}),
+                x_oct)
 
-        x = np.arange(3.0)
-        assert_(
-            np.array2string(x, formatter={"float_kind": lambda x: "%.2f" % x})
-            == "[0.00 1.00 2.00]"
-        )
-        assert_(
-            np.array2string(x, formatter={"float": lambda x: "%.2f" % x})
-            == "[0.00 1.00 2.00]"
-        )
+        x = np.arange(3.)
+        assert_(np.array2string(x, formatter={'float_kind':lambda x: "%.2f" % x}) ==
+                "[0.00 1.00 2.00]")
+        assert_(np.array2string(x, formatter={'float':lambda x: "%.2f" % x}) ==
+                "[0.00 1.00 2.00]")
 
-        s = np.array(["abc", "def"])
-        assert_(
-            np.array2string(s, formatter={"numpystr": lambda s: s * 2})
-            == "[abcabc defdef]"
-        )
+        s = np.array(['abc', 'def'])
+        assert_(np.array2string(s, formatter={'numpystr':lambda s: s*2}) ==
+                '[abcabc defdef]')
+
 
     def test_structure_format(self):
-        dt = np.dtype([("name", np.str_, 16), ("grades", np.float64, (2,))])
-        x = np.array([("Sarah", (8.0, 7.0)), ("John", (6.0, 7.0))], dtype=dt)
-        assert_equal(np.array2string(x), "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
+        dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
+        x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)
+        assert_equal(np.array2string(x),
+                "[('Sarah', [8., 7.]) ('John', [6., 7.])]")
 
-        np.set_printoptions(legacy="1.13")
+        np.set_printoptions(legacy='1.13')
         try:
             # for issue #5692
             A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
-            A[5:].fill(np.datetime64("NaT"))
+            A[5:].fill(np.datetime64('NaT'))
             assert_equal(
                 np.array2string(A),
-                textwrap.dedent(
-                    """\
+                textwrap.dedent("""\
                 [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
                  ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('NaT',) ('NaT',)
-                 ('NaT',) ('NaT',) ('NaT',)]"""
-                ),
+                 ('NaT',) ('NaT',) ('NaT',)]""")
             )
         finally:
             np.set_printoptions(legacy=False)
@@ -370,56 +283,46 @@ class TestArray2String:
         # same again, but with non-legacy behavior
         assert_equal(
             np.array2string(A),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
              ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
              ('1970-01-01T00:00:00',) (                'NaT',)
              (                'NaT',) (                'NaT',)
-             (                'NaT',) (                'NaT',)]"""
-            ),
+             (                'NaT',) (                'NaT',)]""")
         )
 
         # and again, with timedeltas
         A = np.full(10, 123456, dtype=[("A", "m8[s]")])
-        A[5:].fill(np.datetime64("NaT"))
+        A[5:].fill(np.datetime64('NaT'))
         assert_equal(
             np.array2string(A),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             [(123456,) (123456,) (123456,) (123456,) (123456,) ( 'NaT',) ( 'NaT',)
-             ( 'NaT',) ( 'NaT',) ( 'NaT',)]"""
-            ),
+             ( 'NaT',) ( 'NaT',) ( 'NaT',)]""")
         )
 
         # See #8160
-        struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[("B", "i4", 2)])
-        assert_equal(np.array2string(struct_int), "[([  1,  -1],) ([123,   1],)]")
-        struct_2dint = np.array(
-            [([[0, 1], [2, 3]],), ([[12, 0], [0, 0]],)], dtype=[("B", "i4", (2, 2))]
-        )
-        assert_equal(
-            np.array2string(struct_2dint),
-            "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]",
-        )
+        struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[('B', 'i4', 2)])
+        assert_equal(np.array2string(struct_int),
+                "[([  1,  -1],) ([123,   1],)]")
+        struct_2dint = np.array([([[0, 1], [2, 3]],), ([[12, 0], [0, 0]],)],
+                dtype=[('B', 'i4', (2, 2))])
+        assert_equal(np.array2string(struct_2dint),
+                "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]")
 
         # See #8172
-        array_scalar = np.array((1.0, 2.1234567890123456789, 3.0), dtype=("f8,f8,f8"))
+        array_scalar = np.array(
+                (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))
         assert_equal(np.array2string(array_scalar), "(1., 2.12345679, 3.)")
 
     def test_unstructured_void_repr(self):
-        a = np.array(
-            [27, 91, 50, 75, 7, 65, 10, 8, 27, 91, 51, 49, 109, 82, 101, 100],
-            dtype="u1",
-        ).view("V8")
+        a = np.array([27, 91, 50, 75,  7, 65, 10,  8,
+                      27, 91, 51, 49,109, 82,101,100], dtype='u1').view('V8')
         assert_equal(repr(a[0]), r"void(b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08')")
         assert_equal(str(a[0]), r"b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'")
-        assert_equal(
-            repr(a),
-            r"array([b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08',"
-            "\n"
-            r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64'], dtype='|V8')",
-        )
+        assert_equal(repr(a),
+            r"array([b'\x1B\x5B\x32\x4B\x07\x41\x0A\x08'," "\n"
+            r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64'], dtype='|V8')")
 
         assert_equal(eval(repr(a), vars(np)), a)
         assert_equal(eval(repr(a[0]), vars(np)), a[0])
@@ -427,28 +330,27 @@ class TestArray2String:
     def test_edgeitems_kwarg(self):
         # previously the global print options would be taken over the kwarg
         arr = np.zeros(3, int)
-        assert_equal(np.array2string(arr, edgeitems=1, threshold=0), "[0 ... 0]")
+        assert_equal(
+            np.array2string(arr, edgeitems=1, threshold=0),
+            "[0 ... 0]"
+        )
 
     def test_summarize_1d(self):
         A = np.arange(1001)
-        strA = "[   0    1    2 ...  998  999 1000]"
+        strA = '[   0    1    2 ...  998  999 1000]'
         assert_equal(str(A), strA)
 
-        reprA = "array([   0,    1,    2, ...,  998,  999, 1000])"
+        reprA = 'array([   0,    1,    2, ...,  998,  999, 1000])'
         assert_equal(repr(A), reprA)
 
     def test_summarize_2d(self):
         A = np.arange(1002).reshape(2, 501)
-        strA = (
-            "[[   0    1    2 ...  498  499  500]\n"
-            " [ 501  502  503 ...  999 1000 1001]]"
-        )
+        strA = '[[   0    1    2 ...  498  499  500]\n' \
+               ' [ 501  502  503 ...  999 1000 1001]]'
         assert_equal(str(A), strA)
 
-        reprA = (
-            "array([[   0,    1,    2, ...,  498,  499,  500],\n"
-            "       [ 501,  502,  503, ...,  999, 1000, 1001]])"
-        )
+        reprA = 'array([[   0,    1,    2, ...,  498,  499,  500],\n' \
+                '       [ 501,  502,  503, ...,  999, 1000, 1001]])'
         assert_equal(repr(A), reprA)
 
     def test_linewidth(self):
@@ -457,28 +359,41 @@ class TestArray2String:
         def make_str(a, width, **kw):
             return np.array2string(a, separator="", max_line_width=width, **kw)
 
-        assert_equal(make_str(a, 8, legacy="1.13"), "[111111]")
-        assert_equal(make_str(a, 7, legacy="1.13"), "[111111]")
-        assert_equal(make_str(a, 5, legacy="1.13"), "[1111\n" " 11]")
+        assert_equal(make_str(a, 8, legacy='1.13'), '[111111]')
+        assert_equal(make_str(a, 7, legacy='1.13'), '[111111]')
+        assert_equal(make_str(a, 5, legacy='1.13'), '[1111\n'
+                                                    ' 11]')
 
-        assert_equal(make_str(a, 8), "[111111]")
-        assert_equal(make_str(a, 7), "[11111\n" " 1]")
-        assert_equal(make_str(a, 5), "[111\n" " 111]")
+        assert_equal(make_str(a, 8), '[111111]')
+        assert_equal(make_str(a, 7), '[11111\n'
+                                     ' 1]')
+        assert_equal(make_str(a, 5), '[111\n'
+                                     ' 111]')
 
-        b = a[None, None, :]
+        b = a[None,None,:]
 
-        assert_equal(make_str(b, 12, legacy="1.13"), "[[[111111]]]")
-        assert_equal(make_str(b, 9, legacy="1.13"), "[[[111111]]]")
-        assert_equal(make_str(b, 8, legacy="1.13"), "[[[11111\n" "   1]]]")
+        assert_equal(make_str(b, 12, legacy='1.13'), '[[[111111]]]')
+        assert_equal(make_str(b,  9, legacy='1.13'), '[[[111111]]]')
+        assert_equal(make_str(b,  8, legacy='1.13'), '[[[11111\n'
+                                                     '   1]]]')
 
-        assert_equal(make_str(b, 12), "[[[111111]]]")
-        assert_equal(make_str(b, 9), "[[[111\n" "   111]]]")
-        assert_equal(make_str(b, 8), "[[[11\n" "   11\n" "   11]]]")
+        assert_equal(make_str(b, 12), '[[[111111]]]')
+        assert_equal(make_str(b,  9), '[[[111\n'
+                                      '   111]]]')
+        assert_equal(make_str(b,  8), '[[[11\n'
+                                      '   11\n'
+                                      '   11]]]')
 
     def test_wide_element(self):
-        a = np.array(["xxxxx"])
-        assert_equal(np.array2string(a, max_line_width=5), "['xxxxx']")
-        assert_equal(np.array2string(a, max_line_width=5, legacy="1.13"), "[ 'xxxxx']")
+        a = np.array(['xxxxx'])
+        assert_equal(
+            np.array2string(a, max_line_width=5),
+            "['xxxxx']"
+        )
+        assert_equal(
+            np.array2string(a, max_line_width=5, legacy='1.13'),
+            "[ 'xxxxx']"
+        )
 
     def test_multiline_repr(self):
         class MultiLine:
@@ -489,18 +404,26 @@ class TestArray2String:
 
         assert_equal(
             np.array2string(a),
-            "[[None Line 1\n" "       Line 2]\n" " [Line 1\n" "  Line 2 None]]",
+            '[[None Line 1\n'
+            '       Line 2]\n'
+            ' [Line 1\n'
+            '  Line 2 None]]'
         )
         assert_equal(
             np.array2string(a, max_line_width=5),
-            "[[None\n" "  Line 1\n" "  Line 2]\n" " [Line 1\n" "  Line 2\n" "  None]]",
+            '[[None\n'
+            '  Line 1\n'
+            '  Line 2]\n'
+            ' [Line 1\n'
+            '  Line 2\n'
+            '  None]]'
         )
         assert_equal(
             repr(a),
-            "array([[None, Line 1\n"
-            "              Line 2],\n"
-            "       [Line 1\n"
-            "        Line 2, None]], dtype=object)",
+            'array([[None, Line 1\n'
+            '              Line 2],\n'
+            '       [Line 1\n'
+            '        Line 2, None]], dtype=object)'
         )
 
         class MultiLineLong:
@@ -510,24 +433,24 @@ class TestArray2String:
         a = np.array([[None, MultiLineLong()], [MultiLineLong(), None]])
         assert_equal(
             repr(a),
-            "array([[None, Line 1\n"
-            "              LooooooooooongestLine2\n"
-            "              LongerLine 3          ],\n"
-            "       [Line 1\n"
-            "        LooooooooooongestLine2\n"
-            "        LongerLine 3          , None]], dtype=object)",
+            'array([[None, Line 1\n'
+            '              LooooooooooongestLine2\n'
+            '              LongerLine 3          ],\n'
+            '       [Line 1\n'
+            '        LooooooooooongestLine2\n'
+            '        LongerLine 3          , None]], dtype=object)'
         )
         assert_equal(
             np.array_repr(a, 20),
-            "array([[None,\n"
-            "        Line 1\n"
-            "        LooooooooooongestLine2\n"
-            "        LongerLine 3          ],\n"
-            "       [Line 1\n"
-            "        LooooooooooongestLine2\n"
-            "        LongerLine 3          ,\n"
-            "        None]],\n"
-            "      dtype=object)",
+            'array([[None,\n'
+            '        Line 1\n'
+            '        LooooooooooongestLine2\n'
+            '        LongerLine 3          ],\n'
+            '       [Line 1\n'
+            '        LooooooooooongestLine2\n'
+            '        LongerLine 3          ,\n'
+            '        None]],\n'
+            '      dtype=object)'
         )
 
     def test_nested_array_repr(self):
@@ -538,13 +461,13 @@ class TestArray2String:
         a[1, 1] = np.ones((3, 1))
         assert_equal(
             repr(a),
-            "array([[array([[1., 0.],\n"
-            "               [0., 1.]]), array([[1., 0., 0.],\n"
-            "                                  [0., 1., 0.],\n"
-            "                                  [0., 0., 1.]])],\n"
-            "       [None, array([[1.],\n"
-            "                     [1.],\n"
-            "                     [1.]])]], dtype=object)",
+            'array([[array([[1., 0.],\n'
+            '               [0., 1.]]), array([[1., 0., 0.],\n'
+            '                                  [0., 1., 0.],\n'
+            '                                  [0., 0., 1.]])],\n'
+            '       [None, array([[1.],\n'
+            '                     [1.],\n'
+            '                     [1.]])]], dtype=object)'
         )
 
     @given(hynp.from_dtype(np.dtype("U")))
@@ -573,7 +496,6 @@ class TestArray2String:
         gc.enable()
         assert_(r1 == r2)
 
-
 class TestPrintOptions:
     """Test getting and setting global print options."""
 
@@ -592,371 +514,310 @@ class TestPrintOptions:
     def test_precision_zero(self):
         np.set_printoptions(precision=0)
         for values, string in (
-            ([0.0], "0."),
-            ([0.3], "0."),
-            ([-0.3], "-0."),
-            ([0.7], "1."),
-            ([1.5], "2."),
-            ([-1.5], "-2."),
-            ([-15.34], "-15."),
-            ([100.0], "100."),
-            ([0.2, -1, 122.51], "  0.,  -1., 123."),
-            ([0], "0"),
-            ([-12], "-12"),
-            ([complex(0.3, -0.7)], "0.-1.j"),
-        ):
+                ([0.], "0."), ([.3], "0."), ([-.3], "-0."), ([.7], "1."),
+                ([1.5], "2."), ([-1.5], "-2."), ([-15.34], "-15."),
+                ([100.], "100."), ([.2, -1, 122.51], "  0.,  -1., 123."),
+                ([0], "0"), ([-12], "-12"), ([complex(.3, -.7)], "0.-1.j")):
             x = np.array(values)
             assert_equal(repr(x), "array([%s])" % string)
 
     def test_formatter(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
+        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
 
     def test_formatter_reset(self):
         x = np.arange(3)
-        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
+        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={"int": None})
+        np.set_printoptions(formatter={'int':None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={"all": lambda x: str(x - 1)})
+        np.set_printoptions(formatter={'all':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={"all": None})
+        np.set_printoptions(formatter={'all':None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        np.set_printoptions(formatter={"int": lambda x: str(x - 1)})
+        np.set_printoptions(formatter={'int':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1, 0, 1])")
-        np.set_printoptions(formatter={"int_kind": None})
+        np.set_printoptions(formatter={'int_kind':None})
         assert_equal(repr(x), "array([0, 1, 2])")
 
-        x = np.arange(3.0)
-        np.set_printoptions(formatter={"float": lambda x: str(x - 1)})
+        x = np.arange(3.)
+        np.set_printoptions(formatter={'float':lambda x: str(x-1)})
         assert_equal(repr(x), "array([-1.0, 0.0, 1.0])")
-        np.set_printoptions(formatter={"float_kind": None})
+        np.set_printoptions(formatter={'float_kind':None})
         assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
-        assert_equal(str(np.array("café", "<U4")), "café")
+        assert_equal(str(np.array('café', '<U4')), 'café')
 
-        assert_equal(repr(np.array("café", "<U4")), "array('café', dtype='<U4')")
-        assert_equal(str(np.array("test", np.str_)), "test")
+        assert_equal(repr(np.array('café', '<U4')),
+                     "array('café', dtype='<U4')")
+        assert_equal(str(np.array('test', np.str_)), 'test')
 
-        a = np.zeros(1, dtype=[("a", "<i4", (3,))])
-        assert_equal(str(a[0]), "([0, 0, 0],)")
+        a = np.zeros(1, dtype=[('a', '<i4', (3,))])
+        assert_equal(str(a[0]), '([0, 0, 0],)')
 
-        assert_equal(
-            repr(np.datetime64("2005-02-25")[...]),
-            "array('2005-02-25', dtype='datetime64[D]')",
-        )
+        assert_equal(repr(np.datetime64('2005-02-25')[...]),
+                     "array('2005-02-25', dtype='datetime64[D]')")
 
-        assert_equal(
-            repr(np.timedelta64("10", "Y")[...]), "array(10, dtype='timedelta64[Y]')"
-        )
+        assert_equal(repr(np.timedelta64('10', 'Y')[...]),
+                     "array(10, dtype='timedelta64[Y]')")
 
         # repr of 0d arrays is affected by printoptions
         x = np.array(1)
-        np.set_printoptions(formatter={"all": lambda x: "test"})
+        np.set_printoptions(formatter={'all':lambda x: "test"})
         assert_equal(repr(x), "array(test)")
         # str is unaffected
         assert_equal(str(x), "1")
 
         # check `style` arg raises
-        assert_warns(DeprecationWarning, np.array2string, np.array(1.0), style=repr)
+        assert_warns(DeprecationWarning, np.array2string,
+                                         np.array(1.), style=repr)
         # but not in legacy mode
-        np.array2string(np.array(1.0), style=repr, legacy="1.13")
+        np.array2string(np.array(1.), style=repr, legacy='1.13')
         # gh-10934 style was broken in legacy mode, check it works
-        np.array2string(np.array(1.0), legacy="1.13")
+        np.array2string(np.array(1.), legacy='1.13')
 
     def test_float_spacing(self):
-        x = np.array([1.0, 2.0, 3.0])
-        y = np.array([1.0, 2.0, -10.0])
-        z = np.array([100.0, 2.0, -1.0])
-        w = np.array([-100.0, 2.0, 1.0])
+        x = np.array([1., 2., 3.])
+        y = np.array([1., 2., -10.])
+        z = np.array([100., 2., -1.])
+        w = np.array([-100., 2., 1.])
 
-        assert_equal(repr(x), "array([1., 2., 3.])")
-        assert_equal(repr(y), "array([  1.,   2., -10.])")
-        assert_equal(repr(np.array(y[0])), "array(1.)")
-        assert_equal(repr(np.array(y[-1])), "array(-10.)")
-        assert_equal(repr(z), "array([100.,   2.,  -1.])")
-        assert_equal(repr(w), "array([-100.,    2.,    1.])")
+        assert_equal(repr(x), 'array([1., 2., 3.])')
+        assert_equal(repr(y), 'array([  1.,   2., -10.])')
+        assert_equal(repr(np.array(y[0])), 'array(1.)')
+        assert_equal(repr(np.array(y[-1])), 'array(-10.)')
+        assert_equal(repr(z), 'array([100.,   2.,  -1.])')
+        assert_equal(repr(w), 'array([-100.,    2.,    1.])')
 
-        assert_equal(repr(np.array([np.nan, np.inf])), "array([nan, inf])")
-        assert_equal(repr(np.array([np.nan, -np.inf])), "array([ nan, -inf])")
+        assert_equal(repr(np.array([np.nan, np.inf])), 'array([nan, inf])')
+        assert_equal(repr(np.array([np.nan, -np.inf])), 'array([ nan, -inf])')
 
         x = np.array([np.inf, 100000, 1.1234])
         y = np.array([np.inf, 100000, -1.1234])
         z = np.array([np.inf, 1.1234, -1e120])
         np.set_printoptions(precision=2)
-        assert_equal(repr(x), "array([     inf, 1.00e+05, 1.12e+00])")
-        assert_equal(repr(y), "array([      inf,  1.00e+05, -1.12e+00])")
-        assert_equal(repr(z), "array([       inf,  1.12e+000, -1.00e+120])")
+        assert_equal(repr(x), 'array([     inf, 1.00e+05, 1.12e+00])')
+        assert_equal(repr(y), 'array([      inf,  1.00e+05, -1.12e+00])')
+        assert_equal(repr(z), 'array([       inf,  1.12e+000, -1.00e+120])')
 
     def test_bool_spacing(self):
-        assert_equal(repr(np.array([True, True])), "array([ True,  True])")
-        assert_equal(repr(np.array([True, False])), "array([ True, False])")
-        assert_equal(repr(np.array([True])), "array([ True])")
-        assert_equal(repr(np.array(True)), "array(True)")
-        assert_equal(repr(np.array(False)), "array(False)")
+        assert_equal(repr(np.array([True,  True])),
+                     'array([ True,  True])')
+        assert_equal(repr(np.array([True, False])),
+                     'array([ True, False])')
+        assert_equal(repr(np.array([True])),
+                     'array([ True])')
+        assert_equal(repr(np.array(True)),
+                     'array(True)')
+        assert_equal(repr(np.array(False)),
+                     'array(False)')
 
     def test_sign_spacing(self):
-        a = np.arange(4.0)
+        a = np.arange(4.)
         b = np.array([1.234e9])
-        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype="c16")
+        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
 
-        assert_equal(repr(a), "array([0., 1., 2., 3.])")
-        assert_equal(repr(np.array(1.0)), "array(1.)")
-        assert_equal(repr(b), "array([1.234e+09])")
-        assert_equal(repr(np.array([0.0])), "array([0.])")
-        assert_equal(repr(c), "array([1.        +1.j        , 1.12345679+1.12345679j])")
-        assert_equal(repr(np.array([0.0, -0.0])), "array([ 0., -0.])")
+        assert_equal(repr(a), 'array([0., 1., 2., 3.])')
+        assert_equal(repr(np.array(1.)), 'array(1.)')
+        assert_equal(repr(b), 'array([1.234e+09])')
+        assert_equal(repr(np.array([0.])), 'array([0.])')
+        assert_equal(repr(c),
+            "array([1.        +1.j        , 1.12345679+1.12345679j])")
+        assert_equal(repr(np.array([0., -0.])), 'array([ 0., -0.])')
 
-        np.set_printoptions(sign=" ")
-        assert_equal(repr(a), "array([ 0.,  1.,  2.,  3.])")
-        assert_equal(repr(np.array(1.0)), "array( 1.)")
-        assert_equal(repr(b), "array([ 1.234e+09])")
-        assert_equal(
-            repr(c), "array([ 1.        +1.j        ,  1.12345679+1.12345679j])"
-        )
-        assert_equal(repr(np.array([0.0, -0.0])), "array([ 0., -0.])")
+        np.set_printoptions(sign=' ')
+        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
+        assert_equal(repr(np.array(1.)), 'array( 1.)')
+        assert_equal(repr(b), 'array([ 1.234e+09])')
+        assert_equal(repr(c),
+            "array([ 1.        +1.j        ,  1.12345679+1.12345679j])")
+        assert_equal(repr(np.array([0., -0.])), 'array([ 0., -0.])')
 
-        np.set_printoptions(sign="+")
-        assert_equal(repr(a), "array([+0., +1., +2., +3.])")
-        assert_equal(repr(np.array(1.0)), "array(+1.)")
-        assert_equal(repr(b), "array([+1.234e+09])")
-        assert_equal(
-            repr(c), "array([+1.        +1.j        , +1.12345679+1.12345679j])"
-        )
+        np.set_printoptions(sign='+')
+        assert_equal(repr(a), 'array([+0., +1., +2., +3.])')
+        assert_equal(repr(np.array(1.)), 'array(+1.)')
+        assert_equal(repr(b), 'array([+1.234e+09])')
+        assert_equal(repr(c),
+            "array([+1.        +1.j        , +1.12345679+1.12345679j])")
 
-        np.set_printoptions(legacy="1.13")
-        assert_equal(repr(a), "array([ 0.,  1.,  2.,  3.])")
-        assert_equal(repr(b), "array([  1.23400000e+09])")
-        assert_equal(repr(-b), "array([ -1.23400000e+09])")
-        assert_equal(repr(np.array(1.0)), "array(1.0)")
-        assert_equal(repr(np.array([0.0])), "array([ 0.])")
-        assert_equal(
-            repr(c), "array([ 1.00000000+1.j        ,  1.12345679+1.12345679j])"
-        )
+        np.set_printoptions(legacy='1.13')
+        assert_equal(repr(a), 'array([ 0.,  1.,  2.,  3.])')
+        assert_equal(repr(b),  'array([  1.23400000e+09])')
+        assert_equal(repr(-b), 'array([ -1.23400000e+09])')
+        assert_equal(repr(np.array(1.)), 'array(1.0)')
+        assert_equal(repr(np.array([0.])), 'array([ 0.])')
+        assert_equal(repr(c),
+            "array([ 1.00000000+1.j        ,  1.12345679+1.12345679j])")
         # gh-10383
-        assert_equal(str(np.array([-1.0, 10])), "[ -1.  10.]")
+        assert_equal(str(np.array([-1., 10])), "[ -1.  10.]")
 
         assert_raises(TypeError, np.set_printoptions, wrongarg=True)
 
     def test_float_overflow_nowarn(self):
         # make sure internal computations in FloatingFormat don't
         # warn about overflow
-        repr(np.array([1e4, 0.1], dtype="f2"))
+        repr(np.array([1e4, 0.1], dtype='f2'))
 
     def test_sign_spacing_structured(self):
-        a = np.ones(2, dtype="<f,<f")
-        assert_equal(
-            repr(a), "array([(1., 1.), (1., 1.)], dtype=[('f0', '<f4'), ('f1', '<f4')])"
-        )
+        a = np.ones(2, dtype='<f,<f')
+        assert_equal(repr(a),
+            "array([(1., 1.), (1., 1.)], dtype=[('f0', '<f4'), ('f1', '<f4')])")
         assert_equal(repr(a[0]), "(1., 1.)")
 
     def test_floatmode(self):
-        x = np.array(
-            [
-                0.6104,
-                0.922,
-                0.457,
-                0.0906,
-                0.3733,
-                0.007244,
-                0.5933,
-                0.947,
-                0.2383,
-                0.4226,
-            ],
-            dtype=np.float16,
-        )
-        y = np.array(
-            [
-                0.2918820979355541,
-                0.5064172631089138,
-                0.2848750619642916,
-                0.4342965294660567,
-                0.7326538397312751,
-                0.3459503329096204,
-                0.0862072768214508,
-                0.39112753029631175,
-            ],
-            dtype=np.float64,
-        )
-        z = np.arange(6, dtype=np.float16) / 10
-        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype="c16")
+        x = np.array([0.6104, 0.922, 0.457, 0.0906, 0.3733, 0.007244,
+                      0.5933, 0.947, 0.2383, 0.4226], dtype=np.float16)
+        y = np.array([0.2918820979355541, 0.5064172631089138,
+                      0.2848750619642916, 0.4342965294660567,
+                      0.7326538397312751, 0.3459503329096204,
+                      0.0862072768214508, 0.39112753029631175],
+                      dtype=np.float64)
+        z = np.arange(6, dtype=np.float16)/10
+        c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
 
         # also make sure 1e23 is right (is between two fp numbers)
-        w = np.array([f"1e{i}" for i in range(25)], dtype=np.float64)
+        w = np.array(['1e{}'.format(i) for i in range(25)], dtype=np.float64)
         # note: we construct w from the strings `1eXX` instead of doing
         # `10.**arange(24)` because it turns out the two are not equivalent in
         # python. On some architectures `1e23 != 10.**23`.
         wp = np.array([1.234e1, 1e2, 1e123])
 
         # unique mode
-        np.set_printoptions(floatmode="unique")
-        assert_equal(
-            repr(x),
+        np.set_printoptions(floatmode='unique')
+        assert_equal(repr(x),
             "array([0.6104  , 0.922   , 0.457   , 0.0906  , 0.3733  , 0.007244,\n"
-            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)",
-        )
-        assert_equal(
-            repr(y),
+            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)")
+        assert_equal(repr(y),
             "array([0.2918820979355541 , 0.5064172631089138 , 0.2848750619642916 ,\n"
             "       0.4342965294660567 , 0.7326538397312751 , 0.3459503329096204 ,\n"
-            "       0.0862072768214508 , 0.39112753029631175])",
-        )
-        assert_equal(repr(z), "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(
-            repr(w),
+            "       0.0862072768214508 , 0.39112753029631175])")
+        assert_equal(repr(z),
+            "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(repr(w),
             "array([1.e+00, 1.e+01, 1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06, 1.e+07,\n"
             "       1.e+08, 1.e+09, 1.e+10, 1.e+11, 1.e+12, 1.e+13, 1.e+14, 1.e+15,\n"
             "       1.e+16, 1.e+17, 1.e+18, 1.e+19, 1.e+20, 1.e+21, 1.e+22, 1.e+23,\n"
-            "       1.e+24])",
-        )
+            "       1.e+24])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(
-            repr(c), "array([1.         +1.j         , 1.123456789+1.123456789j])"
-        )
+        assert_equal(repr(c),
+            "array([1.         +1.j         , 1.123456789+1.123456789j])")
 
         # maxprec mode, precision=8
-        np.set_printoptions(floatmode="maxprec", precision=8)
-        assert_equal(
-            repr(x),
+        np.set_printoptions(floatmode='maxprec', precision=8)
+        assert_equal(repr(x),
             "array([0.6104  , 0.922   , 0.457   , 0.0906  , 0.3733  , 0.007244,\n"
-            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)",
-        )
-        assert_equal(
-            repr(y),
+            "       0.5933  , 0.947   , 0.2383  , 0.4226  ], dtype=float16)")
+        assert_equal(repr(y),
             "array([0.2918821 , 0.50641726, 0.28487506, 0.43429653, 0.73265384,\n"
-            "       0.34595033, 0.08620728, 0.39112753])",
-        )
-        assert_equal(repr(z), "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(repr(w[::5]), "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
+            "       0.34595033, 0.08620728, 0.39112753])")
+        assert_equal(repr(z),
+            "array([0. , 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(repr(w[::5]),
+            "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(repr(c), "array([1.        +1.j        , 1.12345679+1.12345679j])")
+        assert_equal(repr(c),
+            "array([1.        +1.j        , 1.12345679+1.12345679j])")
 
         # fixed mode, precision=4
-        np.set_printoptions(floatmode="fixed", precision=4)
-        assert_equal(
-            repr(x),
+        np.set_printoptions(floatmode='fixed', precision=4)
+        assert_equal(repr(x),
             "array([0.6104, 0.9219, 0.4570, 0.0906, 0.3733, 0.0072, 0.5933, 0.9468,\n"
-            "       0.2383, 0.4226], dtype=float16)",
-        )
-        assert_equal(
-            repr(y),
-            "array([0.2919, 0.5064, 0.2849, 0.4343, 0.7327, 0.3460, 0.0862, 0.3911])",
-        )
-        assert_equal(
-            repr(z),
-            "array([0.0000, 0.1000, 0.2000, 0.3000, 0.3999, 0.5000], dtype=float16)",
-        )
-        assert_equal(
-            repr(w[::5]),
-            "array([1.0000e+00, 1.0000e+05, 1.0000e+10, 1.0000e+15, 1.0000e+20])",
-        )
+            "       0.2383, 0.4226], dtype=float16)")
+        assert_equal(repr(y),
+            "array([0.2919, 0.5064, 0.2849, 0.4343, 0.7327, 0.3460, 0.0862, 0.3911])")
+        assert_equal(repr(z),
+            "array([0.0000, 0.1000, 0.2000, 0.3000, 0.3999, 0.5000], dtype=float16)")
+        assert_equal(repr(w[::5]),
+            "array([1.0000e+00, 1.0000e+05, 1.0000e+10, 1.0000e+15, 1.0000e+20])")
         assert_equal(repr(wp), "array([1.2340e+001, 1.0000e+002, 1.0000e+123])")
         assert_equal(repr(np.zeros(3)), "array([0.0000, 0.0000, 0.0000])")
-        assert_equal(repr(c), "array([1.0000+1.0000j, 1.1235+1.1235j])")
+        assert_equal(repr(c),
+            "array([1.0000+1.0000j, 1.1235+1.1235j])")
         # for larger precision, representation error becomes more apparent:
-        np.set_printoptions(floatmode="fixed", precision=8)
-        assert_equal(
-            repr(z),
+        np.set_printoptions(floatmode='fixed', precision=8)
+        assert_equal(repr(z),
             "array([0.00000000, 0.09997559, 0.19995117, 0.30004883, 0.39990234,\n"
-            "       0.50000000], dtype=float16)",
-        )
+            "       0.50000000], dtype=float16)")
 
         # maxprec_equal  mode, precision=8
-        np.set_printoptions(floatmode="maxprec_equal", precision=8)
-        assert_equal(
-            repr(x),
+        np.set_printoptions(floatmode='maxprec_equal', precision=8)
+        assert_equal(repr(x),
             "array([0.610352, 0.921875, 0.457031, 0.090576, 0.373291, 0.007244,\n"
-            "       0.593262, 0.946777, 0.238281, 0.422607], dtype=float16)",
-        )
-        assert_equal(
-            repr(y),
+            "       0.593262, 0.946777, 0.238281, 0.422607], dtype=float16)")
+        assert_equal(repr(y),
             "array([0.29188210, 0.50641726, 0.28487506, 0.43429653, 0.73265384,\n"
-            "       0.34595033, 0.08620728, 0.39112753])",
-        )
-        assert_equal(repr(z), "array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
-        assert_equal(repr(w[::5]), "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
+            "       0.34595033, 0.08620728, 0.39112753])")
+        assert_equal(repr(z),
+            "array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5], dtype=float16)")
+        assert_equal(repr(w[::5]),
+            "array([1.e+00, 1.e+05, 1.e+10, 1.e+15, 1.e+20])")
         assert_equal(repr(wp), "array([1.234e+001, 1.000e+002, 1.000e+123])")
-        assert_equal(repr(c), "array([1.00000000+1.00000000j, 1.12345679+1.12345679j])")
+        assert_equal(repr(c),
+            "array([1.00000000+1.00000000j, 1.12345679+1.12345679j])")
 
         # test unique special case (gh-18609)
-        a = np.float64.fromhex("-1p-97")
-        assert_equal(np.float64(np.array2string(a, floatmode="unique")), a)
+        a = np.float64.fromhex('-1p-97')
+        assert_equal(np.float64(np.array2string(a, floatmode='unique')), a)
 
     def test_legacy_mode_scalars(self):
         # in legacy mode, str of floats get truncated, and complex scalars
         # use * for non-finite imaginary part
-        np.set_printoptions(legacy="1.13")
-        assert_equal(str(np.float64(1.123456789123456789)), "1.12345678912")
-        assert_equal(str(np.complex128(complex(1, np.nan))), "(1+nan*j)")
+        np.set_printoptions(legacy='1.13')
+        assert_equal(str(np.float64(1.123456789123456789)), '1.12345678912')
+        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nan*j)')
 
         np.set_printoptions(legacy=False)
-        assert_equal(str(np.float64(1.123456789123456789)), "1.1234567891234568")
-        assert_equal(str(np.complex128(complex(1, np.nan))), "(1+nanj)")
+        assert_equal(str(np.float64(1.123456789123456789)),
+                     '1.1234567891234568')
+        assert_equal(str(np.complex128(complex(1, np.nan))), '(1+nanj)')
 
     def test_legacy_stray_comma(self):
-        np.set_printoptions(legacy="1.13")
-        assert_equal(str(np.arange(10000)), "[   0    1    2 ..., 9997 9998 9999]")
+        np.set_printoptions(legacy='1.13')
+        assert_equal(str(np.arange(10000)), '[   0    1    2 ..., 9997 9998 9999]')
 
         np.set_printoptions(legacy=False)
-        assert_equal(str(np.arange(10000)), "[   0    1    2 ... 9997 9998 9999]")
+        assert_equal(str(np.arange(10000)), '[   0    1    2 ... 9997 9998 9999]')
 
     def test_dtype_linewidth_wrapping(self):
         np.set_printoptions(linewidth=75)
-        assert_equal(
-            repr(np.arange(10, 20.0, dtype="f4")),
-            "array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19.], dtype=float32)",
-        )
-        assert_equal(
-            repr(np.arange(10, 23.0, dtype="f4")),
-            textwrap.dedent(
-                """\
+        assert_equal(repr(np.arange(10,20., dtype='f4')),
+            "array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19.], dtype=float32)")
+        assert_equal(repr(np.arange(10,23., dtype='f4')), textwrap.dedent("""\
             array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22.],
-                  dtype=float32)"""
-            ),
-        )
+                  dtype=float32)"""))
 
-        styp = "<U4"
-        assert_equal(
-            repr(np.ones(3, dtype=styp)),
-            f"array(['1', '1', '1'], dtype='{styp}')",
-        )
-        assert_equal(
-            repr(np.ones(12, dtype=styp)),
-            textwrap.dedent(
-                """\
+        styp = '<U4'
+        assert_equal(repr(np.ones(3, dtype=styp)),
+            "array(['1', '1', '1'], dtype='{}')".format(styp))
+        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
-                  dtype='{}')""".format(
-                    styp
-                )
-            ),
-        )
+                  dtype='{}')""".format(styp)))
 
     def test_dtype_endianness_repr(self):
-        """
-        there was an issue where
+        '''
+        there was an issue where 
         repr(array([0], dtype='<u2')) and repr(array([0], dtype='>u2')) both returned the same thing:
         array([0], dtype=uint16)
         even though their dtypes have different endianness.
-        """
-        dtype_combos = [  # little-endian first, big-endian second
-            ("bool", "bool"),
-            ("uint8", "u1"),
-            ("uint16", ">u2"),
-            ("uint32", ">u4"),
-            ("uint64", ">u8"),
-            ("int16", ">i2"),
-            ("int32", ">i4"),
-            ("int64", ">i8"),
-            ("float16", ">e"),
-            ("float32", ">f"),
-            ("float64", ">d"),
-            ("<U", ">U"),  # string
-            ("<U1", ">U1"),  # 4-byte width string
+        '''
+        dtype_combos = [ # little-endian first, big-endian second
+            ('bool', 'bool'),
+            ('uint8', 'u1'),
+            ('uint16', '>u2'),
+            ('uint32', '>u4'),
+            ('uint64', '>u8'),
+            ('int16', '>i2'),
+            ('int32', '>i4'),
+            ('int64', '>i8'),
+            ('float16', '>e'),
+            ('float32', '>f'),
+            ('float64', '>d'),
+            ('<U', '>U'), # string
+            ('<U1', '>U1'), # 4-byte width string
         ]
         for little_end, big_end in dtype_combos:
             big_dtype = np.dtype(big_end)
@@ -964,42 +825,30 @@ class TestPrintOptions:
             big_end_repr = repr(np.array([1], big_dtype))
             little_end_repr = repr(np.array([1], little_dtype))
             # preserve the sensible default of only showing dtype if nonstandard
-            assert_(
-                not ("dtype" in big_end_repr and big_dtype in _typelessdata),
-                (
-                    "if a type has default size and endianness (e.g., int32, bool, float64) "
-                    "should not show dtype, but it does"
-                ),
-            )
+            assert_(not ('dtype' in big_end_repr and big_dtype in _typelessdata),
+                    ('if a type has default size and endianness (e.g., int32, bool, float64) '
+                    'should not show dtype, but it does'))
             # only show difference if > 1 byte
-            assert_(
-                not (big_end_repr == little_end_repr and big_dtype.itemsize > 1),
-                (
-                    "expected little endian repr != big endian repr, "
-                    f"but {little_end_repr = }, {big_end_repr = }"
-                ),
-            )
+            assert_(not (big_end_repr == little_end_repr and big_dtype.itemsize > 1),
+                    ('expected little endian repr != big endian repr, '
+                    f'but {little_end_repr = }, {big_end_repr = }'))
 
     def test_linewidth_repr(self):
         a = np.full(7, fill_value=2)
         np.set_printoptions(linewidth=17)
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([2, 2, 2,
                    2, 2, 2,
-                   2])"""
-            ),
+                   2])""")
         )
-        np.set_printoptions(linewidth=17, legacy="1.13")
+        np.set_printoptions(linewidth=17, legacy='1.13')
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([2, 2, 2,
-                   2, 2, 2, 2])"""
-            ),
+                   2, 2, 2, 2])""")
         )
 
         a = np.full(8, fill_value=2)
@@ -1007,22 +856,18 @@ class TestPrintOptions:
         np.set_printoptions(linewidth=18, legacy=False)
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([2, 2, 2,
                    2, 2, 2,
-                   2, 2])"""
-            ),
+                   2, 2])""")
         )
 
-        np.set_printoptions(linewidth=18, legacy="1.13")
+        np.set_printoptions(linewidth=18, legacy='1.13')
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([2, 2, 2, 2,
-                   2, 2, 2, 2])"""
-            ),
+                   2, 2, 2, 2])""")
         )
 
     def test_linewidth_str(self):
@@ -1030,21 +875,17 @@ class TestPrintOptions:
         np.set_printoptions(linewidth=18)
         assert_equal(
             str(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             [2 2 2 2 2 2 2 2
              2 2 2 2 2 2 2 2
-             2 2]"""
-            ),
+             2 2]""")
         )
-        np.set_printoptions(linewidth=18, legacy="1.13")
+        np.set_printoptions(linewidth=18, legacy='1.13')
         assert_equal(
             str(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             [2 2 2 2 2 2 2 2 2
-             2 2 2 2 2 2 2 2 2]"""
-            ),
+             2 2 2 2 2 2 2 2 2]""")
         )
 
     def test_edgeitems(self):
@@ -1052,8 +893,7 @@ class TestPrintOptions:
         a = np.arange(27).reshape((3, 3, 3))
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([[[ 0, ...,  2],
                     ...,
                     [ 6, ...,  8]],
@@ -1062,15 +902,13 @@ class TestPrintOptions:
 
                    [[18, ..., 20],
                     ...,
-                    [24, ..., 26]]])"""
-            ),
+                    [24, ..., 26]]])""")
         )
 
         b = np.zeros((3, 3, 1, 1))
         assert_equal(
             repr(b),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([[[[0.]],
 
                     ...,
@@ -1085,17 +923,15 @@ class TestPrintOptions:
 
                     ...,
 
-                    [[0.]]]])"""
-            ),
+                    [[0.]]]])""")
         )
 
         # 1.13 had extra trailing spaces, and was missing newlines
-        np.set_printoptions(legacy="1.13")
+        np.set_printoptions(legacy='1.13')
 
         assert_equal(
             repr(a),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([[[ 0, ...,  2],
                     ..., 
                     [ 6, ...,  8]],
@@ -1103,14 +939,12 @@ class TestPrintOptions:
                    ..., 
                    [[18, ..., 20],
                     ..., 
-                    [24, ..., 26]]])"""
-            ),
+                    [24, ..., 26]]])""")
         )
 
         assert_equal(
             repr(b),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
             array([[[[ 0.]],
 
                     ..., 
@@ -1121,22 +955,20 @@ class TestPrintOptions:
                    [[[ 0.]],
 
                     ..., 
-                    [[ 0.]]]])"""
-            ),
+                    [[ 0.]]]])""")
         )
 
     def test_bad_args(self):
-        assert_raises(ValueError, np.set_printoptions, threshold=float("nan"))
-        assert_raises(TypeError, np.set_printoptions, threshold="1")
-        assert_raises(TypeError, np.set_printoptions, threshold=b"1")
+        assert_raises(ValueError, np.set_printoptions, threshold=float('nan'))
+        assert_raises(TypeError, np.set_printoptions, threshold='1')
+        assert_raises(TypeError, np.set_printoptions, threshold=b'1')
 
-        assert_raises(TypeError, np.set_printoptions, precision="1")
+        assert_raises(TypeError, np.set_printoptions, precision='1')
         assert_raises(TypeError, np.set_printoptions, precision=1.5)
-
 
 def test_unicode_object_array():
     expected = "array(['é'], dtype=object)"
-    x = np.array(["\xe9"], dtype=object)
+    x = np.array(['\xe9'], dtype=object)
     assert_equal(repr(x), expected)
 
 
@@ -1145,14 +977,13 @@ class TestContextManager:
         # test that context manager actually works
         with np.printoptions(precision=2):
             s = str(np.array([2.0]) / 3)
-        assert_equal(s, "[0.67]")
+        assert_equal(s, '[0.67]')
 
     def test_ctx_mgr_restores(self):
         # test that print options are actually restrored
         opts = np.get_printoptions()
-        with np.printoptions(
-            precision=opts["precision"] - 1, linewidth=opts["linewidth"] - 4
-        ):
+        with np.printoptions(precision=opts['precision'] - 1,
+                             linewidth=opts['linewidth'] - 4):
             pass
         assert_equal(np.get_printoptions(), opts)
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -812,7 +812,7 @@ class TestPrintOptions:
             ('float16',),
             ('float32',),
             ('float64',),
-            ('<U1',),     # 4-byte width string
+            ('U1',),     # 4-byte width string
         ],
     )
     def test_dtype_endianness_repr(self, native):
@@ -823,8 +823,6 @@ class TestPrintOptions:
         array([0], dtype=uint16)
         even though their dtypes have different endianness.
         '''
-        if native == '<U1' and sys.byteorder == 'big':
-            native = '>U1'
         native_dtype = np.dtype(native)
         non_native_dtype = native_dtype.newbyteorder()
         non_native_repr = repr(np.array([1], non_native_dtype))

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -797,7 +797,6 @@ class TestPrintOptions:
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
                   dtype='{}')""".format(styp)))
 
-    
     @pytest.mark.parametrize(
         ['little_end', 'big_end'],
         [
@@ -834,7 +833,7 @@ class TestPrintOptions:
                  '(e.g., int32, bool, float64) '
                  'should not show dtype, but it does'))
         # only show difference if > 1 byte
-        assert_(big_end_repr != little_end_repr or big_dtype.itemsize == 1,
+        assert_(big_end_repr != little_end_repr or big_dtype.itemsize <= 1,
                 ('expected little endian repr != big endian repr, '
                 f'but {little_end_repr = }, {big_end_repr = }'))
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -823,24 +823,27 @@ class TestPrintOptions:
         array([0], dtype=uint16)
         even though their dtypes have different endianness.
         '''
-        import sys
         if sys.byteorder == 'big':
             # flip native and non-native for big-endian systems
             non_native = non_native.replace('>', '<')
             native = native.replace('<', '>')
-        big_dtype = np.dtype(non_native)
-        little_dtype = np.dtype(native)
-        big_end_repr = repr(np.array([1], big_dtype))
-        little_end_repr = repr(np.array([1], little_dtype))
+        non_native_dtype = np.dtype(non_native)
+        native_dtype = np.dtype(native)
+        non_native_repr = repr(np.array([1], non_native_dtype))
+        native_repr = repr(np.array([1], native_dtype))
         # preserve the sensible default of only showing dtype if nonstandard
-        assert_(not ('dtype' in big_end_repr and big_dtype in _typelessdata),
-                ('if a type has default size and endianness '
-                 '(e.g., int32, bool, float64) '
-                 'should not show dtype, but it does'))
-        # only show difference if > 1 byte
-        assert_(big_end_repr != little_end_repr or big_dtype.itemsize <= 1,
-                ('expected little endian repr != big endian repr, '
-                f'but {little_end_repr = }, {big_end_repr = }'))
+        assert ('dtype' in native_repr) ^ (native_dtype in _typelessdata),\
+                ("an array's repr should show dtype if and only if the type "
+                 'of the array is NOT one of the standard types '
+                 '(e.g., int32, bool, float64) ')
+        if non_native_dtype.itemsize > 1:
+            # if the type is >1 byte, the non-native endian version
+            # must show endianness.
+            assert non_native_repr != native_repr,\
+                ('expected native repr != non-native repr, '
+                f'but {native_repr = }, {non_native_repr = }')
+            assert f"dtype='{non_native[0]}" in non_native_repr,\
+                'non-native endian repr did not include > or < for endianness'
 
     def test_linewidth_repr(self):
         a = np.full(7, fill_value=2)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -798,7 +798,7 @@ class TestPrintOptions:
                   dtype='{}')""".format(styp)))
 
     @pytest.mark.parametrize(
-        ['little_end', 'big_end'],
+        ['native', 'non_native'],
         [
             ('bool', 'bool'),
             ('uint8', 'u1'),
@@ -811,11 +811,11 @@ class TestPrintOptions:
             ('float16', '>e'),
             ('float32', '>f'),
             ('float64', '>d'),
-            ('<U', '>U'),       # string
+            # ('<U', '>U'),     # these get cast to '<U1' and '>U1'
             ('<U1', '>U1'),     # 4-byte width string
         ],
     )
-    def test_dtype_endianness_repr(self, little_end, big_end):
+    def test_dtype_endianness_repr(self, native, non_native):
         '''
         there was an issue where 
         repr(array([0], dtype='<u2')) and repr(array([0], dtype='>u2'))
@@ -823,8 +823,13 @@ class TestPrintOptions:
         array([0], dtype=uint16)
         even though their dtypes have different endianness.
         '''
-        big_dtype = np.dtype(big_end)
-        little_dtype = np.dtype(little_end)
+        import sys
+        if sys.byteorder == 'big':
+            # flip native and non-native for big-endian systems
+            non_native = non_native.replace('>', '<')
+            native = native.replace('<', '>')
+        big_dtype = np.dtype(non_native)
+        little_dtype = np.dtype(native)
         big_end_repr = repr(np.array([1], big_dtype))
         little_end_repr = repr(np.array([1], little_dtype))
         # preserve the sensible default of only showing dtype if nonstandard


### PR DESCRIPTION
See #19059.
Goal is to get
```py
>>> import numpy as np
>>> np.array([1], dtype='>u2') # nonstandard endianness should be reflected in repr
array([1], dtype='>u2')
>>> np.array([1], dtype='<u2')
array([1], dtype=uint16)
```
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
