### PR TITLE
API: Switch to NEP 50 behavior by default

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -2,6 +2,13 @@ from .common import Benchmark
 
 import numpy as np
 
+try:
+    # SkipNotImplemented is available since 6.0
+    from asv_runner.benchmarks.mark import SkipNotImplemented
+except ImportError:
+    SkipNotImplemented = NotImplementedError
+
+
 class Linspace(Benchmark):
     def setup(self):
         self.d = np.array([1, 2, 3])
@@ -169,6 +176,13 @@ class SortGenerator:
         """
         Returns an array that's in descending order.
         """
+        dtype = np.dtype(dtype)
+        try:
+            with np.errstate(over="raise"):
+                res = dtype.type(size-1)
+        except (OverflowError, FloatingPointError):
+            raise SkipNotImplemented("Cannot construct arange for this size.")
+
         return np.arange(size-1, -1, -1, dtype=dtype)
 
     @staticmethod

--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -43,13 +43,18 @@ When you use :func:`numpy.array` to define a new array, you should
 consider the :doc:`dtype <basics.types>` of the elements in the array,
 which can be specified explicitly. This feature gives you
 more control over the underlying data structures and how the elements
-are handled in C/C++ functions. If you are not careful with ``dtype``
-assignments, you can get unwanted overflow, as such 
+are handled in C/C++ functions.
+When values do not fit and you are using a ``dtype`` NumPy may raise an
+error::
 
-::
+  >>> np.array([127, 128, 129], dtype=np.int8)
+  Traceback (most recent call last):
+  ...
+  OverflowError: Python integer 128 out of bounds for int8
 
-  >>> a = np.array([127, 128, 129], dtype=np.int8)
-  >>> a
+However, NumPy integers are force-cast and may silently overflow::
+
+  >>> np.array([127, np.int64(128), np.int64(129)], dtype=np.int8)
   array([ 127, -128, -127], dtype=int8)
 
 An 8-bit signed integer represents integers from -128 to 127.

--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -44,18 +44,13 @@ consider the :doc:`dtype <basics.types>` of the elements in the array,
 which can be specified explicitly. This feature gives you
 more control over the underlying data structures and how the elements
 are handled in C/C++ functions.
-When values do not fit and you are using a ``dtype`` NumPy may raise an
+When values do not fit and you are using a ``dtype``, NumPy may raise an
 error::
 
   >>> np.array([127, 128, 129], dtype=np.int8)
   Traceback (most recent call last):
   ...
   OverflowError: Python integer 128 out of bounds for int8
-
-However, NumPy integers are force-cast and may silently overflow::
-
-  >>> np.array([127, np.int64(128), np.int64(129)], dtype=np.int8)
-  array([ 127, -128, -127], dtype=int8)
 
 An 8-bit signed integer represents integers from -128 to 127.
 Assigning the ``int8`` array to integers outside of this range results

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -517,9 +517,9 @@ else:
     # it is tidier organized.
     _core.multiarray._multiarray_umath._reload_guard()
 
