### PR TITLE
BUG: Add size check for threaded array assignment

### DIFF
--- a/benchmarks/benchmarks/bench_manipulate.py
+++ b/benchmarks/benchmarks/bench_manipulate.py
@@ -66,6 +66,11 @@ class ConcatenateStackArrays(Benchmark):
         np.stack(self.xarg, axis=1)
 
 
+class ConcatenateNestedArrays(ConcatenateStackArrays):
+    # Large number of small arrays to test GIL (non-)release
+    params = [[(1, 1)], [1000, 100000], TYPES1]
+
+
 class DimsManipulations(Benchmark):
     params = [
         [(2, 1, 4), (2, 1), (5, 2, 3, 1)],

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -134,9 +134,12 @@ raw_array_assign_array(int ndim, npy_intp const *shape,
     }
 
     /* Ensure number of elements exceeds threshold for threading */
-    if (!(flags & NPY_METH_REQUIRES_PYAPI)
-            && PyArray_MultiplyList(shape_it, ndim) > 512) {
-        NPY_BEGIN_THREADS;
+    if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+        npy_intp nitems = 1, i;
+        for (i = 0; i < ndim; i++) {
+            nitems *= shape_it[i];
+        }
+        NPY_BEGIN_THREADS_THRESHOLDED(nitems);
     }
 
     npy_intp strides[2] = {src_strides_it[0], dst_strides_it[0]};
@@ -241,7 +244,11 @@ raw_array_wheremasked_assign_array(int ndim, npy_intp const *shape,
         npy_clear_floatstatus_barrier(src_data);
     }
     if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
-        NPY_BEGIN_THREADS;
+        npy_intp nitems = 1, i;
+        for (i = 0; i < ndim; i++) {
+            nitems *= shape_it[i];
+        }
+        NPY_BEGIN_THREADS_THRESHOLDED(nitems);
     }
     npy_intp strides[2] = {src_strides_it[0], dst_strides_it[0]};
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -132,7 +132,10 @@ raw_array_assign_array(int ndim, npy_intp const *shape,
     if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
         npy_clear_floatstatus_barrier((char*)&src_data);
     }
-    if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+
+    /* Ensure number of elements exceeds threshold for threading */
+    if (!(flags & NPY_METH_REQUIRES_PYAPI)
+            && PyArray_MultiplyList(shape_it, ndim) > 512) {
         NPY_BEGIN_THREADS;
     }
 


### PR DESCRIPTION
Many small array assignments releasing the GIL can cause slowdowns, and in multithreaded environments, can cause significant thread contention. 

Add a size check to array assignment such that only assignments that exceed a certain number of elements (512) will release the GIL. 

Closes [gh-24252](https://github.com/numpy/numpy/issues/24252).