### PR TITLE
API: Remove zero names from dtype aliases

### DIFF
--- a/numpy/_typing/_char_codes.py
+++ b/numpy/_typing/_char_codes.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-_BoolCodes = Literal["?", "=?", "<?", ">?", "bool", "bool_", "bool8"]
+_BoolCodes = Literal["?", "=?", "<?", ">?", "bool", "bool_"]
 
 _UInt8Codes = Literal["uint8", "u1", "=u1", "<u1", ">u1"]
 _UInt16Codes = Literal["uint16", "u2", "=u2", "<u2", ">u2"]
@@ -22,14 +22,14 @@ _Complex128Codes = Literal["complex128", "c16", "=c16", "<c16", ">c16"]
 _ByteCodes = Literal["byte", "b", "=b", "<b", ">b"]
 _ShortCodes = Literal["short", "h", "=h", "<h", ">h"]
 _IntCCodes = Literal["intc", "i", "=i", "<i", ">i"]
-_IntPCodes = Literal["intp", "int0", "p", "=p", "<p", ">p"]
+_IntPCodes = Literal["intp", "p", "=p", "<p", ">p"]
 _IntCodes = Literal["long", "int", "int_", "l", "=l", "<l", ">l"]
 _LongLongCodes = Literal["longlong", "q", "=q", "<q", ">q"]
 
 _UByteCodes = Literal["ubyte", "B", "=B", "<B", ">B"]
 _UShortCodes = Literal["ushort", "H", "=H", "<H", ">H"]
 _UIntCCodes = Literal["uintc", "I", "=I", "<I", ">I"]
-_UIntPCodes = Literal["uintp", "uint0", "P", "=P", "<P", ">P"]
+_UIntPCodes = Literal["uintp", "P", "=P", "<P", ">P"]
 _UIntCodes = Literal["ulong", "uint", "L", "=L", "<L", ">L"]
 _ULongLongCodes = Literal["ulonglong", "Q", "=Q", "<Q", ">Q"]
 
@@ -42,9 +42,9 @@ _CSingleCodes = Literal["csingle", "F", "=F", "<F", ">F"]
 _CDoubleCodes = Literal["cdouble", "complex", "D", "=D", "<D", ">D"]
 _CLongDoubleCodes = Literal["clongdouble", "G", "=G", "<G", ">G"]
 
-_StrCodes = Literal["str", "str_", "str0", "unicode", "U", "=U", "<U", ">U"]
-_BytesCodes = Literal["bytes", "bytes_", "bytes0", "S", "=S", "<S", ">S"]
-_VoidCodes = Literal["void", "void0", "V", "=V", "<V", ">V"]
+_StrCodes = Literal["str", "str_", "unicode", "U", "=U", "<U", ">U"]
+_BytesCodes = Literal["bytes", "bytes_", "S", "=S", "<S", ">S"]
+_VoidCodes = Literal["void", "V", "=V", "<V", ">V"]
 _ObjectCodes = Literal["object", "object_", "O", "=O", "<O", ">O"]
 
 _DT64Codes = Literal[

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -106,16 +106,14 @@ def _add_aliases():
         if name in ('longdouble', 'clongdouble') and myname in allTypes:
             continue
 
-        # Add to the main namespace if desired:
         if bit != 0 and base != "bool":
+            # add to the main namespace
             allTypes[myname] = info.type
+            # add mapping for both the bit name
+            sctypeDict[myname] = info.type
 
         # add forward, reverse, and string mapping to numarray
         sctypeDict[char] = info.type
-
-        # add mapping for both the bit name
-        sctypeDict[myname] = info.type
-
 
 _add_aliases()
 
@@ -224,9 +222,7 @@ _set_array_types()
 
 # Add additional strings to the sctypeDict
 _toadd = ['int', ('float', 'double'), ('complex', 'cdouble'), 
-          'bool', 'object',
-          'str', 'bytes', ('a', 'bytes_'),
-          ('int0', 'intp'), ('uint0', 'uintp')]
+          'bool', 'object', 'str', 'bytes', ('a', 'bytes_')]
 
 for name in _toadd:
     if isinstance(name, tuple):

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1845,6 +1845,14 @@ _convert_from_str(PyObject *obj, int align)
             if (PyErr_Occurred()) {
                 return NULL;
             }
