### PR TITLE
API: deprecate size-2 inputs for `np.cross` [Array API]

### DIFF
--- a/doc/release/upcoming_changes/24818.deprecation.rst
+++ b/doc/release/upcoming_changes/24818.deprecation.rst
@@ -1,0 +1,2 @@
+Arrays of 2-dimensional vectors for ``np.cross`` have been deprecated.
+Use arrays of 3-dimensional vectors instead.

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1597,6 +1597,13 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
            "(dimension must be 2 or 3)")
     if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
         raise ValueError(msg)
+    if a.shape[-1] == 2 or b.shape[-1] == 2:
+        # Deprecated in NumPy 2.0, 2023-09-26
+        warnings.warn(
+            "Arrays of 2-dimensional vectors are deprecated. Use arrays of "
+            "3-dimensional vectors instead. (deprecated in NumPy 2.0)",
+            DeprecationWarning, stacklevel=2
+        )
 
     # Create the output array
     shape = broadcast(a[..., 0], b[..., 0]).shape

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3573,6 +3573,9 @@ class TestMoveaxis:
 
 
 class TestCross:
+    @pytest.mark.filterwarnings(
+        "ignore:.*2-dimensional vectors.*:DeprecationWarning"
+    )
     def test_2x2(self):
         u = [1, 2]
         v = [3, 4]
@@ -3582,6 +3585,9 @@ class TestCross:
         cp = np.cross(v, u)
         assert_equal(cp, -z)
 
+    @pytest.mark.filterwarnings(
+        "ignore:.*2-dimensional vectors.*:DeprecationWarning"
+    )
     def test_2x3(self):
         u = [1, 2]
         v = [3, 4, 5]
@@ -3600,6 +3606,9 @@ class TestCross:
         cp = np.cross(v, u)
         assert_equal(cp, -z)
 
+    @pytest.mark.filterwarnings(
+        "ignore:.*2-dimensional vectors.*:DeprecationWarning"
+    )
     def test_broadcasting(self):
         # Ticket #2624 (Trac #2032)
         u = np.tile([1, 2], (11, 1))
@@ -3630,6 +3639,9 @@ class TestCross:
         assert_equal(np.cross(v.T, u), -z)
         assert_equal(np.cross(u, u), 0)
 
+    @pytest.mark.filterwarnings(
+        "ignore:.*2-dimensional vectors.*:DeprecationWarning"
+    )
     def test_broadcasting_shapes(self):
         u = np.ones((2, 1, 3))
         v = np.ones((5, 3))


### PR DESCRIPTION
Hi @rgommers,

As NEP 52 comes closer to the end I decided to start a warmup for the next milestone. IIRC you mentioned I could potentially focus on "Array API support in NumPy" workstream.

From our conversation in July I noted such introductory tasks:
```
making `cross` avoid size-2 inputs (deprecating that first), 
adding a new `svdvals` function, 
adding `np.linalg.trace` or `np.linalg.diagonal`.
```

Some questions:
- I see that `numpy.array_api` already has compatible `trace` and `diagonal`, but you meant adding these methods to `np.linalg` directly, right? (so duplicating a bit `np.trace` and `np.diagonal`)
- For a reference I'm looking at: https://github.com/numpy/archive/blob/main/2.0_developer_meeting/NumPy_2.0_devmeeting_array_API_adoption.pdf

This small PR adds a deprecation to `np.cross` for 2-size input.
