### PR TITLE
DOC: Rm bool8 from docs

### DIFF
--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -337,8 +337,6 @@ are also provided.
 .. note that these are documented with ..attribute because that is what
    autoclass does for aliases under the hood.
 
-.. autoclass:: numpy.bool8
-
 .. attribute:: int8
                int16
                int32

--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -93,7 +93,7 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     add_newdoc('numpy.core.numerictypes', obj, docstring)
 
 
-add_newdoc_for_scalar_type('bool_', ['bool8'],
+add_newdoc_for_scalar_type('bool_', [],
     """
     Boolean type (True or False), stored as a byte.
 


### PR DESCRIPTION
Closes #23755 

Takes a more aggressive approach and attempts to remove references to `bool8` from the docs entirely rather than add more deprecation messages. I'm happy to go with the other approach if preferred, just LMK.