### PR TITLE
CI: Change "weekly" to "nightly" in cirrus

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -115,7 +115,7 @@ wheels_upload_task:
     export IS_PUSH="false"
 
     # cron job
-    if [[ "$CIRRUS_CRON" == "weekly" ]]; then
+    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
       export IS_SCHEDULE_DISPATCH="true"
     fi
 


### PR DESCRIPTION
Yes, the job runs weekly right now, but we call it nightly in most places (including in the cirrus.start file, although that doesn't matter much in practice)

---

@andyfaff does this seem right?  I changed the job name on Cirrus already to "nightly".  I am still considering bumping our run regularity to twice a week, but that is a different change.