### PR TITLE
DOC: Update documentation for user-defined converters in np.genfromtxt

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -790,8 +790,16 @@ class StringConverter:
         `update` takes the same parameters as the constructor of
         `StringConverter`, except that `func` does not accept a `dtype`
         whereas `dtype_or_func` in the constructor does.
+        
 
+    Be aware that user-defined converters may receive extraneous inputs
+    during the type determination process. In particular, a '1' value will
+    be passed to the converter when determining the output dtype. This
+    behavior should be considered when writing custom converter functions,
+    and users should ensure that their converters can handle such input
+    without raising unexpected exceptions.
         """
+        
         self.func = func
         self._locked = locked
 


### PR DESCRIPTION

Title: DOC: Update documentation for user-defined converters in np.genfromtxt

Description:
This PR addresses issue #23429 and aims to improve the documentation for user-defined converters in the `np.genfromtxt` function. The changes include:

- Clarifying the behavior of the `update` method in the `StringConverter` class, specifically when testing values are passed to the user-defined converter function.
- Adding a note to inform users that their converters might receive extraneous testing values during the dtype determination process.
- Providing guidance on how users can handle these testing values within their converters.

These updates should help users better understand the behavior of user-defined converters and how to handle unexpected inputs during the dtype determination process.
