### PR TITLE
MAINT: improve error when a dtype doesn't support the buffer interface

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -418,8 +418,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             break;
         }
         default:
-            PyArray_DTypeMeta *DType = NPY_DTYPE(descr);
-            if (NPY_DT_is_legacy(DType)) {
+            if (NPY_DT_is_legacy(NPY_DTYPE(descr))) {
                 PyErr_Format(PyExc_ValueError,
                              "cannot include dtype '%c' in a buffer",
                              descr->kind);
@@ -427,7 +426,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             else {
                 PyErr_Format(PyExc_ValueError,
                              "cannot include dtype '%s' in a buffer",
-                             ((PyTypeObject*)DType)->tp_name);
+                             ((PyTypeObject*)NPY_DTYPE(descr))->tp_name);
             }
             return -1;
         }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -17,6 +17,7 @@
 #include "numpyos.h"
 #include "arrayobject.h"
 #include "scalartypes.h"
+#include "dtypemeta.h"
 
 /*************************************************************************
  ****************   Implement Buffer Protocol ****************************
@@ -417,9 +418,17 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             break;
         }
         default:
-            PyErr_Format(PyExc_ValueError,
-                         "cannot include dtype '%c' in a buffer",
-                         descr->type);
+            PyArray_DTypeMeta *DType = NPY_DTYPE(descr);
+            if (NPY_DT_is_legacy(DType)) {
+                PyErr_Format(PyExc_ValueError,
+                             "cannot include dtype '%c' in a buffer",
+                             descr->kind);
+            }
+            else {
+                PyErr_Format(PyExc_ValueError,
+                             "cannot include dtype '%s' in a buffer",
+                             ((PyTypeObject*)DType)->tp_name);
+            }
             return -1;
         }
     }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -421,7 +421,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             if (NPY_DT_is_legacy(NPY_DTYPE(descr))) {
                 PyErr_Format(PyExc_ValueError,
                              "cannot include dtype '%c' in a buffer",
-                             descr->kind);
+                             descr->type);
             }
             else {
                 PyErr_Format(PyExc_ValueError,


### PR DESCRIPTION
An easy way to hit this error right now is to pass a new-style dtype to a cython function that accepts a typed memoryview:

`t.pyx`:
```
# cython: language_level=3
cimport numpy as np

def function_with_ndarray_args(np.float64_t[:] a):
    pass
```

`main.py`:
```
import os

os.environ['NUMPY_EXPERIMENTAL_DTYPE_API'] = '1'

from t import function_with_ndarray_args
from stringdtype import StringDType
import numpy as np

a = np.array(['a', 'b'], dtype=StringDType())

function_with_ndarray_args(a)
```

Currently this script generates a TypeError like this: `ValueError: cannot include dtype '' in a buffer`

With this PR the error is: `ValueError: cannot include dtype 'stringdtype.StringDType' in a buffer`.