### PR TITLE
DOC: PR adds casting option's description to Glossary and `numpy.concatenate`.

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -546,7 +546,8 @@ Glossary
          >>> y
          array([3, 2, 4])
     
-   casting : Optional Controls what kind of data casting may occur during concatenation.
+   casting
+       Controls what kind of data casting may occur. The different options are:
 
        ``no``: No casting is allowed. The data types should not be cast at all.
        Any mismatch in data types between the arrays being concatenated will

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -546,7 +546,7 @@ Glossary
          >>> y
          array([3, 2, 4])
     
-   casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional Controls what kind of data casting may occur during concatenation.
+   casting : Optional Controls what kind of data casting may occur during concatenation.
 
        ``no``: No casting is allowed. The data types should not be cast at all.
        Any mismatch in data types between the arrays being concatenated will

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -545,4 +545,26 @@ Glossary
          >>> x[0] = 3 # changing x changes y as well, since y is a view on x
          >>> y
          array([3, 2, 4])
+    
+   casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional Controls what kind of data casting may occur during concatenation.
 
+       ``no``: No casting is allowed. The data types should not be cast at all.
+       Any mismatch in data types between the arrays being concatenated will
+       raise a TypeError.
+       ``equiv``: Only byte-order changes are allowed. Casting between different
+       byte orders is permitted. However, other types of casting, such as
+       changing the data type or size, are not allowed.
+       ``safe``: Only casts that can preserve values are allowed. Upcasting
+       (e.g., from int to float) is allowed, but downcasting is not. It ensures
+       that the values are not lost or corrupted during casting.
+       ``same_kind``: The 'same_kind' casting option allows safe casts and casts
+       within a kind. It means that it allows casting between data types that
+       are of the same kind or category. For example, casting from float64 to
+       float32 is considered safe because both are floating-point data types,
+       and the casting only involves reducing the precision. Casting between
+       different kinds, such as from float to int, is not allowed.
+       ``unsafe``: The 'unsafe' casting option allows any data conversions to be
+       performed, even if it may result in loss of precision or data corruption.
+       It allows casting between different data types, sizes, and kinds without
+       any restrictions. This casting option should be used with caution, as it
+       can lead to unexpected results or data inconsistencies.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -275,29 +275,18 @@ Glossary
        Same as :term:`row-major`.
 
    casting
-       The process of converting data from one dtype to another. There exist
-       several casting modes:
+       The process of converting array data from one dtype to another. There
+       exist several casting modes, defined by the following casting rules:
 
        - ``no``: The data types should not be cast at all.
          Any mismatch in data types between the arrays will raise a
          `TypeError`.
-       - ``equiv``: Only byte-order changes are allowed. Casting between different
-       byte orders is permitted. However, other types of casting, such as
-       changing the data type or size, are not allowed.
+       - ``equiv``: Only byte-order changes are allowed.
        - ``safe``: Only casts that can preserve values are allowed. Upcasting
