### PR TITLE
MAINT: remove `NUMPY_EXPERIMENTAL_ARRAY_FUNCTION` environment variable

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -272,13 +272,11 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
-  numpy2_flag_and_no_array_func:
+  numpy2_flag:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
-      NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: 0
-      # Array func and numpy-2 should be involved, so use this
-      # to have a test for feature flagged behavior.
+      # Test for numpy-2.0 feature-flagged behavior.
       NPY_NUMPY_2_BEHAVIOR: 1
       # Using the future "weak" state doesn't pass tests
       # currently unfortunately

--- a/doc/release/upcoming_changes/23376.expired.rst
+++ b/doc/release/upcoming_changes/23376.expired.rst
@@ -1,0 +1,9 @@
+Environment variable to disable dispatching removed
+---------------------------------------------------
+Support for the ``NUMPY_EXPERIMENTAL_ARRAY_FUNCTION`` environment variable has
+been removed. This variable disabled dispatching with ``__array_function__``.
+
+Support for ``y=`` as an alias of ``out=`` removed
+--------------------------------------------------
+The ``fix``, ``isposinf`` and ``isneginf`` functions allowed using ``y=`` as a
+(deprecated) alias for ``out=``. This is no longer supported.

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -162,15 +162,6 @@ NumPy provides several hooks that classes can customize:
 
    .. versionadded:: 1.16
 
-   .. note::
-
-       - In NumPy 1.17, the protocol is enabled by default, but can be disabled
-         with ``NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0``.
-       - In NumPy 1.16, you need to set the environment variable
-         ``NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1`` before importing NumPy to use
-         NumPy function overrides.
-       - Eventually, expect to ``__array_function__`` to always be enabled.
-
    -  ``func`` is an arbitrary callable exposed by NumPy's public API,
       which was called in the form ``func(*args, **kwargs)``.
    -  ``types`` is a collection :py:class:`collections.abc.Collection`

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -55,19 +55,6 @@ SIMD feature selection
 Setting ``NPY_DISABLE_CPU_FEATURES`` will exclude simd features at runtime.
 See :ref:`runtime-simd-dispatch`.
 
-Interoperability-Related Options
-================================
-
-The array function protocol which allows array-like objects to
-hook into the NumPy API is currently enabled by default.
-This option exists since NumPy 1.16 and is enabled by default since
-NumPy 1.17. It can be disabled using::
-
-    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
-
-See also :py:meth:`numpy.class.__array_function__` for more information.
-This flag is checked at import time.
-
 
 Debugging-Related Options
 =========================

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3830,10 +3830,6 @@ def round_(a, decimals=0, out=None):
     --------
     around : equivalent function; see for details.
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # call dispatch helper explicitly, as it emits a deprecation warning
-        _round__dispatcher(a, decimals=decimals, out=out)
-
     return around(a, decimals=decimals, out=out)
 
 
@@ -3859,10 +3855,6 @@ def product(*args, **kwargs):
     --------
     prod : equivalent function; see for details.
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # call dispatch helper explicitly, as it emits a deprecation warning
-        _product_dispatcher(*args, **kwargs)
-
     return prod(*args, **kwargs)
 
 
@@ -3887,10 +3879,6 @@ def cumproduct(*args, **kwargs):
     --------
     cumprod : equivalent function; see for details.
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # call dispatch helper explicitly, as it emits a deprecation warning
-        _cumproduct_dispatcher(*args, **kwargs)
-
     return cumprod(*args, **kwargs)
 
 
@@ -3918,10 +3906,6 @@ def sometrue(*args, **kwargs):
     --------
     any : equivalent function; see for details.
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # call dispatch helper explicitly, as it emits a deprecation warning
-        _sometrue_dispatcher(*args, **kwargs)
-
     return any(*args, **kwargs)
 
 
@@ -3946,8 +3930,4 @@ def alltrue(*args, **kwargs):
     --------
     numpy.all : Equivalent function; see for details.
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # call dispatch helper explicitly, as it emits a deprecation warning
-        _alltrue_dispatcher(*args, **kwargs)
-
     return all(*args, **kwargs)

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -11,9 +11,6 @@ from numpy.core._multiarray_umath import (
 
 ARRAY_FUNCTIONS = set()
 
-ARRAY_FUNCTION_ENABLED = bool(
-    int(os.environ.get('NUMPY_EXPERIMENTAL_ARRAY_FUNCTION', 1)))
-
 array_function_like_doc = (
     """like : array_like, optional
         Reference object to allow the creation of arrays which are not
@@ -140,17 +137,8 @@ def array_function_dispatch(dispatcher=None, module=None, verify=True,
     Returns
     -------
     Function suitable for decorating the implementation of a NumPy function.
+
     """
-
-    if not ARRAY_FUNCTION_ENABLED:
-        def decorator(implementation):
-            if docs_from_dispatcher:
-                add_docstring(implementation, dispatcher.__doc__)
-            if module is not None:
-                implementation.__module__ = module
-            return implementation
-        return decorator
-
     def decorator(implementation):
         if verify:
             if dispatcher is not None:

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -283,9 +283,6 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
            [6]])
 
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # reject non-sequences (and make tuple)
-        tup = _arrays_for_stack_dispatcher(tup)
     arrs = atleast_2d(*tup)
     if not isinstance(arrs, list):
         arrs = [arrs]
