### PR TITLE
MAINT: Ignore hadolint info error DL3059.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ./tools/gitpod/Dockerfile
+          ignore: DL3059
       - name: Get refs
         shell: bash
         run: |

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -23,6 +23,7 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ./tools/gitpod/gitpod.Dockerfile
+          ignore: DL3059
       - name: Get refs
         shell: bash
         run: |

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -34,6 +34,8 @@ COPY --from=clone --chown=gitpod /tmp/numpy ${WORKSPACE}
 WORKDIR ${WORKSPACE}
 
 # Build numpy to populate the cache used by ccache
+# Note, hadolint suggests consolidating the RUN commands. That info
+# level complaint (DL3059) is currently ignored to avoid errors.
 RUN git config --global --add safe.directory /workspace/numpy
 RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml numpy/core/src/npysort/x86-simd-sort
 RUN conda activate ${CONDA_ENV} && \ 


### PR DESCRIPTION
DL3059 is a suggestion to consolidate RUN lines. I suppose we could raise the error threshold from the current default "info" level, but it seems easier to just ignore what is effectively a "style" suggestion.

[skip ci]  [skip cirrus]

Note that this may be an error in hadolink-actions, hadolink itself says that only errors more severe than the threshold will cause the program to exit with an error. That makes more sense than failing at the "info" level.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
