### PR TITLE
DOC: Fix trailing backticks characters.

### DIFF
--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -528,7 +528,7 @@ than in numpy 1.13. Arrays printed in scientific notation now also use the
 shortest scientific representation, instead of fixed precision as before.
 
  Additionally, the `str` of float scalars scalars will no longer be truncated
- in python2, unlike python2 `float`s.  `np.double` scalars now have a ``str``
+ in python2, unlike python2 `float`\ s.  `np.double` scalars now have a ``str``
  and ``repr`` identical to that of a python3 float.
 
 New functions ``np.format_float_scientific`` and ``np.format_float_positional``

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -417,8 +417,8 @@ cdef class SeedSequence():
             The size of each word. This should only be either `uint32` or
             `uint64`. Strings (`'uint32'`, `'uint64'`) are fine. Note that
             requesting `uint64` will draw twice as many bits as `uint32` for
-            the same `n_words`. This is a convenience for `BitGenerator`s that
-            express their states as `uint64` arrays.
+            the same `n_words`. This is a convenience for `BitGenerator`\ s
+            that express their states as `uint64` arrays.
 
         Returns
         -------


### PR DESCRIPTION
s needs to be escaped or the interpreted text will not be closed by the parser.
