### PR TITLE
DOC: Add brief note about custom converters to genfromtext.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1875,6 +1875,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
       exception is raised).
     * Individual values are not stripped of spaces by default.
       When using a custom converter, make sure the function does remove spaces.
+    * Custom converters may receive unexpected values when ``dtype=None``.
 
     References
     ----------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1875,7 +1875,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
       exception is raised).
     * Individual values are not stripped of spaces by default.
       When using a custom converter, make sure the function does remove spaces.
-    * Custom converters may receive unexpected values when ``dtype=None``.
+    * Custom converters may receive unexpected values due to dtype
+      discovery. 
 
     References
     ----------


### PR DESCRIPTION
An alternative to #23511 that closes #23429.

Adds a bullet to the notes of `genfromtext` about the potential clash between custom converter functions and the dtype discovery mechanism. I went with minimal detail, but am happy to add more as others see fit.