### PR TITLE
WIP: CI: switch Emscripten job to Meson

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -52,14 +52,23 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install "pydantic<2" pyodide-build==$PYODIDE_VERSION
+        run: pip install "pydantic<2" build pyodide-build==$PYODIDE_VERSION
 
       - name: Build
         run: |
-          # Pyodide is still in the process of adding better/easier support for
-          # non-setup.py based builds.
-          cp pyproject.toml.setuppy pyproject.toml
-          CFLAGS=-g2 LDFLAGS=-g2 pyodide build
+          # Note that we need to cross-compile here. Using `pyodide build`
+          # fails on not having a cross file. The `source() function in
+          # `pyodide_build/cli/build.py` needs a --backend-flags parameter so
+          # that we can pass config-settings arguments to the backend.
+          # We'll then run into static assert issues in `pyconfig.h` due to:
+          # https://github.com/pyodide/pyodide/pull/2494#issuecomment-1118500743
+          # See also https://github.com/pyodide/pyodide/pull/2238 and the patches
+          # to _numpyconfig.h in https://github.com/pyodide/pyodide/tree/main/packages/numpy
+          #
+          # tl;dr this needs some work, and it seems like cross-compilation is
+          # hard because Pyodide doesn't ship its own Python interpreter that
+          # we can actually target during a direct cross build.
+          python -m build --wheel -Csetup-args=--cross-file=$PWD/tools/ci/emscripten.meson.cross -Csetup-args=-Dallow-noblas=true
 
       - name: set up node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
@@ -77,4 +86,4 @@ jobs:
         run: |
           source .venv-pyodide/bin/activate
           cd ..
-          python numpy/runtests.py -n -vv
+          pytest --pyargs numpy -m "not slow"

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -92,7 +92,8 @@ min_features = {
   'ppc64': [],
   's390x': [],
   'arm': [],
-  'aarch64': [ASIMD]
+  'aarch64': [ASIMD],
+  'wasm32': [],
 }.get(cpu_family, [])
 if host_machine.endian() == 'little' and cpu_family == 'ppc64'
   min_features = [VSX2]
@@ -106,6 +107,7 @@ max_features_dict = {
   's390x': S390X_FEATURES,
   'arm': ARM_FEATURES,
   'aarch64': ARM_FEATURES,
+  'wasm32': {},
 }.get(cpu_family, {})
 max_features = []
 foreach fet_name, fet_obj : max_features_dict

--- a/tools/ci/emscripten.meson.cross
+++ b/tools/ci/emscripten.meson.cross
@@ -1,0 +1,17 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+fortran = '/usr/bin/gfortran'
+
+cmake = ['emmake', 'cmake']
+sdl2-config = ['emconfigure', 'sdl2-config']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'
+
+[properties]
+longdouble_format = 'IEEE_QUAD_LE'


### PR DESCRIPTION
This is one of the last CI jobs to be converted to Meson. Still a work in progress.

Note that we need to cross-compile here. Using `pyodide build` fails on not having a cross file. The `source()` function in `pyodide_build/cli/build.py` needs a `--backend-flags` parameter so that we can pass config-settings arguments to the backend. In the meantime, we use `python -m build ...`.

One can also try this locally with:
```
$ python -m build -wnx -Csetup-args=--cross-file=\$PWD/tools/ci/emscripten.meson.cross  -Csetup-args=-Dallow-noblas=true
```
as long as both `pyodide-build` and the exact version of Emscripten (currently 3.1.32, can be installed with https://emscripten.org/docs/tools_reference/emsdk.html) are available. The configure stage of the build looks fine, the build itself fails halfway through due to:
```
include/python3.11/pyport.h:601:2: error: "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
#error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
```
That issue is due to a static assert in `pyconfig.h`, also discussed at: https://github.com/pyodide/pyodide/pull/2494#issuecomment-1118500743

See also https://github.com/pyodide/pyodide/pull/2238 and the patches to `_numpyconfig.h` in https://github.com/pyodide/pyodide/tree/main/packages/numpy. 

tl;dr this needs some work, and it seems like cross-compilation is hard because Pyodide doesn't ship its own Python interpreter that we can actually target during a direct cross build.

Cc @hoodmane @rth. I hope I can bother you with this. If I got any of the above wrong or if you've got a suggestion to get past the `LONG_BIT` error, I'd love to hear it. Also, a couple of questions:
- If I didn't overlook a way to pass `--config-settings` flags to the backend in the `pyodide build` CLI, would you accept a PR to Pyodide to add that? It should match [`backend-flags` in `meta.yaml` recipes](https://github.com/pyodide/pyodide/blob/8b7a9d5e3796d7abc4317f1fc21c6ffbe6c6bf1a/packages/scikit-image/meta.yaml#L17) I think.
- Since scikit-image can be cross-compiled, I had expected to be able to make that work for `numpy` too. But after reading [this comment](https://github.com/pyodide/pyodide/pull/2494#issuecomment-1118500743), that may not be true? Is that still the case, and do you see a road to a regular cross-compile working for NumPy? It's actually not clear to me how the `distutils`-based build works right now, it doesn't seem to be doing the "playback" thing explained in that comment.