### PR TITLE
MAINT: Fix broken link in runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -26,7 +26,7 @@ Disable pytest capturing of output by using its '-s' option:
     $ python runtests.py -- -s
 
 Generate C code coverage listing under build/lcov/:
-(requires http://ltp.sourceforge.net/coverage/lcov.php)
+(requires https://github.com/linux-test-project/lcov)
 
     $ python runtests.py --gcov [...other args...]
     $ python runtests.py --lcov-html


### PR DESCRIPTION
This little PR fixes an outdated link in `runtests.py`.
Link <http://ltp.sourceforge.net/coverage/lcov.php> is outdated, because this library has moved to GitHub.
The new link <https://github.com/linux-test-project/lcov> was taken from the outdated website.