### PR TITLE
API: Remove legacy-inner-loop-selector

### DIFF
--- a/doc/release/upcoming_changes/24271.c_api_removal.rst
+++ b/doc/release/upcoming_changes/24271.c_api_removal.rst
@@ -1,0 +1,3 @@
+* The ``legacy_inner_loop_selector`` member of the ufunc struct is removed
+  to simplify improvements to the dispatching system.
+  There are no known users overriding or directly accessing this member.

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -820,8 +820,8 @@ PyUFunc_Type and PyUFuncObject
           int *core_offsets;
           char *core_signature;
           PyUFunc_TypeResolutionFunc *type_resolver;
-          PyUFunc_LegacyInnerLoopSelectionFunc *legacy_inner_loop_selector;
           void *reserved2;
+          void *reserved3;
           npy_uint32 *op_flags;
           npy_uint32 *iter_flags;
           /* new in API version 0x0000000D */
@@ -889,10 +889,6 @@ PyUFunc_Type and PyUFuncObject
        The number of supported data types for the ufunc. This number
        specifies how many different 1-d loops (of the builtin data
        types) are available.
-
-   .. c:member:: int reserved1
-
-       Unused.
 
    .. c:member:: char *name
 
@@ -965,19 +961,6 @@ PyUFunc_Type and PyUFuncObject
 
        A function which resolves the types and fills an array with the dtypes
        for the inputs and outputs
-
-   .. c:member:: PyUFunc_LegacyInnerLoopSelectionFunc *legacy_inner_loop_selector
-
-       .. deprecated:: 1.22
-
-            Some fallback support for this slot exists, but will be removed
-            eventually.  A universal function that relied on this will
-            have to be ported eventually.
-            See :ref:`NEP 41 <NEP41>` and :ref:`NEP 43 <NEP43>`
-
-   .. c:member:: void *reserved2
-
-       For a possible future loop selector with a different signature.
 
    .. c:member:: npy_uint32 op_flags
 

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -65,30 +65,6 @@ typedef int (PyUFunc_TypeResolutionFunc)(
                                 PyObject *type_tup,
                                 PyArray_Descr **out_dtypes);
 
-/*
- * Legacy loop selector. (This should NOT normally be used and we can expect
- * that only the `PyUFunc_DefaultLegacyInnerLoopSelector` is ever set).
- * However, unlike the masked version, it probably still works.
- *
- * ufunc:             The ufunc object.
- * dtypes:            An array which has been populated with dtypes,
- *                    in most cases by the type resolution function
- *                    for the same ufunc.
- * out_innerloop:     Should be populated with the correct ufunc inner
- *                    loop for the given type.
- * out_innerloopdata: Should be populated with the void* data to
- *                    be passed into the out_innerloop function.
- * out_needs_api:     If the inner loop needs to use the Python API,
- *                    should set the to 1, otherwise should leave
- *                    this untouched.
- */
-typedef int (PyUFunc_LegacyInnerLoopSelectionFunc)(
-                            struct _tagPyUFuncObject *ufunc,
-                            PyArray_Descr **dtypes,
-                            PyUFuncGenericFunction *out_innerloop,
-                            void **out_innerloopdata,
-                            int *out_needs_api);
-
 
 typedef struct _tagPyUFuncObject {
         PyObject_HEAD
@@ -161,13 +137,8 @@ typedef struct _tagPyUFuncObject {
          * with the dtypes for the inputs and outputs.
          */
         PyUFunc_TypeResolutionFunc *type_resolver;
-        /*
-         * A function which returns an inner loop written for
-         * NumPy 1.6 and earlier ufuncs. This is for backwards
-         * compatibility, and may be NULL if inner_loop_selector
-         * is specified.
-         */
-        PyUFunc_LegacyInnerLoopSelectionFunc *legacy_inner_loop_selector;
+        /* Was the legacy loop resolver */
+        void *reserved2;
         /*
          * This was blocked off to be the "new" inner loop selector in 1.7,
          * but this was never implemented. (This is also why the above
@@ -180,7 +151,7 @@ typedef struct _tagPyUFuncObject {
         #endif
 
         /* Was previously the `PyUFunc_MaskedInnerLoopSelectionFunc` */
-        void *_always_null_previously_masked_innerloop_selector;
+        void *reserved3;
 
         /*
          * List of flags for each operand when ufunc is called by nditer object.

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -19,6 +19,7 @@
 #include "dtypemeta.h"
 
 #include "ufunc_object.h"
+#include "ufunc_type_resolution.h"
 
 
 typedef struct {
@@ -216,7 +217,7 @@ get_wrapped_legacy_ufunc_loop(PyArrayMethod_Context *context,
 
     PyUFuncGenericFunction loop = NULL;
     /* Note that `needs_api` is not reliable (it was in fact unused normally) */
-    if (ufunc->legacy_inner_loop_selector(ufunc,
+    if (PyUFunc_DefaultLegacyInnerLoopSelector(ufunc,
             context->descriptors, &loop, &user_data, &needs_api) < 0) {
         return -1;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1422,18 +1422,6 @@ execute_ufunc_loop(PyArrayMethod_Context *context, int masked,
 
     if (masked) {
         assert(PyArray_TYPE(op[nop]) == NPY_BOOL);
-        if (ufunc->_always_null_previously_masked_innerloop_selector != NULL) {
-            if (PyErr_WarnFormat(PyExc_UserWarning, 1,
-                    "The ufunc %s has a custom masked-inner-loop-selector."
-                    "NumPy assumes that this is NEVER used. If you do make "
-                    "use of this please notify the NumPy developers to discuss "
-                    "future solutions. (See NEP 41 and 43)\n"
-                    "NumPy will continue, but ignore the custom loop selector. "
-                    "This should only affect performance.",
-                    ufunc_get_name_cstr(ufunc)) < 0) {
-                return -1;
-            }
-        }
 
         /*
          * NOTE: In the masked version, we consider the output read-write,
@@ -5109,8 +5097,6 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
 
     /* Type resolution and inner loop selection functions */
     ufunc->type_resolver = &PyUFunc_DefaultTypeResolver;
-    ufunc->legacy_inner_loop_selector = &PyUFunc_DefaultLegacyInnerLoopSelector;
-    ufunc->_always_null_previously_masked_innerloop_selector = NULL;
 
     ufunc->op_flags = NULL;
     ufunc->_loops = NULL;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -58,19 +58,6 @@ object_ufunc_type_resolver(PyUFuncObject *ufunc,
     return 0;
 }
 
-static int
-object_ufunc_loop_selector(PyUFuncObject *ufunc,
-                            PyArray_Descr **NPY_UNUSED(dtypes),
-                            PyUFuncGenericFunction *out_innerloop,
-                            void **out_innerloopdata,
-                            int *out_needs_api)
-{
-    *out_innerloop = ufunc->functions[0];
-    *out_innerloopdata = (ufunc->data == NULL) ? NULL : ufunc->data[0];
-    *out_needs_api = 1;
-
-    return 0;
-}
 
 PyObject *
 ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
@@ -166,7 +153,6 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
     self->ptr = ptr;
 
     self->type_resolver = &object_ufunc_type_resolver;
-    self->legacy_inner_loop_selector = &object_ufunc_loop_selector;
     PyObject_GC_Track(self);
 
     return (PyObject *)self;


### PR DESCRIPTION
Remove legacy-inner-loop-selector and clean up the masked one (This was effectivly removed a while ago, but a deprecation was added for ABI compatibility if compiling against a newer NumPy that still had the slot).

Removed the `reservedX` struct member docs, seems clear enough to not have them explicitly...
