### PR TITLE
ENH: Add Cython enumeration for NPY_FR_GENERIC

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -848,6 +848,7 @@ cdef extern from "numpy/arrayscalars.h":
         NPY_FR_ps
         NPY_FR_fs
         NPY_FR_as
+        NPY_FR_GENERIC
 
 
 cdef extern from "numpy/arrayobject.h":

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -807,6 +807,7 @@ cdef extern from "numpy/arrayscalars.h":
         NPY_FR_ps
         NPY_FR_fs
         NPY_FR_as
+        NPY_FR_GENERIC
 
 
 cdef extern from "numpy/arrayobject.h":


### PR DESCRIPTION
We use this downstream in pandas. I think it is an oversight to have been left out of the Cython file

https://github.com/numpy/numpy/blob/67539a40cb13bad56a650809bf10a49e905a250d/numpy/core/include/numpy/ndarraytypes.h#L258