### PR TITLE
MAINT: Remove ability to enter errstate twice (sequentially)

### DIFF
--- a/doc/release/upcoming_changes/23936.change.rst
+++ b/doc/release/upcoming_changes/23936.change.rst
@@ -1,5 +1,4 @@
 * Being fully context and thread-safe, ``np.errstate`` can only
-  be entered once now.  It is possible to enter it again after
-  exiting first.
+  be entered once now.
 * ``np.setbufsize`` is now tied to ``np.errstate()``:  Leaving an
   ``np.errstate`` context will also reset the ``bufsize``.

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -348,7 +348,7 @@ class errstate:
 
     .. versionchanged:: 2.0
         `errstate` is now fully thread and asyncio safe, but may not be
-        entered more than once (unless sequentially).
+        entered more than once.
         It is not safe to decorate async functions using ``errstate``.
 
     Parameters
@@ -424,8 +424,6 @@ class errstate:
 
     def __exit__(self, *exc_info):
         _extobj_contextvar.reset(self._token)
-        # Allow entering twice, so long as it is sequential:
-        self._token = None
 
     def __call__(self, func):
         # We need to customize `__call__` compared to `ContextDecorator`

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -71,6 +71,18 @@ class TestErrstate:
             
         foo()
 
+    def test_errstate_enter_once(self):
+        errstate = np.errstate(invalid="warn")
+        with errstate:
+            pass
+
+        # The errstate context cannot be entered twice as that would not be
+        # thread-safe
+        with pytest.raises(TypeError,
+                match="Cannot enter `np.errstate` twice"):
+            with errstate:
+                pass
+
     @pytest.mark.skipif(IS_WASM, reason="wasm doesn't support asyncio")
     def test_asyncio_safe(self):
         # asyncio may not always work, lets assume its fine if missing


### PR DESCRIPTION
That was a bit of a slip.  The issue why I allowed it was that it "fixed" the decorator version, but it was not the correct fix.

Considering that things like `warnings.catch_warnings()` do not allow this either, this seems better.
I also don't think it was technically thread-safe.