### PR TITLE
CI: apt update before apt install on cirrus

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -38,6 +38,7 @@ linux_aarch64_task:
         CIBW_BUILD: cp312-*
 
   build_script: |
+    apt update
     apt install -y python3-venv python-is-python3 gfortran libatlas-base-dev libgfortran5 eatmydata
     git fetch origin
     ./tools/travis-before-install.sh


### PR DESCRIPTION
This should hopefully fix the CI failures on cirrus seen on #24154.