### PR TITLE
DOC: Fix link from mtrand.randint -> Generator.integers.

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -686,7 +686,7 @@ cdef class RandomState:
         `high` is None (the default), then results are from [0, `low`).
 
         .. note::
-            New code should use the `~numpy.random.Generator.randint`
+            New code should use the `~numpy.random.Generator.integers`
             method of a `~numpy.random.Generator` instance instead;
             please see the :ref:`random-quick-start`.
 


### PR DESCRIPTION
Closes #23778 