### PR TITLE
BUG: Fix memory leak in timsort's buffer resizing

### DIFF
--- a/numpy/core/src/npysort/timsort.cpp
+++ b/numpy/core/src/npysort/timsort.cpp
@@ -74,20 +74,15 @@ resize_buffer_intp(buffer_intp *buffer, npy_intp new_size)
         return 0;
     }
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
-        buffer->pw = (npy_intp *)malloc(new_size * sizeof(npy_intp));
-    }
-    else {
-        buffer->pw =
-                (npy_intp *)realloc(buffer->pw, new_size * sizeof(npy_intp));
-    }
+    npy_intp *new_pw = (npy_intp *)realloc(buffer->pw, new_size * sizeof(npy_intp));
 
     buffer->size = new_size;
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
+    if (NPY_UNLIKELY(new_pw == NULL)) {
         return -NPY_ENOMEM;
     }
     else {
+        buffer->pw = new_pw;
         return 0;
     }
 }
@@ -113,19 +108,14 @@ resize_buffer_(buffer_<Tag> *buffer, npy_intp new_size)
         return 0;
     }
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
-        buffer->pw = (type *)malloc(new_size * sizeof(type));
-    }
-    else {
-        buffer->pw = (type *)realloc(buffer->pw, new_size * sizeof(type));
-    }
-
+    type *new_pw = (type *)realloc(buffer->pw, new_size * sizeof(type));
     buffer->size = new_size;
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
+    if (NPY_UNLIKELY(new_pw == NULL)) {
         return -NPY_ENOMEM;
     }
     else {
+        buffer->pw = new_pw;
         return 0;
     }
 }
@@ -986,20 +976,14 @@ resize_buffer_(string_buffer_<Tag> *buffer, npy_intp new_size)
         return 0;
     }
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
-        buffer->pw = (type *)malloc(sizeof(type) * new_size * buffer->len);
-    }
-    else {
-        buffer->pw = (type *)realloc(buffer->pw,
-                                     sizeof(type) * new_size * buffer->len);
-    }
-
+    type *new_pw = (type *)realloc(buffer->pw, sizeof(type) * new_size * buffer->len);
     buffer->size = new_size;
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
+    if (NPY_UNLIKELY(new_pw == NULL)) {
         return -NPY_ENOMEM;
     }
     else {
+        buffer->pw = new_pw;
         return 0;
     }
 }
@@ -1880,20 +1864,14 @@ resize_buffer_char(buffer_char *buffer, npy_intp new_size)
         return 0;
     }
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
-        buffer->pw = (char *)malloc(sizeof(char) * new_size * buffer->len);
-    }
-    else {
-        buffer->pw = (char *)realloc(buffer->pw,
-                                     sizeof(char) * new_size * buffer->len);
-    }
-
+    char *new_pw = (char *)realloc(buffer->pw, sizeof(char) * new_size * buffer->len);
     buffer->size = new_size;
 
-    if (NPY_UNLIKELY(buffer->pw == NULL)) {
+    if (NPY_UNLIKELY(new_pw == NULL)) {
         return -NPY_ENOMEM;
     }
     else {
+        buffer->pw = new_pw;
         return 0;
     }
 }


### PR DESCRIPTION
Fixed a potential memory leak in buffer resizing when realloc fails. This commit addresses the issue by handling realloc results correctly and simplifies the code by eliminating the unnecessary special case for allocating memory for a NULL buffer.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
