### PR TITLE
MAINT: print error from verify_c_api_version.py failing

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -53,7 +53,11 @@ C_API_VERSION = '0x00000012'
 
 # Check whether we have a mismatch between the set C API VERSION and the
 # actual C API VERSION. Will raise a MismatchCAPIError if so.
-run_command('code_generators/verify_c_api_version.py', '--api-version', C_API_VERSION, check: true)
+r = run_command('code_generators/verify_c_api_version.py', '--api-version', C_API_VERSION)
+
+if r.returncode() != 0
+  error('verify_c_api_version.py failed with output:\n' + r.stderr().strip())
+endif
 
 
 # Generate config.h and _numpyconfig.h


### PR DESCRIPTION
While working on #21199 I noticed that meson wasn't capturing stderr from this script failing. Explicitly printing it seems to fix that, not sure if there's a more idiomatic way to do this in meson.