### PR TITLE
BLD: use classic linker on macOS, the new one in XCode 15 has issues

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,5 +82,11 @@ if cc_id.startswith('clang')
   endif
 endif
 
+if host_machine.system() == 'darwin' and cc.has_link_argument('-Wl,-ld_classic')
+  # New linker introduced in macOS 14 not working yet with at least OpenBLAS in Spack,
+  # see gh-24964 (and linked scipy issue from there).
+  add_project_link_arguments('-Wl,-ld_classic', language : ['c', 'cpp'])
+endif
+
 subdir('meson_cpu')
 subdir('numpy')

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -93,7 +93,7 @@ mkl_may_use_sdl = not use_ilp64 and _threading_opt in ['auto', 'iomp']
 # First try scipy-openblas, and if found don't look for cblas or lapack, we
 # know what's inside the scipy-openblas wheels already.
 if blas_name == 'openblas' or blas_name == 'auto'
-  blas = dependency('scipy-openblas', required: false)
+  blas = dependency('scipy-openblas', method: 'pkg-config', required: false)
   if blas.found()
     blas_name = 'scipy-openblas'
   endif


### PR DESCRIPTION
Backport of #24967.

Closes gh-24964

The second commit is a minor improvement, noticed when inspecting the build logs posted on gh-24964.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
