### PR TITLE
DOC: Fix reference warning for size.

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -756,18 +756,18 @@ class ABCPolyBase(abc.ABC):
         return self.__class__(coef, self.domain, self.window, self.symbol)
 
     def truncate(self, size):
-        """Truncate series to length `size`.
+        """Truncate series to length ``size``.
 
-        Reduce the series to length `size` by discarding the high
-        degree terms. The value of `size` must be a positive integer. This
+        Reduce the series to length ``size`` by discarding the high
+        degree terms. The value of ``size`` must be a positive integer. This
         can be useful in least squares where the coefficients of the
         high degree terms may be very small.
 
         Parameters
         ----------
         size : positive int
-            The series is reduced to length `size` by discarding the high
-            degree terms. The value of `size` must be a positive integer.
+            The series is reduced to length ``size`` by discarding the high
+            degree terms. The value of ``size`` must be a positive integer.
 
         Returns
         -------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -325,7 +325,7 @@ cdef class Generator:
         Returns
         -------
         out : float or ndarray of floats
-            Array of random floats of shape `size` (unless ``size=None``, in which
+            Array of random floats of shape ``size`` (unless ``size=None``, in which
             case a single float is returned).
 
         See Also
@@ -561,8 +561,8 @@ cdef class Generator:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         Notes
         -----
@@ -693,7 +693,7 @@ cdef class Generator:
         size : {int, tuple[int]}, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn from the 1-d `a`. If `a` has more
-            than one dimension, the `size` shape will be inserted into the
+            than one dimension, the ``size`` shape will be inserted into the
             `axis` dimension, so the output ``ndim`` will be ``a.ndim - 1 +
             len(size)``. Default is None, in which case a single value is
             returned.
@@ -1587,12 +1587,12 @@ cdef class Generator:
         Raises
         ------
         ValueError
-            When `df` <= 0 or when an inappropriate `size` (e.g. ``size=-1``)
+            When ``df`` <= 0 or when an inappropriate ``size`` (e.g. ``size=-1``)
             is given.
 
         Notes
         -----
-        The variable obtained by summing the squares of `df` independent,
+        The variable obtained by summing the squares of ``df`` independent,
         standard normally distributed random variables:
 
         .. math:: Q = \\sum_{i=0}^{\\mathtt{df}} X^2_i
@@ -4121,7 +4121,7 @@ cdef class Generator:
             holding the shape of the array of variates.  If the given size is,
             e.g., ``(k, m)``, then ``k * m`` variates are drawn, where one
             variate is a vector of length ``len(colors)``, and the return value
-            has shape ``(k, m, len(colors))``.  If `size` is an integer, the
+            has shape ``(k, m, len(colors))``.  If ``size`` is an integer, the
             output has shape ``(size, len(colors))``.  Default is None, in
             which case a single variate is returned as an array with shape
             ``(len(colors),)``.
@@ -4303,7 +4303,7 @@ cdef class Generator:
 
         Draw samples from the Dirichlet distribution.
 
-        Draw `size` samples of dimension k from a Dirichlet distribution. A
+        Draw ``size`` samples of dimension k from a Dirichlet distribution. A
         Dirichlet-distributed random variable can be seen as a multivariate
         generalization of a Beta distribution. The Dirichlet distribution
         is a conjugate prior of a multinomial distribution in Bayesian

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -408,7 +408,7 @@ cdef class RandomState:
         Returns
         -------
         out : float or ndarray of floats
-            Array of random floats of shape `size` (unless ``size=None``, in which
+            Array of random floats of shape ``size`` (unless ``size=None``, in which
             case a single float is returned).
 
         See Also
@@ -713,8 +713,8 @@ cdef class RandomState:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         See Also
         --------
@@ -1318,8 +1318,8 @@ cdef class RandomState:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         See Also
         --------
@@ -1940,7 +1940,7 @@ cdef class RandomState:
         Raises
         ------
         ValueError
-            When `df` <= 0 or when an inappropriate `size` (e.g. ``size=-1``)
+            When ``df`` <= 0 or when an inappropriate ``size`` (e.g. ``size=-1``)
             is given.
 
         See Also
@@ -1949,7 +1949,7 @@ cdef class RandomState:
 
         Notes
         -----
-        The variable obtained by summing the squares of `df` independent,
+        The variable obtained by summing the squares of ``df`` independent,
         standard normally distributed random variables:
 
         .. math:: Q = \\sum_{i=0}^{\\mathtt{df}} X^2_i
@@ -4396,7 +4396,7 @@ cdef class RandomState:
 
         Draw samples from the Dirichlet distribution.
 
-        Draw `size` samples of dimension k from a Dirichlet distribution. A
+        Draw ``size`` samples of dimension k from a Dirichlet distribution. A
         Dirichlet-distributed random variable can be seen as a multivariate
         generalization of a Beta distribution. The Dirichlet distribution
         is a conjugate prior of a multinomial distribution in Bayesian


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

To fix size reference warning. 
I think single backquotes let sphinx recognize size as a function or class name. So I used double backquotes to let it be code examples.
 Also update single backquotes for df to double backquotes.