### PR TITLE
DOC: switching to use the plot directive

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2969,6 +2969,7 @@ def blackman(M):
     .. plot::
         :include-source:
 
+        import matplotlib.pyplot as plt
         from numpy.fft import fft, fftshift
         window = np.blackman(51)
         plt.plot(window)
@@ -3075,6 +3076,7 @@ def bartlett(M):
     .. plot::
         :include-source:
 
+        import matplotlib.pyplot as plt
         from numpy.fft import fft, fftshift
         window = np.bartlett(51)
         plt.plot(window)
@@ -3551,6 +3553,7 @@ def kaiser(M, beta):
     .. plot::
         :include-source:
 
+        import matplotlib.pyplot as plt
         from numpy.fft import fft, fftshift
         window = np.kaiser(51, 14)
         plt.plot(window)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2964,39 +2964,32 @@ def blackman(M):
             9.67046769e-01,   7.36045180e-01,   4.14397981e-01,
             1.59903635e-01,   3.26064346e-02,  -1.38777878e-17])
 
-    Plot the window and the frequency response:
+    Plot the window and the frequency response.
 
-    >>> from numpy.fft import fft, fftshift
-    >>> window = np.blackman(51)
-    >>> plt.plot(window)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Blackman window")
-    Text(0.5, 1.0, 'Blackman window')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("Sample")
-    Text(0.5, 0, 'Sample')
-    >>> plt.show()
+    .. plot::
+        :include-source:
 
-    >>> plt.figure()
-    <Figure size 640x480 with 0 Axes>
-    >>> A = fft(window, 2048) / 25.5
-    >>> mag = np.abs(fftshift(A))
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> with np.errstate(divide='ignore', invalid='ignore'):
-    ...     response = 20 * np.log10(mag)
-    ...
-    >>> response = np.clip(response, -100, 100)
-    >>> plt.plot(freq, response)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Frequency response of Blackman window")
-    Text(0.5, 1.0, 'Frequency response of Blackman window')
-    >>> plt.ylabel("Magnitude [dB]")
-    Text(0, 0.5, 'Magnitude [dB]')
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-    Text(0.5, 0, 'Normalized frequency [cycles per sample]')
-    >>> _ = plt.axis('tight')
-    >>> plt.show()
+        from numpy.fft import fft, fftshift
+        window = np.blackman(51)
+        plt.plot(window)
+        plt.title("Blackman window")
+        plt.ylabel("Amplitude")
+        plt.xlabel("Sample")
+        plt.show()  # doctest: +SKIP
+
+        plt.figure()
+        A = fft(window, 2048) / 25.5
+        mag = np.abs(fftshift(A))
+        freq = np.linspace(-0.5, 0.5, len(A))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            response = 20 * np.log10(mag)
+        response = np.clip(response, -100, 100)
+        plt.plot(freq, response)
+        plt.title("Frequency response of Blackman window")
+        plt.ylabel("Magnitude [dB]")
+        plt.xlabel("Normalized frequency [cycles per sample]")
+        plt.axis('tight')
+        plt.show()
 
     """
     # Ensures at least float64 via 0.0.  M should be an integer, but conversion
@@ -3077,39 +3070,31 @@ def bartlett(M):
             0.90909091,  0.90909091,  0.72727273,  0.54545455,  0.36363636,
             0.18181818,  0.        ])
 
-    Plot the window and its frequency response (requires SciPy and matplotlib):
+    Plot the window and its frequency response (requires SciPy and matplotlib).
 
-    >>> from numpy.fft import fft, fftshift
-    >>> window = np.bartlett(51)
-    >>> plt.plot(window)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Bartlett window")
-    Text(0.5, 1.0, 'Bartlett window')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("Sample")
-    Text(0.5, 0, 'Sample')
-    >>> plt.show()
+    .. plot::
+        :include-source:
 
-    >>> plt.figure()
-    <Figure size 640x480 with 0 Axes>
-    >>> A = fft(window, 2048) / 25.5
-    >>> mag = np.abs(fftshift(A))
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> with np.errstate(divide='ignore', invalid='ignore'):
-    ...     response = 20 * np.log10(mag)
-    ...
-    >>> response = np.clip(response, -100, 100)
-    >>> plt.plot(freq, response)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Frequency response of Bartlett window")
-    Text(0.5, 1.0, 'Frequency response of Bartlett window')
-    >>> plt.ylabel("Magnitude [dB]")
-    Text(0, 0.5, 'Magnitude [dB]')
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-    Text(0.5, 0, 'Normalized frequency [cycles per sample]')
-    >>> _ = plt.axis('tight')
-    >>> plt.show()
+        from numpy.fft import fft, fftshift
+        window = np.bartlett(51)
+        plt.plot(window)
+        plt.title("Bartlett window")
+        plt.ylabel("Amplitude")
+        plt.xlabel("Sample")
+        plt.show()
+        plt.figure()
+        A = fft(window, 2048) / 25.5
+        mag = np.abs(fftshift(A))
+        freq = np.linspace(-0.5, 0.5, len(A))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            response = 20 * np.log10(mag)
+        response = np.clip(response, -100, 100)
+        plt.plot(freq, response)
+        plt.title("Frequency response of Bartlett window")
+        plt.ylabel("Magnitude [dB]")
+        plt.xlabel("Normalized frequency [cycles per sample]")
+        plt.axis('tight')
+        plt.show()
 
     """
     # Ensures at least float64 via 0.0.  M should be an integer, but conversion
