### PR TITLE
NEP: add NEP on a Python API cleanup for NumPy 2.0

### DIFF
--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -77,11 +77,8 @@ incur significant costs:
   This happens even when the changes are warranted, because they are
   aware of the above concerns.
 
-.. R: Link discussion about restructuring namespaces! (e.g., find the thread
-   with the GUI explorer person)
-
-.. S: I first thought you were talking about Manim,
-   but looks like it's something different.
+.. R: TODO: find and link discussion about restructuring namespaces! (e.g.,
+   find the thread with the GUI explorer person)
 
 .. S: Aaron's post re: array API and NumPy 2.0:
    https://mail.python.org/archives/list/numpy-discussion@python.org/thread/TTZEUKXUICDHGTCX5EMR6DQTYOSDGRV7/#YKBWQ2AP76WYWAP6GFRYMPHZCKTC43KM
@@ -115,7 +112,7 @@ backward compatible, there is no guarantee of forward compatibility from 1.25.X
 to 2.0. Code will have to be updated to account for deprecated, moved, or
 removed functions/classes, as well as for more strictly enforced private APIs.
 
-In order to make it easier to adapt to the changes in this NEP, we will:
+In order to make it easier to adopt the changes in this NEP, we will:
 
 1. Provide a transition guide that lists each API change and its replacement.
 2. Provide a script to automate the migration wherever possible. This will be
@@ -154,9 +151,6 @@ Here is a representative set of examples:
 New namespaces are introduced for warnings/exceptions (``np.exceptions``) and
 for dtype-related functionality (``np.types``). NumPy 2.0 is a good opportunity
 to populate these submodules from the main namespace.
-
-.. S: Has the ``np.types`` name been fixed? Wonder if we're going to
-   create confusion with that name.
 
 Functionality that is widely used but has a preferred alternative may either be
 deprecated (with the deprecation message pointing out what to use instead) or
@@ -218,7 +212,7 @@ Details TBD, something like:
 
     # To remove
     numpy.compat
-    numpy.core?
+    numpy.core  # rename to _core
     numpy.doc
     numpy.matlib
     numpy.version
@@ -231,6 +225,10 @@ Details TBD, something like:
     functions/objects, like ``Arrayterator`` (a candidate for removal) and the
     ``stride_tricks`` subsubmodule. ``numpy.lib`` itself is not a coherent
     namespace, and does not even have a reference guide page.
+
+.. note::
+
+   TBD: is `numpy.math` actually used at all? If not, should we hide/remove it?
 
 We will make all submodules available lazily, so that users don't have to type
 ``import numpy.xxx`` but can use ``import numpy as np; np.xxx.*``, while at the

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -17,7 +17,7 @@ Abstract
 
 We propose to clean up NumPy's Python API for the NumPy 2.0 release.
 This includes a more clearly defined split between what is public and what is
-private, reducing the size of the main namespace by removing aliases
+private, and reducing the size of the main namespace by removing aliases
 and functions that have better alternatives.
 
 
@@ -178,15 +178,13 @@ there was already rough consensus on that - however it was hard to pull off in
 a minor release.
 
 A basic principle we will adhere to is "one function, one location". Functions
-that are exposes in more than one namespace (e.g., many functions are present
-in ``numpy`` and ``numpy.lib``) need to get a single home.
+that are exposed in more than one namespace (e.g., many functions are present
+in ``numpy`` and ``numpy.lib``) need to find a single home.
 
 We will reorganize the API reference guide along main and submodule namespaces,
 and only within the main namespace use the current subdivision along
 functionality groupings. Also by "mainstream" and special-purpose namespaces.
 Details TBD, something like:
-
-.. Ralf's original grouping, with a few more comments:
 
 ::
 
@@ -224,59 +222,8 @@ Details TBD, something like:
     numpy.doc
     numpy.matlib
     numpy.version
