### PR TITLE
MAINT: Simplify ufunc.at and advanced indexing logic

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -88,6 +88,21 @@ class At(Benchmark):
     def time_maximum_at(self, dtype):
         np.maximum.at(self.res, self.idx, self.vals)
 
+class At2D(Benchmark):
+    def setup(self):
+        rng = np.random.default_rng(1)
+        self.vals = rng.random(10_000)
+        self.idx = rng.integers(1000, size=10_000).astype(np.intp)
+        self.res = np.zeros((1000, 1000))
+
+    def time_add_at_sliced(self):
+        # Only one index to a 2-D array:
+        np.add.at(self.res, self.idx, self.vals[:, None])
+
+    def time_add_at_2d(self):
+        # Both dimension of the result are indexed:
+        np.add.at(self.res, (self.idx, self.idx), self.vals)
+
 
 class UFunc(Benchmark):
     params = [ufuncs]

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -64,16 +64,28 @@ class Broadcast(Benchmark):
 
 
 class At(Benchmark):
-    def setup(self):
+    params = (np.int8,  np.int16,  np.int32,  np.int64, np.uint8, np.uint16,
+              np.uint32, np.uint64, np.float32, np.float64)
+    param_names = ['dtype']
+
+    def setup(self, dtype):
         rng = np.random.default_rng(1)
         self.vals = rng.random(10_000_000, dtype=np.float64)
-        self.idx = rng.integers(1000, size=10_000_000).astype(np.intp)
-        self.res = np.zeros(1000, dtype=self.vals.dtype)
+        if isinstance(dtype, np.integer):
+            self.vals *= np.iinfo(dtype).max
+        self.vals = self.vals.astype(dtype)
+        self.idx = rng.integers(100000, size=10_000_000).astype(np.intp)
+        self.idx_shuffled = self.idx.copy()
+        rng.shuffle(self.idx_shuffled)
+        self.res = np.zeros(100000, dtype=dtype)
 
-    def time_sum_at(self):
+    def time_sum_at(self, dtype):
         np.add.at(self.res, self.idx, self.vals)
 
-    def time_maximum_at(self):
+    def time_sum_at_random(self, dtype):
+        np.add.at(self.res, self.idx_shuffled, self.vals)
+
+    def time_maximum_at(self, dtype):
         np.maximum.at(self.res, self.idx, self.vals)
 
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1366,17 +1366,19 @@ typedef struct {
         NpyIter_IterNextFunc  *outer_next;
         char                  **outer_ptrs;
         npy_intp              *outer_strides;
+        npy_intp              outer_count;
 
         /*
          * Information about the subspace iterator.
          */
         NpyIter               *subspace_iter;
+        npy_intp              subspace_count;
         NpyIter_IterNextFunc  *subspace_next;
         char                  **subspace_ptrs;
         npy_intp              *subspace_strides;
 
         /* Count for the external loop (which ever it is) for API iteration */
-        npy_intp              iter_count;
+        char                  **array_pointers;
 
 } PyArrayMapIterObject;
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1296,7 +1296,11 @@ typedef struct {
  * fields are slightly unordered to keep consec, dataptr and subspace
  * where they were originally.
  */
-typedef struct {
+struct PyArrayMapIterObject_tag;
+typedef int (_mapiter_update_pointers_func)(
+    struct PyArrayMapIterObject_tag *mit, npy_intp count, PyThreadState *_save);
+
+typedef struct PyArrayMapIterObject_tag {
         PyObject_HEAD
         /*
          * Multi-iterator portion --- needs to be present in this
@@ -1378,6 +1382,7 @@ typedef struct {
         npy_intp              *subspace_strides;
 
         /* Count for the external loop (which ever it is) for API iteration */
+        _mapiter_update_pointers_func *update_pointers;
         char                  **array_pointers;
 
 } PyArrayMapIterObject;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -22,6 +22,7 @@
 #include "array_assign.h"
 #include "array_method.h"
 #include "usertypes.h"
+#include "mapping.h"
 
 #include "umathmodule.h"
 
@@ -1581,31 +1582,14 @@ mapiter_@name@(
         NPY_ARRAYMETHOD_FLAGS flags, int is_aligned)
 {
     npy_intp *counter, count;
-    int i;
 
     /* Cached mit info */
     int numiter = mit->numiter;
     int needs_api = (flags & NPY_METH_REQUIRES_PYAPI) != 0;
-    /* Constant information */
-    npy_intp fancy_dims[NPY_MAXDIMS];
-    npy_intp fancy_strides[NPY_MAXDIMS];
-#if @isget@
-    int iteraxis;
-#endif
 
-    char *baseoffset = mit->baseoffset;
     char **outer_ptrs = mit->outer_ptrs;
     npy_intp *outer_strides = mit->outer_strides;
     PyArrayObject *array= mit->array;
-
-    /* Fill constant information */
-#if @isget@
-    iteraxis = mit->iteraxes[0];
-#endif
-    for (i = 0; i < numiter; i++) {
-        fancy_dims[i] = mit->fancy_dims[i];
-        fancy_strides[i] = mit->fancy_strides[i];
-    }
 
     if (mit->size == 0) {
        return 0;
@@ -1627,114 +1611,80 @@ mapiter_@name@(
 
         /************ Optimized inner loops without subspace *************/
 
+        NPY_BEGIN_THREADS_DEF;
+        if (!needs_api) {
+            NPY_BEGIN_THREADS;
+        }
+
+        /* Optimization for aligned types that do not need the api */
+        switch ((is_aligned && !needs_api) ? itemsize : 0) {
+
 /**begin repeat1
- * #one_iter = 1, 0#
- * #numiter = 1, numiter#
- */
-
-#if @one_iter@
-        if (numiter == 1) {
-#else
-        else {
-#endif
-            NPY_BEGIN_THREADS_DEF;
-            if (!needs_api) {
-                NPY_BEGIN_THREADS;
-            }
-
-            /* Optimization for aligned types that do not need the api */
-            switch ((is_aligned && !needs_api) ? itemsize : 0) {
-
-/**begin repeat2
  * #elsize = 1, 2, 4, 8, 16, 0#
  * #copytype = npy_uint8, npy_uint16, npy_uint32, npy_uint64, copytype128, 0#
  */
 
 #if @elsize@
-            case @elsize@:
+        case @elsize@:
 #else
-            default:
+        default:
 #endif
-                /* Outer iteration (safe because mit->size != 0) */
-                do {
-#if !@isget@
-                    /*
-                     * When the API is needed the casting might fail
-                     * TODO: (only if buffering is enabled).
-                     */
-                    if (needs_api && PyErr_Occurred()) {
-                        return -1;
-                    }
-#endif
-                    count = *counter;
-                    while (count--) {
-                        char * self_ptr = baseoffset;
-                        for (i=0; i < @numiter@; i++) {
-                            npy_intp indval = *((npy_intp*)outer_ptrs[i]);
-                            assert(npy_is_aligned(outer_ptrs[i],
-                                                  _UINT_ALIGN(npy_intp)));
+            /* Outer iteration (safe because mit->size != 0) */
+            do {
+                count = *counter;
 
-#if @isget@ && @one_iter@
-                            if (check_and_adjust_index(&indval, fancy_dims[i],
-                                                       iteraxis, _save) < 0 ) {
-                                return -1;
-                            }
-#else
-                            if (indval < 0) {
-                                indval += fancy_dims[i];
-                            }
-#endif
-                            self_ptr += indval * fancy_strides[i];
+                if (mapiter_update_pointers_@name@(mit, count, _save) < 0) {
+                    return -1;
+                }
 
-                            /* advance indexing arrays */
-                            outer_ptrs[i] += outer_strides[i];
-                        }
-
+                char **self_ptrs = mit->array_pointers;
+                char *other_ptr = outer_ptrs[numiter];
+                npy_intp other_stride = outer_strides[numiter];
+                while (count--) {
+                    char *self_ptr = *self_ptrs;
 #if @isget@
 #if @elsize@
-                        assert(npy_is_aligned(outer_ptrs[i],
-                                              _UINT_ALIGN(@copytype@)));
-                        assert(npy_is_aligned(self_ptr,
-                                              _UINT_ALIGN(@copytype@)));
-                        *(@copytype@ *)(outer_ptrs[i]) = *(@copytype@ *)self_ptr;
+                    assert(npy_is_aligned(other_ptr, _UINT_ALIGN(@copytype@)));
+                    assert(npy_is_aligned(self_ptr, _UINT_ALIGN(@copytype@)));
+
+                    *(@copytype@ *)(other_ptr) = *(@copytype@ *)self_ptr;
 #else
-                        char *args[2] = {self_ptr, outer_ptrs[i]};
-                        if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
-                                               args, &one, strides,
-                                               cast_info->auxdata) < 0)) {
-                                           NPY_END_THREADS;
-                                           return -1;
-                                       }
+                    char *args[2] = {self_ptr, other_ptr};
+                    if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                                            args, &one, strides,
+                                            cast_info->auxdata) < 0)) {
+                                        NPY_END_THREADS;
+                                        return -1;
+                                    }
 #endif
 #else /* !@isget@ */
 #if @elsize@
-                        assert(npy_is_aligned(outer_ptrs[i],
-                               _UINT_ALIGN(@copytype@)));
-                        assert(npy_is_aligned(self_ptr,
-                               _UINT_ALIGN(@copytype@)));
-                        *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
+                    assert(npy_is_aligned(other_ptr,
+                            _UINT_ALIGN(@copytype@)));
+                    assert(npy_is_aligned(self_ptr,
+                            _UINT_ALIGN(@copytype@)));
+                    *(@copytype@ *)self_ptr = *(@copytype@ *)(other_ptr);
 #else
-                        char *args[2] = {outer_ptrs[i], self_ptr};
-                        if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
-                                               args, &one, strides,
-                                               cast_info->auxdata) < 0)) {
-                                           NPY_END_THREADS;
-                                           return -1;
-                                       }
+                    char *args[2] = {other_ptr, self_ptr};
+                    if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
+                                            args, &one, strides,
+                                            cast_info->auxdata) < 0)) {
+                                        NPY_END_THREADS;
+                                        return -1;
+                                    }
 #endif
 #endif
-                        /* advance extra operand */
-                        outer_ptrs[i] += outer_strides[i];
-                    }
-                } while (mit->outer_next(mit->outer));
+                    /* advance extra operand and pointer array*/
+                    other_ptr += other_stride;
+                    self_ptrs++;
+                }
+            } while (mit->outer_next(mit->outer));
 
