### PR TITLE
BLD: add SSL2 default path for Fujitsu C/C++ compiler

### DIFF
--- a/site.cfg.example
+++ b/site.cfg.example
@@ -253,10 +253,12 @@
 #include_dirs = /usr/local/djbfft/include
 #library_dirs = /usr/local/djbfft/lib
 
-# SSL2
+# Fujitsu SSL2
 # ----
-#
-# [ssl2]
-# library_dirs = /opt/FJSVstclanga/v1.1.0/lib64
-# include_dirs = /opt/FJSVstclanga/v1.1.0/clang-comp/include
-# extra_link_args = -SSL2BLAMP
+#[ssl2]
+#library_dirs = /opt/FJSVstclanga/v1.1.0/lib64
+#include_dirs = /opt/FJSVstclanga/v1.1.0/clang-comp/include
+# Single-threaded version.
+#libraies = fjlapacksve
+# Multi-threaded version. Python itself must be built by Fujitsu compiler.
+#libraies = fjlapackexsve


### PR DESCRIPTION
Fujitsu C/C++ compiler has been supported by https://github.com/numpy/numpy/pull/22982
If the ssl2 section of `site.cfg` is enabled, SSL2 (OpenBLAS compatible S/W library) is linked with NumPy.

This PR automatically enables linking SSL2 even if the ssl2 section in `site.cfg` is not enabled. Because SSL2 is usually distributed with Fujitsu C/C++ compiler, it would be more convenient for users if SSL2 is automatically linked when it exists.

Thank you.