### PR TITLE
BUG: Allow np.info on non-hashable objects with a dtype

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -482,9 +482,12 @@ class finfo:
     _finfo_cache = {}
 
     def __new__(cls, dtype):
-        obj = cls._finfo_cache.get(dtype)  # most common path
-        if obj is not None:
-            return obj
+        try:
+            obj = cls._finfo_cache.get(dtype)  # most common path
+            if obj is not None:
+                return obj
+        except TypeError:
+            obj = None
 
         if dtype is None:
             # Deprecated in NumPy 1.25, 2023-01-16

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -487,7 +487,7 @@ class finfo:
             if obj is not None:
                 return obj
         except TypeError:
-            obj = None
+            pass
 
         if dtype is None:
             # Deprecated in NumPy 1.25, 2023-01-16

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -75,8 +75,8 @@ class TestFinfo:
 
     def test_regression_gh23867(self):
         class NonHashableWithDtype:
-          __hash__ = None
-          dtype = np.dtype('float32')
+            __hash__ = None
+            dtype = np.dtype('float32')
   
         x = NonHashableWithDtype()
         assert np.finfo(x) == np.finfo(x.dtype)

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -73,6 +73,15 @@ class TestFinfo:
         f2 = np.finfo(np.float64(1.0))
         assert f1 != f2
 
+    def test_regression_gh23867(self):
+        class NonHashableWithDtype:
+          __hash__ = None
+          dtype = np.dtype('float32')
+  
+        x = NonHashableWithDtype()
+        assert np.finfo(x) == np.finfo(x.dtype)
+        
+
 class TestIinfo:
     def test_basic(self):
         dts = list(zip(['i1', 'i2', 'i4', 'i8',


### PR DESCRIPTION
In this PR we restore the functionality to call `np.finfo` on non-hashable objects with a `dtype`.

Fixes #23867.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
