### PR TITLE
MAINT: Remove unhelpful error replacements from ``import_array()``

### DIFF
--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -53,15 +53,12 @@ _import_array(void)
   }
 
   if (numpy == NULL) {
-      PyErr_SetString(PyExc_ImportError,
-                      "_multiarray_umath failed to import");
       return -1;
   }
 
   PyObject *c_api = PyObject_GetAttrString(numpy, "_ARRAY_API");
   Py_DECREF(numpy);
   if (c_api == NULL) {
-      PyErr_SetString(PyExc_AttributeError, "_ARRAY_API not found");
       return -1;
   }
 


### PR DESCRIPTION
Replacing the original error is just not useful and actively unhelpful since the original array may have more information.

We could chain the error, but there seems little reason to do so.

---

Should backport this, although we would need to backport it very far back to be very helpful in practice.