### PR TITLE
DOC: Fix reference warning for routines.polynomials.rst.

### DIFF
--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -18,14 +18,14 @@ Therefore :mod:`numpy.polynomial` is recommended for new coding.
 .. note:: **Terminology**
 
    The term *polynomial module* refers to the old API defined in
-   `numpy.lib.polynomial`, which includes the :class:`numpy.poly1d` class and
+   ``numpy.lib.polynomial``, which includes the :class:`numpy.poly1d` class and
    the polynomial functions prefixed with *poly* accessible from the `numpy`
    namespace (e.g. `numpy.polyadd`, `numpy.polyval`, `numpy.polyfit`, etc.).
 
    The term *polynomial package* refers to the new API defined in 
    `numpy.polynomial`, which includes the convenience classes for the
-   different kinds of polynomials (`numpy.polynomial.Polynomial`,
-   `numpy.polynomial.Chebyshev`, etc.).
+   different kinds of polynomials (:class:`~numpy.polynomial.polynomial.Polynomial`,
+   :class:`~numpy.polynomial.chebyshev.Chebyshev`, etc.).
 
 Transitioning from `numpy.poly1d` to `numpy.polynomial`
 -------------------------------------------------------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix reference warning as following:
```
numpy/doc/source/reference/routines.polynomials.rst:20: WARNING: py:obj reference target not found: numpy.lib.polynomial
numpy/doc/source/reference/routines.polynomials.rst:25: WARNING: py:obj reference target not found: numpy.polynomial.Polynomial
numpy/doc/source/reference/routines.polynomials.rst:25: WARNING: py:obj reference target not found: numpy.polynomial.Chebyshev
```

For the `numpy.lib.polynomial `, I updated it to code example as other same references in this rst file. For the `numpy.polynomial.Polynomial ` and `numpy.polynomial.Chebyshev `, I used full class path reference.