### PR TITLE
MAINT: fix signed/unsigned int comparison warnings

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -393,7 +393,7 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     char *value = (char *)value_buffer_stack;
     PyArray_Descr *descr = PyArray_DESCR(arr);
 
-    if (descr->elsize > sizeof(value_buffer_stack)) {
+    if ((size_t)descr->elsize > sizeof(value_buffer_stack)) {
         /* We need a large temporary buffer... */
         value_buffer_heap = PyObject_Calloc(1, descr->elsize);
         if (value_buffer_heap == NULL) {

--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -354,7 +354,7 @@ simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
                 npyv_storen_till_f32(dst, sdst, len, cos);
             }
         }
-        if (simd_maski != ((1 << vstep) - 1)) {
+        if (simd_maski != (npy_uint64)((1 << vstep) - 1)) {
             float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) ip_fback[npyv_nlanes_f32];
             npyv_storea_f32(ip_fback, x_in);
 


### PR DESCRIPTION
These lines trigger compiler warnings in the current numpy build:

```
   numpy/core/src/multiarray/convert.c: In function ‘PyArray_FillWithScalar’:
    numpy/core/src/multiarray/convert.c:396:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
      396 |     if (descr->elsize > sizeof(value_buffer_stack)) {
          |                       ^
```

```
   numpy/core/src/umath/loops_trigonometric.dispatch.c.src:357:24: warning: comparison of integer expressions of different signedness: ‘npy_uint64’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
      357 |         if (simd_maski != ((1 << vstep) - 1)) {
          |                        ^~
```

I wasn't sure whether `elsize` is ever negative in practice. If so I think the more correct thing to do for the first change is to cast the `size_t` returned by `sizeof` to `int`.