### PR TITLE
BLD: update pypy in CI to latest version

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -66,7 +66,7 @@ jobs:
     if: github.event_name != 'push'
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "pypy3.9-v7.3.11"]
+        python-version: ["3.9", "3.10", "3.11", "pypy3.9-v7.3.12"]
     env:
       EXPECT_CPU_FEATURES: "SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL"
     steps:


### PR DESCRIPTION
PyPy released a new version, use it in CI. They now have python3.10, but I don't think we need an additional CI job. We could change it when we start dropping 3.9 in Oct 2023.