### PR TITLE
BUG: Fix NpyIter cleanup in einsum error path

### DIFF
--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -814,7 +814,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
     int *op_axes[NPY_MAXARGS];
     npy_uint32 iter_flags, op_flags[NPY_MAXARGS];
 
-    NpyIter *iter;
+    NpyIter *iter = NULL;
     sum_of_products_fn sop;
     npy_intp fixed_strides[NPY_MAXARGS];
 
@@ -1133,7 +1133,6 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
 
         iternext = NpyIter_GetIterNext(iter, NULL);
         if (iternext == NULL) {
-            NpyIter_Deallocate(iter);
             goto fail;
         }
         dataptr = NpyIter_GetDataPtrArray(iter);
@@ -1168,6 +1167,7 @@ finish:
     return ret;
 
 fail:
+    NpyIter_Deallocate(iter);
     for (iop = 0; iop < nop; ++iop) {
         Py_XDECREF(op[iop]);
     }


### PR DESCRIPTION
Backport of #23941.

`NpyIter_Dealloc` was not correctly called on error here (except in one place).  Also initialize it, since it is OK to call `NpyIter_Dealloc` with `NULL`.

---

I admit, I haven't rerun the tests yet to verify, but this seemed clear enough...

Closes gh-23939

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
