### PR TITLE
API: Readd `sctypeDict` to the main namespace

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -137,7 +137,7 @@ else:
         datetime_data, deg2rad, degrees, diagonal, divide, divmod, dot, 
         double, dtype, e, einsum, einsum_path, empty, empty_like, equal,
         errstate, euler_gamma, exp, exp2, expm1, fabs, 
-        flatiter, flatnonzero, flexible, 
+        flatiter, flatnonzero, flexible, sctypeDict,
         float_power, floating, floor, floor_divide, fmax, fmin, fmod, 
         format_float_positional, format_float_scientific, format_parser, 
         frexp, from_dlpack, frombuffer, fromfile, fromfunction, fromiter, 

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -106,7 +106,7 @@ from . import _internal
 from . import _dtype
 from . import _methods
 
-__all__ = ['char', 'rec', 'memmap']
+__all__ = ['char', 'rec', 'memmap', 'sctypeDict']
 __all__ += numeric.__all__
 __all__ += ['record', 'recarray', 'format_parser', 'chararray', 'abs']
 __all__ += function_base.__all__


### PR DESCRIPTION
Hi @ngoldbaum,

In this PR I restored `np.sctypeDict`.
