### PR TITLE
BUG: random: Fix check for both uniform variates being 0 in random_beta()

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -417,8 +417,8 @@ double random_beta(bitgen_t *bitgen_state, double a, double b) {
       Y = pow(V, 1.0 / b);
       XpY = X + Y;
       /* Reject if both U and V are 0.0, which is approx 1 in 10^106 */
-      if ((XpY <= 1.0) && (XpY > 0.0)) {
-        if (X + Y > 0) {
+      if ((XpY <= 1.0) && (U + V > 0.0)) {
+        if (XpY > 0) {
           return X / XpY;
         } else {
           double logX = log(U) / a;

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -75,6 +75,10 @@ class TestRegression:
         x = self.mt19937.beta(0.0001, 0.0001, size=100)
         assert_(not np.any(np.isnan(x)), 'Nans in mt19937.beta')
 
+    def test_beta_very_small_parameters(self):
+        # gh-24203: beta would hang with very small parameters.
+        self.mt19937.beta(1e-49, 1e-40)
+
     def test_choice_sum_of_probs_tolerance(self):
         # The sum of probs should be 1.0 with some tolerance.
         # For low precision dtypes the tolerance was too tight.


### PR DESCRIPTION
The check for both uniform variates being 0 was using `X + Y` (which is `U**(1/a) + V**(1/b)`), instead of `U + V`.  When `a` and `b` are both sufficiently small, it will be common for `X + Y` to be 0.

Closes gh-24203.
