### PR TITLE
MAINT: Fix codespaces setup.sh script

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-curl micro.mamba.pm/install.sh | bash
+"${SHELL}" <(curl -Ls micro.mamba.pm/install.sh) < /dev/null
 
 conda init --all
 micromamba shell init -s bash


### PR DESCRIPTION
A change in how codespaces is configured upstream causes the installation script for micromamba to wait for input unless stdin is explicitly made empty, which causes codespaces creation to fail.