### PR TITLE
BUG: properly handle negative indexes in ufunc_at fast path

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5955,14 +5955,19 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
         }
     }
 
-    npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
-
     if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
         npy_clear_floatstatus_barrier((char *)context);
     }
 
     do {
-        args[1] = (char *) iter->outer_ptrs[0];
+        npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
+        npy_intp * indxP = (npy_intp *)iter->outer_ptrs[0];
+        for (npy_intp i=0; i < *inner_size; i++) {
+            if (indxP[i] < 0) {
+                indxP[i] += iter->fancy_dims[0];
+            }
+        }
+        args[1] = (char *)indxP;
         steps[1] = iter->outer_strides[0];
 
         res = ufuncimpl->contiguous_indexed_loop(

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2215,6 +2215,14 @@ class TestUfunc:
         np.maximum.at(a, [0], 0)
         assert_equal(a, np.array([1, 2, 3]))
 
+    def test_at_negative_indexes(self):
+        a = np.arange(10)
+        indxs = np.array([-1, 1, -1, 2])
+        np.add.at(a, indxs, 1)
+        assert a[-1] == 11  # issue 24147
+        assert a[1] == 2
+        assert a[2] == 3
+
     def test_at_not_none_signature(self):
         # Test ufuncs with non-trivial signature raise a TypeError
         a = np.ones((2, 2, 2))


### PR DESCRIPTION
Backport of #24150.

Fixes #24147 

When avoiding the iter API for faster iteration, negative indexes need to be unwrapped.

Other places this is done in a similar way:
- in `mapiter_@name@` https://github.com/numpy/numpy/blob/c143f7b93b125db90960c40f2f245e3530d74ce2/numpy/core/src/multiarray/lowlevel_strided_loops.c.src#L1683-L1684 (and more like that)
- in `PyArray_MapIterReset` https://github.com/numpy/numpy/blob/c143f7b93b125db90960c40f2f245e3530d74ce2/numpy/core/src/multiarray/mapping.c#L2281-L2282
- in `PyArray_MapIterNext` https://github.com/numpy/numpy/blob/c143f7b93b125db90960c40f2f245e3530d74ce2/numpy/core/src/multiarray/mapping.c#L2335-L2336 (and more like that)

Test added that failed before, passes after
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
