### PR TITLE
ENH: fix printing structured dtypes with a non-legacy dtype member

### DIFF
--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -126,7 +126,7 @@ def _scalar_str(dtype, short):
         else:
             return "'%sU%d'" % (byteorder, dtype.itemsize / 4)
 
-    elif dtype.kind == '\x00':
+    elif not type(dtype)._legacy:
         return f"'{byteorder}{type(dtype).__name__}{dtype.itemsize * 8}'"
 
     # unlike the other types, subclasses of void are preserved - but
@@ -353,8 +353,9 @@ def _name_get(dtype):
         # user dtypes don't promise to do anything special
         return dtype.type.__name__
 
-    if dtype.kind == '\x00':
+    if not type(dtype)._legacy:
         name = type(dtype).__name__
+
     elif issubclass(dtype.type, np.void):
         # historically, void subclasses preserve their name, eg `record64`
         name = dtype.type.__name__

--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -126,6 +126,9 @@ def _scalar_str(dtype, short):
         else:
             return "'%sU%d'" % (byteorder, dtype.itemsize / 4)
 
+    elif dtype.kind == '\x00':
+        return f"'{byteorder}{type(dtype).__name__}{dtype.itemsize * 8}'"
+
     # unlike the other types, subclasses of void are preserved - but
     # historically the repr does not actually reveal the subclass
     elif issubclass(dtype.type, np.void):

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -51,6 +51,12 @@ class TestSFloat:
     def test_dtype_name(self):
         assert SF(1.).name == "_ScaledFloatTestDType64"
 
+    def test_sfloat_structured_dtype_printing(self):
+        dt = np.dtype([("id", int), ("value", SF(0.5))])
+        # repr of structured dtypes need special handling because the
+        # implementation bypasses the object repr
+        assert "('value', '_ScaledFloatTestDType64')" in repr(dt)
+
     @pytest.mark.parametrize("scaling", [1., -1., 2.])
     def test_sfloat_from_float(self, scaling):
         a = np.array([1., 2., 3.]).astype(dtype=SF(scaling))


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy-user-dtypes/issues/87

See related PR https://github.com/numpy/numpy/pull/23047 which fixed `dtype.name` in a similar way.

I don't know offhand if structured dtypes are broken in other ways, but basic testing indicates that it seems to work:

```
In [1]: import numpy as np

In [2]: from stringdtype import StringDType

In [3]: arr = np.array(
   ...:     [("Rex", 9, 81.0), ("Fido", 3, 27.0)],
   ...:     dtype=[("name", StringDType()), ("age", "i4"), ("weight", "f4")],
   ...: )

In [4]: arr[0][0]
Out[4]: 'Rex'

In [5]: type(arr[0][0])
Out[5]: str

In [6]: arr.dtype
Out[6]: dtype([('name', 'StringDType128'), ('age', '<i4'), ('weight', '<f4')])

In [7]: print(arr.astype(np.dtype([("name", "<U10"), ("age", "<i4"), ("weight", "<f4")])))
[('Rex', 9, 81.) ('Fido', 3, 27.)]

In [8]: arr.astype(np.dtype([("name", "<U10"), ("age", "<i4"), ("weight", "<f4")]))[0][0]
Out[8]: np.str_('Rex')


```