### PR TITLE
MAINT: Fix broken links in site.cfg.example

### DIFF
--- a/site.cfg.example
+++ b/site.cfg.example
@@ -225,9 +225,10 @@
 #
 # UMFPACK is not used by NumPy.
 #
-#   https://www.cise.ufl.edu/research/sparse/umfpack/
-#   https://www.cise.ufl.edu/research/sparse/amd/
+#   https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/UMFPACK
+#   https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/AMD
 #   https://scikit-umfpack.github.io/scikit-umfpack/
+#   https://people.engr.tamu.edu/davis/suitesparse.html
 #
 #[amd]
 #libraries = amd


### PR DESCRIPTION
In file `site.cfg.example` two links are broken. This PR provides the new links.

In file `site.cfg.example` there is a note that UMFPACK is not used directly by NumPy, but the older links were also present so an update could be senseful.