### PR TITLE
TST: Pin pydantic<2 in Pyodide workflow

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -52,7 +52,7 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install pyodide-build==$PYODIDE_VERSION
+        run: pip install pydantic<2 pyodide-build==$PYODIDE_VERSION
 
       - name: Build
         run: |


### PR DESCRIPTION
This should fix Pyodide CI. Thanks @timkpaine for informing us about this. We'll probably release a Pyodide 0.23.4 with this pin so then we can update Pyodide and remove the pin here.