### PR TITLE
DOC: Note that f2py isn't consiered safe

### DIFF
--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -23,7 +23,11 @@ to have the same privilege as the process/Python interpreter.
 That said, NumPy should be generally safe to use on *data* provided by
 unprivileged users and read through safe API functions (e.g. loaded from a
 text file or ``.npy`` file without pickle support).
-Malicious *values* or *data sizes* should never lead to privilege escalation. 
+Malicious *values* or *data sizes* should never lead to privilege escalation.
+Note that the above refers to array data.  We do not currently consider for
+example ``f2py`` to be safe:
+it is typically used to compile a program that is then run.
+Any ``f2py`` invocation must thus use the same priviledge as the later execution.
 
 The following points may be useful or should be noted when working with
 untrusted data:


### PR DESCRIPTION
Not mentioning distutils explicitly, because it is deprecated anyway. This is basically just because occasionally get those "this is an unsafe regex", etc.  Also, I would not be surprised if f2py isn't full of actual bugs that would allow escalation if you use it on untrusted input.

I don't think it really needs pointing out, but adding it so we have something to point at if it comes up again.
