### PR TITLE
BUG: ``numpy.array_api``: fix ``linalg.cholesky`` upper decomp for complex dtypes

### DIFF
--- a/numpy/array_api/linalg.py
+++ b/numpy/array_api/linalg.py
@@ -9,6 +9,7 @@ from ._dtypes import (
     complex128
 )
 from ._manipulation_functions import reshape
+from ._elementwise_functions import conj
 from ._array_object import Array
 
 from ..core.numeric import normalize_axis_tuple
@@ -53,7 +54,10 @@ def cholesky(x: Array, /, *, upper: bool = False) -> Array:
         raise TypeError('Only floating-point dtypes are allowed in cholesky')
     L = np.linalg.cholesky(x._array)
     if upper:
-        return Array._new(L).mT
+        U = Array._new(L).mT
+        if U.dtype in [complex64, complex128]:
+            U = conj(U)
+        return U
     return Array._new(L)
 
 # Note: cross is the numpy top-level namespace, not np.linalg


### PR DESCRIPTION
Closes gh-24451

cc @asmeurer 