### PR TITLE
API: Cleaning `numpy/__init__.py` and main namespace - Part 4 [NEP 52]

### DIFF
--- a/doc/release/upcoming_changes/24445.deprecation.rst
+++ b/doc/release/upcoming_changes/24445.deprecation.rst
@@ -1,0 +1,5 @@
+* ``np.trapz`` has been deprecated. Use ``scipy.interpolate.trapezoid`` instead.
+
+* ``np.in1d`` has been deprecated. Use ``np.isin`` instead.
+
+* Deprecated alias ``np.row_stack`` has been removed. Use ``np.vstack`` directly.

--- a/doc/release/upcoming_changes/24445.deprecation.rst
+++ b/doc/release/upcoming_changes/24445.deprecation.rst
@@ -2,4 +2,4 @@
 
 * ``np.in1d`` has been deprecated. Use ``np.isin`` instead.
 
-* Deprecated alias ``np.row_stack`` has been removed. Use ``np.vstack`` directly.
+* Alias ``np.row_stack`` has been deprecated. Use ``np.vstack`` directly.

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -72,7 +72,6 @@ Joining arrays
    hstack
    dstack
    column_stack
-   row_stack
 
 Splitting arrays
 ================

--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -145,7 +145,6 @@ Changing the number of dimensions
    ma.hstack
    ma.hsplit
    ma.mr_
-   ma.row_stack
    ma.vstack
 
 

--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -64,7 +64,6 @@ Sums, products, differences
    ediff1d
    gradient
    cross
-   trapz
 
 Exponents and logarithms
 ------------------------

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -767,14 +767,6 @@ It is equivalent to `hstack` only for 2D arrays::
     array([[4., 3.],
            [2., 8.]])
 
-On the other hand, the function `row_stack` is equivalent to `vstack`
-for any input arrays. In fact, `row_stack` is an alias for `vstack`::
-
-    >>> np.column_stack is np.hstack
-    False
-    >>> np.row_stack is np.vstack
-    True
-
 In general, for arrays with more than two dimensions,
 `hstack` stacks along their second
 axes, `vstack` stacks along their

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -68,5 +68,4 @@ __expired_attributes__ = {
     "nbytes": "Use `np.dtype(<dtype>).itemsize` instead.",
     "get_array_wrap": "",
     "DataSource": "It's still available as `np.lib.npyio.DataSource`.", 
-    "row_stack": "Use `np.vstack` instead.",
 }

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -68,4 +68,5 @@ __expired_attributes__ = {
     "nbytes": "Use `np.dtype(<dtype>).itemsize` instead.",
     "get_array_wrap": "",
     "DataSource": "It's still available as `np.lib.npyio.DataSource`.", 
+    "row_stack": "Use `np.vstack` instead.",
 }

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2241,8 +2241,6 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
 
     cumsum : Cumulative sum of array elements.
 
-    trapz : Integration of array values using the composite trapezoidal rule.
-
     mean, average
 
     Notes
@@ -2544,7 +2542,6 @@ def cumsum(a, axis=None, dtype=None, out=None):
     See Also
     --------
     sum : Sum array elements.
-    trapz : Integration of array values using the composite trapezoidal rule.
     diff : Calculate the n-th discrete difference along given axis.
 
     Notes

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -230,8 +230,6 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
     and r/g/b channels (third axis). The functions `concatenate`, `stack` and
     `block` provide more general stacking and concatenation operations.
 
-    ``np.row_stack`` is an alias for `vstack`. They are the same function.
-
     Parameters
     ----------
     tup : sequence of ndarrays

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -755,6 +755,7 @@ class TestLibImports(_DeprecationTestCase):
         from numpy.lib._shape_base_impl import get_array_wrap
         from numpy.core.numerictypes import maximum_sctype
         from numpy.lib.tests.test_io import TextIO
+        from numpy import in1d, row_stack, trapz
         
         self.assert_deprecated(lambda: safe_eval("None"))
 
@@ -766,3 +767,7 @@ class TestLibImports(_DeprecationTestCase):
         self.assert_deprecated(lambda: disp("test"))
         self.assert_deprecated(lambda: get_array_wrap())
         self.assert_deprecated(lambda: maximum_sctype(int))
