### PR TITLE
ENH: add circular mode to numpy.core.numeric.convolve

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -839,7 +839,11 @@ def convolve(a, v, mode='full'):
     mainconvolved = multiarray.correlate(a, v[::-1], mode="valid")
     tipconvolved = multiarray.correlate(tip, v[::-1], mode="valid")
     return multiarray.concatenate(
-        [tipconvolved[len(v) // 2 :], mainconvolved, tipconvolved[: len(v) // 2]]
+        [
+            tipconvolved[len(v) // 2:],
+            mainconvolved,
+            tipconvolved[: len(v) // 2],
+        ]
     )
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -831,7 +831,16 @@ def convolve(a, v, mode='full'):
         raise ValueError('a cannot be empty')
     if len(v) == 0:
         raise ValueError('v cannot be empty')
-    return multiarray.correlate(a, v[::-1], mode)
+
+    if mode != "circular":
+        return multiarray.correlate(a, v[::-1], mode)
+
+    tip = multiarray.concatenate([a[-(len(v) - 1) :], a[: len(v) - 1]])
+    mainconvolved = multiarray.correlate(a, v[::-1], mode="valid")
+    tipconvolved = multiarray.correlate(tip, v[::-1], mode="valid")
+    return multiarray.concatenate(
+        [tipconvolved[len(v) // 2 :], mainconvolved, tipconvolved[: len(v) // 2]]
+    )
 
 
 def _outer_dispatcher(a, b, out=None):

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1,3 +1,13 @@
+from ._ufunc_config import *
+from . import _ufunc_config
+from ._asarray import *
+from . import _asarray
+from .arrayprint import *
+from . import arrayprint
+from .fromnumeric import *
+from . import fromnumeric
+from .numerictypes import *
+from .umath import *
 import functools
 import itertools
 import operator
@@ -268,7 +278,7 @@ def ones_like(a, dtype=None, order='K', subok=True, shape=None):
 
 
 def _full_dispatcher(shape, fill_value, dtype=None, order=None, *, like=None):
-    return(like,)
+    return (like,)
 
 
 @set_array_function_like_doc
@@ -321,7 +331,7 @@ def full(shape, fill_value, dtype=None, order='C', *, like=None):
     """
     if like is not None:
         return _full_with_like(
-                like, shape, fill_value, dtype=dtype, order=order)
+            like, shape, fill_value, dtype=dtype, order=order)
 
     if dtype is None:
         fill_value = asarray(fill_value)
@@ -604,7 +614,7 @@ def argwhere(a):
     if np.ndim(a) == 0:
         a = shape_base.atleast_1d(a)
         # then remove the added dimension
-        return argwhere(a)[:,:0]
+        return argwhere(a)[:, :0]
     return transpose(nonzero(a))
 
 
@@ -835,7 +845,7 @@ def convolve(a, v, mode='full'):
     if mode != "circular":
         return multiarray.correlate(a, v[::-1], mode)
 
-    tip = multiarray.concatenate([a[-(len(v) - 1) :], a[: len(v) - 1]])
+    tip = multiarray.concatenate([a[-(len(v) - 1):], a[: len(v) - 1]])
     mainconvolved = multiarray.correlate(a, v[::-1], mode="valid")
     tipconvolved = multiarray.correlate(tip, v[::-1], mode="valid")
     return multiarray.concatenate(
@@ -1853,7 +1863,7 @@ def fromfunction(function, shape, *, dtype=float, like=None, **kwargs):
     """
     if like is not None:
         return _fromfunction_with_like(
-                like, function, shape, dtype=dtype, **kwargs)
+            like, function, shape, dtype=dtype, **kwargs)
 
     args = indices(shape, dtype=dtype)
     return function(*args, **kwargs)
@@ -2526,16 +2536,6 @@ def extend_all(module):
             __all__.append(a)
 
 
-from .umath import *
-from .numerictypes import *
-from . import fromnumeric
-from .fromnumeric import *
-from . import arrayprint
-from .arrayprint import *
-from . import _asarray
-from ._asarray import *
-from . import _ufunc_config
-from ._ufunc_config import *
 extend_all(fromnumeric)
 extend_all(umath)
 extend_all(numerictypes)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3036,6 +3036,14 @@ class TestConvolve:
         with assert_raises(TypeError):
             np.convolve(d, k, mode=None)
 
+    def test_circular(self):
+        d = [1.] * 100
+        k = [1.] * 3
+        assert_array_equal(
+            np.convolve(d, k, mode='valid'), 
+            np.convolve(d, k, mode='circular')
+        ) 
+
 
 class TestArgwhere:
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3051,7 +3051,7 @@ class TestConvolve:
         d = [1.] * 100
         k = [1.] * 3
         assert_array_equal(
-            np.convolve(d, k, mode='valid'),
+            np.convolve(d, k, mode='same'),
             np.convolve(d, k, mode='circular')
         )
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -13,7 +13,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_warns, assert_array_max_ulp, HAS_REFCOUNT, IS_WASM
-    )
+)
 from numpy.core._rational_tests import rational
 
 from hypothesis import given, strategies as st
@@ -191,8 +191,8 @@ class TestNonarrayArgs:
 
     @pytest.mark.parametrize('val, ndigits', [
         pytest.param(2**31 - 1, -1,
-            marks=pytest.mark.xfail(reason="Out of range of int32")
-        ),
+                     marks=pytest.mark.xfail(reason="Out of range of int32")
+                     ),
         (2**31 - 1, 1-math.ceil(math.log10(2**31 - 1))),
         (2**31 - 1, -math.ceil(math.log10(2**31 - 1)))
     ])
@@ -673,9 +673,9 @@ class TestFloatExceptions:
             # pass the assert
             if not np.isnan(ft_tiny):
                 self.assert_raises_fpe(underflow,
-                                    lambda a, b: a/b, ft_tiny, ft_max)
+                                       lambda a, b: a/b, ft_tiny, ft_max)
                 self.assert_raises_fpe(underflow,
-                                    lambda a, b: a*b, ft_tiny, ft_tiny)
+                                       lambda a, b: a*b, ft_tiny, ft_tiny)
             self.assert_raises_fpe(overflow,
                                    lambda a, b: a*b, ft_max, ftype(2))
             self.assert_raises_fpe(overflow,
@@ -727,7 +727,8 @@ class TestTypes:
         # tests that the scalars get coerced correctly.
         b = np.bool_(0)
         i8, i16, i32, i64 = np.int8(0), np.int16(0), np.int32(0), np.int64(0)
-        u8, u16, u32, u64 = np.uint8(0), np.uint16(0), np.uint32(0), np.uint64(0)
+        u8, u16, u32, u64 = np.uint8(0), np.uint16(
+            0), np.uint32(0), np.uint64(0)
         f32, f64, fld = np.float32(0), np.float64(0), np.longdouble(0)
         c64, c128, cld = np.complex64(0), np.complex128(0), np.clongdouble(0)
 
@@ -905,7 +906,7 @@ class TestTypes:
     @pytest.mark.parametrize("string_dtype", ["U", "S"])
     def test_promote_types_strings(self, swap, string_dtype):
         if swap == "swap":
-            promote_types = lambda a, b: np.promote_types(b, a)
+            def promote_types(a, b): return np.promote_types(b, a)
         else:
             promote_types = np.promote_types
 
@@ -939,27 +940,28 @@ class TestTypes:
         assert_equal(promote_types('O', S+'30'), np.dtype('O'))
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V6"), np.dtype("V10")],  # mismatch shape
-             # Mismatching names:
-             [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
-            ])
+                             [[np.dtype("V6"), np.dtype("V10")],  # mismatch shape
+                              # Mismatching names:
+                              [np.dtype([("name1", "i8")]),
+                               np.dtype([("name2", "i8")])],
+                              ])
     def test_invalid_void_promotion(self, dtype1, dtype2):
         with pytest.raises(TypeError):
             np.promote_types(dtype1, dtype2)
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V10"), np.dtype("V10")],
-             [np.dtype([("name1", "i8")]),
-              np.dtype([("name1", np.dtype("i8").newbyteorder())])],
-             [np.dtype("i8,i8"), np.dtype("i8,>i8")],
-             [np.dtype("i8,i8"), np.dtype("i4,i4")],
-            ])
+                             [[np.dtype("V10"), np.dtype("V10")],
+                              [np.dtype([("name1", "i8")]),
+                                 np.dtype([("name1", np.dtype("i8").newbyteorder())])],
+                              [np.dtype("i8,i8"), np.dtype("i8,>i8")],
+                              [np.dtype("i8,i8"), np.dtype("i4,i4")],
+                              ])
     def test_valid_void_promotion(self, dtype1, dtype2):
         assert np.promote_types(dtype1, dtype2) == dtype1
 
     @pytest.mark.parametrize("dtype",
-            list(np.typecodes["All"]) +
-            ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
+                             list(np.typecodes["All"]) +
+                             ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
     def test_promote_identical_types_metadata(self, dtype):
         # The same type passed in twice to promote types always
         # preserves metadata
@@ -988,10 +990,10 @@ class TestTypes:
     @pytest.mark.slow
     @pytest.mark.filterwarnings('ignore:Promotion of numbers:FutureWarning')
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            itertools.product(
-                list(np.typecodes["All"]) +
-                ["i,i", "S3", "S100", "U3", "U100", rational],
-                repeat=2))
+                             itertools.product(
+        list(np.typecodes["All"]) +
+        ["i,i", "S3", "S100", "U3", "U100", rational],
+        repeat=2))
     def test_promote_types_metadata(self, dtype1, dtype2):
         """Metadata handling in promotion does not appear formalized
         right now in NumPy. This test should thus be considered to
@@ -1189,7 +1191,7 @@ class TestFromiter:
         assert_(len(a) == len(expected))
         assert_(len(a20) == 20)
         assert_raises(ValueError, np.fromiter,
-                          self.makegen(), int, len(expected) + 10)
+                      self.makegen(), int, len(expected) + 10)
 
     def test_values(self):
         expected = np.array(list(self.makegen()))
@@ -1223,14 +1225,14 @@ class TestFromiter:
             np.fromiter([], dtype=dtype)
 
     @pytest.mark.parametrize(["dtype", "data"],
-            [("d", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
-             ("O", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
-             ("i,O", [(1, 2), (5, 4), (2, 3), (9, 8), (6, 7)]),
-             # subarray dtypes (important because their dimensions end up
-             # in the result arrays dimension:
-             ("2i", [(1, 2), (5, 4), (2, 3), (9, 8), (6, 7)]),
-             (np.dtype(("O", (2, 3))),
-              [((1, 2, 3), (3, 4, 5)), ((3, 2, 1), (5, 4, 3))])])
+                             [("d", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                              ("O", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                              ("i,O", [(1, 2), (5, 4), (2, 3), (9, 8), (6, 7)]),
+                              # subarray dtypes (important because their dimensions end up
+                              # in the result arrays dimension:
+                              ("2i", [(1, 2), (5, 4), (2, 3), (9, 8), (6, 7)]),
+                              (np.dtype(("O", (2, 3))),
+                                 [((1, 2, 3), (3, 4, 5)), ((3, 2, 1), (5, 4, 3))])])
     @pytest.mark.parametrize("length_hint", [0, 1])
     def test_growth_and_complicated_dtypes(self, dtype, data, length_hint):
         dtype = np.dtype(dtype)
@@ -1276,6 +1278,7 @@ class TestFromiter:
         iterable = ((2, 3, 4) for i in range(5))
         with pytest.raises(ValueError):
             np.fromiter(iterable, dtype=np.dtype((int, 2)))
+
 
 class TestNonzero:
     def test_nonzero_trivial(self):
@@ -1335,8 +1338,8 @@ class TestNonzero:
         assert_equal(np.nonzero(x), ([0, 1, 2], [0, 1, 2]))
 
         x = np.array([[(0, 1), (0, 0), (1, 11)],
-                   [(1, 1), (1, 0), (0, 0)],
-                   [(0, 0), (1, 5), (0, 1)]], dtype=[('a', 'f4'), ('b', 'u1')])
+                      [(1, 1), (1, 0), (0, 0)],
+                      [(0, 0), (1, 5), (0, 1)]], dtype=[('a', 'f4'), ('b', 'u1')])
         assert_equal(np.count_nonzero(x['a']), 4)
         assert_equal(np.count_nonzero(x['b']), 5)
         assert_equal(np.nonzero(x['a']), ([0, 1, 1, 2], [2, 0, 1, 1]))
@@ -1517,6 +1520,7 @@ class TestNonzero:
         # gh-13631
         class FalseThenTrue:
             _val = False
+
             def __bool__(self):
                 try:
                     return self._val
@@ -1525,6 +1529,7 @@ class TestNonzero:
 
         class TrueThenFalse:
             _val = True
+
             def __bool__(self):
                 try:
                     return self._val
@@ -1602,6 +1607,7 @@ class TestNonzero:
         dt = np.dtype([("", dt)] * 2)
         # The array should be large enough to likely run into threading issues
         arr = np.random.uniform(size=(5000, 4)).view(dt)[:, 0]
+
         def func(arr):
             arr.nonzero()
 
@@ -1620,7 +1626,8 @@ class TestIndex:
         g1 = randint(0, 5, size=15)
         g2 = randint(0, 8, size=15)
         V[g1, g2] = -V[g1, g2]
-        assert_((np.array([a[0][V > 0], a[1][V > 0], a[2][V > 0]]) == a[:, V > 0]).all())
+        assert_(
+            (np.array([a[0][V > 0], a[1][V > 0], a[2][V > 0]]) == a[:, V > 0]).all())
 
     def test_boolean_edgecase(self):
         a = np.array([], dtype='int32')
@@ -1708,7 +1715,8 @@ class TestArrayComparisons:
         res = np.array_equal(np.array([1, 2]), np.array([1, 3]))
         assert_(not res)
         assert_(type(res) is bool)
-        res = np.array_equal(np.array(['a'], dtype='S1'), np.array(['a'], dtype='S1'))
+        res = np.array_equal(
+            np.array(['a'], dtype='S1'), np.array(['a'], dtype='S1'))
         assert_(res)
         assert_(type(res) is bool)
         res = np.array_equal(np.array([('a', 1)], dtype='S1,u4'),
@@ -1781,7 +1789,8 @@ class TestArrayComparisons:
         res = np.array_equiv(np.array([1, 2]), np.array([[1], [2]]))
         assert_(not res)
         assert_(type(res) is bool)
-        res = np.array_equiv(np.array([1, 2]), np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+        res = np.array_equiv(np.array([1, 2]), np.array(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
         assert_(not res)
         assert_(type(res) is bool)
 
@@ -2313,7 +2322,7 @@ class TestClip:
         (1, np.zeros(10)),
         # two arrays
         (np.ones(10), np.zeros(10)),
-        ])
+    ])
     def test_clip_value_min_max_flip(self, amin, amax):
         a = np.arange(10, dtype=np.int64)
         # requirement from ufunc_docstrings.py
@@ -2402,9 +2411,9 @@ class TestClip:
         s = numeric_dtypes.flatmap(
             lambda x: hynp.from_dtype(x, allow_nan=False))
         amin = data.draw(s | hynp.arrays(dtype=numeric_dtypes,
-            shape=in_shapes[0], elements={"allow_nan": False}))
+                                         shape=in_shapes[0], elements={"allow_nan": False}))
         amax = data.draw(s | hynp.arrays(dtype=numeric_dtypes,
-            shape=in_shapes[1], elements={"allow_nan": False}))
+                                         shape=in_shapes[1], elements={"allow_nan": False}))
 
         # Then calculate our result and expected result and check that they're
         # equal!  See gh-12519 and gh-19457 for discussion deciding on this
@@ -2512,43 +2521,43 @@ class TestIsclose:
         aran = np.arange(125).reshape((5, 5, 5))
 
         self.all_close_tests = [
-                ([1, 0], [1, 0]),
-                ([atol], [0]),
-                ([1], [1 + rtol + atol]),
-                (arr, arr + arr*rtol),
-                (arr, arr + arr*rtol + atol),
-                (aran, aran + aran*rtol),
-                (np.inf, np.inf),
-                (np.inf, [np.inf]),
-                ([np.inf, -np.inf], [np.inf, -np.inf]),
-                ]
+            ([1, 0], [1, 0]),
+            ([atol], [0]),
+            ([1], [1 + rtol + atol]),
+            (arr, arr + arr*rtol),
+            (arr, arr + arr*rtol + atol),
+            (aran, aran + aran*rtol),
+            (np.inf, np.inf),
+            (np.inf, [np.inf]),
+            ([np.inf, -np.inf], [np.inf, -np.inf]),
+        ]
         self.none_close_tests = [
-                ([np.inf, 0], [1, np.inf]),
-                ([np.inf, -np.inf], [1, 0]),
-                ([np.inf, np.inf], [1, -np.inf]),
-                ([np.inf, np.inf], [1, 0]),
-                ([np.nan, 0], [np.nan, -np.inf]),
-                ([atol*2], [0]),
-                ([1], [1 + rtol + atol*2]),
-                (aran, aran + rtol*1.1*aran + atol*1.1),
-                (np.array([np.inf, 1]), np.array([0, np.inf])),
-                ]
+            ([np.inf, 0], [1, np.inf]),
+            ([np.inf, -np.inf], [1, 0]),
+            ([np.inf, np.inf], [1, -np.inf]),
+            ([np.inf, np.inf], [1, 0]),
+            ([np.nan, 0], [np.nan, -np.inf]),
+            ([atol*2], [0]),
+            ([1], [1 + rtol + atol*2]),
+            (aran, aran + rtol*1.1*aran + atol*1.1),
+            (np.array([np.inf, 1]), np.array([0, np.inf])),
+        ]
         self.some_close_tests = [
-                ([np.inf, 0], [np.inf, atol*2]),
-                ([atol, 1, 1e6*(1 + 2*rtol) + atol], [0, np.nan, 1e6]),
-                (np.arange(3), [0, 1, 2.1]),
-                (np.nan, [np.nan, np.nan, np.nan]),
-                ([0], [atol, np.inf, -np.inf, np.nan]),
-                (0, [atol, np.inf, -np.inf, np.nan]),
-                ]
+            ([np.inf, 0], [np.inf, atol*2]),
+            ([atol, 1, 1e6*(1 + 2*rtol) + atol], [0, np.nan, 1e6]),
+            (np.arange(3), [0, 1, 2.1]),
+            (np.nan, [np.nan, np.nan, np.nan]),
+            ([0], [atol, np.inf, -np.inf, np.nan]),
+            (0, [atol, np.inf, -np.inf, np.nan]),
+        ]
         self.some_close_results = [
-                [True, False],
-                [True, False, False],
-                [True, True, False],
-                [False, False, False],
-                [True, False, False, False],
-                [True, False, False, False],
-                ]
+            [True, False],
+            [True, False, False],
+            [True, True, False],
+            [False, False, False],
+            [True, False, False, False],
+            [True, False, False, False],
+        ]
 
     def test_ip_isclose(self):
         self._setup()
@@ -2570,7 +2579,8 @@ class TestIsclose:
         if np.isscalar(x) and np.isscalar(y):
             assert_(np.isclose(x, y) == np.allclose(x, y), msg=msg2 % (x, y))
         else:
-            assert_array_equal(np.isclose(x, y).all(), np.allclose(x, y), msg % (x, y))
+            assert_array_equal(np.isclose(x, y).all(),
+                               np.allclose(x, y), msg % (x, y))
 
     def test_ip_all_isclose(self):
         self._setup()
@@ -2643,7 +2653,8 @@ class TestIsclose:
         # an integer or also a timedelta64
         a = np.array([[1, 2, 3, "NaT"]], dtype="m8[ns]")
         assert np.isclose(a, a, atol=0, equal_nan=True).all()
-        assert np.isclose(a, a, atol=np.timedelta64(1, "ns"), equal_nan=True).all()
+        assert np.isclose(a, a, atol=np.timedelta64(
+            1, "ns"), equal_nan=True).all()
         assert np.allclose(a, a, atol=0, equal_nan=True)
         assert np.allclose(a, a, atol=np.timedelta64(1, "ns"), equal_nan=True)
 
@@ -2775,29 +2786,29 @@ class TestLikeFuncs:
 
     def setup_method(self):
         self.data = [
-                # Array scalars
-                (np.array(3.), None),
-                (np.array(3), 'f8'),
-                # 1D arrays
-                (np.arange(6, dtype='f4'), None),
-                (np.arange(6), 'c16'),
-                # 2D C-layout arrays
-                (np.arange(6).reshape(2, 3), None),
-                (np.arange(6).reshape(3, 2), 'i1'),
-                # 2D F-layout arrays
-                (np.arange(6).reshape((2, 3), order='F'), None),
-                (np.arange(6).reshape((3, 2), order='F'), 'i1'),
-                # 3D C-layout arrays
-                (np.arange(24).reshape(2, 3, 4), None),
-                (np.arange(24).reshape(4, 3, 2), 'f4'),
-                # 3D F-layout arrays
-                (np.arange(24).reshape((2, 3, 4), order='F'), None),
-                (np.arange(24).reshape((4, 3, 2), order='F'), 'f4'),
-                # 3D non-C/F-layout arrays
-                (np.arange(24).reshape(2, 3, 4).swapaxes(0, 1), None),
-                (np.arange(24).reshape(4, 3, 2).swapaxes(0, 1), '?'),
-                     ]
-        self.shapes = [(), (5,), (5,6,), (5,6,7,)]
+            # Array scalars
+            (np.array(3.), None),
+            (np.array(3), 'f8'),
+            # 1D arrays
+            (np.arange(6, dtype='f4'), None),
+            (np.arange(6), 'c16'),
+            # 2D C-layout arrays
+            (np.arange(6).reshape(2, 3), None),
+            (np.arange(6).reshape(3, 2), 'i1'),
+            # 2D F-layout arrays
+            (np.arange(6).reshape((2, 3), order='F'), None),
+            (np.arange(6).reshape((3, 2), order='F'), 'i1'),
+            # 3D C-layout arrays
+            (np.arange(24).reshape(2, 3, 4), None),
+            (np.arange(24).reshape(4, 3, 2), 'f4'),
+            # 3D F-layout arrays
+            (np.arange(24).reshape((2, 3, 4), order='F'), None),
+            (np.arange(24).reshape((4, 3, 2), order='F'), 'f4'),
+            # 3D non-C/F-layout arrays
+            (np.arange(24).reshape(2, 3, 4).swapaxes(0, 1), None),
+            (np.arange(24).reshape(4, 3, 2).swapaxes(0, 1), '?'),
+        ]
+        self.shapes = [(), (5,), (5, 6,), (5, 6, 7,)]
 
     def compare_array_value(self, dz, value, fill_value):
         if value is not None:
@@ -3040,9 +3051,9 @@ class TestConvolve:
         d = [1.] * 100
         k = [1.] * 3
         assert_array_equal(
-            np.convolve(d, k, mode='valid'), 
+            np.convolve(d, k, mode='valid'),
             np.convolve(d, k, mode='circular')
-        ) 
+        )
 
 
 class TestArgwhere:
@@ -3188,7 +3199,7 @@ class TestRollaxis:
             res = np.rollaxis(a, axis=i, start=j)
             i0, i1, i2, i3 = aind[np.array(res.shape) - 1]
             assert_(np.all(res[i0, i1, i2, i3] == a))
-            assert_(res.shape == self.tgtshape[(i, j)], str((i,j)))
+            assert_(res.shape == self.tgtshape[(i, j)], str((i, j)))
             assert_(not res.flags['OWNDATA'])
 
             # negative axis, positive start
@@ -3233,7 +3244,7 @@ class TestMoveaxis:
                 (0, 1, (2, 1, 3, 4)),
                 (1, 2, (1, 3, 2, 4)),
                 (1, -1, (1, 3, 4, 2)),
-                ]:
+        ]:
             actual = np.moveaxis(x, source, destination).shape
             assert_(actual, expected)
 
@@ -3246,7 +3257,7 @@ class TestMoveaxis:
                 ([0, -1], [0, -1]),
                 ([2, 0], [2, 0]),
                 (range(4), range(4)),
-                ]:
+        ]:
             actual = np.moveaxis(x, source, destination).shape
             assert_(actual, (1, 2, 3, 4))
 
@@ -3258,7 +3269,7 @@ class TestMoveaxis:
                 ([0, 1, 2], [2, 3, 0], (2, 3, 0, 1)),
                 ([3, 0], [1, 0], (0, 3, 1, 2)),
                 ([0, 3], [0, 1], (0, 3, 1, 2)),
-                ]:
+        ]:
             actual = np.moveaxis(x, source, destination).shape
             assert_(actual, expected)
 
@@ -3381,7 +3392,7 @@ def test_outer_out_param():
     arr1 = np.ones((5,))
     arr2 = np.ones((2,))
     arr3 = np.linspace(-2, 2, 5)
-    out1 = np.ndarray(shape=(5,5))
+    out1 = np.ndarray(shape=(5, 5))
     out2 = np.ndarray(shape=(2, 5))
     res1 = np.outer(arr1, arr3, out1)
     assert_equal(res1, out1)
@@ -3415,7 +3426,7 @@ class TestIndices:
         assert_array_equal([[]], np.indices((0,), sparse=True))
 
     def test_sparse(self):
-        [x, y] = np.indices((4,3), sparse=True)
+        [x, y] = np.indices((4, 3), sparse=True)
         assert_array_equal(x, np.array([[0], [1], [2], [3]]))
         assert_array_equal(y, np.array([[0, 1, 2]]))
 
@@ -3542,9 +3553,9 @@ class TestBroadcast:
                 assert_equal(mit.numiter, j)
 
     def test_broadcast_error_kwargs(self):
-        #gh-13455
+        # gh-13455
         arrs = [np.empty((5, 6, 7))]
-        mit  = np.broadcast(*arrs)
+        mit = np.broadcast(*arrs)
         mit2 = np.broadcast(*arrs, **{})
         assert_equal(mit.shape, mit2.shape)
         assert_equal(mit.ndim, mit2.ndim)
@@ -3576,8 +3587,8 @@ class TestTensordot:
 
     def test_zero_dimension(self):
         # Test resolution to issue #5663
-        a = np.ndarray((3,0))
-        b = np.ndarray((0,4))
+        a = np.ndarray((3, 0))
+        b = np.ndarray((0, 4))
         td = np.tensordot(a, b, (1, 0))
         assert_array_equal(td, np.dot(a, b))
         assert_array_equal(td, np.einsum('ij,jk', a, b))
@@ -3585,5 +3596,6 @@ class TestTensordot:
     def test_zero_dimensional(self):
         # gh-12130
         arr_0d = np.array(1)
-        ret = np.tensordot(arr_0d, arr_0d, ([], []))  # contracting no axes is well defined
+        # contracting no axes is well defined
+        ret = np.tensordot(arr_0d, arr_0d, ([], []))
         assert_array_equal(ret, arr_0d)


### PR DESCRIPTION
The circular convolution mode is useful for computing convolution on circular arrays.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
