### PR TITLE
MAINT: refactor to use assignment expressions (walrus operator :=)

### DIFF
--- a/numpy/_typing/_add_docstring.py
+++ b/numpy/_typing/_add_docstring.py
@@ -38,8 +38,7 @@ def _parse_docstrings() -> str:
         new_lines = []
         indent = ""
         for line in lines:
-            m = re.match(r'^(\s+)[-=]+\s*$', line)
-            if m and new_lines:
+            if new_lines and (m := re.match(r'^(\s+)[-=]+\s*$', line)):
                 prev = textwrap.dedent(new_lines.pop())
                 if prev == "Examples":
                     indent = ""

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -93,8 +93,7 @@ def _array_descr(descriptor):
             if descriptor.metadata is None:
                 return descriptor.str
             else:
-                new = descriptor.metadata.copy()
-                if new:
+                if new := descriptor.metadata.copy():
                     return (descriptor.str, new)
                 else:
                     return descriptor.str
@@ -215,8 +214,7 @@ class dummy_ctype:
         return self._cls != other._cls
 
 def _getintp_ctype():
-    val = _getintp_ctype.cache
-    if val is not None:
+    if (val := _getintp_ctype.cache) is not None:
         return val
     if ctypes is None:
         import numpy as np

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -190,8 +190,7 @@ def split_arguments(argstr):
     def finish_arg():
         if current_argument:
             argstr = ''.join(current_argument).strip()
-            m = re.match(r'(.*(\s+|\*))(\w+)$', argstr)
-            if m:
+            if m := re.match(r'(.*(\s+|\*))(\w+)$', argstr):
                 typename = m.group(1).strip()
                 name = m.group(3)
             else:
@@ -265,20 +264,18 @@ def find_functions(filename, tag='API'):
                     doclist.append(line)
             elif state == STATE_RETTYPE:
                 # first line of declaration with return type
-                m = re.match(r'NPY_NO_EXPORT\s+(.*)$', line)
-                if m:
+                if m := re.match(r'NPY_NO_EXPORT\s+(.*)$', line):
                     line = m.group(1)
                 return_type = line
                 state = STATE_NAME
             elif state == STATE_NAME:
                 # second line, with function name
-                m = re.match(r'(\w+)\s*\(', line)
-                if m:
+                if m := re.match(r'(\w+)\s*\(', line):
                     function_name = m.group(1)
+                    function_args.append(line[m.end():])
                 else:
                     raise ParseError(filename, lineno+1,
                                      'could not find function name')
-                function_args.append(line[m.end():])
                 state = STATE_ARGS
             elif state == STATE_ARGS:
                 if line.startswith('{'):
@@ -538,8 +535,7 @@ def get_versions_hash():
     file = os.path.join(os.path.dirname(__file__), 'cversions.txt')
     with open(file) as fid:
         for line in fid:
-            m = VERRE.match(line)
-            if m:
+            if m := VERRE.match(line):
                 d.append((int(m.group(1), 16), m.group(2)))
 
     return dict(d)

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -501,8 +501,7 @@ class finfo:
             # In case a float instance was given
             dtype = numeric.dtype(type(dtype))
 
-        obj = cls._finfo_cache.get(dtype)
-        if obj is not None:
+        if (obj := cls._finfo_cache.get(dtype)) is not None:
             return obj
         dtypes = [dtype]
         newdtype = numeric.obj2sctype(dtype)
@@ -511,8 +510,7 @@ class finfo:
             dtype = newdtype
         if not issubclass(dtype, numeric.inexact):
             raise ValueError("data type %r not inexact" % (dtype))
-        obj = cls._finfo_cache.get(dtype)
-        if obj is not None:
+        if (obj := cls._finfo_cache.get(dtype)) is not None:
             return obj
         if not issubclass(dtype, numeric.floating):
             newdtype = _convert_to_float[dtype]
@@ -520,9 +518,7 @@ class finfo:
                 # dtype changed, for example from complex128 to float64
                 dtypes.append(newdtype)
                 dtype = newdtype
-
-                obj = cls._finfo_cache.get(dtype, None)
-                if obj is not None:
+                if (obj := cls._finfo_cache.get(dtype, None)) is not None:
                     # the original dtype was not in the cache, but the new
                     # dtype is in the cache. we add the original dtypes to
                     # the cache and return the result

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -247,8 +247,7 @@ class record(nt.void):
         except AttributeError:
             pass
         fielddict = nt.void.__getattribute__(self, 'dtype').fields
