### PR TITLE
DOC: Add `n_children` param to rng.spawn() and bitgen.spawn() docs

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -240,12 +240,18 @@ cdef class Generator:
 
     def spawn(self, int n_children):
         """
+        spawn(n_children)
+
         Create new independent child generators.
 
         See :ref:`seedsequence-spawn` for additional notes on spawning
         children.
 
         .. versionadded:: 1.25.0
+
+        Parameters
+        ----------
+        n_children : int
 
         Returns
         -------

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -581,6 +581,8 @@ cdef class BitGenerator():
 
     def spawn(self, int n_children):
         """
+        spawn(n_children)
+
         Create new independent child bit generators.
 
         See :ref:`seedsequence-spawn` for additional notes on spawning
@@ -588,6 +590,10 @@ cdef class BitGenerator():
         as a different approach for creating independent streams.
 
         .. versionadded:: 1.25.0
+
+        Parameters
+        ----------
+        n_children : int
 
         Returns
         -------


### PR DESCRIPTION
The original PR forgot to include the Parameters section (and thus the paraeter itself).
