### PR TITLE
API: Enforce ABI version and print info when compiled against 1.x

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3106,13 +3106,7 @@ array_arange(PyObject *NPY_UNUSED(ignored),
 NPY_NO_EXPORT unsigned int
 PyArray_GetNDArrayCVersion(void)
 {
-    // return (unsigned int)NPY_ABI_VERSION;
-    /*
-     * TODO: Preliminary returning the 1.x API version, that is a lie but
-     *       allows (for the moment) downstream modules to mix and match
-     *       and us to import old matplotlib versions in our doc builds...
-     */
-    return (unsigned int)0x01000009;
+    return (unsigned int)NPY_ABI_VERSION;
 }
 
 /*NUMPY_API

--- a/numpy/core/_multiarray_umath.py
+++ b/numpy/core/_multiarray_umath.py
@@ -8,15 +8,62 @@ for item in _multiarray_umath.__dir__():
     if isinstance(attr, ufunc):
         globals()[item] = attr
 
-# The NumPy 1.x import_array() and import_ufunc() mechanisms expect
-# these symbols to be available without error. If an extension was compiled
-# against NumPy 1.x it will have these paths hard-coded.
-_ARRAY_API = _multiarray_umath._ARRAY_API
-_UFUNC_API = _multiarray_umath._UFUNC_API
 
 def __getattr__(attr_name):
     from numpy._core import _multiarray_umath
     from ._utils import _raise_warning
+
+    if attr_name in {"_ARRAY_API", "_UFUNC_API"}:
+        from numpy.version import short_version, release
+        import textwrap
+        import sys
+
+        msg = textwrap.dedent(f"""
+            A module that was compiled using NumPy 1.x cannot be run in
+            NumPy {short_version} as it may crash. To support both 1.x and 2.x
+            versions of NumPy, modules must be compiled against NumPy 2.0.
+
+            If you are a user of the module, the easiest solution will be to
+            either downgrade NumPy or update the failing module (if available).
+
+            """)
+        if not release and short_version.startswith("2.0.0"):
+            # TODO: Can remove this after the release.
+            msg += textwrap.dedent("""\
+                NOTE: When testing against pre-release versions of NumPy 2.0
+                or building nightly wheels for it, it is necessary to ensure
+                the NumPy pre-release is used at build time.
+                The main way to ensure this is using no build isolation
+                and installing dependencies manually with NumPy.
+                For cibuildwheel for example, this may be achieved by using
+                the flag to pip:
+                    CIBW_BUILD_FRONTEND: pip; args: --no-build-isolation
+                installing NumPy with:
+                    pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+                in the `CIBW_BEFORE_BUILD` step.  Please compare with the
+                solutions e.g. in astropy or matplotlib for how to make this
+                conditional for nightly wheel builds using expressions.
+                If you do not worry about using pre-releases of all
+                dependencies, you can also use `--pre --extra-index-url` in the
+                build frontend (instead of build isolation).
+                This will become unnecessary as soon as NumPy 2.0 is released.
+
+                If your dependencies have the issue, check whether they
+                have nightly wheels build against NumPy 2.0.
+
+                pybind11 note: You may see this message if using pybind11,
+                this is not problematic at pre-release time
+                it indicates the need for a new pybind11 release.
+
+                """)
+        # Only print the message.  This has two reasons (for now!):
+        # 1. Old NumPy replaced the error here making it never actually show
+        #    in practice, thus raising alone would not be helpful.
+        # 2. pybind11 simply reaches into NumPy internals and requires a
+        #    new release that includes the fix. That is missing as of 2023-11.
+        #    But, it "conveniently" ignores the ABI version.
+        sys.stderr.write(msg)
+
     ret = getattr(_multiarray_umath, attr_name, None)
     if ret is None:
         raise AttributeError(


### PR DESCRIPTION
Eventually, the ``import_array()`` helper would also raise such an error anyway, but this is nicer because it gives us cleaner control of the error message (allowing us to update recommendations with new releases for example).

The error message given by ``import_array()`` is controlled by us but most likely compiled in from a many years old NumPy version...

---

This the error alternative/replacement for gh-24943.  It would be my preference to go this way, we need to go through the pain of doing this anyway soon.

~The big question is, do we like the `<2.0.0.rc9` suggestion?~

Closes gh-24943