### PR TITLE
DOC: fix DOI on badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://pypi.org/project/numpy/)
 https://anaconda.org/conda-forge/numpy)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg)](
 https://stackoverflow.com/questions/tagged/numpy)
-[![Nature Paper](https://img.shields.io/badge/DOI-10.1038%2Fs41592--019--0686--2-blue)](
+[![Nature Paper](https://img.shields.io/badge/DOI-10.1038%2Fs41586--020--2649--2-blue)](
 https://doi.org/10.1038/s41586-020-2649-2)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/numpy/numpy/badge)](https://api.securityscorecards.dev/projects/github.com/numpy/numpy)
 


### PR DESCRIPTION
The badge is showing a different DOI than the link. It's actually the DOI for SciPy on the badge 😅 

NumPy: https://www.nature.com/articles/s41586-020-2649-2
SciPy: https://www.nature.com/articles/s41592-019-0686-2
