### PR TITLE
BLD: use ``-ftrapping-math`` with Clang on macOS in Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,15 @@ endif
 add_project_arguments(
   cc.get_supported_arguments( '-fno-strict-aliasing'), language : 'c'
 )
+#
+# Clang defaults to a non-strict floating error point model, but we need strict
+# behavior. `-ftrapping-math` is equivalent to `-ffp-exception-behavior=strict`.
+# Note that this is only supported on macOS arm64 as of XCode 14.3
+if cc.get_id() == 'clang'
+  add_project_arguments(
+    cc.get_supported_arguments('-ftrapping-math'), language: ['c', 'cpp'],
+  )
+endif
 
 # Generate version number. Note that this will not (yet) update the version
 # number seen by pip or reflected in wheel filenames. See


### PR DESCRIPTION
The distutils build also uses this flag, and it avoids some problems with `floor_divide` and similar functions (xref gh-19479).

For older macOS arm64 Clang versions, the flag does get accepted, but then gets overridden because it's not actually supported - which yields these warnings:
```
warning: overriding currently unsupported use of floating point exceptions on this target [-Wunsupported-floating-point-opt]
```
Since they're a little annoying to suppress (at least without completely disabling those warnings, which doesn't seem desirable) and will go away when updating to the latest XCode version, we'll ignore these warnings.