### PR TITLE
API: Add `diagonal` and `trace` to `numpy.linalg` [Array API]

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -95,6 +95,7 @@ Norms and other numbers
    linalg.matrix_rank
    linalg.slogdet
    trace
+   linalg.trace (Array API compatible)
 
 Solving equations and inverting matrices
 ----------------------------------------
@@ -107,6 +108,12 @@ Solving equations and inverting matrices
    linalg.inv
    linalg.pinv
    linalg.tensorinv
+
+Other matrix operations
+-----------------------
+
+   diagonal
+   linalg.diagonal (Array API compatible)
 
 Exceptions
 ----------

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -52,6 +52,7 @@ Norms and other numbers
    det
    matrix_rank
    slogdet
+   trace (Array API compatible)
 
 Solving equations and inverting matrices
 ----------------------------------------
@@ -62,6 +63,11 @@ Solving equations and inverting matrices
    inv
    pinv
    tensorinv
+
+Other matrix operations
+-----------------------
+
+   diagonal (Array API compatible)
 
 Exceptions
 ----------

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -19,6 +19,8 @@ from numpy.linalg.linalg import (
     cond as cond,
     matrix_rank as matrix_rank,
     multi_dot as multi_dot,
+    trace as trace,
+    diagonal as diagonal,
 )
 
 from numpy._pytesttester import PytestTester

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -12,26 +12,24 @@ zgetrf, dpotrf, zpotrf, dgeqrf, zgeqrf, zungqr, dorgqr.
 __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
            'cholesky', 'eigvals', 'eigvalsh', 'pinv', 'slogdet', 'det',
            'svd', 'eig', 'eigh', 'lstsq', 'norm', 'qr', 'cond', 'matrix_rank',
-           'LinAlgError', 'multi_dot']
+           'LinAlgError', 'multi_dot', 'trace', 'diagonal']
 
 import functools
 import operator
 import warnings
 from typing import NamedTuple, Any
 
-from .._utils import set_module
+from numpy._utils import set_module
 from numpy.core import (
     array, asarray, zeros, empty, empty_like, intc, single, double,
     csingle, cdouble, inexact, complexfloating, newaxis, all, inf, dot,
-    add, multiply, sqrt, sum, isfinite,
-    finfo, errstate, moveaxis, amin, amax, prod, abs,
-    atleast_2d, intp, asanyarray, object_, matmul,
+    add, multiply, sqrt, sum, isfinite, finfo, errstate, moveaxis, amin,
+    amax, prod, abs, atleast_2d, intp, asanyarray, object_, matmul,
     swapaxes, divide, count_nonzero, isnan, sign, argsort, sort,
-    reciprocal
+    reciprocal, overrides, diagonal as _core_diagonal, trace as _core_trace
 )
-from numpy.core.multiarray import normalize_axis_index
-from numpy.core import overrides
 from numpy.lib._twodim_base_impl import triu, eye
+from numpy.lib.array_utils import normalize_axis_index
 from numpy.linalg import _umath_linalg
 
 from numpy._typing import NDArray
@@ -2832,3 +2830,98 @@ def _multi_dot(arrays, order, i, j, out=None):
         return dot(_multi_dot(arrays, order, i, order[i, j]),
                    _multi_dot(arrays, order, order[i, j] + 1, j),
                    out=out)
