### PR TITLE
CI: enable use of Cirrus CI compute credits by collaborators

### DIFF
--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -22,6 +22,7 @@ modified_clone: &MODIFIED_CLONE
 
 
 linux_aarch64_test_task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder-arm64
@@ -66,6 +67,7 @@ linux_aarch64_test_task:
 
 
 macos_arm64_test_task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   depends_on:
     - linux_aarch64_test
   macos_instance:

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -11,6 +11,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 ######################################################################
 
 linux_aarch64_task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder-arm64
@@ -52,6 +53,7 @@ linux_aarch64_task:
 ######################################################################
 
 macosx_arm64_task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   matrix:
@@ -101,6 +103,7 @@ macosx_arm64_task:
 ######################################################################
 
 wheels_upload_task:
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   # Artifacts don't seem to be persistent from task to task.
   # Rather than upload wheels at the end of each cibuildwheel run we do a
   # final upload here. This is because a run may be on different OS for


### PR DESCRIPTION
See docs at https://cirrus-ci.org/pricing/#compute-credits Starting with collaborators only, because those are the only ones who should trigger wheel builds, and also author the vast majority of PRs where architecture-specific CI is actually useful. We can always set it to an unconditional "true" later on.

xref gh-24280

[skip actions] [skip azp] [skip circle]