### PR TITLE
CI/BUG: add Python 3.12 CI job and fix `numpy.distutils` AttributeError

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -130,7 +130,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: '3.12-dev'
     - uses: ./.github/meson_actions
 
   with_baseline_only:

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -225,8 +225,10 @@ else:
     __numpy_submodules__ = {
         "linalg", "fft", "dtypes", "random", "polynomial", "ma", 
         "exceptions", "lib", "ctypeslib", "testing", "typing",
-        "array_api", "f2py", "distutils", "test"
+        "array_api", "f2py", "test"
     }
+    if sys.version_info < (3, 12):
+        __numpy_submodules__.add('distutils')
 
     # We build warning messages for former attributes
     _msg = (
@@ -325,8 +327,12 @@ else:
             import numpy.array_api as array_api
             return array_api
         elif attr == "distutils":
-            import numpy.distutils as distutils
-            return distutils
+            if 'distutils' in __numpy_submodules__:
+                import numpy.distutils as distutils
+                return distutils
+            else:
+                raise AttributeError("`numpy.distutils` is not available from "
+                                     "Python 3.12 onwards")
 
         if attr in __future_scalars__:
             # And future warnings for those that will change, but also give

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -213,6 +213,10 @@ class TestAsArray:
         # shape argument is required
         assert_raises(TypeError, as_array, p)
 
+    @pytest.mark.skipif(
+            sys.version_info[:2] == (3, 12),
+            reason="Broken in 3.12.0rc1, see gh-24399",
+    )
     def test_struct_array_pointer(self):
         from ctypes import c_int16, Structure, pointer
 

--- a/tools/check_installed_files.py
+++ b/tools/check_installed_files.py
@@ -74,6 +74,11 @@ def get_files(dir_to_check, kind='test'):
         relpath = os.path.relpath(path, dir_to_check)
         files[relpath] = path
 
+    if sys.version_info >= (3, 12):
+        files = {
+            k: v for k, v in files.items() if not k.startswith('distutils')
+        }
+
     return files
 
 


### PR DESCRIPTION
We did not have a regular CI job for Python 3.12, adding it means that we actually catch simple stuff like this next time around.

Closes gh-24417