### PR TITLE
BUG, ENH: Access `PyArrayMultiIterObject` fields using macros.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2497,6 +2497,48 @@ Broadcasting (multi-iterators)
     through all of the elements (of the broadcasted result), otherwise
     it evaluates FALSE.
 
+.. c:function:: npy_intp PyArray_MultiIter_SIZE(PyObject* multi)
+
+    .. versionadded:: 1.26.0
+
+    Returns the total broadcasted size of a multi-iterator object. 
+
+.. c:function:: int PyArray_MultiIter_NDIM(PyObject* multi)
+
+    .. versionadded:: 1.26.0
+
+    Returns the number of dimensions in the broadcasted result of
+    a multi-iterator object.
+
+.. c:function:: npy_intp PyArray_MultiIter_INDEX(PyObject* multi)
+
+    .. versionadded:: 1.26.0
+
+    Returns the current (1-d) index into the broadcasted result
+    of a multi-iterator object.
+
+.. c:function:: int PyArray_MultiIter_NUMITER(PyObject* multi)
+
+    .. versionadded:: 1.26.0
+
+    Returns the number of iterators that are represented by a
+    multi-iterator object.
+
+.. c:function:: void** PyArray_MultiIter_ITERS(PyObject* multi)
+
+    .. versionadded:: 1.26.0
+
+    Returns an array of iterator objects that holds the iterators for the
+    arrays to be broadcast together. On return, the iterators are adjusted
+    for broadcasting.
+
+.. c:function:: npy_intp* PyArray_MultiIter_DIMS(PyObject* multi)
+
+    .. versionadded:: 1.26
+
+    Returns a pointer to the dimensions/shape of the broadcasted result of a
+    multi-iterator object.
+
 .. c:function:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
 
     This function encapsulates the broadcasting rules. The *mit*

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2497,34 +2497,34 @@ Broadcasting (multi-iterators)
     through all of the elements (of the broadcasted result), otherwise
     it evaluates FALSE.
 
-.. c:function:: npy_intp PyArray_MultiIter_SIZE(PyObject* multi)
+.. c:function:: npy_intp PyArray_MultiIter_SIZE(PyArrayMultiIterObject* multi)
 
     .. versionadded:: 1.26.0
 
     Returns the total broadcasted size of a multi-iterator object. 
 
-.. c:function:: int PyArray_MultiIter_NDIM(PyObject* multi)
+.. c:function:: int PyArray_MultiIter_NDIM(PyArrayMultiIterObject* multi)
 
     .. versionadded:: 1.26.0
 
     Returns the number of dimensions in the broadcasted result of
     a multi-iterator object.
 
-.. c:function:: npy_intp PyArray_MultiIter_INDEX(PyObject* multi)
+.. c:function:: npy_intp PyArray_MultiIter_INDEX(PyArrayMultiIterObject* multi)
 
     .. versionadded:: 1.26.0
 
     Returns the current (1-d) index into the broadcasted result
     of a multi-iterator object.
 
-.. c:function:: int PyArray_MultiIter_NUMITER(PyObject* multi)
+.. c:function:: int PyArray_MultiIter_NUMITER(PyArrayMultiIterObject* multi)
 
     .. versionadded:: 1.26.0
 
     Returns the number of iterators that are represented by a
     multi-iterator object.
 
-.. c:function:: void** PyArray_MultiIter_ITERS(PyObject* multi)
+.. c:function:: void** PyArray_MultiIter_ITERS(PyArrayMultiIterObject* multi)
 
     .. versionadded:: 1.26.0
 
@@ -2532,9 +2532,9 @@ Broadcasting (multi-iterators)
     arrays to be broadcast together. On return, the iterators are adjusted
     for broadcasting.
 
-.. c:function:: npy_intp* PyArray_MultiIter_DIMS(PyObject* multi)
+.. c:function:: npy_intp* PyArray_MultiIter_DIMS(PyArrayMultiIterObject* multi)
 
