### PR TITLE
MAINT, BLD: Pin rtools to version 4.0 for Windows builds.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,11 +108,14 @@ jobs:
         with:
           python-version: "3.x"
 
+      # We need rtools 4.0 to have 32 bit support on windows
+      - if: runner.os == 'windows'
+        uses: r-windows/install-rtools@13886bb4048f1b862d33869a18b73cdd446a3961 # main
+
       - name: setup rtools for 32-bit
         run: |
           echo "PLAT=i686" >> $env:GITHUB_ENV
-          echo "MSYSTEM=MINGW32" >> $env:GITHUB_ENV
-          echo "PATH=$env:RTOOLS40_HOME\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
+          echo "PATH=c:\rtools40\mingw32\bin;$env:PATH" >> $env:GITHUB_ENV
           gfortran --version
         if: ${{ matrix.buildplat[1] == 'win32' }}
 

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -32,8 +32,9 @@ steps:
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
 - powershell: |
-    choco install -y rtools
-    refreshenv
+    # rtools 42+ does not support 32 bits builds.
+    choco install -y rtools --noprogress --force --version=4.0.0.20220206
+    echo "##vso[task.setvariable variable=RTOOLS40_HOME]c:\rtools40"
   displayName: 'Install rtools'
 
 - powershell: |


### PR DESCRIPTION
Backports of #23678, #23715, #23716.

Windows 32 bit builds require rtools 4.0 but a recent upgrade has made 4.3 the default. This
PR pins the version used to 4.0
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