-        res = fielddict.get(attr, None)
-        if res:
+        if res := fielddict.get(attr, None):
             obj = self.getfield(*res[:2])
             # if it has fields return a record,
             # otherwise return the object
@@ -268,8 +267,7 @@ class record(nt.void):
         if attr in ('setfield', 'getfield', 'dtype'):
             raise AttributeError("Cannot set '%s' attribute" % attr)
         fielddict = nt.void.__getattribute__(self, 'dtype').fields
-        res = fielddict.get(attr, None)
-        if res:
+        if res := fielddict.get(attr, None):
             return self.setfield(val, *res[:2])
         else:
             if getattr(self, attr, None):

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -235,14 +235,12 @@ def check_complex(config, mathlibs):
     pub = []
 
     # Check for complex support
-    st = config.check_header('complex.h')
-    if st:
+    if config.check_header('complex.h'):
         priv.append(('HAVE_COMPLEX_H', 1))
         pub.append(('NPY_USE_C99_COMPLEX', 1))
 
         for t in C99_COMPLEX_TYPES:
-            st = config.check_type(t, headers=["complex.h"])
-            if st:
+            if config.check_type(t, headers=["complex.h"]):
                 pub.append(('NPY_HAVE_%s' % type2def(t), 1))
 
         def check_prec(prec):
@@ -284,12 +282,10 @@ def check_types(config_cmd, ext, build_dir):
         raise SystemError(
                 "Cannot compile 'Python.h'. Perhaps you need to "
                 "install {0}-dev|{0}-devel.".format(python))
-    res = config_cmd.check_header("endian.h")
-    if res:
+    if config_cmd.check_header("endian.h"):
         private_defines.append(('HAVE_ENDIAN_H', 1))
         public_defines.append(('NPY_HAVE_ENDIAN_H', 1))
-    res = config_cmd.check_header("sys/endian.h")
-    if res:
+    if config_cmd.check_header("sys/endian.h"):
         private_defines.append(('HAVE_SYS_ENDIAN_H', 1))
         public_defines.append(('NPY_HAVE_SYS_ENDIAN_H', 1))
 
@@ -370,8 +366,7 @@ def check_mathlib(config_cmd):
     # Testing the C math library
     mathlibs = []
     mathlibs_choices = [[], ["m"], ["cpml"]]
-    mathlib = os.environ.get("MATHLIB")
-    if mathlib:
+    if mathlib := os.environ.get("MATHLIB"):
         mathlibs_choices.insert(0, mathlib.split(","))
     for libs in mathlibs_choices:
         if config_cmd.check_func(
@@ -515,12 +510,11 @@ def configuration(parent_package='',top_path=None):
             log.info('EOF')
         else:
             mathlibs = []
+            s = '#define MATHLIB'
             with open(target) as target_f:
                 for line in target_f:
-                    s = '#define MATHLIB'
                     if line.startswith(s):
-                        value = line[len(s):].strip()
-                        if value:
+                        if value := line[len(s):].strip():
                             mathlibs.extend(value.split(','))
 
         # Ugly: this can be called within a library and not an extension,

--- a/numpy/doc/constants.py
+++ b/numpy/doc/constants.py
@@ -392,8 +392,7 @@ if __doc__:
         lines = s.split("\n")
         new_lines = []
         for line in lines:
-            m = re.match(r'^(\s+)[-=]+\s*$', line)
-            if m and new_lines:
+            if new_lines and (m := re.match(r'^(\s+)[-=]+\s*$', line)):
                 prev = textwrap.dedent(new_lines.pop())
                 new_lines.append('%s.. rubric:: %s' % (m.group(1), prev))
                 new_lines.append('')

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -671,8 +671,7 @@ def getcallstatement(rout):
 
 
 def getcallprotoargument(rout, cb_map={}):
-    r = getmultilineblock(rout, 'callprotoargument', comment=0)
-    if r:
+    if r := getmultilineblock(rout, 'callprotoargument', comment=0):
         return r
     if hascallstatement(rout):
         outmess(

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -530,8 +530,7 @@ def readfortrancode(ffile, dowithline=show, istop=1):
                 "Flag sourcecodeform must be either 'fix' or 'free': %s" % repr(sourcecodeform))
         filepositiontext = 'Line #%d in %s:"%s"\n\t' % (
             fin.filelineno() - 1, currentfilename, l1)
-        m = includeline.match(origfinalline)
-        if m:
+        if m := includeline.match(origfinalline):
             fn = m.group('name')
             if os.path.isfile(fn):
                 readfortrancode(fn, dowithline=dowithline, istop=0)
@@ -558,8 +557,7 @@ def readfortrancode(ffile, dowithline=show, istop=1):
     origfinalline = ll
     filepositiontext = 'Line #%d in %s:"%s"\n\t' % (
         fin.filelineno() - 1, currentfilename, l1)
-    m = includeline.match(origfinalline)
-    if m:
+    if m := includeline.match(origfinalline):
         fn = m.group('name')
         if os.path.isfile(fn):
             readfortrancode(fn, dowithline=dowithline, istop=0)
@@ -680,8 +678,7 @@ def split_by_unquoted(line, characters):
             char="[{}]".format(re.escape(characters)),
             single_quoted=r"('([^'\\]|(\\.))*')",
             double_quoted=r'("([^"\\]|(\\.))*")'))
