### PR TITLE
MAINT: bump website theme version

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,7 +1,7 @@
 # doxygen required, use apt-get or dnf
 sphinx>=4.5.0
 numpydoc==1.4
-pydata-sphinx-theme==0.9.0
+pydata-sphinx-theme==0.13.3
 sphinx-design
 ipython!=8.1.0
 scipy

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - scipy
   - pandas
   - matplotlib
-  - pydata-sphinx-theme=0.9.0
+  - pydata-sphinx-theme=0.13.3
   - doxygen
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe>4.33.0

--- a/numpy/dtypes.py
+++ b/numpy/dtypes.py
@@ -22,7 +22,7 @@ The following are the classes of the corresponding NumPy dtype instances and
 NumPy scalar types.  The classes can be used in ``isinstance`` checks and can
 also be instantiated or used directly.  Direct use of these classes is not
 typical, since their scalar counterparts (e.g. ``np.float64``) or strings
-like ``"float64"` can be used.
+like ``"float64"`` can be used.
 
 .. list-table::
     :header-rows: 1


### PR DESCRIPTION
closes #23647 

#23658 removed the upper pin on `sphinx`, which broke some features of the website (sphinx 6 does not ship with jQuery, which the 0.9.0 version of the website theme assumed to be present). This updates the website theme to 0.13.3 which no longer makes use of jQuery.

NB: On the advice of @rossbar I haven't touched the CSS at all, so you'll surely notice a few color changes due to the theme version update.  I'm willing to do a few CSS tweaks though, just LMK what bothers you when browsing the PR docs build :)