-                break;
+            break;
 
-/**end repeat2**/
-            }
-            NPY_END_THREADS;
-        }
 /**end repeat1**/
+        }
+        NPY_END_THREADS;
     }
 
     /******************* Nested Iteration Situation *******************/
@@ -1750,48 +1700,30 @@ mapiter_@name@(
             needs_api = 1;
         }
 
-        counter = NpyIter_GetInnerLoopSizePtr(mit->subspace_iter);
-        if (*counter == PyArray_SIZE(mit->subspace)) {
+        counter = NpyIter_GetInnerLoopSizePtr(mit->outer);
+        npy_intp *subspace_counter = NpyIter_GetInnerLoopSizePtr(mit->subspace_iter);
+        if (*subspace_counter == PyArray_SIZE(mit->subspace)) {
            /*
             * subspace is trivially iterable.
             * manipulate pointers to avoid expensive resetting
             */
             is_subiter_trivial = 1;
         }
-/**begin repeat1
- * #one_iter = 1, 0#
- * #numiter = 1, numiter#
- */
 
-#if @one_iter@
-        if (numiter == 1) {
-#else
-        else {
-#endif
-            NPY_BEGIN_THREADS_DEF;
-            if (!needs_api) {
-                NPY_BEGIN_THREADS;
+        NPY_BEGIN_THREADS_DEF;
+        if (!needs_api) {
+            NPY_BEGIN_THREADS;
+        }
+        /* Outer iteration (safe because mit->size != 0) */
+        do {
+            npy_intp count = *counter;
+
+            if (mapiter_update_pointers_@name@(mit, count, _save) < 0) {
+                return -1;
             }
-
-            /* Outer iteration (safe because mit->size != 0) */
-            do {
-                char * self_ptr = baseoffset;
-                for (i=0; i < @numiter@; i++) {
-                    npy_intp indval = *((npy_intp*)outer_ptrs[i]);
-
-#if @isget@ && @one_iter@
-                    if (check_and_adjust_index(&indval, fancy_dims[i],
-                                               iteraxis, _save) < 0 ) {
-                        return -1;
-                    }
-#else
-                    if (indval < 0) {
-                        indval += fancy_dims[i];
-                    }
-#endif
-
-                    self_ptr += indval * fancy_strides[i];
-                }
+            char **self_ptrs = mit->array_pointers;
+            while (count--) {
+                char *self_ptr = *self_ptrs;
 
                 /*
                  * Resetting is slow, so try to avoid resetting
@@ -1850,7 +1782,7 @@ mapiter_@name@(
 
 #if @isget@
                     if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
-                            subspace_ptrs, counter, subspace_strides,
+                            subspace_ptrs, subspace_counter, subspace_strides,
                             cast_info->auxdata) < 0)) {
                         NPY_END_THREADS;
                         return -1;
@@ -1860,18 +1792,18 @@ mapiter_@name@(
                     char *args[2] = {subspace_ptrs[1], subspace_ptrs[0]};
                     npy_intp strides[2] = {subspace_strides[1], subspace_strides[0]};
                     if (NPY_UNLIKELY(cast_info->func(&cast_info->context,
-                            args, counter, strides, cast_info->auxdata) < 0)) {
+                            args, subspace_counter, strides, cast_info->auxdata) < 0)) {
                         NPY_END_THREADS;
                         return -1;
                     }
 #endif
                 } while (mit->subspace_next(mit->subspace_iter));
 
+                self_ptrs++;
                 mit->extra_op_next(mit->extra_op_iter);
-            } while (mit->outer_next(mit->outer));
-            NPY_END_THREADS;
-        }
-/**end repeat1**/
+            }
+        } while (mit->outer_next(mit->outer));
+        NPY_END_THREADS;
     }
     return 0;
 }

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1441,6 +1441,88 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
 /****************** MapIter (Advanced indexing) Get/Set ********************/
 /***************************************************************************/
 
+/**begin repeat
+ * #name = checked, unchecked#
+ * #unchecked = 0, 1#
+ */
+
+/**begin repeat1
+ * #contig = , _contig#
+ * #iscontig = 0, 1#
+ * #indval_stride = _indval_stride, NPY_SIZEOF_INTP#
+ */
+
+NPY_NO_EXPORT int
+mapiter_update_pointers_@name@@contig@(
+        PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save)
+{
+    /* Specialize for a single iterator (could specialize function) */
+    npy_intp fancy_dim = mit->fancy_dims[0];
+    npy_intp fancy_stride = mit->fancy_strides[0];
+    char *baseoffset = mit->baseoffset;
+
+    char *indval = mit->outer_ptrs[0];
+#if @unchecked@
+    int iteraxis = mit->iteraxes[0];
+#endif
+#if !@iscontig@
+    npy_intp _indval_stride = mit->outer_strides[0];
+#endif
+    char **pointers = mit->array_pointers;
+
+    for (npy_intp i = 0; i < count; i++, indval += @indval_stride@, pointers++) {
+        npy_intp curr_indval = *(npy_intp *)indval;
+#if @unchecked@
+        if (NPY_UNLIKELY(check_and_adjust_index(
+                &curr_indval, fancy_dim, iteraxis, _save) < 0 )) {
+            return -1;
+        }
+#else
+        if (curr_indval < 0) {
+            curr_indval += fancy_dim;
+        }
+#endif
+        *pointers = baseoffset + curr_indval * fancy_stride;
+    }
+    if (NPY_LIKELY(mit->numiter == 1)) {
+        return 0;
+    }
+
+    for (int op = 1; op < mit->numiter; op++) {
+        fancy_dim = mit->fancy_dims[op];
+        fancy_stride = mit->fancy_strides[op];
+        indval = mit->outer_ptrs[op];
+#if @unchecked@
+        iteraxis = mit->iteraxes[op];
+#endif
+#if !@iscontig@
+        _indval_stride = mit->outer_strides[op];
+#endif
+        pointers = mit->array_pointers;
+
+        for (npy_intp i = 0; i < count; i++, indval += @indval_stride@, pointers++) {
+            npy_intp curr_indval = *(npy_intp *)indval;
+#if @unchecked@
+            if (NPY_UNLIKELY(check_and_adjust_index(
+                    &curr_indval, fancy_dim, iteraxis, _save) < 0 )) {
+                return -1;
+            }
+#else
+            if (curr_indval < 0) {
+                curr_indval += fancy_dim;
+            }
+#endif
+            *pointers += curr_indval * fancy_stride;
+        }
+    }
+
+    return 0;
+}
+
+/**end repeat1**/
+/**end repeat**/
+
+
 typedef struct {npy_uint64 a; npy_uint64 b;} copytype128;
 
 /**begin repeat
@@ -1591,6 +1673,8 @@ mapiter_@name@(
     npy_intp *outer_strides = mit->outer_strides;
     PyArrayObject *array= mit->array;
 
+    _mapiter_update_pointers_func *update_pointers = mit->update_pointers;
+
     if (mit->size == 0) {
        return 0;
     }
@@ -1633,7 +1717,7 @@ mapiter_@name@(
             do {
                 count = *counter;
 
-                if (mapiter_update_pointers_@name@(mit, count, _save) < 0) {
+                if (update_pointers(mit, count, _save) < 0) {
                     return -1;
                 }
 
@@ -1718,7 +1802,7 @@ mapiter_@name@(
         do {
             npy_intp count = *counter;
 
-            if (mapiter_update_pointers_@name@(mit, count, _save) < 0) {
+            if (update_pointers(mit, count, _save) < 0) {
                 return -1;
             }
             char **self_ptrs = mit->array_pointers;

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -71,12 +71,24 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                    npy_uint32 extra_op_flags, PyArrayObject *extra_op,
                    PyArray_Descr *extra_op_dtype);
 
+/* checked version assumes indices are checked and cannot fail. */
 NPY_NO_EXPORT int
-mapiter_update_pointers_set(
+mapiter_update_pointers_checked(
         PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
 
+/* unchecked version assumes indices are unchecked and can fail. */
 NPY_NO_EXPORT int
-mapiter_update_pointers_get(
+mapiter_update_pointers_unchecked(
+        PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
+
+/* checked version assumes indices are checked and cannot fail. */
+NPY_NO_EXPORT int
+mapiter_update_pointers_checked_contig(
+        PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
+
+/* unchecked version assumes indices are unchecked and can fail. */
+NPY_NO_EXPORT int
+mapiter_update_pointers_unchecked_contig(
         PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
 
 

--- a/numpy/core/src/multiarray/mapping.h
+++ b/numpy/core/src/multiarray/mapping.h
@@ -70,4 +70,14 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
                    npy_uint32 subspace_iter_flags, npy_uint32 subspace_flags,
                    npy_uint32 extra_op_flags, PyArrayObject *extra_op,
                    PyArray_Descr *extra_op_dtype);
+
+NPY_NO_EXPORT int
+mapiter_update_pointers_set(
+        PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
+
+NPY_NO_EXPORT int
+mapiter_update_pointers_get(
+        PyArrayMapIterObject *mit, npy_intp count, PyThreadState *_save);
+
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MAPPING_H_ */

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -376,6 +376,7 @@ INT32_negative_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
 {
     int32_t **indexed = (int32_t **)args[0];
     npy_intp n = dimensions[0];
+
     for (npy_intp i = 0; i < n; i++, indexed++) {
         if (i == 3) {
             **indexed = -200;

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -374,23 +374,13 @@ INT32_negative_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
                            char * const*args, npy_intp const *dimensions,
                            npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    npy_intp is1 = steps[0], isindex = steps[1];
+    int32_t **indexed = (int32_t **)args[0];
     npy_intp n = dimensions[0];
-    npy_intp shape = steps[3];
-    npy_intp i;
-    int32_t *indexed;
-    for(i = 0; i < n; i++, indxp += isindex) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (int32_t *)(ip1 + is1 * indx);
+    for (npy_intp i = 0; i < n; i++, indexed++) {
         if (i == 3) {
-            *indexed = -200;
+            **indexed = -200;
         } else {
-            *indexed = - *indexed;
+            **indexed = - **indexed;
         }
     }
     return 0;

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -453,8 +453,8 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 int
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = **indexed @OP@ *(@type@ *)value;
     }
     return 0;
@@ -1241,8 +1241,8 @@ NPY_NO_EXPORT int
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = npy_floor_divide@c@(**indexed, *(@type@ *)value);
     }
     return 0;
@@ -1392,8 +1392,8 @@ LONGDOUBLE_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = **indexed @OP@ *(npy_longdouble *)value;
     }
     return 0;
@@ -1514,8 +1514,8 @@ HALF_@kind@_indexed(void *NPY_UNUSED(context),
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for(npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         const float v = npy_half_to_float(*(npy_half *)value);
         **indexed = npy_float_to_half(npy_half_to_float(**indexed) @OP@ v);
     }
@@ -1632,8 +1632,8 @@ HALF_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         npy_half v = *(npy_half *)value;
         **indexed = (@OP@(**indexed, v) || npy_half_isnan(**indexed)) ? **indexed : v;
     }
@@ -1667,8 +1667,8 @@ HALF_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for (i = 0; i < n; i++, indexed ++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed ++, value += isv) {
         npy_half v = *(npy_half *)value;
         **indexed = (@OP@(**indexed, v) || npy_half_isnan(v)) ? **indexed: v;
     }
@@ -1702,8 +1702,8 @@ HALF_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for (i = 0; i < n; i++, indexed ++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed ++, value += isv) {
         float v = npy_half_to_float(*(npy_half *)value);
         float div = npy_floor_dividef(npy_half_to_float(**indexed), v);
         **indexed = npy_float_to_half(div);
@@ -1929,8 +1929,8 @@ NPY_NO_EXPORT int @TYPE@_@kind@_indexed
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         const @ftype@ b_r = ((@ftype@ *)value)[0];
         const @ftype@ b_i = ((@ftype@ *)value)[1];
         (*indexed)[0] @OP@= b_r;
@@ -1960,8 +1960,8 @@ NPY_NO_EXPORT int @TYPE@_multiply_indexed
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         const @ftype@ a_r = (*indexed)[0];
         const @ftype@ a_i = (*indexed)[1];
         const @ftype@ b_r = ((@ftype@ *)value)[0];

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -449,21 +449,13 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 int
                       char **args, npy_intp const *dimensions, npy_intp const *steps,
                       void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
-        *indexed = *indexed @OP@ *(@type@ *)value;
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = **indexed @OP@ *(@type@ *)value;
     }
     return 0;
 }
@@ -1245,21 +1237,13 @@ NPY_NO_EXPORT int
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
-        *indexed = npy_floor_divide@c@(*indexed, *(@type@ *)value);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = npy_floor_divide@c@(**indexed, *(@type@ *)value);
     }
     return 0;
 }
@@ -1404,21 +1388,13 @@ LONGDOUBLE_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    npy_longdouble **indexed = (npy_longdouble **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    npy_longdouble *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (npy_longdouble *)(ip1 + is1 * indx);
-        *indexed = *indexed @OP@ *(npy_longdouble *)value;
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = **indexed @OP@ *(npy_longdouble *)value;
     }
     return 0;
 }
@@ -1534,22 +1510,14 @@ HALF_@kind@_indexed(void *NPY_UNUSED(context),
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    npy_half **indexed = (npy_half **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    npy_half *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (npy_half *)(ip1 + is1 * indx);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
         const float v = npy_half_to_float(*(npy_half *)value);
-        *indexed = npy_float_to_half(npy_half_to_float(*indexed) @OP@ v);
+        **indexed = npy_float_to_half(npy_half_to_float(**indexed) @OP@ v);
     }
     return 0;
 }
@@ -1660,22 +1628,14 @@ HALF_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    npy_half **indexed = (npy_half **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    npy_half *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (npy_half *)(ip1 + is1 * indx);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
         npy_half v = *(npy_half *)value;
-        *indexed = (@OP@(*indexed, v) || npy_half_isnan(*indexed)) ? *indexed : v;
+        **indexed = (@OP@(**indexed, v) || npy_half_isnan(**indexed)) ? **indexed : v;
     }
     return 0;
 }
@@ -1703,22 +1663,14 @@ HALF_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    npy_half **indexed = (npy_half **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    npy_half *indexed;
-    for (i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (npy_half *)(ip1 + is1 * indx);
+    for (i = 0; i < n; i++, indexed ++, value += isv) {
         npy_half v = *(npy_half *)value;
-        *indexed = (@OP@(*indexed, v) || npy_half_isnan(v)) ? *indexed: v;
+        **indexed = (@OP@(**indexed, v) || npy_half_isnan(v)) ? **indexed: v;
     }
     return 0;
 }
@@ -1746,23 +1698,15 @@ HALF_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
          char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    npy_half **indexed = (npy_half **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    npy_half *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (npy_half *)(ip1 + is1 * indx);
+    for (i = 0; i < n; i++, indexed ++, value += isv) {
         float v = npy_half_to_float(*(npy_half *)value);
-        float div = npy_floor_dividef(npy_half_to_float(*indexed), v);
-        *indexed = npy_float_to_half(div);
+        float div = npy_floor_dividef(npy_half_to_float(**indexed), v);
+        **indexed = npy_float_to_half(div);
     }
     return 0;
 }
@@ -1981,24 +1925,16 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT int @TYPE@_@kind@_indexed
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @ftype@ **indexed = (@ftype@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @ftype@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@ftype@ *)(ip1 + is1 * indx);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
         const @ftype@ b_r = ((@ftype@ *)value)[0];
         const @ftype@ b_i = ((@ftype@ *)value)[1];
-        indexed[0] @OP@= b_r;
-        indexed[1] @OP@= b_i;
+        (*indexed)[0] @OP@= b_r;
+        (*indexed)[1] @OP@= b_i;
     }
     return 0;
 }
@@ -2020,26 +1956,18 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT int @TYPE@_multiply_indexed
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @ftype@ **indexed = (@ftype@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @ftype@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@ftype@ *)(ip1 + is1 * indx);
-        const @ftype@ a_r = indexed[0];
-        const @ftype@ a_i = indexed[1];
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        const @ftype@ a_r = (*indexed)[0];
+        const @ftype@ a_i = (*indexed)[1];
         const @ftype@ b_r = ((@ftype@ *)value)[0];
         const @ftype@ b_i = ((@ftype@ *)value)[1];
-        indexed[0] = a_r*b_r - a_i*b_i;
-        indexed[1] = a_r*b_i + a_i*b_r;
+        (*indexed)[0] = a_r*b_r - a_i*b_i;
+        (*indexed)[1] = a_r*b_i + a_i*b_r;
     }
     return 0;
 }

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -257,21 +257,13 @@ loop_scalar:
 NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
-        *indexed = *indexed @OP@ *(@type@ *)value;
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = **indexed @OP@ *(@type@ *)value;
     }
     return 0;
 }
