### PR TITLE
BUG: fix the method for checking local files

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -50,7 +50,10 @@ def isfileobj(f):
     if not isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter)):
         return False
     try:
-        return isinstance(f.fileno(), int)
+        # BufferedReader/Writer may raise OSError when
+        # fetching `fileno()` (e.g. when wrapping BytesIO).
+        f.fileno()
+        return True
     except OSError:
         return False
 

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -47,7 +47,12 @@ def asstr(s):
     return str(s)
 
 def isfileobj(f):
-    return isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter))
+    if not isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter)):
+        return False
+    try:
+        return isinstance(f.fileno(), int)
+    except OSError:
+        return False
 
 def open_latin1(filename, mode='r'):
     return open(filename, mode=mode, encoding='iso-8859-1')

--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -1,4 +1,5 @@
 from os.path import join
+from io import BufferedReader, BytesIO
 
 from numpy.compat import isfileobj
 from numpy.testing import assert_
@@ -17,3 +18,5 @@ def test_isfileobj():
 
         with open(filename, 'rb') as f:
             assert_(isfileobj(f))
+
+        assert_(isfileobj(BufferedReader(BytesIO())) is False)


### PR DESCRIPTION
BufferedReader and BufferedWriter cannot be used to determine local files. For example, users can implement CustomFile to operate on OSS files, and then use BufferedReader(CustomFile) to achieve the buffered effect. But fileno method can do it.