### PR TITLE
Update np.vectorize documentation in function_base.py

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2265,18 +2265,16 @@ class vectorize:
            [0., 0., 0., 1., 2., 1.]])
 
     Decorator syntax is supported.  The decorator can be called as
-    a function to provide keyword arguments.
+    a function to provide keyword arguments:
 
     >>> @np.vectorize
     ... def identity(x):
     ...     return x
-    ...
     >>> identity([0, 1, 2])
     array([0, 1, 2])
     >>> @np.vectorize(otypes=[float])
     ... def as_float(x):
     ...     return x
-    ...
     >>> as_float([0, 1, 2])
     array([0., 1., 2.])
     """


### PR DESCRIPTION
The last code block in the Sphinx documentation isn't rendered correctly.
![Screenshot 2023-07-14 7 43 46 AM](https://github.com/numpy/numpy/assets/11398666/dc565701-bba2-4b64-b36d-befcc3aa2d34)