+
+        self.assert_deprecated(lambda: in1d([1], [1]))
+        self.assert_deprecated(lambda: row_stack([[]]))
+        self.assert_deprecated(lambda: trapz([1], [1]))

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -737,24 +737,3 @@ def test_function_like():
     bound = np.mean.__get__(MyClass)  # classmethod
     with pytest.raises(TypeError, match="unsupported operand type"):
         bound()
-
-
-def test_scipy_trapz_support_shim():
-    # SciPy 1.10 and earlier "clone" trapz in this way, so we have a
-    # support shim in place: https://github.com/scipy/scipy/issues/17811
-    # That should be removed eventually.  This test copies what SciPy does.
-    # Hopefully removable 1 year after SciPy 1.11; shim added to NumPy 1.25.
-    import types
-    import functools
-
-    def _copy_func(f):
-        # Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)
-        g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
-                            argdefs=f.__defaults__, closure=f.__closure__)
-        g = functools.update_wrapper(g, f)
-        g.__kwdefaults__ = f.__kwdefaults__
-        return g
-
-    trapezoid = _copy_func(np.trapz)
-
-    assert np.trapz([1, 2]) == trapezoid([1, 2])

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -614,6 +614,10 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         stacklevel=2
     )
 
+    return _in1d(ar1, ar2, assume_unique, invert, kind=kind)
+
+
+def _in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     # Ravel both arrays, behavior for the first array could be different
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
@@ -882,13 +886,8 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
            [ True, False]])
     """
     element = np.asarray(element)
-    
-    # TODO: remove warning catch once `in1d` deprecation period passes
-    #       and import it as a private method.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        result = in1d(element, test_elements, assume_unique=assume_unique,
-                      invert=invert, kind=kind).reshape(element.shape)
+    result = _in1d(element, test_elements, assume_unique=assume_unique,
+                    invert=invert, kind=kind).reshape(element.shape)
     return result
 
 
@@ -969,9 +968,5 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     else:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
-    # TODO: remove warning catch once `in1d` deprecation period passes
-    #       and import it as a private method.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        result = ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
+    result = ar1[_in1d(ar1, ar2, assume_unique=True, invert=True)]
     return result

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -886,9 +886,8 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
            [ True, False]])
     """
     element = np.asarray(element)
-    result = _in1d(element, test_elements, assume_unique=assume_unique,
-                    invert=invert, kind=kind).reshape(element.shape)
-    return result
+    return _in1d(element, test_elements, assume_unique=assume_unique,
+                 invert=invert, kind=kind).reshape(element.shape)
 
 
 def _union1d_dispatcher(ar1, ar2):
@@ -968,5 +967,4 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     else:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
-    result = ar1[_in1d(ar1, ar2, assume_unique=True, invert=True)]
-    return result
+    return ar1[_in1d(ar1, ar2, assume_unique=True, invert=True)]

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -15,6 +15,7 @@ Original author: Robert Cimrman
 
 """
 import functools
+import warnings
 
 import numpy as np
 from numpy.core import overrides
@@ -518,10 +519,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     """
     Test whether each element of a 1-D array is also present in a second array.
 
+    .. deprecated:: 2.0
+        Use :func:`isin` instead of `in1d` for new code.
+
     Returns a boolean array the same length as `ar1` that is True
     where an element of `ar1` is in `ar2` and False otherwise.
-
-    We recommend using :func:`isin` instead of `in1d` for new code.
 
     Parameters
     ----------
@@ -604,6 +606,14 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     >>> test[mask]
     array([1, 5])
     """
+
+    # Deprecated in NumPy 2.0, 2023-08-18
+    warnings.warn(
+        "`in1d` is deprecated. Use `np.isin` instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     # Ravel both arrays, behavior for the first array could be different
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
@@ -805,10 +815,6 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
         Has the same shape as `element`. The values `element[isin]`
         are in `test_elements`.
 
-    See Also
-    --------
-    in1d                  : Flattened version of this function.
-
     Notes
     -----
 
@@ -876,8 +882,14 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
            [ True, False]])
     """
     element = np.asarray(element)
