### PR TITLE
ENH: Add `spin benchmark` command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -152,3 +152,195 @@ def gdb(python_expr):
          'python', '-P', '-c', python_expr],
         replace=True
     )
+
+
+
+# From scipy: benchmarks/benchmarks/common.py
+def _set_mem_rlimit(max_mem=None):
+    """
+    Set address space rlimit
+    """
+    import resource
+    import psutil
+
+    mem = psutil.virtual_memory()
+
+    if max_mem is None:
+        max_mem = int(mem.total * 0.7)
+    cur_limit = resource.getrlimit(resource.RLIMIT_AS)
+    if cur_limit[0] > 0:
+        max_mem = min(max_mem, cur_limit[0])
+
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (max_mem, cur_limit[1]))
+    except ValueError:
+        # on macOS may raise: current limit exceeds maximum limit
+        pass
+
+
+def _commit_to_sha(commit):
+    p = util.run(['git', 'rev-parse', commit], output=False, echo=False)
+    if p.returncode != 0:
+        raise(click.ClickException(f'Could not find SHA matching commit `{commit}`'))
+
+    return p.stdout.decode('ascii').strip()
+
+
+def _dirty_git_working_dir():
+    # Changes to the working directory
+    p0 = util.run(['git', 'diff-files', '--quiet'])
+
+    # Staged changes
+    p1 = util.run(['git', 'diff-index', '--quiet', '--cached', 'HEAD'])
+
+    return (p0.returncode != 0 or p1.returncode != 0)
+
+
+def _run_asv(cmd):
+    # Always use ccache, if installed
+    PATH = os.environ['PATH']
+    EXTRA_PATH = os.pathsep.join([
+        '/usr/lib/ccache', '/usr/lib/f90cache',
+        '/usr/local/lib/ccache', '/usr/local/lib/f90cache'
+    ])
+    env = os.environ
+    env['PATH'] = f'EXTRA_PATH:{PATH}'
+
+    # Control BLAS/LAPACK threads
+    env['OPENBLAS_NUM_THREADS'] = '1'
+    env['MKL_NUM_THREADS'] = '1'
+
+    # Limit memory usage
+    try:
+        _set_mem_rlimit()
+    except (ImportError, RuntimeError):
+        pass
+
+    try:
+        util.run(cmd, cwd='benchmarks', env=env, sys_exit=False)
+    except FileNotFoundError:
+        click.secho(
+            (
+                "Cannot find `asv`. "
+                "Please install Airspeed Velocity:\n\n"
+                "  https://asv.readthedocs.io/en/latest/installing.html\n"
+                "\n"
+                "Depending on your system, one of the following should work:\n\n"
+                "  pip install asv\n"
+                "  conda install asv\n"
+            ),
+            fg="red"
+        )
+        sys.exit(1)
+
+
+@click.command()
+@click.option(
+    '--tests', '-t',
+    default=None, metavar='TESTS', multiple=True,
+    help="Which tests to run"
+)
+@click.option(
+    '--compare', '-c',
+    is_flag=True,
+    default=False,
+    help="Compare benchmarks between the current branch and main "
+         "(unless other branches specified). "
+         "The benchmarks are each executed in a new isolated "
+         "environment."
+)
+@click.option(
+    '--verbose', '-v', is_flag=True, default=False
+)
+@click.argument(
+    'commits', metavar='',
+    required=False,
+    nargs=-1
+)
+@click.pass_context
+def bench(ctx, tests, compare, verbose, commits):
+    """🏋 Run benchmarks.
+
+    \b
+    Examples:
+
+    \b
+    $ spin bench -t bench_lib
+    $ spin bench -t bench_random.Random
+    $ spin bench -t Random -t Shuffle
+
+    Two benchmark runs can be compared.
+    By default, `HEAD` is compared to `main`.
+    You can also specify the branches/commits to compare:
+
+    \b
+    $ spin bench --compare
+    $ spin bench --compare main
+    $ spin bench --compare main HEAD
+
+    You can also choose which benchmarks to run in comparison mode:
+
+    $ spin bench -t Random --compare
+    """
+    if not commits:
+        commits = ('main', 'HEAD')
+    elif len(commits) == 1:
+        commits = commits + ('HEAD',)
+    elif len(commits) > 2:
+        raise click.ClickException('Need a maximum of two revisions to compare')
+
+    bench_args = []
+    for t in tests:
+        bench_args += ['--bench', t]
+
+    if verbose:
+        bench_args = ['-v'] + bench_args
+
+    if not compare:
+        # No comparison requested; we build and benchmark the current version
+
+        click.secho(
+            "Invoking `build` prior to running benchmarks:", bold=True, fg="bright_green"
+        )
+        ctx.invoke(meson.build)
+
+        meson._set_pythonpath()
+
+        p = util.run(
+            ['python', '-c', 'import numpy as np; print(np.__version__)'],
+            cwd='benchmarks',
+            echo=False,
+            output=False
+        )
+        os.chdir('..')
+
+        np_ver = p.stdout.strip().decode('ascii')
+        click.secho(
+            f'Running benchmarks on NumPy {np_ver}',
+            bold=True, fg="bright_green"
+        )
+        cmd = [
+            'asv', 'run', '--dry-run', '--show-stderr', '--python=same'
+        ] + bench_args
+
+        _run_asv(cmd)
+
+    else:
+        # Benchmark comparison
+
+        # Ensure that we don't have uncommited changes
+        commit_a, commit_b = [_commit_to_sha(c) for c in commits]
+
+        if commit_b == 'HEAD':
+            if _dirty_git_working_dir():
+                click.secho(
+                    "WARNING: you have uncommitted changes --- "
+                    "these will NOT be benchmarked!",
+                    fg="red"
+                )
+
+        cmd_compare = [
+            'asv', 'continuous', '--factor', '1.05',
+        ] + bench_args + [commit_a, commit_b]
+
+        _run_asv(cmd_compare)

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -154,7 +154,6 @@ def gdb(python_expr):
     )
 
 
