### PR TITLE
CI: Ensure coverage is run for merges

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -202,6 +202,15 @@ jobs:
     - uses: ./.github/actions
 
   full:
+    on:
+      # Job creates coverage comparison, so needs to run on main for merges.
+      push:
+        braches:
+          - main
+      pull_request:
+        branches:
+          - main
+          - maintenance/**
     needs: [smoke_test]
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
Recently, coverage has been starting to pile up bad "changed files" that didn't actually change.  For now it was a minor nuisance but this will just increase.

We could probably just run this every few days also, coverage doesn't change too quickly.  But it needs to run on merges regularly.