### PR TITLE
BUG: Make errstate decorator compatible with threading

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -7,7 +7,6 @@ import datetime as dt
 import enum
 from abc import abstractmethod
 from types import TracebackType, MappingProxyType, GenericAlias
-from contextlib import ContextDecorator
 from contextlib import contextmanager
 
 from numpy._pytesttester import PytestTester
@@ -3321,11 +3320,7 @@ class RankWarning(UserWarning): ...
 
 _CallType = TypeVar("_CallType", bound=_ErrFunc | _SupportsWrite[str])
 
-class errstate(Generic[_CallType], ContextDecorator):
-    call: _CallType
-    kwargs: _ErrDictOptional
-
-    # Expand `**kwargs` into explicit keyword-only arguments
+class errstate(Generic[_CallType]):
     def __init__(
         self,
         *,
@@ -3344,6 +3339,7 @@ class errstate(Generic[_CallType], ContextDecorator):
         traceback: None | TracebackType,
         /,
     ) -> None: ...
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]: ...
 
 @contextmanager
 def _no_nep50_warning() -> Generator[None, None, None]: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3318,9 +3318,9 @@ class _CopyMode(enum.Enum):
 # Warnings
 class RankWarning(UserWarning): ...
 
-_CallType = TypeVar("_CallType", bound=_ErrFunc | _SupportsWrite[str])
+_CallType = TypeVar("_CallType", bound=Callable[..., Any])
 
-class errstate(Generic[_CallType]):
+class errstate:
     def __init__(
         self,
         *,
@@ -3339,7 +3339,7 @@ class errstate(Generic[_CallType]):
         traceback: None | TracebackType,
         /,
     ) -> None: ...
-    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]: ...
+    def __call__(self, func: _CallType) -> _CallType: ...
 
 @contextmanager
 def _no_nep50_warning() -> Generator[None, None, None]: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3324,7 +3324,7 @@ class errstate:
     def __init__(
         self,
         *,
-        call: _CallType = ...,
+        call: _ErrFunc | _SupportsWrite[str] = ...,
         all: None | _ErrKind = ...,
         divide: None | _ErrKind = ...,
         over: None | _ErrKind = ...,

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -393,8 +393,8 @@ class errstate:
     >>> olderr = np.seterr(**olderr)  # restore original state
 
     """
-    __slots__ = [
-        "_call", "_all", "_divide", "_over", "_under", "_invalid", "_token"]
+    __slots__ = (
+        "_call", "_all", "_divide", "_over", "_under", "_invalid", "_token")
 
     def __init__(self, *, call=_Unspecified,
                  all=None, divide=None, over=None, under=None, invalid=None):

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -71,8 +71,11 @@ class TestErrstate:
             
         foo()
 
+    @pytest.mark.skipif(IS_WASM, reason="wasm doesn't support asyncio")
     def test_asyncio_safe(self):
-        # May not be available e.g. on web assembly
+        # asyncio may not always work, lets assume its fine if missing
+        # Pyiodine/wasm doesn't support it.  If this test makes problems,
+        # it should just be skipped liberally (or run differently).
         asyncio = pytest.importorskip("asyncio")
 
         @np.errstate(invalid="ignore")

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -74,7 +74,7 @@ class TestErrstate:
     @pytest.mark.skipif(IS_WASM, reason="wasm doesn't support asyncio")
     def test_asyncio_safe(self):
         # asyncio may not always work, lets assume its fine if missing
-        # Pyiodine/wasm doesn't support it.  If this test makes problems,
+        # Pyodide/wasm doesn't support it.  If this test makes problems,
         # it should just be skipped liberally (or run differently).
         asyncio = pytest.importorskip("asyncio")
 

--- a/numpy/typing/tests/data/reveal/ufunc_config.pyi
+++ b/numpy/typing/tests/data/reveal/ufunc_config.pyi
@@ -21,5 +21,5 @@ reveal_type(np.seterrcall(func))  # E: Union[None, def (builtins.str, builtins.i
 reveal_type(np.seterrcall(Write()))  # E: Union[None, def (builtins.str, builtins.int) -> Any, _SupportsWrite[builtins.str]]
 reveal_type(np.geterrcall())  # E: Union[None, def (builtins.str, builtins.int) -> Any, _SupportsWrite[builtins.str]]
 
-reveal_type(np.errstate(call=func, all="call"))  # E: errstate[def (a: builtins.str, b: builtins.int)]
-reveal_type(np.errstate(call=Write(), divide="log", over="log"))  # E: errstate[ufunc_config.Write]
+reveal_type(np.errstate(call=func, all="call"))  # E: errstate
+reveal_type(np.errstate(call=Write(), divide="log", over="log"))  # E: errstate


### PR DESCRIPTION
We need to store the token per-thread, which doesn't work if one instance of errstate is shared between threads (and we store it on the instance).  `ContextDecorator` has a mechanism for this, but it is not public.

So, this just implements it the full manual style.

I additionally add a new note on async-safety and the missing test (yes, fails on 1.25).

Closes gh-24013