### PR TITLE
BUG: polynomial: Handle non-array inputs in polynomial class __call__ method.

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -508,8 +508,7 @@ class ABCPolyBase(abc.ABC):
     # Call
 
     def __call__(self, arg):
-        off, scl = pu.mapparms(self.domain, self.window)
-        arg = off + scl*arg
+        arg = pu.mapdomain(arg, self.domain, self.window)
         return self._val(arg, self.coef)
 
     def __iter__(self):

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -523,6 +523,13 @@ def test_call(Poly):
     assert_almost_equal(res, tgt)
 
 
+def test_call_with_list(Poly):
+    p = Poly([1, 2, 3])
+    x = [-1, 0, 2]
+    res = p(x)
+    assert_equal(res, p(np.array(x)))
+
+
 def test_cutdeg(Poly):
     p = Poly([1, 2, 3])
     assert_raises(ValueError, p.cutdeg, .5)


### PR DESCRIPTION
Use the utility function `polyutils.mapdomain()` in the `__call__` method of `ABCPolyBase`.  This closes gh-17949 because `mapdomain` calls `np.asanyarray(x)` on its first argument.

Closes gh-17949.
