### PR TITLE
DOC: Fix warnings and errors caused by reference/c-api/datetimes

### DIFF
--- a/doc/source/reference/c-api/datetimes.rst
+++ b/doc/source/reference/c-api/datetimes.rst
@@ -29,7 +29,7 @@ an "exploded" view of a datetime.
 
        The unit of the datetime.
 
-   .. c:member:: num
+   .. c:member:: int num
 
        A multiplier for the unit.
 
@@ -170,17 +170,22 @@ Conversion functions
       day according to local time) and "Now" (current time in UTC).
 
     ``str`` must be a NULL-terminated string, and ``len`` must be its length.
+
     ``unit`` should contain -1 if the unit is unknown, or the unit
-       which will be used if it is.
+    which will be used if it is.
+
     ``casting`` controls how the detected unit from the string is allowed
-       to be cast to the 'unit' parameter.
+    to be cast to the 'unit' parameter.
+
     ``out`` gets filled with the parsed date-time.
+
     ``out_bestunit`` gives a suggested unit based on the amount of
-       resolution provided in the string, or -1 for NaT.
+    resolution provided in the string, or -1 for NaT.
+    
     ``out_special`` gets set to 1 if the parsed time was 'today',
-       'now', or ''/'NaT'. For 'today', the unit recommended is
-       'D', for 'now', the unit recommended is 's', and for 'NaT'
-       the unit recommended is 'Y'.
+    'now', or 'NaT'. For 'today', the unit recommended is
+    'D', for 'now', the unit recommended is 's', and for 'NaT'
+    the unit recommended is 'Y'.
 
     Returns 0 on success, -1 on failure.
 

--- a/doc/source/reference/c-api/datetimes.rst
+++ b/doc/source/reference/c-api/datetimes.rst
@@ -183,7 +183,7 @@ Conversion functions
     resolution provided in the string, or -1 for NaT.
     
     ``out_special`` gets set to 1 if the parsed time was 'today',
-    'now', or 'NaT'. For 'today', the unit recommended is
+    'now', empty string, or 'NaT'. For 'today', the unit recommended is
     'D', for 'now', the unit recommended is 's', and for 'NaT'
     the unit recommended is 'Y'.
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Several small typos in the source datetimes.rst file were causing warnings and errors during the docs build. 

I have a doubt of the desired formatting of the section, which starts on the line 172. Based on the similar section of the same file (starts from 217 of the unchanged file) I think, that the format is correct now. @ngoldbaum could you clarify this moment?