### PR TITLE
DOC: Update building docs to use Meson

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -38,7 +38,7 @@ Hypothesis__ https://hypothesis.readthedocs.io/en/latest/
 .. note::
 
    If you want to build NumPy in order to work on NumPy itself, use
-   ``runtests.py``.  For more details, see
+   ``spin``.  For more details, see
    https://numpy.org/devdocs/dev/development_environment.html
 
 .. note::
@@ -52,37 +52,36 @@ Basic Installation
 
 To install NumPy, run::
 
-    python setup.py build -j 4 install --prefix $HOME/.local
+    pip install .
 
-This will compile numpy on 4 CPUs and install it into the specified prefix.
-To perform an inplace build that can be run from the source folder run::
+This will compile NumPy on all available CPUs and install it into the active
+environment.
 
-    python setup.py build_ext --inplace -j 4
+To run the build from the source folder for development purposes, use the
+``spin`` development CLI::
+
+    spin build    # installs in-tree under `build-install/`
+    spin ipython  # drop into an interpreter where `import numpy` picks up the local build
+
+Alternatively, use an editable install with::
+
+    pip install -e . --no-build-isolation
 
 See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_
 for more details.
-
-The number of build jobs can also be specified via the environment variable
-NPY_NUM_BUILD_JOBS.
 
 
 Choosing compilers
 ==================
 
-NumPy needs a C compiler, and for development versions also needs Cython.  A Fortran
-compiler isn't needed to build NumPy itself; the ``numpy.f2py`` tests will be
-skipped when running the test suite if no Fortran compiler is available.  For
-building Scipy a Fortran compiler is needed though, so we include some details
-on Fortran compilers in the rest of this section.
+NumPy needs C and C++ compilers, and for development versions also needs
+Cython.  A Fortran compiler isn't needed to build NumPy itself; the
+``numpy.f2py`` tests will be skipped when running the test suite if no Fortran
+compiler is available. 
 
-On OS X and Linux, all common compilers will work. The minimum supported GCC
-version is 6.5.
-
-For Fortran, ``gfortran`` works, ``g77`` does not.  In case ``g77`` is
-installed then ``g77`` will be detected and used first.  To explicitly select
-``gfortran`` in that case, do::
-
-    python setup.py build --fcompiler=gnu95
+For more options including selecting compilers, setting custom compiler flags
+and controlling parallelism, see
+https://scipy.github.io/devdocs/building/compilers_and_options.html
 
 Windows
 -------
@@ -104,10 +103,11 @@ for more details.
 Building with optimized BLAS support
 ====================================
 
-Configuring which BLAS/LAPACK is used if you have multiple libraries installed,
-or you have only one installed but in a non-standard location, is done via a
-``site.cfg`` file.  See the ``site.cfg.example`` shipped with NumPy for more
-details.
+Configuring which BLAS/LAPACK is used if you have multiple libraries installed
+is done via a ``--config-settings`` CLI flag - if not given, the default choice
+is OpenBLAS. If your installed library is in a non-standard location, selecting
+that location is done via a pkg-config ``.pc`` file.
+See http://scipy.github.io/devdocs/building/blas_lapack.html for more details.
 
 Windows
 -------
@@ -120,9 +120,8 @@ For an overview of the state of BLAS/LAPACK libraries on Windows, see
 macOS
 -----
 
-You will need to install a BLAS/LAPACK library. We recommend using OpenBLAS or
-Intel MKL. Apple's Accelerate also still works, however it has bugs and we are
-likely to drop support for it in the near future.
+On macOS >= 13.3, you can use Apple's Accelerate library. On older macOS versions,
+Accelerate has bugs and we recommend using OpenBLAS or (on x86-64) Intel MKL.
 
 Ubuntu/Debian
 -------------

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -11,9 +11,7 @@ Usage
 -----
 
 Airspeed Velocity manages building and Python virtualenvs by itself,
-unless told otherwise. Some of the benchmarking features in
-``runtests.py`` also tell ASV to use the NumPy compiled by
-``runtests.py``. To run the benchmarks, you do not need to install a
+unless told otherwise. To run the benchmarks, you do not need to install a
 development version of NumPy to your current Python environment.
 
 Before beginning, ensure that *airspeed velocity* is installed.
@@ -28,10 +26,9 @@ submitting a pull request.
 To run all benchmarks, navigate to the root NumPy directory at
 the command line and execute::
 
-    python runtests.py --bench
+    spin bench
 
