### PR TITLE
DOC: improve the docstring's examples for np.searchsorted

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1389,11 +1389,11 @@ def searchsorted(a, v, side='left', sorter=None):
 
     Examples
     --------
-    >>> np.searchsorted([1,2,3,4,5], 3)
+    >>> np.searchsorted([11,12,13,14,15], 13)
     2
-    >>> np.searchsorted([1,2,3,4,5], 3, side='right')
+    >>> np.searchsorted([11,12,13,14,15], 13, side='right')
     3
-    >>> np.searchsorted([1,2,3,4,5], [-10, 10, 2, 3])
+    >>> np.searchsorted([11,12,13,14,15], [-10, 20, 12, 13])
     array([0, 5, 1, 2])
 
     """


### PR DESCRIPTION
Modified   np.searchsorted`([1,2,3,4,5], 3)` output 2 to `np.searchsorted([11,12,13,14,15], 13)` output 2 in the doctring'sof `np.searchsorted`.

The reason is that in the previous example, the output 2, which is an index, is also in the example array which can be confusing for a new user. 

That is, the user might mistakenly think that the function is returned the number 2 from the array because is before the 3 instead of the index Same problem in the example with 'side = right'. 

I admit that this is a small win as probably most users don't fall for this ambiguity but I don't see any downside to eliminate the ambiguity.   


