### PR TITLE
ENH: Restore TypeError cleanup in array function dispatching

### DIFF
--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -474,13 +474,13 @@ fix_name_if_typeerror(PyArray_ArrayFunctionDispatcherObject *self)
     }
 
     Py_ssize_t cmp = PyUnicode_Tailmatch(
-        message, self->dispatcher_name, 0, -1, 0);
+            message, self->dispatcher_name, 0, -1, -1);
     if (cmp <= 0) {
         Py_DECREF(message);
         goto restore_error;
     }
     Py_SETREF(message, PyUnicode_Replace(
-        message, self->dispatcher_name, self->public_name, 1));
+            message, self->dispatcher_name, self->public_name, 1));
     if (message == NULL) {
         goto restore_error;
     }

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -485,6 +485,9 @@ fix_name_if_typeerror(PyArray_ArrayFunctionDispatcherObject *self)
         goto restore_error;
     }
     PyErr_SetObject(PyExc_TypeError, message);
+    Py_DECREF(exc);
+    Py_XDECREF(val);
+    Py_XDECREF(tb);
     Py_DECREF(message);
     return;
 

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -389,6 +389,12 @@ class TestArrayFunctionImplementation:
             func(bad_arg=3)
             raise AssertionError("must fail")
         except TypeError as exc:
+            if exc.args[0].startswith("_dispatcher"):
+                # We replace the qualname currently, but it used `__name__`
+                # (relevant functions have the same name and qualname anyway)
+                pytest.skip("Python version is not using __qualname__ for "
+                            "TypeError formatting.")
+
             assert exc.args == expected_exception.args
 
     @pytest.mark.parametrize("value", [234, "this func is not replaced"])

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -359,6 +359,17 @@ class TestArrayFunctionImplementation:
                 TypeError, "no implementation found for 'my.func'"):
             func(MyArray())
 
+    @pytest.mark.parametrize("name", ["concatenate", "mean", "asarray"])
+    def test_signature_error_message_simple(self, name):
+        func = getattr(np, name)
+        try:
+            # all of these functions need an argument:
+            func()
+        except TypeError as e:
+            exc = e
+
+        assert exc.args[0].startswith(f"{name}()")
+
     def test_signature_error_message(self):
         # The lambda function will be named "<lambda>", but the TypeError
         # should show the name as "func"
@@ -370,7 +381,7 @@ class TestArrayFunctionImplementation:
             pass
 
         try:
-            func(bad_arg=3)
+            func._implementation(bad_arg=3)
         except TypeError as e:
             expected_exception = e
 


### PR DESCRIPTION
When the dispatcher raises a TypeError and it starts with the dispatchers name (or actually __qualname__ not that it normally matters), then it is nicer for users if we just raise a new error with the public symbol name.

Python does not seem to normalize exception and goes down the unicode path, but I assume that e.g. PyPy may not do that.  And there might be other weirder reason why we go down the full path.  I have manually tested it by forcing Normalization.

Closes gh-23029
