### PR TITLE
ENH: isclose/allclose: support array_like `atol`/`rtol`

### DIFF
--- a/doc/release/upcoming_changes/14343.future_change.rst
+++ b/doc/release/upcoming_changes/14343.future_change.rst
@@ -1,0 +1,5 @@
+Support for array ``atol`` and ``rtol`` in ``np.all_isclose`` and ``np.isclose``
+--------------------------------------------------------------------------------
+The keywords ``atol`` and ``rtol`` in ``np.isclose`` and ``np.all_isclose``
+now accepts both scalars and arrays. An array, if given, must broadcast
+to the shapes of x and y.

--- a/doc/release/upcoming_changes/14343.future_change.rst
+++ b/doc/release/upcoming_changes/14343.future_change.rst
@@ -1,5 +1,0 @@
-Support for array ``atol`` and ``rtol`` in ``np.all_isclose`` and ``np.isclose``
---------------------------------------------------------------------------------
-The keywords ``atol`` and ``rtol`` in ``np.isclose`` and ``np.all_isclose``
-now accepts both scalars and arrays. An array, if given, must broadcast
-to the shapes of x and y.

--- a/doc/release/upcoming_changes/24878.improvement.rst
+++ b/doc/release/upcoming_changes/24878.improvement.rst
@@ -1,0 +1,5 @@
+Support for array ``atol`` and ``rtol`` in ``np.isclose`` and ``np.allclose``
+-----------------------------------------------------------------------------
+The keywords ``atol`` and ``rtol`` in ``np.isclose`` and ``np.allclose``
+now accept both scalars and arrays. An array, if given, must broadcast
+to the shapes of the arguments `a` and `b`.

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -51,7 +51,7 @@ __all__ = [
     'fromiter', 'array_equal', 'array_equiv', 'indices', 'fromfunction',
     'isclose', 'isscalar', 'binary_repr', 'base_repr', 'ones',
     'identity', 'allclose', 'putmask',
-    'flatnonzero', 'inf', 'nan', 'False_', 'True_', 'bitwise_not', 
+    'flatnonzero', 'inf', 'nan', 'False_', 'True_', 'bitwise_not',
     'full', 'full_like', 'matmul', 'shares_memory', 'may_share_memory',
     '_get_promotion_state', '_set_promotion_state']
 
@@ -682,22 +682,22 @@ def correlate(a, v, mode='valid'):
     See Also
     --------
     convolve : Discrete, linear convolution of two one-dimensional sequences.
-    scipy.signal.correlate : uses FFT which has superior performance 
+    scipy.signal.correlate : uses FFT which has superior performance
         on large arrays.
 
     Notes
     -----
-    The definition of correlation above is not unique and sometimes 
+    The definition of correlation above is not unique and sometimes
     correlation may be defined differently. Another common definition is [1]_:
 
     .. math:: c'_k = \sum_n a_{n} \cdot \overline{v_{n+k}}
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
 
-    `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5) 
+    `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5)
     because it does not use the FFT to compute the convolution; in that case,
     `scipy.signal.correlate` might be preferable.
-    
+
     References
     ----------
     .. [1] Wikipedia, "Cross-correlation",
@@ -1585,7 +1585,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
     if (a.ndim < 1) or (b.ndim < 1):
         raise ValueError("At least one array has zero dimension")
-    
+
     # Check axisa and axisb are within bounds
     axisa = normalize_axis_index(axisa, a.ndim, msg_prefix='axisa')
     axisb = normalize_axis_index(axisb, b.ndim, msg_prefix='axisb')
@@ -1889,7 +1889,7 @@ def isscalar(element):
 
     In most cases ``np.ndim(x) == 0`` should be used instead of this function,
     as that will also return true for 0d arrays. This is how numpy overloads
-    functions in the style of the ``dx`` arguments to `gradient` and 
+    functions in the style of the ``dx`` arguments to `gradient` and
     the ``bins`` argument to `histogram`. Some key differences:
 
     +------------------------------------+---------------+-------------------+
@@ -1965,12 +1965,12 @@ def binary_repr(num, width=None):
     width : int, optional
         The length of the returned string if `num` is positive, or the length
         of the two's complement if `num` is negative, provided that `width` is
-        at least a sufficient number of bits for `num` to be represented in 
+        at least a sufficient number of bits for `num` to be represented in
         the designated form.
 
         If the `width` value is insufficient, it will be ignored, and `num`
         will be returned in binary (`num` > 0) or two's complement (`num` < 0)
