### PR TITLE
ENH: improve dlpack protocol detection

### DIFF
--- a/doc/release/upcoming_changes/23360.improvement.rst
+++ b/doc/release/upcoming_changes/23360.improvement.rst
@@ -1,0 +1,8 @@
+Improved DLPack protocol detection
+----------------------------------
+Prior to this release, detecting DLPack protocol support in NumPy was limited
+to checking the existence of the `__dlpack__` method on the object's type.
+However, this method could be defined on the object itself, leading to
+inaccuracies.
+With this enhancement, NumPy now checks for the `__dlpack__` method on the
+object itself, providing more accurate detection of DLPack protocol support.

--- a/numpy/core/src/multiarray/dlpack.c
+++ b/numpy/core/src/multiarray/dlpack.c
@@ -288,8 +288,7 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args))
 
 NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
-    PyObject *capsule = PyObject_CallMethod((PyObject *)obj->ob_type,
-            "__dlpack__", "O", obj);
+    PyObject *capsule = PyObject_CallMethod(obj, "__dlpack__", NULL);
     if (capsule == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Currently, dlpack protocol detection is done by checking the existence of `__dlpack__` method on the object's type.

This is not enough to detect the dlpack protocol support, because the method can be defined on the object itself, not on the object's type.

This patch improves the detection by checking the existence of `__dlpack__` method on the object itself.

This patch allows the following code:

```python
    def test_from_dlpack_dynamic_method(self):
        class TensorWrapper:
            def __init__(self, tensor):
                self.tensor = tensor
                if not hasattr(self, '__dlpack__'):
                    self.__dlpack__ = tensor.__dlpack__
        x = np.arange(5)
        y = TensorWrapper(x)
        z = np.from_dlpack(y)
        assert_array_equal(x, z)
```

FYI, CuPy checks `__dlpack__` method on the object itself, not on the type of the object so it doesn't have a problem with the code like above.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
