### PR TITLE
CI: Switch SIMD tests to meson

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -3,19 +3,34 @@ description: "checkout repo, build, and test numpy"
 runs:
   using: composite
   steps:
-  - name: Install dependencies
-    shell: bash
-    run: pip install -r build_requirements.txt
   - name: Build
     shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     env:
       TERM: xterm-256color
-    run:
-      spin build -- ${MESON_ARGS[@]}
+    run: |
+      echo "::group::Installing Build Dependencies"
+      pip install -r build_requirements.txt
+      echo "::endgroup::"
+      echo "::group::Building NumPy"
+      spin build --clean -- ${MESON_ARGS[@]}
+      echo "::endgroup::"
+
+  - name: Meson Log
+    shell: bash
+    if: always()
+    run: |
+      echo "::group::Meson Log"
+      cat build/meson-logs/meson-log.txt
+      echo "::endgroup::"
+
   - name: Test
     shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     env:
       TERM: xterm-256color
     run: |
+      echo "::group::Installing Test Dependencies"
       pip install pytest pytest-xdist hypothesis typing_extensions
-      spin test -j auto
+      echo "::endgroup::"
+      echo "::group::Test NumPy"
+      spin test
+      echo "::endgroup::"

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -98,8 +98,8 @@ jobs:
 
     - name: Enable gcc-9
       run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 2
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 2
 
     - uses: ./.github/meson_actions
       name: Build/Test against gcc-9

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -1,37 +1,35 @@
-name: SIMD tests (Linux)
+name: Linux SIMD tests
 
 # This file is meant for testing different SIMD-related build options and
 # optimization levels. See `meson_options.txt` for the available build options.
 #
-# Jobs and their purpose:
+# Jobs and their purposes:
 #
-#   - smoke_test:
-#         Meant to complete as quickly as possible, and acts as a filter for
-#         the other, more expensive jobs (those only start once `smoke_test`
-#         passes).
-#   - old_gcc:
-#         Tests the oldest supported GCC version with the default build
-#         settings.
-#   - without_optimizations:
-#         Completely disables both all SIMD optimizations and other compiler
-#         optimizations like loop unrolling.
-#   - with_baseline_only:
-#         Only uses the baseline SIMD settings, but no runtime dispatch based
-#         on compiler features detected at runtime.
-#   - without_avx512_avx2_fma3:
-#         Uses runtime SIMD dispatching, with AVX2, FMA3 and AVX512 disabled.
-#   - without_avx512:
-#         Uses runtime SIMD dispatching, with AVX512 disabled.
-#   - armv7_simd_test:
-#         Cross-compiles from x86-64 to armv7, and then runs only the
-#         SIMD-specific tests under QEMU.
-#   - sde_simd_avx512_test:
-#         Runs only the SIMD tests for several AVX512-xxx instruction sets
-#         under the Intel Software Development Emulator (SDE).
-#   - intel_spr_sde_test:
-#         Similar to the SDE test above, but for AVX512-SPR which requires some
-#         special-casing.
-
+# - baseline_only:
+#   Focuses on completing as quickly as possible and acts as a filter for other, more resource-intensive jobs.
+#   Utilizes only the default baseline targets (e.g., SSE3 on X86_64) without enabling any runtime dispatched features.
+#
+# - old_gcc:
+#   Tests the oldest supported GCC version with default CPU/baseline/dispatch settings.
+#
+# - without_optimizations:
+#   Completely disables all SIMD optimizations and other compiler optimizations such as loop unrolling.
+#
+# - native:
+#   Tests against the host CPU features set as the baseline without enabling any runtime dispatched features.
+#   Intended to assess the entire NumPy codebase against host flags, even for code sections lacking handwritten SIMD intrincis.
+#
+# - without_avx512/avx2/fma3:
+#   Uses runtime SIMD dispatching but disables AVX2, FMA3, and AVX512.
+#   Intended to evaluate 128-bit SIMD extensions without FMA support.
+#
+# - without_avx512:
+#   Uses runtime SIMD dispatching but disables AVX512.
+#   Intended to evaluate 128-bit/256-bit SIMD extensions.
+#
+# - intel_sde:
+#   Executes only the SIMD tests for various AVX512 SIMD extensions under the Intel Software Development Emulator (SDE).
+#
 on:
   pull_request:
     branches:
@@ -40,10 +38,10 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
 
 env:
-  DOWNLOAD_OPENBLAS: 1
+  TERM: xterm-256color
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -53,71 +51,9 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  smoke_test:
+  baseline_only:
     if: "github.repository == 'numpy/numpy'"
     runs-on: ubuntu-latest
-    env:
-      MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      with:
-        python-version: '3.9'
-    - uses: ./.github/meson_actions
-
-  old_gcc:
-    needs: [smoke_test]
-    # provides GCC 8
-    runs-on: ubuntu-20.04
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - name: Install Python3.9
-      run: |
-        sudo apt update
-        # for add-apt-repository
-        sudo apt install software-properties-common -y
-        sudo add-apt-repository ppa:deadsnakes/ppa -y
-        sudo apt install python3.9-dev ninja-build -y
-        sudo ln -s /usr/bin/python3.9 /usr/bin/pythonx
-        pythonx -m pip install --upgrade pip setuptools wheel
-        pythonx -m pip install -r test_requirements.txt
-    - name: Install GCC 8
-      run: sudo apt install g++-8 -y
-    - name: Build gcc-8
-      run: |
-        export CC=/usr/bin/gcc-8
-        export CXX=/usr/bin/g++-8
-        rm -rf build && pythonx setup.py install --user
-    - name: Run test suite
-      run: pythonx runtests.py -n
-
-  without_optimizations:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    env:
-      MESON_ARGS: "-Dallow-noblas=true -Ddisable-optimization=true"
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      with:
-        python-version: '3.12-dev'
-    - uses: ./.github/meson_actions
-
-  with_baseline_only:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=none"
     steps:
@@ -127,102 +63,16 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
-        python-version: '3.10'
+        python-version: '3.9'
     - uses: ./.github/meson_actions
+      name: Build/Test
 
-  without_avx512:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
+  old_gcc:
     if: github.event_name != 'push'
+    needs: [baseline_only]
+    runs-on: ubuntu-latest
     env:
-      MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,AVX2,FMA3"
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      with:
-        python-version: '3.10'
-    - uses: ./.github/meson_actions
-
-  without_avx512_avx2_fma3:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    env:
-      MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C"
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
-      with:
-        python-version: '3.10'
-    - uses: ./.github/meson_actions
-
-  armv7_simd_test:
-    needs: [smoke_test]
-    # make sure this matches the base docker image below
-    runs-on: ubuntu-22.04
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - name: Initialize binfmt_misc for qemu-user-static
-      run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    - name: Creates new container
-      run: |
-        # use x86_64 cross-compiler to speed up the build
-        sudo apt update
-        sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gfortran-arm-linux-gnueabihf
-
-        docker run --name the_container --interactive -v /:/host -v $(pwd):/numpy arm32v7/ubuntu:22.04 /bin/bash -c "
-          apt update &&
-          apt install -y git python3 python3-dev python3-pip  &&
-          python3 -m pip install -r /numpy/test_requirements.txt
-          ln -s /host/lib64 /lib64 &&
-          ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&
-          ln -s /host/usr/arm-linux-gnueabihf /usr/arm-linux-gnueabihf &&
-          rm -rf /usr/lib/gcc/arm-linux-gnueabihf && ln -s /host/usr/lib/gcc-cross/arm-linux-gnueabihf /usr/lib/gcc/arm-linux-gnueabihf &&
-          rm -f /usr/bin/arm-linux-gnueabihf-gcc && ln -s /host/usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc &&
-          rm -f /usr/bin/arm-linux-gnueabihf-g++ && ln -s /host/usr/bin/arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++ &&
-          rm -f /usr/bin/arm-linux-gnueabihf-gfortran && ln -s /host/usr/bin/arm-linux-gnueabihf-gfortran /usr/bin/arm-linux-gnueabihf-gfortran &&
-          rm -f /usr/bin/arm-linux-gnueabihf-ar && ln -s /host/usr/bin/arm-linux-gnueabihf-ar /usr/bin/arm-linux-gnueabihf-ar &&
-          rm -f /usr/bin/arm-linux-gnueabihf-as && ln -s /host/usr/bin/arm-linux-gnueabihf-as /usr/bin/arm-linux-gnueabihf-as &&
-          rm -f /usr/bin/arm-linux-gnueabihf-ld && ln -s /host/usr/bin/arm-linux-gnueabihf-ld /usr/bin/arm-linux-gnueabihf-ld &&
-          rm -f /usr/bin/arm-linux-gnueabihf-ld.bfd && ln -s /host/usr/bin/arm-linux-gnueabihf-ld.bfd /usr/bin/arm-linux-gnueabihf-ld.bfd
-        "
-        docker commit the_container the_container
-    - name: Build
-      run: |
-        sudo docker run --name the_build --interactive -v $(pwd):/numpy -v /:/host the_container /bin/bash -c "
-          uname -a &&
-          gcc --version &&
-          g++ --version &&
-          arm-linux-gnueabihf-gfortran --version &&
-          python3 --version &&
-          git config --global --add safe.directory /numpy
-          cd /numpy &&
-          python3 setup.py install
-        "
-        docker commit the_build the_build
-    - name: Run SIMD Tests
-      run: |
-        docker run --rm --interactive -v $(pwd):/numpy the_build /bin/bash -c "
-          cd /numpy && F90=arm-linux-gnueabihf-gfortran python3 runtests.py -n -v -- -k 'test_simd or test_kind'
-        "
-
-  sde_simd_avx512_test:
-    # Intel Software Development Emulator (SDE) is used to run a given program
-    # on a specific instruction set architecture and capture various performance details.
-    # see https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
+      MESON_ARGS: "-Dallow-noblas=true"
     steps:
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
@@ -231,56 +81,131 @@ jobs:
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.9'
-    - name: Install Intel SDE
-      run: |
-        curl -o /tmp/sde.tar.xz https://downloadmirror.intel.com/732268/sde-external-9.7.0-2022-05-09-lin.tar.xz
-        mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
-        sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
-    - name: Install dependencies
-      run: python -m pip install -r test_requirements.txt
-    - name: Build
-      run: python setup.py build
-           --simd-test="\$werror AVX512F AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL"
-           install
-    # KNM implies KNL
-    - name: Run SIMD tests (Xeon PHI)
-      run: sde -knm -- python runtests.py -n -v -- -k test_simd
-    # ICL implies SKX, CLX and CNL
-    - name: Run SIMD tests (Ice Lake)
-      run: sde -icl -- python runtests.py -n -v -- -k test_simd
 
-  intel_spr_sde_test:
-    needs: [smoke_test]
+    - name: Install GCC/8/9
+      run: |
+        echo "deb http://archive.ubuntu.com/ubuntu focal main universe" | sudo tee /etc/apt/sources.list.d/focal.list
+        sudo apt update
+        sudo apt install -y g++-8 g++-9
+
+    - name: Enable gcc-8
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
+
+    - uses: ./.github/meson_actions
+      name: Build/Test against gcc-8
+
+    - name: Enable gcc-9
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1
+
+    - uses: ./.github/meson_actions
+      name: Build/Test against gcc-9
+
+  specialize:
+    needs: [baseline_only]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push'
+    continue-on-error: true
+    strategy:
+      matrix:
+        BUILD_PROP:
+          - [
+            "without optimizations",
+            "-Dallow-noblas=true -Ddisable-optimization=true",
+            "3.12-dev"
+          ]
+          - [
+            "native",
+            "-Dallow-noblas=true -Dcpu-baseline=native -Dcpu-dispatch=none",
+            "3.11"
+          ]
+          - [
+            "without avx512",
+            "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,AVX2,FMA3",
+            "3.10"
+          ]
+          - [
+            "without avx512/avx2/fma3",
+            "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C",
+            "3.9"
+          ]
+
+    env:
+      MESON_ARGS: ${{ matrix.BUILD_PROP[1] }}
+
+    name: "${{ matrix.BUILD_PROP[0] }}"
+    steps:
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+      with:
+        python-version: "${{ matrix.BUILD_PROP[2] }}"
+    - uses: ./.github/meson_actions
+      name: Build/Test
+
+  intel_sde:
+    needs: [baseline_only]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.4.0
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         submodules: recursive
         fetch-depth: 0
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.11'
+
     - name: Install Intel SDE
       run: |
         curl -o /tmp/sde.tar.xz https://downloadmirror.intel.com/784319/sde-external-9.24.0-2023-07-13-lin.tar.xz
         mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
         sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
