### PR TITLE
ENH: add fast path for str(scalar_int)

### DIFF
--- a/benchmarks/benchmarks/bench_scalar.py
+++ b/benchmarks/benchmarks/bench_scalar.py
@@ -66,10 +66,12 @@ class ScalarMath(Benchmark):
         other + int32
         other + int32
 
+
 class ScalarStr(Benchmark):
     # Test scalar to str conversion
     params = [TYPES1]
     param_names = ["type"]
+
     def setup(self, typename):
         self.a = np.array([100] * 100, dtype=typename)
 

--- a/benchmarks/benchmarks/bench_scalar.py
+++ b/benchmarks/benchmarks/bench_scalar.py
@@ -65,3 +65,13 @@ class ScalarMath(Benchmark):
         other + int32
         other + int32
         other + int32
+
+class ScalarStr(Benchmark):
+    # Test scalar to str conversion
+    params = [TYPES1]
+    param_names = ["type"]
+    def setup(self, typename):
+        self.a = np.array([100] * 100, dtype=typename)
+
+    def time_str_repr(self, typename):
+        res = [str(x) for x in self.a]

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -279,7 +279,43 @@ static PyObject *
 genint_type_str(PyObject *self)
 {
     PyObject  *item, *item_str;
-    item = gentype_generic_method(self, NULL, NULL, "item");
+    PyArray_Descr *descr = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(self));
+    void *val = scalar_value(self, descr);
+    switch (descr->type_num) {
+        case NPY_BYTE:
+            item = PyLong_FromLong(*(int8_t *)val);
+            break;
+        case NPY_UBYTE:
+            item = PyLong_FromUnsignedLong(*(uint8_t *)val);
+            break;
+        case NPY_SHORT:
+            item = PyLong_FromLong(*(int16_t *)val);
+            break;
+        case NPY_USHORT:
+            item = PyLong_FromUnsignedLong(*(uint16_t *)val);
+            break;
+        case NPY_INT:
+            item = PyLong_FromLong(*(int32_t *)val);
+            break;
+        case NPY_UINT:
+            item = PyLong_FromUnsignedLong(*(int32_t *)val);
+            break;
+        case NPY_LONG:
+            item = PyLong_FromLong(*(int64_t *)val);
+            break;
+        case NPY_ULONG:
+            item = PyLong_FromUnsignedLong(*(uint64_t *)val);
+            break;
+        case NPY_LONGLONG:
+            item = PyLong_FromLongLong(*(long long *)val);
+            break;
+        case NPY_ULONGLONG:
+            item = PyLong_FromUnsignedLongLong(*(unsigned long long *)val);
+            break;
+        default:
+            item = gentype_generic_method(self, NULL, NULL, "item");
+            break;
+    }
     if (item == NULL) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -298,7 +298,7 @@ genint_type_str(PyObject *self)
             item = PyLong_FromLong(*(int32_t *)val);
             break;
         case NPY_UINT:
-            item = PyLong_FromUnsignedLong(*(int32_t *)val);
+            item = PyLong_FromUnsignedLong(*(uint32_t *)val);
             break;
         case NPY_LONG:
             item = PyLong_FromLong(*(int64_t *)val);

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -258,7 +258,6 @@ class TestArray2String:
         assert_(np.array2string(s, formatter={'numpystr':lambda s: s*2}) ==
                 '[abcabc defdef]')
 
-
     def test_structure_format_mixed(self):
         dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -259,7 +259,7 @@ class TestArray2String:
                 '[abcabc defdef]')
 
 
-    def test_structure_format(self):
+    def test_structure_format_mixed(self):
         dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array([('Sarah', (8.0, 7.0)), ('John', (6.0, 7.0))], dtype=dt)
         assert_equal(np.array2string(x),
@@ -301,6 +301,7 @@ class TestArray2String:
              ( 'NaT',) ( 'NaT',) ( 'NaT',)]""")
         )
 
+    def test_structure_format_int(self):
         # See #8160
         struct_int = np.array([([1, -1],), ([123, 1],)], dtype=[('B', 'i4', 2)])
         assert_equal(np.array2string(struct_int),
@@ -310,6 +311,7 @@ class TestArray2String:
         assert_equal(np.array2string(struct_2dint),
                 "[([[ 0,  1], [ 2,  3]],) ([[12,  0], [ 0,  0]],)]")
 
+    def test_structure_format_float(self):
         # See #8172
         array_scalar = np.array(
                 (1., 2.1234567890123456789, 3.), dtype=('f8,f8,f8'))


### PR DESCRIPTION
Create a fast path for `str(scalar_int)`. The call to `str(x)` when `x` is an `int` scalar goes to `genint_type_str`, which calls `PyObject_Str(gentype_generic_method(self, NULL, NULL, "item"))`. The `gentype_generic_method` creates a 0d array of the scalar (allocating a PyArrayObject with 1 data item), copies the item into the new 0d array, then calls arr.item() to get the int value, then wraps that in a `PyLongObject`.

It is faster to avoid all that and use `scalar_value` to get the `void *` value, then cast that to the proper `int` type before wrapping it in a `PyLongObject`.

I also added a benchmark to prove there is a speedup.

```
       before           after         ratio
     [181c15b2]       [fcf8a88e]
     <main>           <scalar-str>
-      29.3±0.3μs      27.8±0.09μs     0.95  bench_scalar.ScalarStr.time_addition('complex128')
-      15.9±0.3μs       15.0±0.2μs     0.94  bench_scalar.ScalarStr.time_addition('float64')
-      42.6±0.9μs       11.7±0.1μs     0.27  bench_scalar.ScalarStr.time_addition('int32')
-      42.1±0.9μs      11.2±0.06μs     0.27  bench_scalar.ScalarStr.time_addition('int16')
-      41.7±0.8μs       11.0±0.2μs     0.26  bench_scalar.ScalarStr.time_addition('int64')
```

This was motivated by a user who noticed that `[str(int(x)) for x in numpy.arange(10000)]` is much faster than `[str(x) for x in numpy.arange(10000)]`