### PR TITLE
Add read-only token to linux_qemu.yml

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   linux_qemu:
     if: "github.repository == 'numpy/numpy'"


### PR DESCRIPTION
Related to #22481 and #23294.

Like the linked PRs, this one adds top-level read-only permissions to the new `linux_qemu.yml` workflow.