### PR TITLE
Use tuple instead of string for (LOWER|UPPER)_TABLEs.

### DIFF
--- a/numpy/core/_string_helpers.py
+++ b/numpy/core/_string_helpers.py
@@ -9,8 +9,8 @@ Used primarily to generate type name aliases.
 _all_chars = tuple(map(chr, range(256)))
 _ascii_upper = _all_chars[65:65+26]
 _ascii_lower = _all_chars[97:97+26]
-LOWER_TABLE = "".join(_all_chars[:65] + _ascii_lower + _all_chars[65+26:])
-UPPER_TABLE = "".join(_all_chars[:97] + _ascii_upper + _all_chars[97+26:])
+LOWER_TABLE = _all_chars[:65] + _ascii_lower + _all_chars[65+26:]
+UPPER_TABLE = _all_chars[:97] + _ascii_upper + _all_chars[97+26:]
 
 
 def english_lower(s):


### PR DESCRIPTION
This avoids unnecessary join and speeds up translation.

You can see benchmarks and memory measurements in the [colab](https://colab.research.google.com/gist/ttsugriy/461ae12926d42a69f0f19aa7780b06ef/str-tuple-english_upper.ipynb).

The summary:
```
%timeit "".join(_all_chars[:97] + _ascii_upper + _all_chars[97+26:])
3.25 µs ± 120 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
vs
```
%timeit _all_chars[:97] + _ascii_upper + _all_chars[97+26:]
1.37 µs ± 234 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
which reduces import time and
```
%timeit english_upper('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_')
1.08 µs ± 227 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
vs
```
%timeit english_upper2('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_')
872 ns ± 6.37 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
which suggests more than 10% faster `english_upper` runtime perf. The cons of this approach are potentially breaking change if anyone clients rely on these constants to be `str`s (but I couldn't find any usages on github or by googling) and tuple uses more memory - 2088 vs 329.