### PR TITLE
BLD: fix "Failed to guess install tag" in meson-log.txt, add explicit tags

### DIFF
--- a/numpy/core/meson.build
+++ b/numpy/core/meson.build
@@ -512,7 +512,8 @@ _numpyconfig_h = configure_file(
   output: '_numpyconfig.h',
   configuration: cdata,
   install: true,
-  install_dir: np_dir / 'core/include/numpy'
+  install_dir: np_dir / 'core/include/numpy',
+  install_tag: 'devel'
 )
 
 # Build npymath static library
@@ -567,7 +568,8 @@ configure_file(
     'sep' : dir_separator,
   }),
   install: true,
-  install_dir: np_dir / 'core/lib/npy-pkg-config'
+  install_dir: np_dir / 'core/lib/npy-pkg-config',
+  install_tag: 'devel'
 )
 configure_file(
   input: 'mlib.ini.in',
@@ -577,7 +579,8 @@ configure_file(
     'msvc_mathlib' : 'm.lib',
   }),
   install: true,
-  install_dir: np_dir / 'core/lib/npy-pkg-config'
+  install_dir: np_dir / 'core/lib/npy-pkg-config',
+  install_tag: 'devel'
 )
 
 if false
@@ -622,7 +625,8 @@ src_numpy_api = custom_target('__multiarray_api',
   input : 'code_generators/generate_numpy_api.py',
   command: [py, '@INPUT@', '-o', '@OUTDIR@', '--ignore', src_umath_api_c],
   install: true,  # NOTE: setup.py build installs all, but just need .h?
-  install_dir: np_dir / 'core/include/numpy'
+  install_dir: np_dir / 'core/include/numpy',
+  install_tag: 'devel'
 )
 
 src_ufunc_api = custom_target('__ufunc_api',
@@ -630,7 +634,8 @@ src_ufunc_api = custom_target('__ufunc_api',
   input : 'code_generators/generate_ufunc_api.py',
   command: [py, '@INPUT@', '-o', '@OUTDIR@'],
   install: true,  # NOTE: setup.py build installs all, but just need .h?
-  install_dir: np_dir / 'core/include/numpy'
+  install_dir: np_dir / 'core/include/numpy',
+  install_tag: 'devel'
 )
 
 
@@ -1260,4 +1265,4 @@ py.install_sources(
 )
 
 subdir('include')
-install_subdir('tests', install_dir: np_dir / 'core')
+install_subdir('tests', install_dir: np_dir / 'core', install_tag: 'python-runtime')

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -331,7 +331,8 @@ if not fs.exists('version.py')
     output: 'version.py',
     input: '_build_utils/gitversion.py',
     command: [py, '@INPUT@', '--write', '@OUTPUT@'],
-    install_dir: np_dir
+    install_dir: np_dir,
+    install_tag: 'python-runtime'
   )
 else
   # When building from sdist, version.py exists and should be included
@@ -342,7 +343,7 @@ else
 endif
 
 foreach subdir: pure_subdirs
-  install_subdir(subdir, install_dir: np_dir)
+  install_subdir(subdir, install_dir: np_dir, install_tag: 'python-runtime')
 endforeach
 
 compilers = {
@@ -423,6 +424,7 @@ configure_file(
   output: '__config__.py',
   configuration : conf_data,
   install_dir: np_dir,
+  install_tag: 'python-runtime'
 )
 
 subdir('core')

--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -34,7 +34,8 @@ _cython_tree_random += custom_target('_bounded_integer_pxd',
   input: '_bounded_integers.pxd.in',
   command: [tempita_cli, '@INPUT@', '-o', '@OUTPUT@'],
   install: true,
-  install_dir: np_dir / 'random'
+  install_dir: np_dir / 'random',
+  install_tag: 'devel'
 )
 
 _bounded_integers_pyx = custom_target('_bounded_integer_pyx',


### PR DESCRIPTION
Removed about ~100 lines from `meson-log.txt`. For `custom_target`, `configure_file` and other such generic calls, Meson can't know what install tags to add automatically, hence it adds a warning to the build log and adds a "dummy" tag. These aren't really needed for Python packaging, but it's possible that Linux distros could want to use tags. Either way, best to get it right.