### PR TITLE
DOC: Use correct fill_value instead of value for np.full in 1.24.0 note

### DIFF
--- a/doc/source/release/1.24.0-notes.rst
+++ b/doc/source/release/1.24.0-notes.rst
@@ -389,7 +389,7 @@ Users can modify the behavior of these warnings using ``np.errstate``.
 Note that for float to int casts, the exact warnings that are given may
 be platform dependent.  For example::
 
-    arr = np.full(100, value=1000, dtype=np.float64)
+    arr = np.full(100, fill_value=1000, dtype=np.float64)
     arr.astype(np.int8)
 
 May give a result equivalent to (the intermediate cast means no warning is


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

**Description**
Use correct fill_value instead of value for np.full in 1.24.0 note.

**Motivation**
Just bumped into an error while trying code in: https://numpy.org/devdocs/release/1.24.0-notes.html:
```
import numpy as mp
arr = np.full(100, value=1000, dtype=np.float64)
```

The error is:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [8], in <cell line: 2>()
      1 import numpy as mp
----> 2 arr = np.full(100, value=1000, dtype=np.float64)

TypeError: full() got an unexpected keyword argument 'value'
```
The parameter name should be fill_value instead of value I believe: https://numpy.org/doc/stable/reference/generated/numpy.full.html.