### PR TITLE
MAINT: Simplify codespaces conda environment activation

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,3 +11,7 @@ micromamba env create -f environment.yml --yes
 # user (same applies to `conda activate`)
 
 git submodule update --init
+
+# Enables users to activate environment without having to specify the full path
+echo "envs_dirs:
+  - /home/codespace/micromamba/envs" > /opt/conda/.condarc


### PR DESCRIPTION
With this change, users can use `conda activate numpy-dev` after the creation of the codespace, instead of having to type the full path of the micromamba environment (see https://github.com/numpy/numpy/issues/23134#issuecomment-1518081160)

[skip ci]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
