### PR TITLE
DOC: fixing a typo in polynomial roots Doc & cross-referencing domain #23374 

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -887,7 +887,7 @@ class ABCPolyBase(abc.ABC):
         """Return the roots of the series polynomial.
 
         Compute the roots for the series. Note that the accuracy of the
-        roots decrease the further outside the domain they lie.
+        roots decreases the further outside the `domain` they lie.
 
         Returns
         -------


### PR DESCRIPTION
Closes #23374 
1. fixing a typo in [polynomial roots](https://numpy.org/doc/stable/reference/generated/numpy.polynomial.polynomial.Polynomial.roots.html) documentation.
2. cross-referencing [domain ](https://numpy.org/doc/stable/reference/generated/numpy.polynomial.polynomial.Polynomial.domain.html#numpy.polynomial.polynomial.Polynomial.domain)in the same document