### PR TITLE
MAINT: Pin PyPy to 3.9.12 on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ stages:
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
           PyPy39-64bit-fast:
-            PYTHON_VERSION: 'pypy3.9'
+            PYTHON_VERSION: 'pypy3.10'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64


### PR DESCRIPTION
There is a failing test when running 3.9.13.

Closes #24862

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
