### PR TITLE
MAINT: Do not use copyswap as part of indexing

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -1,4 +1,5 @@
-from .common import Benchmark, get_squares_, get_indexes_, get_indexes_rand_
+from .common import (
+    Benchmark, get_square_, get_indexes_, get_indexes_rand_, TYPES1)
 
 from os.path import join as pjoin
 import shutil
@@ -8,27 +9,49 @@ from tempfile import mkdtemp
 
 
 class Indexing(Benchmark):
-    params = [["indexes_", "indexes_rand_"],
+    params = [TYPES1 + ["object", "O,i"],
+              ["indexes_", "indexes_rand_"],
               ['I', ':,I', 'np.ix_(I, I)'],
               ['', '=1']]
-    param_names = ['indexes', 'sel', 'op']
+    param_names = ['dtype', 'indexes', 'sel', 'op']
 
-    def setup(self, indexes, sel, op):
+    def setup(self, dtype, indexes, sel, op):
         sel = sel.replace('I', indexes)
 
-        ns = {'squares_': get_squares_(("object", "O,i")),
+        ns = {'a': get_square_(dtype),
               'np': np,
               'indexes_': get_indexes_(),
               'indexes_rand_': get_indexes_rand_()}
 
-        code = "def run():\n    for a in squares_.values(): a[%s]%s"
+        code = "def run():\n    a[%s]%s"
         code = code % (sel, op)
 
         exec(code, ns)
         self.func = ns['run']
 
-    def time_op(self, indexes, sel, op):
+    def time_op(self, dtype, indexes, sel, op):
         self.func()
+
+
+class IndexingWith1DArr(Benchmark):
+    # Benchmark similar to the take one
+    params = [
+        [(1000,), (1000, 1), (1000, 2), (2, 1000, 1), (1000, 3)],
+        TYPES1 + ["O", "i,O"]]
+    param_names = ["shape", "dtype"]
+
+    def setup(self, shape, dtype):
+        self.arr = np.ones(shape, dtype)
+        self.index = np.arange(1000)
+        # index the second dimension:
+        if len(shape) == 3:
+            self.index = (slice(None), self.index)
+
+    def time_getitem_ordered(self, shape, dtype):
+        self.arr[self.index]
+
+    def time_setitem_ordered(self, shape, dtype):
+        self.arr[self.index] = 0
 
 
 class ScalarIndexing(Benchmark):

--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -16,7 +16,7 @@ class Indexing(Benchmark):
     def setup(self, indexes, sel, op):
         sel = sel.replace('I', indexes)
 
-        ns = {'squares_': get_squares_(),
+        ns = {'squares_': get_squares_(("object", "O,i")),
               'np': np,
               'indexes_': get_indexes_(),
               'indexes_rand_': get_indexes_rand_()}

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -49,27 +49,32 @@ def get_values():
 
 
 @lru_cache(typed=True)
-def get_squares(additional=None):
+def get_square(dtype):
     values = get_values()
-    types = TYPES1
-    if additional is not None:
-        types += additional
-    squares = {t: np.array(values, dtype=t).reshape((nx, ny))
-               for t in TYPES1}
+    arr = values.astype(dtype=dtype).reshape((nx, ny))
 
     # adjust complex ones to have non-degenerated imagery part -- use
     # original data transposed for that
-    for t, v in squares.items():
-        if t.startswith('complex'):
-            v += v.T*1j
-    return squares
+    if arr.dtype.kind == 'c':
+        arr += arr.T*1j
+
+    return arr
+
+@lru_cache(typed=True)
+def get_squares():
+    return {t: get_square(t) for t in TYPES1}
 
 
 @lru_cache(typed=True)
-def get_squares_(additional=None):
+def get_square_(dtype):
+    arr = get_square(dtype)
+    return arr[:nxs, :nys]
+
+
+@lru_cache(typed=True)
+def get_squares_():
     # smaller squares
-    squares_ = {t: s[:nxs, :nys] for t, s in get_squares(additional).items()}
-    return squares_
+    return {t: get_square_(t) for t in TYPES1}
 
 
 @lru_cache(typed=True)

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -49,10 +49,12 @@ def get_values():
 
 
 @lru_cache(typed=True)
-def get_squares():
+def get_squares(additional=None):
     values = get_values()
-    squares = {t: np.array(values,
-                              dtype=getattr(np, t)).reshape((nx, ny))
+    types = TYPES1
+    if additional is not None:
+        types += additional
+    squares = {t: np.array(values, dtype=t).reshape((nx, ny))
                for t in TYPES1}
 
     # adjust complex ones to have non-degenerated imagery part -- use
@@ -64,9 +66,9 @@ def get_squares():
 
 
 @lru_cache(typed=True)
-def get_squares_():
+def get_squares_(additional=None):
     # smaller squares
-    squares_ = {t: s[:nxs, :nys] for t, s in get_squares().items()}
+    squares_ = {t: s[:nxs, :nys] for t, s in get_squares(additional).items()}
     return squares_
 
 

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -328,12 +328,14 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
                 NPY_cast_info *cast_info);
 
 NPY_NO_EXPORT int
-mapiter_trivial_get(PyArrayObject *self, PyArrayObject *ind,
-                       PyArrayObject *result);
+mapiter_trivial_get(
+        PyArrayObject *self, PyArrayObject *ind, PyArrayObject *result,
+        int is_aligned, NPY_cast_info *cast_info);
 
 NPY_NO_EXPORT int
-mapiter_trivial_set(PyArrayObject *self, PyArrayObject *ind,
-                       PyArrayObject *result);
+mapiter_trivial_set(
+        PyArrayObject *self, PyArrayObject *ind, PyArrayObject *result,
+        int is_aligned, NPY_cast_info *cast_info);
 
 NPY_NO_EXPORT int
 mapiter_get(

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1440,6 +1440,8 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
 /****************** MapIter (Advanced indexing) Get/Set ********************/
 /***************************************************************************/
 
+typedef struct {npy_uint64 a; npy_uint64 b;} copytype128;
+
 /**begin repeat
  * #name = set, get#
  * #isget = 0, 1#
@@ -1501,8 +1503,8 @@ mapiter_trivial_@name@(
     switch ((is_aligned && !needs_api) ? itemsize : 0) {
 
 /**begin repeat1
- * #elsize = 1, 2, 4, 8, 0#
- * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, 0#
+ * #elsize = 1, 2, 4, 8, 16, 0#
+ * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, copytype128, 0#
  */
 
 #if @elsize@
@@ -1642,8 +1644,8 @@ mapiter_@name@(
             switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
 
 /**begin repeat2
- * #elsize = 1, 2, 4, 8, 0#
- * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, 0#
+ * #elsize = 1, 2, 4, 8, 16, 0#
+ * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, copytype128, 0#
  */
 
 #if @elsize@

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1614,11 +1614,13 @@ mapiter_@name@(
     if (mit->subspace_iter == NULL) {
         /*
          * Item by item copy situation, the operand is buffered
-         * so use copyswap.  The iterator may not do any transfers, so may
+         * so use a cast to copy.  The iterator may not do any transfers, so may
          * not have set `needs_api` yet, set it if necessary:
          */
         needs_api |= PyDataType_REFCHK(PyArray_DESCR(array));
-        PyArray_CopySwapFunc *copyswap = PyArray_DESCR(array)->f->copyswap;
+        npy_intp itemsize = PyArray_ITEMSIZE(array);
+        npy_intp strides[2] = {itemsize, itemsize};
+        npy_intp one = 1;
 
         /* We have only one iterator handling everything */
         counter = NpyIter_GetInnerLoopSizePtr(mit->outer);
@@ -1641,7 +1643,7 @@ mapiter_@name@(
             }
 
             /* Optimization for aligned types that do not need the api */
-            switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(array) : 0) {
+            switch ((is_aligned && !needs_api) ? itemsize : 0) {
 
 /**begin repeat2
  * #elsize = 1, 2, 4, 8, 16, 0#
@@ -1696,7 +1698,13 @@ mapiter_@name@(
                                               _UINT_ALIGN(@copytype@)));
                         *(@copytype@ *)(outer_ptrs[i]) = *(@copytype@ *)self_ptr;
 #else
-                        copyswap(outer_ptrs[i], self_ptr, 0, array);
+                        char *args[2] = {self_ptr, outer_ptrs[i]};
+                        if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                                               args, &one, strides,
+                                               cast_info->auxdata) < 0)) {
+                                           NPY_END_THREADS;
+                                           return -1;
+                                       }
 #endif
 #else /* !@isget@ */
 #if @elsize@
@@ -1706,7 +1714,13 @@ mapiter_@name@(
                                _UINT_ALIGN(@copytype@)));
                         *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
 #else
-                        copyswap(self_ptr, outer_ptrs[i], 0, array);
+                        char *args[2] = {outer_ptrs[i], self_ptr};
+                        if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                                               args, &one, strides,
+                                               cast_info->auxdata) < 0)) {
+                                           NPY_END_THREADS;
+                                           return -1;
+                                       }
 #endif
 #endif
                         /* advance extra operand */

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1451,8 +1451,9 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
  * can be trivially iterated (single stride, aligned, no casting necessary).
  */
 NPY_NO_EXPORT int
-mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
-                       PyArrayObject *result)
+mapiter_trivial_@name@(
+        PyArrayObject *self, PyArrayObject *ind, PyArrayObject *result,
+        int is_aligned, NPY_cast_info *cast_info)
 {
     char *base_ptr, *ind_ptr, *result_ptr;
     npy_intp self_stride, ind_stride, result_stride;
@@ -1460,10 +1461,12 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 
     npy_intp itersize;
 
-    int is_aligned = IsUintAligned(self) && IsUintAligned(result);
+    /* copying between the same dtype, we can assume this is correct: */
     int needs_api = PyDataType_REFCHK(PyArray_DESCR(self));
+    npy_intp itemsize = PyArray_ITEMSIZE(self);
+    npy_intp strides[2] = {itemsize, itemsize};
+    npy_intp one = 1;
 
-    PyArray_CopySwapFunc *copyswap = PyArray_DESCR(self)->f->copyswap;
     NPY_BEGIN_THREADS_DEF;
 
     base_ptr = PyArray_BYTES(self);
@@ -1495,7 +1498,7 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
 #endif
 
     /* Optimization for aligned types that do not need the api */
-    switch ((is_aligned && !needs_api) ? PyArray_ITEMSIZE(self) : 0) {
+    switch ((is_aligned && !needs_api) ? itemsize : 0) {
 
 /**begin repeat1
  * #elsize = 1, 2, 4, 8, 0#
@@ -1528,7 +1531,13 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
             assert(npy_is_aligned(self_ptr, _UINT_ALIGN(@copytype@)));
             *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
 #else
-            copyswap(result_ptr, self_ptr, 0, self);
+            char *args[2] = {self_ptr, result_ptr};
+            if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                    args, &one, strides,
+                    cast_info->auxdata) < 0)) {
+                NPY_END_THREADS;
+                return -1;
+            }
 #endif
 
 #else /* !@isget@ */
@@ -1537,7 +1546,13 @@ mapiter_trivial_@name@(PyArrayObject *self, PyArrayObject *ind,
             assert(npy_is_aligned(self_ptr, _UINT_ALIGN(@copytype@)));
             *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
 #else
-            copyswap(self_ptr, result_ptr, 0, self);
+            char *args[2] = {result_ptr, self_ptr};
+            if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                    args, &one, strides,
+                    cast_info->auxdata) < 0)) {
+                NPY_END_THREADS;
+                return -1;
+            }
 #endif
 #endif
 


### PR DESCRIPTION
This is in an effort to just avoid copyswap for new DTypes.  Unfortunately, it does signficantly slow down copy of `object`.  It also slows down the copy of complex128, but I can special case that element size to make it faster than it was (in principle complex256 is probably still quite a lot slower, but it is niche).

Changes:
* `object` is about 33% slower for simple advanced indexing
* Structured dtypes are at least 50% faster for such cases.
* `complex128` is much faster, but this is due to a new fast-path.
* All other changes should be random fluctuations


Overall, I think I would be in favor of just going rolling with this, but also very interested if anyone has a good thought on a *followup* story below.

---

*Sorry for the story below... @ngoldbaum this is the continuation from your issue...*

The question is what alternatives exist.  I don't like `copyswap` (it is old-style with getting the array passed in, and doesn't really work for structured dtypes and more complicated parametric dtypes in general).

I could imagine a few ways to improve this:
1.  Maybe, we *should* have a simple "single item" copy function that is more lightweight.  If we do that that we probably have to _force_ users to provide this function for dtypes with references (without references, we can and should provide it).
   * As an alternative, we could limit it to *most* DTypes, e.g. by giving a signature of `DType->slots->get_item_copy_func(dtype)`, which would return a *lightweight* function with a signature of e.g. just `copy(dst, src, itemsize)`.  If your dtype is complicated enough that this doesn't work, don't use it.  One annoyance is that we would still need the current heavy-weight path *additionally* for structured dtypes or dtypes that fail to implement it.  OTOH, it could be a nice pattern overall.  Since we could write the "auto specialization" as:
   ```
   if (trivial_copy == &copy_8bit_func) {
       core_loop(trivial_copy, ...);
   }
   else if (trivial_copy != NULL {
       core_loop(trivial_copy, ...);  // same pattern
   }
   else if (trivial_copy == NULL) {
       core_loop(...);  // Version would use the heavy weight path as here.
   }
   ```
3. To really optimize it, doing something similar to the new `ufunc.at` approach has the potential of being 50% faster, rather than slower.
4. Just specializing the inner-loop for `N=1` (e.g. by abusing `strides=0`, since in that case `N` doesn't matter for copies at least), does recover quite a bit of the slowdown.

Overall, I am tempted to ignore the 1/3 slowdown for objects here.  In most code it is probably not very noticable (you are working with objects after all).  For a light-weight type with references (i.e. the new `StringDType`) the overhead might be larger

<details>  <summary> <b> Timing details </b> </summary>

Changes in (new) benchmarks:
```
       before           after         ratio
     [dd6a36c0]       [cf9989b4]
     <main>           <indexing-no-copyswap>
+        4.34±0μs       4.70±0.1μs     1.08  bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000,), 'O')
+     6.31±0.09μs      6.83±0.07μs     1.08  bench_indexing.Indexing.time_op('complex128', 'indexes_', ':,I', '')
+      6.73±0.1μs      7.17±0.03μs     1.07  bench_indexing.Indexing.time_op('complex128', 'indexes_rand_', ':,I', '')
-     40.0±0.02μs      37.8±0.02μs     0.94  bench_indexing.Indexing.time_op('complex64', 'indexes_', 'np.ix_(I, I)', '=1')
-     7.20±0.01μs      6.79±0.06μs     0.94  bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'float16')
-     4.84±0.05μs      4.56±0.04μs     0.94  bench_indexing.Indexing.time_op('int16', 'indexes_rand_', ':,I', '=1')
-      33.5±0.5μs      31.6±0.01μs     0.94  bench_indexing.Indexing.time_op('float16', 'indexes_', 'np.ix_(I, I)', '')
-        6.15±0μs      5.73±0.03μs     0.93  bench_indexing.Indexing.time_op('int64', 'indexes_', ':,I', '')
-      40.6±0.2μs      37.8±0.02μs     0.93  bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', 'np.ix_(I, I)', '=1')
-      34.8±0.3μs         32.4±1μs     0.93  bench_indexing.Indexing.time_op('int16', 'indexes_rand_', 'np.ix_(I, I)', '')
-     6.14±0.02μs      5.70±0.01μs     0.93  bench_indexing.Indexing.time_op('longdouble', 'indexes_', ':,I', '')
-     6.14±0.01μs      5.69±0.01μs     0.93  bench_indexing.Indexing.time_op('float64', 'indexes_', ':,I', '')
-     7.33±0.05μs      6.79±0.01μs     0.93  bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'int16')
-     5.97±0.01μs      5.52±0.01μs     0.92  bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', ':,I', '')
-     5.45±0.01μs      5.03±0.02μs     0.92  bench_indexing.Indexing.time_op('float16', 'indexes_rand_', ':,I', '')
-     5.98±0.02μs      5.50±0.01μs     0.92  bench_indexing.Indexing.time_op('int64', 'indexes_rand_', ':,I', '')
-     6.02±0.08μs      5.52±0.01μs     0.92  bench_indexing.Indexing.time_op('float64', 'indexes_rand_', ':,I', '')
-     5.53±0.01μs      5.07±0.04μs     0.92  bench_indexing.Indexing.time_op('int32', 'indexes_', ':,I', '')
-     7.65±0.01μs       7.01±0.1μs     0.92  bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'complex64')
-     5.56±0.02μs      5.08±0.05μs     0.91  bench_indexing.Indexing.time_op('int32', 'indexes_rand_', ':,I', '')
-     1.96±0.02μs         1.79±0μs     0.91  bench_indexing.Indexing.time_op('float16', 'indexes_', 'I', '')
-     5.56±0.02μs      5.05±0.02μs     0.91  bench_indexing.Indexing.time_op('float32', 'indexes_rand_', ':,I', '')
-      5.69±0.1μs       5.15±0.2μs     0.91  bench_indexing.Indexing.time_op('int16', 'indexes_rand_', ':,I', '')
-     8.26±0.01μs      7.47±0.07μs     0.90  bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'complex64')
-     5.65±0.06μs      5.06±0.06μs     0.90  bench_indexing.Indexing.time_op('float32', 'indexes_', ':,I', '')
-      5.81±0.1μs      5.03±0.02μs     0.87  bench_indexing.Indexing.time_op('int16', 'indexes_', ':,I', '')
-     5.92±0.08μs      5.04±0.01μs     0.85  bench_indexing.Indexing.time_op('float16', 'indexes_', ':,I', '')
-     7.61±0.01μs       6.27±0.1μs     0.82  bench_indexing.Indexing.time_op('complex64', 'indexes_', ':,I', '')
-     7.12±0.03μs      5.85±0.03μs     0.82  bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'complex64')
-        2.27±0μs         1.86±0μs     0.82  bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'complex128')
-     7.55±0.01μs      5.97±0.01μs     0.79  bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', ':,I', '')
-        2.18±0μs         1.65±0μs     0.75  bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'complex128')
-     7.48±0.02μs      5.09±0.02μs     0.68  bench_indexing.Indexing.time_op('complex64', 'indexes_', 'I', '=1')
-     7.47±0.02μs      5.09±0.01μs     0.68  bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', 'I', '=1')
-     1.47±0.01μs          978±7ns     0.66  bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000,), 'complex128')
-        1.92±0μs         1.27±0μs     0.66  bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000,), 'complex128')
-     25.5±0.05μs       12.6±0.2μs     0.50  bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000,), 'i,O')
-     24.1±0.01μs      11.2±0.05μs     0.46  bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000,), 'i,O')
```

Note that the benchmark sizes are relatively small.  The actual maximum slow-down is about 1/3 or 33% on my machine for `object` dtype.  `complex128` had a much heftier slowdown, so I added a special case for it's itemsize making it much faster instead.  Structured dtypes are much faster with this of course.
