### PR TITLE
DOC: Rm np.who from autosummary.

### DIFF
--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -55,7 +55,6 @@ Matlab-like Functions
 .. autosummary::
    :toctree: generated/
 
-   who
    disp
 
 .. automodule:: numpy.exceptions


### PR DESCRIPTION
Minor doc fixup related to the namespace cleanup. `np.who` was removed but was still present in the autosummary, causing sphinx errors during doc build.

[skip cirrus] [skip azp] [skip travis] [skip actions]