### PR TITLE
BUG: fix choose refcount leak

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1088,15 +1088,16 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
                 break;
             }
         }
-        if (cast_info.func != NULL) {
+        if (cast_info.func == NULL) {
+            /* We ensure memory doesn't overlap, so can use memcpy */
+            memcpy(ret_data, PyArray_MultiIter_DATA(multi, mi), elsize);
+        }
+        else {
             char *args[2] = {PyArray_MultiIter_DATA(multi, mi), ret_data};
             if (cast_info.func(&cast_info.context, args, &one,
                                 transfer_strides, cast_info.auxdata) < 0) {
                 goto fail;
             }
-        }
-        else {
-            memmove(ret_data, PyArray_MultiIter_DATA(multi, mi), elsize);
         }
         ret_data += elsize;
         PyArray_MultiIter_NEXT(multi);

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -993,9 +993,10 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     if (multi == NULL) {
         goto fail;
     }
+    dtype = PyArray_DESCR(mps[0]);
+
     /* Set-up return array */
     if (out == NULL) {
-        dtype = PyArray_DESCR(mps[0]);
         Py_INCREF(dtype);
         obj = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(ap),
                                                     dtype,
@@ -1032,7 +1033,6 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
              */
             flags |= NPY_ARRAY_ENSURECOPY;
         }
-        dtype = PyArray_DESCR(mps[0]);
         Py_INCREF(dtype);
         obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
     }
@@ -1040,15 +1040,14 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     if (obj == NULL) {
         goto fail;
     }
-    elsize = PyArray_DESCR(obj)->elsize;
+    elsize = dtype->elsize;
     ret_data = PyArray_DATA(obj);
     npy_intp transfer_strides[2] = {elsize, elsize};
     npy_intp one = 1;
     NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
     NPY_cast_info cast_info = {.func = NULL};
     if (PyDataType_REFCHK(dtype)) {
-        PyArrayIterObject *ind_it = (PyArrayIterObject *)PyArray_IterNew((PyObject *)out);
-        int is_aligned = IsUintAligned(ind_it->ao);
+        int is_aligned = IsUintAligned(obj);
         PyArray_GetDTypeTransferFunction(
                     is_aligned,
                     dtype->elsize,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -10028,3 +10028,13 @@ def test_argsort_int(N, dtype):
     arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
     arr[N-1] = maxv
     assert_arg_sorted(arr, np.argsort(arr, kind='quick'))
+
+
+@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+def test_gh_22683():
+    a = np.ones(10000, dtype=object)
+    refc_start = sys.getrefcount(1)
+    np.choose(np.zeros(10000, dtype=int), [a], out=a)
+    np.choose(np.zeros(10000, dtype=int), [a], out=a)
+    refc_end = sys.getrefcount(1)
+    assert refc_end - refc_start < 10

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -10032,9 +10032,10 @@ def test_argsort_int(N, dtype):
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 def test_gh_22683():
-    a = np.ones(10000, dtype=object)
-    refc_start = sys.getrefcount(1)
+    b = 777.68760986
+    a = np.array([b] * 10000, dtype=object)
+    refc_start = sys.getrefcount(b)
     np.choose(np.zeros(10000, dtype=int), [a], out=a)
     np.choose(np.zeros(10000, dtype=int), [a], out=a)
-    refc_end = sys.getrefcount(1)
+    refc_end = sys.getrefcount(b)
     assert refc_end - refc_start < 10


### PR DESCRIPTION
* Fixes #22683

* use `copyswap` to avoid the reference count leaking reported above when `np.choose` is used with `out`

* my impression from the ticket is that Sebastian doesn't think `copyswap` is a perfect solution, but may suffice short-term?