### PR TITLE
MAINT: remove `wheel` as a build dependency

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -20,7 +20,7 @@ Building NumPy requires the following installed software:
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 0.29.35
+2) Cython >= 3.0
 
 3) pytest__ (optional)
 

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,6 +1,5 @@
 meson-python>=0.13.1
 Cython>=3.0
-wheel==0.38.1
 ninja
 spin==0.7
 build


### PR DESCRIPTION
Also correct the lower bound on Cython in INSTALL.rst