-where ``--bench`` activates the benchmark suite instead of the
-test suite. This builds NumPy and runs all available benchmarks
+This builds NumPy and runs all available benchmarks
 defined in ``benchmarks/``. (Note: this could take a while. Each
 benchmark is run multiple times to measure the distribution in
 execution times.)
@@ -49,18 +46,19 @@ and `--quick` is used to avoid repetitions.
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::
 
-    python runtests.py --bench bench_core
+    spin bench -t bench_core
 
-To run a benchmark defined in a class, such as ``Mandelbrot``
-from ``bench_avx.py``::
+To run a benchmark defined in a class, such as ``MeshGrid``
+from ``bench_creation.py``::
 
-    python runtests.py --bench bench_avx.Mandelbrot
+    spin bench -t bench_creation.MeshGrid
 
-Compare change in benchmark results to another version/commit/branch::
+Compare changes in benchmark results to another version/commit/branch, use the
+``--compare`` option (or the equivalent ``-c``)::
 
-    python runtests.py --bench-compare v1.6.2 bench_core
-    python runtests.py --bench-compare 8bf4e9b bench_core
-    python runtests.py --bench-compare main bench_core
+    spin bench --compare v1.6.2 -t bench_core
+    spin bench --compare 20d03bcfd -t bench_core
+    spin bench -c main -t bench_core
 
 All of the commands above display the results in plain text in
 the console, and the results are not saved for comparison with

--- a/building_with_meson.md
+++ b/building_with_meson.md
@@ -37,12 +37,9 @@ pytest --pyargs numpy
 
 ### pip install
 
-Note that `pip` will use the default build system, which is (as of now) still
-`numpy.distutils`. In order to switch that default to Meson, uncomment the
-`build-backend = "mesonpy"` line at the top of `pyproject.toml`.
-
-After that is done, `pip install .` or `pip install --no-build-isolation .`
-will work as expected. As does building an sdist or wheel with `python -m build`,
+Note that `pip` will use the default build system, which is now Meson.
+Commands such as `pip install .` or `pip install --no-build-isolation .`
+will work as expected, as does building an sdist or wheel with `python -m build`,
 or `pip install -e . --no-build-isolation` for an editable install.
 For a more complete developer experience than editable installs, consider using
 `spin` instead though (see above).

--- a/doc/RELEASE_WALKTHROUGH.rst
+++ b/doc/RELEASE_WALKTHROUGH.rst
@@ -122,7 +122,7 @@ repository::
 
 Sanity check::
 
-    $ python3 runtests.py -m "full"
+    $ python3 -m spin test -m full
 
 Tag the release and push the tag. This requires write permission for the numpy
 repository::

--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -63,14 +63,14 @@ example, the ``core`` module, use the following::
 Running tests from the command line
 -----------------------------------
 
-If you want to build NumPy in order to work on NumPy itself, use
-``runtests.py``.To run NumPy's full test suite::
+If you want to build NumPy in order to work on NumPy itself, use the ``spin``
+utility. To run NumPy's full test suite::
 
-  $ python runtests.py
+  $ spin test -m full
 
 Testing a subset of NumPy::
 
-  $python runtests.py -t numpy/core/tests
+  $ spin test -t numpy/core/tests
 
 For detailed info on testing, see :ref:`testing-builds`
 

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -38,129 +38,6 @@ of this chapter we assume that you have set up your git repo as described in
    relevant parts of the NumPy documentation to build, test, develop, write
    docs, and contribute to NumPy.
 
