### PR TITLE
BUG: Fix SIMD f32 trunc test on s390x when baseline is none

### DIFF
--- a/numpy/core/tests/test_simd_module.py
+++ b/numpy/core/tests/test_simd_module.py
@@ -86,6 +86,8 @@ class Test_SIMD_MODULE:
         assert lanes == [0] * nlanes
 
     def test_truncate_f32(self):
+        if not npyv.simd_f32:
+            pytest.skip("F32 isn't support by the SIMD extension")
         f32 = npyv.setall_f32(0.1)[0]
         assert f32 != 0.1
         assert round(f32, 1) == 0.1


### PR DESCRIPTION
Partial backport of #24479

Relates to https://github.com/numpy/numpy/issues/24750

Fix the following test error:
```Bash
self = <numpy.core.tests.test_simd_module.Test_SIMD_MODULE object at 0x3ff2e4e9bb0>
    def test_truncate_f32(self):
>       f32 = npyv.setall_f32(0.1)[0]
E       AttributeError: module 'numpy.core._simd.VX' has no attribute 'setall_f32'. Did you mean: 'setall_s32'?
self       = <numpy.core.tests.test_simd_module.Test_SIMD_MODULE object at 0x3ff2e4e9bb0>
../../../../BUILDROOT/numpy-1.26.0-1.fc40.s390x/usr/lib64/python3.12/site-packages/numpy/core/tests/test_simd_module.py:89: AttributeError
```
