### PR TITLE
MAINT: Fix 'tranform' and 'paramter' typos

### DIFF
--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -1,6 +1,6 @@
 """
 Tests for array coercion, mainly through testing `np.array` results directly.
-Note that other such tests exist e.g. in `test_api.py` and many corner-cases
+Note that other such tests exist, e.g., in `test_api.py` and many corner-cases
 are tested (sometimes indirectly) elsewhere.
 """
 
@@ -20,8 +20,8 @@ from numpy.testing import (
 def arraylikes():
     """
     Generator for functions converting an array into various array-likes.
-    If full is True (default) includes array-likes not capable of handling
-    all dtypes
+    If full is True (default) it includes array-likes not capable of handling
+    all dtypes.
     """
     # base array:
     def ndarray(a):
@@ -40,8 +40,8 @@ def arraylikes():
 
     class _SequenceLike():
         # We are giving a warning that array-like's were also expected to be
-        # sequence-like in `np.array([array_like])`, this can be removed
-        # when the deprecation exired (started NumPy 1.20)
+        # sequence-like in `np.array([array_like])`. This can be removed
+        # when the deprecation expired (started NumPy 1.20).
         def __len__(self):
             raise TypeError
 
@@ -259,7 +259,7 @@ class TestScalarDiscovery:
     @pytest.mark.parametrize("scalar", scalar_instances())
     def test_scalar_coercion(self, scalar):
         # This tests various scalar coercion paths, mainly for the numerical
-        # types.  It includes some paths not directly related to `np.array`
+        # types. It includes some paths not directly related to `np.array`.
         if isinstance(scalar, np.inexact):
             # Ensure we have a full-precision number if available
             scalar = type(scalar)((scalar * 2)**0.5)
@@ -294,7 +294,7 @@ class TestScalarDiscovery:
            * `np.array(scalar, dtype=dtype)`
            * `np.empty((), dtype=dtype)[()] = scalar`
            * `np.array(scalar).astype(dtype)`
-        should behave the same.  The only exceptions are paramteric dtypes
+        should behave the same.  The only exceptions are parametric dtypes
         (mainly datetime/timedelta without unit) and void without fields.
         """
         dtype = cast_to.dtype  # use to parametrize only the target dtype
@@ -386,7 +386,7 @@ class TestScalarDiscovery:
         """
         dtype = np.dtype(dtype)
 
-        # This is a special case using casting logic.  It warns for the NaN
+        # This is a special case using casting logic. It warns for the NaN
         # but allows the cast (giving undefined behaviour).
         with np.errstate(invalid="ignore"):
             coerced = np.array(scalar, dtype=dtype)


### PR DESCRIPTION
In several source files the words _transform_, _parameter_ and _parametric_ have typos.
This little PR solves them.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
