### PR TITLE
ENH: Add Cython enumeration for NPY_FR_GENERIC

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -852,6 +852,7 @@ cdef extern from "numpy/arrayscalars.h":
         NPY_FR_ps
         NPY_FR_fs
         NPY_FR_as
+        NPY_FR_GENERIC
 
 
 #

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -810,6 +810,7 @@ cdef extern from "numpy/arrayscalars.h":
         NPY_FR_ps
         NPY_FR_fs
         NPY_FR_as
+        NPY_FR_GENERIC
 
 
 #


### PR DESCRIPTION
Backport of #24923.

Add Cython enumeration for NPY_FR_GENERIC

We use this downstream in pandas. I think it is an oversight to have been left out of the Cython file

https://github.com/numpy/numpy/blob/67539a40cb13bad56a650809bf10a49e905a250d/numpy/core/include/numpy/ndarraytypes.h#L258

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
