### PR TITLE
BUG: Avoid uses -Werror during tests default C/C++ standards

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,9 +193,6 @@ def get_build_overrides():
     from numpy._utils import _pep440
 
     def try_compile(compiler, file, flags = [], verbose=False):
-        # To bypass trapping warnings by Travis CI
-        if getattr(compiler, 'compiler_type', '') == 'unix':
-            flags = ['-Werror'] + flags
         bk_ver = getattr(compiler, 'verbose', False)
         compiler.verbose = verbose
         try:
@@ -270,7 +267,7 @@ def get_build_overrides():
             constexpr bool test_fold = (... && std::is_const_v<T>);
             int main()
             {
-                if constexpr (test_fold<int, const int>) {
+                if (test_fold<int, const int>) {
                     return 0;
                 }
                 else {


### PR DESCRIPTION
closes #23538

  This may break the test if any unsupported
  compiler options are specified. e.g. `error: overriding currently unsupported use of floating point exceptions on this target `

  This patch also removes the testing of constexpr and keeps only fold
  expressions and inline variables to avoid triggering the constexpr
  warning warning: ‘if constexpr’ only available with ‘-std=c++17’ or
  ‘-std=gnu++17 by Travis CI, which can cause the build to fail due to warning trapping.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
