### PR TITLE
TYP: Add the missing ``casting`` keyword to ``np.clip``

### DIFF
--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -21,6 +21,7 @@ from numpy import (
     _PartitionKind,
     _SortKind,
     _SortSide,
+    _CastingKind,
 )
 from numpy._typing import (
     DTypeLike,
@@ -392,7 +393,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> _SCT: ...
 @overload
 def clip(
@@ -406,7 +407,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
 def clip(
@@ -420,7 +421,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def clip(
@@ -434,7 +435,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> NDArray[Any]: ...
 @overload
 def clip(
@@ -448,7 +449,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
 def clip(
@@ -462,7 +463,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
-    extobj: list[Any] = ...,
+    casting: _CastingKind = ...,
 ) -> _ArrayType: ...
 
 @overload


### PR DESCRIPTION
Backport of #24611.

Closes https://github.com/numpy/numpy/issues/24391

Quite straightforward: this PR adds annotations for the previously missing `casting` keyword to the `np.clip` function.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
