### PR TITLE
ENH: start to use OpenBLAS from a wheel

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -12,6 +12,7 @@ runs:
       pip install -r build_requirements.txt
       echo "::endgroup::"
       echo "::group::Building NumPy"
+      # spin build will pick up any scipy-openblas openblas.pc in ./openblas
       spin build --clean -- ${MESON_ARGS[@]}
       echo "::endgroup::"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,7 @@ jobs:
         python-version: 'pypy3.9-v7.3.12'
     - name: Setup using scipy-openblas
       run: |
-        python -m pip install scipy-openblas=32
+        python -m pip install scipy-openblas32 spin
         spin config-openblas --with-scipy-openblas=32
     - uses: ./.github/meson_actions
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,10 +73,10 @@ jobs:
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: 'pypy3.9-v7.3.12'
-    - name: Install system dependencies
+    - name: Setup using scipy-openblas
       run: |
-        sudo apt-get update
-        sudo apt-get install libopenblas-dev ninja-build
+        python -m pip install scipy-openblas=32
+        spin config-openblas --with-scipy-openblas=32
     - uses: ./.github/meson_actions
 
   debug:
@@ -124,16 +124,16 @@ jobs:
       run: |
         pip install -r build_requirements.txt
         pip install -r test_requirements.txt
-    - name: Install gfortran and OpenBLAS (MacPython build)
+    - name: Install gfortran and setup OpenBLAS (MacPython build)
       run: |
         set -xe
         sudo apt update
         sudo apt install gfortran libgfortran5
