### PR TITLE
BUG: cleanup warnings [skip azp][skip circle][skip travis][skip cirrus]

### DIFF
--- a/numpy/_build_utils/gitversion.py
+++ b/numpy/_build_utils/gitversion.py
@@ -4,7 +4,8 @@ import textwrap
 
 def init_version():
     init = os.path.join(os.path.dirname(__file__), '../../pyproject.toml')
-    data = open(init).readlines()
+    with open(init) as fid:
+        data = fid.readlines()
 
     version_line = next(
         line for line in data if line.startswith('version =')

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1412,7 +1412,18 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
     static char *msg = "already has a different docstring";
 
     /* Don't add docstrings */
+#if PY_VERSION_HEX > 0x030b0000
+    static long optimize = -1000;
+    if (optimize < 0) {
+        PyObject *flags = PySys_GetObject("flags");  /* borrowed object */
+        PyObject *level = PyObject_GetAttrString(flags, "optimize");
+        optimize = PyLong_AsLong(level);
+        Py_DECREF(level);
+    }
+    if (optimize > 1) {
+#else
     if (Py_OptimizeFlag > 1) {
+#endif
         Py_RETURN_NONE;
     }
 


### PR DESCRIPTION
Backport of #24413.

Two fixes:
- use a context manager when opening a file
- use the equivalent of `sys.flags.optimize` instead of `Py_OptimizeFlag` which was deprecated in 3.12. See the discussion in python/cpython#99872. Cython also came across this deprecation, and chose a different solution to avoid holding the GIL but uses private interfaces.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
