### PR TITLE
MAINT: allow sphinx6, sync with conda environment.yml

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx>=4.5.0,<6.0
+sphinx>=4.5.0
 numpydoc==1.4
 pydata-sphinx-theme==0.9.0
 sphinx-design
@@ -7,7 +7,7 @@ ipython!=8.1.0
 scipy
 matplotlib
 pandas
-breathe
+breathe>4.33.0
 
 # needed to build release notes
 towncrier


### PR DESCRIPTION
Revert #23640 in order to be able to debug the problems from #23647. Also pin the minimum version of breathe as done in the conda `environment.yml`.