### PR TITLE
DOC: Fix reference warning for ABCPolyBase.

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1997,7 +1997,7 @@ class Chebyshev(ABCPolyBase):
 
     The Chebyshev class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    methods listed below.
+    attributes and methods listed below.
 
     Parameters
     ----------

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1660,7 +1660,7 @@ class Hermite(ABCPolyBase):
 
     The Hermite class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    attributes and methods listed in the `ABCPolyBase` documentation.
+    attributes and methods listed below.
 
     Parameters
     ----------

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1652,7 +1652,7 @@ class HermiteE(ABCPolyBase):
 
     The HermiteE class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    attributes and methods listed in the `ABCPolyBase` documentation.
+    attributes and methods listed below.
 
     Parameters
     ----------

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1608,7 +1608,7 @@ class Laguerre(ABCPolyBase):
 
     The Laguerre class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    attributes and methods listed in the `ABCPolyBase` documentation.
+    attributes and methods listed below.
 
     Parameters
     ----------

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1621,7 +1621,7 @@ class Legendre(ABCPolyBase):
 
     The Legendre class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    attributes and methods listed in the `ABCPolyBase` documentation.
+    attributes and methods listed below.
 
     Parameters
     ----------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1474,7 +1474,7 @@ class Polynomial(ABCPolyBase):
 
     The Polynomial class provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' as well as the
-    attributes and methods listed in the `ABCPolyBase` documentation.
+    attributes and methods listed below.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix following reference warning:
```

hermite.py:docstring of numpy.polynomial.hermite.Hermite:4: WARNING: py:obj reference target not found: ABCPolyBase
hermite_e.py:docstring of numpy.polynomial.hermite_e.HermiteE:4: WARNING: py:obj reference target not found: ABCPolyBase
laguerre.py:docstring of numpy.polynomial.laguerre.Laguerre:4: WARNING: py:obj reference target not found: ABCPolyBase
legendre.py:docstring of numpy.polynomial.legendre.Legendre:4: WARNING: py:obj reference target not found: ABCPolyBase
polynomial.py:docstring of numpy.polynomial.polynomial.Polynomial:4: WARNING: py:obj reference target not found: ABCPolyBase

```

I created a new module for polybase.ABCPolyBase.