### PR TITLE
BLD: vendor meson-python to make the Windows builds with SIMD work

### DIFF
--- a/.github/workflows/windows_clangcl.yml
+++ b/.github/workflows/windows_clangcl.yml
@@ -20,7 +20,7 @@ jobs:
   meson:
     name: Meson windows build/test
     runs-on: windows-2019
-    # if: "github.repository == 'numpy/numpy'"
+    if: "github.repository == 'numpy/numpy'"
     steps:
     - name: Checkout
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -32,14 +32,14 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install dependencies
+    - name: Install build dependencies from PyPI
       run: |
-        pip install -r build_requirements.txt
-    - name: openblas-libs
+        pip install spin Cython
+
+    - name: Install OpenBLAS and Clang-cl
       run: |
-        # Download and install pre-built OpenBLAS library
-        # with 32-bit interfaces
-        # Unpack it in the pkg-config hardcoded path
+        # Download and install pre-built OpenBLAS library with 32-bit
+        # interfaces Unpack it in the pkg-config hardcoded path
         choco install unzip -y
         choco install wget -y
         # Install llvm, which contains clang-cl
@@ -48,24 +48,23 @@ jobs:
         wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
         unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
         echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
-    - name: meson-configure
-      run: |
-        "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'"  | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        meson setup build --prefix=$PWD\build-install --native-file=$PWD/clang-cl-build.ini -Ddebug=false --optimization 2 --vsenv
-    - name: meson-build
-      run: |
-        meson compile -C build -v
 
-    - name: meson-install
+    - name: Write native file for Clang-cl binaries
       run: |
-        cd build
-        meson install --no-rebuild
-    - name: build-path
+        # TODO: this job is identical to the one in `windows_meson.yml` aside
+        # from installing Clang-cl and usage of this .ini file. So merge the
+        # two and use a matrix'ed CI job run.
+        "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
+
+    - name: Install NumPy
       run: |
-        echo "installed_path=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
-    - name: post-install
+        spin build -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
+
+    - name: Copy OpenBLAS DLL, write _distributor_init.py
       run: |
-        $numpy_path = "${env:installed_path}\numpy"
+        # Getting the OpenBLAS DLL to the right place so it loads
+        $installed_path = "$PWD\build-install\usr\Lib\site-packages"
+        $numpy_path = "${installed_path}\numpy"
         $libs_path = "${numpy_path}\.libs"
         mkdir ${libs_path}
         $ob_path = "C:/opt/64/bin/"
@@ -73,19 +72,11 @@ jobs:
         # Write _distributor_init.py to load .libs DLLs.
         python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
 
-    - name: prep-test
+    - name: Install test dependencies
       run: |
-        echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
         python -m pip install -r test_requirements.txt
         python -m pip install threadpoolctl
 
-    - name: test
+    - name: Run test suite
       run: |
-        mkdir tmp
-        cd tmp
-        echo "============================================"
-        python -c "import numpy; print(numpy.show_runtime())"
-        echo "============================================"
-        echo "LASTEXITCODE is '$LASTEXITCODE'"
-        python -c "import numpy, sys; sys.exit(numpy.test(verbose=3) is False)"
-        echo "LASTEXITCODE is '$LASTEXITCODE'"
+        spin test

--- a/.github/workflows/windows_meson.yml
+++ b/.github/workflows/windows_meson.yml
@@ -27,42 +27,36 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+
     - name: Setup Python
       uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install dependencies
+    - name: Install build dependencies from PyPI
       run: |
-        pip install -r build_requirements.txt
-    - name: openblas-libs
+        python -m pip install spin Cython
+
+    - name: Install OpenBLAS (MacPython build)
       run: |
-        # Download and install pre-built OpenBLAS library
-        # with 32-bit interfaces
-        # Unpack it in the pkg-config hardcoded path
+        # Download and install pre-built OpenBLAS library with 32-bit
+        # interfaces. Unpack it in the pkg-config hardcoded path
         choco install unzip -y
         choco install wget -y
         choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
         wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
         unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
         echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
-    - name: meson-configure
-      run: |
-        meson setup build --prefix=$PWD\build-install -Ddebug=false --optimization 2 --vsenv 
-    - name: meson-build
-      run: |
-        meson compile -C build -v
 
-    - name: meson-install
+    - name: Install NumPy
       run: |