-    return in1d(element, test_elements, assume_unique=assume_unique,
-                invert=invert, kind=kind).reshape(element.shape)
+    
+    # TODO: remove warning catch once `in1d` deprecation period passes
+    #       and import it as a private method.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = in1d(element, test_elements, assume_unique=assume_unique,
+                      invert=invert, kind=kind).reshape(element.shape)
+    return result
 
 
 def _union1d_dispatcher(ar1, ar2):
@@ -957,4 +969,9 @@ def setdiff1d(ar1, ar2, assume_unique=False):
     else:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
-    return ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
+    # TODO: remove warning catch once `in1d` deprecation period passes
+    #       and import it as a private method.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = ar1[in1d(ar1, ar2, assume_unique=True, invert=True)]
+    return result

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4783,6 +4783,9 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     r"""
     Integrate along the given axis using the composite trapezoidal rule.
 
+    .. deprecated:: 2.0
+        Use `scipy.integrate.trapezoid` instead.
+
     If `x` is provided, the integration happens in sequence along its
     elements - they are not sorted.
 
@@ -4880,6 +4883,14 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     >>> np.trapz(a, axis=1)
     array([2.,  8.])
     """
+
+    # Deprecated in NumPy 2.0, 2023-08-18
+    warnings.warn(
+        "`trapz` is deprecated. Use `scipy.integrate.trapezoid` instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     y = asanyarray(y)
     if x is None:
         d = dx

--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -604,7 +604,19 @@ def expand_dims(a, axis):
     return a.reshape(shape)
 
 
-row_stack = vstack
+# TODO: Remove once deprecation period passes
+def row_stack(tup, *, dtype=None, casting="same_kind"):
+    # Deprecated in NumPy 2.0, 2023-08-18
+    warnings.warn(
+        "`row_stack` alias is deprecated. "
+        "Use `np.vstack` directly.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return vstack(tup, dtype=dtype, casting=casting)
+
+
+row_stack.__doc__ = vstack.__doc__
 
 
 def _column_stack_dispatcher(tup):

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from numpy import (
-    ediff1d, intersect1d, setxor1d, union1d, setdiff1d, unique, in1d, isin
+    ediff1d, intersect1d, setxor1d, union1d, setdiff1d, unique, isin
     )
 from numpy.exceptions import AxisError
 from numpy.testing import (assert_array_equal, assert_equal,
@@ -198,8 +198,8 @@ class TestSetOps:
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_isin(self, kind):
-        # the tests for in1d cover most of isin's behavior
-        # if in1d is removed, would need to change those tests to test
+        # the tests for isin cover most of isin's behavior
+        # if isin is removed, would need to change those tests to test
         # isin instead.
         def _isin_slow(a, b):
             b = np.asarray(b).flatten().tolist()
@@ -258,86 +258,86 @@ class TestSetOps:
             assert_isin_equal(empty_array, empty_array)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d(self, kind):
+    def test_isin(self, kind):
         # we use two different sizes for the b array here to test the
-        # two different paths in in1d().
+        # two different paths in isin().
         for mult in (1, 10):
             # One check without np.array to make sure lists are handled correct
             a = [5, 7, 1, 2]
             b = [2, 4, 3, 1, 5] * mult
             ec = np.array([True, False, True, True])
-            c = in1d(a, b, assume_unique=True, kind=kind)
+            c = isin(a, b, assume_unique=True, kind=kind)
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
-            c = in1d(a, b, assume_unique=True, kind=kind)
+            c = isin(a, b, assume_unique=True, kind=kind)
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
-            c = in1d(a, b, assume_unique=True, kind=kind)
+            c = isin(a, b, assume_unique=True, kind=kind)
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
             b = [2, 3, 4] * mult
             ec = [False, True, False, True, True, True, True, True, True,
                   False, True, False, False, False]
-            c = in1d(a, b, kind=kind)
+            c = isin(a, b, kind=kind)
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
             ec = [True, True, True, True, True, True, True, True, True, True,
                   True, False, True, True]
-            c = in1d(a, b, kind=kind)
+            c = isin(a, b, kind=kind)
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
             b = np.array([2, 4, 3, 1, 5] * mult)
             ec = np.array([True, False, True, True])
-            c = in1d(a, b, kind=kind)
+            c = isin(a, b, kind=kind)
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
             b = np.array([2, 4, 3, 3, 1, 5] * mult)
             ec = np.array([True, False, True, True, True])
-            c = in1d(a, b, kind=kind)
+            c = isin(a, b, kind=kind)
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
             b = np.array([2, 2] * mult)
             ec = np.array([False, False])
-            c = in1d(a, b, kind=kind)
+            c = isin(a, b, kind=kind)
             assert_array_equal(c, ec)
 
         a = np.array([5])
         b = np.array([2])
         ec = np.array([False])
-        c = in1d(a, b, kind=kind)
+        c = isin(a, b, kind=kind)
         assert_array_equal(c, ec)
 
         if kind in {None, "sort"}:
-            assert_array_equal(in1d([], [], kind=kind), [])
+            assert_array_equal(isin([], [], kind=kind), [])
 
-    def test_in1d_char_array(self):
+    def test_isin_char_array(self):
         a = np.array(['a', 'b', 'c', 'd', 'e', 'c', 'e', 'b'])
         b = np.array(['a', 'c'])
 
         ec = np.array([True, False, True, False, False, True, False, False])
-        c = in1d(a, b)
+        c = isin(a, b)
 
         assert_array_equal(c, ec)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d_invert(self, kind):
-        "Test in1d's invert parameter"
+    def test_isin_invert(self, kind):
+        "Test isin's invert parameter"
         # We use two different sizes for the b array here to test the
-        # two different paths in in1d().
+        # two different paths in isin().
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
             b = [2, 3, 4] * mult
-            assert_array_equal(np.invert(in1d(a, b, kind=kind)),
-                               in1d(a, b, invert=True, kind=kind))
+            assert_array_equal(np.invert(isin(a, b, kind=kind)),
+                               isin(a, b, invert=True, kind=kind))
 
         # float:
         if kind in {None, "sort"}:
@@ -346,74 +346,53 @@ class TestSetOps:
                             dtype=np.float32)
                 b = [2, 3, 4] * mult
                 b = np.array(b, dtype=np.float32)
-                assert_array_equal(np.invert(in1d(a, b, kind=kind)),
-                                   in1d(a, b, invert=True, kind=kind))
+                assert_array_equal(np.invert(isin(a, b, kind=kind)),
+                                   isin(a, b, invert=True, kind=kind))
 
-    @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d_ravel(self, kind):
-        # Test that in1d ravels its input arrays. This is not documented
-        # behavior however. The test is to ensure consistentency.
-        a = np.arange(6).reshape(2, 3)
-        b = np.arange(3, 9).reshape(3, 2)
-        long_b = np.arange(3, 63).reshape(30, 2)
-        ec = np.array([False, False, False, True, True, True])
-
-        assert_array_equal(in1d(a, b, assume_unique=True, kind=kind),
-                           ec)
-        assert_array_equal(in1d(a, b, assume_unique=False,
-                                kind=kind),
-                           ec)
-        assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                kind=kind),
-                           ec)
-        assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                kind=kind),
-                           ec)
-
-    def test_in1d_hit_alternate_algorithm(self):
+    def test_isin_hit_alternate_algorithm(self):
         """Hit the standard isin code with integers"""
         # Need extreme range to hit standard code
         # This hits it without the use of kind='table'
         a = np.array([5, 4, 5, 3, 4, 4, 1e9], dtype=np.int64)
         b = np.array([2, 3, 4, 1e9], dtype=np.int64)
         expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=bool)
