### PR TITLE
DOC: Update debugging section

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -238,6 +238,23 @@ Most python builds do not include debug symbols and are built with compiler
 optimizations enabled. To get the best debugging experience using a debug build
 of Python is encouraged, see :ref:`advanced_debugging`.
 
+In terms of debugging, NumPy also needs to be built in a debug mode. You need to use
+``debug`` build type and disable optimizations to make sure ``-O0`` flag is used
+during object building. To generate source-level debug information within the build process run::
+
+    $ CFLAGS="-O0 -g" CXXFLAGS="-O0 -g" spin build --clean -- -Dbuildtype=debug -Ddisable-optimization=true
+
+.. note::
+
+    In case you are using conda environment be aware that conda sets ``CFLAGS``
+    and ``CXXFLAGS`` automatically, and they will include the ``-O2`` flag by default.
+    To take control of these variables in conda, you can create ``env_vars.sh``
+    file in the ``<path-to-conda-envs>/numpy-dev/etc/conda/activate.d`` directory.
+    In this file you can export ``CFLAGS`` and ``CXXFLAGS`` variables.
+    For complete instructions please refer to
+    https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables.
+
+
 Next you need to write a Python script that invokes the C code whose execution
 you want to debug. For instance ``mytest.py``::
 
@@ -249,9 +266,18 @@ Now, you can run::
 
     $ spin gdb mytest.py
 
+In case you are using clang toolchain::
+
+    $ lldb python mytest.py
+
 And then in the debugger::
 
     (gdb) break array_empty_like
+    (gdb) run
+
+lldb counterpart::
+
+    (gdb) breakpoint set --name array_empty_like
     (gdb) run
 
 The execution will now stop at the corresponding C function and you can step

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -242,15 +242,17 @@ In terms of debugging, NumPy also needs to be built in a debug mode. You need to
 ``debug`` build type and disable optimizations to make sure ``-O0`` flag is used
 during object building. To generate source-level debug information within the build process run::
 
-    $ CFLAGS="-O0 -g" CXXFLAGS="-O0 -g" spin build --clean -- -Dbuildtype=debug -Ddisable-optimization=true
+    $ spin build --clean -- -Dbuildtype=debug -Ddisable-optimization=true
 
 .. note::
 
     In case you are using conda environment be aware that conda sets ``CFLAGS``
     and ``CXXFLAGS`` automatically, and they will include the ``-O2`` flag by default.
-    To take control of these variables in conda, you can create ``env_vars.sh``
-    file in the ``<path-to-conda-envs>/numpy-dev/etc/conda/activate.d`` directory.
-    In this file you can export ``CFLAGS`` and ``CXXFLAGS`` variables.
+    You can safely use ``unset CFLAGS && unset CXXFLAGS`` to avoid them or provide them
+    at the beginning of the ``spin`` command: ``CFLAGS="-O0 -g" CXXFLAGS="-O0 -g"``.
+    Alternatively, to take control of these variables more permanently, you can create
+    ``env_vars.sh`` file in the ``<path-to-conda-envs>/numpy-dev/etc/conda/activate.d``
+    directory. In this file you can export ``CFLAGS`` and ``CXXFLAGS`` variables.
     For complete instructions please refer to
     https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables.
 
@@ -277,8 +279,8 @@ And then in the debugger::
 
 lldb counterpart::
 
-    (gdb) breakpoint set --name array_empty_like
-    (gdb) run
+    (lldb) breakpoint set --name array_empty_like
+    (lldb) run
 
 The execution will now stop at the corresponding C function and you can step
 through it as usual. A number of useful Python-specific commands are available.


### PR DESCRIPTION
Connected to https://github.com/numpy/numpy/issues/24788.

Hi @rgommers @ngoldbaum @mattip,

This small PR contains a change to "Debugging" section in docs: A description which command to use to remove skippable `-O2/-O3` flags (where unskippable means `-O3` flags for dispatchable objects) and `CFLAGS` setup for conda.

I managed to ran numpy with llvm debugger on macos (gdb installed via brew required code-signing, llvm worked out-of-the-box) - added one-line comments about it. 