### PR TITLE
MAINT: fix a few issues with CPython main/3.13.0a1

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -168,6 +168,9 @@
     #define npy_ftell ftell
 #endif
     #include <sys/types.h>
+    #ifndef _WIN32
+        #include <unistd.h>
+    #endif
     #define npy_lseek lseek
     #define npy_off_t off_t
 


### PR DESCRIPTION
Follows up on https://github.com/numpy/numpy/issues/24318#issuecomment-1772571108. As noted there, `numpy` still doesn't build, because Cython currently doesn't work with CPython main. But the `lseek` issue seems like a valid fix anyway (EDIT: due to https://github.com/python/cpython/pull/108783), and the Meson fix can't hurt.