### PR TITLE
BUG: Use output when given on numpy.dot C-API branch

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1045,6 +1045,16 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
         result = (PyArray_NDIM(ap1) == 0 ? ap1 : ap2);
         result = (PyArrayObject *)Py_TYPE(result)->tp_as_number->nb_multiply(
                                         (PyObject *)ap1, (PyObject *)ap2);
+        if (out) {
+            if (PyArray_AssignArray(out, (PyArrayObject *)result,
+                        NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {
+                Py_DECREF(result);
+                return NULL;
+            }
+            Py_DECREF(result);
+            Py_INCREF(out);
+            return (PyObject *)out;
+        }
         Py_DECREF(ap1);
         Py_DECREF(ap2);
         return (PyObject *)result;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1042,7 +1042,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
 #endif
 
     if (PyArray_NDIM(ap1) == 0 || PyArray_NDIM(ap2) == 0) {
-        result = PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
+        (PyObject *)result = PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
         Py_DECREF(ap1);
         Py_DECREF(ap2);
         return (PyObject *)result;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1042,23 +1042,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
 #endif
 
     if (PyArray_NDIM(ap1) == 0 || PyArray_NDIM(ap2) == 0) {
-        result = (PyArray_NDIM(ap1) == 0 ? ap1 : ap2);
-        result = (PyArrayObject *)Py_TYPE(result)->tp_as_number->nb_multiply(
-                                        (PyObject *)ap1, (PyObject *)ap2);
-        if (out) {
-            if (PyArray_AssignArray(out, (PyArrayObject *)result,
-                        NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {
-                Py_DECREF(result);
-                Py_DECREF(ap1);
-                Py_DECREF(ap2);
-                return NULL;
-            }
-            Py_DECREF(result);
-            Py_DECREF(ap1);
-            Py_DECREF(ap2);
-            Py_INCREF(out);
-            return (PyObject *)out;
-        }
+        result = PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
         Py_DECREF(ap1);
         Py_DECREF(ap2);
         return (PyObject *)result;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1042,7 +1042,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
 #endif
 
     if (PyArray_NDIM(ap1) == 0 || PyArray_NDIM(ap2) == 0) {
-        (PyObject *)result = PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
+        result = (PyArrayObject *)PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
         Py_DECREF(ap1);
         Py_DECREF(ap2);
         return (PyObject *)result;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1049,9 +1049,13 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
             if (PyArray_AssignArray(out, (PyArrayObject *)result,
                         NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {
                 Py_DECREF(result);
+                Py_DECREF(ap1);
+                Py_DECREF(ap2);
                 return NULL;
             }
             Py_DECREF(result);
+            Py_DECREF(ap1);
+            Py_DECREF(ap2);
             Py_INCREF(out);
             return (PyObject *)out;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1042,10 +1042,11 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
 #endif
 
     if (PyArray_NDIM(ap1) == 0 || PyArray_NDIM(ap2) == 0) {
-        result = (PyArrayObject *)PyObject_CallFunctionObjArgs(n_ops.multiply, ap1, ap2, out, NULL);
+        PyObject *mul_res = PyObject_CallFunctionObjArgs(
+                n_ops.multiply, ap1, ap2, out, NULL);
         Py_DECREF(ap1);
         Py_DECREF(ap2);
-        return (PyObject *)result;
+        return mul_res;
     }
     l = PyArray_DIMS(ap1)[PyArray_NDIM(ap1) - 1];
     if (PyArray_NDIM(ap2) > 1) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6675,6 +6675,22 @@ class TestDot:
         r = np.empty((1024, 32), dtype=int)
         assert_raises(ValueError, dot, f, v, r)
 
+    def test_dot_out_result(self):
+        x = np.ones((), dtype=np.float16)
+        y = np.ones((5,), dtype=np.float16)
+        z = np.zeros((5,), dtype=np.float16)
+        res = x.dot(y, out=z)
+        assert np.array_equal(res, y)
+        assert np.array_equal(z, y)
+
+    def test_dot_out_aliasing(self):
+        x = np.ones((), dtype=np.float16)
+        y = np.ones((5,), dtype=np.float16)
+        z = np.zeros((5,), dtype=np.float16)
+        res = x.dot(y, out=z)
+        z[0] = 2
+        assert np.array_equal(res, z)
+
     def test_dot_array_order(self):
         a = np.array([[1, 2], [3, 4]], order='C')
         b = np.array([[1, 2], [3, 4]], order='F')

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -150,7 +150,7 @@ A.argpartition([0])
 A.diagonal()
 
 A.dot(1)
-A.dot(1, out=B0)
+A.dot(1, out=B2)
 
 A.nonzero()
 


### PR DESCRIPTION
Updated the numpy.dot C-API so that it now copies the result to the out parameter and returns it on branch of the function where the correct behaviour was not in place. Added two tests regarding this issue. Closes #21081.