### PR TITLE
ENH: refactor zero-filling and expose dtype API slot for it

### DIFF
--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -12,7 +12,7 @@ struct PyArrayMethodObject_tag;
 /*
  * Largely opaque struct for DType classes (i.e. metaclass instances).
  * The internal definition is currently in `ndarraytypes.h` (export is a bit
- * more complex because `PyArray_Descr` is a DTypeMeta internall but not
+ * more complex because `PyArray_Descr` is a DTypeMeta internally but not
  * externally).
  */
 #if !(defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)
@@ -258,13 +258,13 @@ typedef int translate_loop_descrs_func(int nin, int nout,
  * element of a single array.
  *
  * Currently this is only used for array clearing, via the
- * NPY_DT_get_clear_loop, api hook, particularly for arrays storing embedded
+ * NPY_DT_get_clear_loop api hook, particularly for arrays storing embedded
  * references to python objects or heap-allocated data. If you define a dtype
  * that uses embedded references, the NPY_ITEM_REFCOUNT flag must be set on the
  * dtype instance.
  *
  * The `void *traverse_context` is passed in because we may need to pass in
- * Intepreter state or similar in the futurem, but we don't want to pass in
+ * Intepreter state or similar in the future, but we don't want to pass in
  * a full context (with pointers to dtypes, method, caller which all make
  * no sense for a traverse function).
  *

--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -5,7 +5,7 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 #define NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 
-#define __EXPERIMENTAL_DTYPE_API_VERSION 9
+#define __EXPERIMENTAL_DTYPE_API_VERSION 10
 
 struct PyArrayMethodObject_tag;
 
@@ -199,6 +199,14 @@ typedef int (get_reduction_initial_function)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         char *initial);
 
+/**
+ * A function to fill an array with an initial value.
+ *
+ * @param arr The array to be filled.
+ *
+ * @returns -1 or 0 indicating error and arr being successfully filled.
+ */
+typedef int (fill_initial_function)(PyArrayObject *arr);
 
 /*
  * The following functions are only used be the wrapping array method defined
@@ -319,6 +327,7 @@ typedef int (get_traverse_loop_function)(
 #define NPY_DT_setitem 7
 #define NPY_DT_getitem 8
 #define NPY_DT_get_clear_loop 9
+#define NPY_DT_fill_zero_value 10
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;

--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -199,17 +199,8 @@ typedef int (get_reduction_initial_function)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         char *initial);
 
-/**
- * A function to fill an array with an initial value.
- *
- * @param arr The array to be filled.
- *
- * @returns -1 or 0 indicating error and arr being successfully filled.
- */
-typedef int (fill_initial_function)(PyArrayObject *arr);
-
 /*
- * The following functions are only used be the wrapping array method defined
+ * The following functions are only used by the wrapping array method defined
  * in umath/wrapping_array_method.c
  */
 
