### PR TITLE
DOC: Fix reference warning in some rst files

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -733,7 +733,7 @@ General check of Python Type
 .. c:function:: int PyArray_CheckScalar(PyObject *op)
 
     Evaluates true if *op* is either an array scalar (an instance of a
-    sub-type of :c:data:`PyGenericArr_Type` ), or an instance of (a
+    sub-type of :c:data:`PyGenericArrType_Type` ), or an instance of (a
     sub-class of) :c:data:`PyArray_Type` whose dimensionality is 0.
 
 .. c:function:: int PyArray_IsPythonNumber(PyObject *op)
@@ -750,13 +750,13 @@ General check of Python Type
 
     Evaluates true if *op* is either a Python scalar object (see
     :c:func:`PyArray_IsPythonScalar`) or an array scalar (an instance of a sub-
-    type of :c:data:`PyGenericArr_Type` ).
+    type of :c:data:`PyGenericArrType_Type` ).
 
 .. c:function:: int PyArray_CheckAnyScalar(PyObject *op)
 
     Evaluates true if *op* is a Python scalar object (see
     :c:func:`PyArray_IsPythonScalar`), an array scalar (an instance of a
-    sub-type of :c:data:`PyGenericArr_Type`) or an instance of a sub-type of
+    sub-type of :c:data:`PyGenericArrType_Type`) or an instance of a sub-type of
     :c:data:`PyArray_Type` whose dimensionality is 0.
 
 

--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -19,9 +19,7 @@ Historical overview
 
 Since version 1.7.0, NumPy has exposed a set of ``PyDataMem_*`` functions
 (:c:func:`PyDataMem_NEW`, :c:func:`PyDataMem_FREE`, :c:func:`PyDataMem_RENEW`)
-which are backed by `alloc`, `free`, `realloc` respectively. In that version
-NumPy also exposed the `PyDataMem_EventHook` function (now deprecated)
-described below, which wrap the OS-level calls.
+which are backed by `alloc`, `free`, `realloc` respectively.
 
 Since those early days, Python also improved its memory management
 capabilities, and began providing
@@ -49,8 +47,7 @@ less suited to NumPy's needs. User who wish to change the NumPy data memory
 management routines can use :c:func:`PyDataMem_SetHandler`, which uses a
 :c:type:`PyDataMem_Handler` structure to hold pointers to functions used to
 manage the data memory. The calls are still wrapped by internal routines to
-call :c:func:`PyTraceMalloc_Track`, :c:func:`PyTraceMalloc_Untrack`, and will
-use the deprecated :c:func:`PyDataMem_EventHookFunc` mechanism. Since the
+call :c:func:`PyTraceMalloc_Track`, :c:func:`PyTraceMalloc_Untrack`. Since the
 functions may change during the lifetime of the process, each ``ndarray``
 carries with it the functions used at the time of its instantiation, and these
 will be used to reallocate or free the data memory of the instance.

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -17,7 +17,7 @@ select the precision desired.
     The names for the types in c code follows c naming conventions
     more closely. The Python names for these types follow Python
     conventions.  Thus, :c:data:`NPY_FLOAT` picks up a 32-bit float in
-    C, but :class:`numpy.float_` in Python corresponds to a 64-bit
+    C, but :class:`numpy.float64` in Python corresponds to a 64-bit
     double. The bit-width names can be used in both Python and C for
     clarity.
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -196,6 +196,14 @@ PyArray_Type and PyArrayObject
       A solution guaranteed to be compatible with any future NumPy version
       requires the use of a runtime calculate offset and allocation size.
 
+PyGenericArrType_Type
+---------------------
+
+.. c:var:: PyTypeObject PyGenericArrType_Type
+
+   The :c:data:`PyGenericArrType_Type` is the PyTypeObject definition which
+   create the `numpy.generic` python type.
+
 
 PyArrayDescr_Type and PyArray_Descr
 -----------------------------------


### PR DESCRIPTION
[skip actions] [skip cirrus] [skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix following reference warning:
```
numpy/doc/source/reference/c-api/array.rst:735: WARNING: c:data reference target not found: PyGenericArr_Type
numpy/doc/source/reference/c-api/array.rst:751: WARNING: c:data reference target not found: PyGenericArr_Type
numpy/doc/source/reference/c-api/array.rst:757: WARNING: c:data reference target not found: PyGenericArr_Type
numpy/doc/source/reference/c-api/data_memory.rst:44: WARNING: c:func reference target not found: PyDataMem_EventHookFunc
numpy/doc/source/reference/c-api/dtype.rst:17: WARNING: py:class reference target not found: numpy.float_

```

For the following reference warning and other similar warning:
```
numpy/doc/source/reference/c-api/array.rst:572: WARNING: c:identifier reference target not found: FILE
```
If I put single&double backtick for FILE, then there will be new warning like following:
```
numpy/doc/source/reference/c-api/array.rst:572: WARNING: Error in declarator or parameters
Invalid C declaration: Expected identifier in nested name. [error at 32]
  PyObject* PyArray_FromFile(     `FILE`* fp, PyArray_Descr* dtype, npy_intp num, char* sep)
```

So I leave these `c:identifier` warning unchanged.
