### PR TITLE
TST: Remove crackfortran.nameargspattern time test that failed randomly

### DIFF
--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -290,36 +290,26 @@ class TestNameArgsPatternBacktracking:
     def test_nameargspattern_backtracking(self, adversary):
         '''address ReDOS vulnerability:
         https://github.com/numpy/numpy/issues/23338'''
-        last_median = 0.
-        trials_per_count = 128
+        trials_per_batch = 12
+        batches_per_regex = 4
         start_reps, end_reps = 15, 25
-        times_median_doubled = 0
         for ii in range(start_reps, end_reps):
             repeated_adversary = adversary * ii
-            times = []
-            for _ in range(trials_per_count):
-                t0 = time.perf_counter()
-                mtch = nameargspattern.search(repeated_adversary)
-                times.append(time.perf_counter() - t0)
-            # We should use a measure of time that's resilient to outliers.
-            # Times jump around a lot due to the CPU's scheduler.
-            median = np.median(times)
+            # test times in small batches.
+            # this gives us more chances to catch a bad regex
+            # while still catching it before too long if it is bad
+            for _ in range(batches_per_regex):
+                times = []
+                for _ in range(trials_per_batch):
+                    t0 = time.perf_counter()
+                    mtch = nameargspattern.search(repeated_adversary)
+                    times.append(time.perf_counter() - t0)
+                # our pattern should be much faster than 0.2s per search
+                # it's unlikely that a bad regex will pass even on fast CPUs
+                assert np.median(times) < 0.2
             assert not mtch
             # if the adversary is capped with @)@, it becomes acceptable
             # according to the old version of the regex.
             # that should still be true.
             good_version_of_adversary = repeated_adversary + '@)@'
             assert nameargspattern.search(good_version_of_adversary)
-            if ii > start_reps:
-                # the hallmark of exponentially catastrophic backtracking
-                # is that runtime doubles for every added instance of
-                # the problematic pattern.
-                times_median_doubled += median > 2 * last_median
-                # also try to rule out non-exponential but still bad cases
-                # arbitrarily, we should set a hard limit of 10ms as too slow
-                assert median < trials_per_count * 0.01
-            last_median = median
-        # we accept that maybe the median might double once, due to
-        # the CPU scheduler acting weird or whatever. More than that
-        # seems suspicious.
-        assert times_median_doubled < 2


### PR DESCRIPTION
Address @seberg 's comment on PR #23460 that the median doubling test failed too much even though the regex is good.
I removed that test to address the problem.
Also made the threshold for rejecting a regex as too slow much more lenient.
200ms should be enough time even for a bad CPU on a bad day, while a bad regex should fail with near certainty even on super fast CPUs.

I ran all the tests like 20 times on my own machine and it never failed once. I then subbed in the *old* nameargspattern (`re.compile(r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>.*)\s*@\)@))*\s*\Z', re.I)`) and it failed every time I tested it (which was about 5 times because I'm not *that* patient).

Bottom line: the tests will now run faster and bad regexes should fail in less than 10 seconds.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
