### PR TITLE
DOC: Fixing incorrect sentence - Boolean array indexing #23377

### DIFF
--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -481,12 +481,15 @@ tuple (of length :attr:`obj.ndim <ndarray.ndim>`) of integer index
 arrays showing the :py:data:`True` elements of *obj*. However, it is
 faster when ``obj.shape == x.shape``.
 
-If ``obj.ndim == x.ndim``, ``x[obj]`` returns a 1-dimensional array
-filled with the elements of *x* corresponding to the :py:data:`True`
-values of *obj*.  The search order will be :term:`row-major`,
-C-style. If *obj* has :py:data:`True` values at entries that are outside
-of the bounds of *x*, then an index error will be raised. If *obj* is
-smaller than *x* it is identical to filling it with :py:data:`False`.
+It is important to note that a boolean index array must match a
+subset of the indexed array's shape in the corresponding location
+where it is being indexed. If ``obj.ndim == x.ndim``, ``x[obj]``
+returns a 1-dimensional array filled with the elements of *x*
+corresponding to the :py:data:`True` values of *obj*. The search order
+will be :term:`row-major`, C-style. An index error will be raised if
+the shape of *obj* does not match the corresponding dimensions of *x*,
+regardless of whether those values are :py:data:`True` or
+:py:data:`False`.
 
 A common use case for this is filtering for desired element values.
 For example, one may wish to select all entries from an array which

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -481,9 +481,7 @@ tuple (of length :attr:`obj.ndim <ndarray.ndim>`) of integer index
 arrays showing the :py:data:`True` elements of *obj*. However, it is
 faster when ``obj.shape == x.shape``.
 
-It is important to note that a boolean index array must match a
-subset of the indexed array's shape in the corresponding location
-where it is being indexed. If ``obj.ndim == x.ndim``, ``x[obj]``
+If ``obj.ndim == x.ndim``, ``x[obj]``
 returns a 1-dimensional array filled with the elements of *x*
 corresponding to the :py:data:`True` values of *obj*. The search order
 will be :term:`row-major`, C-style. An index error will be raised if


### PR DESCRIPTION
Modifying a paragraph in the documentation of Boolean array indexing, discussed #23377
you can find the two modifications below:

```
1. It is important to note that a boolean index array must match a subset of the indexed array's shape in the corresponding location where it is being indexed.

2. An index error will be raised if the shape of *obj* does not match the corresponding dimensions of *x*, regardless of whether those values are :py:data:`True` or :py:data:`False`.
```