### PR TITLE
ENH: add copy parameter for api.reshape function

### DIFF
--- a/doc/release/upcoming_changes/23789.new_feature.rst
+++ b/doc/release/upcoming_changes/23789.new_feature.rst
@@ -1,15 +1,1 @@
 Add copy parameter for api.reshape function.
---------------------------------------------
-
-It is now possible to specify a copy parameter in the 
-Array API ``reshape`` function.
-
-.. code-block:: python
-
-   >>> import numpy.array_api as nx
-   >>> array = nx.arange(10, dtype=nx.int64)
-   >>> other = nx.reshape(array, (2, 5), copy=True)
-   >>> array[:5] = -1
-   >>> print(other)
-   [[0 1 2 3 4]
-    [5 6 7 8 9]]

--- a/doc/release/upcoming_changes/23789.new_feature.rst
+++ b/doc/release/upcoming_changes/23789.new_feature.rst
@@ -1,0 +1,15 @@
+Add copy parameter for api.reshape function.
+--------------------------------------------
+
+It is now possible to specify a copy parameter in the 
+Array API ``reshape`` function.
+
+.. code-block:: python
+
+   >>> import numpy.array_api as nx
+   >>> array = nx.arange(10, dtype=nx.int64)
+   >>> other = nx.reshape(array, (2, 5), copy=True)
+   >>> array[:5] = -1
+   >>> print(other)
+   [[0 1 2 3 4]
+    [5 6 7 8 9]]

--- a/doc/release/upcoming_changes/23789.new_feature.rst
+++ b/doc/release/upcoming_changes/23789.new_feature.rst
@@ -1,1 +1,0 @@
-Add copy parameter for api.reshape function.

--- a/numpy/array_api/_manipulation_functions.py
+++ b/numpy/array_api/_manipulation_functions.py
@@ -53,13 +53,24 @@ def permute_dims(x: Array, /, axes: Tuple[int, ...]) -> Array:
 
 
 # Note: the optional argument is called 'shape', not 'newshape'
