### PR TITLE
ENH: structured_to_unstructured: view more often

### DIFF
--- a/doc/release/upcoming_changes/23652.improvement.rst
+++ b/doc/release/upcoming_changes/23652.improvement.rst
@@ -1,0 +1,7 @@
+``numpy.lib.recfunctions.structured_to_unstructured`` returns views in more cases
+---------------------------------------------------------------------------------
+``structured_to_unstructured`` now returns a view, if the stride between the
+fields is constant. Prior, padding between the fields or a reversed field
+would lead to a copy.
+This change only applies to ``ndarray``, ``memmap`` and ``recarray``. For all
+other array subclasses, the behavior remains unchanged.

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1043,6 +1043,9 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
             if common_stride < 0:
                 arr = arr[..., ::-1]  # reverse, if the stride was negative
             if type(arr) is not type(wrap.__self__):
+                # Some types (e.g. recarray) turn into an ndarray along the
+                # way, so we have to wrap it again in order to match the
+                # behavior with copy=True.
                 arr = wrap(arr)
             return arr
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -885,6 +885,52 @@ def _get_fields_and_offsets(dt, offset=0):
                     fields.extend([(d, c, o + i*size) for d, c, o in subfields])
     return fields
 
+def _common_stride(offsets, counts, itemsize):
+    """
+    Returns the stride between the fields, or None if the stride is not
+    constant. The values in "counts" designate the lengths of
+    sub-arrays. Sub-arrays are treated as many contiguous fields, with
+    always positive stride.
+    """
+
+    if len(offsets) <= 1:
+        return itemsize
+
+    negative = offsets[1] < offsets[0]  # negative stride
+    if negative:
+        # reverse, so offsets will be ascending
+        it = zip(reversed(offsets), reversed(counts))
+    else:
+        it = zip(offsets, counts)
+
+    prev_offset = None
+    stride = None
+    for offset, count in it:
+        if count != 1:  # sub array: always c-contiguous
+            if negative:
+                return None  # sub-arrays can never have a negative stride
+            if stride is None:
+                stride = itemsize
+            if stride != itemsize:
+                return None
+            end_offset = offset + (count - 1) * itemsize
+        else:
+            end_offset = offset
+
+        if prev_offset is not None:
+            new_stride = offset - prev_offset
+            if stride is None:
+                stride = new_stride
+            if stride != new_stride:
+                return None
+
+        prev_offset = end_offset
+
+    if stride is not None:
+        if negative:
+            return -stride
+        return stride
+
 
 def _structured_to_unstructured_dispatcher(arr, dtype=None, copy=None,
                                            casting=None):
@@ -960,7 +1006,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     if dtype is None:
         out_dtype = np.result_type(*[dt.base for dt in dts])
     else:
-        out_dtype = dtype
+        out_dtype = np.dtype(dtype)
 
     # Use a series of views and casts to convert to an unstructured array:
 
@@ -971,6 +1017,30 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
                                  'offsets': offsets,
                                  'itemsize': arr.dtype.itemsize})
     arr = arr.view(flattened_fields)
