### PR TITLE
BUG: Fix piecewise implicit return type conversion

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -758,7 +758,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
             vals = x[cond]
             if vals.size > 0:
 
-                func_val =  func(vals, *args, **kw)
+                func_val = func(vals, *args, **kw)
                 y = y.astype(asarray(func_val).dtype)
                 y[cond] = func_val
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -749,12 +749,15 @@ def piecewise(x, condlist, funclist, *args, **kw):
         )
 
     y = zeros_like(x)
+
     for cond, func in zip(condlist, funclist):
         if not isinstance(func, collections.abc.Callable):
+            y = y.astype(asarray(func).dtype)
             y[cond] = func
         else:
             vals = x[cond]
             if vals.size > 0:
+                y = y.astype(asarray(func(vals, *args, **kw)).dtype)
                 y[cond] = func(vals, *args, **kw)
 
     return y

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -751,13 +751,16 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
     for cond, func in zip(condlist, funclist):
         if not isinstance(func, collections.abc.Callable):
+
             y = y.astype(asarray(func).dtype)
             y[cond] = func
         else:
             vals = x[cond]
             if vals.size > 0:
-                y = y.astype(asarray(func(vals, *args, **kw)).dtype)
-                y[cond] = func(vals, *args, **kw)
+
+                func_val =  func(vals, *args, **kw)
+                y = y.astype(asarray(func_val).dtype)
+                y[cond] = func_val
 
     return y
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #24155 and #19755.

Fix for the bug which resulted in the output of piecewise function to be same dtype as the input. Now, the output dtype matches with the dtype of funclist output instead of the input.