### PR TITLE
ENH: Add support for complex weights in `np.bincount`

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -115,9 +115,10 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
 {
     PyObject *list = NULL, *weight = Py_None, *mlength = NULL;
     PyArrayObject *lst = NULL, *ans = NULL, *wts = NULL;
-    npy_intp *numbers, *ians, *iweights, len, mx, mn, ans_size;
+    npy_intp *numbers, len, mx, mn, ans_size;
     npy_intp minlength = 0;
     npy_intp i;
+    npy_uintp *ians, *iweights;
     double *weights , *dans;
 
     NPY_PREPARE_ARGPARSER;
@@ -206,12 +207,12 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
             goto fail;
         }
         if (PyArray_ISINTEGER(wts)) {
-            iweights = (npy_intp *)PyArray_DATA(wts);
-            ans = (PyArrayObject *)PyArray_ZEROS(1, &ans_size, NPY_INTP, 0);
+            iweights = (npy_uintp *)PyArray_DATA(wts);
+            ans = (PyArrayObject *)PyArray_ZEROS(1, &ans_size, NPY_UINTP, 0);
             if (ans == NULL) {
                 goto fail;
             }
-            ians = (npy_intp *)PyArray_DATA(ans);
+            ians = (npy_uintp *)PyArray_DATA(ans);
             NPY_BEGIN_ALLOW_THREADS;
             for (i = 0; i < len; i++) {
                 ians[numbers[i]] += iweights[i];

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -119,7 +119,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
     npy_intp minlength = 0;
     npy_intp i;
     npy_uintp *ians, *iweights;
-    double *weights , *dans;
+    double *weights = NULL, *dans;
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("bincount", args, len_args, kwnames,
@@ -231,6 +231,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
             }
             NPY_END_ALLOW_THREADS;
         } else if (PyArray_ISCOMPLEX(wts)) {
+            weights = (double *)PyArray_DATA(wts);
             ans = (PyArrayObject *)PyArray_ZEROS(1, &ans_size, NPY_CDOUBLE, 0);
             if (ans == NULL) {
                 goto fail;

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -184,11 +184,11 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
         }
     }
     if (weight == Py_None) {
-        ans = (PyArrayObject *)PyArray_ZEROS(1, &ans_size, NPY_INTP, 0);
+        ans = (PyArrayObject *)PyArray_ZEROS(1, &ans_size, NPY_UINTP, 0);
         if (ans == NULL) {
             goto fail;
         }
-        ians = (npy_intp *)PyArray_DATA(ans);
+        ians = (npy_uintp *)PyArray_DATA(ans);
         NPY_BEGIN_ALLOW_THREADS;
         for (i = 0; i < len; i++)
             ians[numbers[i]] += 1;


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR adds support for complex array weights in the `np.bincount` method.

Things that still need to be done:

- [ ] Update unit tests
- [ ] Update documentation
- [x] Add support for integer weights

Could somebody please give some feedback on the changes so far? In particular I am not sure if this is the best way to do complex addition. Also, I am not sure if changing the behaviour based on datatype using the if/else statements is the best approach.

Closes #23313