-       (e.g., from int to float) is allowed, but downcasting is not. It ensures
-       that the values are not lost or corrupted during casting.
-       - ``same_kind``: The 'same_kind' casting option allows safe casts and casts
-       within a kind. It means that it allows casting between data types that
-       are of the same kind or category. For example, casting from float64 to
-       float32 is considered safe because both are floating-point data types,
-       and the casting only involves reducing the precision. Casting between
-       different kinds, such as from float to int, is not allowed.
-       - ``unsafe``: The 'unsafe' casting option allows any data conversions to be
-       performed, even if it may result in loss of precision or data corruption.
-       It allows casting between different data types, sizes, and kinds without
-       any restrictions. This casting option should be used with caution, as it
-       can lead to unexpected results or data inconsistencies.
+         (e.g., from int to float) is allowed, but downcasting is not.
+       - ``same_kind``: The 'same_kind' casting option allows safe casts and
+         casts within a kind, like float64 to float32.
+       - ``unsafe``: any data conversions may be done.
 
    column-major
        See `Row- and column-major order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -550,7 +550,7 @@ Glossary
        Controls what kind of data casting may occur. The different options are:
 
        ``no``: No casting is allowed. The data types should not be cast at all.
-       Any mismatch in data types between the arrays being concatenated will
+       Any mismatch in data types between the arrays will
        raise a TypeError.
        ``equiv``: Only byte-order changes are allowed. Casting between different
        byte orders is permitted. However, other types of casting, such as

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -274,6 +274,30 @@ Glossary
    C order
        Same as :term:`row-major`.
 
+   casting
+       The process of converting data from one dtype to another. There exist
+       several casting modes:
+
+       - ``no``: The data types should not be cast at all.
+         Any mismatch in data types between the arrays will raise a
+         `TypeError`.
+       - ``equiv``: Only byte-order changes are allowed. Casting between different
+       byte orders is permitted. However, other types of casting, such as
+       changing the data type or size, are not allowed.
+       - ``safe``: Only casts that can preserve values are allowed. Upcasting
+       (e.g., from int to float) is allowed, but downcasting is not. It ensures
+       that the values are not lost or corrupted during casting.
+       - ``same_kind``: The 'same_kind' casting option allows safe casts and casts
+       within a kind. It means that it allows casting between data types that
+       are of the same kind or category. For example, casting from float64 to
+       float32 is considered safe because both are floating-point data types,
+       and the casting only involves reducing the precision. Casting between
+       different kinds, such as from float to int, is not allowed.
+       - ``unsafe``: The 'unsafe' casting option allows any data conversions to be
+       performed, even if it may result in loss of precision or data corruption.
+       It allows casting between different data types, sizes, and kinds without
+       any restrictions. This casting option should be used with caution, as it
+       can lead to unexpected results or data inconsistencies.
 
    column-major
        See `Row- and column-major order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_.
@@ -545,27 +569,3 @@ Glossary
          >>> x[0] = 3 # changing x changes y as well, since y is a view on x
          >>> y
          array([3, 2, 4])
-    
-   casting
-       Controls what kind of data casting may occur. The different options are:
-
-       ``no``: No casting is allowed. The data types should not be cast at all.
-       Any mismatch in data types between the arrays will
-       raise a TypeError.
-       ``equiv``: Only byte-order changes are allowed. Casting between different
-       byte orders is permitted. However, other types of casting, such as
-       changing the data type or size, are not allowed.
-       ``safe``: Only casts that can preserve values are allowed. Upcasting
-       (e.g., from int to float) is allowed, but downcasting is not. It ensures
-       that the values are not lost or corrupted during casting.
-       ``same_kind``: The 'same_kind' casting option allows safe casts and casts
-       within a kind. It means that it allows casting between data types that
-       are of the same kind or category. For example, casting from float64 to
-       float32 is considered safe because both are floating-point data types,
-       and the casting only involves reducing the precision. Casting between
-       different kinds, such as from float to int, is not allowed.
-       ``unsafe``: The 'unsafe' casting option allows any data conversions to be
-       performed, even if it may result in loss of precision or data corruption.
-       It allows casting between different data types, sizes, and kinds without
-       any restrictions. This casting option should be used with caution, as it
-       can lead to unexpected results or data inconsistencies.

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -174,7 +174,6 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
         For a description of the options, please see :term:`casting`.
