### PR TITLE
BUG: Create complex scalars from real and imaginary parts

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2929,11 +2929,9 @@ static PyObject *
     PyObject *real_obj = NULL;
     PyObject *imag_obj = NULL;
     if (PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwnames, &real_obj, &imag_obj)) {
-        if ((real_obj == NULL) && (imag_obj == NULL)) {
-            obj = PyComplex_Type.tp_new(&PyComplex_Type, args, NULL);
-            if (obj == NULL) {
-                return NULL;
-            }
+        if (imag_obj == NULL) {
+            obj = real_obj;
+            Py_XINCREF(obj);
         }
         else if (PyNumber_Check(real_obj) && PyNumber_Check(imag_obj)) {
             if (PyComplex_Check(real_obj) || PyComplex_Check(imag_obj)) {
@@ -2944,26 +2942,6 @@ static PyObject *
             if (obj == NULL) {
                 return NULL;
             }
-        }
-        else if (PyNumber_Check(real_obj) && imag_obj == NULL) {
-            if (PyComplex_Check(real_obj) || PyArray_Check(real_obj)) {
-                obj = real_obj;
-                Py_INCREF(obj);
-            }
-            else {
-                PyObject *arg = PyTuple_Pack(1, real_obj);
-                obj = PyComplex_Type.tp_new(&PyComplex_Type, arg, NULL);
-                Py_DECREF(arg);
-                if (obj == NULL) {
-                    return NULL;
-                }
-            }
-        }
-        else if (imag_obj == NULL) {
-            // let PyArray_FromAny handle all other things that
-            // can be converted to scalars (e.g. strings) or array-likes
-            obj = real_obj;
-            Py_INCREF(obj);
         }
         else {
             PyErr_Format(PyExc_TypeError, parse_error, args);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2928,37 +2928,33 @@ static PyObject *
     static char *parse_error = "Could not convert arguments into a complex scalar. '%R' given.";
     PyObject *real_obj = NULL;
     PyObject *imag_obj = NULL;
-    if (PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwnames, &real_obj, &imag_obj)) {
-        if (imag_obj == NULL) {
-            obj = real_obj;
-            Py_XINCREF(obj);
-        }
-        else if (PyNumber_Check(real_obj) && PyNumber_Check(imag_obj)) {
-            if (PyComplex_Check(real_obj) || PyComplex_Check(imag_obj)) {
-                PyErr_Format(PyExc_TypeError, parse_error, args);
-                return NULL;
-            }
-            obj = PyComplex_Type.tp_new(&PyComplex_Type, args, NULL);
-            if (obj == NULL) {
-                return NULL;
-            }
-        }
-        else {
-            PyErr_Format(PyExc_TypeError, parse_error, args);
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwnames, &real_obj, &imag_obj)) {
+        return NULL;
+    }
+    if (!((imag_obj == NULL) ||
+          ((PyNumber_Check(real_obj) && PyNumber_Check(imag_obj)) &&
+           !(PyComplex_Check(real_obj) || PyComplex_Check(imag_obj))))) {
+        PyErr_Format(PyExc_TypeError, parse_error, args);
+        return NULL;
+    }
+    if (imag_obj == NULL) {
+        obj = real_obj;
+        Py_XINCREF(obj);
+    }
+    else {
+        obj = PyObject_CallObject((PyObject *)&PyComplex_Type, args);
+        if (obj == NULL) {
             return NULL;
         }
     }
-    else {
 #else
     static char *kwnames[] = {"", NULL};  /* positional-only */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwnames, &obj)) {
+        return NULL;
+    }
 #endif
-        return NULL;
-    }
+    // getting the typecode like this cannot fail
     PyArray_Descr *typecode = PyArray_DescrFromType(NPY_@TYPE@);
-    if (typecode == NULL) {
-        return NULL;
-    }
     if (obj == NULL) {
         PyObject *robj = PyArray_Scalar(NULL, typecode, NULL);
         Py_DECREF(typecode);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2923,8 +2923,58 @@ static PyObject *
 
     /* TODO: include type name in error message, which is not @name@ */
     PyObject *obj = NULL;
+#if defined(_@TYPE@_IS_CDOUBLE) || defined(_@TYPE@_IS_CFLOAT)
+    static char *kwnames[] = {"", "", NULL};  /* positional-only */
+    static char *parse_error = "Could not convert arguments into a complex scalar. '%R' given.";
+    PyObject *real_obj = NULL;
+    PyObject *imag_obj = NULL;
+    if (PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwnames, &real_obj, &imag_obj)) {
+        if ((real_obj == NULL) && (imag_obj == NULL)) {
+            obj = PyComplex_Type.tp_new(&PyComplex_Type, args, NULL);
+            if (obj == NULL) {
+                return NULL;
+            }
+        }
+        else if (PyNumber_Check(real_obj) && PyNumber_Check(imag_obj)) {
+            if (PyComplex_Check(real_obj) || PyComplex_Check(imag_obj)) {
+                PyErr_Format(PyExc_TypeError, parse_error, args);
+                return NULL;
+            }
+            obj = PyComplex_Type.tp_new(&PyComplex_Type, args, NULL);
+            if (obj == NULL) {
+                return NULL;
+            }
+        }
+        else if (PyNumber_Check(real_obj) && imag_obj == NULL) {
+            if (PyComplex_Check(real_obj) || PyArray_Check(real_obj)) {
+                obj = real_obj;
+                Py_INCREF(obj);
+            }
+            else {
+                PyObject *arg = PyTuple_Pack(1, real_obj);
+                obj = PyComplex_Type.tp_new(&PyComplex_Type, arg, NULL);
+                Py_DECREF(arg);
+                if (obj == NULL) {
+                    return NULL;
+                }
+            }
+        }
+        else if (imag_obj == NULL) {
+            // let PyArray_FromAny handle all other things that
+            // can be converted to scalars (e.g. strings) or array-likes
+            obj = real_obj;
+            Py_INCREF(obj);
+        }
+        else {
+            PyErr_Format(PyExc_TypeError, parse_error, args);
+            return NULL;
+        }
+    }
+    else {
+#else
     static char *kwnames[] = {"", NULL};  /* positional-only */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwnames, &obj)) {
+#endif
         return NULL;
     }
     PyArray_Descr *typecode = PyArray_DescrFromType(NPY_@TYPE@);
@@ -2947,6 +2997,9 @@ static PyObject *
     Py_INCREF(typecode);
     PyArrayObject *arr = (PyArrayObject *)PyArray_FromAny(
             obj, typecode, 0, 0, NPY_ARRAY_FORCECAST, NULL);
+#if defined(_@TYPE@_IS_CDOUBLE) || defined(_@TYPE@_IS_CFLOAT)
+    Py_DECREF(obj);
+#endif
     if (arr == NULL) {
         Py_DECREF(typecode);
         return NULL;


### PR DESCRIPTION
fixes gh-19125

If anyone has an idea for how to generalize this for `np.clongdouble` I'm all ears. I couldn't come up with a straightforward way to do that. I can't go through python complex numbers for `clongdouble` because the cast from `clongdouble` to `complex` is unsafe. Proposing this PR as-is without that support because extended precision types like `clongdouble` are already kind of an odd duck.