@@ -654,30 +646,22 @@ loop_scalar:
 NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @ftype@ **indexed = (@ftype@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @ftype@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@ftype@ *)(ip1 + is1 * indx);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
         const @ftype@ b_r = ((@ftype@ *)value)[0];
         const @ftype@ b_i = ((@ftype@ *)value)[1];
     #if @is_mul@
-        const @ftype@ a_r = indexed[0];
-        const @ftype@ a_i = indexed[1];
-        indexed[0] = a_r*b_r - a_i*b_i;
-        indexed[1] = a_r*b_i + a_i*b_r;
+        const @ftype@ a_r = (*indexed)[0];
+        const @ftype@ a_i = (*indexed)[1];
+        (*indexed)[0] = a_r*b_r - a_i*b_i;
+        (*indexed)[1] = a_r*b_i + a_i*b_r;
     #else
-        indexed[0] @OP@= b_r;
-        indexed[1] @OP@= b_i;
+        (*indexed)[0] @OP@= b_r;
+        (*indexed)[1] @OP@= b_i;
     #endif
     }
     return 0;

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -261,8 +261,8 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = **indexed @OP@ *(@type@ *)value;
     }
     return 0;
@@ -650,8 +650,8 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         const @ftype@ b_r = ((@ftype@ *)value)[0];
         const @ftype@ b_i = ((@ftype@ *)value)[1];
     #if @is_mul@

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -403,8 +403,8 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = floor_div_@TYPE@(**indexed, *(@type@ *)value);
     }
     return 0;
