### PR TITLE
BLD: allow specifying the long double format to avoid the runtime check

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -380,7 +380,9 @@ endforeach
 # https://github.com/numpy/numpy/blob/eead09a3d02c09374942cdc787c0b5e4fe9e7472/numpy/core/setup_common.py#L264-L434
 # This port is in service of solving gh-23972
 # as well as https://github.com/mesonbuild/meson/issues/11068
-longdouble_format = meson.get_compiler('c').run(
+longdouble_format = meson.get_external_property('longdouble_format', 'UNKNOWN')
+if longdouble_format == 'UNKNOWN'
+  longdouble_format = meson.get_compiler('c').run(
 '''
 #include <stdio.h>
 #include <string.h>
@@ -459,7 +461,8 @@ int main(void) {
   }
   }
 }
-''').stdout()
+  ''').stdout()
+endif
 if longdouble_format == 'UNKNOWN' or longdouble_format == 'UNDEFINED'
   error('Unknown long double format of size: ' + cc.sizeof('long double').to_string())
 endif


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This builds towards the goal of being able to cross-build NumPy without requiring code
execution on the target environment, or an emulator thereof.

With this patch, setting the `longdouble_format` key on `properties` section of the
Meson cross file, will skip the runtime check.

Example:
```
[properties]
longdouble_format = 'IEEE_DOUBLE_LE'
```

It may be possible to rewrite the check to entirely skip the need of running code on the
target at build time, but I haven't looked into that at this point. That would be a possible
future improvement.