### PR TITLE
CI/BENCH: move more jobs to Meson and fix all broken benchmarks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -148,14 +148,6 @@ jobs:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
-    env:
-      PYTHONOPTIMIZE: 2
-      BLAS: None
-      LAPACK: None
-      ATLAS: None
-      NPY_BLAS_ORDER: mkl,blis,openblas,atlas,blas
-      NPY_LAPACK_ORDER: MKL,OPENBLAS,ATLAS,LAPACK
-      USE_ASV: 1
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
@@ -164,7 +156,23 @@ jobs:
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.9'
-    - uses: ./.github/actions
+    - name: Install build and benchmarking dependencies
+      run: |
+        sudo apt-get install libopenblas-dev ninja-build
+        pip install spin cython asv virtualenv packaging
+    - name: Install NumPy
+      run: |
+        spin build -- -Dcpu-dispatch=none
+    # Ensure to keep the below steps as single-line bash commands (it's a
+    # workaround for asv#1333, and it may have side-effects on multi-line commands)
+    - name: Appease asv's need for machine info
+      shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
+      run: |
+        asv machine --yes --config benchmarks/asv.conf.json
+    - name: Run benchmarks
+      shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
+      run: |
+        spin bench --quick
 
   relaxed_strides_debug:
     needs: [smoke_test]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,18 +87,29 @@ jobs:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
-    env:
-      USE_DEBUG: 1
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         submodules: recursive
         fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      with:
-        python-version: '3.11'
-
-    - uses: ./.github/actions
+    - name: Install debug Python
+      run: |
+        sudo apt-get install python3-dbg ninja-build
+    - name: Build NumPy and install into venv
+      run: |
+        python3-dbg -m venv venv
+        source venv/bin/activate
+        pip install -U pip
+        pip install . -v -Csetup-args=-Dbuildtype=debug -Csetup-args=-Dallow-noblas=true
+    - name: Install test dependencies
+      run: |
+        source venv/bin/activate
+        pip install -r test_requirements.txt
+    - name: Run test suite
+      run: |
+        source venv/bin/activate
+        cd tools
+        pytest --pyargs numpy -m "not slow"
 
   full:
     # Build a wheel, install it, then run the full test suite with code coverage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,15 +64,10 @@ jobs:
         python-version: '3.9'
     - uses: ./.github/meson_actions
 
-  basic:
+  pypy:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
-    strategy:
-      matrix:
-        python-version: ["3.9", "pypy3.9-v7.3.12"]
-    env:
-      EXPECT_CPU_FEATURES: "SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL"
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
@@ -80,8 +75,11 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
-        python-version: ${{ matrix.python-version }}
-    - uses: ./.github/actions
+        python-version: 'pypy3.9-v7.3.12'
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install libopenblas-dev ninja-build
+    - uses: ./.github/meson_actions
 
   debug:
     needs: [smoke_test]

--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -217,19 +217,13 @@ class Indices(Benchmark):
 
 
 class StatsMethods(Benchmark):
-    # Not testing, but in array_api (redundant)
-    # 8, 16, 32 bit variants, and 128 complexes
-    params = [['int64', 'uint64', 'float64', 'intp',
-               'complex64', 'bool', 'float', 'int',
-               'complex', 'complex256'],
-              [100**n for n in range(0, 2)]]
+    params = [['int64', 'uint64', 'float32', 'float64',
+               'complex64', 'bool_'],
+              [100, 10000]]
     param_names = ['dtype', 'size']
 
     def setup(self, dtype, size):
-        try:
-            self.data = np.ones(size, dtype=getattr(np, dtype))
-        except AttributeError:  # builtins throw AttributeError after 1.20
-            self.data = np.ones(size, dtype=dtype)
+        self.data = np.ones(size, dtype=dtype)
         if dtype.startswith('complex'):
             self.data = np.random.randn(size) + 1j * np.random.randn(size)
 

--- a/benchmarks/benchmarks/bench_creation.py
+++ b/benchmarks/benchmarks/bench_creation.py
@@ -1,4 +1,4 @@
-from .common import Benchmark, TYPES1
+from .common import Benchmark, TYPES1, get_squares_
 
 import numpy as np
 