-        cd build
-        meson install --no-rebuild
-    - name: build-path
+        spin build -j2 -- --vsenv
+
+    - name: Copy OpenBLAS DLL, write _distributor_init.py
       run: |
-        echo "installed_path=$PWD\build-install\Lib\site-packages" >> $env:GITHUB_ENV
-    - name: post-install
-      run: |
-        $numpy_path = "${env:installed_path}\numpy"
+        # Getting the OpenBLAS DLL to the right place so it loads
+        $installed_path = "$PWD\build-install\usr\Lib\site-packages"
+        $numpy_path = "${installed_path}\numpy"
         $libs_path = "${numpy_path}\.libs"
         mkdir ${libs_path}
         $ob_path = "C:/opt/64/bin/"
@@ -70,22 +64,14 @@ jobs:
         # Write _distributor_init.py to load .libs DLLs.
         python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
 
-    - name: prep-test
+    - name: Install test dependencies
       run: |
-        echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
         python -m pip install -r test_requirements.txt
         python -m pip install threadpoolctl
 
-    - name: test
+    - name: Run test suite
       run: |
-        mkdir tmp
-        cd tmp
-        echo "============================================"
-        python -c "import numpy; print(numpy.show_runtime())"
-        echo "============================================"
-        echo "LASTEXITCODE is '$LASTEXITCODE'"
-        python -c "import numpy, sys; sys.exit(numpy.test(verbose=3) is False)"
-        echo "LASTEXITCODE is '$LASTEXITCODE'"
+        spin test
 
   msvc_32bit_python_openblas:
     name: MSVC, 32-bit Python, no BLAS

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendored-meson/meson"]
 	path = vendored-meson/meson
 	url = https://github.com/numpy/meson.git
+[submodule "vendored-meson/meson-python"]
+	path = vendored-meson/meson-python
+	url = https://github.com/numpy/meson-python.git

--- a/.spin/LICENSE
+++ b/.spin/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021--2022, Scientific Python project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -5,10 +5,433 @@ import argparse
 import tempfile
 import pathlib
 import shutil
+import json
+import pathlib
 
 import click
-from spin.cmds import meson
 from spin import util