@@ -352,10 +349,6 @@ def hstack(tup, *, dtype=None, casting="same_kind"):
            [3, 6]])
 
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # reject non-sequences (and make tuple)
-        tup = _arrays_for_stack_dispatcher(tup)
-
     arrs = atleast_1d(*tup)
     if not isinstance(arrs, list):
         arrs = [arrs]
@@ -447,10 +440,6 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
            [3, 6]])
 
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # reject non-sequences (and make tuple)
-        arrays = _arrays_for_stack_dispatcher(arrays)
-
     arrays = [asanyarray(arr) for arr in arrays]
     if not arrays:
         raise ValueError('need at least one array to stack')

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -10,14 +10,9 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex)
 from numpy.core.overrides import (
     _get_implementing_args, array_function_dispatch,
-    verify_matching_signatures, ARRAY_FUNCTION_ENABLED)
+    verify_matching_signatures)
 from numpy.compat import pickle
 import pytest
-
-
-requires_array_function = pytest.mark.skipif(
-    not ARRAY_FUNCTION_ENABLED,
-    reason="__array_function__ dispatch not enabled.")
 
 
 def _return_not_implemented(self, *args, **kwargs):
@@ -150,7 +145,6 @@ class TestGetImplementingArgs:
 
 class TestNDArrayArrayFunction:
 
-    @requires_array_function
     def test_method(self):
 
         class Other:
@@ -209,7 +203,6 @@ class TestNDArrayArrayFunction:
                                      args=(array,), kwargs={})
 
 
-@requires_array_function
 class TestArrayFunctionDispatch:
 
     def test_pickle(self):
@@ -249,7 +242,6 @@ class TestArrayFunctionDispatch:
             dispatched_one_arg(array)
 
 
-@requires_array_function
 class TestVerifyMatchingSignatures:
 
     def test_verify_matching_signatures(self):
@@ -302,7 +294,6 @@ def _new_duck_type_and_implements():
     return (MyArray, implements)
 
 
-@requires_array_function
 class TestArrayFunctionImplementation:
 
     def test_one_arg(self):
@@ -472,7 +463,6 @@ class TestNumPyFunctions:
         signature = inspect.signature(np.sum)
         assert_('axis' in signature.parameters)
 
-    @requires_array_function
     def test_override_sum(self):
         MyArray, implements = _new_duck_type_and_implements()
 
@@ -482,7 +472,6 @@ class TestNumPyFunctions:
 
         assert_equal(np.sum(MyArray()), 'yes')
 
-    @requires_array_function
     def test_sum_on_mock_array(self):
 
         # We need a proxy for mocks because __array_function__ is only looked
@@ -503,7 +492,6 @@ class TestNumPyFunctions:
             np.sum, (ArrayProxy,), (proxy,), {})
         proxy.value.__array__.assert_not_called()
 
-    @requires_array_function
     def test_sum_forwarding_implementation(self):
 
         class MyArray(np.ndarray):
@@ -555,7 +543,6 @@ class TestArrayLike:
     def func_args(*args, **kwargs):
         return args, kwargs
 
-    @requires_array_function
     def test_array_like_not_implemented(self):
         self.add_method('array', self.MyArray)
 
@@ -588,7 +575,6 @@ class TestArrayLike:
 
     @pytest.mark.parametrize('function, args, kwargs', _array_tests)
     @pytest.mark.parametrize('numpy_ref', [True, False])
-    @requires_array_function
     def test_array_like(self, function, args, kwargs, numpy_ref):
         self.add_method('array', self.MyArray)
         self.add_method(function, self.MyArray)
@@ -621,7 +607,6 @@ class TestArrayLike:
 
     @pytest.mark.parametrize('function, args, kwargs', _array_tests)
     @pytest.mark.parametrize('ref', [1, [1], "MyNoArrayFunctionArray"])
