### PR TITLE
CI: cirrus run linux_aarch64 first

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -13,7 +13,7 @@ def main(ctx):
     # Only test on the numpy/numpy repository
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "numpy/numpy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/numpy":
         return []
 
     # only run the wheels entry on a cron job
@@ -51,4 +51,4 @@ def main(ctx):
     if int(pr_number) < 0:
         return []
 
-    return fs.read("tools/ci/cirrus_macosx_arm64.yml")
+    return fs.read("tools/ci/cirrus_arm.yml")

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -13,7 +13,7 @@ def main(ctx):
     # Only test on the numpy/numpy repository
     ######################################################################
 
-    if env.get("CIRRUS_REPO_FULL_NAME") != "andyfaff/numpy":
+    if env.get("CIRRUS_REPO_FULL_NAME") != "numpy/numpy":
         return []
 
     # only run the wheels entry on a cron job

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -21,19 +21,75 @@ modified_clone: &MODIFIED_CLONE
     fi
 
 
+linux_aarch64_test_task:
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 1
+    memory: 4G
+
+  <<: *MODIFIED_CLONE
+
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-linux_aarch64
+
+  prepare_env_script: |
+    apt-get update
+    apt-get install -y --no-install-recommends software-properties-common gcc g++ gfortran pkg-config ccache
+    apt-get install -y --no-install-recommends python3.10 python3.10-venv libopenblas-dev libatlas-base-dev liblapack-dev
+
+    # python3.10 -m ensurepip --default-pip --user
+    ln -s $(which python3.10) python
+
+    # put ccache and python on PATH
+    export PATH=/usr/lib/ccache:$PWD:$PATH
+    echo "PATH=$PATH" >> $CIRRUS_ENV
+    echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
+
+    # required for figuring out the system tags in openblas_support
+    pip install packaging
+
+    pip install -r build_requirements.txt
+    pip install -r test_requirements.txt
+
+  build_script: |
+    spin build -- -Dallow-noblas=true
+
+  test_script: |
+    spin test -j 1
+    ccache -s
+
+
 macos_arm64_test_task:
+  depends_on:
+    - linux_aarch64_test
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
 
   <<: *MODIFIED_CLONE
 
+  ccache_cache:
+    folder: .ccache
+    populate_script:
+      - mkdir -p .ccache
+    fingerprint_key: ccache-macosx_arm64
+
   pip_cache:
     folder: ~/.cache/pip
 
   test_script: |
-    brew install python@3.10
+    brew install python@3.10 ccache
 
     export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
+    export CCACHE_DIR=$PWD/.ccache
+    echo "PATH=$PATH" >> $CIRRUS_ENV
+
     python --version
 
     RUNNER_OS="macOS"
@@ -55,3 +111,5 @@ macos_arm64_test_task:
     
     spin build -- -Dallow-noblas=true
     spin test -j auto
+
+    ccache -s


### PR DESCRIPTION
This PR:

- adds a linux_aarch64 test for cirrus CI.
- makes the macosx_arm64 test dependent on the linux_aarch64 test passing first.

The rationale is that the linux runs are a *lot* cheaper and can be done with single CPU. The macosx tests are more expensive and use four CPU. Price is related to computing power.

- ccache is added. The use of ccache can ~halve the linux_aarch64 runtime from 11:24 to 5:47.