### PR TITLE
MAINT: compatibility with cython3

### DIFF
--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -26,8 +26,8 @@ cdef extern from "src/pcg64/pcg64.h":
     void pcg64_get_state(pcg64_state *state, uint64_t *state_arr, int *has_uint32, uint32_t *uinteger)
     void pcg64_set_state(pcg64_state *state, uint64_t *state_arr, int has_uint32, uint32_t uinteger)
 
-    uint64_t pcg64_cm_next64(pcg64_state *state)  nogil
-    uint32_t pcg64_cm_next32(pcg64_state *state)  nogil
+    uint64_t pcg64_cm_next64(pcg64_state *state)  noexcept nogil
+    uint32_t pcg64_cm_next32(pcg64_state *state)  noexcept nogil
     void pcg64_cm_advance(pcg64_state *state, uint64_t *step)
 
 cdef uint64_t pcg64_uint64(void* st) noexcept nogil:
@@ -39,13 +39,13 @@ cdef uint32_t pcg64_uint32(void *st) noexcept nogil:
 cdef double pcg64_double(void* st) noexcept nogil:
     return uint64_to_double(pcg64_next64(<pcg64_state *>st))
 
-cdef uint64_t pcg64_cm_uint64(void* st) nogil:
+cdef uint64_t pcg64_cm_uint64(void* st) noexcept nogil:
     return pcg64_cm_next64(<pcg64_state *>st)
 
-cdef uint32_t pcg64_cm_uint32(void *st) nogil:
+cdef uint32_t pcg64_cm_uint32(void *st) noexcept nogil:
     return pcg64_cm_next32(<pcg64_state *> st)
 
-cdef double pcg64_cm_double(void* st) nogil:
+cdef double pcg64_cm_double(void* st) noexcept nogil:
     return uint64_to_double(pcg64_cm_next64(<pcg64_state *>st))
 
 cdef class PCG64(BitGenerator):
@@ -515,4 +515,3 @@ cdef class PCG64DXSM(BitGenerator):
         pcg64_cm_advance(&self.rng_state, <uint64_t *>np.PyArray_DATA(d))
         self._reset_state_variables()
         return self
-

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -36,8 +36,8 @@ cdef extern from 'src/philox/philox.h':
 
     ctypedef s_philox_state philox_state
 
-    uint64_t philox_next64(philox_state *state)  nogil
-    uint32_t philox_next32(philox_state *state)  nogil
+    uint64_t philox_next64(philox_state *state)  noexcept nogil
+    uint32_t philox_next32(philox_state *state)  noexcept nogil
     void philox_jump(philox_state *state)
     void philox_advance(uint64_t *step, philox_state *state)
 


### PR DESCRIPTION
This is fallout from https://github.com/cython/cython/pull/5386

This adds some additional `noexcept` flags to match new (implicit) `noexcept` on members of structs.