### PR TITLE
MAINT: do not use copyswap in where internals

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -308,7 +308,9 @@ class SortWorst(Benchmark):
 class Where(Benchmark):
     def setup(self):
         self.d = np.arange(20000)
+        self.d_o = self.d.astype(object)
         self.e = self.d.copy()
+        self.e_o = self.d_o.copy()
         self.cond = (self.d > 5000)
         size = 1024 * 1024 // 8
         rnd_array = np.random.rand(size)
@@ -331,6 +333,11 @@ class Where(Benchmark):
 
     def time_2(self):
         np.where(self.cond, self.d, self.e)
+
+    def time_2_object(self):
+        # object and byteswapped arrays have a
+        # special slow path in the where internals
+        np.where(self.cond, self.d_o, self.e_o)
 
     def time_2_broadcast(self):
         np.where(self.cond, self.d, 0)

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3453,16 +3453,19 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 
         npy_intp one = 1;
 
-        if (PyArray_GetDTypeTransferFunction(
-                x_is_aligned, xstrides[0], xstrides[1], dtx, common_dt, 0,
-                &x_cast_info, &x_transfer_flags) != NPY_SUCCEED) {
-            goto fail;
-        }
+        if (!native || ((itemsize != 16) && (itemsize != 8) && (itemsize != 4) &&
+                        (itemsize != 2) && (itemsize != 1))) {
+            if (PyArray_GetDTypeTransferFunction(
+                    x_is_aligned, xstrides[0], xstrides[1], dtx, common_dt, 0,
+                    &x_cast_info, &x_transfer_flags) != NPY_SUCCEED) {
+                goto fail;
+            }
 
-        if (PyArray_GetDTypeTransferFunction(
-                y_is_aligned, ystrides[0], ystrides[1], dty, common_dt, 0,
-                &y_cast_info, &y_transfer_flags) != NPY_SUCCEED) {
-            goto fail;
+            if (PyArray_GetDTypeTransferFunction(
+                    y_is_aligned, ystrides[0], ystrides[1], dty, common_dt, 0,
+                    &y_cast_info, &y_transfer_flags) != NPY_SUCCEED) {
+                goto fail;
+            }
         }
 
         NPY_BEGIN_THREADS_NDITER(iter);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3431,23 +3431,19 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         /* Get the result from the iterator object array */
         ret = (PyObject*)NpyIter_GetOperandArray(iter)[0];
 
-        PyArray_Descr **dts = NpyIter_GetDescrArray(iter);
-        PyArray_Descr *dtx = dts[2];
-        PyArray_Descr *dty = dts[3];
-        npy_intp itemsize = dts[0]->elsize;
+        npy_intp itemsize = common_dt->elsize;
 
         npy_intp *strides = NpyIter_GetInnerStrideArray(iter);
         npy_intp cstride = strides[1];
         npy_intp xstride = strides[2];
         npy_intp ystride = strides[3];
 
-        int axswap = PyDataType_ISBYTESWAPPED(dtx);
-        int ayswap = PyDataType_ISBYTESWAPPED(dty);
-        int native = (axswap == ayswap) && (axswap == 0) && !needs_api;
+        int swap = PyDataType_ISBYTESWAPPED(common_dt);
+        int native = (swap == 0) && !needs_api;
 
         NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
 
-        npy_intp transfer_strides[2] = {xstride, itemsize};
+        npy_intp transfer_strides[2] = {itemsize, itemsize};
 
         npy_intp one = 1;
 
@@ -3459,7 +3455,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
             // There's also no need to set up a cast for y, since the iterator
             // ensures both casts are identical.
             if (PyArray_GetDTypeTransferFunction(
-                    1, xstride, itemsize, dtx, common_dt, 0,
+                    1, xstride, itemsize, common_dt, common_dt, 0,
                     &cast_info, &transfer_flags) != NPY_SUCCEED) {
                 goto fail;
             }


### PR DESCRIPTION
This makes it possible to do e.g. `np.where(condition, string_array, other_string_array)` for `StringDType`.

Also added a new benchmark for the code path I modified. It ends up being 33% slower for object arrays and 10% slower for the non-object case:

```
       before           after         ratio
     [9d08632f]       [f8b1a3e4]
     <rm-copyswap-in-where~1>       <rm-copyswap-in-where>
+      82.8±0.8μs        110±0.8μs     1.33  bench_function_base.Where.time_2_object
+      14.2±0.2μs       15.6±0.2μs     1.10  bench_function_base.Where.time_2
-      75.5±0.7μs       71.5±0.6μs     0.95  bench_function_base.Where.time_interleaved_zeros_x8
```

Not sure about the last change, I think that might be noise?