### PR TITLE
BUG: Fix reference count leak in str(scalar).

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -316,6 +316,7 @@ genint_type_str(PyObject *self)
             item = gentype_generic_method(self, NULL, NULL, "item");
             break;
     }
+    Py_DECREF(descr);
     if (item == NULL) {
         return NULL;
     }


### PR DESCRIPTION
PyArray_DescrFromTypeObject() returns a fresh reference to the descriptor object, which must be freed.

This leak was introduced in
https://github.com/numpy/numpy/commit/670842b38005febf64259f268332e46d86233ef0

The leak was released in NumPy 1.25, so this change may be a 1.25 backport candidate.

Bug found while running the Google Protobuf test suite under NumPy 1.25, which stringifies NumPy arrays in some of its tests, and has a test harness for detecting reference count leaks: https://github.com/protocolbuffers/protobuf/blob/49d3bca39f96f7709d48aaea4f5d30c11a943690/python/google/protobuf/internal/testing_refleaks.py