### PR TITLE
DOC: Fix np.vectorize Doc

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2266,6 +2266,7 @@ class vectorize:
 
     Decorator syntax is supported.  The decorator can be called as
     a function to provide keyword arguments.
+
     >>> @np.vectorize
     ... def identity(x):
     ...     return x

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2266,17 +2266,17 @@ class vectorize:
 
     Decorator syntax is supported.  The decorator can be called as
     a function to provide keyword arguments.
-    >>>@np.vectorize
-    ...def identity(x):
+    >>> @np.vectorize
+    ... def identity(x):
     ...    return x
     ...
-    >>>identity([0, 1, 2])
+    >>> identity([0, 1, 2])
     array([0, 1, 2])
-    >>>@np.vectorize(otypes=[float])
-    ...def as_float(x):
+    >>> @np.vectorize(otypes=[float])
+    ... def as_float(x):
     ...    return x
     ...
-    >>>as_float([0, 1, 2])
+    >>> as_float([0, 1, 2])
     array([0., 1., 2.])
     """
     def __init__(self, pyfunc=np._NoValue, otypes=None, doc=None,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2268,13 +2268,13 @@ class vectorize:
     a function to provide keyword arguments.
     >>> @np.vectorize
     ... def identity(x):
-    ...    return x
+    ...     return x
     ...
     >>> identity([0, 1, 2])
     array([0, 1, 2])
     >>> @np.vectorize(otypes=[float])
     ... def as_float(x):
-    ...    return x
+    ...     return x
     ...
     >>> as_float([0, 1, 2])
     array([0., 1., 2.])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
version `1.25.0` will cause the following snippet error:
```python
from doctest import DocTestFinder
import numpy as np
finder = DocTestFinder(verbose=True, recurse=False)

finder.find(np.vectorize, "vectorize")
```
Error Message:
```
ValueError: line 154 of the docstring for vectorize lacks blank after >>>: '>>>@np.vectorize'
```
