### PR TITLE
DOC: add a note on the ``.c.src`` format to the distutils migration page

### DIFF
--- a/doc/source/reference/distutils_status_migration.rst
+++ b/doc/source/reference/distutils_status_migration.rst
@@ -75,6 +75,7 @@ present in ``setuptools``:
 - Per-compiler build flag customization (e.g. `-O3` and `SSE2` flags are default)
 - a simple user build config system, see `site.cfg.example <https://github.com/numpy/numpy/blob/master/site.cfg.example>`__
 - SIMD intrinsics support
+- Support for the NumPy-specific ``.src`` templating format for ``.c``/``.h`` files
 
 The most widely used feature is nested ``setup.py`` files. This feature may
 perhaps still be ported to ``setuptools`` in the future (it needs a volunteer


### PR DESCRIPTION
Detailed migration guidance should probably be out of scope here, since this is a rarely used feature. Not using the format at all would be best, since it's a very poor format and we'd like to get of it in NumPy itself. Better options include using C++ templates, using a more standard templating library, or using C11's ``_Generic``.