-        assert_array_equal(expected, in1d(a, b))
-        assert_array_equal(np.invert(expected), in1d(a, b, invert=True))
+        assert_array_equal(expected, isin(a, b))
+        assert_array_equal(np.invert(expected), isin(a, b, invert=True))
 
         a = np.array([5, 7, 1, 2], dtype=np.int64)
         b = np.array([2, 4, 3, 1, 5, 1e9], dtype=np.int64)
         ec = np.array([True, False, True, True])
-        c = in1d(a, b, assume_unique=True)
+        c = isin(a, b, assume_unique=True)
         assert_array_equal(c, ec)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d_boolean(self, kind):
-        """Test that in1d works for boolean input"""
+    def test_isin_boolean(self, kind):
+        """Test that isin works for boolean input"""
         a = np.array([True, False])
         b = np.array([False, False, False])
         expected = np.array([False, True])
         assert_array_equal(expected,
-                           in1d(a, b, kind=kind))
+                           isin(a, b, kind=kind))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, kind=kind))
+                           isin(a, b, invert=True, kind=kind))
 
     @pytest.mark.parametrize("kind", [None, "sort"])
-    def test_in1d_timedelta(self, kind):
-        """Test that in1d works for timedelta input"""
+    def test_isin_timedelta(self, kind):
+        """Test that isin works for timedelta input"""
         rstate = np.random.RandomState(0)
         a = rstate.randint(0, 100, size=10)
         b = rstate.randint(0, 100, size=10)
