### PR TITLE
BUG: Fix meson build failure due to unchanged inplace auto-generated dispatch config headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,11 +208,6 @@ tools/swig/test/Array.py
 
 # SIMD generated files #
 ###################################
-# config headers of dispatchable sources
-*.dispatch.h
-# wrapped sources of dispatched targets, e.g. *.dispatch.avx2.c
-*.dispatch.*.c
-*.dispatch.*.cpp
 # _simd module
 numpy/core/src/_simd/_simd.dispatch.c
 numpy/core/src/_simd/_simd_data.inc

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -320,8 +320,8 @@ class build_clib(old_build_clib):
             dispatch_hpath = os.path.join("numpy", "distutils", "include")
             dispatch_hpath = os.path.join(bsrc_dir, dispatch_hpath)
             include_dirs.append(dispatch_hpath)
-
-            copt_build_src = None if self.inplace else bsrc_dir
+            # copt_build_src = None if self.inplace else bsrc_dir
+            copt_build_src = bsrc_dir
             for _srcs, _dst, _ext in (
                 ((c_sources,), copt_c_sources, ('.dispatch.c',)),
                 ((c_sources, cxx_sources), copt_cxx_sources,

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -458,7 +458,18 @@ class build_ext (old_build_ext):
             dispatch_hpath = os.path.join(bsrc_dir, dispatch_hpath)
             include_dirs.append(dispatch_hpath)
 
-            copt_build_src = None if self.inplace else bsrc_dir
+            # copt_build_src = None if self.inplace else bsrc_dir
+            # Always generate the generated config files and
+            # dispatch-able sources inside the build directory,
+            # even if the build option `inplace` is enabled.
+            # This approach prevents conflicts with Meson-generated
+            # config headers. Since `spin build --clean` will not remove
+            # these headers, they might overwrite the generated Meson headers,
+            # causing compatibility issues. Maintaining separate directories
+            # ensures compatibility between distutils dispatch config headers
+            # and Meson headers, avoiding build disruptions.
+            # See gh-24450 for more details.
+            copt_build_src = bsrc_dir
             for _srcs, _dst, _ext in (
                 ((c_sources,), copt_c_sources, ('.dispatch.c',)),
                 ((c_sources, cxx_sources), copt_cxx_sources,


### PR DESCRIPTION
Ensure that the distutils generated config files and wrapped sources,
derived from dispatch-able sources are consistently generated within the build directory
when the inplace build option is enabled.

This change is crucial to prevent conflicts with meson-generated config headers.
Given that `spin build --clean` does not remove these headers, which
requires cleaning up the numpy root via `git clean` otherwise
the build will fails.

closes #24450 