### PR TITLE
BUG: Fix iinfo functionality with timedelta64 datatype

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -690,7 +690,7 @@ class iinfo:
         self.kind = self.dtype.kind
         self.bits = self.dtype.itemsize * 8
         self.key = "%s%d" % (self.kind, self.bits)
-        if self.kind not in 'iu':
+        if self.kind not in 'ium':
             raise ValueError("Invalid integer data type %r." % (self.kind,))
 
     @property

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -698,6 +698,8 @@ class iinfo:
         """Minimum value of given dtype."""
         if self.kind == 'u':
             return 0
+        elif self.kind == 'm':
+            raise ValueError("Minimum for timedelta64 depends on units")
         else:
             try:
                 val = iinfo._min_vals[self.key]
@@ -709,6 +711,8 @@ class iinfo:
     @property
     def max(self):
         """Maximum value of given dtype."""
+        if self.kind == 'm':
+            raise ValueError("Maximum for timedelta64 depends on units")
         try:
             val = iinfo._max_vals[self.key]
         except KeyError:
@@ -728,7 +732,10 @@ class iinfo:
             'max = %(max)s\n'
             '---------------------------------------------------------------\n'
             )
-        return fmt % {'dtype': self.dtype, 'min': self.min, 'max': self.max}
+        if self.kind == 'm':
+            return fmt % {'dtype': self.dtype, 'min': 'depends on units', 'max': 'depends on units'}
+        else:
+            return fmt % {'dtype': self.dtype, 'min': self.min, 'max': self.max}
 
     def __repr__(self):
         return "%s(min=%s, max=%s, dtype=%s)" % (self.__class__.__name__,

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -733,9 +733,11 @@ class iinfo:
             '---------------------------------------------------------------\n'
             )
         if self.kind == 'm':
-            return fmt % {'dtype': self.dtype, 'min': 'depends on units', 'max': 'depends on units'}
+            return fmt % {'dtype': self.dtype, 'min': 'depends on units',
+                          'max': 'depends on units'}
         else:
-            return fmt % {'dtype': self.dtype, 'min': self.min, 'max': self.max}
+            return fmt % {'dtype': self.dtype, 'min': self.min,
+                          'max': self.max}
 
     def __repr__(self):
         return "%s(min=%s, max=%s, dtype=%s)" % (self.__class__.__name__,

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -100,6 +100,13 @@ class TestIinfo:
                 max_calculated = T(0) - T(1)
             assert_equal(iinfo(T).max, max_calculated)
 
+    def test_timedelta64(self):
+        assert_equal(iinfo(np.timedelta64).bits, 64)
+        with assert_raises(ValueError):
+            iinfo(np.timedelta64).min
+        with assert_raises(ValueError):
+            iinfo(np.timedelta64).max
+
 class TestRepr:
     def test_iinfo_repr(self):
         expected = "iinfo(min=-32768, max=32767, dtype=int16)"


### PR DESCRIPTION
BUG: Fix iinfo functionality with timedelta64 datatype

The iinfo function now works with timedelta64 datatype and provides
the .bits attribute. With .min and .max attributes the function raises
ValueError, since the minimum and maximum values of timedelta64
depend on the time unit. Closes #24430
