### PR TITLE
BUG: Fix C types in scalartypes

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -283,34 +283,34 @@ genint_type_str(PyObject *self)
     void *val = scalar_value(self, descr);
     switch (descr->type_num) {
         case NPY_BYTE:
-            item = PyLong_FromLong(*(int8_t *)val);
+            item = PyLong_FromLong(*(npy_byte *)val);
             break;
         case NPY_UBYTE:
-            item = PyLong_FromUnsignedLong(*(uint8_t *)val);
+            item = PyLong_FromUnsignedLong(*(npy_ubyte *)val);
             break;
         case NPY_SHORT:
-            item = PyLong_FromLong(*(int16_t *)val);
+            item = PyLong_FromLong(*(npy_short *)val);
             break;
         case NPY_USHORT:
-            item = PyLong_FromUnsignedLong(*(uint16_t *)val);
+            item = PyLong_FromUnsignedLong(*(npy_ushort *)val);
             break;
         case NPY_INT:
-            item = PyLong_FromLong(*(int32_t *)val);
+            item = PyLong_FromLong(*(npy_int *)val);
             break;
         case NPY_UINT:
-            item = PyLong_FromUnsignedLong(*(uint32_t *)val);
+            item = PyLong_FromUnsignedLong(*(npy_uint *)val);
             break;
         case NPY_LONG:
-            item = PyLong_FromLong(*(int64_t *)val);
+            item = PyLong_FromLong(*(npy_long *)val);
             break;
         case NPY_ULONG:
-            item = PyLong_FromUnsignedLong(*(uint64_t *)val);
+            item = PyLong_FromUnsignedLong(*(npy_ulong *)val);
             break;
         case NPY_LONGLONG:
-            item = PyLong_FromLongLong(*(long long *)val);
+            item = PyLong_FromLongLong(*(npy_longlong *)val);
             break;
         case NPY_ULONGLONG:
-            item = PyLong_FromUnsignedLongLong(*(unsigned long long *)val);
+            item = PyLong_FromUnsignedLongLong(*(npy_ulonglong *)val);
             break;
         default:
             item = gentype_generic_method(self, NULL, NULL, "item");


### PR DESCRIPTION
Backport of #24240.

https://github.com/numpy/numpy/pull/23746 introduced a fast path for scalar int conversions, but the map between Python types and C types was subtly wrong.

This fixes tests on at least ppc32 (big-endian).

Many thanks to Sebastian Berg for debugging this with me and pointing out what needed to be fixed.

Closes #24239.

Fixes: 81caed6e3c34c4bf4b22b4f6167e816ba2a3f73c

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
