### PR TITLE
ENH: drop dtype metadata

### DIFF
--- a/doc/release/upcoming_changes/23371.improvement.rst
+++ b/doc/release/upcoming_changes/23371.improvement.rst
@@ -1,0 +1,5 @@
+Drop dtype metadata before saving in .npy or .npz files
+-------------------------------------------------------
+Currently, a npy file containing a table with a dtype with
+metadata cannot be read back.
+Now, `np.save` and `np.savez` drop metadata before saving.

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -1021,8 +1021,7 @@ def test_metadata_dtype(dt, fail):
     else:
         arr2 = np.load(buf)
         # BUG: assert_array_equal does not check metadata
-        from numpy.lib.format import _has_metadata
+        from numpy.lib.utils import drop_metadata
         assert_array_equal(arr, arr2)
-        assert _has_metadata(arr.dtype)
-        assert not _has_metadata(arr2.dtype)
-
+        assert drop_metadata(arr.dtype) is not arr.dtype
+        assert drop_metadata(arr2.dtype) is arr2.dtype

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -212,5 +212,3 @@ def test__drop_metadata():
     dt_m = utils.drop_metadata(dt)
     assert _compare_dtypes(dt, dt_m) is True
     assert dt_m.metadata is None
-
-    

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -178,7 +178,8 @@ def test_info_method_heading():
     assert _has_method_heading(WithPublicMethods)
     assert not _has_method_heading(NoPublicMethods)
 
-def test__drop_metadata():
+
+def test_drop_metadata():
     def _compare_dtypes(dt1, dt2):
         return np.can_cast(dt1, dt2, casting='no')
 
@@ -212,3 +213,16 @@ def test__drop_metadata():
     dt_m = utils.drop_metadata(dt)
     assert _compare_dtypes(dt, dt_m) is True
     assert dt_m.metadata is None
+
+
+@pytest.mark.parametrize("dtype",
+        [np.dtype("i,i,i,i")[["f1", "f3"]],
+        np.dtype("f8"),
+        np.dtype("10i")])
+def test_drop_metadata_identity_and_copy(dtype):
+    # If there is no metadata, the identity is preserved:
+    assert utils.drop_metadata(dtype) is dtype
+
+    # If there is any, it is dropped (subforms are checked above)
+    dtype = np.dtype(dtype, metadata={1: 2})
+    assert utils.drop_metadata(dtype).metadata is None

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -2,6 +2,7 @@ import inspect
 import sys
 import pytest
 
+import numpy as np
 from numpy.core import arange
 from numpy.testing import assert_, assert_equal, assert_raises_regex
 from numpy.lib import deprecate, deprecate_with_doc
@@ -176,3 +177,40 @@ def test_info_method_heading():
 
     assert _has_method_heading(WithPublicMethods)
     assert not _has_method_heading(NoPublicMethods)
+
+def test__drop_metadata():
+    def _compare_dtypes(dt1, dt2):
+        return np.can_cast(dt1, dt2, casting='no')
+
+    # structured dtype
+    dt = np.dtype([('l1', [('l2', np.dtype('S8', metadata={'msg': 'toto'}))])],
+                  metadata={'msg': 'titi'})
+    dt_m = utils.drop_metadata(dt)
+    assert _compare_dtypes(dt, dt_m) is True
+    assert dt_m.metadata is None
+    assert dt_m['l1'].metadata is None
+    assert dt_m['l1']['l2'].metadata is None
+    
+    # alignement
+    dt = np.dtype([('x', '<f8'), ('y', '<i4')],
+                  align=True,
+                  metadata={'msg': 'toto'})
+    dt_m = utils.drop_metadata(dt)
+    assert _compare_dtypes(dt, dt_m) is True
+    assert dt_m.metadata is None
+
+    # subdtype
+    dt = np.dtype('8f',
+                  metadata={'msg': 'toto'})
+    dt_m = utils.drop_metadata(dt)
+    assert _compare_dtypes(dt, dt_m) is True
+    assert dt_m.metadata is None
+
+    # scalar
+    dt = np.dtype('uint32',
+                  metadata={'msg': 'toto'})
+    dt_m = utils.drop_metadata(dt)
+    assert _compare_dtypes(dt, dt_m) is True
+    assert dt_m.metadata is None
+
+    

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1150,13 +1150,11 @@ def drop_metadata(dt):
         l = list()
         for n in dt.names:
             t = dt.fields[n]
