### PR TITLE
MAINT: exclude min, max and round from `np.__all__`

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -235,6 +235,12 @@ else:
     __all__.extend(lib.__all__)
     __all__.extend(['linalg', 'fft', 'random', 'ctypeslib', 'ma'])
 
+    # Remove min and max from __all__ to avoid `from numpy import *` override
+    # the builtins min/max. Temporary fix for 1.25.x/1.26.x, see gh-24229.
+    __all__.remove('min')
+    __all__.remove('max')
+    __all__.remove('round')
+
     # Remove one of the two occurrences of `issubdtype`, which is exposed as
     # both `numpy.core.issubdtype` and `numpy.lib.issubdtype`.
     __all__.remove('issubdtype')


### PR DESCRIPTION
This is a workaround for breakage in downstream packages that do `from numpy import *`, see gh-24229.

Note that there are other builtins that are contained in `__all__`:

```
>>> for s in dir(builtins):
...     if s in np.__all__:
...         print(s)
...
all
any
divmod
sum
```

Those were already there before the change in 1.25.0, and can stay. The downstream code should be fixed before the numpy 2.0 release.

Closes gh-24229