### PR TITLE
ENH: Change default values in polynomial package

### DIFF
--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -52,7 +52,7 @@ the conventional Polynomial class because of its familiarity::
    >>> from numpy.polynomial import Polynomial as P
    >>> p = P([1,2,3])
    >>> p
-   Polynomial([1., 2., 3.], domain=[-1,  1], window=[-1,  1], symbol='x')
+   Polynomial([1., 2., 3.], domain=[-1.,  1.], window=[-1.,  1.], symbol='x')
 
 Note that there are three parts to the long version of the printout. The
 first is the coefficients, the second is the domain, and the third is the
@@ -61,9 +61,9 @@ window::
    >>> p.coef
    array([1., 2., 3.])
    >>> p.domain
-   array([-1,  1])
+   array([-1.,  1.])
    >>> p.window
-   array([-1,  1])
+   array([-1.,  1.])
 
 Printing a polynomial yields the polynomial expression in a more familiar
 format::

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -97,7 +97,7 @@ can't be mixed in arithmetic::
 
     >>> p1 = np.polynomial.Polynomial([1, 2, 3])
     >>> p1
-    Polynomial([1., 2., 3.], domain=[-1,  1], window=[-1,  1], symbol='x')
+    Polynomial([1., 2., 3.], domain=[-1.,  1.], window=[-1.,  1.], symbol='x')
     >>> p2 = np.polynomial.Polynomial([1, 2, 3], domain=[-2, 2])
     >>> p1 == p2
     False

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -461,7 +461,7 @@ def cheb2poly(c):
 #
 
 # Chebyshev default domain.
-chebdomain = np.array([-1, 1])
+chebdomain = np.array([-1., 1.])
 
 # Chebyshev coefficients representing zero.
 chebzero = np.array([0])

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -202,7 +202,7 @@ def herm2poly(c):
 #
 
 # Hermite
-hermdomain = np.array([-1, 1])
+hermdomain = np.array([-1., 1.])
 
 # Hermite coefficients representing zero.
 hermzero = np.array([0])

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -196,6 +196,7 @@ def herm2poly(c):
             c1 = polyadd(tmp, polymulx(c1)*2)
         return polyadd(c0, polymulx(c1)*2)
 
+
 #
 # These are constant arrays are of integer type so as to be compatible
 # with the widest range of other types, such as Decimal.

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -202,7 +202,7 @@ def herme2poly(c):
 #
 
 # Hermite
-hermedomain = np.array([-1, 1])
+hermedomain = np.array([-1., 1.])
 
 # Hermite coefficients representing zero.
 hermezero = np.array([0])

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -196,6 +196,7 @@ def herme2poly(c):
             c1 = polyadd(tmp, polymulx(c1))
         return polyadd(c0, polymulx(c1))
 
+
 #
 # These are constant arrays are of integer type so as to be compatible
 # with the widest range of other types, such as Decimal.

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -192,6 +192,7 @@ def lag2poly(c):
             c1 = polyadd(tmp, polysub((2*i - 1)*c1, polymulx(c1))/i)
         return polyadd(c0, polysub(c1, polymulx(c1)))
 
+
 #
 # These are constant arrays are of integer type so as to be compatible
 # with the widest range of other types, such as Decimal.

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -198,7 +198,7 @@ def lag2poly(c):
 #
 
 # Laguerre
-lagdomain = np.array([0, 1])
+lagdomain = np.array([0., 1.])
 
 # Laguerre coefficients representing zero.
 lagzero = np.array([0])

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -206,6 +206,7 @@ def leg2poly(c):
             c1 = polyadd(tmp, (polymulx(c1)*(2*i - 1))/i)
         return polyadd(c0, polymulx(c1))
 
+
 #
 # These are constant arrays are of integer type so as to be compatible
 # with the widest range of other types, such as Decimal.

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -212,7 +212,7 @@ def leg2poly(c):
 #
 
 # Legendre
-legdomain = np.array([-1, 1])
+legdomain = np.array([-1., 1.])
 
 # Legendre coefficients representing zero.
 legzero = np.array([0])

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -94,7 +94,7 @@ polytrim = pu.trimcoef
 #
 
 # Polynomial default domain.
-polydomain = np.array([-1, 1])
+polydomain = np.array([-1., 1.])
 
 # Polynomial coefficients representing zero.
 polyzero = np.array([0])

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -327,7 +327,7 @@ class TestRepr:
     def test_polynomial_str(self):
         res = repr(poly.Polynomial([0, 1]))
         tgt = (
-            "Polynomial([0., 1.], domain=[-1,  1], window=[-1,  1], "
+            "Polynomial([0., 1.], domain=[-1.,  1.], window=[-1.,  1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)
@@ -335,7 +335,7 @@ class TestRepr:
     def test_chebyshev_str(self):
         res = repr(poly.Chebyshev([0, 1]))
         tgt = (
-            "Chebyshev([0., 1.], domain=[-1,  1], window=[-1,  1], "
+            "Chebyshev([0., 1.], domain=[-1.,  1.], window=[-1.,  1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)
@@ -343,7 +343,7 @@ class TestRepr:
     def test_legendre_repr(self):
         res = repr(poly.Legendre([0, 1]))
         tgt = (
-            "Legendre([0., 1.], domain=[-1,  1], window=[-1,  1], "
+            "Legendre([0., 1.], domain=[-1.,  1.], window=[-1.,  1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)
@@ -351,7 +351,7 @@ class TestRepr:
     def test_hermite_repr(self):
         res = repr(poly.Hermite([0, 1]))
         tgt = (
-            "Hermite([0., 1.], domain=[-1,  1], window=[-1,  1], "
+            "Hermite([0., 1.], domain=[-1.,  1.], window=[-1.,  1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)
@@ -359,7 +359,7 @@ class TestRepr:
     def test_hermiteE_repr(self):
         res = repr(poly.HermiteE([0, 1]))
         tgt = (
-            "HermiteE([0., 1.], domain=[-1,  1], window=[-1,  1], "
+            "HermiteE([0., 1.], domain=[-1.,  1.], window=[-1.,  1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)
@@ -367,7 +367,7 @@ class TestRepr:
     def test_laguerre_repr(self):
         res = repr(poly.Laguerre([0, 1]))
         tgt = (
-            "Laguerre([0., 1.], domain=[0, 1], window=[0, 1], "
+            "Laguerre([0., 1.], domain=[0., 1.], window=[0., 1.], "
             "symbol='x')"
         )
         assert_equal(res, tgt)


### PR DESCRIPTION
Change default values for `domain` and `window` parameters for all convenience classes in numpy.polynomial, as discussed in issue #24568. This will lead to better consistency since when defined by the user in the constructor, `domain` and `window` always get cast to double dtype, while the default values are of integer dtype.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
