### PR TITLE
TST: Add tests for np.argsort

### DIFF
--- a/doc/release/upcoming_changes/23707.performance.rst
+++ b/doc/release/upcoming_changes/23707.performance.rst
@@ -1,0 +1,7 @@
+Faster ``np.argsort`` on AVX-512 enabled processors
+---------------------------------------------------
+32-bit and 64-bit quicksort algorithm for np.argsort gain up to 6x speed up on
+processors that support AVX-512 instruction set.
+
+Thanks to `Intel corporation <https://open.intel.com/>`_ for sponsoring this
+work.

--- a/doc/release/upcoming_changes/23707.performance.rst
+++ b/doc/release/upcoming_changes/23707.performance.rst
@@ -1,7 +1,0 @@
-Faster ``np.argsort`` on AVX-512 enabled processors
----------------------------------------------------
-32-bit and 64-bit quicksort algorithm for np.argsort gain up to 6x speed up on
-processors that support AVX-512 instruction set.
-
-Thanks to `Intel corporation <https://open.intel.com/>`_ for sponsoring this
-work.

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -10002,7 +10002,7 @@ def test_private_get_ndarray_c_version():
 def test_argsort_float(N, dtype):
     rnd = np.random.RandomState(116112)
     # (1) Regular data with a few nan: doesn't use vectorized sort
-    arr = -0.5 + rnd.rand(N).astype(dtype)
+    arr = -0.5 + rnd.random(N).astype(dtype)
     arr[rnd.choice(arr.shape[0], 3)] = np.nan
     assert_arg_sorted(arr, np.argsort(arr, kind='quick'))
 


### PR DESCRIPTION
Contributing a few tests I had used when developing AVX-512 based argsort. Also added a release note.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
