### PR TITLE
MAINT: Refactor of `core/_type_aliases.py`

### DIFF
--- a/numpy/core/_expired_type_aliases.py
+++ b/numpy/core/_expired_type_aliases.py
@@ -85,10 +85,9 @@ def _add_types():
 _add_types()
 
 # This is the priority order used to assign the bit-sized NPY_INTxx names, 
-# which must match the order in npy_common.h in order for NPY_INTxx and 
-# np.intxx to be consistent.
-# If two C types have the same size, then the earliest one in this list 
-# is used as the sized name.
+# which must match the order in npy_common.h in order for NPY_INTxx 
+# and np.intxx to be consistent. If two C types have the same size, 
+# then the earliest one in this list is used as the sized name.
 _int_ctypes = ['long', 'longlong', 'int', 'short', 'byte']
 _uint_ctypes = list('u' + t for t in _int_ctypes)
 
@@ -151,32 +150,23 @@ void = allTypes['void']
 #                            with Python usage)
 #
 def _set_up_aliases():
-    type_pairs = [('complex_', 'cdouble'),
-                  ('single', 'float'),
+    type_pairs = [('single', 'float'),
                   ('csingle', 'cfloat'),
-                  ('singlecomplex', 'cfloat'),
-                  ('float_', 'double'),
                   ('intc', 'int'),
                   ('uintc', 'uint'),
                   ('int_', 'long'),
                   ('uint', 'ulong'),
-                  ('cfloat', 'cdouble'),
-                  ('longfloat', 'longdouble'),
-                  ('clongfloat', 'clongdouble'),
-                  ('longcomplex', 'clongdouble'),
                   ('bool_', 'bool'),
                   ('bytes_', 'string'),
-                  ('string_', 'string'),
                   ('str_', 'unicode'),
-                  ('unicode_', 'unicode'),
-                  ('object_', 'object')]
+                  ('object_', 'object'),
+                  ('cfloat', 'cdouble')]
     for alias, t in type_pairs:
         allTypes[alias] = allTypes[t]
         sctypeDict[alias] = sctypeDict[t]
     # Remove aliases overriding python types and modules
-    to_remove = ['object', 'int', 'float',
-                 'complex', 'bool', 'string', 'datetime', 'timedelta',
-                 'bytes', 'str']
+    to_remove = ['object', 'int', 'float', 'complex', 'bool', 
+                 'string', 'datetime', 'timedelta', 'bytes', 'str']
 
     for t in to_remove:
         try:
@@ -186,7 +176,7 @@ def _set_up_aliases():
             pass
 
     # Additional aliases in sctypeDict that should not be exposed as attributes
-    attrs_to_remove = ['ulong', 'long', 'unicode']
+    attrs_to_remove = ['ulong', 'long', 'unicode', 'cfloat']
 
     for t in attrs_to_remove:
         try:
@@ -239,7 +229,8 @@ _set_array_types()
 
 
 # Add additional strings to the sctypeDict
