### PR TITLE
BUG: Fix masked array ravel order for A (and somewhat K)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4656,7 +4656,7 @@ class MaskedArray(ndarray):
         # TODO: We don't actually support K, so use A instead.  We could
         #       try to guess this correct by sorting strides or deprecate.
         if order in "kKaA":
-            order = "C" if self._data.flags.fnc else "F"
+            order = "F" if self._data.flags.fnc else "C"
         r = ndarray.ravel(self._data, order=order).view(type(self))
         r._update_from(self)
         if self._mask is not nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3441,6 +3441,8 @@ class TestMaskedArrayMethods:
         raveled = x.ravel(order)
         assert (raveled.filled(0) == 0).all()
 
+        # NOTE: Can be wrong if arr order is neither C nor F and `order="K"` 
+        assert_array_equal(arr.ravel(order), x.ravel(order)._data)
 
     def test_reshape(self):
         # Tests reshape


### PR DESCRIPTION
Backport of #23680.

Swaps the order to the correct thing and thus

closes gh-23651

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
