### PR TITLE
ENH: Add endpoint argument to np.digitize

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5714,16 +5714,16 @@ def digitize(x, bins, right=False, endpoint=False):
         if right:
             if mono > 0:
                 # include the left edge in the first bin.
-                indices[(indices == 0) & (x == bins[0])] += 1
+                indices[x == bins[0]] = 1
             else:
                 # include the right edge in the first bin.
-                indices[(indices == 2) & (x == bins[1])] -= 1
+                indices[x == bins[1]] = 1
         else:
             if mono > 0:
                 # include the right edge in the last bin.
-                indices[(indices == n_bins) & (x == bins[-1])] -= 1
+                indices[x == bins[-1]] = n_bins - 1
             else:
                 # include the left edge in the last bin.
-                indices[(indices == n_bins - 2) & (x == bins[-2])] += 1
+                indices[x == bins[-2]] = n_bins - 1
 
     return indices

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -5592,12 +5592,12 @@ def append(arr, values, axis=None):
     return concatenate((arr, values), axis=axis)
 
 
-def _digitize_dispatcher(x, bins, right=None):
+def _digitize_dispatcher(x, bins, right=None, endpoint=None):
     return (x, bins)
 
 
 @array_function_dispatch(_digitize_dispatcher)
-def digitize(x, bins, right=False):
+def digitize(x, bins, right=False, endpoint=False):
     """
     Return the indices of the bins to which each value in input array belongs.
 
@@ -5626,6 +5626,9 @@ def digitize(x, bins, right=False):
         does not include the right edge. The left bin end is open in this
         case, i.e., bins[i-1] <= x < bins[i] is the default behavior for
         monotonically increasing bins.
+    endpoint : bool, optional
+        Indicating whether the last bin (if right==False) or the first one
+        (if right==True) include both edges.
 
     Returns
     -------
@@ -5689,6 +5692,7 @@ def digitize(x, bins, right=False):
     """
     x = _nx.asarray(x)
     bins = _nx.asarray(bins)
+    n_bins = len(bins)
 
     # here for compatibility, searchsorted below is happy to take this
     if np.issubdtype(x.dtype, _nx.complexfloating):
@@ -5702,6 +5706,24 @@ def digitize(x, bins, right=False):
     side = 'left' if right else 'right'
     if mono == -1:
         # reverse the bins, and invert the results
-        return len(bins) - _nx.searchsorted(bins[::-1], x, side=side)
+        indices = n_bins - _nx.searchsorted(bins[::-1], x, side=side)
     else:
-        return _nx.searchsorted(bins, x, side=side)
+        indices = _nx.searchsorted(bins, x, side=side)
+
+    if endpoint:
+        if right:
+            if mono > 0:
+                # include the left edge in the first bin.
+                indices[(indices == 0) & (x == bins[0])] += 1
+            else:
+                # include the right edge in the first bin.
+                indices[(indices == 2) & (x == bins[1])] -= 1
+        else:
+            if mono > 0:
+                # include the right edge in the last bin.
+                indices[(indices == n_bins) & (x == bins[-1])] -= 1
+            else:
+                # include the left edge in the last bin.
+                indices[(indices == n_bins - 2) & (x == bins[-2])] += 1
+
+    return indices

--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -683,10 +683,12 @@ def digitize(
     x: _FloatLike_co,
     bins: _ArrayLikeFloat_co,
     right: bool = ...,
+    endpoint: bool = ...,
 ) -> intp: ...
 @overload
 def digitize(
     x: _ArrayLikeFloat_co,
     bins: _ArrayLikeFloat_co,
     right: bool = ...,
+    endpoint: bool = ...,
 ) -> NDArray[intp]: ...

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1978,14 +1978,18 @@ class TestDigitize:
     def test_endpoint(self):
         x = np.arange(-3, 4)
         bins = [-2, 0, 2]
-        assert_array_equal(digitize(x, bins, False, True), [0, 1, 1, 2, 2, 2, 3])
-        assert_array_equal(digitize(x, bins, True, True), [0, 1, 1, 1, 2, 2, 3])
+        answer = [0, 1, 1, 2, 2, 2, 3]
+        assert_array_equal(digitize(x, bins, False, True), answer)
+        answer = [0, 1, 1, 1, 2, 2, 3]
+        assert_array_equal(digitize(x, bins, True, True), answer)
 
     def test_endpoint_decreasing(self):
         x = np.arange(3, -4, -1)
         bins = [2, 0, -2]
-        assert_array_equal(digitize(x, bins, False, True), [0, 0, 1, 2, 2, 2, 3])
-        assert_array_equal(digitize(x, bins, True, True), [0, 1, 1, 1, 2, 3, 3])
+        answer = [0, 0, 1, 2, 2, 2, 3]
+        assert_array_equal(digitize(x, bins, False, True), answer)
+        answer = [0, 1, 1, 1, 2, 3, 3]
+        assert_array_equal(digitize(x, bins, True, True), answer)
 
 
 class TestUnwrap:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1975,6 +1975,18 @@ class TestDigitize:
         x = 2**54  # loses precision in a float
         assert_equal(np.digitize(x, [x + 1, x - 1]), 1)
 
+    def test_endpoint(self):
+        x = np.arange(-3, 4)
+        bins = [-2, 0, 2]
+        assert_array_equal(digitize(x, bins, False, True), [0, 1, 1, 2, 2, 2, 3])
+        assert_array_equal(digitize(x, bins, True, True), [0, 1, 1, 1, 2, 2, 3])
+
+    def test_endpoint_decreasing(self):
+        x = np.arange(3, -4, -1)
+        bins = [2, 0, -2]
+        assert_array_equal(digitize(x, bins, False, True), [0, 0, 1, 2, 2, 2, 3])
+        assert_array_equal(digitize(x, bins, True, True), [0, 1, 1, 1, 2, 3, 3])
+
 
 class TestUnwrap:
 


### PR DESCRIPTION
Make the function slightly more useful by allowing the user to specify whether the first/last bin includes both edges.
This way the function behavior aligns more closely to the one of np.histogram while retaining the half-open default.

The logic is a bit hairy because of the interaction with the `right` parameter and the ascending/descending monotonicity of the bins, suggestions welcome.

Documentation could be better, again suggestions are more than welcome.

Closes #4217