### PR TITLE
BUG: Fixup for win64 fwrite issue

### DIFF
--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -157,7 +157,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             size = PyArray_SIZE(self);
             NPY_BEGIN_ALLOW_THREADS;
 
-#if defined(NPY_OS_WIN64)
+#if defined(_WIN64)
             /*
              * Workaround Win64 fwrite() bug. Issue gh-2256
              * The native 64 windows runtime has this issue, the above will


### PR DESCRIPTION
Backport 0f #23942.

The temporary code got a bit lost in hard to understand macros, see gh-23806.

This applies the minimal suggested fix, which is already being shipped by msys2:
https://github.com/msys2/MINGW-packages/pull/16931
