### PR TITLE
DEP: deprecate np.math and np.lib.math

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -215,7 +215,14 @@ else:
     __deprecated_attrs__.update({
         n: (alias, _msg.format(n=n, an=an)) for n, alias, an in _type_info})
 
-    del _msg, _type_info
+    import math
+
+    __deprecated_attrs__['math'] = (math,
+        "`np.math` is a deprecated alias for the standard library `math` "
+        "module (Deprecated Numpy 1.25). Replace usages of `np.math` with "
+        "`math`")
+
+    del math, _msg, _type_info
 
     from .core import abs
     # now that numpy modules are imported, can initialize limits
@@ -272,6 +279,7 @@ else:
         # Warn for expired attributes, and return a dummy function
         # that always raises an exception.
         import warnings
+        import math
         try:
             msg = __expired_functions__[attr]
         except KeyError:

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -922,3 +922,12 @@ class TestFromnumeric(_DeprecationTestCase):
     # 2023-03-02, 1.25.0
     def test_alltrue(self):
         self.assert_deprecated(lambda: np.alltrue(np.array([True, False])))
+
+
+class TestMathAlias(_DeprecationTestCase):
+    # Deprecated in Numpy 1.25, 2023-04-06
+    def test_deprecated_np_math(self):
+        self.assert_deprecated(lambda: np.math)
+
+    def test_deprecated_np_lib_math(self):
+        self.assert_deprecated(lambda: np.lib.math)

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -11,7 +11,6 @@ Most contains basic functions that are used by several submodules and are
 useful to have in the main name-space.
 
 """
-import math
 
 from numpy.version import version as __version__
 
@@ -58,7 +57,7 @@ from .arraypad import *
 from ._version import *
 from numpy.core._multiarray_umath import tracemalloc_domain
 
-__all__ = ['emath', 'math', 'tracemalloc_domain', 'Arrayterator']
+__all__ = ['emath', 'tracemalloc_domain', 'Arrayterator']
 __all__ += type_check.__all__
 __all__ += index_tricks.__all__
 __all__ += function_base.__all__
@@ -77,3 +76,19 @@ __all__ += histograms.__all__
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)
 del PytestTester
+
+def __getattr__(attr):
+    # Warn for reprecated attributes
+    import math
+    import warnings
+
+    if attr == 'math':
+        warnings.warn(
+            "`np.lib.math` is a deprecated alias for the standard library "
+            "`math` module (Deprecated Numpy 1.25). Replace usages of "
+            "`numpy.lib.math` with `math`", DeprecationWarning, stacklevel=2)
+        return math
+    else:
+        raise AttributeError("module {!r} has no attribute "
+                             "{!r}".format(__name__, attr))
+        


### PR DESCRIPTION
Following https://github.com/numpy/numpy/pull/23537#discussion_r1160541000 this deprecates `np.math` and `np.lib.math`, which are aliases to the `math` module in the standard library. 

Both usages have more than a hundred results in a github search for [`from numpy import math`](https://github.com/search?q=%22from+numpy+import+math%22&type=code) and [`from numpy.lib import math`](https://github.com/search?q=%22from+numpy.lib+import+math%22&type=code) so I think this might be too widely used to remove without a deprecation cycle. It was originally [added 17 years ago](https://github.com/numpy/numpy/commit/f544e777b5124da236b2fb2afefcf310f025042f) so there might be ancient code using it.