### PR TITLE
Replace a divider with a colon for _monotonicity

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -239,7 +239,7 @@ arr__monotonicity(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     npy_intp len_x;
     NPY_BEGIN_THREADS_DEF;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|_monotonicity", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:_monotonicity", kwlist,
                                      &obj_x)) {
         return NULL;
     }


### PR DESCRIPTION
This is simple adjustment for the format provided to `PyArg_ParseTupleAndKeywords` in `_monotonicity`