### PR TITLE
MAINT: set([]) → set()

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -451,12 +451,12 @@ def validate_rst_syntax(text, name, dots=True):
             output_dot('E')
         return False, "ERROR: %s: no documentation" % (name,)
 
-    ok_unknown_items = set([
+    ok_unknown_items = set(
         'mod', 'doc', 'currentmodule', 'autosummary', 'data', 'attr',
         'obj', 'versionadded', 'versionchanged', 'module', 'class',
         'ref', 'func', 'toctree', 'moduleauthor', 'term', 'c:member',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'
-    ])
+    )
 
     # Run through docutils
     error_stream = io.StringIO()
@@ -981,10 +981,11 @@ def check_doctests_testfile(fname, verbose, ns=None,
     with open(fname, encoding='utf-8') as f:
         text = f.read()
 
-    PSEUDOCODE = set(['some_function', 'some_module', 'import example',
-                      'ctypes.CDLL',     # likely need compiling, skip it
-                      'integrate.nquad(func,'  # ctypes integrate tutotial
-    ])
+    PSEUDOCODE = set(
+        'some_function', 'some_module', 'import example',
+        'ctypes.CDLL',     # likely need compiling, skip it
+        'integrate.nquad(func,'  # ctypes integrate tutotial
+    )
 
     # split the text into "blocks" and try to detect and omit pseudocode blocks.
     parser = doctest.DocTestParser()


### PR DESCRIPTION
Also, `{}` might be better than `set()`, but that would be a different merge request:
```python
>>> {'xerbla'}
{'xerbla'}
>>> {('xerbla',)}
{('xerbla',)}
>>> {['xerbla']}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'list'
>>> 
```
```python
>>> set('xerbla')
{'l', 'x', 'a', 'b', 'r', 'e'}
>>> set(('xerbla',))
{'xerbla'}
>>> set(['xerbla'])
{'xerbla'}
>>> 
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
