### PR TITLE
BUG: Fix cblas detection for the wheel builds

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -48,6 +48,11 @@ else
 endif
 
 
+# This is currently injected directly into CFLAGS/CXXFLAGS for wheel builds
+# (see cibuildwheel settings in pyproject.toml)
+blas_symbol_suffix = get_option('blas-symbol-suffix')
+
+
 # TODO: 64-bit BLAS and LAPACK
 #
 # Note that this works as long as BLAS and LAPACK are detected properly via
@@ -69,6 +74,14 @@ endif
 have_blas = blas.found()
 cblas = []
 if have_blas
+  # As noted above, at this point the BLAS_SYMBOL_SUFFIX may be injected into
+  # the CFLAGS directly, so this requires care to use that when it happens:
+  if blas_symbol_suffix != ''
+    probe_args = ['-DBLAS_SYMBOL_SUFFIX=' + blas_symbol_suffix]
+  else
+    probe_args = []
+  endif
+
   # Netlib BLAS has a separate `libcblas.so` which we use directly in the g77
   # ABI wrappers, so detect it and error out if we cannot find it. OpenBLAS can
   # be built without CBLAS too (see gh-23909, done by Arch Linux until
@@ -78,15 +91,22 @@ if have_blas
   # see https://github.com/mesonbuild/meson/pull/10921.
   have_cblas = false
   if cc.links('''
+      #ifndef BLAS_SYMBOL_SUFFIX
+      #  define BLAS_SYMBOL_SUFFIX
+      #endif
+      #define EXPAND(suffix) cblas_ddot ## suffix
+      #define DDOT(suffix) EXPAND(suffix)
+
       #include <cblas.h>
       int main(int argc, const char *argv[])
       {
           double a[4] = {1,2,3,4};
           double b[4] = {5,6,7,8};
-          return cblas_ddot(4, a, 1, b, 1) > 10;
+          return DDOT(BLAS_SYMBOL_SUFFIX)(4, a, 1, b, 1) > 10;
       }
       ''',
       dependencies: blas,
+      args: probe_args,
       name: 'CBLAS',
     )
     have_cblas = true
@@ -133,9 +153,6 @@ if have_blas
   if use_ilp64
     c_args_blas += ['-DHAVE_BLAS_ILP64']
   endif
-  # This is currently injected directly into CFLAGS/CXXFLAGS for wheel builds
-  # (see cibuildwheel settings in pyproject.toml)
-  blas_symbol_suffix = get_option('blas-symbol-suffix')
   if blas_symbol_suffix != ''
     c_args_blas += ['-DBLAS_SYMBOL_SUFFIX=' + blas_symbol_suffix]
   endif


### PR DESCRIPTION
This is a mess and doesn't attempt to fix the issues around gh-24200, but it should fix the issue of our wheels not using CBLAS.

The suffix may be directly injected into the flags to get the define and there is also a tangle between `HAVE_CBLAS` and `HAVE_LAPACK` and we only probe the first.

I tried this locally by checking that *if* the define exist redefining it to nonesense gives the slow version.
(I cannot test the full thing without a prefixed blas locally, because setting the prefix will not avoid blas use in LAPACK meaning you don't use CBLAS, but the blas symbols used by lapack are missing)

---

CC @mattip and @rgommers, I do not plan to attempt the "full" fix, it seems that may require untangling the way these things are set.  I think this works, but we may have to give it a roll to be sure probably.