### PR TITLE
REL: Prepare for the NumPy 1.26.1 release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,7 +118,8 @@ jobs:
           python-version: "3.x"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # v2.16.2
+        uses: pypa/cibuildwheel@a873dd9cbf9e3c4c73a1fd11ac31cf835f6eb502 # v2.16.0
+        #uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # v2.16.2
         env:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}

--- a/.mailmap
+++ b/.mailmap
@@ -42,7 +42,8 @@
 @yan-wyb <yan-wyb@foxmail.com>
 @yetanothercheer <yetanothercheer@protonmail.com>
 Aaron Baecker <abaecker@localhost>
-arunkumarkota <arunkumarkota@gmail.com>
+Arun Kota <arunkumarkota@gmail.com>
+Arun Kota <arunkumarkota@gmail.com> Arun Kota <arunkota@Aruns-iMac.local>
 Aarthi Agurusa <agurusa@gmail.com>
 Adarsh Singh <adarshsng090@gmail.com> ADARSH SINGH <adarshsng090@gmail.com>
 Andrei Batomunkuev <abatomunkuev@myseneca.ca>
@@ -104,6 +105,7 @@ Anne Archibald <peridot.faceted@gmail.com> <archibald@astron.nl>
 Anne Bonner <bonn0062@yahoo.com> <35413198+bonn0062@users.noreply.github.com>
 Anthony Vo <anthonyhvo12@gmail.com> <43098273+anthonyhvo12@users.noreply.github.com>
 Antoine Pitrou <antoine@python.org> <pitrou@free.fr>
+Anton Prosekin <jncots@users.noreply.github.com>
 Anže Starič <anze.staric@gmail.com>
 Arfy Slowy <slowy.arfy@gmail.com>
 Aron Ahmadia <aron@ahmadia.net>
@@ -428,6 +430,7 @@ Mitchell Faas <Faas.Mitchell@gmail.com> <35742861+Mitchell-Faas@users.noreply.gi
 Muhammad Kasim <firman.kasim@gmail.com>
 Mukulika Pahari <mukulikapahari@gmail.com>
 Mukulika Pahari <mukulikapahari@gmail.com> <60316606+Mukulikaa@users.noreply.github.com>
+Munira Alduraibi <alduraibimunirah@gmail.com>
 Namami Shanker <namami2011@gmail.com>
 Namami Shanker <namami2011@gmail.com> NamamiShanker <NamamiShanker@users.noreply.github.com>
 Nathaniel J. Smith <njs@pobox.com>