-    .. versionadded:: 1.26
+    .. versionadded:: 1.26.0
 
     Returns a pointer to the dimensions/shape of the broadcasted result of a
     multi-iterator object.

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -542,6 +542,12 @@ cdef extern from "numpy/arrayobject.h":
     void* PyArray_MultiIter_DATA(broadcast multi, npy_intp i) nogil
     void PyArray_MultiIter_NEXTi(broadcast multi, npy_intp i) nogil
     bint PyArray_MultiIter_NOTDONE(broadcast multi) nogil
+    npy_intp PyArray_MultiIter_SIZE(broadcast multi) nogil
+    int PyArray_MultiIter_NDIM(broadcast multi) nogil
+    npy_intp PyArray_MultiIter_INDEX(broadcast multi) nogil
+    int PyArray_MultiIter_NUMITER(broadcast multi) nogil
+    npy_intp* PyArray_MultiIter_DIMS(broadcast multi) nogil
+    void** PyArray_MultiIter_ITERS(broadcast multi) nogil
 
     # Functions from __multiarray_api.h
 

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -227,8 +227,38 @@ cdef extern from "numpy/arrayobject.h":
         pass
 
     ctypedef class numpy.broadcast [object PyArrayMultiIterObject, check_size ignore]:
-        # Use through macros
-        pass
+
+        @property
+        cdef inline int numiter(self) nogil:
+            """The number of arrays that need to be broadcast to the same shape."""
+            return PyArray_MultiIter_NUMITER(self)
+
+        @property
+        cdef inline npy_intp size(self) nogil:
+            """The total broadcasted size."""
+            return PyArray_MultiIter_SIZE(self)
+
+        @property
+        cdef inline npy_intp index(self) nogil:
+            """The current (1-d) index into the broadcasted result."""
+            return PyArray_MultiIter_INDEX(self)
+
+        @property
+        cdef inline int nd(self) nogil:
+            """The number of dimensions in the broadcasted result."""
+            return PyArray_MultiIter_NDIM(self)
+
+        @property
+        cdef inline npy_intp* dimensions(self) nogil:
+            """The shape of the broadcasted result."""
+            return PyArray_MultiIter_DIMS(self)
+
+        @property
+        cdef inline void** iters(self) nogil:
+            """An array of iterator objects that holds the iterators for the arrays to be broadcast together.
+            On return, the iterators are adjusted for broadcasting."""
+            return PyArray_MultiIter_ITERS(self)
+
 
     ctypedef struct PyArrayObject:
         # For use in situations where ndarray can't replace PyArrayObject*,

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -500,6 +500,12 @@ cdef extern from "numpy/arrayobject.h":
     void* PyArray_MultiIter_DATA(broadcast multi, npy_intp i) nogil
     void PyArray_MultiIter_NEXTi(broadcast multi, npy_intp i) nogil
     bint PyArray_MultiIter_NOTDONE(broadcast multi) nogil
+    npy_intp PyArray_MultiIter_SIZE(broadcast multi) nogil
+    int PyArray_MultiIter_NDIM(broadcast multi) nogil
+    npy_intp PyArray_MultiIter_INDEX(broadcast multi) nogil
+    int PyArray_MultiIter_NUMITER(broadcast multi) nogil
+    npy_intp* PyArray_MultiIter_DIMS(broadcast multi) nogil
+    void** PyArray_MultiIter_ITERS(broadcast multi) nogil
 
     # Functions from __multiarray_api.h
 

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -500,12 +500,6 @@ cdef extern from "numpy/arrayobject.h":
     void* PyArray_MultiIter_DATA(broadcast multi, npy_intp i) nogil
     void PyArray_MultiIter_NEXTi(broadcast multi, npy_intp i) nogil
     bint PyArray_MultiIter_NOTDONE(broadcast multi) nogil
