### PR TITLE
BUG: Fix NEP 50 promotion in some concat/choose paths

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -2344,10 +2344,12 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
         }
 
         mps[i] = (PyArrayObject *)PyArray_FROM_O(tmp);
-        Py_DECREF(tmp);
         if (mps[i] == NULL) {
+            Py_DECREF(tmp);
             goto fail;
         }
+        npy_mark_tmp_array_if_pyscalar(tmp, mps[i], NULL);
+        Py_DECREF(tmp);
     }
 
     common_descr = PyArray_ResultType(n, mps, 0, NULL);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -714,11 +714,13 @@ PyArray_ConcatenateInto(PyObject *op,
             goto fail;
         }
         arrays[iarrays] = (PyArrayObject *)PyArray_FROM_O(item);
-        Py_DECREF(item);
         if (arrays[iarrays] == NULL) {
+            Py_DECREF(item);
             narrays = iarrays;
             goto fail;
         }
+        npy_mark_tmp_array_if_pyscalar(item, arrays[iarrays], NULL);
+        Py_DECREF(item);
     }
 
     if (axis >= NPY_MAXDIMS) {

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -232,3 +232,15 @@ def test_nep50_huge_integers(ufunc, state):
     # This would go to object and thus a Python float, not a NumPy one:
     res = ufunc(1.0, 2**100)
     assert isinstance(res, np.float64)
+
+
+def test_nep50_in_concat_and_choose():
+    np._set_promotion_state("weak_and_warn")
+
+    with pytest.warns(UserWarning, match="result dtype changed"):
+        res = np.concatenate([np.float32(1), 1.], axis=None)
+    assert res.dtype == "float32"
+
+    with pytest.warns(UserWarning, match="result dtype changed"):
+        res = np.choose(1, [np.float32(1), 1.])
+    assert res.dtype == "float32"


### PR DESCRIPTION
This fixes promotion in concatenate/choose paths (and probably a bit more paths which use the same function).

<details>  <summary> old description with other commit </summary>

This fixes two issues with NEP 50 promotions in the current implementation.

The first commit, fixes concatenation related promotion to do the expected thing, it previously converted arrays early on and lost the information that `ResultType` needs  (this only shows up when running tests with warnings enabled, which is currently tedious).

The second one fixes the issues around `np.array(2**63)` returning uint or object dtype.  It side-steps the warnings effectively, but I think any path that does change the result dtype there away from uit64 or object should reliably error.

Fixes gh-22454