### PR TITLE
MAINT: use PyArray_ClearBuffer in PyArray_FillWithScalar

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -21,6 +21,7 @@
 
 #include "convert.h"
 #include "array_coercion.h"
+#include "refcount.h"
 
 int
 fallocate(int fd, int mode, off_t offset, off_t len);
@@ -416,7 +417,7 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
             descr, value);
 
     if (PyDataType_REFCHK(descr)) {
-        PyArray_Item_XDECREF(value, descr);
+        PyArray_ClearBuffer(descr, value, 0, 1, 1);
     }
     PyMem_FREE(value_buffer_heap);
     return retcode;


### PR DESCRIPTION
This fixes the issue with `fill` for `stringdtype` pointed out in https://github.com/numpy/numpy-user-dtypes/issues/49.

I tried a benchmark filling a tiny object array and found the extra indirection made a negligible impact on performance. Before:

```
In [2]: %%timeit
   ...: for _ in range(100000):
   ...:     arr = np.empty(5, dtype=object)
   ...:     arr.fill('hello')
   ...: 
234 ms ± 1.38 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:

```
In [2]: %%timeit
   ...: for _ in range(100000):
   ...:     arr = np.empty(5, dtype=object)
   ...:     arr.fill('hello')
   ...: 
241 ms ± 3.01 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```