### PR TITLE
DOC: Add note for installing `asv` library to run benchmark tests

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -75,11 +75,8 @@ Testing builds
 Before running the tests, first install the test dependencies::
 
     $ python -m pip install -r test_requirements.txt
-
-.. note:: 
-    For running the benchmarks, install the ``asv`` library by running command in the interactive shell::
-
-        $ python -m pip install asv
+    $ python -m pip install asv # only for running benchmarks
+      
 
 To build the development version of NumPy and run tests, spawn
 interactive shells with the Python import paths properly set up etc.,

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -76,6 +76,11 @@ Before running the tests, first install the test dependencies::
 
     $ python -m pip install -r test_requirements.txt
 
+.. note:: 
+    For running the benchmarks, install the ``asv`` library by running command in the interactive shell::
+
+        $ python -m pip install asv
+
 To build the development version of NumPy and run tests, spawn
 interactive shells with the Python import paths properly set up etc.,
 do one of::

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,5 +15,3 @@ mypy==0.981; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer
-# for automatic benchmarking with Airspeed velocity
-asv==0.5.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -16,4 +16,4 @@ typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer
 # for automatic benchmarking with Airspeed velocity
-asv
+asv==0.5.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,3 +15,5 @@ mypy==0.981; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer
+# for automatic benchmarking with Airspeed velocity
+asv==0.5.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -16,4 +16,4 @@ typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer
 # for automatic benchmarking with Airspeed velocity
-asv==0.5.1
+asv


### PR DESCRIPTION
The `test_requirements.txt` file did not contain the `asv`(Airspeed velocity) library which resulted in failure of benchmarks unless it was installed separately.

fixes #24024 

