### PR TITLE
DOC: NumPy 2.0 migration guide

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -4,7 +4,7 @@ NumPy 2.0 Migration Guide
 
 This document contains a set of instructions on how to update your codebase to NumPy 2.0
 Python API compatible version. Most of the changes are trivial, and require the end user
-to use different name/module to access a given function/constant.
+to use a different name/module to access a given function/constant.
 
 Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html>`_ for more details.
 
@@ -14,7 +14,7 @@ Main namespace
 
 About 100 members of the main ``np`` namespace has been deprecated, removed or 
 moved to a new place. It was done to reduce clutter and establish only one way to
-access a given attribute. The table below shows memebers that have been removed:
+access a given attribute. The table below shows members that have been removed:
 
 ======================  =================================================================
 removed member          migration guidline
@@ -134,7 +134,7 @@ to the deprecation period policy.
 NDArray and scalar namespace
 ----------------------------
 
-A few methods from ``np.ndarray`` and ``np.generic`` scalar classes has been removed.
+A few methods from ``np.ndarray`` and ``np.generic`` scalar classes have been removed.
 The table below provides replacements for the removed members:
 
 ======================  ========================================================

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -2,8 +2,8 @@
 NumPy 2.0 Migration Guide
 *************************
 
-This document contains a set of instructions on how to update your codebase to NumPy 2.0
-Python API compatible version. Most of the changes are trivial, and require the end user
+This document contains a set of instructions on how to update your code to work with
+the Numpy 2.0 Python API. Most of the changes are trivial, and require the end user
 to use a different name/module to access a given function/constant.
 
 Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html>`_ for more details.
@@ -12,7 +12,7 @@ Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html
 Main namespace
 --------------
 
-About 100 members of the main ``np`` namespace has been deprecated, removed or 
+About 100 members of the main ``np`` namespace has been deprecated, removed, or
 moved to a new place. It was done to reduce clutter and establish only one way to
 access a given attribute. The table below shows members that have been removed:
 
@@ -22,7 +22,7 @@ removed member          migration guidline
 add_docstring           It's still available as ``np.lib.add_docstring``.
 add_newdoc              It's still available as ``np.lib.add_newdoc``.
 add_newdoc_ufunc        It's an internal function and doesn't have a replacement.
-asfarray                Use ``np.asarray`` with a proper dtype instead.
+asfarray                Use ``np.asarray`` with a float dtype instead.
 byte_bounds             Now it's available under ``np.lib.array_utils.byte_bounds``
 cast                    Use ``np.asarray(arr, dtype=dtype)`` instead.
 cfloat                  Use ``np.complex128`` instead.
@@ -30,8 +30,10 @@ clongfloat              Use ``np.clongdouble`` instead.
 compat                  There's no replacement, as Python 2 is no longer supported.
 complex\_               Use ``np.complex128`` instead.
 DataSource              It's still available as ``np.lib.npyio.DataSource``.
-deprecate               Raise ``DeprecationWarning`` instead.
-deprecate_with_doc      Raise ``DeprecationWarning`` instead.
+deprecate               Emit ``DeprecationWarning`` with ``warnings.warn`` directly,
+                        or use ``typing.deprecated``.
+deprecate_with_doc      Emit ``DeprecationWarning`` with ``warnings.warn`` directly,
+                        or use ``typing.deprecated``.
 disp                    Use your own printing function instead.
 fastCopyAndTranspose    Use ``arr.T.copy()`` instead.
 find_common_type        Use ``numpy.promote_types`` or ``numpy.result_type`` instead. 
@@ -64,7 +66,6 @@ recfromtxt              Use ``np.genfromtxt`` instead.
 round\_                 Use ``np.round`` instead.
 safe_eval               Use ``ast.literal_eval`` instead.
 sctype2char
-sctypeDict
 sctypes
 seterrobj               Use the np.errstate context manager instead.
 set_numeric_ops         For the general case, use ``PyUFunc_ReplaceLoopBySignature``. 
