### PR TITLE
ENH: Raise error for invalid input type to `np.histogram`

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -781,6 +781,9 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     """
     a, weights = _ravel_and_check_weights(a, weights)
 
+    if not np.issubdtype(a.dtype, np.number):
+        raise ValueError(f"expected numeric input data type, got: {a.dtype}")
+
     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
 
     # Histogram is an integer or a float array depending on the weights.

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -781,7 +781,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     """
     a, weights = _ravel_and_check_weights(a, weights)
 
-    if not np.issubdtype(a.dtype, np.number):
+    if not (np.issubdtype(a.dtype, np.number) or np.issubdtype(a.dtype, np.datetime64)):
         raise ValueError(f"expected numeric input data type, got: {a.dtype}")
 
     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -781,7 +781,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     """
     a, weights = _ravel_and_check_weights(a, weights)
 
-    if not (np.issubdtype(a.dtype, np.number) or np.issubdtype(a.dtype, np.datetime64)):
+    if not ((np.issubdtype(a.dtype, np.number)) or 
+            (np.issubdtype(a.dtype, np.datetime64))):
         raise ValueError(f"expected numeric input data type, got: {a.dtype}")
 
     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)


### PR DESCRIPTION
added check to see if the histograms function values are numeric. if not, raises Value Error as discussed in #24032 
