### PR TITLE
MAINT: do not use copyswap in flatiter internals

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -527,24 +527,22 @@ iter_subscript_int(PyArrayIterObject *self, PyArrayObject *ind,
     while (counter--) {
         num = *((npy_intp *)(ind_it->dataptr));
         if (check_and_adjust_index(&num, self->size, -1, NULL) < 0) {
-            Py_DECREF(ind_it);
-            Py_DECREF(ret);
-            PyArray_ITER_RESET(self);
-            return NULL;
+            Py_CLEAR(ret);
+            goto finish;
         }
         PyArray_ITER_GOTO1D(self, num);
         char *args[2] = {self->dataptr, optr};
         npy_intp transfer_strides[2] = {itemsize, itemsize};
         if (cast_info->func(&cast_info->context, args, &one,
                             transfer_strides, cast_info->auxdata) < 0) {
-            Py_DECREF(ind_it);
-            Py_DECREF(ret);
-            PyArray_ITER_RESET(self);
-            return NULL;
+            Py_CLEAR(ret);
+            goto finish;
         }
         optr += itemsize;
         PyArray_ITER_NEXT(ind_it);
     }
+
+ finish:
     Py_DECREF(ind_it);
     PyArray_ITER_RESET(self);
     return (PyObject *)ret;

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -1,3 +1,4 @@
+import sys
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -272,20 +273,21 @@ class TestSFloat:
         for i, val in enumerate(arr.flat):
             assert arr[i] == val
 
-        indices = [[1, 2], ..., slice(None, 2, None),
-                   np.array([True, True, False]), np.array([0, 1])]
+    @pytest.mark.parametrize(
+        "index", [
+            [1, 2], ..., slice(None, 2, None),
+            np.array([True, True, False]), np.array([0, 1])
+        ], ids=["int_list", "ellipsis", "slice", "bool_array", "int_array"])
+    def test_flatiter_index(self, index):
+        arr = np.array([1.0, 2.0, 3.0], dtype=SF(1.0))
+        np.testing.assert_array_equal(
+            arr[index].view(np.float64), arr.flat[index].view(np.float64))
 
-        for ind in indices:
-            arr = np.array([1.0, 2.0, 3.0], dtype=SF(1.0))
-            np.testing.assert_array_equal(
-                arr[ind].view(np.float64), arr.flat[ind].view(np.float64))
-
-            arr2 = arr.copy()
-            arr[ind] = 5.0
-            arr2.flat[ind] = 5.0
-            np.testing.assert_array_equal(
-                arr.view(np.float64), arr2.view(np.float64))
-
+        arr2 = arr.copy()
+        arr[index] = 5.0
+        arr2.flat[index] = 5.0
+        np.testing.assert_array_equal(
+            arr.view(np.float64), arr2.view(np.float64))
 
 def test_type_pickle():
     # can't actually unpickle, but we can pickle (if in namespace)

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -266,6 +266,25 @@ class TestSFloat:
 
         del np._ScaledFloatTestDType
 
+    def test_flatiter(self):
+        arr = np.array([1.0, 2.0, 3.0], dtype=SF(1.0))
+
+        for i, val in enumerate(arr.flat):
+            assert arr[i] == val
+
+        indices = [[1, 2], ..., slice(None, 2, None),
+                   np.array([True, True, False]), np.array([0, 1])]
+
+        for ind in indices:
+            arr = np.array([1.0, 2.0, 3.0], dtype=SF(1.0))
+            np.testing.assert_array_equal(
+                arr[ind].view(np.float64), arr.flat[ind].view(np.float64))
+
+            arr2 = arr.copy()
+            arr[ind] = 5.0
+            arr2.flat[ind] = 5.0
+            np.testing.assert_array_equal(
+                arr.view(np.float64), arr2.view(np.float64))
 
 
 def test_type_pickle():


### PR DESCRIPTION
Fixes #23486.

Updates all the code paths used by the flatiter getter and setter to use single-element casts instead of copyswap. This allows new dtypes to use these code paths without seg faulting.

I ran the flatiter benchmarks and didn't see any significant performance changes, but there seem to only be benchmarks for boolean indexing. I could probably substantially improve performance by only using copyswap in situations where it's required but using a hand-unrolled `memcpy` like `fasttake` otherwise but only want to fix the seg faults for now.