+
     - name: Install dependencies
       run: |
-        python -m pip install -r test_requirements.txt
-        sudo apt install gcc-12 g++-12
-    - name: Build and install NumPy
+        sudo apt install -y g++-13
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1
+        python -m pip install -r build_requirements.txt
+        python -m pip install pytest pytest-xdist hypothesis typing_extensions
+
+    - name: Build
+      run: spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512f -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
+
+    - name: Meson Log
+      if: always()
+      run: cat build/meson-logs/meson-log.txt
+
+    - name: SIMD tests (KNM)
       run: |
-        export CC=/usr/bin/gcc-12
-        export CXX=/usr/bin/g++-12
-        python setup.py develop
-    - name: Show config
+        export NUMPY_SITE=$(realpath build-install/usr/lib/python*/site-packages/)
+        export PYTHONPATH="$PYTHONPATH:$NUMPY_SITE"
+        cd build-install &&
+        sde -knm -- python -c "import numpy; numpy.show_config()" &&
+        sde -knm -- python -m pytest $NUMPY_SITE/numpy/core/tests/test_simd*
+
+    - name: SIMD tests (SPR)
       run: |
-        python -c "import numpy as np; np.show_config()"
-    # Run only a few tests, running everything in an SDE takes a long time
-    # Using pytest directly, unable to use python runtests.py -n -t ...
-    - name: Run linalg/ufunc/umath tests
-      run: |
-        python -m pytest numpy/core/tests/test_umath* numpy/core/tests/test_ufunc.py numpy/linalg/tests/test_*
-        # Can't run on SDE just yet: see https://github.com/numpy/numpy/issues/23545#issuecomment-1659047365
-        #sde -spr -- python -m pytest numpy/core/tests/test_umath* numpy/core/tests/test_ufunc.py numpy/linalg/tests/test_*
+        export NUMPY_SITE=$(realpath build-install/usr/lib/python*/site-packages/)
+        export PYTHONPATH="$PYTHONPATH:$NUMPY_SITE"
+        cd build-install &&
+        sde -spr -- python -c "import numpy; numpy.show_config()" &&
+        sde -spr -- python -m pytest $NUMPY_SITE/numpy/core/tests/test_simd*
+
+    # Can't run on SDE just yet: see https://github.com/numpy/numpy/issues/23545#issuecomment-1659047365
+    #
+    #- name: linalg/ufunc/umath tests (SPR)
+    #  run: |
+    #    export NUMPY_SITE=$(realpath build-install/usr/lib/python*/site-packages/)
+    #    export PYTHONPATH="$PYTHONPATH:$NUMPY_SITE"
+    #    cd build-install &&
+    #    sde -spr -- python -c "import numpy; numpy.show_config()" &&
+    #    sde -spr -- python -m pytest $NUMPY_SITE/numpy/core/tests/test_umath* \
+    #                                 $NUMPY_SITE/numpy/core/tests/test_ufunc.py \
+    #                                 $NUMPY_SITE/numpy/linalg/tests/test_*
+


### PR DESCRIPTION
  All SIMD tests have been transitioned to utilize the Meson build system.
  The Intel SDE tests are now consolidated into a single action.
  Additionally, the Arm7 test has been removed as it is already
  covered by Linux QEMU tests for armhf.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
