### PR TITLE
BUG: dot -0. semantics

### DIFF
--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -387,6 +387,10 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
                                                  *((double *)PyArray_DATA(ap1));
             }
             else if (ap1shape != _matrix) {
+                for (size_t i = 0; i < PyArray_SIZE(out_buf); i += 1) {
+                    ((double *)PyArray_DATA(out_buf))[i] = -0.0;
+                }
+
                 CBLAS_FUNC(cblas_daxpy)(l,
                             *((double *)PyArray_DATA(ap2)),
                             (double *)PyArray_DATA(ap1),

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3671,7 +3671,7 @@ NPY_NO_EXPORT void
     else
 #endif
     {
-        @type@ sum = (@type@)0;  /* could make this double */
+        @type@ sum = (@type@)-0.0;  /* could make this double */
         npy_intp i;
 
         for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3653,14 +3653,21 @@ NPY_NO_EXPORT void
 
     if (is1b && is2b)
     {
-        double sum = 0.;  /* double for stability */
+        double sum = -0.;  /* double for stability */
+        double result;
 
         while (n > 0) {
             CBLAS_INT chunk = n < NPY_CBLAS_CHUNK ? n : NPY_CBLAS_CHUNK;
 
-            sum += CBLAS_FUNC(cblas_@prefix@dot)(chunk,
+            result = CBLAS_FUNC(cblas_@prefix@dot)(chunk,
                                      (@type@ *) ip1, is1b,
                                      (@type@ *) ip2, is2b);
+            if (npy_signbit(((@type@ *)ip1)[0]) &&
+                ((@type@ *)ip1)[0] == 0 &&
+                !npy_signbit(((@type@ *)ip2)[0])) {
+                result = -0.0;
+            }
+            sum += result;
             /* use char strides here */
             ip1 += chunk * is1;
             ip2 += chunk * is2;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6797,6 +6797,15 @@ class TestDot:
         with pytest.raises(TypeError):
             np.dot(3.0, BadObject())
 
+    @pytest.mark.parametrize("operand", [
+        np.array([[0.]]),
+        np.array([[1.]]),
+        ])
+    def test_gh_21342(self, operand):
+        actual = np.signbit(np.dot(np.array([[-0.], [-0.]]), operand))
+        expected = np.signbit(np.array([[-0.], [-0.]]))
+        assert_array_equal(actual, expected)
+
 
 class MatmulCommon:
     """Common tests for '@' operator and numpy.matmul.

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6797,13 +6797,57 @@ class TestDot:
         with pytest.raises(TypeError):
             np.dot(3.0, BadObject())
 
-    @pytest.mark.parametrize("operand", [
-        np.array([[0.]]),
-        np.array([[1.]]),
+    @pytest.mark.parametrize("arr1, arr2, expected", [
+        # arr1 strides (8, 8)
+        (np.array([[-0.], [-0.]]),
+         np.array([[0.]]),
+         np.array([[-0.], [-0.]]),
+        ),
+        # arr1 strides (8, 8)
+        (np.array([[-0.], [-0.]]),
+         np.array([[1.]]),
+         np.array([[-0.], [-0.]]),
+        ),
+        # arr1 strides (8, 16)
+        (np.array([[-0.], [-0.]], order="F"),
+         np.array([[1.]]),
+         np.array([[-0.], [-0.]]),
+        ),
+        # arr1 strides (16, 16, 8, 8)
+        (np.array([[-0.], [-0.]]).reshape(1, 1, 2, 1),
+         np.array([[1.]]),
+         np.array([[-0.], [-0.]]).reshape(1, 1, 2, 1),
+        ),
+        # arr1 strides (24, 8, 8, 8, 8)
+        # check for sign flip
+        (np.array([[-0.], [-0.], [-0.]]).reshape(1, 3, 1, 1, 1),
+         np.array([[-0.]]),
+         np.array([[0.], [0.], [0.]]).reshape(1, 3, 1, 1, 1),
+        ),
+        # 2 0-D arrays
+        (np.array(-0.),
+         np.array(0.),
+         np.array(-0.),
+        ),
+        # 2-D * 0-D
+        (np.array([[-0.], [-0.]]),
+         np.array(0.),
+         np.array([[-0.], [-0.]]),
+        ),
+        # 2-D * 0-D sign flip
+        (np.array([[-0.], [-0.]]),
+         np.array(-0.),
+         np.array([[0.], [0.]]),
+        ),
+        # two arrays of size 0
+        (np.array([]),
+         np.array([]),
+         np.array(0.),
+        ),
         ])
-    def test_gh_21342(self, operand):
-        actual = np.signbit(np.dot(np.array([[-0.], [-0.]]), operand))
-        expected = np.signbit(np.array([[-0.], [-0.]]))
+    def test_gh_21342(self, arr1, arr2, expected):
+        actual = np.signbit(np.dot(arr1, arr2))
+        expected = np.signbit(expected)
         assert_array_equal(actual, expected)
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6801,49 +6801,40 @@ class TestDot:
         # arr1 strides (8, 8)
         (np.array([[-0.], [-0.]]),
          np.array([[0.]]),
-         np.array([[-0.], [-0.]]),
-        ),
+         np.array([[-0.], [-0.]])),
         # arr1 strides (8, 8)
         (np.array([[-0.], [-0.]]),
          np.array([[1.]]),
-         np.array([[-0.], [-0.]]),
-        ),
+         np.array([[-0.], [-0.]])),
         # arr1 strides (8, 16)
         (np.array([[-0.], [-0.]], order="F"),
          np.array([[1.]]),
-         np.array([[-0.], [-0.]]),
-        ),
+         np.array([[-0.], [-0.]])),
         # arr1 strides (16, 16, 8, 8)
         (np.array([[-0.], [-0.]]).reshape(1, 1, 2, 1),
          np.array([[1.]]),
-         np.array([[-0.], [-0.]]).reshape(1, 1, 2, 1),
-        ),
+         np.array([[-0.], [-0.]]).reshape(1, 1, 2, 1)),
         # arr1 strides (24, 8, 8, 8, 8)
         # check for sign flip
         (np.array([[-0.], [-0.], [-0.]]).reshape(1, 3, 1, 1, 1),
          np.array([[-0.]]),
-         np.array([[0.], [0.], [0.]]).reshape(1, 3, 1, 1, 1),
-        ),
+         np.array([[0.], [0.], [0.]]).reshape(1, 3, 1, 1, 1)),
         # 2 0-D arrays
         (np.array(-0.),
          np.array(0.),
-         np.array(-0.),
-        ),
+         np.array(-0.)),
         # 2-D * 0-D
         (np.array([[-0.], [-0.]]),
          np.array(0.),
-         np.array([[-0.], [-0.]]),
-        ),
+         np.array([[-0.], [-0.]])),
         # 2-D * 0-D sign flip
         (np.array([[-0.], [-0.]]),
          np.array(-0.),
-         np.array([[0.], [0.]]),
-        ),
+         np.array([[0.], [0.]])),
         # two arrays of size 0
         (np.array([]),
          np.array([]),
-         np.array(0.),
-        ),
+         np.array(0.)),
         ])
     def test_gh_21342(self, arr1, arr2, expected):
         actual = np.signbit(np.dot(arr1, arr2))


### PR DESCRIPTION
* Fixes #21342

* add a regression test and fix for the above issue, which seems to boil down to `memset` not being a great fit for negative zero floating point semantics because it zeros out using unsigned char bit patterns

* the testsuite was happy about this solution, but I'll add one or two comments inline re: residual concerns

* @stefanv helped me with a bit of debugging here as well, during the SciPy sprint