### PR TITLE
MAINT: Fixup ``fromnumeric.pyi``

### DIFF
--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -393,6 +393,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> _SCT: ...
 @overload
@@ -407,6 +408,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
@@ -421,6 +423,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> NDArray[_SCT]: ...
 @overload
@@ -435,6 +438,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -449,6 +453,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> Any: ...
 @overload
@@ -463,6 +468,7 @@ def clip(
     order: _OrderKACF = ...,
     subok: bool = ...,
     signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
     casting: _CastingKind = ...,
 ) -> _ArrayType: ...
 


### PR DESCRIPTION
The line
```
    extobj: list[Any] = ...,
```
was cut when backporting #24611. We want to keep it in 1.26.x.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
