### PR TITLE
TST: try readding test_new_policy on musl

### DIFF
--- a/numpy/core/tests/test_mem_policy.py
+++ b/numpy/core/tests/test_mem_policy.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 import threading
 import warnings
-from numpy.testing import extbuild, assert_warns, IS_WASM, IS_MUSL
+from numpy.testing import extbuild, assert_warns, IS_WASM
 import sys
 
 
@@ -358,7 +358,6 @@ def test_thread_locality(get_module):
     assert np.core.multiarray.get_handler_name() == orig_policy_name
 
 
-@pytest.mark.xfail(IS_MUSL, reason="gh23050")
 @pytest.mark.slow
 def test_new_policy(get_module):
     a = np.arange(10)


### PR DESCRIPTION
This test seems to locally pass on musllinux now. Would close #23050.

Was disabled previously because of test fails, but I'm wondering if this was because other tests were failing.