@@ -486,8 +486,8 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         @type@ in2 = *(@type@ *)value;
         if (NPY_UNLIKELY(in2 == 0)) {
             npy_set_floatstatus_divbyzero();

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -399,21 +399,13 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)
 NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
-        *indexed = floor_div_@TYPE@(*indexed, *(@type@ *)value);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = floor_div_@TYPE@(**indexed, *(@type@ *)value);
     }
     return 0;
 }
@@ -490,26 +482,18 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)
 NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
-    npy_intp shape = steps[3];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
         @type@ in2 = *(@type@ *)value;
         if (NPY_UNLIKELY(in2 == 0)) {
             npy_set_floatstatus_divbyzero();
-            *indexed = 0;
+            **indexed = 0;
         } else {
-            *indexed = *indexed / in2;
+            **indexed = **indexed / in2;
         }
     }
     return 0;

--- a/numpy/core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/core/src/umath/loops_minmax.dispatch.c.src
@@ -459,8 +459,8 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
     char *value = args[1];
     npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp i;
-    for(i = 0; i < n; i++, indexed++, value += isv) {
+
+    for (npy_intp i = 0; i < n; i++, indexed++, value += isv) {
         **indexed = SCALAR_OP(**indexed, *(@type@ *)value);
     }
     return 0;

--- a/numpy/core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/core/src/umath/loops_minmax.dispatch.c.src
@@ -455,21 +455,13 @@ clear_fp:
 NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
-    char *ip1 = args[0];
-    char *indxp = args[1];
-    char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
+    @type@ **indexed = (@type@ **)args[0];
+    char *value = args[1];
+    npy_intp isv = steps[1];
     npy_intp n = dimensions[0];
-    npy_intp shape = steps[3];
     npy_intp i;
-    @type@ *indexed;
-    for(i = 0; i < n; i++, indxp += isindex, value += isb) {
-        npy_intp indx = *(npy_intp *)indxp;
-        if (indx < 0) {
-            indx += shape;
-        }
-        indexed = (@type@ *)(ip1 + is1 * indx);
-        *indexed = SCALAR_OP(*indexed, *(@type@ *)value);
+    for(i = 0; i < n; i++, indexed++, value += isv) {
+        **indexed = SCALAR_OP(**indexed, *(@type@ *)value);
     }
     return 0;
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -53,6 +53,7 @@
 #include "arrayobject.h"
 #include "common.h"
 #include "ctors.h"
+#include "mapping.h"
 #include "dtypemeta.h"
 #include "numpyos.h"
 #include "dispatching.h"
@@ -5781,20 +5782,23 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
 {
     int buffersize=0, errormask = 0;
     int res;
-    char *args[3];
-    npy_intp steps[4];
-    args[0] = (char *) iter->baseoffset;
-    steps[0] = iter->fancy_strides[0];
+    char *args[2];
+    npy_intp steps[2];
+
+    args[0] = (char *)iter->array_pointers;
+    steps[0] = NPY_MIN_INTP;  /* unused since it is indexed */
+    npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
+
     if (ufuncimpl->nin == 1) {
-        args[2] = NULL;
-        steps[2] = 0;
+        args[1] = NULL;
+        steps[1] = 0;
     } else {
-        args[2] = (char *)PyArray_DATA(op2_array);
+        args[1] = (char *)PyArray_DATA(op2_array);
         if (PyArray_NDIM(op2_array) == 0
-            || PyArray_DIM(op2_array, 0) <= 1) {
-            steps[2] = 0;
+                || PyArray_DIM(op2_array, 0) <= 1) {
+            steps[1] = 0;
         } else {
-            steps[2] = PyArray_STRIDE(op2_array, 0);
+            steps[1] = PyArray_STRIDE(op2_array, 0);
         }
     }
 
@@ -5802,24 +5806,26 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
         npy_clear_floatstatus_barrier((char *)context);
     }
 
-    do {
-        npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
-        npy_intp * indxP = (npy_intp *)iter->outer_ptrs[0];
-        args[1] = (char *)indxP;
-        steps[1] = iter->outer_strides[0];
-        /* 
-         * The value of iter->fancy_dims[0] is added to negative indexes
-         * inside the inner loop
-         */
-        steps[3] = iter->fancy_dims[0];
-
+    while (1) {
         res = ufuncimpl->contiguous_indexed_loop(
                 context, args, inner_size, steps, NULL);
-
-        if (args[2] != NULL) {
-            args[2] += (*inner_size) * steps[2];
+        if (res != 0) {
+            break;
         }
-    } while (res == 0 && iter->outer_next(iter->outer));
+
+        if (args[1] != NULL) {
+            args[1] += (*inner_size) * steps[1];
+        }
+
+        /*
+         * NOTE: Loop setup is slightly different because the way we set up
+         *       the mapiter `mapiter_update_pointers_set` was already called.
+         */
+        if (!iter->outer_next(iter->outer)) {
+            break;
+        }
+        mapiter_update_pointers_set(iter, *inner_size, NULL);
+    }
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
         const char * ufunc_name =

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5789,6 +5789,8 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
     steps[0] = NPY_MIN_INTP;  /* unused since it is indexed */
     npy_intp *inner_size = NpyIter_GetInnerLoopSizePtr(iter->outer);
 
+    _mapiter_update_pointers_func *update_pointers = iter->update_pointers;
+
     if (ufuncimpl->nin == 1) {
         args[1] = NULL;
         steps[1] = 0;
@@ -5819,12 +5821,13 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
 
         /*
          * NOTE: Loop setup is slightly different because the way we set up
-         *       the mapiter `mapiter_update_pointers_set` was already called.
+         *       the mapiter `update_pointers` was already called.
+         *       (we know this is a checked version which cannot fail)
          */
         if (!iter->outer_next(iter->outer)) {
             break;
         }
-        mapiter_update_pointers_set(iter, *inner_size, NULL);
+        update_pointers(iter, *inner_size, NULL);
     }
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -6328,9 +6328,8 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
          * by adding an iteration loop inside trivial_at_loop
          */
         if ((ufuncimpl->contiguous_indexed_loop != NULL) &&
-                (PyArray_NDIM(op1_array) == 1)  &&
                 (op2_array == NULL || PyArray_NDIM(op2_array) <= 1) &&
-                (iter->subspace_iter == NULL) && (iter->numiter == 1)) {
+                (iter->subspace_iter == NULL)) {
             res = trivial_at_loop(ufuncimpl, flags, iter, op1_array,
                         op2_array, &context);
 


### PR DESCRIPTION
I had to try this out a bit, unfortunately the slowdown is a bit more than I had hoped (and then it looked like starting with advanced indexing.

For @mattip the focus would on the second commit, which is the `ufunc.at` change.

The idea here is the following:
* Keep a buffer of pointers into the indexed array. 
* This is filled with a single machinery from all the index arrays (with 1 being somewhat special).  (At the moment, the super-fast indexing path is still special here.)
* Use this also for the case where we also have slice dimensions ("subspace"), to keep things more similar.
 
This means:
* The logic in the main advanced indexing cast gets somewhat easier.
* The logic in `ufunc.at` inner-loops gets much simpler
* `ufunc.at` special-loops can generalize to N-D or other cases much easier.

Performance-wise, it is a bit of a mixed bag:
* `ufunc.at` seems 35-50% slower unfortunately...  I had really hoped the difference would be less
  * (the first bug-fix that adjusted the buffer in-place actually also is slower of course)
  * Playing with the buffer-size might shift it slightly, but didn't seem to do much really.
  * Slowdown below on M1, I think my intel linux laptop may be have a bit less slowdown.
* The advanced indexing using the new approach seem typically faster.  Some fluctuations are probably unrelated (and the largest ones almost certainly!)
* Anything that was not easy to do before in `ufunc.at` will of course be much faster.

I am a bit bummed by the slow-down.  OTOH, if @mattip isn't very bothered by it, I think I prefer the more general and simpler code this gives for `ufunc.at` loops (and advanced indexing.

**EDIT/UPDATE:**  I realized that if I have dedicate function for this, it is much easier to specialize it for the index arrays being contiguous (implementation isn't polished yet).
That recovers about half of the slowdown in `ufunc.at`, since chances are we don't do the same specialization for the `ufunc.at` loops.

<details>  <summary>  Performance results (with contiguous specialization)  </summary>

|   | [ee16c222]  | main |   Ratio | Benchmark (Parameter)                                                                |
|----------|-------------------------------------|--------------------------------------------|---------|--------------------------------------------------------------------------------------|
| +        | 11.9±0.01ms                         | 15.3±0.04ms                                |    1.29 | bench_ufunc.At.time_sum_at_random(<class 'numpy.uint16'>)                            |
| +        | 11.9±0.02ms                         | 15.2±0.04ms                                |    1.28 | bench_ufunc.At.time_sum_at(<class 'numpy.int16'>)                                    |
| +        | 11.9±0.03ms                         | 15.3±0.07ms                                |    1.28 | bench_ufunc.At.time_sum_at(<class 'numpy.uint16'>)                                   |
| +        | 11.9±0.02ms                         | 15.3±0.06ms                                |    1.28 | bench_ufunc.At.time_sum_at_random(<class 'numpy.int16'>)                             |
| +        | 10.2±0.03ms                         | 13.0±0.1ms                                 |    1.28 | bench_ufunc.At.time_sum_at_random(<class 'numpy.int8'>)                              |
| +        | 10.2±0.02ms                         | 12.9±0.03ms                                |    1.27 | bench_ufunc.At.time_sum_at(<class 'numpy.int8'>)                                     |
| +        | 10.2±0.01ms                         | 12.9±0.03ms                                |    1.27 | bench_ufunc.At.time_sum_at_random(<class 'numpy.uint8'>)                             |
| +        | 10.2±0.04ms                         | 12.9±0ms                                   |    1.26 | bench_ufunc.At.time_sum_at(<class 'numpy.uint8'>)                                    |
| +        | 12.5±0.02ms                         | 15.2±0.05ms                                |    1.22 | bench_ufunc.At.time_maximum_at(<class 'numpy.uint16'>)                               |
| +        | 13.8±0.01ms                         | 16.9±0ms                                   |    1.22 | bench_ufunc.At.time_sum_at(<class 'numpy.float32'>)                                  |
| +        | 14.0±0.03ms                         | 17.1±0.1ms                                 |    1.22 | bench_ufunc.At.time_sum_at(<class 'numpy.uint32'>)                                   |
| +        | 13.8±0.01ms                         | 16.9±0.02ms                                |    1.22 | bench_ufunc.At.time_sum_at_random(<class 'numpy.float32'>)                           |
| +        | 14.0±0.01ms                         | 17.0±0.02ms                                |    1.21 | bench_ufunc.At.time_maximum_at(<class 'numpy.float32'>)                              |
| +        | 12.5±0.02ms                         | 15.2±0.08ms                                |    1.21 | bench_ufunc.At.time_maximum_at(<class 'numpy.int16'>)                                |
| +        | 14.0±0.1ms                          | 16.9±0.06ms                                |    1.21 | bench_ufunc.At.time_sum_at(<class 'numpy.int32'>)                                    |
| +        | 14.0±0.01ms                         | 16.9±0.01ms                                |    1.21 | bench_ufunc.At.time_sum_at_random(<class 'numpy.int32'>)                             |
| +        | 14.0±0.01ms                         | 16.9±0.06ms                                |    1.21 | bench_ufunc.At.time_sum_at_random(<class 'numpy.uint32'>)                            |
| +        | 15.3±0.02ms                         | 18.2±0.1ms                                 |    1.19 | bench_ufunc.At.time_maximum_at(<class 'numpy.float64'>)                              |
| +        | 14.3±0.01ms                         | 16.9±0.05ms                                |    1.19 | bench_ufunc.At.time_maximum_at(<class 'numpy.int32'>)                                |
| +        | 14.3±0.03ms                         | 16.9±0.08ms                                |    1.19 | bench_ufunc.At.time_maximum_at(<class 'numpy.uint32'>)                               |
| +        | 15.3±0.06ms                         | 18.0±0.02ms                                |    1.18 | bench_ufunc.At.time_sum_at(<class 'numpy.float64'>)                                  |
| +        | 15.3±0.03ms                         | 18.1±0.01ms                                |    1.18 | bench_ufunc.At.time_sum_at_random(<class 'numpy.float64'>)                           |
| +        | 15.4±0.09ms                         | 18.1±0.01ms                                |    1.17 | bench_ufunc.At.time_sum_at(<class 'numpy.int64'>)                                    |
| +        | 15.4±0.07ms                         | 18.0±0.01ms                                |    1.17 | bench_ufunc.At.time_sum_at(<class 'numpy.uint64'>)                                   |
| +        | 15.4±0.02ms                         | 18.1±0.05ms                                |    1.17 | bench_ufunc.At.time_sum_at_random(<class 'numpy.int64'>)                             |
| +        | 15.4±0.01ms                         | 18.1±0.01ms                                |    1.17 | bench_ufunc.At.time_sum_at_random(<class 'numpy.uint64'>)                            |
| +        | 15.6±0.05ms                         | 18.2±0.1ms                                 |    1.16 | bench_ufunc.At.time_maximum_at(<class 'numpy.int64'>)                                |
| +        | 15.6±0.04ms                         | 18.1±0.02ms                                |    1.16 | bench_ufunc.At.time_maximum_at(<class 'numpy.uint64'>)                               |
| +        | 11.3±0.01ms                         | 12.9±0.03ms                                |    1.15 | bench_ufunc.At.time_maximum_at(<class 'numpy.int8'>)                                 |
| +        | 11.3±0.02ms                         | 12.9±0.02ms                                |    1.15 | bench_ufunc.At.time_maximum_at(<class 'numpy.uint8'>)                                |
| +        | 86.0±0.04μs                         | 97.2±0.4μs                                 |    1.13 | bench_indexing.Indexing.time_op('object', 'indexes_', 'np.ix_(I, I)', '=1')          |
| +        | 4.56±0.01μs                         | 5.12±0.2μs                                 |    1.12 | bench_indexing.Indexing.time_op('int16', 'indexes_', ':,I', '=1')                    |
| +        | 86.6±0.4μs                          | 97.1±0.6μs                                 |    1.12 | bench_indexing.Indexing.time_op('object', 'indexes_rand_', 'np.ix_(I, I)', '=1')     |
| +        | 4.62±0.01μs                         | 5.15±0μs                                   |    1.11 | bench_indexing.Indexing.time_op('float64', 'indexes_', ':,I', '=1')                  |
| +        | 4.62±0.02μs                         | 5.11±0μs                                   |    1.11 | bench_indexing.Indexing.time_op('int64', 'indexes_', ':,I', '=1')                    |
| +        | 4.62±0.01μs                         | 5.11±0.01μs                                |    1.11 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', ':,I', '=1')               |
| +        | 4.78±0μs                            | 5.32±0.01μs                                |    1.11 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', ':,I', '=1')               |
| +        | 4.56±0.01μs                         | 5.03±0.01μs                                |    1.1  | bench_indexing.Indexing.time_op('float16', 'indexes_', ':,I', '=1')                  |
| +        | 4.57±0.01μs                         | 5.03±0.01μs                                |    1.1  | bench_indexing.Indexing.time_op('float16', 'indexes_rand_', ':,I', '=1')             |
| +        | 4.63±0.01μs                         | 5.10±0μs                                   |    1.1  | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', ':,I', '=1')             |
| +        | 4.80±0.01μs                         | 5.29±0.01μs                                |    1.1  | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', ':,I', '=1')          |
| +        | 4.62±0.07μs                         | 5.02±0.01μs                                |    1.09 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', ':,I', '=1')               |
| +        | 1.71±0.01μs                         | 1.84±0.03μs                                |    1.08 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'complex64')        |
| +        | 1.71±0μs                            | 1.85±0μs                                   |    1.08 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'float64')          |
| +        | 1.71±0μs                            | 1.84±0μs                                   |    1.08 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'int64')            |
| +        | 1.71±0μs                            | 1.85±0.02μs                                |    1.08 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'longdouble')       |
| +        | 1.71±0.02μs                         | 1.83±0.01μs                                |    1.07 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'float32')          |
| +        | 1.71±0μs                            | 1.83±0.01μs                                |    1.07 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'int32')            |
| +        | 1.71±0.01μs                         | 1.82±0.01μs                                |    1.06 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'int16')            |
| +        | 1.71±0.01μs                         | 1.80±0.01μs                                |    1.05 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 1), 'float16')          |
| -        | 1.75±0μs                            | 1.64±0.01μs                                |    0.94 | bench_indexing.Indexing.time_op('float16', 'indexes_', 'I', '=1')                    |
| -        | 1.74±0μs                            | 1.63±0.01μs                                |    0.94 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', 'I', '=1')                 |
| -        | 1.88±0μs                            | 1.77±0μs                                   |    0.94 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'complex128')       |
| -        | 1.86±0μs                            | 1.75±0μs                                   |    0.94 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'int64')            |
| -        | 2.02±0μs                            | 1.90±0.01μs                                |    0.94 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'longdouble')       |
| -        | 1.88±0.01μs                         | 1.76±0μs                                   |    0.93 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'complex64')        |
| -        | 1.88±0.01μs                         | 1.75±0.01μs                                |    0.93 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'float64')          |
| -        | 1.90±0.03μs                         | 1.77±0.01μs                                |    0.93 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'int16')            |
| -        | 5.60±0.01μs                         | 5.12±0.07μs                                |    0.92 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', ':,I', '')               |
| -        | 1.79±0.05μs                         | 1.65±0.03μs                                |    0.92 | bench_indexing.Indexing.time_op('int16', 'indexes_', 'I', '=1')                      |
| -        | 64.6±0.1ms                          | 59.3±0.06ms                                |    0.92 | bench_ufunc.At2D.time_add_at_sliced                                                  |
| -        | 5.59±0.01μs                         | 5.06±0.01μs                                |    0.91 | bench_indexing.Indexing.time_op('float16', 'indexes_', ':,I', '')                    |
| -        | 5.59±0.01μs                         | 5.07±0.01μs                                |    0.91 | bench_indexing.Indexing.time_op('float16', 'indexes_rand_', ':,I', '')               |
| -        | 22.2±0.3μs                          | 20.2±0.2μs                                 |    0.91 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'i,O')              |
| -        | 5.57±0.01μs                         | 5.04±0.01μs                                |    0.9  | bench_indexing.Indexing.time_op('float32', 'indexes_', ':,I', '')                    |
| -        | 5.58±0.01μs                         | 5.04±0.01μs                                |    0.9  | bench_indexing.Indexing.time_op('int32', 'indexes_', ':,I', '')                      |
| -        | 5.59±0.01μs                         | 5.04±0μs                                   |    0.9  | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', ':,I', '')                 |
| -        | 22.4±0.01μs                         | 20.2±0.02μs                                |    0.9  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'i,O')           |
| -        | 2.06±0μs                            | 1.82±0μs                                   |    0.89 | bench_indexing.Indexing.time_op('float32', 'indexes_', 'I', '=1')                    |
| -        | 2.07±0.01μs                         | 1.83±0.02μs                                |    0.89 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', 'I', '=1')               |
| -        | 5.69±0.1μs                          | 5.08±0.03μs                                |    0.89 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', ':,I', '')                 |
| -        | 2.06±0.01μs                         | 1.83±0.03μs                                |    0.89 | bench_indexing.Indexing.time_op('int32', 'indexes_', 'I', '=1')                      |
| -        | 26.0±0.2μs                          | 23.1±0.04μs                                |    0.89 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'i,O')              |
| -        | 9.14±0.01μs                         | 8.11±0μs                                   |    0.89 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'complex128')       |
| -        | 13.1±0.03μs                         | 11.6±0.1μs                                 |    0.89 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'i,O')              |
| -        | 6.19±0.1μs                          | 5.42±0.03μs                                |    0.88 | bench_indexing.Indexing.time_op('complex128', 'indexes_', ':,I', '')                 |
| -        | 2.06±0μs                            | 1.82±0μs                                   |    0.88 | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', 'I', '=1')                 |
| -        | 9.08±0μs                            | 8.02±0.01μs                                |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'float16')          |
| -        | 8.79±0μs                            | 7.71±0.02μs                                |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'float32')          |
| -        | 9.09±0.01μs                         | 8.02±0.01μs                                |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'int16')            |
| -        | 8.78±0.01μs                         | 7.71±0μs                                   |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'int32')            |
| -        | 8.17±0.01μs                         | 7.18±0.09μs                                |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'longdouble')       |
| -        | 26.4±0.3μs                          | 23.3±0.03μs                                |    0.88 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'i,O')           |
| -        | 6.70±0.1μs                          | 5.81±0.02μs                                |    0.87 | bench_indexing.Indexing.time_op('complex128', 'indexes_rand_', ':,I', '')            |
| -        | 1.83±0μs                            | 1.60±0.01μs                                |    0.87 | bench_indexing.Indexing.time_op('float16', 'indexes_', 'I', '')                      |
| -        | 8.48±0.02μs                         | 7.40±0.02μs                                |    0.87 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'float16')          |
| -        | 8.47±0.01μs                         | 7.39±0.01μs                                |    0.87 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'int16')            |
| -        | 8.18±0.04μs                         | 7.09±0.01μs                                |    0.87 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'complex64')        |
| -        | 8.18±0.01μs                         | 7.11±0.01μs                                |    0.87 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'float64')          |
| -        | 8.17±0.02μs                         | 7.08±0.01μs                                |    0.87 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 3), 'int64')            |
| -        | 1.84±0μs                            | 1.58±0μs                                   |    0.86 | bench_indexing.Indexing.time_op('float16', 'indexes_rand_', 'I', '')                 |
| -        | 6.01±0.01μs                         | 5.14±0.02μs                                |    0.86 | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', ':,I', '')               |
| -        | 3.03±0.01μs                         | 2.60±0.01μs                                |    0.86 | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', 'I', '=1')               |
| -        | 5.18±0.02μs                         | 4.44±0μs                                   |    0.86 | bench_indexing.Indexing.time_op('int32', 'indexes_', ':,I', '=1')                    |
| -        | 5.19±0.02μs                         | 4.45±0μs                                   |    0.86 | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', ':,I', '=1')               |
| -        | 3.03±0.01μs                         | 2.60±0.01μs                                |    0.86 | bench_indexing.Indexing.time_op('int64', 'indexes_', 'I', '=1')                      |
| -        | 3.21±0.01μs                         | 2.76±0μs                                   |    0.86 | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', 'I', '=1')            |
| -        | 8.63±0.1μs                          | 7.43±0.03μs                                |    0.86 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'complex128')       |
| -        | 7.87±0.01μs                         | 6.78±0.01μs                                |    0.86 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'complex64')        |
| -        | 5.26±0.06μs                         | 4.47±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('float32', 'indexes_', ':,I', '=1')                  |
| -        | 5.24±0.07μs                         | 4.46±0.06μs                                |    0.85 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', ':,I', '=1')             |
| -        | 3.05±0.01μs                         | 2.61±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('float64', 'indexes_', 'I', '=1')                    |
| -        | 5.95±0.06μs                         | 5.06±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('int16', 'indexes_', ':,I', '')                      |
| -        | 1.90±0.07μs                         | 1.61±0μs                                   |    0.85 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', 'I', '')                   |
| -        | 6.03±0.04μs                         | 5.13±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', ':,I', '')                 |
| -        | 3.03±0.02μs                         | 2.58±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', 'I', '=1')                 |
| -        | 3.26±0.06μs                         | 2.78±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', 'I', '=1')                 |
| -        | 6.00±0.02μs                         | 5.11±0.01μs                                |    0.85 | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', ':,I', '')            |
| -        | 8.01±0.1μs                          | 6.77±0.02μs                                |    0.85 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'int64')            |
| -        | 7.97±0.1μs                          | 6.77±0.1μs                                 |    0.85 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'longdouble')       |
| -        | 12.2±0.05μs                         | 10.4±0.2μs                                 |    0.85 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'O')             |
| -        | 14.1±0.7μs                          | 12.0±0.01μs                                |    0.85 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'complex128')    |
| -        | 2.71±0.02μs                         | 2.27±0.01μs                                |    0.84 | bench_indexing.Indexing.time_op('float32', 'indexes_', 'I', '')                      |
| -        | 1.97±0.01μs                         | 1.65±0.04μs                                |    0.84 | bench_indexing.Indexing.time_op('int16', 'indexes_', 'I', '')                        |
| -        | 2.72±0.01μs                         | 2.27±0.01μs                                |    0.84 | bench_indexing.Indexing.time_op('int32', 'indexes_', 'I', '')                        |
| -        | 12.1±0.04μs                         | 10.2±0.2μs                                 |    0.84 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'O')                |
| -        | 8.06±0.1μs                          | 6.78±0.01μs                                |    0.84 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'float64')          |
| -        | 6.93±0.01μs                         | 5.84±0.01μs                                |    0.84 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'int32')            |
| -        | 2.70±0.01μs                         | 2.24±0.03μs                                |    0.83 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', 'I', '')                 |
| -        | 6.19±0.01μs                         | 5.11±0.02μs                                |    0.83 | bench_indexing.Indexing.time_op('float64', 'indexes_', ':,I', '')                    |
| -        | 6.17±0.01μs                         | 5.11±0.01μs                                |    0.83 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', ':,I', '')                 |
| -        | 7.03±0.1μs                          | 5.87±0.07μs                                |    0.83 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((1000, 2), 'float32')          |
| -        | 7.99±0μs                            | 6.61±0.06μs                                |    0.83 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'float64')          |
| -        | 2.71±0.01μs                         | 2.21±0.02μs                                |    0.82 | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', 'I', '')                   |
| -        | 6.19±0.01μs                         | 5.10±0.01μs                                |    0.82 | bench_indexing.Indexing.time_op('int64', 'indexes_', ':,I', '')                      |
| -        | 7.68±0.01μs                         | 6.27±0.04μs                                |    0.82 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'complex128')       |
| -        | 8.13±0.01μs                         | 6.64±0μs                                   |    0.82 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'longdouble')       |
| -        | 60.2±0.1μs                          | 48.7±0.5μs                                 |    0.81 | bench_indexing.Indexing.time_op('object', 'indexes_', 'np.ix_(I, I)', '')            |
| -        | 7.99±0μs                            | 6.51±0.01μs                                |    0.81 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'float16')          |
| -        | 7.99±0.01μs                         | 6.50±0.01μs                                |    0.81 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'float32')          |
| -        | 7.98±0μs                            | 6.50±0μs                                   |    0.81 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'int16')            |
| -        | 7.99±0.04μs                         | 6.49±0.01μs                                |    0.81 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'int32')            |
| -        | 7.98±0.01μs                         | 6.49±0.01μs                                |    0.81 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'int64')            |
| -        | 5.63±0.09μs                         | 4.52±0.01μs                                |    0.8  | bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', ':,I', '')             |
| -        | 7.71±0.02μs                         | 6.20±0.01μs                                |    0.8  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 3), 'complex64')        |
| -        | 5.70±0.02μs                         | 4.53±0.01μs                                |    0.79 | bench_indexing.Indexing.time_op('complex64', 'indexes_', ':,I', '')                  |
| -        | 32.8±0.7μs                          | 24.8±0.4μs                                 |    0.76 | bench_indexing.Indexing.time_op('float16', 'indexes_', 'np.ix_(I, I)', '')           |
| -        | 32.3±0.03μs                         | 24.6±0.3μs                                 |    0.76 | bench_indexing.Indexing.time_op('float16', 'indexes_rand_', 'np.ix_(I, I)', '')      |
| -        | 33.1±0.8μs                          | 25.2±0.8μs                                 |    0.76 | bench_indexing.Indexing.time_op('int16', 'indexes_', 'np.ix_(I, I)', '')             |
| -        | 32.8±0.05μs                         | 24.9±0.3μs                                 |    0.76 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', 'np.ix_(I, I)', '')        |
| -        | 65.0±0.06μs                         | 49.7±0.4μs                                 |    0.76 | bench_indexing.Indexing.time_op('object', 'indexes_rand_', 'np.ix_(I, I)', '')       |
| -        | 5.92±0.03μs                         | 4.49±0.05μs                                |    0.76 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'complex128')    |
| -        | 5.90±0.03μs                         | 4.46±0.04μs                                |    0.76 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'complex64')     |
| -        | 5.89±0.04μs                         | 4.47±0.05μs                                |    0.76 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'int16')         |
| -        | 32.8±0.02μs                         | 24.5±0.3μs                                 |    0.75 | bench_indexing.Indexing.time_op('complex64', 'indexes_', 'np.ix_(I, I)', '')         |
| -        | 32.8±0.3μs                          | 24.5±0.2μs                                 |    0.75 | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', 'np.ix_(I, I)', '')        |
| -        | 5.89±0.04μs                         | 4.41±0μs                                   |    0.75 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'float16')       |
| -        | 5.93±0.01μs                         | 4.47±0.03μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'float32')       |
| -        | 5.91±0.03μs                         | 4.43±0.01μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'float64')       |
| -        | 5.91±0.04μs                         | 4.42±0.01μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'int32')         |
| -        | 5.91±0.03μs                         | 4.43±0.01μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'longdouble')    |
| -        | 6.69±0.04μs                         | 5.01±0.05μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'float16')          |
| -        | 6.70±0.04μs                         | 5.01±0.05μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'float64')          |
| -        | 6.86±0.05μs                         | 5.16±0.05μs                                |    0.75 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'longdouble')       |
| -        | 6.28±0.02μs                         | 4.62±0.04μs                                |    0.74 | bench_indexing.Indexing.time_op('complex128', 'indexes_', 'I', '')                   |
| -        | 34.3±0.2μs                          | 25.4±0.4μs                                 |    0.74 | bench_indexing.Indexing.time_op('complex128', 'indexes_rand_', 'np.ix_(I, I)', '')   |
| -        | 33.4±0.2μs                          | 24.6±0.3μs                                 |    0.74 | bench_indexing.Indexing.time_op('int32', 'indexes_', 'np.ix_(I, I)', '')             |
| -        | 5.97±0.04μs                         | 4.42±0.01μs                                |    0.74 | bench_indexing.IndexingWith1DArr.time_getitem_ordered((2, 1000, 1), 'int64')         |
| -        | 6.75±0.04μs                         | 4.99±0.05μs                                |    0.74 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'float32')          |
| -        | 6.74±0.04μs                         | 4.96±0.01μs                                |    0.74 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'int16')            |
| -        | 6.70±0.04μs                         | 4.95±0μs                                   |    0.74 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'int32')            |
| -        | 6.74±0.1μs                          | 4.99±0.04μs                                |    0.74 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'int64')            |
| -        | 6.28±0.07μs                         | 4.57±0.01μs                                |    0.73 | bench_indexing.Indexing.time_op('complex128', 'indexes_rand_', 'I', '')              |
| -        | 33.0±0.2μs                          | 24.2±0.05μs                                |    0.73 | bench_indexing.Indexing.time_op('float32', 'indexes_', 'np.ix_(I, I)', '')           |
| -        | 32.7±0.3μs                          | 24.0±0.03μs                                |    0.73 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', 'np.ix_(I, I)', '')      |
| -        | 33.4±0.6μs                          | 24.3±0.02μs                                |    0.73 | bench_indexing.Indexing.time_op('float64', 'indexes_', 'np.ix_(I, I)', '')           |
| -        | 32.9±0.3μs                          | 24.0±0.01μs                                |    0.73 | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', 'np.ix_(I, I)', '')      |
| -        | 33.1±1μs                            | 24.1±0.03μs                                |    0.73 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', 'np.ix_(I, I)', '')        |
| -        | 33.4±0.6μs                          | 24.4±0.02μs                                |    0.73 | bench_indexing.Indexing.time_op('int64', 'indexes_', 'np.ix_(I, I)', '')             |
| -        | 33.4±0.5μs                          | 24.3±0.3μs                                 |    0.73 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', 'np.ix_(I, I)', '')        |
| -        | 34.3±0.1μs                          | 24.8±0.3μs                                 |    0.72 | bench_indexing.Indexing.time_op('complex128', 'indexes_', 'np.ix_(I, I)', '')        |
| -        | 33.4±0.5μs                          | 24.2±0.06μs                                |    0.72 | bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', 'np.ix_(I, I)', '')    |
| -        | 33.4±0.6μs                          | 24.0±0.06μs                                |    0.72 | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', 'np.ix_(I, I)', '')   |
| -        | 14.1±2μs                            | 10.1±0.03μs                                |    0.72 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'complex64')     |
| -        | 6.90±0.06μs                         | 4.89±0.03μs                                |    0.71 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'float16')       |
| -        | 6.94±0.06μs                         | 4.92±0.02μs                                |    0.71 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'float64')       |
| -        | 6.92±0.08μs                         | 4.88±0.03μs                                |    0.71 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'int16')         |
| -        | 7.14±0.06μs                         | 5.05±0.04μs                                |    0.71 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'longdouble')    |
| -        | 6.99±0.04μs                         | 4.86±0.04μs                                |    0.7  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'complex128')       |
| -        | 6.94±0.06μs                         | 4.87±0.05μs                                |    0.7  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'float32')       |
| -        | 6.93±0.06μs                         | 4.88±0.04μs                                |    0.7  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'int32')         |
| -        | 6.93±0.07μs                         | 4.87±0.04μs                                |    0.7  | bench_indexing.IndexingWith1DArr.time_setitem_ordered((2, 1000, 1), 'int64')         |
| -        | 7.04±0.07μs                         | 4.87±0.04μs                                |    0.69 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 2), 'complex64')        |
| -        | 37.4±0.1μs                          | 25.1±0.03μs                                |    0.67 | bench_indexing.Indexing.time_op('complex64', 'indexes_', 'np.ix_(I, I)', '=1')       |
| -        | 38.9±0.03μs                         | 25.6±0.02μs                                |    0.66 | bench_indexing.Indexing.time_op('complex128', 'indexes_rand_', 'np.ix_(I, I)', '=1') |
| -        | 4.08±0.01μs                         | 2.70±0.01μs                                |    0.66 | bench_indexing.Indexing.time_op('complex64', 'indexes_', 'I', '')                    |
| -        | 4.08±0.02μs                         | 2.68±0.03μs                                |    0.66 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', 'I', '')                   |
| -        | 35.3±0.02μs                         | 23.3±0.2μs                                 |    0.66 | bench_indexing.Indexing.time_op('int64', 'indexes_rand_', 'np.ix_(I, I)', '=1')      |
| -        | 4.09±0.01μs                         | 2.69±0.01μs                                |    0.66 | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', 'I', '')              |
| -        | 4.09±0.02μs                         | 2.64±0.01μs                                |    0.65 | bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', 'I', '')               |
| -        | 4.17±0.07μs                         | 2.70±0.04μs                                |    0.65 | bench_indexing.Indexing.time_op('float64', 'indexes_', 'I', '')                      |
| -        | 4.07±0.01μs                         | 2.64±0.01μs                                |    0.65 | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', 'I', '')                 |
| -        | 4.14±0.07μs                         | 2.70±0.02μs                                |    0.65 | bench_indexing.Indexing.time_op('int64', 'indexes_', 'I', '')                        |
| -        | 4.15±0.06μs                         | 2.70±0.01μs                                |    0.65 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', 'I', '')                   |
| -        | 39.9±0.07μs                         | 25.5±0.1μs                                 |    0.64 | bench_indexing.Indexing.time_op('complex128', 'indexes_', 'np.ix_(I, I)', '=1')      |
| -        | 37.8±0.6μs                          | 24.4±0.1μs                                 |    0.64 | bench_indexing.Indexing.time_op('complex64', 'indexes_rand_', 'np.ix_(I, I)', '=1')  |
| -        | 34.0±0.02μs                         | 21.6±0.4μs                                 |    0.64 | bench_indexing.Indexing.time_op('float16', 'indexes_rand_', 'np.ix_(I, I)', '=1')    |
| -        | 35.3±0.01μs                         | 22.6±0.02μs                                |    0.64 | bench_indexing.Indexing.time_op('float64', 'indexes_rand_', 'np.ix_(I, I)', '=1')    |
| -        | 36.1±0.5μs                          | 23.0±0.4μs                                 |    0.64 | bench_indexing.Indexing.time_op('longdouble', 'indexes_', 'np.ix_(I, I)', '=1')      |
| -        | 35.5±0.03μs                         | 22.9±0.1μs                                 |    0.64 | bench_indexing.Indexing.time_op('longdouble', 'indexes_rand_', 'np.ix_(I, I)', '=1') |
| -        | 34.7±0.1μs                          | 22.0±0.2μs                                 |    0.63 | bench_indexing.Indexing.time_op('float32', 'indexes_', 'np.ix_(I, I)', '=1')         |
| -        | 35.3±0.03μs                         | 22.4±0.05μs                                |    0.63 | bench_indexing.Indexing.time_op('float64', 'indexes_', 'np.ix_(I, I)', '=1')         |
| -        | 34.1±0.06μs                         | 21.6±0.4μs                                 |    0.63 | bench_indexing.Indexing.time_op('int16', 'indexes_rand_', 'np.ix_(I, I)', '=1')      |
| -        | 35.3±0.02μs                         | 22.3±0.09μs                                |    0.63 | bench_indexing.Indexing.time_op('int64', 'indexes_', 'np.ix_(I, I)', '=1')           |
| -        | 34.0±0.03μs                         | 21.2±0.04μs                                |    0.62 | bench_indexing.Indexing.time_op('float16', 'indexes_', 'np.ix_(I, I)', '=1')         |
| -        | 34.5±0.03μs                         | 21.5±0.01μs                                |    0.62 | bench_indexing.Indexing.time_op('float32', 'indexes_rand_', 'np.ix_(I, I)', '=1')    |
| -        | 34.3±1μs                            | 21.2±0.07μs                                |    0.62 | bench_indexing.Indexing.time_op('int16', 'indexes_', 'np.ix_(I, I)', '=1')           |
| -        | 34.5±0.3μs                          | 21.3±0.1μs                                 |    0.62 | bench_indexing.Indexing.time_op('int32', 'indexes_', 'np.ix_(I, I)', '=1')           |
| -        | 34.7±0.4μs                          | 21.6±0.04μs                                |    0.62 | bench_indexing.Indexing.time_op('int32', 'indexes_rand_', 'np.ix_(I, I)', '=1')      |
| -        | 9.38±0.3μs                          | 5.49±0.01μs                                |    0.59 | bench_indexing.IndexingWith1DArr.time_setitem_ordered((1000, 1), 'O')                |
| -        | 97.7±0.08μs                         | 24.4±0.04μs                                |    0.25 | bench_ufunc.At2D.time_add_at_2d                                                      |