--- a/doc/changelog/1.26.1-changelog.rst
+++ b/doc/changelog/1.26.1-changelog.rst
@@ -1,0 +1,46 @@
+
+Contributors
+============
+
+A total of 13 people contributed to this release.  People with a "+" by their
+names contributed a patch for the first time.
+
+* Andrew Nelson
+* Anton Prosekin +
+* Charles Harris
+* Chongyun Lee +
+* Ivan A. Melnikov +
+* Jake Lishman +
+* Mahder Gebremedhin +
+* Mateusz Sokół
+* Matti Picus
+* Munira Alduraibi +
+* Ralf Gommers
+* Rohit Goswami
+* Sayed Adel
+
+Pull requests merged
+====================
+
+A total of 20 pull requests were merged for this release.
+
+* `#24742 <https://github.com/numpy/numpy/pull/24742>`__: MAINT: Update cibuildwheel version
+* `#24748 <https://github.com/numpy/numpy/pull/24748>`__: MAINT: fix version string in wheels built with setup.py
+* `#24771 <https://github.com/numpy/numpy/pull/24771>`__: BLD, BUG: Fix build failure for host flags e.g. ``-march=native``...
+* `#24773 <https://github.com/numpy/numpy/pull/24773>`__: DOC: Updated the f2py docs to remove a note on -fimplicit-none
+* `#24776 <https://github.com/numpy/numpy/pull/24776>`__: BUG: Fix SIMD f32 trunc test on s390x when baseline is none
+* `#24785 <https://github.com/numpy/numpy/pull/24785>`__: BLD: add libquadmath to licences and other tweaks (#24753)
+* `#24786 <https://github.com/numpy/numpy/pull/24786>`__: MAINT: Activate ``use-compute-credits`` for Cirrus.
+* `#24803 <https://github.com/numpy/numpy/pull/24803>`__: BLD: updated vendored-meson/meson for mips64 fix
+* `#24804 <https://github.com/numpy/numpy/pull/24804>`__: MAINT: fix licence path win
+* `#24813 <https://github.com/numpy/numpy/pull/24813>`__: BUG: Fix order of Windows OS detection macros.
+* `#24831 <https://github.com/numpy/numpy/pull/24831>`__: BUG, SIMD: use scalar cmul on bad Apple clang x86_64 (#24828)
+* `#24840 <https://github.com/numpy/numpy/pull/24840>`__: BUG: Fix DATA statements for f2py
+* `#24870 <https://github.com/numpy/numpy/pull/24870>`__: API: Add ``NumpyUnpickler`` for backporting
+* `#24872 <https://github.com/numpy/numpy/pull/24872>`__: MAINT: Xfail test failing on PyPy.
+* `#24879 <https://github.com/numpy/numpy/pull/24879>`__: BLD: fix math func feature checks, fix FreeBSD build, add CI...
+* `#24899 <https://github.com/numpy/numpy/pull/24899>`__: ENH: meson: implement BLAS/LAPACK auto-detection and many CI...
+* `#24902 <https://github.com/numpy/numpy/pull/24902>`__: DOC: add a 1.26.1 release notes section for BLAS/LAPACK build...
+* `#24906 <https://github.com/numpy/numpy/pull/24906>`__: MAINT: Backport ``numpy._core`` stubs. Remove ``NumpyUnpickler``
+* `#24911 <https://github.com/numpy/numpy/pull/24911>`__: MAINT: Bump pypa/cibuildwheel from 2.16.1 to 2.16.2
+* `#24912 <https://github.com/numpy/numpy/pull/24912>`__: BUG: loongarch doesn't use REAL(10)

--- a/doc/release/upcoming_changes/24906.new_feature.rst
+++ b/doc/release/upcoming_changes/24906.new_feature.rst
@@ -1,6 +1,0 @@
-`numpy._core` submodules' stubs
--------------------------------
-
-`numpy._core` submodules' stubs were added
-to provide a stable way for loading pickled arrays,
-created with NumPy 2.0, with Numpy 1.26.

--- a/doc/source/release/1.26.1-notes.rst
+++ b/doc/source/release/1.26.1-notes.rst
@@ -6,9 +6,13 @@ NumPy 1.26.1 Release Notes
 
 NumPy 1.26.1 is a maintenance release that fixes bugs and regressions
 discovered after the 1.26.0 release. In addition, it adds new functionality for
-detecting BLAS and LAPACK when building from source. The 1.26.release series is
-the last planned minor release series before NumPy 2.0. The Python versions
-supported by this release are 3.9-3.12.
+detecting BLAS and LAPACK when building from source. Highlights are:
+
+- Improved detection of BLAS and LAPACK libraries for meson builds
+- Pickle compatibility with the upcoming NumPy 2.0.
+
+The 1.26.release series is the last planned minor release series before NumPy
+2.0. The Python versions supported by this release are 3.9-3.12.
 
 
 Build system changes
@@ -46,9 +50,9 @@ to control BLAS/LAPACK selection and behavior:
   releases.
 - ``-Dallow-noblas``: if set to ``true``, allow NumPy to build with its
   internal (very slow) fallback routines instead of linking against an external
-  BLAS/LAPACK library. *The default for this flag may be changed to ``false``
+  BLAS/LAPACK library. *The default for this flag may be changed to ``true``
   in a future 1.26.x release, however for 1.26.1 we'd prefer to keep it as
-  ``true`` because if failures to detect an installed library are happening,
+  ``false`` because if failures to detect an installed library are happening,
   we'd like a bug report for that, so we can quickly assess whether the new
   auto-detection machinery needs further improvements.*
 - ``-Dmkl-threading``: to select the threading layer for MKL. There are four
@@ -58,3 +62,62 @@ to control BLAS/LAPACK selection and behavior:
 - ``-Dblas-symbol-suffix``: manually select the symbol suffix to use for the
   library - should only be needed for linking against libraries built in a
   non-standard way.
+
+
+New features
+============
+
+``numpy._core`` submodule stubs
+-------------------------------
+
+``numpy._core`` submodule stubs were added to provide compatibility with
+pickled arrays created using NumPy 2.0 when running Numpy 1.26.
+
+
+Contributors
+============
+
+A total of 13 people contributed to this release.  People with a "+" by their
+names contributed a patch for the first time.
+
+* Andrew Nelson
+* Anton Prosekin +
+* Charles Harris
+* Chongyun Lee +
+* Ivan A. Melnikov +
+* Jake Lishman +
+* Mahder Gebremedhin +
+* Mateusz Sokół
+* Matti Picus
+* Munira Alduraibi +
+* Ralf Gommers
+* Rohit Goswami
+* Sayed Adel
+
+
+Pull requests merged
+====================
+
+A total of 20 pull requests were merged for this release.
+
+* `#24742 <https://github.com/numpy/numpy/pull/24742>`__: MAINT: Update cibuildwheel version
+* `#24748 <https://github.com/numpy/numpy/pull/24748>`__: MAINT: fix version string in wheels built with setup.py
+* `#24771 <https://github.com/numpy/numpy/pull/24771>`__: BLD, BUG: Fix build failure for host flags e.g. ``-march=native``...
+* `#24773 <https://github.com/numpy/numpy/pull/24773>`__: DOC: Updated the f2py docs to remove a note on -fimplicit-none
+* `#24776 <https://github.com/numpy/numpy/pull/24776>`__: BUG: Fix SIMD f32 trunc test on s390x when baseline is none
+* `#24785 <https://github.com/numpy/numpy/pull/24785>`__: BLD: add libquadmath to licences and other tweaks (#24753)
+* `#24786 <https://github.com/numpy/numpy/pull/24786>`__: MAINT: Activate ``use-compute-credits`` for Cirrus.
+* `#24803 <https://github.com/numpy/numpy/pull/24803>`__: BLD: updated vendored-meson/meson for mips64 fix
+* `#24804 <https://github.com/numpy/numpy/pull/24804>`__: MAINT: fix licence path win
+* `#24813 <https://github.com/numpy/numpy/pull/24813>`__: BUG: Fix order of Windows OS detection macros.
+* `#24831 <https://github.com/numpy/numpy/pull/24831>`__: BUG, SIMD: use scalar cmul on bad Apple clang x86_64 (#24828)
+* `#24840 <https://github.com/numpy/numpy/pull/24840>`__: BUG: Fix DATA statements for f2py
+* `#24870 <https://github.com/numpy/numpy/pull/24870>`__: API: Add ``NumpyUnpickler`` for backporting
+* `#24872 <https://github.com/numpy/numpy/pull/24872>`__: MAINT: Xfail test failing on PyPy.
+* `#24879 <https://github.com/numpy/numpy/pull/24879>`__: BLD: fix math func feature checks, fix FreeBSD build, add CI...
+* `#24899 <https://github.com/numpy/numpy/pull/24899>`__: ENH: meson: implement BLAS/LAPACK auto-detection and many CI...
+* `#24902 <https://github.com/numpy/numpy/pull/24902>`__: DOC: add a 1.26.1 release notes section for BLAS/LAPACK build...
+* `#24906 <https://github.com/numpy/numpy/pull/24906>`__: MAINT: Backport ``numpy._core`` stubs. Remove ``NumpyUnpickler``
+* `#24911 <https://github.com/numpy/numpy/pull/24911>`__: MAINT: Bump pypa/cibuildwheel from 2.16.1 to 2.16.2
+* `#24912 <https://github.com/numpy/numpy/pull/24912>`__: BUG: loongarch doesn't use REAL(10)
+


### PR DESCRIPTION
- Create 1.26.1-changelog.py
- Update 1.26.1-notes.py
- Update .mailmap
- Clear ``doc/release/upcoming_changes``
- Revert cibuildwheel update -- v2.16.2 failed on macos pp39.

[wheel build]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
