### PR TITLE
BUG: random: Don't return negative values from Generator.geometric.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -960,7 +960,15 @@ RAND_INT_TYPE random_geometric_search(bitgen_t *bitgen_state, double p) {
 }
 
 int64_t random_geometric_inversion(bitgen_t *bitgen_state, double p) {
-  return (int64_t)ceil(-random_standard_exponential(bitgen_state) / npy_log1p(-p));
+  double z = ceil(-random_standard_exponential(bitgen_state) / npy_log1p(-p));
+  /*
+   * The constant 9.223372036854776e+18 is the smallest double that is
+   * larger than INT64_MAX.
+   */
+  if (z >= 9.223372036854776e+18) {
+    return INT64_MAX;
+  }
+  return (int64_t) z;
 }
 
 int64_t random_geometric(bitgen_t *bitgen_state, double p) {

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -3,32 +3,32 @@ import numpy as np
 import pytest
 from numpy.random import Generator, MT19937
 
-mt19937 = Generator(MT19937())
-
 
 class TestRegression:
+
+    def setup_method(self):
+        self.mt19937 = Generator(MT19937(121263137472525314065))
 
     def test_vonmises_range(self):
         # Make sure generated random variables are in [-pi, pi].
         # Regression test for ticket #986.
         for mu in np.linspace(-7., 7., 5):
-            r = mt19937.vonmises(mu, 1, 50)
+            r = self.mt19937.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
     def test_hypergeometric_range(self):
         # Test for ticket #921
-        assert_(np.all(mt19937.hypergeometric(3, 18, 11, size=10) < 4))
-        assert_(np.all(mt19937.hypergeometric(18, 3, 11, size=10) > 0))
+        assert_(np.all(self.mt19937.hypergeometric(3, 18, 11, size=10) < 4))
+        assert_(np.all(self.mt19937.hypergeometric(18, 3, 11, size=10) > 0))
 
         # Test for ticket #5623
         args = (2**20 - 2, 2**20 - 2, 2**20 - 2)  # Check for 32-bit systems
-        assert_(mt19937.hypergeometric(*args) > 0)
+        assert_(self.mt19937.hypergeometric(*args) > 0)
 
     def test_logseries_convergence(self):
         # Test for ticket #923
         N = 1000
-        mt19937 = Generator(MT19937(0))
-        rvsn = mt19937.logseries(0.8, size=N)
+        rvsn = self.mt19937.logseries(0.8, size=N)
         # these two frequency counts should be close to theoretical
         # numbers with this large sample
         # theoretical large N result is 0.49706795
@@ -65,41 +65,38 @@ class TestRegression:
         # Test for multivariate_normal issue with 'size' argument.
         # Check that the multivariate_normal size argument can be a
         # numpy integer.
-        mt19937.multivariate_normal([0], [[0]], size=1)
-        mt19937.multivariate_normal([0], [[0]], size=np.int_(1))
-        mt19937.multivariate_normal([0], [[0]], size=np.int64(1))
+        self.mt19937.multivariate_normal([0], [[0]], size=1)
+        self.mt19937.multivariate_normal([0], [[0]], size=np.int_(1))
+        self.mt19937.multivariate_normal([0], [[0]], size=np.int64(1))
 
     def test_beta_small_parameters(self):
         # Test that beta with small a and b parameters does not produce
         # NaNs due to roundoff errors causing 0 / 0, gh-5851
-        mt19937 = Generator(MT19937(1234567890))
-        x = mt19937.beta(0.0001, 0.0001, size=100)
+        x = self.mt19937.beta(0.0001, 0.0001, size=100)
         assert_(not np.any(np.isnan(x)), 'Nans in mt19937.beta')
 
     def test_choice_sum_of_probs_tolerance(self):
         # The sum of probs should be 1.0 with some tolerance.
         # For low precision dtypes the tolerance was too tight.
         # See numpy github issue 6123.
-        mt19937 = Generator(MT19937(1234))
         a = [1, 2, 3]
         counts = [4, 4, 2]
         for dt in np.float16, np.float32, np.float64:
             probs = np.array(counts, dtype=dt) / sum(counts)
-            c = mt19937.choice(a, p=probs)
+            c = self.mt19937.choice(a, p=probs)
             assert_(c in a)
             with pytest.raises(ValueError):
-                mt19937.choice(a, p=probs*0.9)
+                self.mt19937.choice(a, p=probs*0.9)
 
     def test_shuffle_of_array_of_different_length_strings(self):
         # Test that permuting an array of different length strings
         # will not cause a segfault on garbage collection
         # Tests gh-7710
-        mt19937 = Generator(MT19937(1234))
 
         a = np.array(['a', 'a' * 1000])
 
         for _ in range(100):
-            mt19937.shuffle(a)
+            self.mt19937.shuffle(a)
 
         # Force Garbage Collection - should not segfault.
         import gc
@@ -109,17 +106,17 @@ class TestRegression:
         # Test that permuting an array of objects will not cause
         # a segfault on garbage collection.
         # See gh-7719
-        mt19937 = Generator(MT19937(1234))
         a = np.array([np.arange(1), np.arange(4)], dtype=object)
 
         for _ in range(1000):
-            mt19937.shuffle(a)
+            self.mt19937.shuffle(a)
 
         # Force Garbage Collection - should not segfault.
         import gc
         gc.collect()
 
     def test_permutation_subclass(self):
+
         class N(np.ndarray):
             pass
 
@@ -142,10 +139,10 @@ class TestRegression:
         assert_array_equal(m.__array__(), np.arange(5))
 
     def test_gamma_0(self):
-        assert mt19937.standard_gamma(0.0) == 0.0
-        assert_array_equal(mt19937.standard_gamma([0.0]), 0.0)
+        assert self.mt19937.standard_gamma(0.0) == 0.0
+        assert_array_equal(self.mt19937.standard_gamma([0.0]), 0.0)
 
-        actual = mt19937.standard_gamma([0.0], dtype='float')
+        actual = self.mt19937.standard_gamma([0.0], dtype='float')
         expected = np.array([0.], dtype=np.float32)
         assert_array_equal(actual, expected)
 
@@ -153,5 +150,5 @@ class TestRegression:
         # Regression test for gh-17007.
         # When p = 1e-30, the probability that a sample will exceed 2**63-1
         # is 0.9999999999907766, so we expect the result to be all 2**63-1.
-        assert_array_equal(mt19937.geometric(p=1e-30, size=3),
+        assert_array_equal(self.mt19937.geometric(p=1e-30, size=3),
                            np.iinfo(np.int64).max)

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -148,3 +148,10 @@ class TestRegression:
         actual = mt19937.standard_gamma([0.0], dtype='float')
         expected = np.array([0.], dtype=np.float32)
         assert_array_equal(actual, expected)
+
+    def test_geometric_tiny_prob(self):
+        # Regression test for gh-17007.
+        # When p = 1e-30, the probability that a sample will exceed 2**63-1
+        # is 0.9999999999907766, so we expect the result to be all 2**63-1.
+        assert_array_equal(mt19937.geometric(p=1e-30, size=3),
+                           np.iinfo(np.int64).max)


### PR DESCRIPTION
In C, when the integer part of a double exceeds the maximum int64, casting the double to int64_t is undefined behavior.  On some platforms, the result is `2**64-1` and on others it is `-2**64`.  That results in rng.geometric() returning `-2**64` when p was sufficiently small on some platforms.

The fix is to never invoke undefined behavior by ensuring we don't attempt to cast very large double values to int64_t.

See gh-17007.