-    m = r.match(line)
-    if m:
+    if m := r.match(line):
         d = m.groupdict()
         return (d["before"], d["after"])
     return (line, "")
@@ -788,12 +785,10 @@ def crackline(line, reset=0):
                     name = invbadnames[name]
                 if 'interfaced' in groupcache[groupcounter] and name in groupcache[groupcounter]['interfaced']:
                     continue
-                m1 = re.match(
-                    r'(?P<before>[^"]*)\b%s\b\s*@\(@(?P<args>[^@]*)@\)@.*\Z' % name, markouterparen(line), re.I)
-                if m1:
-                    m2 = re_1.match(m1.group('before'))
+                p1 = fr'(?P<before>[^"]*)\b{name}\b\s*@\(@(?P<args>[^@]*)@\)@.*\Z'
+                if m1 := re.match(p1, markouterparen(line), re.I):
                     a = _simplifyargs(m1.group('args'))
-                    if m2:
+                    if m2 := re_1.match(m1.group('before')):
                         line = 'callfun %s(%s) result (%s)' % (
                             name, a, m2.group('result'))
                     else:
@@ -969,15 +964,12 @@ def _resolvetypedefpattern(line):
 
 def _resolvenameargspattern(line):
     line = markouterparen(line)
-    m1 = nameargspattern.match(line)
-    if m1:
+    if m1 := nameargspattern.match(line):
         return m1.group('name'), m1.group('args'), m1.group('result'), m1.group('bind')
-    m1 = operatorpattern.match(line)
-    if m1:
+    if m1 := operatorpattern.match(line):
         name = m1.group('scheme') + '(' + m1.group('name') + ')'
         return name, [], None, None
-    m1 = callnameargspattern.match(line)
-    if m1:
+    if m1 := callnameargspattern.match(line):
         return m1.group('name'), m1.group('args'), None, None
     return None, [], None, None
 
@@ -1155,8 +1147,7 @@ def analyzeline(m, case, line):
             except Exception:
                 pass
         if block == 'function':
-            t = typespattern[0].match(m.group('before') + ' ' + name)
-            if t:
+            if t := typespattern[0].match(m.group('before') + ' ' + name):
                 typespec, selector, attr, edecl = cracktypespec0(
                     t.group('this'), t.group('after'))
                 updatevars(typespec, selector, attr, edecl)
@@ -1291,8 +1282,7 @@ def analyzeline(m, case, line):
             if '=' in edecl[k] and (not edecl[k]['='] == initexpr):
                 outmess('analyzeline: Overwriting the value of parameter "%s" ("%s") with "%s".\n' % (
                     k, edecl[k]['='], initexpr))
-            t = determineexprtype(initexpr, params)
-            if t:
+            if t := determineexprtype(initexpr, params):
                 if t.get('typespec') == 'real':
                     tt = list(initexpr)
                     for m in real16pattern.finditer(initexpr):
@@ -1485,9 +1475,10 @@ def analyzeline(m, case, line):
         groupcache[groupcounter]['common'] = commonkey
         previous_context = ('common', bn, groupcounter)
     elif case == 'use':