-    
-    # To clean out or somehow deal with: everything in `numpy.lib`
-
-Or like this:
-
-.. Stefan's changed version:
-
-.. S: not sure what to call these submodules; made something up, but
-   should be improved
-
-::
-
-    # `numpy.util`: Regular/recommended user-facing namespaces for general use
-    numpy
-    numpy.exceptions
-    numpy.testing
-    numpy.typing
-    numpy.lib.stride_tricks
-    numpy.types
-
-    # `numpy.algorithms`: special purpose computation algorithms
-    numpy.emath
-    numpy.math
-    numpy.fft
-    numpy.linalg
-    numpy.polynomial
-    numpy.random
-
-    # `numpy.ffi`: Special-purpose
-    numpy.array_api
-    numpy.ctypeslib
-    numpy.f2py
-
-    # `numpy.containers`:
-    numpy.ma
-    numpy.rec
-
-    # Legacy (prefer not to use)
-    numpy.char
-    numpy.distutils
-    numpy.matrixlib
-
-    # To remove
-    numpy.compat
-    numpy.core?
-    numpy.doc
-    numpy.matlib
-    numpy.version
 
     # To clean out or somehow deal with: everything in `numpy.lib`
-
-.. S: Are you thinking that even math.* will disappear out of the name
-   mainspace? That's quite a big change.
 
 .. note::
 

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -177,10 +177,59 @@ When this was discussed before (see
 there was already rough consensus on that - however it was hard to pull off in
 a minor release.
 
+A basic principle we will adhere to is "one function, one location". Functions
+that are exposes in more than one namespace (e.g., many functions are present
+in ``numpy`` and ``numpy.lib``) need to get a single home.
+
 We will reorganize the API reference guide along main and submodule namespaces,
 and only within the main namespace use the current subdivision along
 functionality groupings. Also by "mainstream" and special-purpose namespaces.
 Details TBD, something like:
+
+.. Ralf's original grouping, with a few more comments:
+
+::
+
+    # Regular/recommended user-facing namespaces for general use. Present these
+    # as the primary set of namespaces to the users.
+    numpy
+    numpy.exceptions
+    numpy.fft
+    numpy.linalg
+    numpy.ma
+    numpy.polynomial
+    numpy.random
+    numpy.testing
+    numpy.typing
+
+    # Special-purpose namespaces. Keep these, but document them in a separate
+    # grouping in the reference guide and explain their purpose.
+    numpy.array_api
+    numpy.ctypeslib
+    numpy.emath
+    numpy.f2py  # only a couple of public functions, like `compile` and `get_include`
+    numpy.math
+    numpy.lib.stride_tricks
+    numpy.rec
+    numpy.types
+
+    # Legacy (prefer not to use). Third grouping in the reference guide.
+    numpy.char
+    numpy.distutils
+    numpy.matrixlib  # or deprecate?
+
+    # To remove
+    numpy.compat
+    numpy.core?
+    numpy.doc
+    numpy.matlib
+    numpy.version
+    
+    # To clean out or somehow deal with: everything in `numpy.lib`
+
+Or like this:
+
+.. Stefan's changed version:
 
 .. S: not sure what to call these submodules; made something up, but
    should be improved
@@ -227,10 +276,14 @@ Details TBD, something like:
     # To clean out or somehow deal with: everything in `numpy.lib`
 
 .. S: Are you thinking that even math.* will disappear out of the name
-   mainspace? That's quite a big change.  I like the principle you
-   proposed on Sebastian's PR above: one function, one home.
+   mainspace? That's quite a big change.
 
-.. S: Will we preserve `np.lib` as per the above discussion?
+.. note::
+
+    TBD: will we preserve ``np.lib`` or not? It only has a couple of unique
+    functions/objects, like ``Arrayterator`` (a candidate for removal) and the
+    ``stride_tricks`` subsubmodule. ``numpy.lib`` itself is not a coherent
+    namespace, and does not even have a reference guide page.
 
 We will make all submodules available lazily, so that users don't have to type
 ``import numpy.xxx`` but can use ``import numpy as np; np.xxx.*``, while at the

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -1,0 +1,266 @@
+.. _NEP52:
+
+=========================================
+NEP 52 — Python API cleanup for NumPy 2.0
+=========================================
+
+:Author: Ralf Gommers <ralf.gommers@gmail.com>
+:Author: Stéfan van der Walt <stefanv@berkeley.edu>
+:Status: Draft
+:Type: Standards Track
+:Created: 2023-03-28
+:Resolution:
+
+
+Abstract
+--------
+
+We propose to clean up NumPy's Python API for the NumPy 2.0 release.
+This includes a more clearly defined split between what is public and what is
+private, reducing the size of the main namespace by removing many aliases and
+other functionality which has better alternatives.
+
+
+Motivation and Scope
+--------------------
+
+NumPy has a very large, and not very well-defined, API surface:
+
+.. code:: python
+
+   >>> objects_in_api = [s for s in dir(np) if not s.startswith('_')]
+   >>> len(objects_in_api)
+   562
+   >>> modules = [s for s in objects_in_api if inspect.ismodule(eval(f'np.{s}'))]
+   >>> modules
+   ['char', 'compat', 'ctypeslib', 'emath', 'fft', 'lib', 'linalg', 'ma', 'math', 'polynomial', 'random', 'rec', 'testing', 'version']
+   >>> len(modules)
+   14
+
+The above doesn't even include items that look public but are not included in
+``__dir__``. A particularly unhelpful module in that category is ``np.core``,
+which is private but in practice heavily used. For a full overview of what's
+consider public, private or a bit in between, see
+`numpy/tests/test_public_api.py <https://github.com/numpy/numpy/blob/main/numpy/tests/test_public_api.py>`__.
+
+The size and lack of clear boundaries of this API surface has costs:
+
+- For users it is difficult to choose between similar functions or know what
+  the recommended way of implementing something is. Looking for functions with
+  tab completion in IPython or a notebook or IDE is a challenge (e.g., type
+  ``np.<TAB>`` and look at the first six items offered - there's two ufuncs
+  (``abs``, ``add``), one alias (``absolute``), and three functions that are
+  not useful to them (``add_docstring``, ``add_newdoc``, ``add_newdoc_ufunc``).
+  As a result, the learning curve for NumPy is steeper than it has to be.
+- For maintainers of other libraries which aim to implement a NumPy-compatible
+  API - Dask, CuPy, JAX, PyTorch, TensorFlow, cuNumeric, etc. - or that aim to
+  support NumPy in some other way - Numba, Pythran - there is an implementation
+  cost to every extra object in the namespace. In practice, no other library
+  has full support for everything in NumPy, and making decisions about niche or
+  legacy objects in NumPy is a time-consuming effort.
+- Teaching the NumPy API to others or making it accessible in a
+  learner-oriented GUI has similar costs.
+
+Link discussion about restructuring namespaces! (e.g., find the thread with the
+GUI explorer person)
+
+The scope of this NEP includes:
+
+- xxx
+
+Out of scope for this NEP are:
+
+- xxx
+
+
+
+
+Usage and Impact
+----------------
+
+
+A key principle of this API refactor is to ensure that, when code has been
+adapted to the changes and is 2.0-compatible, that code then *also* works with
+NumPy ``1.2x.x``. This keeps the burden on users and downstream library
+maintainers low by not having to carry duplicate code which switches on the
+NumPy major version number.
+
+
+Backward compatibility
+----------------------
+
+There is a backwards compatibility impact for users of deprecated or removed
+functionality, as well as for users and libraries that were relying on private
+NumPy APIs that will move due to the clearer namespacing.
+
+In order to make it easier to adapt to the changes in this NEP, we will:
+
+1. Ensure that NumPy 2.0 will come with guidance for each removed API, pointing
+   to the preferred alternative API to use,
+2. Provide a script to automate the migration wherever possible. This will be
+   similar to ``tools/replace_old_macros.sed`` (which adapts code for a
+   previous C API naming scheme change).
+
+
+Detailed description
+--------------------
+
+Cleaning up the main namespace
+``````````````````````````````
+
+We expect to reduce the main namespace by a large number of entries - O(100)
+probably. Here is a representative set of examples:
+
+- ``np.inf`` and ``np.nan`` have 8 aliases between them, most can be removed.
+- A collection of random and undocumented functions (e.g., ``byte_bounds``, ``disp``,
+  ``safe_eval``, ``who``) listed in
+  `gh-12385 <https://github.com/numpy/numpy/issues/12385>`__
+  can be deprecated and removed.
+- All ``*sctype`` functions can be deprecated and removed, they (see
+  `gh-17325 <https://github.com/numpy/numpy/issues/17325>`__,
+  `gh-12334 <https://github.com/numpy/numpy/issues/12334>`__,
+  and other issues for ``maximum_sctype`` and related functions).
+- Business day functionality can likely be removed (unclear if it needs
+  splitting out like was done for ``np.financial``).
+- The ``np.compat`` namespace can be removed.
+- There are lots of one-off functions that can be deprecated and removed, such as
+  ``real_if_close`` (see `gh-11375 <https://github.com/numpy/numpy/issues/11375>`__).
+  These can be identified via triaging the issue tracker and/or via going
+  through the main namespace manually.
+
+There are new namespaces for warnings/exceptions (``np.exceptions``) and for dtype-related
+functionality (``np.types``). NumPy 2.0 is a good opportunity to move things
+there from the main namespace.
+
+Functionality that gets a fair amount of usage but has a preferred alternative
+may be hidden by not including it in ``__dir__``, rather than deprecating it. A
+``.. legacy::`` directory may be used to mark such functionality in the
+documentation.
+
+A more comprehensive test will be added to the test suite to ensure that we won't get
+any more accidental additions to any namespace - every new entry will need to be
+allow-listed.
+
+Cleaning up the submodule structure
+```````````````````````````````````
+
+Let's reorganize the API reference guide along main and submodule namespaces,
+and only within the main namespace use the current subdivision along
+functionality groupings. Also by "mainstream" and special-purpose namespaces.
+Details TBD, something like::
+
+    # Regular/recommended user-facing namespaces for general use
+    numpy
+    numpy.exceptions
+    numpy.fft
+    numpy.linalg
+    numpy.ma
+    numpy.polynomial
+    numpy.random
+    numpy.testing
+    numpy.typing
+
+    # Special-purpose
+    numpy.array_api
+    numpy.ctypeslib
+    numpy.emath
+    numpy.f2py
+    numpy.math
+    numpy.lib.stride_tricks
+    numpy.rec
+    numpy.types
+
+    # Legacy (prefer not to use)
+    numpy.char
+    numpy.distutils
+    numpy.matrixlib
+
+    # To remove
+    numpy.compat
+    numpy.core?
+    numpy.doc
+    numpy.matlib
+    numpy.version
+    
+    # To clean out or somehow deal with: everything in `numpy.lib`
+
+Reducing the number of ways to select dtypes
+````````````````````````````````````````````
+
+The many dtype classes, instances, aliases and ways to select them are one of
+the larger usability problems in the NumPy API. E.g.:
+
+.. code:: python
+
+   >>> # np.intp is different, but compares equal too
+   >>> np.int64 == np.int_ == np.dtype('i8') == np.sctypeDict['i8']
+   True
+   >>> np.float64 == np.double == np.float_ == np.dtype('f8') == np.sctypeDict['f8']
+   True
+   ### Really?
+   >>> np.clongdouble == np.clongfloat == np.longcomplex == np.complex256
+   True
+
+These aliases can go: https://numpy.org/devdocs/reference/arrays.scalars.html#other-aliases
+
+To discuss:
+
+- move *all* dtype-related classes to ``np.types``?
+- mark one-character type code strings and related routines like ``mintypecode`` as legacy?
+- canonical way to compare/select dtypes: ``np.isdtype`` (new, xref array API
+  NEP), leaving ``np.issubdtype`` for the more niche use of numpy's dtype class
+  hierarchy, and hide most other stuff.
+- possibly remove ``float96``/``float128``? they're aliases that may not exist,
+  and are too easy to shoot yourself in the foot with.
+
+
+Related Work
+------------
+
+A clear split between public and private API was fairly recently done in SciPy
+for 1.8.0 (2021), see `tracking issue scipy#14360 <https://github.com/scipy/scipy/issues/14360>`__).
+The results of that were beneficial, and the impact relatively modest.
+
+
+Implementation
+--------------
+
+The full implementation will be split over many different PRs, each touching on
+a single API or a set of related APIs. To illustrate what those PRs will look
+like, we will link here to a representative set of example PRs:
+
+Deprecating non-preferred aliases and scheduling them for removal in 2.0:
+
+- `gh-23302: deprecate np.round_; add round/min/max to the docs <https://github.com/numpy/numpy/pull/23302>`__
+- `gh-23314: deprecate product/cumproduct/sometrue/alltrue <https://github.com/numpy/numpy/pull/23314>`__
+
+Hiding or removing objects that are accidentally made public or not even NumPy objects at all:
+
+- `gh-21403: remove some names from main numpy namespace <https://github.com/numpy/numpy/pull/21403>`__
+
+Restructuring of public submodules:
+
+- `gh-18447: hide internals of np.lib to only show submodules <https://github.com/numpy/numpy/pull/18447>`__
+
+Create new namespaces to make it easier to navigate the module structure:
+
+- `gh-22644: Add new np.exceptions namespace for errors and warnings <https://github.com/numpy/numpy/pull/22644>`__
+
+
+Alternatives
+------------
+
+
+
+Discussion
+----------
+
+
+References and Footnotes
+------------------------
+
+
+Copyright
+---------
+
+This document has been placed in the public domain.

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -85,13 +85,21 @@ incur significant costs:
 
 The scope of this NEP includes:
 
-- xxx
+- Deprecating or removing functionality that is too niche for NumPy, not
+  well-designed, superceded by better alternatives, or otherwise a candidate
+  for removal.
+- Clearly separating public from private NumPy API by use of underscores.
+- Restructuring the NumPy namespaces to be easier to understand and navigate.
 
 Out of scope for this NEP are:
 
-- xxx
+- Introducing new functionality or performance enhancements.
 
+TBD whether in or out of scope for this NEP:
 
+- Whether or not to clean up some of the more niche ``ndarray`` methods (this
+  was suggested in the NumPy 2.0 developer meeting, with mildly positive
+  feedback from the crowd).
 
 
 Usage and Impact

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -86,20 +86,14 @@ incur significant costs:
 The scope of this NEP includes:
 
 - Deprecating or removing functionality that is too niche for NumPy, not
-  well-designed, superceded by better alternatives, or otherwise a candidate
-  for removal.
+  well-designed, superseded by better alternatives, an unnecessary alias,
+  or otherwise a candidate for removal.
 - Clearly separating public from private NumPy API by use of underscores.
 - Restructuring the NumPy namespaces to be easier to understand and navigate.
 
 Out of scope for this NEP are:
 
 - Introducing new functionality or performance enhancements.
-
-TBD whether in or out of scope for this NEP:
-
-- Whether or not to clean up some of the more niche ``ndarray`` methods (this
-  was suggested in the NumPy 2.0 developer meeting, with mildly positive
-  feedback from the crowd).
 
 
 Usage and Impact
@@ -196,7 +190,6 @@ Details TBD, something like:
     numpy.exceptions
     numpy.fft
     numpy.linalg
-    numpy.ma
     numpy.polynomial
     numpy.random
     numpy.testing
@@ -208,21 +201,25 @@ Details TBD, something like:
     numpy.ctypeslib
     numpy.emath
     numpy.f2py  # only a couple of public functions, like `compile` and `get_include`
-    numpy.math
     numpy.lib.stride_tricks
     numpy.rec
     numpy.types
 
-    # Legacy (prefer not to use). Third grouping in the reference guide.
+    # Legacy (prefer not to use, there are better alternatives and/or this code
+    # is deprecated or isn't reliable). This will be a third grouping in the
+    # reference guide; it's still there, but de-emphasized and the problems
+    # with it or better alternatives are explained in the docs.
     numpy.char
     numpy.distutils
-    numpy.matrixlib  # or deprecate?
+    numpy.ma
 
     # To remove
     numpy.compat
     numpy.core  # rename to _core
     numpy.doc
+    numpy.math
     numpy.matlib
+    numpy.matrixlib
     numpy.version
 
     # To clean out or somehow deal with: everything in `numpy.lib`
@@ -233,11 +230,6 @@ Details TBD, something like:
     functions/objects, like ``Arrayterator`` (a candidate for removal) and the
     ``stride_tricks`` subsubmodule. ``numpy.lib`` itself is not a coherent
     namespace, and does not even have a reference guide page.
-
-.. note::
-
-   TBD: is ``numpy.math`` actually used at all? If not, should we hide/remove
-   it?
 
 We will make all submodules available lazily, so that users don't have to type
 ``import numpy.xxx`` but can use ``import numpy as np; np.xxx.*``, while at the
@@ -264,10 +256,12 @@ the larger usability problems in the NumPy API. E.g.:
 
 These aliases can go: https://numpy.org/devdocs/reference/arrays.scalars.html#other-aliases
 
+All one-character type code strings and related routines like ``mintypecode``
+will be marked as legacy.
+
 To discuss:
 
-- move *all* dtype-related classes to ``np.types``?
-- mark one-character type code strings and related routines like ``mintypecode`` as legacy?
+- move *all* dtype-related classes to ``np.dtypes``?
 - canonical way to compare/select dtypes: ``np.isdtype`` (new, xref array API
   NEP), leaving ``np.issubdtype`` for the more niche use of numpy's dtype class
   hierarchy, and hide most other stuff.
@@ -275,7 +269,18 @@ To discuss:
   and are too easy to shoot yourself in the foot with.
 
 
-.. S: consider `np.dtypes`.
+Cleaning up the niche methods on ``numpy.ndarray``
+``````````````````````````````````````````````````
+
+The ``ndarray`` object has a lot of attributes and  methods, some of which are
+too niche to be that prominent, all that does is distract the average user.
+E.g.:
+
+- ``.ctypes``
+- ``.itemset`` (already discouraged)
+- ``.newbyteorder`` (too niche)
+- ``.ptp`` (niche, use ``np.ptp`` function instead)
+- ``.repeat`` (niche, use ``np.ptp`` function instead)
 
 
 Related Work

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -24,8 +24,7 @@ and functions that have better alternatives.
 Motivation and Scope
 --------------------
 
-NumPy has a large API surface that evolved organically over many
-years:
+NumPy has a large API surface that evolved organically over many years:
 
 .. code:: python
 
@@ -42,7 +41,7 @@ The above doesn't even include items that are public but have been
 been hidden from ``__dir__``.
 A particularly problematic example of that is ``np.core``,
 which is technically private but heavily used in practice.
-For a full overview of what's consider public, private or a bit in between, see
+For a full overview of what's considered public, private or a bit in between, see
 `<https://github.com/numpy/numpy/blob/main/numpy/tests/test_public_api.py>`__.
 
 The size of the API and the lacking definition of its boundaries
@@ -51,31 +50,31 @@ incur significant costs:
 - **Users find it hard to disambiguate between similarly named
   functions.**
 
-  Looking for functions with
-  tab completion in IPython, a notebook, or an IDE is a challenge. E.g., type
-  ``np.<TAB>`` and look at the first six items offered: two ufuncs
-  (``abs``, ``add``), one alias (``absolute``), and three functions that are
-  not intended for end-users (``add_docstring``, ``add_newdoc``, ``add_newdoc_ufunc``).
-  As a result, the learning curve for NumPy is steeper than it has to be.
+  Looking for functions with tab completion in IPython, a notebook, or an IDE
+  is a challenge. E.g., type ``np.<TAB>`` and look at the first six items
+  offered: two ufuncs (``abs``, ``add``), one alias (``absolute``), and three
+  functions that are not intended for end-users (``add_docstring``,
+  ``add_newdoc``, ``add_newdoc_ufunc``). As a result, the learning curve for
+  NumPy is steeper than it has to be.
 
 - **Libraries that mimic the NumPy API face significant implementation barriers.**
 
-  For maintainers of NumPy API-compatible array libraries (Dask, CuPy, JAX, PyTorch,
-  TensorFlow, cuNumeric, etc.) and compilers/transpilers (Numba, Pythran,
-  Cython, etc.) there is an implementation cost to each object in the
+  For maintainers of NumPy API-compatible array libraries (Dask, CuPy, JAX,
+  PyTorch, TensorFlow, cuNumeric, etc.) and compilers/transpilers (Numba,
+  Pythran, Cython, etc.) there is an implementation cost to each object in the
   namespace. In practice, no other library has full support for the entire
   NumPy API, partly because it is so hard to know what to include when faced
   with a slew of aliases and legacy objects.
 
 - **Teaching NumPy is more complicated than it needs to be.**
 
-  Similarly, a larger API is confusing to learners, who not only have
-  to *find* functions but have to choose *which* functions to use.
+  Similarly, a larger API is confusing to learners, who not only have to *find*
+  functions but have to choose *which* functions to use.
 
 - **Developers are hesitant to grow the API surface.**
 
-  This happens even when the changes are warranted, because they are
-  aware of the above concerns.
+  This happens even when the changes are warranted, because they are aware of
+  the above concerns.
 
 .. R: TODO: find and link discussion about restructuring namespaces! (e.g.,
    find the thread with the GUI explorer person)
@@ -129,9 +128,8 @@ Detailed description
 Cleaning up the main namespace
 ``````````````````````````````
 
-We expect to reduce the main namespace by a large number of entries,
-on the order of 100.
-Here is a representative set of examples:
+We expect to reduce the main namespace by a large number of entries, on the
+order of 100. Here is a representative set of examples:
 
 - ``np.inf`` and ``np.nan`` have 8 aliases between them, of which most can be removed.
 - A collection of random and undocumented functions (e.g., ``byte_bounds``, ``disp``,
@@ -179,8 +177,7 @@ in ``numpy`` and ``numpy.lib``) need to find a single home.
 
 We will reorganize the API reference guide along main and submodule namespaces,
 and only within the main namespace use the current subdivision along
-functionality groupings. Also by "mainstream" and special-purpose namespaces.
-Details TBD, something like:
+functionality groupings. Also by "mainstream" and special-purpose namespaces:
 
 ::
 
@@ -287,8 +284,8 @@ Related Work
 ------------
 
 A clear split between public and private API was recently established
-as part of SciPy 1.8.0 (2021),
-see `tracking issue scipy#14360 <https://github.com/scipy/scipy/issues/14360>`__.
+as part of SciPy 1.8.0 (2021), see
+`tracking issue scipy#14360 <https://github.com/scipy/scipy/issues/14360>`__.
 The results were beneficial, and the impact on users relatively modest.
 
 

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -236,7 +236,8 @@ Details TBD, something like:
 
 .. note::
 
-   TBD: is `numpy.math` actually used at all? If not, should we hide/remove it?
+   TBD: is ``numpy.math`` actually used at all? If not, should we hide/remove
+   it?
 
 We will make all submodules available lazily, so that users don't have to type
 ``import numpy.xxx`` but can use ``import numpy as np; np.xxx.*``, while at the

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -224,14 +224,18 @@ functionality groupings. Also by "mainstream" and special-purpose namespaces:
 .. note::
 
     TBD: will we preserve ``np.lib`` or not? It only has a couple of unique
-    functions/objects, like ``Arrayterator`` (a candidate for removal) and the
-    ``stride_tricks`` subsubmodule. ``numpy.lib`` itself is not a coherent
-    namespace, and does not even have a reference guide page.
+    functions/objects, like ``Arrayterator`` (a candidate for removal), ``NumPyVersion``,
+    and the ``stride_tricks``, ``mixins`` and ``format`` subsubmodules.
+    ``numpy.lib`` itself is not a coherent namespace, and does not even have a
+    reference guide page.
 
 We will make all submodules available lazily, so that users don't have to type
 ``import numpy.xxx`` but can use ``import numpy as np; np.xxx.*``, while at the
 same time not negatively impacting the overhead of ``import numpy``. This has
-been very helpful for teaching scikit-image and SciPy.
+been very helpful for teaching scikit-image and SciPy, and it resolves a
+potential issue for Spyder users because Spyder already makes all submodules
+available - so code using the above import pattern then works in Spyder but not
+outside it.
 
 
 Reducing the number of ways to select dtypes
@@ -277,7 +281,7 @@ E.g.:
 - ``.itemset`` (already discouraged)
 - ``.newbyteorder`` (too niche)
 - ``.ptp`` (niche, use ``np.ptp`` function instead)
-- ``.repeat`` (niche, use ``np.ptp`` function instead)
+- ``.repeat`` (niche, use ``np.repeat`` function instead)
 
 
 Related Work


### PR DESCRIPTION
This is still draft, but close enough for now. It was discussed in the NumPy 2.0 developer meeting a few days ago, with mostly positive feedback.