### PR TITLE
DOC: update distutils migration guide

### DIFF
--- a/doc/source/reference/distutils_status_migration.rst
+++ b/doc/source/reference/distutils_status_migration.rst
@@ -17,55 +17,45 @@ the Python 3.12 release (Oct 2025).
 Migration advice
 ----------------
 
-It is **not necessary** to migrate immediately - the release date for Python 3.12
-is October 2023. It may be beneficial to wait with migrating until there are
-examples from other projects to follow (see below).
-
 There are several build systems which are good options to migrate to. Assuming
-you have compiled code in your package (if not, we recommend using Flit_) and
-you want to be using a well-designed, modern and reliable build system, we
-recommend:
+you have compiled code in your package (if not, you have several good options,
+e.g. the build backends offered by Poetry, Hatch or PDM) and you want to be
+using a well-designed, modern and reliable build system, we recommend:
 
-1. Meson_
-2. CMake_ (or scikit-build_ as an interface to CMake)
+1. Meson_, and the meson-python_ build backend
+2. CMake_, and the scikit-build-core_ build backend
 
-If you have modest needs (only simple Cython/C extensions, and perhaps nested
-``setup.py`` files) and have been happy with ``numpy.distutils`` so far, you
+If you have modest needs (only simple Cython/C extensions; no need for Fortran,
+BLAS/LAPACK, nested ``setup.py`` files, or other features of
+``numpy.distutils``) and have been happy with ``numpy.distutils`` so far, you
 can also consider switching to ``setuptools``. Note that most functionality of
 ``numpy.distutils`` is unlikely to be ported to ``setuptools``.
-
 
 Moving to Meson
 ~~~~~~~~~~~~~~~
 
-SciPy is moving to Meson for its 1.9.0 release, planned for July 2022. During
-this process, any remaining issues with Meson's Python support and achieving
-feature parity with ``numpy.distutils`` will be resolved. *Note: parity means a
-large superset, but right now some BLAS/LAPACK support is missing and there are
-a few open issues related to Cython.* SciPy uses almost all functionality that
-``numpy.distutils`` offers, so if SciPy has successfully made a release with
-Meson as the build system, there should be no blockers left to migrate, and
-SciPy will be a good reference for other packages who are migrating.
-For more details about the SciPy migration, see:
+SciPy has moved to Meson and meson-python for its 1.9.0 release. During
+this process, remaining issues with Meson's Python support and
+feature parity with ``numpy.distutils`` were resolved. *Note: parity means a
+large superset (because Meson is a good general-purpose build system); only
+a few BLAS/LAPACK library selection niceties are missing*. SciPy uses almost
+all functionality that ``numpy.distutils`` offers, so if SciPy has successfully
+made a release with Meson as the build system, there should be no blockers left
+to migrate, and SciPy will be a good reference for other packages who are
+migrating. For more details about the SciPy migration, see:
 
 - `RFC: switch to Meson as a build system <https://github.com/scipy/scipy/issues/13615>`__
 - `Tracking issue for Meson support <https://github.com/rgommers/scipy/issues/22>`__
 
-NumPy itself will very likely migrate to Meson as well, once the SciPy
-migration is done.
+NumPy will migrate to Meson for the 1.26 release.
 
 
 Moving to CMake / scikit-build
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See the `scikit-build documentation <https://scikit-build.readthedocs.io/en/latest/>`__
-for how to use scikit-build. Please note that as of Feb 2022, scikit-build
-still relies on setuptools, so it's probably not quite ready yet for a
-post-distutils world. How quickly this changes depends on funding, the current
-(Feb 2022) estimate is that if funding arrives then a viable ``numpy.distutils``
-replacement will be ready at the end of 2022, and a very polished replacement
-mid-2023.  For more details on this, see
-`this blog post by Henry Schreiner <https://iscinumpy.gitlab.io/post/scikit-build-proposal/>`__.
+The next generation of scikit-build is called scikit-build-core_. Where the
+older ``scikit-build`` used ``setuptools`` underneath, the rewrite does not.
+Like Meson, CMake is a good general-purpose build system.
 
 
 Moving to ``setuptools``
@@ -86,14 +76,15 @@ present in ``setuptools``:
 - a simple user build config system, see `site.cfg.example <https://github.com/numpy/numpy/blob/master/site.cfg.example>`__
 - SIMD intrinsics support
 
-The most widely used feature is nested ``setup.py`` files. This feature will
-likely be ported to ``setuptools`` (see
-`gh-18588 <https://github.com/numpy/numpy/issues/18588>`__ for status).
-Projects only using that feature could move to ``setuptools`` after that is
-done. In case a project uses only a couple of ``setup.py`` files, it also could
-make sense to simply aggregate all the content of those files into a single
-``setup.py`` file and then move to ``setuptools``. This involves dropping all
-``Configuration`` instances, and using ``Extension`` instead. E.g.,::
+The most widely used feature is nested ``setup.py`` files. This feature may
+perhaps still be ported to ``setuptools`` in the future (it needs a volunteer
+though, see `gh-18588 <https://github.com/numpy/numpy/issues/18588>`__ for
+status). Projects only using that feature could move to ``setuptools`` after
+that is done. In case a project uses only a couple of ``setup.py`` files, it
+also could make sense to simply aggregate all the content of those files into a
+single ``setup.py`` file and then move to ``setuptools``. This involves
+dropping all ``Configuration`` instances, and using ``Extension`` instead.
+E.g.,::
 
     from distutils.core import setup
     from distutils.extension import Extension
@@ -131,8 +122,7 @@ build requirement in ``pyproject.toml`` to avoid future breakage - see
 :ref:`for-downstream-package-authors`.
 
 
-.. _Flit: https://flit.readthedocs.io
 .. _CMake: https://cmake.org/
 .. _Meson: https://mesonbuild.com/
-.. _scikit-build: https://scikit-build.readthedocs.io/
-
+.. _meson-python: https://meson-python.readthedocs.io
+.. _scikit-build-core: https://scikit-build-core.readthedocs.io/en/latest/


### PR DESCRIPTION
Backport of #23936.

Update according to my understanding of the status of the alternatives to distutils.

The need to update this document came from another issue, it would be good to update this part of the documentation for the 1.25 release.

[skip cirrus] [skip actions] [skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
