### PR TITLE
BUG: Fix the signature for np.array_api.take

### DIFF
--- a/numpy/array_api/_indexing_functions.py
+++ b/numpy/array_api/_indexing_functions.py
@@ -5,14 +5,16 @@ from ._dtypes import _integer_dtypes
 
 import numpy as np
 
-def take(x: Array, indices: Array, /, *, axis: int) -> Array:
+def take(x: Array, indices: Array, /, *, axis: Optional[int] = None) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.take <numpy.take>`.
 
     See its docstring for more information.
-    """    
+    """
+    if axis is None and x.ndim != 1:
+        raise ValueError("axis must be specified when ndim > 1")
     if indices.dtype not in _integer_dtypes:
         raise TypeError("Only integer dtypes are allowed in indexing")
-    if indices.ndim != 1: 
+    if indices.ndim != 1:
         raise ValueError("Only 1-dim indices array is supported")
     return Array._new(np.take(x._array, indices._array, axis=axis))


### PR DESCRIPTION
The array_api take() doesn't flatten the array by default, so the axis argument must be provided for multidimensional arrays. However, it should be optional when the input array is 1-D, which the signature previously did not allow.

c.f. https://github.com/data-apis/array-api/pull/644

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
