### PR TITLE
DOC: how-to-io.rst: document solution for NumPy JSON serialization

### DIFF
--- a/doc/source/user/how-to-io.rst
+++ b/doc/source/user/how-to-io.rst
@@ -303,8 +303,10 @@ NetCDF (see :ref:`how-to-io-large-arrays`).
 Write or read a JSON file
 =========================
 
-NumPy arrays are **not** directly
+NumPy arrays and most NumPy scalars are **not** directly
 `JSON serializable <https://github.com/numpy/numpy/issues/12481>`_.
+Instead, use a custom `json.JSONEncoder` for NumPy types, which can
+be found using your favorite search engine.
 
 
 .. _how-to-io-pickle-file:


### PR DESCRIPTION
Closes gh-16432
gh-12481 will remain open

Users have reported that NumPy types are not JSON serializable. This is documented, but no solution is recommended. This PR suggests trying a custom NumPy JSON encoder, several of which are easily found online. Whether NumPy should provide a solution as part of the package remains an open feature request.

@rkern this makes the change discussed in https://github.com/numpy/numpy/issues/16432#issuecomment-1751945300. The intersphinx link rendered correctly:

![image](https://github.com/numpy/numpy/assets/6570539/40264bb0-99fe-4334-b685-850023083ff7)
