### PR TITLE
DOC: Add link to NEPs in top navbar

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,8 +191,10 @@ html_theme_options = {
   "twitter_url": "https://twitter.com/numpy_team",
   "collapse_navigation": True,
   "external_links": [
-      {"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"}
+      {"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"},
+      {"name": "NEPs", "url": "https://numpy.org/neps"}
       ],
+  "header_links_before_dropdown": 6,
   # Add light/dark mode and documentation version switcher:
   "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
   "switcher": {


### PR DESCRIPTION
From numpy.org it is not obvious how to get to the NEPs page. Unless you know the number of a specific NEP or know the URL, there are no (obvious) links pointing to them. This PR adds a link to the NEPs index from the main User Guide menu.

This may not be the best place to link, better suggestions are welcome.
