### PR TITLE
TEST: change subprocess call to capture stderr too

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1248,8 +1248,8 @@ def check_support_sve():
     import subprocess
     cmd = 'lscpu'
     try:
-        return "sve" in (subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            shell=True).communicate()[0]).decode('utf-8')
+        output = subprocess.run(cmd, capture_output=True, text=True)
+        return 'sve' in output.stdout
     except OSError:
         return False
 


### PR DESCRIPTION
Fixes #23954. 
We could do a little better by lazily evaluating the function instead of doing it at import, but :shrug: