### PR TITLE
[BUG] Return value of use_hugepage in hugepage_setup

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -445,6 +445,7 @@ else:
             use_hugepage = 1
         else:
             use_hugepage = int(use_hugepage)
+        return use_hugepage
 
     # Note that this will currently only make a difference on Linux
     core.multiarray._set_madvise_hugepage(hugepage_setup())

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -438,8 +438,6 @@ else:
                     use_hugepage = 0
             except ValueError:
                 use_hugepage = 0
-            finally:
-                del kernel_version
         elif use_hugepage is None:
             # This is not Linux, so it should not matter, just enable anyway
             use_hugepage = 1


### PR DESCRIPTION
In #24316 the checks on hugepage settings in the numpy initialization have been refactored. It seems a return value was omitted.

@rgommers @mtsokol 

Comparison from the other PR:

https://github.com/numpy/numpy/pull/24316/files#diff-09a2c2e86cca91dac0c336e4dad47197ba3cd837ff6c85abf8525cc3b879d3e6R302