### PR TITLE
MAINT: Use ``--allow-downgrade`` option for rtools.

### DIFF
--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -15,7 +15,7 @@ steps:
 
 - powershell: |
     # rtools 42+ does not support 32 bits builds.
-    choco install --confirm --no-progress --side-by-side rtools --version=4.0.0.20220206
+    choco install --confirm --no-progress --allow-downgrade rtools --version=4.0.0.20220206
     echo "##vso[task.setvariable variable=RTOOLS40_HOME]c:\rtools40"
   displayName: 'Install rtools'
 


### PR DESCRIPTION
Chocolatey has deprecated the `--side-by-side` option and suggest either `--force` or `--allow-downgrade` instead. IIRC, we started with `--force` and it failed.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
