### PR TITLE
MAINT: pipes.quote → shlex.quote

### DIFF
--- a/numpy/distutils/_shell_utils.py
+++ b/numpy/distutils/_shell_utils.py
@@ -5,10 +5,6 @@ parameters provided in config files.
 import os
 import shlex
 import subprocess
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
 
 __all__ = ['WindowsParser', 'PosixParser', 'NativeParser']
 
@@ -78,7 +74,7 @@ class PosixParser:
     """
     @staticmethod
     def join(argv):
-        return ' '.join(quote(arg) for arg in argv)
+        return ' '.join(shlex.quote(arg) for arg in argv)
 
     @staticmethod
     def split(cmd):


### PR DESCRIPTION
`pipes.quote` has long been deprecated, according to the [`pipes.quote`](https://docs.python.org/2.7/library/pipes.html#pipes.quote) documentation from Python 2.7.15:
> _Deprecated since version 2.7:_ Prior to Python 2.7, this function was not publicly documented. It is finally exposed publicly in Python 3.3 as the `quote` function in the [`shlex`](https://docs.python.org/2.7/library/shlex.html#module-shlex) module.

and the [`pipes`](https://docs.python.org/3.11/library/pipes.html) documentation from Python 3.11:
> _Deprecated since version 3.11, will be removed in version 3.13:_ The [`pipes`](https://docs.python.org/3.11/library/pipes.html#module-pipes) module is deprecated (see [**PEP 594**](https://peps.python.org/pep-0594/#pipes) for details). Please use the [`subprocess`](https://docs.python.org/3.11/library/subprocess.html#module-subprocess) module instead.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
