### PR TITLE
BUG: fix NPY_cast_info error handling in choose

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -968,6 +968,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     PyArrayObject **mps, *ap;
     PyArrayMultiIterObject *multi = NULL;
     npy_intp mi;
+    NPY_cast_info cast_info = {.func = NULL};
     ap = NULL;
 
     /*
@@ -1045,7 +1046,6 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     npy_intp transfer_strides[2] = {elsize, elsize};
     npy_intp one = 1;
     NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
-    NPY_cast_info cast_info = {.func = NULL};
     if (PyDataType_REFCHK(dtype)) {
         int is_aligned = IsUintAligned(obj);
         PyArray_GetDTypeTransferFunction(

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -10042,3 +10042,9 @@ def test_gh_22683():
     np.choose(np.zeros(10000, dtype=int), [a], out=a)
     refc_end = sys.getrefcount(b)
     assert refc_end - refc_start < 10
+
+
+def test_gh_24459():
+    a = np.zeros((50, 3), dtype=np.float64)
+    with pytest.raises(TypeError):
+        np.choose(a, [3, -1])


### PR DESCRIPTION
Backport of #24484.

Closes #24459.

`cast_info` needs to be declared before the first `goto fail`, otherwise the `xfree` in the `fail` block receives uninitialized data.

@tylerjereddy sorry I missed this when we were reviewing #24188, going to try to keep this pattern in mind when looking at code that uses the cast C API in the future.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
