### PR TITLE
DOC: Fix reference warning in some rst files

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5494,11 +5494,6 @@ add_newdoc('numpy.core', 'ufunc', ('resolve_dtypes',
         The dtypes which NumPy would use for the calculation.  Note that
         dtypes may not match the passed in ones (casting is necessary).
 
-    See Also
-    --------
-    numpy.ufunc._resolve_dtypes_and_context :
-        Similar function to this, but returns additional information which
-        give access to the core C functionality of NumPy.
 
     Examples
     --------
@@ -5845,7 +5840,7 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('flags',
     """
     Bit-flags describing how this data type is to be interpreted.
 
-    Bit-masks are in `numpy.core.multiarray` as the constants
+    Bit-masks are in ``numpy.core.multiarray`` as the constants
     `ITEM_HASOBJECT`, `LIST_PICKLE`, `ITEM_IS_POINTER`, `NEEDS_INIT`,
     `NEEDS_PYAPI`, `USE_GETITEM`, `USE_SETITEM`. A full explanation
     of these flags is in C-API documentation; they are largely useful

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1617,7 +1617,7 @@ add_newdoc('numpy.core.umath', 'invert',
 
     Notes
     -----
-    `bitwise_not` is an alias for `invert`:
+    ``numpy.bitwise_not`` is an alias for `invert`:
 
     >>> np.bitwise_not is np.invert
     True

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1075,13 +1075,12 @@ def einsum(*operands, out=None, optimize=False, **kwargs):
     See Also
     --------
     einsum_path, dot, inner, outer, tensordot, linalg.multi_dot
-    einops :
-        similar verbose interface is provided by
+    einsum:
+        Similar verbose interface is provided by the
         `einops <https://github.com/arogozhnikov/einops>`_ package to cover
         additional operations: transpose, reshape/flatten, repeat/tile,
         squeeze/unsqueeze and reductions.
-    opt_einsum :
-        `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_
+        The `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_
         optimizes contraction order for einsum-like expressions
         in backend-agnostic manner.
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2236,9 +2236,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     See Also
     --------
     ndarray.sum : Equivalent method.
-
-    add.reduce : Equivalent functionality of `add`.
-
+    add: ``numpy.add.reduce`` equivalent function.
     cumsum : Cumulative sum of array elements.
 
     mean, average

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -125,7 +125,7 @@ class format_parser:
 
     See Also
     --------
-    dtype, typename
+    numpy.dtype, numpy.typename
 
     Examples
     --------
@@ -369,7 +369,7 @@ class recarray(ndarray):
     --------
     core.records.fromrecords : Construct a record array from data.
     record : fundamental data-type for `recarray`.
-    format_parser : determine a data-type from formats, names, titles.
+    numpy.rec.format_parser : determine a data-type from formats, names, titles.
 
     Notes
     -----

--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -720,7 +720,7 @@ class IndexExpression:
     A nicer way to build up index tuples for arrays.
 
     .. note::
-       Use one of the two predefined instances `index_exp` or `s_`
+       Use one of the two predefined instances ``index_exp`` or `s_`
        rather than directly using `IndexExpression`.
 
     For any index combination, including slicing and axis insertion,
@@ -736,10 +736,11 @@ class IndexExpression:
 
     See Also
     --------
-    index_exp : Predefined instance that always returns a tuple:
-       `index_exp = IndexExpression(maketuple=True)`.
     s_ : Predefined instance without tuple conversion:
        `s_ = IndexExpression(maketuple=False)`.
+       The ``index_exp`` is another predefined instance that
+       always returns a tuple:
+       `index_exp = IndexExpression(maketuple=True)`.
 
     Notes
     -----

--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -545,7 +545,7 @@ def expand_dims(a, axis):
     --------
     squeeze : The inverse operation, removing singleton dimensions
     reshape : Insert, remove, and combine dimensions, and resize existing ones
-    doc.indexing, atleast_1d, atleast_2d, atleast_3d
+    atleast_1d, atleast_2d, atleast_3d
 
     Examples
     --------

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -589,7 +589,7 @@ def typename(char):
 
     See Also
     --------
-    dtype, typecodes
+    dtype
 
     Examples
     --------

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1208,7 +1208,7 @@ def rundocs(filename=None, raise_on_error=True):
     -----
     The doctests can be run by the user/developer by adding the ``doctests``
     argument to the ``test()`` call. For example, to run all tests (including
-    doctests) for `numpy.lib`:
+    doctests) for ``numpy.lib``:
 
     >>> np.lib.test(doctests=True)  # doctest: +SKIP
     """


### PR DESCRIPTION
[skip actions][skip cirrus][skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix following reference warning:
```
numpy/doc/docstring of numpy.dtype.flags:4: WARNING: py:obj reference target not found: numpy.core.multiarray
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.einsum:77: WARNING: py:obj reference target not found: einops
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.einsum:79: WARNING: py:obj reference target not found: opt_einsum
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.expand_dims:43: WARNING: py:obj reference target not found: doc.indexing
numpy/doc/docstring of numpy.invert:63: WARNING: py:obj reference target not found: bitwise_not
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.expand_dims:43: WARNING: py:obj reference target not found: doc.indexing
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/rec/__init__.py:docstring of numpy.rec.format_parser:46: WARNING: py:obj reference target not found: dtype
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/rec/__init__.py:docstring of numpy.rec.format_parser:46: WARNING: py:obj reference target not found: typename
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/rec/__init__.py:docstring of numpy.rec.recarray:79: WARNING: py:obj reference target not found: format_parser
numpy/doc/docstring of numpy.s_:5: WARNING: py:obj reference target not found: index_exp
numpy/doc/docstring of numpy.s_:29: WARNING: py:obj reference target not found: index_exp
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.sum:74: WARNING: py:obj reference target not found: add.reduce
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/testing/_private/utils.py:docstring of numpy.testing._private.utils.rundocs:25: WARNING: py:obj reference target not found: numpy.lib
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.typename:24: WARNING: py:obj reference target not found: typecodes
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/__init__.py:docstring of numpy.ufunc.resolve_dtypes:53: WARNING: py:obj reference target not found: numpy.ufunc._resolve_dtypes_and_context

```

Some of my changes(maybe all) are not very good since I don't know the better solution. The `numpy.s_` have docstring but the same alias `index_exp` don't have one. The `See Also` section can't have external hyperlink as function name. These two issues are difficult to me.