### PR TITLE
TYP: Add annotations for the py3.12 buffer protocol

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Collection, Callable, Sequence
 from typing import Any, Protocol, Union, TypeVar, runtime_checkable
+
 from numpy import (
     ndarray,
     dtype,
@@ -76,17 +78,18 @@ _DualArrayLike = Union[
     _NestedSequence[_T],
 ]
 
-# TODO: support buffer protocols once
-#
-# https://bugs.python.org/issue27501
-#
-# is resolved. See also the mypy issue:
-#
-# https://github.com/python/typing/issues/593
-ArrayLike = _DualArrayLike[
-    dtype[Any],
-    Union[bool, int, float, complex, str, bytes],
-]
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+
+    ArrayLike = Buffer | _DualArrayLike[
+        dtype[Any],
+        Union[bool, int, float, complex, str, bytes],
+    ]
+else:
+    ArrayLike = _DualArrayLike[
+        dtype[Any],
+        Union[bool, int, float, complex, str, bytes],
+    ]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`

--- a/numpy/array_api/_typing.py
+++ b/numpy/array_api/_typing.py
@@ -17,6 +17,8 @@ __all__ = [
     "PyCapsule",
 ]
 
+import sys
+
 from typing import (
     Any,
     Literal,
@@ -63,8 +65,11 @@ Dtype = dtype[Union[
     float64,
 ]]
 
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer as SupportsBufferProtocol
+else:
+    SupportsBufferProtocol = Any
 
-SupportsBufferProtocol = Any
 PyCapsule = Any
 
 class SupportsDLPack(Protocol):

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -211,3 +211,11 @@ assert_type(np.stack([A, A], out=B), SubClass[np.float64])
 
 assert_type(np.block([[A, A], [A, A]]), npt.NDArray[Any])
 assert_type(np.block(C), npt.NDArray[Any])
+
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+
+    def create_array(obj: npt.ArrayLike) -> npt.NDArray[Any]: ...
+
+    buffer: Buffer
+    assert_type(create_array(buffer), npt.NDArray[Any])


### PR DESCRIPTION
With the implementation of [PEP 688](https://peps.python.org/pep-0688/) the buffer protocol is, as of Python 3.12, now accessible in Python. This PR updates the `np.ndarray` and `np.generic` annotations, adding the corresponding `__buffer__` method to the both of them in addition to the definition of `npt.ArrayLike`.

Marking as 1.26 backport as this is a reasonably py3.12 typing feature.