### PR TITLE
DOC: Fix reference warning for buffer.

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -176,16 +176,16 @@ Built-in Python types
     Several python types are equivalent to a corresponding
     array scalar when used to generate a :class:`dtype` object:
 
-    ================  ===============
-    :class:`int`      :class:`int\_`
-    :class:`bool`     :class:`bool\_`
-    :class:`float`    :class:`float\_`
-    :class:`complex`  :class:`cfloat`
-    :class:`bytes`    :class:`bytes\_`
-    :class:`str`      :class:`str\_`
-    :class:`buffer`   :class:`void`
-    (all others)      :class:`object_`
-    ================  ===============
+    ===================      ===============
+    :class:`int`             :class:`int\_`
+    :class:`bool`            :class:`bool\_`
+    :class:`float`           :class:`float\_`
+    :class:`complex`         :class:`cfloat`
+    :class:`bytes`           :class:`bytes\_`
+    :class:`str`             :class:`str\_`
+    :class:`memoryview`      :class:`void`
+    (all others)             :class:`object_`
+    ===================      ===============
 
     Note that ``str_`` corresponds to UCS4 encoded unicode strings, while
     ``string_`` is an alias to ``bytes_``. The name ``np.unicode_`` is also

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -179,7 +179,7 @@ This approach to the interface consists of the object having an
 
    **offset** (optional)
        An integer offset into the array data region. This can only be
-       used when data is ``None`` or returns a :class:`buffer`
+       used when data is ``None`` or returns a :class:`memoryview`
        object.
 
        **Default**: ``0``.

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -26,7 +26,7 @@ changes made in one :class:`ndarray` may be visible in another. That
 is, an ndarray can be a *"view"* to another ndarray, and the data it
 is referring to is taken care of by the *"base"* ndarray. ndarrays can
 also be views to memory owned by Python :class:`strings <str>` or
-objects implementing the :class:`buffer` or :ref:`array
+objects implementing the :class:`memoryview` or :ref:`array
 <arrays.interface>` interfaces.
 
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix following warning:
```
arrays.dtypes.rst:187: WARNING: py:class reference target not found: buffer
arrays.interface.rst:181: WARNING: py:class reference target not found: buffer
arrays.ndarray.rst:24: WARNING: py:class reference target not found: buffer
```

I searched to find that buffer is replaced by memoryview. So I used memoryview class reference.