### PR TITLE
MAINT: Improve readability of _select_matrix_shape in file cblasfuncs.c

### DIFF
--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -159,24 +159,32 @@ static MatrixShape
 _select_matrix_shape(PyArrayObject *array)
 {
     switch (PyArray_NDIM(array)) {
+
         case 0:
             return _scalar;
+
         case 1:
             if (PyArray_DIM(array, 0) > 1)
                 return _column;
-            return _scalar;
-        case 2:
-            if (PyArray_DIM(array, 0) > 1) {
-                if (PyArray_DIM(array, 1) == 1)
-                    return _column;
-                else
-                    return _matrix;
-            }
-            if (PyArray_DIM(array, 1) == 1)
+            else
                 return _scalar;
-            return _row;
+
+        case 2:
+            if (PyArray_DIM(array, 0) > 1)
+                if (PyArray_DIM(array, 1) > 1)                    
+                    return _matrix;
+                else
+                    return _column;
+
+            else
+                if (PyArray_DIM(array, 1) > 1)
+                    return _row;
+                else
+                    return _scalar;
+
+        default:
+            return _matrix;
     }
-    return _matrix;
 }
 
 


### PR DESCRIPTION
The function _select_matrix_shape classifies the shape of (PyArrayObject *), this pr aims to improve the clarity. The test output before and after the change are the same: 35313 passed, 172 skipped, 1308 deselected, 32 xfailed, 3 xpassed.

First pr, thanks!