### PR TITLE
MAINT: Pin upper version of sphinx.

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx>=4.5.0
+sphinx>=4.5.0,<7.2.0
 numpydoc==1.4
 pydata-sphinx-theme==0.13.3
 sphinx-design


### PR DESCRIPTION
Backport of #24439.

The 7.2.x versions of sphinx broke the circleci document builds.

[skip azp] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
