### PR TITLE
CI: Exclude import libraries from list of DLLs on Cygwin.

### DIFF
--- a/tools/list_numpy_dlls.sh
+++ b/tools/list_numpy_dlls.sh
@@ -5,5 +5,5 @@ py_ver=${1}
 site_packages=`python${py_ver} -m pip show numpy | \
 		    grep Location | cut -d " " -f 2 -`;
 dll_list=`for name in $(python${py_ver} -m pip show -f numpy | \
-			     grep -F .dll); do echo ${site_packages}/${name}; done`
+			     grep -E -e '\.dll$'); do echo ${site_packages}/${name}; done`
 echo ${dll_list}


### PR DESCRIPTION
Backport of #24570.

There are import libraries in numpy.random that are intended for distribution.   This script should not include those, only actual DLLs.

See #24206 for the issue prompting this PR.



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
