### PR TITLE
DEV: use micromamba to set up Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,4 @@
 {
-	// Conda requires lots of memory to resolve our environment
-	"hostRequirements": {
-		"memory": "8gb"
-	},
-
 	// More info about Features: https://containers.dev/features
 	"image": "mcr.microsoft.com/devcontainers/universal:2",
 	"features": {},

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,7 +2,12 @@
 
 set -e
 
+curl micro.mamba.pm/install.sh | bash
+
 conda init --all
-conda env create -f environment.yml
+micromamba shell init -s bash
+micromamba env create -f environment.yml --yes
+# Note that `micromamba activate numpy-dev` doesn't work, it must be run by the
+# user (same applies to `conda activate`)
 
 git submodule update --init


### PR DESCRIPTION
This is faster, and allows using 2-core instances instead of requiring a minimum of 8 GB / 4 cores. Users can now use `conda` or `micromamba` after the container starts.

xref gh-23134 for more context.