### PR TITLE
BUG: support masked arrays in `recfunctions.drop_fields`

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -528,12 +528,12 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
     >>> from numpy.lib import recfunctions as rfn
     >>> a = np.array([(1, (2, 3.0)), (4, (5, 6.0))],
     ...   dtype=[('a', np.int64), ('b', [('ba', np.double), ('bb', np.int64)])])
-    >>> rfn.drop_fields(a, 'a')
+    >>> rfn.drop_fields(a, 'a', usemask=False)
     array([((2., 3),), ((5., 6),)],
           dtype=[('b', [('ba', '<f8'), ('bb', '<i8')])])
-    >>> rfn.drop_fields(a, 'ba')
+    >>> rfn.drop_fields(a, 'ba', usemask=False)
     array([(1, (3,)), (4, (6,))], dtype=[('a', '<i8'), ('b', [('bb', '<i8')])])
-    >>> rfn.drop_fields(a, ['ba', 'bb'])
+    >>> rfn.drop_fields(a, ['ba', 'bb'], usemask=False)
     array([(1,), (4,)], dtype=[('a', '<i8')])
     """
     if _is_string_like(drop_names):
@@ -558,7 +558,7 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
 
     newdtype = _drop_descr(base.dtype, drop_names)
 
-    output = np.empty(base.shape, dtype=newdtype)
+    output = ma.masked_all(base.shape, dtype=newdtype)
     output = recursive_fill_fields(base, output)
     return _fix_output(output, usemask=usemask, asrecarray=asrecarray)
 

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -94,6 +94,16 @@ class TestRecFunctions:
         control = np.array([(), ()], dtype=[])
         assert_equal(test, control)
 
+        a = ma.array([(1, 2), (3, 4)],
+                     mask=[(0, 1), (1, 0)],
+                     dtype=[('a', int), ('b', int)])
+        control = ma.array([(1,), (3,)],
+                           mask=[(0,), (1,)],
+                           dtype=[('a', int)])
+        test = drop_fields(a, 'b')
+        assert_equal(test, control)
+        assert_equal(test.mask, control.mask)
+
     def test_rename_fields(self):
         # Test rename fields
         a = np.array([(1, (2, [3.0, 30.])), (4, (5, [6.0, 60.]))],


### PR DESCRIPTION
Unlike documented, `drop_fields` always ignored mask from input and returned `ndarray`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
