### PR TITLE
MAINT: Remove all "NumPy 2" as that should be main now

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -289,26 +289,6 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
-  numpy2_flag:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    env:
-      # Test for numpy-2.0 feature-flagged behavior.
-      NPY_NUMPY_2_BEHAVIOR: 1
-      # Using the future "weak" state doesn't pass tests
-      # currently unfortunately
-      NPY_PROMOTION_STATE: legacy
-    steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-    - uses: ./.github/actions
-
   no_openblas:
     needs: [smoke_test]
     runs-on: ubuntu-latest

--- a/doc/release/upcoming_changes/23861.change.rst
+++ b/doc/release/upcoming_changes/23861.change.rst
@@ -1,0 +1,3 @@
+* ``np.gradient()`` now returns a tuple rather than list making the
+  return value immutable.
+

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -82,17 +82,3 @@ memory allocation policy, the default will be to call ``free``. If
 ``NUMPY_WARN_IF_NO_MEM_POLICY`` is set to ``"1"``, a ``RuntimeWarning`` will
 be emitted. A better alternative is to use a ``PyCapsule`` with a deallocator
 and set the ``ndarray.base``.
-
-
-Testing planned future behavior
-===============================
-
-NumPy has some code paths which are planned to be activated in the future
-but are not yet the default behavior.
-You can try testing some of these which may be shipped with a new "major"
-release (NumPy 2.0) by setting an environment before importing NumPy:
-
-    NPY_NUMPY_2_BEHAVIOR=1
-
-By default this will also activate the :ref:`NEP 50 <NEP50>` related setting
-``NPY_PROMOTION_STATE`` (please see the NEP for details on this).

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -427,10 +427,9 @@ else:
     # it is tidier organized.
     core.multiarray._multiarray_umath._reload_guard()
 
-    # default to "weak" promotion for "NumPy 2".
+    # TODO: Switch to defaulting to "weak".
     core._set_promotion_state(
-        os.environ.get("NPY_PROMOTION_STATE",
-                       "weak" if _using_numpy2_behavior() else "legacy"))
+        os.environ.get("NPY_PROMOTION_STATE", "legacy"))
 
     # Tell PyInstaller where to find hook-numpy.py
     def _pyinstaller_hooks_dir():

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -17,7 +17,7 @@ from ._multiarray_umath import (
     fastCopyAndTranspose, _flagdict, from_dlpack, _place, _reconstruct,
     _vec_string, _ARRAY_API, _monotonicity, _get_ndarray_c_version,
     _get_madvise_hugepage, _set_madvise_hugepage,
-    _get_promotion_state, _set_promotion_state, _using_numpy2_behavior
+    _get_promotion_state, _set_promotion_state
     )
 
 __all__ = [
@@ -42,7 +42,7 @@ __all__ = [
     'set_legacy_print_mode', 'set_numeric_ops', 'set_string_function',
     'set_typeDict', 'shares_memory', 'tracemalloc_domain', 'typeinfo',
     'unpackbits', 'unravel_index', 'vdot', 'where', 'zeros',
-    '_get_promotion_state', '_set_promotion_state', '_using_numpy2_behavior']
+    '_get_promotion_state', '_set_promotion_state']
 
 # For backward compatibility, make sure pickle imports these functions from here
 _reconstruct.__module__ = 'numpy.core.multiarray'
@@ -72,7 +72,6 @@ seterrobj.__module__ = 'numpy'
 zeros.__module__ = 'numpy'
 _get_promotion_state.__module__ = 'numpy'
 _set_promotion_state.__module__ = 'numpy'
-_using_numpy2_behavior.__module__ = 'numpy'
 
 
 # We can't verify dispatcher signatures because NumPy's C functions don't

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -18,8 +18,7 @@ from .multiarray import (
     fromstring, inner, lexsort, matmul, may_share_memory,
     min_scalar_type, ndarray, nditer, nested_iters, promote_types,
     putmask, result_type, set_numeric_ops, shares_memory, vdot, where,
-    zeros, normalize_axis_index, _get_promotion_state, _set_promotion_state,
-    _using_numpy2_behavior)
+    zeros, normalize_axis_index, _get_promotion_state, _set_promotion_state)
 
 from . import overrides
 from . import umath
