### PR TITLE
ENH: Add a dtype slot for array initialization

### DIFF
--- a/numpy/core/include/numpy/_dtype_api.h
+++ b/numpy/core/include/numpy/_dtype_api.h
@@ -5,7 +5,7 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 #define NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 
-#define __EXPERIMENTAL_DTYPE_API_VERSION 13
+#define __EXPERIMENTAL_DTYPE_API_VERSION 14
 
 struct PyArrayMethodObject_tag;
 
@@ -257,7 +257,8 @@ typedef int translate_loop_descrs_func(int nin, int nout,
  * element of a single array.
  *
  * Currently this is used for array clearing, via the NPY_DT_get_clear_loop
- * API hook, and zero-filling, via the NPY_DT_get_fill_zero_loop API hook.
+ * API hook, and zero-filling, via the NPY_DT_get_fill_zero_loop API hook, or
+ * array initialization, via the NPY_DT_get_initialization_loop API hook.
  * These are most useful for handling arrays storing embedded references to
  * python objects or heap-allocated data.
  *
@@ -319,6 +320,7 @@ typedef int (get_traverse_loop_function)(
 #define NPY_DT_getitem 8
 #define NPY_DT_get_clear_loop 9
 #define NPY_DT_get_fill_zero_loop 10
+#define NPY_DT_get_initialization_loop 11
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -878,6 +878,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr,
     dt_slots->common_instance = NULL;
     dt_slots->ensure_canonical = ensure_native_byteorder;
     dt_slots->get_fill_zero_loop = NULL;
+    dt_slots->get_initialization_loop = NULL;
 
     if (PyTypeNum_ISSIGNED(dtype_class->type_num)) {
         /* Convert our scalars (raise on too large unsigned and NaN, etc.) */

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -58,6 +58,7 @@ typedef struct {
        that, clear the array first.
     */
     get_traverse_loop_function *get_fill_zero_loop;
+    get_traverse_loop_function *get_initialization_loop;
     /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
@@ -80,7 +81,7 @@ typedef struct {
 
 // This must be updated if new slots before within_dtype_castingimpl
 // are added
-#define NPY_NUM_DTYPE_SLOTS 10
+#define NPY_NUM_DTYPE_SLOTS 11
 #define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
 #define NPY_DT_MAX_ARRFUNCS_SLOT \
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -164,6 +164,8 @@ PyArrayInitDTypeMeta_FromSpec(
     NPY_DT_SLOTS(DType)->setitem = NULL;
     NPY_DT_SLOTS(DType)->getitem = NULL;
     NPY_DT_SLOTS(DType)->get_clear_loop = NULL;
+    NPY_DT_SLOTS(DType)->get_fill_zero_loop = NULL;
+    NPY_DT_SLOTS(DType)->get_initialization_loop = NULL;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
     PyType_Slot *spec_slot = spec->slots;
@@ -280,6 +282,13 @@ PyArrayInitDTypeMeta_FromSpec(
         PyErr_SetString(PyExc_RuntimeError,
                         "A DType must provide an ensure_canonical implementation.");
         return -1;
+    }
+
+    if ((NPY_DT_SLOTS(DType)->get_fill_zero_loop != NULL) &&
+        (NPY_DT_SLOTS(DType)->get_initialization_loop != NULL)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "A DType cannot simultaneously define a zero-filling "
+                        "loop and an initialization loop");
     }
 
     /*

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -295,6 +295,12 @@ class TestSFloat:
         np.testing.assert_array_equal(
             arr.view(np.float64), arr2.view(np.float64))
 
+    def test_initialization_loop(self):
+        dt = SF(3.0)
+        assert dt.initialized == 0
+        arr = np.array([1.0, 2.0, 3.0], dtype=dt)
+        assert dt.initialized == 1
+
 def test_type_pickle():
     # can't actually unpickle, but we can pickle (if in namespace)
     import pickle


### PR DESCRIPTION
This adds a slot to the dtype API that allows defining dtype-specific initialization logic for every newly created array. I need this for stringdtype to initialize per-array storage. It needs to be a traversal loop like this because I need to be able to see the array data and the number of array entries. I think allowing dtypes to generically override array initialization like this, and not just zero-filling, will be useful for other dtypes, particularly ones that hold references like stringdtype.


EDIT: (seberg) converted to draft, since it isn't quite settled that this is the direction we wish to push.
