### PR TITLE
BUG: Add packaging to benchmark dependencies

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -43,7 +43,8 @@
     // version.
     "matrix": {
         "Cython": [],
-        "setuptools": ["59.2.0"]
+        "setuptools": ["59.2.0"],
+        "packaging": []
     },
 
     // The directory (relative to the current directory) that benchmarks are

--- a/benchmarks/asv_compare.conf.json.tpl
+++ b/benchmarks/asv_compare.conf.json.tpl
@@ -47,7 +47,8 @@
     // version.
     "matrix": {
         "Cython": [],
-        "setuptools": ["59.2.0"]
+        "setuptools": ["59.2.0"],
+        "packaging": []
     },
 
     // The directory (relative to the current directory) that benchmarks are


### PR DESCRIPTION
After #23010 we now need packaging to run the ufunc benchmarks:

```
·· Error running /home/ubuntu/numpy/benchmarks/env/ba529ea4db3c4898fd0db27ab1552c85/bin/python /home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py discover /home/ubuntu/numpy/benchmarks/benchmarks /tmp/tmp_m66yxhd/result.json (exit status 1)
   STDOUT -------->
   NumPy CPU features: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP* ASIMDDP* ASIMDFHM*
   STDERR -------->
   Traceback (most recent call last):
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 1435, in <module>
       main()
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 1428, in main
       commands[mode](args)
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 1103, in main_discover
       list_benchmarks(benchmark_dir, fp)
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 1088, in list_benchmarks
       for benchmark in disc_benchmarks(root):
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 985, in disc_benchmarks
       for module in disc_modules(root_name, ignore_import_errors=ignore_import_errors):
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 967, in disc_modules
       for item in disc_modules(name, ignore_import_errors=ignore_import_errors):
     File "/home/ubuntu/np-venv/lib/python3.9/site-packages/asv/benchmark.py", line 950, in disc_modules
       module = import_module(module_name)
     File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
     File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
     File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
     File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 855, in exec_module
     File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
     File "/home/ubuntu/numpy/benchmarks/benchmarks/bench_ufunc.py", line 5, in <module>
       from packaging import version
   ModuleNotFoundError: No module named 'packaging'
```