### PR TITLE
BUG: Fix reduction ``return NULL`` to be ``goto fail``

### DIFF
--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -366,7 +366,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
                     "reduction operation '%s' does not have an identity, "
                     "so to use a where mask one has to specify 'initial'",
                     funcname);
-            return NULL;
+            goto fail;
         }
 
         /*


### PR DESCRIPTION
Backport of #24004.

This should clearly have been a cleanup.

Closes gh-24003

---

I think the following failure I mentioned is just valgrind late detecting some indirect losses with a delay for whatever reason, since it shouldn't even alloc an iterator.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
