### PR TITLE
DOC: TESTS.rst: suggest np.testing assertion function strict=True

### DIFF
--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -126,10 +126,12 @@ assertion fails, the test fails. Common assertion functions include:
 - :func:`numpy.testing.assert_array_less` for testing (strict) elementwise
   ordering between a result array and a reference.
 
-Note that these assertion functions only compare the numerical values of the
-arrays. Consider adding separate ``assert`` statements regarding the array
-dtype and shape (when the reference is a scalar). Note that
-``pytest`` internally rewrites the ``assert`` statement to give informative
+By default, these assertion functions only compare the numerical values in the
+arrays. Consider using the ``strict=True`` option to check the array dtype
+and shape, too.
+
+When you need custom assertions, use the Python ``assert`` statement. Note that
+``pytest`` internally rewrites ``assert`` statements to give informative
 output when it fails, so it should be preferred over the legacy variant
 ``numpy.testing.assert_``. Whereas plain ``assert`` statements are ignored
 when running Python in optimized mode with ``-O``, this is not an issue when


### PR DESCRIPTION
In https://github.com/numpy/numpy/pull/24667#discussion_r1319594662, @seberg commented that `TESTS.RST` could suggest the use of kwarg `strict=True` with `np.testing` assertion functions.

At the time, parameter `strict` was only implemented for `assert_array_equal`, but now it is available for the three assertion functions recommended in `TESTS.RST`.

This PR implements the comment. 


