### PR TITLE
MAINT: import numpy as ``np`` in ``spin ipython``

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -390,8 +390,9 @@ def ipython(ctx, ipython_args):
     ppath = meson._set_pythonpath()
 
     # Get NumPy version
-    p = util.run(
-        [sys.executable, '-c', 'import sys; sys.path.pop(0); import numpy; print(numpy.__version__)'],
+    p = util.run([
+        sys.executable, '-c',
+        'import sys; sys.path.pop(0); import numpy; print(numpy.__version__)'],
         output=False, echo=False
     )
     np_ver = p.stdout.strip().decode('ascii')
@@ -405,7 +406,8 @@ def ipython(ctx, ipython_args):
             f.write('import numpy as np\n')
 
         print(f'💻 Launching IPython with PYTHONPATH="{ppath}"')
-        util.run(["ipython", "--profile-dir", profile_dir, "--ignore-cwd"] + list(ipython_args))
+        util.run(["ipython", "--profile-dir", profile_dir, "--ignore-cwd"] +
+                 list(ipython_args))
 
 
 @click.command(context_settings={"ignore_unknown_options": True})

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -2,6 +2,9 @@ import os
 import shutil
 import sys
 import argparse
+import tempfile
+import pathlib
+import shutil
 
 import click
 from spin.cmds import meson
@@ -347,3 +350,82 @@ def bench(ctx, tests, compare, verbose, commits):
         ] + bench_args + [commit_a, commit_b]
 
         _run_asv(cmd_compare)
+
+
+@click.command(context_settings={
+    'ignore_unknown_options': True
+})
+@click.argument("python_args", metavar='', nargs=-1)
+@click.pass_context
+def python(ctx, python_args):
+    """🐍 Launch Python shell with PYTHONPATH set
+
+    OPTIONS are passed through directly to Python, e.g.:
+
+    spin python -c 'import sys; print(sys.path)'
+    """
+    env = os.environ
+    env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
+    ctx.invoke(meson.build)
+    ctx.forward(meson.python)
+
+
+@click.command(context_settings={
+    'ignore_unknown_options': True
+})
+@click.argument("ipython_args", metavar='', nargs=-1)
+@click.pass_context
+def ipython(ctx, ipython_args):
+    """💻 Launch IPython shell with PYTHONPATH set
+
+    OPTIONS are passed through directly to IPython, e.g.:
+
+    spin ipython -i myscript.py
+    """
+    env = os.environ
+    env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
+
+    ctx.invoke(meson.build)
+
+    ppath = meson._set_pythonpath()
+
+    # Get NumPy version
+    p = util.run(
+        [sys.executable, '-c', 'import sys; sys.path.pop(0); import numpy; print(numpy.__version__)'],
+        output=False, echo=False
+    )
+    np_ver = p.stdout.strip().decode('ascii')
+
+    with tempfile.TemporaryDirectory() as d:
+        profile_dir = os.path.join(d, f'numpy_{np_ver}')
+        startup_dir = os.path.join(profile_dir, 'startup')
+
+        pathlib.Path(startup_dir).mkdir(parents=True)
+        with open(os.path.join(startup_dir, '00_numpy.py'), 'w') as f:
+            f.write('import numpy as np\n')
+
+        print(f'💻 Launching IPython with PYTHONPATH="{ppath}"')
+        util.run(["ipython", "--profile-dir", profile_dir, "--ignore-cwd"] + list(ipython_args))
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1)
+@click.pass_context
+def run(ctx, args):
+    """🏁 Run a shell command with PYTHONPATH set
+
+    \b
+    spin run make
+    spin run 'echo $PYTHONPATH'
+    spin run python -c 'import sys; del sys.path[0]; import mypkg'
+
+    If you'd like to expand shell variables, like `$PYTHONPATH` in the example
+    above, you need to provide a single, quoted command to `run`:
+
+    spin run 'echo $SHELL && echo $PWD'
+
+    On Windows, all shell commands are run via Bash.
+    Install Git for Windows if you don't have Bash already.
+    """
+    ctx.invoke(meson.build)
+    ctx.forward(meson.run)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,8 +183,8 @@ package = 'numpy'
 [tool.spin.commands]
 "Build" = ["spin.cmds.meson.build", ".spin/cmds.py:test"]
 "Environments" = [
-  "spin.cmds.meson.run", "spin.cmds.meson.shell", "spin.cmds.meson.ipython",
-  "spin.cmds.meson.python", ".spin/cmds.py:gdb"
+  ".spin/cmds.py:run", ".spin/cmds.py:ipython",
+  ".spin/cmds.py:python", ".spin/cmds.py:gdb"
 ]
 "Documentation" = [".spin/cmds.py:docs"]
 "Metrics" = [".spin/cmds.py:bench"]


### PR DESCRIPTION
@seberg requested that we import numpy upon invocation of IPython.
I'll implement some internal support for this in spin 0.5, then we can get rid of most of the code here.

This PR also runs `build` before all run commands (`run`, `python`, `ipython`), and removes the `shell` command, which is likely less intuitive to use than `run`.

Another little perk is that you now see the numpy version when launching IPython:

```
Python 3.11.1 (main, Dec  7 2022, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0 -- An enhanced Interactive Python. Type '?' for help.

IPython profile: numpy_1.25.0rc1+446.g027ec8024

In [1]:
```