### PR TITLE
BUG: Fix weak promotion with some mixed float/int dtypes

### DIFF
--- a/numpy/core/src/multiarray/abstractdtypes.c
+++ b/numpy/core/src/multiarray/abstractdtypes.c
@@ -155,12 +155,6 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
             /* Use the default integer for bools: */
             return PyArray_DTypeFromTypeNum(NPY_LONG);
         }
-        else if (PyTypeNum_ISNUMBER(other->type_num) ||
-                 other->type_num == NPY_TIMEDELTA) {
-            /* All other numeric types (ant timedelta) are preserved: */
-            Py_INCREF(other);
-            return other;
-        }
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
@@ -211,11 +205,6 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             /* Use the default integer for bools and ints: */
             return PyArray_DTypeFromTypeNum(NPY_DOUBLE);
         }
-        else if (PyTypeNum_ISNUMBER(other->type_num)) {
-            /* All other numeric types (float+complex) are preserved: */
-            Py_INCREF(other);
-            return other;
-        }
     }
     else if (other == &PyArray_PyIntAbstractDType) {
         Py_INCREF(cls);
@@ -254,25 +243,6 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
                 PyTypeNum_ISINTEGER(other->type_num)) {
             /* Use the default integer for bools and ints: */
             return PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
-        }
-        else if (PyTypeNum_ISFLOAT(other->type_num)) {
-            /*
-             * For floats we choose the equivalent precision complex, although
-             * there is no CHALF, so half also goes to CFLOAT.
-             */
-            if (other->type_num == NPY_HALF || other->type_num == NPY_FLOAT) {
-                return PyArray_DTypeFromTypeNum(NPY_CFLOAT);
-            }
-            if (other->type_num == NPY_DOUBLE) {
-                return PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
-            }
-            assert(other->type_num == NPY_LONGDOUBLE);
-            return PyArray_DTypeFromTypeNum(NPY_CLONGDOUBLE);
-        }
-        else if (PyTypeNum_ISCOMPLEX(other->type_num)) {
-            /* All other numeric types are preserved: */
-            Py_INCREF(other);
-            return other;
         }
     }
     else if (NPY_DT_is_legacy(other)) {

--- a/numpy/core/src/multiarray/common_dtype.c
+++ b/numpy/core/src/multiarray/common_dtype.c
@@ -95,12 +95,13 @@ PyArray_CommonDType(PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2)
  * `a.__common_dtype__(b) is a` (and thus `b` cannot alter the end-result).
  * Clearing means, we do not have to worry about them later.
  *
- * For the moment, abstract dtypes are not handled special here.  In a first
+ * Abstract dtypes are not handled specially here.  In a first
  * version they were but this version also tried to be able to do value-based
  * behavior.
  * There may be some advantage to special casing the abstract ones (e.g.
  * so that the concrete ones do not have to deal with it), but this would
- * require more complex handling later on.
+ * require more complex handling later on. See the logic in
+ * default_builtin_common_dtype
  *
  * @param length Number of DTypes
  * @param dtypes

--- a/numpy/core/src/multiarray/common_dtype.c
+++ b/numpy/core/src/multiarray/common_dtype.c
@@ -90,26 +90,17 @@ PyArray_CommonDType(PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2)
  * NotImplemented (so `c` knows more).  You may notice that the result
  * `res = a.__common_dtype__(b)` is not important.  We could try to use it
  * to remove the whole branch if `res is c` or by checking if
- * `c.__common_dtype(res) is c`.
+ * `c.__common_dtype__(res) is c`.
  * Right now, we only clear initial elements in the most simple case where
- * `a.__common_dtype(b) is a` (and thus `b` cannot alter the end-result).
+ * `a.__common_dtype__(b) is a` (and thus `b` cannot alter the end-result).
  * Clearing means, we do not have to worry about them later.
  *
- * There is one further subtlety. If we have an abstract DType and a
- * non-abstract one, we "prioritize" the non-abstract DType here.
- * In this sense "prioritizing" means that we use:
- *       abstract.__common_dtype__(other)
- * If both return NotImplemented (which is acceptable and even expected in
- * this case, see later) then `other` will be considered to know more.
- *
- * The reason why this may be acceptable for abstract DTypes, is that
- * the value-dependent abstract DTypes may provide default fall-backs.
- * The priority inversion effectively means that abstract DTypes are ordered
- * just below their concrete counterparts.
- * (This fall-back is convenient but not perfect, it can lead to
- * non-minimal promotions: e.g. `np.uint24 + 2**20 -> int32`. And such
- * cases may also be possible in some mixed type scenarios; they can be
- * avoided by defining the promotion explicitly in the user DType.)
+ * For the moment, abstract dtypes are not handled special here.  In a first
+ * version they were but this version also tried to be able to do value-based
+ * behavior.
+ * There may be some advantage to special casing the abstract ones (e.g.
+ * so that the concrete ones do not have to deal with it), but this would
+ * require more complex handling later on.
  *
  * @param length Number of DTypes
  * @param dtypes
@@ -126,20 +117,11 @@ reduce_dtypes_to_most_knowledgeable(
     for (npy_intp low = 0; low < half; low++) {
         npy_intp high = length - 1 - low;
         if (dtypes[high] == dtypes[low]) {
+            /* Fast path for identical dtypes: do not call common_dtype */
             Py_INCREF(dtypes[low]);
             Py_XSETREF(res, dtypes[low]);
         }
         else {
-            if (NPY_DT_is_abstract(dtypes[high])) {
-                /*
-                 * Priority inversion, start with abstract, because if it
-                 * returns `other`, we can let other pass instead.
-                 */
-                PyArray_DTypeMeta *tmp = dtypes[low];
-                dtypes[low] = dtypes[high];
-                dtypes[high] = tmp;
-            }
-
             Py_XSETREF(res, NPY_DT_CALL_common_dtype(dtypes[low], dtypes[high]));
             if (res == NULL) {
                 return NULL;
@@ -147,12 +129,13 @@ reduce_dtypes_to_most_knowledgeable(
         }
 
         if (res == (PyArray_DTypeMeta *)Py_NotImplemented) {
+            /* guess at other being more "knowledgable" */
             PyArray_DTypeMeta *tmp = dtypes[low];
             dtypes[low] = dtypes[high];
             dtypes[high] = tmp;
         }
-        if (res == dtypes[low]) {
-            /* `dtypes[high]` cannot influence the final result, so clear: */
+        else if (res == dtypes[low]) {
+            /* `dtypes[high]` cannot influence result: clear */
             dtypes[high] = NULL;
         }
     }


### PR DESCRIPTION
This reorganizes/simplifies promotion a bit, but unfortunately this means moving the promotion of our concrete DTypes with the abstract "weak" ones into the concrete DTypes making the order of "who deals with whom" fully defined by:

    complex' > floats > pycomplex > pyfloat > ints > pyint > bool

where py<...> is the DType corresponding to the Python type. There are two points here:
* "inexact" is the meaningful category not complex
* previously, the abstract DTypes `pyfloat`, etc. knew about the concrete ones and there was some special handling for that. (as mentioned above, this is gone now)

Why was it this complicated?!  I think the initial code wanted to deal with value-based promotion and the abstract DTypes could have had a value attached to them.
There was thus more code later on, dealing with abstract DTypes more concretely (rather than identical to the rest).

This is now gone, concrete DTypes promote basically the same as their concrete counter-parts.  This makes the promotion logic simpler (and I think still just as correct), although the concrete type promotion now needs to know about it.