-
-.. _testing-builds:
-
-Testing builds
---------------
-
-Before running the tests, first install the test dependencies::
-
-    $ python -m pip install -r test_requirements.txt
-
-To build the development version of NumPy and run tests, spawn
-interactive shells with the Python import paths properly set up etc.,
-do one of::
-
-    $ python runtests.py -v
-    $ python runtests.py -v -s random
-    $ python runtests.py -v -t numpy/core/tests/test_nditer.py::test_iter_c_order
-    $ python runtests.py --ipython
-    $ python runtests.py --python somescript.py
-    $ python runtests.py --bench
-    $ python runtests.py -g -m full
-
-This builds NumPy first, so the first time it may take a few minutes.  If
-you specify ``-n``, the tests are run against the version of NumPy (if
-any) found on current PYTHONPATH.
-
-.. note::
-
-    If the above commands result in ``RuntimeError: Cannot parse version 0+untagged.xxxxx``,
-    run ``git pull upstream main --tags``.
-
-When specifying a target using ``-s``, ``-t``, or ``--python``, additional
-arguments may be forwarded to the target embedded by ``runtests.py`` by passing
-the extra arguments after a bare ``--``. For example, to run a test method with
-the ``--pdb`` flag forwarded to the target, run the following::
-
-    $ python runtests.py -t numpy/tests/test_scripts.py::test_f2py -- --pdb
-
-When using pytest as a target (the default), you can
-`match test names using python operators`_ by passing the ``-k`` argument to pytest::
-
-    $ python runtests.py -v -t numpy/core/tests/test_multiarray.py -- -k "MatMul and not vector"
-
-.. note::
-
-    Remember that all tests of NumPy should pass before committing your changes.
-
-Using ``runtests.py`` is the recommended approach to running tests.
-There are also a number of alternatives to it, for example in-place
-build or installing to a virtualenv or a conda environment. See the FAQ below
-for details.
-
-.. note::
-
-   Some of the tests in the test suite require a large amount of
-   memory, and are skipped if your system does not have enough.
-
-   To override the automatic detection of available memory, set the
-   environment variable ``NPY_AVAILABLE_MEM``, for example
-   ``NPY_AVAILABLE_MEM=32GB``, or using pytest ``--available-memory=32GB``
-   target option.
-
-
-Building in-place
------------------
-
-For development, you can set up an in-place build so that changes made to
-``.py`` files have effect without rebuild. First, run::
-
-    $ python setup.py build_ext -i
-
-This allows you to import the in-place built NumPy *from the repo base
-directory only*.  If you want the in-place build to be visible outside that
-base dir, you need to point your ``PYTHONPATH`` environment variable to this
-directory.  Some IDEs (`Spyder`_ for example) have utilities to manage
-``PYTHONPATH``.  On Linux and OSX, you can run the command::
-
-    $ export PYTHONPATH=$PWD
-
-and on Windows::
-
-    $ set PYTHONPATH=/path/to/numpy
-
-Now editing a Python source file in NumPy allows you to immediately
-test and use your changes (in ``.py`` files), by simply restarting the
-interpreter.
-
-Note that another way to do an inplace build visible outside the repo base dir
-is with ``python setup.py develop``.  Instead of adjusting ``PYTHONPATH``, this
-installs a ``.egg-link`` file into your site-packages as well as adjusts the
-``easy-install.pth`` there, so its a more permanent (and magical) operation.
-
-
-.. _Spyder: https://www.spyder-ide.org/
-
-Other build options
--------------------
-
-Build options can be discovered by running any of::
-
-    $ python setup.py --help
-    $ python setup.py --help-commands
-
-It's possible to do a parallel build with ``numpy.distutils`` with the ``-j`` option;
-see :ref:`parallel-builds` for more details.
-
-A similar approach to in-place builds and use of ``PYTHONPATH`` but outside the
-source tree is to use::
-
-    $ pip install . --prefix /some/owned/folder
-    $ export PYTHONPATH=/some/owned/folder/lib/python3.4/site-packages
-
-
-NumPy uses a series of tests to probe the compiler and libc libraries for
-functions. The results are stored in ``_numpyconfig.h`` and ``config.h`` files
-using ``HAVE_XXX`` definitions. These tests are run during the ``build_src``
-phase of the ``_multiarray_umath`` module in the ``generate_config_h`` and
-``generate_numpyconfig_h`` functions. Since the output of these calls includes
-many compiler warnings and errors, by default it is run quietly. If you wish
-to see this output, you can run the ``build_src`` stage verbosely::
-
-    $ python build build_src -v
-
 Using virtual environments
 --------------------------
 
@@ -190,10 +67,73 @@ command ``source numpy-dev/bin/activate``, and ``deactivate`` to exit from the
 virtual environment and back to your previous shell.
 
 
