### PR TITLE
BUG: loongarch doesn't use REAL(10)

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2452,7 +2452,7 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'arm64', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
+    if machine.startswith(('aarch64', 'arm64', 'loongarch', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
         if p <= 33:
             return 16
     else:


### PR DESCRIPTION
This fixes numpy.f2py.tests.test_kind.TestKind.

Here is an example of the test failure from my loongarch64 box building numpy 1.25.2:

```
______________________________ TestKind.test_real ______________________________

self = <numpy.f2py.tests.test_kind.TestKind object at 0x7fffc51cc350>

    def test_real(self):
        """
        Test (processor-dependent) `real` kind_func for real numbers
        of up to 31 digits precision (extended/quadruple).
        """
        selectedrealkind = self.module.selectedrealkind

        for i in range(32):
>           assert selectedrealkind(i) == selected_real_kind(
                i
            ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
E           AssertionError: selectedrealkind(16): expected 10 but got 16
E           assert 16 == 10
E            +  where 16 = <fortran function selectedrealkind>(16)
E            +  and   10 = selected_real_kind(16)

i          = 16
selectedrealkind = <fortran function selectedrealkind>
self       = <numpy.f2py.tests.test_kind.TestKind object at 0x7fffc51cc350>

../../.run_venv/lib64/python3/site-packages/numpy/f2py/tests/test_kind.py:32: AssertionError
```

This commit fixes that.