### PR TITLE
DOC: Fix reference warning for recarray.

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -511,8 +511,8 @@ on item retrieval and comparison operations.
 
 .. _arrays.classes.rec:
 
-Record arrays (:mod:`numpy.rec`)
-================================
+Record arrays
+=============
 
 .. seealso:: :ref:`routines.array-creation.rec`, :ref:`routines.dtype`,
              :ref:`arrays.dtypes`.
@@ -528,6 +528,11 @@ scalar data type object :class:`record`.
 
    recarray
    record
+
+.. note::
+
+   The pandas DataFrame is more powerful than record array. If possible,
+   please use pandas DataFrame instead.
 
 Masked arrays (:mod:`numpy.ma`)
 ===============================

--- a/doc/source/reference/routines.array-creation.rst
+++ b/doc/source/reference/routines.array-creation.rst
@@ -44,11 +44,12 @@ From existing data
 
 .. _routines.array-creation.rec:
 
-Creating record arrays (:mod:`numpy.rec`)
------------------------------------------
+Creating record arrays
+----------------------
 
-.. note:: :mod:`numpy.rec` is the preferred alias for
-   :mod:`numpy.core.records`.
+.. note:: :mod:`numpy.core.records` is used to create record
+   array. Please refer to :ref:`arrays.classes.rec` for
+   record arrays.
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This is to fix reference warning for module numpy.rec. Put it in draft since I am not sure about current solution.
@rossbar , Please give comment. My current solution is add a new section for "record arrays" just after "masked arrays". 
Do you think it is reasonable? If yes, I can add related content in "record arrays" section.