### PR TITLE
Add Python 3.11 compatibility to 1.16.x

### DIFF
--- a/numpy/core/src/common/npy_pycompat.h
+++ b/numpy/core/src/common/npy_pycompat.h
@@ -3,4 +3,20 @@
 
 #include "numpy/npy_3kcompat.h"
 
+
+/*
+ * In Python 3.10a7 (or b1), python started using the identity for the hash
+ * when a value is NaN.  See https://bugs.python.org/issue43475
+ */
+#if PY_VERSION_HEX > 0x030a00a6
+#define Npy_HashDouble _Py_HashDouble
+#else
+static NPY_INLINE Py_hash_t
+Npy_HashDouble(PyObject *NPY_UNUSED(identity), double val)
+{
+    return _Py_HashDouble(val);
+}
+#endif
+
+
 #endif /* _NPY_COMPAT_H_ */

--- a/numpy/core/src/common/npy_pycompat.h
+++ b/numpy/core/src/common/npy_pycompat.h
@@ -11,7 +11,12 @@
 #if PY_VERSION_HEX > 0x030a00a6
 #define Npy_HashDouble _Py_HashDouble
 #else
-static NPY_INLINE Py_hash_t
+static NPY_INLINE
+#if PY_VERSION_HEX < 0x03020000
+long
+#else
+Py_hash_t
+#endif
 Npy_HashDouble(PyObject *NPY_UNUSED(identity), double val)
 {
     return _Py_HashDouble(val);

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1843,21 +1843,21 @@ PrintFloat_Printf_g(PyObject *obj, int precision)
     char str[1024];
 
     if (PyArray_IsScalar(obj, Half)) {
-        npy_half x = ((PyHalfScalarObject *)obj)->obval;
+        npy_half x = PyArrayScalar_VAL(obj, Half);
         PyOS_snprintf(str, sizeof(str), "%.*g", precision,
                       npy_half_to_double(x));
     }
     else if (PyArray_IsScalar(obj, Float)) {
-        npy_float x = ((PyFloatScalarObject *)obj)->obval;
+        npy_float x = PyArrayScalar_VAL(obj, Float);
         PyOS_snprintf(str, sizeof(str), "%.*g", precision, x);
     }
     else if (PyArray_IsScalar(obj, Double)) {
-        npy_double x = ((PyDoubleScalarObject *)obj)->obval;
+        npy_double x = PyArrayScalar_VAL(obj, Double);
         PyOS_snprintf(str, sizeof(str), "%.*g", precision, x);
         /* would be better to use lg, but not available in C90 */
     }
     else if (PyArray_IsScalar(obj, LongDouble)) {
-        npy_longdouble x = ((PyLongDoubleScalarObject *)obj)->obval;
+        npy_longdouble x = PyArrayScalar_VAL(obj, LongDouble);
         PyOS_snprintf(str, sizeof(str), "%.*Lg", precision, x);
     }
     else{

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -210,7 +210,7 @@ static int
     @type@ temp;  /* ensures alignment */
 
     if (PyArray_IsScalar(op, @kind@)) {
-        temp = ((Py@kind@ScalarObject *)op)->obval;
+        temp = PyArrayScalar_VAL(op, @kind@);
     }
     else {
         temp = (@type@)@func2@(op);
@@ -293,7 +293,7 @@ static int
     }
 
     if (PyArray_IsScalar(op, @kind@)){
-        temp = ((Py@kind@ScalarObject *)op)->obval;
+        temp = PyArrayScalar_VAL(op, @kind@);
     }
     else {
         if (op == Py_None) {
@@ -412,7 +412,7 @@ LONGDOUBLE_setitem(PyObject *op, void *ov, void *vap)
     }
 
     if (PyArray_IsScalar(op, LongDouble)) {
-        temp = ((PyLongDoubleScalarObject *)op)->obval;
+        temp = PyArrayScalar_VAL(op, LongDouble);
     }
     else {
         /* In case something funny happened in PyArray_IsScalar */

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -3181,19 +3181,19 @@ Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
     opt.exp_digits = -1;
 
     if (PyArray_IsScalar(obj, Half)) {
-        npy_half x = ((PyHalfScalarObject *)obj)->obval;
+        npy_half x = PyArrayScalar_VAL(obj, Half);
         return Dragon4_Positional_Half_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, Float)) {
-        npy_float x = ((PyFloatScalarObject *)obj)->obval;
+        npy_float x = PyArrayScalar_VAL(obj, Float);
         return Dragon4_Positional_Float_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, Double)) {
-        npy_double x = ((PyDoubleScalarObject *)obj)->obval;
+        npy_double x = PyArrayScalar_VAL(obj, Double);
         return Dragon4_Positional_Double_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, LongDouble)) {
-        npy_longdouble x = ((PyLongDoubleScalarObject *)obj)->obval;
+        npy_longdouble x = PyArrayScalar_VAL(obj, LongDouble);
         return Dragon4_Positional_LongDouble_opt(&x, &opt);
     }
 
@@ -3222,19 +3222,19 @@ Dragon4_Scientific(PyObject *obj, DigitMode digit_mode, int precision,
     opt.exp_digits = exp_digits;
 
     if (PyArray_IsScalar(obj, Half)) {
-        npy_half x = ((PyHalfScalarObject *)obj)->obval;
+        npy_half x = PyArrayScalar_VAL(obj, Half);
         return Dragon4_Scientific_Half_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, Float)) {
-        npy_float x = ((PyFloatScalarObject *)obj)->obval;
+        npy_float x = PyArrayScalar_VAL(obj, Float);
         return Dragon4_Scientific_Float_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, Double)) {
-        npy_double x = ((PyDoubleScalarObject *)obj)->obval;
+        npy_double x = PyArrayScalar_VAL(obj, Double);
         return Dragon4_Scientific_Double_opt(&x, &opt);
     }
     else if (PyArray_IsScalar(obj, LongDouble)) {
-        npy_longdouble x = ((PyLongDoubleScalarObject *)obj)->obval;
+        npy_longdouble x = PyArrayScalar_VAL(obj, LongDouble);
         return Dragon4_Scientific_LongDouble_opt(&x, &opt);
     }
 

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -789,7 +789,11 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             vobj->descr = descr;
             Py_INCREF(descr);
             vobj->obval = NULL;
