### PR TITLE
TYP: Fix typing of where method in multiarray 

### DIFF
--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -366,8 +366,8 @@ def where(
 @overload
 def where(
     condition: ArrayLike,
-    x: ArrayLike,
-    y: ArrayLike,
+    x: None | ArrayLike,
+    y: None | ArrayLike,
     /,
 ) -> NDArray[Any]: ...
 


### PR DESCRIPTION
The typing of where method in multiarray does not allow to pass None as x/y conditional values, but None is actually a valid type that can be passed there explicitly (and it is even set by default when no parameters are passed).

Example case where it might be useful is an explicit conversion to Python None values where column value isnull() is True:

```python

where(df[col].isnull(), None, df[col])
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
