### PR TITLE
REL: Remove Python upper version from the release branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [{name = "Travis E. Oliphant et al."}]
 maintainers = [
     {name = "NumPy Developers", email="numpy-discussion@python.org"},
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 readme = "README.md"
 classifiers = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
While the upper version is technically correct for the released version of NumPy (we are sure it will not work on Python 3.13) advertising it creates some problems, mostly for locking resolvers. They try to guess correct versions for non-released Python versions...

This is probably an ecosystem or just "reasons", but it seems less useful than trouble to do the correct advertising here.

See gh-24810 for *way* too much discussion about the why (and you will still be confused afterwards probably, so...).
This needs to be fixed or at least documented clearer upstream by PyPA or similar, but...

Closes gh-24810