### PR TITLE
API: Remove deprecated `msort` function

### DIFF
--- a/doc/release/upcoming_changes/24494.expired.rst
+++ b/doc/release/upcoming_changes/24494.expired.rst
@@ -1,0 +1,2 @@
+* ``np.msort`` has been removed. For a replacement, ``np.sort(a, axis=0)`` 
+should be used instead.

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -200,7 +200,7 @@ else:
         index_exp, info, insert, interp, intersect1d, iscomplex,
         iscomplexobj, isin, isneginf, isreal, isrealobj, issubclass_,
         issubsctype, iterable, ix_, kaiser, kron, load, loadtxt, mask_indices,
-        median, meshgrid, mgrid, mintypecode, msort, nan_to_num, 
+        median, meshgrid, mgrid, mintypecode, nan_to_num, 
         nanargmax, nanargmin, nancumprod, nancumsum, nanmax, nanmean,
         nanmedian, nanmin, nanpercentile, nanprod, nanquantile, nanstd,
         nansum, nanvar, ndenumerate, ndindex, ogrid, packbits, pad,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -341,8 +341,6 @@ from numpy.core.multiarray import (
     fromiter as fromiter,
     is_busday as is_busday,
     promote_types as promote_types,
-    seterrobj as seterrobj,
-    geterrobj as geterrobj,
     fromstring as fromstring,
     frompyfunc as frompyfunc,
     nested_iters as nested_iters,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -42,7 +42,7 @@ __all__ = [
     'diff', 'gradient', 'angle', 'unwrap', 'sort_complex', 'disp', 'flip',
     'rot90', 'extract', 'place', 'vectorize', 'asarray_chkfinite', 'average',
     'bincount', 'digitize', 'cov', 'corrcoef',
-    'msort', 'median', 'sinc', 'hamming', 'hanning', 'bartlett',
+    'median', 'sinc', 'hamming', 'hanning', 'bartlett',
     'blackman', 'kaiser', 'trapz', 'i0',
     'meshgrid', 'delete', 'insert', 'append', 'interp',
     'quantile'
@@ -3683,56 +3683,6 @@ def sinc(x):
     x = np.asanyarray(x)
     y = pi * where(x == 0, 1.0e-20, x)
     return sin(y)/y
-
-
-def _msort_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_msort_dispatcher)
-def msort(a):
-    """
-    Return a copy of an array sorted along the first axis.
-
-    .. deprecated:: 1.24
-
-       msort is deprecated, use ``np.sort(a, axis=0)`` instead.
-
-    Parameters
-    ----------
-    a : array_like
-        Array to be sorted.
-
-    Returns
-    -------
-    sorted_array : ndarray
-        Array of the same type and shape as `a`.
-
-    See Also
-    --------
-    sort
-
-    Notes
-    -----
-    ``np.msort(a)`` is equivalent to  ``np.sort(a, axis=0)``.
-
-    Examples
-    --------
-    >>> a = np.array([[1, 4], [3, 1]])
-    >>> np.msort(a)  # sort along the first axis
-    array([[1, 1],
-           [3, 4]])
-
-    """
-    # 2022-10-20 1.24
-    warnings.warn(
-        "msort is deprecated, use np.sort(a, axis=0) instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    b = array(a, subok=True, copy=True)
-    b.sort(0)
-    return b
 
 
 def _ureduce(a, func, keepdims=False, **kwargs):

--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -436,9 +436,6 @@ def sinc(x: _ArrayLikeFloat_co) -> NDArray[floating[Any]]: ...
 @overload
 def sinc(x: _ArrayLikeComplex_co) -> NDArray[complexfloating[Any, Any]]: ...
 
-# NOTE: Deprecated
-# def msort(a: ArrayLike) -> NDArray[Any]: ...
-
 @overload
 def median(
     a: _ArrayLikeFloat_co,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -23,7 +23,7 @@ from numpy.random import rand
 from numpy.lib import (
     angle, average, bartlett, blackman, corrcoef, cov,
     delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
-    i0, insert, interp, kaiser, meshgrid, msort, piecewise, place, rot90,
+    i0, insert, interp, kaiser, meshgrid, piecewise, place, rot90,
     select, setxor1d, sinc, trapz, trim_zeros, unwrap, unique, vectorize
     )
 from numpy.core.numeric import normalize_axis_tuple
@@ -2489,20 +2489,6 @@ class TestKaiser:
 
     def test_int_beta(self):
         kaiser(3, 4)
-
-
-class TestMsort:
-
-    def test_simple(self):
-        A = np.array([[0.44567325, 0.79115165, 0.54900530],
-                      [0.36844147, 0.37325583, 0.96098397],
-                      [0.64864341, 0.52929049, 0.39172155]])
-        with pytest.warns(DeprecationWarning, match="msort is deprecated"):
-            assert_almost_equal(
-                msort(A),
-                np.array([[0.36844147, 0.37325583, 0.39172155],
-                          [0.44567325, 0.52929049, 0.54900530],
-                          [0.64864341, 0.79115165, 0.96098397]]))
 
 
 class TestMeshgrid:


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

`msort` was deprecated in 1.24 - this small PR removes it completely. (Plus some leftovers from removed `geterrobj`).