### PR TITLE
BLD: use ``-ftrapping-math`` with Clang on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,15 @@ endif
 add_project_arguments(
   cc.get_supported_arguments( '-fno-strict-aliasing'), language : 'c'
 )
+#
+# Clang defaults to a non-strict floating error point model, but we need strict
+# behavior. `-ftrapping-math` is equivalent to `-ffp-exception-behavior=strict`.
+# Note that this is only supported on macOS arm64 as of XCode 14.3
+if cc.get_id() == 'clang'
+  add_project_arguments(
+    cc.get_supported_arguments('-ftrapping-math'), language: ['c', 'cpp'],
+  )
+endif
 
 # Generate version number. Note that this will not (yet) update the version
 # number seen by pip or reflected in wheel filenames. See


### PR DESCRIPTION
Backport of #24060.

The distutils build also uses this flag, and it avoids some problems with `floor_divide` and similar functions (xref gh-19479).

For older macOS arm64 Clang versions, the flag does get accepted, but then gets overridden because it's not actually supported - which yields these warnings:
```
warning: overriding currently unsupported use of floating point exceptions on this target [-Wunsupported-floating-point-opt]
```
Since they're a little annoying to suppress and will go away when updating to the latest XCode version, we'll ignore these warnings.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
