### PR TITLE
DOC: pull tags and initialize submodules in development install insructions

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -60,12 +60,16 @@ Here's the short summary, complete TOC links are below:
      - ``upstream``, which refers to the ``numpy`` repository
      - ``origin``, which refers to your personal fork
 
-2. Develop your contribution:
-
-   * Pull the latest changes from upstream::
+   * Pull the latest changes from upstream, including tags::
 
       git checkout main
-      git pull upstream main
+      git pull upstream main --tags
+
+   * Initialize numpy's submodules::
+
+      git submodule update --init
+
+2. Develop your contribution:
 
    * Create a branch for the feature you want to work on. Since the
      branch name will appear in the merge message, use a sensible name


### PR DESCRIPTION
This is already covered [elsewhere](https://numpy.org/devdocs/dev/gitwash/development_setup.html#make-the-local-copy) but these instructions are at a higher level in the docs, so probably best to include instructions that will generate a working build.