### PR TITLE
API: Add missing deprecation and release note files

### DIFF
--- a/doc/release/upcoming_changes/24376.python_removal.rst
+++ b/doc/release/upcoming_changes/24376.python_removal.rst
@@ -38,7 +38,7 @@
 * ``np.recfromcsv`` and ``recfromtxt`` are now only available from ``np.lib.npyio``.
 
 * ``np.issctype``, ``np.maximum_sctype``, ``np.obj2sctype``, ``np.sctype2char``,
-  ``np.sctypeDict``, ``np.sctypes``, ``np.issubsctype`` were all removed from the
+  ``np.sctypes``, ``np.issubsctype`` were all removed from the
   main namespace without replacement, as they where niche members.
 
 * Deprecated ``np.deprecate`` and ``np.deprecate_with_doc`` has been removed 

--- a/doc/release/upcoming_changes/24807.python_removal.rst
+++ b/doc/release/upcoming_changes/24807.python_removal.rst
@@ -1,0 +1,2 @@
+Seven data type aliases have been removed from ``np.dtype(alias)`` search:
+``int0``, ``uint0``, ``void0``, ``object0``, ``str0``, ``bytes0`` and ``bool8``.

--- a/doc/release/upcoming_changes/24854.deprecation.rst
+++ b/doc/release/upcoming_changes/24854.deprecation.rst
@@ -1,0 +1,2 @@
+``np.dtype("a")`` alias for ``np.dtype(np.bytes_)`` was deprecated.
+Use ``np.dtype("S")`` alias instead.

--- a/doc/release/upcoming_changes/24854.python_removal.rst
+++ b/doc/release/upcoming_changes/24854.python_removal.rst
@@ -1,2 +1,0 @@
-``np.dtype("a")`` alias for ``np.dtype(np.bytes_)`` was removed.
-Use ``np.dtype("S")`` alias instead.

