### PR TITLE
DOC: fix incorrect description of raise condition in numpy.testing.assert_array_less's docstring

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1067,7 +1067,7 @@ def assert_array_less(x, y, err_msg='', verbose=True):
     Raises
     ------
     AssertionError
-      If actual and desired objects are not equal.
+      If x is not strictly smaller than y, element-wise.
 
     See Also
     --------


### PR DESCRIPTION
Looks like some left-overs of an old copy pasta from `assert_array_equal`