### PR TITLE
BUG: Fix np.quantile([0, 1], 0, method='weibull')

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4893,9 +4893,11 @@ def _quantile(
         virtual_indexes = method_props["get_virtual_index"](values_count, quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
-        int_virtual_indices = np.issubdtype(virtual_indexes.dtype, np.integer)
-        supports_integers = method_props["fix_gamma"] is None
-        supports_integers = supports_integers or (method == 'linear' and int_virtual_indices)
+        if method_props["fix_gamma"] is None:
+            supports_integers = True
+        else:
+            int_virtual_indices = np.issubdtype(virtual_indexes.dtype, np.integer)
+            supports_integers = method == 'linear' and int_virtual_indices
 
         if supports_integers:
             # No interpolation needed, take the points along axis

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4890,13 +4890,15 @@ def _quantile(
             raise ValueError(
                 f"{method!r} is not a valid method. Use one of: "
                 f"{_QuantileMethods.keys()}") from None
-        virtual_indexes = method_props["get_virtual_index"](values_count, quantiles)
+        virtual_indexes = method_props["get_virtual_index"](values_count,
+                                                            quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
         if method_props["fix_gamma"] is None:
             supports_integers = True
         else:
-            int_virtual_indices = np.issubdtype(virtual_indexes.dtype, np.integer)
+            int_virtual_indices = np.issubdtype(virtual_indexes.dtype,
+                                                np.integer)
             supports_integers = method == 'linear' and int_virtual_indices
 
         if supports_integers:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -50,7 +50,7 @@ __all__ = [
 # _QuantileMethods is a dictionary listing all the supported methods to
 # compute quantile/percentile.
 #
-# Below virtual_index refer to the index of the element where the percentile
+# Below virtual_index refers to the index of the element where the percentile
 # would be found in the sorted sample.
 # When the sample contains exactly the percentile wanted, the virtual_index is
 # an integer to the index of this element.
@@ -68,7 +68,7 @@ _QuantileMethods = dict(
     # Discrete methods
     inverted_cdf=dict(
         get_virtual_index=lambda n, quantiles: _inverted_cdf(n, quantiles),
-        fix_gamma=lambda gamma, _: gamma,  # should never be called
+        fix_gamma=None,  # should never be called
     ),
     averaged_inverted_cdf=dict(
         get_virtual_index=lambda n, quantiles: (n * quantiles) - 1,
@@ -81,7 +81,7 @@ _QuantileMethods = dict(
     closest_observation=dict(
         get_virtual_index=lambda n, quantiles: _closest_observation(n,
                                                                     quantiles),
-        fix_gamma=lambda gamma, _: gamma,  # should never be called
+        fix_gamma=None,  # should never be called
     ),
     # Continuous methods
     interpolated_inverted_cdf=dict(
@@ -121,14 +121,12 @@ _QuantileMethods = dict(
     lower=dict(
         get_virtual_index=lambda n, quantiles: np.floor(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=lambda gamma, _: gamma,
-        # should never be called, index dtype is int
+        fix_gamma=None,  # should never be called, index dtype is int
     ),
     higher=dict(
         get_virtual_index=lambda n, quantiles: np.ceil(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=lambda gamma, _: gamma,
-        # should never be called, index dtype is int
+        fix_gamma=None,  # should never be called, index dtype is int
     ),
     midpoint=dict(
         get_virtual_index=lambda n, quantiles: 0.5 * (
@@ -143,7 +141,7 @@ _QuantileMethods = dict(
     nearest=dict(
         get_virtual_index=lambda n, quantiles: np.around(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=lambda gamma, _: gamma,
+        fix_gamma=None,
         # should never be called, index dtype is int
     ))
 
@@ -4887,15 +4885,19 @@ def _quantile(
         # Virtual because it is a floating point value, not an valid index.
         # The nearest neighbours are used for interpolation
         try:
-            method = _QuantileMethods[method]
+            method_props = _QuantileMethods[method]
         except KeyError:
             raise ValueError(
                 f"{method!r} is not a valid method. Use one of: "
                 f"{_QuantileMethods.keys()}") from None
-        virtual_indexes = method["get_virtual_index"](values_count, quantiles)
+        virtual_indexes = method_props["get_virtual_index"](values_count, quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
-        if np.issubdtype(virtual_indexes.dtype, np.integer):
+        int_virtual_indices = np.issubdtype(virtual_indexes.dtype, np.integer)
+        supports_integers = method_props["fix_gamma"] is None
+        supports_integers = supports_integers or (method == 'linear' and int_virtual_indices)
+
+        if supports_integers:
             # No interpolation needed, take the points along axis
             if supports_nans:
                 # may contain nan, which would sort to the end
@@ -4927,7 +4929,7 @@ def _quantile(
             previous = arr[previous_indexes]
             next = arr[next_indexes]
             # --- Linear interpolation
-            gamma = _get_gamma(virtual_indexes, previous_indexes, method)
+            gamma = _get_gamma(virtual_indexes, previous_indexes, method_props)
             result_shape = virtual_indexes.shape + (1,) * (arr.ndim - 1)
             gamma = gamma.reshape(result_shape)
             result = _lerp(previous,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3733,6 +3733,13 @@ class TestQuantile:
         assert res.dtype == dtype
 
     @pytest.mark.parametrize("method", quantile_methods)
+    def test_q_zero_one(self, method):
+        # gh-24710
+        arr = [10, 11, 12]
+        quantile = np.quantile(arr, q = [0, 1], method=method)
+        assert_equal(quantile,  np.array([10, 12]))
+
+    @pytest.mark.parametrize("method", quantile_methods)
     def test_quantile_monotonic(self, method):
         # GH 14685
         # test that the return value of quantile is monotonic if p0 is ordered
@@ -3966,6 +3973,13 @@ class TestQuantile:
         msg = "Only method 'inverted_cdf' supports weights"
         with pytest.raises(ValueError, match=msg):
             np.quantile(y, 0.5, weights=w, method=method)
+
+    def test_weibull_fraction(self):
+        arr = [Fraction(0, 1), Fraction(1, 10)]
+        quantile = np.quantile(arr, [0, ], method='weibull')
+        assert_equal(quantile, np.array(Fraction(0, 1)))
+        quantile = np.quantile(arr, [Fraction(1, 2)], method='weibull')
+        assert_equal(quantile, np.array(Fraction(1, 20)))
 
 
 class TestLerp:


### PR DESCRIPTION
Issue https://github.com/numpy/numpy/issues/24592 was opened because the `np.quantile` method gives incorrect answers for the `weibull` method. The problem:

```   
import numpy as np
x=np.arange(10)
np.quantile(x, 0., method='weibull') # output 0.0, correct
np.quantile(x, 0, method='weibull') # output 9, incorrect!
np.quantile(x, 1, method='weibull') # raises an error
```
The value of `np.quantile(x, q=0, method='weibull')` is incorrect for integer inputs. Two options to address this:
    
1. Do not allow integer input for `np.quantile`. The documentation for the probability argument states that "q : array_like of float", so this seems reasonable. But this would be a behaviour change that might have a large impact and there are unit tests that test for integer input as well.

2. Automatically cast the input argument `q` to float. Also this would be a behaviour change and break existing tests.

We rejected these two options because of the issues mentioned. Applying either one of the options only for `weibull` would make the input handling less uniform.

The problem with `weibull` (and some other methods) is that inside `np.lib._function_base_impl._quantile` there are two paths: one for integer virtual indices and one for other types of virtual indices (in the code the statement `if np.issubdtype(virtual_indexes.dtype, np.integer):`. The integer path is only valid for methods returning integer indices in the range `[0, size(arr)>`. For the `weibull` method something like `q = [0, .5, 1]` is cast to float, which results in float `virtual_indices` (which contains floats with integer values, but that is okay).

We can either:
    
i) Modify the code in the integer path to handle integers < 0 and > size(arr) -1
ii) Check whether the methods supports integer output, and if not use the alternative path

We opted for the second option.

Fixes #24592                                                          
                                                          