### PR TITLE
ENH: Perf improvements to np.sort, np.argsort, np.partition and np.argpartition 

### DIFF
--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -107,11 +107,7 @@ inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
     #ifndef NPY_DISABLE_OPTIMIZATION
         #include "simd_qsort.dispatch.h"
     #endif
-    /* x86-simd-sort uses 8-byte int to store arg values, npy_intp is 4 bytes
-     * in 32-bit*/
-    if (sizeof(npy_intp) == sizeof(int64_t)) {
-        NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
-    }
+    NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template ArgQSort, <TF>);
     if (dispfunc) {
         (*dispfunc)(reinterpret_cast<TF*>(start), arg, num);
         return true;

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -36,17 +36,10 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
     /*
      * Only defined for int16_t, uint16_t, float16, int32_t, uint32_t, float32,
      * int64_t, uint64_t, double
-     * TODO: Enable quickselect for 32-bit. np.argpartition is only vectorized
-     * for 64-bit when npy_intp is 8 bytes, which means np.partition and
-     * np.argpartition will produces different results on 32-bit systems.
-     * Several tests in test_multiarray.py rely on these results being
-     * identical. We should get rid of this constraint and re-write
-     * these tests once we enable this for 32-bit.
      */
     if constexpr (
         (std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, np::Half>) &&
-        (sizeof(T) == sizeof(uint16_t) || sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) &&
-        sizeof(npy_intp) == sizeof(int64_t)) {
+        (sizeof(T) == sizeof(uint16_t) || sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t))) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         void (*dispfunc)(TF*, npy_intp, npy_intp) = nullptr;
         if constexpr (sizeof(T) == sizeof(uint16_t)) {
@@ -80,9 +73,7 @@ inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp 
      */
     if constexpr (
         (std::is_integral_v<T> || std::is_floating_point_v<T>) &&
-        (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) &&
-        // x86-simd-sort uses 8-byte int to store arg values, npy_intp is 4 bytes in 32-bit
-        sizeof(npy_intp) == sizeof(int64_t)) {
+        (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t))) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         #ifndef NPY_DISABLE_OPTIMIZATION
             #include "simd_qsort.dispatch.h"

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -19,27 +19,27 @@ namespace np { namespace qsort_simd {
 #if defined(NPY_HAVE_AVX512_SKX)
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+    avx512_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
@@ -65,53 +65,53 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_i
 {
     avx512_qselect(arr, kth, num, true);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
 {
-    avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+    avx512_argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 #endif  // NPY_HAVE_AVX512_SKX
 

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -11,10 +11,7 @@
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
-/* arg methods are only intended to 64-bit platforms */
-#ifdef NPY_CPU_AMD64
     #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
-#endif
 #endif
 
 namespace np { namespace qsort_simd {
@@ -22,39 +19,27 @@ namespace np { namespace qsort_simd {
 #if defined(NPY_HAVE_AVX512_SKX)
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
@@ -106,39 +91,27 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
 {
-#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
-#endif
 }
 #endif  // NPY_HAVE_AVX512_SKX
 

--- a/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort.dispatch.cpp
@@ -11,7 +11,10 @@
 #if defined(NPY_HAVE_AVX512_SKX)
     #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
     #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
+/* arg methods are only intended to 64-bit platforms */
+#ifdef NPY_CPU_AMD64
     #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
+#endif
 #endif
 
 namespace np { namespace qsort_simd {
@@ -19,27 +22,39 @@ namespace np { namespace qsort_simd {
 #if defined(NPY_HAVE_AVX512_SKX)
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argselect(arr, reinterpret_cast<int64_t*>(arg), kth, num);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
@@ -91,27 +106,39 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
 {
+#ifdef NPY_CPU_AMD64
     avx512_argsort(arr, reinterpret_cast<int64_t*>(arg), size);
+#endif
 }
 #endif  // NPY_HAVE_AVX512_SKX
 

--- a/numpy/_core/src/npysort/simd_qsort.hpp
+++ b/numpy/_core/src/npysort/simd_qsort.hpp
@@ -8,7 +8,7 @@ namespace np { namespace qsort_simd {
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort.dispatch.h"
 #endif
-NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSort, (T *arr, npy_intp* arg, npy_intp size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSelect, (T *arr, npy_intp* arg, npy_intp kth, npy_intp size))
@@ -16,7 +16,7 @@ NPY_CPU_DISPATCH_DECLARE(template <typename T> void ArgQSelect, (T *arr, npy_int
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "simd_qsort_16bit.dispatch.h"
 #endif
-NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, intptr_t size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 
 } } // np::qsort_simd

--- a/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/simd_qsort_16bit.dispatch.cpp
@@ -14,19 +14,19 @@
  * Wrapper function declarations to avoid multiple definitions of
  * avx512_qsort<uint16_t> and avx512_qsort<int16_t>
  */
-void avx512_qsort_uint16(uint16_t*, intptr_t);
-void avx512_qsort_int16(int16_t*, intptr_t);
+void avx512_qsort_uint16(uint16_t*, npy_intp);
+void avx512_qsort_int16(int16_t*, npy_intp);
 void avx512_qselect_uint16(uint16_t*, npy_intp, npy_intp);
 void avx512_qselect_int16(int16_t*, npy_intp, npy_intp);
 
 #elif defined(NPY_HAVE_AVX512_ICL)
     #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
 /* Wrapper function defintions here: */
-void avx512_qsort_uint16(uint16_t* arr, intptr_t size)
+void avx512_qsort_uint16(uint16_t* arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
-void avx512_qsort_int16(int16_t* arr, intptr_t size)
+void avx512_qsort_int16(int16_t* arr, npy_intp size)
 {
     avx512_qsort(arr, size);
 }
@@ -76,7 +76,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
 /*
  * QSort dispatch functions:
  */
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, npy_intp size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
     avx512_qsort(reinterpret_cast<_Float16*>(arr), size);
@@ -84,7 +84,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
     avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size);
 #endif
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, npy_intp size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
     avx512_qsort_uint16(arr, size);
@@ -92,7 +92,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, intptr_t size)
     avx512_qsort(arr, size);
 #endif
 }
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, npy_intp size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
     avx512_qsort_int16(arr, size);


### PR DESCRIPTION
Updating x86-simd-sort to latest commit. Includes 2 major updates:

1. Speed up `np.sort` by up-to **2x** for 32-bit and up-to **1.5x** for 64-bit data. Ref: https://github.com/intel/x86-simd-sort/pull/83 adds optimal sorting networks and minor improvements to vectorized partitioning. This also speeds up `np.partition` by up-to **1.3x.** 
2. `np.argsort` and `np.argparition` relied heavily on the gather instruction which unfortunately is terrible for performance because of a new vulnerability DOWNFALL (see https://www.phoronix.com/review/downfall). We reverted back to using scalar emulation of gather (see https://github.com/intel/x86-simd-sort/pull/65) which then improves performance by about **1.6x** for both `np.argsort `and `np.argpartition`. 

Benchmarks for random data: 

```
| Change   | Before [67539a40] <main>   | After [da55324f] <xss-perf>   |   Ratio | Benchmark (Parameter)                                                                    |
|----------|----------------------------|-------------------------------|---------|------------------------------------------------------------------------------------------|
| -        | 124±2μs                    | 118±0.9μs                     |    0.95 | bench_function_base.Partition.time_partition('int64', ('random',), 10)                   |
| -        | 124±0.8μs                  | 118±0.3μs                     |    0.95 | bench_function_base.Partition.time_partition('int64', ('random',), 1000)                 |
| -        | 124±0.3μs                  | 107±1μs                       |    0.87 | bench_function_base.Partition.time_partition('float32', ('random',), 10)                 |
| -        | 123±0.4μs                  | 105±0.4μs                     |    0.86 | bench_function_base.Partition.time_partition('float32', ('random',), 1000)               |
| -        | 123±0.4μs                  | 105±0.2μs                     |    0.85 | bench_function_base.Partition.time_partition('float32', ('random',), 100)                |
| -        | 56.5±0.5μs                 | 44.7±1μs                      |    0.79 | bench_function_base.Partition.time_partition('int32', ('random',), 10)                   |
| -        | 57.4±0.4μs                 | 43.6±1μs                      |    0.76 | bench_function_base.Partition.time_partition('int32', ('random',), 100)                  |
| -        | 58.1±0.8μs                 | 43.4±0.8μs                    |    0.75 | bench_function_base.Partition.time_partition('int32', ('random',), 1000)                 |
| -        | 73.2±0.06μs                | 50.5±0.02μs                   |    0.69 | bench_function_base.Sort.time_sort('quick', 'int64', ('random',))                        |
| -        | 210±0.2μs                  | 142±0.2μs                     |    0.68 | bench_function_base.Sort.time_argsort('quick', 'int64', ('random',))                     |
| -        | 60.0±0.1μs                 | 40.2±0.2μs                    |    0.67 | bench_function_base.Sort.time_sort('quick', 'float64', ('random',))                      |
| -        | 447±0.6μs                  | 295±2μs                       |    0.66 | bench_function_base.Partition.time_argpartition('float64', ('random',), 10)              |
| -        | 449±1μs                    | 298±1μs                       |    0.66 | bench_function_base.Partition.time_argpartition('float64', ('random',), 100)             |
| -        | 445±1μs                    | 294±1μs                       |    0.66 | bench_function_base.Partition.time_argpartition('float64', ('random',), 1000)            |
| -        | 34.4±0.05μs                | 22.7±0.03μs                   |    0.66 | bench_function_base.Sort.time_sort('quick', 'int32', ('random',))                        |
| -        | 218±0.5μs                  | 142±0.2μs                     |    0.65 | bench_function_base.Sort.time_argsort('quick', 'float64', ('random',))                   |
| -        | 211±0.7μs                  | 136±1μs                       |    0.64 | bench_function_base.Sort.time_argsort('quick', 'float32', ('random',))                   |
| -        | 35.7±0.1μs                 | 22.8±0.05μs                   |    0.64 | bench_function_base.Sort.time_sort('quick', 'uint32', ('random',))                       |
| -        | 418±3μs                    | 264±1μs                       |    0.63 | bench_function_base.Partition.time_argpartition('float32', ('random',), 10)              |
| -        | 419±3μs                    | 264±2μs                       |    0.63 | bench_function_base.Partition.time_argpartition('float32', ('random',), 100)             |
| -        | 416±3μs                    | 261±1μs                       |    0.63 | bench_function_base.Partition.time_argpartition('float32', ('random',), 1000)            |
| -        | 424±0.7μs                  | 264±1μs                       |    0.62 | bench_function_base.Partition.time_argpartition('int64', ('random',), 10)                |
| -        | 427±1μs                    | 266±0.5μs                     |    0.62 | bench_function_base.Partition.time_argpartition('int64', ('random',), 100)               |
| -        | 423±0.7μs                  | 264±1μs                       |    0.62 | bench_function_base.Partition.time_argpartition('int64', ('random',), 1000)              |
| -        | 410±3μs                    | 251±2μs                       |    0.61 | bench_function_base.Partition.time_argpartition('int32', ('random',), 100)               |
| -        | 408±3μs                    | 248±2μs                       |    0.61 | bench_function_base.Partition.time_argpartition('int32', ('random',), 1000)              |
| -        | 190±0.7μs                  | 116±0.2μs                     |    0.61 | bench_function_base.Sort.time_argsort('quick', 'int32', ('random',))                     |
| -        | 190±0.6μs                  | 115±0.2μs                     |    0.61 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('random',))                    |
| -        | 412±3μs                    | 249±2μs                       |    0.6  | bench_function_base.Partition.time_argpartition('int32', ('random',), 10)                |
| -        | 44.5±0.07μs                | 22.6±0.04μs                   |    0.51 | bench_function_base.Sort.time_sort('quick', 'float32', ('random',))     

```

Detailed benchmarks can be seen here: https://gist.github.com/r-devulap/21dc3afdbab47c7aa08087c1445954b7

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
