### PR TITLE
MAINT: Avoid creating an intermediate array in np.quantile

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4493,7 +4493,7 @@ def _quantile_is_valid(q):
             if not (0.0 <= q[i] <= 1.0):
                 return False
     else:
-        if not (q.min()>=0 and q.max() <= 1):
+        if not (q.min() >= 0 and q.max() <= 1):
             return False
     return True
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4493,7 +4493,7 @@ def _quantile_is_valid(q):
             if not (0.0 <= q[i] <= 1.0):
                 return False
     else:
-        if not (np.all(0 <= q) and np.all(q <= 1)):
+        if not (q.min()>=0 and q.max() <= 1):
             return False
     return True
 


### PR DESCRIPTION
In the internal `_quantile_is_valid` we avoid creation of an array by using the `min` and `max` methods, instead of a comparison and `any`.

There is a special case in the method `_quantile_is_valid` for small arrays (size <10). We keep this, as for small arrays the fast path is still faster. The cut-off at size 10 is a reasonable choice (a better choice than for main).

```
import timeit
from numpy.lib._function_base_impl import _quantile_is_valid

for n in [1, 2, 4, 8, 10, 20, 40, 100, 1000, 10_000]:
    q=np.linspace(0.1, .9,n)
    dt = 0
    for j in range(3):
       dt+=timeit.timeit(stmt='_quantile_is_valid(q)', globals={'_quantile_is_valid': _quantile_is_valid_mm, 'q': q}, number=100_000)
    print(f'{n}: {dt}')
```
Output:
```
1: 0.1132213999517262
2: 0.15505559998564422
4: 0.23200139997061342
8: 0.44427839980926365
9: 0.42877330002374947
10: 0.8802806999301538
11: 0.9487818999914452
20: 0.8889040999347344
40: 0.8844934998778626
100: 1.046445099869743
1000: 1.2339798000175506
10000: 2.535388399963267
```


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
