### PR TITLE
CI: improve test suite runtime via pytest parallelism and disabling mypy in most jobs

### DIFF
--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -68,6 +68,5 @@ jobs:
         TERM: xterm-256color
         LD_LIBRARY_PATH: "/usr/local/lib/"  # to find libopenblas.so.0
       run: |
-        export NPY_RUN_MYPY_IN_TESTSUITE=1
         pip install pytest pytest-xdist hypothesis typing_extensions
         spin test -j auto

--- a/.github/workflows/linux_meson.yml
+++ b/.github/workflows/linux_meson.yml
@@ -68,5 +68,6 @@ jobs:
         TERM: xterm-256color
         LD_LIBRARY_PATH: "/usr/local/lib/"  # to find libopenblas.so.0
       run: |
+        export NPY_RUN_MYPY_IN_TESTSUITE=1
         pip install pytest pytest-xdist hypothesis typing_extensions
         spin test -j auto

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,67 @@
+name: Run MyPy
+
+# Mypy is too slow to run as part of regular CI. The purpose of the jobs in
+# this file is to cover running Mypy across:
+#
+#   - OSes: Linux, Windows and macOS
+#   - Python versions: lowest/highest supported versions, and an intermediate one
+#
+# The build matrix aims for sparse coverage across those two dimensions.
+# Use of BLAS/LAPACK and SIMD is disabled on purpose, because those things
+# don't matter for static typing and this speeds up the builds.
+#
+# This is a separate job file so it's easy to trigger by hand.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+    paths-ignore:
+      - 'benchmarks/'
+      - '.circlecl/'
+      - 'docs/'
+      - 'meson_cpu/'
+      - 'tools/'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  mypy:
+    if: "github.repository == 'numpy/numpy'"
+    name: "MyPy"
+    runs-on: ${{ matrix.os_python[0] }}
+    strategy:
+      matrix:
+        os_python:
+          - [ubuntu-latest, '3.10']  # switch to 3.12-dev after mypy is upgraded (see gh-23764)
+          - [windows-2019, '3.11']
+          - [macos-12, '3.9']
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+      with:
+        python-version: ${{ matrix.os_python[1] }}
+    - name: Install dependencies
+      run: |
+        pip install -r build_requirements.txt
+        pip install -r test_requirements.txt
+    - name: Build
+      run: |
+        spin build -j2 -- -Dallow-noblas=true -Ddisable-optimization=true --vsenv
+    - name: Run Mypy
+      run: |
+        spin mypy

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -925,3 +925,16 @@ def run(ctx, args):
     """
     ctx.invoke(build)
     ctx.forward(meson_run)
+ 
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.pass_context
+def mypy(ctx):
+    """Run Mypy tests for NumPy
+    """
+    env = os.environ
+    env['NPY_RUN_MYPY_IN_TESTSUITE'] = '1'
+    ctx.params['pytest_args'] = [os.path.join('numpy', 'typing')]
+    ctx.params['markexpr'] = 'full'
+    ctx.forward(test)
+

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -18,6 +18,21 @@ from numpy.typing.mypy_plugin import (
     _C_INTP,
 )
 
+
+# Only trigger a full `mypy` run if this environment variable is set
+# Note that these tests tend to take over a minute even on a macOS M1 CPU,
+# and more than that in CI.
+RUN_MYPY = "NPY_RUN_MYPY_IN_TESTSUITE" in os.environ
+if RUN_MYPY and RUN_MYPY not in ('0', '', 'false'):
+    RUN_MYPY = True
+
+# Skips all functions in this file
+pytestmark = pytest.mark.skipif(
+    not RUN_MYPY,
+    reason="`NPY_RUN_MYPY_IN_TESTSUITE` not set"
+)
+
+
 try:
     from mypy import api
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,11 @@ repair-wheel-command = "bash ./tools/wheels/repair_windows.sh {wheel} {dest_dir}
 package = 'numpy'
 
 [tool.spin.commands]
-"Build" = [".spin/cmds.py:build", ".spin/cmds.py:test"]
+"Build" = [
+  ".spin/cmds.py:build",
+  ".spin/cmds.py:test",
+  ".spin/cmds.py:mypy",
+]
 "Environments" = [
   ".spin/cmds.py:run", ".spin/cmds.py:ipython",
   ".spin/cmds.py:python", ".spin/cmds.py:gdb"

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -26,5 +26,7 @@ fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.
 export NPY_AVAILABLE_MEM="4 GB"
-python -c "import sys; import numpy; sys.exit(not numpy.test(label='full'))"
+# Run full tests with -n=auto. This makes pytest-xdist distribute tests across
+# the available N CPU cores: 2 by default for Linux instances and 4 for macOS arm64
+python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto']))"
 python $PROJECT_DIR/tools/wheels/check_license.py


### PR DESCRIPTION
Should address some of the issues identified in [gh-24280](https://github.com/numpy/numpy/issues/24280#issuecomment-1657094780).

Regarding the Mypy tests: these tests are super slow, and they're effectively always passing in CI. Running them on all "full" test suite runs is too expensive, so enable them on a single job instead. Note that SciPy has an XSLOW mark, NumPy does not. So use an env var for now. Typical guidelines are that fast tests should be >0.5 sec, slow only in the 0.5-5 sec range, and anything above that should be avoided. The boundaries are fuzzy, but Mypy takes 1-2 minutes to run, so needs custom opt-in. Cc @BvB93 for visibility.

Also adds a `spin mypy` developer command to make it easier to run only static typing tests.