+.. _testing-builds:
+
+Testing builds
+--------------
+
+Before running the tests, first install the test dependencies::
+
+    $ python -m pip install -r test_requirements.txt
+    $ python -m pip install asv # only for running benchmarks
+
+To build the development version of NumPy and run tests, spawn
+interactive shells with the Python import paths properly set up etc., use the
+`spin <https://github.com/scientific-python/spin>`_ utility. To run tests, do
+one of::
+
+    $ spin test -v
+    $ spin test numpy/random  # to run the tests in a specific module
+    $ spin test -v -t numpy/core/tests/test_nditer.py::test_iter_c_order
+
+This builds NumPy first, so the first time it may take a few minutes.
+
+You can also use ``spin bench`` for benchmarking. See ``spin --help`` for more
+command line options.
+
+.. note::
+
+    If the above commands result in ``RuntimeError: Cannot parse version 0+untagged.xxxxx``,
+    run ``git pull upstream main --tags``.
+
+Additional arguments may be forwarded to ``pytest`` by passing the extra
+arguments after a bare ``--``. For example, to run a test method with the
+``--pdb`` flag forwarded to the target, run the following::
+
+    $ spin test -t numpy/tests/test_scripts.py::test_f2py -- --pdb
+
+You can also  `match test names using python operators`_ by passing the ``-k``
+argument to pytest::
+
+    $ spin test -v -t numpy/core/tests/test_multiarray.py -- -k "MatMul and not vector"
+
+.. note::
+
+    Remember that all tests of NumPy should pass before committing your changes.
+
+.. note::
+
+   Some of the tests in the test suite require a large amount of
+   memory, and are skipped if your system does not have enough.
+
+..
+   To override the automatic detection of available memory, set the
+   environment variable ``NPY_AVAILABLE_MEM``, for example
+   ``NPY_AVAILABLE_MEM=32GB``, or using pytest ``--available-memory=32GB``
+   target option.
+
+Other build options
+-------------------
+
+For more options including selecting compilers, setting custom compiler flags
+and controlling parallelism, see :doc:`scipy:building/compilers_and_options`
+(from the SciPy documentation.)
+
+
 Running tests
 -------------
 
-Besides using ``runtests.py``, there are various ways to run the tests.  Inside
+Besides using ``spin``, there are various ways to run the tests.  Inside
 the interpreter, tests can be run like this::
 
     >>> np.test()  # doctest: +SKIPBLOCK
@@ -208,7 +148,7 @@ Or a similar way from the command line::
     $ python -c "import numpy as np; np.test()"
 
 Tests can also be run with ``pytest numpy``, however then the NumPy-specific
-plugin is not found which causes strange side effects
+plugin is not found which causes strange side effects.
 
 Running individual test files can be useful; it's much faster than running the
 whole test suite or that of a whole module (example: ``np.random.test()``).
@@ -224,10 +164,10 @@ run the test suite with Python 3.9, use::
 
     $ tox -e py39
 
-For more extensive information, see :ref:`testing-guidelines`
+For more extensive information, see :ref:`testing-guidelines`.
 
-*Note: do not run the tests from the root directory of your numpy git repo without ``runtests.py``,
-that will result in strange test errors.*
+Note: do not run the tests from the root directory of your numpy git repo without ``spin``,
+that will result in strange test errors.
 
 Running Linting
 ---------------
@@ -239,15 +179,16 @@ Install all dependent packages using pip::
 
 To run lint checks before committing new code, run::
 
-    $ python runtests.py --lint uncommitted
+    $ python tools/linter.py
 
 To check all changes in newly added Python code of current branch with target branch, run::
 
-    $ python runtests.py --lint main
+    $ python tools/linter.py --branch main
 
-If there are no errors, the script exits with no message. In case of errors::
+If there are no errors, the script exits with no message. In case of errors,
+check the error message for details::
 
-    $ python runtests.py --lint main
+    $ python tools/linter.py --branch main
     ./numpy/core/tests/test_scalarmath.py:34:5: E303 too many blank lines (3)
     1       E303 too many blank lines (3)
 
@@ -256,8 +197,8 @@ since the linter runs as part of the CI pipeline.
 
 For more details on Style Guidelines:
 
-   - `Python Style Guide`_
-   - `C Style Guide`_
+- `Python Style Guide`_
+- `C Style Guide`_
 
 Rebuilding & cleaning the workspace
 -----------------------------------
@@ -306,7 +247,7 @@ you want to debug. For instance ``mytest.py``::
 
 Now, you can run::
 
-    $ gdb --args python runtests.py -g --python mytest.py
+    $ spin gdb mytest.py
 
 And then in the debugger::
 
@@ -336,10 +277,6 @@ needs a ``.gdbinit`` file with the following contents:
 .. code-block:: text
 
     add-auto-load-safe-path ~/.pyenv
-
-Instead of plain ``gdb`` you can of course use your favourite
-alternative debugger; run it on the python binary with arguments
-``runtests.py -g --python mytest.py``.
 
 Building NumPy with a Python built with debug support (on Linux distributions
 typically packaged as ``python-dbg``) is highly recommended.

--- a/doc/source/dev/howto_build_docs.rst
+++ b/doc/source/dev/howto_build_docs.rst
@@ -7,7 +7,7 @@ Building the NumPy API and reference docs
 If you only want to get the documentation, note that pre-built
 versions can be found at
 
