### PR TITLE
DOC: clarify int type constraint in numpy.bincount

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -971,8 +971,8 @@ def bincount(x, weights=None, minlength=None):
     >>> np.bincount(x).size == np.amax(x)+1
     True
 
-    The input array needs to be of the native integer index type, otherwise a
-    TypeError is raised:
+    The input array needs have an integer dtype smaller or equal to the
+    native Python array index type, otherwise a TypeError is raised:
 
     >>> np.bincount(np.arange(5, dtype=float))
     Traceback (most recent call last):

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -971,7 +971,7 @@ def bincount(x, weights=None, minlength=None):
     >>> np.bincount(x).size == np.amax(x)+1
     True
 
-    The input array needs to be of integer dtype, otherwise a
+    The input array needs to be of the native integer index type, otherwise a
     TypeError is raised:
 
     >>> np.bincount(np.arange(5, dtype=float))
@@ -979,6 +979,20 @@ def bincount(x, weights=None, minlength=None):
       ...
     TypeError: Cannot cast array data from dtype('float64') to dtype('int64')
     according to the rule 'safe'
+
+    This also means that the following code will not work on a 32-bit system:
+
+    >>> import sys
+    >>> if sys.maxsize <= 2**32:
+    ...     np.bincount(np.arange(5, dtype=np.int64))
+    ...     # TypeError: Cannot cast array data from dtype('int64') to
+    ...     # dtype('int32') according to the rule 'safe'
+
+    The easiest way to solve this is by always using the Python int type
+    (or np.int_):
+
+    >>> np.bincount(np.arange(5, dtype=int))
+    array([1, 1, 1, 1, 1])
 
     A possible use of ``bincount`` is to perform sums over
     variable-size chunks of an array, using the ``weights`` keyword.

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -953,7 +953,8 @@ def bincount(x, weights=None, minlength=None):
         If the input is not 1-dimensional, or contains elements with negative
         values, or if `minlength` is negative.
     TypeError
-        If the type of the input is float or complex.
+        If the type of the input is float or complex, or larger than the
+        native integer type.
 
     See Also
     --------
@@ -972,7 +973,7 @@ def bincount(x, weights=None, minlength=None):
     True
 
     The input array needs have an integer dtype smaller or equal to the
-    native Python array index type, otherwise a TypeError is raised:
+    native array index type, otherwise a TypeError is raised:
 
     >>> np.bincount(np.arange(5, dtype=float))
     Traceback (most recent call last):
@@ -987,12 +988,6 @@ def bincount(x, weights=None, minlength=None):
     ...     np.bincount(np.arange(5, dtype=np.int64))
     ...     # TypeError: Cannot cast array data from dtype('int64') to
     ...     # dtype('int32') according to the rule 'safe'
-
-    The easiest way to solve this is by always using the Python int type
-    (or np.int_):
-
-    >>> np.bincount(np.arange(5, dtype=int))
-    array([1, 1, 1, 1, 1])
 
     A possible use of ``bincount`` is to perform sums over
     variable-size chunks of an array, using the ``weights`` keyword.

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -954,7 +954,7 @@ def bincount(x, weights=None, minlength=None):
         values, or if `minlength` is negative.
     TypeError
         If the type of the input is float or complex, or larger than the
-        native array index type.
+        native array index type (which is equivalent to `np.intp`).
 
     See Also
     --------

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -954,7 +954,7 @@ def bincount(x, weights=None, minlength=None):
         values, or if `minlength` is negative.
     TypeError
         If the type of the input is float or complex, or larger than the
-        native integer type.
+        native array index type.
 
     See Also
     --------


### PR DESCRIPTION
This doc string change clarifies the `int` dtype constraint in `np.bincount()`.

The type of input elements is not only required to be positive integers, as stated, but it must actually be of the native int type. Otherwise, it will raise a TypeError when the input type is wider than the native array index type.

This was discovered while debugging the https://github.com/mikedh/trimesh library on a 32-bit system. This library uses `np.int64` gratuitously, which causes many unit test to fail: https://salsa.debian.org/3dprinting-team/trimesh/-/jobs/4103005#L2836

It would be very helpful if this is clearly explained in the numpy documentation.

Fixes: #23526 