@@ -56,8 +55,7 @@ __all__ = [
     'False_', 'True_', 'bitwise_not', 'CLIP', 'RAISE', 'WRAP', 'MAXDIMS',
     'BUFSIZE', 'ALLOW_THREADS', 'full', 'full_like',
     'matmul', 'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS',
-    'MAY_SHARE_EXACT', '_get_promotion_state', '_set_promotion_state',
-    '_using_numpy2_behavior']
+    'MAY_SHARE_EXACT', '_get_promotion_state', '_set_promotion_state']
 
 
 def _zeros_like_dispatcher(a, dtype=None, order=None, subok=None, shape=None):

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -103,11 +103,6 @@ _umath_strings_richcompare(
  * future.
  */
 int npy_legacy_print_mode = INT_MAX;
-/*
- * Global variable to check whether NumPy 2.0 behavior is opted in.
- * This flag is considered a runtime constant.
- */
-int npy_numpy2_behavior = NPY_FALSE;
 
 
 static PyObject *
@@ -4511,14 +4506,6 @@ _reload_guard(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args)) {
 }
 
 
-static PyObject *
-_using_numpy2_behavior(
-        PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args))
-{
-    return PyBool_FromLong(npy_numpy2_behavior);
-}
-
-
 static struct PyMethodDef array_module_methods[] = {
     {"_get_implementing_args",
         (PyCFunction)array__get_implementing_args,
@@ -4744,8 +4731,6 @@ static struct PyMethodDef array_module_methods[] = {
     {"_reload_guard", (PyCFunction)_reload_guard,
         METH_NOARGS,
         "Give a warning on reload and big warning in sub-interpreters."},
-    {"_using_numpy2_behavior", (PyCFunction)_using_numpy2_behavior,
-        METH_NOARGS, NULL},
     {"from_dlpack", (PyCFunction)from_dlpack,
         METH_O, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
@@ -5021,12 +5006,6 @@ initialize_static_globals(void)
             &npy_UFuncNoLoopError);
     if (npy_UFuncNoLoopError == NULL) {
         return -1;
-    }
-
-    /* Initialize from certain environment variabels: */
-    char *env = getenv("NPY_NUMPY_2_BEHAVIOR");
-    if (env != NULL && strcmp(env, "0") != 0) {
-        npy_numpy2_behavior = NPY_TRUE;
     }
 
     return 0;

--- a/numpy/core/src/multiarray/multiarraymodule.h
+++ b/numpy/core/src/multiarray/multiarraymodule.h
@@ -1,8 +1,6 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 
-NPY_VISIBILITY_HIDDEN extern int npy_numpy2_behavior;
-
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_current_allocator;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_function;

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1311,10 +1311,7 @@ def gradient(f, *varargs, axis=None, edge_order=1):
 
     if len_axes == 1:
         return outvals[0]
-    elif np._using_numpy2_behavior():
-        return tuple(outvals)
-    else:
-        return outvals
+    return tuple(outvals)
 
 
 def _diff_dispatcher(a, n=None, axis=None, prepend=None, append=None):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1219,10 +1219,7 @@ class TestGradient:
 
     def test_return_type(self):
         res = np.gradient(([1, 2], [2, 3]))
-        if np._using_numpy2_behavior():
-            assert type(res) is tuple
-        else:
-            assert type(res) is list
+        assert type(res) is tuple
 
 
 class TestAngle:


### PR DESCRIPTION
This effectively reverts most of gh-23089, the array function disabling has been removed in the meantime, so the test is now not needed anymore (the test set it to 0 before).

I am sad that there weren't actually any changes, but it doesn't really matter.

---

@charris this was that release note related cleanup.