### PR TITLE
ENH: Vendor meson for multi-target build support

### DIFF
--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -44,6 +44,7 @@ jobs:
             git checkout $GITHUB_BASE_REF
             git -c user.email="you@example.com" merge --no-commit my_ref_name
         fi
+        git submodule update --init
 
         ln -s /usr/local/bin/python3.10 /usr/local/bin/python
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "numpy/core/src/npysort/x86-simd-sort"]
 	path = numpy/core/src/npysort/x86-simd-sort
 	url = https://github.com/intel/x86-simd-sort
+[submodule "vendored-meson/meson"]
+	path = vendored-meson/meson
+	url = https://github.com/numpy/meson.git

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -11,6 +11,54 @@ from spin.cmds import meson
 from spin import util
 
 
+# The numpy-vendored version of Meson. Put the directory that the executable
+# `meson` is in at the front of the PATH.
+curdir = pathlib.Path(__file__).parent.resolve()
+meson_executable_dir = str(curdir.parent / 'vendored-meson' / 'entrypoint')
+os.environ['PATH'] = meson_executable_dir + os.pathsep + os.environ['PATH']
+
+# Check that the meson git submodule is present
+meson_import_dir = curdir.parent / 'vendored-meson' / 'meson' / 'mesonbuild'
+if not meson_import_dir.exists():
+    raise RuntimeError(
+        'The `vendored-meson/meson` git submodule does not exist! ' +
+        'Run `git submodule update --init` to fix this problem.'
+    )
+
+
+@click.command()
+@click.option(
+    "-j", "--jobs",
+    help="Number of parallel tasks to launch",
+    type=int
+)
+@click.option(
+    "--clean", is_flag=True,
+    help="Clean build directory before build"
+)
+@click.option(
+    "-v", "--verbose", is_flag=True,
+    help="Print all build output, even installation"
+)
+@click.argument("meson_args", nargs=-1)
+@click.pass_context
+def build(ctx, meson_args, jobs=None, clean=False, verbose=False):
+    """🔧 Build package with Meson/ninja and install
+
+    MESON_ARGS are passed through e.g.:
+
+    spin build -- -Dpkg_config_path=/lib64/pkgconfig
+
+    The package is installed to build-install
+
+    By default builds for release, to be able to use a debugger set CFLAGS
+    appropriately. For example, for linux use
+
+    CFLAGS="-O0 -g" spin build
+    """
+    ctx.forward(meson.build)
+
+
 @click.command()
 @click.argument("sphinx_target", default="html")
 @click.option(

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -80,7 +80,7 @@ def build(ctx, meson_args, jobs=None, clean=False, verbose=False):
 )
 @click.option(
     "--install-deps/--no-install-deps",
-    default=True,
+    default=False,
     help="Install dependencies before building"
 )
 @click.pass_context

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -20,3 +20,12 @@ Name: libdivide
 Files: numpy/core/include/numpy/libdivide/*
 License: Zlib
   For license text, see numpy/core/include/numpy/libdivide/LICENSE.txt
+
+
+Note that the following files are vendored in the repository and sdist but not
+installed in built numpy packages:
+
+Name: Meson
+Files: vendored-meson/meson/*
+License: Apache 2.0
+  For license text, see vendored-meson/meson/COPYING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-build-backend = "mesonpy"
+build-backend = "npbuild"
+backend-path = ['./vendored-meson/build-backend-wrapper']
 requires = [
     "Cython>=0.29.34,<3.1",
     "meson-python>=0.13.1,<0.16.0",
@@ -184,7 +185,7 @@ repair-wheel-command = "bash ./tools/wheels/repair_windows.sh {wheel} {dest_dir}
 package = 'numpy'
 
 [tool.spin.commands]
-"Build" = ["spin.cmds.meson.build", ".spin/cmds.py:test"]
+"Build" = [".spin/cmds.py:build", ".spin/cmds.py:test"]
 "Environments" = [
   ".spin/cmds.py:run", ".spin/cmds.py:ipython",
   ".spin/cmds.py:python", ".spin/cmds.py:gdb"

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -16,7 +16,7 @@ fi
 
 source builds/venv/bin/activate
 
-pip install --upgrade pip 'setuptools<49.2.0'
+pip install --upgrade pip 'setuptools<49.2.0' build
 
 pip install -r build_requirements.txt
 
@@ -223,7 +223,7 @@ elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
   $PYTHON -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   # ensure some warnings are not issued
   export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result -Wno-error=undef"
-  $PYTHON setup.py sdist
+  $PYTHON -m build --sdist
   # Make another virtualenv to install into
   $PYTHON -m venv venv-for-wheel
   . venv-for-wheel/bin/activate

--- a/vendored-meson/build-backend-wrapper/npbuild/__init__.py
+++ b/vendored-meson/build-backend-wrapper/npbuild/__init__.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pathlib
+
+from mesonpy import (
+    build_sdist,
+    build_wheel,
+    build_editable,
+    get_requires_for_build_sdist,
+    get_requires_for_build_wheel,
+    get_requires_for_build_editable,
+)
+
+
+# The numpy-vendored version of Meson. Put the directory that the executable
+# `meson` is in at the front of the PATH.
+curdir = pathlib.Path(__file__).parent.resolve()
+meson_executable_dir = str(curdir.parent.parent / 'entrypoint')
+os.environ['PATH'] = meson_executable_dir + os.pathsep + os.environ['PATH']
+
+# Check that the meson git submodule is present
+meson_import_dir = curdir.parent.parent / 'meson' / 'mesonbuild'
+if not meson_import_dir.exists():
+    raise RuntimeError(
+        'The `vendored-meson/meson` git submodule does not exist! ' +
+        'Run `git submodule update --init` to fix this problem.'
+    )

--- a/vendored-meson/entrypoint/meson
+++ b/vendored-meson/entrypoint/meson
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import re
+import sys
+import pathlib
+
+
+# The numpy-vendored version of Meson
+meson_dir = str(pathlib.Path(__file__).resolve().parent.parent / 'meson')
+sys.path.insert(0, meson_dir)
+
+from mesonbuild.mesonmain import main
+import mesonbuild
+if not 'vendored-meson' in mesonbuild.__path__[0]:
+    # Note: only the print statement will show most likely, not the exception.
+    # If this goes wrong, it first fails inside meson-python on the `meson
+    # --version` check.
+    print(f'picking up the wrong `meson`: {mesonbuild.__path__}')
+    raise RuntimeError('incorrect mesonbuild module, exiting')
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())


### PR DESCRIPTION
Backport of #24379.

This is a much more minimal alternative to gh-24365. It only vendors Meson, and uses PATH manipulation to get `meson-python` and `spin` to pick up our vendored Meson - which is a friendly fork which lives at https://github.com/numpy/meson and is meant to temporarily include the feature we need for SIMD support.

Tested in combination with gh-23096, and it looks like everything works. Let's see how happy CI is ....
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
