### PR TITLE
BUG: flexible inheritance segfault

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4122,7 +4122,7 @@ initialize_numeric_types(void)
 
     /**begin repeat
      * #NAME= Number, Integer, SignedInteger, UnsignedInteger, Inexact,
-     *        Floating, ComplexFloating, Flexible, Character#
+     *        Floating, ComplexFloating, Character#
      */
 
     Py@NAME@ArrType_Type.tp_flags = BASEFLAGS;

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2567,3 +2567,12 @@ class TestRegression:
         expected = np.ones(size, dtype=np.bool_)
         assert_array_equal(np.logical_and(a, b), expected)
 
+    @pytest.mark.skipif(IS_PYPY, reason="PyPy issue 2742")
+    def test_gh_23737(self):
+        with pytest.raises(TypeError, match="not an acceptable base type"):
+            class Y(np.flexible):
+                pass
+
+        with pytest.raises(TypeError, match="not an acceptable base type"):
+            class X(np.flexible, np.ma.core.MaskedArray):
+                pass


### PR DESCRIPTION
* Fixes #23737

* based on the discussion in the issue above, this completely blocks subclassing `np.flexible` at the Python level and adds a test to ensure the segfault codepath is no longer accessible