### PR TITLE
WIP, BLD: PYTHONSAFEPATH support

### DIFF
--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 import os
 import argparse
+import sys
+from pathlib import Path
 
+file_dir = Path(__file__).absolute().parents[0]
+sys.path.append(str(file_dir))
 import genapi
 from genapi import \
         TypeApi, GlobalVarApi, FunctionApi, BoolValuesApi

--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -1,6 +1,11 @@
 import os
 import argparse
+import sys
+from pathlib import Path
 
+# see gh-24907 for import shenanigans
+file_dir = Path(__file__).absolute().parents[0]
+sys.path.append(str(file_dir))
 import genapi
 from genapi import TypeApi, FunctionApi
 import numpy_api


### PR DESCRIPTION
* Fixes #24907

* marked as WIP (and CI skipped) for now because this is ugly and we could also just decide not to fix it at all, and/or to error out when that env var is set with a clear error message
 
* we can avoid `PYTHONSAFEPATH` causing our build to choke on the fact that the NumPy build requires Python code to execute an "unsafe" import from its own build dir

* here, the chosen approach is to perform the import "manually," but we could also decide to refuse to build if that environment variable is set for example, depending on our view on the matter

[ci skip] [skip cirrus]