-        truth = in1d(a, b)
+        truth = isin(a, b)
         a_timedelta = a.astype("timedelta64[s]")
         b_timedelta = b.astype("timedelta64[s]")
-        assert_array_equal(truth, in1d(a_timedelta, b_timedelta, kind=kind))
+        assert_array_equal(truth, isin(a_timedelta, b_timedelta, kind=kind))
 
-    def test_in1d_table_timedelta_fails(self):
+    def test_isin_table_timedelta_fails(self):
         a = np.array([0, 1, 2], dtype="timedelta64[s]")
         b = a
         # Make sure it raises a value error:
         with pytest.raises(ValueError):
-            in1d(a, b, kind="table")
+            isin(a, b, kind="table")
 
     @pytest.mark.parametrize(
         "dtype1,dtype2",
@@ -427,8 +406,8 @@ class TestSetOps:
         ]
     )
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d_mixed_dtype(self, dtype1, dtype2, kind):
-        """Test that in1d works as expected for mixed dtype input."""
+    def test_isin_mixed_dtype(self, dtype1, dtype2, kind):
+        """Test that isin works as expected for mixed dtype input."""
         is_dtype2_signed = np.issubdtype(dtype2, np.signedinteger)
         ar1 = np.array([0, 0, 1, 1], dtype=dtype1)
 
@@ -446,61 +425,61 @@ class TestSetOps:
 
         if expect_failure:
             with pytest.raises(RuntimeError, match="exceed the maximum"):
-                in1d(ar1, ar2, kind=kind)
+                isin(ar1, ar2, kind=kind)
         else:
-            assert_array_equal(in1d(ar1, ar2, kind=kind), expected)
+            assert_array_equal(isin(ar1, ar2, kind=kind), expected)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
-    def test_in1d_mixed_boolean(self, kind):
-        """Test that in1d works as expected for bool/int input."""
+    def test_isin_mixed_boolean(self, kind):
+        """Test that isin works as expected for bool/int input."""
         for dtype in np.typecodes["AllInteger"]:
             a = np.array([True, False, False], dtype=bool)
             b = np.array([0, 0, 0, 0], dtype=dtype)
             expected = np.array([False, True, True], dtype=bool)
-            assert_array_equal(in1d(a, b, kind=kind), expected)
+            assert_array_equal(isin(a, b, kind=kind), expected)
 
             a, b = b, a
             expected = np.array([True, True, True, True], dtype=bool)
-            assert_array_equal(in1d(a, b, kind=kind), expected)
+            assert_array_equal(isin(a, b, kind=kind), expected)
 
-    def test_in1d_first_array_is_object(self):
+    def test_isin_first_array_is_object(self):
         ar1 = [None]
         ar2 = np.array([1]*10)
         expected = np.array([False])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
 
-    def test_in1d_second_array_is_object(self):
+    def test_isin_second_array_is_object(self):
         ar1 = 1
         ar2 = np.array([None]*10)
         expected = np.array([False])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
 
-    def test_in1d_both_arrays_are_object(self):
+    def test_isin_both_arrays_are_object(self):
         ar1 = [None]
         ar2 = np.array([None]*10)
         expected = np.array([True])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
 
-    def test_in1d_both_arrays_have_structured_dtype(self):
+    def test_isin_both_arrays_have_structured_dtype(self):
         # Test arrays of a structured data type containing an integer field
         # and a field of dtype `object` allowing for arbitrary Python objects
         dt = np.dtype([('field1', int), ('field2', object)])
         ar1 = np.array([(1, None)], dtype=dt)
         ar2 = np.array([(1, None)]*10, dtype=dt)
         expected = np.array([True])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
 
