### PR TITLE
Use Highway with Dynamic Dispatch for some types in Absolute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "numpy/core/src/npysort/x86-simd-sort"]
 	path = numpy/core/src/npysort/x86-simd-sort
 	url = https://github.com/intel/x86-simd-sort
+[submodule "numpy/core/src/highway"]
+	path = numpy/core/src/highway
+	url = https://github.com/google/highway.git

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -76,6 +76,10 @@ endif
 # important, because code in NumPy typically does not check the value but only
 # whether the symbol is defined. So `#define HAVE_SOMETHING 0` is wrong.
 
+#cmake = import('cmake')
+#hwy = cmake.subproject('highway')
+
+
 cdata = configuration_data()
 
 cdata.set('NPY_ABI_VERSION', C_ABI_VERSION)
@@ -840,6 +844,7 @@ src_umath = [
   src_file.process('src/umath/matmul.c.src'),
   src_file.process('src/umath/matmul.h.src'),
   'src/umath/ufunc_type_resolution.c',
+  'src/umath/absolute.cpp',
   'src/umath/clip.cpp',
   'src/umath/clip.h',
   'src/umath/dispatching.c',
@@ -932,6 +937,7 @@ py.extension_module('_multiarray_umath',
     'src/multiarray',
     'src/npymath',
     'src/umath',
+    'src/highway',
   ],
   dependencies: blas_dep,
   link_with: npymath_lib,

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -700,6 +700,7 @@ test_modules_src = [
       src_file.process('src/umath/_umath_tests.c.src'),
       'src/umath/_umath_tests.dispatch.c',
       'src/common/npy_cpu_features.c',
+      'src/common/npy_hwy_features.cpp',
     ]],
   ['_rational_tests', 'src/umath/_rational_tests.c'],
   ['_struct_ufunc_tests', 'src/umath/_struct_ufunc_tests.c'],
@@ -728,6 +729,7 @@ src_multiarray_umath_common = [
   'src/common/ufunc_override.c',
   'src/common/numpyos.c',
   'src/common/npy_cpu_features.c',
+  'src/common/npy_hwy_features.cpp',
   src_file.process('src/common/templ_common.h.src')
 ]
 if have_blas
@@ -859,6 +861,12 @@ src_umath = [
   'src/umath/wrapping_array_method.c',
   # For testing. Eventually, should use public API and be separate:
   'src/umath/_scaled_float_dtype.c',
+  # Highway mapped to meson from CMake
+  'src/highway/hwy/aligned_allocator.cc',
+  'src/highway/hwy/per_target.cc',
+  'src/highway/hwy/print.cc',
+  'src/highway/hwy/targets.cc',
+  'src/highway/hwy/timer.cc'
 ]
 
 # SVML object files. If functionality is migrated to universal intrinsics and
@@ -951,13 +959,14 @@ py.extension_module('_multiarray_umath',
 py.extension_module('_simd',
   [
     'src/common/npy_cpu_features.c',
+    'src/common/npy_hwy_features.cpp',
     'src/_simd/_simd.c',
     src_file.process('src/_simd/_simd_inc.h.src'),
     src_file.process('src/_simd/_simd_data.inc.src'),
     src_file.process('src/_simd/_simd.dispatch.c.src'),
   ],
   c_args: c_args_common,
-  include_directories: ['src/_simd', 'src/npymath'],
+  include_directories: ['src/_simd', 'src/npymath', 'src/highway'],
   dependencies: np_core_dep,
   link_with: npymath_lib,
   install: true,

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -547,6 +547,7 @@ def configuration(parent_package='',top_path=None):
         # allows using code generation in headers
         config.add_include_dirs(join(build_dir, "src", "common"))
         config.add_include_dirs(join(build_dir, "src", "npymath"))
+        config.add_include_dirs(join(build_dir, "src", "highway"))
 
         target = join(build_dir, header_dir, '_numpyconfig.h')
         d = os.path.dirname(target)
@@ -747,6 +748,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'common', 'ufunc_override.c'),
             join('src', 'common', 'numpyos.c'),
             join('src', 'common', 'npy_cpu_features.c'),
+            join('src', 'common', 'npy_hwy_features.cpp'),
             ]
 
     if os.environ.get('NPY_USE_BLAS_ILP64', "0") != "0":
@@ -913,6 +915,12 @@ def configuration(parent_package='',top_path=None):
             join('src', 'npymath', 'arm64_exports.c'),
             join('src', 'npysort', 'simd_qsort.dispatch.cpp'),
             join('src', 'npysort', 'simd_qsort_16bit.dispatch.cpp'),
