### PR TITLE
BLD: add static to std_c_flags program. Move macosx_arm64 wheel build to cirrus. Add regular macosx_arm64 job (closes #23538, #21765)

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -16,8 +16,9 @@ def main(ctx):
     if env.get("CIRRUS_REPO_FULL_NAME") != "numpy/numpy":
         return []
 
-    # if env.get("CIRRUS_CRON", "") == "nightly":
-    #     return fs.read("ci/cirrus_wheels.yml")
+    # only run the wheels entry on a cron job
+    if env.get("CIRRUS_CRON", "") == "nightly":
+        return fs.read("tool/ci/cirrus_wheels.yml")
 
     # Obtain commit message for the event. Unfortunately CIRRUS_CHANGE_MESSAGE
     # only contains the actual commit message on a non-PR trigger event.
@@ -31,8 +32,8 @@ def main(ctx):
     if "[skip cirrus]" in dct["message"] or "[skip ci]" in dct["message"]:
         return []
 
-    config =  fs.read("tools/ci/cirrus_general.yml")
-
     # add extra jobs to the cirrus run by += adding to config
+    config = fs.read("tools/ci/cirrus_wheels.yml")
+    config += fs.read("tools/ci/cirrus_macosx_arm64.yml")
 
     return config

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,7 +76,7 @@ jobs:
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-12, macosx_*]
+          - [macos-12, macosx_x86_64]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
         python: ["cp39", "cp310", "cp311", "pp39"]

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -401,7 +401,7 @@ def CCompiler_customize_cmd(self, cmd, ignore=()):
         not (platform.machine() == 'arm64' and sys.platform == 'darwin')
     ):
         # clang defaults to a non-strict floating error point model.
-        # However, '-ftrapping-math' is not currently supported (2022-04-08)
+        # However, '-ftrapping-math' is not currently supported (2023-04-08)
         # for macosx_arm64.
         # Since NumPy and most Python libs give warnings for these, override:
         self.compiler.append('-ftrapping-math')

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import platform
 import shlex
 import time
 import subprocess
@@ -394,8 +395,14 @@ def CCompiler_customize_cmd(self, cmd, ignore=()):
     log.info('customize %s using %s' % (self.__class__.__name__,
                                         cmd.__class__.__name__))
 
-    if hasattr(self, 'compiler') and 'clang' in self.compiler[0]:
+    if (
+        hasattr(self, 'compiler') and
+        'clang' in self.compiler[0] and
+        not (platform.machine() == 'arm64' and sys.platform == 'darwin')
+    ):
         # clang defaults to a non-strict floating error point model.
+        # However, '-ftrapping-math' is not currently supported (2022-04-08)
+        # for macosx_arm64.
         # Since NumPy and most Python libs give warnings for these, override:
         self.compiler.append('-ftrapping-math')
         self.compiler_so.append('-ftrapping-math')

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2393,7 +2393,7 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
+    if machine.startswith(('aarch64', 'power', 'ppc', 'riscv', 's390x', 'sparc', 'arm64')):
         if p <= 20:
             return 16
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,9 @@ environment = { CFLAGS="-std=c99 -fno-strict-aliasing", LDFLAGS="-Wl,--strip-deb
 # https://github.com/multi-build/multibuild/blame/devel/README.rst#L541-L565
 # for more info
 archs = "x86_64 arm64"
-test-skip = "*_arm64 *_universal2:arm64"
+test-skip = "*_universal2:arm64"
 # MACOS linker doesn't support stripping symbols
-environment = { CFLAGS="-std=c99 -fno-strict-aliasing", OPENBLAS64_="/usr/local", NPY_USE_BLAS_ILP64="1", CC="clang", CXX = "clang++" }
+environment = { CFLAGS="-std=c99 -fno-strict-aliasing", OPENBLAS64_="/usr/local", NPY_USE_BLAS_ILP64="1", CC="clang", CXX = "clang++", RUNNER_OS="macOS" }
 
 [tool.cibuildwheel.windows]
 environment = { OPENBLAS64_="openblas", OPENBLAS="", NPY_USE_BLAS_ILP64="1", CFLAGS="", LDFLAGS="" }

--- a/setup.py
+++ b/setup.py
@@ -293,7 +293,7 @@ def get_build_overrides():
         ).get(compiler.compiler_type, ['-std=c99'])
 
         if not flags_is_required(compiler, False, flags, textwrap.dedent('''
-            inline int test_inline() { return 0; }
+            inline static int test_inline() { return 0; }
             int main(void)
             { return test_inline(); }
         ''')):

