### PR TITLE
ENH: let zeros, empty, and empty_like accept dtype classes

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -461,7 +461,7 @@ copy_and_swap(void *dst, void *src, int itemsize, npy_intp numitems,
 
 // private helper to get a default descriptor from a
 // possibly NULL dtype, returns NULL on error, which
-// can only happen if PyAray_GetDefaultDescr errors.
+// can only happen if NPY_DT_CALL_default_descr errors.
 
 static PyArray_Descr *
 _infer_descr_from_dtype(PyArray_DTypeMeta *dtype) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2946,8 +2946,6 @@ PyArray_Empty(int nd, npy_intp const *dims, PyArray_Descr *type, int is_f_order)
     Py_XDECREF(type);
 
     if (res < 0) {
-        Py_XDECREF(dt_info.descr);
-        Py_XDECREF(dt_info.dtype);
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/ctors.h
+++ b/numpy/core/src/multiarray/ctors.h
@@ -40,7 +40,8 @@ PyArray_NewFromDescr_int(
 NPY_NO_EXPORT PyObject *
 PyArray_NewLikeArrayWithShape(
         PyArrayObject *prototype, NPY_ORDER order,
-        PyArray_Descr *dtype, int ndim, npy_intp const *dims, int subok);
+        PyArray_Descr *descr, PyArray_DTypeMeta *dtype,
+        int ndim, npy_intp const *dims, int subok);
 
 NPY_NO_EXPORT PyObject *
 PyArray_New(
@@ -133,5 +134,12 @@ byte_swap_vector(void *p, npy_intp n, int size);
 NPY_NO_EXPORT PyArrayObject *
 PyArray_SubclassWrap(PyArrayObject *arr_of_subclass, PyArrayObject *towrap);
 
+NPY_NO_EXPORT PyObject *
+PyArray_Zeros_int(int nd, npy_intp const *dims, PyArray_Descr *descr,
+                  PyArray_DTypeMeta *dtype, int is_f_order);
+
+NPY_NO_EXPORT PyObject *
+PyArray_Empty_int(int nd, npy_intp const *dims, PyArray_Descr *descr,
+                  PyArray_DTypeMeta *dtype, int is_f_order);
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_CTORS_H_ */

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2051,7 +2051,7 @@ static PyObject *
 array_empty(PyObject *NPY_UNUSED(ignored),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
-    PyArray_Descr *typecode = NULL;
+    npy_dtype_info dt_info = {NULL, NULL};
     PyArray_Dims shape = {NULL, 0};
     NPY_ORDER order = NPY_CORDER;
     npy_bool is_f_order;
@@ -2061,7 +2061,7 @@ array_empty(PyObject *NPY_UNUSED(ignored),
 
     if (npy_parse_arguments("empty", args, len_args, kwnames,
             "shape", &PyArray_IntpConverter, &shape,
-            "|dtype", &PyArray_DescrConverter, &typecode,
+            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
             "|order", &PyArray_OrderConverter, &order,
             "$like", NULL, &like,
             NULL, NULL, NULL) < 0) {
@@ -2072,7 +2072,8 @@ array_empty(PyObject *NPY_UNUSED(ignored),
         PyObject *deferred = array_implement_c_array_function_creation(
                 "empty", like, NULL, NULL, args, len_args, kwnames);
         if (deferred != Py_NotImplemented) {
-            Py_XDECREF(typecode);
+            Py_XDECREF(dt_info.descr);
+            Py_XDECREF(dt_info.dtype);
             npy_free_cache_dim_obj(shape);
             return deferred;
         }
@@ -2091,14 +2092,15 @@ array_empty(PyObject *NPY_UNUSED(ignored),
             goto fail;
     }
 
-    ret = (PyArrayObject *)PyArray_Empty(shape.len, shape.ptr,
-                                            typecode, is_f_order);
+    ret = (PyArrayObject *)PyArray_Empty_int(
+        shape.len, shape.ptr, dt_info.descr, dt_info.dtype, is_f_order);
 
     npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;
 
 fail:
-    Py_XDECREF(typecode);
+    Py_XDECREF(dt_info.descr);
+    Py_XDECREF(dt_info.dtype);
     npy_free_cache_dim_obj(shape);
     return NULL;
 }
@@ -2108,7 +2110,7 @@ array_empty_like(PyObject *NPY_UNUSED(ignored),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyArrayObject *prototype = NULL;
-    PyArray_Descr *dtype = NULL;
+    npy_dtype_info dt_info = {NULL, NULL};
     NPY_ORDER order = NPY_KEEPORDER;
     PyArrayObject *ret = NULL;
     int subok = 1;
@@ -2119,27 +2121,30 @@ array_empty_like(PyObject *NPY_UNUSED(ignored),
 
     if (npy_parse_arguments("empty_like", args, len_args, kwnames,
             "prototype", &PyArray_Converter, &prototype,
-            "|dtype", &PyArray_DescrConverter2, &dtype,
+            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
             "|order", &PyArray_OrderConverter, &order,
             "|subok", &PyArray_PythonPyIntFromInt, &subok,
             "|shape", &PyArray_OptionalIntpConverter, &shape,
             NULL, NULL, NULL) < 0) {
         goto fail;
     }
-    /* steals the reference to dtype if it's not NULL */
-    ret = (PyArrayObject *)PyArray_NewLikeArrayWithShape(prototype, order, dtype,
-                                                         shape.len, shape.ptr, subok);
+    /* steals the reference to dt_info.descr if it's not NULL */
+    ret = (PyArrayObject *)PyArray_NewLikeArrayWithShape(
+            prototype, order, dt_info.descr, dt_info.dtype,
+            shape.len, shape.ptr, subok);
     npy_free_cache_dim_obj(shape);
     if (!ret) {
         goto fail;
     }
+    Py_XDECREF(dt_info.dtype);
     Py_DECREF(prototype);
 
     return (PyObject *)ret;
 
 fail:
     Py_XDECREF(prototype);
-    Py_XDECREF(dtype);
+    Py_XDECREF(dt_info.dtype);
+    Py_XDECREF(dt_info.descr);
     return NULL;
 }
 
@@ -2255,7 +2260,7 @@ static PyObject *
 array_zeros(PyObject *NPY_UNUSED(ignored),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
-    PyArray_Descr *typecode = NULL;
+    npy_dtype_info dt_info = {NULL, NULL};
     PyArray_Dims shape = {NULL, 0};
     NPY_ORDER order = NPY_CORDER;
     npy_bool is_f_order = NPY_FALSE;
@@ -2265,11 +2270,11 @@ array_zeros(PyObject *NPY_UNUSED(ignored),
 
     if (npy_parse_arguments("zeros", args, len_args, kwnames,
             "shape", &PyArray_IntpConverter, &shape,
-            "|dtype", &PyArray_DescrConverter, &typecode,
+            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
             "|order", &PyArray_OrderConverter, &order,
             "$like", NULL, &like,
             NULL, NULL, NULL) < 0) {
-        goto fail;
+        goto finish;
     }
 
 
@@ -2277,7 +2282,8 @@ array_zeros(PyObject *NPY_UNUSED(ignored),
         PyObject *deferred = array_implement_c_array_function_creation(
                 "zeros", like, NULL, NULL, args, len_args, kwnames);
         if (deferred != Py_NotImplemented) {
-            Py_XDECREF(typecode);
+            Py_XDECREF(dt_info.descr);
+            Py_XDECREF(dt_info.dtype);
             npy_free_cache_dim_obj(shape);
             return deferred;
         }
@@ -2293,18 +2299,16 @@ array_zeros(PyObject *NPY_UNUSED(ignored),
         default:
             PyErr_SetString(PyExc_ValueError,
                             "only 'C' or 'F' order is permitted");
-            goto fail;
+            goto finish;
     }
 
-    ret = (PyArrayObject *)PyArray_Zeros(shape.len, shape.ptr,
-                                        typecode, (int) is_f_order);
+    ret = (PyArrayObject *)PyArray_Zeros_int(
+        shape.len, shape.ptr, dt_info.descr, dt_info.dtype, (int) is_f_order);
 
+finish:
     npy_free_cache_dim_obj(shape);
-    return (PyObject *)ret;
-
-fail:
-    Py_XDECREF(typecode);
-    npy_free_cache_dim_obj(shape);
+    Py_XDECREF(dt_info.descr);
+    Py_XDECREF(dt_info.dtype);
     return (PyObject *)ret;
 }
 

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -230,18 +230,18 @@ class TestSFloat:
         assert_array_equal(res.view(np.float64), expected.view(np.float64))
 
     def test_creation_class(self):
+        # passing in a dtype class should return
+        # the default descriptor
         arr1 = np.array([1., 2., 3.], dtype=SF)
         assert arr1.dtype == SF(1.)
         arr2 = np.array([1., 2., 3.], dtype=SF(1.))
         assert_array_equal(arr1.view(np.float64), arr2.view(np.float64))
+        assert arr1.dtype == arr2.dtype
 
-        # empty and zeros don't support creating arrays using
-        # a parametric dtype class
-        with pytest.raises(RuntimeError):
-            np.empty(3, dtype=SF)
-
-        with pytest.raises(RuntimeError):
-            np.zeros(3, dtype=SF)
+        assert np.empty(3, dtype=SF).dtype == SF(1.)
+        assert np.empty_like(arr1, dtype=SF).dtype == SF(1.)
+        assert np.zeros(3, dtype=SF).dtype == SF(1.)
+        assert np.zeros_like(arr1, dtype=SF).dtype == SF(1.)
 
 
 def test_type_pickle():

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -235,6 +235,14 @@ class TestSFloat:
         arr2 = np.array([1., 2., 3.], dtype=SF(1.))
         assert_array_equal(arr1.view(np.float64), arr2.view(np.float64))
 
+        # empty and zeros don't support creating arrays using
+        # a parametric dtype class
+        with pytest.raises(RuntimeError):
+            np.empty(3, dtype=SF)
+
+        with pytest.raises(RuntimeError):
+            np.zeros(3, dtype=SF)
+
 
 def test_type_pickle():
     # can't actually unpickle, but we can pickle (if in namespace)


### PR DESCRIPTION
Following on from #23404, this converts `np.empty`, `np.empty_like`, and `np.zeros` to accept dtype classes in the `dtype` argument.

`np.array` and similar can use `PyArray_AdaptDescriptorToArray` to detect the appropriate dtype for a given input array by scanning input entries. However, I think functions like `np.empty` need a dtype instance for parametric dtypes. 

For non-legacy dtypes that is trivial to implement, but I wasn't clear how to handle the legacy parametric instances, which `PyArray_ExtractDTypeAndDescriptor` will discard in favor of the dtype class. That means I can't just reject legacy parametric dtype classes, so I use the singleton instead. I don't know if that's the correct thing to do.

For what it's worth, `np.empty(.., dtype='U')` is probably pretty useless, and maybe we could deprecate it? For strings, you end up with a `U1` dtype, which is likely not what people really want if they are working with other non-empty string arrays.

Suggestions on better ways to handle legacy parametric dtypes are very welcome.