+
+
+# diagonal
+
+def _diagonal_dispatcher(x, /, *, offset=None):
+    return (x,)
+
+
+@array_function_dispatch(_diagonal_dispatcher)
+def diagonal(x, /, *, offset=0):
+    """
+    Returns specified diagonals of a matrix (or a stack of matrices) ``x``.
+
+    This function is Array API compatible, contrary to
+    :py:func:`numpy.diagonal`.
+
+    Parameters
+    ----------
+    x : (...,M,N) array_like
+        Input array having shape (..., M, N) and whose innermost two
+        dimensions form MxN matrices.
+    offset : int, optional
+        Offset specifying the off-diagonal relative to the main diagonal,
+        where::
+
+            * offset = 0: the main diagonal.
+            * offset > 0: off-diagonal above the main diagonal.
+            * offset < 0: off-diagonal below the main diagonal.
+
+    Returns
+    -------
+    out : (...,min(N,M)) ndarray
+        An array containing the diagonals and whose shape is determined by
+        removing the last two dimensions and appending a dimension equal to
+        the size of the resulting diagonals. The returned array must have
+        the same data type as ``x``.
+
+    See Also
+    --------
+    numpy.diagonal
+    """
+    return _core_diagonal(x, offset, axis1=-2, axis2=-1)
+
+
+# trace
+
+def _trace_dispatcher(
+        x, /, *, offset=None, dtype=None):
+    return (x,)
+
+
+@array_function_dispatch(_trace_dispatcher)
+def trace(x, /, *, offset=0, dtype=None):
+    """
+    Returns the sum along the specified diagonals of a matrix
+    (or a stack of matrices) ``x``.
+
+    This function is Array API compatible, contrary to
+    :py:func:`numpy.trace`.
+
+    Parameters
+    ----------
+    x : (...,M,N) array_like
+        Input array having shape (..., M, N) and whose innermost two
+        dimensions form MxN matrices.
+    offset : int, optional
+        Offset specifying the off-diagonal relative to the main diagonal,
+        where::
+
+            * offset = 0: the main diagonal.
+            * offset > 0: off-diagonal above the main diagonal.
+            * offset < 0: off-diagonal below the main diagonal.
+
+    dtype : dtype, optional
+        Data type of the returned array.
+
+    Returns
+    -------
+    out : ndarray
+        An array containing the traces and whose shape is determined by
+        removing the last two dimensions and storing the traces in the last
+        array dimension. For example, if x has rank k and shape:
+        (I, J, K, ..., L, M, N), then an output array has rank k-2 and shape:
+        (I, J, K, ..., L) where::
+
+            out[i, j, k, ..., l] = trace(a[i, j, k, ..., l, :, :])
+
+        The returned array must have a data type as described by the dtype
+        parameter above.
+
+    See Also
+    --------
+    numpy.trace
+    """
+    return _core_trace(x, offset, axis1=-2, axis2=-1, dtype=dtype)

--- a/numpy/linalg/linalg.pyi
+++ b/numpy/linalg/linalg.pyi
@@ -29,6 +29,7 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
     _ArrayLikeObject_co,
+    DTypeLike,
 )
 
 _T = TypeVar("_T")
@@ -294,4 +295,15 @@ def multi_dot(
     arrays: Iterable[_ArrayLikeComplex_co | _ArrayLikeObject_co | _ArrayLikeTD64_co],
     *,
     out: None | NDArray[Any] = ...,
+) -> Any: ...
+
+def diagonal(
+    x: ArrayLike,  # >= 2D array
+    offset: SupportsIndex = ...,
+) -> NDArray[Any]: ...
+
+def trace(
+    x: ArrayLike,  # >= 2D array
+    offset: SupportsIndex = ...,
+    dtype: DTypeLike = ...,
 ) -> Any: ...

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2201,3 +2201,30 @@ def test_blas64_geqrf_lwork_smoketest():
     # Should result to an integer of a reasonable size
     lwork = int(work.item())
     assert_(2**32 < lwork < 2**42)
+
+
+def test_diagonal():
+    # Here we only test if selected axes are compatible
+    # with Array API (last two). Core implementation
+    # of `diagonal` is tested in `test_multiarray.py`.
+    x = np.arange(60).reshape((3, 4, 5))
+    actual = np.linalg.diagonal(x)
+    expected = np.array(
+        [
+            [0,  6, 12, 18],
+            [20, 26, 32, 38],
+            [40, 46, 52, 58],
+        ]
+    )
+    assert_equal(actual, expected)
+
+
+def test_trace():
+    # Here we only test if selected axes are compatible
+    # with Array API (last two). Core implementation
+    # of `trace` is tested in `test_multiarray.py`.
+    x = np.arange(60).reshape((3, 4, 5))
+    actual = np.linalg.trace(x)
+    expected = np.array([36, 116, 196])
+
+    assert_equal(actual, expected)


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

This PR contains another set of small Array API compatibility changes. It adds `numpy.linalg.diagonal` and `numpy.linalg.trace` with docs taken from Array API specification. 
