### PR TITLE
Avoid spurious double cast in _monotonicity

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -251,7 +251,7 @@ arr__monotonicity(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     }
 
     if (PyArray_DESCR(array)->f->compare == NULL) {
-        PyErr_SetString(PyExc_TypeError,
+        PyErr_Format(PyExc_TypeError,
                         "dtype %S does not have compare function", array);
         Py_DECREF(array);
         return NULL;

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -252,9 +252,9 @@ arr__monotonicity(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
 
     if (PyArray_DESCR(array)->f->compare == NULL) {
         PyErr_SetString(PyExc_TypeError,
-                        "type does not have compare function");
+                        "dtype %S does not have compare function", array);
         Py_DECREF(array);
-        return -1;
+        return NULL;
     }
 
     assert(PyArray_TRIVIALLY_ITERABLE(array));

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5653,6 +5653,8 @@ def digitize(x, bins, right=False):
     # here for compatibility, searchsorted below is happy to take this
     if np.issubdtype(x.dtype, _nx.complexfloating):
         raise TypeError("x may not be complex")
+    if np.issubdtype(bins.dtype, _nx.complexfloating):
+        raise TypeError("bins may not be complex")
 
     mono = _monotonicity(bins)
     if mono == 0:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1967,8 +1967,6 @@ class TestDigitize:
         x = 2**54  # loses precision in a float
         assert_equal(np.digitize(x, [x - 1, x + 1]), 1)
 
-    @pytest.mark.xfail(
-        reason="gh-11022: np.core.multiarray._monoticity loses precision")
     def test_large_integers_decreasing(self):
         # gh-11022
         x = 2**54  # loses precision in a float


### PR DESCRIPTION
Rewrite the underlying C implementation of the monotonicity check in a generic fashion, allowing the use on arrays with comparable types.

Closes #11022

cc @eric-wieser 