### PR TITLE
DOC: Added `pathlib.Path` where applicable

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -161,7 +161,7 @@ def open(path, mode='r', destpath=os.curdir, encoding=None, newline=None):
 
     Parameters
     ----------
-    path : str
+    path : str or pathlib.Path
         Local file path or URL to open.
     mode : str, optional
         Mode to open `path`. Mode 'r' for reading, 'w' for writing, 'a' to
@@ -382,7 +382,7 @@ class DataSource:
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Can be a local file or a remote URL.
 
         Returns
@@ -442,7 +442,7 @@ class DataSource:
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Can be a local file or a remote URL.
 
         Returns
@@ -493,7 +493,7 @@ class DataSource:
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Local file path or URL to open.
         mode : {'r', 'w', 'a'}, optional
             Mode to open `path`.  Mode 'r' for reading, 'w' for writing,
@@ -604,7 +604,7 @@ class Repository (DataSource):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Can be a local file or a remote URL. This may, but does not
             have to, include the `baseurl` with which the `Repository` was
             initialized.
@@ -631,7 +631,7 @@ class Repository (DataSource):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Can be a local file or a remote URL. This may, but does not
             have to, include the `baseurl` with which the `Repository` was
             initialized.
@@ -660,7 +660,7 @@ class Repository (DataSource):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
             Local file path or URL to open. This may, but does not have to,
             include the `baseurl` with which the `Repository` was
             initialized.
@@ -689,7 +689,7 @@ class Repository (DataSource):
 
         Returns
         -------
-        files : list of str
+        files : list of str or pathlib.Path
             List of file names (not containing a directory part).
 
         Notes

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -148,7 +148,7 @@ class NpzFile(Mapping):
 
     Parameters
     ----------
-    fid : file or str
+    fid : file, str, or pathlib.Path
         The zipped archive to open. This is either a file-like object
         or a string containing the path to the archive.
     own_fid : bool, optional
@@ -564,7 +564,7 @@ def savez(file, *args, **kwds):
 
     Parameters
     ----------
-    file : str or file
+    file : file, str, or pathlib.Path
         Either the filename (string) or an open file (file-like object)
         where the data will be saved. If file is a string or a Path, the
         ``.npz`` extension will be appended to the filename if it is not
@@ -657,7 +657,7 @@ def savez_compressed(file, *args, **kwds):
 
     Parameters
     ----------
-    file : str or file
+    file : file, str, or pathlib.Path
         Either the filename (string) or an open file (file-like object)
         where the data will be saved. If file is a string or a Path, the
         ``.npz`` extension will be appended to the filename if it is not
@@ -824,7 +824,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
 
     Parameters
     ----------
-    fname : str or file object
+    fname : file, str, or pathlib.Path
         The filename or the file to be read.
     delimiter : str, optional
         Field delimiter of the fields in line of the file.
@@ -1395,7 +1395,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
 
     Parameters
     ----------
-    fname : filename or file handle
+    fname : filename, file handle or pathlib.Path
         If the filename ends in ``.gz``, the file is automatically saved in
         compressed gzip format.  `loadtxt` understands gzipped files
         transparently.
@@ -1646,7 +1646,7 @@ def fromregex(file, regexp, dtype, encoding=None):
 
     Parameters
     ----------
-    file : path or file
+    file : file, str, or pathlib.Path
         Filename or file object to read.
 
         .. versionchanged:: 1.22.0

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -471,11 +471,12 @@ class TestSaveTxt:
         assert_equal(c.read(),
                      asbytes('1 2\n3 4\n' + commentstr + test_header_footer + '\n'))
 
-    def test_file_roundtrip(self):
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_file_roundtrip(self, filename_type):
         with temppath() as name:
             a = np.array([(1, 2), (3, 4)])
-            np.savetxt(name, a)
-            b = np.loadtxt(name)
+            np.savetxt(filename_type(name), a)
+            b = np.loadtxt(filename_type(name))
             assert_array_equal(a, b)
 
     def test_complex_arrays(self):
@@ -2567,10 +2568,10 @@ class TestPathUsage:
                 break_cycles()
 
     @pytest.mark.xfail(IS_WASM, reason="memmap doesn't work correctly")
-    def test_save_load_memmap_readwrite(self):
-        # Test that pathlib.Path instances can be written mem-mapped.
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_save_load_memmap_readwrite(self, filename_type):
         with temppath(suffix='.npy') as path:
-            path = Path(path)
+            path = filename_type(path)
             a = np.array([[1, 2], [3, 4]], int)
             np.save(path, a)
             b = np.load(path, mmap_mode='r+')
@@ -2583,35 +2584,37 @@ class TestPathUsage:
             data = np.load(path)
             assert_array_equal(data, a)
 
-    def test_savez_load(self):
-        # Test that pathlib.Path instances can be used with savez.
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_savez_load(self, filename_type):
         with temppath(suffix='.npz') as path:
-            path = Path(path)
+            path = filename_type(path)
             np.savez(path, lab='place holder')
             with np.load(path) as data:
                 assert_array_equal(data['lab'], 'place holder')
 
-    def test_savez_compressed_load(self):
-        # Test that pathlib.Path instances can be used with savez.
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_savez_compressed_load(self, filename_type):
         with temppath(suffix='.npz') as path:
-            path = Path(path)
+            path = filename_type(path)
             np.savez_compressed(path, lab='place holder')
             data = np.load(path)
             assert_array_equal(data['lab'], 'place holder')
             data.close()
 
-    def test_genfromtxt(self):
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_genfromtxt(self, filename_type):
         with temppath(suffix='.txt') as path:
-            path = Path(path)
+            path = filename_type(path)
             a = np.array([(1, 2), (3, 4)])
             np.savetxt(path, a)
             data = np.genfromtxt(path)
             assert_array_equal(a, data)
 
-    def test_recfromtxt(self):
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_recfromtxt(self, filename_type):
         with temppath(suffix='.txt') as path:
-            path = Path(path)
-            with path.open('w') as f:
+            path = filename_type(path)
+            with open(path, 'w') as f:
                 f.write('A,B\n0,1\n2,3')
 
             kwargs = dict(delimiter=",", missing_values="N/A", names=True)
@@ -2621,10 +2624,11 @@ class TestPathUsage:
             assert_(isinstance(test, np.recarray))
             assert_equal(test, control)
 
-    def test_recfromcsv(self):
+    @pytest.mark.parametrize("filename_type", [Path, str])
+    def test_recfromcsv(self, filename_type):
         with temppath(suffix='.txt') as path:
-            path = Path(path)
-            with path.open('w') as f:
+            path = filename_type(path)
+            with open(path, 'w') as f:
                 f.write('A,B\n0,1\n2,3')
 
             kwargs = dict(missing_values="N/A", names=True, case_sensitive=True)


### PR DESCRIPTION
### Problem
- [input/output docs](https://numpy.org/doc/stable/reference/routines.io.html) is inconsistent with respect to type of input args of `file`, `fin`, etc
  - [save](https://numpy.org/doc/stable/reference/generated/numpy.save.html) has `pathlib.Path`
  - [savez](https://numpy.org/doc/stable/reference/generated/numpy.savez.html) does not

### Changes
- Add `pathlib.Path` where support exists.

### Future work:
The plan is to rewrite some parts that use `os.path`. This can be achieved more cleanly with `pathlib.Path`. [Example](https://github.com/numpy/numpy/blob/00e5923cb8173f7b4b57f6db2777c986bcc6e9f8/numpy/lib/_datasource.py#L417-L429)