### PR TITLE
ENH: add parameter `strict` to `assert_array_less`

### DIFF
--- a/doc/release/upcoming_changes/24775.new_feature.rst
+++ b/doc/release/upcoming_changes/24775.new_feature.rst
@@ -1,0 +1,5 @@
+``strict`` option for `testing.assert_array_less`
+-------------------------------------------------
+The ``strict`` option is now available for `testing.assert_array_less`.
+Setting ``strict=True`` will disable the broadcasting behaviour for scalars
+and ensure that input arrays have the same data type.

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -229,6 +229,8 @@ def assert_array_less(
     y: _ArrayLikeNumber_co | _ArrayLikeObject_co,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 @overload
 def assert_array_less(
@@ -236,6 +238,8 @@ def assert_array_less(
     y: _ArrayLikeTD64_co,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 @overload
 def assert_array_less(
@@ -243,6 +247,8 @@ def assert_array_less(
     y: _ArrayLikeDT64_co,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 
 def runstring(

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -790,6 +790,18 @@ class TestArrayAssertLess:
         assert_raises(AssertionError, lambda: self._assert_func(-ainf, -x))
         self._assert_func(-ainf, x)
 
+    def test_strict(self):
+        """Test the behavior of the `strict` option."""
+        x = np.zeros(3)
+        y = np.ones(())
+        self._assert_func(x, y)
+        with pytest.raises(AssertionError):
+            self._assert_func(x, y, strict=True)
+        y = np.broadcast_to(y, x.shape)
+        self._assert_func(x, y)
+        with pytest.raises(AssertionError):
+            self._assert_func(x, y.astype(np.float32), strict=True)
+
 
 class TestWarns:
 


### PR DESCRIPTION
This adds the parameter `strict` to `np.testing.assert_array_less`. With `strict=True`, the shape and dtype of the two arguments must match for the assertion to pass.

Follows the example of https://github.com/numpy/numpy/pull/21595
Partially addresses suggestion in https://github.com/numpy/numpy/pull/24667#discussion_r1319991254
Addresses https://github.com/numpy/numpy/pull/24770#issuecomment-1730148472