### PR TITLE
ENH: Add prefix to _ALIGN Macro

### DIFF
--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1938,7 +1938,7 @@ get_struct_alignments(PyObject *NPY_UNUSED(self), PyObject *args) {
 /**begin repeat
  * #N = 1,2,3#
  */
-    alignment = PyLong_FromLong(_ALIGN(struct TestStruct@N@));
+    alignment = PyLong_FromLong(NPY_ALIGNOF(struct TestStruct@N@));
     size = PyLong_FromLong(sizeof(struct TestStruct@N@));
     val = PyTuple_Pack(2, alignment, size);
     Py_DECREF(alignment);

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -392,7 +392,7 @@ NPY_NO_EXPORT int
         return -1;
     }
     if (ap == NULL || PyArray_ISBEHAVED(ap)) {
-        assert(npy_is_aligned(ov, _ALIGN(@type@)));
+        assert(npy_is_aligned(ov, NPY_ALIGNOF(@type@)));
         *((@type@ *)ov)=temp;
     }
     else {
@@ -810,7 +810,7 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
 
 /* OBJECT */
 
-#define __ALIGNED(obj, sz) ((((size_t) obj) % (sz))==0)
+#define NPY__ALIGNED(obj, sz) ((((size_t) obj) % (sz))==0)
 
 static PyObject *
 OBJECT_getitem(void *ip, void *NPY_UNUSED(ap))
@@ -2423,10 +2423,10 @@ OBJECT_copyswapn(PyObject **dst, npy_intp dstride, PyObject **src,
 {
     npy_intp i;
     if (src != NULL) {
-        if (__ALIGNED(dst, sizeof(PyObject **))
-                && __ALIGNED(src, sizeof(PyObject **))
-                && __ALIGNED(dstride, sizeof(PyObject **))
-                && __ALIGNED(sstride, sizeof(PyObject **))) {
+        if (NPY__ALIGNED(dst, sizeof(PyObject **))
+                && NPY__ALIGNED(src, sizeof(PyObject **))
+                && NPY__ALIGNED(dstride, sizeof(PyObject **))
+                && NPY__ALIGNED(sstride, sizeof(PyObject **))) {
             dstride /= sizeof(PyObject **);
             sstride /= sizeof(PyObject **);
             for (i = 0; i < n; i++) {
@@ -2463,8 +2463,8 @@ OBJECT_copyswap(PyObject **dst, PyObject **src, int NPY_UNUSED(swap),
 {
 
     if (src != NULL) {
-        if (__ALIGNED(dst,sizeof(PyObject **)) &&
-                __ALIGNED(src,sizeof(PyObject **))) {
+        if (NPY__ALIGNED(dst,sizeof(PyObject **)) &&
+                NPY__ALIGNED(src,sizeof(PyObject **))) {
             Py_XINCREF(*src);
             Py_XDECREF(*dst);
             *dst = *src;
@@ -2899,7 +2899,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
             }
 
             dummy_fields.descr = new;
-            if ((new->alignment > 1) && !__ALIGNED(ip + offset,
+            if ((new->alignment > 1) && !NPY__ALIGNED(ip + offset,
                         new->alignment)) {
                 PyArray_CLEARFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
@@ -2924,7 +2924,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
     return nonz;
 }
 
-#undef __ALIGNED
+#undef NPY__ALIGNED
 
 
 /*
@@ -4298,7 +4298,7 @@ static PyArray_Descr @from@_Descr = {
     /* elsize */
     0,
     /* alignment */
-    _ALIGN(@align@),
+    NPY_ALIGNOF(@align@),
     /* subarray */
     NULL,
     /* fields */
@@ -4448,7 +4448,7 @@ NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
     /* elsize */
     sizeof(@fromtype@),
     /* alignment */
-    _ALIGN(@fromtype@),
+    NPY_ALIGNOF(@fromtype@),
     /* subarray */
     NULL,
     /* fields */
@@ -4787,7 +4787,7 @@ set_typeinfo(PyObject *dict)
      */
 
     s = PyArray_typeinforanged(
-        NPY_@name@LTR, NPY_@name@, NPY_BITSOF_@uname@, _ALIGN(@type@),
+        NPY_@name@LTR, NPY_@name@, NPY_BITSOF_@uname@, NPY_ALIGNOF(@type@),
         Py_BuildValue("@cx@", @max@),
         Py_BuildValue("@cn@", @min@),
         &Py@Name@ArrType_Type
@@ -4818,7 +4818,7 @@ set_typeinfo(PyObject *dict)
      */
     s = PyArray_typeinfo(
         NPY_@name@LTR, NPY_@name@, NPY_BITSOF_@name@,
-        _ALIGN(@type@), &Py@Name@ArrType_Type
+        NPY_ALIGNOF(@type@), &Py@Name@ArrType_Type
     );
     if (s == NULL) {
         Py_DECREF(infodict);
@@ -4835,7 +4835,7 @@ set_typeinfo(PyObject *dict)
 
     s = PyArray_typeinfo(
         NPY_OBJECTLTR, NPY_OBJECT, sizeof(PyObject *) * CHAR_BIT,
-        _ALIGN(PyObject *),
+        NPY_ALIGNOF(PyObject *),
         &PyObjectArrType_Type
     );
     if (s == NULL) {
@@ -4849,7 +4849,7 @@ set_typeinfo(PyObject *dict)
         return -1;
     }
     s = PyArray_typeinfo(
-        NPY_STRINGLTR, NPY_STRING, 0, _ALIGN(char),
+        NPY_STRINGLTR, NPY_STRING, 0, NPY_ALIGNOF(char),
         &PyStringArrType_Type
     );
     if (s == NULL) {
@@ -4863,7 +4863,7 @@ set_typeinfo(PyObject *dict)
         return -1;
     }
     s = PyArray_typeinfo(
-        NPY_UNICODELTR, NPY_UNICODE, 0, _ALIGN(npy_ucs4),
+        NPY_UNICODELTR, NPY_UNICODE, 0, NPY_ALIGNOF(npy_ucs4),
         &PyUnicodeArrType_Type
     );
     if (s == NULL) {
@@ -4877,7 +4877,7 @@ set_typeinfo(PyObject *dict)
         return -1;
     }
     s = PyArray_typeinfo(
-        NPY_VOIDLTR, NPY_VOID, 0, _ALIGN(char),
+        NPY_VOIDLTR, NPY_VOID, 0, NPY_ALIGNOF(char),
         &PyVoidArrType_Type
     );
     if (s == NULL) {
@@ -4892,7 +4892,7 @@ set_typeinfo(PyObject *dict)
     }
     s = PyArray_typeinforanged(
         NPY_DATETIMELTR, NPY_DATETIME, NPY_BITSOF_DATETIME,
-        _ALIGN(npy_datetime),
+        NPY_ALIGNOF(npy_datetime),
         MyPyLong_FromInt64(NPY_MAX_DATETIME),
         MyPyLong_FromInt64(NPY_MIN_DATETIME),
         &PyDatetimeArrType_Type
@@ -4909,7 +4909,7 @@ set_typeinfo(PyObject *dict)
     }
     s = PyArray_typeinforanged(
         NPY_TIMEDELTALTR, NPY_TIMEDELTA, NPY_BITSOF_TIMEDELTA,
-        _ALIGN(npy_timedelta),
+        NPY_ALIGNOF(npy_timedelta),
         MyPyLong_FromInt64(NPY_MAX_TIMEDELTA),
         MyPyLong_FromInt64(NPY_MIN_TIMEDELTA),
         &PyTimedeltaArrType_Type

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -175,7 +175,7 @@ check_and_adjust_axis(int *axis, int ndim)
 }
 
 /* used for some alignment checks */
-/* 
+/*
  * GCC releases before GCC 4.9 had a bug in _Alignof.  See GCC bug 52023
  * <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52023>.
  * clang versions < 8.0.0 have the same bug.
@@ -184,11 +184,11 @@ check_and_adjust_axis(int *axis, int ndim)
      || (defined __GNUC__ && __GNUC__ < 4 + (__GNUC_MINOR__ < 9) \
   && !defined __clang__) \
      || (defined __clang__ && __clang_major__ < 8))
-# define _ALIGN(type) offsetof(struct {char c; type v;}, v)
+# define NPY_ALIGNOF(type) offsetof(struct {char c; type v;}, v)
 #else
-# define _ALIGN(type) _Alignof(type)
+# define NPY_ALIGNOF(type) _Alignof(type)
 #endif
-#define _UINT_ALIGN(type) npy_uint_alignment(sizeof(type))
+#define  NPY_ALIGNOF_UINT(type) npy_uint_alignment(sizeof(type))
 /*
  * Disable harmless compiler warning "4116: unnamed type definition in
  * parentheses" which is caused by the _ALIGN macro.
@@ -223,20 +223,20 @@ npy_uint_alignment(int itemsize)
         case 1:
             return 1;
         case 2:
-            alignment = _ALIGN(npy_uint16);
+            alignment = NPY_ALIGNOF(npy_uint16);
             break;
         case 4:
-            alignment = _ALIGN(npy_uint32);
+            alignment = NPY_ALIGNOF(npy_uint32);
             break;
         case 8:
-            alignment = _ALIGN(npy_uint64);
+            alignment = NPY_ALIGNOF(npy_uint64);
             break;
         case 16:
             /*
              * 16 byte types are copied using 2 uint64 assignments.
              * See the strided copy function in lowlevel_strided_loops.c.
              */
-            alignment = _ALIGN(npy_uint64);
+            alignment = NPY_ALIGNOF(npy_uint64);
             break;
         default:
             break;

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -134,8 +134,8 @@ static int
 
 #if @is_aligned@
     /* sanity check */
-    assert(N == 0 || npy_is_aligned(dst, _UINT_ALIGN(@type@)));
-    assert(N == 0 || npy_is_aligned(src, _UINT_ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(dst, NPY_ALIGNOF_UINT(@type@)));
+    assert(N == 0 || npy_is_aligned(src, NPY_ALIGNOF_UINT(@type@)));
 #endif
     /*printf("fn @prefix@_@oper@_size@elsize@\n");*/
     while (N > 0) {
@@ -220,8 +220,8 @@ static NPY_GCC_OPT_3 int
     }
 #if @is_aligned@ && @elsize@ != 16
     /* sanity check */
-    assert(N == 0 || npy_is_aligned(dst, _UINT_ALIGN(@type@)));
-    assert(N == 0 || npy_is_aligned(src, _UINT_ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(dst, NPY_ALIGNOF_UINT(@type@)));
+    assert(N == 0 || npy_is_aligned(src, NPY_ALIGNOF_UINT(@type@)));
 #endif
 #if @elsize@ == 1 && @dst_contig@
     memset(dst, *src, N);
@@ -864,8 +864,8 @@ static NPY_GCC_OPT_3 int
 
 #if @aligned@
    /* sanity check */
-    assert(N == 0 || npy_is_aligned(src, _ALIGN(_TYPE1)));
-    assert(N == 0 || npy_is_aligned(dst, _ALIGN(_TYPE2)));
+    assert(N == 0 || npy_is_aligned(src, NPY_ALIGNOF(_TYPE1)));
+    assert(N == 0 || npy_is_aligned(dst, NPY_ALIGNOF(_TYPE2)));
 #endif
 
     /*printf("@prefix@_cast_@name1@_to_@name2@\n");*/
@@ -1515,7 +1515,7 @@ mapiter_trivial_@name@(
         while (itersize--) {
             char * self_ptr;
             npy_intp indval = *((npy_intp*)ind_ptr);
-            assert(npy_is_aligned(ind_ptr, _UINT_ALIGN(npy_intp)));
+            assert(npy_is_aligned(ind_ptr, NPY_ALIGNOF_UINT(npy_intp)));
 #if @isget@
             if (check_and_adjust_index(&indval, fancy_dim, 0, _save) < 0 ) {
                 return -1;
@@ -1529,8 +1529,8 @@ mapiter_trivial_@name@(
 
 #if @isget@
 #if @elsize@
-            assert(npy_is_aligned(result_ptr, _UINT_ALIGN(@copytype@)));
-            assert(npy_is_aligned(self_ptr, _UINT_ALIGN(@copytype@)));
+            assert(npy_is_aligned(result_ptr, NPY_ALIGNOF_UINT(@copytype@)));
+            assert(npy_is_aligned(self_ptr, NPY_ALIGNOF_UINT(@copytype@)));
             *(@copytype@ *)result_ptr = *(@copytype@ *)self_ptr;
 #else
             char *args[2] = {self_ptr, result_ptr};
@@ -1544,8 +1544,8 @@ mapiter_trivial_@name@(
 
 #else /* !@isget@ */
 #if @elsize@
-            assert(npy_is_aligned(result_ptr, _UINT_ALIGN(@copytype@)));
-            assert(npy_is_aligned(self_ptr, _UINT_ALIGN(@copytype@)));
+            assert(npy_is_aligned(result_ptr, NPY_ALIGNOF_UINT(@copytype@)));
+            assert(npy_is_aligned(self_ptr, NPY_ALIGNOF_UINT(@copytype@)));
             *(@copytype@ *)self_ptr = *(@copytype@ *)result_ptr;
 #else
             char *args[2] = {result_ptr, self_ptr};
@@ -1672,7 +1672,7 @@ mapiter_@name@(
                         for (i=0; i < @numiter@; i++) {
                             npy_intp indval = *((npy_intp*)outer_ptrs[i]);
                             assert(npy_is_aligned(outer_ptrs[i],
-                                                  _UINT_ALIGN(npy_intp)));
+                                                  NPY_ALIGNOF_UINT(npy_intp)));
 
 #if @isget@ && @one_iter@
                             if (check_and_adjust_index(&indval, fancy_dims[i],
@@ -1693,9 +1693,9 @@ mapiter_@name@(
 #if @isget@
 #if @elsize@
                         assert(npy_is_aligned(outer_ptrs[i],
-                                              _UINT_ALIGN(@copytype@)));
+                                              NPY_ALIGNOF_UINT(@copytype@)));
                         assert(npy_is_aligned(self_ptr,
-                                              _UINT_ALIGN(@copytype@)));
+                                              NPY_ALIGNOF_UINT(@copytype@)));
                         *(@copytype@ *)(outer_ptrs[i]) = *(@copytype@ *)self_ptr;
 #else
                         char *args[2] = {self_ptr, outer_ptrs[i]};
@@ -1709,9 +1709,9 @@ mapiter_@name@(
 #else /* !@isget@ */
 #if @elsize@
                         assert(npy_is_aligned(outer_ptrs[i],
-                               _UINT_ALIGN(@copytype@)));
+                               NPY_ALIGNOF_UINT(@copytype@)));
                         assert(npy_is_aligned(self_ptr,
-                               _UINT_ALIGN(@copytype@)));
+                               NPY_ALIGNOF_UINT(@copytype@)));
                         *(@copytype@ *)self_ptr = *(@copytype@ *)(outer_ptrs[i]);
 #else
                         char *args[2] = {outer_ptrs[i], self_ptr};

--- a/numpy/core/src/umath/_scaled_float_dtype.c
+++ b/numpy/core/src/umath/_scaled_float_dtype.c
@@ -149,7 +149,7 @@ static PyArray_SFloatDescr SFloatSingleton = {{
         .flags = NPY_USE_GETITEM|NPY_USE_SETITEM,
         .type_num = -1,
         .elsize = sizeof(double),
-        .alignment = _ALIGN(double),
+        .alignment = NPY_ALIGNOF(double),
         .f = &sfloat_slots.f,
     },
     .scaling = 1,


### PR DESCRIPTION
  This change adds a prefix to the `_ALIGN` macro to prevent compiler warnings on OpenBSD,
  where the macro's definition conflicts with system headers.

relates to #20799 (not a fix)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