@@ -23,57 +23,49 @@ class MeshGrid(Benchmark):
 class Create(Benchmark):
     """ Benchmark for creation functions
     """
-    # (64, 64), (128, 128), (256, 256)
-    # , (512, 512), (1024, 1024)
-    params = [[16, 32, 128, 256, 512,
-               (16, 16), (32, 32)],
-              ['C', 'F'],
-              TYPES1]
-    param_names = ['shape', 'order', 'npdtypes']
-    timeout = 10
-
-    def setup(self, shape, order, npdtypes):
-        values = get_squares_()
-        self.xarg = values.get(npdtypes)[0]
-
-    def time_full(self, shape, order, npdtypes):
-        np.full(shape, self.xarg[1], dtype=npdtypes, order=order)
-
-    def time_full_like(self, shape, order, npdtypes):
-        np.full_like(self.xarg, self.xarg[0], order=order)
-
-    def time_ones(self, shape, order, npdtypes):
-        np.ones(shape, dtype=npdtypes, order=order)
-
-    def time_ones_like(self, shape, order, npdtypes):
-        np.ones_like(self.xarg, order=order)
-
-    def time_zeros(self, shape, order, npdtypes):
-        np.zeros(shape, dtype=npdtypes, order=order)
-
-    def time_zeros_like(self, shape, order, npdtypes):
-        np.zeros_like(self.xarg, order=order)
-
-    def time_empty(self, shape, order, npdtypes):
-        np.empty(shape, dtype=npdtypes, order=order)
-
-    def time_empty_like(self, shape, order, npdtypes):
-        np.empty_like(self.xarg, order=order)
-
-
-class UfuncsFromDLP(Benchmark):
-    """ Benchmark for creation functions
-    """
-    params = [[16, 32, (16, 16),
-               (32, 32), (64, 64)],
+    params = [[16, 512, (32, 32)],
               TYPES1]
     param_names = ['shape', 'npdtypes']
     timeout = 10
 
     def setup(self, shape, npdtypes):
-        if npdtypes in ['longdouble', 'clongdouble']:
-            raise NotImplementedError(
-                'Only IEEE dtypes are supported')
+        values = get_squares_()
+        self.xarg = values.get(npdtypes)[0]
+
+    def time_full(self, shape, npdtypes):
+        np.full(shape, self.xarg[1], dtype=npdtypes)
+
+    def time_full_like(self, shape, npdtypes):
+        np.full_like(self.xarg, self.xarg[0])
+
+    def time_ones(self, shape, npdtypes):
+        np.ones(shape, dtype=npdtypes)
+
+    def time_ones_like(self, shape, npdtypes):
+        np.ones_like(self.xarg)
+
+    def time_zeros(self, shape, npdtypes):
+        np.zeros(shape, dtype=npdtypes)
+
+    def time_zeros_like(self, shape, npdtypes):
+        np.zeros_like(self.xarg)
+
+    def time_empty(self, shape, npdtypes):
+        np.empty(shape, dtype=npdtypes)
+
+    def time_empty_like(self, shape, npdtypes):
+        np.empty_like(self.xarg)
+
+
+class UfuncsFromDLP(Benchmark):
+    """ Benchmark for creation functions
+    """
+    params = [[16, 32, (16, 16), (64, 64)],
+              TYPES1]
+    param_names = ['shape', 'npdtypes']
+    timeout = 10
+
+    def setup(self, shape, npdtypes):
         values = get_squares_()
         self.xarg = values.get(npdtypes)[0]
 

--- a/benchmarks/benchmarks/bench_itemselection.py
+++ b/benchmarks/benchmarks/bench_itemselection.py
@@ -5,7 +5,7 @@ import numpy as np
 
 class Take(Benchmark):
     params = [
-        [(1000, 1), (1000, 2), (2, 1000, 1), (1000, 3)],
+        [(1000, 1), (2, 1000, 1), (1000, 3)],
         ["raise", "wrap", "clip"],
         TYPES1 + ["O", "i,O"]]
     param_names = ["shape", "mode", "dtype"]

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -72,37 +72,39 @@ class Eindot(Benchmark):
 
 
 class Linalg(Benchmark):
-    params = [['svd', 'pinv', 'det', 'norm'],
-              TYPES1]
-    param_names = ['op', 'type']
+    params = set(TYPES1) - set(['float16'])
+    param_names = ['dtype']
 
-    def setup(self, op, typename):
+    def setup(self, typename):
         np.seterr(all='ignore')
+        self.a = get_squares_()[typename]
 
-        self.func = getattr(np.linalg, op)
+    def time_svd(self, typename):
+        np.linalg.svd(self.a)
 
-        if op == 'cholesky':
-            # we need a positive definite
-            self.a = np.dot(get_squares_()[typename],
-                            get_squares_()[typename].T)
-        else:
-            self.a = get_squares_()[typename]
+    def time_pinv(self, typename):
+        np.linalg.pinv(self.a)
 
-        # check that dtype is supported at all
-        try:
-            self.func(self.a[:2, :2])
-        except TypeError as e:
-            raise NotImplementedError() from e
+    def time_det(self, typename):
+        np.linalg.det(self.a)
 
-    def time_op(self, op, typename):
-        self.func(self.a)
+
+class LinalgNorm(Benchmark):
+    params = TYPES1
+    param_names = ['dtype']
+
+    def setup(self, typename):
+        self.a = get_squares_()[typename]
+
+    def time_norm(self, typename):
+        np.linalg.norm(self.a)
 
 
 class LinalgSmallArrays(Benchmark):
     """ Test overhead of linalg methods for small arrays """
     def setup(self):
         self.array_5 = np.arange(5.)
-        self.array_5_5 = np.reshape(np.arange(25.), (5., 5.))
+        self.array_5_5 = np.reshape(np.arange(25.), (5, 5))
 
     def time_norm_small_array(self):
         np.linalg.norm(self.array_5)

--- a/benchmarks/benchmarks/bench_ma.py
+++ b/benchmarks/benchmarks/bench_ma.py
@@ -128,10 +128,10 @@ class MAFunctions1v(Benchmark):
               ['small', 'big']]
 
     def setup(self, mtype, func, msize):