-    https://numpy.org/doc/
+https://numpy.org/doc/
 
 in several different formats.
 
@@ -89,37 +89,11 @@ Instructions
 
 Now you are ready to generate the docs, so write::
 
-    cd doc
-    make html
+    spin docs
 
-If all goes well, this will generate a
-``build/html`` subdirectory in the ``/doc`` directory, containing the built documentation. If
-you get a message about ``installed numpy != current repo git version``, you must
-either override the check by setting ``GITVER`` or re-install NumPy.
-
-If you have built NumPy into a virtual environment and get an error
-that says ``numpy not found, cannot build documentation without...``,
-you need to override the makefile ``PYTHON`` variable at the command
-line, so instead of writing ``make  html`` write::
-
-    make PYTHON=python html
-
-To build the PDF documentation, do instead::
-
-   make latex
-   make -C build/latex all-pdf
-
-You will need to have LaTeX_ installed for this, inclusive of support for
-Greek letters.  For example, on Ubuntu xenial ``texlive-lang-greek`` and
-``cm-super`` are needed.  Also, ``latexmk`` is needed on non-Windows systems.
-
-Instead of the above, you can also do::
-
-   make dist
-
-which will rebuild NumPy, install it to a temporary location, and
-build the documentation in all formats. This will most likely again
-only work on Unix platforms.
+This will build NumPy from source if you haven't already, and run Sphinx to
+build the ``html`` docs. If all goes well, this will generate a ``build/html``
+subdirectory in the ``/doc`` directory, containing the built documentation.
 
 The documentation for NumPy distributed at https://numpy.org/doc in html and
 pdf format is also built with ``make dist``.  See `HOWTO RELEASE`_ for details

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -219,13 +219,12 @@ be installed with::
 Tests for a module should ideally cover all code in that module,
 i.e., statement coverage should be at 100%.
 
-To measure the test coverage, install
-`pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`__
-and then run::
+To measure the test coverage, run::
 
-  $ python runtests.py --coverage
+  $ spin test --coverage
 
-This will create a report in ``build/coverage``, which can be viewed with::
+This will create a report in ``html`` format at ``build/coverage``, which can be
+viewed with your browser, e.g.::
 
   $ firefox build/coverage/index.html
 
@@ -234,10 +233,12 @@ This will create a report in ``build/coverage``, which can be viewed with::
 Building docs
 -------------
 
-To build docs, run ``make`` from the ``doc`` directory. ``make help`` lists
-all targets. For example, to build the HTML documentation, you can run::
+To build the HTML documentation, use::
 
-    make html
+  spin docs
+
+You can also run ``make`` from the ``doc`` directory. ``make help`` lists
+all targets.
 
 To get the appropriate dependencies and other requirements,
 see :ref:`howto-build-docs`.

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -50,11 +50,8 @@ Building NumPy requires the following software installed:
    them and use them for building. A number of different LAPACK library setups
    can be used, including optimized LAPACK libraries such as OpenBLAS or MKL.
    The choice and location of these libraries as well as include paths and
-   other such build options can be specified in a ``site.cfg`` file located in
-   the NumPy root repository or a ``.numpy-site.cfg`` file in your home
-   directory. See the ``site.cfg.example`` example file included in the NumPy
-   repository or sdist for documentation, and below for specifying search
-   priority from environmental variables.
+   other such build options can be specified in a ``.pc`` file, as documented in
+   :ref:`scipy:using-pkg-config-to-detect-libraries-in-a-nonstandard-location`.
 
 4) Cython
 
@@ -64,19 +61,50 @@ Building NumPy requires the following software installed:
 
    Clone the repository following the instructions in :doc:`/dev/index`.
 
-Basic Installation
+.. note::
+
+    Starting on version 1.26, NumPy will adopt Meson as its build system (see
+    :ref:`distutils-status-migration` and
+    :doc:`scipy:building/understanding_meson` for more details.)
+
+Basic installation
 ------------------
 
-To install NumPy, run::
+To build and install NumPy from a local copy of the source code, run::
 
     pip install .
 
+This will install all build dependencies and use Meson to compile and install
+the NumPy C-extensions and Python modules. If you need more control of build
+options and commands, see the following sections.
+
 To perform an in-place build that can be run from the source folder run::
 
-    python setup.py build_ext --inplace
+    pip install -r build_requirements.txt
+    pip install -e . --no-build-isolation
 
 *Note: for build instructions to do development work on NumPy itself, see*
 :ref:`development-environment`.
