### PR TITLE
DOC: fix `import mat` warning.

### DIFF
--- a/doc/source/reference/routines.matlib.rst
+++ b/doc/source/reference/routines.matlib.rst
@@ -15,7 +15,6 @@ Functions that are also in the numpy namespace and return matrices
 
 .. autosummary::
 
-   mat
    matrix
    asmatrix
    bmat


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
fix following warning:
```
numpy/doc/source/reference/routines.matlib.rst:16: WARNING: autosummary: failed to import mat.
Possible hints:
* ModuleNotFoundError: No module named 'numpy.mat'
* ValueError: not enough values to unpack (expected 2, got 1)
* KeyError: 'mat'
* ModuleNotFoundError: No module named 'mat'
* AttributeError: `np.mat` was removed in the NumPy 2.0 release. Use `np.asmatrix` instead.
```