-        xs = np.random.uniform(-1, 1, 6).reshape(2, 3)
+        xs = 2.0 + np.random.uniform(-1, 1, 6).reshape(2, 3)
         m1 = [[True, False, False], [False, False, True]]
-        xl = np.random.uniform(-1, 1, 100*100).reshape(100, 100)
-        maskx = xl > 0.8
+        xl = 2.0 + np.random.uniform(-1, 1, 100*100).reshape(100, 100)
+        maskx = xl > 2.8
         self.nmxs = np.ma.array(xs, mask=m1)
         self.nmxl = np.ma.array(xl, mask=maskx)
 
@@ -173,17 +173,17 @@ class MAFunctions2v(Benchmark):
 
     def setup(self, mtype, func, msize):
         # Small arrays
-        xs = np.random.uniform(-1, 1, 6).reshape(2, 3)
-        ys = np.random.uniform(-1, 1, 6).reshape(2, 3)
+        xs = 2.0 + np.random.uniform(-1, 1, 6).reshape(2, 3)
+        ys = 2.0 + np.random.uniform(-1, 1, 6).reshape(2, 3)
         m1 = [[True, False, False], [False, False, True]]
         m2 = [[True, False, True], [False, False, True]]
         self.nmxs = np.ma.array(xs, mask=m1)
         self.nmys = np.ma.array(ys, mask=m2)
         # Big arrays
-        xl = np.random.uniform(-1, 1, 100*100).reshape(100, 100)
-        yl = np.random.uniform(-1, 1, 100*100).reshape(100, 100)
-        maskx = xl > 0.8
-        masky = yl < -0.8
+        xl = 2.0 + np.random.uniform(-1, 1, 100*100).reshape(100, 100)
+        yl = 2.0 + np.random.uniform(-1, 1, 100*100).reshape(100, 100)
+        maskx = xl > 2.8
+        masky = yl < 1.8
         self.nmxl = np.ma.array(xl, mask=maskx)
         self.nmyl = np.ma.array(yl, mask=masky)
 

--- a/benchmarks/benchmarks/bench_manipulate.py
+++ b/benchmarks/benchmarks/bench_manipulate.py
@@ -4,9 +4,7 @@ import numpy as np
 from collections import deque
 
 class BroadcastArrays(Benchmark):
