### PR TITLE
MAINT: don't warn for symbols needed by import_array()

### DIFF
--- a/numpy/core/_multiarray_umath.py
+++ b/numpy/core/_multiarray_umath.py
@@ -8,6 +8,12 @@ for item in _multiarray_umath.__dir__():
     if isinstance(attr, ufunc):
         globals()[item] = attr
 
+# The NumPy 1.x import_array() and import_ufunc() mechanisms expect
+# these symbols to be available without error. If an extension was compiled
+# against NumPy 1.x it will have these paths hard-coded.
+_ARRAY_API = _multiarray_umath._ARRAY_API
+_UFUNC_API = _multiarray_umath._UFUNC_API
+
 def __getattr__(attr_name):
     from numpy._core import _multiarray_umath
     from ._utils import _raise_warning


### PR DESCRIPTION
`_ARRAY_API` and `_UFUNC_API` are needed by the `import_array()` and `import_ufunc()` mechanisms, respectively. I don't think it's worthwhile to warn on accessing either from `np.core` since there's little users can do to fix this for old compiled code.

See https://github.com/astropy/astropy/pull/15495 where warning on these attributes using the old paths caused inscrutible CI breakage because erroring on this can leave behind a partially imported module or a partially imported dependency or transitive dependency.

ping @mtsokol since I pinged you on the astropy issue that this should fix.