### PR TITLE
BLD: use the C++ linker to link `_multiarray_umath.so`

### DIFF
--- a/doc/release/upcoming_changes/23601.change.rst
+++ b/doc/release/upcoming_changes/23601.change.rst
@@ -1,0 +1,6 @@
+C++ standard library usage
+--------------------------
+
+NumPy builds now depend on the C++ standard library, because
+the ``numpy.core._multiarray_umath`` extension is linked with
+the C++ linker.

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -1010,9 +1010,6 @@ def configuration(parent_package='',top_path=None):
         svml_objs.sort()
 
     config.add_extension('_multiarray_umath',
-                         # Forcing C language even though we have C++ sources.
-                         # It forces the C linker and don't link C++ runtime.
-                         language = 'c',
                          sources=multiarray_src + umath_src +
                                  common_src +
                                  [generate_config_h,


### PR DESCRIPTION
This gets rid of undefined symbol issues for `assert`.

Closes gh-23122
~Closes gh-23595~ EDIT: apparently not, something else is wrong there.
