### PR TITLE
DOC: added note for git tagging

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -66,9 +66,8 @@ any) found on current PYTHONPATH.
 
 .. note::
 
-    If the above commands return a RuntimeError with the message "Cannot parse version 0+untagged.xxxxx,"
-    it indicates that you are currently developing on a fork that lacks release tags.
-    To resolve this issue, execute the following command in your ``main`` branch: ``git pull upstream main --tags`` 
+    If the above commands result in ``RuntimeError: Cannot parse version 0+untagged.xxxxx``,
+    run ``git pull upstream main --tags``.
 
 When specifying a target using ``-s``, ``-t``, or ``--python``, additional
 arguments may be forwarded to the target embedded by ``runtests.py`` by passing

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -67,9 +67,8 @@ any) found on current PYTHONPATH.
 .. note::
 
     If the above commands return a RuntimeError with the message "Cannot parse version 0+untagged.xxxxx,"
-    it indicates that you are currently developing on a commit that lacks a release tag.
-    To resolve this issue, execute the following command: ``git tag -a vX.XX.X.dev+<commit_id>``,
-    replacing ``X`` with the latest release version and ``<commit_id>`` with the current commit.
+    it indicates that you are currently developing on a fork that lacks release tags.
+    To resolve this issue, execute the following command in your ``main`` branch: ``git pull upstream main --tags`` 
 
 When specifying a target using ``-s``, ``-t``, or ``--python``, additional
 arguments may be forwarded to the target embedded by ``runtests.py`` by passing

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -64,6 +64,13 @@ This builds NumPy first, so the first time it may take a few minutes.  If
 you specify ``-n``, the tests are run against the version of NumPy (if
 any) found on current PYTHONPATH.
 
+.. note::
+
+    If the above commands return a RuntimeError with the message "Cannot parse version 0+untagged.xxxxx,"
+    it indicates that you are currently developing on a commit that lacks a release tag.
+    To resolve this issue, execute the following command: ``git tag -a vX.XX.X.dev+<commit_id>``,
+    replacing ``X`` with the latest release version and ``<commit_id>`` with the current commit.
+
 When specifying a target using ``-s``, ``-t``, or ``--python``, additional
 arguments may be forwarded to the target embedded by ``runtests.py`` by passing
 the extra arguments after a bare ``--``. For example, to run a test method with


### PR DESCRIPTION
adds a note in getting started contribution documentation to prevent others from making the same mistake #23771 
