### PR TITLE
BUG: Fix reduction ``return NULL`` to be ``goto fail``

### DIFF
--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -366,7 +366,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
                     "reduction operation '%s' does not have an identity, "
                     "so to use a where mask one has to specify 'initial'",
                     funcname);
-            return NULL;
+            goto fail;
         }
 
         /*


### PR DESCRIPTION
This should clearly have been a cleanup.

Closes gh-24003

---

I think the following failure I mentioned is just valgrind late detecting some indirect losses with a delay for whatever reason, since it shouldn't even alloc an iterator.