### PR TITLE
MAINT: Refactor partial load Workaround for Clang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,11 +55,33 @@ add_project_arguments(
 #
 # Clang defaults to a non-strict floating error point model, but we need strict
 # behavior. `-ftrapping-math` is equivalent to `-ffp-exception-behavior=strict`.
-# Note that this is only supported on macOS arm64 as of XCode 14.3
-if cc.get_id() == 'clang'
-  add_project_arguments(
-    cc.get_supported_arguments('-ftrapping-math'), language: ['c', 'cpp'],
-  )
+# This flag is also required to prevent the activation of SIMD partial load workarounds.
+# For further clarification, refer to gh-24461.
+cc_id = cc.get_id()
+if cc_id.startswith('clang')
+  # Determine the compiler flags for trapping math exceptions.
+  trapping_math = {
+    'clang-cl': '/clang:-ftrapping-math',
+  }.get(cc_id, '-ftrapping-math')
+  # Check if the compiler supports the trapping math flag.
+  if cc.has_argument(trapping_math)
+    # TODO: Consider upgrading the vendored Meson to 1.3.0 to support the parameter `werror`
+    # Detect whether the compiler actually supports strict handling of floating-point exceptions
+    # by treating warnings as errors.
+    if cc.compiles('int main() { return 0; }', args: [trapping_math, '-Werror'])
+      trapping_math = [trapping_math, '-DNPY_HAVE_CLANG_FPSTRICT']
+    else
+      # Suppress warnings about unsupported floating-point optimization.
+      trapping_math = [trapping_math, '-Wno-unsupported-floating-point-opt']
+      # Inform the user about the workaround.
+      message(
+        'NumPy is being built against a version of Clang that does not strictly enforce ' +
+        'floating-point exception handling. Workarounds will be used, which may impact performance.\n' +
+        'Consider upgrading Clang to the latest version.'
+      )
+    endif
+    add_project_arguments(trapping_math, language: ['c', 'cpp'])
+  endif
 endif
 
 subdir('meson_cpu')

--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -838,9 +838,7 @@ foreach gen_mtargets : [
   [
     'loops_exponent_log.dispatch.h',
     src_file.process('src/umath/loops_exponent_log.dispatch.c.src'),
-    # Enabling SIMD on clang-cl raises spurious FP exceptions
-    # TODO (seiko2plus): debug spurious FP exceptions for single-precision log/exp
-    compiler_id == 'clang-cl' ? [] : [
+    [
       AVX512_SKX, AVX512F, [AVX2, FMA3]
     ]
   ],
@@ -884,9 +882,7 @@ foreach gen_mtargets : [
   [
     'loops_trigonometric.dispatch.h',
     src_file.process('src/umath/loops_trigonometric.dispatch.c.src'),
-    # Enabling SIMD on clang-cl raises spurious FP exceptions
-    # TODO (seiko2plus): debug spurious FP exceptions for single-precision sin/cos
-    compiler_id == 'clang-cl' ? [] : [
+    [
       AVX512F, [AVX2, FMA3],
       VSX4, VSX3, VSX2,
       NEON_VFPV4,

--- a/numpy/core/src/common/simd/avx512/memory.h
+++ b/numpy/core/src/common/simd/avx512/memory.h
@@ -248,14 +248,24 @@ NPY_FINLINE npyv_s32 npyv_load_till_s32(const npy_int32 *ptr, npy_uintp nlane, n
     assert(nlane > 0);
     const __m512i vfill = _mm512_set1_epi32(fill);
     const __mmask16 mask = nlane > 15 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_loadu_epi32(vfill, mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_mask_loadu_epi32(vfill, mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s32 npyv_load_tillz_s32(const npy_int32 *ptr, npy_uintp nlane)
 {
     assert(nlane > 0);
     const __mmask16 mask = nlane > 15 ? -1 : (1 << nlane) - 1;
-    return _mm512_maskz_loadu_epi32(mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_maskz_loadu_epi32(mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 //// 64
 NPY_FINLINE npyv_s64 npyv_load_till_s64(const npy_int64 *ptr, npy_uintp nlane, npy_int64 fill)
@@ -263,14 +273,24 @@ NPY_FINLINE npyv_s64 npyv_load_till_s64(const npy_int64 *ptr, npy_uintp nlane, n
     assert(nlane > 0);
     const __m512i vfill = npyv_setall_s64(fill);
     const __mmask8 mask = nlane > 7 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s64 npyv_load_tillz_s64(const npy_int64 *ptr, npy_uintp nlane)
 {
     assert(nlane > 0);
     const __mmask8 mask = nlane > 7 ? -1 : (1 << nlane) - 1;
-    return _mm512_maskz_loadu_epi64(mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_maskz_loadu_epi64(mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 
 //// 64-bit nlane
@@ -280,7 +300,12 @@ NPY_FINLINE npyv_s32 npyv_load2_till_s32(const npy_int32 *ptr, npy_uintp nlane,
     assert(nlane > 0);
     const __m512i vfill = _mm512_set4_epi32(fill_hi, fill_lo, fill_hi, fill_lo);
     const __mmask8 mask = nlane > 7 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s32 npyv_load2_tillz_s32(const npy_int32 *ptr, npy_uintp nlane)
@@ -293,14 +318,24 @@ NPY_FINLINE npyv_u64 npyv_load2_till_s64(const npy_int64 *ptr, npy_uintp nlane,
     assert(nlane > 0);
     const __m512i vfill = _mm512_set4_epi64(fill_hi, fill_lo, fill_hi, fill_lo);
     const __mmask8 mask = nlane > 3 ? -1 : (1 << (nlane*2)) - 1;
-    return _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_mask_loadu_epi64(vfill, mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s64 npyv_load2_tillz_s64(const npy_int64 *ptr, npy_uintp nlane)
 {
     assert(nlane > 0);
     const __mmask8 mask = nlane > 3 ? -1 : (1 << (nlane*2)) - 1;
-    return _mm512_maskz_loadu_epi64(mask, (const __m512i*)ptr);
+    __m512i ret = _mm512_maskz_loadu_epi64(mask, (const __m512i*)ptr);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 /*********************************
  * Non-contiguous partial load
@@ -317,7 +352,12 @@ npyv_loadn_till_s32(const npy_int32 *ptr, npy_intp stride, npy_uintp nlane, npy_
     const __m512i idx = _mm512_mullo_epi32(steps, _mm512_set1_epi32((int)stride));
     const __m512i vfill = _mm512_set1_epi32(fill);
     const __mmask16 mask = nlane > 15 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_i32gather_epi32(vfill, mask, idx, (const __m512i*)ptr, 4);
+    __m512i ret = _mm512_mask_i32gather_epi32(vfill, mask, idx, (const __m512i*)ptr, 4);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s32
@@ -334,7 +374,12 @@ npyv_loadn_till_s64(const npy_int64 *ptr, npy_intp stride, npy_uintp nlane, npy_
     );
     const __m512i vfill = npyv_setall_s64(fill);
     const __mmask8 mask = nlane > 15 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 8);
+    __m512i ret = _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 8);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s64
@@ -352,7 +397,12 @@ NPY_FINLINE npyv_s64 npyv_loadn2_till_s32(const npy_int32 *ptr, npy_intp stride,
     );
     const __m512i vfill = _mm512_set4_epi32(fill_hi, fill_lo, fill_hi, fill_lo);
     const __mmask8 mask = nlane > 7 ? -1 : (1 << nlane) - 1;
-    return _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 4);
+    __m512i ret = _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 4);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s32 npyv_loadn2_tillz_s32(const npy_int32 *ptr, npy_intp stride, npy_uintp nlane)
@@ -369,7 +419,12 @@ NPY_FINLINE npyv_s64 npyv_loadn2_till_s64(const npy_int64 *ptr, npy_intp stride,
     );
     const __mmask8 mask = nlane > 3 ? -1 : (1 << (nlane*2)) - 1;
     const __m512i vfill = _mm512_set4_epi64(fill_hi, fill_lo, fill_hi, fill_lo);
-    return _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 8);
+    __m512i ret = _mm512_mask_i64gather_epi64(vfill, mask, idx, (const __m512i*)ptr, 8);
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile __m512i workaround = ret;
+    ret = _mm512_or_si512(workaround, ret);
+#endif
+    return ret;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s64 npyv_loadn2_tillz_s64(const npy_int64 *ptr, npy_intp stride, npy_uintp nlane)

--- a/numpy/core/src/common/simd/neon/memory.h
+++ b/numpy/core/src/common/simd/neon/memory.h
@@ -187,19 +187,28 @@ NPY_FINLINE void npyv_storen2_f64(double *ptr, npy_intp stride, npyv_f64 a)
 NPY_FINLINE npyv_s32 npyv_load_till_s32(const npy_int32 *ptr, npy_uintp nlane, npy_int32 fill)
 {
     assert(nlane > 0);
+    npyv_s32 a;
     switch(nlane) {
     case 1:
-        return vld1q_lane_s32((const int32_t*)ptr, vdupq_n_s32(fill), 0);
+        a = vld1q_lane_s32((const int32_t*)ptr, vdupq_n_s32(fill), 0);
+        break;
     case 2:
-        return vcombine_s32(vld1_s32((const int32_t*)ptr), vdup_n_s32(fill));
+        a = vcombine_s32(vld1_s32((const int32_t*)ptr), vdup_n_s32(fill));
+        break;
     case 3:
-        return vcombine_s32(
+        a = vcombine_s32(
             vld1_s32((const int32_t*)ptr),
             vld1_lane_s32((const int32_t*)ptr + 2, vdup_n_s32(fill), 0)
         );
+        break;
     default:
         return npyv_load_s32(ptr);
     }
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile npyv_s32 workaround = a;
+    a = vorrq_s32(workaround, a);
+#endif
+    return a;
 }
 // fill zero to rest lanes
 NPY_FINLINE npyv_s32 npyv_load_tillz_s32(const npy_int32 *ptr, npy_uintp nlane)
@@ -209,7 +218,12 @@ NPY_FINLINE npyv_s64 npyv_load_till_s64(const npy_int64 *ptr, npy_uintp nlane, n
 {
     assert(nlane > 0);
     if (nlane == 1) {
-        return vcombine_s64(vld1_s64((const int64_t*)ptr), vdup_n_s64(fill));
+        npyv_s64 a = vcombine_s64(vld1_s64((const int64_t*)ptr), vdup_n_s64(fill));
+    #if NPY_SIMD_GUARD_PARTIAL_LOAD
+        volatile npyv_s64 workaround = a;
+        a = vorrq_s64(workaround, a);
+    #endif
+        return a;
     }
     return npyv_load_s64(ptr);
 }
@@ -224,7 +238,12 @@ NPY_FINLINE npyv_s32 npyv_load2_till_s32(const npy_int32 *ptr, npy_uintp nlane,
     assert(nlane > 0);
     if (nlane == 1) {
         const int32_t NPY_DECL_ALIGNED(16) fill[2] = {fill_lo, fill_hi};
-        return vcombine_s32(vld1_s32((const int32_t*)ptr), vld1_s32(fill));
+        npyv_s32 a = vcombine_s32(vld1_s32((const int32_t*)ptr), vld1_s32(fill));
+    #if NPY_SIMD_GUARD_PARTIAL_LOAD
+        volatile npyv_s32 workaround = a;
+        a = vorrq_s32(workaround, a);
+    #endif
+        return a;
     }
     return npyv_load_s32(ptr);
 }
@@ -256,10 +275,15 @@ npyv_loadn_till_s32(const npy_int32 *ptr, npy_intp stride, npy_uintp nlane, npy_
         vfill = vld1q_lane_s32((const int32_t*)ptr + stride, vfill, 1);
     case 1:
         vfill = vld1q_lane_s32((const int32_t*)ptr, vfill, 0);
-        return vfill;
+        break;
     default:
         return npyv_loadn_s32(ptr, stride);
     }
+#if NPY_SIMD_GUARD_PARTIAL_LOAD
+    volatile npyv_s32 workaround = vfill;
+    vfill = vorrq_s32(workaround, vfill);
+#endif
+    return vfill;
 }
 NPY_FINLINE npyv_s32
 npyv_loadn_tillz_s32(const npy_int32 *ptr, npy_intp stride, npy_uintp nlane)
@@ -270,7 +294,7 @@ npyv_loadn_till_s64(const npy_int64 *ptr, npy_intp stride, npy_uintp nlane, npy_
 {
     assert(nlane > 0);
     if (nlane == 1) {
-        return vcombine_s64(vld1_s64((const int64_t*)ptr), vdup_n_s64(fill));
+        return npyv_load_till_s64(ptr, 1, fill);
     }
     return npyv_loadn_s64(ptr, stride);
 }
@@ -285,7 +309,12 @@ NPY_FINLINE npyv_s32 npyv_loadn2_till_s32(const npy_int32 *ptr, npy_intp stride,
     assert(nlane > 0);
     if (nlane == 1) {
         const int32_t NPY_DECL_ALIGNED(16) fill[2] = {fill_lo, fill_hi};
-        return vcombine_s32(vld1_s32((const int32_t*)ptr), vld1_s32(fill));
+        npyv_s32 a = vcombine_s32(vld1_s32((const int32_t*)ptr), vld1_s32(fill));
+    #if NPY_SIMD_GUARD_PARTIAL_LOAD
+        volatile npyv_s32 workaround = a;
+        a = vorrq_s32(workaround, a);
+    #endif
+        return a;
     }
     return npyv_loadn2_s32(ptr, stride);
 }
@@ -293,7 +322,12 @@ NPY_FINLINE npyv_s32 npyv_loadn2_tillz_s32(const npy_int32 *ptr, npy_intp stride
 {
     assert(nlane > 0);
     if (nlane == 1) {
-        return vcombine_s32(vld1_s32((const int32_t*)ptr), vdup_n_s32(0));
+        npyv_s32 a = vcombine_s32(vld1_s32((const int32_t*)ptr), vdup_n_s32(0));
+    #if NPY_SIMD_GUARD_PARTIAL_LOAD
+        volatile npyv_s32 workaround = a;
+        a = vorrq_s32(workaround, a);
+    #endif
+        return a;
     }
     return npyv_loadn2_s32(ptr, stride);
 }

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -31,59 +31,6 @@
 /********************************************************************************
  ** Defining ufunc inner functions
  ********************************************************************************/
-
-/*
- * clang has a bug that's present at -O1 or greater.  When partially loading a
- * vector register for a divide operation, the remaining elements are set
- * to 1 to avoid divide-by-zero.  The partial load is paired with a partial
- * store after the divide operation.  clang notices that the entire register
- * is not needed for the store and optimizes out the fill of 1 to the remaining
- * elements.  This causes either a divide-by-zero or 0/0 with invalid exception
- * that we were trying to avoid by filling.
- *
- * Using a dummy variable marked 'volatile' convinces clang not to ignore
- * the explicit fill of remaining elements.  If `-ftrapping-math` is
- * supported, then it'll also avoid the bug.  `-ftrapping-math` is supported
- * on Apple clang v12+ for x86_64.  It is not currently supported for arm64.
- * `-ftrapping-math` is set by default of Numpy builds in
- * numpy/distutils/ccompiler.py.
- *
- * Note: Apple clang and clang upstream have different versions that overlap
- */
-#if defined(__clang__)
-    #if defined(__apple_build_version__)
-    // Apple Clang
-        #if __apple_build_version__ < 12000000
-        // Apple Clang before v12
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 1
-        #elif defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64)
-        // Apple Clang after v12, targeting i386 or x86_64
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 0
-        #else
-        // Apple Clang after v12, not targeting i386 or x86_64
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 1
-        #endif
-    #else
-    // Clang, not Apple Clang
-        #if __clang_major__ < 10
-        // Clang before v10
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 1
-        #elif defined(_MSC_VER)
-        // clang-cl has the same bug
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 1
-        #elif defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64)
-        // Clang v10+, targeting i386 or x86_64
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 0
-        #else
-        // Clang v10+, not targeting i386 or x86_64
-        #define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 1
-        #endif
-    #endif
-#else
-// Not a Clang compiler
-#define WORKAROUND_CLANG_PARTIAL_LOAD_BUG 0
-#endif
-
 /**begin repeat
  * Float types
  *  #type = npy_float, npy_double#
@@ -148,12 +95,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_store_@sfx@((@type@*)dst, r0);
                 npyv_store_@sfx@((@type@*)(dst + vstep), r1);
             }
-        #if @is_div@ && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            const int vstop = hstep - 1;
-        #else
-            const int vstop = 0;
-        #endif // #if @is_div@ && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            for (; len > vstop; len -= hstep, src0 += vstep, src1 += vstep, dst += vstep) {
+            for (; len > 0; len -= hstep, src0 += vstep, src1 += vstep, dst += vstep) {
             #if @is_div@
                 npyv_@sfx@ a = npyv_load_till_@sfx@((const @type@*)src0, len, 1.0@c@);
                 npyv_@sfx@ b = npyv_load_till_@sfx@((const @type@*)src1, len, 1.0@c@);
@@ -164,15 +106,6 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
                 npyv_store_till_@sfx@((@type@*)dst, len, r);
             }
-        #if @is_div@ && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            // last partial iteration for divide and working around clang partial load bug
-            if(len > 0){
-                npyv_@sfx@ a = npyv_load_till_@sfx@((const @type@*)src0, len, 1.0@c@);
-                volatile npyv_@sfx@ b = npyv_load_till_@sfx@((const @type@*)src1, len, 1.0@c@);
-                npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
-                npyv_store_till_@sfx@((@type@*)dst, len, r);
-            }
-        #endif // #if @is_div@ && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
         }
         else if (ssrc0 == 0 && ssrc1 == sizeof(@type@) && sdst == ssrc1) {
             npyv_@sfx@ a = npyv_setall_@sfx@(*((@type@*)src0));
@@ -184,12 +117,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_store_@sfx@((@type@*)dst, r0);
                 npyv_store_@sfx@((@type@*)(dst + vstep), r1);
             }
-        #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            const int vstop = hstep - 1;
-        #else
-            const int vstop = 0;
-        #endif // #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            for (; len > vstop; len -= hstep, src1 += vstep, dst += vstep) {
+            for (; len > 0; len -= hstep, src1 += vstep, dst += vstep) {
             #if @is_div@ || @is_mul@
                 npyv_@sfx@ b = npyv_load_till_@sfx@((const @type@*)src1, len, 1.0@c@);
             #else
@@ -198,14 +126,6 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
                 npyv_store_till_@sfx@((@type@*)dst, len, r);
             }
-        #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            // last partial iteration for multiply / divide and working around clang partial load bug
-            if(len > 0){
-                volatile npyv_@sfx@ b = npyv_load_till_@sfx@((const @type@*)src1, len, 1.0@c@);
-                npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
-                npyv_store_till_@sfx@((@type@*)dst, len, r);
-            }
-        #endif // #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
         }
         else if (ssrc1 == 0 && ssrc0 == sizeof(@type@) && sdst == ssrc0) {
             npyv_@sfx@ b = npyv_setall_@sfx@(*((@type@*)src1));
@@ -217,12 +137,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_store_@sfx@((@type@*)dst, r0);
                 npyv_store_@sfx@((@type@*)(dst + vstep), r1);
             }
-        #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            const int vstop = hstep - 1;
-        #else
-            const int vstop = 0;
-        #endif // #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            for (; len > vstop; len -= hstep, src0 += vstep, dst += vstep) {
+            for (; len > 0; len -= hstep, src0 += vstep, dst += vstep) {
             #if @is_div@ || @is_mul@
                 npyv_@sfx@ a = npyv_load_till_@sfx@((const @type@*)src0, len, 1.0@c@);
             #else
@@ -231,14 +146,6 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
                 npyv_store_till_@sfx@((@type@*)dst, len, r);
             }
-        #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
-            // last partial iteration for multiply / divide and working around clang partial load bug
-            if(len > 0){
-                volatile npyv_@sfx@ a = npyv_load_till_@sfx@((const @type@*)src0, len, 1.0@c@);
-                npyv_@sfx@ r = npyv_@intrin@_@sfx@(a, b);
-                npyv_store_till_@sfx@((@type@*)dst, len, r);
-            }
-        #endif // #if (@is_div@ || @is_mul@) && WORKAROUND_CLANG_PARTIAL_LOAD_BUG
         } else {
             goto loop_scalar;
         }
@@ -278,8 +185,6 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 
 /**end repeat1**/
 /**end repeat**/
-
-#undef WORKAROUND_CLANG_PARTIAL_LOAD_BUG
 
 //###############################################################################
 //## Complex Single/Double precision

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -93,58 +93,6 @@ NPY_FINLINE double c_square_f64(double a)
 #define CONTIG  0
 #define NCONTIG 1
 
-/*
- * clang has a bug that's present at -O1 or greater.  When partially loading a
- * vector register for a reciprocal operation, the remaining elements are set
- * to 1 to avoid divide-by-zero.  The partial load is paired with a partial
- * store after the reciprocal operation.  clang notices that the entire register
- * is not needed for the store and optimizes out the fill of 1 to the remaining
- * elements.  This causes either a divide-by-zero or 0/0 with invalid exception
- * that we were trying to avoid by filling.
- *
- * Using a dummy variable marked 'volatile' convinces clang not to ignore
- * the explicit fill of remaining elements.  If `-ftrapping-math` is
- * supported, then it'll also avoid the bug.  `-ftrapping-math` is supported
- * on Apple clang v12+ for x86_64.  It is not currently supported for arm64.
- * `-ftrapping-math` is set by default of Numpy builds in
- * numpy/distutils/ccompiler.py.
- *
- * Note: Apple clang and clang upstream have different versions that overlap
- */
-#if defined(__clang__)
-    #if defined(__apple_build_version__)
-    // Apple Clang
-        #if __apple_build_version__ < 12000000
-        // Apple Clang before v12
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 1
-        #elif defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64)
-        // Apple Clang after v12, targeting i386 or x86_64
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 0
-        #else
-        // Apple Clang after v12, not targeting i386 or x86_64
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 1
-        #endif
-    #else
-    // Clang, not Apple Clang
-        #if __clang_major__ < 10
-        // Clang before v10
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 1
-        #elif defined(_MSC_VER)
-        // clang-cl has the same bug
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 1
-        #elif defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64)
-        // Clang v10+, targeting i386 or x86_64
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 0
-        #else
-        // Clang v10+, not targeting i386 or x86_64
-        #define WORKAROUND_CLANG_RECIPROCAL_BUG 1
-        #endif
-    #endif
-#else
-// Not a Clang compiler
-#define WORKAROUND_CLANG_RECIPROCAL_BUG 0
-#endif
-
 /**begin repeat
  * #TYPE = FLOAT, DOUBLE#
  * #sfx  = f32, f64#
@@ -155,7 +103,6 @@ NPY_FINLINE double c_square_f64(double a)
  * #kind     = rint,  floor, ceil, trunc, sqrt, absolute, square, reciprocal#
  * #intr     = rint,  floor, ceil, trunc, sqrt, abs,      square, recip#
  * #repl_0w1 = 0*7, 1#
- * #RECIP_WORKAROUND = 0*7, WORKAROUND_CLANG_RECIPROCAL_BUG#
  */
 /**begin repeat2
  * #STYPE  = CONTIG, NCONTIG, CONTIG,  NCONTIG#
@@ -228,15 +175,6 @@ static void simd_@TYPE@_@kind@_@STYPE@_@DTYPE@
             npyv_@sfx@ v_src0 = npyv_loadn_tillz_@sfx@(src, ssrc, len);
         #endif
     #endif
-        #if @RECIP_WORKAROUND@
-            /*
-             * Workaround clang bug.  We use a dummy variable marked 'volatile'
-             * to convince clang that the entire vector is needed.  We only
-             * want to do this for the last iteration / partial load-store of
-             * the loop since 'volatile' forces a refresh of the contents.
-             */
-             volatile npyv_@sfx@ unused_but_workaround_bug = v_src0;
-        #endif // @RECIP_WORKAROUND@
         npyv_@sfx@ v_unary0 = npyv_@intr@_@sfx@(v_src0);
     #if @DTYPE@ == CONTIG
         npyv_store_till_@sfx@(dst, len, v_unary0);
@@ -251,8 +189,6 @@ static void simd_@TYPE@_@kind@_@STYPE@_@DTYPE@
 /**end repeat1**/
 #endif // @VCHK@
 /**end repeat**/
-
-#undef WORKAROUND_CLANG_RECIPROCAL_BUG
 
 /********************************************************************************
  ** Defining ufunc inner functions


### PR DESCRIPTION
Backport of #24461. 

 Clang exhibits aggressive optimization behavior when the `-ftrapping-math` flag is not fully supported,
  starting from -O1 optimization level. When partially loading a vector register for operations that
  require filling up the remaining lanes with specific values (e.g., divide operations needing non-zero
  integers to prevent FP exception divide-by-zero), Clang's optimizer recognizes that the full register
  is unnecessary for the store operation. Consequently, it optimizes out the fill step involving
  non-zero integers for the remaining elements.

  As a solution, we apply the `volatile` keyword to the returned register, followed by a symmetric
  operand operation like `or`, to inform the compiler about the necessity of the full vector.

  This refactor involves transferring this workaround from the source files to the universal intrinsic headers,
  also to guarantee that it is applied by all kernels. Furthermore, the workaround is disabled when the
  `-ftrapping-math` flag is fully supported by the Clang compiler.

  This patch also enables `-ftrapping-math` flag for clang-cl and
  suppress floating point exceptions warnings.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
