### PR TITLE
ENH: allow int sequences as shape arguments in numpy.memmap

### DIFF
--- a/doc/release/upcoming_changes/23729.improvement.rst
+++ b/doc/release/upcoming_changes/23729.improvement.rst
@@ -1,0 +1,5 @@
+Integer sequences as the ``shape`` argument for `np.memmap`
+-----------------------------------------------------------
+`np.memmap` can now be created with any integer sequence as the ``shape`` 
+argument, such as a list or numpy array of integers. Previously, only the 
+types of tuple and int could be used without raising an error. 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -22,7 +22,6 @@ mode_equivalents = {
 @set_module('numpy')
 class memmap(ndarray):
     """Create a memory-map to an array stored in a *binary* file on disk.
-    
     Memory-mapped files are used for accessing small segments of large files
     on disk, without reading the entire file into memory.  NumPy's
     memmap's are array-like objects.  This differs from Python's ``mmap``
@@ -82,7 +81,7 @@ class memmap(ndarray):
         will be 1-D with the number of elements determined by file size
         and data-type.
 
-        .. versionchanged:: 1.25
+        .. versionchanged:: 2.0
          The shape parameter can now be any integer sequence type, previously
          types were limited to tuple and int.
     

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -22,6 +22,7 @@ mode_equivalents = {
 @set_module('numpy')
 class memmap(ndarray):
     """Create a memory-map to an array stored in a *binary* file on disk.
+
     Memory-mapped files are used for accessing small segments of large files
     on disk, without reading the entire file into memory.  NumPy's
     memmap's are array-like objects.  This differs from Python's ``mmap``

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -75,7 +75,7 @@ class memmap(ndarray):
         additional data. By default, ``memmap`` will start at the beginning of
         the file, even if ``filename`` is a file pointer ``fp`` and
         ``fp.tell() != 0``.
-    shape : tuple, optional
+    shape : int or sequence of ints, optional
         The desired shape of the array. If ``mode == 'r'`` and the number
         of remaining bytes after `offset` is not a multiple of the byte-size
         of `dtype`, you must specify `shape`. By default, the returned array
@@ -242,7 +242,7 @@ class memmap(ndarray):
                 size = bytes // _dbytes
                 shape = (size,)
             else:
-                if not isinstance(shape, tuple):
+                if not hasattr(shape, '__iter__'):
                     shape = (shape,)
                 size = np.intp(1)  # avoid default choice of np.int_, which might overflow
                 for k in shape:

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -244,6 +244,8 @@ class memmap(ndarray):
             else:
                 if not hasattr(shape, '__iter__'):
                     shape = (shape,)
+                elif not instance(shape, tuple):
+                    shape = tuple(shape)
                 size = np.intp(1)  # avoid default choice of np.int_, which might overflow
                 for k in shape:
                     size *= k

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -244,7 +244,7 @@ class memmap(ndarray):
             else:
                 if not hasattr(shape, '__iter__'):
                     shape = (shape,)
-                elif not instance(shape, tuple):
+                elif not isinstance(shape, tuple):
                     shape = tuple(shape)
                 size = np.intp(1)  # avoid default choice of np.int_, which might overflow
                 for k in shape:

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile
 
 from numpy import (
-    memmap, sum, average, prod, ndarray, isscalar, add, subtract, multiply)
+    memmap, sum, average, prod, ndarray, isscalar, add, subtract, multiply, 
+    array
+    )
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (
@@ -215,6 +217,7 @@ class TestMemmap:
         memmap(self.tmpfp, shape=(0,4), mode='w+')
     
     def test_shape_type(self):
-        shapearg = (2, 3)
-        memmap(self.tmpfp, shape=shapearg, mode = 'w+')
-        memmap(self.tmpfp, shape=list(shapearg), mode='w+')
+        memmap(self.tmpfp, shape=3, mode='w+')
+        memmap(self.tmpfp, shape=self.shape, mode='w+')
+        memmap(self.tmpfp, shape=list(self.shape), mode='w+')
+        memmap(self.tmpfp, shape=array(self.shape), mode='w+')

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -6,9 +6,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile
 
 from numpy import (
-    memmap, sum, average, prod, ndarray, isscalar, add, subtract, multiply, 
-    array
-    )
+    memmap, sum, average, prod, ndarray, isscalar, add, subtract, multiply)
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (
@@ -220,4 +218,4 @@ class TestMemmap:
         memmap(self.tmpfp, shape=3, mode='w+')
         memmap(self.tmpfp, shape=self.shape, mode='w+')
         memmap(self.tmpfp, shape=list(self.shape), mode='w+')
-        memmap(self.tmpfp, shape=array(self.shape), mode='w+')
+        memmap(self.tmpfp, shape=asarray(self.shape), mode='w+')

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -213,3 +213,8 @@ class TestMemmap:
 
         # ok now the file is not empty
         memmap(self.tmpfp, shape=(0,4), mode='w+')
+    
+    def test_shape_type(self):
+        shapearg = (2, 3)
+        memmap(self.tmpfp, shape=shapearg, mode = 'w+')
+        memmap(self.tmpfp, shape=list(shapearg), mode='w+')


### PR DESCRIPTION
The constructor for memmap objects initially required the shape argument to be a tuple, where non-tuple shape arguments would be made into a single member tuple. This behaviour was intended to allow an integer shape arguments. However this caused list or numpy.array shape arguments to raise errors within the constructor. Modifications made to the shape argument handling within the constructor now allow for integer sequences to be used for shape. A test was added and constructor docstring was updated to account for these changes.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
