### PR TITLE
CI: Fix cron syntax for nightly wheel action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ on:
     #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #        │  │ │ │ │
-    - cron: "42 2 ? * SUN,WED *"
+    - cron: "42 2 * * SUN,WED"
   push:
   pull_request:
     types: [labeled, opened, synchronize, reopened]


### PR DESCRIPTION
Copied the cirrus one and didn't make sure to reduce it to the posix syntax used by actions:

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

(thanks Matti)

---

OK, I think this should work now...