### PR TITLE
ENH: add automated arange conversion to numpy.lib.index_tricks.ix_

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -48,11 +48,13 @@ def ix_(*args):
 
     Parameters
     ----------
-    args : 1-D sequences
-        Each sequence should be of integer or boolean type.
-        Boolean sequences will be interpreted as boolean masks for the
-        corresponding dimension (equivalent to passing in
-        ``np.nonzero(boolean_sequence)``).
+    args : sequence of 1-D sequences or ints
+        If an argument is a sequence, it should be a sequence of
+        integer or boolean type. Boolean sequences will be interpreted
+        as boolean masks for the corresponding dimension (equivalent
+        to passing in ``np.nonzero(boolean_sequence)``).
+        If an argument is an integer, it will be interpreted as
+        ``np.arange(arg)`` for the corresponding dimension.
 
     Returns
     -------
@@ -89,10 +91,25 @@ def ix_(*args):
     array([[2, 4],
            [7, 9]])
 
+    >>> ixgrid = np.ix_(3, 4)
+    >>> ixgrid
+    (array([[0],
+           [1],
+           [2]]), array([[0, 1, 2, 3]]))
+    >>> ixgrid = np.ix_(3, [2, 4])
+    >>> ixgrid
+    (array([[0],
+           [1],
+           [2]]), array([[2, 4]]))
+
     """
     out = []
     nd = len(args)
     for k, new in enumerate(args):
+        if isinstance(new, (float, complex, _nx.inexact)):
+            raise ValueError("Scalar arguments must be integers")
+        if isinstance(new, (int, _nx.integer)):
+            new = arange(new)
         if not isinstance(new, _nx.ndarray):
             new = asarray(new)
             if new.size == 0:

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -394,6 +394,10 @@ class TestIx_:
         idx2d = [[1, 2, 3], [4, 5, 6]]
         assert_raises(ValueError, np.ix_, idx2d)
 
+    def test_float(self):
+        idx_float = 1.5
+        assert_raises(ValueError, np.ix_, idx_float)
+
     def test_repeated_input(self):
         length_of_vector = 5
         x = np.arange(length_of_vector)
@@ -403,6 +407,25 @@ class TestIx_:
         # check that input shape is not modified
         assert_equal(x.shape, (length_of_vector,))
 
+    def test_int(self):
+        int_x = 3
+        expected = np.arange(int_x)
+        out, = np.ix_(int_x)
+        assert_equal(out, expected)
+
+    def test_all_dtypes(self):
+        sample_int_a = np.array([2, 5])
+        sample_bool_a = np.array([True, False, True])
+        sample_int = 4
+
+        expected_int_a = sample_int_a[:, np.newaxis, np.newaxis]
+        expected_bool_a = np.flatnonzero(sample_bool_a)[np.newaxis, :, np.newaxis]
+        expected_int = np.arange(sample_int)[np.newaxis, np.newaxis, :]
+
+        arrays = np.ix_(sample_int_a, sample_bool_a, sample_int)
+        assert_equal(arrays[0], expected_int_a)
+        assert_equal(arrays[1], expected_bool_a)
+        assert_equal(arrays[2], expected_int)
 
 def test_c_():
     a = np.c_[np.array([[1, 2, 3]]), 0, 0, np.array([[4, 5, 6]])]

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -418,9 +418,12 @@ class TestIx_:
         sample_bool_a = np.array([True, False, True])
         sample_int = 4
 
+        transformed_bool_a = np.flatnonzero(sample_bool_a)
+        transformed_int = np.arange(sample_int)
+
         expected_int_a = sample_int_a[:, np.newaxis, np.newaxis]
-        expected_bool_a = np.flatnonzero(sample_bool_a)[np.newaxis, :, np.newaxis]
-        expected_int = np.arange(sample_int)[np.newaxis, np.newaxis, :]
+        expected_bool_a = transformed_bool_a[np.newaxis, :, np.newaxis]
+        expected_int = transformed_int[np.newaxis, np.newaxis, :]
 
         arrays = np.ix_(sample_int_a, sample_bool_a, sample_int)
         assert_equal(arrays[0], expected_int_a)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Dear numpy team,

The following PR contains an implementation for a small enhancement to [`np.ix_`](https://numpy.org/doc/stable/reference/generated/numpy.ix_.html). This would make it possible to use integers directly to generate an open index mesh. This is much like how [`np.permutation`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.permutation.html) used with an integer permutes `np.arange(x)`.

I've found myself needing to generate an index mesh based on (part of) the shape of an array. This usually results in something like
```
x, y, z = arr.shape[:3]
out = np.ix_(np.arange(x), np.arange(y), np.arange(z))
# or
out = tuple(np.ogrid[:x, :y, :z])
```
both of which feel unnecessarily complex. Why not allow `np.ix_(x, y, z)` or similarly `np.ix_(*arr.shape[:3])`? If `np.ix_` accepts integers `i` to be interpreted as `np.arange(i)`, this would be possible. I don't see any competing interpretations of `np.ix_` used with integers.

I have
- added an implementation for the proposed behavior to `np.ix_`,
- added a separate error message for inexact dtypes (all of which currently trigger the 1d sequence only exception) to indicate only integral scalars are valid for this purpose,
- adapted the docstrings where relevant, and
- added tests to verify the expected behavior.

Any thoughts or feedback is appreciated. Please let me know if anything needs to be added or changed.

With best regards,

Pieter


