### PR TITLE
BUG: make use of locals() in a comprehension fully compatible with Python 3.12

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -69,7 +69,8 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     *legacy* and sanity checks.
     """
 
-    options = {k: v for k, v in locals().items() if v is not None}
+    optitems = list(locals().items())
+    options = {k: v for k, v in optitems if v is not None}
 
     if suppress is not None:
         options['suppress'] = bool(suppress)

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -69,8 +69,7 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     *legacy* and sanity checks.
     """
 
-    optitems = list(locals().items())
-    options = {k: v for k, v in optitems if v is not None}
+    options = {k: v for k, v in list(locals().items()) if v is not None}
 
     if suppress is not None:
         options['suppress'] = bool(suppress)


### PR DESCRIPTION
In Python 3.12, comprehensions are inlined; they are no longer a separate function. (See PEP 709.) Although comprehension iteration variables are still isolated (any prior value is pushed to the stack before the comprehension runs and restored after), they are now part of the local variables of the surrounding function. So in this case, `k` and `v` will become part of the locals of `_make_options_dict` (temporarily, while the comprehension is running.)

The frame locals dictionary is lazily updated from the "fast locals" array on the frame object, only whenever someone calls `locals()` or accesses `frame.f_locals`. So this code will still work on Python 3.12 most of the time; nothing triggers an update of the locals dictionary after the `locals()` call (which happens before the comprehension runs).

But, if this code runs under a `sys.settrace` function (e.g. test coverage measurement) which accesses `frame.f_locals` within the trace handler, then the locals dictionary will gain the new keys `k` and `v` while the comprehension is running, and this will cause a `RuntimeError: dictionary changed size during iteration`.

The fix is to avoid lazy iteration of `locals()`, and ensure we capture the locals we want before running any more code that could add/change locals.