### PR TITLE
TYP,DOC: Document the `np.number` parameter type as invariant

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -93,7 +93,7 @@ Please see : :ref:`Data type objects <arrays.dtypes>`
 Number precision
 ~~~~~~~~~~~~~~~~
 
-The precision of `numpy.number` subclasses is treated as a covariant generic
+The precision of `numpy.number` subclasses is treated as a invariant generic
 parameter (see :class:`~NBitBase`), simplifying the annotating of processes
 involving precision-based casting.
 


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/24569

The `np.number` generic parameter type was changed from covariant to invariant back in https://github.com/numpy/numpy/pull/18174, this is now also reflected in the documentation.