### PR TITLE
DOC: Remove promoting twitter in heading

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -91,7 +91,6 @@ html_favicon = '../source/_static/favicon/favicon.ico'
 
 html_theme_options = {
   "github_url": "https://github.com/numpy/numpy",
-  "twitter_url": "https://twitter.com/numpy_team",
   "external_links": [
       {"name": "Wishlist",
        "url": "https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22",
@@ -183,4 +182,3 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None)
 }
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -188,7 +188,6 @@ html_theme_options = {
       "image_dark": "numpylogo_dark.svg",
   },
   "github_url": "https://github.com/numpy/numpy",
-  "twitter_url": "https://twitter.com/numpy_team",
   "collapse_navigation": True,
   "external_links": [
       {"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"},


### PR DESCRIPTION
I noticed the prominent placing of the logo on the docs pages, IMO while it's OK to have github there it probably shouldn't pick and choose one social media to go with it, too.