@@ -80,6 +81,9 @@ unicode\_               Use ``np.str_`` instead.
 who                     Use an IDE variable explorer or ``locals()`` instead.
 ======================  =================================================================
 
+If the table doesn't contain an item that you were using but was removed in ``2.0``,
+then it means it was a private member. You should either use the existing API or,
+in case it's infeasible, reach out to us with a request to restore the removed entry.
 
 The next table presents deprecated members, which will be removed in a release after ``2.0``:
 
@@ -106,19 +110,22 @@ Lib namespace
 
 Most of the functions available within ``np.lib`` are also present in the main
 namespace, which is their primary location. To make it unambiguous how to access each
-public function, ``np.lib`` is now empty and contains only a handful of specialized submodules 
-and functions, such as:
+public function, ``np.lib`` is now empty and contains only a handful of specialized submodules,
+classes and functions:
 
--  ``np.lib.array_utils`` submodule,
+- ``array_utils``, ``format``, ``introspect``, ``mixins``, ``npyio``
+  and ``stride_tricks`` submodules,
 
--  ``np.lib.npyio`` submodule,
+- ``Arrayterator`` and ``NumpyVersion`` classes,
 
--  ``np.lib.stride_tricks`` submodule,
+- ``add_docstring`` and ``add_newdoc`` functions,
 
-- ``Arrayterator``, ``tracemalloc_domain``.
+- ``tracemalloc_domain`` constant.
 
 If you get an ``AttributeError`` when accessing an attribute from ``np.lib`` you should
-try accessing it from the main ``np`` namespace then.
+try accessing it from the main ``np`` namespace then. If an item is also missing from
+the main namespace, then you're using a private member. You should either use the existing
+API or, in case it's infeasible, reach out to us with a request to restore the removed entry.
 
 
 Core namespace
@@ -128,7 +135,9 @@ Core namespace
 The user should never fetch members from the ``_core`` directly - instead the main 
 namespace should be used to access the attribute in question. The layout of the ``_core``
 module might change in the future without notice, contrary to public modules which adhere 
