### PR TITLE
BLD: use cython3 for one CI run

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -181,7 +181,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
-  debug:
+  debug_and_cython3:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
@@ -195,6 +195,10 @@ jobs:
     - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: install cython3
+      run: python -m pip install --pre cython
+
     - uses: ./.github/actions
 
   blas64:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -187,6 +187,7 @@ jobs:
     if: github.event_name != 'push'
     env:
       USE_DEBUG: 1
+      USE_CYTHON3: 1
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
@@ -195,9 +196,6 @@ jobs:
     - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-
-    - name: install cython3
-      run: python -m pip install --pre cython
 
     - uses: ./.github/actions
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -20,6 +20,13 @@ from numpy.testing._private.utils import requires_memory
 from numpy.compat import pickle
 
 
+import cython
+from packaging.version import parse, Version
+
+# Remove this when cython fixes https://github.com/cython/cython/issues/5411
+cython_version = parse(cython.__version__)
+BUG_5411 = Version("3.0.0a7") <= cython_version <= Version("3.0.0b3")
+
 UNARY_UFUNCS = [obj for obj in np.core.umath.__dict__.values()
                     if isinstance(obj, np.ufunc)]
 UNARY_OBJECT_UFUNCS = [uf for uf in UNARY_UFUNCS if "O->O" in uf.types]
@@ -203,6 +210,9 @@ class TestUfunc:
                    b"(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
         assert_(pickle.loads(astring) is np.cos)
 
+    @pytest.mark.skipif(BUG_5411,
+        reason=("cython raises a AttributeError where it should raise a "
+                "ModuleNotFoundError"))
     @pytest.mark.skipif(IS_PYPY, reason="'is' check does not work on PyPy")
     def test_pickle_name_is_qualname(self):
         # This tests that a simplification of our ufunc pickle code will

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3477,7 +3477,7 @@ cdef class Generator:
         #   answer = 0.003 ... pretty unlikely!
 
         """
-        DEF HYPERGEOM_MAX = 10**9
+        cdef double HYPERGEOM_MAX = 10**9
         cdef bint is_scalar = True
         cdef np.ndarray ongood, onbad, onsample
         cdef int64_t lngood, lnbad, lnsample

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -11,7 +11,7 @@ __all__ = ['Philox']
 
 np.import_array()
 
-DEF PHILOX_BUFFER_SIZE=4
+cdef int PHILOX_BUFFER_SIZE=4
 
 cdef extern from 'src/philox/philox.h':
     struct s_r123array2x64:
@@ -30,7 +30,7 @@ cdef extern from 'src/philox/philox.h':
         philox4x64_ctr_t *ctr
         philox4x64_key_t *key
         int buffer_pos
-        uint64_t buffer[PHILOX_BUFFER_SIZE]
+        uint64_t *buffer
         int has_uint32
         uint32_t uinteger
 
@@ -193,11 +193,13 @@ cdef class Philox(BitGenerator):
         self._bitgen.next_raw = &philox_uint64
 
     cdef _reset_state_variables(self):
-        self.rng_state.has_uint32 = 0
-        self.rng_state.uinteger = 0
-        self.rng_state.buffer_pos = PHILOX_BUFFER_SIZE
+        cdef philox_state *rng_state = &self.rng_state
+         
+        rng_state[0].has_uint32 = 0
+        rng_state[0].uinteger = 0
+        rng_state[0].buffer_pos = PHILOX_BUFFER_SIZE
         for i in range(PHILOX_BUFFER_SIZE):
-            self.rng_state.buffer[i] = 0
+            rng_state[0].buffer[i] = 0
 
     @property
     def state(self):

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -48,7 +48,12 @@ pip install --upgrade pip 'setuptools<49.2.0' wheel
 # A specific version of cython is required, so we read the cython package
 # requirement using `grep cython test_requirements.txt` instead of simply
 # writing 'pip install setuptools wheel cython'.
-pip install `grep cython test_requirements.txt`
+if [ -n "$USE_CYTHON3" ]
+then
+  pip install --pre --force-reinstall cython
+else
+  pip install `grep cython test_requirements.txt`
+fi
 
 if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -87,6 +87,9 @@ run_test()
   # file does not install correctly when Python's optimization level is set
   # to strip docstrings (see https://github.com/eliben/pycparser/issues/291).
   PYTHONOPTIMIZE="" $PIP install -r test_requirements.txt pyinstaller
+  if [ -n "$USE_CYTHON3" ] ; then
+    $PIP install --pre --force-reinstall cython
+  fi
   DURATIONS_FLAG="--durations 10"
 
   if [ -n "$USE_DEBUG" ]; then


### PR DESCRIPTION
Test one CI run with cython3.0.0 pre-release.

xref [this comment](https://github.com/numpy/numpy/pull/23797#issuecomment-1559334894) from a PR that noticed a tweak needed for cython3.