@@ -265,11 +256,10 @@ typedef int translate_loop_descrs_func(int nin, int nout,
  * strided-loop function. This is designed for loops that need to visit every
  * element of a single array.
  *
- * Currently this is only used for array clearing, via the
- * NPY_DT_get_clear_loop api hook, particularly for arrays storing embedded
- * references to python objects or heap-allocated data. If you define a dtype
- * that uses embedded references, the NPY_ITEM_REFCOUNT flag must be set on the
- * dtype instance.
+ * Currently this is used for array clearing, via the NPY_DT_get_clear_loop
+ * API hook, and zero-filling, via the NPY_DT_get_fill_zero_loop API hook.
+ * These are most useful for handling arrays storing embedded references to
+ * python objects or heap-allocated data.
  *
  * The `void *traverse_context` is passed in because we may need to pass in
  * Intepreter state or similar in the future, but we don't want to pass in
@@ -288,9 +278,10 @@ typedef int (traverse_loop_function)(
 /*
  * Simplified get_loop function specific to dtype traversal
  *
- * Currently this is only used for clearing arrays. It should set the flags
- * needed for the traversal loop and set out_loop to the loop function, which
- * must be a valid traverse_loop_function pointer.
+ * It should set the flags needed for the traversal loop and set out_loop to the
+ * loop function, which must be a valid traverse_loop_function
+ * pointer. Currently this is used for zero-filling and clearing arrays storing
+ * embedded references.
  *
  */
 typedef int (get_traverse_loop_function)(
@@ -327,7 +318,7 @@ typedef int (get_traverse_loop_function)(
 #define NPY_DT_setitem 7
 #define NPY_DT_getitem 8
 #define NPY_DT_get_clear_loop 9
-#define NPY_DT_fill_zero_value 10
+#define NPY_DT_get_fill_zero_loop 10
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -128,24 +128,6 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, PyArray_Descr **out_dtype)
 }
 
 
-NPY_NO_EXPORT int
-_zerofill(PyArrayObject *ret)
-{
-    if (PyDataType_REFCHK(PyArray_DESCR(ret))) {
-        PyObject *zero = PyLong_FromLong(0);
-        PyArray_FillObjectArray(ret, zero);
-        Py_DECREF(zero);
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-    }
-    else {
-        npy_intp n = PyArray_NBYTES(ret);
-        memset(PyArray_DATA(ret), 0, n);
-    }
-    return 0;
-}
-
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap)
 {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -55,9 +55,6 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims,
 NPY_NO_EXPORT PyArray_Descr *
 _array_find_python_scalar_type(PyObject *op);
 
-NPY_NO_EXPORT int
-_zerofill(PyArrayObject *ret);
-
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -3913,21 +3913,6 @@ PyArray_InitializeObjectToObjectCast(void)
 }
 
 
-static int
-PyArray_SetClearFunctions(void)
-{
-    PyArray_DTypeMeta *Object = PyArray_DTypeFromTypeNum(NPY_OBJECT);
-    NPY_DT_SLOTS(Object)->get_clear_loop = &npy_get_clear_object_strided_loop;
-    Py_DECREF(Object);  /* use borrowed */
-
-    PyArray_DTypeMeta *Void = PyArray_DTypeFromTypeNum(NPY_VOID);
-    NPY_DT_SLOTS(Void)->get_clear_loop = &npy_get_clear_void_and_legacy_user_dtype_loop;
-    Py_DECREF(Void);  /* use borrowed */
-    return 0;
-}
-
-
-
 NPY_NO_EXPORT int
 PyArray_InitializeCasts()
 {
@@ -3945,9 +3930,6 @@ PyArray_InitializeCasts()
     }
     /* Datetime casts are defined in datetime.c */
     if (PyArray_InitializeDatetimeCasts() < 0) {
-        return -1;
-    }
-    if (PyArray_SetClearFunctions() < 0) {
         return -1;
     }
     return 0;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -949,11 +949,11 @@ PyArray_NewFromDescr_int(
             }
         }
     }
-    NPY_traverse_info_xfree(fill_zero_info);
+    NPY_traverse_info_xfree(&fill_zero_info);
     return (PyObject *)fa;
 
  fail:
-    NPY_traverse_info_xfree(fill_zero_info);
+    NPY_traverse_info_xfree(&fill_zero_info);
     Py_XDECREF(fa->mem_handler);
     Py_DECREF(fa);
     return NULL;

