### PR TITLE
MAINT: update pytest, hypothesis, pytest-cov, and pytz in test_requirements.txt

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -11,3 +11,4 @@ breathe>4.33.0
 
 # needed to build release notes
 towncrier
+toml

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,10 +2,10 @@ cython>=0.29.34,<3.0
 wheel==0.38.1
 setuptools==59.2.0 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
-hypothesis==6.24.1
-pytest==6.2.5
-pytz==2021.3
-pytest-cov==3.0.0
+hypothesis==6.81.1
+pytest==7.4.0
+pytz==2023.3
+pytest-cov==4.1.0
 pytest-xdist
 # for numpy.random.test.test_extending
 cffi; python_version < '3.10'


### PR DESCRIPTION
These dependencies haven't been updated since 2021 when dependabot was disabled. Let's see if updating them causes any issues in any CI jobs.