### PR TITLE
BUG: lib: Tiny fix for the loadtxt tokenizer when PyMem_Malloc() fails.

### DIFF
--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -449,6 +449,8 @@ npy_tokenizer_init(tokenizer_state *ts, parser_config *config)
 
     ts->fields = (field_info *)PyMem_Malloc(4 * sizeof(*ts->fields));
     if (ts->fields == nullptr) {
+        PyMem_Free(ts->field_buffer);
+        ts->field_buffer = nullptr;
         PyErr_NoMemory();
         return -1;
     }


### PR DESCRIPTION
This fixes a memory leak that can occur if the second call of `PyMem_Malloc()` in `npy_tokenizer_init()` fails.  You would have to be pretty unlucky to encounter this leak, and the failure of the second `PyMem_Malloc()` probably means you have bigger problems and the leaked 128 bytes will never become an issue.  Still, freeing the result from the first call of `PyMem_Malloc()` is the correct thing to do...