### PR TITLE
MAINT: Do not use ``--side-by-side`` choco option

### DIFF
--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -16,7 +16,7 @@ steps:
 - powershell: |
     # Note that rtools 42+ does not support 32 bits builds. We dropped testing
     # those, but if there's a need to go back on that, use version 4.0.0.20220206
-    choco install --confirm --no-progress --side-by-side rtools --version=4.3.5550
+    choco install --confirm --no-progress --allow-downgrade rtools --version=4.3.5550
     choco install unzip -y
     choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
     echo "##vso[task.setvariable variable=RTOOLS43_HOME]c:\rtools43"


### PR DESCRIPTION
The `--side-by-side` option is deprecated, use `--allow-downgrade` instead.

This is a regression that I suspect crept in with the meson work.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