-
 # From scipy: benchmarks/benchmarks/common.py
 def _set_mem_rlimit(max_mem=None):
     """
@@ -181,7 +180,11 @@ def _set_mem_rlimit(max_mem=None):
 def _commit_to_sha(commit):
     p = util.run(['git', 'rev-parse', commit], output=False, echo=False)
     if p.returncode != 0:
-        raise(click.ClickException(f'Could not find SHA matching commit `{commit}`'))
+        raise(
+            click.ClickException(
+                f'Could not find SHA matching commit `{commit}`'
+            )
+        )
 
     return p.stdout.decode('ascii').strip()
 
@@ -219,18 +222,15 @@ def _run_asv(cmd):
     try:
         util.run(cmd, cwd='benchmarks', env=env, sys_exit=False)
     except FileNotFoundError:
-        click.secho(
-            (
-                "Cannot find `asv`. "
-                "Please install Airspeed Velocity:\n\n"
-                "  https://asv.readthedocs.io/en/latest/installing.html\n"
-                "\n"
-                "Depending on your system, one of the following should work:\n\n"
-                "  pip install asv\n"
-                "  conda install asv\n"
-            ),
-            fg="red"
-        )
+        click.secho((
+            "Cannot find `asv`. "
+            "Please install Airspeed Velocity:\n\n"
+            "  https://asv.readthedocs.io/en/latest/installing.html\n"
+            "\n"
+            "Depending on your system, one of the following should work:\n\n"
+            "  pip install asv\n"
+            "  conda install asv\n"
+        ), fg="red")
         sys.exit(1)
 
 
@@ -287,7 +287,9 @@ def bench(ctx, tests, compare, verbose, commits):
     elif len(commits) == 1:
         commits = commits + ('HEAD',)
     elif len(commits) > 2:
-        raise click.ClickException('Need a maximum of two revisions to compare')
+        raise click.ClickException(
+            'Need a maximum of two revisions to compare'
+        )
 
     bench_args = []
     for t in tests:
@@ -300,7 +302,8 @@ def bench(ctx, tests, compare, verbose, commits):
         # No comparison requested; we build and benchmark the current version
 
         click.secho(
-            "Invoking `build` prior to running benchmarks:", bold=True, fg="bright_green"
+            "Invoking `build` prior to running benchmarks:",
+            bold=True, fg="bright_green"
         )
         ctx.invoke(meson.build)
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "numpy",
 
     // The project's homepage
-    "project_url": "https://www.numpy.org/",
+    "project_url": "https://numpy.org",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
@@ -16,6 +16,10 @@
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "tip" (for mercurial).
     "branches": ["HEAD"],
+
+    "build_command": [
+        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+    ],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
@@ -43,7 +47,7 @@
     // version.
     "matrix": {
         "Cython": [],
-        "setuptools": ["59.2.0"],
+        "build": [],
         "packaging": []
     },
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,3 +187,4 @@ package = 'numpy'
   "spin.cmds.meson.python", ".spin/cmds.py:gdb"
 ]
 "Documentation" = [".spin/cmds.py:docs"]
+"Metrics" = [".spin/cmds.py:bench"]


### PR DESCRIPTION
This is based off of SciPy's `dev.py spin` command, with slightly modified argument parsing.

It also changes the ASV config to build using Meson.

Partially closes https://github.com/scientific-python/spin/issues/40. Closes https://github.com/scientific-python/spin/issues/71.