### PR TITLE
MAINT: Update actions in gitpod/docker workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
       - name: Lint Docker
-        uses: brpaz/hadolint-action@v1.2.1
+        uses: hadolint/hadolint-action@v3
         with:
           dockerfile: ./tools/gitpod/Dockerfile
       - name: Get refs
@@ -32,7 +32,7 @@ jobs:
           echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
@@ -40,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Docker
-        uses: brpaz/hadolint-action@v1.2.1
+        uses: hadolint/hadolint-action@v3
         with:
           dockerfile: ./tools/gitpod/gitpod.Dockerfile
       - name: Get refs
@@ -32,7 +32,7 @@ jobs:
           echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
         id: getrefs
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
@@ -40,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Update the following actions to see if the deprecation warnings for `save-state` and `set-output` in gitpod are fixed.

- hadolint-action (->v3)
- login-action (->v2)
- setup-buildx-action (->v2)

Gitpod is only run on merge, so cannot be tested prior to that.

See gh-23320 for further information.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
