### PR TITLE
BUG: Fix common block handling in f2py

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -614,7 +614,8 @@ groupends = (r'end|endprogram|endblockdata|endmodule|endpythonmodule|'
              r'endinterface|endsubroutine|endfunction')
 endpattern = re.compile(
     beforethisafter % ('', groupends, groupends, '.*'), re.I), 'end'
-endifs = r'end\s*(if|do|where|select|while|forall|associate|block|' + \
+# block, the Fortran 2008 construct needs special handling in the rest of the file
+endifs = r'end\s*(if|do|where|select|while|forall|associate|' + \
          r'critical|enum|team)'
 endifpattern = re.compile(
     beforethisafter % (r'[\w]*?', endifs, endifs, '.*'), re.I), 'endif'

--- a/numpy/f2py/tests/src/crackfortran/gh22648.pyf
+++ b/numpy/f2py/tests/src/crackfortran/gh22648.pyf
@@ -1,0 +1,7 @@
+python module iri16py ! in
+    interface  ! in :iri16py
+        block data  ! in :iri16py:iridreg_modified.for
+           COMMON /fircom/ eden,tabhe,tabla,tabmo,tabza,tabfl
+       end block data 
+    end interface 
+end python module iri16py

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -8,6 +8,8 @@ from numpy.f2py.crackfortran import markinnerspaces, nameargspattern
 from . import util
 from numpy.f2py import crackfortran
 import textwrap
+import contextlib
+import io
 
 
 class TestNoSpace(util.F2PyTest):
@@ -338,3 +340,11 @@ class TestFortranGroupCounters(util.F2PyTest):
             crackfortran.crackfortran([str(fpath)])
         except Exception as exc:
             assert False, f"'crackfortran.crackfortran' raised an exception {exc}"
+
+
+class TestF77CommonBlockReader():
+    def test_gh22648(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh22648.pyf")
+        with contextlib.redirect_stdout(io.StringIO()) as stdout_f2py:
+            mod = crackfortran.crackfortran([str(fpath)])
+        assert "Mismatch" not in stdout_f2py.getvalue()


### PR DESCRIPTION
Backport of #22657.

Closes #22648.

The issue is that some part of the parser updates the `groupcounter` when it shouldn't.

EDIT: The actual issue can be traced to https://github.com/numpy/numpy/commit/e6dab4ff15f25793c81b808d49d5359b8901809f where the parser was updated to include the Fortran 2008 block construct, which is used in several other places in the file and caused the issue.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
