### PR TITLE
BUG: Fix datetime hash to be a bit more sane and start on timedelta

### DIFF
--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -1,6 +1,8 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY__DATETIME_H_
 #define NUMPY_CORE_SRC_MULTIARRAY__DATETIME_H_
 
+#include "numpy/arrayscalars.h"
+
 extern NPY_NO_EXPORT char const *_datetime_strings[NPY_DATETIME_NUMUNITS];
 extern NPY_NO_EXPORT int _days_per_month_table[2][12];
 
@@ -18,6 +20,12 @@ is_leapyear(npy_int64 year);
  */
 NPY_NO_EXPORT npy_int64
 get_datetimestruct_days(const npy_datetimestruct *dts);
+
+NPY_NO_EXPORT Py_hash_t
+datetime_arrtype_hash(PyDatetimeScalarObject* key);
+
+NPY_NO_EXPORT Py_hash_t
+timedelta_arrtype_hash(PyTimedeltaScalarObject* key);
 
 /*
  * Creates a datetime or timedelta dtype using a copy of the provided metadata.

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -729,7 +729,7 @@ timedelta_arrtype_hash(PyTimedeltaScalarObject* key) {
     acc = (Py_uhash_t)value;
 #else
     /* Mix lower and uper bits of the timedelta if int64 is larger */
-    Py_uhash_t acc = _NpyHASH_XXPRIME_5;
+    acc = _NpyHASH_XXPRIME_5;
     acc = tuple_update_uhash(acc, (Py_uhash_t)value);
     acc = tuple_update_uhash(acc, (Py_uhash_t)(value >> SIZEOF_PY_UHASH_T));
 #endif

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -16,6 +16,7 @@
 #include "npy_pycompat.h"
 
 #include "arraytypes.h"
+#include "_datetime.h"
 #include "npy_config.h"
 #include "mapping.h"
 #include "ctors.h"
@@ -3554,49 +3555,6 @@ static inline npy_hash_t
     return x;
 }
 /**end repeat**/
-
-
-/**begin repeat
- * #lname = datetime, timedelta#
- * #name = Datetime, Timedelta#
- */
-#if NPY_SIZEOF_HASH_T==NPY_SIZEOF_DATETIME
-static npy_hash_t
-@lname@_arrtype_hash(PyObject *obj)
-{
-    npy_hash_t x = (npy_hash_t)(PyArrayScalar_VAL(obj, @name@));
-    if (x == -1) {
-        x = -2;
-    }
-    return x;
-}
-#elif NPY_SIZEOF_LONGLONG==NPY_SIZEOF_DATETIME
-static npy_hash_t
-@lname@_arrtype_hash(PyObject *obj)
-{
-    npy_hash_t y;
-    npy_longlong x = (PyArrayScalar_VAL(obj, @name@));
-
-    if ((x <= LONG_MAX)) {
-        y = (npy_hash_t) x;
-    }
-    else {
-        union Mask {
-            long hashvals[2];
-            npy_longlong v;
-        } both;
-
-        both.v = x;
-        y = both.hashvals[0] + (1000003)*both.hashvals[1];
-    }
-    if (y == -1) {
-        y = -2;
-    }
-    return y;
-}
-#endif
-/**end repeat**/
-
 
 
 /* Wrong thing to do for longdouble, but....*/

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4121,7 +4121,7 @@ initialize_numeric_types(void)
      *         Datetime, Timedelta#
      */
 
-    Py@NAME@ArrType_Type.tp_hash = @name@_arrtype_hash;
+    Py@NAME@ArrType_Type.tp_hash = (hashfunc)@name@_arrtype_hash;
 
     /**end repeat**/
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2568,3 +2568,20 @@ def test_comparisons_return_not_implemented():
         assert item.__lt__(obj) is NotImplemented
         assert item.__ge__(obj) is NotImplemented
         assert item.__gt__(obj) is NotImplemented
+
+
+
+@pytest.mark.parametrize("unit", [
+        "s", "ms", "us", "ns", "ps", "fs", "as"])
+def test_hash(unit):
+    d = datetime.datetime(1970, 1, 1)
+    dt = np.datetime64(d, unit)
+
+    if isinstance(dt.item(), datetime.datetime):
+        assert d == dt
+        assert hash(d) == hash(dt)
+    else:
+        # compare with nanosecods instead of Python datetime:
+        d = np.datetime64(d, "ns")
+        assert d == dt
+        assert hash(d) == hash(dt)


### PR DESCRIPTION
This is a start, it should work for datetime64, I am not attempting to do anything about timedelta yet, because we don't really have the timedeltastruct so it needs more reorganization.

I don't like this, but TBH, I don't see that it is better to add a bad hack into pandas than to add the same bad hack into NumPy...

---

This is moving the start from Pandas in https://github.com/pandas-dev/pandas/pull/50960 to NumPy.  I chose to move it into the datetime.c file, but I don't care about where it lives.  We can probably cut down the hash calculation a little, but TBH, I doubt it matters in practice and we can change it later.

Timedelta is proving more annoying.  We need to cut corners even more heavily probably because a huge number of casts/comparisons that are allowed probably shouldn't be allowed to begin with.

CC @jbrockmendel