+            # Highway mapped to meson from CMake
+            'src/highway/hwy/aligned_allocator.cc',
+            'src/highway/hwy/per_target.cc',
+            'src/highway/hwy/print.cc',
+            'src/highway/hwy/targets.cc',
+            'src/highway/hwy/timer.cc'
             ]
 
     #######################################################################
@@ -972,6 +980,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'umath', 'matmul.c.src'),
             join('src', 'umath', 'clip.h'),
             join('src', 'umath', 'clip.cpp'),
+            join('src', 'umath', 'absolute.cpp'),
             join('src', 'umath', 'dispatching.c'),
             join('src', 'umath', 'legacy_array_method.c'),
             join('src', 'umath', 'wrapping_array_method.c'),
@@ -1042,6 +1051,7 @@ def configuration(parent_package='',top_path=None):
         join('src', 'umath', '_umath_tests.c.src'),
         join('src', 'umath', '_umath_tests.dispatch.c'),
         join('src', 'common', 'npy_cpu_features.c'),
+        join('src', 'common', 'npy_hwy_features.cpp'),
     ])
 
     #######################################################################
@@ -1073,6 +1083,7 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_simd',
         sources=[
             join('src', 'common', 'npy_cpu_features.c'),
+            join('src', 'common', 'npy_hwy_features.cpp'),
             join('src', '_simd', '_simd.c'),
             join('src', '_simd', '_simd_inc.h.src'),
             join('src', '_simd', '_simd_data.inc.src'),

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -192,6 +192,30 @@ npy_cpu_baseline_list(void);
 NPY_VISIBILITY_HIDDEN PyObject *
 npy_cpu_dispatch_list(void);
 
+/*
+Init Highway
+*/
+NPY_VISIBILITY_HIDDEN int
+npy_hwy_init(void);
+
+/*
+Get features list from highway
+*/
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_features_dict(void);
+
+/*
+Get dispatch list from highway
+*/
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_dispatch_list(void);
+
+/*
+Get baseline list from highway
+*/
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_baseline_list(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/core/src/common/npy_hwy_features.cpp
+++ b/numpy/core/src/common/npy_hwy_features.cpp
@@ -1,0 +1,246 @@
+#include <string>
+#include <algorithm>
+#include <hwy/targets.h>
+
+#include <Python.h> // for PyObject
+#include "numpy/numpyconfig.h" // for NPY_VISIBILITY_HIDDEN
+
+namespace np {
+
+static PyObject* create_target_list(std::vector<int64_t> targets) {
+    PyObject *list = PyList_New(targets.size());
+    for(std::size_t i = 0; i < targets.size(); ++i) {
+        int64_t target = targets[i];
+        PyList_SetItem(list, i, PyUnicode_FromString(hwy::TargetName(target)));
+    }
+    return list;
+}
+
+static std::string create_target_string(std::vector<std::string> targets) {
+    std::string target_string;
+    if (targets.size() == 0) {
+        return "";
+    }
+
+    for(std::size_t i = 0; i < targets.size(); ++i) {
+        std::string target = targets[i];
+        target_string.append(" ");
+        target_string.append(target);
+    }
+    
+    // Skip first space
+    return target_string.substr(1);
+}
+
+static std::string create_target_string(std::vector<int64_t> targets) {
+    std::string target_string;
+    if (targets.size() == 0) {
+        return "";
+    }
+
+    for(std::size_t i = 0; i < targets.size(); ++i) {
+        int64_t target = targets[i];
+        target_string.append(" ");
+        target_string.append(hwy::TargetName(target));
+    }
+    
+    // Skip first space
+    return target_string.substr(1);
+}
+
+static std::vector<int64_t> baseline_targets() {
+    std::vector<int64_t> baseline_targets;
+    for (int64_t targets = HWY_BASELINE_TARGETS; targets != 0; targets = targets & (targets - 1)) {
+        int64_t current_target = targets & ~(targets - 1);
+        baseline_targets.push_back(current_target);
+    }
+    return baseline_targets;
+}
+
+static std::vector<int64_t> dispatch_targets() {
+    std::vector<int64_t> dispatch_targets;
+    for (int64_t targets = hwy::SupportedTargets() & HWY_TARGETS; targets != 0;
+        targets = targets & (targets - 1)) {
+        int64_t current_target = targets & ~(targets - 1);
+        if (!(HWY_BASELINE_TARGETS & current_target)) {
+            dispatch_targets.push_back(current_target);
+        }
+    }
+    return dispatch_targets;
+}
+
+static bool is_dispatch_target(int64_t target_id) {
+    std::vector<int64_t> dispatchable_targets = dispatch_targets();
+    return std::find(dispatchable_targets.begin(), dispatchable_targets.end(), target_id) != dispatchable_targets.end();
+}
+
+
+static int64_t get_target_id(const char *feature)
+{
+    std::vector<int64_t> baseline_targets;
+    for (int64_t targets = HWY_TARGETS; targets != 0; targets = targets & (targets - 1)) {
+        int64_t current_target = targets & ~(targets - 1);
+        if (strcmp(hwy::TargetName(current_target), feature) == 0) {
+            return current_target;
+        }
+    }
+    return 0;
+}
+
+static int check_env(int disable, char *env) {
+    static const char *names[] = {
+        "enable", "disable",
+        "During parsing environment variable: 'NPY_ENABLE_CPU_FEATURES':\n",
+        "During parsing environment variable: 'NPY_DISABLE_CPU_FEATURES':\n"
+    };
+    disable = disable ? 1 : 0;
+    const char *act_name = names[disable];
+    const char *err_head = names[disable + 2];
+
+    const char *delim = ", \t\v\r\n\f";
+
+    int64_t enable_targets = 0;
+    int64_t disable_targets = 0;
+    std::vector<std::string> not_in_dispatch;
+    std::vector<std::string> not_in_supported;
+
+    char *feature = strtok(env, delim);
+    while (feature) {
+        int64_t target_id = get_target_id(feature);
+        if (target_id == 0) {
+            // Got no target back
+            not_in_dispatch.push_back(feature);
+        } else {
+            if (disable && (target_id & HWY_BASELINE_TARGETS)) {
+                // Escape early when trying to disable baseline features
+                PyErr_Format(PyExc_RuntimeError,
+                    "%s"
+                    "You cannot disable CPU feature '%s', since it is part of "
+                    "the baseline optimizations:\n"
+                    "(%s).",
+                    err_head, feature, create_target_string(baseline_targets()).c_str()
+                );
+                return -1;
+            } else if (is_dispatch_target(target_id)) {
+                if (disable) {
+                    disable_targets |= target_id;
+                } else {
+                    enable_targets |= target_id;
+                }
+            } else {
+                if (target_id & hwy::SupportedTargets()) {
+                    not_in_dispatch.push_back(feature);
+                } else if (!disable) {
+                    not_in_supported.push_back(feature);
+                }
+            }
+        }
+
+        feature = strtok(NULL, delim);
+    }
+
+    if (not_in_dispatch.size()) {
+        if (PyErr_WarnFormat(
+            PyExc_ImportWarning, 0,
+            "%sYou cannot %s CPU features (%s), since "
+            "they are not part of the dispatched optimizations\n"
+            "(%s).",
+            err_head, act_name,
+            create_target_string(not_in_dispatch).c_str(),
+            create_target_string(dispatch_targets()).c_str()
+        ) < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+    if (not_in_supported.size()) {
+        PyErr_Format(PyExc_RuntimeError,
+            "%s" \
+            "You cannot %s CPU features (%s), since " \
+            "they are not supported by your machine.", \
+            err_head, act_name, 
+            create_target_string(not_in_supported).c_str()
+        );
+
+        return -1;
+    }
+
+    // disable any targets which are not marked as enabled
+    if (disable && disable_targets != 0) {
+        hwy::DisableTargets(disable_targets);
+    }
+    if (!disable && enable_targets != 0) {
+        hwy::DisableTargets(~enable_targets);
+    }
+
+    return 0;
+}
+
+extern "C" {
+
+NPY_VISIBILITY_HIDDEN int
+npy_hwy_init(void)
+{
+    char *enable_env = getenv("NPY_ENABLE_CPU_FEATURES");
+    char *disable_env = getenv("NPY_DISABLE_CPU_FEATURES");
+    int is_enable = enable_env && enable_env[0];
+    int is_disable = disable_env && disable_env[0];
+    if (is_enable & is_disable) {
+        PyErr_Format(PyExc_ImportError,
+            "Both NPY_DISABLE_CPU_FEATURES and NPY_ENABLE_CPU_FEATURES "
+            "environment variables cannot be set simultaneously."
+        );
+        return -1;
+    }
+
+    if (is_enable | is_disable) {
+        if (check_env(is_disable, is_disable ? disable_env : enable_env) < 0) {
+            return -1;
+        }
+    }
+       
+    return 0;
+}
+
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_baseline_list(void) {
+    std::vector<int64_t> baseline_targets;
+    for (int64_t targets = HWY_BASELINE_TARGETS; targets != 0; targets = targets & (targets - 1)) {
+        int64_t current_target = targets & ~(targets - 1);
+        baseline_targets.push_back(current_target);
+    }
+    return create_target_list(baseline_targets);
+}
+
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_features_dict(void) {
+    PyObject *dict = PyDict_New();
+    if (dict) {
+        for (int64_t targets = HWY_ATTAINABLE_TARGETS; targets != 0; targets = targets & (targets - 1)) {
+            int64_t current_target = targets & ~(targets - 1);
+            PyDict_SetItemString(
+                dict,
+                hwy::TargetName(current_target),
+                (hwy::SupportedTargets() & current_target) ? Py_True : Py_False
+            );
+        }
+    }
+    return dict;
+}
+
+NPY_VISIBILITY_HIDDEN PyObject *
+npy_hwy_dispatch_list(void)
+{
+    std::vector<int64_t> dispatch_targets;
+    for (int64_t targets = hwy::SupportedTargets() & HWY_TARGETS; targets != 0;
+        targets = targets & (targets - 1)) {
+        int64_t current_target = targets & ~(targets - 1);
+        if (!(HWY_BASELINE_TARGETS & current_target)) {
+            dispatch_targets.push_back(current_target);
+        }
+    }
+    return create_target_list(dispatch_targets);
+}
+}
+}

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4941,9 +4941,12 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     }
 
     /* Initialize CPU features */
-    if (npy_cpu_init() < 0) {
+    if (npy_hwy_init() < 0) {
         goto err;
     }
+    // if (npy_cpu_init() < 0) {
+    //     goto err;
+    // }
 
 #if defined(MS_WIN64) && defined(__GNUC__)
   PyErr_WarnEx(PyExc_Warning,
@@ -5079,7 +5082,25 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
     Py_DECREF(s);
+    s = npy_hwy_features_dict();
+    if (s == NULL) {
+        goto err;
+    }
+    if (PyDict_SetItemString(d, "__hwy_features__", s) < 0) {
+        Py_DECREF(s);
+        goto err;
+    }
+    Py_DECREF(s);
 
+    s = npy_hwy_baseline_list();
+    if (s == NULL) {
+        goto err;
+    }
+    if (PyDict_SetItemString(d, "__hwy_baseline__", s) < 0) {
+        Py_DECREF(s);
+        goto err;
+    }
+    Py_DECREF(s);
     s = npy_cpu_baseline_list();
     if (s == NULL) {
         goto err;
@@ -5095,6 +5116,15 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
     if (PyDict_SetItemString(d, "__cpu_dispatch__", s) < 0) {
+        Py_DECREF(s);
+        goto err;
+    }
+    Py_DECREF(s);
+    s = npy_hwy_dispatch_list();
+    if (s == NULL) {
+        goto err;
+    }
+    if (PyDict_SetItemString(d, "__hwy_dispatch__", s) < 0) {
         Py_DECREF(s);
         goto err;
     }

--- a/numpy/core/src/umath/absolute.cpp
+++ b/numpy/core/src/umath/absolute.cpp
@@ -1,0 +1,66 @@
+#define _UMATHMODULE
+#define _MULTIARRAYMODULE
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "absolute.cpp"  // this file
+#include <hwy/foreach_target.h>  // must come before highway.h
+#include <hwy/highway.h>
+
+#include "numpy/ndarraytypes.h"
+#include "numpy/npy_common.h"
+#include "numpy/npy_math.h"
+#include "numpy/utils.h"
+
+namespace numpy {
+namespace HWY_NAMESPACE {  // required: unique per target
+
+// Can skip hn:: prefixes if already inside hwy::HWY_NAMESPACE.
+namespace hn = hwy::HWY_NAMESPACE;
+using T = npy_int;
+
+// Alternative to per-function HWY_ATTR: see HWY_BEFORE_NAMESPACE
+HWY_ATTR void SuperAbsolute(const T* HWY_RESTRICT input_array,
+                T* HWY_RESTRICT output_array,
+                const size_t size) {
+  const hn::ScalableTag<T> d;
+  for (size_t i = 0; i < size; i += hn::Lanes(d)) {
+    const auto in = hn::Load(d, input_array + i);
+    auto x = hn::Abs(in);
+    hn::Store(x, d, output_array + i);
+  }
+}
+
+}
+}
+
+#if HWY_ONCE
+namespace numpy {
+
+HWY_EXPORT(SuperAbsolute);
+
+extern "C" {
+NPY_NO_EXPORT void
+INT_absolute(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    npy_int *ip1 = (npy_int*) args[0];
+    npy_int *op1 = (npy_int*) args[1];
+    // npy_intp is1 = steps[0];
+    // npy_intp os1 = steps[1];
+    npy_intp n = dimensions[0];
+    // npy_intp i;
+  // This must reside outside of HWY_NAMESPACE because it references (calls the
+  // appropriate one from) the per-target implementations there.
+  // For static dispatch, use HWY_STATIC_DISPATCH.
+  static auto dispatcher = HWY_DYNAMIC_DISPATCH(SuperAbsolute);
+  return dispatcher(ip1, op1, n);
+}
+}
+
+}
+#endif
+
+

--- a/numpy/core/src/umath/loops_autovec.dispatch.c.src
+++ b/numpy/core/src/umath/loops_autovec.dispatch.c.src
@@ -213,13 +213,16 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_invert)
  * #TYPE = BYTE, SHORT, INT, LONG, LONGLONG#
  * #type = npy_byte, npy_short, npy_int, npy_long, npy_longlong#
  * #c    = ,,,l,ll#
+ * #abs  = 1,1,0,1,1#
  */
 
+#if @abs@
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_absolute)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     UNARY_LOOP_FAST(@type@, @type@, *out = (in >= 0) ? in : -in);
 }
+#endif
 
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_sign)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -152,10 +152,10 @@ NPY_FINLINE double c_square_f64(double a)
  */
 #if @VCHK@
 /**begin repeat1
- * #kind     = rint,  floor, ceil, trunc, sqrt, absolute, square, reciprocal#
- * #intr     = rint,  floor, ceil, trunc, sqrt, abs,      square, recip#
- * #repl_0w1 = 0*7, 1#
- * #RECIP_WORKAROUND = 0*7, WORKAROUND_CLANG_RECIPROCAL_BUG#
+ * #kind     = rint,  floor, ceil, trunc, sqrt, square, reciprocal#
+ * #intr     = rint,  floor, ceil, trunc, sqrt, square, recip#
+ * #repl_0w1 = 0*6, 1#
+ * #RECIP_WORKAROUND = 0*6, WORKAROUND_CLANG_RECIPROCAL_BUG#
  */
 /**begin repeat2
  * #STYPE  = CONTIG, NCONTIG, CONTIG,  NCONTIG#
@@ -263,9 +263,9 @@ static void simd_@TYPE@_@kind@_@STYPE@_@DTYPE@
  * #VCHK = NPY_SIMD_F32, NPY_SIMD_F64#
  */
 /**begin repeat1
- * #kind  = rint, floor, ceil, trunc, sqrt, absolute, square, reciprocal#
- * #intr  = rint, floor, ceil, trunc, sqrt, abs,      square, recip#
- * #clear = 0,    0,     0,    0,     0,    1,        0,      0#
+ * #kind  = rint, floor, ceil, trunc, sqrt, square, reciprocal#
+ * #intr  = rint, floor, ceil, trunc, sqrt, square, recip#
+ * #clear = 0,    0,     0,    0,     0,    0,      0#
  */
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))

--- a/show.py
+++ b/show.py
@@ -1,0 +1,13 @@
+
+import numpy as np
+print("Features:")
+print(f"Current: {np.core._multiarray_umath.__cpu_features__}")
+print(f"Highway: {np.core._multiarray_umath.__hwy_features__}")
+
+print("Baseline: ")
+print(f"Current: {np.core._multiarray_umath.__cpu_baseline__}")
+print(f"Highway: {np.core._multiarray_umath.__hwy_baseline__}")
+
+print("Dispatch: ")
+print(f"Current: {np.core._multiarray_umath.__cpu_dispatch__}")
+print(f"Highway: {np.core._multiarray_umath.__hwy_dispatch__}")


### PR DESCRIPTION
This demonstrates how Highway can fit into the project, using the Highway dynamic dispatcher, including querying for detected features via the Highway API to mirror the existing NumPy APIs. I've only done a few data types to demonstrate the functionality.

Loads and stores can only be contiguous rather than supporting all potential layouts (waiting for the Scatter equivalent for https://github.com/google/highway/commit/c6c09c402da635b3e0f2ea1a3a8c72acf91ad06f, then it should be trivial).