### PR TITLE
BUG: Fix error message for nanargmin/max of empty sequence

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -546,7 +546,7 @@ def nanargmin(a, axis=None, out=None, *, keepdims=np._NoValue):
 
     """
     a, mask = _replace_nan(a, np.inf)
-    if mask is not None:
+    if mask is not None and mask.size:
         mask = np.all(mask, axis=axis)
         if np.any(mask):
             raise ValueError("All-NaN slice encountered")
@@ -607,7 +607,7 @@ def nanargmax(a, axis=None, out=None, *, keepdims=np._NoValue):
 
     """
     a, mask = _replace_nan(a, -np.inf)
-    if mask is not None:
+    if mask is not None and mask.size:
         mask = np.all(mask, axis=axis)
         if np.any(mask):
             raise ValueError("All-NaN slice encountered")

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -7,7 +7,7 @@ from numpy.core.numeric import normalize_axis_tuple
 from numpy.lib.nanfunctions import _nan_mask, _replace_nan
 from numpy.testing import (
     assert_, assert_equal, assert_almost_equal, assert_raises,
-    assert_array_equal, suppress_warnings
+    assert_raises_regex, assert_array_equal, suppress_warnings
     )
 
 
@@ -303,7 +303,10 @@ class TestNanFunctions_ArgminArgmax:
         mat = np.zeros((0, 3))
         for f in self.nanfuncs:
             for axis in [0, None]:
-                assert_raises(ValueError, f, mat, axis=axis)
+                assert_raises_regex(
+                        ValueError,
+                        "attempt to get argm.. of an empty sequence",
+                        f, mat, axis=axis)
             for axis in [1]:
                 res = f(mat, axis=axis)
                 assert_equal(res, np.zeros(0))


### PR DESCRIPTION
For arrays with a length-zero dimension (e.g. shape (0, 50)), nanargmin and nanargmax would incorrectly raise `ValueError: All-NaN slice encountered`, despite there being no NaNs in the input array. This commit avoids proceeding to the all-NaNs check for size-zero arrays, falling through to argmin/argmax which handle empty sequences.

Before:

```
In [1]: import numpy as np

In [2]: x = np.zeros((0, 50))

In [3]: np.nanargmin(x)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 np.nanargmin(x)

File ~/.anaconda/envs/numpydev/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:552, in nanargmin(a, axis, out, keepdims)
    550     mask = np.all(mask, axis=axis)
    551     if np.any(mask):
--> 552         raise ValueError("All-NaN slice encountered")
    553 res = np.argmin(a, axis=axis, out=out, keepdims=keepdims)
    554 return res

ValueError: All-NaN slice encountered

```


After:

```
In [1]: import numpy as np

In [2]: x = np.zeros((0, 50))

In [3]: np.nanargmin(x)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 np.nanargmin(x)

File ~/.anaconda/envs/numpydev/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:553, in nanargmin(a, axis, out, keepdims)
    551     if np.any(mask):
    552         raise ValueError("All-NaN slice encountered")
--> 553 res = np.argmin(a, axis=axis, out=out, keepdims=keepdims)
    554 return res

File ~/.anaconda/envs/numpydev/lib/python3.10/site-packages/numpy/core/fromnumeric.py:1325, in argmin(a, axis, out, keepdims)
   1238 """
   1239 Returns the indices of the minimum values along an axis.
   1240 
   (...)
   1322 (2, 1, 4)
   1323 """
   1324 kwds = {'keepdims': keepdims} if keepdims is not np._NoValue else {}
-> 1325 return _wrapfunc(a, 'argmin', axis=axis, out=out, **kwds)

File ~/.anaconda/envs/numpydev/lib/python3.10/site-packages/numpy/core/fromnumeric.py:59, in _wrapfunc(obj, method, *args, **kwds)
     56     return _wrapit(obj, method, *args, **kwds)
     58 try:
---> 59     return bound(*args, **kwds)
     60 except TypeError:
     61     # A TypeError occurs if the object does have such a method in its
     62     # class, but its signature is not identical to that of NumPy's. This
   (...)
     66     # Call _wrapit from within the except clause to ensure a potential
     67     # exception has a traceback chain.
     68     return _wrapit(obj, method, *args, **kwds)

ValueError: attempt to get argmin of an empty sequence
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
