### PR TITLE
DOC: fix some double includes in f2py.getting-started.rst

### DIFF
--- a/doc/source/f2py/index.rst
+++ b/doc/source/f2py/index.rst
@@ -36,10 +36,6 @@ replace all calls to ``f2py`` mentioned in this guide with the longer version.
 
    f2py-user
    f2py-reference
-   python-usage
-   signature-file
-   buildtools/index
-   advanced
    windows/index
 
 .. _Python: https://www.python.org/

--- a/doc/source/f2py/index.rst
+++ b/doc/source/f2py/index.rst
@@ -34,10 +34,8 @@ replace all calls to ``f2py`` mentioned in this guide with the longer version.
 .. toctree::
    :maxdepth: 3
 
-   f2py.getting-started
    f2py-user
    f2py-reference
-   usage
    python-usage
    signature-file
    buildtools/index


### PR DESCRIPTION
The .rst files

- f2py.getting-started.rst
- usage.rst

were included twice, in index.rst and in f2py-user.rst, but f2py-user.rst is part of index.rst.

Fix: delete them in index.rst.