### PR TITLE
DEP: Ensure the __float__ DeprecationWarning is not eaten in np.float64()

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3079,6 +3079,9 @@ static PyObject *
         if (PyTuple_GET_SIZE(args) != 1 || (kwds && PyDict_Size(kwds) != 0)) {
             return NULL;
         }
+        if (PyErr_ExceptionMatches(PyExc_DeprecationWarning)) {
+            return NULL;
+        }
         PyErr_Clear();
     }
     else {

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1934,18 +1934,20 @@ class TestAVXUfuncs:
             # various array sizes to ensure masking in AVX is tested
             for size in range(1,32):
                 myfunc = getattr(np, func)
-                x_f32 = np.float32(np.random.uniform(low=minval, high=maxval,
-                    size=size))
-                x_f64 = np.float64(x_f32)
-                x_f128 = np.longdouble(x_f32)
+                x_f32 = np.random.uniform(
+                    low=minval, high=maxval, size=size).astype(np.float32)
+                x_f64 = x_f32.astype(np.float64)
+                x_f128 = x_f32.astype(np.longdouble)
                 y_true128 = myfunc(x_f128)
                 if maxulperr == 0:
-                    assert_equal(myfunc(x_f32), np.float32(y_true128))
-                    assert_equal(myfunc(x_f64), np.float64(y_true128))
+                    assert_equal(myfunc(x_f32), y_true128.astype(np.float32))
+                    assert_equal(myfunc(x_f64), y_true128.astype(np.float64))
                 else:
-                    assert_array_max_ulp(myfunc(x_f32), np.float32(y_true128),
+                    assert_array_max_ulp(
+                            myfunc(x_f32), y_true128.astype(np.float32),
                             maxulp=maxulperr)
-                    assert_array_max_ulp(myfunc(x_f64), np.float64(y_true128),
+                    assert_array_max_ulp(
+                            myfunc(x_f64), y_true128.astype(np.float64),
                             maxulp=maxulperr)
                 # various strides to test gather instruction
                 if size > 1:


### PR DESCRIPTION
@tylerjereddy had this issue in SciPy.  The DeprecationWarning when raised is just swallowed, example:
```
np.float64(np.array([1.]))
import warnings
warnings.simplefilter("error")
np.float64(np.array([1.]))
```

This should probably have a test, and in principle maybe it is a FutureWarning in this specific branch because maybe we will allow it in the future.

(I have always disliked this overloaded use for "scalar or array", i.e. as a way to cast).

The changed tests also show the downside of how this might not matter at all, but the work-around is trickier.  If you want a preference for a scalar result, you will need `np.array(x, dtype=np.float64)[()]` maybe even.