### PR TITLE
BLD: update requirements to use cython>3.0

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -181,13 +181,12 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
-  debug_and_cython3:
+  debug:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
     env:
       USE_DEBUG: 1
-      USE_CYTHON3: 1
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
@@ -343,11 +342,10 @@ jobs:
         sudo apt update
         sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gfortran-arm-linux-gnueabihf
 
-        # Keep the `test_requirements.txt` dependency-subset synced
-        docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:22.04 /bin/bash -c "
+        docker run --name the_container --interactive -v /:/host -v $(pwd):/numpy arm32v7/ubuntu:22.04 /bin/bash -c "
           apt update &&
           apt install -y git python3 python3-dev python3-pip  &&
-          python3 -m pip install cython==0.29.34 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 'typing_extensions>=4.2.0' &&
+          python3 -m pip install -r /numpy/test_requirements.txt
           ln -s /host/lib64 /lib64 &&
           ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&
           ln -s /host/usr/arm-linux-gnueabihf /usr/arm-linux-gnueabihf &&

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -20,7 +20,7 @@ Building NumPy requires the following installed software:
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 0.29.30 but < 3.0
+2) Cython >= 0.29.35
 
 3) pytest__ (optional)
 

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.10.0
-Cython<3.1
+Cython
 wheel==0.38.1
 ninja
 spin==0.4

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.10.0
-Cython>=0.29.34,<3.0
+Cython<3.1
 wheel==0.38.1
 ninja
 spin==0.4

--- a/environment.yml
+++ b/environment.yml
@@ -8,16 +8,15 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9 #need to pin to avoid issues with builds
-  - cython>=0.29.30
+  - cython>=3.0
   - compilers
   - openblas
   - nomkl
   - setuptools=59.2.0
-  - meson >= 0.64.0
   - ninja
   - pkg-config
-  - meson-python
-  - pip   # so you can use pip to install spin
+  - meson-python>=0.10.0
+  - spin=0.4
   # For testing
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,9 @@ dependencies:
   - setuptools=59.2.0
   - ninja
   - pkg-config
-  - meson-python>=0.10.0
-  - spin=0.4
+  - meson-python
+  - pip
+  - spin
   # For testing
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "Cython>=0.29.34",
+    "Cython>=3.0",
     "meson-python>=0.13.1",
 ]
 

--- a/pyproject.toml.setuppy
+++ b/pyproject.toml.setuppy
@@ -5,5 +5,5 @@
 requires = [
     "setuptools==59.2.0",
     "wheel==0.38.1",
-    "Cython>=0.29.34,<3.0",
+    "Cython>=0.29.34,<3.1",
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.29.34,<3.0
+Cython
 wheel==0.38.1
 setuptools==59.2.0 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -36,26 +36,11 @@ gcc --version
 
 popd
 
-pip install --upgrade pip 'setuptools<49.2.0' wheel
-
-# 'setuptools', 'wheel' and 'cython' are build dependencies.  This information
-# is stored in pyproject.toml, but there is not yet a standard way to install
-# those dependencies with, say, a pip command, so we'll just hard-code their
-# installation here.  We only need to install them separately for the cases
-# where numpy is installed with setup.py, which is the case for the Travis jobs
-# where the environment variables USE_DEBUG or USE_WHEEL are set. When pip is
-# used to install numpy, pip gets the build dependencies from pyproject.toml.
-# A specific version of cython is required, so we read the cython package
-# requirement using `grep cython test_requirements.txt` instead of simply
-# writing 'pip install setuptools wheel cython'.
-pip install `grep cython test_requirements.txt`
-
 if [ -n "$DOWNLOAD_OPENBLAS" ]; then
-  pwd
   target=$(python tools/openblas_support.py)
   sudo cp -r $target/lib/* /usr/lib
   sudo cp $target/include/* /usr/include
 fi
 
 
-if [ -n "$USE_ASV" ]; then pip install asv; fi
+

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -48,12 +48,7 @@ pip install --upgrade pip 'setuptools<49.2.0' wheel
 # A specific version of cython is required, so we read the cython package
 # requirement using `grep cython test_requirements.txt` instead of simply
 # writing 'pip install setuptools wheel cython'.
-if [ -n "$USE_CYTHON3" ]
-then
-  pip install --pre --force-reinstall cython
-else
-  pip install `grep cython test_requirements.txt`
-fi
+pip install `grep cython test_requirements.txt`
 
 if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -16,6 +16,11 @@ fi
 
 source builds/venv/bin/activate
 
+pip install --upgrade pip 'setuptools<49.2.0'
+
+pip install -r build_requirements.txt
+
+if [ -n "$USE_ASV" ]; then pip install asv; fi
 # travis venv tests override python
 PYTHON=${PYTHON:-python}
 PIP=${PIP:-pip}

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -90,9 +90,6 @@ run_test()
   # file does not install correctly when Python's optimization level is set
   # to strip docstrings (see https://github.com/eliben/pycparser/issues/291).
   PYTHONOPTIMIZE="" $PIP install -r test_requirements.txt pyinstaller
-  if [ -n "$USE_CYTHON3" ] ; then
-    $PIP install --pre --force-reinstall cython
-  fi
   DURATIONS_FLAG="--durations 10"
 
   if [ -n "$USE_DEBUG" ]; then


### PR DESCRIPTION
Cython3.0 has been released. Let's update to use it everywhere. For builds I pinned an upper limit `<3.1`, but for tests we can try the latest release.