+
+    if (not copy) and all(dt.base == out_dtype for dt in dts):
+        # all elements have the right dtype already; if they have a common
+        # stride, we can just return a view
+        common_stride = _common_stride(offsets, counts, out_dtype.itemsize)
+        if common_stride is not None:
+            # ensure that we have a real ndarray; other types (e.g. matrix)
+            # have strange slicing behavior
+            arr = arr.view(type=np.ndarray)
+            new_shape = arr.shape + (sum(counts), out_dtype.itemsize)
+            new_strides = arr.strides + (abs(common_stride), 1)
+
+            arr = arr[..., None].view(np.uint8)  # view as bytes
+            arr = arr[..., min(offsets):]  # remove the leading unused data
+            arr = np.lib.stride_tricks.as_strided(arr,
+                                                  new_shape,
+                                                  new_strides)
+
+            # cast and drop the last dimension again
+            arr = arr.view(out_dtype)[..., 0]
+
+            if common_stride < 0:
+                arr = arr[..., ::-1]  # reverse, if the stride was negative
+            return arr
 
     # next cast to a packed format with all fields converted to new dtype
     packed_fields = np.dtype({'names': names,

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1031,7 +1031,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
             new_shape = arr.shape + (sum(counts), out_dtype.itemsize)
             new_strides = arr.strides + (abs(common_stride), 1)
 
-            arr = arr[..., None].view(np.uint8)  # view as bytes
+            arr = arr[..., np.newaxis].view(np.uint8)  # view as bytes
             arr = arr[..., min(offsets):]  # remove the leading unused data
             arr = np.lib.stride_tricks.as_strided(arr,
                                                   new_shape,

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -955,7 +955,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
        The dtype of the output unstructured array.
     copy : bool, optional
         If true, always return a copy. If false, a view is returned if
-        possible, which is when the `dtype` and strides of the fields are
+        possible, such as when the `dtype` and strides of the fields are
         suitable and the array subtype is one of `np.ndarray`, `np.recarray`
         or `np.memmap`.
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -954,9 +954,15 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     dtype : dtype, optional
        The dtype of the output unstructured array.
     copy : bool, optional
-        See copy argument to `numpy.ndarray.astype`. If true, always return a
-        copy. If false, and `dtype` requirements are satisfied, a view is
-        returned.
+        If true, always return a copy. If false, a view is returned if
+        possible, which is when the `dtype` and strides of the fields are
+        suitable and the array subtype is one of `np.ndarray`, `np.recarray`
+        or `np.memmap`.
+
+        .. versionchanged:: 1.25.0
+            A view can now be returned if the fields are separated by a
+            uniform stride.
+
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         See casting argument of `numpy.ndarray.astype`. Controls what kind of
         data casting may occur.

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -889,10 +889,9 @@ def _common_stride(offsets, counts, itemsize):
     """
     Returns the stride between the fields, or None if the stride is not
     constant. The values in "counts" designate the lengths of
-    sub-arrays. Sub-arrays are treated as many contiguous fields, with
+    subarrays. Subarrays are treated as many contiguous fields, with
     always positive stride.
     """
-
     if len(offsets) <= 1:
         return itemsize
 
@@ -906,9 +905,9 @@ def _common_stride(offsets, counts, itemsize):
     prev_offset = None
     stride = None
     for offset, count in it:
-        if count != 1:  # sub array: always c-contiguous
+        if count != 1:  # subarray: always c-contiguous
             if negative:
-                return None  # sub-arrays can never have a negative stride
+                return None  # subarrays can never have a negative stride
             if stride is None:
                 stride = itemsize
             if stride != itemsize:
@@ -926,10 +925,9 @@ def _common_stride(offsets, counts, itemsize):
 
         prev_offset = end_offset
 
-    if stride is not None:
-        if negative:
-            return -stride
-        return stride
+    if negative:
+        return -stride
+    return stride
 
 
 def _structured_to_unstructured_dispatcher(arr, dtype=None, copy=None,

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1016,7 +1016,6 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
                                  'itemsize': arr.dtype.itemsize})
     arr = arr.view(flattened_fields)
 
-
     # we only allow a few types to be unstructured by manipulating the
     # strides, because we know it won't work with, for example, np.matrix nor
     # np.ma.MaskedArray.

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1026,6 +1026,8 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
         # stride, we can just return a view
         common_stride = _common_stride(offsets, counts, out_dtype.itemsize)
         if common_stride is not None:
+            wrap = arr.__array_wrap__
+
             new_shape = arr.shape + (sum(counts), out_dtype.itemsize)
             new_strides = arr.strides + (abs(common_stride), 1)
 
@@ -1041,6 +1043,8 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
 
             if common_stride < 0:
                 arr = arr[..., ::-1]  # reverse, if the stride was negative
+            if type(arr) is not type(wrap.__self__):
+                arr = wrap(arr)
             return arr
 
     # next cast to a packed format with all fields converted to new dtype

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -345,7 +345,6 @@ class TestRecFunctions:
         assert_raises(NotImplementedError, unstructured_to_structured,
                                            np.zeros((3,0), dtype=np.int32))
 
-
         # test supported ndarray subclasses
         d_plain = np.array([(1, 2), (3, 4)], dtype=[('a', 'i4'), ('b', 'i4')])
         dd_expected = structured_to_unstructured(d_plain, copy=True)


### PR DESCRIPTION
Converting with `structured_to_unstructured()` now returns a view, if all the fields have a constant stride.

This is useful, if a structured array has attributes with multiple types, but all the attributes with the same type are contiguous, e.g. a vertex with *x*, *y*, *z* as `float32`, and *r*, *g*, *b* as `uint8`.

This will allow the following now (all the `np.shares_memory()` calls now return true):

```python
import numpy as np
import numpy.lib.recfunctions as rfn

a = np.array([(1, 2, 3, 50, 127, 255), (4, 5, 6, 80, 100, 120)],
             dtype=[('x', 'f4'), ('y', 'f4'), ('z', 'f4'), ('red', 'u1'), ('green', 'u1'), ('blue', 'u1')])


# We can extract individual fields of a structured array, if they have a constant stride, without needing a copy:
xyz = rfn.structured_to_unstructured(a[['x', 'y', 'z']])
print(np.shares_memory(xyz, a))  # Output: True
print(xyz)
# Output:
# [[1. 2. 3.]
#  [4. 5. 6.]]

rgb = rfn.structured_to_unstructured(a[['red', 'green', 'blue']])
print(np.shares_memory(rgb, a))  # Output: True
print(rgb)
# Output:
# [[ 50 127 255]
#  [ 80 100 120]]


# Changing the order of fields is allowed too, as long as the stride remains constant:
rgb = rfn.structured_to_unstructured(a[['blue', 'red']])
print(np.shares_memory(rgb, a))  # Output: True
print(rgb)
# Output:
# [[255  50]
#  [120  80]]


# Arrays with sub-arrays are supported too:
a2 = np.array([((1, 2, 3), ((4, 5), (6, 7)), 999)], dtype=[('a', ('f4', 3)), ('b', (('f4', 2), 2)), ('unused', 'f4')])
print(a2)

ab = rfn.structured_to_unstructured(a2[['a', 'b']])
print(np.shares_memory(a2, ab))  # Output: True
print(ab)
# Output:
# [[1. 2. 3. 4. 5. 6. 7.]]
```

Observable changes / issues:
* the .bases attribute of the returned array is more deeply nested now
* darray subclasses are not preserved anymore, if copy is False
  - some subclasses would have strange behavior, e.g. matrix always keeps 2 dimensions, but we want to add a new dimension during unstructuring
  - `as_strided()` does not ensure all dimensions are kept on array subclasses either
  - Is this an issue? The only I can think of to fix this is to go through the __array_interface__.
