### PR TITLE
MAINT: IOError → OSError

### DIFF
--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -43,7 +43,7 @@ def dirty_lock(lock_name, lock_on_count=1):
             f.seek(0)
             f.truncate()
             f.write(f"{str(count)} {str(ppid)}")
-    except IOError:
+    except OSError:
         pass
     return False
 

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -44,14 +44,14 @@ class config(old_config):
         if sys.platform == 'win32' and (self.compiler.compiler_type in
                                         ('msvc', 'intelw', 'intelemw')):
             # XXX: hack to circumvent a python 2.6 bug with msvc9compiler:
-            # initialize call query_vcvarsall, which throws an IOError, and
+            # initialize call query_vcvarsall, which throws an OSError, and
             # causes an error along the way without much information. We try to
             # catch it here, hoping it is early enough, and print a helpful
             # message instead of Error: None.
             if not self.compiler.initialized:
                 try:
                     self.compiler.initialize()
-                except IOError as e:
+                except OSError as e:
                     msg = textwrap.dedent("""\
                         Could not initialize compiler instance: do you have Visual Studio
                         installed?  If you are trying to build with MinGW, please use "python setup.py


### PR DESCRIPTION
`IOError` has been merged into `OSError` in Python 3.3.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