+
+
+Advanced building with Meson
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Meson supports the standard environment variables ``CC``, ``CXX`` and ``FC`` to
+select specific C, C++ and/or Fortran compilers. These environment variables are
+documented in `the reference tables in the Meson docs
+<https://mesonbuild.com/Reference-tables.html#compiler-and-linker-flag-environment-variables>`_.
+
+Note that environment variables only get applied from a clean build, because
+they affect the configure stage (i.e., meson setup). An incremental rebuild does
+not react to changes in environment variables - you have to run
+``git clean -xdf`` and do a full rebuild, or run ``meson setup --reconfigure``.
+
+For more options including selecting compilers, setting custom compiler flags
+and controlling parallelism, see :doc:`scipy:building/compilers_and_options`
+(from the SciPy documentation) and `the Meson FAQ
+<https://mesonbuild.com/howtox.html#set-extra-compiler-and-linker-flags-from-the-outside-when-eg-building-distro-packages>`_.
+
 
 Testing
 -------
@@ -87,52 +115,14 @@ all tests pass.
 The test suite requires additional dependencies, which can easily be 
 installed with::
 
-    $ python -m pip install -r test_requirements.txt
+    python -m pip install -r test_requirements.txt
 
-Run tests::
+Run the full test suite with::
 
-    $ python runtests.py -v -m full
+    cd ..  # avoid picking up the source tree
+    pytest --pyargs numpy
 
 For detailed info on testing, see :ref:`testing-builds`.
-
-.. _parallel-builds:
-
-Parallel builds
-~~~~~~~~~~~~~~~
-
-It's possible to do a parallel build with::
-
-    python setup.py build -j 4 install --prefix $HOME/.local
-
-This will compile numpy on 4 CPUs and install it into the specified prefix.
-to perform a parallel in-place build, run::
-
-    python setup.py build_ext --inplace -j 4
-
-The number of build jobs can also be specified via the environment variable
-``NPY_NUM_BUILD_JOBS``.
-
-Choosing the fortran compiler
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Compilers are auto-detected; building with a particular compiler can be done
-with ``--fcompiler``.  E.g. to select gfortran::
-
-    python setup.py build --fcompiler=gnu95
-
-For more information see::
-
-    python setup.py build --help-fcompiler
-
-How to check the ABI of BLAS/LAPACK libraries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One relatively simple and reliable way to check for the compiler used to
-build a library is to use ldd on the library. If libg2c.so is a dependency,
-this means that g77 has been used (note: g77 is no longer supported for
-building NumPy). If libgfortran.so is a dependency, gfortran has been used.
-If both are dependencies, this means both have been used, which is almost
-always a very bad idea.
 
 .. _accelerated-blas-lapack-libraries:
 
@@ -141,243 +131,14 @@ Accelerated BLAS/LAPACK libraries
 
 NumPy searches for optimized linear algebra libraries such as BLAS and LAPACK.
 There are specific orders for searching these libraries, as described below and
