### PR TITLE
API: Readd `add_docstring` and `add_newdoc` to `np.lib`

### DIFF
--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -20,9 +20,9 @@ __expired_attributes__ = {
     "NZERO": "Use `-0.0` instead.",
     "PZERO": "Use `0.0` instead.",
     "add_newdoc": 
-        "It's an internal function and doesn't have a replacement.",
+        "It's still available as `np.lib.add_newdoc`.",
     "add_docstring": 
-        "It's an internal function and doesn't have a replacement.",
+        "It's still available as `np.lib.add_docstring`.",
     "add_newdoc_ufunc": 
         "It's an internal function and doesn't have a replacement.",
     "compat": "There's no replacement, as Python 2 is no longer supported.",

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -50,7 +50,8 @@ from .npyio import *
 from .arrayterator import Arrayterator
 from .arraypad import *
 from ._version import *
-from numpy.core._multiarray_umath import tracemalloc_domain
+from numpy.core._multiarray_umath import add_docstring, tracemalloc_domain
+from numpy.core.function_base import add_newdoc
 
 __all__ = ['emath']
 __all__ += type_check.__all__

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -156,7 +156,12 @@ from numpy.lib.utils import (
 )
 
 from numpy.core.multiarray import (
+    add_docstring as add_docstring,
     tracemalloc_domain as tracemalloc_domain,
+)
+
+from numpy.core.function_base import (
+    add_newdoc as add_newdoc,
 )
 
 __all__: list[str]

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -21,10 +21,9 @@ from numpy.core.fromnumeric import (
     )
 from numpy.core.numerictypes import typecodes
 from numpy.core import overrides
-from numpy.core.function_base import add_newdoc
 from numpy.lib.twodim_base import diag
 from numpy.core.multiarray import (
-    _place, add_docstring, bincount, normalize_axis_index, _monotonicity,
+    _place, bincount, normalize_axis_index, _monotonicity,
     interp as compiled_interp, interp_complex as compiled_interp_complex
     )
 from numpy._utils import set_module

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -48,12 +48,7 @@ from numpy._typing import (
     _ComplexLike_co,
 )
 
-from numpy.core.function_base import (
-    add_newdoc as add_newdoc,
-)
-
 from numpy.core.multiarray import (
-    add_docstring as add_docstring,
     bincount as bincount,
 )
 


### PR DESCRIPTION
Relevant issue https://github.com/numpy/numpy/issues/24507

Hi @rgommers, 

Reverts a change introduced in https://github.com/numpy/numpy/pull/24538. 
As agreed in the [main namespace design](https://github.com/numpy/numpy/issues/24306#issuecomment-1663564574), `add_docstring` and `add_newdoc` should stay in `np.lib` and be available only from that namespace. These two were unnecessarily removed from there in https://github.com/numpy/numpy/pull/24538. (`np.lib` namespace refactor PR is still TBD, but this needs to be merged to fix SciPy builds)