### PR TITLE
ENH: updated numpy.Generator.normal to have a dtype parameter

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -396,7 +396,24 @@ class Generator:
         loc: _FloatLike_co = ...,
         scale: _FloatLike_co = ...,
         size: None = ...,
+        dtype: _DTypeLikeFloat32 | _DTypeLikeFloat64 = ...,
     ) -> float: ...  # type: ignore[misc]
+    @overload
+    def normal(
+        self,
+        loc: _FloatLike_co = ...,
+        scale: _FloatLike_co = ...,
+        size: None = ...,
+        dtype: _DTypeLikeFloat32 = ...,
+    ) -> ndarray[Any, dtype[float32]]: ...  # type: ignore[misc]
+    @overload
+    def normal(
+        self,
+        loc: _FloatLike_co = ...,
+        scale: _FloatLike_co = ...,
+        size: None = ...,
+        dtype: _DTypeLikeFloat64 = ...,
+    ) -> ndarray[Any, dtype[float64]]: ...  # type: ignore[misc]
     @overload
     def normal(
         self,


### PR DESCRIPTION
This adds a dtype parameter in numpy.Generator.normal.
I compared a similar function mentioned in the issue numpy/numpy#23694 to gain some insight on adding the parameter.
closes numpy/numpy#23694