-in the ``site.cfg.example`` file.
-
-BLAS
-~~~~
-
-Note that both BLAS and CBLAS interfaces are needed for a properly
-optimized build of NumPy.
-
-The default order for the libraries are:
-
-1. MKL
-2. BLIS
-3. OpenBLAS
-4. ATLAS
-5. BLAS (NetLIB)
-
-The detection of BLAS libraries may be bypassed by defining the environment
-variable ``NPY_BLAS_LIBS`` , which should contain the exact linker flags you
-want to use (interface is assumed to be Fortran 77).  Also define
-``NPY_CBLAS_LIBS`` (even empty if CBLAS is contained in your BLAS library) to
-trigger use of CBLAS and avoid slow fallback code for matrix calculations.
-
-If you wish to build against OpenBLAS but you also have BLIS available one
-may predefine the order of searching via the environment variable
-``NPY_BLAS_ORDER`` which is a comma-separated list of the above names which
-is used to determine what to search for, for instance::
-
-      NPY_BLAS_ORDER=ATLAS,blis,openblas,MKL python setup.py build
-
-will prefer to use ATLAS, then BLIS, then OpenBLAS and as a last resort MKL.
-If neither of these exists the build will fail (names are compared
-lower case).
-
-Alternatively one may use ``!`` or ``^`` to negate all items::
-
-        NPY_BLAS_ORDER='^blas,atlas' python setup.py build
-
-will allow using anything **but** NetLIB BLAS and ATLAS libraries, the order
-of the above list is retained.
-
-One cannot mix negation and positives, nor have multiple negations, such
-cases will raise an error.
-
-LAPACK
-~~~~~~
-
-The default order for the libraries are:
-
-1. MKL
-2. OpenBLAS
-3. libFLAME
-4. ATLAS
-5. LAPACK (NetLIB)
-
-The detection of LAPACK libraries may be bypassed by defining the environment
-variable ``NPY_LAPACK_LIBS``, which should contain the exact linker flags you
-want to use (language is assumed to be Fortran 77).
-
-If you wish to build against OpenBLAS but you also have MKL available one
-may predefine the order of searching via the environment variable
-``NPY_LAPACK_ORDER`` which is a comma-separated list of the above names,
-for instance::
-
-      NPY_LAPACK_ORDER=ATLAS,openblas,MKL python setup.py build
-
-will prefer to use ATLAS, then OpenBLAS and as a last resort MKL.
-If neither of these exists the build will fail (names are compared
-lower case).
-
-Alternatively one may use ``!`` or ``^`` to negate all items::
-
-        NPY_LAPACK_ORDER='^lapack' python setup.py build
-
-will allow using anything **but** the NetLIB LAPACK library, the order of
-the above list is retained.
-
-One cannot mix negation and positives, nor have multiple negations, such
-cases will raise an error.
-
-.. deprecated:: 1.20
-  The native libraries on macOS, provided by Accelerate, are not fit for use
-  in NumPy since they have bugs that cause wrong output under easily
-  reproducible conditions. If the vendor fixes those bugs, the library could
-  be reinstated, but until then users compiling for themselves should use
-  another linear algebra library or use the built-in (but slower) default,
-  see the next section.
-
-
-Disabling ATLAS and other accelerated libraries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Usage of ATLAS and other accelerated libraries in NumPy can be disabled
-via::
-
-    NPY_BLAS_ORDER= NPY_LAPACK_ORDER= python setup.py build
-
-or::
-
-    BLAS=None LAPACK=None ATLAS=None python setup.py build
-
-
-64-bit BLAS and LAPACK
-~~~~~~~~~~~~~~~~~~~~~~
-
-You can tell Numpy to use 64-bit BLAS/LAPACK libraries by setting the
-environment variable::
-
-    NPY_USE_BLAS_ILP64=1
-
-when building Numpy. The following 64-bit BLAS/LAPACK libraries are
-supported:
-
-1. OpenBLAS ILP64 with ``64_`` symbol suffix (``openblas64_``)
-2. OpenBLAS ILP64 without symbol suffix (``openblas_ilp64``)
-
-The order in which they are preferred is determined by
-``NPY_BLAS_ILP64_ORDER`` and ``NPY_LAPACK_ILP64_ORDER`` environment
-variables. The default value is ``openblas64_,openblas_ilp64``.
-
-.. note::
-
-   Using non-symbol-suffixed 64-bit BLAS/LAPACK in a program that also
-   uses 32-bit BLAS/LAPACK can cause crashes under certain conditions
-   (e.g. with embedded Python interpreters on Linux).
-
-   The 64-bit OpenBLAS with ``64_`` symbol suffix is obtained by
-   compiling OpenBLAS with settings::
-
-       make INTERFACE64=1 SYMBOLSUFFIX=64_
-
-   The symbol suffix avoids the symbol name clashes between 32-bit and
-   64-bit BLAS/LAPACK libraries.
-
-
-Supplying additional compiler flags
------------------------------------
-
-Additional compiler flags can be supplied by setting the ``OPT``,
-``FOPT`` (for Fortran), and ``CC`` environment variables.
-When providing options that should improve the performance of the code
-ensure that you also set ``-DNDEBUG`` so that debugging code is not
-executed.
+in the
+`meson_options.txt <https://github.com/numpy/numpy/blob/main/meson_options.txt>`_
+file.
 
 Cross compilation
 -----------------
 
-Although ``numpy.distutils`` and ``setuptools`` do not directly support cross
-compilation, it is possible to build NumPy on one system for different
-architectures with minor modifications to the build environment. This may be
-desirable, for example, to use the power of a high-performance desktop to
-create a NumPy package for a low-power, single-board computer. Because the
-``setup.py`` scripts are unaware of cross-compilation environments and tend to
-make decisions based on the environment detected on the build system, it is
-best to compile for the same type of operating system that runs on the builder.
-Attempting to compile a Mac version of NumPy on Windows, for example, is likely
-to be met with challenges not considered here.
-
-For the purpose of this discussion, the nomenclature adopted by `meson`_ will
-be used: the "build" system is that which will be running the NumPy build
-process, while the "host" is the platform on which the compiled package will be
-run. A native Python interpreter, the setuptools and Cython packages and the
-desired cross compiler must be available for the build system. In addition, a
-Python interpreter and its development headers as well as any external linear
-algebra libraries must be available for the host platform. For convenience, it
-is assumed that all host software is available under a separate prefix
-directory, here called ``$CROSS_PREFIX``.
+For cross compilation instructions, see :doc:`scipy:cross_compilation` and the
+`Meson documentation <meson>`_.
 
 .. _meson: https://mesonbuild.com/Cross-compilation.html#cross-compilation
