### PR TITLE
Revert "TST: disable longdouble string/print tests on Linux aarch64"

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,4 +1,3 @@
-import platform
 import sys
 import gc
 from hypothesis import given
@@ -162,8 +161,6 @@ class TestArrayRepr:
 
 
 class TestComplexArray:
-    @pytest.mark.xfail(platform.machine() == 'aarch64',
-                       reason="Failing on Meson build, see gh-23974")
     def test_str(self):
         rvals = [0, 1, -1, np.inf, -np.inf, np.nan]
         cvals = [complex(rp, ip) for rp in rvals for ip in rvals]

--- a/numpy/core/tests/test_longdouble.py
+++ b/numpy/core/tests/test_longdouble.py
@@ -33,8 +33,6 @@ repr_precision = len(repr(np.longdouble(0.1)))
 # +2 from macro block starting around line 842 in scalartypes.c.src.
 
 
-@pytest.mark.xfail(platform.machine() == 'aarch64',
-                   reason="Failing on Meson build, see gh-23974")
 @pytest.mark.skipif(IS_MUSL,
                     reason="test flaky on musllinux")
 @pytest.mark.skipif(LD_INFO.precision + 2 >= repr_precision,

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -1,5 +1,4 @@
 import sys
-import platform
 
 import pytest
 
@@ -13,14 +12,7 @@ from io import StringIO
 _REF = {np.inf: 'inf', -np.inf: '-inf', np.nan: 'nan'}
 
 
-# longdouble printing issue on aarch64, see gh-23974
-if platform.machine() == 'aarch64':
-    _real_dtypes = [np.float32, np.double]
-    _complex_dtypes = [np.complex64, np.cdouble]
-else:
-    _real_dtypes = [np.float32, np.double, np.longdouble]
-    _complex_dtypes = [np.complex64, np.cdouble, np.clongdouble]
-@pytest.mark.parametrize('tp', _real_dtypes)
+@pytest.mark.parametrize('tp', [np.float32, np.double, np.longdouble])
 def test_float_types(tp):
     """ Check formatting.
 
@@ -42,7 +34,7 @@ def test_float_types(tp):
                      err_msg='Failed str formatting for type %s' % tp)
 
 
-@pytest.mark.parametrize('tp', _real_dtypes)
+@pytest.mark.parametrize('tp', [np.float32, np.double, np.longdouble])
 def test_nan_inf_float(tp):
     """ Check formatting of nan & inf.
 
@@ -56,7 +48,7 @@ def test_nan_inf_float(tp):
                      err_msg='Failed str formatting for type %s' % tp)
 
 
-@pytest.mark.parametrize('tp', _complex_dtypes)
+@pytest.mark.parametrize('tp', [np.complex64, np.cdouble, np.clongdouble])
 def test_complex_types(tp):
     """Check formatting of complex types.
 
@@ -82,7 +74,7 @@ def test_complex_types(tp):
                      err_msg='Failed str formatting for type %s' % tp)
 
 
-@pytest.mark.parametrize('dtype', _complex_dtypes)
+@pytest.mark.parametrize('dtype', [np.complex64, np.cdouble, np.clongdouble])
 def test_complex_inf_nan(dtype):
     """Check inf/nan formatting of complex types."""
     TESTS = {
@@ -127,7 +119,7 @@ def _test_redirected_print(x, tp, ref=None):
                  err_msg='print failed for type%s' % tp)
 
 
-@pytest.mark.parametrize('tp', _real_dtypes)
+@pytest.mark.parametrize('tp', [np.float32, np.double, np.longdouble])
 def test_float_type_print(tp):
     """Check formatting when using print """
     for x in [0, 1, -1, 1e20]:
@@ -143,7 +135,7 @@ def test_float_type_print(tp):
         _test_redirected_print(float(1e16), tp, ref)
 
 
-@pytest.mark.parametrize('tp', _complex_dtypes)
+@pytest.mark.parametrize('tp', [np.complex64, np.cdouble, np.clongdouble])
 def test_complex_type_print(tp):
     """Check formatting when using print """
     # We do not create complex with inf/nan directly because the feature is

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -13,11 +13,7 @@ from numpy.testing import assert_, assert_equal, assert_raises, IS_MUSL
 class TestRealScalars:
     def test_str(self):
         svals = [0.0, -0.0, 1, -1, np.inf, -np.inf, np.nan]
-        # longdouble printing issue on aarch64, see gh-23974
-        if platform.machine() == 'aarch64':
-            styps = [np.float16, np.float32, np.float64]
-        else:
-            styps = [np.float16, np.float32, np.float64, np.longdouble]
+        styps = [np.float16, np.float32, np.float64, np.longdouble]
         wanted = [
              ['0.0',  '0.0',  '0.0',  '0.0' ],
              ['-0.0', '-0.0', '-0.0', '-0.0'],
@@ -267,9 +263,7 @@ class TestRealScalars:
     def test_dragon4_interface(self):
         tps = [np.float16, np.float32, np.float64]
         # test is flaky for musllinux on np.float128
-        # also currently failing on Linux aarch64 with Meson (see gh-23974)
-        is_aarch64 = platform.machine() == 'aarch64'
-        if hasattr(np, 'float128') and not IS_MUSL and not is_aarch64:
+        if hasattr(np, 'float128') and not IS_MUSL:
             tps.append(np.float128)
 
         fpos = np.format_float_positional

--- a/numpy/core/tests/test_strings.py
+++ b/numpy/core/tests/test_strings.py
@@ -1,6 +1,5 @@
 import pytest
 
-import platform
 import operator
 import numpy as np
 
@@ -89,9 +88,6 @@ def test_string_comparisons_empty(op, ufunc, sym, dtypes):
 @pytest.mark.parametrize("str_dt", ["S", "U"])
 @pytest.mark.parametrize("float_dt", np.typecodes["AllFloat"])
 def test_float_to_string_cast(str_dt, float_dt):
-    if platform.machine() == 'aarch64' and float_dt == 'g':
-        pytest.xfail("string repr issues with longdouble, see gh-23974")
-
     float_dt = np.dtype(float_dt)
     fi = np.finfo(float_dt)
     arr = np.array([np.nan, np.inf, -np.inf, fi.max, fi.min], dtype=float_dt)


### PR DESCRIPTION
This reverts commit 79484648894c974f68b5bf1624ce1548b13eaabb.

[skip actions] [skip circle] [skip azp]

This may pass now that `long double` format detection is fixed.

Closes gh-23974