### PR TITLE
BUG: random: Fix generation of nan by beta.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -403,11 +403,29 @@ float random_gamma_f(bitgen_t *bitgen_state, float shape, float scale) {
   return scale * random_standard_gamma_f(bitgen_state, shape);
 }
 
+#define BETA_TINY_THRESHOLD 3e-103
+
+/*
+ *  Note: random_beta assumes that a != 0 and b != 0.
+ */
 double random_beta(bitgen_t *bitgen_state, double a, double b) {
   double Ga, Gb;
 
   if ((a <= 1.0) && (b <= 1.0)) {
     double U, V, X, Y, XpY;
+
+    if (a < BETA_TINY_THRESHOLD && b < BETA_TINY_THRESHOLD) {
+      /*
+       * When a and b are this small, the probability that the
+       * sample would be a double precision float that is not
+       * 0 or 1 is less than approx. 1e-100.  So we use the
+       * proportion a/(a + b) and a single uniform sample to
+       * generate the result.
+       */
+      U = next_double(bitgen_state);
+      return (a + b)*U < a;
+    }
+
     /* Use Johnk's algorithm */
 
     while (1) {

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -79,6 +79,13 @@ class TestRegression:
         # gh-24203: beta would hang with very small parameters.
         self.mt19937.beta(1e-49, 1e-40)
 
+    def test_beta_ridiculously_small_parameters(self):
+        # gh-24266: beta would generate nan when the parameters
+        # were subnormal or a small multiple of the smallest normal.
+        tiny = np.finfo(1.0).tiny
+        x = self.mt19937.beta(tiny/32, tiny/40, size=50)
+        assert not np.any(np.isnan(x))
+
     def test_choice_sum_of_probs_tolerance(self):
         # The sum of probs should be 1.0 with some tolerance.
         # For low precision dtypes the tolerance was too tight.


### PR DESCRIPTION
The implementation of Johnk's algorithm for beta(a, b) could generate nan values if both a and b were extremely small (i.e. subnormal or a small multiple of the smallest normal double precision float).

The fix is to handle variate generation in this case by noting that when both a and b are extremely small, the probability of generating a double precision value that is not either 0 or 1 is also extremely small.  In particular, if a and b are less than 3e-103, the probability of generating a (double precision) value that is not 0 or 1 is less than approximately 1e-100.  So instead of using Johnk's algorithm in this extreme case, we can generate the values 0 or 1 as Bernoulli trials, with the probability of 1 being a/(a + b).

Closes gh-24266.
