### PR TITLE
DOC: Fix import find_common_type warning[skip actions][skip cirrus][s…

### DIFF
--- a/doc/source/reference/routines.dtype.rst
+++ b/doc/source/reference/routines.dtype.rst
@@ -36,7 +36,6 @@ Data type testing
    :toctree: generated/
 
    issubdtype
-   find_common_type
 
 Miscellaneous
 -------------


### PR DESCRIPTION
…kip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix following warning:
```
numpy/doc/source/reference/routines.dtype.rst:35: WARNING: autosummary: failed to import find_common_type.
Possible hints:
* KeyError: 'find_common_type'
* ModuleNotFoundError: No module named 'find_common_type'
* ValueError: not enough values to unpack (expected 2, got 1)
* ModuleNotFoundError: No module named 'numpy.find_common_type'
* AttributeError: `np.find_common_type` was removed in the NumPy 2.0 release. This function is deprecated, use `numpy.promote_types` or `numpy.result_type` instead.  To achieve semantics for the `scalar_types` argument, use `numpy.result_type` and pass the Python values `0`, `0.0`, or `0j`.

```