### PR TITLE
BUG: ma with structured dtype

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2857,7 +2857,7 @@ class MaskedArray(ndarray):
                     mask = np.array(
                         [getmaskarray(np.asanyarray(m, dtype=_data.dtype))
                          for m in data], dtype=mdtype)
-                except ValueError:
+                except (ValueError, TypeError):
                     # If data is nested
                     mask = nomask
                 # Force shrinking of the mask if needed (and possible)

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -89,3 +89,9 @@ class TestRegression:
     def test_masked_array_tobytes_fortran(self):
         ma = np.ma.arange(4).reshape((2,2))
         assert_array_equal(ma.tobytes(order='F'), ma.T.tobytes())
+
+    def test_structured_array(self):
+        # see gh-22041
+        np.ma.array((1, (b"", b"")),
+                    dtype=[("x", np.int_),
+                          ("y", [("i", np.void), ("j", np.void)])])


### PR DESCRIPTION
Fixes #22041

* add regression test and fix for creating a masked array with a structured dtype; the test is simply for lack of error in the repoducer

* the concern expressed by core team in matching issue was that `astropy` might be negatively affected; I ran full `astropy` (hash: `c9ad7c56`) test suite locally with this feature branch and it seemed "ok," just 1 unrelated network failure in the network-requiring tests (`test_ftp_tls_auto`):

```
1 failed, 21430 passed, 3490 skipped, 176 xfailed, 23275 warnings in 430.18s (0:07:10)
```