### PR TITLE
MAINT: Update download-wheels

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -61,7 +61,7 @@ def get_wheel_names(version):
     index_url = f"{STAGING_URL}/files"
     index_html = http.request("GET", index_url)
     soup = BeautifulSoup(index_html.data, "html.parser")
-    return soup.findAll(text=tmpl)
+    return soup.find_all(string=tmpl)
 
 
 def download_wheels(version, wheelhouse):


### PR DESCRIPTION
Replace the beautifulsoup deprecated usage of `findAll(text=tmpl)` by `find_all(string=tmpl)`. Fixes a DeprecationWarning.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
