### PR TITLE
DOC: Fix the reference in the docstring of numpy.meshgrid

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5050,7 +5050,7 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     mgrid : Construct a multi-dimensional "meshgrid" using indexing notation.
     ogrid : Construct an open multi-dimensional "meshgrid" using indexing
             notation.
-    how-to-index
+    :ref:`how-to-index`
 
     Examples
     --------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

There is an entry "how-to-index" in the "See Also" section of docstring of the numpy.meshgrid, which is not rendered as a link in the html documentation. I checked the [style guide](https://numpydoc.readthedocs.io/en/latest/format.html#see-also) and did not find the specification for the handling of references to the internal doc files in the "See Also" section. 

As I understand "how-to-index" is meant to lead to [this page](https://numpy.org/doc/stable/user/how-to-index.html) of the documentation. Reformatting "how-to-index" to the explicit ref role: ":ref:`how-to-index`" works, but  I'm not sure if it is the best solution.

Feedback on the proposed solution will be appreciated.  Probably, it make sense to add the comment about the usage of :ref: role in the "[See Also](https://numpydoc.readthedocs.io/en/latest/format.html#see-also)" section.
