### PR TITLE
BLD: meson-cpu: fix SIMD support on platforms with no features

### DIFF
--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -106,7 +106,7 @@ max_features_dict = {
   's390x': S390X_FEATURES,
   'arm': ARM_FEATURES,
   'aarch64': ARM_FEATURES,
-}.get(cpu_family, [])
+}.get(cpu_family, {})
 max_features = []
 foreach fet_name, fet_obj : max_features_dict
   max_features += [fet_obj]


### PR DESCRIPTION
Backport of #24601.

This code returned an empty list rather than an empty dict on platforms that don't have a key in `max_features_dict`. That would break the build on the next `foreach` statement, which needs a dict.

[skip cirrus] [skip circle] [skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