-        `<https://numpy.org/devdocs/glossary.html#glossary>`.
         
         .. versionadded:: 1.20.0
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -173,34 +173,9 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
-    
-    
-    - `'no'`: No casting is allowed. The data types should not be cast at all.
-    Any mismatch in data types between the arrays being concatenated will raise a `TypeError`.
-
-    - `'equiv'`: Only byte-order changes are allowed. Casting between different 
-    byte orders is permitted. However, other types of casting, 
-    such as changing the data type or size, are not allowed.
-
-    - `'safe'`:  Only casts that can preserve values are allowed. 
-    Upcasting (e.g., from int to float) is allowed, but downcasting is not. 
-    It ensures that the values are not lost or corrupted during casting.
-
-    - `'same_kind'`: The `'same_kind'` casting option allows safe casts and casts within a kind. 
-    It means that it allows casting between data types that are of the same kind or category. 
-    For example, casting from float64 to float32 is considered safe because both are floating-point data types,
-    and the casting only involves reducing the precision. Casting between different kinds, 
-    such as from float to int, is not allowed.
-
-    - `'unsafe'`: The `'unsafe'` casting option allows any data conversions to be performed, 
-    even if it may result in loss of precision or data corruption. It allows casting between different data types,
-    sizes, and kinds without any restrictions. This casting option should be used with caution, 
-    as it can lead to unexpected results or data inconsistencies.
-
-    By specifying the appropriate casting option, you can control the behavior of casting 
-    when performing array concatenation, ensuring that it aligns with your desired requirements for 
-    preserving data integrity and precision.
-
+        For more information, see the `documentation <https://numpy.org/devdocs/glossary.html#glossary>`.
+        .. versionadded:: 1.20.0
+        
     Returns
     -------
     res : ndarray

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -173,7 +173,7 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
-        For more information
+        For a description of the options, please see :term:`casting`.
         `<https://numpy.org/devdocs/glossary.html#glossary>`.
         
         .. versionadded:: 1.20.0

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -178,8 +178,8 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
     - `'no'`: No casting is allowed. The data types should not be cast at all.
     Any mismatch in data types between the arrays being concatenated will raise a `TypeError`.
 
-    - `'equiv'`: Only byte-order changes are allowed. 
-    Casting between different byte orders is permitted. However, other types of casting, 
+    - `'equiv'`: Only byte-order changes are allowed. Casting between different 
+    byte orders is permitted. However, other types of casting, 
     such as changing the data type or size, are not allowed.
 
     - `'safe'`:  Only casts that can preserve values are allowed. 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -176,7 +176,7 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
         For more information:
         see the `documentation <https://numpy.org/devdocs/glossary.html#glossary>`.
         .. versionadded:: 1.20.0
-        
+
     Returns
     -------
     res : ndarray

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -173,8 +173,9 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
-        For more information:
-        see the `documentation <https://numpy.org/devdocs/glossary.html#glossary>`.
+        For more information
+        `<https://numpy.org/devdocs/glossary.html#glossary>`.
+        
         .. versionadded:: 1.20.0
 
     Returns

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -173,8 +173,33 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
+    
+    
+    - `'no'`: No casting is allowed. The data types should not be cast at all.
+    Any mismatch in data types between the arrays being concatenated will raise a `TypeError`.
 
-        .. versionadded:: 1.20.0
+    - `'equiv'`: Only byte-order changes are allowed. 
+    Casting between different byte orders is permitted. However, other types of casting, 
+    such as changing the data type or size, are not allowed.
+
+    - `'safe'`:  Only casts that can preserve values are allowed. 
+    Upcasting (e.g., from int to float) is allowed, but downcasting is not. 
+    It ensures that the values are not lost or corrupted during casting.
+
+    - `'same_kind'`: The `'same_kind'` casting option allows safe casts and casts within a kind. 
+    It means that it allows casting between data types that are of the same kind or category. 
+    For example, casting from float64 to float32 is considered safe because both are floating-point data types,
+    and the casting only involves reducing the precision. Casting between different kinds, 
+    such as from float to int, is not allowed.
+
+    - `'unsafe'`: The `'unsafe'` casting option allows any data conversions to be performed, 
+    even if it may result in loss of precision or data corruption. It allows casting between different data types,
+    sizes, and kinds without any restrictions. This casting option should be used with caution, 
+    as it can lead to unexpected results or data inconsistencies.
+
+    By specifying the appropriate casting option, you can control the behavior of casting 
+    when performing array concatenation, ensuring that it aligns with your desired requirements for 
+    preserving data integrity and precision.
 
     Returns
     -------

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -173,7 +173,8 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
-        For more information, see the `documentation <https://numpy.org/devdocs/glossary.html#glossary>`.
+        For more information:
+        see the `documentation <https://numpy.org/devdocs/glossary.html#glossary>`.
         .. versionadded:: 1.20.0
         
     Returns


### PR DESCRIPTION
Solves #20958. This PR resolves suggestions by @rossbar in #24057.
