### PR TITLE
BUG: fix comparisons between masked and unmasked structured arrays

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4140,6 +4140,9 @@ class MaskedArray(ndarray):
             # Now take care of the mask; the merged mask should have an item
             # masked if all fields were masked (in one and/or other).
             mask = (mask == np.ones((), mask.dtype))
+            # Ensure we can compare masks below if other was not masked.
+            if omask is np.False_:
+                omask = np.zeros((), smask.dtype)
 
         else:
             # For regular arrays, just use the data as they come.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4159,10 +4159,11 @@ class MaskedArray(ndarray):
             # Note that this works automatically for structured arrays too.
             # Ignore this for operations other than `==` and `!=`
             check = np.where(mask, compare(smask, omask), check)
-            if mask.shape != check.shape:
-                # Guarantee consistency of the shape, making a copy since the
-                # the mask may need to get written to later.
-                mask = np.broadcast_to(mask, check.shape).copy()
+
+        if mask.shape != check.shape:
+            # Guarantee consistency of the shape, making a copy since the
+            # the mask may need to get written to later.
+            mask = np.broadcast_to(mask, check.shape).copy()
 
         check = check.view(type(self))
         check._update_from(self)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1310,7 +1310,7 @@ class TestMaskedArrayArithmetic:
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
         xm = masked_array(x, mask=m1)
         xm.set_fill_value(1e+20)
-        float_dtypes = [np.float16, np.float32, np.float64, np.longdouble, 
+        float_dtypes = [np.float16, np.float32, np.float64, np.longdouble,
                         np.complex64, np.complex128, np.clongdouble]
         for float_dtype in float_dtypes:
             assert_equal(masked_array(x, mask=m1, dtype=float_dtype).max(),
@@ -1613,6 +1613,23 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.data, [[False, True], [True, True]])
         assert_equal(test.mask, [[False, False], [False, True]])
         assert_(test.fill_value == True)
+
+    def test_eq_ne_structured_with_non_masked(self):
+        a = array([(1, 1), (2, 2), (3, 4)],
+                  mask=[(0, 1), (0, 0), (1, 1)], dtype='i4,i4')
+        eq = a == a.data
+        ne = a.data != a
+        # Test the obvious.
+        assert_(np.all(eq))
+        assert_(not np.any(ne))
+        # Expect the mask set only for items with all fields masked.
+        expected_mask = a.mask == np.ones((), a.mask.dtype)
+        assert_array_equal(eq.mask, expected_mask)
+        assert_array_equal(ne.mask, expected_mask)
+        # The masked element will indicated not equal, because the
+        # masks did not match.
+        assert_equal(eq.data, [True, True, False])
+        assert_array_equal(eq.data, ~ne.data)
 
     def test_eq_ne_structured_extra(self):
         # ensure simple examples are symmetric and make sense.
@@ -3444,7 +3461,7 @@ class TestMaskedArrayMethods:
         raveled = x.ravel(order)
         assert (raveled.filled(0) == 0).all()
 
-        # NOTE: Can be wrong if arr order is neither C nor F and `order="K"` 
+        # NOTE: Can be wrong if arr order is neither C nor F and `order="K"`
         assert_array_equal(arr.ravel(order), x.ravel(order)._data)
 
     def test_reshape(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1762,6 +1762,14 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, False])
         assert_(test.fill_value == True)
 
+    @pytest.mark.parametrize("op", [operator.eq, operator.lt])
+    def test_eq_broadcast_with_unmasked(self, op):
+        a = array([0, 1], mask=[0, 1])
+        b = np.arange(10).reshape(5, 2)
+        result = op(a, b)
+        assert_(result.mask.shape == b.shape)
+        assert_equal(result.mask, np.zeros(b.shape, bool) | a.mask)
+
     @pytest.mark.parametrize('dt1', num_dts, ids=num_ids)
     @pytest.mark.parametrize('dt2', num_dts, ids=num_ids)
     @pytest.mark.parametrize('fill', [None, 1])


### PR DESCRIPTION
Fixes #24554, where it was noted that currently comparing a masked structured array with an unmasked one fails:
```
import numpy as np
a = np.array([(1., 2.), (3., 4.)], "f8,f8")
ma = np.ma.MaskedArray(a)
ma == a
# TypeError: Cannot compare structured or void to non-void arrays.
```

While looking at the code, it seemed obvious that a correction to the mask shape done inside an `if` statement should really be outside. A quick test confirmed that. So, the second commit fixes that too. I can make it 2 PRs if need be (but am trying to just be done...)

Not sure about the milestone. I put 1.26.0, but that may be too late. This definitely is not very urgent, since the bug has been there for years.