### PR TITLE
MAINT: align test_dispatcher s390x targets with _umath_tests_mtargets

### DIFF
--- a/numpy/core/tests/test_cpu_dispatcher.py
+++ b/numpy/core/tests/test_cpu_dispatcher.py
@@ -9,7 +9,8 @@ def test_dispatcher():
     targets = (
         "SSE2", "SSE41", "AVX2",
         "VSX", "VSX2", "VSX3",
-        "NEON", "ASIMD", "ASIMDHP"
+        "NEON", "ASIMD", "ASIMDHP",
+        "VX", "VXE"
     )
     highest_sfx = "" # no suffix for the baseline
     all_sfx = []


### PR DESCRIPTION
This updates https://github.com/numpy/numpy/blob/main/numpy/core/tests/test_cpu_dispatcher.py#L12 targets matching what is set at https://github.com/numpy/numpy/blob/main/numpy/core/meson.build#L688 (i.e. adding VE and VXE).

This was discovered when testing an s390x build with optimization on.

