### PR TITLE
DOC: default integer dtype reflect C long size

### DIFF
--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -75,8 +75,8 @@ the computation, here ``uint32`` and ``int32`` can both be represented in
 as ``int64``. 
 
 The default NumPy behavior is to create arrays in either 32 or 64-bit signed
-integers (platform dependent and matches C int size) or double precision
-floating point numbers, int32/int64 and float, respectively. If you expect your
+integers (platform dependent and matches C ``long`` size) or double precision
+floating point numbers. If you expect your
 integer arrays to be a specific type, then you need to specify the dtype while
 you create the array.
 


### PR DESCRIPTION
Closes #18540. The default integer dtype matches C `long` not C `int`.

@bashtage, @melissawm I think reviewed PR #18846 which last touched these lines.