### PR TITLE
TYP: Add the missing ``casting`` keyword to ``np.clip``

### DIFF
--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -21,6 +21,7 @@ from numpy import (
     _PartitionKind,
     _SortKind,
     _SortSide,
+    _CastingKind,
 )
 from numpy._typing import (
     DTypeLike,
@@ -392,6 +393,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> _SCT: ...
 @overload
 def clip(
@@ -405,6 +407,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
 def clip(
@@ -418,6 +421,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def clip(
@@ -431,6 +435,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> NDArray[Any]: ...
 @overload
 def clip(
@@ -444,6 +449,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
 def clip(
@@ -457,6 +463,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    casting: _CastingKind = ...,
 ) -> _ArrayType: ...
 
 @overload


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/24391

Quite straightforward: this PR adds annotations for the previously missing `casting` keyword to the `np.clip` function.