### PR TITLE
BLD: change file extension for installed static libraries back to `.lib`

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -537,6 +537,8 @@ npymath_lib = static_library('npymath',
   dependencies: py_dep,
   install: true,
   install_dir: np_dir / 'core/lib',
+  name_prefix: name_prefix_staticlib,
+  name_suffix: name_suffix_staticlib,
 )
 
 dir_separator = '/'

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -22,6 +22,18 @@ if is_mingw
   add_project_arguments('-D__USE_MINGW_ANSI_STDIO=1', language: ['c', 'cpp'])
 endif
 
+# We install libnpymath and libnpyrandom; ensure they're using a `.lib` rather
+# than a `.a` file extension in order not to break including them in a
+# distutils-based build (see gh-23981 and
+# https://mesonbuild.com/FAQ.html#why-does-building-my-project-with-msvc-output-static-libraries-called-libfooa)
+if is_windows and cc.get_id() == 'msvc'
+  name_prefix_staticlib = ''
+  name_suffix_staticlib = 'lib'
+else
+  name_prefix_staticlib = []
+  name_suffix_staticlib = []
+endif
+
 # Enable UNIX large file support on 32-bit systems (64 bit off_t,
 # lseek -> lseek64, etc.)
 cflags_large_file_support = []

--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -15,6 +15,8 @@ npyrandom_lib = static_library('npyrandom',
   dependencies: [py_dep, np_core_dep],
   install: true,
   install_dir: np_dir / 'random/lib',
+  name_prefix: name_prefix_staticlib,
+  name_suffix: name_suffix_staticlib,
 )
 
 # Build Cython extensions for numpy.random

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.distutils.misc_util import exec_mod_from_location
 from numpy.testing import IS_WASM
 
-IS_WINDOWS = os.name == "nt"
 
 try:
     import cffi
@@ -46,7 +45,6 @@ else:
         cython = None
 
 
-@pytest.mark.xfail(IS_WINDOWS, reason="Wheel builds are missing npyrandom.lib")
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")
 @pytest.mark.slow


### PR DESCRIPTION
This fixes the `test_cython` failure mentioned in gh-23981.