-_toadd = ['int', 'float', 'complex', 'bool', 'object',
+_toadd = ['int', ('float', 'double'), ('complex', 'cdouble'), 
+          'bool', 'object',
           'str', 'bytes', ('a', 'bytes_'),
           ('int0', 'intp'), ('uint0', 'uintp')]
 

--- a/numpy/core/_expired_type_aliases.py
+++ b/numpy/core/_expired_type_aliases.py
@@ -1,0 +1,252 @@
+"""
+Due to compatibility, numpy has a very large number of different naming
+conventions for the scalar types (those subclassing from `numpy.generic`).
+This file produces a convoluted set of dictionaries mapping names to types,
+and sometimes other mappings too.
+
+.. data:: allTypes
+    A dictionary of names to types that will be exposed as attributes through
+    ``np.core.numerictypes.*``
+
+.. data:: sctypeDict
+    Similar to `allTypes`, but maps a broader set of aliases to their types.
+
+.. data:: sctypes
+    A dictionary keyed by a "type group" string, providing a list of types
+    under that group.
+
+"""
+
+from numpy.core._string_helpers import english_lower
+from numpy.core.multiarray import typeinfo, dtype
+from numpy.core._dtype import _kind_name
+
+
+sctypeDict = {}      # Contains all leaf-node scalar types with aliases
+allTypes = {}            # Collect the types we will add to the module
+
+
+# separate the actual type info from the abstract base classes
+_abstract_types = {}
+_concrete_typeinfo = {}
+for k, v in typeinfo.items():
+    # make all the keys lowercase too
+    k = english_lower(k)
+    if isinstance(v, type):
+        _abstract_types[k] = v
+    else:
+        _concrete_typeinfo[k] = v
+
+_concrete_types = {v.type for k, v in _concrete_typeinfo.items()}
+
+
+def _bits_of(obj):
+    try:
+        info = next(v for v in _concrete_typeinfo.values() if v.type is obj)
+    except StopIteration:
+        if obj in _abstract_types.values():
+            msg = "Cannot count the bits of an abstract type"
+            raise ValueError(msg) from None
+
+        # some third-party type - make a best-guess
+        return dtype(obj).itemsize * 8
+    else:
+        return info.bits
+
+
+def bitname(obj):
+    """Return a bit-width name for a given type object"""
+    bits = _bits_of(obj)
+    dt = dtype(obj)
+    char = dt.kind
+    base = _kind_name(dt)
+
+    if base == 'object':
+        bits = 0
+
+    if bits != 0:
+        char = "%s%d" % (char, bits // 8)
+
+    return base, bits, char
+
+
+def _add_types():
+    for name, info in _concrete_typeinfo.items():
+        # define C-name and insert typenum and typechar references also
+        allTypes[name] = info.type
+        sctypeDict[name] = info.type
+        sctypeDict[info.char] = info.type
+        sctypeDict[info.num] = info.type
+
+    for name, cls in _abstract_types.items():
+        allTypes[name] = cls
+
+
+_add_types()
+
+# This is the priority order used to assign the bit-sized NPY_INTxx names, 
+# which must match the order in npy_common.h in order for NPY_INTxx and 
+# np.intxx to be consistent.
+# If two C types have the same size, then the earliest one in this list 
+# is used as the sized name.
+_int_ctypes = ['long', 'longlong', 'int', 'short', 'byte']
+_uint_ctypes = list('u' + t for t in _int_ctypes)
+
+def _add_aliases():
+    for name, info in _concrete_typeinfo.items():
+        # these are handled by _add_integer_aliases
+        if name in _int_ctypes or name in _uint_ctypes:
+            continue
+
+        # insert bit-width version for this class (if relevant)
+        base, bit, char = bitname(info.type)
+
+        myname = "%s%d" % (base, bit)
+
+        # ensure that (c)longdouble does not overwrite the aliases assigned to
+        # (c)double
+        if name in ('longdouble', 'clongdouble') and myname in allTypes:
+            continue
+
+        # Add to the main namespace if desired:
+        if bit != 0 and base != "bool":
+            allTypes[myname] = info.type
+
+        # add forward, reverse, and string mapping to numarray
+        sctypeDict[char] = info.type
+
+        # add mapping for both the bit name
+        sctypeDict[myname] = info.type
+
+
+_add_aliases()
+
+def _add_integer_aliases():
+    seen_bits = set()
+    for i_ctype, u_ctype in zip(_int_ctypes, _uint_ctypes):
+        i_info = _concrete_typeinfo[i_ctype]
+        u_info = _concrete_typeinfo[u_ctype]
+        bits = i_info.bits  # same for both
+
+        for info, charname, intname in [
+                (i_info, 'i%d' % (bits//8,), 'int%d' % bits),
+                (u_info, 'u%d' % (bits//8,), 'uint%d' % bits)]:
+            if bits not in seen_bits:
+                # sometimes two different types have the same number of bits
+                # if so, the one iterated over first takes precedence
+                allTypes[intname] = info.type
+                sctypeDict[intname] = info.type
+                sctypeDict[charname] = info.type
+
+        seen_bits.add(bits)
+
+
+_add_integer_aliases()
+
+# We use these later
+void = allTypes['void']
+
+#
+# Rework the Python names (so that float and complex and int are consistent
+#                            with Python usage)
+#
+def _set_up_aliases():
+    type_pairs = [('complex_', 'cdouble'),
+                  ('single', 'float'),
+                  ('csingle', 'cfloat'),
+                  ('singlecomplex', 'cfloat'),
+                  ('float_', 'double'),
+                  ('intc', 'int'),
+                  ('uintc', 'uint'),
+                  ('int_', 'long'),
+                  ('uint', 'ulong'),
+                  ('cfloat', 'cdouble'),
+                  ('longfloat', 'longdouble'),
+                  ('clongfloat', 'clongdouble'),
+                  ('longcomplex', 'clongdouble'),
+                  ('bool_', 'bool'),
+                  ('bytes_', 'string'),
+                  ('string_', 'string'),
+                  ('str_', 'unicode'),
+                  ('unicode_', 'unicode'),
+                  ('object_', 'object')]
+    for alias, t in type_pairs:
+        allTypes[alias] = allTypes[t]
+        sctypeDict[alias] = sctypeDict[t]
+    # Remove aliases overriding python types and modules
+    to_remove = ['object', 'int', 'float',
+                 'complex', 'bool', 'string', 'datetime', 'timedelta',
+                 'bytes', 'str']
+
+    for t in to_remove:
+        try:
+            del allTypes[t]
+            del sctypeDict[t]
+        except KeyError:
+            pass
+
+    # Additional aliases in sctypeDict that should not be exposed as attributes
+    attrs_to_remove = ['ulong', 'long', 'unicode']
+
+    for t in attrs_to_remove:
+        try:
+            del allTypes[t]
+        except KeyError:
+            pass
+
+
+_set_up_aliases()
+
+
+sctypes = {'int': [],
+           'uint': [],
+           'float': [],
+           'complex': [],
+           'others': [bool, object, bytes, str, void]}
+
+
+def _add_array_type(typename, bits):
+    try:
+        t = allTypes['%s%d' % (typename, bits)]
+    except KeyError:
+        pass
+    else:
+        sctypes[typename].append(t)
+
+def _set_array_types():
+    ibytes = [1, 2, 4, 8, 16, 32, 64]
+    fbytes = [2, 4, 8, 10, 12, 16, 32, 64]
+    for bytes in ibytes:
+        bits = 8*bytes
+        _add_array_type('int', bits)
+        _add_array_type('uint', bits)
+    for bytes in fbytes:
+        bits = 8*bytes
+        _add_array_type('float', bits)
+        _add_array_type('complex', 2*bits)
+    _gi = dtype('p')
+    if _gi.type not in sctypes['int']:
+        indx = 0
+        sz = _gi.itemsize
+        _lst = sctypes['int']
+        while (indx < len(_lst) and sz >= _lst[indx](0).itemsize):
+            indx += 1
+        sctypes['int'].insert(indx, _gi.type)
+        sctypes['uint'].insert(indx, dtype('P').type)
+
+
+_set_array_types()
+
+
+# Add additional strings to the sctypeDict
+_toadd = ['int', 'float', 'complex', 'bool', 'object',
+          'str', 'bytes', ('a', 'bytes_'),
+          ('int0', 'intp'), ('uint0', 'uintp')]
+
+for name in _toadd:
+    if isinstance(name, tuple):
+        sctypeDict[name[0]] = allTypes[name[1]]
+    else:
+        sctypeDict[name] = allTypes['%s_' % name]
+
+del _toadd, name

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -38,7 +38,7 @@ for k, v in typeinfo.items():
         _abstract_types[k] = v
     else:
         _concrete_typeinfo[k] = v
-_concrete_types = {v.type for k, v in _concrete_typeinfo.items()}
+_concrete_types = {v.type for v in _concrete_typeinfo.values()}
 
 
 # 1. `words`
@@ -149,8 +149,10 @@ def _build_dicts() -> None:
 _build_dicts()
 
 
-# Rename types to Python conventions and introduce aliases
 def _renaming_and_aliases() -> None:
+    """
+    Rename types to Python conventions and introduce aliases
+    """
     renaming_dict = [
         # In Python `float` is `double`
         ("single", "float"),
@@ -173,16 +175,6 @@ def _renaming_and_aliases() -> None:
         ("str_", "unicode"),
         ("object_", "object"),
         ("object0", "object"),
-
-        # aliases to be removed
-        ("float_", "double"),
-        ("complex_", "cdouble"),
-        ("longfloat", "longdouble"),
-        ("clongfloat", "clongdouble"),
-        ("longcomplex", "clongdouble"),
-        ("singlecomplex", "csingle"),
-        ("string_", "string"),
-        ("unicode_", "unicode")
     ]
 
     for alias, t in renaming_dict:
@@ -211,7 +203,7 @@ allTypes = word_dict | word_bits_dict | abstract_types_dict
 # delete C names in `allTypes` and exceptions
 for s in ["ulong", "long", "unicode", "object", "bool", "datetime",
           "string", "timedelta", "float", "int", "bool8", "bytes0", 
-          "object32", "object64", "str0", "void0", "object0"]:
+          "object32", "object64", "str0", "void0", "object0", "cfloat"]:
     try:
         del allTypes[s]
     except KeyError:
@@ -249,11 +241,11 @@ def _build_sctypes() -> Dict[str, List[type]]:
     ibytes = [1, 2, 4, 8, 16, 32, 64]
     fbytes = [2, 4, 8, 10, 12, 16, 32, 64]
     for b in ibytes:
-        bits = 8*b
+        bits = 8 * b
         _add_array_type('int', bits, sctypes)
         _add_array_type('uint', bits, sctypes)
     for b in fbytes:
-        bits = 8*b
+        bits = 8 * b
         _add_array_type('float', bits, sctypes)
         _add_array_type('complex', 2*bits, sctypes)
     

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -1221,6 +1221,7 @@ python_sources = [
   '_string_helpers.py',
   '_type_aliases.py',
   '_type_aliases.pyi',
+  '_expired_type_aliases.py',
   '_ufunc_config.py',
   '_ufunc_config.pyi',
   'arrayprint.py',

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -100,11 +100,9 @@ from ._string_helpers import (
 from ._type_aliases import (
     sctypeDict,
     allTypes,
-    bitname,
     sctypes,
     _concrete_types,
     _concrete_typeinfo,
-    _bits_of,
 )
 from ._dtype import _kind_name
 

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -454,11 +454,6 @@ class TestSctypeDict:
             assert not hasattr(np, 'ulong')
 
 
-class TestBitName:
-    def test_abstract(self):
-        assert_raises(ValueError, np.core.numerictypes.bitname, np.floating)
-
-
 @pytest.mark.filterwarnings("ignore:.*maximum_sctype.*:DeprecationWarning")
 class TestMaximumSctype:
 
@@ -571,3 +566,15 @@ class TestScalarTypeNames:
     def test_names_are_undersood_by_dtype(self, t):
         """ Test the dtype constructor maps names back to the type """
         assert np.dtype(t.__name__).type is t
+
+
+def test_new_vs_expired_type_aliases():
+    from numpy.core._type_aliases import sctypes, sctypeDict, allTypes
+    from numpy.core._expired_type_aliases import (
+        sctypes as expired_sctypes, sctypeDict as expired_sctypeDict,
+        allTypes as expired_allTypes
+    )
+
+    assert(sctypes == expired_sctypes)
+    assert(allTypes == expired_allTypes)
+    assert(sctypeDict == expired_sctypeDict)


### PR DESCRIPTION
Hi @rgommers @seberg @ngoldbaum,

Here I'm sharing a proposition of `numpy/core/_type_aliases.py` file refactor.
While working on removing [other scalar aliases](https://numpy.org/devdocs/reference/arrays.scalars.html#other-aliases
) I had some difficulties understanding how `allTypes/sctypeDict` dictionaries are being created. For example, I noticed that the `float` alias is originally present in `sctypeDict`, then [it's removed](https://github.com/numpy/numpy/blob/104addf377577d12ea34547303822369fcb6e44e/numpy/core/_type_aliases.py#L174
) and then [added again](https://github.com/numpy/numpy/blob/104addf377577d12ea34547303822369fcb6e44e/numpy/core/_type_aliases.py#L235
).

I decided to try to refactor this file to decompose the creation of these dictionaries into well-defined stages.
I think the purpose of this file is straightforward: Read types from the compiled `multiarray` module, and expose them as Python dictionaries, while mapping C naming conventions to Python conventions (e.g. interpret `float` as `double` instead of `single`).

I identified which "group" of entries is present in each dictionary (could it be modified for NumPy 2.0?): 

|                                                   | allTypes | sctypeDict |
|---------------------------------------------------|----------|------------|
| `words` (e.g. "float", "cdouble", "int_")      | ✅        | ✅        |
| `words+bits` (e.g. "int16", "complex64")          | ✅      | ✅        |
| `symbols` (e.g. "p", "L")                         | ❌          | ✅       |
| `symbols+bytes` (e.g. "c8", "b1")                 | ❌      | ✅        |
| `abstracts` (e.g. "inexact", "integer")           | ✅       | ❌         |
| `numbers` (e.g. 1, 2, 3)                          |    ❌    | ✅         |
| `aliases` (e.g. "complex_", "longfloat")          | ✅       | ✅       |
| `extra/other aliases` (e.g. "bool")               | ❌     | ✅      |
| ...and there are just a few custom cases for both |          |            |

Additionally, here's a decomposition of `words` and `words+bits` into three columns (`/` symbol means that it may vary depending on 32 or 64-bit arch):

| Canonical Python API name | Python API "C-like" name | Actual C type                                    |
|---------------------------|--------------------------|--------------------------------------------------|
| bool                     |                          |                                                  |
| int8                      | byte                     | char                                             |
| uint8                     | ubyte                    | unsigned char                                    |
| int16                     | short                    | short                                            |
| uint16                    | ushort                   | unsigned short                                   |
| int32                    | intc              | int                                    |
| uint32                   | uintc             | unsigned int                     |
|  intp                   |           | long                                         |
|   uintp                 |          | unsigned long                                |
| int64                      |  longlong                        | longlong                          |
| uint64                     |  ulonglong                        | unsigned longlong |
| float16                   | half                     |                                                  |
| float32                   | single                   | float                                            |
| float64                   | double                   | double                                           |
| float128                  | longdouble               | long double                                      |
| complex64                 | csingle                  | complex float                                                 |
| complex128                | cdouble                  | complex double                                                 |
| complex256                | clongdouble              | complex long double                                                 |
| object_                   |                          |                                                  |
| bytes_                    |                          |                                                  |
| str_                      |                          |                                                  |
| void                      |                          | void                                             |
| datetime64                |                          |                                                  |
| timedelta64               |                          |                                                  |

In the refactored file I build each of these groups to then join them into final dicts. I do it in a loop in `def _build_dicts()`, where sized `int` & `uint` aliases must take under consideration a "priority" of types - in case at least two of them are same bitsize.  
After that I rename and add aliases to the created groups. In the last stage I clean entries that aren't present in the original implementation (these are custom cases).

The last, and separate, stage creates `sctypes` which I copied, as the implementation was clear to me.


Important to mention, this modifies a crucial piece of code that could be tricky to debug (e.g. canonical int names are aliased incorrectly on some architecture (I tested it locally only on macbook with Intel)).  
I renamed the old implementation to `_expired_type_aliases.py` and added a test `test_new_vs_expired_type_aliases` that checks if dictionaries created by the new implementation are **exactly the same** as done by the previous code. This should flag in the CI if the new implementation fails to mimic the previous one on a specific architecture. (After some time, the original impl could be completely removed)

Please share your feedback!