### PR TITLE
BUG: Fix hash of user-defined dtype

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -382,8 +382,7 @@ PyArrayDescr_Type and PyArray_Descr
    .. c:type:: npy_hash_t
    .. c:member:: npy_hash_t *hash
 
-       Currently unused. Reserved for future use in caching
-       hash values.
+       Used for caching hash values.
 
 .. c:macro:: NPY_ITEM_REFCOUNT
 

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -213,6 +213,9 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
         }
     }
 
+    /* Invalidate cached hash value */
+    descr->hash = -1;
+
     userdescrs = realloc(userdescrs,
                          (NPY_NUMUSERTYPES+1)*sizeof(void *));
     if (userdescrs == NULL) {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1364,14 +1364,23 @@ class TestPickling:
 
     @pytest.mark.parametrize("DType",
         [type(np.dtype(t)) for t in np.typecodes['All']] +
-        [np.dtype(rational), np.dtype])
-    def test_pickle_types(self, DType):
-        # Check that DTypes (the classes/types) roundtrip when pickling and
-        # that pickling doesn't change the hash value
-        pre_pickle_hash = hash(DType)
+        [type(np.dtype(rational))])
+    def test_pickle_metaclasses(self, DType):
+        # Check that DTypes (the classes/types) roundtrip when pickling
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
             assert roundtrip_DType is DType
+
+    @pytest.mark.parametrize("DType",
+        [np.dtype(t) for t in np.typecodes['All']] +
+        [np.dtype(rational), np.dtype])
+    def test_pickle_types(self, DType):
+        # Check that DTypes (the instances) roundtrip when pickling and that
+        # pickling doesn't change the hash value
+        pre_pickle_hash = hash(DType)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
+            assert roundtrip_DType == DType
             assert hash(DType) == pre_pickle_hash
 
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1364,24 +1364,24 @@ class TestPickling:
 
     @pytest.mark.parametrize("DType",
         [type(np.dtype(t)) for t in np.typecodes['All']] +
-        [type(np.dtype(rational))])
-    def test_pickle_metaclasses(self, DType):
+        [type(np.dtype(rational)), np.dtype])
+    def test_pickle_dtype_class(self, DType):
         # Check that DTypes (the classes/types) roundtrip when pickling
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
             assert roundtrip_DType is DType
 
-    @pytest.mark.parametrize("DType",
+    @pytest.mark.parametrize("dt",
         [np.dtype(t) for t in np.typecodes['All']] +
-        [np.dtype(rational), np.dtype])
-    def test_pickle_types(self, DType):
-        # Check that DTypes (the instances) roundtrip when pickling and that
-        # pickling doesn't change the hash value
-        pre_pickle_hash = hash(DType)
+        [np.dtype(rational)])
+    def test_pickle_dtype(self, dt):
+        # Check that dtype instances roundtrip when pickling and that pickling
+        # doesn't change the hash value
+        pre_pickle_hash = hash(dt)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
-            assert roundtrip_DType == DType
-            assert hash(DType) == pre_pickle_hash
+            roundtrip_dt = pickle.loads(pickle.dumps(dt, proto))
+            assert roundtrip_dt == dt
+            assert hash(dt) == pre_pickle_hash
 
 
 class TestPromotion:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1366,10 +1366,13 @@ class TestPickling:
         [type(np.dtype(t)) for t in np.typecodes['All']] +
         [np.dtype(rational), np.dtype])
     def test_pickle_types(self, DType):
-        # Check that DTypes (the classes/types) roundtrip when pickling
+        # Check that DTypes (the classes/types) roundtrip when pickling and
+        # that pickling doesn't change the hash value
+        pre_pickle_hash = hash(DType)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
             assert roundtrip_DType is DType
+            assert hash(DType) == pre_pickle_hash
 
 
 class TestPromotion:


### PR DESCRIPTION
User-defined dtypes will often have PyArray_Descr->hash set to 0. However, the sentinel value for indicating a not-yet-cached value is -1. Set this in PyArray_RegisterDataType().

Closes #24595

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
