### PR TITLE
DOC: unpin sphinx to pick up 7.2.5

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx>=4.5.0,<7.2.0
+sphinx>=4.5.0
 numpydoc==1.4
 pydata-sphinx-theme==0.13.3
 sphinx-design


### PR DESCRIPTION
cc @AA-turner

Please check that, for instance, on the the chebyshev page the "Note" renders mathjax correctly before merging.
