### PR TITLE
BENCH: fix small array det benchmark

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -102,7 +102,7 @@ class LinalgSmallArrays(Benchmark):
     """ Test overhead of linalg methods for small arrays """
     def setup(self):
         self.array_5 = np.arange(5.)
-        self.array_5_5 = np.arange(5.)
+        self.array_5_5 = np.reshape(np.arange(25.), (5., 5.))
 
     def time_norm_small_array(self):
         np.linalg.norm(self.array_5)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This pull request aims to resolve the `np.linalg.det` benchmark for small arrays which fails:

```
[ 80.66%] ··· ...inalg.LinalgSmallArrays.time_det_small_array             failed
[ 80.66%] ···· Traceback (most recent call last):
                 File "/home/users/allstaff/yang.e/.local/lib/python3.11/site-packages/asv/benchmark.py", line 1293, in main_run_server
                   main_run(run_args)
                 File "/home/users/allstaff/yang.e/.local/lib/python3.11/site-packages/asv/benchmark.py", line 1167, in main_run
                   result = benchmark.do_run()
                            ^^^^^^^^^^^^^^^^^^
                 File "/home/users/allstaff/yang.e/.local/lib/python3.11/site-packages/asv/benchmark.py", line 573, in do_run
                   return self.run(*self._current_params)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 File "/home/users/allstaff/yang.e/.local/lib/python3.11/site-packages/asv/benchmark.py", line 669, in run
                   samples, number = self.benchmark_timing(timer, min_repeat, max_repeat,
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 File "/home/users/allstaff/yang.e/.local/lib/python3.11/site-packages/asv/benchmark.py", line 705, in benchmark_timing
                   timing = timer.timeit(number)
                            ^^^^^^^^^^^^^^^^^^^^
                 File "/stornext/System/data/apps/python/python-3.11.2/lib/python3.11/timeit.py", line 178, in timeit
                   timing = self.inner(it, self.timer)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
                 File "<timeit-src>", line 6, in inner
                 File "/vast/scratch/users/yang.e/nextflow/work/6a/476da717b4b569d8f6d66209549f98/numpy/benchmarks/benchmarks/bench_linalg.py", line 111, in time_det_small_array
                   np.linalg.det(self.array_5_5)
                 File "<__array_function__ internals>", line 200, in det
                 File "/vast/scratch/users/yang.e/nextflow/work/6a/476da717b4b569d8f6d66209549f98/numpy/build/testenv/lib/python3.11/site-packages/numpy/linalg/linalg.py", line 2135, in det
                   _assert_stacked_2d(a)
                 File "/vast/scratch/users/yang.e/nextflow/work/6a/476da717b4b569d8f6d66209549f98/numpy/build/testenv/lib/python3.11/site-packages/numpy/linalg/linalg.py", line 183, in _assert_stacked_2d
                   raise LinAlgError('%d-dimensional array given. Array must be '
               numpy.linalg.LinAlgError: 1-dimensional array given. Array must be at least two-dimensional
               asv: benchmark failed (exit status 1)
```

I've resolved it by creating a 5x5 matrix instead of a 5 element vector. Given that this benchmark is supposed to be for "small" arrays, I'm not sure that a 5x5 matrix constitutes a "small" array. Let me know if the size should be reduced.