### PR TITLE
BUG: Fix ma.convolve if propagate_mask=False

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8031,7 +8031,7 @@ def _convolve_or_correlate(f, a, v, mode, propagate_mask):
         data = f(getdata(a), getdata(v), mode=mode)
     else:
         # results which are not contributed to by any pair of valid elements
-        mask = ~f(~getmaskarray(a), ~getmaskarray(v))
+        mask = ~f(~getmaskarray(a), ~getmaskarray(v), mode=mode)
         data = f(filled(a, 0), filled(v, 0), mode=mode)
 
     return masked_array(data, mask=mask)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4921,11 +4921,26 @@ class TestMaskedArrayFunctions:
     def test_convolve(self):
         a = masked_equal(np.arange(5), 2)
         b = np.array([1, 1])
-        test = np.ma.convolve(a, b)
-        assert_equal(test, masked_equal([0, 1, -1, -1, 7, 4], -1))
 
-        test = np.ma.convolve(a, b, propagate_mask=False)
-        assert_equal(test, masked_equal([0, 1, 1, 3, 7, 4], -1))
+        result = masked_equal([0, 1, -1, -1, 7, 4], -1)
+        test = np.ma.convolve(a, b, mode='full')
+        assert_equal(test, result)
+
+        test = np.ma.convolve(a, b, mode='same')
+        assert_equal(test, result[:-1])
+
+        test = np.ma.convolve(a, b, mode='valid')
+        assert_equal(test, result[1:-1])
+
+        result = masked_equal([0, 1, 1, 3, 7, 4], -1)
+        test = np.ma.convolve(a, b, mode='full', propagate_mask=False)
+        assert_equal(test, result)
+
+        test = np.ma.convolve(a, b, mode='same', propagate_mask=False)
+        assert_equal(test, result[:-1])
+
+        test = np.ma.convolve(a, b, mode='valid', propagate_mask=False)
+        assert_equal(test, result[1:-1])
 
         test = np.ma.convolve([1, 1], [1, 1, 1])
         assert_equal(test, masked_equal([1, 2, 2, 1], -1))


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

`np.ma.convolve` currently raises a `MaskError` if `propagate_mask=False` and `mode` is set to `'same'` or `'valid'`:

```python
>>> import numpy as np
>>> a = np.ma.masked_equal(np.arange(5), 2)
>>> b = np.array([1, 1])
>>> np.ma.convolve(a, b, mode='same', propagate_mask=False)
MaskError: Mask and data not compatible: data size is 5, mask size is 6.

>>> np.ma.convolve(a, b, mode='valid', propagate_mask=False)
MaskError: Mask and data not compatible: data size is 4, mask size is 6.
```

This PR fixes the issue by passing the `mode` keyword when creating the output mask.

