### PR TITLE
NEP: Fix NEP 53 file format and minor formatting issue

### DIFF
--- a/doc/neps/nep-0053-c-abi-evolution.rst
+++ b/doc/neps/nep-0053-c-abi-evolution.rst
@@ -36,6 +36,7 @@ The implementation of this NEP consists would consist of two steps:
    compatible builds with the newest available NumPy version.
    (New API is not available unless opted-in.)
 2. The NumPy 2.0 will:
+
    * require recompilation of downstream packages against NumPy 2.0 to be
      compatible with NumPy 2.0.
    * need a ``numpy2_compat`` as a dependency when running on NumPy 1.x.

--- a/doc/neps/nep-0053-c-abi-evolution.rst
+++ b/doc/neps/nep-0053-c-abi-evolution.rst
@@ -55,7 +55,7 @@ Further, many structs used by NumPy have always been public making it
 impossible to change them outside of a major release.
 Some changes have been planned for years and were the reason for
 ``NPY_NO_DEPRECATED_API`` and further deprecations as explained in
-`c_api_deprecations`_.
+:ref:`c_api_deprecations`.
 
 While we probably have little reason to change the layout of the array struct
 (``PyArrayObject_fields``) for example the development and improvement of


### PR DESCRIPTION
I had accidentally named this `.md` which isn't something that currently works.  Also adds a newline, which was causing the bullet to be incorrectl rendered.
