### PR TITLE
MAINT: align test_dispatcher s390x targets with _umath_tests_mtargets

### DIFF
--- a/numpy/core/src/umath/_umath_tests.dispatch.c
+++ b/numpy/core/src/umath/_umath_tests.dispatch.c
@@ -5,6 +5,7 @@
  * SSE2 SSE41 AVX2
  * VSX VSX2 VSX3
  * NEON ASIMD ASIMDHP
+ * VX VXE
  */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>

--- a/numpy/core/tests/test_cpu_dispatcher.py
+++ b/numpy/core/tests/test_cpu_dispatcher.py
@@ -9,7 +9,8 @@ def test_dispatcher():
     targets = (
         "SSE2", "SSE41", "AVX2",
         "VSX", "VSX2", "VSX3",
-        "NEON", "ASIMD", "ASIMDHP"
+        "NEON", "ASIMD", "ASIMDHP",
+        "VX", "VXE"
     )
     highest_sfx = "" # no suffix for the baseline
     all_sfx = []


### PR DESCRIPTION
Backport of #24772.

This updates https://github.com/numpy/numpy/blob/main/numpy/core/tests/test_cpu_dispatcher.py#L12 targets matching what is set at https://github.com/numpy/numpy/blob/main/numpy/core/meson.build#L688 (i.e. adding VE and VXE).

This was discovered when testing an s390x build with optimization on.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
