### PR TITLE
BUILD: add ci run after merge for coverage

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,10 @@
 name: Build_Test
 
 on:
+  push:
+    branches:
+      # coverage comparison in the "full" step needs to run on main after merges
+      - main
   pull_request:
     branches:
       - main
@@ -23,7 +27,7 @@ permissions:
 
 jobs:
   lint:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy' && github.event != 'push'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -59,6 +63,7 @@ jobs:
   basic:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "pypy3.9-v7.3.11"]
@@ -78,6 +83,7 @@ jobs:
     needs: [smoke_test]
     # provides GCC  7, 8
     runs-on: ubuntu-20.04
+    if: github.event != 'push'
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
@@ -114,6 +120,7 @@ jobs:
   without_optimizations:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       WITHOUT_OPTIMIZATIONS: 1
     steps:
@@ -129,6 +136,7 @@ jobs:
   with_baseline_only:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       CPU_DISPATCH: "none"
     steps:
@@ -144,6 +152,7 @@ jobs:
   without_avx512:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       CPU_DISPATCH: "max -xop -fma4 -avx512f -avx512cd -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl"
     steps:
@@ -159,6 +168,7 @@ jobs:
   without_avx512_avx2_fma3:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       CPU_DISPATCH: "SSSE3 SSE41 POPCNT SSE42 AVX F16C"
     steps:
@@ -174,6 +184,7 @@ jobs:
   debug:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       USE_DEBUG: 1
     steps:
@@ -189,6 +200,7 @@ jobs:
   blas64:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       NPY_USE_BLAS_ILP64: 1
     steps:
@@ -202,15 +214,6 @@ jobs:
     - uses: ./.github/actions
 
   full:
-    on:
-      # Job creates coverage comparison, so needs to run on main for merges.
-      push:
-        braches:
-          - main
-      pull_request:
-        branches:
-          - main
-          - maintenance/**
     needs: [smoke_test]
     runs-on: ubuntu-22.04
     env:
@@ -231,6 +234,7 @@ jobs:
   benchmark:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       PYTHONOPTIMIZE: 2
       BLAS: None
@@ -252,6 +256,7 @@ jobs:
   relaxed_strides_debug:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       CHECK_BLAS: 1
       NPY_USE_BLAS_ILP64: 1
@@ -269,6 +274,7 @@ jobs:
   use_wheel:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       USE_WHEEL: 1
     steps:
@@ -284,6 +290,7 @@ jobs:
   numpy2_flag:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       # Test for numpy-2.0 feature-flagged behavior.
       NPY_NUMPY_2_BEHAVIOR: 1
@@ -303,6 +310,7 @@ jobs:
   no_openblas:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       BLAS: None
       LAPACK: None
@@ -321,6 +329,7 @@ jobs:
   sdist:
     needs: [smoke_test]
     runs-on: ubuntu-latest
+    if: github.event != 'push'
     env:
       USE_SDIST: 1
     steps:
@@ -337,6 +346,7 @@ jobs:
     needs: [smoke_test]
     # make sure this matches the base docker image below
     runs-on: ubuntu-22.04
+    if: github.event != 'push'
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   lint:
-    if: github.repository == 'numpy/numpy' && github.event != 'push'
+    if: github.repository == 'numpy/numpy' && github.event_name != 'push'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -63,7 +63,7 @@ jobs:
   basic:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "pypy3.9-v7.3.11"]
@@ -83,7 +83,7 @@ jobs:
     needs: [smoke_test]
     # provides GCC  7, 8
     runs-on: ubuntu-20.04
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
@@ -120,7 +120,7 @@ jobs:
   without_optimizations:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       WITHOUT_OPTIMIZATIONS: 1
     steps:
@@ -136,7 +136,7 @@ jobs:
   with_baseline_only:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       CPU_DISPATCH: "none"
     steps:
@@ -152,7 +152,7 @@ jobs:
   without_avx512:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       CPU_DISPATCH: "max -xop -fma4 -avx512f -avx512cd -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl"
     steps:
@@ -168,7 +168,7 @@ jobs:
   without_avx512_avx2_fma3:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       CPU_DISPATCH: "SSSE3 SSE41 POPCNT SSE42 AVX F16C"
     steps:
@@ -184,7 +184,7 @@ jobs:
   debug:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       USE_DEBUG: 1
     steps:
@@ -200,7 +200,7 @@ jobs:
   blas64:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       NPY_USE_BLAS_ILP64: 1
     steps:
@@ -234,7 +234,7 @@ jobs:
   benchmark:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       PYTHONOPTIMIZE: 2
       BLAS: None
@@ -256,7 +256,7 @@ jobs:
   relaxed_strides_debug:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       CHECK_BLAS: 1
       NPY_USE_BLAS_ILP64: 1
@@ -274,7 +274,7 @@ jobs:
   use_wheel:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       USE_WHEEL: 1
     steps:
@@ -290,7 +290,7 @@ jobs:
   numpy2_flag:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       # Test for numpy-2.0 feature-flagged behavior.
       NPY_NUMPY_2_BEHAVIOR: 1
@@ -310,7 +310,7 @@ jobs:
   no_openblas:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       BLAS: None
       LAPACK: None
@@ -329,7 +329,7 @@ jobs:
   sdist:
     needs: [smoke_test]
     runs-on: ubuntu-latest
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     env:
       USE_SDIST: 1
     steps:
@@ -346,7 +346,7 @@ jobs:
     needs: [smoke_test]
     # make sure this matches the base docker image below
     runs-on: ubuntu-22.04
-    if: github.event != 'push'
+    if: github.event_name != 'push'
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:


### PR DESCRIPTION
#23455 was meant to add a CI run of the "full" job to update the coverage database after merging. The workflow syntax was faulty, so the jobs did not run. This PR tries a different approach: always run the workflow but skip most of the jobs on a push to `main` (i.e. after a merge)