-    @requires_array_function
     def test_no_array_function_like(self, function, args, kwargs, ref):
         self.add_method('array', self.MyNoArrayFunctionArray)
         self.add_method(function, self.MyNoArrayFunctionArray)
@@ -663,7 +648,6 @@ class TestArrayLike:
                 assert type(array_like) is self.MyArray
                 assert array_like.function is self.MyArray.fromfile
 
-    @requires_array_function
     def test_exception_handling(self):
         self.add_method('array', self.MyArray, enable_value_error=True)
 
@@ -692,7 +676,6 @@ class TestArrayLike:
         assert_equal(array_like, expected)
 
 
-@requires_array_function
 def test_function_like():
     # We provide a `__get__` implementation, make sure it works
     assert type(np.mean) is np.core._multiarray_umath._ArrayFunctionDispatcher 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4910,23 +4910,22 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     return ret
 
 
-if overrides.ARRAY_FUNCTION_ENABLED:
-    # If array-function is enabled (normal), we wrap everything into a C
-    # callable, which has no __code__ or other attributes normal Python funcs
-    # have.  SciPy however, tries to "clone" `trapz` into a new Python function
-    # which requires `__code__` and a few other attributes.
-    # So we create a dummy clone and copy over its attributes allowing
-    # SciPy <= 1.10 to work: https://github.com/scipy/scipy/issues/17811
-    assert not hasattr(trapz, "__code__")
+# __array_function__ has no __code__ or other attributes normal Python funcs we
+# wrap everything into a C callable. SciPy however, tries to "clone" `trapz`
+# into a new Python function which requires `__code__` and a few other
+# attributes. So we create a dummy clone and copy over its attributes allowing
+# SciPy <= 1.10 to work: https://github.com/scipy/scipy/issues/17811
+assert not hasattr(trapz, "__code__")
 
-    def _fake_trapz(y, x=None, dx=1.0, axis=-1):
-        return trapz(y, x=x, dx=dx, axis=axis)
+def _fake_trapz(y, x=None, dx=1.0, axis=-1):
+    return trapz(y, x=x, dx=dx, axis=axis)
 
-    trapz.__code__ = _fake_trapz.__code__
-    trapz.__globals__ = _fake_trapz.__globals__
-    trapz.__defaults__ = _fake_trapz.__defaults__
-    trapz.__closure__ = _fake_trapz.__closure__
-    trapz.__kwdefaults__ = _fake_trapz.__kwdefaults__
+
+trapz.__code__ = _fake_trapz.__code__
+trapz.__globals__ = _fake_trapz.__globals__
+trapz.__defaults__ = _fake_trapz.__defaults__
+trapz.__closure__ = _fake_trapz.__closure__
+trapz.__kwdefaults__ = _fake_trapz.__kwdefaults__
 
 
 def _meshgrid_dispatcher(*xi, copy=None, sparse=None, indexing=None):

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -643,10 +643,6 @@ def column_stack(tup):
            [3, 4]])
 
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # reject non-sequences (and make tuple)
-        tup = _arrays_for_stack_dispatcher(tup)
-
     arrays = []
     for v in tup:
         arr = asanyarray(v)
