### PR TITLE
DOC: use nightly dependencies [skip actions] [azp skip] [skip travis]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,8 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --progress-bar=off -r test_requirements.txt
-            # first install newer versions
-            pip install --progress-bar=off -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib scipy pandas
-            # then install the standard versions of the other requirements
-            pip install --progress-bar=off -r doc_requirements.txt
+            # get newer versions of critical packages
+            pip install --progress-bar=off --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r doc_requirements.txt
             # then install numpy HEAD, which will override the version installed above
             pip install . --config-settings=setup-args="-Dallow-noblas=true"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,8 @@ version: 2.1
 _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.1/circleci-images/
-    # circleci/python3.8 images come with old versions of Doxygen(1.6.x),
-    # therefore a new base image chose instead to guarantee to
-    # have a newer version >= 1.8.10 to avoid warnings
-    # that related to the default behaviors or non-exist config options
-    - image: cimg/python:3.9
+    # documented at https://circleci.com/developer/images/image/cimg/python
+    - image: cimg/python:3.11.4
   working_directory: ~/repo
 
 
@@ -54,7 +50,7 @@ jobs:
             #sudo apt-get install -y python3.9 python3.9-dev python3-venv graphviz texlive-fonts-recommended texlive-latex-recommended \
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended \
               texlive-latex-extra latexmk texlive-xetex texlive-lang-chinese doxygen
-            python3.9 -m venv venv
+            python3.11 -m venv venv
             . venv/bin/activate
 
       - run:
@@ -62,7 +58,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --progress-bar=off -r test_requirements.txt
-            pip install --progress-bar=off -r doc_requirements.txt
+            pip install --progress-bar=off -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r doc_requirements.txt
             pip install . --config-settings=setup-args="-Dallow-noblas=true"
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,11 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --progress-bar=off -r test_requirements.txt
-            pip install --progress-bar=off -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r doc_requirements.txt
+            # first install newer versions
+            pip install --progress-bar=off -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib scipy pandas
+            # then install the standard versions of the other requirements
+            pip install --progress-bar=off -r doc_requirements.txt
+            # then install numpy HEAD, which will override the version installed above
             pip install . --config-settings=setup-args="-Dallow-noblas=true"
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,8 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --progress-bar=off -r test_requirements.txt
-            # get newer versions of critical packages
-            pip install --progress-bar=off --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r doc_requirements.txt
+            # get newer, pre-release versions of critical packages
+            pip install --progress-bar=off --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r doc_requirements.txt
             # then install numpy HEAD, which will override the version installed above
             pip install . --config-settings=setup-args="-Dallow-noblas=true"
 

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -196,8 +196,8 @@ from running the test suite on different operating systems and hardware
 platforms to building the docs. In some cases you already know that CI isn't
 needed (or not all of it), for example if you work on CI config files, text in
 the README, or other files that aren't involved in regular build, test or docs
-sequences. In such cases you may explicitly skip CI by including one of these
-fragments in your commit message:
+sequences. In such cases you may explicitly skip CI by including one or more of
+these fragments in each commit message of a PR:
 
 * ``[skip ci]``: skip all CI
 

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -785,7 +785,7 @@ exceptions (assigning complex to floats or ints): ::
  >>> x[1] = 1.2
  >>> x[1]
  1
- >>> x[1] = 1.2j
+ >>> x[1] = 1.2j  # doctest: +IGNORE_EXCEPTION_DETAIL
  Traceback (most recent call last):
    ...
  TypeError: can't convert complex to int


### PR DESCRIPTION
Fixes #24334

Use the nightlies index to install documentation dependencies, since building docs requires a newer scipy, matplotlib, pandas. Also update the docker image used to build docs to python3.11, since it should be faster.