### PR TITLE
DOC: adding release note for 23809

### DIFF
--- a/doc/release/upcoming_changes/23809.expired.rst
+++ b/doc/release/upcoming_changes/23809.expired.rst
@@ -1,0 +1,2 @@
+* The ``np.core.umath_tests`` submodule has been removed from the public API.
+  (Deprecated in NumPy 1.15)


### PR DESCRIPTION
This was left out from https://github.com/numpy/numpy/pull/23809