### PR TITLE
TST: Skip f2py compilation tests on 3.12

### DIFF
--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -17,6 +17,10 @@ def setup_module():
         pytest.skip("Needs C compiler")
     if not util.has_f77_compiler():
         pytest.skip("Needs FORTRAN 77 compiler")
+    if sys.version_info[:2] >= (3, 12):
+        pytest.skip(
+            "F2PY compilation tests do not work with meson."
+        )
 
 
 # extra_args can be a list (since gh-11937) or string.


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This should have been done as part of https://github.com/numpy/numpy/pull/24532 which mentioned (correctly) that the CI tests haven't been updated for `meson` yet.

Should actually be fixed in the next release but just in case anyone needs the patch (e.g.) https://github.com/numpy/numpy/issues/24750 