### PR TITLE
DOC: update code comment about `NPY_USE_BLAS_ILP64` environment variable

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -55,8 +55,9 @@ blas_symbol_suffix = get_option('blas-symbol-suffix')
 
 use_ilp64 = get_option('use-ilp64')
 if not use_ilp64
-  # For now, keep supporting this environment variable too (same as in setup.py)
-  # `false is the default for the CLI flag, so check if env var was set
+  # For now, keep supporting the `NPY_USE_BLAS_ILP64` environment variable too
+  # (same as in setup.py) `false is the default for the CLI flag, so check if
+  # env var was set
   use_ilp64 = run_command(py,
     [
       '-c',


### PR DESCRIPTION
As suggested by Chuck in a review comment on a previous PR. Sending as a separate follow-up also because it helps to check Cirrus CI triggering which we are looking at in issue 24280.

[skip azp] [skip circle] [skip actions] [skip travis]