### PR TITLE
MAINT: Fix new or residual typos found by codespell

### DIFF
--- a/doc/neps/nep-0018-array-function-protocol.rst
+++ b/doc/neps/nep-0018-array-function-protocol.rst
@@ -132,9 +132,9 @@ Unlike ``__array_ufunc__``, there are no high-level guarantees about the
 type of ``func``, or about which of ``args`` and ``kwargs`` may contain objects
 implementing the array API.
 
-As a convenience for ``__array_function__`` implementors, ``types`` provides all
+As a convenience for ``__array_function__`` implementers, ``types`` provides all
 argument types with an ``'__array_function__'`` attribute. This
-allows implementors to quickly identify cases where they should defer to
+allows implementers to quickly identify cases where they should defer to
 ``__array_function__`` implementations on other arguments.
 The type of ``types`` is intentionally vague:
 ``frozenset`` would most closely match intended use, but we may use ``tuple``
@@ -487,7 +487,7 @@ gymnastics when we decided to add new optional arguments, e.g., the new
             kwargs['keepdims'] = keepdims
         return array.sum(..., **kwargs)
 
-For ``__array_function__`` implementors, this also means that it is possible
+For ``__array_function__`` implementers, this also means that it is possible
 to implement even existing optional arguments incrementally, and only in cases
 where it makes sense. For example, a library implementing immutable arrays
 would not be required to explicitly include an unsupported ``out`` argument in

--- a/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
+++ b/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
@@ -37,7 +37,7 @@ inappropriate, and users find they need sparse arrays, lazily
 evaluated arrays (as in dask), compressed arrays (as in blosc), arrays
 stored in GPU memory, arrays stored in alternative formats such as
 Arrow, and so forth – yet users still want to work with these arrays
-using the familiar NumPy APIs, and re-use existing code with minimal
+using the familiar NumPy APIs, and reuse existing code with minimal
 (ideally zero) porting overhead. As a working shorthand, we call these
 “duck arrays”, by analogy with Python’s “duck typing”: a “duck array”
 is a Python object which “quacks like” a numpy array in the sense that
@@ -341,7 +341,7 @@ to support (at least) these features:
   example, because they use some kinds of sparse or compressed
   storage, or are in read-only shared memory), and it turns out that
   frequently-used code like the default implementation of ``np.mean``
