### PR TITLE
BUG: Fix order of Windows OS detection macros.

### DIFF
--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -19,12 +19,12 @@
     #define NPY_OS_SOLARIS
 #elif defined(__CYGWIN__)
     #define NPY_OS_CYGWIN
-#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-    #define NPY_OS_WIN32
-#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
-    #define NPY_OS_WIN64
 #elif defined(__MINGW32__) || defined(__MINGW64__)
     #define NPY_OS_MINGW
+#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
+    #define NPY_OS_WIN64
+#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+    #define NPY_OS_WIN32
 #elif defined(__APPLE__)
     #define NPY_OS_DARWIN
 #elif defined(__HAIKU__)

--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -20,12 +20,12 @@
 #elif defined(__CYGWIN__)
     #define NPY_OS_CYGWIN
 /* We are on Windows.*/
-#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#elif defined(_WIN32)
   /* We are using MinGW (64-bit or 32-bit)*/
   #if defined(__MINGW32__) || defined(__MINGW64__)
     #define NPY_OS_MINGW
   /* Otherwise, if _WIN64 is defined, we are targeting 64-bit Windows*/
-  #elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
+  #elif defined(_WIN64)
     #define NPY_OS_WIN64
   /* Otherwise assume we are targeting 32-bit Windows*/
   #else

--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -19,12 +19,18 @@
     #define NPY_OS_SOLARIS
 #elif defined(__CYGWIN__)
     #define NPY_OS_CYGWIN
-#elif defined(__MINGW32__) || defined(__MINGW64__)
-    #define NPY_OS_MINGW
-#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
-    #define NPY_OS_WIN64
+/* We are on Windows.*/
 #elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+  /* We are using MinGW (64-bit or 32-bit)*/
+  #if defined(__MINGW32__) || defined(__MINGW64__)
+    #define NPY_OS_MINGW
+  /* Otherwise, if _WIN64 is defined, we are targeting 64-bit Windows*/
+  #elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
+    #define NPY_OS_WIN64
+  /* Otherwise assume we are targeting 32-bit Windows*/
+  #else
     #define NPY_OS_WIN32
+  #endif
 #elif defined(__APPLE__)
     #define NPY_OS_DARWIN
 #elif defined(__HAIKU__)


### PR DESCRIPTION
  - The order should be `__MINGW32__/__MINGW64__`, then `_WIN64`, and then `_WIN32`.

    - 64 bit MinGW compilers define `_MINGW32__`, `__MINGW64__`, `_WIN32`, and `_WIN64`. 
    - 32 bit MinGW compilers define `__MINGW32__`, and `_WIN32`. 
    - 64 bit MSVC compilation defines `_WIN32` and  `_WIN64`. 
    - 32 bit MSVC compilation defines `_WIN32`.

  - Closes #24761. See the linked issue for more details.

This is a preliminary PR to accompany issue #24761. Please feel free to close it if there is a more appropriate way to handle it. 
