### PR TITLE
BUG: Use 2GiB chunking code for fwrite() on mingw32/64

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -129,7 +129,7 @@
  #define NPY_STEALS_REF_TO_ARG(n)
 #endif
 
-/* 64 bit file position support, also on win-amd64. Ticket #1660 */
+/* 64 bit file position support, also on win-amd64. Issue gh-2256 */
 #if defined(_MSC_VER) && defined(_WIN64) && (_MSC_VER > 1400) || \
     defined(__MINGW32__) || defined(__MINGW64__)
     #include <io.h>

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -157,11 +157,15 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             size = PyArray_SIZE(self);
             NPY_BEGIN_ALLOW_THREADS;
 
-#if defined (_MSC_VER) && defined(_WIN64)
-            /* Workaround Win64 fwrite() bug. Issue gh-2556
+#if defined(_MSC_VER) && defined(_WIN64) || \
+    defined(__MINGW32__) || defined(__MINGW64__)
+            /* Workaround Win64 fwrite() bug. Issue gh-2256
              * If you touch this code, please run this test which is so slow
-             * it was removed from the test suite
+             * it was removed from the test suite. Note that the original
+             * failure mode involves an infinite loop during tofile()
              *
+             * import tempfile, numpy as np
+             * from numpy.testing import (assert_)
              * fourgbplus = 2**32 + 2**16
              * testbytes = np.arange(8, dtype=np.int8)
              * n = len(testbytes)


### PR DESCRIPTION
Addresses #2256, and fixes https://github.com/msys2/MINGW-packages/issues/15856; tested on Win10 19045.2604 (22H2, x86_64). Includes a typo fix and some added detail to the "orphaned" suite test.

I included the check for `__MINGW32__` for consistency with the corresponding check in [npy_common.h](https://github.com/numpy/numpy/blob/7b27c3ebe7f35684aeb2dfa2fd3125b2a69aed49/numpy/core/include/numpy/npy_common.h#L132-L134). I currently have no way of testing this fix on x86, but I did consider the possibility of 32-bit software - running on some editions of Windows - being able to allocate a full 4GiB or more, and who knows what MS's x86 `fwrite()` would do with that.

Numpy has more detailed guidelines than projects I've contributed to before, please tell me if I missed anything.