### PR TITLE
MAINT Fix broken links in absoft.py

### DIFF
--- a/numpy/distutils/fcompiler/absoft.py
+++ b/numpy/distutils/fcompiler/absoft.py
@@ -1,6 +1,6 @@
 
-# http://www.absoft.com/literature/osxuserguide.pdf
-# http://www.absoft.com/documentation.html
+# Absoft Corporation ceased operations on 12/31/2022.
+# Thus, all links to <http://www.absoft.com> are invalid.
 
 # Notes:
 # - when using -g77 then use -DUNDERSCORE_G77 to compile f2py


### PR DESCRIPTION
In module `numpy/distutils/fcompiler/absoft.py` the links to <http://www.absoft.com> are forever broken now, since the company ceased operations on 12/31/2022.
I removed the links and set a notice about it.