### PR TITLE
TST: convert cython test from setup.py to meson

### DIFF
--- a/numpy/core/tests/examples/cython/meson.build
+++ b/numpy/core/tests/examples/cython/meson.build
@@ -1,0 +1,27 @@
+project('checks', 'c', 'cython')
+
+py = import('python').find_installation(pure: false)
+
+cc = meson.get_compiler('c')
+cy = meson.get_compiler('cython')
+
+if not cy.version().version_compare('>=0.29.35')
+  error('tests requires Cython >= 0.29.35')
+endif
+
+npy_include_path = run_command(py, [
+    '-c',
+    'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
+    ], check: true).stdout().strip()
+
+py.extension_module(
+    'checks',
+    'checks.pyx',
+    install: false,
+    c_args: [
+      '-DNPY_NO_DEPRECATED_API=0',  # Cython still uses old NumPy C API
+      # Require 1.25+ to test datetime additions
+      '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
+    ],
+    include_directories: [npy_include_path],
+)


### PR DESCRIPTION
Backport of #24206.

I tried to remove `setuptools` from `test_requirements.txt`, and found these tests were building c-extension modules using setup.py. I converted them to meson.

We still need setuptools to pass the `numpy/tests/test_public_api.py` tests. Some of the distutils modules fail to import if it is not found. I am leaving that for a further cleanup
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
