### PR TITLE
CI: correct URL in cirrus.star [skip cirrus]

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -24,7 +24,7 @@ def main(ctx):
     # only contains the actual commit message on a non-PR trigger event.
     # For a PR event it contains the PR title and description.
     SHA = env.get("CIRRUS_CHANGE_IN_REPO")
-    url = "https://api.github.com/repos/scipy/scipy/git/commits/" + SHA
+    url = "https://api.github.com/repos/numpy/numpy/git/commits/" + SHA
     dct = http.get(url).json()
     # if "[wheel build]" in dct["message"]:
     #     return fs.read("ci/cirrus_wheels.yml")


### PR DESCRIPTION
Backport of #24285.

Corrects the URL tested in .cirrus.star. Related to #24280
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
