### PR TITLE
BUG: Fix order of Windows OS detection macros. 

### DIFF
--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -19,12 +19,18 @@
     #define NPY_OS_SOLARIS
 #elif defined(__CYGWIN__)
     #define NPY_OS_CYGWIN
-#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-    #define NPY_OS_WIN32
-#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
-    #define NPY_OS_WIN64
-#elif defined(__MINGW32__) || defined(__MINGW64__)
+/* We are on Windows.*/
+#elif defined(_WIN32)
+  /* We are using MinGW (64-bit or 32-bit)*/
+  #if defined(__MINGW32__) || defined(__MINGW64__)
     #define NPY_OS_MINGW
+  /* Otherwise, if _WIN64 is defined, we are targeting 64-bit Windows*/
+  #elif defined(_WIN64)
+    #define NPY_OS_WIN64
+  /* Otherwise assume we are targeting 32-bit Windows*/
+  #else
+    #define NPY_OS_WIN32
+  #endif
 #elif defined(__APPLE__)
     #define NPY_OS_DARWIN
 #elif defined(__HAIKU__)


### PR DESCRIPTION
Backport of #24762.
* BUG: Fix order of Windows OS detection macros.

  - The order should be `__MINGW32__/__MINGW64__`, then `_WIN64`, and then `_WIN32`.

    64 bit MinGW compilers define `_MINGW32__`, `__MINGW64__`, `_WIN32`, and `_WIN64`. 32 bit MinGW compilers define `__MINGW32__`, and `_WIN32`. 64 bit MSVC compilation defines `_WIN32` and  `_WIN64`. 32 bit MSVC compilation defines `_WIN32`.

  - Fixes #24761.

* Adjust the structure slightly and add comments.

  - This is better than just relying on the order of evaluation in the whole chain. Once Windows is detected (`_WIN32`), handle the possible known Windows environments separately.

* Remove check for non-standard macros.

  - `WIN32`, `__WIN32__`, `WIN64`, `__WIN64__` are not standard macros defined by Window compilers.

    It should be enough to check for `_WIN32` and `_WIN64` alone.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