--- a/doc/release/upcoming_changes/24887.new_feature.rst
+++ b/doc/release/upcoming_changes/24887.new_feature.rst
@@ -1,0 +1,7 @@
+``diagonal`` and ``trace`` for `numpy.linalg`
+---------------------------------------------
+
+`numpy.linalg.diagonal` and `numpy.linalg.trace` have been
+added, which are Array API compatible variants of `numpy.diagonal`
+and `numpy.trace`. They differ in the default axis selection
+which define 2-D sub-arrays.

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -69,6 +69,7 @@ _extra_aliases = {
     "long": "int_",
     "ulong": "uint",
     "str": "str_",
+    "unicode": "str_",
 }
 
 for k, v in _extra_aliases.items():

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -65,6 +65,7 @@ _extra_aliases = {
     "complex": "complex128",
     "object": "object_",
     "bytes": "bytes_",
+    "a": "bytes_",
     "int": "int_",
     "long": "int_",
     "ulong": "uint",

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -112,6 +112,7 @@ enum NPY_TYPECHAR {
         NPY_CLONGDOUBLELTR = 'G',
         NPY_OBJECTLTR = 'O',
         NPY_STRINGLTR = 'S',
+        NPY_DEPRECATED_STRINGLTR2 = 'a',
         NPY_UNICODELTR = 'U',
         NPY_VOIDLTR = 'V',
         NPY_DATETIMELTR = 'M',

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1301,12 +1301,11 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             break;
 
         case NPY_DEPRECATED_STRINGLTR2:
-            {
-                DEPRECATE(
-                    "Data type alias `a` was removed in NumPy 2.0. "
-                    "Use `S` alias instead."
-                );
-            }
+            DEPRECATE(
+                "Data type alias `a` was removed in NumPy 2.0. "
+                "Use `S` alias instead."
+            );
+            newtype = NPY_STRING;
             break;
 
         case NPY_UNICODELTR:

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1300,6 +1300,15 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             newtype = NPY_STRING;
             break;
 
+        case NPY_DEPRECATED_STRINGLTR2:
+            {
+                DEPRECATE(
+                    "Data type alias `a` was removed in NumPy 2.0. "
+                    "Use `S` alias instead."
+                );
+            }
+            break;
+
         case NPY_UNICODELTR:
             newtype = NPY_UNICODE;
             break;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1795,6 +1795,14 @@ _convert_from_str(PyObject *obj, int align)
                     check_num = NPY_STRING;
                     break;
 
+                case NPY_DEPRECATED_STRINGLTR2:
+                    DEPRECATE(
+                        "Data type alias `a` was removed in NumPy 2.0. "
+                        "Use `S` alias instead."
+                    );
+                    check_num = NPY_STRING;
+                    break;
+
                 /*
                  * When specifying length of UNICODE
                  * the number of characters is given to match
@@ -1855,14 +1863,15 @@ _convert_from_str(PyObject *obj, int align)
                         "without a digit at the end.", obj);
                 return NULL;
             }
-            if (strcmp(type, "a") == 0) {
-                PyErr_Format(PyExc_TypeError,
-                        "Data type alias `a` was removed in NumPy 2.0. "
-                        "Use `S` alias instead.", obj);
-                return NULL;
-            }
 
             goto fail;
+        }
+
+        if (strcmp(type, "a") == 0) {
+            DEPRECATE(
+                "Data type alias `a` was removed in NumPy 2.0. "
+                "Use `S` alias instead."
+            );
         }
 
         /*

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1855,6 +1855,13 @@ _convert_from_str(PyObject *obj, int align)
                         "without a digit at the end.", obj);
                 return NULL;
             }
+            if (strcmp(type, "a") == 0) {
+                PyErr_Format(PyExc_TypeError,
+                        "Data type alias `a` was removed in NumPy 2.0. "
+                        "Use `S` alias instead.", obj);
+                return NULL;
+            }
+
             goto fail;
         }
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -772,3 +772,19 @@ class TestLibImports(_DeprecationTestCase):
         self.assert_deprecated(lambda: row_stack([[]]))
         self.assert_deprecated(lambda: trapz([1], [1]))
         self.assert_deprecated(lambda: np.chararray)
+
+
+class TestDeprecatedDTypeAliases(_DeprecationTestCase):
+
+    @staticmethod
+    def _check_for_warning(func):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            func()
+        assert len(caught_warnings) == 1
+        w = caught_warnings[0]
+        assert w.category is DeprecationWarning
+        assert "alias `a` was removed in NumPy 2.0" in str(w.message)
+
+    def test_a_dtype_alias(self):
+        self._check_for_warning(lambda: np.dtype("a"))
+        self._check_for_warning(lambda: np.dtype("a10"))

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -142,6 +142,12 @@ class TestBuiltin:
             np.dtype("object0")
         with pytest.raises(TypeError, match=match):
             np.dtype("void0")
+        # `a` alias was also removed (both with and without bytesize)
+        with pytest.raises(TypeError, match=match):
+            np.dtype("a")
+        # warning is still issued from the C layer for bytsized variant
+        with pytest.raises(TypeError):
+            np.dtype("a8")
 
     @pytest.mark.parametrize(
         'value',

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -142,12 +142,6 @@ class TestBuiltin:
             np.dtype("object0")
         with pytest.raises(TypeError, match=match):
             np.dtype("void0")
-        # `a` alias was also removed (both with and without bytesize)
-        with pytest.raises(TypeError, match=match):
-            np.dtype("a")
-        # warning is still issued from the C layer for bytsized variant
-        with pytest.raises(TypeError):
-            np.dtype("a8")
 
     @pytest.mark.parametrize(
         'value',


### PR DESCRIPTION
Hi @ngoldbaum @charris,

Here's a PR with a small batch of changes:
- Proper error message for `np.dtype("a")` (for bytesized alias a warning is raised additionally)
- Restoring of `np.dtype(unicode)`
- Missing release note files from previous PRs
- Delete `np.sctypeDict` removal from the changelog

