### PR TITLE
BLD: remove `NPY_USE_BLAS_ILP64` environment variable [wheel build]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,13 +99,13 @@ stages:
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64
-            NPY_USE_BLAS_ILP64: '1'
+            _USE_BLAS_ILP64: '1'
           PyPy39-64bit-fast:
             PYTHON_VERSION: 'pypy3.9'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64
-            NPY_USE_BLAS_ILP64: '1'
+            _USE_BLAS_ILP64: '1'
 
     steps:
     - template: azure-steps-windows.yml

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -29,7 +29,7 @@ steps:
     If ( Test-Path env:DISABLE_BLAS ) {
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
-    elseif ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
+    elseif ( Test-Path env:_USE_BLAS_ILP64 ) {
         python -m pip install scipy-openblas64 spin
         spin config-openblas --with-scipy-openblas=64
         $env:PKG_CONFIG_PATH="$pwd/.openblas"

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -27,7 +27,7 @@ typedef CBLAS_INT        fortran_int;
 #else
 #error No compatible 64-bit integer size. \
        Please contact NumPy maintainers and give detailed information about your \
-       compiler and platform, or set NPY_USE_BLAS64_=0
+       compiler and platform, or dont try to use ILP64 BLAS
 #endif
 
 #else

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -56,19 +56,6 @@ allow_noblas = get_option('allow-noblas')
 blas_symbol_suffix = get_option('blas-symbol-suffix')
 
 use_ilp64 = get_option('use-ilp64')
-if not use_ilp64
-  # TODO: clean this up
-  # For now, keep supporting the `NPY_USE_BLAS_ILP64` environment variable too
-  # `false` is the default for the CLI flag, so check if env var was set
-  use_ilp64 = run_command(py,
-    [
-      '-c',
-      'import os; print(1) if os.environ.get("NPY_USE_BLAS_ILP64", "0") != "0" else print(0)'
-    ],
-    check: true
-  ).stdout().strip() == '1'
-endif
-
 if use_ilp64
   blas_interface = ['interface: ilp64']
 else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 musllinux-x86_64-image = "musllinux_1_1"
-environment = {CFLAGS="-fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", NPY_USE_BLAS_ILP64="1", RUNNER_OS="Linux"}
+environment = {CFLAGS="-fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", RUNNER_OS="Linux"}
 
 [tool.cibuildwheel.macos]
 # For universal2 wheels, we will need to fuse them manually
@@ -177,11 +177,10 @@ environment = {CFLAGS="-fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", NPY_U
 archs = "x86_64 arm64"
 test-skip = "*_universal2:arm64"
 # MACOS linker doesn't support stripping symbols.
-# Note that NPY_USE_BLAS_ILP64 is used in `tools/openblas_support.py`.
-environment = {CFLAGS="-fno-strict-aliasing", CC="clang", CXX = "clang++", NPY_USE_BLAS_ILP64="1", RUNNER_OS="macOS"}
+environment = {CFLAGS="-fno-strict-aliasing", RUNNER_OS="macOS"}
 
 [tool.cibuildwheel.windows]
-environment = {NPY_USE_BLAS_ILP64="1", PKG_CONFIG_PATH="C:/opt/64/lib/pkgconfig"}
+environment = {PKG_CONFIG_PATH="C:/opt/64/lib/pkgconfig"}
 config-settings = "setup-args=--vsenv setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas"
 repair-wheel-command = "bash ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
 

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -79,10 +79,6 @@ macosx_arm64_task:
       RUNNER_OS=macOS
       SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
       LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-      CFLAGS="-fno-strict-aliasing -DBLAS_SYMBOL_SUFFIX=64_ -DHAVE_BLAS_ILP64"
-      CXXFLAGS="-DBLAS_SYMBOL_SUFFIX=64_ -DHAVE_BLAS_ILP64"
-      OPENBLAS64_="/usr/local"
-      NPY_USE_BLAS_ILP64="1"
 
   build_script:
     - brew install python@3.10

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -33,24 +33,14 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     # delvewheel is the equivalent of delocate/auditwheel for windows.
     python -m pip install delvewheel
 
-    # make the DLL available for tools/wheels/repair_windows.sh. If you change
-    # this location you need to alter that script.
-    mkdir -p /c/opt/openblas/openblas_dll
-
-    mkdir -p /c/opt/32/lib/pkgconfig
-    mkdir -p /c/opt/64/lib/pkgconfig
-    target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, libsuffix='64_');print(target)")
     if [[ $PLATFORM == 'win-32' ]]; then
         echo "No BLAS used for 32-bit wheels"
     else
-        # 64-bit openBLAS
+        # Note: DLLs are copied from /c/opt/64/bin by delvewheel, see
+        # tools/wheels/repair_windows.sh
+        mkdir -p /c/opt/64/lib/pkgconfig
+        target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, libsuffix='64_');print(target)")
         unzip -o -d /c/opt/ $target
-        if [[ -f /c/opt/64/lib/pkgconfig/openblas64.pc ]]; then
-            # As of v0.3.23, the 64-bit interface has a openblas64.pc file,
-            # but this is wrong. It should be openblas.pc
-            cp /c/opt/64/lib/pkgconfig/openblas{64,}.pc
-        fi
-        cp /c/opt/64/bin/*.dll /c/opt/openblas/openblas_dll
     fi
 fi
 

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -15,7 +15,7 @@ fi
 
 # Install Openblas
 if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]] ; then
-    basedir=$(python tools/openblas_support.py)
+    basedir=$(python tools/openblas_support.py --use-ilp64)
     if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
         # /usr/local/lib doesn't exist on cirrus-ci runners
         sudo mkdir -p /usr/local/lib /usr/local/include /usr/local/lib/cmake/openblas
@@ -39,12 +39,9 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
 
     mkdir -p /c/opt/32/lib/pkgconfig
     mkdir -p /c/opt/64/lib/pkgconfig
-    target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); ilp64=obs.get_ilp64(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, ilp64);print(target)")
+    target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, libsuffix='64_');print(target)")
     if [[ $PLATFORM == 'win-32' ]]; then
-        # 32-bit openBLAS
-        # Download 32 bit openBLAS and put it into c/opt/32/lib
-        unzip -o -d /c/opt/ $target
-        cp /c/opt/32/bin/*.dll /c/opt/openblas/openblas_dll
+        echo "No BLAS used for 32-bit wheels"
     else
         # 64-bit openBLAS
         unzip -o -d /c/opt/ $target

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -22,10 +22,6 @@ elif [[ $RUNNER_OS == "Windows" && $IS_32_BIT == true ]] ; then
   echo "Skip OpenBLAS version check for 32-bit Windows, no OpenBLAS used"
   # Avoid this in GHA: "ERROR: Found GNU link.exe instead of MSVC link.exe"
   rm /c/Program\ Files/Git/usr/bin/link.EXE
-else
-  # For some reason the macos-x86_64 runner does not work with threadpoolctl
-  # Skip this check there
-  python $PROJECT_DIR/tools/openblas_support.py --check_version
 fi
 # Set available memory value to avoid OOM problems on aarch64.
 # See gh-22418.

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -29,4 +29,4 @@ rm -rf tmp
 
 # the libopenblas.dll is placed into this directory in the cibw_before_build
 # script.
-delvewheel repair --add-path /c/opt/openblas/openblas_dll -w $DEST_DIR $WHEEL
+delvewheel repair --add-path /c/opt/64/bin -w $DEST_DIR $WHEEL


### PR DESCRIPTION
This was the numpy.distutils way; with Meson the preferred way is the `-Duse-ilp64` CLI flag.

The benefits of this PR are:
- Making it more explicit what is downloaded if `python tools/openblas_support.py` is run; that can be directly deduced from the command now
- Removing the manual tweaking of CFLAGS/CXXFLAGS; this is done automatically already when `-Duse-ilp64=true` is used
- Removing a `run_command(py, ...)` from `meson.build`; those are undesirable when cross compiling