### PR TITLE
BUG: fix cron syntax

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ on:
     #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #        │  │ │ │ │
-    - cron: "42 2 ? * SUN,WED *"
+    - cron: "42 2 * * SUN,WED"
   push:
   pull_request:
     types: [labeled, opened, synchronize, reopened]


### PR DESCRIPTION
Apparently the documentation is not exactly correct and names cannot be used. Fixes #23856.