### PR TITLE
BUG: Return ValueError for non-numeric histogram, see #24032

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import operator
 import warnings
+import numbers
 
 import numpy as np
 from numpy.core import overrides
@@ -779,6 +780,26 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
         plt.show()
 
     """
+    # Validate that input is numeric
+    if isinstance(a, np.ndarray):
+        # May want to further consider mM cases, see test_datetime
+        if a.dtype.kind in 'OSUV':
+            raise ValueError(
+                f"Input numpy array must have a numeric type, "
+                f"input array is {a.dtype.name} type.")
+    else:
+        for idx, elem in enumerate(a):
+            if not (isinstance(elem, numbers.Number)
+                    or isinstance(elem, np.ndarray)):
+                raise ValueError(
+                    f"Input array must be all numeric values. "
+                    f"Non-numeric value {elem} found at index {idx}.")
+            if isinstance(elem, np.ndarray) and elem.dtype.kind in 'OSUV':
+                raise ValueError(
+                    f"Input array must be all numeric values. "
+                    f"Non-numeric value {elem} found at index {idx}.")
+
+
     a, weights = _ravel_and_check_weights(a, weights)
 
     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -323,6 +323,19 @@ class TestHistogram:
         assert_equal(d_edge.dtype, dates.dtype)
         assert_equal(t_edge.dtype, td)
 
+    def test_fails_on_bad_input(self):
+        # gh-24032
+        # Fails on OSUV arrays
+        assert_raises(ValueError, histogram, np.array([object]))
+        assert_raises(ValueError, histogram, np.array([b'x']))
+        assert_raises(ValueError, histogram, np.array(['x']))
+        assert_raises(
+            ValueError, histogram, a = np.array([b'x'], dtype=np.dtype('V')))
+
+        # Fails on non-numeric, non-np arrays
+        assert_raises(ValueError, histogram, [0, None])
+        assert_raises(ValueError, histogram, [0, '1'])
+
     def do_signed_overflow_bounds(self, dtype):
         exponent = 8 * np.dtype(dtype).itemsize - 1
         arr = np.array([-2**exponent + 4, 2**exponent - 4], dtype=dtype)


### PR DESCRIPTION
This adds a test to the top of `np.histogram` to ensure that values are numeric. Original issue noted problems with strings, I am testing over the `OUSV` categories of dtypes. If we are given something that is not an ndarray (e.g. a list) I can only really check data element-wise.

A couple of questions that occurred to me while working on this (potentially out of scope?):
- Do we want to consider some other monotype arrays (e.g. what if we feed a Pandas Series to this?)
- Do we want to worry about complex numbers?
- Do we want to impose limits on datetime/timedelta like data (`mM` kind)? The `test_datetime` indicates that we get failures if we don't hard-code the bins, but we get a unhelpful error message in this case. Perhaps it would be better to return a similar ValueError.

Closes #24032