### PR TITLE
API: expose NPY_DTYPE macro in the dtype API

### DIFF
--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -404,5 +404,11 @@ typedef PyArray_Descr *(ensure_canonical_function)(PyArray_Descr *dtype);
 typedef int(setitemfunction)(PyArray_Descr *, PyObject *, char *);
 typedef PyObject *(getitemfunction)(PyArray_Descr *, char *);
 
+/*
+ * Convenience utility for getting a reference to the DType metaclass associated
+ * with a dtype instance.
+ */
+#define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
+
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_ */

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -86,7 +86,6 @@ typedef struct {
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET
 
 
-#define NPY_DTYPE(descr) ((PyArray_DTypeMeta *)Py_TYPE(descr))
 #define NPY_DT_SLOTS(dtype) ((NPY_DType_Slots *)(dtype)->dt_slots)
 
 #define NPY_DT_is_legacy(dtype) (((dtype)->flags & NPY_DT_LEGACY) != 0)


### PR DESCRIPTION
This macro is used extensively in numpy internals and is also useful in user dtype implementations but so far has not been publicly exposed. I don't see a strong reason not to expose it as it will make it easier to reuse idioms found inside numpy in user dtypes.