### PR TITLE
BUG: Fix use of renamed variable.

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -319,7 +319,7 @@ genint_type_str(PyObject *self)
             item = gentype_generic_method(self, NULL, NULL, "item");
             break;
     }
-    Py_DECREF(descr);
+    Py_DECREF(dtype);
     if (item == NULL) {
         return NULL;
     }


### PR DESCRIPTION
In gh-22449 `descr` was renamed `dtype`, which broke the build as gh-24211 decrefed the old variable to fix a reference leak. This bug slipped in because gh-22449 was not retested after the merge.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
