### PR TITLE
TYP: Replace duplicate reduce in ufunc type signature with reduceat.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3211,7 +3211,7 @@ class ufunc:
     # can't type them very precisely.
     reduce: Any
     accumulate: Any
-    reduce: Any
+    reduceat: Any
     outer: Any
     # Similarly at won't be defined for ufuncs that return multiple
     # outputs, so we can't type it very precisely.


### PR DESCRIPTION
`reduce` appears twice. Presumably this is a typo: ufuncs have both `reduce` and `reduceat`. This makes pytype unhappy with this pyi file.

This change may make sense to backport.