-        m1 = re.match(
-            r'\A\s*(?P<name>\b\w+\b)\s*((,(\s*\bonly\b\s*:|(?P<notonly>))\s*(?P<list>.*))|)\s*\Z', m.group('after'), re.I)
-        if m1:
+        p1 = r'\A\s*(?P<name>\b\w+\b)\s*((,(\s*\bonly\b\s*:|(?P<notonly>))\s*'\
+            r'(?P<list>.*))|)\s*\Z'
+        p2 = r'\A\s*(?P<local>\b\w+\b)\s*=\s*>\s*(?P<use>\b\w+\b)\s*\Z'
+        if m1 := re.match(p1, m.group('after'), re.I):
             mm = m1.groupdict()
             if 'use' not in groupcache[groupcounter]:
                 groupcache[groupcounter]['use'] = {}
@@ -1502,9 +1493,7 @@ def analyzeline(m, case, line):
                 rl = {}
                 for l in ll:
                     if '=' in l:
-                        m2 = re.match(
-                            r'\A\s*(?P<local>\b\w+\b)\s*=\s*>\s*(?P<use>\b\w+\b)\s*\Z', l, re.I)
-                        if m2:
+                        if m2 := re.match(p2, l, re.I):
                             rl[m2.group('local').strip()] = m2.group(
                                 'use').strip()
                         else:
@@ -1656,8 +1645,7 @@ def updatevars(typespec, selector, attrspec, entitydecl):
         for a in attrspec:
             if not a:
                 continue
-            m = c.match(a)
-            if m:
+            if m := c.match(a):
                 s = m.group('start').lower()
                 a = s + a[len(s):]
             l.append(a)
@@ -1728,8 +1716,7 @@ def updatevars(typespec, selector, attrspec, entitydecl):
                 groupcache[groupcounter]['externals'] = []
             groupcache[groupcounter]['externals'].append(e)
         if m.group('after'):
-            m1 = lenarraypattern.match(markouterparen(m.group('after')))
-            if m1:
+            if m1 := lenarraypattern.match(markouterparen(m.group('after'))):
                 d1 = m1.groupdict()
                 for lk in ['len', 'array', 'init']:
                     if d1[lk + '2'] is not None:
@@ -1845,9 +1832,8 @@ def cracktypespec(typespec, selector):
             for k, i in list(charselect.items()):
                 charselect[k] = rmbadname1(i)
         elif typespec == 'type':
-            typename = re.match(r'\s*\(\s*(?P<name>\w+)\s*\)', selector, re.I)
-            if typename:
-                typename = typename.group('name')
+            if m1 := re.match(r'\s*\(\s*(?P<name>\w+)\s*\)', selector, re.I):
+                typename = m1.group('name')
             else:
                 outmess('cracktypespec: no typename found in %s\n' %
                         (repr(typespec + selector)))
@@ -2136,12 +2122,11 @@ def analyzecommon(block):
     if not hascommon(block):
         return block
     commonvars = []
+    pat = r'\A\s*\b(?P<name>.*?)\b\s*(\((?P<dims>.*?)\)|)\s*\Z'
     for k in list(block['common'].keys()):
         comvars = []
         for e in block['common'][k]:
-            m = re.match(
-                r'\A\s*\b(?P<name>.*?)\b\s*(\((?P<dims>.*?)\)|)\s*\Z', e, re.I)
-            if m:
+            if m := re.match(pat, e, re.I):
                 dims = []
                 if m.group('dims'):
                     dims = [x.strip()
@@ -2275,8 +2260,7 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
             # skip function calls having x as an argument, e.g max(1, x)
             continue
         re_1 = re.compile(r'(?P<before>.*?)\b' + x + r'\b(?P<after>.*)', re.I)
-        m = re_1.match(e)
-        if m:
+        if re_1.match(e):
             try:
                 m1 = re_1.match(e)
                 while m1:
@@ -2561,8 +2545,7 @@ def analyzevars(block):
     dep_matches = {}
     name_match = re.compile(r'[A-Za-z][\w$]*').match
     for v in list(vars.keys()):
-        m = name_match(v)
-        if m:
+        if m := name_match(v):
             n = v[m.start():m.end()]
             try:
                 dep_matches[n]
@@ -2849,8 +2832,7 @@ def analyzevars(block):
                     ispure = (not pr == pr1)
                     pr = pr1.replace('recursive', '')
                     isrec = (not pr == pr1)
-                    m = typespattern[0].match(pr)
-                    if m:
+                    if m := typespattern[0].match(pr):
                         typespec, selector, attr, edecl = cracktypespec0(
                             m.group('this'), m.group('after'))
                         kindselect, charselect, typename = cracktypespec(
@@ -3002,14 +2984,12 @@ def determineexprtype(expr, vars, rules={}):
     expr = expr.strip()
     if determineexprtype_re_1.match(expr):
         return {'typespec': 'complex'}
-    m = determineexprtype_re_2.match(expr)
-    if m:
+    if m := determineexprtype_re_2.match(expr):
         if 'name' in m.groupdict() and m.group('name'):
             outmess(
                 'determineexprtype: selected kind types not supported (%s)\n' % repr(expr))
         return {'typespec': 'integer'}
-    m = determineexprtype_re_3.match(expr)
-    if m:
+    if m := determineexprtype_re_3.match(expr):
         if 'name' in m.groupdict() and m.group('name'):
             outmess(
                 'determineexprtype: selected kind types not supported (%s)\n' % repr(expr))
@@ -3022,8 +3002,7 @@ def determineexprtype(expr, vars, rules={}):
     if determineexprtype_re_4.match(expr):  # in parenthesis
         t = determineexprtype(expr[1:-1], vars, rules)
     else:
-        m = determineexprtype_re_5.match(expr)
-        if m:
+        if m := determineexprtype_re_5.match(expr):
             rn = m.group('name')
             t = determineexprtype(m.group('name'), vars, rules)
             if t and 'attrspec' in t:

--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -132,8 +132,7 @@ def _pairs_add(d, k, v):
     if c is None:
         d[k] = v
     else:
-        c = c + v
-        if c:
+        if c := c + v:
             d[k] = c
         else:
             del d[k]
@@ -584,8 +583,8 @@ class Expr:
             value = symbols_map.get(self)
             if value is None:
                 return self
-            m = re.match(r'\A(@__f2py_PARENTHESIS_(\w+)_\d+@)\Z', self.data)
-            if m:
+            pat = r'\A(@__f2py_PARENTHESIS_(\w+)_\d+@)\Z'
+            if m := re.match(pat, self.data):
                 # complement to fromstring method
                 items, paren = m.groups()
                 if paren in ['ROUNDDIV', 'SQUARE']:
@@ -660,8 +659,7 @@ class Expr:
         None, otherwise return a new normalized expression with
         traverse-visit sub-expressions.
         """
-        result = visit(self, *args, **kwargs)
-        if result is not None:
+        if (result := visit(self, *args, **kwargs)) is not None:
             return result
 
         if self.op in (Op.INTEGER, Op.REAL, Op.STRING, Op.SYMBOL):
@@ -1345,8 +1343,7 @@ class _FromStringWorker:
                 f'parsing comma-separated list (context={context}): {r}')
 
         # ternary operation
-        m = re.match(r'\A([^?]+)[?]([^:]+)[:](.+)\Z', r)
-        if m:
+        if m := re.match(r'\A([^?]+)[?]([^:]+)[:](.+)\Z', r):
             assert context == 'expr', context
             oper, expr1, expr2 = restore(m.groups())
             oper = self.process(oper)
@@ -1370,8 +1367,7 @@ class _FromStringWorker:
             return Expr(Op.RELATIONAL, (rop, left, right))
 
         # keyword argument
-        m = re.match(r'\A(\w[\w\d_]*)\s*[=](.*)\Z', r)
-        if m:
+        if m := re.match(r'\A(\w[\w\d_]*)\s*[=](.*)\Z', r):
             keyname, value = m.groups()
             value = restore(value)
             return _Pair(keyname, self.process(value))
@@ -1433,22 +1429,22 @@ class _FromStringWorker:
             return result
 
         # int-literal-constant
-        m = re.match(r'\A({digit_string})({kind}|)\Z'.format(
+        pat = r'\A({digit_string})({kind}|)\Z'.format(
             digit_string=r'\d+',
-            kind=r'_(\d+|\w[\w\d_]*)'), r)
-        if m:
+            kind=r'_(\d+|\w[\w\d_]*)')
+        if m := re.match(pat, r):
             value, _, kind = m.groups()
             if kind and kind.isdigit():
                 kind = int(kind)
             return as_integer(int(value), kind or 4)
 
         # real-literal-constant
-        m = re.match(r'\A({significant}({exponent}|)|\d+{exponent})({kind}|)\Z'
-                     .format(
-                         significant=r'[.]\d+|\d+[.]\d*',
-                         exponent=r'[edED][+-]?\d+',
-                         kind=r'_(\d+|\w[\w\d_]*)'), r)
-        if m:
+        pat = r'\A({significant}({exponent}|)|\d+{exponent})({kind}|)\Z'\
+            .format(
+                significant=r'[.]\d+|\d+[.]\d*',
+                exponent=r'[edED][+-]?\d+',
+                kind=r'_(\d+|\w[\w\d_]*)')
+        if m := re.match(pat, r):
             value, _, _, kind = m.groups()
             if kind and kind.isdigit():
                 kind = int(kind)
@@ -1478,9 +1474,8 @@ class _FromStringWorker:
                 return as_array(items)
 
         # function call/indexing
-        m = re.match(r'\A(.+)\s*(@__f2py_PARENTHESIS_(ROUND|SQUARE)_\d+@)\Z',
-                     r)
-        if m:
+        pat = r'\A(.+)\s*(@__f2py_PARENTHESIS_(ROUND|SQUARE)_\d+@)\Z'
+        if m := re.match(pat, r):
             target, args, paren = m.groups()
             target = self.process(restore(target))
             args = self.process(restore(args)[1:-1], 'args')
@@ -1499,8 +1494,7 @@ class _FromStringWorker:
                 return target[args]
 
         # Fortran standard conforming identifier
-        m = re.match(r'\A\w[\w\d_]*\Z', r)
-        if m:
+        if re.match(r'\A\w[\w\d_]*\Z', r):
             return as_symbol(r)
 
         # fall-back to symbol

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -189,8 +189,7 @@ class Type:
                 if not isinstance(i, type) and dtype0.type is i.type:
                     name = n
                     break
-        obj = cls._type_cache.get(name.upper(), None)
-        if obj is not None:
+        if (obj := cls._type_cache.get(name.upper(), None)) is not None:
             return obj
         obj = object.__new__(cls)
         obj._init(name)

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -155,8 +155,7 @@ class TestF77Callback(util.F2PyTest):
         for t in threads:
             t.join()
 
-        errors = "\n\n".join(errors)
-        if errors:
+        if errors := "\n\n".join(errors):
             raise AssertionError(errors)
 
     def test_hidden_callback(self):

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -252,8 +252,7 @@ def _get_compiler_status():
     finally:
         shutil.rmtree(tmpdir)
 
-    m = re.search(br"COMPILERS:(\d+),(\d+),(\d+)", out)
-    if m:
+    if m := re.search(br"COMPILERS:(\d+),(\d+),(\d+)", out):
         _compiler_status = (
             bool(int(m.group(1))),
             bool(int(m.group(2))),

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -522,8 +522,7 @@ class DataSource:
             raise ValueError("URLs are not writeable")
 
         # NOTE: _findfile will fail on a new file opened for writing.
-        found = self._findfile(path)
-        if found:
+        if found := self._findfile(path):
             _fname, ext = self._splitzipext(found)
             if ext == 'bz2':
                 mode.replace("+", "")

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -175,8 +175,7 @@ def _get_indent(lines):
     """
     indent = sys.maxsize
     for line in lines:
-        content = len(line.lstrip())
-        if content:
+        if content := len(line.lstrip()):
             indent = min(indent, len(line) - content)
     if indent == sys.maxsize:
         indent = 0

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -204,8 +204,7 @@ def removeHeader(source):
     lines = LineQueue()
 
     def LookingForHeader(line):
-        m = re.match(r'/\*[^\n]*-- translated', line)
-        if m:
+        if re.match(r'/\*[^\n]*-- translated', line):
             return InHeader
         else:
             lines.add(line)

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -113,8 +113,7 @@ def getDependencies(filename):
     routines = []
     with open(filename) as fo:
         for lineno, line in fortranSourceLines(fo):
-            m = external_pat.match(line)
-            if m:
+            if m := external_pat.match(line):
                 names = line[m.end():].strip().split(',')
                 names = [n.strip().lower() for n in names]
                 names = [n for n in names if n]

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -298,16 +298,14 @@ def create_name_header(output_dir):
 
         with open(fn) as f:
             for line in f:
-                m = routine_re.match(line)
-                if m:
+                if m := routine_re.match(line):
                     symbols.add(m.group(2).lower())
 
     # f2c symbols
     f2c_symbols = set()
     with open('f2c.h') as f:
         for line in f:
-            m = extern_re.match(line)
-            if m:
+            if m := extern_re.match(line):
                 f2c_symbols.add(m.group(1))
 
     with open(os.path.join(output_dir, 'lapack_lite_names.h'), 'w') as f:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2427,8 +2427,7 @@ def _recursive_printoption(result, mask, printopt):
     Private function allowing for recursion
 
     """
-    names = result.dtype.names
-    if names is not None:
+    if (names := result.dtype.names) is not None:
         for name in names:
             curdata = result[name]
             curmask = mask[name]
@@ -6129,8 +6128,7 @@ class MaskedArray(ndarray):
         if fill_value is not None:
             return self.filled(fill_value).tolist()
         # Structured array.
-        names = self.dtype.names
-        if names:
+        if names := self.dtype.names:
             result = self._data.astype([(_, object) for _ in names])
             for n in names:
                 result[n][_mask[n]] = None

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -310,8 +310,7 @@ class MaskedRecords(MaskedArray):
             obj = _data[indx].view(MaskedArray)
             obj._mask = _mask[indx]
             obj._sharedmask = True
-            fval = _localdict['_fill_value']
-            if fval is not None:
+            if (fval := _localdict['_fill_value']) is not None:
                 obj._fill_value = fval[indx]
             # Force to masked if the mask is True
             if not obj.ndim and obj._mask:
@@ -597,8 +596,7 @@ def fromrecords(reclist, dtype=None, shape=None, formats=None, names=None,
     # Now, let's deal w/ the mask
     if mask is not nomask:
         mask = np.array(mask, copy=False)
-        maskrecordlength = len(mask.dtype)
-        if maskrecordlength:
+        if len(mask.dtype):
             mrec._mask.flat = mask
         elif mask.ndim == 2:
             mrec._mask.flat = [tuple(m) for m in mask]

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2395,8 +2395,7 @@ def requires_memory(free_bytes):
     def decorator(func):
         @wraps(func)
         def wrapper(*a, **kw):
-            msg = check_free_memory(free_bytes)
-            if msg is not None:
+            if (msg := check_free_memory(free_bytes)) is not None:
                 pytest.skip(msg)
 
             try:

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -135,8 +135,7 @@ def collect_stats(files, fd, pattern):
             current_function = line.split('=', 2)[1].strip()
         elif current_file is not None:
             for regex in line_regexs:
-                match = regex.match(line)
-                if match:
+                if match := regex.match(line):
                     lineno = int(match.group('lineno'))
                     current_file.mark_line(lineno, current_function)
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -174,6 +174,7 @@ def find_process_files(root_dir):
                                  name.endswith('.pxd.in')),
                reverse=True)
 
+    cpp_pat = br"^\s*#\s*distutils:\s*language\s*=\s*c\+\+\s*$"
     for filename in files:
         in_file = os.path.join(root_dir, filename + ".in")
         for fromext, value in rules.items():
@@ -183,9 +184,7 @@ def find_process_files(root_dir):
                 function, toext = value
                 if toext == '.c':
                     with open(os.path.join(root_dir, filename), 'rb') as f:
-                        data = f.read()
-                        m = re.search(br"^\s*#\s*distutils:\s*language\s*=\s*c\+\+\s*$", data, re.I|re.M)
-                        if m:
+                        if re.search(cpp_pat, f.read(), re.I | re.M):
                             toext = ".cxx"
                 fromfile = filename
                 tofile = filename[:-len(fromext)] + toext

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -124,8 +124,7 @@ run_test()
 from numpy.core._multiarray_umath import (__cpu_baseline__, __cpu_dispatch__)
 features = __cpu_baseline__ + __cpu_dispatch__
 expected = '$EXPECT_CPU_FEATURES'.upper().split()
-diff = set(expected).difference(set(features))
-if diff:
+if diff := set(expected).difference(set(features)):
     print("Unexpected compile-time CPU features detection!\n"
           f"The current build is missing the support of CPU features '{diff}':\n"
           "This error is triggered because of one of the following reasons:\n\n"


### PR DESCRIPTION
This PR refactors the codebase to use assignment expressions (aka “the walrus operator”) described by [PEP 572](https://peps.python.org/pep-0572/) supported by Python 3.8+. A common use-case for the operator is to evaluate [`re.match`](https://docs.python.org/3/library/re.html#re.match) results in a `if` statement, limiting the scope of the resulting variable.