-    def test_in1d_with_arrays_containing_tuples(self):
+    def test_isin_with_arrays_containing_tuples(self):
         ar1 = np.array([(1,), 2], dtype=object)
         ar2 = np.array([(1,), 2], dtype=object)
         expected = np.array([True, True])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
-        result = np.in1d(ar1, ar2, invert=True)
+        result = np.isin(ar1, ar2, invert=True)
         assert_array_equal(result, np.invert(expected))
 
         # An integer is added at the end of the array to make sure
@@ -513,32 +492,32 @@ class TestSetOps:
         ar2 = np.array([(1,), (2, 1), 1], dtype=object)
         ar2 = ar2[:-1]
         expected = np.array([True, True])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
-        result = np.in1d(ar1, ar2, invert=True)
+        result = np.isin(ar1, ar2, invert=True)
         assert_array_equal(result, np.invert(expected))
 
         ar1 = np.array([(1,), (2, 3), 1], dtype=object)
         ar1 = ar1[:-1]
         ar2 = np.array([(1,), 2], dtype=object)
         expected = np.array([True, False])
-        result = np.in1d(ar1, ar2)
+        result = np.isin(ar1, ar2)
         assert_array_equal(result, expected)
-        result = np.in1d(ar1, ar2, invert=True)
+        result = np.isin(ar1, ar2, invert=True)
         assert_array_equal(result, np.invert(expected))
 
-    def test_in1d_errors(self):
-        """Test that in1d raises expected errors."""
+    def test_isin_errors(self):
+        """Test that isin raises expected errors."""
 
         # Error 1: `kind` is not one of 'sort' 'table' or None.
         ar1 = np.array([1, 2, 3, 4, 5])
         ar2 = np.array([2, 4, 6, 8, 10])
-        assert_raises(ValueError, in1d, ar1, ar2, kind='quicksort')
+        assert_raises(ValueError, isin, ar1, ar2, kind='quicksort')
 
         # Error 2: `kind="table"` does not work for non-integral arrays.
         obj_ar1 = np.array([1, 'a', 3, 'b', 5], dtype=object)
         obj_ar2 = np.array([1, 'a', 3, 'b', 5], dtype=object)
-        assert_raises(ValueError, in1d, obj_ar1, obj_ar2, kind='table')
+        assert_raises(ValueError, isin, obj_ar1, obj_ar2, kind='table')
 
         for dtype in [np.int32, np.int64]:
             ar1 = np.array([-1, 2, 3, 4, 5], dtype=dtype)
@@ -550,15 +529,15 @@ class TestSetOps:
             #  range of ar2
             assert_raises(
                 RuntimeError,
-                in1d, ar1, overflow_ar2, kind='table'
+                isin, ar1, overflow_ar2, kind='table'
             )
 
             # Non-error: `kind=None` will *not* trigger a runtime error
             #  if there is an integer overflow, it will switch to
             #  the `sort` algorithm.
-            result = np.in1d(ar1, overflow_ar2, kind=None)
+            result = np.isin(ar1, overflow_ar2, kind=None)
             assert_array_equal(result, [True] + [False] * 4)
-            result = np.in1d(ar1, overflow_ar2, kind='sort')
+            result = np.isin(ar1, overflow_ar2, kind='sort')
             assert_array_equal(result, [True] + [False] * 4)
 
     def test_union1d(self):

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -198,9 +198,6 @@ class TestSetOps:
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_isin(self, kind):
-        # the tests for isin cover most of isin's behavior
-        # if isin is removed, would need to change those tests to test
-        # isin instead.
         def _isin_slow(a, b):
             b = np.asarray(b).flatten().tolist()
             return a in b

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2114,68 +2114,6 @@ class TestFilterwindows:
             assert_almost_equal(np.sum(w, axis=0), 10, 15)
 
 
