### PR TITLE
MAINT: Improve docstring and performance of trimseq

### DIFF
--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -57,8 +57,7 @@ def trimseq(seq):
     Parameters
     ----------
     seq : sequence
-        Sequence of Poly series coefficients. This routine fails for
-        empty sequences.
+        Sequence of Poly series coefficients.
 
     Returns
     -------
@@ -72,7 +71,7 @@ def trimseq(seq):
     Do not lose the type info if the sequence contains unknown objects.
 
     """
-    if len(seq) == 0:
+    if len(seq) == 0 or seq[-1] != 0:
         return seq
     else:
         for i in range(len(seq) - 1, -1, -1):

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -11,9 +11,9 @@ from numpy.testing import (
 class TestMisc:
 
     def test_trimseq(self):
-        for i in range(5):
-            tgt = [1]
-            res = pu.trimseq([1] + [0]*5)
+        tgt = [1]
+        for num_trailing_zeros in range(5):
+            res = pu.trimseq([1] + [0] * num_trailing_zeros)
             assert_equal(res, tgt)
 
     def test_trimseq_empty_input(self):

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -16,6 +16,10 @@ class TestMisc:
             res = pu.trimseq([1] + [0]*5)
             assert_equal(res, tgt)
 
+    def test_trimseq_empty_input(self):
+        for empty_seq in [[], np.array([], dtype=np.int32)]:
+            assert_equal(pu.trimseq(empty_seq), empty_seq)
+
     def test_as_series(self):
         # check exceptions
         assert_raises(ValueError, pu.as_series, [[]])


### PR DESCRIPTION
* The docstring of `numpy.polynomial.polyutils.trimseq` stated "This routine fails for empty sequences.". This is incorrect, as `trimseq` works fine on empty sequences (there is in fact an if statement especially for this case). In this PR we modify the docstring and add tests to make sure the `trimseq` works fine on empty sequences.
* The most common case for `trimseq` are non-empty sequences (the coefficients of polynomials are non-empty by construction) with final coefficient non-zero. We add a fast path for the case where the final coefficient is non-zero.

Benchmark
```
from numpy.polynomial import Polynomial
from numpy.polynomial.polyutils import trimseq

p = Polynomial([1,2,3])

%timeit trimseq(p.coef)
``` 
Results:
```
main: 565 ns ± 36 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
PR: 224 ns ± 21.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
