### PR TITLE
MAINT: Remove references to removed functions

### DIFF
--- a/doc/source/reference/routines.err.rst
+++ b/doc/source/reference/routines.err.rst
@@ -14,12 +14,3 @@ Setting and getting error handling
    seterrcall
    geterrcall
    errstate
-
-Internal functions
-------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   seterrobj
-   geterrobj

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -158,7 +158,7 @@ def setbufsize(size):
 
     .. versionchanged:: 2.0
         The scope of setting the buffer is tied to the `np.errstate` context.
-        Exiting a ``with errstate():` will also restore the bufsize.
+        Exiting a ``with errstate():`` will also restore the bufsize.
 
     Parameters
     ----------


### PR DESCRIPTION
Some references to {get|set}errobj were not removed in #23922.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
