### PR TITLE
TST: Add a test for inconsistent vectorize

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1857,21 +1857,21 @@ class TestVectorize:
 
         result = vf(0)
 
-        expected1 = np.array([0, 1, 2])
-        expected2 = np.empty(1, dtype=object)
-        expected2[0] = np.array([0, 1, 2])
+        expected_1 = np.array([0, 1, 2])
+        expected_2 = np.empty(1, dtype=object)
+        expected_2[0] = np.array([0, 1, 2])
 
         # Assert that the result is an ndarray with dtype=object
         assert isinstance(result, np.ndarray) and result.dtype == object, \
             "Output should be an ndarray with dtype=object for scalar input"
 
         # Check if the result is equal to either of the expected results
-        if np.array_equal(result, expected1):
+        if np.array_equal(result, expected_1):
             assert result.dtype == np.int_, \
-                "Output representation for scalar input should be array([0, 1, 2]) with dtype=int"
+                "Output for scalar input should be array([0, 1, 2]) with dtype=int"
         else:
-            assert_array_equal(result, expected2), \
-                "Output representation for scalar input should be array(array([0, 1, 2]), dtype=object)"
+            assert_array_equal(result, expected_2), \
+                "Output for scalar input should be array(array([0, 1, 2]), dtype=object)"
 
 
 class TestLeaks:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1850,6 +1850,28 @@ class TestVectorize:
         f = vectorize((lambda x: x), ['float64'])
         r = f([2])
         assert_equal(r.dtype, np.dtype('float64'))
+    
+    def test_scalar_input_expected_output_representation(self):
+        # Test that the output representation is as expected for scalar inputs
+        vf = np.vectorize(lambda _: np.arange(3), otypes=[object])
+
+        result = vf(0)
+
+        expected1 = np.array([0, 1, 2])
+        expected2 = np.empty(1, dtype=object)
+        expected2[0] = np.array([0, 1, 2])
+
+        # Assert that the result is an ndarray with dtype=object
+        assert isinstance(result, np.ndarray) and result.dtype == object, \
+            "Output should be an ndarray with dtype=object for scalar input"
+
+        # Check if the result is equal to either of the expected results
+        if np.array_equal(result, expected1):
+            assert result.dtype == np.int_, \
+                "Output representation for scalar input should be array([0, 1, 2]) with dtype=int"
+        else:
+            assert_array_equal(result, expected2), \
+                "Output representation for scalar input should be array(array([0, 1, 2]), dtype=object)"
 
 
 class TestLeaks:


### PR DESCRIPTION
TST: Added a test for inconsistent vectorize

Added a test to TestVectorize class in numpy/lib/tests/test_function_base.py to test for inconsistency issue mentioned in #21274. I was unable to fix the issue itself, but I am hoping the additional unit test may help someone else find a working solution.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
