### PR TITLE
ENH: Make SupportsDType public

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -43,7 +43,7 @@ from numpy._typing import (
     DTypeLike,
     _DTypeLike,
     _DTypeLikeVoid,
-    _SupportsDType,
+    SupportsDType,
     _VoidDTypeLike,
 
     # Shapes
@@ -817,7 +817,7 @@ class dtype(Generic[_DTypeScalar_co]):
     @overload
     def __new__(
         cls,
-        dtype: _SupportsDType[dtype[_DTypeScalar_co]],
+        dtype: SupportsDType[dtype[_DTypeScalar_co]],
         align: bool = ...,
         copy: bool = ...,
     ) -> dtype[_DTypeScalar_co]: ...

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -164,7 +164,7 @@ from ._shape import (
 from ._dtype_like import (
     DTypeLike as DTypeLike,
     _DTypeLike as _DTypeLike,
-    _SupportsDType as _SupportsDType,
+    SupportsDType as SupportsDType,
     _VoidDTypeLike as _VoidDTypeLike,
     _DTypeLikeBool as _DTypeLikeBool,
     _DTypeLikeUInt as _DTypeLikeUInt,

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -79,7 +79,7 @@ class _DTypeDict(_DTypeDictBase, total=False):
 
 # A protocol for anything with the dtype attribute
 @runtime_checkable
-class _SupportsDType(Protocol[_DType_co]):
+class SupportsDType(Protocol[_DType_co]):
     @property
     def dtype(self) -> _DType_co: ...
 
@@ -88,7 +88,7 @@ class _SupportsDType(Protocol[_DType_co]):
 _DTypeLike = Union[
     np.dtype[_SCT],
     type[_SCT],
-    _SupportsDType[np.dtype[_SCT]],
+    SupportsDType[np.dtype[_SCT]],
 ]
 
 
@@ -120,7 +120,7 @@ DTypeLike = Union[
     # array-scalar types and generic types
     type[Any],  # NOTE: We're stuck with `type[Any]` due to object dtypes
     # anything with a dtype attribute
-    _SupportsDType[np.dtype[Any]],
+    SupportsDType[np.dtype[Any]],
     # character codes, type strings or comma-separated fields, e.g., 'float64'
     str,
     _VoidDTypeLike,
@@ -139,13 +139,13 @@ _DTypeLikeBool = Union[
     type[bool],
     type[np.bool_],
     np.dtype[np.bool_],
-    _SupportsDType[np.dtype[np.bool_]],
+    SupportsDType[np.dtype[np.bool_]],
     _BoolCodes,
 ]
 _DTypeLikeUInt = Union[
     type[np.unsignedinteger],
     np.dtype[np.unsignedinteger],
-    _SupportsDType[np.dtype[np.unsignedinteger]],
+    SupportsDType[np.dtype[np.unsignedinteger]],
     _UInt8Codes,
     _UInt16Codes,
     _UInt32Codes,
@@ -161,7 +161,7 @@ _DTypeLikeInt = Union[
     type[int],
     type[np.signedinteger],
     np.dtype[np.signedinteger],
-    _SupportsDType[np.dtype[np.signedinteger]],
+    SupportsDType[np.dtype[np.signedinteger]],
     _Int8Codes,
     _Int16Codes,
     _Int32Codes,
@@ -177,7 +177,7 @@ _DTypeLikeFloat = Union[
     type[float],
     type[np.floating],
     np.dtype[np.floating],
-    _SupportsDType[np.dtype[np.floating]],
+    SupportsDType[np.dtype[np.floating]],
     _Float16Codes,
     _Float32Codes,
     _Float64Codes,
@@ -190,7 +190,7 @@ _DTypeLikeComplex = Union[
     type[complex],
     type[np.complexfloating],
     np.dtype[np.complexfloating],
-    _SupportsDType[np.dtype[np.complexfloating]],
+    SupportsDType[np.dtype[np.complexfloating]],
     _Complex64Codes,
     _Complex128Codes,
     _CSingleCodes,
@@ -200,40 +200,40 @@ _DTypeLikeComplex = Union[
 _DTypeLikeDT64 = Union[
     type[np.timedelta64],
     np.dtype[np.timedelta64],
-    _SupportsDType[np.dtype[np.timedelta64]],
+    SupportsDType[np.dtype[np.timedelta64]],
     _TD64Codes,
 ]
 _DTypeLikeTD64 = Union[
     type[np.datetime64],
     np.dtype[np.datetime64],
-    _SupportsDType[np.dtype[np.datetime64]],
+    SupportsDType[np.dtype[np.datetime64]],
     _DT64Codes,
 ]
 _DTypeLikeStr = Union[
     type[str],
     type[np.str_],
     np.dtype[np.str_],
-    _SupportsDType[np.dtype[np.str_]],
+    SupportsDType[np.dtype[np.str_]],
     _StrCodes,
 ]
 _DTypeLikeBytes = Union[
     type[bytes],
     type[np.bytes_],
     np.dtype[np.bytes_],
-    _SupportsDType[np.dtype[np.bytes_]],
+    SupportsDType[np.dtype[np.bytes_]],
     _BytesCodes,
 ]
 _DTypeLikeVoid = Union[
     type[np.void],
     np.dtype[np.void],
-    _SupportsDType[np.dtype[np.void]],
+    SupportsDType[np.dtype[np.void]],
     _VoidCodes,
     _VoidDTypeLike,
 ]
 _DTypeLikeObject = Union[
     type,
     np.dtype[np.object_],
-    _SupportsDType[np.dtype[np.object_]],
+    SupportsDType[np.dtype[np.object_]],
     _ObjectCodes,
 ]
 

--- a/numpy/lib/index_tricks.pyi
+++ b/numpy/lib/index_tricks.pyi
@@ -36,7 +36,7 @@ from numpy._typing import (
 
     # DTypes
     DTypeLike,
-    _SupportsDType,
+    SupportsDType,
 
     # Shapes
     _ShapeLike,
@@ -56,7 +56,7 @@ _ArrayType = TypeVar("_ArrayType", bound=ndarray[Any, Any])
 __all__: list[str]
 
 @overload
-def ix_(*args: _FiniteNestedSequence[_SupportsDType[_DType]]) -> tuple[ndarray[Any, _DType], ...]: ...
+def ix_(*args: _FiniteNestedSequence[SupportsDType[_DType]]) -> tuple[ndarray[Any, _DType], ...]: ...
 @overload
 def ix_(*args: str | _NestedSequence[str]) -> tuple[NDArray[str_], ...]: ...
 @overload

--- a/numpy/lib/type_check.pyi
+++ b/numpy/lib/type_check.pyi
@@ -23,7 +23,7 @@ from numpy._typing import (
     NBitBase,
     NDArray,
     _64Bit,
-    _SupportsDType,
+    SupportsDType,
     _ScalarLike_co,
     _ArrayLike,
     _DTypeLikeComplex,
@@ -89,9 +89,9 @@ def isreal(x: _ScalarLike_co) -> bool_: ...  # type: ignore[misc]
 @overload
 def isreal(x: ArrayLike) -> NDArray[bool_]: ...
 
-def iscomplexobj(x: _SupportsDType[dtype[Any]] | ArrayLike) -> bool: ...
+def iscomplexobj(x: SupportsDType[dtype[Any]] | ArrayLike) -> bool: ...
 
-def isrealobj(x: _SupportsDType[dtype[Any]] | ArrayLike) -> bool: ...
+def isrealobj(x: SupportsDType[dtype[Any]] | ArrayLike) -> bool: ...
 
 @overload
 def nan_to_num(  # type: ignore[misc]
@@ -192,31 +192,31 @@ def typename(char: L['O']) -> L['object']: ...
 
 @overload
 def common_type(  # type: ignore[misc]
-    *arrays: _SupportsDType[dtype[
+    *arrays: SupportsDType[dtype[
         integer[Any]
     ]]
 ) -> type[floating[_64Bit]]: ...
 @overload
 def common_type(  # type: ignore[misc]
-    *arrays: _SupportsDType[dtype[
+    *arrays: SupportsDType[dtype[
         floating[_NBit1]
     ]]
 ) -> type[floating[_NBit1]]: ...
 @overload
 def common_type(  # type: ignore[misc]
-    *arrays: _SupportsDType[dtype[
+    *arrays: SupportsDType[dtype[
         integer[Any] | floating[_NBit1]
     ]]
 ) -> type[floating[_NBit1 | _64Bit]]: ...
 @overload
 def common_type(  # type: ignore[misc]
-    *arrays: _SupportsDType[dtype[
+    *arrays: SupportsDType[dtype[
         floating[_NBit1] | complexfloating[_NBit2, _NBit2]
     ]]
 ) -> type[complexfloating[_NBit1 | _NBit2, _NBit1 | _NBit2]]: ...
 @overload
 def common_type(
-    *arrays: _SupportsDType[dtype[
+    *arrays: SupportsDType[dtype[
         integer[Any] | floating[_NBit1] | complexfloating[_NBit2, _NBit2]
     ]]
 ) -> type[complexfloating[_64Bit | _NBit1 | _NBit2, _64Bit | _NBit1 | _NBit2]]: ...

--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -36,7 +36,7 @@ from numpy._typing import (
     _IntCodes,
     _ShapeLike,
     _SingleCodes,
-    _SupportsDType,
+    SupportsDType,
     _UInt8Codes,
     _UInt16Codes,
     _UInt32Codes,
@@ -48,7 +48,7 @@ _ArrayType = TypeVar("_ArrayType", bound=ndarray[Any, Any])
 
 _DTypeLikeFloat32 = Union[
     dtype[float32],
-    _SupportsDType[dtype[float32]],
+    SupportsDType[dtype[float32]],
     type[float32],
     _Float32Codes,
     _SingleCodes,
@@ -56,7 +56,7 @@ _DTypeLikeFloat32 = Union[
 
 _DTypeLikeFloat64 = Union[
     dtype[float64],
-    _SupportsDType[dtype[float64]],
+    SupportsDType[dtype[float64]],
     type[float],
     type[float64],
     _Float64Codes,
@@ -245,7 +245,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int8] | type[int8] | _Int8Codes | _SupportsDType[dtype[int8]] = ...,
+        dtype: dtype[int8] | type[int8] | _Int8Codes | SupportsDType[dtype[int8]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[int8]]: ...
     @overload
@@ -254,7 +254,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int16] | type[int16] | _Int16Codes | _SupportsDType[dtype[int16]] = ...,
+        dtype: dtype[int16] | type[int16] | _Int16Codes | SupportsDType[dtype[int16]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[int16]]: ...
     @overload
@@ -263,7 +263,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int32] | type[int32] | _Int32Codes | _SupportsDType[dtype[int32]] = ...,
+        dtype: dtype[int32] | type[int32] | _Int32Codes | SupportsDType[dtype[int32]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[int32]]: ...
     @overload
@@ -272,7 +272,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: None | dtype[int64] | type[int64] | _Int64Codes | _SupportsDType[dtype[int64]] = ...,
+        dtype: None | dtype[int64] | type[int64] | _Int64Codes | SupportsDType[dtype[int64]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[int64]]: ...
     @overload
@@ -281,7 +281,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | _SupportsDType[dtype[uint8]] = ...,
+        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | SupportsDType[dtype[uint8]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[uint8]]: ...
     @overload
@@ -290,7 +290,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | _SupportsDType[dtype[uint16]] = ...,
+        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | SupportsDType[dtype[uint16]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[uint16]]: ...
     @overload
@@ -299,7 +299,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | _SupportsDType[dtype[uint32]] = ...,
+        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | SupportsDType[dtype[uint32]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[uint32]]: ...
     @overload
@@ -308,7 +308,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | _SupportsDType[dtype[uint64]] = ...,
+        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | SupportsDType[dtype[uint64]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[uint64]]: ...
     @overload
@@ -317,7 +317,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | _SupportsDType[dtype[int_]] = ...,
+        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | SupportsDType[dtype[int_]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[int_]]: ...
     @overload
@@ -326,7 +326,7 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint] | type[uint] | _UIntCodes | _SupportsDType[dtype[uint]] = ...,
+        dtype: dtype[uint] | type[uint] | _UIntCodes | SupportsDType[dtype[uint]] = ...,
         endpoint: bool = ...,
     ) -> ndarray[Any, dtype[uint]]: ...
     # TODO: Use a TypeVar _T here to get away from Any output?  Should be int->ndarray[Any,dtype[int64]], ArrayLike[_T] -> _T | ndarray[Any,Any]

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -12,19 +12,19 @@ from typing import (
 )
 
 from numpy import dtype, ndarray, uint32, uint64
-from numpy._typing import _ArrayLikeInt_co, _ShapeLike, _SupportsDType, _UInt32Codes, _UInt64Codes
+from numpy._typing import _ArrayLikeInt_co, _ShapeLike, SupportsDType, _UInt32Codes, _UInt64Codes
 
 _T = TypeVar("_T")
 
 _DTypeLikeUint32 = Union[
     dtype[uint32],
-    _SupportsDType[dtype[uint32]],
+    SupportsDType[dtype[uint32]],
     type[uint32],
     _UInt32Codes,
 ]
 _DTypeLikeUint64 = Union[
     dtype[uint64],
-    _SupportsDType[dtype[uint64]],
+    SupportsDType[dtype[uint64]],
     type[uint64],
     _UInt64Codes,
 ]

--- a/numpy/random/mtrand.pyi
+++ b/numpy/random/mtrand.pyi
@@ -36,7 +36,7 @@ from numpy._typing import (
     _IntCodes,
     _ShapeLike,
     _SingleCodes,
-    _SupportsDType,
+    SupportsDType,
     _UInt8Codes,
     _UInt16Codes,
     _UInt32Codes,
@@ -46,7 +46,7 @@ from numpy._typing import (
 
 _DTypeLikeFloat32 = Union[
     dtype[float32],
-    _SupportsDType[dtype[float32]],
+    SupportsDType[dtype[float32]],
     type[float32],
     _Float32Codes,
     _SingleCodes,
@@ -54,7 +54,7 @@ _DTypeLikeFloat32 = Union[
 
 _DTypeLikeFloat64 = Union[
     dtype[float64],
-    _SupportsDType[dtype[float64]],
+    SupportsDType[dtype[float64]],
     type[float],
     type[float64],
     _Float64Codes,
@@ -150,7 +150,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int8] | type[int8] | _Int8Codes | _SupportsDType[dtype[int8]] = ...,
+        dtype: dtype[int8] | type[int8] | _Int8Codes | SupportsDType[dtype[int8]] = ...,
     ) -> ndarray[Any, dtype[int8]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -158,7 +158,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int16] | type[int16] | _Int16Codes | _SupportsDType[dtype[int16]] = ...,
+        dtype: dtype[int16] | type[int16] | _Int16Codes | SupportsDType[dtype[int16]] = ...,
     ) -> ndarray[Any, dtype[int16]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -166,7 +166,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int32] | type[int32] | _Int32Codes | _SupportsDType[dtype[int32]] = ...,
+        dtype: dtype[int32] | type[int32] | _Int32Codes | SupportsDType[dtype[int32]] = ...,
     ) -> ndarray[Any, dtype[int32]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -174,7 +174,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: None | dtype[int64] | type[int64] | _Int64Codes | _SupportsDType[dtype[int64]] = ...,
+        dtype: None | dtype[int64] | type[int64] | _Int64Codes | SupportsDType[dtype[int64]] = ...,
     ) -> ndarray[Any, dtype[int64]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -182,7 +182,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | _SupportsDType[dtype[uint8]] = ...,
+        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | SupportsDType[dtype[uint8]] = ...,
     ) -> ndarray[Any, dtype[uint8]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -190,7 +190,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | _SupportsDType[dtype[uint16]] = ...,
+        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | SupportsDType[dtype[uint16]] = ...,
     ) -> ndarray[Any, dtype[uint16]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -198,7 +198,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | _SupportsDType[dtype[uint32]] = ...,
+        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | SupportsDType[dtype[uint32]] = ...,
     ) -> ndarray[Any, dtype[uint32]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -206,7 +206,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | _SupportsDType[dtype[uint64]] = ...,
+        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | SupportsDType[dtype[uint64]] = ...,
     ) -> ndarray[Any, dtype[uint64]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -214,7 +214,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | _SupportsDType[dtype[int_]] = ...,
+        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | SupportsDType[dtype[int_]] = ...,
     ) -> ndarray[Any, dtype[int_]]: ...
     @overload
     def randint(  # type: ignore[misc]
@@ -222,7 +222,7 @@ class RandomState:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
-        dtype: dtype[uint] | type[uint] | _UIntCodes | _SupportsDType[dtype[uint]] = ...,
+        dtype: dtype[uint] | type[uint] | _UIntCodes | SupportsDType[dtype[uint]] = ...,
     ) -> ndarray[Any, dtype[uint]]: ...
     def bytes(self, length: int) -> bytes: ...
     @overload

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -160,9 +160,10 @@ from numpy._typing import (
     DTypeLike,
     NBitBase,
     NDArray,
+    SupportsDType
 )
 
-__all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray"]
+__all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray", "SupportsDType"]
 
 if __doc__ is not None:
     from numpy._typing._add_docstring import _docstrings

--- a/numpy/typing/tests/test_runtime.py
+++ b/numpy/typing/tests/test_runtime.py
@@ -84,8 +84,8 @@ def test_get_type_hints_str(name: type, tup: TypeTup) -> None:
 
 
 def test_keys() -> None:
-    """Test that ``TYPES.keys()`` and ``numpy.typing.__all__`` are synced."""
-    keys = TYPES.keys()
+    """Test the contents of ``numpy.typing.__all__``."""
+    keys = {*TYPES.keys(), "SupportsDType"}
     ref = set(npt.__all__)
     assert keys == ref
 

--- a/numpy/typing/tests/test_runtime.py
+++ b/numpy/typing/tests/test_runtime.py
@@ -91,7 +91,7 @@ def test_keys() -> None:
 
 
 PROTOCOLS: dict[str, tuple[type[Any], object]] = {
-    "_SupportsDType": (_npt._SupportsDType, np.int64(1)),
+    "SupportsDType": (_npt.SupportsDType, np.int64(1)),
     "_SupportsArray": (_npt._SupportsArray, np.arange(10)),
     "_SupportsArrayFunc": (_npt._SupportsArrayFunc, np.arange(10)),
     "_NestedSequence": (_npt._NestedSequence, [1]),
@@ -105,7 +105,7 @@ class TestRuntimeProtocol:
         assert not isinstance(None, cls)
 
     def test_issubclass(self, cls: type[Any], obj: object) -> None:
-        if cls is _npt._SupportsDType:
+        if cls is _npt.SupportsDType:
             pytest.xfail(
                 "Protocols with non-method members don't support issubclass()"
             )


### PR DESCRIPTION
Renamed _SupportsDType to SupportsDType and made it public via `numpy.typing.SupportsDType` as per https://github.com/numpy/numpy/issues/23308.