### PR TITLE
MAINT: fix version string in wheels built with setup.py

### DIFF
--- a/numpy/distutils/core.py
+++ b/numpy/distutils/core.py
@@ -65,7 +65,8 @@ def _dict_append(d, **kws):
         elif isinstance(dv, dict):
             _dict_append(dv, **v)
         elif is_string(dv):
-            d[k] = dv + v
+            assert is_string(v)
+            d[k] = v
         else:
             raise TypeError(repr(type(dv)))
 


### PR DESCRIPTION
Since numpy 1.26.0, when building with setup.py, the building system generates a weird verion string 1.26.1.26.0. Commit a880c68752c47a63577e55689275b5fb9d6595a3 has a logical error when doing some code clean-up. This generates the abnormal version string 1.26.01.26.0, and then setuptools normalized this string as 1.26.1.26.0.
