### PR TITLE
DOC: Fix reference warning in some rst files

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -477,7 +477,7 @@ Character arrays (:mod:`numpy.char`)
    single: character arrays
 
 .. note::
-   The `chararray` class exists for backwards compatibility with
+   The `~numpy.char.chararray` class exists for backwards compatibility with
    Numarray, it is not recommended for new development. Starting from numpy
    1.4, if one needs arrays of strings, it is recommended to use arrays of
    `dtype` `object_`, `bytes_` or `str_`, and use the free functions
@@ -488,13 +488,13 @@ These are enhanced arrays of either :class:`str_` type or
 :class:`ndarray`, but specially-define the operations ``+``, ``*``,
 and ``%`` on a (broadcasting) element-by-element basis.  These
 operations are not available on the standard :class:`ndarray` of
-character type. In addition, the :class:`chararray` has all of the
+character type. In addition, the :class:`~numpy.char.chararray` has all of the
 standard :class:`str` (and :class:`bytes`) methods,
 executing them on an element-by-element basis. Perhaps the easiest
 way to create a chararray is to use :meth:`self.view(chararray)
 <ndarray.view>` where *self* is an ndarray of str or unicode
 data-type. However, a chararray can also be created using the
-:meth:`numpy.char.chararray` constructor, or via the
+:meth:`~numpy.char.chararray` constructor, or via the
 :func:`numpy.char.array <core.defchararray.array>` function:
 
 .. autosummary::

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -410,9 +410,6 @@ def mod(a, values):
     out : ndarray
         Output array of str or unicode, depending on input types
 
-    See Also
-    --------
-    str.__mod__
 
     """
     return _to_bytes_or_str_array(
@@ -1931,10 +1928,10 @@ class chararray(ndarray):
        The `chararray` class exists for backwards compatibility with
        Numarray, it is not recommended for new development. Starting from numpy
        1.4, if one needs arrays of strings, it is recommended to use arrays of
-       `dtype` `object_`, `bytes_` or `str_`, and use the free functions
+       `dtype` `~numpy.object_`, `~numpy.bytes_` or `~numpy.str_`, and use the free functions
        in the `numpy.char` module for fast vectorized string operations.
 
-    Versus a NumPy array of dtype `bytes_` or `str_`, this
+    Versus a NumPy array of dtype `~numpy.bytes_` or `~numpy.str_`, this
     class adds the following functionality:
 
     1) values automatically have whitespace removed from the end
@@ -2036,7 +2033,7 @@ class chararray(ndarray):
         Fixed stride displacement from the beginning of an axis?
         Default is 0. Needs to be >=0.
     strides : array_like of ints, optional
-        Strides for the array (see `ndarray.strides` for full description).
+        Strides for the array (see `~numpy.ndarray.strides` for full description).
         Default is None.
     order : {'C', 'F'}, optional
         The order in which the array data is stored in memory: 'C' ->
@@ -2731,13 +2728,13 @@ class chararray(ndarray):
 @set_module("numpy.char")
 def array(obj, itemsize=None, copy=True, unicode=None, order=None):
     """
-    Create a `chararray`.
+    Create a `~numpy.char.chararray`.
 
     .. note::
        This class is provided for numarray backward-compatibility.
        New code (not concerned with numarray compatibility) should use
        arrays of type `bytes_` or `str_` and use the free functions
-       in :mod:`numpy.char <numpy.core.defchararray>` for fast
+       in :mod:`numpy.char` for fast
        vectorized string operations instead.
 
     Versus a NumPy array of dtype `bytes_` or `str_`, this
@@ -2750,7 +2747,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
        end when comparing values
 
     3) vectorized string operations are provided as methods
-       (e.g. `~chararray.endswith`) and infix operators (e.g. ``+, *, %``)
+       (e.g. `chararray.endswith <numpy.char.chararray.endswith>`) and infix operators (e.g. ``+, *, %``)
 
     Parameters
     ----------
@@ -2771,11 +2768,11 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
         requirements (`itemsize`, unicode, `order`, etc.).
 
     unicode : bool, optional
-        When true, the resulting `chararray` can contain Unicode
+        When true, the resulting `~numpy.char.chararray` can contain Unicode
         characters, when false only 8-bit characters.  If unicode is
         None and `obj` is one of the following:
 
-        - a `chararray`,
+        - a `~numpy.char.chararray`,
         - an ndarray of type `str_` or `unicode_`
         - a Python str or unicode object,
 
@@ -2865,7 +2862,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
 @set_module("numpy.char")
 def asarray(obj, itemsize=None, unicode=None, order=None):
     """
-    Convert the input to a `chararray`, copying the data only if
+    Convert the input to a `~numpy.char.chararray`, copying the data only if
     necessary.
 
     Versus a NumPy array of dtype `bytes_` or `str_`, this
@@ -2878,7 +2875,7 @@ def asarray(obj, itemsize=None, unicode=None, order=None):
        end when comparing values
 
     3) vectorized string operations are provided as methods
-       (e.g. `~chararray.endswith`) and infix operators
+       (e.g. `chararray.endswith <numpy.char.chararray.endswith>`) and infix operators
        (e.g. ``+``, ``*``, ``%``)
 
     Parameters
@@ -2894,11 +2891,11 @@ def asarray(obj, itemsize=None, unicode=None, order=None):
         chunked into `itemsize` pieces.
 
     unicode : bool, optional
-        When true, the resulting `chararray` can contain Unicode
+        When true, the resulting `~numpy.char.chararray` can contain Unicode
         characters, when false only 8-bit characters.  If unicode is
         None and `obj` is one of the following:
 
-        - a `chararray`,
+        - a `~numpy.char.chararray`,
         - an ndarray of type `str_` or `unicode_`
         - a Python str or unicode object,
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -671,9 +671,6 @@ def correlate(a, v, mode='valid'):
     mode : {'valid', 'same', 'full'}, optional
         Refer to the `convolve` docstring.  Note that the default
         is 'valid', unlike `convolve`, which uses 'full'.
-    old_behavior : bool
-        `old_behavior` was removed in NumPy 1.10. If you need the old
-        behavior, use `multiarray.correlate`.
 
     Returns
     -------
@@ -683,7 +680,6 @@ def correlate(a, v, mode='valid'):
     See Also
     --------
     convolve : Discrete, linear convolution of two one-dimensional sequences.
-    multiarray.correlate : Old, no conjugate, version of correlate.
     scipy.signal.correlate : uses FFT which has superior performance on large arrays.
 
     Notes


### PR DESCRIPTION
[skip actions][skip cirrus][skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix following reference warning:
```
numpy/doc/source/reference/arrays.classes.rst:480: WARNING: py:obj reference target not found: chararray
numpy/doc/source/reference/arrays.classes.rst:486: WARNING: py:class reference target not found: chararray
numpy/doc/source/reference/arrays.classes.rst:505:<autosummary>:1: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:5: WARNING: py:mod reference target not found: numpy.core.defchararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.mod:29: WARNING: py:obj reference target not found: str.__mod__
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:2: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:5: WARNING: py:mod reference target not found: numpy.core.defchararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:20: WARNING: py:obj reference target not found: chararray.endswith
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:43: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.array:47: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.asarray:2: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.asarray:14: WARNING: py:obj reference target not found: chararray.endswith
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.asarray:32: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/char/__init__.py:docstring of numpy.char.asarray:36: WARNING: py:obj reference target not found: chararray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.correlate:41: WARNING: py:obj reference target not found: multiarray.correlate


```