--- a/numpy/core/src/multiarray/dtype_traversal.c
+++ b/numpy/core/src/multiarray/dtype_traversal.c
@@ -135,6 +135,7 @@ fill_zero_object_strided_loop(
     PyObject *zero = PyLong_FromLong(0);
     while (size--) {
         Py_INCREF(zero);
+        // assumes `data` doesn't have a pre-existing object inside it
         memcpy(data, &zero, sizeof(zero));
         data += stride;
     }

--- a/numpy/core/src/multiarray/dtype_traversal.h
+++ b/numpy/core/src/multiarray/dtype_traversal.h
@@ -19,6 +19,22 @@ npy_get_clear_void_and_legacy_user_dtype_loop(
         traverse_loop_function **out_loop, NpyAuxData **out_traversedata,
         NPY_ARRAYMETHOD_FLAGS *flags);
 
+/* NumPy DType zero-filling implementations */
+
+NPY_NO_EXPORT int
+npy_object_get_fill_zero_loop(
+        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        int NPY_UNUSED(aligned), npy_intp NPY_UNUSED(fixed_stride),
+        traverse_loop_function **out_loop, NpyAuxData **NPY_UNUSED(out_auxdata),
+        NPY_ARRAYMETHOD_FLAGS *flags);
+
+NPY_NO_EXPORT int
+npy_void_get_fill_zero_loop(
+        void *NPY_UNUSED(traverse_context), PyArray_Descr *descr,
+        int NPY_UNUSED(aligned), npy_intp NPY_UNUSED(fixed_stride),
+        traverse_loop_function **out_loop, NpyAuxData **NPY_UNUSED(out_auxdata),
+        NPY_ARRAYMETHOD_FLAGS *flags);
+
 
 /* Helper to deal with calling or nesting simple strided loops */
 

--- a/numpy/core/src/multiarray/dtype_traversal.h
+++ b/numpy/core/src/multiarray/dtype_traversal.h
@@ -34,6 +34,7 @@ NPY_traverse_info_init(NPY_traverse_info *cast_info)
 {
     cast_info->func = NULL;  /* mark as uninitialized. */
     cast_info->auxdata = NULL;  /* allow leaving auxdata untouched */
+    cast_info->descr = NULL;  /* mark as uninitialized. */
 }
 
 
@@ -45,7 +46,7 @@ NPY_traverse_info_xfree(NPY_traverse_info *traverse_info)
     }
     traverse_info->func = NULL;
     NPY_AUXDATA_FREE(traverse_info->auxdata);