-    params = [[(16, 32), (32, 64),
-               (64, 128), (128, 256),
-               (256, 512), (512, 1024)],
+    params = [[(16, 32), (128, 256), (512, 1024)],
               TYPES1]
     param_names = ['shape', 'ndtype']
     timeout = 10
@@ -22,7 +20,7 @@ class BroadcastArrays(Benchmark):
 
 
 class BroadcastArraysTo(Benchmark):
-    params = [[16, 32, 64, 128, 256, 512],
+    params = [[16, 64, 512],
               TYPES1]
     param_names = ['size', 'ndtype']
     timeout = 10
@@ -39,9 +37,8 @@ class BroadcastArraysTo(Benchmark):
 
 
 class ConcatenateStackArrays(Benchmark):
-    # (64, 128), (128, 256), (256, 512)
     params = [[(16, 32), (32, 64)],
-              [2, 3, 4, 5],
+              [2, 5],
               TYPES1]
     param_names = ['shape', 'narrays', 'ndtype']
     timeout = 10

--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -46,18 +46,11 @@ class AnyAll(Benchmark):
 
 
 class StatsReductions(Benchmark):
-    # Not testing, but in array_api (redundant)
-    # 8, 16, 32 bit variants, and 128 complexes
-    params = ['int64', 'uint64', 'float64', 'intp',
-               'complex64', 'bool', 'float', 'int',
-               'complex', 'complex256'],
+    params = ['int64', 'uint64', 'float32', 'float64', 'complex64', 'bool_'],
     param_names = ['dtype']
 
     def setup(self, dtype):
-        try:
-            self.data = np.ones(200, dtype=getattr(np, dtype))
-        except AttributeError:  # builtins throw AttributeError after 1.20
-            self.data = np.ones(200, dtype=dtype)
+        self.data = np.ones(200, dtype=dtype)
         if dtype.startswith('complex'):
             self.data = self.data * self.data.T*1j
 

--- a/benchmarks/benchmarks/bench_shape_base.py
+++ b/benchmarks/benchmarks/bench_shape_base.py
@@ -68,7 +68,7 @@ class Block(Benchmark):
 
 
 class Block2D(Benchmark):
-    params = [[(16, 16), (32, 32), (64, 64), (128, 128), (256, 256), (512, 512), (1024, 1024)],
+    params = [[(16, 16), (64, 64), (256, 256), (1024, 1024)],
               ['uint8', 'uint16', 'uint32', 'uint64'],
               [(2, 2), (4, 4)]]
     param_names = ['shape', 'dtype', 'n_chunks']

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -159,23 +159,49 @@ class Methods0D(Benchmark):
 class MethodsV1(Benchmark):
     """ Benchmark for the methods which take an argument
     """
-    params = [['__and__', '__add__', '__eq__', '__floordiv__', '__ge__',
-               '__gt__', '__le__', '__lt__', '__matmul__',
-               '__mod__', '__mul__', '__ne__', '__or__',
-               '__pow__', '__sub__', '__truediv__', '__xor__'],
+    params = [['__add__', '__eq__', '__ge__', '__gt__', '__le__',
+               '__lt__', '__matmul__', '__mul__', '__ne__',
+               '__pow__', '__sub__', '__truediv__'],
               TYPES1]
     param_names = ['methods', 'npdtypes']
     timeout = 10
 
     def setup(self, methname, npdtypes):
-        if (
-            npdtypes.startswith("complex")
-                and methname in ["__floordiv__", "__mod__"]
-        ) or (
-            not npdtypes.startswith("int")
-            and methname in ["__and__", "__or__", "__xor__"]
-        ):
-            raise NotImplementedError  # skip
+        values = get_squares_().get(npdtypes)
+        self.xargs = [values[0], values[1]]
+        if np.issubdtype(npdtypes, np.inexact):
+            # avoid overflow in __pow__/__matmul__ for low-precision dtypes
+            self.xargs[1] *= 0.01
+
+    def time_ndarray_meth(self, methname, npdtypes):
+        getattr(operator, methname)(*self.xargs)
+
+
+class MethodsV1IntOnly(Benchmark):
+    """ Benchmark for the methods which take an argument
+    """
+    params = [['__and__', '__or__', '__xor__'],
+              ['int16', 'int32', 'int64']]
+    param_names = ['methods', 'npdtypes']
+    timeout = 10
+
+    def setup(self, methname, npdtypes):
+        values = get_squares_().get(npdtypes)
+        self.xargs = [values[0], values[1]]
+
+    def time_ndarray_meth(self, methname, npdtypes):
+        getattr(operator, methname)(*self.xargs)
+
+
+class MethodsV1NoComplex(Benchmark):
+    """ Benchmark for the methods which take an argument
+    """
+    params = [['__floordiv__', '__mod__'],
+              [dt for dt in TYPES1 if not dt.startswith('complex')]]
+    param_names = ['methods', 'npdtypes']
+    timeout = 10
+
+    def setup(self, methname, npdtypes):
         values = get_squares_().get(npdtypes)
         self.xargs = [values[0], values[1]]
 

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -135,25 +135,52 @@ class NDArrayLRShifts(Benchmark):
         getattr(operator, methname)(*[self.vals, 2])
 
 
-class Methods0D(Benchmark):
+class Methods0DBoolComplex(Benchmark):
     """Zero dimension array methods
     """
-    params = [['__bool__', '__complex__', '__invert__',
-               '__float__', '__int__'], TYPES1]
+    params = [['__bool__', '__complex__'],
+              TYPES1]
     param_names = ['methods', 'npdtypes']
     timeout = 10
 
     def setup(self, methname, npdtypes):
         self.xarg = np.array(3, dtype=npdtypes)
-        if (npdtypes.startswith('complex') and
-           methname in ['__float__', '__int__']) or \
-           (npdtypes.startswith('int') and methname == '__invert__'):
-            # Skip
-            raise NotImplementedError
 
     def time_ndarray__0d__(self, methname, npdtypes):
         meth = getattr(self.xarg, methname)
         meth()
+
+
+class Methods0DFloatInt(Benchmark):
+    """Zero dimension array methods
+    """
+    params = [['__int__', '__float__'],
+              [dt for dt in TYPES1 if not dt.startswith('complex')]
+             ]
+    param_names = ['methods', 'npdtypes']
+    timeout = 10
+
+    def setup(self, methname, npdtypes):
+        self.xarg = np.array(3, dtype=npdtypes)
+
+    def time_ndarray__0d__(self, methname, npdtypes):
+        meth = getattr(self.xarg, methname)
+        meth()
+
+
+
+class Methods0DInvert(Benchmark):
+    """Zero dimension array methods
+    """
+    params = ['int16', 'int32', 'int64']
+    param_names = ['npdtypes']
+    timeout = 10
+
+    def setup(self, npdtypes):
+        self.xarg = np.array(3, dtype=npdtypes)
+
+    def time_ndarray__0d__(self, npdtypes):
+        self.xarg.__invert__()
 
 
 class MethodsV1(Benchmark):

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -155,8 +155,7 @@ class Methods0DFloatInt(Benchmark):
     """Zero dimension array methods
     """
     params = [['__int__', '__float__'],
-              [dt for dt in TYPES1 if not dt.startswith('complex')]
-             ]
+              [dt for dt in TYPES1 if not dt.startswith('complex')]]
     param_names = ['methods', 'npdtypes']
     timeout = 10
 
@@ -166,7 +165,6 @@ class Methods0DFloatInt(Benchmark):
     def time_ndarray__0d__(self, methname, npdtypes):
         meth = getattr(self.xarg, methname)
         meth()
-
 
 
 class Methods0DInvert(Benchmark):
@@ -444,15 +442,11 @@ class CustomComparison(Benchmark):
 
 
 class CustomScalarFloorDivideInt(Benchmark):
-    params = (np.core.sctypes['int'] + 
-              np.core.sctypes['uint'], [8, -8, 43, -43])
+    params = (np.core.sctypes['int'],
+              [8, -8, 43, -43])
     param_names = ['dtype', 'divisors']
 
     def setup(self, dtype, divisor):
-        if dtype in np.core.sctypes['uint'] and divisor < 0:
-            raise NotImplementedError(
-                    "Skipping test for negative divisor with unsigned type")
-
         iinfo = np.iinfo(dtype)
         self.x = np.random.randint(
                     iinfo.min, iinfo.max, size=10000, dtype=dtype)
@@ -460,9 +454,24 @@ class CustomScalarFloorDivideInt(Benchmark):
     def time_floor_divide_int(self, dtype, divisor):
         self.x // divisor
 
+
+class CustomScalarFloorDivideUInt(Benchmark):
+    params = (np.core.sctypes['uint'],
+              [8, 43])
+    param_names = ['dtype', 'divisors']
+
+    def setup(self, dtype, divisor):
+        iinfo = np.iinfo(dtype)
+        self.x = np.random.randint(
+                    iinfo.min, iinfo.max, size=10000, dtype=dtype)
+
+    def time_floor_divide_uint(self, dtype, divisor):
+        self.x // divisor
+
+
 class CustomArrayFloorDivideInt(Benchmark):
-    params = (np.core.sctypes['int'] + 
-              np.core.sctypes['uint'], [100, 10000, 1000000])
+    params = (np.core.sctypes['int'] + np.core.sctypes['uint'],
+              [100, 10000, 1000000])
     param_names = ['dtype', 'size']
 
     def setup(self, dtype, size):

--- a/benchmarks/benchmarks/bench_ufunc_strides.py
+++ b/benchmarks/benchmarks/bench_ufunc_strides.py
@@ -100,7 +100,10 @@ class _AbstractUnary(Benchmark):
         ufunc(*self.ufunc_args)
 
 class UnaryFP(_AbstractUnary):
-    params = [UFUNCS_UNARY, [1, 2, 4], [1, 2, 4], ['e', 'f', 'd']]
+    params = [[uf for uf in UFUNCS_UNARY if uf != np.invert],
+              [1, 4],
+              [1, 2],
+              ['e', 'f', 'd']]
 
     def setup(self, ufunc, stride_in, stride_out, dtype):
         _AbstractUnary.setup(self, ufunc, stride_in, stride_out, dtype)
@@ -115,7 +118,7 @@ class UnaryFPSpecial(UnaryFP):
 class BinaryFP(_AbstractBinary):
     params = [
         [np.maximum, np.minimum, np.fmax, np.fmin, np.ldexp],
-        [1, 2, 4], [1, 2, 4], [1, 2, 4], ['f', 'd']
+        [1, 2], [1, 4], [1, 2, 4], ['f', 'd']
     ]
 
 class BinaryFPSpecial(BinaryFP):

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -22,10 +22,8 @@ TYPES1 = [
     'int16', 'float16',
     'int32', 'float32',
     'int64', 'float64',  'complex64',
-    'longdouble', 'complex128',
+    'complex128',
 ]
-if 'complex256' in np.core.sctypeDict:
-    TYPES1.append('clongdouble')
 
 DLPACK_TYPES = [
     'int16', 'float16',


### PR DESCRIPTION
The changed jobs are:
- The `basic` job was de-matrixed (the basic Python 3.9 job served no purpose, duplicate with other jobs) and rename to be specifically for PyPy
- The `debug` job (this was straightforward)
- The `benchmark` job (this one was broken in many ways, and the benchmarks weren't even running before despite the job being green)

Making the `benchmark` job run uncovered a ton of warnings and bugs in both our benchmark suite and in `asv`. Everything should work after this PR with `asv` 0.6 (a recent release), some open issues in `asv` are worked around. The fixes were mostly in these categories:
- Avoid using deprecated or removed APIs
- Avoid raising `NotImplementedError` where possible - this is extremely noisy, because `spin bench` will show stderr output (that is a good idea, because it should run cleanly) - and instead split up benchmarks to avoid trying unsupported dtypes/values,
- Remove long double types from the default list of types in `common.py`. They caused a lot of problems, and they're not very interesting dtypes to test that extensively. For the few performance-critical ops, whoever cares can write a dedicated benchmark,
- Reduce the level of parametrization of a number of tests. This is a good idea for at least two reasons: reduce runtime, and keep the CI log output reasonable (it went from >50,000 lines with all the warnings and heavy parametrization to ~8.000 lines) 
- `spin bench` improvements:
  - ensure the exit code is always propagated so that when benchmarks fail the CI job fails, and
  - add a `--quick` option to `spin bench` - necessary to make the CI job run in a reasonable amount of time.