--- a/tools/ci/cirrus_macosx_arm64.yml
+++ b/tools/ci/cirrus_macosx_arm64.yml
@@ -1,0 +1,55 @@
+modified_clone: &MODIFIED_CLONE
+  # makes sure that for a PR the CI runs against a merged main
+  clone_script: |
+    if [ -z "$CIRRUS_PR" ]; then
+      # if you're not in a PR then clone against the branch name that was pushed to.
+      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      # it's a PR so clone the main branch then merge the changes from the PR
+      git clone https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+    
+      # CIRRUS_BASE_BRANCH will probably be `main` for the majority of the time
+      # However, if you do a PR against a maintenance branch we will want to
+      # merge the PR into the maintenance branch, not main
+      git checkout $CIRRUS_BASE_BRANCH
+
+      # alpine git package needs default user.name and user.email to be set before a merge
+      git -c user.email="you@example.com" merge --no-commit pull/$CIRRUS_PR
+      git submodule update --init --recursive
+    fi
+
+
+macos_arm64_test_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+
+  <<: *MODIFIED_CLONE
+
+  pip_cache:
+    folder: ~/.cache/pip
+
+  test_script: |
+    brew install python@3.10
+
+    export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    python --version
+
+    RUNNER_OS="macOS"
+    CFLAGS="-std=c99 -fno-strict-aliasing"
+    SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
+    
+    # used for installing OpenBLAS/gfortran
+    bash tools/wheels/cibw_before_build.sh $PWD
+
+    pushd ~/
+    python -m venv numpy-dev
+    source numpy-dev/bin/activate
+    popd
+
+    pip install -r build_requirements.txt
+    pip install pytest hypothesis typing_extensions
+    
+    spin build
+    spin test

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.12.0
+    - python -m pip install cibuildwheel==2.12.1
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:
@@ -43,6 +43,50 @@ linux_aarch64_task:
 
 
 ######################################################################
+# Build macosx_arm64 natively
+######################################################################
+
+macosx_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+  matrix:
+    - env:
+        CIRRUS_CLONE_SUBMODULES: true
+        CIBW_BUILD: cp39-*
+    - env:
+        CIRRUS_CLONE_SUBMODULES: true
+        CIBW_BUILD: cp310-* cp311-*
+  env:
+    PATH: /opt/homebrew/opt/python@3.10/bin:/usr/local/lib:/usr/local/include:$PATH
+    CIBW_ARCHS: arm64
+    # Specifying CIBW_ENVIRONMENT_MACOS overrides pyproject.toml, so include
+    # all the settings from there, otherwise they're lost.
+    # SDKROOT needs to be set for repackaged conda-forge gfortran compilers
+    # supplied by isuruf.
+    # Find out SDKROOT via `xcrun --sdk macosx --show-sdk-path`
+    CIBW_ENVIRONMENT_MACOS: >
+      RUNNER_OS=macOS
+      SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
+      LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+      CFLAGS="-std=c99 -fno-strict-aliasing"
+      OPENBLAS64_="/usr/local"
+      NPY_USE_BLAS_ILP64="1"
+
+  build_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+    - which python
+    # needed for submodules
+    - git submodule update --init
+    # need to obtain all the tags so setup.py can determine FULLVERSION
+    - git fetch origin
+    - uname -m
+    - python -c "import platform;print(platform.python_version());print(platform.system());print(platform.machine())"
+    - clang --version
+  <<: *BUILD_AND_STORE_WHEELS
+
+
+######################################################################
 # Upload all wheels
 ######################################################################
 
@@ -53,6 +97,7 @@ wheels_upload_task:
   # which bash, etc, may not be present.
   depends_on:
     - linux_aarch64
