### PR TITLE
MAINT: Overhaul and refactor NPY_OS_WIN*

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -138,8 +138,8 @@
 #endif
 
 /* 64 bit file position support, also on win-amd64. Issue gh-2256 */
-#if defined(_MSC_VER) && defined(_WIN64) && (_MSC_VER > 1400) || \
-    defined(__MINGW32__) || defined(__MINGW64__)
+#if (defined(_MSC_VER) && (_MSC_VER > 1400) && defined(NPY_OS_WIN_64BIT)) || \
+    defined(__MINGW32__)
     #include <io.h>
 
     #define npy_fseek _fseeki64

--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -20,11 +20,13 @@
 #elif defined(__CYGWIN__)
     #define NPY_OS_CYGWIN
 #elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-    #define NPY_OS_WIN32
-#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
-    #define NPY_OS_WIN64
-#elif defined(__MINGW32__) || defined(__MINGW64__)
-    #define NPY_OS_MINGW
+/* _WIN32 is defined on 64-bit as well as 32-bit */
+    #define NPY_OS_WINDOWS
+    #if defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
+        #define NPY_OS_WIN_64BIT
+    #else
+        #define NPY_OS_WIN_32BIT
+    #endif
 #elif defined(__APPLE__)
     #define NPY_OS_DARWIN
 #elif defined(__HAIKU__)

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -157,7 +157,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             size = PyArray_SIZE(self);
             NPY_BEGIN_ALLOW_THREADS;
 
-#if defined(NPY_OS_WIN64)
+#if defined(NPY_OS_WIN_64BIT)
             /*
              * Workaround Win64 fwrite() bug. Issue gh-2256
              * The native 64 windows runtime has this issue, the above will

--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -44,7 +44,7 @@ simd_range_reduction_@sfx@(npyv_@sfx@ x, npyv_@sfx@ y, npyv_@sfx@ c1, npyv_@sfx@
 /**begin repeat
  *  #op = cos, sin#
  */
-#if defined(NPY_OS_WIN32) || defined(NPY_OS_CYGWIN)
+#if defined(NPY_OS_WINDOWS) || defined(NPY_OS_CYGWIN)
 NPY_FINLINE npyv_f64
 #else
 NPY_NOINLINE npyv_f64

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -64,7 +64,7 @@ typedefs['unsigned_short'] = 'typedef unsigned short unsigned_short;'
 typedefs['unsigned_long'] = 'typedef unsigned long unsigned_long;'
 typedefs['signed_char'] = 'typedef signed char signed_char;'
 typedefs['long_long'] = """\
-#if defined(NPY_OS_WIN32)
+#if defined(NPY_OS_WINDOWS)
 typedef __int64 long_long;
 #else
 typedef long long long_long;
@@ -72,7 +72,7 @@ typedef unsigned long long unsigned_long_long;
 #endif
 """
 typedefs['unsigned_long_long'] = """\
-#if defined(NPY_OS_WIN32)
+#if defined(NPY_OS_WINDOWS)
 typedef __uint64 long_long;
 #else
 typedef unsigned long long unsigned_long_long;
@@ -542,7 +542,7 @@ cppmacros["F2PY_THREAD_LOCAL_DECL"] = """\
 #ifndef F2PY_THREAD_LOCAL_DECL
 #if defined(_MSC_VER)
 #define F2PY_THREAD_LOCAL_DECL __declspec(thread)
-#elif defined(NPY_OS_MINGW)
+#elif defined(__MINGW32__)
 #define F2PY_THREAD_LOCAL_DECL __thread
 #elif defined(__STDC_VERSION__) \\
       && (__STDC_VERSION__ >= 201112L) \\


### PR DESCRIPTION
When #20884 added `NPY_OS_WIN64`, the meaning of `NPY_OS_WIN32` became ambiguous; some might take it to mean "32-bit only", while others might assume its original meaning of "any Windows".

Besides that, the directives as written confuse the nature of `_WIN32`, which I understand to be always defined in any native Windows toolchain. Thus `#define NPY_OS_WIN64` would never be reached.

This commit disambiguates by removing `NPY_OS_WIN32` (in case anyone uses it in future without looking again at its definition), and adding `NPY_OS_WINDOWS` with `NPY_OS_WIN_xxBIT` children, in the pattern of `NPY_OS_BSD`.

It also removes `NPY_OS_MINGW`, which for the same reason never got defined. MINGW is not an OS, but a toolchain like MSVC. Maybe there could be `NPY_BUILD_MINGW` and `NPY_BUILD_MSVC` or some such?

I'm not attached to this particular solution, or the names I've chosen. Input is welcome.

@Mousius: I won't pretend to understand the stack alignment problem in #23399. In [loops_trigonometric.dispatch.c.src](https://github.com/Mousius/numpy/commit/fe5472fa4eae131ff9646d7c980c6c4081c10386#diff-4ce69850e0011abbbeb8d176091ca7297e13cc85da738df8c5d0616f54a3365aR47), can you confirm you wanted to force inlining on all windows systems, not just 32-bit?