### PR TITLE
BUG: fix invalid function pointer conversion error

### DIFF
--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -161,8 +161,8 @@ def buildhooks(pymod):
                 fargs.append('f2py_%s_getdims_%s' % (m['name'], n))
                 efargs.append(fargs[-1])
                 sargs.append(
-                    'void (*%s)(int*,int*,void(*)(char*,int*),int*)' % (n))
-                sargsp.append('void (*)(int*,int*,void(*)(char*,int*),int*)')
+                    'void (*%s)(int*,npy_intp*,void(*)(char*,npy_intp*),int*)' % (n))
+                sargsp.append('void (*)(int*,npy_intp*,void(*)(char*,npy_intp*),int*)')
                 iadd('\tf2py_%s_def[i_f2py++].func = %s;' % (m['name'], n))
                 fadd('subroutine %s(r,s,f2pysetdata,flag)' % (fargs[-1]))
                 fadd('use %s, only: d => %s\n' %


### PR DESCRIPTION
Backport of #24212.

I am working on updating the Darwin stdenv in nixpkgs to clang 16. I ran into an issue building numpy with clang 16 due to an invalid function pointer conversion. This fix updates f90mod_rules.py to provide compatible prototypes.

Test were run successfully on macOS 13.4.1(c) using clang 16 from nixpkgs on both aarch64-darwin and x86_64-darwin. The fix is covered by f2py/tests/test_module_doc.py::TestModuleDocString::test_module_docstring, which otherwise fails with clang 16.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