-
-When building and installing NumPy for a host system, the ``CC`` environment
-variable must provide the path the cross compiler that will be used to build
-NumPy C extensions. It may also be necessary to set the ``LDSHARED``
-environment variable to the path to the linker that can link compiled objects
-for the host system. The compiler must be told where it can find Python
-libraries and development headers. On Unix-like systems, this generally
-requires adding, *e.g.*, the following parameters to the ``CFLAGS`` environment
-variable::
-
-    -I${CROSS_PREFIX}/usr/include
-    -I${CROSS_PREFIX}/usr/include/python3.y
-
-for Python version 3.y. (Replace the "y" in this path with the actual minor
-number of the installed Python runtime.) Likewise, the linker should be told
-where to find host libraries by adding a parameter to the ``LDFLAGS``
-environment variable::
-
-    -L${CROSS_PREFIX}/usr/lib
-
-To make sure Python-specific system configuration options are provided for the
-intended host and not the build system, set::
-
-    _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_${ARCH_TRIPLET}
-
-where ``${ARCH_TRIPLET}`` is an architecture-dependent suffix appropriate for
-the host architecture. (This should be the name of a ``_sysconfigdata`` file,
-without the ``.py`` extension, found in the host Python library directory.)
-
-When using external linear algebra libraries, include and library directories
-should be provided for the desired libraries in ``site.cfg`` as described
-above and in the comments of the ``site.cfg.example`` file included in the
-NumPy repository or sdist. In this example, set::
-
-    include_dirs = ${CROSS_PREFIX}/usr/include
-    library_dirs = ${CROSS_PREFIX}/usr/lib
-
-under appropriate sections of the file to allow ``numpy.distutils`` to find the
-libraries.
-
-As of NumPy 1.22.0, a vendored copy of SVML will be built on ``x86_64`` Linux
-hosts to provide AVX-512 acceleration of floating-point operations. When using
-an ``x86_64`` Linux build system to cross compile NumPy for hosts other than
-``x86_64`` Linux, set the environment variable ``NPY_DISABLE_SVML`` to prevent
-the NumPy build script from incorrectly attempting to cross-compile this
-platform-specific library::
-
-    NPY_DISABLE_SVML=1
-
-With the environment configured, NumPy may be built as it is natively::
-
-    python setup.py build
-
-When the ``wheel`` package is available, the cross-compiled package may be
-packed into a wheel for installation on the host with::
-
-    python setup.py bdist_wheel
-
-It may be possible to use ``pip`` to build a wheel, but ``pip`` configures its
-own environment; adapting the ``pip`` environment to cross-compilation is
-beyond the scope of this guide.
-
-The cross-compiled package may also be installed into the host prefix for
-cross-compilation of other packages using, *e.g.*, the command::
-
-    python setup.py install --prefix=${CROSS_PREFIX}
-
-When cross compiling other packages that depend on NumPy, the host
-npy-pkg-config file must be made available. For further discussion, refer to
-`numpy distutils documentation`_.
-
-.. _numpy distutils documentation: https://numpy.org/devdocs/reference/distutils.html#numpy.distutils.misc_util.Configuration.add_npy_pkg_config


### PR DESCRIPTION
Backport of #24573.

Removes mentions of runtests.py when appropriate and replaces them with equivalent spin commands.

A few pending questions:

- What to do with the custom blas/lapack instructions? (I know we talked about ditching those in favor of the [SciPy documentation](https://scipy.github.io/devdocs/building/blas_lapack.html) but our docs seem much more detailed and I'm hesitant to just delete.
- I haven't updated https://numpy.org/doc/stable/dev/development_advanced_debugging.html yet, could do it on a follow-up or on a separate commit.
- There are a couple of mentions to site.cfg that I didn't remove yet either since I'm not 100% sure of the replacement (if any).

I haven't completely redone the docs to mirror SciPy as I still feel there is justification for the current organization, but I'm happy to reconsider.

Partly addresses #23981

[skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
