### PR TITLE
MAINT: Improve performance of common_type and use result_type internally

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -12,7 +12,7 @@ from .._utils import set_module
 import numpy._core.numeric as _nx
 from numpy._core.numeric import asarray, asanyarray, isnan, zeros
 from numpy._core import overrides, getlimits
-from numpy._core import _multiarray_umath
+from numpy._core._multiarray_umath import result_type as _result_type
 from ._ufunclike_impl import isneginf, isposinf
 
 
@@ -669,7 +669,7 @@ def common_type(*arrays):
     <class 'numpy.complex128'>
 
     """
-    common_type = _multiarray_umath.result_type(0., *[a.dtype for a in arrays]).type
+    common_type = _result_type(0., *[a.dtype for a in arrays]).type
     if not issubclass(common_type, _nx.inexact):
         raise TypeError("can't get common type for non-numeric array")
     return common_type

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -13,8 +13,8 @@ import numpy._core.numeric as _nx
 from numpy._core.numeric import asarray, asanyarray, isnan, zeros
 from numpy._core import overrides, getlimits
 from numpy._core._multiarray_umath import result_type as _result_type
+from numpy import integer as _integer_type
 from ._ufunclike_impl import isneginf, isposinf
-
 
 array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
@@ -669,7 +669,9 @@ def common_type(*arrays):
     <class 'numpy.complex128'>
 
     """
-    common_type = _result_type(0., *[a.dtype for a in arrays]).type
+    common_type = _result_type(*[a.dtype for a in arrays]).type
+    if issubclass(common_type, _integer_type):
+        return _nx.float64
     if not issubclass(common_type, _nx.inexact):
         raise TypeError("can't get common type for non-numeric array")
     return common_type

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -309,7 +309,9 @@ def test_truediv(Poly):
     p2 = p1 * 5
 
     for stype in np.ScalarType:
-        if not issubclass(stype, Number) or issubclass(stype, bool):
+        if not issubclass(stype, Number):
+            continue
+        if issubclass(stype, (bool, np.timedelta64)):
             continue
         s = stype(5)
         assert_poly_almost_equal(op.truediv(p2, s), p1)


### PR DESCRIPTION
Cleanup implementation of `np.common_type` using `np.result_type` and improve performance.

* The performance of `np.common_type(x, x)` with `x=np.array([1.])` goes from 1.6952696400003333 (main) to 1.1668818179987284 (this PR).
* See additional discussion at #24656
* There is a slight behaviour change in the sense that 
```
i16=np.array(2, dtype=np.int16)
f32=np.array(2, dtype=np.float32)
np.common_type(i16, f32)
```
now returns `float32` instead of `float64`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