+
+_run = util.run
+
+# START of spin/cmds/meson.py
+install_dir = "build-install"
+
+# The numpy-vendored version of Meson
+meson_cli = [sys.executable,
+             str(pathlib.Path(__file__).parent.parent.resolve() /
+                 'vendored-meson' / 'meson' / 'meson.py')
+            ]
+
+
+def _set_pythonpath(quiet=False):
+    site_packages = _get_site_packages()
+    env = os.environ
+
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{site_packages}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = site_packages
+
+    if not quiet:
+        click.secho(
+            f'$ export PYTHONPATH="{site_packages}"', bold=True, fg="bright_blue"
+        )
+
+    return env["PYTHONPATH"]
+
+
+def _get_site_packages():
+    candidate_paths = []
+    for root, dirs, _files in os.walk(install_dir):
+        for subdir in dirs:
+            if subdir == "site-packages" or subdir == "dist-packages":
+                candidate_paths.append(os.path.abspath(os.path.join(root, subdir)))
+
+    X, Y = sys.version_info.major, sys.version_info.minor
+
+    site_packages = None
+    if any(f"python{X}." in p for p in candidate_paths):
+        # We have a system that uses `python3.X/site-packages` or `python3.X/dist-packages`
+        site_packages = [p for p in candidate_paths if f"python{X}.{Y}" in p]
+        if len(site_packages) == 0:
+            raise FileNotFoundError(
+                f"No site-packages found in {install_dir} for Python {X}.{Y}"
+            )
+        else:
+            site_packages = site_packages[0]
+    else:
+        # A naming scheme that does not encode the Python major/minor version is used, so return
+        # whatever site-packages path was found
+        if len(candidate_paths) > 1:
+            raise FileNotFoundError(
+                f"Multiple `site-packages` found in `{install_dir}`, but cannot use Python version to disambiguate"
+            )
+        elif len(candidate_paths) == 1:
+            site_packages = candidate_paths[0]
+
+    if site_packages is None:
+        raise FileNotFoundError(
+            f"No `site-packages` or `dist-packages` found under `{install_dir}`"
+        )
+
+    return site_packages
+
+
+def _meson_version():
+    try:
+        p = _run(meson_cli + ["--version"], output=False, echo=False)
+        return p.stdout.decode("ascii").strip()
+    except:
+        pass
+
+
+def _meson_version_configured():
+    try:
+        meson_info_fn = os.path.join("build", "meson-info", "meson-info.json")
+        meson_info = json.load(open(meson_info_fn))
+        return meson_info["meson_version"]["full"]
+    except:
+        pass
+
+
+@click.command()
+@click.option("-j", "--jobs", help="Number of parallel tasks to launch", type=int)
+@click.option("--clean", is_flag=True, help="Clean build directory before build")
+@click.option(
+    "-v", "--verbose", is_flag=True, help="Print all build output, even installation"
+)
+@click.argument("meson_args", nargs=-1)
+def meson_build(meson_args, jobs=None, clean=False, verbose=False):
+    """🔧 Build package with Meson/ninja and install
+
+    MESON_ARGS are passed through e.g.:
+
+    spin build -- -Dpkg_config_path=/lib64/pkgconfig
+
+    The package is installed to build-install
+
+    By default builds for release, to be able to use a debugger set CFLAGS
+    appropriately. For example, for linux use
+
+    CFLAGS="-O0 -g" spin build
+    """
+    build_dir = "build"
+    setup_cmd = meson_cli + ["setup", build_dir, "--prefix=/usr"] + list(meson_args)
+
+    if clean:
+        print(f"Removing `{build_dir}`")
+        if os.path.isdir(build_dir):
+            shutil.rmtree(build_dir)
+        print(f"Removing `{install_dir}`")
+        if os.path.isdir(install_dir):
+            shutil.rmtree(install_dir)
+
+    if not (os.path.exists(build_dir) and _meson_version_configured()):
+        p = _run(setup_cmd, sys_exit=False)
+        if p.returncode != 0:
+            raise RuntimeError(
+                "Meson configuration failed; please try `spin build` again with the `--clean` flag."
+            )
+    else:
+        # Build dir has been configured; check if it was configured by
+        # current version of Meson
+
+        if _meson_version() != _meson_version_configured():
+            _run(setup_cmd + ["--reconfigure"])
+
+        # Any other conditions that warrant a reconfigure?
+
+    p = _run(meson_cli + ["compile", "-C", build_dir], sys_exit=False)
+    p = _run(meson_cli +
+        [
+            "install",
+            "--only-changed",
+            "-C",
+            build_dir,
+            "--destdir",
+            f"../{install_dir}",
+        ],
+        output=verbose,
+    )
+
+
+def _get_configured_command(command_name):
+    from spin.cmds.util import get_commands
+    command_groups = get_commands()
+    commands = [cmd for section in command_groups for cmd in command_groups[section]]
+    return next((cmd for cmd in commands if cmd.name == command_name), None)
+
+
+@click.command()
+@click.argument("pytest_args", nargs=-1)
+@click.pass_context
+def meson_test(ctx, pytest_args):
+    """🔧 Run tests
+
+    PYTEST_ARGS are passed through directly to pytest, e.g.:
+
+      spin test -- -v
+
+    To run tests on a directory or file:
+
+     \b
+     spin test numpy/linalg
+     spin test numpy/linalg/tests/test_linalg.py
+
+    To run specific tests, by module, function, class, or method:
+
+     \b
+     spin test -- --pyargs numpy.random
+     spin test -- --pyargs numpy.random.tests.test_generator_mt19937
+     spin test -- --pyargs numpy.random.tests.test_generator_mt19937::TestMultivariateHypergeometric
+     spin test -- --pyargs numpy.random.tests.test_generator_mt19937::TestMultivariateHypergeometric::test_edge_cases
+
+    To report the durations of the N slowest tests:
+
+      spin test -- --durations=N
+
+    To run tests that match a given pattern:
+
+     \b
+     spin test -- -k "geometric"
+     spin test -- -k "geometric and not rgeometric"
+
+    To skip tests with a given marker:
+
+      spin test -- -m "not slow"
+
+    To parallelize test runs (requires `pytest-xdist`):
+
+      spin test -- -n NUM_JOBS
+
+    For more, see `pytest --help`.
+
+    """
+    from spin.cmds.util import get_config
+    cfg = get_config()
+
+    build_cmd = _get_configured_command("build")
+    if build_cmd:
+        click.secho(
+            "Invoking `build` prior to running tests:", bold=True, fg="bright_green"
+        )
+        ctx.invoke(build_cmd)
+
+    package = cfg.get("tool.spin.package", None)
+    if not pytest_args:
+        pytest_args = (package,)
+        if pytest_args == (None,):
+            print(
+                "Please specify `package = packagename` under `tool.spin` section of `pyproject.toml`"
+            )
+            sys.exit(1)
+
+    site_path = _set_pythonpath()
+
+    # Sanity check that library built properly
+    if sys.version_info[:2] >= (3, 11):
+        p = _run([sys.executable, "-P", "-c", f"import {package}"], sys_exit=False)
+        if p.returncode != 0:
+            print(f"As a sanity check, we tried to import {package}.")
+            print("Stopping. Please investigate the build error.")
+            sys.exit(1)
+
+    print(f'$ export PYTHONPATH="{site_path}"')
+    _run(
+        [sys.executable, "-m", "pytest", f"--rootdir={site_path}"] + list(pytest_args),
+        cwd=site_path,
+        replace=True,
+    )
+
+
+@click.command()
+@click.argument("ipython_args", nargs=-1)
+def ipython(ipython_args):
+    """💻 Launch IPython shell with PYTHONPATH set
+
+    IPYTHON_ARGS are passed through directly to IPython, e.g.:
+
+    spin ipython -- -i myscript.py
+    """
+    p = _set_pythonpath()
+    print(f'💻 Launching IPython with PYTHONPATH="{p}"')
+    _run(["ipython", "--ignore-cwd"] + list(ipython_args), replace=True)
+
+
+@click.command()
+@click.argument("shell_args", nargs=-1)
+def meson_shell(shell_args=[]):
+    """💻 Launch shell with PYTHONPATH set
+
+    SHELL_ARGS are passed through directly to the shell, e.g.:
+
+    spin shell -- -c 'echo $PYTHONPATH'
+
+    Ensure that your shell init file (e.g., ~/.zshrc) does not override
+    the PYTHONPATH.
+    """
+    p = _set_pythonpath()
+    shell = os.environ.get("SHELL", "sh")
+    cmd = [shell] + list(shell_args)
+    print(f'💻 Launching shell with PYTHONPATH="{p}"')
+    print("⚠  Change directory to avoid importing source instead of built package")
+    print("⚠  Ensure that your ~/.shellrc does not unset PYTHONPATH")
+    _run(cmd, replace=True)
+
+
+@click.command()
+@click.argument("python_args", nargs=-1)
+def meson_python(python_args):
+    """🐍 Launch Python shell with PYTHONPATH set
+
+    PYTHON_ARGS are passed through directly to Python, e.g.:
+
+    spin python -- -c 'import sys; print(sys.path)'
+    """
+    p = _set_pythonpath()
+    v = sys.version_info
+    if (v.major < 3) or (v.major == 3 and v.minor < 11):
+        print("We're sorry, but this feature only works on Python 3.11 and greater 😢")
+        print()
+        print(
+            "Why? Because we need the '-P' flag so the interpreter doesn't muck with PYTHONPATH"
+        )
+        print()
+        print("However! You can still launch your own interpreter:")
+        print()
+        print(f"  PYTHONPATH='{p}' python")
+        print()
+        print("And then call:")
+        print()
+        print("import sys; del(sys.path[0])")
+        sys.exit(-1)
+
+    print(f'🐍 Launching Python with PYTHONPATH="{p}"')
+
+    _run(["/usr/bin/env", "python", "-P"] + list(python_args), replace=True)
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1)
+def meson_run(args):
+    """🏁 Run a shell command with PYTHONPATH set
+
+    \b
+    spin run make
+    spin run 'echo $PYTHONPATH'
+    spin run python -c 'import sys; del sys.path[0]; import mypkg'
+
+    If you'd like to expand shell variables, like `$PYTHONPATH` in the example
+    above, you need to provide a single, quoted command to `run`:
+
+    spin run 'echo $SHELL && echo $PWD'
+
+    On Windows, all shell commands are run via Bash.
+    Install Git for Windows if you don't have Bash already.
+    """
+    if not len(args) > 0:
+        raise RuntimeError("No command given")
+
+    is_posix = sys.platform in ("linux", "darwin")
+    shell = len(args) == 1
+    if shell:
+        args = args[0]
+
+    if shell and not is_posix:
+        # On Windows, we're going to try to use bash
+        args = ["bash", "-c", args]
+
+    _set_pythonpath(quiet=True)
+    _run(args, echo=False, shell=shell)
+
+
+@click.command()
+@click.argument("sphinx_target", default="html")
+@click.option(
+    "--clean",
+    is_flag=True,
+    default=False,
+    help="Clean previously built docs before building",
+)
+@click.option(
+    "--build/--no-build",
+    "first_build",
+    default=True,
+    help="Build numpy before generating docs",
+)
+@click.option("--jobs", "-j", default="auto", help="Number of parallel build jobs")
+@click.pass_context
+def meson_docs(ctx, sphinx_target, clean, first_build, jobs):
+    """📖 Build Sphinx documentation
+
+    By default, SPHINXOPTS="-W", raising errors on warnings.
+    To build without raising on warnings:
+
+      SPHINXOPTS="" spin docs
+
+    To list all Sphinx targets:
+
+      spin docs targets
+
+    To build another Sphinx target:
+
+      spin docs TARGET
+
+    """
+    # Detect docs dir
+    doc_dir_candidates = ("doc", "docs")
+    doc_dir = next((d for d in doc_dir_candidates if os.path.exists(d)), None)
+    if doc_dir is None:
+        print(
+            f"No documentation folder found; one of {', '.join(doc_dir_candidates)} must exist"
+        )
+        sys.exit(1)
+
+    if sphinx_target in ("targets", "help"):
+        clean = False
+        first_build = False
+        sphinx_target = "help"
+
+    if clean:
+        doc_dirs = [
+            "./doc/build/",
+            "./doc/source/api/",
+            "./doc/source/auto_examples/",
+            "./doc/source/jupyterlite_contents/",
+        ]
+        for doc_dir in doc_dirs:
+            if os.path.isdir(doc_dir):
+                print(f"Removing {doc_dir!r}")
+                shutil.rmtree(doc_dir)
+
+    build_cmd = _get_configured_command("build")
+
+    if build_cmd and first_build:
+        click.secho(
+            "Invoking `build` prior to building docs:", bold=True, fg="bright_green"
+        )
+        ctx.invoke(build_cmd)
+
+    try:
+        site_path = _get_site_packages()
+    except FileNotFoundError:
+        print("No built numpy found; run `spin build` first.")
+        sys.exit(1)
+
+    opts = os.environ.get("SPHINXOPTS", "-W")
+    os.environ["SPHINXOPTS"] = f"{opts} -j {jobs}"
+    click.secho(
+        f"$ export SPHINXOPTS={os.environ['SPHINXOPTS']}", bold=True, fg="bright_blue"
+    )
+
+    os.environ["PYTHONPATH"] = f'{site_path}{os.sep}:{os.environ.get("PYTHONPATH", "")}'
+    click.secho(
+        f"$ export PYTHONPATH={os.environ['PYTHONPATH']}", bold=True, fg="bright_blue"
+    )
+    _run(["make", "-C", "doc", sphinx_target], replace=True)
+
+
+# END of spin/cmds/meson.py
 
 
 # The numpy-vendored version of Meson. Put the directory that the executable
