### PR TITLE
BUG: Move legacy check for void printing

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1415,6 +1415,10 @@ def _void_scalar_to_string(x, is_repr=True):
     formatters defined above.
     """
     options = _format_options.copy()
+
+    if options["legacy"] <= 125:
+        return StructuredVoidFormat.from_data(array(x), **_format_options)(x)
+
     if options.get('formatter') is None:
         options['formatter'] = {}
     options['formatter'].setdefault('float_kind', str)

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -622,8 +622,8 @@ voidtype_repr(PyObject *self)
 {
     PyVoidScalarObject *s = (PyVoidScalarObject*) self;
     if (PyDataType_HASFIELDS(s->descr)) {
-        /* use string on old versions */
-        return _void_scalar_to_string(self, npy_legacy_print_mode > 125);
+        /* Python helper checks for the legacy mode printing */
+        return _void_scalar_to_string(self, 1);
     }
     if (npy_legacy_print_mode > 125) {
         return _void_to_hex(s->obval, s->descr->elsize, "np.void(b'", "\\x", "')");

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1084,6 +1084,9 @@ def test_scalar_repr_numbers(dtype, value):
         (np.void((True, 2), dtype="?,<i8"),
             "(True, 2)",
             "np.void((True, 2), dtype=[('f0', '?'), ('f1', '<i8')])"),
+        (np.void((1, 2), dtype="<f8,>f4"),
+            "(1., 2.)",
+            "np.void((1.0, 2.0), dtype=[('f0', '<f8'), ('f1', '>f4')])"),
         (np.void(b'a'), r"void(b'\x61')", r"np.void(b'\x61')"),
     ])
 def test_scalar_repr_special(scalar, legacy_repr, representation):
@@ -1092,3 +1095,10 @@ def test_scalar_repr_special(scalar, legacy_repr, representation):
 
     with np.printoptions(legacy="1.25"):
         assert repr(scalar) == legacy_repr
+
+def test_scalar_void_float_str():
+    # Note that based on this currently we do not print the same as a tuple
+    # would, since the tuple would include the repr() inside for floats, but
+    # we do not do that.
+    scalar = np.void((1.0, 2.0), dtype=[('f0', '<f8'), ('f1', '>f4')])
+    assert str(scalar) == "(1.0, 2.0)"


### PR DESCRIPTION
The check needs to be in the python path, because also the printing for `str()` subtly changed.

To be the same as tuples, we should actually print `(np.float32(3.), np.int8(1))` for `str()` (tuples include the repr), while for `repr()` we include the dtype so we would print similar (but ideally with full precision) to arrays.

This isn't quite ideal, I would be happy to print the full repr in the `str()` but I guess that might be a bit annoying in practice, so maybe our Numeric types are special enough for now.

---

@mhvk this should fix the remaining things in astropy.  (As said above, no solution seems quite ideal, but it seemed more practical to stay with "numpy builtin types are special for `str(void)`.)