### PR TITLE
MAINT: Remove unused variable `i`

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2131,7 +2131,6 @@ static PyObject *
     npy_@name@ frac;
 #endif
     int exponent;
-    int i;
 
     PyObject *py_exponent = NULL;
     PyObject *numerator = NULL;
@@ -2153,7 +2152,7 @@ static PyObject *
     frac = npy_frexp@c@(val, &exponent); /* val == frac * 2**exponent exactly */
 
     /* This relies on the floating point type being base 2 to converge */
-    for (i = 0; frac != npy_floor@c@(frac); i++) {
+    while (frac != npy_floor@c@(frac)) {
         frac *= 2.0;
         exponent--;
     }


### PR DESCRIPTION
This shows up in the wasm tests as a warning, not sure why only there.  Thought it was related to a CI failure.  That is probably not the case, but can't hurt.