### PR TITLE
MAINT: const correctness for the generalized ufunc C API

### DIFF
--- a/doc/release/upcoming_changes/23847.c_api.rst
+++ b/doc/release/upcoming_changes/23847.c_api.rst
@@ -1,0 +1,11 @@
+Const correctness for the generalized ufunc C API
+-------------------------------------------------
+The Numpy C API's functions for constructing generalized ufuncs
+(``PyUFunc_FromFuncAndData``, ``PyUFunc_FromFuncAndDataAndSignature``,
+``PyUFunc_FromFuncAndDataAndSignatureAndIdentity``) take ``types`` and ``data``
+arguments that are not modified by Numpy's internals. Like the ``name`` and
+``doc`` arguments, third-party Python extension modules are likely to supply
+these arguments from static constants. The ``types`` and ``data`` arguments are
+now const-correct: they are declared as ``const char *types`` and
+``void *const *data``, respectively. C code should not be affected, but C++
+code may be.

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -109,7 +109,7 @@ typedef struct _tagPyUFuncObject {
         /* Array of one-dimensional core loops */
         PyUFuncGenericFunction *functions;
         /* Array of funcdata that gets passed into the functions */
-        void **data;
+        void *const *data;
         /* The number of elements in 'functions' and 'data' */
         int ntypes;
 
@@ -120,7 +120,7 @@ typedef struct _tagPyUFuncObject {
         const char *name;
 
         /* Array of type numbers, of size ('nargs' * 'ntypes') */
-        char *types;
+        const char *types;
 
         /* Documentation string */
         const char *doc;

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -826,7 +826,7 @@ promote_and_get_info_and_ufuncimpl(PyUFuncObject *ufunc,
          * This check should ensure a the right error message, but in principle
          * we could try to call the loop getter here.
          */
-        char *types = ufunc->types;
+        const char *types = ufunc->types;
         npy_bool loop_exists = NPY_FALSE;
         for (int i = 0; i < ufunc->ntypes; ++i) {
             loop_exists = NPY_TRUE;  /* assume it exists, break if not */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5157,8 +5157,8 @@ PyUFunc_ReplaceLoopBySignature(PyUFuncObject *func,
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndData(PyUFuncGenericFunction *func, void **data,
-                        char *types, int ntypes,
+PyUFunc_FromFuncAndData(PyUFuncGenericFunction *func, void *const *data,
+                        const char *types, int ntypes,
                         int nin, int nout, int identity,
                         const char *name, const char *doc, int unused)
 {
@@ -5168,8 +5168,8 @@ PyUFunc_FromFuncAndData(PyUFuncGenericFunction *func, void **data,
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
-                                     char *types, int ntypes,
+PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void *const *data,
+                                     const char *types, int ntypes,
                                      int nin, int nout, int identity,
                                      const char *name, const char *doc,
                                      int unused, const char *signature)
@@ -5181,8 +5181,8 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void **data,
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, void **data,
-                                     char *types, int ntypes,
+PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, void *const *data,
+                                     const char *types, int ntypes,
                                      int nin, int nout, int identity,
                                      const char *name, const char *doc,
                                      const int unused, const char *signature,
@@ -5287,7 +5287,7 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
         }
     }
 
-    char *curr_types = ufunc->types;
+    const char *curr_types = ufunc->types;
     for (int i = 0; i < ntypes * (nin + nout); i += nin + nout) {
         /*
          * Add all legacy wrapping loops here. This is normally not necessary,

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1494,7 +1494,7 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
                                 int *out_needs_api)
 {
     int nargs = ufunc->nargs;
-    char *types;
+    const char *types;
     int i, j;
 
     /*
@@ -1960,7 +1960,7 @@ linear_search_type_resolver(PyUFuncObject *self,
      */
     no_castable_output = 0;
     for (i = 0; i < self->ntypes; ++i) {
-        char *orig_types = self->types + i*self->nargs;
+        const char *orig_types = self->types + i*self->nargs;
 
         /* Copy the types into an int array for matching */
         for (j = 0; j < nop; ++j) {
@@ -2042,7 +2042,7 @@ type_tuple_type_resolver_core(PyUFuncObject *self,
     }
 
     for (i = 0; i < self->ntypes; ++i) {
-        char *orig_types = self->types + i*self->nargs;
+        const char *orig_types = self->types + i*self->nargs;
 
         /*
          * Check specified types and copy into an int array for matching


### PR DESCRIPTION
Numpy's internals do not modify this field, and C extensions that call `PyUFunc_FromFuncAndDataAndSignature` and friends are likely to pass a (static) const char array for the types argument. Make this field const so that calling code does not see discarded qualifier warnings.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