+    - macosx_arm64
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -15,14 +15,16 @@ fi
 # Install Openblas
 if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]] ; then
     basedir=$(python tools/openblas_support.py)
-    cp -r $basedir/lib/* /usr/local/lib
-    cp $basedir/include/* /usr/local/include
     if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
+        # /usr/local/lib doesn't exist on cirrus-ci runners
+        sudo mkdir -p /usr/local/lib /usr/local/include /usr/local/lib/cmake/openblas
         sudo mkdir -p /opt/arm64-builds/lib /opt/arm64-builds/include
         sudo chown -R $USER /opt/arm64-builds
         cp -r $basedir/lib/* /opt/arm64-builds/lib
         cp $basedir/include/* /opt/arm64-builds/include
     fi
+    sudo cp -r $basedir/lib/* /usr/local/lib
+    sudo cp $basedir/include/* /usr/local/include
 elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
@@ -42,5 +44,7 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     fi
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
+
+    ls -al /usr/local/lib
     pip install "delocate==0.10.4"
 fi

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,9 +22,12 @@ if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]] ; then
         sudo chown -R $USER /opt/arm64-builds
         cp -r $basedir/lib/* /opt/arm64-builds/lib
         cp $basedir/include/* /opt/arm64-builds/include
+        sudo cp -r $basedir/lib/* /usr/local/lib
+        sudo cp $basedir/include/* /usr/local/include
+    else
+        cp -r $basedir/lib/* /usr/local/lib
+        cp $basedir/include/* /usr/local/include
     fi
-    sudo cp -r $basedir/lib/* /usr/local/lib
-    sudo cp $basedir/include/* /usr/local/include
 elif [[ $RUNNER_OS == "Windows" ]]; then
     PYTHONPATH=tools python -c "import openblas_support; openblas_support.make_init('numpy')"
     target=$(python tools/openblas_support.py)
@@ -44,7 +47,5 @@ if [[ $RUNNER_OS == "macOS" ]]; then
     fi
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
-
-    ls -al /usr/local/lib
     pip install "delocate==0.10.4"
 fi

--- a/tools/wheels/gfortran_utils.sh
+++ b/tools/wheels/gfortran_utils.sh
@@ -123,7 +123,7 @@ if [ "$(uname)" == "Darwin" ]; then
         curl -L -O https://github.com/isuruf/gcc/releases/download/gcc-11.3.0-2/gfortran-darwin-${arch}-${type}.tar.gz
 	case ${arch}-${type} in
 	    arm64-native)
-	        export GFORTRAN_SHA=142290685240f4f86cdf359cb2030d586105d7e4
+	        export GFORTRAN_SHA=0d5c118e5966d0fb9e7ddb49321f63cac1397ce8
 		;;
 	    arm64-cross)
 		export GFORTRAN_SHA=527232845abc5af21f21ceacc46fb19c190fe804
@@ -148,10 +148,10 @@ if [ "$(uname)" == "Darwin" ]; then
 	if [[ "${type}" == "native" ]]; then
 	    # Link these into /usr/local so that there's no need to add rpath or -L
 	    for f in libgfortran.dylib libgfortran.5.dylib libgcc_s.1.dylib libgcc_s.1.1.dylib libquadmath.dylib libquadmath.0.dylib; do
-                ln -sf /opt/gfortran-darwin-${arch}-${type}/lib/$f /usr/local/lib/$f
+                sudo ln -sf /opt/gfortran-darwin-${arch}-${type}/lib/$f /usr/local/lib/$f
             done
 	    # Add it to PATH
-	    ln -sf /opt/gfortran-darwin-${arch}-${type}/bin/gfortran /usr/local/bin/gfortran
+	    sudo ln -sf /opt/gfortran-darwin-${arch}-${type}/bin/gfortran /usr/local/bin/gfortran
 	fi
     }
 


### PR DESCRIPTION
#23538 reports that the `macosx_arm64` wheel build is failing. This is because the test program outlined in `std_c_flags` in `setup.py` is not compilable with clang.

The reason for this is outlined in https://github.com/llvm/llvm-project/issues/55274.

This PR makes the test program compilable with clang.