### PR TITLE
CI: only run cirrus on commit to PR [skip actions]

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -48,4 +48,7 @@ def main(ctx):
     if wheel:
         return fs.read("tools/ci/cirrus_wheels.yml")
 
+    if pr_number < 0:
+        return []
+
     return fs.read("tools/ci/cirrus_macosx_arm64.yml")

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -48,7 +48,7 @@ def main(ctx):
     if wheel:
         return fs.read("tools/ci/cirrus_wheels.yml")
 
-    if pr_number < 0:
+    if int(pr_number) < 0:
         return []
 
     return fs.read("tools/ci/cirrus_macosx_arm64.yml")


### PR DESCRIPTION
This PR reduces cirrus ci usage by only allowing commit to PRs to start general CI. Merge commits won't trigger a run.