+            if (
+                strcmp(type, "int0") == 0 || strcmp(type, "uint0") == 0 ||
+                strcmp(type, "void0") == 0 || strcmp(type, "object0") == 0 ||
+                strcmp(type, "str0") == 0 || strcmp(type, "bytes0") == 0 ||
+                strcmp(type, "bool8") == 0
+            ) {
+                goto expired_alias_fail;
+            }
             goto fail;
         }
 
@@ -1874,6 +1882,10 @@ _convert_from_str(PyObject *obj, int align)
     }
     return ret;
 
+expired_alias_fail:
+    PyErr_Format(PyExc_TypeError, "Alias %R was removed in NumPy 2.0. Use "
+                                  "a name without a digit at the end.", obj);
+    return NULL;
 fail:
     PyErr_Format(PyExc_TypeError, "data type %R not understood", obj);
     return NULL;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1851,7 +1851,10 @@ _convert_from_str(PyObject *obj, int align)
                 strcmp(type, "str0") == 0 || strcmp(type, "bytes0") == 0 ||
                 strcmp(type, "bool8") == 0
             ) {
-                goto expired_alias_fail;
+                PyErr_Format(PyExc_TypeError,
+                        "Alias %R was removed in NumPy 2.0. Use a name "
+                        "without a digit at the end.", obj);
+                return NULL;
             }
             goto fail;
         }
@@ -1882,10 +1885,6 @@ _convert_from_str(PyObject *obj, int align)
     }
     return ret;
 
-expired_alias_fail:
-    PyErr_Format(PyExc_TypeError, "Alias %R was removed in NumPy 2.0. Use "
-                                  "a name without a digit at the end.", obj);
-    return NULL;
 fail:
     PyErr_Format(PyExc_TypeError, "data type %R not understood", obj);
     return NULL;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -126,14 +126,22 @@ class TestBuiltin:
         with assert_raises(TypeError):
             np.dtype(dtype)
 
-    def test_remaining_dtypes_with_bad_bytesize(self):
-        # The np.<name> aliases were deprecated, these probably should be too 
-        assert np.dtype("int0") is np.dtype("intp")
-        assert np.dtype("uint0") is np.dtype("uintp")
-        assert np.dtype("bool8") is np.dtype("bool")
-        assert np.dtype("bytes0") is np.dtype("bytes")
-        assert np.dtype("str0") is np.dtype("str")
-        assert np.dtype("object0") is np.dtype("object")
+    def test_expired_dtypes_with_bad_bytesize(self):
+        match: str = r".*removed in NumPy 2.0.*"
+        with pytest.raises(TypeError, match=match):
+            np.dtype("int0")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("uint0")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("bool8")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("bytes0")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("str0")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("object0")
+        with pytest.raises(TypeError, match=match):
+            np.dtype("void0")
 
     @pytest.mark.parametrize(
         'value',


### PR DESCRIPTION
Hi @rgommers @ngoldbaum @seberg,

This PR removes 7 names from the `np.dtype(<str_alias>)` search:
```
int0
uint0
void0
object0
str0
bytes0
bool8
``` 
as these have been deprecated in https://github.com/numpy/numpy/pull/22607 in 1.24 release. Their `np.*` types counterparts have been already removed from the main namespace.

For informational purposes I added `if` check in the C code that explicitly verifies if one of these names is provided to display a custom error message. I'm not sure how much overhead such additional check will have on `np.dtype` but it's only evaluated when the execution is going to fail anyway with `data type *** not understood`.