### PR TITLE
BUG: Fix masked array ravel order for A (and somewhat K)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4668,7 +4668,7 @@ class MaskedArray(ndarray):
         # TODO: We don't actually support K, so use A instead.  We could
         #       try to guess this correct by sorting strides or deprecate.
         if order in "kKaA":
-            order = "C" if self._data.flags.fnc else "F"
+            order = "F" if self._data.flags.fnc else "C"
         r = ndarray.ravel(self._data, order=order).view(type(self))
         r._update_from(self)
         if self._mask is not nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3444,6 +3444,8 @@ class TestMaskedArrayMethods:
         raveled = x.ravel(order)
         assert (raveled.filled(0) == 0).all()
 
+        # NOTE: Can be wrong if arr order is neither C nor F and `order="K"` 
+        assert_array_equal(arr.ravel(order), x.ravel(order)._data)
 
     def test_reshape(self):
         # Tests reshape


### PR DESCRIPTION
Swaps the order to the correct thing and thus

closes gh-23651


---

Clearly, doesn't attempt to get "K" right, which would need manual transposing and stuff...