-def reshape(x: Array, /, shape: Tuple[int, ...]) -> Array:
+def reshape(x: Array, 
+            /, 
+            shape: Tuple[int, ...],
+            *,
+            copy: Optional[Bool] = None) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.reshape <numpy.reshape>`.
 
     See its docstring for more information.
     """
-    return Array._new(np.reshape(x._array, shape))
+    if copy is False:
+        raise NotImplementedError("copy=False is not yet implemented")
+
+    data = x._array
+    if copy:
+        data = np.copy(data)
+
+    return Array._new(np.reshape(data, shape))
 
 
 def roll(

--- a/numpy/array_api/_manipulation_functions.py
+++ b/numpy/array_api/_manipulation_functions.py
@@ -63,14 +63,17 @@ def reshape(x: Array,
 
     See its docstring for more information.
     """
-    if copy is False:
-        raise NotImplementedError("copy=False is not yet implemented")
 
     data = x._array
     if copy:
         data = np.copy(data)
 
-    return Array._new(np.reshape(data, shape))
+    reshaped = np.reshape(data, shape)
+
+    if copy is False and not np.shares_memory(data, reshaped):
+        raise AttributeError("Incompatible shape for in-place modification.")
+
+    return Array._new(reshaped)
 
 
 def roll(

--- a/numpy/array_api/tests/test_manipulation_functions.py
+++ b/numpy/array_api/tests/test_manipulation_functions.py
@@ -13,11 +13,12 @@ from .._manipulation_functions import (
 
 def test_concat_errors():
     assert_raises(TypeError, lambda: concat((1, 1), axis=None))
-    assert_raises(TypeError, lambda: concat([asarray([1], dtype=int8), asarray([1], dtype=float64)]))
+    assert_raises(TypeError, lambda: concat([asarray([1], dtype=int8),
+                                             asarray([1], dtype=float64)]))
 
 
 def test_stack_errors():
-    assert_raises(TypeError, lambda: stack([asarray([1, 1], dtype=int8), 
+    assert_raises(TypeError, lambda: stack([asarray([1, 1], dtype=int8),
                                             asarray([2, 2], dtype=float64)]))
 
 

--- a/numpy/array_api/tests/test_manipulation_functions.py
+++ b/numpy/array_api/tests/test_manipulation_functions.py
@@ -23,10 +23,15 @@ def test_stack_errors():
 
 
 def test_reshape_copy():
-    a = asarray([1])
-    b = reshape(a, (1, 1), copy=True)
-    a[0] = 0
-    assert all(b[0, 0] == 1)
-    assert all(a[0] == 0)
-    assert_raises(NotImplementedError, lambda: reshape(a, (1, 1), copy=False))
+    a = asarray(np.ones((2,3)))
+    b = reshape(a, (3, 2), copy=True)
+    assert not np.shares_memory(a._array, b._array)
+    
+    a = asarray(np.ones((2,3)))
+    b = reshape(a, (3, 2), copy=False)
+    assert np.shares_memory(a._array, b._array)
+
+    a = asarray(np.ones((2,3)).T)
+    b = reshape(a, (3, 2), copy=True)
+    assert_raises(AttributeError, lambda: reshape(a, (2, 3), copy=False))
 

--- a/numpy/array_api/tests/test_manipulation_functions.py
+++ b/numpy/array_api/tests/test_manipulation_functions.py
@@ -1,0 +1,30 @@
+from numpy.testing import assert_raises
+import numpy as np
+
+from .. import all
+from .._creation_functions import asarray
+from .._dtypes import float64, int8
+from .._manipulation_functions import (
+        concat,
+        reshape,
+        stack
+)
+
+
+def test_concat_errors():
+    assert_raises(TypeError, lambda: concat((1, 1), axis=None))
+    assert_raises(TypeError, lambda: concat([asarray([1], dtype=int8), asarray([1], dtype=float64)]))
+
+
+def test_stack_errors():
+    assert_raises(TypeError, lambda: stack([asarray([1, 1], dtype=int8), asarray([2, 2], dtype=float64)]))
+
+
+def test_reshape_copy():
+    a = asarray([1])
+    b = reshape(a, (1, 1), copy=True)
+    a[0] = 0
+    assert all(b[0, 0] == 1)
+    assert all(a[0] == 0)
+    assert_raises(NotImplementedError, lambda: reshape(a, (1, 1), copy=False))
+

--- a/numpy/array_api/tests/test_manipulation_functions.py
+++ b/numpy/array_api/tests/test_manipulation_functions.py
@@ -23,15 +23,15 @@ def test_stack_errors():
 
 
 def test_reshape_copy():
-    a = asarray(np.ones((2,3)))
+    a = asarray(np.ones((2, 3)))
     b = reshape(a, (3, 2), copy=True)
     assert not np.shares_memory(a._array, b._array)
     
-    a = asarray(np.ones((2,3)))
+    a = asarray(np.ones((2, 3)))
     b = reshape(a, (3, 2), copy=False)
     assert np.shares_memory(a._array, b._array)
 
-    a = asarray(np.ones((2,3)).T)
+    a = asarray(np.ones((2, 3)).T)
     b = reshape(a, (3, 2), copy=True)
     assert_raises(AttributeError, lambda: reshape(a, (2, 3), copy=False))
 

--- a/numpy/array_api/tests/test_manipulation_functions.py
+++ b/numpy/array_api/tests/test_manipulation_functions.py
@@ -17,7 +17,8 @@ def test_concat_errors():
 
 
 def test_stack_errors():
-    assert_raises(TypeError, lambda: stack([asarray([1, 1], dtype=int8), asarray([2, 2], dtype=float64)]))
+    assert_raises(TypeError, lambda: stack([asarray([1, 1], dtype=int8), 
+                                            asarray([2, 2], dtype=float64)]))
 
 
 def test_reshape_copy():


### PR DESCRIPTION
Backport of #23789.

This adds a parameter to api.reshape to specify if data should be copied. This parameter is required so that api.reshape conforms to the standard. See #23410

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
