### PR TITLE
DOC: Fix reference warning in some rst files

### DIFF
--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -19,9 +19,7 @@ Packaging (:mod:`numpy.distutils`)
 
 NumPy provides enhanced distutils functionality to make it easier to
 build and install sub-packages, auto-generate code, and extension
-modules that use Fortran-compiled libraries. To use features of NumPy
-distutils, use the :func:`setup <core.setup>` command from
-:mod:`numpy.distutils.core`. A useful :class:`Configuration
+modules that use Fortran-compiled libraries. A useful :class:`Configuration
 <misc_util.Configuration>` class is also provided in
 :mod:`numpy.distutils.misc_util` that can make it easier to construct
 keyword arguments to pass to the setup function (by passing the
@@ -189,9 +187,7 @@ This will install the file foo.ini into the directory package_dir/lib, and the
 foo.ini file will be generated from foo.ini.in, where each ``@version@`` will be
 replaced by ``subst_dict['version']``. The dictionary has an additional prefix
 substitution rule automatically added, which contains the install prefix (since
-this is not easy to get from setup.py).  npy-pkg-config files can also be
-installed at the same location as used for numpy, using the path returned from
-`get_npy_pkg_dir` function.
+this is not easy to get from setup.py).
 
 Reusing a C library from another package
 ----------------------------------------

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -382,7 +382,7 @@ def CCompiler_customize_cmd(self, cmd, ignore=()):
     cmd : class instance
         An instance inheriting from `distutils.cmd.Command`.
     ignore : sequence of str, optional
-        List of `CCompiler` commands (without ``'set_'``) that should not be
+        List of ``distutils.ccompiler.CCompiler`` commands (without ``'set_'``) that should not be
         altered. Strings that are checked for are:
         ``('include_dirs', 'define', 'undef', 'libraries', 'library_dirs',
         'rpath', 'link_objects')``.
@@ -581,7 +581,7 @@ def simple_version_match(pat=r'[-.\d]+', ignore='', start=''):
     -------
     matcher : callable
         A function that is appropriate to use as the ``.version_match``
-        attribute of a `CCompiler` class. `matcher` takes a single parameter,
+        attribute of a ``distutils.ccompiler.CCompiler`` class. `matcher` takes a single parameter,
         a version string.
 
     """
@@ -623,7 +623,7 @@ def CCompiler_get_version(self, force=False, ok_status=[0]):
     Returns
     -------
     version : str or None
-        Version string, in the format of `distutils.version.LooseVersion`.
+        Version string, in the format of ``distutils.version.LooseVersion``.
 
     """
     if not force and hasattr(self, 'version'):
@@ -686,7 +686,7 @@ def CCompiler_cxx_compiler(self):
     Returns
     -------
     cxx : class instance
-        The C++ compiler, as a `CCompiler` instance.
+        The C++ compiler, as a ``distutils.ccompiler.CCompiler`` instance.
 
     """
     if self.compiler_type in ('msvc', 'intelw', 'intelemw'):

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -1308,7 +1308,7 @@ class _Feature:
     def feature_is_exist(self, name):
         """
         Returns True if a certain feature is exist and covered within
-        `_Config.conf_features`.
+        ``_Config.conf_features``.
 
         Parameters
         ----------


### PR DESCRIPTION
[skip actions][skip cirrus][skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fix following reference warning:
```
numpy/doc/source/reference/distutils.rst:20: WARNING: py:func reference target not found: core.setup
numpy/doc/source/reference/distutils.rst:20: WARNING: py:mod reference target not found: numpy.distutils.core
numpy/doc/source/reference/distutils.rst:188: WARNING: py:obj reference target not found: get_npy_pkg_dir
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/distutils/ccompiler.py:docstring of numpy.distutils.ccompiler.CCompiler_customize_cmd:11: WARNING: py:obj reference target not found: CCompiler
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/distutils/ccompiler.py:docstring of numpy.distutils.ccompiler.CCompiler_cxx_compiler:13: WARNING: py:obj reference target not found: CCompiler
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/distutils/ccompiler.py:docstring of numpy.distutils.ccompiler.CCompiler_get_version:19: WARNING: py:obj reference target not found: distutils.version.LooseVersion
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/distutils/ccompiler.py:docstring of numpy.distutils.ccompiler.simple_version_match:24: WARNING: py:obj reference target not found: CCompiler
mambaforge/envs/numpy-dev/lib/python3.9/site-packages/numpy/distutils/ccompiler_opt.py:docstring of numpy.distutils.ccompiler_opt.CCompilerOpt:61:<autosummary>:1: WARNING: py:obj reference target not found: _Config.conf_features


```