@@ -713,10 +709,6 @@ def dstack(tup):
            [[3, 4]]])
 
     """
-    if not overrides.ARRAY_FUNCTION_ENABLED:
-        # reject non-sequences (and make tuple)
-        tup = _arrays_for_stack_dispatcher(tup)
-
     arrs = atleast_3d(*tup)
     if not isinstance(arrs, list):
         arrs = [arrs]

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -4,19 +4,13 @@
 from numpy.testing import (
     assert_equal, assert_array_equal, assert_array_max_ulp,
     assert_array_almost_equal, assert_raises, assert_
-    )
-
+)
 from numpy import (
     arange, add, fliplr, flipud, zeros, ones, eye, array, diag, histogram2d,
     tri, mask_indices, triu_indices, triu_indices_from, tril_indices,
     tril_indices_from, vander,
-    )
-
+)
 import numpy as np
-
-
-from numpy.core.tests.test_overrides import requires_array_function
-
 
 import pytest
 
@@ -283,7 +277,6 @@ class TestHistogram2d:
         assert_array_equal(H, answer)
         assert_array_equal(xe, array([0., 0.25, 0.5, 0.75, 1]))
 
-    @requires_array_function
     def test_dispatch(self):
         class ShouldDispatch:
             def __array_function__(self, function, types, args, kwargs):

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -80,12 +80,6 @@ class TestUfunclike:
         assert_(isinstance(f0d, MyArray))
         assert_equal(f0d.metadata, 'bar')
 
-    def test_deprecated(self):
-        # NumPy 1.13.0, 2017-04-26
-        assert_warns(DeprecationWarning, ufl.fix, [1, 2], y=nx.empty(2))
-        assert_warns(DeprecationWarning, ufl.isposinf, [1, 2], y=nx.empty(2))
-        assert_warns(DeprecationWarning, ufl.isneginf, [1, 2], y=nx.empty(2))
-
     def test_scalar(self):
         x = np.inf
         actual = np.isposinf(x)

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -6,72 +6,16 @@ storing results in an output array.
 __all__ = ['fix', 'isneginf', 'isposinf']
 
 import numpy.core.numeric as nx
-from numpy.core.overrides import (
-    array_function_dispatch, ARRAY_FUNCTION_ENABLED,
-)
+from numpy.core.overrides import array_function_dispatch
 import warnings
 import functools
 
 
-def _deprecate_out_named_y(f):
-    """
-    Allow the out argument to be passed as the name `y` (deprecated)
-
-    In future, this decorator should be removed.
-    """
-    @functools.wraps(f)
-    def func(x, out=None, **kwargs):
-        if 'y' in kwargs:
-            if 'out' in kwargs:
-                raise TypeError(
-                    "{} got multiple values for argument 'out'/'y'"
-                    .format(f.__name__)
-                )
-            out = kwargs.pop('y')
-            # NumPy 1.13.0, 2017-04-26
-            warnings.warn(
-                "The name of the out argument to {} has changed from `y` to "
-                "`out`, to match other ufuncs.".format(f.__name__),
-                DeprecationWarning, stacklevel=3)
-        return f(x, out=out, **kwargs)
-
-    return func
-
-
-def _fix_out_named_y(f):
-    """
-    Allow the out argument to be passed as the name `y` (deprecated)
-
-    This decorator should only be used if _deprecate_out_named_y is used on
-    a corresponding dispatcher function.
-    """
-    @functools.wraps(f)
-    def func(x, out=None, **kwargs):
-        if 'y' in kwargs:
-            # we already did error checking in _deprecate_out_named_y
-            out = kwargs.pop('y')
-        return f(x, out=out, **kwargs)
-
-    return func
-
-
-def _fix_and_maybe_deprecate_out_named_y(f):
-    """
-    Use the appropriate decorator, depending upon if dispatching is being used.
-    """
-    if ARRAY_FUNCTION_ENABLED:
-        return _fix_out_named_y(f)
-    else:
-        return _deprecate_out_named_y(f)
-
-
-@_deprecate_out_named_y
 def _dispatcher(x, out=None):
     return (x, out)
 
 
 @array_function_dispatch(_dispatcher, verify=False, module='numpy')
-@_fix_and_maybe_deprecate_out_named_y
 def fix(x, out=None):
     """
     Round to nearest integer towards zero.
@@ -125,7 +69,6 @@ def fix(x, out=None):
 
 
 @array_function_dispatch(_dispatcher, verify=False, module='numpy')
-@_fix_and_maybe_deprecate_out_named_y
 def isposinf(x, out=None):
     """
     Test element-wise for positive infinity, return result as bool array.
@@ -197,7 +140,6 @@ def isposinf(x, out=None):
 
 
 @array_function_dispatch(_dispatcher, verify=False, module='numpy')
-@_fix_and_maybe_deprecate_out_named_y
 def isneginf(x, out=None):
     """
     Test element-wise for negative infinity, return result as bool array.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -14,7 +14,6 @@ from numpy.testing import (
     clear_and_catch_warnings, suppress_warnings, assert_string_equal, assert_,
     tempdir, temppath, assert_no_gc_cycles, HAS_REFCOUNT
     )
-from numpy.core.overrides import ARRAY_FUNCTION_ENABLED
 
 
 class _GenericTest:
@@ -191,8 +190,6 @@ class TestArrayEqual(_GenericTest):
         self._test_not_equal(a, b)
         self._test_not_equal(b, a)
 
-    @pytest.mark.skipif(
-        not ARRAY_FUNCTION_ENABLED, reason='requires __array_function__')
     def test_subclass_that_does_not_implement_npall(self):
         class MyArray(np.ndarray):
             def __array_function__(self, *args, **kwargs):


### PR DESCRIPTION
As discussed in https://mail.python.org/archives/list/numpy-discussion@python.org/thread/UKZJACAP5FUG7KP2AQDPE4P5ADNWLOHZ/. This flag was always meant to be temporary, and cleaning it up is long overdue.

During removal I came across a very old deprecation for `y=` as an alias for `out=` in `fix`/`isposinf`/`isneginf`, so I took that along as well.
