### PR TITLE
BUILD: remove `max_opt` variable

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -318,15 +318,6 @@ optional_function_attributes = [
 #  endif
 #endforeach
 
-# Max possible optimization flags. We pass this flags to all our dispatch-able
-# (multi_targets) sources.
-compiler_id = cc.get_id()
-max_opt = {
-  'msvc': ['/O2'],
-  'intel-cl': ['/O3'],
-}.get(compiler_id, ['-O3'])
-max_opt = cc.has_multi_arguments(max_opt) ? max_opt : []
-
 # Optional GCC compiler builtins and their call arguments.
 # If given, a required header and definition name (HAVE_ prepended)
 # Call arguments are required as the compiler will do strict signature checking
@@ -739,8 +730,8 @@ foreach gen_mtargets : [
     baseline: CPU_BASELINE,
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common,
+    cpp_args: cpp_args_common,
     include_directories: [
       'include',
       'src/common',
@@ -776,8 +767,8 @@ foreach gen_mtargets : [
     # baseline: CPU_BASELINE, it doesn't provide baseline fallback
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common,
+    cpp_args: cpp_args_common,
     include_directories: [
       'include',
       'src/common',
@@ -947,8 +938,8 @@ foreach gen_mtargets : [
     baseline: CPU_BASELINE,
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common,
+    cpp_args: cpp_args_common,
     include_directories: [
       'include',
       'src/common',


### PR DESCRIPTION
Hi @rgommers @seiko2plus,

Recently I tried to run debugger through numpy's C code with lldb but I noticed that although I'm using debug build type with optimization disabled I still get some `<optimized out>` variables when inspecting frames. I noticed that some `-O3` flags are included for a few files. (Full story here: https://github.com/numpy/numpy/issues/24788)

In a nutshell: I found that `-O2/-O3` are included two to three times in build commands:
1. From `-Dbuildtype=release` that uses `-O3`. Switching to `-Dbuildtype=debug` changes it to `-O0 -g`.
2. From `CFLAGS`, `CXXFLAGS` and `FFLAGS`, if set (my conda env sets them with `... -O2 ...` on activation).
3. Originally I thought that `-C'setup-args=-Dallow-noblas=false'` or `-C'setup-args=-Ddisable-optimization=false'` might also include additional `-O3` but I'm not sure about it now. WDYT?

Additionally I found that for dispatch-able sources `-O3` is hard-coded and injected at the end of the command, so that it overrides `-O0` from the debug build type setting. Here's an example command:

```
x86_64-apple-darwin13.4.0-clang -Inumpy/core/libloops_autovec.dispatch.h_baseline.a.p 
-Inumpy/core -I../numpy/core -Inumpy/core/include -I../numpy/core/include 
-I../numpy/core/src/common -I../numpy/core/src/multiarray -I../numpy/core/src/npymath 
-I../numpy/core/src/umath -I/usr/local/Caskroom/miniconda/base/envs/numpy-dev/include/python3.9 
-I/Users/mateusz/CLionProjects/numpy/build/meson_cpu -fcolor-diagnostics 
-Wall -Winvalid-pch -std=c99 -O0 -g -fno-strict-aliasing -ftrapping-math 
-DNPY_HAVE_CLANG_FPSTRICT -DNPY_DISABLE_OPTIMIZATION -D_FORTIFY_SOURCE=2 
-isystem /usr/local/Caskroom/miniconda/base/envs/numpy-dev/include 
-DNPY_INTERNAL_BUILD -DHAVE_NPY_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 
-D_LARGEFILE64_SOURCE=1 -O3 -DNPY_MTARGETS_BASELINE 
-MD -MQ numpy/core/libloops_autovec.dispatch.h_baseline.a.p/meson-generated_loops_autovec.dispatch.c.o
-MF numpy/core/libloops_autovec.dispatch.h_baseline.a.p/meson-generated_loops_autovec.dispatch.c.o.d 
-o numpy/core/libloops_autovec.dispatch.h_baseline.a.p/meson-generated_loops_autovec.dispatch.c.o 
-c numpy/core/libloops_autovec.dispatch.h_baseline.a.p/loops_autovec.dispatch.c
```

---

In this PR I remove `max_opt` as `-O...` flag is already provided by meson `buildtype` 
(or should these sources be built with `-O3` regardless of the build type?)

I'm not familiar with meson and numpy build process at all so I might have got ii wrong.


----

P.S. Here's a build command that I'm using:
```
python -m pip install . -v --no-build-isolation -Cbuilddir=build -C'compile-args=-v' -C'setup-args=-Dbuildtype=debug' -C'setup-args=-Ddisable-optimization=true' -C'setup-args=-Dallow-noblas=true'
```