-to the deprecation period policy.
+to the deprecation period policy. If an item is also missing from the main namespace,
+then you should either use the existing API or, in case it's infeasible, reach out to us
+with a request to restore the removed entry.
 
 
 NDArray and scalar namespace

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -1,0 +1,147 @@
+*************************
+NumPy 2.0 Migration Guide
+*************************
+
+This document contains a set of instructions on how to update your codebase to NumPy 2.0
+Python API compatible version. Most of the changes are trivial, and require the end user
+to use different name/module to access a given function/constant.
+
+Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html>`_ for more details.
+
+
+Main namespace
+--------------
+
+About 100 members of the main ``np`` namespace has been deprecated, removed or 
+moved to a new place. It was done to reduce clutter and establish only one way to
+access a given attribute. The table below shows memebers that have been removed:
+
+======================  =================================================================
+removed member          migration guidline
+======================  =================================================================
+add_docstring           It's still available as ``np.lib.add_docstring``.
+add_newdoc              It's still available as ``np.lib.add_newdoc``.
+add_newdoc_ufunc        It's an internal function and doesn't have a replacement.
+asfarray                Use ``np.asarray`` with a proper dtype instead.
+byte_bounds             Now it's available under ``np.lib.array_utils.byte_bounds``
+cast                    Use ``np.asarray(arr, dtype=dtype)`` instead.
+cfloat                  Use ``np.complex128`` instead.
+clongfloat              Use ``np.clongdouble`` instead.
+compat                  There's no replacement, as Python 2 is no longer supported.
+complex\_               Use ``np.complex128`` instead.
+DataSource              It's still available as ``np.lib.npyio.DataSource``.
+deprecate               Raise ``DeprecationWarning`` instead.
+deprecate_with_doc      Raise ``DeprecationWarning`` instead.
+disp                    Use your own printing function instead.
+fastCopyAndTranspose    Use ``arr.T.copy()`` instead.
+find_common_type        Use ``numpy.promote_types`` or ``numpy.result_type`` instead. 
+                        To achieve semantics for the ``scalar_types`` argument, 
+                        use ``numpy.result_type`` and pass the Python values ``0``, 
+                        ``0.0``, or ``0j``.
+get_array_wrap
+float\_                 Use ``np.float64`` instead.
+geterrobj               Use the np.errstate context manager instead.
+Inf                     Use ``np.inf`` instead.
+Infinity                Use ``np.inf`` instead.
+infty                   Use ``np.inf`` instead.
+issctype
+issubclass\_            Use ``issubclass`` builtin instead.
+issubsctype             Use ``np.issubdtype`` instead.
+mat                     Use ``np.asmatrix`` instead.
+maximum_sctype
+NaN                     Use ``np.nan`` instead.
+nbytes                  Use ``np.dtype(<dtype>).itemsize`` instead.
+NINF                    Use ``-np.inf`` instead.
+NZERO                   Use ``-0.0`` instead.
+longcomplex             Use ``np.clongdouble`` instead.
+longfloat               Use ``np.longdouble`` instead.      
+lookfor                 Search NumPy's documentation directly.
+obj2sctype
+PINF                    Use ``np.inf`` instead.
+PZERO                   Use ``0.0`` instead.
+recfromcsv              Use ``np.genfromtxt`` with comma delimiter instead.
+recfromtxt              Use ``np.genfromtxt`` instead.
+round\_                 Use ``np.round`` instead.
+safe_eval               Use ``ast.literal_eval`` instead.
+sctype2char
+sctypeDict
+sctypes
+seterrobj               Use the np.errstate context manager instead.
+set_numeric_ops         For the general case, use ``PyUFunc_ReplaceLoopBySignature``. 
+                        For ndarray subclasses, define the ``__array_ufunc__`` method 
+                        and override the relevant ufunc.
+set_string_function     Use ``np.set_printoptions`` instead with a formatter 
+                        for custom printing of NumPy objects.
+singlecomplex           Use ``np.complex64`` instead.
+string\_                Use ``np.bytes_`` instead.
+source                  Use ``inspect.getsource`` instead.
+tracemalloc_domain      It's now available from ``np.lib``.
+unicode\_               Use ``np.str_`` instead.
+who                     Use an IDE variable explorer or ``locals()`` instead.
+======================  =================================================================
+
+
+The next table presents deprecated members, which will be removed in a release after ``2.0``:
+
+================= =======================================================================
+deprecated member migration guidline
+================= =======================================================================
+in1d              Use ``np.isin`` instead.
+row_stack         Use ``np.vstack`` instead (``row_stack`` was an alias for ``v_stack``).
+trapz             Use ``scipy.interpolate.trapezoid`` instead.
+================= =======================================================================
+
+
+Finally, a set of internal enums has been removed. As they weren't used in
+downstream libraries we don't provide any information on how to replace them:
+
+[``FLOATING_POINT_SUPPORT``, ``FPE_DIVIDEBYZERO``, ``FPE_INVALID``, ``FPE_OVERFLOW``, 
+``FPE_UNDERFLOW``, ``UFUNC_BUFSIZE_DEFAULT``, ``UFUNC_PYVALS_NAME``, ``CLIP``, ``WRAP``, 
+``RAISE``, ``BUFSIZE``, ``ALLOW_THREADS``, ``MAXDIMS``, ``MAY_SHARE_EXACT``, 
+``MAY_SHARE_BOUNDS``]
+
+
+Lib namespace
+-------------
+
+Most of the functions available within ``np.lib`` are also present in the main
+namespace, which is their primary location. To make it unambiguous how to access each
+public function, ``np.lib`` is now empty and contains only a handful of specialized submodules 
+and functions, such as:
+
+-  ``np.lib.array_utils`` submodule,
+
+-  ``np.lib.npyio`` submodule,
+
+-  ``np.lib.stride_tricks`` submodule,
+
+- ``Arrayterator``, ``tracemalloc_domain``.
+
+If you get an ``AttributeError`` when accessing an attribute from ``np.lib`` you should
+try accessing it from the main ``np`` namespace then.
+
+
+Core namespace
+--------------
+
+``np.core`` namespace is now officially private and has been renamed to ``np._core``.
+The user should never fetch members from the ``_core`` directly - instead the main 
+namespace should be used to access the attribute in question. The layout of the ``_core``
+module might change in the future without notice, contrary to public modules which adhere 
+to the deprecation period policy.
+
+
+NDArray and scalar namespace
+----------------------------
+
+A few methods from ``np.ndarray`` and ``np.generic`` scalar classes has been removed.
+The table below provides replacements for the removed members:
+
+======================  ========================================================
+expired member          migration guidline
+======================  ========================================================
+newbyteorder            Use ``arr.view(arr.dtype.newbyteorder(order))`` instead.
+ptp                     Use ``np.ptp(arr, ...)`` instead.
+setitem                 Use ``arr[index] = value`` instead.
+...                     ...
+======================  ========================================================

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -51,4 +51,5 @@ details are found in :ref:`reference`.
 
    ../glossary
    ../release
+   ../numpy_2_0_migration_guide
    ../license

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -60,10 +60,9 @@ __expired_attributes__ = {
     "deprecate_with_doc": "Raise `DeprecationWarning` instead.",
     "disp": "Use your own printing function instead.",
     "find_common_type": 
-        "This function is deprecated, use `numpy.promote_types` or "
-        "`numpy.result_type` instead.  To achieve semantics for the "
-        "`scalar_types` argument, use `numpy.result_type` and pass the "
-        "Python values `0`, `0.0`, or `0j`.",
+        "Use `numpy.promote_types` or `numpy.result_type` instead. "
+        "To achieve semantics for the `scalar_types` argument, use "
+        "`numpy.result_type` and pass the Python values `0`, `0.0`, or `0j`.",
     "round_": "Use `np.round` instead.",
     "get_array_wrap": "",
     "DataSource": "It's still available as `np.lib.npyio.DataSource`.", 

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -56,8 +56,10 @@ __expired_attributes__ = {
     "mat": "Use `np.asmatrix` instead.",
     "recfromcsv": "Use `np.genfromtxt` with comma delimiter instead.",
     "recfromtxt": "Use `np.genfromtxt` instead.",
-    "deprecate": "Raise `DeprecationWarning` instead.",
-    "deprecate_with_doc": "Raise `DeprecationWarning` instead.",
+    "deprecate": "Emit `DeprecationWarning` with `warnings.warn` directly, "
+        "or use `typing.deprecated`.",
+    "deprecate_with_doc": "Emit `DeprecationWarning` with `warnings.warn` "
+        "directly, or use `typing.deprecated`.",
     "disp": "Use your own printing function instead.",
     "find_common_type": 
         "Use `numpy.promote_types` or `numpy.result_type` instead. "

--- a/numpy/lib/_array_utils_impl.py
+++ b/numpy/lib/_array_utils_impl.py
@@ -28,12 +28,12 @@ def byte_bounds(a):
     --------
     >>> I = np.eye(2, dtype='f'); I.dtype
     dtype('float32')
-    >>> low, high = np.byte_bounds(I)
+    >>> low, high = np.lib.array_utils.byte_bounds(I)
     >>> high - low == I.size*I.itemsize
     True
     >>> I = np.eye(2); I.dtype
     dtype('float64')
-    >>> low, high = np.byte_bounds(I)
+    >>> low, high = np.lib.array_utils.byte_bounds(I)
     >>> high - low == I.size*I.itemsize
     True
 


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

Here I share WIP migration guide that could be placed at: 
https://numpy.org/doc/stable/numpy_2_0_migration_guide.html

It contains all items that have been deprecated, removed or moved to another place. Contents of tables might still change a bit (if we still remove/restore any items), but this is the layout that I had in mind.

What do you think?