@@ -56,7 +479,7 @@ def build(ctx, meson_args, jobs=None, clean=False, verbose=False):
 
     CFLAGS="-O0 -g" spin build
     """
-    ctx.forward(meson.build)
+    ctx.forward(meson_build)
 
 
 @click.command()
@@ -105,9 +528,9 @@ def docs(ctx, sphinx_target, clean, first_build, jobs, install_deps):
         if install_deps:
             util.run(['pip', 'install', '-q', '-r', 'doc_requirements.txt'])
 
-    meson.docs.ignore_unknown_options = True
+    meson_docs.ignore_unknown_options = True
     del ctx.params['install_deps']
-    ctx.forward(meson.docs)
+    ctx.forward(meson_docs)
 
 
 @click.command()
@@ -193,7 +616,7 @@ def test(ctx, pytest_args, markexpr, n_jobs, tests, verbose):
 
     for extra_param in ('markexpr', 'n_jobs', 'tests', 'verbose'):
         del ctx.params[extra_param]
-    ctx.forward(meson.test)
+    ctx.forward(meson_test)
 
 
 @click.command()
@@ -220,7 +643,7 @@ def gdb(code, gdb_args):
      spin gdb my_tests.py
      spin gdb -- my_tests.py --mytest-flag
     """
-    meson._set_pythonpath()
+    _set_pythonpath()
     gdb_args = list(gdb_args)
 
     if gdb_args and gdb_args[0].endswith('.py'):
