### PR TITLE
TYP: Fix static type checking of ufuncs fails for sequences of ``np.dtype | Number``

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -72,8 +72,8 @@ _ArrayLike = Union[
 _DualArrayLike = Union[
     _SupportsArray[_DType],
     _NestedSequence[_SupportsArray[_DType]],
-    _T,
-    _NestedSequence[_T],
+    Union[_SupportsArray[_DType], _T],
+    _NestedSequence[Union[_SupportsArray[_DType], _T]]
 ]
 
 # TODO: support buffer protocols once

--- a/numpy/_typing/_nested_sequence.py
+++ b/numpy/_typing/_nested_sequence.py
@@ -20,11 +20,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 class _NestedSequence(Protocol[_T_co]):
     """A protocol for representing nested sequences.
 
-    Warning
-    -------
-    `_NestedSequence` currently does not work in combination with typevars,
-    *e.g.* ``def func(a: _NestedSequnce[T]) -> T: ...``.
-
     See Also
     --------
     collections.abc.Sequence

--- a/numpy/typing/tests/data/mypy.ini
+++ b/numpy/typing/tests/data/mypy.ini
@@ -4,7 +4,7 @@ show_absolute_path = True
 implicit_reexport = False
 
 [mypy-numpy]
-ignore_errors = True
+# ignore_errors = True
 
 [mypy-numpy.*]
-ignore_errors = True
+# ignore_errors = True

--- a/numpy/typing/tests/data/pass/array_like.py
+++ b/numpy/typing/tests/data/pass/array_like.py
@@ -39,3 +39,9 @@ a.__array__()
 # array.
 object_array_scalar: Any = (i for i in range(10))
 np.array(object_array_scalar)
+
+# Test that a Sequence[Union[type, np.dtype]] counts as ArrayLike per gh-23081
+Number_or_float = np.number | float
+num_or_float_1: Number_or_float = 1
+num_or_float_2: Number_or_float = 2
+tuple_of_num_or_float: np.typing.ArrayLike= (num_or_float_1, num_or_float_1)

--- a/numpy/typing/tests/data/pass/ufuncs.py
+++ b/numpy/typing/tests/data/pass/ufuncs.py
@@ -15,3 +15,49 @@ np.sin.__name__
 np.sin.__doc__
 
 np.abs(np.array([1]))
+
+# Test gh-23081 issue is resolved: mypy will not give a type error if ufuncs are
+# called a python Sequence of Union[<python type>, <np.dtype>]
+Scalar = np.number | float
+
+def nin1_nout1(
+        x: Scalar = 1,
+        y: Scalar = 2
+):
+    return np.isfinite((x, y))
+
+def nin2_nout1(
+        w: Scalar = 0,
+        x: Scalar = 1,
+        y: Scalar = 2,
+        z: Scalar = 3
+):
+    return np.add((w, x), (y, z))
+
+def nin1_nout2(
+        x: Scalar = 1,
+        y: Scalar = 2
+):
+    return np.frexp((x, y))
+
+def nin2_nout2(
+        w: Scalar = 0,
+        x: Scalar = 1,
+        y: Scalar = 2,
+        z: Scalar = 3
+):
+    return np.divmod((w, x), (y, z))
+
+def gufunc_nin2_nout1(
+        w: Scalar = 0,
+        x: Scalar = 1,
+        y: Scalar = 2,
+        z: Scalar = 3
+):
+    return np.matmul((w, x), (y, z))
+
+nin1_nout1()
+nin2_nout1()
+nin1_nout2()
+nin2_nout2()
+gufunc_nin2_nout1()


### PR DESCRIPTION
ufuncs accept python sequences of either np.dtype or python numbers or a mix of both, but a static type checker will return an error prior to this commit.

Additionally, the .mypy.ini file contained two "ignore_errors = true" lines which hid all errors produced by mypy during testing.  I commented these lines to allow my tests to run properly but if I should be running tests differently, I will un-comment them.

Closes #23081 