### PR TITLE
DOC: Fix transpose() description with a correct reference to atleast_2d()

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -593,7 +593,7 @@ def transpose(a, axes=None):
     For a 1-D array, this returns an unchanged view of the original array, as a
     transposed vector is simply the same vector.
     To convert a 1-D array into a 2-D column vector, an additional dimension
-    must be added, e.g., ``np.atleast2d(a).T`` achieves this, as does
+    must be added, e.g., ``np.atleast_2d(a).T`` achieves this, as does
     ``a[:, np.newaxis]``.
     For a 2-D array, this is the standard matrix transpose.
     For an n-D array, if axes are given, their order indicates how the


### PR DESCRIPTION
Transpose method documentation fix -  should contain atleast_2d as the correct method name, and not atleast2d.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
