### PR TITLE
TST: convert remaining setup.py tests to meson instead

### DIFF
--- a/numpy/core/tests/examples/cython/meson.build
+++ b/numpy/core/tests/examples/cython/meson.build
@@ -1,0 +1,27 @@
+project('checks', 'c', 'cython')
+
+py = import('python').find_installation(pure: false)
+
+cc = meson.get_compiler('c')
+cy = meson.get_compiler('cython')
+
+if not cy.version().version_compare('>=0.29.35')
+  error('tests requires Cython >= 0.29.35')
+endif
+
+npy_include_path = run_command(py, [
+    '-c',
+    'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
+    ], check: true).stdout().strip()
+
+py.extension_module(
+    'checks',
+    'checks.pyx',
+    install: false,
+    c_args: [
+      '-DNPY_NO_DEPRECATED_API=0',  # Cython still uses old NumPy C API
+      # Require 1.25+ to test datetime additions
+      '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
+    ],
+    include_directories: [npy_include_path],
+)

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -58,7 +58,6 @@ def install_temp(tmp_path):
     sys.path.append(str(build_dir))
 
 def test_is_timedelta64_object(install_temp):
-    print(sys.path)
     import checks
 
     assert checks.is_td64(np.timedelta64(1234))

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -31,46 +31,30 @@ pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
 
 
 @pytest.fixture
-def install_temp(request, tmp_path):
+def install_temp(tmp_path):
     # Based in part on test_cython from random.tests.test_extending
     if IS_WASM:
         pytest.skip("No subprocess")
 
-    here = os.path.dirname(__file__)
-    ext_dir = os.path.join(here, "examples", "cython")
+    srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'cython')
+    build_dir = tmp_path / "build"
+    os.makedirs(build_dir, exist_ok=True)
+    if sys.platform == "win32":
+        subprocess.check_call(["meson", "setup",
+                               "--buildtype=release",
+                               "--vsenv", str(srcdir)],
+                              cwd=build_dir,
+                              )
+    else:
+        subprocess.check_call(["meson", "setup", str(srcdir)],
+                              cwd=build_dir
+                              )
+    subprocess.check_call(["meson", "compile", "-vv"], cwd=build_dir)
 
-    cytest = str(tmp_path / "cytest")
-
-    shutil.copytree(ext_dir, cytest)
-    # build the examples and "install" them into a temporary directory
-
-    install_log = str(tmp_path / "tmp_install_log.txt")
-    subprocess.check_output(
-        [
-            sys.executable,
-            "setup.py",
-            "build",
-            "install",
-            "--prefix", str(tmp_path / "installdir"),
-            "--single-version-externally-managed",
-            "--record",
-            install_log,
-        ],
-        cwd=cytest,
-    )
-
-    # In order to import the built module, we need its path to sys.path
-    # so parse that out of the record
-    with open(install_log) as fid:
-        for line in fid:
-            if "checks" in line:
-                sys.path.append(os.path.dirname(line))
-                break
-        else:
-            raise RuntimeError(f'could not parse "{install_log}"')
-
+    sys.path.append(str(build_dir))
 
 def test_is_timedelta64_object(install_temp):
+    print(sys.path)
     import checks
 
     assert checks.is_td64(np.timedelta64(1234))

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -39,6 +39,10 @@ def install_temp(tmp_path):
     srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'cython')
     build_dir = tmp_path / "build"
     os.makedirs(build_dir, exist_ok=True)
+    try:
+        subprocess.check_call(["meson", "--version"])
+    except FileNotFoundError:
+        pytest.skip("No usable 'meson' found")
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
                                "--buildtype=release",

--- a/numpy/core/tests/test_limited_api.py
+++ b/numpy/core/tests/test_limited_api.py
@@ -7,11 +7,6 @@ import pytest
 
 from numpy.testing import IS_WASM
 
-try:
-    import setuptools
-except ModuleNotFoundError:
-    pytest.skip("setuptools required", allow_module_level=True)
-
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.xfail(
     sysconfig.get_config_var("Py_DEBUG"),

--- a/numpy/core/tests/test_limited_api.py
+++ b/numpy/core/tests/test_limited_api.py
@@ -7,6 +7,10 @@ import pytest
 
 from numpy.testing import IS_WASM
 
+try:
+    import setuptools
+except ModuleNotFoundError:
+    pytest.skip("setuptools required", allow_module_level=True)
 
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.xfail(

--- a/numpy/core/tests/test_limited_api.py
+++ b/numpy/core/tests/test_limited_api.py
@@ -7,6 +7,7 @@ import pytest
 
 from numpy.testing import IS_WASM
 
+
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.xfail(
     sysconfig.get_config_var("Py_DEBUG"),


### PR DESCRIPTION
I tried to remove `setuptools` from `test_requirements.txt`, and found these tests were building c-extension modules using setup.py. I converted them to meson.

We still need setuptools to pass the `numpy/tests/test_public_api.py` tests. Some of the distutils modules fail to import if it is not found. I am leaving that for a further cleanup