### PR TITLE
DOC: Fix reference warning in Arrayterator and recfunctions.

### DIFF
--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -48,9 +48,10 @@ class Arrayterator:
 
     See Also
     --------
-    ndenumerate : Multidimensional array iterator.
-    flatiter : Flat array iterator.
-    memmap : Create a memory-map to an array stored in a binary file on disk.
+    numpy.ndenumerate : Multidimensional array iterator.
+    numpy.flatiter : Flat array iterator.
+    numpy.memmap : Create a memory-map to an array stored
+                   in a binary file on disk.
 
     Notes
     -----

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -956,8 +956,8 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     copy : bool, optional
         If true, always return a copy. If false, a view is returned if
         possible, such as when the `dtype` and strides of the fields are
-        suitable and the array subtype is one of `np.ndarray`, `np.recarray`
-        or `np.memmap`.
+        suitable and the array subtype is one of `numpy.ndarray`,
+        `numpy.recarray` or `numpy.memmap`.
 
         .. versionchanged:: 1.25.0
             A view can now be returned if the fields are separated by a


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix following reference warning:
```
numpy/lib/arrayterator.py:docstring of numpy.lib.arrayterator.Arrayterator:34: WARNING: py:obj reference target not found: ndenumerate
numpy/lib/arrayterator.py:docstring of numpy.lib.arrayterator.Arrayterator:36: WARNING: py:obj reference target not found: flatiter
numpy/lib/arrayterator.py:docstring of numpy.lib.arrayterator.Arrayterator:38: WARNING: py:obj reference target not found: memmap
numpy/lib/recfunctions.py:docstring of numpy.lib.recfunctions.structured_to_unstructured:21: WARNING: py:obj reference target not found: np.ndarray
numpy/lib/recfunctions.py:docstring of numpy.lib.recfunctions.structured_to_unstructured:21: WARNING: py:obj reference target not found: np.recarray
numpy/lib/recfunctions.py:docstring of numpy.lib.recfunctions.structured_to_unstructured:21: WARNING: py:obj reference target not found: np.memmap

```