### PR TITLE
BUG: Ensure like is only stripped for `like=` dispatched functions

### DIFF
--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -136,5 +136,5 @@ def require(a, dtype=None, requirements=None, *, like=None):
 
 
 _require_with_like = array_function_dispatch(
-    _require_dispatcher
+    _require_dispatcher, use_like=True
 )(require)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -208,7 +208,7 @@ def ones(shape, dtype=None, order='C', *, like=None):
 
 
 _ones_with_like = array_function_dispatch(
-    _ones_dispatcher
+    _ones_dispatcher, use_like=True
 )(ones)
 
 
@@ -347,7 +347,7 @@ def full(shape, fill_value, dtype=None, order='C', *, like=None):
 
 
 _full_with_like = array_function_dispatch(
-    _full_dispatcher
+    _full_dispatcher, use_like=True
 )(full)
 
 
@@ -1867,7 +1867,7 @@ def fromfunction(function, shape, *, dtype=float, like=None, **kwargs):
 
 
 _fromfunction_with_like = array_function_dispatch(
-    _fromfunction_dispatcher
+    _fromfunction_dispatcher, use_like=True
 )(fromfunction)
 
 
@@ -2188,7 +2188,7 @@ def identity(n, dtype=None, *, like=None):
 
 
 _identity_with_like = array_function_dispatch(
-    _identity_dispatcher
+    _identity_dispatcher, use_like=True
 )(identity)
 
 

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -126,7 +126,7 @@ def set_module(module):
 
 
 def array_function_dispatch(dispatcher, module=None, verify=True,
-                            docs_from_dispatcher=False):
+                            docs_from_dispatcher=False, use_like=False):
     """Decorator for adding dispatch with the __array_function__ protocol.
 
     See NEP-18 for example usage.
@@ -198,7 +198,8 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
                 raise TypeError(new_msg) from None
 
             return implement_array_function(
-                implementation, public_api, relevant_args, args, kwargs)
+                implementation, public_api, relevant_args, args, kwargs,
+                use_like)
 
         public_api.__code__ = public_api.__code__.replace(
                 co_name=implementation.__name__,

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1354,7 +1354,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 
 
 _loadtxt_with_like = array_function_dispatch(
-    _loadtxt_dispatcher
+    _loadtxt_dispatcher, use_like=True
 )(loadtxt)
 
 
@@ -2464,7 +2464,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
 
 _genfromtxt_with_like = array_function_dispatch(
-    _genfromtxt_dispatcher
+    _genfromtxt_dispatcher, use_like=True
 )(genfromtxt)
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -232,6 +232,16 @@ class TestSavezLoad(RoundtripTest):
         assert_equal(a, l['file_a'])
         assert_equal(b, l['file_b'])
 
+    def test_named_arrays_with_like(self):
+        a = np.array([[1, 2], [3, 4]], float)
+        b = np.array([[1 + 2j, 2 + 7j], [3 - 6j, 4 + 12j]], complex)
+        c = BytesIO()
+        np.savez(c, file_a=a, like=b)
+        c.seek(0)
+        l = np.load(c)
+        assert_equal(a, l['file_a'])
+        assert_equal(b, l['like'])
+
     def test_BagObj(self):
         a = np.array([[1, 2], [3, 4]], float)
         b = np.array([[1 + 2j, 2 + 7j], [3 - 6j, 4 + 12j]], complex)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -229,7 +229,7 @@ def eye(N, M=None, k=0, dtype=float, order='C', *, like=None):
 
 
 _eye_with_like = array_function_dispatch(
-    _eye_dispatcher
+    _eye_dispatcher, use_like=True
 )(eye)
 
 
@@ -431,7 +431,7 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
 
 
 _tri_with_like = array_function_dispatch(
-    _tri_dispatcher
+    _tri_dispatcher, use_like=True
 )(tri)
 
 


### PR DESCRIPTION
This issue is already fixed differently on the main (1.25) branch,
an alternative might be to check for functions with **kwargs, there seem
to be three: savez, savez_compressed, and apply_along_axes.

Closes gh-23365

---

After some back and forth, this seemed like the easiest approach after all.  @pentschev what do you think?