-    Py_DECREF(traverse_info->descr);
+    Py_XDECREF(traverse_info->descr);
 }
 
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -742,15 +742,11 @@ fill_zero_object_strided_loop(
         NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyObject *zero = PyLong_FromLong(0);
-    PyObject **optr = (PyObject **)data;
     while (size--) {
         Py_INCREF(zero);
-        *optr++ = zero;
+        memcpy(data, &zero, sizeof(zero));
     }
     Py_DECREF(zero);
-    if (PyErr_Occurred()) {
-        return -1;
-    }
     return 0;
 }
 

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -51,6 +51,11 @@ typedef struct {
        called to fill the buffer. For the best performance, avoid using this
        function if a zero-filled array buffer allocated with calloc makes sense
        for the dtype.
+
+       Note that this is currently used only for zero-filling a newly allocated
+       array. While it can be used to zero-fill an already-filled buffer, that
+       will not work correctly for arrays holding references. If you need to do
+       that, clear the array first.
     */
     get_traverse_loop_function *get_fill_zero_loop;
     /*

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -42,15 +42,17 @@ typedef struct {
      */
     get_traverse_loop_function *get_clear_loop;
     /*
-       Either NULL or a function that fills an array with zero values
-       appropriate for the dtype. If this function pointer is NULL, the initial
-       value is assumed to be zero. If this function is defined, the array
-       buffer is allocated with malloc and then this function is called to fill
-       the buffer. As a performance optimization, the array buffer is allocated
-       using calloc if this function is NULL, so it is best to avoid using this
-       function if zero-filling the array buffer makes sense for the dtype.
+       Either NULL or a function that sets a function pointer to a traversal
+       loop that fills an array with zero values appropriate for the dtype. If
+       get_fill_zero_loop is undefined or the function pointer set by it is
+       NULL, the array buffer is allocated with calloc. If this function is
+       defined and it sets a non-NULL function pointer, the array buffer is
+       allocated with malloc and the zero-filling loop function pointer is
+       called to fill the buffer. For the best performance, avoid using this
+       function if a zero-filled array buffer allocated with calloc makes sense
+       for the dtype.
     */
-    fill_initial_function *fill_zero_value;
+    get_traverse_loop_function *get_fill_zero_loop;
     /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -42,6 +42,16 @@ typedef struct {
      */
     get_traverse_loop_function *get_clear_loop;
     /*
+       Either NULL or a function that fills an array with zero values
+       appropriate for the dtype. If this function pointer is NULL, the initial
+       value is assumed to be zero. If this function is defined, the array
+       buffer is allocated with malloc and then this function is called to fill
+       the buffer. As a performance optimization, the array buffer is allocated
+       using calloc if this function is NULL, so it is best to avoid using this
+       function if zero-filling the array buffer makes sense for the dtype.
+    */
+    fill_initial_function *fill_zero_value;
+    /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
      */
@@ -63,7 +73,7 @@ typedef struct {
 
 // This must be updated if new slots before within_dtype_castingimpl
 // are added
-#define NPY_NUM_DTYPE_SLOTS 9
+#define NPY_NUM_DTYPE_SLOTS 10
 #define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
 #define NPY_DT_MAX_ARRFUNCS_SLOT \
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -797,18 +797,15 @@ array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     }
     else {
         Py_INCREF(PyArray_DESCR(self));
-        ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self),
-                                                    PyArray_DESCR(self),
-                                                    PyArray_NDIM(self),
-                                                    PyArray_DIMS(self),
-                                                    NULL, NULL,
-                                                    PyArray_ISFORTRAN(self),
-                                                    (PyObject *)self);
+        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
+                Py_TYPE(self),
+                PyArray_DESCR(self),
+                PyArray_NDIM(self),
+                PyArray_DIMS(self),
+                NULL, NULL,
+                PyArray_ISFORTRAN(self),
+                (PyObject *)self, NULL, 1, 0);
         if (ret == NULL) {
-            return NULL;
-        }
-        if (_zerofill(ret) < 0) {
-            Py_DECREF(ret);
             return NULL;
         }
         PyArray_CLEARFLAGS(ret, NPY_ARRAY_WRITEABLE);

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -17,14 +17,11 @@
 #include "numpy/arrayscalars.h"
 #include "iterators.h"
 #include "dtypemeta.h"
+#include "refcount.h"
 
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
-
-static void
-_fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype);
-
 
 /*
  * Helper function to clear a strided memory (normally or always contiguous)
@@ -395,7 +392,7 @@ PyArray_FillObjectArray(PyArrayObject *arr, PyObject *obj)
     }
 }
 
-static void
+NPY_NO_EXPORT void
 _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
 {
     if (!PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)) {

--- a/numpy/core/src/multiarray/refcount.h
+++ b/numpy/core/src/multiarray/refcount.h
@@ -24,4 +24,7 @@ PyArray_XDECREF(PyArrayObject *mp);
 NPY_NO_EXPORT void
 PyArray_FillObjectArray(PyArrayObject *arr, PyObject *obj);
 
+NPY_NO_EXPORT void
+_fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype);
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_REFCOUNT_H_ */


### PR DESCRIPTION
This refactors zero-filling to be controlled by dtype-specific logic. It also moves all zero-filling logic inside `PyArray_NewFromDescr_int` and removes the `_zerofill` helper, which now has no consumers.

I experimented with making the API slot only provide the initial zero value and let numpy fill the buffer with that value by doing e.g. repeated `memcpy` calls, but this ended up not being sufficient, since in principle each zero value might contain embedded references that must be unique, so we need control over filling the entire array buffer. It also makes it slightly simpler to handle object and void dtypes, since I can just move the existing logic from `_zerofill` to the new `object_fill_zero_value` function I added.

I didn't see the need to add a test for this to the scaled float dtype, since the legacy dtypes should use all the code paths I modified, but am happy to add such a test if that's desired.