### PR TITLE
Revert "ENH: Enabled the use of numpy.vectorize as a decorator"

### DIFF
--- a/doc/release/upcoming_changes/23061.new_feature.rst
+++ b/doc/release/upcoming_changes/23061.new_feature.rst
@@ -1,6 +1,0 @@
-``vectorize`` can now be used as a decorator
---------------------------------------------
-When using ``vectorize`` as a decorator, the user
-needs to specify the keywords for the arguments.
-``vectorize`` will continue to accept arguments
-positionally when used normally.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1787,61 +1787,6 @@ class TestVectorize:
         assert_equal(type(r), subclass)
         assert_equal(r, m * v)
 
-    def test_name(self):
-        #See gh-23021
-        @np.vectorize
-        def f2(a, b):
-            return a + b
-
-        assert f2.__name__ == 'f2'
-
-    def test_decorator(self):
-        @vectorize
-        def addsubtract(a, b):
-            if a > b:
-                return a - b
-            else:
-                return a + b
-
-        r = addsubtract([0, 3, 6, 9], [1, 3, 5, 7])
-        assert_array_equal(r, [1, 6, 1, 2])
-
-    def test_docstring(self):
-        @vectorize
-        def f(x):
-            """Docstring"""
-            return x
-
-        assert f.__doc__ == "Docstring"
-
-    def test_signature_otypes_decorator(self):
-        @vectorize(signature='(n)->(n)', otypes=['float64'])
-        def f(x):
-            return x
-
-        r = f([1, 2, 3])
-        assert_equal(r.dtype, np.dtype('float64'))
-        assert_array_equal(r, [1, 2, 3])
-        assert f.__name__ == 'f'
-
-    def test_bad_input(self):
-        with assert_raises(TypeError):
-            A = np.vectorize(pyfunc = 3)
-
-    def test_no_keywords(self):
-        with assert_raises(TypeError):
-            @np.vectorize("string")
-            def foo():
-                return "bar"
-
-    def test_positional_regression_9477(self):
-        # This supplies the first keyword argument as a positional,
-        # to ensure that they are still properly forwarded after the
-        # enhancement for #9477
-        f = vectorize((lambda x: x), ['float64'])
-        r = f([2])
-        assert_equal(r.dtype, np.dtype('float64'))
-
 
 class TestLeaks:
     class A:


### PR DESCRIPTION
Revert #23061. This was generated by pushing the "revert" button on the original PR.

There are problems with this:
- a broken test that I did not notice when merging
- it broke scipy, see [this comment](https://github.com/numpy/numpy/pull/23061#issuecomment-1484561901)