### PR TITLE
CI: switch the Cygwin job to Meson

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -30,11 +30,8 @@ jobs:
           platform: x86_64
           install-dir: 'C:\tools\cygwin'
           packages: >-
-            python39-devel python39-zipp python39-importlib-metadata
-            python39-cython python39-pip python39-wheel python39-cffi
-            python39-pytz python39-setuptools python39-pytest
-            python39-hypothesis liblapack-devel
-            gcc-fortran gcc-g++ git dash
+            python39-devel python39-pip python-pip-wheel python-setuptools-wheel
+            liblapack-devel gcc-fortran gcc-g++ git dash cmake ninja
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@8469525c8ee3eddabbd3487658621a6235b3c581 # v3
         with:
@@ -52,10 +49,9 @@ jobs:
           dash -c "which python3.9; /usr/bin/python3.9 --version -V"
       - name: Build NumPy wheel
         run: |
-          dash -c "/usr/bin/python3.9 -m pip install 'setuptools<49.2.0' pytest pytz cffi pickle5 importlib_metadata typing_extensions"
-          dash -c "/usr/bin/python3.9 -m pip install -r test_requirements.txt"
-          dash -c "/usr/bin/python3.9 setup.py bdist_wheel"
-      - name: Install new NumPy
+          dash -c "/usr/bin/python3.9 -m pip install build pytest hypothesis pytest-xdist Cython meson"
+          dash -c "/usr/bin/python3.9 -m build . --wheel -Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack -Csetup-args=-Dcpu-dispatch=none -Csetup-args=-Dcpu-baseline=native"
+      - name: Install NumPy from wheel
         run: |
           bash -c "/usr/bin/python3.9 -m pip install dist/numpy-*cp39*.whl"
       - name: Rebase NumPy compiled extensions
@@ -64,7 +60,8 @@ jobs:
       - name: Run NumPy test suite
         shell: "C:\\tools\\cygwin\\bin\\bash.exe -o igncr -eo pipefail {0}"
         run: |
-          /usr/bin/python3.9 runtests.py -n
+          cd tools
+          /usr/bin/python3.9 -m pytest --pyargs numpy -n2 -m "not slow"
       - name: Upload wheel if tests fail
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: failure()

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -488,7 +488,7 @@ if cc.has_header_symbol('inttypes.h', 'PRIdPTR')
 endif
 
 visibility_hidden = ''
-if cc.has_function_attribute('visibility:hidden')
+if cc.has_function_attribute('visibility:hidden') and host_machine.system() != 'cygwin'
   visibility_hidden = '__attribute__((visibility("hidden")))'
 endif
 cdata.set('NPY_VISIBILITY_HIDDEN', visibility_hidden)


### PR DESCRIPTION
Fixing the Cygwin workflow as requested in #24410. @rgommers 

This gets the Cygwin build to this point.

```
Library m found: YES
Found CMake: /usr/bin/cmake (3.25.3)
WARNING: CMake Toolchain: Failed to determine CMake compilers state
Run-time dependency openblas found: NO (tried pkgconfig and cmake)
Run-time dependency openblas found: NO (tried pkgconfig and cmake)

../../numpy/meson.build:174:4: ERROR: Problem encountered: No BLAS library detected! Install one, or use the `allow-noblas` build option (note, this may be up to 100x slower for some linear algebra operations).
```

Fixing that is beyond the scope of this PR.
