### PR TITLE
DOC: Fix links to random.Generator methods in quickstart

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -230,8 +230,8 @@ of elements that we want, instead of the step::
     `empty_like`,
     `arange`,
     `linspace`,
-    `numpy.random.Generator.rand`,
-    `numpy.random.Generator.randn`,
+    `random.Generator.random`,
+    `random.Generator.normal`,
     `fromfunction`,
     `fromfile`
 


### PR DESCRIPTION
Let me know if these are not the most appropriate replacements.