### PR TITLE
CI: bump nightly upload frequency to twice a week

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ on:
     #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #        │  │ │ │ │
-    - cron: "42 1 * * 4"
+    - cron: "42 2 ? * SUN,WED *"
   push:
   pull_request:
     types: [labeled, opened, synchronize, reopened]


### PR DESCRIPTION
With Nathan working on dtypes I occasionally triggered wheels on CI manually and I think we have a decent amount of PRs merged every day so that twice a week seems fine.

Time chosen to be a mix of what we had on cirrus and here (this aligns it, but I am happy to adjust both).