### PR TITLE
DOC: Add note that NEP 29 is superseded by SPEC 0

### DIFF
--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -11,6 +11,9 @@ NEP 29 — Recommend Python and NumPy version support as a community policy stan
 :Created: 2019-07-13
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2019-October/080128.html
 
+.. note::
+  This NEP is superseded by the scientific python ecosystem coordination guideline
+  `SPEC 0 — Minimum Supported Versions <https://scientific-python.org/specs/spec-0000/>`__.
 
 Abstract
 --------


### PR DESCRIPTION
The SPEC is basically the predecessor, we should try to slowly refer to it mostly, so add a note here.

Ping @stefanv.