### PR TITLE
ENH: Use AVX512 FP16 ISA for sorting float16 arrays

### DIFF
--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -1,5 +1,5 @@
 /*@targets
- * $maxopt $keep_baseline avx512_icl
+ * $maxopt $keep_baseline avx512_icl avx512_spr
  */
 // policy $keep_baseline is used to avoid skip building avx512_skx
 // when its part of baseline features (--cpu-baseline), since
@@ -7,16 +7,23 @@
 
 #include "simd_qsort.hpp"
 
-#if defined(NPY_HAVE_AVX512_ICL) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SPR) && !defined(_MSC_VER)
+    #include "x86-simd-sort/src/avx512fp16-16bit-qsort.hpp"
+#elif defined(NPY_HAVE_AVX512_ICL) && !defined(_MSC_VER)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
 #endif
 
 namespace np { namespace qsort_simd {
 
-#if defined(NPY_HAVE_AVX512_ICL) && !defined(_MSC_VER)
+#if !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
 {
+#if defined(NPY_HAVE_AVX512_SPR)
+    avx512_qsort(reinterpret_cast<_Float16*>(arr), size);
+#else
     avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, intptr_t size)
 {
@@ -26,6 +33,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
-#endif // NPY_HAVE_AVX512_ICL
+#endif // NPY_HAVE_AVX512_ICL || SPR
+#endif // _MSC_VER
 
 }} // namespace np::qsort_simd


### PR DESCRIPTION
Leverages AVX512 FP16 simd sort from x86-simd-sort to speed up sorting float16 arrays by nearly 3x. 

```
       before           after         ratio
     [094416f7]       [9d1ef15e]
     <main>           <spr-simd-sort>
+     7.67±0.02μs      12.7±0.01μs     1.66  bench_function_base.Sort.time_sort('merge', 'int16', ('uniform',))
+     7.67±0.02μs      12.7±0.02μs     1.66  bench_function_base.Sort.time_sort('merge', 'int16', ('ordered',))
+      42.5±0.1μs       69.2±0.3μs     1.63  bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 1000))
+     42.5±0.07μs       69.1±0.7μs     1.63  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 1000))
+      78.5±0.3μs          128±1μs     1.62  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 100))
+      78.6±0.2μs        125±0.5μs     1.60  bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 100))
+       102±0.5μs          150±2μs     1.47  bench_function_base.Sort.time_sort('merge', 'float16', ('sorted_block', 1000))
+     8.53±0.02μs       12.1±0.1μs     1.42  bench_function_base.Sort.time_sort('merge', 'uint32', ('uniform',))
+     8.54±0.02μs       12.0±0.3μs     1.41  bench_function_base.Sort.time_sort('merge', 'uint32', ('ordered',))
+     18.1±0.03μs      23.7±0.06μs     1.31  bench_function_base.Sort.time_sort('merge', 'float64', ('uniform',))
+     18.1±0.01μs      23.6±0.05μs     1.30  bench_function_base.Sort.time_sort('merge', 'float64', ('ordered',))
+       142±0.1μs        173±0.3μs     1.22  bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 10))
+       141±0.3μs        172±0.5μs     1.21  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 10))
+     8.54±0.03μs       10.3±0.6μs     1.21  bench_function_base.Sort.time_sort('merge', 'int32', ('ordered',))
+     8.53±0.05μs       10.3±0.5μs     1.20  bench_function_base.Sort.time_sort('merge', 'int32', ('uniform',))
+      30.5±0.1μs       35.9±0.5μs     1.18  bench_function_base.Sort.time_sort('heap', 'int32', ('uniform',))
+         174±1μs          199±2μs     1.14  bench_function_base.Sort.time_sort('merge', 'float16', ('sorted_block', 100))
+       125±0.9μs        142±0.4μs     1.13  bench_function_base.Sort.time_sort('merge', 'float64', ('sorted_block', 100))
+       124±0.1μs        140±0.3μs     1.13  bench_function_base.Sort.time_sort('merge', 'float32', ('sorted_block', 100))
+       186±0.2μs        209±0.7μs     1.12  bench_function_base.Sort.time_sort('merge', 'float32', ('sorted_block', 10))
+      71.0±0.1μs       79.5±0.1μs     1.12  bench_function_base.Sort.time_sort('merge', 'float32', ('sorted_block', 1000))
+     73.0±0.07μs       79.5±0.4μs     1.09  bench_function_base.Sort.time_sort('merge', 'float64', ('sorted_block', 1000))
+     29.8±0.05μs       31.6±0.3μs     1.06  bench_function_base.Sort.time_sort('heap', 'uint32', ('uniform',))
+       720±0.9μs          765±6μs     1.06  bench_function_base.Sort.time_sort('heap', 'int32', ('reversed',))
+         869±3μs          921±6μs     1.06  bench_function_base.Sort.time_sort('merge', 'float64', ('random',))
+         314±3μs          332±2μs     1.06  bench_function_base.Sort.time_sort('merge', 'float16', ('sorted_block', 10))
+      19.4±0.1μs       20.5±0.2μs     1.05  bench_function_base.Sort.time_sort('merge', 'float64', ('reversed',))
+         971±4μs         1.02±0ms     1.05  bench_function_base.Sort.time_sort('heap', 'int16', ('sorted_block', 100))
+        1.09±0ms      1.15±0.01ms     1.05  bench_function_base.Sort.time_sort('heap', 'float64', ('sorted_block', 1000))
-         860±2μs          819±2μs     0.95  bench_function_base.Sort.time_sort('heap', 'float64', ('ordered',))
-         977±4μs          924±2μs     0.95  bench_function_base.Sort.time_sort('heap', 'int64', ('sorted_block', 1000))
-      18.0±0.7μs      16.9±0.05μs     0.94  bench_function_base.Sort.time_sort('merge', 'float32', ('reversed',))
-        70.3±2μs       65.3±0.2μs     0.93  bench_function_base.Sort.time_sort('heap', 'float16', ('uniform',))
-      18.1±0.3μs      16.8±0.07μs     0.93  bench_function_base.Sort.time_sort('merge', 'float32', ('uniform',))
-      18.1±0.1μs       16.7±0.1μs     0.92  bench_function_base.Sort.time_sort('merge', 'float32', ('ordered',))
-         943±4μs          869±5μs     0.92  bench_function_base.Sort.time_sort('merge', 'float32', ('random',))
-      36.4±0.5μs       32.4±0.2μs     0.89  bench_function_base.Sort.time_sort('heap', 'int16', ('uniform',))
-      55.4±0.4μs      48.2±0.02μs     0.87  bench_function_base.Sort.time_sort('merge', 'int64', ('sorted_block', 1000))
-      99.3±0.1μs       84.7±0.2μs     0.85  bench_function_base.Sort.time_sort('merge', 'int64', ('sorted_block', 100))
-      38.1±0.1μs       30.7±0.1μs     0.81  bench_function_base.Sort.time_sort('heap', 'int64', ('uniform',))
-         187±7μs        148±0.2μs     0.79  bench_function_base.Sort.time_sort('merge', 'int64', ('sorted_block', 10))
-     9.09±0.05μs      6.37±0.07μs     0.70  bench_function_base.Sort.time_sort('quick', 'float16', ('uniform',))
-     9.20±0.05μs      6.32±0.05μs     0.69  bench_function_base.Sort.time_sort('quick', 'float16', ('reversed',))
-       164±0.3μs      61.9±0.07μs     0.38  bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 100))
-       172±0.2μs      63.9±0.05μs     0.37  bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 1000))
-        170±0.2μs      63.2±0.02μs     0.37  bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 10))
-       169±0.4μs      62.7±0.05μs     0.37  bench_function_base.Sort.time_sort('quick', 'float16', ('random',))
-       180±0.2μs      65.8±0.08μs     0.37  bench_function_base.Sort.time_sort('quick', 'float16', ('ordered',))
```




<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
