### PR TITLE
ENH: add parameter `strict` to `assert_allclose`

### DIFF
--- a/doc/release/upcoming_changes/24680.new_feature.rst
+++ b/doc/release/upcoming_changes/24680.new_feature.rst
@@ -1,0 +1,5 @@
+``strict`` option for `testing.assert_allclose`
+-----------------------------------------------
+The ``strict`` option is now available for `testing.assert_allclose`.
+Setting ``strict=True`` will disable the broadcasting behaviour for scalars
+and ensure that input arrays have the same data type.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1499,8 +1499,8 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
     >>> np.testing.assert_allclose(x, y, rtol=1e-5, atol=0)
 
     As mentioned in the Notes section, `assert_allclose` has special
-    handling for scalars. Here, the test checks that the value of `np.sin`
-    is nearly zero at integer multiples of pi.
+    handling for scalars. Here, the test checks that the value of `numpy.sin`
+    is nearly zero at integer multiples of π.
 
     >>> x = np.arange(3) * np.pi
     >>> np.testing.assert_allclose(np.sin(x), 0, atol=1e-15)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1513,7 +1513,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
         ...
     AssertionError:
     Not equal to tolerance rtol=1e-07, atol=1e-15
-
+    <BLANKLINE>
     (shapes (3,), () mismatch)
      x: array([ 0.000000e+00,  1.224647e-16, -2.449294e-16])
      y: array(0)
@@ -1526,7 +1526,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
         ...
     AssertionError:
     Not equal to tolerance rtol=1e-07, atol=1e-15
-
+    <BLANKLINE>
     (dtypes float64, float32 mismatch)
      x: array([ 0.000000e+00,  1.224647e-16, -2.449294e-16])
      y: array([0., 0., 0.], dtype=float32)

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -312,6 +312,8 @@ def assert_allclose(
     equal_nan: bool = ...,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 @overload
 def assert_allclose(
@@ -322,6 +324,8 @@ def assert_allclose(
     equal_nan: bool = ...,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 
 def assert_array_almost_equal_nulp(

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -930,6 +930,17 @@ class TestAssertAllclose:
         msgs = str(exc_info.value).split('\n')
         assert_equal(msgs[4], 'Max absolute difference: 4')
 
+    def test_strict(self):
+        """Test the behavior of the `strict` option."""
+        x = np.ones(3)
+        y = np.ones(())
+        assert_allclose(x, y)
+        with pytest.raises(AssertionError):
+            assert_allclose(x, y, strict=True)
+        assert_allclose(x, x)
+        with pytest.raises(AssertionError):
+            assert_allclose(x, x.astype(np.float32), strict=True)
+
 
 class TestArrayAlmostEqualNulp:
 


### PR DESCRIPTION
This PR adds the parameter `strict` to `np.testing.assert_allclose`. With `strict=True`, the shape and dtype of the two arguments must match for the assertion to pass.

Follows the example of gh-21595
Partially addresses suggestion in https://github.com/numpy/numpy/pull/24667#discussion_r1319991254


