### PR TITLE
DOC: Resolve length/index ambiguity in numpy.outer docstring

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -844,12 +844,12 @@ def outer(a, b, out=None):
     Compute the outer product of two vectors.
 
     Given two vectors `a` and `b` of length ``M`` and ``N``, repsectively,
-    the outer product is::
+    the outer product [1]_ is::
 
-      [[a_0*b_0  a_0*b_1 ... a_0*b_N-1 ]
+      [[a_0*b_0  a_0*b_1 ... a_0*b_{N-1} ]
        [a_1*b_0    .
        [ ...          .
-       [a_M-1*b_0            a_M-1*b_N-1 ]]
+       [a_{M-1}*b_0            a_{M-1}*b_{N-1} ]]
 
     Parameters
     ----------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -881,9 +881,9 @@ def outer(a, b, out=None):
 
     References
     ----------
-    .. [1] : G. H. Golub and C. F. Van Loan, *Matrix Computations*, 3rd
-             ed., Baltimore, MD, Johns Hopkins University Press, 1996,
-             pg. 8.
+    .. [1] G. H. Golub and C. F. Van Loan, *Matrix Computations*, 3rd
+           ed., Baltimore, MD, Johns Hopkins University Press, 1996,
+           pg. 8.
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -843,14 +843,13 @@ def outer(a, b, out=None):
     """
     Compute the outer product of two vectors.
 
-    Given two vectors, ``a = [a0, a1, ..., aM]`` and
-    ``b = [b0, b1, ..., bN]``,
-    the outer product [1]_ is::
+    Given two vectors `a` and `b` of length ``M`` and ``N``, repsectively,
+    the outer product is::
 
-      [[a0*b0  a0*b1 ... a0*bN ]
-       [a1*b0    .
+      [[a_0*b_0  a_0*b_1 ... a_0*b_N-1 ]
+       [a_1*b_0    .
        [ ...          .
-       [aM*b0            aM*bN ]]
+       [a_M-1*b_0            a_M-1*b_N-1 ]]
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #23664 by modifying the indices in the example array.

Also includes a minor formatting update to the References section.