### PR TITLE
MAINT: error when a non-legacy dtype's scalar is used with another non-legacy dtype

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -284,6 +284,16 @@ discover_dtype_from_pyobject(
 
     PyArray_DTypeMeta *DType = npy_discover_dtype_from_pytype(Py_TYPE(obj));
     if (DType != NULL) {
+        if (fixed_DType != NULL && DType != Py_None &&
+            !NPY_DT_is_legacy(DType) &&
+            !NPY_DT_is_legacy(fixed_DType)) {
+            PyErr_Format(PyExc_RuntimeError,
+                         "Received scalar type '%S' which maps to DType '%S', "
+                         "but DType '%S' was explicitly specified",
+                         (PyObject *)Py_TYPE(obj), (PyObject *)DType,
+                         (PyObject *)fixed_DType);
+            return NULL;
+        }
         return DType;
     }
     /*

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -284,7 +284,7 @@ discover_dtype_from_pyobject(
 
     PyArray_DTypeMeta *DType = npy_discover_dtype_from_pytype(Py_TYPE(obj));
     if (DType != NULL) {
-        if (fixed_DType != NULL && DType != Py_None &&
+        if (fixed_DType != NULL && DType != (PyArray_DTypeMeta *)Py_None &&
             !NPY_DT_is_legacy(DType) &&
             !NPY_DT_is_legacy(fixed_DType)) {
             PyErr_Format(PyExc_RuntimeError,


### PR DESCRIPTION
I hit this case working on https://github.com/numpy/numpy-user-dtypes/pull/67 (see that PR for more context) doing something like:

```
arr = np.array(["a", "b", "c"], dtype=PandasStringDType())
arr[1] = StringScalar("e")
```

This is incorrect and should error in my opinion, since `PandasStringDType.type` is `PandasStringScalar`, a distinct type from `StringScalar`, which is `StringDType.type`. Up until now it's likely that no one has tried to mix scalars from different non-legacy dtypes like this. I think you'd hit this case if you tried to set an MPF scalar into a string dtype array for example, so it's not totally contrived for my somewhat idiosyncratic use case.

Right now this is not an error and leads to a failed assertion later when numpy tries to use a descriptor of a different type than the one associated with the array:

<details>

```
python: numpy/core/src/multiarray/refcount.c:232: PyArray_Item_XDECREF: Assertion `0' failed.

Thread 1 "python" received signal SIGABRT, Aborted.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=140737353776000) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737353776000)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737353776000)
    at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737353776000, signo=signo@entry=6)
    at ./nptl/pthread_kill.c:89
#3  0x00007ffff7642476 in __GI_raise (sig=sig@entry=6)
    at ../sysdeps/posix/raise.c:26
#4  0x00007ffff76287f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff762871b in __assert_fail_base (
    fmt=0x7ffff77dd150 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=0x7ffff6717eac "0", 
    file=0x7ffff6717e58 "numpy/core/src/multiarray/refcount.c", line=232, 
    function=<optimized out>) at ./assert/assert.c:92
#6  0x00007ffff7639e96 in __GI___assert_fail (assertion=0x7ffff6717eac "0", 
    file=0x7ffff6717e58 "numpy/core/src/multiarray/refcount.c", line=232, 
    function=0x7ffff6717ef0 <__PRETTY_FUNCTION__.1> "PyArray_Item_XDECREF")
    at ./assert/assert.c:101
#7  0x00007ffff65806e4 in PyArray_Item_XDECREF (data=0x7fffe5749030 "\004", 
    descr=0x7fffe5684940) at numpy/core/src/multiarray/refcount.c:232
#8  0x00007ffff6446b4f in PyArray_Pack (descr=0x7ffff55be3c0, 
    item=0x555556191230 "\001", value=<StringScalar at remote 0x7fffe5648dd0>)
    at numpy/core/src/multiarray/array_coercion.c:546
#9  0x00007ffff653e0ae in array_assign_subscript (self=0x7fffe56849c0, ind=1, 
    op=<StringScalar at remote 0x7fffe5648dd0>)
    at numpy/core/src/multiarray/mapping.c:1833
#10 0x00007ffff7afff47 in PyObject_SetItem (
    o=<numpy.ndarray at remote 0x7fffe56849c0>, key=1, 
    value=<StringScalar at remote 0x7fffe5648dd0>) at Objects/abstract.c:210
#11 0x00007ffff7ca464d in _PyEval_EvalFrameDefault (tstate=0x555555577220, 
    f=Frame 0x5555555d9d00, for file /home/nathan/Documents/numpy-experiments/setup-stringdtype.py, line 27, in <module> (), throwflag=0) at Python/ceval.c:2372
#12 0x00007ffff7c9ca91 in _PyEval_EvalFrame (tstate=0x555555577220, 
    f=Frame 0x5555555d9d00, for file /home/nathan/Documents/numpy-experiments/setup-stringdtype.py, line 27, in <module> (), throwflag=0)
(further frames elided)
```

</details>

With this PR you get the following error:

```
RuntimeError: Received scalar type '<class 'stringdtype.scalar.StringScalar'>' which maps to DType '<class 'stringdtype.StringDType'>', but DType '<class 'stringdtype.PandasStringDType'>' was explicitly specified
```