### PR TITLE
DOC: Indicate shape param of ndarray.reshape is position-only

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3764,7 +3764,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('repeat',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('reshape',
     """
-    a.reshape(shape, order='C')
+    a.reshape(shape, /, order='C')
 
     Returns an array containing the same data with a new shape.
 


### PR DESCRIPTION
Minor doc update to the `ndarray.reshape` signature at the top of the docstring to indicate that the `shape` parameter behaves as if it's position-only.

Addresses #24942