### PR TITLE
ENH: speed up 32-bit and 64-bit np.argsort by 5x with AVX-512 

### DIFF
--- a/numpy/core/src/npysort/quicksort.cpp
+++ b/numpy/core/src/npysort/quicksort.cpp
@@ -115,7 +115,9 @@ inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
     #ifndef NPY_DISABLE_OPTIMIZATION
         #include "simd_qsort.dispatch.h"
     #endif
-    NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
+    if (sizeof(npy_intp) == sizeof(int64_t)) {
+        NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
+    }
     if (dispfunc) {
         (*dispfunc)(reinterpret_cast<TF*>(start), reinterpret_cast<intptr_t*>(arg), static_cast<intptr_t>(num));
         return true;

--- a/numpy/core/src/npysort/quicksort.cpp
+++ b/numpy/core/src/npysort/quicksort.cpp
@@ -77,6 +77,11 @@ inline bool quicksort_dispatch(T*, npy_intp)
 {
     return false;
 }
+template<typename T>
+inline bool aquicksort_dispatch(T*, npy_intp*. npy_intp)
+{
+    return false;
+}
 #else
 template<typename T>
 inline bool quicksort_dispatch(T *start, npy_intp num)
@@ -97,6 +102,22 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
     }
     if (dispfunc) {
         (*dispfunc)(reinterpret_cast<TF*>(start), static_cast<intptr_t>(num));
+        return true;
+    }
+    return false;
+}
+
+template<typename T>
+inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
+{
+    using TF = typename np::meta::FixedWidth<T>::Type;
+    void (*dispfunc)(TF*, intptr_t*, intptr_t) = nullptr;
+    #ifndef NPY_DISABLE_OPTIMIZATION
+        #include "simd_qsort.dispatch.h"
+    #endif
+    NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
+    if (dispfunc) {
+        (*dispfunc)(reinterpret_cast<TF*>(start), reinterpret_cast<intptr_t*>(arg), static_cast<intptr_t>(num));
         return true;
     }
     return false;
@@ -852,34 +873,52 @@ aquicksort_ushort(void *vv, npy_intp *tosort, npy_intp n,
 NPY_NO_EXPORT int
 aquicksort_int(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_int *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::int_tag>((npy_int *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_uint(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_uint *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::uint_tag>((npy_uint *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_long(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_long *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::long_tag>((npy_long *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_ulong(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_ulong *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::ulong_tag>((npy_ulong *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_longlong(void *vv, npy_intp *tosort, npy_intp n,
                     void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_longlong *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::longlong_tag>((npy_longlong *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_ulonglong(void *vv, npy_intp *tosort, npy_intp n,
                      void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_ulonglong *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::ulonglong_tag>((npy_ulonglong *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
@@ -891,12 +930,18 @@ NPY_NO_EXPORT int
 aquicksort_float(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_float *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::float_tag>((npy_float *)vv, tosort, n);
 }
 NPY_NO_EXPORT int
 aquicksort_double(void *vv, npy_intp *tosort, npy_intp n,
                   void *NPY_UNUSED(varr))
 {
+    if (aquicksort_dispatch((npy_double *)vv, tosort, n)) {
+        return 0;
+    }
     return aquicksort_<npy::double_tag>((npy_double *)vv, tosort, n);
 }
 NPY_NO_EXPORT int

--- a/numpy/core/src/npysort/quicksort.cpp
+++ b/numpy/core/src/npysort/quicksort.cpp
@@ -111,15 +111,17 @@ template<typename T>
 inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
 {
     using TF = typename np::meta::FixedWidth<T>::Type;
-    void (*dispfunc)(TF*, intptr_t*, intptr_t) = nullptr;
+    void (*dispfunc)(TF*, npy_intp*, npy_intp) = nullptr;
     #ifndef NPY_DISABLE_OPTIMIZATION
         #include "simd_qsort.dispatch.h"
     #endif
+    /* x86-simd-sort uses 8-byte int to store arg values, npy_intp is 4 bytes
+     * in 32-bit*/
     if (sizeof(npy_intp) == sizeof(int64_t)) {
         NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
     }
     if (dispfunc) {
-        (*dispfunc)(reinterpret_cast<TF*>(start), reinterpret_cast<intptr_t*>(arg), static_cast<intptr_t>(num));
+        (*dispfunc)(reinterpret_cast<TF*>(start), arg, num);
         return true;
     }
     return false;

--- a/numpy/core/src/npysort/quicksort.cpp
+++ b/numpy/core/src/npysort/quicksort.cpp
@@ -78,7 +78,7 @@ inline bool quicksort_dispatch(T*, npy_intp)
     return false;
 }
 template<typename T>
-inline bool aquicksort_dispatch(T*, npy_intp*. npy_intp)
+inline bool aquicksort_dispatch(T*, npy_intp*, npy_intp)
 {
     return false;
 }

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -10,6 +10,7 @@
 #if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
+    #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
 #endif
 
 namespace np { namespace qsort_simd {
@@ -38,6 +39,30 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, intptr_t size)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, intptr_t *arg, intptr_t size)
+{
+    avx512_argsort(arr, arg, size);
 }
 #endif  // NPY_HAVE_AVX512_SKX
 

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -42,27 +42,27 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, intptr_t *arg, intptr_t size)
 {
-    avx512_argsort(arr, arg, size);
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
 #endif  // NPY_HAVE_AVX512_SKX
 

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -40,27 +40,27 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, intptr_t *arg, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }

--- a/numpy/core/src/npysort/simd_qsort.hpp
+++ b/numpy/core/src/npysort/simd_qsort.hpp
@@ -9,7 +9,7 @@ namespace np { namespace qsort_simd {
     #include "simd_qsort.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
-NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, intptr_t* arg, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, npy_intp* arg, npy_intp size))
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort_16bit.dispatch.h"

--- a/numpy/core/src/npysort/simd_qsort.hpp
+++ b/numpy/core/src/npysort/simd_qsort.hpp
@@ -9,6 +9,7 @@ namespace np { namespace qsort_simd {
     #include "simd_qsort.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, intptr_t* arg, intptr_t size))
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort_16bit.dispatch.h"


### PR DESCRIPTION
Leverages latest optimizations to `x86-simd-sort` which provides AVX-512 routines for `argsort`. Algorithm details: 

- Broadly the same algorithm that was used to vectorize quicksort. Instead of using load instructions to load array into registers, this uses gather instructions to load the array elements via the index array. This allows sorting only the indices without modifying the original array or having to make a copy of it. 
- O(1) space 
- Up to 5x speed up on random arrays.
- See PR: https://github.com/intel/x86-simd-sort/pull/34 for all the details of the algorithm. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
