### PR TITLE
MAINT: revert adding `distutils` and `array_api` to `np.__all__`

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -220,15 +220,15 @@ else:
         asmatrix, bmat, mat, matrix
     )
 
-    # public submodules are imported lazily, 
-    # therefore are accessible from __getattr__
+    # public submodules are imported lazily, therefore are accessible from
+    # __getattr__. Note that `distutils` (deprecated) and `array_api`
+    # (experimental label) are not added here, because `from numpy import *`
+    # must not raise any warnings - that's too disruptive.
     __numpy_submodules__ = {
         "linalg", "fft", "dtypes", "random", "polynomial", "ma", 
         "exceptions", "lib", "ctypeslib", "testing", "typing",
-        "array_api", "f2py", "test"
+        "f2py", "test"
     }
-    if sys.version_info < (3, 12):
-        __numpy_submodules__.add('distutils')
 
     # We build warning messages for former attributes
     _msg = (
@@ -357,7 +357,7 @@ else:
         )
         public_symbols -= {
             "core", "matrixlib", "matlib", "tests", "conftest", "version", 
-            "compat"
+            "compat", "distutils", "array_api"
             }
         return list(public_symbols)
 


### PR DESCRIPTION
This has turned out to be too disruptive; `from numpy import *` has to remain warning-free and these two modules emit a warning on import rather than when they're actually used.

`array_api` we have to decide on for 2.0 (either remove the experimental warning or remove it), I'll open a separate issue to follow up on that, because it may take a bit of time to decide on that one.

For issues this caused, see for example:
- https://github.com/data-apis/array-api-compat/issues/53
- https://github.com/scipy/scipy/issues/19065

This was my fault by the way - I suggested including these modules in `__all__` and `__dir__` in gh-24357. All the other changes there are still fine.

Cc @pllim, @mroeschke, @mtsokol for info.