-  needs to check this (to decide whether it can re-use temporary
+  needs to check this (to decide whether it can reuse temporary
   arrays).
 
 We intentionally do not describe exactly how to add support for these

--- a/doc/neps/nep-0037-array-module.rst
+++ b/doc/neps/nep-0037-array-module.rst
@@ -420,7 +420,7 @@ opt-in and would also allow for unambiguously overriding functions like
 ``asarray``, because ``np.api.asarray`` would always mean "convert an
 array-like object."  But it wouldn't solve all the dispatching needs met by
 ``__array_module__``, and would leave us with supporting a considerably more
-complex protocol both for array users and implementors.
+complex protocol both for array users and implementers.
 
 We could potentially implement such a new namespace *via* the
 ``__array_module__`` protocol. Certainly some users would find this convenient,

--- a/doc/neps/nep-0041-improved-dtype-support.rst
+++ b/doc/neps/nep-0041-improved-dtype-support.rst
@@ -532,7 +532,7 @@ are not yet fully clear, we anticipate, and accept the following changes:
     have to be changed to use the new API. Such changes are expected to be
     necessary in very few project.
 
-* **dtype implementors (C-API)**:
+* **dtype implementers (C-API)**:
 
   * The array which is currently provided to some functions (such as cast functions),
     will no longer be provided.

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -171,9 +171,9 @@ NumPy provides several hooks that classes can customize:
    -  The tuple ``args`` and dict ``kwargs`` are directly passed on from the
       original call.
 
-   As a convenience for ``__array_function__`` implementors, ``types``
+   As a convenience for ``__array_function__`` implementers, ``types``
    provides all argument types with an ``'__array_function__'`` attribute.
-   This allows implementors to quickly identify cases where they should defer
+   This allows implementers to quickly identify cases where they should defer
    to ``__array_function__`` implementations on other arguments.
    Implementations should not rely on the iteration order of ``types``.
 

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -66,7 +66,7 @@ The *compile-time* environment variable::
 
     NPY_RELAXED_STRIDES_DEBUG=0
 
-can be set to help debug code written in C which iteraters through arrays
+can be set to help debug code written in C which iterators through arrays
 manually.  When an array is contiguous and iterated in a contiguous manner,
 its ``strides`` should not be queried.  This option can help find errors where
 the ``strides`` are incorrectly used.

--- a/doc/source/user/basics.interoperability.rst
+++ b/doc/source/user/basics.interoperability.rst
@@ -21,7 +21,7 @@ physical units (astropy.units_, pint_, unyt_), among others that add additional
 functionality on top of the NumPy API.
 
 Yet, users still want to work with these arrays using the familiar NumPy API and
-re-use existing code with minimal (ideally zero) porting overhead. With this
+reuse existing code with minimal (ideally zero) porting overhead. With this
 goal in mind, various protocols are defined for implementations of
 multi-dimensional arrays with high-level APIs matching NumPy.
 
@@ -69,7 +69,7 @@ The array interface protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`array interface protocol <arrays.interface>` defines a way for
-array-like objects to re-use each other's data buffers. Its implementation
+array-like objects to reuse each other's data buffers. Its implementation
 relies on the existence of the following attributes or methods:
 
 -  ``__array_interface__``: a Python dictionary containing the shape, the

--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -767,7 +767,7 @@ C-code. Its advantages for extending Python include
 
     - no need to learn a new syntax except Python and C
 
-    - allows re-use of C code
+    - allows reuse of C code
 
     - functionality in shared libraries written for other purposes can be
       obtained with a simple Python wrapper and search for the library.

--- a/numpy/core/src/common/npy_cpu_dispatch.h
+++ b/numpy/core/src/common/npy_cpu_dispatch.h
@@ -187,7 +187,7 @@
 /**
  * Macro NPY_CPU_DISPATCH_CALL(LEFT, ...) is used for runtime dispatching
  * of the exported functions and variables within the dispatch-able sources
- * according to the highested interesed CPU features that supported by the
+ * according to the highest interested CPU features that are supported by the
  * running machine depending on the required optimizations.
  *
  * The first argument should ends with the exported function or variable name,

--- a/numpy/core/src/common/npy_cpu_features.c
+++ b/numpy/core/src/common/npy_cpu_features.c
@@ -815,7 +815,7 @@ npy__cpu_init_features(void)
 {
     /*
      * just in case if the compiler doesn't respect ANSI
-     * but for knowing paltforms it still nessecery, because @npy__cpu_init_features
+     * but for knowing platforms it still nessecery, because @npy__cpu_init_features
      * may called multiple of times and we need to clear the disabled features by
      * ENV Var or maybe in the future we can support other methods like
      * global variables, go back to @npy__cpu_try_disable_env for more understanding

--- a/numpy/core/src/common/simd/emulate_maskop.h
+++ b/numpy/core/src/common/simd/emulate_maskop.h
@@ -1,6 +1,6 @@
 /**
  * This header is used internally by all current supported SIMD extensions,
- * execpt for AVX512.
+ * except for AVX512.
  */
 #ifndef NPY_SIMD
     #error "Not a standalone header, use simd/simd.h instead"

--- a/numpy/core/src/multiarray/dtype_traversal.c
+++ b/numpy/core/src/multiarray/dtype_traversal.c
@@ -200,7 +200,7 @@ npy_object_get_fill_zero_loop(void *NPY_UNUSED(traverse_context),
     return 0;
 }
 
-/**************** Structured DType generic funcationality ***************/
+/**************** Structured DType generic functionality ***************/
 
 /*
  * Note that legacy user dtypes also make use of this.  Someone managed to

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -242,7 +242,7 @@ PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
     /*
      * sometimes we have to create a new copy of the array
      * in order to get the right orientation and
-     * because we can't just re-use the buffer with the
+     * because we can't just reuse the buffer with the
      * data in the order it is in.
      */
     Py_INCREF(self);

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -282,7 +282,7 @@ get_initial_from_ufunc(
         return -1;
     }
     if (identity_obj == Py_None) {
-        /* UFunc has no idenity (should not happen) */
+        /* UFunc has no identity (should not happen) */
         Py_DECREF(identity_obj);
         return 0;
     }

--- a/numpy/core/src/umath/loops_autovec.dispatch.c.src
+++ b/numpy/core/src/umath/loops_autovec.dispatch.c.src
@@ -178,7 +178,7 @@ NPY_NO_EXPORT void  NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 {
     /*
      * The (void)in; suppresses an unused variable warning raised by gcc and allows
-     * us to re-use this macro even though we do not depend on in
+     * us to reuse this macro even though we do not depend on in
      */
     UNARY_LOOP_FAST(@type@, npy_bool, (void)in; *out = @val@);
 }

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -300,7 +300,7 @@ class TestNonarrayArgs:
         assert_almost_equal(np.var(B), 0.25)
 
     def test_std_with_mean_keyword(self):
-        # Setting the seed to make the test reproducable
+        # Setting the seed to make the test reproducible
         rng = np.random.RandomState(1234)
         A = rng.randn(10, 20, 5) + 0.5
 
@@ -335,7 +335,7 @@ class TestNonarrayArgs:
         assert_almost_equal(std, std_old)
 
     def test_var_with_mean_keyword(self):
-        # Setting the seed to make the test reproducable
+        # Setting the seed to make the test reproducible
         rng = np.random.RandomState(1234)
         A = rng.randn(10, 20, 5) + 0.5
 
@@ -470,7 +470,7 @@ class TestNonarrayArgs:
         assert_equal(var, var_old)
 
     def test_std_with_mean_keyword_multiple_axis(self):
-        # Setting the seed to make the test reproducable
+        # Setting the seed to make the test reproducible
         rng = np.random.RandomState(1234)
         A = rng.randn(10, 20, 5) + 0.5
 
@@ -496,7 +496,7 @@ class TestNonarrayArgs:
         assert_almost_equal(std, std_old)
 
     def test_std_with_mean_keyword_axis_None(self):
-        # Setting the seed to make the test reproducable
+        # Setting the seed to make the test reproducible
         rng = np.random.RandomState(1234)
         A = rng.randn(10, 20, 5) + 0.5
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1705,11 +1705,11 @@ class TestUfunc:
         res = np.add.reduce(a, initial=5)
         assert_equal(res, 15)
 
-    def test_empty_reduction_and_idenity(self):
+    def test_empty_reduction_and_identity(self):
         arr = np.zeros((0, 5))
         # OK, since the reduction itself is *not* empty, the result is
         assert np.true_divide.reduce(arr, axis=1).shape == (0,)
-        # Not OK, the reduction itself is empty and we have no idenity
+        # Not OK, the reduction itself is empty and we have no identity
         with pytest.raises(ValueError):
             np.true_divide.reduce(arr, axis=0)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -447,7 +447,7 @@ def average(a, axis=None, weights=None, returned=False, *,
         Return the average along the specified axis. When `returned` is `True`,
         return a tuple with the average as the first element and the sum
         of the weights as the second element. `sum_of_weights` is of the
-        same type as `retval`. The result dtype follows a genereal pattern.
+        same type as `retval`. The result dtype follows a general pattern.
         If `weights` is None, the result dtype will be that of `a` , or ``float64``
         if `a` is integral. Otherwise, if `weights` is not None and `a` is non-
         integral, the result type will be the type of lowest precision capable of

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -770,7 +770,7 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
             np.testing.assert_allclose(ret, reference)
 
     def test_nanstd_with_mean_keyword(self):
-        # Setting the seed to make the test reproducable
+        # Setting the seed to make the test reproducible
         rng = np.random.RandomState(1234)
         A = rng.randn(10, 20, 5) + 0.5
         A[:, 5, :] = np.nan

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -237,7 +237,7 @@ def removeSubroutinePrototypes(source):
     # While we could "fix" this function to do what the name implies
     # it should do, we have no hint of what it should really do.
     #
-    # Therefore we keep the existing (non-)functionaity, documenting
+    # Therefore we keep the existing (non-)functionality, documenting
     # this function as doing nothing at all.
     return source
 

--- a/numpy/random/src/pcg64/pcg64.orig.h
+++ b/numpy/random/src/pcg64/pcg64.orig.h
@@ -766,7 +766,7 @@ inline void pcg_setseq_128_srandom_r(struct pcg_state_setseq_128 *rng,
  *     such as raw LCGs do better using a technique based on division.)
  *     Empricical tests show that division is preferable to modulus for
  *     reducting the range of an RNG.  It's faster, and sometimes it can
- *     even be statistically prefereable.
+ *     even be statistically preferable.
  */
 
 /* Generation functions for XSH RS */

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -715,7 +715,7 @@ class Checker(doctest.OutputChecker):
             # Maybe we're printing a numpy array? This produces invalid python
             # code: `print(np.arange(3))` produces "[0 1 2]" w/o commas between
             # values. So, reinsert commas and retry.
-            # TODO: handle (1) abberivation (`print(np.arange(10000))`), and
+            # TODO: handle (1) abbreviation (`print(np.arange(10000))`), and
             #              (2) n-dim arrays with n > 1
             s_want = want.strip()
             s_got = got.strip()

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -49,7 +49,7 @@ setup_base()
   else
     # SIMD extensions that need to be tested on both runtime and compile-time via (test_simd.py)
     # any specified features will be ignored if they're not supported by compiler or platform
-    # note: it almost the same default value of --simd-test execpt adding policy `$werror` to treat all
+    # note: it almost the same default value of --simd-test except adding policy `$werror` to treat all
     # warnings as errors
     build_args+=("--simd-test=\$werror BASELINE SSE2 SSE42 XOP FMA4 (FMA3 AVX2) AVX512F AVX512_SKX VSX VSX2 VSX3 NEON ASIMD VX VXE VXE2")
   fi
@@ -154,7 +154,7 @@ EOF
   fi
 
   if [ -n "$RUN_FULL_TESTS" ]; then
-    # Travis has a limit on log length that is causeing test failutes.
+    # Travis has a limit on log length that is causing test failutes.
     # The fix here is to remove the "-v" from the runtest arguments.
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
     $PYTHON -b ../runtests.py -n --mode=full $DURATIONS_FLAG $COVERAGE_FLAG


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
About `implementor` → `implementer`: Both seem acceptable, but most dictionaries suggest `implementer` alone or as a first choice ([Cambridge](https://dictionary.cambridge.org/fr/dictionnaire/anglais/implementer), [Merriam-Webster](https://www.merriam-webster.com/dictionary/implementor)) and the Google Books Ngram database suggests that `implementer` outdistanced `implementor` around 2000, and curiously even more in American than British English:
https://books.google.com/ngrams/graph?content=implementer%2Cimplementor&year_start=1800&year_end=2019&corpus=en-2019

About `re-use` → `reuse`: `reuse` is found in all dictionaries, and more importantly, it occurs more often in the repository, so this is more a question of consistency than correctness.