-        target=$(python tools/openblas_support.py)
-        sudo cp -r $target/lib/* /usr/lib
-        sudo cp $target/include/* /usr/include
+        pip install scipy-openblas32
+        spin config-openblas --with-scipy-openblas=32
     - name: Build a wheel
       run: |
+        export PKG_CONFIG_PATH=${PWD}/.openblas
         python -m build --wheel --no-isolation --skip-dependency-check
         pip install dist/numpy*.whl
     - name: Run full test suite
@@ -185,17 +185,17 @@ jobs:
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
         python-version: '3.11'
-    - name: Install gfortran and OpenBLAS (MacPython build)
+    - name: Install gfortran and setup OpenBLAS (MacPython build)
       run: |
         set -xe
         sudo apt update
         sudo apt install gfortran libgfortran5
-        target=$(python tools/openblas_support.py)
-        sudo cp -r $target/lib/* /usr/lib
-        sudo cp $target/include/* /usr/include
+        pip install scipy-openblas32 spin
+        spin config-openblas --with-scipy-openblas=32
     - name: Build a wheel via an sdist
       run: |
         pip install build
+        export PKG_CONFIG_PATH=${PWD}/.openblas
         python -m build
         pip install dist/numpy*.whl
     - name: Install test dependencies

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -7,13 +7,9 @@ name: BLAS tests (Linux)
 #
 # Jobs and their purpose:
 #
-#   - openblas64_setuppy:
-#         This job uses the default 64-bit build of OpenBLAS with the
-#         `numpy.distutils`-based build. It can be removed once we remove
-#         support for those builds.
 #   - openblas32_stable_nightly:
-#         Uses the 32-bit OpenBLAS builds, both the latest stable release and a
-#         nightly build.
+#         Uses the 32-bit OpenBLAS builds, both the latest stable release
+#         and a nightly build.
 #
 # TODO: coverage here is limited, we should add non-OpenBLAS libraries and
 #       exercise the BLAS-related build options (see `meson_options.txt`).

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r build_requirements.txt
-        sudo apt-get update
-        sudo apt-get install -y libopenblas-serial-dev
+        pip install scipy-openblas32 spin
+        spin config-openblas --with-scipy-openblas=32
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -53,23 +53,15 @@ jobs:
         python -m venv test_env
         source test_env/bin/activate
 
-        # install openblas by co-opting the CIBW setup script
         pip install scipy-openblas64
-        RUNNER_OS=Linux sh tools/wheels/cibw_before_build.sh .
 
-        pip install -r build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install -r build_requirements.txt -r test_requirements.txt
 
         # use meson to build and test 
         spin build --with-scipy-openblas=64
         spin test -j auto
 
-      - name: Meson Log
-        shell: bash
-        if: ${{ failure() && steps.test-musllinux_x86_64.conclusion == 'failure' }}
-        run: |
-          echo "::group::Meson Log"
-          cat build/meson-logs/meson-log.txt
-          echo "::endgroup::"
-
-
+    - name: Meson Log
+      shell: bash
+      run: |
+        cat build/meson-logs/meson-log.txt

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -48,20 +48,28 @@ jobs:
 
         ln -s /usr/local/bin/python3.10 /usr/local/bin/python
 
-    - name: test musllinux_x86_64
+    - name: test-musllinux_x86_64
       run: |
         python -m venv test_env
         source test_env/bin/activate
 
-        # required for figuring out the system tags in openblas_support
-        pip install packaging       
-        
         # install openblas by co-opting the CIBW setup script
+        pip install scipy-openblas64
         RUNNER_OS=Linux sh tools/wheels/cibw_before_build.sh .
 
         pip install -r build_requirements.txt
         pip install pytest pytest-xdist hypothesis typing_extensions
 
         # use meson to build and test 
-        spin build
+        spin build --with-scipy-openblas=64
         spin test -j auto
+
+      - name: Meson Log
+        shell: bash
+        if: ${{ failure() && steps.test-musllinux_x86_64.conclusion == 'failure' }}
+        run: |
+          echo "::group::Meson Log"
+          cat build/meson-logs/meson-log.txt
+          echo "::endgroup::"
+
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,16 +37,9 @@ jobs:
       run: |
         python -m pip install spin Cython
 
-    - name: Install OpenBLAS (MacPython build)
+    - name: Install pkg-config
       run: |
-        # Download and install pre-built OpenBLAS library with 32-bit
-        # interfaces. Unpack it in the pkg-config hardcoded path
-        choco install unzip -y
-        choco install wget -y
         choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-        wget https://anaconda.org/multibuild-wheels-staging/openblas-libs/v0.3.21/download/openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
-        unzip -d c:\opt openblas-v0.3.21-win_amd64-gcc_10_3_0.zip
-        echo "PKG_CONFIG_PATH=c:\opt\64\lib\pkgconfig;" >> $env:GITHUB_ENV
 
     - name: Install Clang-cl
       if: matrix.compiler == 'Clang-cl'
@@ -56,25 +49,15 @@ jobs:
     - name: Install NumPy (MSVC)
       if: matrix.compiler == 'MSVC'
       run: |
-        spin build -j2 -- --vsenv
+        python -m pip install scipy-openblas32
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
       if: matrix.compiler == 'Clang-cl'
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        spin build -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
-
-    - name: Copy OpenBLAS DLL, write _distributor_init.py
-      run: |
-        # Getting the OpenBLAS DLL to the right place so it loads
-        $installed_path = "$PWD\build-install\usr\Lib\site-packages"
-        $numpy_path = "${installed_path}\numpy"
-        $libs_path = "${installed_path}\numpy.libs"
-        mkdir ${libs_path}
-        $ob_path = "C:/opt/64/bin/"
-        cp $ob_path/*.dll $libs_path
-        # Write _distributor_init.py to load .libs DLLs.
-        python -c "from tools import openblas_support; openblas_support.make_init(r'${numpy_path}')"
+        python -m pip install scipy-openblas32
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Install test dependencies
       run: |
@@ -85,7 +68,7 @@ jobs:
       run: |
         spin test
 
-  msvc_32bit_python_openblas:
+  msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS
     runs-on: windows-2019
     if: "github.repository == 'numpy/numpy'"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,6 +59,12 @@ jobs:
         python -m pip install scipy-openblas32
         spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
+    - name: Meson Log
+      shell: bash
+      if: ${{ failure()  }}
+      run: |
+        cat build/meson-logs/meson-log.txt
+
     - name: Install test dependencies
       run: |
         python -m pip install -r test_requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ doc/source/**/generated/
 
 # Things specific to this project #
 ###################################
-# The line below should change to numpy/_version.py for NumPy 2.0
 benchmarks/results
 benchmarks/html
 benchmarks/env
@@ -139,3 +138,4 @@ tools/swig/test/Tensor.py
 tools/swig/test/Vector.py
 tools/swig/test/Vector_wrap.cxx
 tools/swig/test/Array.py
+.openblas

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -419,34 +419,7 @@ def ipython(ctx, ipython_args):
     util.run(["ipython", "--ignore-cwd",
               f"--TerminalIPythonApp.exec_lines={preimport}"] +
              list(ipython_args))
-<<<<<<< HEAD
- 
-=======
 
-
-@click.command(context_settings={"ignore_unknown_options": True})
-@click.argument("args", nargs=-1)
-@click.pass_context
-def run(ctx, args):
-    """🏁 Run a shell command with PYTHONPATH set
-
-    \b
-    spin run make
-    spin run 'echo $PYTHONPATH'
-    spin run python -c 'import sys; del sys.path[0]; import mypkg'
-
-    If you'd like to expand shell variables, like `$PYTHONPATH` in the example
-    above, you need to provide a single, quoted command to `run`:
-
-    spin run 'echo $SHELL && echo $PWD'
-
-    On Windows, all shell commands are run via Bash.
-    Install Git for Windows if you don't have Bash already.
-    """
-    ctx.invoke(build)
-    ctx.forward(meson.run)
-
->>>>>>> b68dd546e (ENH: use OpenBLAS from a wheel)
 
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.pass_context
@@ -490,7 +463,7 @@ def _config_openblas(blas_variant):
         openblas.write__distributor_init(os.path.join(basedir, "numpy"))
         os.makedirs(openblas_dir, exist_ok=True)
         with open(pkg_config_fname, "wt", encoding="utf8") as fid:
-            fid.write(openblas.get_pkg_config())
+            fid.write(openblas.get_pkg_config().replace("\\", "/"))
  
 def _maybe_setup_openblas(ctx, blas_variant):
     _config_openblas(blas_variant)
@@ -498,7 +471,7 @@ def _maybe_setup_openblas(ctx, blas_variant):
     basedir = os.getcwd()
     openblas_dir = os.path.join(basedir, ".openblas")
     pkg_config_fname = os.path.join(openblas_dir, "openblas.pc")
-    if blas_variant == 64:
+    if blas_variant == "64":
         ctx.params["meson_args"] += (
             "-Dblas-symbol-suffix=64_",
             "-Duse-ilp64=true",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,13 +73,11 @@ stages:
             cd /numpy && \
             /opt/python/cp39-cp39/bin/python -mvenv venv && \
             source venv/bin/activate && \
-            target=\$(python3 tools/openblas_support.py) && \
-            cp -r \$target/lib/* /usr/lib && \
-            cp \$target/include/* /usr/include && \
-            python3 -m pip install ninja && \
+            python3 -m pip install ninja scipy-openblas32 && \
             python3 -m pip install -r test_requirements.txt && \
             echo CFLAGS \$CFLAGS && \
-            python3 -m pip install -v . && \
+            export PKG_CONFIG_PATH=/numpy/.openblas && \
+            python3 -m pip install  . && \
             cd tools && \
             python3 -m pytest --pyargs numpy"
       displayName: 'Run 32-bit manylinux2014 Docker Build / Tests'
@@ -107,8 +105,6 @@ stages:
             TEST_MODE: fast
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
-            # Broken - it builds but _multiarray_umath doesn't import - needs investigating
-            DISABLE_BLAS: '1'
 
     steps:
     - template: azure-steps-windows.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,9 +73,10 @@ stages:
             cd /numpy && \
             /opt/python/cp39-cp39/bin/python -mvenv venv && \
             source venv/bin/activate && \
-            python3 -m pip install ninja scipy-openblas32 && \
+            python3 -m pip install ninja scipy-openblas32 spin && \
             python3 -m pip install -r test_requirements.txt && \
             echo CFLAGS \$CFLAGS && \
+            spin openblas-config --with-scipy-openblas=32 && \
             export PKG_CONFIG_PATH=/numpy/.openblas && \
             python3 -m pip install  . && \
             cd tools && \

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -24,42 +24,19 @@ steps:
   displayName: 'Install utilities'
 
 - powershell: |
-    $ErrorActionPreference = "Stop"
-    mkdir  C:/opt/openblas/openblas_dll
-    mkdir  C:/opt/32/lib/pkgconfig
-    mkdir  C:/opt/64/lib/pkgconfig
-    $target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); ilp64=obs.get_ilp64(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, ilp64);print(target)")
-    unzip -o -d c:/opt/ $target
-    echo "##vso[task.setvariable variable=PKG_CONFIG_PATH]c:/opt/64/lib/pkgconfig"
-    copy C:/opt/64/bin/*.dll C:/opt/openblas/openblas_dll
-  displayName: 'Download / Install OpenBLAS'
-
-- powershell: |
-    # Note: ensure the `pip install .` command remains the last one here, to
-    # avoid "green on failure" issues
-    python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
+    # Note: ensure the `pip install .` command remains the last one here,
+    # to avoid "green on failure" issues
     If ( Test-Path env:DISABLE_BLAS ) {
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
     elseif ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
-        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true" -Csetup-args="-Dblas-symbol-suffix=64_"
+        python -m pip install scipy-openblas64
+        spin build --with-scipy-openblas=64
     } else {
-        python -m pip install . -v -Csetup-args="--vsenv"
+        python -m pip install scipy-openblas32
+        spin build --with-scipy-openblas=32
     }
   displayName: 'Build NumPy'
-
-- powershell: |
-    # copy from c:/opt/openblas/openblas_dll to numpy/../numpy.libs to ensure it can
-    # get loaded when numpy is imported (no RPATH on Windows)
-    $target = $(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")
-    mkdir $target/numpy.libs
-    copy C:/opt/openblas/openblas_dll/*.dll $target/numpy.libs
-  displayName: 'Copy OpenBLAS DLL to site-packages'
-
-- script: |
-    python -m pip install threadpoolctl
-    python tools/openblas_support.py --check_version
-  displayName: 'Check OpenBLAS version'
 
 - powershell: |
     cd tools  # avoid root dir to not pick up source tree

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -30,11 +30,15 @@ steps:
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
     elseif ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
-        python -m pip install scipy-openblas64
-        spin build --with-scipy-openblas=64
+        python -m pip install scipy-openblas64 spin
+        spin config-openblas --with-scipy-openblas=64
+        $env:PKG_CONFIG_PATH="$pwd/.openblas"
+        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true" -Csetup-args="-Dblas-symbol-suffix=64_"
     } else {
-        python -m pip install scipy-openblas32
-        spin build --with-scipy-openblas=32
+        python -m pip install scipy-openblas32 spin
+        spin config-openblas --with-scipy-openblas=32
+        $env:PKG_CONFIG_PATH="$pwd/.openblas"
+        python -m pip install . -v -Csetup-args="--vsenv" 
     }
   displayName: 'Build NumPy'
 

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -66,6 +66,10 @@ Now, whenever you want to switch to the virtual environment, you can use the
 command ``source numpy-dev/bin/activate``, and ``deactivate`` to exit from the
 virtual environment and back to your previous shell.
 
+Building from source
+--------------------
+
+See building-from-source_
 
 .. _testing-builds:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ cli = 'vendored-meson/meson/meson.py'
   ".spin/cmds.py:build",
   ".spin/cmds.py:test",
   ".spin/cmds.py:mypy",
+  ".spin/cmds.py:config_openblas",
 ]
 "Environments" = [
   "spin.cmds.meson.run", ".spin/cmds.py:ipython",

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -52,9 +52,6 @@ linux_aarch64_test_task:
     echo "PATH=$PATH" >> $CIRRUS_ENV
     echo "CCACHE_DIR=$PWD/.ccache" >> $CIRRUS_ENV
 
-    # required for figuring out the system tags in openblas_support
-    pip install packaging
-
     pip install -r build_requirements.txt
     pip install -r test_requirements.txt
 
@@ -97,10 +94,6 @@ macos_arm64_test_task:
     RUNNER_OS="macOS"
     SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
     
-    # NOTE: OpenBLAS is not used in this job; if that's done in the future, ensure
-    # PKG_CONFIG_PATH points to the directory containing the openblas.pc file
-    # that's installed with the cibw_before_build.sh command.
-    # used for installing OpenBLAS/gfortran
     bash tools/wheels/cibw_before_build.sh $PWD
 
     pushd ~/

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -1,5 +1,5 @@
 # This script is used by .github/workflows/wheels.yml to run the full test
-# suite, checks for lincense inclusion and that the openblas version is correct.
+# suite and checks for license inclusion
 set -xe
 
 PROJECT_DIR="$1"
@@ -19,13 +19,8 @@ if [[ $RUNNER_OS == "macOS"  && $RUNNER_ARCH == "X64" ]]; then
   # in f2py tests
   export LIBRARY_PATH="$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
 elif [[ $RUNNER_OS == "Windows" && $IS_32_BIT == true ]] ; then
-  echo "Skip OpenBLAS version check for 32-bit Windows, no OpenBLAS used"
   # Avoid this in GHA: "ERROR: Found GNU link.exe instead of MSVC link.exe"
   rm /c/Program\ Files/Git/usr/bin/link.EXE
-else
-  # For some reason the macos-x86_64 runner does not work with threadpoolctl
-  # Skip this check there
-  python $PROJECT_DIR/tools/openblas_support.py --check_version
 fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.


### PR DESCRIPTION
Follow on for MacPython/openblas-libs#87 which creates OpenBLAS wheels, available as [scipy-openblas32](https://pypi.org/project/scipy-openblas32/) and [scipy-openblas64](https://pypi.org/project/scipy-openblas32/). The wheel provides facilities for generating a `openblas.pc` file and for rewriting the `_distributor_init.py` file to first import the project, which will inject the dll/so into the process namespace and make the interfaces available. In order to use the wheel you must do one of these to build NumPy:
```
pip install scipy-openblas32 -r build_requirements.txt
spin build --with-scipy-openblas=32
```

or 
```
pip install scipy-openblas64 -r build_requirements.txt
spin build --with-scipy-openblas=64
```

You can also use the non-spin `pip install` route for the 32-bit interfaces:
```
pip install scipy-openblas32 spin
spin config-openblas --with-scipy-openblas=32
export PKG_CONFIG_PATH=".openblas"
pip install .
```

I tried to modify most of the builds ~and wheel builds~ to use one of these workflows. ~One problem left to solve is specifying the runtime dependency for the wheels: which scipy-openblas should each platform use?~