### PR TITLE
TYP: Remove duplicate CLIP/WRAP/RAISE in __init__.pyi.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3139,10 +3139,6 @@ infty: Final[float]
 nan: Final[float]
 pi: Final[float]
 
-CLIP: L[0]
-WRAP: L[1]
-RAISE: L[2]
-
 ERR_IGNORE: L[0]
 ERR_WARN: L[1]
 ERR_RAISE: L[2]


### PR DESCRIPTION
These constants are defined twice in this file, to which pytype objects. (mypy appears to tolerate this.)