### PR TITLE
TYP: Trim down the ``_NestedSequence.__getitem__`` signature

### DIFF
--- a/numpy/_typing/_nested_sequence.py
+++ b/numpy/_typing/_nested_sequence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import (
     Any,
-    overload,
     TypeVar,
     Protocol,
     runtime_checkable,
@@ -62,12 +61,7 @@ class _NestedSequence(Protocol[_T_co]):
         """Implement ``len(self)``."""
         raise NotImplementedError
 
-    @overload
-    def __getitem__(self, index: int, /) -> _T_co | _NestedSequence[_T_co]: ...
-    @overload
-    def __getitem__(self, index: slice, /) -> _NestedSequence[_T_co]: ...
-
-    def __getitem__(self, index, /):
+    def __getitem__(self, index: int, /) -> _T_co | _NestedSequence[_T_co]:
         """Implement ``self[x]``."""
         raise NotImplementedError
 

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -1,5 +1,6 @@
 from typing import Any, TypeVar
 from pathlib import Path
+from collections import deque
 
 import numpy as np
 import numpy.typing as npt
@@ -26,6 +27,7 @@ reveal_type(np.array(A))  # E: ndarray[Any, dtype[{float64}]]
 reveal_type(np.array(B))  # E: ndarray[Any, dtype[{float64}]]
 reveal_type(np.array(B, subok=True))  # E: SubClass[{float64}]
 reveal_type(np.array([1, 1.0]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.array(deque([1, 2, 3])))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.array(A, dtype=np.int64))  # E: ndarray[Any, dtype[{int64}]]
 reveal_type(np.array(A, dtype='c16'))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.array(A, like=A))  # E: ndarray[Any, dtype[{float64}]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/24265

Remove the `slice`-based overload so that it successfully supertypes `deque.__getitem__`, the latter lacking support for it despite subtyping the `Sequence` abstract base class.