+#if PY_VERSION_HEX >= 0x030a0000
+            Py_SET_SIZE(vobj, itemsize);
+#else
             Py_SIZE(vobj) = itemsize;
+#endif
             vobj->flags = NPY_ARRAY_CARRAY | NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_OWNDATA;
             swap = 0;
             if (PyDataType_HASFIELDS(descr)) {

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3067,7 +3067,11 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
             return PyErr_NoMemory();
         }
         ((PyVoidScalarObject *)ret)->obval = destptr;
+#if PY_VERSION_HEX >= 0x030a0000
+        Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
+#else
         Py_SIZE((PyVoidScalarObject *)ret) = (int) memu;
+#endif
         ((PyVoidScalarObject *)ret)->descr =
             PyArray_DescrNewFromType(NPY_VOID);
         ((PyVoidScalarObject *)ret)->descr->elsize = (int) memu;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3211,7 +3211,7 @@ static npy_hash_t
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
-    return _Py_HashDouble((double) PyArrayScalar_VAL(obj, @name@));
+    return Npy_HashDouble(obj, (double)PyArrayScalar_VAL(obj, @name@));
 }
 
 /* borrowed from complex_hash */
@@ -3219,14 +3219,14 @@ static npy_hash_t
 c@lname@_arrtype_hash(PyObject *obj)
 {
     npy_hash_t hashreal, hashimag, combined;
-    hashreal = _Py_HashDouble((double)
-            PyArrayScalar_VAL(obj, C@name@).real);
+    hashreal = Npy_HashDouble(
+            obj, (double)PyArrayScalar_VAL(obj, C@name@).real);
 
     if (hashreal == -1) {
         return -1;
     }
-    hashimag = _Py_HashDouble((double)
-            PyArrayScalar_VAL(obj, C@name@).imag);
+    hashimag = Npy_HashDouble(
+            obj, (double)PyArrayScalar_VAL(obj, C@name@).imag);
     if (hashimag == -1) {
         return -1;
     }
@@ -3241,7 +3241,8 @@ c@lname@_arrtype_hash(PyObject *obj)
 static npy_hash_t
 half_arrtype_hash(PyObject *obj)
 {
-    return _Py_HashDouble(npy_half_to_double(PyArrayScalar_VAL(obj, Half)));
+    return Npy_HashDouble(
+            obj, npy_half_to_double(PyArrayScalar_VAL(obj, Half)));
 }
 
 static npy_hash_t

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -378,7 +378,7 @@ gentype_format(PyObject *self, PyObject *args)
      *       because it throws away precision.
      */
     if (Py_TYPE(self) == &PyBoolArrType_Type) {
-        obj = PyBool_FromLong(((PyBoolScalarObject *)self)->obval);
+        obj = PyBool_FromLong(PyArrayScalar_VAL(self, Bool));
     }
     else if (PyArray_IsScalar(self, Integer)) {
 #if defined(NPY_PY3K)
@@ -967,7 +967,7 @@ static PyObject *
 static PyObject *
 @name@type_@kind@(PyObject *self)
 {
-    return @name@type_@kind@_either(((Py@Name@ScalarObject *)self)->obval,
+    return @name@type_@kind@_either(PyArrayScalar_VAL(self, @Name@),
                                   TrimMode_LeaveOneZero, TrimMode_DptZeros, 0);
 }
 
@@ -975,7 +975,7 @@ static PyObject *
 c@name@type_@kind@(PyObject *self)
 {
     PyObject *rstr, *istr, *ret;
-    npy_c@name@ val = ((PyC@Name@ScalarObject *)self)->obval;
+    npy_c@name@ val = PyArrayScalar_VAL(self, C@Name@);
     TrimMode trim = TrimMode_DptZeros;
 
     if (npy_legacy_print_mode == 113) {
@@ -1039,7 +1039,7 @@ c@name@type_@kind@(PyObject *self)
 static PyObject *
 halftype_@kind@(PyObject *self)
 {
-    npy_half val = ((PyHalfScalarObject *)self)->obval;
+    npy_half val = PyArrayScalar_VAL(self, Half);
     float floatval = npy_half_to_float(val);
     float absval;
 
@@ -1438,7 +1438,7 @@ gentype_real_get(PyObject *self)
         return ret;
     }
     else if (PyArray_IsScalar(self, Object)) {
-        PyObject *obj = ((PyObjectScalarObject *)self)->obval;
+        PyObject *obj = PyArrayScalar_VAL(self, Object);
         ret = PyObject_GetAttrString(obj, "real");
         if (ret != NULL) {
             return ret;
@@ -1463,7 +1463,7 @@ gentype_imag_get(PyObject *self)
         ret = PyArray_Scalar(ptr + typecode->elsize, typecode, NULL);
     }
     else if (PyArray_IsScalar(self, Object)) {
-        PyObject *obj = ((PyObjectScalarObject *)self)->obval;
+        PyObject *obj = PyArrayScalar_VAL(self, Object);
         PyArray_Descr *newtype;
         ret = PyObject_GetAttrString(obj, "imag");
         if (ret == NULL) {
@@ -1884,7 +1884,7 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
     PyTuple_SET_ITEM(ret, 0, obj);
     obj = PyObject_GetAttrString((PyObject *)self, "dtype");
     if (PyArray_IsScalar(self, Object)) {
-        mod = ((PyObjectScalarObject *)self)->obval;
+        mod = PyArrayScalar_VAL(self, Object);
         PyTuple_SET_ITEM(ret, 1, Py_BuildValue("NO", obj, mod));
     }
     else {
@@ -2612,7 +2612,7 @@ void_dealloc(PyVoidScalarObject *v)
 static void
 object_arrtype_dealloc(PyObject *v)
 {
-    Py_XDECREF(((PyObjectScalarObject *)v)->obval);
+    Py_XDECREF(PyArrayScalar_VAL(v, Object));
     Py_TYPE(v)->tp_free(v);
 }
 
@@ -2705,7 +2705,7 @@ static PyObject *
             Py_DECREF(typecode);
             return NULL;
         }
-        memset(&((Py@Name@ScalarObject *)robj)->obval, 0, sizeof(npy_@name@));
+        memset(&PyArrayScalar_VAL(robj, @Name@), 0, sizeof(npy_@name@));
 #elif @default@ == 1
         robj = PyArray_Scalar(NULL, typecode, NULL);
 #elif @default@ == 2
@@ -3091,7 +3091,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
-    return (npy_hash_t)(((Py@name@ScalarObject *)obj)->obval);
+    return (npy_hash_t)(PyArrayScalar_VAL(obj, @name@));
 }
 /**end repeat**/
 
@@ -3102,7 +3102,7 @@ static npy_hash_t
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
-    npy_hash_t x = (npy_hash_t)(((Py@name@ScalarObject *)obj)->obval);
+    npy_hash_t x = (npy_hash_t)(PyArrayScalar_VAL(obj, @name@));
     if (x == -1) {
         x = -2;
     }
@@ -3113,7 +3113,7 @@ static npy_hash_t
 static npy_hash_t
 ulong_arrtype_hash(PyObject *obj)
 {
-    PyObject * l = PyLong_FromUnsignedLong(((PyULongScalarObject*)obj)->obval);
+    PyObject * l = PyLong_FromUnsignedLong(PyArrayScalar_VAL(obj, ULong));
     npy_hash_t x = PyObject_Hash(l);
     Py_DECREF(l);
     return x;
@@ -3123,7 +3123,7 @@ ulong_arrtype_hash(PyObject *obj)
 static npy_hash_t
 int_arrtype_hash(PyObject *obj)
 {
-    npy_hash_t x = (npy_hash_t)(((PyIntScalarObject *)obj)->obval);
+    npy_hash_t x = (npy_hash_t)(PyArrayScalar_VAL(obj, Int));
     if (x == -1) {
         x = -2;
     }
@@ -3135,7 +3135,7 @@ int_arrtype_hash(PyObject *obj)
 static npy_hash_t
 long_arrtype_hash(PyObject *obj)
 {
-    PyObject * l = PyLong_FromLong(((PyLongScalarObject*)obj)->obval);
+    PyObject * l = PyLong_FromLong(PyArrayScalar_VAL(obj, Long));
     npy_hash_t x = PyObject_Hash(l);
     Py_DECREF(l);
     return x;
@@ -3151,7 +3151,7 @@ static NPY_INLINE npy_hash_t
 @char@longlong_arrtype_hash(PyObject *obj)
 {
     PyObject * l = PyLong_From@Word@LongLong(
-                                 ((Py@Char@LongLongScalarObject*)obj)->obval);
+                                 PyArrayScalar_VAL(obj, @Char@LongLong));
     npy_hash_t x = PyObject_Hash(l);
     Py_DECREF(l);
     return x;
@@ -3167,7 +3167,7 @@ static NPY_INLINE npy_hash_t
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
-    npy_hash_t x = (npy_hash_t)(((Py@name@ScalarObject *)obj)->obval);
+    npy_hash_t x = (npy_hash_t)(PyArrayScalar_VAL(obj, @name@));
     if (x == -1) {
         x = -2;
     }
@@ -3178,7 +3178,7 @@ static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
     npy_hash_t y;
-    npy_longlong x = (((Py@name@ScalarObject *)obj)->obval);
+    npy_longlong x = (PyArrayScalar_VAL(obj, @name@));
 
     if ((x <= LONG_MAX)) {
         y = (npy_hash_t) x;
@@ -3211,7 +3211,7 @@ static npy_hash_t
 static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
-    return _Py_HashDouble((double) ((Py@name@ScalarObject *)obj)->obval);
+    return _Py_HashDouble((double) PyArrayScalar_VAL(obj, @name@));
 }
 
 /* borrowed from complex_hash */
@@ -3220,13 +3220,13 @@ c@lname@_arrtype_hash(PyObject *obj)
 {
     npy_hash_t hashreal, hashimag, combined;
     hashreal = _Py_HashDouble((double)
-            (((PyC@name@ScalarObject *)obj)->obval).real);
+            PyArrayScalar_VAL(obj, C@name@).real);
 
     if (hashreal == -1) {
         return -1;
     }
     hashimag = _Py_HashDouble((double)
-            (((PyC@name@ScalarObject *)obj)->obval).imag);
+            PyArrayScalar_VAL(obj, C@name@).imag);
     if (hashimag == -1) {
         return -1;
     }
@@ -3241,13 +3241,13 @@ c@lname@_arrtype_hash(PyObject *obj)
 static npy_hash_t
 half_arrtype_hash(PyObject *obj)
 {
-    return _Py_HashDouble(npy_half_to_double(((PyHalfScalarObject *)obj)->obval));
+    return _Py_HashDouble(npy_half_to_double(PyArrayScalar_VAL(obj, Half)));
 }
 
 static npy_hash_t
 object_arrtype_hash(PyObject *obj)
 {
-    return PyObject_Hash(((PyObjectScalarObject *)obj)->obval);
+    return PyObject_Hash(PyArrayScalar_VAL(obj, Object));
 }
 
 /* we used to just hash the pointer */

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -1193,7 +1193,11 @@ PyMODINIT_FUNC init_rational_tests(void) {
     npyrational_arrfuncs.fill = npyrational_fill;
     npyrational_arrfuncs.fillwithscalar = npyrational_fillwithscalar;
     /* Left undefined: scanfunc, fromstr, sort, argsort */
+#if PY_VERSION_HEX >= 0x030a0000
+    Py_SET_TYPE(&npyrational_descr, &PyArrayDescr_Type);
+#else
     Py_TYPE(&npyrational_descr) = &PyArrayDescr_Type;
+#endif
     npy_rational = PyArray_RegisterDataType(&npyrational_descr);
     if (npy_rational<0) {
         goto fail;

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -208,7 +208,11 @@ PyMODINIT_FUNC init#modulename#(void) {
 #else
 \tm = #modulename#_module = Py_InitModule(\"#modulename#\", f2py_module_methods);
 #endif
+#if PY_VERSION_HEX >= 0x030a0000
+\tPy_SET_TYPE(&PyFortran_Type, &PyType_Type);
+#else
 \tPy_TYPE(&PyFortran_Type) = &PyType_Type;
+#endif
 \timport_array();
 \tif (PyErr_Occurred())
 \t\t{PyErr_SetString(PyExc_ImportError, \"can't initialize module #modulename# (failed to import numpy)\"); return RETVAL;}

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -143,7 +143,11 @@ PyMODINIT_FUNC inittest_array_from_pyobj_ext(void) {
 #else
   m = wrap_module = Py_InitModule("test_array_from_pyobj_ext", f2py_module_methods);
 #endif
+#if PY_VERSION_HEX >= 0x030a0000
+  Py_SET_TYPE(&PyFortran_Type, &PyType_Type);
+#else
   Py_TYPE(&PyFortran_Type) = &PyType_Type;
+#endif
   import_array();
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap (failed to import numpy)");


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This adds Python 3.11 compatibility to Py2-compatible version.