### PR TITLE
BUG: array2string does not add signs for positive integers. Fixes #24181

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -154,6 +154,11 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         print the sign of positive values. If ' ', always prints a space
         (whitespace character) in the sign position of positive values.  If
         '-', omit the sign character of positive values. (default '-')
+
+        .. versionchanged:: 2.0
+             The sign parameter can now be an integer type, previously
+             types were floating-point types.
+
     formatter : dict of callables, optional
         If not None, the keys should indicate the type(s) that the respective
         formatting function applies to.  Callables should return a string.
@@ -407,7 +412,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
     # wrapped in lambdas to avoid taking a code path with the wrong type of data
     formatdict = {
         'bool': lambda: BoolFormat(data),
-        'int': lambda: IntegerFormat(data),
+        'int': lambda: IntegerFormat(data, sign),
         'float': lambda: FloatingFormat(
             data, precision, floatmode, suppress, sign, legacy=legacy),
         'longfloat': lambda: FloatingFormat(
@@ -639,6 +644,11 @@ def array2string(a, max_line_width=None, precision=None,
         (whitespace character) in the sign position of positive values.  If
         '-', omit the sign character of positive values.
         Defaults to ``numpy.get_printoptions()['sign']``.
+
+        .. versionchanged:: 2.0
+             The sign parameter can now be an integer type, previously
+             types were floating-point types.
+
     floatmode : str, optional
         Controls the interpretation of the `precision` option for
         floating-point types.
@@ -1218,19 +1228,24 @@ def format_float_positional(x, precision=None, unique=True,
                               sign=sign, pad_left=pad_left,
                               pad_right=pad_right, min_digits=min_digits)
 
-
 class IntegerFormat:
-    def __init__(self, data):
+    def __init__(self, data, sign='-'):
         if data.size > 0:
-            max_str_len = max(len(str(np.max(data))),
-                              len(str(np.min(data))))
+            data_max = np.max(data)
+            data_min = np.min(data)
+            data_max_str_len = len(str(data_max))
+            if sign == ' ' and data_min < 0:
+                sign = '-'
+            if data_max >= 0 and sign in "+ ":
+                data_max_str_len += 1
+            max_str_len = max(data_max_str_len,
+                              len(str(data_min)))
         else:
             max_str_len = 0
-        self.format = '%{}d'.format(max_str_len)
+        self.format = f'{{:{sign}{max_str_len}d}}'
 
     def __call__(self, x):
-        return self.format % x
-
+        return self.format.format(x)
 
 class BoolFormat:
     def __init__(self, data, **kwargs):

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -524,6 +524,93 @@ class TestArray2String:
         gc.enable()
         assert_(r1 == r2)
 
+    def test_with_sign(self):
+        # mixed negative and positive value array
+        a = np.array([-2, 0, 3])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[-2 +0 +3]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[-2  0  3]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[-2  0  3]'
+        )
+        # all non-negative array
+        a = np.array([2, 0, 3])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[+2 +0 +3]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[2 0 3]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[ 2  0  3]'
+        )
+        # all negative array
+        a = np.array([-2, -1, -3])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[-2 -1 -3]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[-2 -1 -3]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[-2 -1 -3]'
+        )
+        # 2d array mixed negative and positive
+        a = np.array([[10, -1, 1, 1], [10, 10, 10, 10]])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[[+10  -1  +1  +1]\n [+10 +10 +10 +10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[[10 -1  1  1]\n [10 10 10 10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[[10 -1  1  1]\n [10 10 10 10]]'
+        )
+        # 2d array all positive
+        a = np.array([[10, 0, 1, 1], [10, 10, 10, 10]])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[[+10  +0  +1  +1]\n [+10 +10 +10 +10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[[10  0  1  1]\n [10 10 10 10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[[ 10   0   1   1]\n [ 10  10  10  10]]'
+        )
+        # 2d array all negative
+        a = np.array([[-10, -1, -1, -1], [-10, -10, -10, -10]])
+        assert_equal(
+            np.array2string(a, sign='+'),
+            '[[-10  -1  -1  -1]\n [-10 -10 -10 -10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign='-'),
+            '[[-10  -1  -1  -1]\n [-10 -10 -10 -10]]'
+        )
+        assert_equal(
+            np.array2string(a, sign=' '),
+            '[[-10  -1  -1  -1]\n [-10 -10 -10 -10]]'
+        )
+
+
 class TestPrintOptions:
     """Test getting and setting global print options."""
 


### PR DESCRIPTION
This was made to fix [#24181](https://github.com/numpy/numpy/issues/24181).

In this the user described wanting to see similar  behavior in `array2string` for integers as it does for floats when a `sign` argument is given.  I implemented a fix that adds this functionality to the method.

```Python
import numpy as np
arr = np.array([-2, 0, 3])
print(np.array2string(arr, sign='+'))
print(np.array2string(arr.astype(float), sign='+'))

BEFORE FIX:
# output:
# [-2  0  3]
# [-2. +0. +3.]

AFTER FIX:
# output:
# [-2  +0  +3]
# [-2. +0. +3.]
```
