### PR TITLE
DOC: adding examples to ``any`` method of multi-dimensional array

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2414,7 +2414,8 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     >>> np.any(a, axis=1)
     array([ True,  True,  True])
 
-    >>> a = np.array([[[1, 0, 0], [1, 0, 0]], [[0, 0, 1], [0, 0, 1]]], dtype=bool)
+    >>> a = np.array([[[1, 0, 0], [1, 0, 0]],
+                      [[0, 0, 1], [0, 0, 1]]], dtype=bool)
     >>> a
     array([[[ True, False, False],
             [ True, False, False]],

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2397,7 +2397,31 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
 
     >>> np.any([[True, False], [False, False]], where=[[False], [True]])
     False
+    >>> np.any([[[True, False], [True, True]],
+    ...          [[False, False], [False, False]],
+    ...          [[True, True], [False, True]]])
+    True
 
+    >>> np.any([[[True, False], [True, True]],
+    ...          [[False, False], [False, False]],
+    ...          [[True, True], [False, True]]], axis=0)
+    array([[True, True],
+           [True, True]])
+
+    >>> np.any([[[True, False], [True, True]],
+    ...          [[False, False], [False, False]],
+    ...          [[True, True], [False, True]]], axis=1)
+    array([[ True,  True],
+           [False, False],
+           [ True,  True]])
+
+    >>> np.any([[[True, False], [True, True]],
+    ...          [[False, False], [False, False]],
+    ...          [[True, True], [False, True]]], axis=2)
+    array([[ True,  True],
+           [False, False],
+           [ True,  True]])
+    
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)
     >>> z, o
@@ -3813,11 +3837,22 @@ def round_(a, decimals=0, out=None):
         ``round_`` is deprecated as of NumPy 1.25.0, and will be
         removed in NumPy 2.0. Please use `round` instead.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> np.round(56294995342131.5, 3)
+    56294995342131.51
+    >>> round(56294995342131.5, 3)
+    56294995342131.5
+    >>> np.round(16.055, 2), round(16.055, 2)  # equals 16.0549999999999997
+    (16.06, 16.05)
+
     See Also
     --------
     around : equivalent function; see for details.
     """
     return around(a, decimals=decimals, out=out)
+
 
 
 def _product_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2421,6 +2421,20 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     array([[ True,  True],
            [False, False],
            [ True,  True]])
+
+    Examples of using numpy.any with different data types.
+
+    Example 1: Integer array
+    >>> np.any([[0, 0, 0], [0, 0, 0]])
+    False
+
+    Example 2: Float array
+    >>> np.any([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    False
+
+    Example 3: Mixed integer and float array
+    >>> np.any([[0, 0, 0], [0.0, 0.0, 0.0]])
+    False
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2437,28 +2437,16 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     False
 
     Example 4: boolean array
-     >>> a = np.array([[1, 0, 0],
-    ...               [1, 0, 0],
-    ...               [0, 0, 1]], dtype=bool)
-    >>> a
-    array([[ True, False, False],
-           [ True, False, False],
-           [False, False,  True]])
 
-    The input array `a` represents a boolean array 
-    where `1` stands for `True` and `0` stands for `False`.
-
-    >>> np.any(a, axis=0)
+    >>> np.any([[1, 0, 0],
+    ...          [1, 0, 0],
+    ...          [0, 0, 1]], axis=0)
     array([ True, False,  True])
-    
-    Applying `np.any` along `axis=0` checks if there
-    is any `True` value in each column.
 
-    >>> np.any(a, axis=1)
+    >>> np.any([[1, 0, 0],
+    ...          [1, 0, 0],
+    ...          [0, 0, 1]], axis=1)
     array([ True,  True,  True])
-
-    Applying `np.any` along `axis=1` checks if there is
-    any `True` value in each row.
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3837,16 +3837,6 @@ def round_(a, decimals=0, out=None):
         ``round_`` is deprecated as of NumPy 1.25.0, and will be
         removed in NumPy 2.0. Please use `round` instead.
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.round(56294995342131.5, 3)
-    56294995342131.51
-    >>> round(56294995342131.5, 3)
-    56294995342131.5
-    >>> np.round(16.055, 2), round(16.055, 2)  # equals 16.0549999999999997
-    (16.06, 16.05)
-
     See Also
     --------
     around : equivalent function; see for details.

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2397,56 +2397,39 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
 
     >>> np.any([[True, False], [False, False]], where=[[False], [True]])
     False
-    >>> np.any([[[True, False], [True, True]],
-    ...          [[False, False], [False, False]],
-    ...          [[True, True], [False, True]]])
+
+    >>> a = np.array([1, 0, 1], dtype=bool)
+    >>> a
+    array([ True False  True])
+    >>> np.any(a)
     True
 
-    >>> np.any([[[True, False], [True, True]],
-    ...          [[False, False], [False, False]],
-    ...          [[True, True], [False, True]]], axis=0)
-    array([[True, True],
-           [True, True]])
-
-    >>> np.any([[[True, False], [True, True]],
-    ...          [[False, False], [False, False]],
-    ...          [[True, True], [False, True]]], axis=1)
-    array([[ True,  True],
-           [False, False],
-           [ True,  True]])
-
-    >>> np.any([[[True, False], [True, True]],
-    ...          [[False, False], [False, False]],
-    ...          [[True, True], [False, True]]], axis=2)
-    array([[ True,  True],
-           [False, False],
-           [ True,  True]])
-
-    Examples of using numpy.any with different data types.
-
-    Example 1: Integer array
-    >>> np.any([[0, 0, 0], [0, 0, 0]])
-    False
-
-    Example 2: Float array
-    >>> np.any([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
-    False
-
-    Example 3: Mixed integer and float array
-    >>> np.any([[0, 0, 0], [0.0, 0.0, 0.0]])
-    False
-
-    Example 4: boolean array
-
-    >>> np.any([[1, 0, 0],
-    ...          [1, 0, 0],
-    ...          [0, 0, 1]], axis=0)
+    >>> a = np.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]], dtype=bool)
+    >>> a
+    array([[ True, False, False],
+           [ True, False, False],
+           [False, False,  True]])
+    >>> np.any(a, axis=0)
     array([ True, False,  True])
-
-    >>> np.any([[1, 0, 0],
-    ...          [1, 0, 0],
-    ...          [0, 0, 1]], axis=1)
+    >>> np.any(a, axis=1)
     array([ True,  True,  True])
+
+    >>> a = np.array([[[1, 0, 0], [1, 0, 0]], [[0, 0, 1], [0, 0, 1]]], dtype=bool)
+    >>> a
+    array([[[ True, False, False],
+            [ True, False, False]],
+
+           [[False, False,  True],
+            [False, False,  True]]])
+    >>> np.any(a, axis = 0)
+    array([[ True False  True]
+           [ True False  True]])
+    >>> np.any(a, axis = 1)
+    array([[ True False False]
+           [False False  True]])
+    >>> np.any(a, axis = 2)
+    array([[ True  True]
+           [ True  True]])
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2435,6 +2435,27 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     Example 3: Mixed integer and float array
     >>> np.any([[0, 0, 0], [0.0, 0.0, 0.0]])
     False
+
+    Example 4: boolean array
+     >>> a = np.array([[1, 0, 0],
+    ...               [1, 0, 0],
+    ...               [0, 0, 1]], dtype=bool)
+    >>> a
+    array([[ True, False, False],
+           [ True, False, False],
+           [False, False,  True]])
+
+    The input array `a` represents a boolean array where `1` stands for `True` and `0` stands for `False`.
+
+    >>> np.any(a, axis=0)
+    array([ True, False,  True])
+
+    Applying `np.any` along `axis=0` checks if there is any `True` value in each column.
+
+    >>> np.any(a, axis=1)
+    array([ True,  True,  True])
+
+    Applying `np.any` along `axis=1` checks if there is any `True` value in each row.
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2400,7 +2400,7 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
 
     >>> a = np.array([1, 0, 1], dtype=bool)
     >>> a
-    array([ True False  True])
+    array([ True, False,  True])
     >>> np.any(a)
     True
 
@@ -2423,14 +2423,14 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
            [[False, False,  True],
             [False, False,  True]]])
     >>> np.any(a, axis = 0)
-    array([[ True False  True]
-           [ True False  True]])
+    array([[ True, False,  True],
+           [ True, False,  True]])
     >>> np.any(a, axis = 1)
-    array([[ True False False]
-           [False False  True]])
+    array([[ True, False, False],
+           [False, False,  True]])
     >>> np.any(a, axis = 2)
-    array([[ True  True]
-           [ True  True]])
+    array([[ True,  True],
+           [ True,  True]])
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2398,39 +2398,38 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     >>> np.any([[True, False], [False, False]], where=[[False], [True]])
     False
 
-    >>> a = np.array([1, 0, 1], dtype=bool)
-    >>> a
+    >>> a1 = np.array([1, 0, 1], dtype=bool)
+    >>> a1
     array([ True, False,  True])
-    >>> np.any(a)
+    >>> np.any(a1)
     True
 
-    >>> a = np.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]], dtype=bool)
-    >>> a
+    >>> a2 = np.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]], dtype=bool)
+    >>> a2
     array([[ True, False, False],
-           [ True, False, False],
-           [False, False,  True]])
-    >>> np.any(a, axis=0)
+    ...    [ True, False, False],
+    ...    [False, False,  True]])
+    >>> np.any(a2, axis=0)
     array([ True, False,  True])
-    >>> np.any(a, axis=1)
+    >>> np.any(a2, axis=1)
     array([ True,  True,  True])
 
-    >>> a = np.array([[[1, 0, 0], [1, 0, 0]],
-                      [[0, 0, 1], [0, 0, 1]]], dtype=bool)
-    >>> a
+    >>> a3 = np.array([[[1, 0, 0], [1, 0, 0]],
+    ...                 [[0, 0, 1], [0, 0, 1]]], dtype=bool)
+    >>> a3
     array([[[ True, False, False],
-            [ True, False, False]],
-
-           [[False, False,  True],
-            [False, False,  True]]])
-    >>> np.any(a, axis = 0)
+    ...     [ True, False, False]],
+    ...     [[False, False,  True],
+    ...     [False, False,  True]]])
+    >>> np.any(a3, axis = 0)
     array([[ True, False,  True],
-           [ True, False,  True]])
-    >>> np.any(a, axis = 1)
+    ...    [ True, False,  True]])
+    >>> np.any(a3, axis = 1)
     array([[ True, False, False],
-           [False, False,  True]])
-    >>> np.any(a, axis = 2)
+    ...    [False, False,  True]])
+    >>> np.any(a3, axis = 2)
     array([[ True,  True],
-           [ True,  True]])
+    ...    [ True,  True]])
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2445,17 +2445,20 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
            [ True, False, False],
            [False, False,  True]])
 
-    The input array `a` represents a boolean array where `1` stands for `True` and `0` stands for `False`.
+    The input array `a` represents a boolean array 
+    where `1` stands for `True` and `0` stands for `False`.
 
     >>> np.any(a, axis=0)
     array([ True, False,  True])
-
-    Applying `np.any` along `axis=0` checks if there is any `True` value in each column.
+    
+    Applying `np.any` along `axis=0` checks if there
+    is any `True` value in each column.
 
     >>> np.any(a, axis=1)
     array([ True,  True,  True])
 
-    Applying `np.any` along `axis=1` checks if there is any `True` value in each row.
+    Applying `np.any` along `axis=1` checks if there is
+    any `True` value in each row.
     
     >>> o=np.array(False)
     >>> z=np.any([-1, 4, 5], out=o)

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3844,7 +3844,6 @@ def round_(a, decimals=0, out=None):
     return around(a, decimals=decimals, out=out)
 
 
-
 def _product_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
                         initial=None, where=None):
     # 2023-03-02, 1.25.0


### PR DESCRIPTION
This PR solves issue(#22266) of missing examples of `any` method in `fromnumeric.py` by adding examples. These examples have a 3D(3x2) array example, with; without axis, axis=0, axis=1 and axis=2.    
Other examples are about use of different datatypes: 
1. Integer, float and mixed 2D array.
2.  int to bool conversion of 2D array(3x3). This example will show how any method works with `0` and `1`.
