### PR TITLE
MAINT: Pin urllib3 to avoid anaconda-client bug.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -140,7 +140,9 @@ jobs:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
-          conda install -y anaconda-client
+          #conda install -y anaconda-client
+          # pin urllib3 until anaconda-client is fixed upstream
+          conda install -y anaconda-client 'urllib3<2.0.0'
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # trigger an upload to
@@ -222,7 +224,9 @@ jobs:
           # commented out so the sdist doesn't upload to nightly
           # NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
-          conda install -y anaconda-client
+          #conda install -y anaconda-client
+          # pin urllib3 until anaconda-client is fixed upstream
+          conda install -y anaconda-client 'urllib3<2.0.0'
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # trigger an upload to

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -136,31 +136,33 @@ wheels_upload_task:
     # only upload wheels to staging if it's a tag beginning with 'v' and you're
     # on a maintenance branch
     if [[ "$CIRRUS_TAG" == v* ]] && [[ $CIRRUS_TAG != *"dev0"* ]]; then
-      export IS_PUSH="true"    
+      export IS_PUSH="true"
     fi
 
     if [[ $IS_PUSH == "true" ]] || [[ $IS_SCHEDULE_DISPATCH == "true" ]]; then
         # install miniconda in the home directory. For some reason HOME isn't set by Cirrus
         export HOME=$PWD
-    
+
         # install miniconda for uploading to anaconda
         wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda3
         $HOME/miniconda3/bin/conda init bash
         source $HOME/miniconda3/bin/activate
-        conda install -y anaconda-client
-    
+        #conda install -y anaconda-client
+        # pin urllib3 until anaconda-client is fixed upstream
+        conda install -y anaconda-client 'urllib3<2.0.0'
+
         # The name of the zip file is derived from the `wheels_artifact` line.
         # If you change the artifact line to `myfile_artifact` then it would be
         # called myfile.zip
-        
+
         curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
         unzip wheels.zip
-        
+
         source ./tools/wheels/upload_wheels.sh
         # IS_PUSH takes precedence over IS_SCHEDULE_DISPATCH
         set_upload_vars
-        
+
         # Will be skipped if not a push/tag/scheduled build
         upload_wheels
     fi


### PR DESCRIPTION
Urllib3 >= 2.0.0 removed a deprecated function used by anaconda-client. Workaround this by pinning the urllib3 version until the bug is fixed upstream.

Closes gh-24042.

Note that this cannot be tested until wheel uploads are run.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