-class TestTrapz:
-
-    def test_simple(self):
-        x = np.arange(-10, 10, .1)
-        r = trapz(np.exp(-.5 * x ** 2) / np.sqrt(2 * np.pi), dx=0.1)
-        # check integral of normal equals 1
-        assert_almost_equal(r, 1, 7)
-
-    def test_ndim(self):
-        x = np.linspace(0, 1, 3)
-        y = np.linspace(0, 2, 8)
-        z = np.linspace(0, 3, 13)
-
-        wx = np.ones_like(x) * (x[1] - x[0])
-        wx[0] /= 2
-        wx[-1] /= 2
-        wy = np.ones_like(y) * (y[1] - y[0])
-        wy[0] /= 2
-        wy[-1] /= 2
-        wz = np.ones_like(z) * (z[1] - z[0])
-        wz[0] /= 2
-        wz[-1] /= 2
-
-        q = x[:, None, None] + y[None,:, None] + z[None, None,:]
-
-        qx = (q * wx[:, None, None]).sum(axis=0)
-        qy = (q * wy[None, :, None]).sum(axis=1)
-        qz = (q * wz[None, None, :]).sum(axis=2)
-
-        # n-d `x`
-        r = trapz(q, x=x[:, None, None], axis=0)
-        assert_almost_equal(r, qx)
-        r = trapz(q, x=y[None,:, None], axis=1)
-        assert_almost_equal(r, qy)
-        r = trapz(q, x=z[None, None,:], axis=2)
-        assert_almost_equal(r, qz)
-
-        # 1-d `x`
-        r = trapz(q, x=x, axis=0)
-        assert_almost_equal(r, qx)
-        r = trapz(q, x=y, axis=1)
-        assert_almost_equal(r, qy)
-        r = trapz(q, x=z, axis=2)
-        assert_almost_equal(r, qz)
-
-    def test_masked(self):
-        # Testing that masked arrays behave as if the function is 0 where
-        # masked
-        x = np.arange(5)
-        y = x * x
-        mask = x == 2
-        ym = np.ma.array(y, mask=mask)
-        r = 13.0  # sum(0.5 * (0 + 1) * 1.0 + 0.5 * (9 + 16))
-        assert_almost_equal(trapz(ym, x), r)
-
-        xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapz(ym, xm), r)
-
-        xm = np.ma.array(x, mask=mask)
-        assert_almost_equal(trapz(y, xm), r)
-
-
 class TestSinc:
 
     def test_simple(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2114,6 +2114,69 @@ class TestFilterwindows:
             assert_almost_equal(np.sum(w, axis=0), 10, 15)
 
 
+@pytest.mark.filterwarnings('ignore:.*trapz.*:DeprecationWarning')
+class TestTrapz:
+
+    def test_simple(self):
+        x = np.arange(-10, 10, .1)
+        r = trapz(np.exp(-.5 * x ** 2) / np.sqrt(2 * np.pi), dx=0.1)
+        # check integral of normal equals 1
+        assert_almost_equal(r, 1, 7)
+
+    def test_ndim(self):
+        x = np.linspace(0, 1, 3)
+        y = np.linspace(0, 2, 8)
+        z = np.linspace(0, 3, 13)
+
+        wx = np.ones_like(x) * (x[1] - x[0])
+        wx[0] /= 2
+        wx[-1] /= 2
+        wy = np.ones_like(y) * (y[1] - y[0])
+        wy[0] /= 2
+        wy[-1] /= 2
+        wz = np.ones_like(z) * (z[1] - z[0])
+        wz[0] /= 2
+        wz[-1] /= 2
+
+        q = x[:, None, None] + y[None,:, None] + z[None, None,:]
+
+        qx = (q * wx[:, None, None]).sum(axis=0)
+        qy = (q * wy[None, :, None]).sum(axis=1)
+        qz = (q * wz[None, None, :]).sum(axis=2)
+
+        # n-d `x`
+        r = trapz(q, x=x[:, None, None], axis=0)
+        assert_almost_equal(r, qx)
+        r = trapz(q, x=y[None,:, None], axis=1)
+        assert_almost_equal(r, qy)
+        r = trapz(q, x=z[None, None,:], axis=2)
+        assert_almost_equal(r, qz)
+
+        # 1-d `x`
+        r = trapz(q, x=x, axis=0)
+        assert_almost_equal(r, qx)
+        r = trapz(q, x=y, axis=1)
+        assert_almost_equal(r, qy)
+        r = trapz(q, x=z, axis=2)
+        assert_almost_equal(r, qz)
+
+    def test_masked(self):
+        # Testing that masked arrays behave as if the function is 0 where
+        # masked
+        x = np.arange(5)
+        y = x * x
+        mask = x == 2
+        ym = np.ma.array(y, mask=mask)
+        r = 13.0  # sum(0.5 * (0 + 1) * 1.0 + 0.5 * (9 + 16))
+        assert_almost_equal(trapz(ym, x), r)
+
+        xm = np.ma.array(x, mask=mask)
+        assert_almost_equal(trapz(ym, xm), r)
+
+        xm = np.ma.array(x, mask=mask)
+        assert_almost_equal(trapz(y, xm), r)
+
+
 class TestSinc:
 
     def test_simple(self):

--- a/numpy/matrixlib/tests/test_interaction.py
+++ b/numpy/matrixlib/tests/test_interaction.py
@@ -241,15 +241,15 @@ def test_average_matrix():
     assert_equal(r, [[2.5, 10.0/3]])
 
 
-def test_trapz_matrix():
+def test_dot_matrix():
     # Test to make sure matrices give the same answer as ndarrays
     # 2018-04-29: moved here from core.tests.test_function_base.
     x = np.linspace(0, 5)
-    y = x * x
-    r = np.trapz(y, x)
+    y = np.linspace(-5, 0)
     mx = np.matrix(x)
     my = np.matrix(y)
-    mr = np.trapz(my, mx)
+    r = np.dot(x, y)
+    mr = np.dot(mx, my.T)
     assert_almost_equal(mr, r)
 
 

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -36,6 +36,7 @@ def test_numpy_namespace():
     undocumented = {
         'compare_chararrays': 'numpy.core._multiarray_umath.compare_chararrays',
         'show_config': 'numpy.__config__.show',
+        'row_stack': 'numpy.lib._shape_base_impl.row_stack'
     }
     # We override dir to not show these members
     allowlist = undocumented

--- a/numpy/typing/tests/data/reveal/arraysetops.pyi
+++ b/numpy/typing/tests/data/reveal/arraysetops.pyi
@@ -32,11 +32,6 @@ assert_type(np.setxor1d(AR_i8, AR_i8), npt.NDArray[np.int64])
 assert_type(np.setxor1d(AR_M, AR_M, assume_unique=True), npt.NDArray[np.datetime64])
 assert_type(np.setxor1d(AR_f8, AR_i8), npt.NDArray[Any])
 
-assert_type(np.in1d(AR_i8, AR_i8), npt.NDArray[np.bool_])
-assert_type(np.in1d(AR_M, AR_M, assume_unique=True), npt.NDArray[np.bool_])
-assert_type(np.in1d(AR_f8, AR_i8), npt.NDArray[np.bool_])
-assert_type(np.in1d(AR_f8, AR_LIKE_f8, invert=True), npt.NDArray[np.bool_])
-
 assert_type(np.isin(AR_i8, AR_i8), npt.NDArray[np.bool_])
 assert_type(np.isin(AR_M, AR_M, assume_unique=True), npt.NDArray[np.bool_])
 assert_type(np.isin(AR_f8, AR_i8), npt.NDArray[np.bool_])

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -32,9 +32,6 @@ assert_type(np.column_stack([AR_LIKE_f8]), npt.NDArray[Any])
 assert_type(np.dstack([AR_i8]), npt.NDArray[np.int64])
 assert_type(np.dstack([AR_LIKE_f8]), npt.NDArray[Any])
 
-assert_type(np.row_stack([AR_i8]), npt.NDArray[np.int64])
-assert_type(np.row_stack([AR_LIKE_f8]), npt.NDArray[Any])
-
 assert_type(np.array_split(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.array_split(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
 


### PR DESCRIPTION
~~Follow-up PR after https://github.com/numpy/numpy/pull/24376 is merged.~~ Can be merged independently. 
Relevant issue: https://github.com/numpy/numpy/issues/24306. 

Scope of the PR:
- Deprecate `row_stack` (an alias for `vstack`) to be removed completely in 2.0
- Deprecate `trapz` in favor of `scipy.interpolate.trapezoid` (`scipy` uses `trapz` implementation, therefore it must be moved there)
- Deprecate `in1d` (instead use `isin`) and make `in1d` private in 2.0
