### PR TITLE
BUG: Fix undefined behavior in complex pow().

### DIFF
--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -481,7 +481,7 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
           r = npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
           return r;
     }
-    if (bi == 0 && (n=(npy_intp)br) == br) {
+    if (bi == 0 && br > -100 && br < 100 && (n=(npy_intp)br) == br) {
         if (n == 1) {
             /* unroll: handle inf better */
             return npy_cpack@c@(ar, ai);


### PR DESCRIPTION
It is undefined behavior in C++ to convert an out-of-range or invalid floating point value to an integer, and this leads to crashes under clang with UndefinedBehaviorSanitizer. Add an extra if-guard to avoid a conversion in those cases.

This bug is caught by NumPy's existing test suite under ubsan.