### PR TITLE
DOC: Fix reference warning for types-and-structures.rst.

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -534,8 +534,8 @@ PyArrayDescr_Type and PyArray_Descr
 
         These members are both pointers to functions to copy data from
         *src* to *dest* and *swap* if indicated. The value of arr is
-        only used for flexible ( :c:data:`NPY_STRING`, :c:data:`NPY_UNICODE`,
-        and :c:data:`NPY_VOID` ) arrays (and is obtained from
+        only used for flexible ( :c:enumerator:`~NPY_TYPES.NPY_STRING`, :c:enumerator:`~NPY_TYPES.NPY_UNICODE`,
+        and :c:enumerator:`~NPY_TYPES.NPY_VOID` ) arrays (and is obtained from
         ``arr->descr->elsize`` ). The second function copies a single
         value, while the first loops over n values with the provided
         strides. These functions can deal with misbehaved *src*
@@ -629,8 +629,8 @@ PyArrayDescr_Type and PyArray_Descr
 
         An array of function pointers to a particular sorting
         algorithms. A particular sorting algorithm is obtained using a
-        key (so far :c:data:`NPY_QUICKSORT`, :c:data:`NPY_HEAPSORT`,
-        and :c:data:`NPY_MERGESORT` are defined). These sorts are done
+        key (so far :c:enumerator:`~NPY_SORTKIND.NPY_QUICKSORT`, :c:enumerator:`~NPY_SORTKIND.NPY_HEAPSORT`,
+        and :c:enumerator:`~NPY_SORTKIND.NPY_MERGESORT` are defined). These sorts are done
         in-place assuming contiguous and aligned data.
 
     .. c:member:: int argsort( \
@@ -659,7 +659,7 @@ PyArrayDescr_Type and PyArray_Descr
 
     .. c:member:: int **cancastscalarkindto
 
-        Either ``NULL`` or an array of :c:type:`NPY_NSCALARKINDS`
+        Either ``NULL`` or an array of :c:enumerator:`~NPY_SCALARKIND.NPY_NSCALARKINDS`
         pointers. These pointers should each be either ``NULL`` or a
         pointer to an array of integers (terminated by
         :c:data:`NPY_NOTYPE`) indicating data-types that a scalar of


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix reference warning for the following part:
```
types-and-structures.rst:535: WARNING: c:data reference target not found: NPY_STRING
types-and-structures.rst:535: WARNING: c:data reference target not found: NPY_UNICODE
types-and-structures.rst:535: WARNING: c:data reference target not found: NPY_VOID
types-and-structures.rst:630: WARNING: c:data reference target not found: NPY_QUICKSORT
types-and-structures.rst:630: WARNING: c:data reference target not found: NPY_HEAPSORT
types-and-structures.rst:630: WARNING: c:data reference target not found: NPY_MERGESORT
types-and-structures.rst:662: WARNING: c:type reference target not found: NPY_NSCALARKINDS
```

There are two more warning in the types-and-structures.rst. One is:
```
types-and-structures.rst:579: WARNING: c:identifier reference target not found: FILE
```
This one is function parameter type `FILE` not found. I have tried, it seems that sphinx doesn't find it in the standard library.

Another one is:
```
types-and-structures.rst:904: WARNING: c:identifier reference target not found: PyUFunc_TypeResolutionFunc
```

The function parameter `PyUFunc_TypeResolutionFunc` is only defined in the ufuncobject.h. It can't be found in the documentation. I think it is why the warning is reported.


