### PR TITLE
ENH:  Vectorize np.partition and np.argpartition using AVX-512

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -132,7 +132,7 @@ def memoize(f):
     def wrapped(*args):
         if args not in _memoized:
             _memoized[args] = f(*args)
-        
+
         return _memoized[args].copy()
 
     return f
@@ -154,7 +154,7 @@ class SortGenerator:
         arr = np.arange(size, dtype=dtype)
         np.random.shuffle(arr)
         return arr
-    
+
     @staticmethod
     @memoize
     def ordered(size, dtype):
@@ -237,7 +237,6 @@ class SortGenerator:
 
         return cls.random_unsorted_area(size, dtype, frac, bubble_size)
 
-
 class Sort(Benchmark):
     """
     This benchmark tests sorting performance with several
@@ -286,6 +285,35 @@ class Sort(Benchmark):
 
     def time_argsort(self, kind, dtype, array_type):
         np.argsort(self.arr, kind=kind)
+
+
+class Partition(Benchmark):
+    params = [
+        ['float64', 'int64', 'float32', 'int32', 'int16', 'float16'],
+        [
+            ('random',),
+            ('ordered',),
+            ('reversed',),
+            ('uniform',),
+            ('sorted_block', 10),
+            ('sorted_block', 100),
+            ('sorted_block', 1000),
+        ],
+        [10, 100, 1000],
+    ]
+    param_names = ['dtype', 'array_type', 'k']
+
+    # The size of the benchmarked arrays.
+    ARRAY_SIZE = 100000
+
+    def setup(self, dtype, array_type, k):
+        np.random.seed(1234)
+        array_class = array_type[0]
+        self.arr = getattr(SortGenerator, array_class)(self.ARRAY_SIZE,
+                dtype, *array_type[1:])
+
+    def time_partition(self, dtype, array_type, k):
+        np.partition(self.arr, k)
 
 
 class SortWorst(Benchmark):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -313,8 +313,10 @@ class Partition(Benchmark):
                 dtype, *array_type[1:])
 
     def time_partition(self, dtype, array_type, k):
-        np.partition(self.arr, k)
+        temp = np.partition(self.arr, k)
 
+    def time_argpartition(self, dtype, array_type, k):
+        temp = np.argpartition(self.arr, k)
 
 class SortWorst(Benchmark):
     def setup(self):

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4239,7 +4239,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('partition',
     >>> a = np.array([3, 4, 2, 1])
     >>> a.partition(3)
     >>> a
-    array([2, 1, 3, 4])
+    array([2, 1, 3, 4]) # may vary
 
     >>> a.partition((1, 3))
     >>> a

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -740,7 +740,7 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     >>> a = np.array([7, 1, 7, 7, 1, 5, 7, 2, 3, 2, 6, 2, 3, 0])
     >>> p = np.partition(a, 4)
     >>> p
-    array([0, 1, 2, 1, 2, 5, 2, 3, 3, 6, 7, 7, 7, 7])
+    array([0, 1, 2, 1, 2, 5, 2, 3, 3, 6, 7, 7, 7, 7]) # may vary
 
     ``p[4]`` is 2;  all elements in ``p[:4]`` are less than or equal
     to ``p[4]``, and all elements in ``p[5:]`` are greater than or
@@ -838,13 +838,13 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
 
     >>> x = np.array([3, 4, 2, 1])
     >>> x[np.argpartition(x, 3)]
-    array([2, 1, 3, 4])
+    array([2, 1, 3, 4]) # may vary
     >>> x[np.argpartition(x, (1, 3))]
-    array([1, 2, 3, 4])
+    array([1, 2, 3, 4]) # may vary
 
     >>> x = [3, 4, 2, 1]
     >>> np.array(x)[np.argpartition(x, 3)]
-    array([2, 1, 3, 4])
+    array([2, 1, 3, 4]) # may vary
 
     Multi-dimensional array:
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -404,7 +404,7 @@ typedef int (PyArray_PartitionFunc)(void *, npy_intp, npy_intp,
                                     npy_intp *, npy_intp *, npy_intp,
                                     void *);
 typedef int (PyArray_ArgPartitionFunc)(void *, npy_intp *, npy_intp, npy_intp,
-                                       npy_intp *, npy_intp *,
+                                       npy_intp *, npy_intp *, npy_intp,
                                        void *);
 
 typedef int (PyArray_FillWithScalarFunc)(void *, npy_intp, void *, void *);

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -401,7 +401,7 @@ typedef int (PyArray_FillFunc)(void *, npy_intp, void *);
 typedef int (PyArray_SortFunc)(void *, npy_intp, void *);
 typedef int (PyArray_ArgSortFunc)(void *, npy_intp *, npy_intp, void *);
 typedef int (PyArray_PartitionFunc)(void *, npy_intp, npy_intp,
-                                    npy_intp *, npy_intp *,
+                                    npy_intp *, npy_intp *, npy_intp,
                                     void *);
 typedef int (PyArray_ArgPartitionFunc)(void *, npy_intp *, npy_intp, npy_intp,
                                        npy_intp *, npy_intp *,

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -400,12 +400,6 @@ typedef int (PyArray_FillFunc)(void *, npy_intp, void *);
 
 typedef int (PyArray_SortFunc)(void *, npy_intp, void *);
 typedef int (PyArray_ArgSortFunc)(void *, npy_intp *, npy_intp, void *);
-typedef int (PyArray_PartitionFunc)(void *, npy_intp, npy_intp,
-                                    npy_intp *, npy_intp *, npy_intp,
-                                    void *);
-typedef int (PyArray_ArgPartitionFunc)(void *, npy_intp *, npy_intp, npy_intp,
-                                       npy_intp *, npy_intp *, npy_intp,
-                                       void *);
 
 typedef int (PyArray_FillWithScalarFunc)(void *, npy_intp, void *, void *);
 

--- a/numpy/core/src/common/npy_partition.h
+++ b/numpy/core/src/common/npy_partition.h
@@ -11,12 +11,14 @@
 
 #define NPY_MAX_PIVOT_STACK 50
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 NPY_NO_EXPORT PyArray_PartitionFunc *
-get_partition_func(int type, NPY_SELECTKIND which);
+get_partition_func(int type, NPY_SELECTKIND which, npy_intp kthsize);
+
 NPY_NO_EXPORT PyArray_ArgPartitionFunc *
 get_argpartition_func(int type, NPY_SELECTKIND which);
 

--- a/numpy/core/src/common/npy_partition.h
+++ b/numpy/core/src/common/npy_partition.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 NPY_NO_EXPORT PyArray_PartitionFunc *
-get_partition_func(int type, NPY_SELECTKIND which, npy_intp kthsize);
+get_partition_func(int type, NPY_SELECTKIND which);
 
 NPY_NO_EXPORT PyArray_ArgPartitionFunc *
 get_argpartition_func(int type, NPY_SELECTKIND which);

--- a/numpy/core/src/common/npy_partition.h
+++ b/numpy/core/src/common/npy_partition.h
@@ -11,7 +11,12 @@
 
 #define NPY_MAX_PIVOT_STACK 50
 
-
+typedef int (PyArray_PartitionFunc)(void *, npy_intp, npy_intp,
+                                    npy_intp *, npy_intp *, npy_intp,
+                                    void *);
+typedef int (PyArray_ArgPartitionFunc)(void *, npy_intp *, npy_intp, npy_intp,
+                                       npy_intp *, npy_intp *, npy_intp,
+                                       void *);
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1439,7 +1439,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
             npy_intp npiv = 0;
 
             for (i = 0; i < nkth; ++i) {
-                ret = argpart(valptr, idxptr, N, kth[i], pivots, &npiv, op);
+                ret = argpart(valptr, idxptr, N, kth[i], pivots, &npiv, nkth, op);
                 /* Object comparisons may raise an exception in Python 3 */
                 if (needs_api && PyErr_Occurred()) {
                     ret = -1;

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -832,7 +832,7 @@ npy_fastrepeat(
 
     return npy_fastrepeat_impl(
         n_outer, n, nel, chunk, broadcast, counts, new_data, old_data, elsize,
-        cast_info, needs_refcounting);    
+        cast_info, needs_refcounting);
 }
 
 
@@ -1255,7 +1255,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
             npy_intp npiv = 0;
             npy_intp i;
             for (i = 0; i < nkth; ++i) {
-                ret = part(bufptr, N, kth[i], pivots, &npiv, op);
+                ret = part(bufptr, N, kth[i], pivots, &npiv, nkth, op);
                 if (needs_api && PyErr_Occurred()) {
                     ret = -1;
                 }
@@ -1628,7 +1628,7 @@ PyArray_Partition(PyArrayObject *op, PyArrayObject * ktharray, int axis,
         PyErr_SetString(PyExc_ValueError, "not a valid partition kind");
         return -1;
     }
-    part = get_partition_func(PyArray_TYPE(op), which);
+    part = get_partition_func(PyArray_TYPE(op), which, PyArray_SIZE(ktharray));
     if (part == NULL) {
         /* Use sorting, slower but equivalent */
         if (PyArray_DESCR(op)->f->compare) {

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1628,7 +1628,7 @@ PyArray_Partition(PyArrayObject *op, PyArrayObject * ktharray, int axis,
         PyErr_SetString(PyExc_ValueError, "not a valid partition kind");
         return -1;
     }
-    part = get_partition_func(PyArray_TYPE(op), which, PyArray_SIZE(ktharray));
+    part = get_partition_func(PyArray_TYPE(op), which);
     if (part == NULL) {
         /* Use sorting, slower but equivalent */
         if (PyArray_DESCR(op)->f->compare) {

--- a/numpy/core/src/npysort/quicksort.cpp
+++ b/numpy/core/src/npysort/quicksort.cpp
@@ -69,23 +69,12 @@
 #define SMALL_MERGESORT 20
 #define SMALL_STRING 16
 
-// Temporarily disable AVX512 sorting on WIN32 and CYGWIN until we can figure
+// Disable AVX512 sorting on CYGWIN until we can figure
 // out why it has test failures
-#if defined(_MSC_VER) || defined(__CYGWIN__)
-template<typename T>
-inline bool quicksort_dispatch(T*, npy_intp)
-{
-    return false;
-}
-template<typename T>
-inline bool aquicksort_dispatch(T*, npy_intp*, npy_intp)
-{
-    return false;
-}
-#else
 template<typename T>
 inline bool quicksort_dispatch(T *start, npy_intp num)
 {
+#if !defined(__CYGWIN__)
     using TF = typename np::meta::FixedWidth<T>::Type;
     void (*dispfunc)(TF*, intptr_t) = nullptr;
     if (sizeof(T) == sizeof(uint16_t)) {
@@ -104,12 +93,15 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
         (*dispfunc)(reinterpret_cast<TF*>(start), static_cast<intptr_t>(num));
         return true;
     }
+#endif // __CYGWIN__
+    (void)start; (void)num; // to avoid unused arg warn
     return false;
 }
 
 template<typename T>
 inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
 {
+#if !defined(__CYGWIN__)
     using TF = typename np::meta::FixedWidth<T>::Type;
     void (*dispfunc)(TF*, npy_intp*, npy_intp) = nullptr;
     #ifndef NPY_DISABLE_OPTIMIZATION
@@ -124,9 +116,10 @@ inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
         (*dispfunc)(reinterpret_cast<TF*>(start), arg, num);
         return true;
     }
+#endif // __CYGWIN__
+    (void)start; (void)arg; (void)num; // to avoid unused arg warn
     return false;
 }
-#endif // _MSC_VER || CYGWIN
 
 /*
  *****************************************************************************

--- a/numpy/core/src/npysort/selection.cpp
+++ b/numpy/core/src/npysort/selection.cpp
@@ -469,7 +469,7 @@ static int
 introselect_noarg(void *v, npy_intp num, npy_intp kth, npy_intp *pivots,
                   npy_intp *npiv, npy_intp nkth, void *)
 {
-    using T = typename Tag::type;
+    using T = typename std::conditional<std::is_same_v<Tag, npy::half_tag>, np::Half, typename Tag::type>::type;
     if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
         return 0;
     }

--- a/numpy/core/src/npysort/selection.cpp
+++ b/numpy/core/src/npysort/selection.cpp
@@ -103,11 +103,6 @@ inline bool quickselect_dispatch(npy_longdouble* v, npy_intp num, npy_intp kth)
     return false;
 }
 template<>
-inline bool quickselect_dispatch(npy_clongdouble* v, npy_intp num, npy_intp kth)
-{
-    return false;
-}
-template<>
 inline bool argquickselect_dispatch(npy_cfloat* v, npy_intp* arg, npy_intp num, npy_intp kth)
 {
     return false;
@@ -122,11 +117,22 @@ inline bool argquickselect_dispatch(npy_longdouble* v, npy_intp* arg, npy_intp n
 {
     return false;
 }
+/*
+ * Avoid duplicate definition on 32-bit ARM: npy_clongdouble and npy_cdouble
+ * are both __complex__ double
+ */
+#if !defined(__arm__)
+template<>
+inline bool quickselect_dispatch(npy_clongdouble* v, npy_intp num, npy_intp kth)
+{
+    return false;
+}
 template<>
 inline bool argquickselect_dispatch(npy_clongdouble* v, npy_intp* arg, npy_intp num, npy_intp kth)
 {
     return false;
 }
+#endif
 #endif
 
 template <typename Tag, bool arg, typename type>

--- a/numpy/core/src/npysort/selection.cpp
+++ b/numpy/core/src/npysort/selection.cpp
@@ -29,7 +29,7 @@
 
 #define NOT_USED NPY_UNUSED(unused)
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
+#if defined(__CYGWIN__)
 template<typename T>
 inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
 {

--- a/numpy/core/src/npysort/selection.cpp
+++ b/numpy/core/src/npysort/selection.cpp
@@ -499,7 +499,7 @@ struct partition_t {
 constexpr std::array<arg_map, partition_t::taglist::size> partition_t::map;
 
 static inline PyArray_PartitionFunc *
-_get_partition_func(int type, NPY_SELECTKIND which, npy_intp kthsize)
+_get_partition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
     npy_intp ntypes = partition_t::map.size();
@@ -536,9 +536,9 @@ _get_argpartition_func(int type, NPY_SELECTKIND which)
  */
 extern "C" {
 NPY_NO_EXPORT PyArray_PartitionFunc *
-get_partition_func(int type, NPY_SELECTKIND which, npy_intp kthsize)
+get_partition_func(int type, NPY_SELECTKIND which)
 {
-    return _get_partition_func(type, which, kthsize);
+    return _get_partition_func(type, which);
 }
 NPY_NO_EXPORT PyArray_ArgPartitionFunc *
 get_argpartition_func(int type, NPY_SELECTKIND which)

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -16,6 +16,7 @@
 namespace np { namespace qsort_simd {
 
 #if defined(NPY_HAVE_AVX512_SKX)
+#ifndef __CYGWIN__
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
@@ -64,6 +65,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_i
 {
     avx512_qselect(arr, kth, num, true);
 }
+#endif // __CYGWIN__
 #if !defined(_MSC_VER)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -7,7 +7,7 @@
 
 #include "simd_qsort.hpp"
 
-#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
@@ -15,7 +15,7 @@
 
 namespace np { namespace qsort_simd {
 
-#if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SKX)
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
@@ -64,6 +64,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_i
 {
     avx512_qselect(arr, kth, num, true);
 }
+#if !defined(_MSC_VER)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
@@ -112,6 +113,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
+#endif // _MSC_VER
 #endif  // NPY_HAVE_AVX512_SKX
 
 }} // namespace np::simd

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -65,8 +65,6 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_i
 {
     avx512_qselect(arr, kth, num, true);
 }
-#endif // __CYGWIN__
-#if !defined(_MSC_VER)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
     avx512_qsort(arr, size);
@@ -115,7 +113,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-#endif // _MSC_VER
+#endif // __CYGWIN__
 #endif  // NPY_HAVE_AVX512_SKX
 
 }} // namespace np::simd

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -6,6 +6,7 @@
 // 'baseline' option isn't specified within targets.
 
 #include "simd_qsort.hpp"
+#ifndef __CYGWIN__
 
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
@@ -16,7 +17,6 @@
 namespace np { namespace qsort_simd {
 
 #if defined(NPY_HAVE_AVX512_SKX)
-#ifndef __CYGWIN__
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
@@ -113,7 +113,8 @@ template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy
 {
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
 }
-#endif // __CYGWIN__
 #endif  // NPY_HAVE_AVX512_SKX
 
 }} // namespace np::simd
+
+#endif // __CYGWIN__

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -16,6 +16,30 @@
 namespace np { namespace qsort_simd {
 
 #if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint32_t *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int64_t*arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint64_t*arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(float *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
 {
     avx512_qsort(arr, size);

--- a/numpy/core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort.dispatch.cpp
@@ -16,6 +16,30 @@
 namespace np { namespace qsort_simd {
 
 #if defined(NPY_HAVE_AVX512_SKX) && !defined(_MSC_VER)
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
+{
+    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+}
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
     avx512_qselect(arr, kth, num, true);

--- a/numpy/core/src/npysort/simd_qsort.hpp
+++ b/numpy/core/src/npysort/simd_qsort.hpp
@@ -9,12 +9,14 @@ namespace np { namespace qsort_simd {
     #include "simd_qsort.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, npy_intp* arg, npy_intp size))
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort_16bit.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 
 } } // np::qsort_simd
 #endif // NUMPY_SRC_COMMON_NPYSORT_SIMD_QSORT_HPP

--- a/numpy/core/src/npysort/simd_qsort.hpp
+++ b/numpy/core/src/npysort/simd_qsort.hpp
@@ -11,6 +11,7 @@ namespace np { namespace qsort_simd {
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, npy_intp* arg, npy_intp size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSelect, (T *arr, npy_intp* arg, npy_intp kth, npy_intp size))
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort_16bit.dispatch.h"

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -21,6 +21,7 @@ void avx512_qselect_int16(int16_t*, intptr_t);
 #elif defined(NPY_HAVE_AVX512_ICL)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
 /* Wrapper function defintions here: */
+#ifndef __CYGWIN__
 void avx512_qsort_uint16(uint16_t* arr, intptr_t size)
 {
     avx512_qsort(arr, size);
@@ -37,6 +38,7 @@ void avx512_qselect_int16(int16_t* arr, intptr_t size)
 {
     avx512_qselect(arr, size);
 }
+#endif // __CYGWIN__
 #endif
 
 namespace np { namespace qsort_simd {
@@ -45,6 +47,7 @@ namespace np { namespace qsort_simd {
  * QSelect dispatch functions:
  */
 #if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
+#ifndef __CYGWIN__
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
@@ -71,6 +74,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
     avx512_qselect(arr, size);
 #endif
 }
+#endif // __CYGWIN__
 
 /*
  * QSort dispatch functions:

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -15,8 +15,8 @@
  */
 void avx512_qsort_uint16(uint16_t*, intptr_t);
 void avx512_qsort_int16(int16_t*, intptr_t);
-void avx512_qselect_uint16(uint16_t*, intptr_t);
-void avx512_qselect_int16(int16_t*, intptr_t);
+void avx512_qselect_uint16(uint16_t*, npy_intp, npy_intp)
+void avx512_qselect_int16(int16_t*, npy_intp, npy_intp)
 
 #elif defined(NPY_HAVE_AVX512_ICL)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -30,13 +30,13 @@ void avx512_qsort_int16(int16_t* arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
-void avx512_qselect_uint16(uint16_t* arr, intptr_t size)
+void avx512_qselect_uint16(uint16_t* arr, npy_intp kth, npy_intp size)
 {
-    avx512_qselect(arr, size);
+    avx512_qselect(arr, kth, size, true);
 }
-void avx512_qselect_int16(int16_t* arr, intptr_t size)
+void avx512_qselect_int16(int16_t* arr, npy_intp kth, npy_intp size)
 {
-    avx512_qselect(arr, size);
+    avx512_qselect(arr, kth, size, true);
 }
 #endif // __CYGWIN__
 #endif
@@ -60,18 +60,18 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_int
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
-    avx512_qselect_uint16(arr, size);
+    avx512_qselect_uint16(arr, kth, num);
 #else
-    avx512_qselect(arr, size);
+    avx512_qselect(arr, kth, num);
 #endif
 }
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_intp kth)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
-    avx512_qselect_uint16(arr, size);
+    avx512_qselect_int16(arr, kth, num);
 #else
-    avx512_qselect(arr, size);
+    avx512_qselect(arr, kth, num);
 #endif
 }
 

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -32,6 +32,22 @@ namespace np { namespace qsort_simd {
 
 #if !defined(_MSC_VER)
 #if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
+{
+#if defined(NPY_HAVE_AVX512_SPR)
+    avx512_qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
+#else
+    avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true);
+#endif
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_intp kth)
+{
+    avx512_qselect(arr, kth, num, true);
+}
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -74,12 +74,10 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
     avx512_qselect(arr, size);
 #endif
 }
-#endif // __CYGWIN__
 
 /*
  * QSort dispatch functions:
  */
-#if !defined(_MSC_VER)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
@@ -104,7 +102,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
     avx512_qsort(arr, size);
 #endif
 }
-#endif // _MSC_VER
+#endif // __CYGWIN__
 #endif // NPY_HAVE_AVX512_ICL || SPR
 
 }} // namespace np::qsort_simd

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -6,6 +6,7 @@
 // 'baseline' option isn't specified within targets.
 
 #include "simd_qsort.hpp"
+#ifndef __CYGWIN__
 
 #if defined(NPY_HAVE_AVX512_SPR)
     #include "x86-simd-sort/src/avx512fp16-16bit-qsort.hpp"
@@ -15,13 +16,12 @@
  */
 void avx512_qsort_uint16(uint16_t*, intptr_t);
 void avx512_qsort_int16(int16_t*, intptr_t);
-void avx512_qselect_uint16(uint16_t*, npy_intp, npy_intp)
-void avx512_qselect_int16(int16_t*, npy_intp, npy_intp)
+void avx512_qselect_uint16(uint16_t*, npy_intp, npy_intp);
+void avx512_qselect_int16(int16_t*, npy_intp, npy_intp);
 
 #elif defined(NPY_HAVE_AVX512_ICL)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
 /* Wrapper function defintions here: */
-#ifndef __CYGWIN__
 void avx512_qsort_uint16(uint16_t* arr, intptr_t size)
 {
     avx512_qsort(arr, size);
@@ -38,7 +38,6 @@ void avx512_qselect_int16(int16_t* arr, npy_intp kth, npy_intp size)
 {
     avx512_qselect(arr, kth, size, true);
 }
-#endif // __CYGWIN__
 #endif
 
 namespace np { namespace qsort_simd {
@@ -47,7 +46,6 @@ namespace np { namespace qsort_simd {
  * QSelect dispatch functions:
  */
 #if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
-#ifndef __CYGWIN__
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
@@ -102,7 +100,8 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
     avx512_qsort(arr, size);
 #endif
 }
-#endif // __CYGWIN__
 #endif // NPY_HAVE_AVX512_ICL || SPR
 
 }} // namespace np::qsort_simd
+
+#endif // __CYGWIN__

--- a/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -7,7 +7,7 @@
 
 #include "simd_qsort.hpp"
 
-#if defined(NPY_HAVE_AVX512_SPR) && !defined(_MSC_VER)
+#if defined(NPY_HAVE_AVX512_SPR)
     #include "x86-simd-sort/src/avx512fp16-16bit-qsort.hpp"
 /*
  * Wrapper function declarations to avoid multiple definitions of
@@ -15,7 +15,10 @@
  */
 void avx512_qsort_uint16(uint16_t*, intptr_t);
 void avx512_qsort_int16(int16_t*, intptr_t);
-#elif defined(NPY_HAVE_AVX512_ICL) && !defined(_MSC_VER)
+void avx512_qselect_uint16(uint16_t*, intptr_t);
+void avx512_qselect_int16(int16_t*, intptr_t);
+
+#elif defined(NPY_HAVE_AVX512_ICL)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
 /* Wrapper function defintions here: */
 void avx512_qsort_uint16(uint16_t* arr, intptr_t size)
@@ -26,11 +29,21 @@ void avx512_qsort_int16(int16_t* arr, intptr_t size)
 {
     avx512_qsort(arr, size);
 }
+void avx512_qselect_uint16(uint16_t* arr, intptr_t size)
+{
+    avx512_qselect(arr, size);
+}
+void avx512_qselect_int16(int16_t* arr, intptr_t size)
+{
+    avx512_qselect(arr, size);
+}
 #endif
 
 namespace np { namespace qsort_simd {
 
-#if !defined(_MSC_VER)
+/*
+ * QSelect dispatch functions:
+ */
 #if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
@@ -40,14 +53,29 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_int
     avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true);
 #endif
 }
+
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
 {
-    avx512_qselect(arr, kth, num, true);
+#if defined(NPY_HAVE_AVX512_SPR)
+    avx512_qselect_uint16(arr, size);
+#else
+    avx512_qselect(arr, size);
+#endif
 }
+
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_intp kth)
 {
-    avx512_qselect(arr, kth, num, true);
+#if defined(NPY_HAVE_AVX512_SPR)
+    avx512_qselect_uint16(arr, size);
+#else
+    avx512_qselect(arr, size);
+#endif
 }
+
+/*
+ * QSort dispatch functions:
+ */
+#if !defined(_MSC_VER)
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
@@ -72,7 +100,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
     avx512_qsort(arr, size);
 #endif
 }
-#endif // NPY_HAVE_AVX512_ICL || SPR
 #endif // _MSC_VER
+#endif // NPY_HAVE_AVX512_ICL || SPR
 
 }} // namespace np::qsort_simd

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -10050,12 +10050,16 @@ def test_partition_int(N, dtype):
     k = rnd.choice(N, 1)[0]
     assert_arr_partitioned(np.sort(arr)[k], k,
             np.partition(arr, k, kind='introselect'))
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            arr[np.argpartition(arr, k, kind='introselect')])
 
     # (2) random data with max value at the end of array
     arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
     arr[N-1] = maxv
     assert_arr_partitioned(np.sort(arr)[k], k,
             np.partition(arr, k, kind='introselect'))
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            arr[np.argpartition(arr, k, kind='introselect')])
 
 
 @pytest.mark.parametrize("N", np.arange(2, 512))
@@ -10066,3 +10070,5 @@ def test_partition_fp(N, dtype):
     k = rnd.choice(N, 1)[0]
     assert_arr_partitioned(np.sort(arr)[k], k,
             np.partition(arr, k, kind='introselect'))
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            arr[np.argpartition(arr, k, kind='introselect')])


### PR DESCRIPTION
Provides a speed up of **25x** for 16-bit, **17x** for 32-bit dtypes and about **8x** speed up for 64-bit dtypes. Benchmark numbers on an array of size 100000 for varying values of k (10, 100 and 1000). 

Benchmark for random data on Intel TGL: 

```
       before           after         ratio
     [7d18effb]       [0c8fed1f]
     <main>           <np-partition>
-        1.15±0ms          193±1μs     0.17  bench_function_base.Partition.time_partition('float64', ('random',), 10)
-        1.15±0ms        192±0.9μs     0.17  bench_function_base.Partition.time_partition('float64', ('random',), 1000)
-     1.15±0.01ms          192±2μs     0.17  bench_function_base.Partition.time_partition('float64', ('random',), 100)
-        1.13±0ms          135±2μs     0.12  bench_function_base.Partition.time_partition('float32', ('random',), 100)
-        1.13±0ms          135±2μs     0.12  bench_function_base.Partition.time_partition('float32', ('random',), 10)
-         965±1μs          116±2μs     0.12  bench_function_base.Partition.time_partition('int64', ('random',), 100)
-     1.13±0.01ms          135±2μs     0.12  bench_function_base.Partition.time_partition('float32', ('random',), 1000)
-         970±2μs          115±1μs     0.12  bench_function_base.Partition.time_partition('int64', ('random',), 1000)
-        973±10μs        114±0.9μs     0.12  bench_function_base.Partition.time_partition('int64', ('random',), 10)
-         898±2μs       52.2±0.9μs     0.06  bench_function_base.Partition.time_partition('uint32', ('random',), 100)
-         902±6μs       52.2±0.9μs     0.06  bench_function_base.Partition.time_partition('int32', ('random',), 100)
-         904±3μs         52.3±2μs     0.06  bench_function_base.Partition.time_partition('int32', ('random',), 1000)
-         902±6μs         51.8±1μs     0.06  bench_function_base.Partition.time_partition('uint32', ('random',), 10)
-         900±4μs       51.6±0.9μs     0.06  bench_function_base.Partition.time_partition('int32', ('random',), 10)
-         906±4μs         51.9±2μs     0.06  bench_function_base.Partition.time_partition('uint32', ('random',), 1000)
-        1.02±0ms       43.5±0.2μs     0.04  bench_function_base.Partition.time_partition('float16', ('random',), 100)
-        1.02±0ms       43.3±0.2μs     0.04  bench_function_base.Partition.time_partition('float16', ('random',), 10)
-        1.04±0ms       43.4±0.2μs     0.04  bench_function_base.Partition.time_partition('float16', ('random',), 1000)
-        1.14±0ms      45.1±0.09μs     0.04  bench_function_base.Partition.time_partition('int16', ('random',), 1000)
-        1.14±0ms       45.2±0.1μs     0.04  bench_function_base.Partition.time_partition('int16', ('random',), 100)
-        1.14±0ms       45.1±0.3μs     0.04  bench_function_base.Partition.time_partition('int16', ('random',), 10)

```
Benchmark numbers on other kinds of array can be seen [here](https://gist.github.com/r-devulap/d09d05098039fb91ef71dee272deaf38).