@@ -392,9 +815,9 @@ def bench(ctx, tests, compare, verbose, commits):
             "Invoking `build` prior to running benchmarks:",
             bold=True, fg="bright_green"
         )
-        ctx.invoke(meson.build)
+        ctx.invoke(build)
 
-        meson._set_pythonpath()
+        _set_pythonpath()
 
         p = util.run(
             ['python', '-c', 'import numpy as np; print(np.__version__)'],
@@ -450,8 +873,8 @@ def python(ctx, python_args):
     """
     env = os.environ
     env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
-    ctx.invoke(meson.build)
-    ctx.forward(meson.python)
+    ctx.invoke(build)
+    ctx.forward(meson_python)
 
 
 @click.command(context_settings={
@@ -469,9 +892,9 @@ def ipython(ctx, ipython_args):
     env = os.environ
     env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
 
-    ctx.invoke(meson.build)
+    ctx.invoke(build)
 
-    ppath = meson._set_pythonpath()
+    ppath = _set_pythonpath()
 
     print(f'💻 Launching IPython with PYTHONPATH="{ppath}"')
     preimport = (r"import numpy as np; "
@@ -500,5 +923,5 @@ def run(ctx, args):
     On Windows, all shell commands are run via Bash.
     Install Git for Windows if you don't have Bash already.
     """
-    ctx.invoke(meson.build)
-    ctx.forward(meson.run)
+    ctx.invoke(build)
+    ctx.forward(meson_run)

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -29,3 +29,8 @@ Name: Meson
 Files: vendored-meson/meson/*
 License: Apache 2.0
   For license text, see vendored-meson/meson/COPYING
+
+Name: meson-python
+Files: vendored-meson/meson-python/*
+License: MIT
+  For license text, see vendored-meson/meson-python/LICENSE

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -34,3 +34,8 @@ Name: meson-python
 Files: vendored-meson/meson-python/*
 License: MIT
   For license text, see vendored-meson/meson-python/LICENSE
+
+Name: spin
+Files: .spin/cmds.py
+License: BSD-3
+  For license text, see .spin/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,18 @@
 [build-system]
-build-backend = "npbuild"
-backend-path = ['./vendored-meson/build-backend-wrapper']
+build-backend = "mesonpy"
+backend-path = ['./vendored-meson/meson-python']
 requires = [
     "Cython>=3.0",
-    "meson-python>=0.13.1",
+    # All dependencies of the vendored meson-python (except for meson, because
+    # we've got that vendored too - that's the point of this exercise).
+    'pyproject-metadata >= 0.7.1',
+    'tomli >= 1.0.0; python_version < "3.11"',
+    'setuptools >= 60.0; python_version >= "3.12"',
+    'colorama; os_name == "nt"',
+    # Note that `ninja` and (on Linux) `patchelf` are added dynamically by
+    # meson-python if those tools are not already present on the system. No
+    # need to worry about those unless one does a non-isolated build - in that
+    # case they must already be installed on the system.
 ]
 
 [project]

--- a/tools/lint_diff.ini
+++ b/tools/lint_diff.ini
@@ -2,4 +2,4 @@
 max_line_length = 79
 statistics = True
 ignore = E121,E122,E123,E125,E126,E127,E128,E226,E241,E251,E265,E266,E302,E402,E704,E712,E721,E731,E741,W291,W293,W391,W503,W504
-exclude = versioneer.py,numpy/_version.py,numpy/__config__.py,numpy/typing/tests/data
+exclude = versioneer.py,numpy/_version.py,numpy/__config__.py,numpy/typing/tests/data,.spin/cmds.py


### PR DESCRIPTION
Follow-up to gh-24379. See the end of that PR for discussion on why that PR alone was not enough on Windows.

Tested together with SIMD support in gh-24395, and looks good. I plan to merge this asap and then rebase gh-23096 on top.

This also cleans up the Windows GHA CI jobs, they were pretty messy. `meson` as a standalone executable command cannot be used anymore as long as we vendor it.