### PR TITLE
MAINT: prepare 1.25.x for further development

### DIFF
--- a/doc/source/dev/depending_on_numpy.rst
+++ b/doc/source/dev/depending_on_numpy.rst
@@ -63,8 +63,8 @@ Build-time dependency
     have to compile with the oldest version you wish to support.
     This can be done by using
     `oldest-supported-numpy <https://github.com/scipy/oldest-supported-numpy/>`__.
-    Please see the NumPy 1.24 documentation at
-    `https://numpy.org/doc/1.24/dev/depending_on_numpy.html`__.
+    Please see the `NumPy 1.24 documentation
+    <https://numpy.org/doc/1.24/dev/depending_on_numpy.html>`__.
 
 
 If a package either uses the NumPy C API directly or it uses some other tool

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
     :maxdepth: 3
 
+    1.25.1 <release/1.25.1-notes>
     1.25.0 <release/1.25.0-notes>
     1.24.3 <release/1.24.3-notes>
     1.24.2 <release/1.24.2-notes>

--- a/doc/source/release/1.25.1-notes.rst
+++ b/doc/source/release/1.25.1-notes.rst
@@ -1,0 +1,15 @@
+.. currentmodule:: numpy
+
+==========================
+NumPy 1.25.1 Release Notes
+==========================
+NumPy 1.25.1 is a maintenance release that fixes bugs and regressions discovered after the
+1.25.0 release. The Python versions supported by this release are 3.9-3.11.
+
+Contributors
+============
+
+
+Pull requests merged
+====================
+

--- a/pavement.py
+++ b/pavement.py
@@ -38,7 +38,7 @@ from paver.easy import Bunch, options, task, sh
 #-----------------------------------
 
 # Path to the release notes
-RELEASE_NOTES = 'doc/source/release/1.25.0-notes.rst'
+RELEASE_NOTES = 'doc/source/release/1.25.1-notes.rst'
 
 
 #-------------------------------------------------------


### PR DESCRIPTION
Prepare 1.25.x for 1.25.1 development.

- Create doc/source/release/1.25.1-notes.rst
- Update doc/source/release.rst
- Update pavement.py
- Fix markup bug in doc/source/dev/depending_on_numpy.rst

[skip ci]
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