@@ -3184,41 +3169,33 @@ def hanning(M):
            0.97974649, 0.97974649, 0.82743037, 0.57115742, 0.29229249,
            0.07937323, 0.        ])
 
-    Plot the window and its frequency response:
+    Plot the window and its frequency response.
 
-    >>> import matplotlib.pyplot as plt
-    >>> from numpy.fft import fft, fftshift
-    >>> window = np.hanning(51)
-    >>> plt.plot(window)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Hann window")
-    Text(0.5, 1.0, 'Hann window')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("Sample")
-    Text(0.5, 0, 'Sample')
-    >>> plt.show()
+    .. plot::
+        :include-source:
 
-    >>> plt.figure()
-    <Figure size 640x480 with 0 Axes>
-    >>> A = fft(window, 2048) / 25.5
-    >>> mag = np.abs(fftshift(A))
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> with np.errstate(divide='ignore', invalid='ignore'):
-    ...     response = 20 * np.log10(mag)
-    ...
-    >>> response = np.clip(response, -100, 100)
-    >>> plt.plot(freq, response)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Frequency response of the Hann window")
-    Text(0.5, 1.0, 'Frequency response of the Hann window')
-    >>> plt.ylabel("Magnitude [dB]")
-    Text(0, 0.5, 'Magnitude [dB]')
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-    Text(0.5, 0, 'Normalized frequency [cycles per sample]')
-    >>> plt.axis('tight')
-    ...
-    >>> plt.show()
+        import matplotlib.pyplot as plt
+        from numpy.fft import fft, fftshift
+        window = np.hanning(51)
+        plt.plot(window)
+        plt.title("Hann window")
+        plt.ylabel("Amplitude")
+        plt.xlabel("Sample")
+        plt.show()
+
+        plt.figure()
+        A = fft(window, 2048) / 25.5
+        mag = np.abs(fftshift(A))
+        freq = np.linspace(-0.5, 0.5, len(A))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            response = 20 * np.log10(mag)
+        response = np.clip(response, -100, 100)
+        plt.plot(freq, response)
+        plt.title("Frequency response of the Hann window")
+        plt.ylabel("Magnitude [dB]")
+        plt.xlabel("Normalized frequency [cycles per sample]")
+        plt.axis('tight')
+        plt.show()
 
     """
     # Ensures at least float64 via 0.0.  M should be an integer, but conversion
@@ -3291,39 +3268,32 @@ def hamming(M):
             0.98136677,  0.98136677,  0.84123594,  0.60546483,  0.34890909,
             0.15302337,  0.08      ])
 
-    Plot the window and the frequency response:
+    Plot the window and the frequency response.
 
-    >>> import matplotlib.pyplot as plt
-    >>> from numpy.fft import fft, fftshift
-    >>> window = np.hamming(51)
-    >>> plt.plot(window)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Hamming window")
-    Text(0.5, 1.0, 'Hamming window')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("Sample")
-    Text(0.5, 0, 'Sample')
-    >>> plt.show()
+    .. plot::
+        :include-source:
 
-    >>> plt.figure()
-    <Figure size 640x480 with 0 Axes>
-    >>> A = fft(window, 2048) / 25.5
-    >>> mag = np.abs(fftshift(A))
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(mag)
-    >>> response = np.clip(response, -100, 100)
-    >>> plt.plot(freq, response)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Frequency response of Hamming window")
-    Text(0.5, 1.0, 'Frequency response of Hamming window')
-    >>> plt.ylabel("Magnitude [dB]")
-    Text(0, 0.5, 'Magnitude [dB]')
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-    Text(0.5, 0, 'Normalized frequency [cycles per sample]')
-    >>> plt.axis('tight')
-    ...
-    >>> plt.show()
+        import matplotlib.pyplot as plt
+        from numpy.fft import fft, fftshift
+        window = np.hamming(51)
+        plt.plot(window)
+        plt.title("Hamming window")
+        plt.ylabel("Amplitude")
+        plt.xlabel("Sample")
+        plt.show()
+
+        plt.figure()
+        A = fft(window, 2048) / 25.5
+        mag = np.abs(fftshift(A))
+        freq = np.linspace(-0.5, 0.5, len(A))
+        response = 20 * np.log10(mag)
+        response = np.clip(response, -100, 100)
+        plt.plot(freq, response)
+        plt.title("Frequency response of Hamming window")
+        plt.ylabel("Magnitude [dB]")
+        plt.xlabel("Normalized frequency [cycles per sample]")
+        plt.axis('tight')
+        plt.show()
 
     """
     # Ensures at least float64 via 0.0.  M should be an integer, but conversion
