### PR TITLE
CI: remove spurious wheel build action runs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,9 +22,10 @@ on:
     #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #        │  │ │ │ │
     - cron: "42 2 * * SUN,WED"
-  push:
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
+    branches:
+      - main
+      - maintenance/**
   workflow_dispatch:
 
 concurrency:
@@ -62,9 +63,6 @@ jobs:
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      (contains(github.event.pull_request.labels.*.name, '36 - Build') ||
-      contains(github.event.pull_request.labels.*.name, '14 - Release'))) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')))
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:


### PR DESCRIPTION
These unusual label-based and push-based triggers have several negative consequences:

- A ton of spurious do-nothing ~15 second runs: https://github.com/numpy/numpy/actions/workflows/wheels.yml
- A ton more of empty CI actions on your own fork (e.g., https://github.com/rgommers/numpy/actions/workflows/wheels.yml)
- Spurious GitHub email notifications that these builds have triggered when you open a PR
- Retriggers when you manually add/change labels on a PR during PR review/triaging

This is too spammy, and the usefulness of the extra triggers is low. So making them the same as in all other GHA workflow files.