### PR TITLE
CI: do apt update before apt install

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,7 @@ jobs:
         python-version: 'pypy3.9-v7.3.12'
     - name: Install system dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libopenblas-dev ninja-build
     - uses: ./.github/meson_actions
 
@@ -92,6 +93,7 @@ jobs:
         fetch-depth: 0
     - name: Install debug Python
       run: |
+        sudo apt-get update
         sudo apt-get install python3-dbg ninja-build
     - name: Build NumPy and install into venv
       run: |
@@ -128,6 +130,7 @@ jobs:
     - name: Install gfortran and OpenBLAS (MacPython build)
       run: |
         set -xe
+        sudo apt update
         sudo apt install gfortran libgfortran5
         target=$(python tools/openblas_support.py)
         sudo cp -r $target/lib/* /usr/lib
@@ -156,6 +159,7 @@ jobs:
         python-version: '3.9'
     - name: Install build and benchmarking dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libopenblas-dev ninja-build
         pip install spin cython asv virtualenv packaging
     - name: Install NumPy
@@ -205,6 +209,7 @@ jobs:
     - name: Install gfortran and OpenBLAS (MacPython build)
       run: |
         set -xe
+        sudo apt update
         sudo apt install gfortran libgfortran5
         target=$(python tools/openblas_support.py)
         sudo cp -r $target/lib/* /usr/lib

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r build_requirements.txt
+        sudo apt-get update
         sudo apt-get install -y libopenblas-serial-dev
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -168,6 +168,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt install -y g++-13
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1


### PR DESCRIPTION
This should hopefully fix the CI failure on the debug python build currently happening on other PRs. I also updated the other `apt install` locations that didn't do an `apt update` first. My understanding is that you always want to `apt update` before doing `apt install`.