### PR TITLE
MAINT: Fix ReDOS vulnerability in crackfortran.py

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -935,7 +935,7 @@ typedefpattern = re.compile(
     r'(?:,(?P<attributes>[\w(),]+))?(::)?(?P<name>\b[a-z$_][\w$]*\b)'
     r'(?:\((?P<params>[\w,]*)\))?\Z', re.I)
 nameargspattern = re.compile(
-    r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>[^\s@]*)\s*@\)@))*\s*\Z', re.I)
+    r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>(?:(?!@\)@).)*)\s*@\)@))*\s*\Z', re.I)
 operatorpattern = re.compile(
     r'\s*(?P<scheme>(operator|assignment))'
     r'@\(@\s*(?P<name>[^)]+)\s*@\)@\s*\Z', re.I)

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -935,7 +935,7 @@ typedefpattern = re.compile(
     r'(?:,(?P<attributes>[\w(),]+))?(::)?(?P<name>\b[a-z$_][\w$]*\b)'
     r'(?:\((?P<params>[\w,]*)\))?\Z', re.I)
 nameargspattern = re.compile(
-    r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>.*)\s*@\)@))*\s*\Z', re.I)
+    r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>[^\s@]*)\s*@\)@))*\s*\Z', re.I)
 operatorpattern = re.compile(
     r'\s*(?P<scheme>(operator|assignment))'
     r'@\(@\s*(?P<name>[^)]+)\s*@\)@\s*\Z', re.I)

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -279,7 +279,9 @@ class TestUnicodeComment(util.F2PyTest):
         self.module.foo(3)
 
 class TestNameArgsPatternBacktracking:
-    def test_nameargspattern_backtracking():
+    def test_nameargspattern_backtracking(self):
+        '''address ReDOS vulnerability:
+        https://github.com/numpy/numpy/issues/23338'''
         last_time = 0.
         trials_per_count = 32
         start_reps, end_reps = 10, 16
@@ -291,5 +293,10 @@ class TestNameArgsPatternBacktracking:
                 crackfortran.nameargspattern.search(atbindat)
                 total_time += (time.perf_counter() - t0)
             if ii > start_reps:
-                assert total_time < 1.9 * last_time, f'Going from {ii - 1} to {ii} approximately doubled time'
+                # the hallmark of exponentially catastrophic backtracking
+                # is that runtime doubles for every added instance of
+                # the problematic pattern.
+                assert total_time < 1.9 * last_time
+                # also try to rule out non-exponential but still bad cases
+                assert total_time < 1
             last_time = total_time

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,5 +1,6 @@
 import importlib
 import codecs
+import time
 import unicodedata
 import pytest
 import numpy as np
@@ -276,3 +277,19 @@ class TestUnicodeComment(util.F2PyTest):
     )
     def test_encoding_comment(self):
         self.module.foo(3)
+
+class TestNameArgsPatternBacktracking:
+    def test_nameargspattern_backtracking():
+        last_time = 0.
+        trials_per_count = 32
+        start_reps, end_reps = 10, 16
+        for ii in range(start_reps, end_reps):
+            atbindat = '@)@bind@(@' * ii
+            total_time = 0
+            for _ in range(trials_per_count):
+                t0 = time.perf_counter()
+                crackfortran.nameargspattern.search(atbindat)
+                total_time += (time.perf_counter() - t0)
+            if ii > start_reps:
+                assert total_time < 1.9 * last_time, f'Going from {ii - 1} to {ii} approximately doubled time'
+            last_time = total_time

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -298,5 +298,6 @@ class TestNameArgsPatternBacktracking:
                 # the problematic pattern.
                 assert total_time < 1.9 * last_time
                 # also try to rule out non-exponential but still bad cases
-                assert total_time < 1
+                # arbitrarily, we should set a hard limit of 10ms as too slow
+                assert total_time < trials_per_count * 0.01
             last_time = total_time


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Address ReDOS vulnerability flagged by CodeQL first mentioned in #23338.

There was an capture group in `crackfortran.nameargspattern` that used an unchecked `.*` when it could have instead used `[^@\s]*` to achieve the same result.