### PR TITLE
TST: revert xfail in `test_umath.py`

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1764,8 +1764,6 @@ class TestSpecialFloats:
         np.log, np.log2, np.log10, np.reciprocal, np.arccosh
     ]
 
-    @pytest.mark.skipif(sys.platform == "win32" and sys.maxsize < 2**31 + 1,
-                        reason='failures on 32-bit Python, see FIXME below')
     @pytest.mark.parametrize("ufunc", UFUNCS_UNARY_FP)
     @pytest.mark.parametrize("dtype", ('e', 'f', 'd'))
     @pytest.mark.parametrize("data, escape", (
@@ -1812,8 +1810,6 @@ class TestSpecialFloats:
         # FIXME: NAN raises FP invalid exception:
         #  - ceil/float16 on MSVC:32-bit
         #  - spacing/float16 on almost all platforms
-        # FIXME: skipped on MSVC:32-bit during switch to Meson, 10 cases fail
-        #        when SIMD support not present / disabled
         if ufunc in (np.spacing, np.ceil) and dtype == 'e':
             return
         array = np.array(data, dtype=dtype)


### PR DESCRIPTION
This xfail was added in gh-24279 for 32-bit Python + MSVC when switching to Meson and having temporarily no SIMD support. That is back now, so this test passes again.

[skip circle] [skip cirrus] [skip travis]