-    # TODO: Switch to defaulting to "weak".
+    # TODO: Remove the environment variable entirely now that it is "weak"
     _core._set_promotion_state(
-        os.environ.get("NPY_PROMOTION_STATE", "legacy"))
+        os.environ.get("NPY_PROMOTION_STATE", "weak"))
 
     # Tell PyInstaller where to find hook-numpy.py
     def _pyinstaller_hooks_dir():

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -1893,7 +1893,7 @@ add_newdoc('numpy._core.umath', 'left_shift',
     result and can lead to unexpected results in some cases (see
     :ref:`Casting Rules <ufuncs.casting>`):
 
-    >>> a = np.left_shift(np.uint8(255), 1) # Expect 254
+    >>> a = np.left_shift(np.uint8(255), np.int64(1))  # Expect 254
     >>> print(a, type(a)) # Unexpected result due to upcasting
     510 <class 'numpy.int64'>
     >>> b = np.left_shift(np.uint8(255), np.uint8(1))

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -511,14 +511,12 @@ def can_cast(from_, to, casting=None):
     can_cast(from_, to, casting='safe')
 
     Returns True if cast between data types can occur according to the
-    casting rule.  If from is a scalar or array scalar, also returns
-    True if the scalar value can be cast without overflow or truncation
-    to an integer.
+    casting rule.
 
     Parameters
     ----------
-    from_ : dtype, dtype specifier, scalar, or array
-        Data type, scalar, or array to cast from.
+    from_ : dtype, dtype specifier, NumPy scalar, or array
+        Data type, NumPy scalar, or array to cast from.
     to : dtype or dtype specifier
         Data type to cast to.
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
@@ -548,6 +546,10 @@ def can_cast(from_, to, casting=None):
        that the string dtype length is long enough to store the maximum
        integer/float value converted.
 
+    .. versionchanged:: 2.0
+       This function does not support Python scalars anymore and does not
+       apply any value-based logic for 0-D arrays and NumPy scalars.
+
     See also
     --------
     dtype, result_type
@@ -569,52 +571,6 @@ def can_cast(from_, to, casting=None):
     False
     >>> np.can_cast('i4', 'S4')
     False
-
-    Casting scalars
-
-    >>> np.can_cast(100, 'i1')
-    True
-    >>> np.can_cast(150, 'i1')
-    False
-    >>> np.can_cast(150, 'u1')
-    True
-
-    >>> np.can_cast(3.5e100, np.float32)
-    False
-    >>> np.can_cast(1000.0, np.float32)
-    True
-
-    Array scalar checks the value, array does not
-
-    >>> np.can_cast(np.array(1000.0), np.float32)
-    True
-    >>> np.can_cast(np.array([1000.0]), np.float32)
-    False
-
-    Using the casting rules
-
-    >>> np.can_cast('i8', 'i8', 'no')
-    True
-    >>> np.can_cast('<i8', '>i8', 'no')
-    False
-
-    >>> np.can_cast('<i8', '>i8', 'equiv')
-    True
-    >>> np.can_cast('<i4', '>i8', 'equiv')
-    False
-
-    >>> np.can_cast('<i4', '>i8', 'safe')
-    True
-    >>> np.can_cast('<i8', '>i4', 'safe')
-    False
-
-    >>> np.can_cast('<i8', '>i4', 'same_kind')
-    True
-    >>> np.can_cast('<i8', '>u4', 'same_kind')
-    False
-
-    >>> np.can_cast('<i8', '>u4', 'unsafe')
-    True
 
     """
     return (from_,)

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3295,7 +3295,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         NPY_ITER_READONLY | NPY_ITER_ALIGNED,
         NPY_ITER_READONLY | NPY_ITER_ALIGNED
     };
-    PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[0] + 2,
+    PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[2],
                                                     0, NULL);
     PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
                                 common_dt, common_dt};

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3252,7 +3252,7 @@ array_set_datetimeparse_function(PyObject *NPY_UNUSED(self),
 NPY_NO_EXPORT PyObject *
 PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 {
-    PyArrayObject *arr, *ax, *ay;
+    PyArrayObject *arr, *ax, *ay = NULL;
     PyObject *ret = NULL;
 
     arr = (PyArrayObject *)PyArray_FROM_O(condition);
@@ -3274,10 +3274,15 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     NPY_cast_info cast_info = {.func = NULL};
 
     ax = (PyArrayObject*)PyArray_FROM_O(x);
-    ay = (PyArrayObject*)PyArray_FROM_O(y);
-    if (ax == NULL || ay == NULL) {
+    if (ax == NULL) {
         goto fail;
     }
+    ay = (PyArrayObject*)PyArray_FROM_O(y);
+    if (ay == NULL) {
+        goto fail;
+    }
+    npy_mark_tmp_array_if_pyscalar(x, ax, NULL);
+    npy_mark_tmp_array_if_pyscalar(y, ay, NULL);
 
     npy_uint32 flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED |
                         NPY_ITER_REFS_OK | NPY_ITER_ZEROSIZE_OK;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3278,152 +3278,151 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     if (ax == NULL || ay == NULL) {
         goto fail;
     }
-    else {
-        npy_uint32 flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED |
-                           NPY_ITER_REFS_OK | NPY_ITER_ZEROSIZE_OK;
-        PyArrayObject * op_in[4] = {
-            NULL, arr, ax, ay
-        };
-        npy_uint32 op_flags[4] = {
-            NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE | NPY_ITER_NO_SUBTYPE,
-            NPY_ITER_READONLY,
-            NPY_ITER_READONLY | NPY_ITER_ALIGNED,
-            NPY_ITER_READONLY | NPY_ITER_ALIGNED
-        };
-        PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[0] + 2,
-                                                       0, NULL);
-        PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
-                                    common_dt, common_dt};
-        NpyIter * iter;
-        NPY_BEGIN_THREADS_DEF;
 
-        if (common_dt == NULL || op_dt[1] == NULL) {
-            Py_XDECREF(op_dt[1]);
-            Py_XDECREF(common_dt);
-            goto fail;
-        }
-        iter =  NpyIter_MultiNew(4, op_in, flags,
-                                 NPY_KEEPORDER, NPY_UNSAFE_CASTING,
-                                 op_flags, op_dt);
-        Py_DECREF(op_dt[1]);
-        Py_DECREF(common_dt);
-        if (iter == NULL) {
-            goto fail;
-        }
+    npy_uint32 flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED |
+                        NPY_ITER_REFS_OK | NPY_ITER_ZEROSIZE_OK;
+    PyArrayObject * op_in[4] = {
+        NULL, arr, ax, ay
+    };
+    npy_uint32 op_flags[4] = {
+        NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE | NPY_ITER_NO_SUBTYPE,
+        NPY_ITER_READONLY,
+        NPY_ITER_READONLY | NPY_ITER_ALIGNED,
+        NPY_ITER_READONLY | NPY_ITER_ALIGNED
+    };
+    PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[0] + 2,
+                                                    0, NULL);
+    PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
+                                common_dt, common_dt};
+    NpyIter * iter;
+    NPY_BEGIN_THREADS_DEF;
 
-        /* Get the result from the iterator object array */
-        ret = (PyObject*)NpyIter_GetOperandArray(iter)[0];
-
-        npy_intp itemsize = common_dt->elsize;
-
-        int has_ref = PyDataType_REFCHK(common_dt);
-
-        NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
-
-        npy_intp transfer_strides[2] = {itemsize, itemsize};
-        npy_intp one = 1;
-
-        if (has_ref || ((itemsize != 16) && (itemsize != 8) && (itemsize != 4) &&
-                        (itemsize != 2) && (itemsize != 1))) {
-            // The iterator has NPY_ITER_ALIGNED flag so no need to check alignment
-            // of the input arrays.
-            //
-            // There's also no need to set up a cast for y, since the iterator
-            // ensures both casts are identical.
-            if (PyArray_GetDTypeTransferFunction(
-                    1, itemsize, itemsize, common_dt, common_dt, 0,
-                    &cast_info, &transfer_flags) != NPY_SUCCEED) {
-                goto fail;
-            }
-        }
-
-        transfer_flags = PyArrayMethod_COMBINED_FLAGS(
-            transfer_flags, NpyIter_GetTransferFlags(iter));
-
-        if (!(transfer_flags & NPY_METH_REQUIRES_PYAPI)) {
-            NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
-        }
-
-        if (NpyIter_GetIterSize(iter) != 0) {
-            NpyIter_IterNextFunc *iternext = NpyIter_GetIterNext(iter, NULL);
-            npy_intp * innersizeptr = NpyIter_GetInnerLoopSizePtr(iter);
-            char **dataptrarray = NpyIter_GetDataPtrArray(iter);
-            npy_intp *strides = NpyIter_GetInnerStrideArray(iter);
-
-            do {
-                npy_intp n = (*innersizeptr);
-                char * dst = dataptrarray[0];
-                char * csrc = dataptrarray[1];
-                char * xsrc = dataptrarray[2];
-                char * ysrc = dataptrarray[3];
-
-                // the iterator might mutate these pointers,
-                // so need to update them every iteration
-                npy_intp cstride = strides[1];
-                npy_intp xstride = strides[2];
-                npy_intp ystride = strides[3];
-
-                /* constant sizes so compiler replaces memcpy */
-                if (!has_ref && itemsize == 16) {
-                    INNER_WHERE_LOOP(16);
-                }
-                else if (!has_ref && itemsize == 8) {
-                    INNER_WHERE_LOOP(8);
-                }
-                else if (!has_ref && itemsize == 4) {
-                    INNER_WHERE_LOOP(4);
-                }
-                else if (!has_ref && itemsize == 2) {
-                    INNER_WHERE_LOOP(2);
-                }
-                else if (!has_ref && itemsize == 1) {
-                    INNER_WHERE_LOOP(1);
-                }
-                else {
-                    npy_intp i;
-                    for (i = 0; i < n; i++) {
-                        if (*csrc) {
-                            char *args[2] = {xsrc, dst};
-
-                            if (cast_info.func(
-                                    &cast_info.context, args, &one,
-                                    transfer_strides, cast_info.auxdata) < 0) {
-                                goto fail;
-                            }
-                        }
-                        else {
-                            char *args[2] = {ysrc, dst};
-
-                            if (cast_info.func(
-                                    &cast_info.context, args, &one,
-                                    transfer_strides, cast_info.auxdata) < 0) {
-                                goto fail;
-                            }
-                        }
-                        dst += itemsize;
-                        xsrc += xstride;
-                        ysrc += ystride;
-                        csrc += cstride;
-                    }
-                }
-            } while (iternext(iter));
-        }
-
-        NPY_END_THREADS;
-
-        Py_INCREF(ret);
-        Py_DECREF(arr);
-        Py_DECREF(ax);
-        Py_DECREF(ay);
-        NPY_cast_info_xfree(&cast_info);
-
-        if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
-            Py_DECREF(ret);
-            return NULL;
-        }
-
-        return ret;
+    if (common_dt == NULL || op_dt[1] == NULL) {
+        Py_XDECREF(op_dt[1]);
+        Py_XDECREF(common_dt);
+        goto fail;
     }
+    iter =  NpyIter_MultiNew(4, op_in, flags,
+                                NPY_KEEPORDER, NPY_UNSAFE_CASTING,
+                                op_flags, op_dt);
+    Py_DECREF(op_dt[1]);
+    Py_DECREF(common_dt);
+    if (iter == NULL) {
+        goto fail;
+    }
+
+    /* Get the result from the iterator object array */
+    ret = (PyObject*)NpyIter_GetOperandArray(iter)[0];
+
+    npy_intp itemsize = common_dt->elsize;
+
+    int has_ref = PyDataType_REFCHK(common_dt);
+
+    NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
+
+    npy_intp transfer_strides[2] = {itemsize, itemsize};
+    npy_intp one = 1;
+
+    if (has_ref || ((itemsize != 16) && (itemsize != 8) && (itemsize != 4) &&
+                    (itemsize != 2) && (itemsize != 1))) {
+        // The iterator has NPY_ITER_ALIGNED flag so no need to check alignment
+        // of the input arrays.
+        //
+        // There's also no need to set up a cast for y, since the iterator
+        // ensures both casts are identical.
+        if (PyArray_GetDTypeTransferFunction(
+                1, itemsize, itemsize, common_dt, common_dt, 0,
+                &cast_info, &transfer_flags) != NPY_SUCCEED) {
+            goto fail;
+        }
+    }
+
+    transfer_flags = PyArrayMethod_COMBINED_FLAGS(
+        transfer_flags, NpyIter_GetTransferFlags(iter));
+
+    if (!(transfer_flags & NPY_METH_REQUIRES_PYAPI)) {
+        NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
+    }
+
+    if (NpyIter_GetIterSize(iter) != 0) {
+        NpyIter_IterNextFunc *iternext = NpyIter_GetIterNext(iter, NULL);
+        npy_intp * innersizeptr = NpyIter_GetInnerLoopSizePtr(iter);
+        char **dataptrarray = NpyIter_GetDataPtrArray(iter);
+        npy_intp *strides = NpyIter_GetInnerStrideArray(iter);
+
+        do {
+            npy_intp n = (*innersizeptr);
+            char * dst = dataptrarray[0];
+            char * csrc = dataptrarray[1];
+            char * xsrc = dataptrarray[2];
+            char * ysrc = dataptrarray[3];
+
+            // the iterator might mutate these pointers,
+            // so need to update them every iteration
+            npy_intp cstride = strides[1];
+            npy_intp xstride = strides[2];
+            npy_intp ystride = strides[3];
+
+            /* constant sizes so compiler replaces memcpy */
+            if (!has_ref && itemsize == 16) {
+                INNER_WHERE_LOOP(16);
+            }
+            else if (!has_ref && itemsize == 8) {
+                INNER_WHERE_LOOP(8);
+            }
+            else if (!has_ref && itemsize == 4) {
+                INNER_WHERE_LOOP(4);
+            }
+            else if (!has_ref && itemsize == 2) {
+                INNER_WHERE_LOOP(2);
+            }
+            else if (!has_ref && itemsize == 1) {
+                INNER_WHERE_LOOP(1);
+            }
+            else {
+                npy_intp i;
+                for (i = 0; i < n; i++) {
+                    if (*csrc) {
+                        char *args[2] = {xsrc, dst};
+
+                        if (cast_info.func(
+                                &cast_info.context, args, &one,
+                                transfer_strides, cast_info.auxdata) < 0) {
+                            goto fail;
+                        }
+                    }
+                    else {
+                        char *args[2] = {ysrc, dst};
+
+                        if (cast_info.func(
+                                &cast_info.context, args, &one,
+                                transfer_strides, cast_info.auxdata) < 0) {
+                            goto fail;
+                        }
+                    }
+                    dst += itemsize;
+                    xsrc += xstride;
+                    ysrc += ystride;
+                    csrc += cstride;
+                }
+            }
+        } while (iternext(iter));
+    }
+
+    NPY_END_THREADS;
+
+    Py_INCREF(ret);
+    Py_DECREF(arr);
+    Py_DECREF(ax);
+    Py_DECREF(ay);
+    NPY_cast_info_xfree(&cast_info);
+
+    if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
+        Py_DECREF(ret);
+        return NULL;
+    }
+
+    return ret;
 
 fail:
     Py_DECREF(arr);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3254,6 +3254,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 {
     PyArrayObject *arr, *ax, *ay = NULL;
     PyObject *ret = NULL;
+    PyArray_Descr *common_dt = NULL;
 
     arr = (PyArrayObject *)PyArray_FROM_O(condition);
     if (arr == NULL) {
@@ -3295,8 +3296,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         NPY_ITER_READONLY | NPY_ITER_ALIGNED,
         NPY_ITER_READONLY | NPY_ITER_ALIGNED
     };
-    PyArray_Descr * common_dt = PyArray_ResultType(2, &op_in[2],
-                                                    0, NULL);
+    common_dt = PyArray_ResultType(2, &op_in[2], 0, NULL);
     PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
                                 common_dt, common_dt};
     NpyIter * iter;
@@ -3304,14 +3304,12 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 
     if (common_dt == NULL || op_dt[1] == NULL) {
         Py_XDECREF(op_dt[1]);
-        Py_XDECREF(common_dt);
         goto fail;
     }
-    iter =  NpyIter_MultiNew(4, op_in, flags,
-                                NPY_KEEPORDER, NPY_UNSAFE_CASTING,
-                                op_flags, op_dt);
+    iter =  NpyIter_MultiNew(
+            4, op_in, flags, NPY_KEEPORDER, NPY_UNSAFE_CASTING,
+            op_flags, op_dt);
     Py_DECREF(op_dt[1]);
-    Py_DECREF(common_dt);
     if (iter == NULL) {
         goto fail;
     }
@@ -3420,6 +3418,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     Py_DECREF(arr);
     Py_DECREF(ax);
     Py_DECREF(ay);
+    Py_DECREF(common_dt);
     NPY_cast_info_xfree(&cast_info);
 
     if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
@@ -3433,6 +3432,7 @@ fail:
     Py_DECREF(arr);
     Py_XDECREF(ax);
     Py_XDECREF(ay);
+    Py_XDECREF(common_dt);
     NPY_cast_info_xfree(&cast_info);
     return NULL;
 }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3252,7 +3252,7 @@ array_set_datetimeparse_function(PyObject *NPY_UNUSED(self),
 NPY_NO_EXPORT PyObject *
 PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 {
-    PyArrayObject *arr, *ax, *ay = NULL;
+    PyArrayObject *arr = NULL, *ax = NULL, *ay = NULL;
     PyObject *ret = NULL;
     PyArray_Descr *common_dt = NULL;
 
@@ -3300,6 +3300,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     if (common_dt == NULL) {
         goto fail;
     }
+    /* `PyArray_DescrFromType` cannot fail for simple builtin types: */
     PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
                                 common_dt, common_dt};
     NpyIter * iter;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3297,15 +3297,14 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         NPY_ITER_READONLY | NPY_ITER_ALIGNED
     };
     common_dt = PyArray_ResultType(2, &op_in[2], 0, NULL);
+    if (common_dt == NULL) {
+        goto fail;
+    }
     PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL),
                                 common_dt, common_dt};
     NpyIter * iter;
     NPY_BEGIN_THREADS_DEF;
 
-    if (common_dt == NULL || op_dt[1] == NULL) {
-        Py_XDECREF(op_dt[1]);
-        goto fail;
-    }
     iter =  NpyIter_MultiNew(
             4, op_in, flags, NPY_KEEPORDER, NPY_UNSAFE_CASTING,
             op_flags, op_dt);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3502,8 +3502,15 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self),
     if (PyArray_Check(from_obj)) {
         ret = PyArray_CanCastArrayTo((PyArrayObject *)from_obj, d2, casting);
     }
-    else if (PyArray_IsScalar(from_obj, Generic) ||
-                                PyArray_IsPythonNumber(from_obj)) {
+    else if (PyArray_IsPythonNumber(from_obj)) {
+        PyErr_SetString(PyExc_TypeError,
+                "can_cast() does not support Python ints, floats, and "
+                "complex because the result used to depend on the value.\n"
+                "This change was part of adopting NEP 50, we may "
+                "explicitly allow them again in the future.");
+        goto finish;
+    }
+    else if (PyArray_IsScalar(from_obj, Generic)) {
         PyArrayObject *arr;
         arr = (PyArrayObject *)PyArray_FROM_O(from_obj);
         if (arr == NULL) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -935,6 +935,19 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
         Py_INCREF(out_op_DTypes[i]);
 
+        if (nin == 1) {
+            /*
+             * TODO: If nin == 1 we don't promote!  This has exactly the effect
+             *       that right now integers can still go to object/uint64 and
+             *       their behavior is thus unchanged for unary ufuncs (like
+             *       isnan).  This is not ideal, but pragmatic...
+             *       We should eventually have special loops for isnan and once
+             *       we do, we may just deprecate all remaining ones (e.g.
+             *       `negative(2**100)` not working as it is an object.)
+             */
+            break;
+        }
+
         if (!NPY_DT_is_legacy(out_op_DTypes[i])) {
             *allow_legacy_promotion = NPY_FALSE;
             // TODO: A subclass of int, float, complex could reach here and

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -944,6 +944,8 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
              *       We should eventually have special loops for isnan and once
              *       we do, we may just deprecate all remaining ones (e.g.
              *       `negative(2**100)` not working as it is an object.)
+             *
+             *       This is issue is part of the NEP 50 adoption.
              */
             break;
         }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1466,7 +1466,7 @@ class TestPromotion:
     @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2*100])
     def test_python_integer_promotion(self, val):
         # If we only pass scalars (mainly python ones!), NEP 50 means
-        # that we get either the default integer
+        # that we get the default integer
         expected_dtype = np.dtype(int)  # the default integer
         assert np.result_type(val, 0) == expected_dtype
         # With NEP 50, the NumPy scalar wins though:

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1465,13 +1465,12 @@ class TestPromotion:
 
     @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2*100])
     def test_python_integer_promotion(self, val):
-        # If we only path scalars (mainly python ones!), the result must take
-        # into account that the integer may be considered int32, int64, uint64,
-        # or object depending on the input value.  So test those paths!
-        expected_dtype = np.result_type(np.array(val).dtype, np.array(0).dtype)
+        # If we only pass scalars (mainly python ones!), NEP 50 means
+        # that we get either the default integer
+        expected_dtype = np.dtype(int)  # the default integer
         assert np.result_type(val, 0) == expected_dtype
-        # For completeness sake, also check with a NumPy scalar as second arg:
-        assert np.result_type(val, np.int8(0)) == expected_dtype
+        # With NEP 50, the NumPy scalar wins though:
+        assert np.result_type(val, np.int8(0)) == np.int8
 
     @pytest.mark.parametrize(["other", "expected"],
             [(1, rational), (1., np.float64)])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8707,14 +8707,9 @@ class TestConversion:
 
         # Unsigned integers
         for dt1 in 'BHILQP':
-            # NEP 50 broke comparison of unsigned with -1 for the time being
-            # (this may be fixed in the future of course).
-            with pytest.raises(OverflowError):
-                -1 < np.array(1, dtype=dt1)
-            with pytest.raises(OverflowError):
-                -1 > np.array(1, dtype=dt1)
-            with pytest.raises(OverflowError):
-                -1 != np.array(1, dtype=dt1)
+            assert_(-1 < np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1), "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1), "type %s failed" % (dt1,))
 
             # Unsigned vs signed
             for dt2 in 'bhilqp':

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8864,9 +8864,11 @@ class TestWhere:
         assert_equal(np.where(True, d, e).dtype, np.float32)
         e = float('-Infinity')
         assert_equal(np.where(True, d, e).dtype, np.float32)
-        # also check upcast
+        # With NEP 50 adopted, the float will overflow here:
         e = float(1e150)
-        assert_equal(np.where(True, d, e).dtype, np.float64)
+        with pytest.warns(RuntimeWarning, match="overflow"):
+            res = np.where(True, d, e)
+        assert res.dtype == np.float32
 
     def test_ndim(self):
         c = [True, False]

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1131,6 +1131,7 @@ def test_iter_object_arrays_conversions():
 
 def test_iter_common_dtype():
     # Check that the iterator finds a common data type correctly
+    # (some checks are somewhat duplicate after adopting NEP 50)
 
     i = nditer([array([3], dtype='f4'), array([0], dtype='f8')],
                     ['common_dtype'],
@@ -1148,14 +1149,14 @@ def test_iter_common_dtype():
                     ['common_dtype'],
                     [['readonly', 'copy']]*2,
                     casting='same_kind')
-    assert_equal(i.dtypes[0], np.dtype('f4'))
-    assert_equal(i.dtypes[1], np.dtype('f4'))
+    assert_equal(i.dtypes[0], np.dtype('f8'))
+    assert_equal(i.dtypes[1], np.dtype('f8'))
     i = nditer([array([3], dtype='u4'), array(0, dtype='i4')],
                     ['common_dtype'],
                     [['readonly', 'copy']]*2,
                     casting='safe')
-    assert_equal(i.dtypes[0], np.dtype('u4'))
-    assert_equal(i.dtypes[1], np.dtype('u4'))
+    assert_equal(i.dtypes[0], np.dtype('i8'))
+    assert_equal(i.dtypes[1], np.dtype('i8'))
     i = nditer([array([3], dtype='u4'), array(-12, dtype='i4')],
                     ['common_dtype'],
                     [['readonly', 'copy']]*2,
@@ -1554,7 +1555,8 @@ def test_iter_allocate_output_opaxes():
     assert_equal(i.operands[0].dtype, np.dtype('u4'))
 
 def test_iter_allocate_output_types_promotion():
-    # Check type promotion of automatic outputs
+    # Check type promotion of automatic outputs (this was more interesting
+    # before NEP 50...)
 
     i = nditer([array([3], dtype='f4'), array([0], dtype='f8'), None], [],
                     [['readonly']]*2+[['writeonly', 'allocate']])
@@ -1564,10 +1566,10 @@ def test_iter_allocate_output_types_promotion():
     assert_equal(i.dtypes[2], np.dtype('f8'))
     i = nditer([array([3], dtype='f4'), array(0, dtype='f8'), None], [],
                     [['readonly']]*2+[['writeonly', 'allocate']])
-    assert_equal(i.dtypes[2], np.dtype('f4'))
+    assert_equal(i.dtypes[2], np.dtype('f8'))
     i = nditer([array([3], dtype='u4'), array(0, dtype='i4'), None], [],
                     [['readonly']]*2+[['writeonly', 'allocate']])
-    assert_equal(i.dtypes[2], np.dtype('u4'))
+    assert_equal(i.dtypes[2], np.dtype('i8'))
     i = nditer([array([3], dtype='u4'), array(-12, dtype='i4'), None], [],
                     [['readonly']]*2+[['writeonly', 'allocate']])
     assert_equal(i.dtypes[2], np.dtype('i8'))

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1049,7 +1049,8 @@ class TestTypes:
         assert_equal(promote_func(f64, np.array([f32])), np.dtype(np.float64))
         assert_equal(promote_func(fld, np.array([f32])),
                      np.dtype(np.longdouble))
-        assert_equal(promote_func(np.array([f64]), fld), np.dtype(np.float64))
+        assert_equal(promote_func(np.array([f64]), fld),
+                     np.dtype(np.longdouble))
         assert_equal(promote_func(fld, np.array([c64])),
                      np.dtype(np.clongdouble))
         assert_equal(promote_func(c64, np.array([f64])),

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1421,6 +1421,8 @@ class TestTypes:
         assert_(not np.can_cast([('f0', ('i4,i4'), (2,))], 'i4',
                                 casting='unsafe'))
 
+    @pytest.mark.xfail(np._get_promotion_state() != "legacy",
+            reason="NEP 50: no int/float/complex (yet)")
     def test_can_cast_values(self):
         # gh-5917
         for dt in sctypes['int'] + sctypes['uint']:

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1039,19 +1039,24 @@ class TestTypes:
         assert_equal(promote_func(np.array([b]), u8), np.dtype(np.uint8))
         assert_equal(promote_func(np.array([b]), i32), np.dtype(np.int32))
         assert_equal(promote_func(np.array([b]), u32), np.dtype(np.uint32))
-        assert_equal(promote_func(np.array([i8]), i64), np.dtype(np.int8))
-        assert_equal(promote_func(u64, np.array([i32])), np.dtype(np.int32))
-        assert_equal(promote_func(i64, np.array([u32])), np.dtype(np.uint32))
+        assert_equal(promote_func(np.array([i8]), i64), np.dtype(np.int64))
+        # unsigned and signed unfortunately tend to promote to float64:
+        assert_equal(promote_func(u64, np.array([i32])), np.dtype(np.float64))
+        assert_equal(promote_func(i64, np.array([u32])), np.dtype(np.int64))
+        assert_equal(promote_func(np.array([u16]), i32), np.dtype(np.int32))
         assert_equal(promote_func(np.int32(-1), np.array([u64])),
                      np.dtype(np.float64))
-        assert_equal(promote_func(f64, np.array([f32])), np.dtype(np.float32))
-        assert_equal(promote_func(fld, np.array([f32])), np.dtype(np.float32))
+        assert_equal(promote_func(f64, np.array([f32])), np.dtype(np.float64))
+        assert_equal(promote_func(fld, np.array([f32])),
+                     np.dtype(np.longdouble))
         assert_equal(promote_func(np.array([f64]), fld), np.dtype(np.float64))
         assert_equal(promote_func(fld, np.array([c64])),
-                     np.dtype(np.complex64))
+                     np.dtype(np.clongdouble))
         assert_equal(promote_func(c64, np.array([f64])),
                      np.dtype(np.complex128))
         assert_equal(promote_func(np.complex64(3j), np.array([f64])),
+                     np.dtype(np.complex128))
+        assert_equal(promote_func(np.array([f32]), c128),
                      np.dtype(np.complex128))
 
         # coercion between scalars and 1-D arrays, where
@@ -1062,16 +1067,6 @@ class TestTypes:
         assert_equal(promote_func(np.array([i8]), f64), np.dtype(np.float64))
         assert_equal(promote_func(np.array([u16]), f64), np.dtype(np.float64))
 
-        # uint and int are treated as the same "kind" for
-        # the purposes of array-scalar promotion.
-        assert_equal(promote_func(np.array([u16]), i32), np.dtype(np.uint16))
-
-        # float and complex are treated as the same "kind" for
-        # the purposes of array-scalar promotion, so that you can do
-        # (0j + float32array) to get a complex64 array instead of
-        # a complex128 array.
-        assert_equal(promote_func(np.array([f32]), c128),
-                     np.dtype(np.complex64))
 
     def test_coercion(self):
         def res_type(a, b):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2600,7 +2600,7 @@ class TestClip:
     @pytest.mark.parametrize("arr, amin, amax, exp", [
         # for a bug in npy_ObjectClip, based on a
         # case produced by hypothesis
-        (np.zeros(10, dtype=np.int64),
+        (np.zeros(10, dtype=object),
          0,
          -2**64+1,
          np.full(10, -2**64+1, dtype=object)),

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1423,7 +1423,7 @@ class TestTypes:
                                 casting='unsafe'))
 
     @pytest.mark.xfail(np._get_promotion_state() != "legacy",
-            reason="NEP 50: no int/float/complex (yet)")
+            reason="NEP 50: no python int/float/complex support (yet)")
     def test_can_cast_values(self):
         # gh-5917
         for dt in sctypes['int'] + sctypes['uint']:

--- a/numpy/_core/tests/test_scalar_ctors.py
+++ b/numpy/_core/tests/test_scalar_ctors.py
@@ -78,7 +78,7 @@ class TestFromInt:
         assert_equal(1024, np.intp(1024))
 
     def test_uint64_from_negative(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(OverflowError):
             assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
 
 

--- a/numpy/_core/tests/test_scalar_ctors.py
+++ b/numpy/_core/tests/test_scalar_ctors.py
@@ -79,7 +79,7 @@ class TestFromInt:
 
     def test_uint64_from_negative(self):
         with pytest.raises(OverflowError):
-            assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
+            np.uint64(-2)
 
 
 int_types = [np.byte, np.short, np.intc, np.long, np.longlong]

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -911,31 +911,32 @@ def test_operator_scalars(op, type1, type2):
 
 
 @pytest.mark.parametrize("op", reasonable_operators_for_scalars)
-@pytest.mark.parametrize("val", [None, 2**64])
-def test_longdouble_inf_loop(op, val):
-    # Note: The 2**64 value will pass once NEP 50 is adopted.
+@pytest.mark.parametrize("sctype", [np.longdouble, np.clongdouble])
+def test_longdouble_inf_loop(sctype, op):
     try:
-        op(np.longdouble(3), val)
+        op(sctype(3), None)
     except TypeError:
         pass
     try:
-        op(val, np.longdouble(3))
+        op(None, sctype(3))
     except TypeError:
         pass
 
 
 @pytest.mark.parametrize("op", reasonable_operators_for_scalars)
-@pytest.mark.parametrize("val", [None, 2**64])
-def test_clongdouble_inf_loop(op, val):
-    # Note: The 2**64 value will pass once NEP 50 is adopted.
-    try:
-        op(np.clongdouble(3), val)
-    except TypeError:
-        pass
-    try:
-        op(val, np.longdouble(3))
-    except TypeError:
-        pass
+@pytest.mark.parametrize("sctype", [np.longdouble, np.clongdouble])
+@np.errstate(all="ignore")
+def test_longdouble_inf_loop(sctype, op):
+    # NEP 50 means that the result is clearly a (c)longdouble here:
+    if sctype == np.clongdouble and op in [operator.mod, operator.floordiv]:
+        # The above operators are not support for complex though...
+        with pytest.raises(TypeError):
+            op(sctype(3), 2**64)
+        with pytest.raises(TypeError):
+            op(sctype(3), 2**64)
+    else:
+        assert op(sctype(3), 2**64) == op(sctype(3), sctype(2**64))
+        assert op(2**64, sctype(3)) == op(sctype(2**64), sctype(3))
 
 
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -485,10 +485,8 @@ class TestConversion:
 
     def test_iinfo_long_values(self):
         for code in 'bBhH':
-            with pytest.warns(DeprecationWarning):
-                res = np.array(np.iinfo(code).max + 1, dtype=code)
-            tgt = np.iinfo(code).min
-            assert_(res == tgt)
+            with pytest.raises(OverflowError):
+                np.array(np.iinfo(code).max + 1, dtype=code)
 
         for code in np.typecodes['AllInteger']:
             res = np.array(np.iinfo(code).max, dtype=code)
@@ -560,9 +558,13 @@ class TestConversion:
 
         #Unsigned integers
         for dt1 in 'BHILQP':
-            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
-            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            # NEP 50 means the -1 is currently rejected (we may change this)
+            with pytest.raises(OverflowError):
+                -1 < np.array(1, dtype=dt1)[()]
+            with pytest.raises(OverflowError):
+                -1 > np.array(1, dtype=dt1)[()]
+            with pytest.raises(OverflowError):
+                -1 != np.array(1, dtype=dt1)[()]
 
             #unsigned vs signed
             for dt2 in 'bhilqp':

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -558,13 +558,9 @@ class TestConversion:
 
         #Unsigned integers
         for dt1 in 'BHILQP':
-            # NEP 50 means the -1 is currently rejected (we may change this)
-            with pytest.raises(OverflowError):
-                -1 < np.array(1, dtype=dt1)[()]
-            with pytest.raises(OverflowError):
-                -1 > np.array(1, dtype=dt1)[()]
-            with pytest.raises(OverflowError):
-                -1 != np.array(1, dtype=dt1)[()]
+            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
 
             #unsigned vs signed
             for dt2 in 'bhilqp':

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -942,7 +942,7 @@ def test_longdouble_operators_with_large_int(sctype, op):
         with pytest.raises(TypeError):
             op(sctype(3), 2**64)
     else:
-        assert op(sctype(3), 2**64) == op(sctype(3), sctype(2**64))
+        assert op(sctype(3), -2**64) == op(sctype(3), sctype(-2**64))
         assert op(2**64, sctype(3)) == op(sctype(2**64), sctype(3))
 
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -547,6 +547,9 @@ class TestUfunc:
         with pytest.raises(TypeError):
             np.add(np.float16(1), np.uint64(2), sig=("e", "d", None))
 
+    @pytest.mark.xfail(np._get_promotion_state() != "legacy",
+            reason="NEP 50 impl breaks casting checks when `dtype=` is used "
+                   "together with python scalars.")
     def test_use_output_signature_for_all_arguments(self):
         # Test that providing only `dtype=` or `signature=(None, None, dtype)`
         # is sufficient if falling back to a homogeneous signature works.
@@ -1887,7 +1890,7 @@ class TestUfunc:
         result = _rational_tests.test_add(a, b.astype(np.uint16), out=c)
         assert_equal(result, target)
 
-        # This path used to go into legacy promotion, but doesn't now:
+        # This scalar path used to go into legacy promotion, but doesn't now:
         result = _rational_tests.test_add(a, np.uint16(2))
         target = np.array([2, 3, 4], dtype=_rational_tests.rational)
         assert_equal(result, target)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1887,10 +1887,10 @@ class TestUfunc:
         result = _rational_tests.test_add(a, b.astype(np.uint16), out=c)
         assert_equal(result, target)
 
-        # But, it can be fooled, e.g. (use scalars, which forces legacy
-        # type resolution to kick in, which then fails):
-        with assert_raises(TypeError):
-            _rational_tests.test_add(a, np.uint16(2))
+        # This path used to go into legacy promotion, but doesn't now:
+        result = _rational_tests.test_add(a, np.uint16(2))
+        target = np.array([2, 3, 4], dtype=_rational_tests.rational)
+        assert_equal(result, target)
 
     def test_operand_flags(self):
         a = np.arange(16, dtype='l').reshape(4, 4)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -423,12 +423,12 @@ class TestComparisons:
         assert py_comp(arr, -1) == expected
         assert np_comp(arr, -1) == expected
 
-
         scalar = arr[0]
         assert isinstance(scalar, np.integer)
         # The Python operator here is mainly interesting:
         assert py_comp(scalar, -1) == expected
         assert np_comp(scalar, -1) == expected
+
 
 class TestAdd:
     def test_reduce_alignment(self):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4462,7 +4462,7 @@ def quantile(a,
 
     # Use dtype of array if possible (e.g., if q is a python int or float).
     if isinstance(q, (int, float)) and a.dtype.kind == "f":
-        q = np.asanyarray(q, dtype=np.result_type(a, q))
+        q = np.asanyarray(q, dtype=a.dtype)
     else:
         q = np.asanyarray(q)
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -348,13 +348,15 @@ def _unsigned_subtract(a, b):
     }
     dt = np.result_type(a, b)
     try:
-        dt = signed_to_unsigned[dt.type]
+        unsigned_dt = signed_to_unsigned[dt.type]
     except KeyError:
         return np.subtract(a, b, dtype=dt)
     else:
         # we know the inputs are integers, and we are deliberately casting
-        # signed to unsigned
-        return np.subtract(a, b, casting='unsafe', dtype=dt)
+        # signed to unsigned.  The input may be negative python integers so
+        # ensure we pass in arrays with the initial dtype (related to NEP 50).
+        return np.subtract(np.asarray(a, dtype=dt), np.asarray(b, dtype=dt),
+                           casting='unsafe', dtype=unsigned_dt)
 
 
 def _get_bin_edges(a, bins, range, weights):

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1376,7 +1376,8 @@ def nanpercentile(
         raise TypeError("a must be an array of real numbers")
 
     q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100)
-    q = np.asanyarray(q)  # undo any decay that the ufunc performed (see gh-13105)
+    # undo any decay that the ufunc performed (see gh-13105)
+    q = np.asanyarray(q)
     if not fnb._quantile_is_valid(q):
         raise ValueError("Percentiles must be in the range [0, 100]")
     return _nanquantile_unchecked(

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1539,7 +1539,7 @@ def nanquantile(
 
     # Use dtype of array if possible (e.g., if q is a python int or float).
     if isinstance(q, (int, float)) and a.dtype.kind == "f":
-        q = np.asanyarray(q, dtype=np.result_type(a, q))
+        q = np.asanyarray(q, dtype=a.dtype)
     else:
         q = np.asanyarray(q)
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -349,10 +349,8 @@ class TestHistogram:
 
         # previously crashed
         count, x_loc = np.histogram(arr, bins=1, range=range)
-        assert_equal(count, [1])
-
-        # gh-10322 means that the type comes from arr - this may change
-        assert_equal(x_loc.dtype, float_small)
+        assert_equal(count, [0])
+        assert_equal(x_loc.dtype, float_large)
 
     def do_precision_upper_bound(self, float_small, float_large):
         eps = np.finfo(float_large).eps
@@ -366,10 +364,9 @@ class TestHistogram:
 
         # previously crashed
         count, x_loc = np.histogram(arr, bins=1, range=range)
-        assert_equal(count, [1])
+        assert_equal(count, [0])
 
-        # gh-10322 means that the type comes from arr - this may change
-        assert_equal(x_loc.dtype, float_small)
+        assert_equal(x_loc.dtype, float_large)
 
     def do_precision(self, float_small, float_large):
         self.do_precision_lower_bound(float_small, float_large)

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -245,8 +245,10 @@ class TestGrid:
         # regression test for #16466
         grid64 = mgrid[0.1:0.33:0.1, ]
         grid32 = mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1), ]
-        assert_(grid32.dtype == np.float64)
         assert_array_almost_equal(grid64, grid32)
+        # At some point this was float64, but NEP 50 changed it:
+        assert grid32.dtype == np.float32
+        assert grid64.dtype == np.float64
 
         # different code path for single slice
         grid64 = mgrid[0.1:0.33:0.1]

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4229,7 +4229,7 @@ cdef class Generator:
             elif colors.size > 0 and not np.issubdtype(colors.dtype,
                                                        np.integer):
                 invalid_colors = True
-            elif np.any((colors < 0) | (colors > INT64_MAX)):
+            elif np.any((colors < 0) | (colors > np.int64(INT64_MAX))):
                 invalid_colors = True
         except ValueError:
             invalid_colors = True

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4229,7 +4229,7 @@ cdef class Generator:
             elif colors.size > 0 and not np.issubdtype(colors.dtype,
                                                        np.integer):
                 invalid_colors = True
-            elif np.any((colors < 0) | (colors > np.int64(INT64_MAX))):
+            elif np.any((colors < 0) | (colors > INT64_MAX)):
                 invalid_colors = True
         except ValueError:
             invalid_colors = True

--- a/numpy/typing/tests/data/fail/bitwise_ops.pyi
+++ b/numpy/typing/tests/data/fail/bitwise_ops.pyi
@@ -14,6 +14,7 @@ i | f8  # E: Unsupported operand types
 i8 ^ f8  # E: No overload variant
 u8 & f8  # E: No overload variant
 ~f8  # E: Unsupported operand type
+# TODO: Certain mixes like i4 << u8 go to float and thus should fail
 
 # mypys' error message for `NoReturn` is unfortunately pretty bad
 # TODO: Re-enable this once we add support for numerical precision for `number`s

--- a/numpy/typing/tests/data/pass/bitwise_ops.py
+++ b/numpy/typing/tests/data/pass/bitwise_ops.py
@@ -63,11 +63,11 @@ u8 | u8
 u8 ^ u8
 u8 & u8
 
-u8 << AR
-u8 >> AR
-u8 | AR
-u8 ^ AR
-u8 & AR
+i << AR
+i >> AR
+i | AR
+i ^ AR
+i & AR
 
 u4 << u4
 u4 >> u4

--- a/numpy/typing/tests/data/pass/bitwise_ops.py
+++ b/numpy/typing/tests/data/pass/bitwise_ops.py
@@ -21,6 +21,12 @@ i8 | i8
 i8 ^ i8
 i8 & i8
 
+i << AR
+i >> AR
+i | AR
+i ^ AR
+i & AR
+
 i8 << AR
 i8 >> AR
 i8 | AR
@@ -62,12 +68,6 @@ u8 >> u8
 u8 | u8
 u8 ^ u8
 u8 & u8
-
-i << AR
-i >> AR
-i | AR
-i ^ AR
-i & AR
 
 u4 << u4
 u4 >> u4


### PR DESCRIPTION
This is a WIP for discussion and visibility for switching to NEP 50 behavior by default.

As of writing, it fixes up mainly clear tests and one small hack to allow `isnan(2**100)` to pass.  That isn't perfectly clean maybe, but seems pragmatic.
(The individual commits make sense on their own)

There are some remaining tests that need fixing:
* Should `percentile(float32_arr, 30.)` return a float32 or float64 (currently it switches to float64), but we could add `np.result_type` to fix that.
  * Adding `np.result_type` isn't great, it would be nice to have something slightly cleaner.  I am not exactly sure what, though.  (A function to prep multiple arrays, something that @mdhaber would like anyway. A way to mark the array as representing a Python scalar?  But we want that to be used with caution, it would be weird to be used beyond temporaries)
* `can_cast(123, np.uint8)` isn't well defined right now.  I can live with that for the moment.
* `np.where()` doesn't do the weak-promotion, `np.concatenate()` does, so it should not be super hard to fix.
* `np.add(1., 2., dtype=np.int64)` should fail because of unsafe casting, but casting safety+scalars is still a bit of a mess.

I am not sure that all of these are easy, but will chip away.  OTOH some of these also look like things that might be OK as "known issues".

The main thing I would like is figure out `percentile`:  We won't get this right everywhere, but it would be good to know what our story is for such a function.