@@ -3576,38 +3546,31 @@ def kaiser(M, beta):
             4.65200189e-02, 3.46009194e-03, 7.72686684e-06])
 
 
-    Plot the window and the frequency response:
+    Plot the window and the frequency response.
 
-    >>> from numpy.fft import fft, fftshift
-    >>> window = np.kaiser(51, 14)
-    >>> plt.plot(window)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Kaiser window")
-    Text(0.5, 1.0, 'Kaiser window')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("Sample")
-    Text(0.5, 0, 'Sample')
-    >>> plt.show()
+    .. plot::
+        :include-source:
 
-    >>> plt.figure()
-    <Figure size 640x480 with 0 Axes>
-    >>> A = fft(window, 2048) / 25.5
-    >>> mag = np.abs(fftshift(A))
-    >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(mag)
-    >>> response = np.clip(response, -100, 100)
-    >>> plt.plot(freq, response)
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Frequency response of Kaiser window")
-    Text(0.5, 1.0, 'Frequency response of Kaiser window')
-    >>> plt.ylabel("Magnitude [dB]")
-    Text(0, 0.5, 'Magnitude [dB]')
-    >>> plt.xlabel("Normalized frequency [cycles per sample]")
-    Text(0.5, 0, 'Normalized frequency [cycles per sample]')
-    >>> plt.axis('tight')
-    (-0.5, 0.5, -100.0, ...) # may vary
-    >>> plt.show()
+        from numpy.fft import fft, fftshift
+        window = np.kaiser(51, 14)
+        plt.plot(window)
+        plt.title("Kaiser window")
+        plt.ylabel("Amplitude")
+        plt.xlabel("Sample")
+        plt.show()
+
+        plt.figure()
+        A = fft(window, 2048) / 25.5
+        mag = np.abs(fftshift(A))
+        freq = np.linspace(-0.5, 0.5, len(A))
+        response = 20 * np.log10(mag)
+        response = np.clip(response, -100, 100)
+        plt.plot(freq, response)
+        plt.title("Frequency response of Kaiser window")
+        plt.ylabel("Magnitude [dB]")
+        plt.xlabel("Normalized frequency [cycles per sample]")
+        plt.axis('tight')
+        plt.show()
 
     """
     # Ensures at least float64 via 0.0.  M should be an integer, but conversion

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -763,16 +763,20 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     .. versionadded:: 1.11.0
 
     Automated Bin Selection Methods example, using 2 peak random data
-    with 2000 points:
+    with 2000 points.
 
-    >>> import matplotlib.pyplot as plt
-    >>> rng = np.random.RandomState(10)  # deterministic random data
-    >>> a = np.hstack((rng.normal(size=1000),
-    ...                rng.normal(loc=5, scale=2, size=1000)))
-    >>> _ = plt.hist(a, bins='auto')  # arguments are passed to np.histogram
-    >>> plt.title("Histogram with 'auto' bins")
-    Text(0.5, 1.0, "Histogram with 'auto' bins")
-    >>> plt.show()
+    .. plot::
+        :include-source:
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        rng = np.random.RandomState(10)  # deterministic random data
+        a = np.hstack((rng.normal(size=1000),
+                       rng.normal(loc=5, scale=2, size=1000)))
+        plt.hist(a, bins='auto')  # arguments are passed to np.histogram
+        plt.title("Histogram with 'auto' bins")
+        plt.show()
 
     """
     a, weights = _ravel_and_check_weights(a, weights)


### PR DESCRIPTION
These examples in the docstrings seem to have the sole purpose of generating the plot, there isn't anything in them that should be tested, and the pop-up windows somewhat annoying when running the tests locally.

Therefore, after consulting with @seberg, we think it's better to switch to use the `plot` directive. Whether the code is executing without error or not will be checked during the sphinx-build, no need to run the doctests, too.


(This came up during #23812, but that PR will be monster big, and thus I'm chopping it up to smaller pieces. Also, there are more plots generated in the API docs, but those were not triggering pop-up windows)