-            l.append((
-                n,  # name
-                drop_metadata(t[0]),  # format
-                t[1],  # offset
-                t[2] if len(t) == 3 else None,  # title
-            ))
-        d = {k: [e[i] for e in l] for i, k in enumerate(
+            if len(t) == 3:
+                l.append((n, drop_metadata(t[0]), t[1], t[2]))
+            else:
+                l.append((n, drop_metadata(t[0]), t[1], None))
+            d = {k: [e[i] for e in l] for i, k in enumerate(
             ['names', 'formats', 'offsets', 'titles']
         )}
         d['itemsize'] = dt.itemsize

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1147,6 +1147,9 @@ def drop_metadata(dtype, /):
     Returns the dtype unchanged if it contained no metadata or a copy of the
     dtype it (or any of its structure dtypes) contained metadata.
 
+    This utility is used by `np.save` and `np.savez` to drop metadata before
+    saving.
+
     .. note::
 
         Due to its limitation this function may move to a more appropriate

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1145,7 +1145,7 @@ def _opt_info():
 def drop_metadata(dtype, /):
     """
     Returns the dtype unchanged if it contained no metadata or a copy of the
-    dtype it (or any of its structure dtypes) contained metadata.
+    dtype if it (or any of its structure dtypes) contained metadata.
 
     This utility is used by `np.save` and `np.savez` to drop metadata before
     saving.

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1142,7 +1142,9 @@ def _opt_info():
     return enabled_features
 
 def drop_metadata(dt):
-    align = dt.isalignedstruct
+    """
+    Returns the copy of a dtype where all metadata has been removed
+    """
     if dt.names:
         # structured dtype
         l = list()

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1141,30 +1141,62 @@ def _opt_info():
 
     return enabled_features
 
-def drop_metadata(dt):
+
+def drop_metadata(dtype, /):
     """
-    Returns the copy of a dtype where all metadata has been removed
+    Returns the dtype unchanged if it contained no metadata or a copy of the
+    dtype it (or any of its structure dtypes) contained metadata.
+
+    .. note::
+
+        Due to its limitation this function may move to a more appropriate
+        home or change in the future and is considered semi-public API only.
+
+    .. warning::
+
+        This function does not preserve more strange things like record dtypes
+        and user dtypes may simply return the wrong thing.  If you need to be
+        sure about the latter, check the result with:
+        ``np.can_cast(new_dtype, dtype, casting="no")``.
+
     """
-    if dt.names:
-        # structured dtype
-        l = list()
-        for n in dt.names:
-            t = dt.fields[n]
-            if len(t) == 3:
-                l.append((n, drop_metadata(t[0]), t[1], t[2]))
-            else:
-                l.append((n, drop_metadata(t[0]), t[1], None))
-            d = {k: [e[i] for e in l] for i, k in enumerate(
-            ['names', 'formats', 'offsets', 'titles']
-        )}
-        d['itemsize'] = dt.itemsize
-    elif dt.subdtype:
-        # subdtype
-        (item_dtype, shape) = dt.subdtype
-        d = (drop_metadata(item_dtype), shape)
+    if dtype.fields is not None:
+        found_metadata = dtype.metadata is not None
+
+        names = []
+        formats = []
+        offsets = []
+        titles = []
+        for name, field in dtype.fields.items():
+            field_dt = drop_metadata(field[0])
+            if field_dt is not field[0]:
+                found_metadata = True
+
+            names.append(name)
+            formats.append(field_dt)
+            offsets.append(field[1])
+            titles.append(None if len(field) < 3 else field[2])
+
+        if not found_metadata:
+            return dtype
+
+        structure = dict(
+            names=names, formats=formats, offsets=offsets, titles=titles,
+            itemsize=dtype.itemsize)
+
+        # NOTE: Could pass (dtype.type, structure) to preserve record dtypes...
+        return np.dtype(structure, align=dtype.isalignedstruct)
+    elif dtype.subdtype is not None:
+        # subarray dtype
+        subdtype, shape = dtype.subdtype
+        new_subdtype = drop_metadata(subdtype)
+        if dtype.metadata is None and new_subdtype is subdtype:
+            return dtype
+
+        return np.dtype((new_subdtype, shape))
     else:
-        # scalar dtype
-        d = dt.str
-    new_dt = np.dtype(dtype=d, align=dt.isalignedstruct) 
-    return new_dt
-#-----------------------------------------------------------------------------
+        # Normal unstructured dtype
+        if dtype.metadata is None:
+            return dtype
+        # Note that `dt.str` doesn't round-trip e.g. for user-dtypes.
+        return np.dtype(dtype.str)

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1140,4 +1140,31 @@ def _opt_info():
             enabled_features += f" {feature}?"
 
     return enabled_features
+
+def drop_metadata(dt):
+    align = dt.isalignedstruct
+    if dt.names:
+        # structured dtype
+        l = list()
+        for n in dt.names:
+            t = dt.fields[n]
+            l.append((
+                n,  # name
+                drop_metadata(t[0]),  # format
+                t[1],  # offset
+                t[2] if len(t) == 3 else None,  # title
+            ))
+        d = {k: [e[i] for e in l] for i, k in enumerate(
+            ['names', 'formats', 'offsets', 'titles']
+        )}
+        d['itemsize'] = dt.itemsize
+    elif dt.subdtype:
+        # subdtype
+        (item_dtype, shape) = dt.subdtype
+        d = (drop_metadata(item_dtype), shape)
+    else:
+        # scalar dtype
+        d = dt.str
+    new_dt = np.dtype(dtype=d, align=dt.isalignedstruct) 
+    return new_dt
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
the continuation of the  PR #23185

(Doesn't actually fix the `descr` part including things, but the important thing here)
Closes gh-23169, gh-15488