### PR TITLE
BUG: PyObject_IsTrue and PyObject_Not error handling in setflags

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2713,7 +2713,11 @@ array_setflags(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
 
     if (align_flag != Py_None) {
-        if (PyObject_Not(align_flag)) {
+        int isnot = PyObject_Not(align_flag);
+        if (isnot == -1) {
+            return NULL;
+        }
+        if (isnot) {
             PyArray_CLEARFLAGS(self, NPY_ARRAY_ALIGNED);
         }
         else if (IsAligned(self)) {
@@ -2728,7 +2732,11 @@ array_setflags(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (uic != Py_None) {
-        if (PyObject_IsTrue(uic)) {
+        int istrue = PyObject_IsTrue(uic);
+        if (istrue == -1) {
+            return NULL;
+        }
+        if (istrue) {
             fa->flags = flagback;
             PyErr_SetString(PyExc_ValueError,
                             "cannot set WRITEBACKIFCOPY "
@@ -2743,7 +2751,11 @@ array_setflags(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (write_flag != Py_None) {
-        if (PyObject_IsTrue(write_flag)) {
+        int istrue = PyObject_IsTrue(write_flag);
+        if (istrue == -1) {
+            return NULL;
+        }
+        else if (istrue == 1) {
             if (_IsWriteable(self)) {
                 /*
                  * _IsWritable (and PyArray_UpdateFlags) allows flipping this,


### PR DESCRIPTION
Backport of #24178.

Fixes an issue revealed by the fuzzing in #24175. If any of the arguments are ndarrays or any other type that raises an error when trying to figure out its truthiness, the interpreter will get into an inconsistent state.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
