### PR TITLE
ENH: Use Highway's VQSort on AArch64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendored-meson/meson"]
 	path = vendored-meson/meson
 	url = https://github.com/numpy/meson.git
+[submodule "numpy/_core/src/highway"]
+	path = numpy/_core/src/highway
+	url = https://github.com/google/highway.git

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -94,6 +94,9 @@ if use_svml
     error('Missing the `SVML` git submodule! Run `git submodule update --init` to fix this.')
   endif
 endif
+if not fs.exists('src/highway/README.md')
+  error('Missing the `highway` git submodule! Run `git submodule update --init` to fix this.')
+endif
 if not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
@@ -787,7 +790,8 @@ foreach gen_mtargets : [
       'src/common',
       'src/multiarray',
       'src/npymath',
-      'src/umath'
+      'src/umath',
+      'src/highway',
     ]
   )
   if not is_variable('multiarray_umath_mtargets')

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -761,12 +761,17 @@ foreach gen_mtargets : [
   [
     'simd_qsort.dispatch.h',
     'src/npysort/simd_qsort.dispatch.cpp',
-    [AVX512_SKX]
+    [AVX512_SKX, ASIMD]
   ],
   [
     'simd_qsort_16bit.dispatch.h',
     'src/npysort/simd_qsort_16bit.dispatch.cpp',
     [AVX512_SPR, AVX512_ICL]
+  ],
+  [
+    'simd_argsort.dispatch.h',
+    'src/npysort/simd_argsort.dispatch.cpp',
+    [AVX512_SKX]
   ],
 ]
   mtargets = mod_features.multi_targets(

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -84,7 +84,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
         NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
     }
     else if (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
-        #ifndef NPY_DISABLE_OPTIMIZATION
+        #if !defined(NPY_DISABLE_OPTIMIZATION) && !(defined(NPY_HAVE_ASIMD) && !defined(NPY_CAN_LINK_HIGHWAY))
             #include "simd_qsort.dispatch.h"
         #endif
         NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
@@ -105,7 +105,7 @@ inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
     using TF = typename np::meta::FixedWidth<T>::Type;
     void (*dispfunc)(TF*, npy_intp*, npy_intp) = nullptr;
     #ifndef NPY_DISABLE_OPTIMIZATION
-        #include "simd_qsort.dispatch.h"
+        #include "simd_argsort.dispatch.h"
     #endif
     /* x86-simd-sort uses 8-byte int to store arg values, npy_intp is 4 bytes
      * in 32-bit*/

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -60,7 +60,7 @@
 #include <utility>
 
 #define NOT_USED NPY_UNUSED(unused)
-#define DISABLE_HIGHWAY_OPTIMIZATION (defined(__arm__) || (defined(__aarch64__) && !defined(NPY_CAN_LINK_HIGHWAY)))
+#define DISABLE_HIGHWAY_OPTIMIZATION defined(__arm__)
 
 /*
  * pushing largest partition has upper bound of log2(n) space

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -87,7 +87,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
     }
     #if !DISABLE_HIGHWAY_OPTIMIZATION
     else if (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
-        #if !defined(NPY_DISABLE_OPTIMIZATION)
+        #ifndef NPY_DISABLE_OPTIMIZATION
             #include "simd_qsort.dispatch.h"
         #endif
         NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -28,6 +28,7 @@
 #include "simd_qsort.hpp"
 
 #define NOT_USED NPY_UNUSED(unused)
+#define DISABLE_HIGHWAY_OPTIMIZATION (defined(__arm__) || defined(__aarch64__))
 
 template<typename T>
 inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
@@ -55,12 +56,14 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
             #endif
             NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSelect, <TF>);
         }
+        #if !DISABLE_HIGHWAY_OPTIMIZATION
         else if constexpr (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
             #ifndef NPY_DISABLE_OPTIMIZATION
                 #include "simd_qsort.dispatch.h"
             #endif
             NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSelect, <TF>);
         }
+        #endif
         if (dispfunc) {
             (*dispfunc)(reinterpret_cast<TF*>(v), num, kth);
             return true;
@@ -85,7 +88,7 @@ inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp 
         sizeof(npy_intp) == sizeof(int64_t)) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         #ifndef NPY_DISABLE_OPTIMIZATION
-            #include "simd_qsort.dispatch.h"
+            #include "simd_argsort.dispatch.h"
         #endif
         void (*dispfunc)(TF*, npy_intp*, npy_intp, npy_intp) = nullptr;
         NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSelect, <TF>);

--- a/numpy/_core/src/npysort/simd_argsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_argsort.dispatch.cpp
@@ -7,14 +7,39 @@
 // 'baseline' option isn't specified within targets.
 
 #include "simd_qsort.hpp"
+#ifndef __CYGWIN__
 
-#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
 #endif
 
 namespace np { namespace qsort_simd {
 
-#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SKX)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
@@ -42,3 +67,5 @@ template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy
 #endif
 
 }} // namespace np::simd
+
+#endif // __CYGWIN__

--- a/numpy/_core/src/npysort/simd_argsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_argsort.dispatch.cpp
@@ -1,0 +1,44 @@
+/*@targets
+ * $maxopt $keep_baseline
+ * avx512_skx
+ */
+// policy $keep_baseline is used to avoid skip building avx512_skx
+// when its part of baseline features (--cpu-baseline), since
+// 'baseline' option isn't specified within targets.
+
+#include "simd_qsort.hpp"
+
+#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+    #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
+#endif
+
+namespace np { namespace qsort_simd {
+
+#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
+{
+    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+}
+#endif
+
+}} // namespace np::simd

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -23,30 +23,6 @@
 namespace np { namespace qsort_simd {
 
 #if defined(NPY_HAVE_AVX512_SKX)
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-}
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
     avx512_qselect(arr, kth, num, true);

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -10,10 +10,12 @@
 #include "simd_qsort.hpp"
 #ifndef __CYGWIN__
 
+#define USE_HIGHWAY defined(__aarch64__) && defined(NPY_CAN_LINK_HIGHWAY)
+
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
-#elif defined(NPY_HAVE_ASIMD)
+#elif USE_HIGHWAY
     #include "hwy/contrib/sort/vqsort.h"
 #endif
 
@@ -92,7 +94,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
-#elif defined(NPY_HAVE_ASIMD) && defined(NPY_CAN_LINK_HIGHWAY)
+#elif USE_HIGHWAY
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
     hwy::VQSort(arr, size, hwy::SortAscending());

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -16,7 +16,7 @@
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
 #elif USE_HIGHWAY
-    #include "hwy/contrib/sort/vqsort.h"
+    #include "hwy/contrib/sort/vqsort-inl.h"
 #endif
 
 namespace np { namespace qsort_simd {
@@ -97,27 +97,27 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 #elif USE_HIGHWAY
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
-    hwy::VQSort(arr, size, hwy::SortAscending());
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
 }
 #endif
 

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -10,12 +10,13 @@
 #include "simd_qsort.hpp"
 #ifndef __CYGWIN__
 
-#define USE_HIGHWAY defined(__aarch64__) && defined(NPY_CAN_LINK_HIGHWAY)
+#define USE_HIGHWAY defined(__aarch64__)
 
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
 #elif USE_HIGHWAY
+    #define VQSORT_ONLY_STATIC 1
     #include "hwy/contrib/sort/vqsort-inl.h"
 #endif
 

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -1,5 +1,7 @@
 /*@targets
- * $maxopt $keep_baseline avx512_skx
+ * $maxopt $keep_baseline
+ * avx512_skx
+ * asimd
  */
 // policy $keep_baseline is used to avoid skip building avx512_skx
 // when its part of baseline features (--cpu-baseline), since
@@ -11,7 +13,8 @@
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
-    #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
+#elif defined(NPY_HAVE_ASIMD)
+    #include "hwy/contrib/sort/vqsort.h"
 #endif
 
 namespace np { namespace qsort_simd {
@@ -89,31 +92,32 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
+#elif defined(NPY_HAVE_ASIMD) && defined(NPY_CAN_LINK_HIGHWAY)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    hwy::VQSort(arr, size, hwy::SortAscending());
 }
-#endif  // NPY_HAVE_AVX512_SKX
+#endif
 
 }} // namespace np::simd
 

--- a/numpy/_core/src/npysort/simd_qsort.hpp
+++ b/numpy/_core/src/npysort/simd_qsort.hpp
@@ -10,6 +10,10 @@ namespace np { namespace qsort_simd {
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
+
+#ifndef NPY_DISABLE_OPTIMIZATION
+    #include "simd_argsort.dispatch.h"
+#endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, npy_intp* arg, npy_intp size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSelect, (T *arr, npy_intp* arg, npy_intp kth, npy_intp size))
 

--- a/numpy/_core/src/npysort/simd_qsort.hpp
+++ b/numpy/_core/src/npysort/simd_qsort.hpp
@@ -3,13 +3,17 @@
 
 #include "common.hpp"
 
+#define DISABLE_HIGHWAY_OPTIMIZATION (defined(__arm__) || (defined(__aarch64__) && !defined(NPY_CAN_LINK_HIGHWAY)))
+
 namespace np { namespace qsort_simd {
 
+#if !DISABLE_HIGHWAY_OPTIMIZATION
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
+#endif
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_argsort.dispatch.h"
@@ -24,4 +28,7 @@ NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t siz
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 
 } } // np::qsort_simd
+
+#undef DISABLE_HIGHWAY_OPTIMIZATION
+
 #endif // NUMPY_SRC_COMMON_NPYSORT_SIMD_QSORT_HPP

--- a/numpy/_core/src/npysort/simd_qsort.hpp
+++ b/numpy/_core/src/npysort/simd_qsort.hpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 
-#define DISABLE_HIGHWAY_OPTIMIZATION (defined(__arm__) || (defined(__aarch64__) && !defined(NPY_CAN_LINK_HIGHWAY)))
+#define DISABLE_HIGHWAY_OPTIMIZATION defined(__arm__)
 
 namespace np { namespace qsort_simd {
 

--- a/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -1,5 +1,6 @@
 /*@targets
- * $maxopt $keep_baseline avx512_icl avx512_spr
+ * $maxopt $keep_baseline 
+ * avx512_icl avx512_spr
  */
 // policy $keep_baseline is used to avoid skip building avx512_skx
 // when its part of baseline features (--cpu-baseline), since

--- a/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -1,6 +1,5 @@
 /*@targets
- * $maxopt $keep_baseline 
- * avx512_icl avx512_spr
+ * $maxopt $keep_baseline avx512_icl avx512_spr
  */
 // policy $keep_baseline is used to avoid skip building avx512_skx
 // when its part of baseline features (--cpu-baseline), since


### PR DESCRIPTION
Introduces Highway, a SIMD library from Google. Highway has it's own dispatch mechanism and SIMD flavour (which adds padding) which may be a good replacement for NumPy intrinsics. Highway also has its own set of vectorised Math routines we could bolt on.

For this patch, I've integrated the VQSort algorithm only on AArch64 so as not to impact other architectures. The VQSort algorithms performance is comparable to the AVX512 algorithms, according to this report: https://github.com/Voultapher/sort-research-rs/blob/main/writeup/intel_avx512/text.md

Performance improvements in the NumPy benchmark suite are as follows:
```
       before           after         ratio
     [f4b52d53]       [f08058d4]
     <main-setuppy>       <highway-sort>
+     53.0±0.08μs        221±0.4μs     4.18  bench_function_base.Sort.time_sort('quick', 'int64', ('ordered',))
+      84.8±0.3μs        222±0.3μs     2.62  bench_function_base.Sort.time_sort('quick', 'int64', ('reversed',))
+      89.0±0.2μs        197±0.2μs     2.21  bench_function_base.Sort.time_sort('quick', 'float64', ('ordered',))
+     51.5±0.01μs       80.0±0.1μs     1.55  bench_function_base.Sort.time_sort('quick', 'uint32', ('ordered',))
+     52.0±0.07μs       80.3±0.2μs     1.55  bench_function_base.Sort.time_sort('quick', 'int32', ('ordered',))
+       148±0.3μs        197±0.2μs     1.33  bench_function_base.Sort.time_sort('quick', 'float64', ('reversed',))
+       471±0.2μs        598±0.5μs     1.27  bench_function_base.Sort.time_argsort('heap', 'float64', ('ordered',))
+       536±0.7μs        644±0.8μs     1.20  bench_function_base.Sort.time_argsort('heap', 'float64', ('reversed',))
+     39.8±0.02μs      47.4±0.05μs     1.19  bench_function_base.Sort.time_argsort('merge', 'int32', ('sorted_block', 1000))
+     39.8±0.01μs      47.4±0.02μs     1.19  bench_function_base.Sort.time_argsort('merge', 'uint32', ('sorted_block', 1000))
+     40.1±0.01μs      47.6±0.04μs     1.19  bench_function_base.Sort.time_argsort('merge', 'int64', ('sorted_block', 1000))
+     27.9±0.03μs      32.6±0.03μs     1.17  bench_function_base.Sort.time_argsort('heap', 'uint32', ('uniform',))
+       685±0.5μs        796±0.8μs     1.16  bench_function_base.Sort.time_argsort('heap', 'float64', ('sorted_block', 10))
+     68.7±0.05μs      78.4±0.04μs     1.14  bench_function_base.Sort.time_argsort('merge', 'uint32', ('sorted_block', 100))
+     68.7±0.05μs       78.3±0.1μs     1.14  bench_function_base.Sort.time_argsort('merge', 'int32', ('sorted_block', 100))
+     69.4±0.03μs      78.8±0.05μs     1.14  bench_function_base.Sort.time_argsort('merge', 'int64', ('sorted_block', 100))
+     22.0±0.01μs      24.7±0.01μs     1.12  bench_function_base.Sort.time_sort('heap', 'uint32', ('uniform',))
+       674±0.7μs        743±0.4μs     1.10  bench_function_base.Sort.time_argsort('heap', 'float64', ('sorted_block', 1000))
+       730±0.6μs        794±0.8μs     1.09  bench_function_base.Sort.time_argsort('heap', 'float64', ('sorted_block', 100))
+         464±2μs         492±10μs     1.06  bench_function_base.Sort.time_argsort('heap', 'int32', ('reversed',))
+      95.5±0.1μs        101±0.1μs     1.06  bench_function_base.Sort.time_argsort('quick', 'float64', ('ordered',))
+         839±1μs          886±2μs     1.06  bench_function_base.Sort.time_argsort('heap', 'float64', ('random',))
+      95.7±0.1μs       101±0.05μs     1.06  bench_function_base.Sort.time_argsort('quick', 'float32', ('ordered',))
-       516±0.6μs        488±0.9μs     0.95  bench_function_base.Sort.time_sort('heap', 'float32', ('ordered',))
-         532±1μs          499±5μs     0.94  bench_function_base.Sort.time_argsort('heap', 'int16', ('reversed',))
-     34.5±0.05μs      32.2±0.03μs     0.93  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 1000))
-         715±1μs        666±0.4μs     0.93  bench_function_base.Sort.time_sort('heap', 'float64', ('random',))
-         254±2μs        231±0.2μs     0.91  bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 1000))
-       655±0.5μs        592±0.3μs     0.90  bench_function_base.Sort.time_sort('heap', 'float64', ('sorted_block', 100))
-     24.7±0.02μs      22.0±0.07μs     0.89  bench_function_base.Sort.time_sort('heap', 'int32', ('uniform',))
-       621±0.7μs        549±0.3μs     0.88  bench_function_base.Sort.time_sort('heap', 'float64', ('sorted_block', 1000))
-       659±0.9μs        555±0.5μs     0.84  bench_function_base.Sort.time_sort('heap', 'float64', ('sorted_block', 10))
-       545±0.4μs        444±0.5μs     0.81  bench_function_base.Sort.time_sort('heap', 'float64', ('reversed',))
-       511±0.5μs        396±0.4μs     0.78  bench_function_base.Sort.time_sort('heap', 'float64', ('ordered',))
-       316±0.6μs        225±0.2μs     0.71  bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 10))
-       333±0.4μs        233±0.3μs     0.70  bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 100))
-       323±0.2μs        206±0.2μs     0.64  bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 1000))
-       134±0.9μs      85.0±0.07μs     0.64  bench_function_base.Sort.time_sort('quick', 'float32', ('reversed',))
-       376±0.9μs        228±0.3μs     0.61  bench_function_base.Sort.time_sort('quick', 'int64', ('random',))
-       418±0.4μs        207±0.4μs     0.50  bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 100))
-         413±2μs        199±0.2μs     0.48  bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 10))
-      64.4±0.3ms       28.6±0.3ms     0.44  bench_function_base.Sort.time_sort_worst
-         501±2μs        204±0.3μs     0.41  bench_function_base.Sort.time_sort('quick', 'float64', ('random',))
-         248±1μs       86.9±0.2μs     0.35  bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 1000))
-       251±0.7μs       87.0±0.2μs     0.35  bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 1000))
-       329±0.9μs       91.4±0.1μs     0.28  bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 1000))
-         329±1μs      85.2±0.06μs     0.26  bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 100))
-       329±0.7μs      85.0±0.06μs     0.26  bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 100))
-       315±0.5μs      80.4±0.05μs     0.26  bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 10))
-         320±1μs      80.3±0.09μs     0.25  bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 10))
-       372±0.4μs      82.1±0.06μs     0.22  bench_function_base.Sort.time_sort('quick', 'int32', ('random',))
-       414±0.4μs       89.6±0.1μs     0.22  bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 100))
-         384±1μs      81.8±0.02μs     0.21  bench_function_base.Sort.time_sort('quick', 'uint32', ('random',))
-       415±0.3μs       84.8±0.2μs     0.20  bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 10))
-         491±2μs       86.3±0.1μs     0.18  bench_function_base.Sort.time_sort('quick', 'float32', ('random',))
-       111±0.4μs      13.0±0.01μs     0.12  bench_function_base.Sort.time_sort('quick', 'float64', ('uniform',))
-     50.9±0.03μs      4.93±0.01μs     0.10  bench_function_base.Sort.time_sort('quick', 'int64', ('uniform',))
-       108±0.3μs      7.25±0.02μs     0.07  bench_function_base.Sort.time_sort('quick', 'float32', ('uniform',))
-     51.7±0.05μs      3.43±0.01μs     0.07  bench_function_base.Sort.time_sort('quick', 'int32', ('uniform',))
-     51.3±0.07μs      3.35±0.06μs     0.07  bench_function_base.Sort.time_sort('quick', 'uint32', ('uniform',))
```
