### PR TITLE
BUG: Change Cython ``binding`` directive to "False".

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1,5 +1,5 @@
 #!python
-#cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3, binding=True
+#cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3, binding=False
 import operator
 import warnings
 from collections.abc import Sequence

--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -1,4 +1,4 @@
-#cython: binding=True
+#cython: binding=False
 
 import operator
 

--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -1,4 +1,4 @@
-#cython: binding=True
+#cython: binding=False
 
 import numpy as np
 cimport numpy as np

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -1,4 +1,4 @@
-#cython: binding=True
+#cython: binding=False
 
 from cpython.pycapsule cimport PyCapsule_New
 

--- a/numpy/random/_sfc64.pyx
+++ b/numpy/random/_sfc64.pyx
@@ -1,4 +1,4 @@
-#cython: binding=True
+#cython: binding=False
 
 import numpy as np
 cimport numpy as np

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -1,4 +1,4 @@
-#cython: binding=True
+#cython: binding=False
 
 """
 BitGenerator base class and SeedSequence used to seed the BitGenerators.

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1,5 +1,5 @@
 #!python
-#cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3, binding=True
+#cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3, binding=False
 import operator
 import warnings
 from collections.abc import Sequence


### PR DESCRIPTION
The Cython 2 default was "False", in Cython 3 it was changed to "True". Because NumPy 1.26.x supports both Cython versions, make it "False" for compatibility.

The fundamental problem here seems to be that `distributions.c` is a C file, so not affected by the Cython
directive.

Closes #24429.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
