### PR TITLE
ENH: Add madvise for memmap objects

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -443,16 +443,19 @@ the over-head of reading the entire file into memory is typically not
 significant, however for large files using memory mapping can save
 considerable resources.
 
-Memory-mapped-file arrays have one additional method (besides those
+Memory-mapped-file arrays have the additional methods (besides those
 they inherit from the ndarray): :meth:`.flush() <memmap.flush>` which
 must be called manually by the user to ensure that any changes to the
-array actually get written to disk.
+array actually get written to disk and :meth:`.madvise() <memmap.madvise>`
+which gives a hint to the OS how the memory region will be accessed and
+thus can potentially speed up read and writes.
 
 .. autosummary::
    :toctree: generated/
 
    memmap
    memmap.flush
+   memmap.madvise
 
 Example:
 


### PR DESCRIPTION
Adds madvise to memmap. See issue https://github.com/numpy/numpy/issues/13172 for more information

@seberg  we discussed shortly on the sprint day last week about a `TypeError` being raised when the memmap is not backed by any memory, but I could not find a reasonable case where this can happen. It is always backed when constructed. So I changed the access on `base` to `_mmap` so I can make test for the error, since `base` is not writable. Then the function is also more consistent with the `__getitem__` function that also uses `_mmap`. But now the error message is misleading, because `_mmap` can be `None`, while `base` is not `None`, so the memmap it is still backed up. I don't think this `None` check actually makes sense in the current version and would remove it and switch usage everywhere to `base` in memmap.

What can actually happen is that the mmap is closed, and one can get a segfault because of invalid accesses (`my_memmap.base.close()` using functions marked as public). Maybe we test for this instead?
```python
if not(self.base.close):
    raise TypeError("Memory map is closed and can therefore not be accessed.")
```

What do you think?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
        https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
        https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
