### PR TITLE
BUG: Fix empty structured array dtype alignment

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -425,7 +425,7 @@ _convert_from_array_descr(PyObject *obj, int align)
 
     /* Types with fields need the Python C API for field access */
     char dtypeflags = NPY_NEEDS_PYAPI;
-    int maxalign = 0;
+    int maxalign = 1;
     int totalsize = 0;
     PyObject *fields = PyDict_New();
     if (!fields) {
@@ -642,7 +642,7 @@ _convert_from_list(PyObject *obj, int align)
 
     /* Types with fields need the Python C API for field access */
     char dtypeflags = NPY_NEEDS_PYAPI;
-    int maxalign = 0;
+    int maxalign = 1;
     int totalsize = 0;
     for (int i = 0; i < n; i++) {
         PyArray_Descr *conv = _convert_from_any(
@@ -1107,7 +1107,7 @@ _convert_from_dict(PyObject *obj, int align)
     /* Types with fields need the Python C API for field access */
     char dtypeflags = NPY_NEEDS_PYAPI;
     int totalsize = 0;
-    int maxalign = 0;
+    int maxalign = 1;
     int has_out_of_order_fields = 0;
     for (int i = 0; i < n; i++) {
         /* Build item to insert (descr, offset, [title])*/

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -348,6 +348,21 @@ class TestRecord:
                                  ('b', [('f0', '<i2'), ('', '|V2'),
                                  ('f1', '<f4')], (2,))])
 
+    def test_empty_struct_alignment(self):
+        # Empty dtypes should have an alignment of 1
+        dt = np.dtype([], align=True)
+        assert_equal(dt.alignment, 1)
+        dt = np.dtype([('f0', [])], align=True)
+        assert_equal(dt.alignment, 1)
+        dt = np.dtype({'names': [],
+                       'formats': [],
+                       'offsets': []}, align=True)
+        assert_equal(dt.alignment, 1)
+        dt = np.dtype({'names': ['f0'],
+                       'formats': [[]],
+                       'offsets': [0]}, align=True)
+        assert_equal(dt.alignment, 1)
+
     def test_union_struct(self):
         # Should be able to create union dtypes
         dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],


### PR DESCRIPTION
This change ensures that dtypes are given an alignment of at least 1. Prior to this change, dtypes of empty structured arrays with `align` set to True would have an alignment of 0.

For instance, `np.dtype([], align=True).alignment` returns 0. Empty structured array dtypes should have an alignment of 1, meaning that they do not need padding. An alignment of 0 is problematic because the alignment is used to determine offsets, which involves dividing by the alignment. If the alignment is 0, then a division by zero occurs.

The following code raises a ZeroDivisionError when converting the dtype to a string representation:

```python
repr(np.dtype([('f0', [])], align=True))
```

The following code crashes Python because a division by zero occurs in the C code:

```python
np.dtype({'names':['f0'], 'formats':[[]], 'offsets': [0]}, align=True)
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
