### PR TITLE
MAINT, BLD: Disable spr for clang

### DIFF
--- a/numpy/distutils/checks/cpu_avx512_spr.c
+++ b/numpy/distutils/checks/cpu_avx512_spr.c
@@ -15,6 +15,10 @@
 
 int main(int argc, char **argv)
 {
+/* clang has a bug regarding our spr coode, see gh-23730. */
+#if __clang__
+#error
+#endif
     __m512h a = _mm512_loadu_ph((void*)argv[argc-1]);
     __m512h temp = _mm512_fmadd_ph(a, a, a);
     _mm512_storeu_ph((void*)(argv[argc-1]), temp);


### PR DESCRIPTION
Clang has a bug and fails when compiling
`simd_qsort_16bit.dispatch.avx512_spr.cpp`

Closes #23730.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