-    npy_intp PyArray_MultiIter_SIZE(broadcast multi) nogil
-    int PyArray_MultiIter_NDIM(broadcast multi) nogil
-    npy_intp PyArray_MultiIter_INDEX(broadcast multi) nogil
-    int PyArray_MultiIter_NUMITER(broadcast multi) nogil
-    npy_intp* PyArray_MultiIter_DIMS(broadcast multi) nogil
-    void** PyArray_MultiIter_ITERS(broadcast multi) nogil
 
     # Functions from __multiarray_api.h
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1276,12 +1276,47 @@ typedef struct {
 #define PyArray_MultiIter_NOTDONE(multi)                \
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
-#define PyArray_MultiIter_SIZE(multi) (_PyMIT(multi)->size)
-#define PyArray_MultiIter_NDIM(multi) (_PyMIT(multi)->nd)
-#define PyArray_MultiIter_INDEX(multi) (_PyMIT(multi)->index)
-#define PyArray_MultiIter_NUMITER(multi) (_PyMIT(multi)->numiter)
-#define PyArray_MultiIter_DIMS(multi) (_PyMIT(multi)->dimensions)
-#define PyArray_MultiIter_ITERS(multi) ((void **)_PyMIT(multi)->iters)
+
+static int
+PyArray_MultiIter_NUMITER(PyArrayMultiIterObject *multi)
+{
+    return multi->numiter;
+}
+
+
+static npy_intp 
+PyArray_MultiIter_SIZE(PyArrayMultiIterObject *multi)
+{
+    return multi->size;
+}
+
+
+static npy_intp
+PyArray_MultiIter_INDEX(PyArrayMultiIterObject *multi)
+{
+    return multi->index;
+}
+
+
+static int
+PyArray_MultiIter_NDIM(PyArrayMultiIterObject *multi)
+{
+    return multi->nd;
+}
+
+
+static npy_intp *
+PyArray_MultiIter_DIMS(PyArrayMultiIterObject *multi)
+{
+    return multi->dimensions;
+}
+
+
+static PyArrayIterObject **
+PyArray_MultiIter_ITERS(PyArrayMultiIterObject *multi)
+{
+    return multi->iters;
+}
 
 
 /*

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1277,42 +1277,42 @@ typedef struct {
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
 
-static int
+static NPY_INLINE int
 PyArray_MultiIter_NUMITER(PyArrayMultiIterObject *multi)
 {
     return multi->numiter;
 }
 
 
-static npy_intp 
+static NPY_INLINE npy_intp 
 PyArray_MultiIter_SIZE(PyArrayMultiIterObject *multi)
 {
     return multi->size;
 }
 
 
-static npy_intp
+static NPY_INLINE npy_intp
 PyArray_MultiIter_INDEX(PyArrayMultiIterObject *multi)
 {
     return multi->index;
 }
 
 
-static int
+static NPY_INLINE int
 PyArray_MultiIter_NDIM(PyArrayMultiIterObject *multi)
 {
     return multi->nd;
 }
 
 
-static npy_intp *
+static NPY_INLINE npy_intp *
 PyArray_MultiIter_DIMS(PyArrayMultiIterObject *multi)
 {
     return multi->dimensions;
 }
 
 
-static void **
+static NPY_INLINE void **
 PyArray_MultiIter_ITERS(PyArrayMultiIterObject *multi)
 {
     return (void**)multi->iters;

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1281,7 +1281,7 @@ typedef struct {
 #define PyArray_MultiIter_INDEX(multi) (_PyMIT(multi)->index)
 #define PyArray_MultiIter_NUMITER(multi) (_PyMIT(multi)->numiter)
 #define PyArray_MultiIter_DIMS(multi) (_PyMIT(multi)->dimensions)
-#define PyArray_MultiIter_ITERS(multi) (_PyMIT(multi)->iters)
+#define PyArray_MultiIter_ITERS(multi) ((void **)_PyMIT(multi)->iters)
 
 
 /*

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1276,6 +1276,14 @@ typedef struct {
 #define PyArray_MultiIter_NOTDONE(multi)                \
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
+#define PyArray_MultiIter_SIZE(multi) (_PyMIT(multi)->size)
+#define PyArray_MultiIter_NDIM(multi) (_PyMIT(multi)->nd)
+#define PyArray_MultiIter_INDEX(multi) (_PyMIT(multi)->index)
+#define PyArray_MultiIter_NUMITER(multi) (_PyMIT(multi)->numiter)
+#define PyArray_MultiIter_DIMS(multi) (_PyMIT(multi)->dimensions)
+#define PyArray_MultiIter_ITERS(multi) (_PyMIT(multi)->iters)
+
+
 /*
  * Store the information needed for fancy-indexing over an array. The
  * fields are slightly unordered to keep consec, dataptr and subspace

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1312,10 +1312,10 @@ PyArray_MultiIter_DIMS(PyArrayMultiIterObject *multi)
 }
 
 
-static PyArrayIterObject **
+static void **
 PyArray_MultiIter_ITERS(PyArrayMultiIterObject *multi)
 {
-    return multi->iters;
+    return (void**)multi->iters;
 }
 
 

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -77,3 +77,46 @@ def make_iso_8601_datetime(dt: "datetime"):
         cnp.NPY_NO_CASTING,
     )
     return result
+
+
+cdef cnp.broadcast multiiter_from_broadcast_obj(object bcast):
+    cdef dict iter_map = {
+        1: cnp.PyArray_MultiIterNew1,
+        2: cnp.PyArray_MultiIterNew2,
+        3: cnp.PyArray_MultiIterNew3,
+        4: cnp.PyArray_MultiIterNew4,
+        5: cnp.PyArray_MultiIterNew5,
+    }
+    arrays = [x.base for x in bcast.iters]
+    cdef cnp.broadcast result = iter_map[len(arrays)](*arrays)
+    return result
+
+
+def get_multiiter_size(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return multi.size
+
+
+def get_multiiter_number_of_dims(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return multi.nd
+
+
+def get_multiiter_current_index(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return multi.index
+
+
+def get_multiiter_num_of_iterators(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return multi.numiter
+
+
+def get_multiiter_shape(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return tuple([multi.dimensions[i] for i in range(bcast.nd)])
+
+
+def get_multiiter_iters(bcast: "broadcast"):
+    cdef cnp.broadcast multi = multiiter_from_broadcast_obj(bcast)
+    return tuple([<cnp.flatiter>multi.iters[i] for i in range(bcast.numiter)])

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -162,3 +162,29 @@ class TestDatetimeStrings:
         # uses NPY_FR_ns
         res = checks.get_datetime_iso_8601_strlen()
         assert res == 48
+
+
+@pytest.mark.parametrize(
+    "arrays",
+    [
+        [np.random.rand(2)],
+        [np.random.rand(2), np.random.rand(3, 1)],
+        [np.random.rand(3, 2), np.random.rand(2, 3, 2), np.random.rand(1, 2, 3, 2)],
+        [np.random.rand(2, 1)] * 4 + [np.random.rand(1, 1, 1)],
+    ]
+)
+def test_multiiter_fields(install_temp, arrays):
+    import checks
+    bcast = np.broadcast(*arrays)
+
+    assert bcast.ndim == checks.get_multiiter_number_of_dims(bcast)
+    assert bcast.size == checks.get_multiiter_size(bcast)
+    assert bcast.numiter == checks.get_multiiter_num_of_iterators(bcast)
+    assert bcast.shape == checks.get_multiiter_shape(bcast)
+    assert bcast.index == checks.get_multiiter_current_index(bcast)
+    assert all(
+        [
+            x.base is y.base
+            for x, y in zip(bcast.iters, checks.get_multiiter_iters(bcast))
+        ]
+    )

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -169,7 +169,7 @@ class TestDatetimeStrings:
     [
         [np.random.rand(2)],
         [np.random.rand(2), np.random.rand(3, 1)],
-        [np.random.rand(3, 2), np.random.rand(2, 3, 2), np.random.rand(1, 2, 3, 2)],
+        [np.random.rand(2), np.random.rand(2, 3, 2), np.random.rand(1, 3, 2)],
         [np.random.rand(2, 1)] * 4 + [np.random.rand(1, 1, 1)],
     ]
 )


### PR DESCRIPTION
Adds macros to the C-API for accessing `PyArrayMultiIterObject` fields. At the Cython level, these macros can be used to access fields of a `np.broadcast` type. This is to restore Cython 0.29.X functionality that was lost in #16986 where the fields of `np.broadcast` could no longer be accessed directly.

closes #24649

Cc @seberg, Is there a testing framework for the C-API somewhere? I searched and could not see how one would test the added macros.