### PR TITLE
BUG: Correct sin/cos float64 range check functions

### DIFF
--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -104,14 +104,14 @@ simd_range_reduction_pi2(npyv_f64 r, npyv_f64 n) {
     return simd_range_reduction_f64(r, n, pi1, pi2, pi3);
 }
 
-NPY_FINLINE npyv_b64 simd_cos_range_check_f64(npyv_u64 ir) {
+NPY_FINLINE npyv_b64 simd_sin_range_check_f64(npyv_u64 ir) {
     const npyv_u64 tiny_bound = npyv_setall_u64(0x202); /* top12 (asuint64 (0x1p-509)).  */
     const npyv_u64 simd_thresh = npyv_setall_u64(0x214); /* top12 (asuint64 (RangeVal)) - SIMD_TINY_BOUND.  */
 
     return npyv_cmpge_u64(npyv_sub_u64(npyv_shri_u64(ir, 52), tiny_bound), simd_thresh);
 }
 
-NPY_FINLINE npyv_b64 simd_sin_range_check_f64(npyv_u64 ir) {
+NPY_FINLINE npyv_b64 simd_cos_range_check_f64(npyv_u64 ir) {
     const npyv_f64 range_val = npyv_setall_f64(0x1p23);
 
     return npyv_cmpge_u64(ir, npyv_reinterpret_u64_f64(range_val));

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1437,6 +1437,16 @@ class TestSpecialFloats:
             assert_equal(np.cos(yf), xf)
 
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
+    def test_sincos_underflow(self):
+        with np.errstate(under='raise'):
+            underflow_trigger = np.array(
+                float.fromhex("0x1.f37f47a03f82ap-511"),
+                dtype=np.float64
+            )
+            np.sin(underflow_trigger)
+            np.cos(underflow_trigger)
+
+    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     @pytest.mark.parametrize('callable', [np.sin, np.cos])
     @pytest.mark.parametrize('dtype', ['e', 'f', 'd'])
     @pytest.mark.parametrize('value', [np.inf, -np.inf])

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1437,6 +1437,10 @@ class TestSpecialFloats:
             assert_equal(np.cos(yf), xf)
 
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
+    @pytest.mark.xfail(
+        sys.platform.startswith("darwin"),
+        reason="underflow is triggered for scalar 'sin'"
+    )
     def test_sincos_underflow(self):
         with np.errstate(under='raise'):
             underflow_trigger = np.array(


### PR DESCRIPTION
When I translated range checks for [sin](https://github.com/ARM-software/optimized-routines/blob/91d5bbc3091fa568e6856c7c41f9d7492d5957df/math/v_sin.c#L68):

```c
cmp = v_cond_u64 ((ir >> 52) - TinyBound >= Thresh);
```

and [cos](https://github.com/ARM-software/optimized-routines/blob/91d5bbc3091fa568e6856c7c41f9d7492d5957df/math/v_cos.c#L56):

```c
cmp = v_cond_u64 (v_as_u64_f64 (r) >= v_as_u64_f64 (RangeVal));
```

They ended up the wrong way around, this corrects it.