### PR TITLE
DOC: state an other requirement to build a .f90 based module

### DIFF
--- a/doc/source/f2py/f2py.getting-started.rst
+++ b/doc/source/f2py/f2py.getting-started.rst
@@ -18,6 +18,7 @@ following steps:
 
 * F2PY reads a signature file and writes a Python C/API module containing
   Fortran/C/Python bindings.
+
 * F2PY compiles all sources and builds an extension module containing
   the wrappers.
 
@@ -25,6 +26,13 @@ following steps:
     supports a number of Fortran 77/90/95 compilers, including Gnu, Intel, Sun
     Fortran, SGI MIPSpro, Absoft, NAG, Compaq etc. For different build systems,
     see :ref:`f2py-bldsys`.
+
+  * Depending on your operating system, you may need to install the Python
+    development headers (which provide the file ``Python.h``) separately. In
+    Linux Debian-based distributions this package should be called ``python3-dev``,
+    in Fedora-based distributions it is ``python3-devel``. For macOS, depending
+    how Python was installed, your mileage may vary. In Windows, the headers are
+    typically installed already.
 
 Depending on the situation, these steps can be carried out in a single composite
 command or step-by-step; in which case some steps can be omitted or combined


### PR DESCRIPTION
The generation of a Python module based on a Fortran procedure can fail
in absence of ``python3-dev``,[1] a package which may be absent in the
standard installation of CPython.

[1] https://github.com/numpy/numpy/issues/23592

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
