### PR TITLE
BUG: Avoid undefined behavior in array.astype()

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -871,7 +871,7 @@ array_astype(PyArrayObject *self,
      * TODO: UNSAFE default for compatibility, I think
      *       switching to SAME_KIND by default would be good.
      */
-    npy_dtype_info dt_info;
+    npy_dtype_info dt_info = {NULL, NULL};
     NPY_CASTING casting = NPY_UNSAFE_CASTING;
     NPY_ORDER order = NPY_KEEPORDER;
     _PyArray_CopyMode forcecopy = 1;

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -284,6 +284,9 @@ def test_array_astype():
     a = np.array(1000, dtype='i4')
     assert_raises(TypeError, a.astype, 'U1', casting='safe')
 
+    # gh-24023
+    assert_raises(TypeError, a.astype)
+
 @pytest.mark.parametrize("dt", ["S", "U"])
 def test_array_astype_to_string_discovery_empty(dt):
     # See also gh-19085


### PR DESCRIPTION
If we don't initialize `dt_info` then the `Py_XDECREF` in the error path below tries to interpret garbage as a PyObject, leading to undefined behavior.

Fixes one of the issues pointed out in #24023.