### PR TITLE
BUG: Fix reference counting error in arraydescr_new

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2447,7 +2447,6 @@ arraydescr_new(PyTypeObject *subtype,
                 PyErr_NoMemory();
                 return NULL;
             }
-            PyObject_Init((PyObject *)descr, subtype);
             descr->f = &NPY_DT_SLOTS(DType)->f;
             Py_XINCREF(DType->scalar_type);
             descr->typeobj = DType->scalar_type;


### PR DESCRIPTION
Since `tp_alloc` is called a few lines above this, this call to `PyObject_Init` will generate a reference leak. It turns out the default implementation of `tp_alloc` in CPython [calls `PyObject_Init` implicitly](https://github.com/python/cpython/blob/71db5dbcd714b2e1297c43538188dd69715feb9a/Objects/typeobject.c#L1314).