### PR TITLE
BUG: Only replace dtype temporarily if dimensions changed

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1695,8 +1695,10 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
     /* Decrease the number of dimensions to the detected ones */
     int out_ndim = PyArray_NDIM(ret);
     PyArray_Descr *out_descr = PyArray_DESCR(ret);
-    ((PyArrayObject_fields *)ret)->nd = ndim;
-    ((PyArrayObject_fields *)ret)->descr = dtype;
+    if (out_ndim != ndim) {
+        ((PyArrayObject_fields *)ret)->nd = ndim;
+        ((PyArrayObject_fields *)ret)->descr = dtype;
+    }
 
     int success = PyArray_AssignFromCache(ret, cache);
 
@@ -1929,8 +1931,10 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
 
         int actual_ndim = PyArray_NDIM(ret);
         PyArray_Descr *actual_dtype = PyArray_DESCR(ret);
-        ((PyArrayObject_fields *)ret)->nd = PyArray_NDIM(arr);
-        ((PyArrayObject_fields *)ret)->descr = newtype;
+        if (actual_ndim != PyArray_NDIM(arr)) {
+            ((PyArrayObject_fields *)ret)->nd = PyArray_NDIM(arr);
+            ((PyArrayObject_fields *)ret)->descr = newtype;
+        }
 
         int success = PyArray_CopyInto(ret, arr);
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -936,9 +936,10 @@ array_astype(PyArrayObject *self,
     /* Decrease the number of dimensions removing subarray ones again */
     int out_ndim = PyArray_NDIM(ret);
     PyArray_Descr *out_descr = PyArray_DESCR(ret);
-    ((PyArrayObject_fields *)ret)->nd = PyArray_NDIM(self);
-    ((PyArrayObject_fields *)ret)->descr = dtype;
-
+    if (out_ndim != PyArray_NDIM(self)) {
+        ((PyArrayObject_fields *)ret)->nd = PyArray_NDIM(self);
+        ((PyArrayObject_fields *)ret)->descr = dtype;
+    }
     int success = PyArray_CopyInto(ret, self);
 
     Py_DECREF(dtype);

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -890,7 +890,7 @@ def test_empty_string():
     res = np.array(arr, dtype="S")
     assert_array_equal(res, b"")
     # TODO: This is arguably weird/wrong, but seems old:
-    assert res.dtype == "S8"
+    assert res.dtype == f"S{np.dtype('O').itemsize}"
 
     res = np.array([[""] * 10, arr], dtype="S")
     assert_array_equal(res, b"")

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -870,3 +870,29 @@ def test_subarray_from_array_construction():
 
     res = np.array(arr, dtype="(2,2)f")
     assert_array_equal(res, expected)
+
+
+def test_empty_string():
+    # Empty strings are unfortunately often converted to S1 and we need to
+    # make sure we are filling the S1 and not the (possibly) detected S0
+    # result.  This should likely just return S0 and if not maybe the decision
+    # to return S1 should be moved.
+    res = np.array([""] * 10, dtype="S")
+    assert_array_equal(res, np.array("\0", "S1"))
+    assert res.dtype == "S1"
+
+    arr = np.array([""] * 10, dtype=object)
+
+    res = arr.astype("S")
+    assert_array_equal(res, b"")
+    assert res.dtype == "S1"
+
+    res = np.array(arr, dtype="S")
+    assert_array_equal(res, b"")
+    # TODO: This is arguably weird/wrong, but seems old:
+    assert res.dtype == "S8"
+
+    res = np.array([[""] * 10, arr], dtype="S")
+    assert_array_equal(res, b"")
+    assert res.shape == (2, 10)
+    assert res.dtype == "S1"


### PR DESCRIPTION
Backport of #24103.

for strings this is (currently) arguably not correct... Now of course strings shouldn't be changed to S0 probably, but that is a different matter.

It seems there is something odd (possibly I just kept it as a corner case) for coercion from object arrays.

Tests should cover the paths I think (lets see what CI says) but I couldn't reliably trigger failures for all paths.

Closes gh-24043



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
