### PR TITLE
BUG: Fix private procedures in `f2py` modules

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2180,7 +2180,11 @@ def analyzebody(block, args, tab=''):
 
     setmesstext(block)
 
-    maybe_private = {key: value for key, value in block['vars'].items() if 'attrspec' not in value or 'public' not in value['attrspec']}
+    maybe_private = {
+        key: value
+        for key, value in block['vars'].items()
+        if 'attrspec' not in value or 'public' not in value['attrspec']
+    }
 
     body = []
     for b in block['body']:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2180,10 +2180,7 @@ def analyzebody(block, args, tab=''):
 
     setmesstext(block)
 
-    # Add private members to skipfuncs
-    # Fixes gh-23879
-    private_vars = {key: value for key, value in block['vars'].items() if 'attrspec' not in value or 'public' not in value['attrspec']}
-    skipfuncs.extend(private_vars.keys())
+    maybe_private = {key: value for key, value in block['vars'].items() if 'attrspec' not in value or 'public' not in value['attrspec']}
 
     body = []
     for b in block['body']:
@@ -2193,6 +2190,9 @@ def analyzebody(block, args, tab=''):
                 continue
             else:
                 as_ = b['args']
+            # Add private members to skipfuncs for gh-23879
+            if b['name'] in maybe_private.keys():
+                skipfuncs.append(b['name'])
             if b['name'] in skipfuncs:
                 continue
             if onlyfuncs and b['name'] not in onlyfuncs:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2179,6 +2179,12 @@ def analyzebody(block, args, tab=''):
     global usermodules, skipfuncs, onlyfuncs, f90modulevars
 
     setmesstext(block)
+
+    # Add private members to skipfuncs
+    # Fixes gh-23879
+    private_vars = {key: value for key, value in block['vars'].items() if 'attrspec' not in value or 'public' not in value['attrspec']}
+    skipfuncs.extend(private_vars.keys())
+
     body = []
     for b in block['body']:
         b['parent_block'] = block

--- a/numpy/f2py/tests/src/crackfortran/gh23879.f90
+++ b/numpy/f2py/tests/src/crackfortran/gh23879.f90
@@ -1,0 +1,20 @@
+module gh23879
+    implicit none
+    private
+    public :: foo
+
+ contains
+
+    subroutine foo(a, b)
+       integer, intent(in) :: a
+       integer, intent(out) :: b
+       b = a
+       call bar(b)
+    end subroutine
+
+    subroutine bar(x)
+        integer, intent(inout) :: x
+        x = 2*x
+     end subroutine
+
+ end module gh23879

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -188,9 +188,6 @@ class TestDimSpec(util.F2PyTest):
         ! the value of n is computed in f2py wrapper
         !f2py intent(out) n
         integer, dimension({dimspec}), intent(in) :: a
-        if (a({first}).gt.0) then
-          print*, "a=", a
-        endif
       end subroutine
     """)
 

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -57,6 +57,12 @@ class TestPublicPrivate:
         assert set(tt['b_']['attrspec']) == {'public', 'bind(c)'}
         assert set(tt['c']['attrspec']) == {'public'}
 
+    def test_nowrap_private_proceedures(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh23879.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        pyf = crackfortran.crack2fortran(mod)
+        assert 'bar' not in pyf
 
 class TestModuleProcedure():
     def test_moduleOperators(self, tmp_path):


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes #23879. As far as `f2py` is concerned, `private` procedures are equivalent to `skipfuncs`.

One nit about this is that `skipfuncs` is a global variable, one of a few `f2py` uses, and would eventually need to be reworked (but that's a different discussion).