### PR TITLE
ENH: Speed up boolean indexing of flatiters

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -125,3 +125,21 @@ class IndexingStructured0D(Benchmark):
 
     def time_scalar_all(self):
         self.b['a'] = self.a['a']
+
+
+class FlatIterIndexing(Benchmark):
+    def setup(self):
+        self.a = np.ones((200, 50000))
+        self.m_all = np.repeat(True, 200 * 50000)
+        self.m_half = np.copy(self.m_all)
+        self.m_half[::2] = False
+        self.m_none = np.repeat(False, 200 * 50000)
+
+    def time_flat_bool_index_none(self):
+        self.a.flat[self.m_none]
+
+    def time_flat_bool_index_half(self):
+        self.a.flat[self.m_half]
+
+    def time_flat_bool_index_all(self):
+        self.a.flat[self.m_all]


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Speed up flatiter boolean indexing by using `count_boolean_trues`, which is faster than a manual loop. Also only copy data if the number of trues is non-zero. Both of these changes are already used by [`array_boolean_subscript`](https://github.com/numpy/numpy/blob/e75214c1bc34903e6fe0f643dae8ada02529c0d5/numpy/core/src/multiarray/mapping.c#L918).

```
       before           after         ratio
     [e75214c1]       [e9d29d00]
     <main>           <optimize_flatiter_mask>
-     23.2±0.07ms       20.3±0.2ms     0.88  bench_indexing.FlatIterIndexing.time_flat_bool_index_all
-      22.9±0.1ms       17.1±0.4ms     0.75  bench_indexing.FlatIterIndexing.time_flat_bool_index_half
-     12.0±0.02ms          355±1μs     0.03  bench_indexing.FlatIterIndexing.time_flat_bool_index_none

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```