### PR TITLE
BLD: only install the `f2py` command, not `f2py3` or `f2py3.X`

### DIFF
--- a/doc/source/f2py/index.rst
+++ b/doc/source/f2py/index.rst
@@ -26,6 +26,10 @@ available in your system, you may have to run it as a module::
 
    python -m numpy.f2py
 
+Using the ``python -m`` invocation is also good practice if you have multiple
+Python installs with NumPy in your system (outside of virtual environments) and
+you want to ensure you pick up a particular version of Python/F2PY.
+
 If you run ``f2py`` with no arguments, and the line ``numpy Version`` at the
 end matches the NumPy version printed from ``python -m numpy.f2py``, then you
 can use the shorter version. If not, or if you cannot run ``f2py``, you should

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -53,7 +53,10 @@ C_API_VERSION = '0x00000012'
 
 # Check whether we have a mismatch between the set C API VERSION and the
 # actual C API VERSION. Will raise a MismatchCAPIError if so.
-r = run_command('code_generators/verify_c_api_version.py', '--api-version', C_API_VERSION)
+r = run_command(
+  'code_generators/verify_c_api_version.py', '--api-version', C_API_VERSION,
+  check: true
+)
 
 if r.returncode() != 0
   error('verify_c_api_version.py failed with output:\n' + r.stderr().strip())

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -1,5 +1,6 @@
 # We need -lm for all C code (assuming it uses math functions, which is safe to
-# assume for numpy).
+# assume for NumPy). For C++ it isn't needed, because libstdc++/libc++ is
+# guaranteed to depend on it.
 m_dep = cc.find_library('m', required : false)
 mlib_linkflag = ''
 if m_dep.found()
@@ -204,10 +205,6 @@ src_file = generator(src_file_cli,
 )
 
 tempita_cli = find_program('_build_utils/tempita.py')
-tempita = generator(tempita_cli,
-  arguments : ['@INPUT@', '--outfile', '@OUTPUT@'],
-  output : '@BASENAME@'
-)
 
 pure_subdirs = [
   '_pyinstaller',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ tracker = "https://github.com/numpy/numpy/issues"
 
 
 [tool.cibuildwheel]
+# Note: the below skip command doesn't do much currently, the platforms to
+# build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
+# `tools/ci/cirrus_wheels.yml`.
 skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x *-musllinux_aarch64 *-win32"
 build-verbosity = "3"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,15 +40,9 @@ classifiers = [
     'Operating System :: Unix',
     'Operating System :: MacOS',
 ]
-#dynamic = ["scripts"]
 
 [project.scripts]
-# TODO: this is currently dynamic for minor version support. See also the same
-# thing in setup.py. Can we get rid of that? see commit f22a33b71 for rationale
-# for dynamic behavior.
 f2py = 'numpy.f2py.f2py2e:main'
-f2py3 = 'numpy.f2py.f2py2e:main'
-#f2py3.MINOR_VERSION = 'numpy.f2py.f2py2e:main'
 
 [project.entry-points.array_api]
 numpy = 'numpy.array_api'


### PR DESCRIPTION
Also fix a build warning for a missing `check` keyword in a `run_command` call, and some other build file cleanups.

This takes care of an open issue from the Meson build migration (xref gh-23981).
    
Use of `f2py3` is not present at all in the docs, and Python 2.7 is well and truly gone now. Using `f2py3.11` or similar is even less common, difficult to support (it prevents keeping the metadata in `pyproject.toml` completely static), and it's perfectly fine in those cases anyway to use `python3.11 -m numpy.f2py`.
    
Going via a specific Python interpreter executable has become more commonplace, e.g. `python -m pip` to ensure picking up the correct version of `pip`.