### PR TITLE
MAINT: Add expiration notes for NumPy 2.0 removals

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -347,7 +347,7 @@ else:
         
         if attr in __expired_attributes__:
             raise AttributeError(
-                f"`np.{attr}` was removed in NumPy 2.0 release. "
+                f"`np.{attr}` was removed in the NumPy 2.0 release. "
                 f"{__expired_attributes__[attr]}"
             )
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -95,6 +95,7 @@ import sys
 import warnings
 
 from ._globals import _NoValue, _CopyMode
+from ._expired_attrs_2_0 import __expired_attributes__
 
 
 # If a version with git hash was stored, use that instead
@@ -343,6 +344,12 @@ else:
 
         if attr in __former_attrs__:
             raise AttributeError(__former_attrs__[attr])
+        
+        if attr in __expired_attributes__:
+            raise AttributeError(
+                f"`np.{attr}` was removed in NumPy 2.0 release. "
+                f"{__expired_attributes__[attr]}"
+            )
 
         raise AttributeError("module {!r} has no attribute "
                              "{!r}".format(__name__, attr))

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -4,12 +4,12 @@ Each item is associated with a migration note.
 """
 
 __expired_attributes__ = {
-    "geterrobj": "Use context manager `with np.errstate()` instead.",
-    "seterrobj": "Use context manager `with np.errstate()` instead.",
+    "geterrobj": "Use the np.errstate context manager instead.",
+    "seterrobj": "Use the np.errstate context manager instead.",
     "cast": "Use `np.asarray(arr, dtype=dtype)` instead.",
     "source": "Use `inspect.getsource` instead.",
     "lookfor":  "Search NumPy's documentation directly.",
-    "who": "Use IDE variable explorer or `locals()` instead.",
+    "who": "Use an IDE variable explorer or `locals()` instead.",
     "fastCopyAndTranspose": "Use `arr.T.copy()` instead.",
     "set_numeric_ops": 
         "For the general case, use `PyUFunc_ReplaceLoopBySignature`. "
@@ -20,11 +20,11 @@ __expired_attributes__ = {
     "NZERO": "Use `-0.0` instead.",
     "PZERO": "Use `0.0` instead.",
     "add_newdoc": 
-        "It's and internal function and doesn't have a replacement.",
+        "It's an internal function and doesn't have a replacement.",
     "add_docstring": 
-        "It's and internal function and doesn't have a replacement.",
+        "It's an internal function and doesn't have a replacement.",
     "add_newdoc_ufunc": 
-        "It's and internal function and doesn't have a replacement.",
+        "It's an internal function and doesn't have a replacement.",
     "compat": "There's no replacement, as Python 2 is no longer supported.",
     "safe_eval": "Use `ast.literal_eval` instead."
 }

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -1,0 +1,30 @@
+"""
+Dict of expired attributes that are discontinued since 2.0 release.
+Each item is associated with a migration note.
+"""
+
+__expired_attributes__ = {
+    "geterrobj": "Use context manager `with np.errstate()` instead.",
+    "seterrobj": "Use context manager `with np.errstate()` instead.",
+    "cast": "Use `np.asarray(arr, dtype=dtype)` instead.",
+    "source": "Use `inspect.getsource` instead.",
+    "lookfor":  "Search NumPy's documentation directly.",
+    "who": "Use IDE variable explorer or `locals()` instead.",
+    "fastCopyAndTranspose": "Use `arr.T.copy()` instead.",
+    "set_numeric_ops": 
+        "For the general case, use `PyUFunc_ReplaceLoopBySignature`. "
+        "For ndarray subclasses, define the ``__array_ufunc__`` method "
+        "and override the relevant ufunc.",
+    "NINF": "Use `-np.inf` instead.",
+    "PINF": "Use `np.inf` instead.",
+    "NZERO": "Use `-0.0` instead.",
+    "PZERO": "Use `0.0` instead.",
+    "add_newdoc": 
+        "It's and internal function and doesn't have a replacement.",
+    "add_docstring": 
+        "It's and internal function and doesn't have a replacement.",
+    "add_newdoc_ufunc": 
+        "It's and internal function and doesn't have a replacement.",
+    "compat": "There's no replacement, as Python 2 is no longer supported.",
+    "safe_eval": "Use `ast.literal_eval` instead."
+}

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -211,6 +211,7 @@ python_sources = [
   '_globals.py',
   '_pytesttester.py',
   '_pytesttester.pyi',
+  '_expired_attrs_2_0.py',
   'conftest.py',
   'ctypeslib.py',
   'ctypeslib.pyi',


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

This PR adds a separate file and a migration notes mechanism (similar to previously removed functionalities, like "financial") for NumPy 2.0 expired functions and aliases. 

Here I add notes for items that have been removed in Part 1 and Part 2 (excluding some niche internal enums that didn't have a single usage in libraries such as SciPy or Pandas).