-        form with its width equal to the minimum number of bits needed to 
+        form with its width equal to the minimum number of bits needed to
         represent the number in the designated form. This behavior is
         deprecated and will later raise an error.
 
@@ -2337,11 +2337,10 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     >>> np.isclose([1e-10, 1e-10], [1e-20, 0.999999e-10], atol=0.0)
     array([False,  True])
     """
-    def within_tol(x, y, atol, rtol):
-        with errstate(invalid='ignore'), _no_nep50_warning():
-            return less_equal(abs(x-y), atol + rtol * abs(y))
-
-    x, y, atol, rtol = np.broadcast_arrays(a, b, atol, rtol, subok=True)
+    # Turn all but python scalars into arrays.
+    x, y, atol, rtol = (
+        a if isinstance(a, (int, float, complex)) else asanyarray(a)
+        for a in (a, b, atol, rtol))
 
     # Make sure y is an inexact type to avoid bad behavior on abs(MIN_INT).
     # This will cause casting of x later. Also, make sure to allow subclasses
@@ -2350,30 +2349,20 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     #       possibly be deprecated. See also gh-18286.
     #       timedelta works if `atol` is an integer or also a timedelta.
     #       Although, the default tolerances are unlikely to be useful
-    if y.dtype.kind != "m":
+    if (dtype := getattr(y, "dtype", None)) is not None and dtype.kind != "m":
         dt = multiarray.result_type(y, 1.)
         y = asanyarray(y, dtype=dt)
+    elif isinstance(y, int):
+        y = float(y)
 
-    xfin = isfinite(x)
-    yfin = isfinite(y)
-    if all(xfin) and all(yfin):
-        return within_tol(x, y, atol, rtol)
-    else:
-        finite = xfin & yfin
-        cond = zeros_like(finite, subok=True)
-        # Avoid subtraction with infinite/nan values...
-        cond[finite] = within_tol(x[finite], y[finite],
-                                  atol[finite], rtol[finite])
-        # Check for equality of infinite values...
-        cond[~finite] = (x[~finite] == y[~finite])
+    with errstate(invalid='ignore'), _no_nep50_warning():
+        result = (less_equal(abs(x-y), atol + rtol * abs(y))
+                  & isfinite(y)
+                  | (x == y))
         if equal_nan:
-            # Make NaN == NaN
-            both_nan = isnan(x) & isnan(y)
+            result |= isnan(x) & isnan(y)
 
-            # Needed to treat masked arrays correctly. = True would not work.
-            cond[both_nan] = both_nan[both_nan]
-
-        return cond[()]  # Flatten 0d arrays to scalars
+    return result[()]  # Flatten 0d arrays to scalars
 
 
 def _array_equal_dispatcher(a1, a2, equal_nan=None):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2926,6 +2926,21 @@ class TestIsclose:
         for (x, y), result in zip(tests, results):
             assert_array_equal(np.isclose(x, y), result)
 
+        x = np.array([1, 2, 5, np.nan])
+        y = np.array([1, 2, np.nan, 5])
+        expected = np.array([True, True, False, False])
+        assert_array_equal(np.isclose(x, y), expected)
+
+        atol = np.array([1e-8, 1e-8, 1e-8, 1e-8])
+        rtol = np.array([1e-5, 1e-5, 1e-5, 1e-5])
+        assert_array_equal(np.isclose(x, y, rtol=rtol, atol=atol), expected)
+
+        atol = np.array([1e-8, 1e-8])
+        assert_raises(ValueError, np.isclose, x, y, atol=atol)
+
+        rtol = np.array([1e-5, 1e-5])
+        assert_raises(ValueError, np.isclose, x, y, rtol=rtol)
+
     def tst_all_isclose(self, x, y):
         assert_(np.all(np.isclose(x, y)), "%s and %s not close" % (x, y))
 
@@ -2945,6 +2960,13 @@ class TestIsclose:
         self._setup()
         for (x, y) in self.all_close_tests:
             self.tst_all_isclose(x, y)
+        x = np.array([1, 2, np.nan])
+        y = np.array([1, 2, np.nan])
+        expected_nan_is_equal = True
+        assert_equal(np.allclose(x, y, equal_nan=True), expected_nan_is_equal)
+
+        atol = np.array([1e-8, 1e-8, 1e-8])
+        assert_equal(np.allclose(x, y, atol=atol, equal_nan=True), expected_nan_is_equal)
 
     def test_ip_none_isclose(self):
         self._setup()

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2942,6 +2942,21 @@ class TestIsclose:
         with assert_raises(ValueError, msg=message):
             np.isclose(x, y, rtol=rtol)
 
+    def test_nep50_isclose(self):
+        below_one = float(1.-np.finfo('f8').eps)
+        f32 = np.array(below_one, 'f4')  # This is just 1 at float32 precision
+        assert f32 > np.array(below_one)
+        # NEP 50 broadcasting of python scalars
+        assert f32 == below_one
+        # Test that it works for isclose arguments too (and that those fail if
+        # one uses a numpy float64).
+        assert np.isclose(f32, below_one, atol=0, rtol=0)
+        assert np.isclose(f32, np.float32(0), atol=below_one)
+        assert np.isclose(f32, 2, atol=0, rtol=below_one/2)
+        assert not np.isclose(f32, np.float64(below_one), atol=0, rtol=0)
+        assert not np.isclose(f32, np.float32(0), atol=np.float64(below_one))
+        assert not np.isclose(f32, 2, atol=0, rtol=np.float64(below_one/2))
+
     def tst_all_isclose(self, x, y):
         assert_(np.all(np.isclose(x, y)), "%s and %s not close" % (x, y))
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2926,20 +2926,21 @@ class TestIsclose:
         for (x, y), result in zip(tests, results):
             assert_array_equal(np.isclose(x, y), result)
 
-        x = np.array([1, 2, 5, np.nan])
-        y = np.array([1, 2, np.nan, 5])
-        expected = np.array([True, True, False, False])
-        assert_array_equal(np.isclose(x, y), expected)
-
-        atol = np.array([1e-8, 1e-8, 1e-8, 1e-8])
-        rtol = np.array([1e-5, 1e-5, 1e-5, 1e-5])
+        x = np.array([2.1, 2.1, 2.1, 2.1, 5, np.nan])
+        y = np.array([2, 2, 2, 2, np.nan, 5])
+        atol = [0.11, 0.09, 1e-8, 1e-8, 1, 1]
+        rtol = [1e-8, 1e-8, 0.06, 0.04, 1, 1]
+        expected = np.array([True, False, True, False, False, False])
         assert_array_equal(np.isclose(x, y, rtol=rtol, atol=atol), expected)
 
+        message = "operands could not be broadcast together..."
         atol = np.array([1e-8, 1e-8])
-        assert_raises(ValueError, np.isclose, x, y, atol=atol)
+        with assert_raises(ValueError, msg=message):
+            np.isclose(x, y, atol=atol)
 
         rtol = np.array([1e-5, 1e-5])
-        assert_raises(ValueError, np.isclose, x, y, rtol=rtol)
+        with assert_raises(ValueError, msg=message):
+            np.isclose(x, y, rtol=rtol)
 
     def tst_all_isclose(self, x, y):
         assert_(np.all(np.isclose(x, y)), "%s and %s not close" % (x, y))
@@ -2960,13 +2961,17 @@ class TestIsclose:
         self._setup()
         for (x, y) in self.all_close_tests:
             self.tst_all_isclose(x, y)
-        x = np.array([1, 2, np.nan])
-        y = np.array([1, 2, np.nan])
-        expected_nan_is_equal = True
-        assert_equal(np.allclose(x, y, equal_nan=True), expected_nan_is_equal)
 
-        atol = np.array([1e-8, 1e-8, 1e-8])
-        assert_equal(np.allclose(x, y, atol=atol, equal_nan=True), expected_nan_is_equal)
+        x = np.array([2.3, 3.6, 4.4, np.nan])
+        y = np.array([2, 3, 4, np.nan])
+        atol = [0.31, 0, 0, 1]
+        rtol = [0, 0.21, 0.11, 1]
+        assert np.allclose(x, y, atol=atol, rtol=rtol, equal_nan=True)
+        assert not np.allclose(x, y, atol=0.1, rtol=0.1, equal_nan=True)
+
+        # Show that gh-14330 is resolved
+        assert np.allclose([1, 2, float('nan')], [1, 2, float('nan')],
+                           atol=[1, 1, 1], equal_nan=True)
 
     def test_ip_none_isclose(self):
         self._setup()


### PR DESCRIPTION
Supersedes gh-14343
Closes gh-14320

gh-14320 reported that `np.allclose` accepted vector `atol` but failed when a NaN was present.
gh-14343 began to add full support for array `atol`/`rtol` in `allclose`/`isclose`, but became inactive.
@seberg [asked](https://github.com/numpy/numpy/pull/14343#issuecomment-1551072477) if anyone would like to finish it, hence this PR. 

I preserved the original commits and made the requested changes. I also fixed the case of non-array array_like `rtol`/`atol` and strengthened the tests.