### PR TITLE
Speed up _string_helpers init.

### DIFF
--- a/numpy/core/_string_helpers.py
+++ b/numpy/core/_string_helpers.py
@@ -6,7 +6,7 @@ Used primarily to generate type name aliases.
 # "import string" is costly to import!
 # Construct the translation tables directly
 #   "A" = chr(65), "a" = chr(97)
-_all_chars = [chr(_m) for _m in range(256)]
+_all_chars = tuple(map(chr, range(256)))
 _ascii_upper = _all_chars[65:65+26]
 _ascii_lower = _all_chars[97:97+26]
 LOWER_TABLE = "".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])


### PR DESCRIPTION
Using `map(chr...)` is [faster](https://colab.research.google.com/gist/ttsugriy/802cc1f338b5825b3cf2739152903e2a/list-comprehensions-vs-map.ipynb) than using a list comprehension. Also, it's better to use `tuple` instead of `list` because it prevents accidental mutations and uses less memory. [Collab](https://colab.research.google.com/gist/ttsugriy/802cc1f338b5825b3cf2739152903e2a/list-comprehensions-vs-map.ipynb) notebook can be used to verify the speedup.
```
%%timeit
_all_chars = [chr(_m) for _m in range(256)]
_ascii_upper = _all_chars[65:65+26]
_ascii_lower = _all_chars[97:97+26]
LOWER_TABLE = "".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])
UPPER_TABLE = "".join(_all_chars[:97] + _ascii_upper + _all_chars[97+26:])

20.3 µs ± 2.1 µs per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
vs
```
%%timeit 
_all_chars = tuple(map(chr, range(256)))
_ascii_upper = _all_chars[65:65+26]
_ascii_lower = _all_chars[97:97+26]
LOWER_TABLE = "".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])
UPPER_TABLE = "".join(_all_chars[:97] + _ascii_upper + _all_chars[97+26:])

15.5 µs ± 3.44 µs per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

Sure, the absolute numbers are not super impressive, but combined with maintenance improvements mentioned above, it seems worthwhile.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
