### PR TITLE
TST: Added a test for isnat non-datetime

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2524,6 +2524,37 @@ class TestDateTime:
         # week reprs are not distinguishable.
         limit_via_str = np.datetime64(str(limit), time_unit)
         assert limit_via_str == limit
+    
+    def test_isnat_non_datetime_timedelta(self):
+        # Test datetime64 NaT
+        datetime_nat = np.datetime64('NaT')
+        assert(np.isnat(datetime_nat))
+
+        # Test timedelta64 NaT
+        timedelta_nat = np.timedelta64('NaT')
+        assert(np.isnat(timedelta_nat))
+
+        # Test integer input
+        integer_input = 42
+        assert(np.isnat(integer_input))
+
+        # Test float input
+        float_input = 42.0
+        assert(np.isnat(float_input))
+
+        # Test string input
+        string_input = "not a datetime"
+        assert(np.isnat(string_input))
+
+        # Test numpy array with datetime64 NaT
+        datetime_array = np.array(['2021-01-01', 'NaT'], dtype='datetime64')
+        expected_result = np.array([False, True])
+        np.testing.assert_array_equal(np.isnat(datetime_array), expected_result)
+
+        # Test numpy array with integer input
+        integer_array = np.array([1, 2, 3, 4])
+        expected_result = np.array([False, False, False, False])
+        np.testing.assert_array_equal(np.isnat(integer_array), expected_result)
 
 
 class TestDateTimeData:


### PR DESCRIPTION
This is in relation to issue #23582. I have started looking into this issue but so far haven't been able to fix it. I added this test to TestDateTime which fails currently but should pass when the issue is fixed.

I have also investigated a bit into where the code fix needs to be, and it is my hypothesis that lines 662-665 in /numpy/core/src/umath/ufunc_type_resolution.c need to be changed, as these are the ones dealing with type errors and throwing an error instead of returning false. However, I am not sure how to make it return false properly.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
