### PR TITLE
MAINT: Do not call PyArray_Item_XDECREF in PyArray_Pack

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -23,6 +23,7 @@
 #include "common.h"
 #include "_datetime.h"
 #include "npy_import.h"
+#include "refcount.h"
 
 #include "umathmodule.h"
 
@@ -542,9 +543,9 @@ PyArray_Pack(PyArray_Descr *descr, char *item, PyObject *value)
     int res = cast_raw_scalar_item(tmp_descr, data, descr, item);
 
     if (PyDataType_REFCHK(tmp_descr)) {
-        /* We could probably use move-references above */
-        PyArray_Item_XDECREF(data, tmp_descr);
+        PyArray_ClearBuffer(tmp_descr, data, 0, 1, 1);
     }
+
     PyObject_Free(data);
     Py_DECREF(tmp_descr);
     return res;

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -543,7 +543,9 @@ PyArray_Pack(PyArray_Descr *descr, char *item, PyObject *value)
     int res = cast_raw_scalar_item(tmp_descr, data, descr, item);
 
     if (PyDataType_REFCHK(tmp_descr)) {
-        PyArray_ClearBuffer(tmp_descr, data, 0, 1, 1);
+        if (PyArray_ClearBuffer(tmp_descr, data, 0, 1, 1) < 0) {
+            res = -1;
+        }
     }
 
     PyObject_Free(data);


### PR DESCRIPTION
According to codecov, the call to `PyArray_Item_XDECREF` [is uncovered](https://app.codecov.io/gh/numpy/numpy/blob/main/numpy/core/src/multiarray/array_coercion.c#L546) by the tests. I spent a little bit of time trying to come up with a test case that triggers the call without needing to use a non-legacy REFCHK dtype and couldn't come up with one.

I also moved the check for non-legacy dtypes in `PyArray_GetCastingImpl` so that a failed cast between two non-legacy dtypes won't lead to an error about a missing builtin cast.