### PR TITLE
BLD: fix ``_umath_linalg`` dependencies

### DIFF
--- a/numpy/linalg/meson.build
+++ b/numpy/linalg/meson.build
@@ -1,35 +1,37 @@
+# Note that `python_xerbla.c` was excluded on Windows in setup.py;
+# unclear why and it seems needed, so unconditionally used here.
 lapack_lite_sources = [
-  'lapack_lite/f2c.c',
-  'lapack_lite/f2c_c_lapack.c',
-  'lapack_lite/f2c_d_lapack.c',
-  'lapack_lite/f2c_s_lapack.c',
-  'lapack_lite/f2c_z_lapack.c',
-  'lapack_lite/f2c_blas.c',
-  'lapack_lite/f2c_config.c',
-  'lapack_lite/f2c_lapack.c',
   'lapack_lite/python_xerbla.c',
 ]
-
-# TODO: ILP64 support
-
-lapack_lite_module_src = ['lapack_litemodule.c']
 if not have_lapack
-  warning('LAPACK was not found, NumPy is using an unoptimized, naive build from sources!')
-  lapack_lite_module_src += lapack_lite_sources
+  lapack_lite_sources += [
+    'lapack_lite/f2c.c',
+    'lapack_lite/f2c_c_lapack.c',
+    'lapack_lite/f2c_d_lapack.c',
+    'lapack_lite/f2c_s_lapack.c',
+    'lapack_lite/f2c_z_lapack.c',
+    'lapack_lite/f2c_blas.c',
+    'lapack_lite/f2c_config.c',
+    'lapack_lite/f2c_lapack.c',
+  ]
 endif
 
 py.extension_module('lapack_lite',
-  lapack_lite_module_src,
+  [
+    'lapack_litemodule.c',
+    lapack_lite_sources,
+  ],
   dependencies: [np_core_dep, blas_dep, lapack_dep],
   install: true,
   subdir: 'numpy/linalg',
 )
 
-_umath_linalg_src = ['umath_linalg.cpp'] + lapack_lite_sources
-
 py.extension_module('_umath_linalg',
-  _umath_linalg_src,
-  dependencies: np_core_dep,
+  [
+    'umath_linalg.cpp',
+    lapack_lite_sources,
+  ],
+  dependencies: [np_core_dep, blas_dep, lapack_dep],
   link_with: npymath_lib,
   install: true,
   subdir: 'numpy/linalg',


### PR DESCRIPTION
Backport of #24584.

Closes #24512, where `linalg.eigvalsh` was observed to be non-thread safe. I determined that the issue was due to the non-thread safe `lapack_lite` being called instead of the installed BLAS/LAPACK that appears in `np.__show__.config()`. @rgommers found that the issue is due to `blas` and `lapack` being missing from the `_umath_linalg` extension's sources. He proposed the following fix and I've confirmed that it works locally. 


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
