### PR TITLE
DOC: Fix reference warning in some rst and code files.

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -296,7 +296,7 @@ String with comma-separated fields
       >>> dt = np.dtype("a3, 3u8, (3,4)a10")
 
 Type strings
-   Any string in :obj:`numpy.sctypeDict`.keys():
+   Any string name of a NumPy dtype, e.g.:
 
    .. admonition:: Example
 

--- a/doc/source/reference/routines.array-creation.rst
+++ b/doc/source/reference/routines.array-creation.rst
@@ -47,8 +47,7 @@ From existing data
 Creating record arrays
 ----------------------
 
-.. note:: :mod:`numpy.core.records` is used to create record
-   array. Please refer to :ref:`arrays.classes.rec` for
+.. note:: Please refer to :ref:`arrays.classes.rec` for
    record arrays.
 
 .. autosummary::
@@ -66,7 +65,7 @@ Creating character arrays (:mod:`numpy.char`)
 ---------------------------------------------
 
 .. note:: :mod:`numpy.char` is the preferred alias for
-   :mod:`numpy.core.defchararray`.
+   ``numpy.core.defchararray`` module.
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -57,7 +57,7 @@ New deprecations
 
 * The type dictionaries `numpy.core.typeNA` and `numpy.core.sctypeNA` are
   deprecated. They were buggy and not documented and will be removed in the
-  1.18 release. Use `numpy.sctypeDict` instead.
+  1.18 release. Use ``numpy.sctypeDict`` instead.
 
 * The `numpy.asscalar` function is deprecated. It is an alias to the more
   powerful `numpy.ndarray.item`, not tested, and fails for scalars.

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -824,7 +824,7 @@ Callback functions in f2py are now thread safe.
 
 `numpy.core.records.fromfile` now supports file-like objects
 ------------------------------------------------------------
-`numpy.rec.fromfile` can now use file-like objects, for instance
+`numpy.core.records.fromfile` can now use file-like objects, for instance
 :py:class:`io.BytesIO`
 
 (`gh-16675 <https://github.com/numpy/numpy/pull/16675>`__)
@@ -839,7 +839,7 @@ Use f90 compiler specified by the command line args
 ---------------------------------------------------
 
 The compiler command selection for Fortran Portland Group Compiler is changed
-in `numpy.distutils.fcompiler`.  This only affects the linking command.  This
+in ``numpy.distutils.fcompiler``.  This only affects the linking command.  This
 forces the use of the executable provided by the command line option (if
 provided) instead of the pgfortran executable.  If no executable is provided to
 the command line option it defaults to the pgf90 executable, which is an alias

--- a/doc/source/release/1.20.2-notes.rst
+++ b/doc/source/release/1.20.2-notes.rst
@@ -38,7 +38,7 @@ A total of 20 pull requests were merged for this release.
 * `#18488 <https://github.com/numpy/numpy/pull/18488>`__: BUG: check if PyArray_malloc succeeded
 * `#18546 <https://github.com/numpy/numpy/pull/18546>`__: BUG: incorrect error fallthrough in nditer
 * `#18559 <https://github.com/numpy/numpy/pull/18559>`__: CI: Backport CI fixes from main.
-* `#18599 <https://github.com/numpy/numpy/pull/18599>`__: MAINT: Add annotations for `dtype.__getitem__`, `__mul__` and...
+* `#18599 <https://github.com/numpy/numpy/pull/18599>`__: MAINT: Add annotations for ``dtype.__getitem__``, `__mul__` and...
 * `#18611 <https://github.com/numpy/numpy/pull/18611>`__: BUG: NameError in numpy.distutils.fcompiler.compaq
 * `#18612 <https://github.com/numpy/numpy/pull/18612>`__: BUG: Fixed ``where`` keyword for ``np.mean`` & ``np.var`` methods
 * `#18617 <https://github.com/numpy/numpy/pull/18617>`__: CI: Update apt package list before Python install

--- a/doc/source/release/1.7.0-notes.rst
+++ b/doc/source/release/1.7.0-notes.rst
@@ -259,7 +259,7 @@ General
 -------
 
 Specifying a custom string formatter with a `_format` array attribute is
-deprecated. The new `formatter` keyword in ``numpy.set_printoptions`` or
+deprecated. The new ``formatter`` keyword in ``numpy.set_printoptions`` or
 ``numpy.array2string`` can be used instead.
 
 The deprecated imports in the polynomial package have been removed.

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -491,7 +491,7 @@ regardless of whether those values are :py:data:`True` or
 
 A common use case for this is filtering for desired element values.
 For example, one may wish to select all entries from an array which
-are not :const:`NaN`::
+are not :const:`numpy.nan`::
 
     >>> x = np.array([[1., 2.], [np.nan, 3.], [np.nan, np.nan]])
     >>> x[~np.isnan(x)]

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -135,8 +135,8 @@ situation with either `typing.cast` or a ``# type: ignore`` comment.
 Record array dtypes
 ~~~~~~~~~~~~~~~~~~~
 
-The dtype of `numpy.recarray`, and the `numpy.rec` functions in general,
-can be specified in one of two ways:
+The dtype of `numpy.recarray`, and the :ref:`routines.array-creation.rec`
+functions in general, can be specified in one of two ways:
 
 * Directly via the ``dtype`` argument.
 * With up to five helper arguments that operate via `numpy.format_parser`:


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix following reference warning:
```
arrays.dtypes.rst:303: WARNING: py:obj reference target not found: numpy.sctypeDict
routines.array-creation.rst:50: WARNING: py:mod reference target not found: numpy.core.records
routines.array-creation.rst:68: WARNING: py:mod reference target not found: numpy.core.defchararray
routines.ma.rst:36:<autosummary>:1: WARNING: py:class reference target not found: numpy.ma.core.MaskedArray
numpy/typing/__init__.py:docstring of numpy.typing:137: WARNING: py:obj reference target not found: numpy.rec
numpy/doc/source/release/1.16.0-notes.rst:58: WARNING: py:obj reference target not found: numpy.sctypeDict
numpy/doc/source/release/1.20.0-notes.rst:827: WARNING: py:obj reference target not found: numpy.rec.fromfile
numpy/doc/source/release/1.20.0-notes.rst:841: WARNING: py:obj reference target not found: numpy.distutils.fcompiler
numpy/doc/source/release/1.20.2-notes.rst:41: WARNING: py:obj reference target not found: dtype.__getitem__
numpy/doc/source/release/1.7.0-notes.rst:261: WARNING: py:obj reference target not found: formatter
numpy/doc/source/user/basics.indexing.rst:492: WARNING: py:const reference target not found: NaN

```

There are some reference warning about following:
```
routines.ma.rst:36:<autosummary>:1: WARNING: py:class reference target not found: numpy.ma.core.MaskedArray
maskedarray.generic.rst:106:<autosummary>:1: WARNING: py:class reference target not found: numpy.ma.core.MaskedArray
```
The warning is from docstree of masked_array, which  is generated by sphinx.ext.autodoc extensions, something like following:
```
alias of py:class:`numpy.ma.core.MaskedArray`
```
But `numpy.ma.core.MaskedArray` is not a correct class reference, it is a path reference.
Is there a way to add docstring for alias?
