### PR TITLE
ENH: Added a `lint` spin command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -319,6 +319,38 @@ def _run_asv(cmd):
 
     util.run(cmd, cwd='benchmarks', env=env)
 
+@click.command()
+@click.option(
+    "-b", "--branch",
+    metavar='branch',
+    default="main",
+)
+@click.option(
+    '--uncommitted',
+    is_flag=True,
+    default=False,
+    required=False,
+)
+@click.pass_context
+def lint(ctx, branch, uncommitted):
+    """🔦 Run lint checks on diff.
+    Provide target branch name or `uncommitted` to check before committing:
+
+    \b
+    Examples:
+
+    \b
+    $ spin lint
+    $ spin lint --branch main
+    $ spin lint uncommitted
+    """
+    click.secho(
+        f"Performing lint checks against {'uncommitted changes' if uncommitted else branch + ' branch'}",
+        bold=True, fg="bright_green",
+    )
+    from tools.linter import DiffLinter
+    ret = DiffLinter(branch).run_lint(uncommitted)
+    print(ret)
 
 @click.command()
 @click.option(

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -333,24 +333,32 @@ def _run_asv(cmd):
 )
 @click.pass_context
 def lint(ctx, branch, uncommitted):
-    """🔦 Run lint checks on diff.
-    Provide target branch name or `uncommitted` to check before committing:
+    """🔦 Run lint checks on diffs.
+    Provide target branch name or `uncommitted` to check changes before committing:
 
     \b
     Examples:
 
     \b
-    $ spin lint
-    $ spin lint --branch main
-    $ spin lint uncommitted
+    For lint checks of your development brach with `main` or a custom branch:
+
+    \b
+    $ spin lint # defaults to main
+    $ spin lint --branch custom_branch
+
+    \b
+    To check just the uncommitted changes before committing
+
+    \b
+    $ spin lint --uncommitted
     """
     click.secho(
-        f"Performing lint checks against {'uncommitted changes' if uncommitted else branch + ' branch'}",
+        "Performing lint checks " + "for uncommitted changes" if uncommitted
+        else f"against {branch} branch",
         bold=True, fg="bright_green",
     )
     from tools.linter import DiffLinter
-    ret = DiffLinter(branch).run_lint(uncommitted)
-    print(ret)
+    DiffLinter(branch).run_lint(uncommitted)
 
 @click.command()
 @click.option(

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -357,7 +357,13 @@ def lint(ctx, branch, uncommitted):
         else f"against {branch} branch",
         bold=True, fg="bright_green",
     )
-    from tools.linter import DiffLinter
+    try:
+        from tools.linter import DiffLinter
+    except ModuleNotFoundError as e:
+        raise click.ClickException(
+            f"{e.msg}. Install using linter_requirements.txt"
+        )
+
     DiffLinter(branch).run_lint(uncommitted)
 
 @click.command()

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -352,19 +352,14 @@ def lint(ctx, branch, uncommitted):
     \b
     $ spin lint --uncommitted
     """
-    click.secho(
-        "Performing lint checks " + "for uncommitted changes" if uncommitted
-        else f"against {branch} branch",
-        bold=True, fg="bright_green",
-    )
     try:
-        from tools.linter import DiffLinter
+        linter = _get_numpy_tools(pathlib.Path('linter.py'))
     except ModuleNotFoundError as e:
         raise click.ClickException(
             f"{e.msg}. Install using linter_requirements.txt"
         )
 
-    DiffLinter(branch).run_lint(uncommitted)
+    linter.DiffLinter(branch).run_lint(uncommitted)
 
 @click.command()
 @click.option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ cli = 'vendored-meson/meson/meson.py'
   ".spin/cmds.py:test",
   ".spin/cmds.py:mypy",
   ".spin/cmds.py:config_openblas",
+  ".spin/cmds.py:lint",
 ]
 "Environments" = [
   "spin.cmds.meson.run", ".spin/cmds.py:ipython",


### PR DESCRIPTION
### Changes
Added a `lint` spin command

### Testing
Basic
```
~/os/numpy (main*) » spin lint --uncommitted                                                                                                                                ganesh@ganesh-MS-7B86
Performing lint checks for uncommitted changes
./numpy/testing/overrides.py:11:80: E501 line too long (114 > 79 characters)
./numpy/testing/overrides.py:66:80: E501 line too long (110 > 79 characters)
2       E501 line too long (114 > 79 characters)
                                                                                                                                         
                                                                                                 
(np-test) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/os/numpy (main*) » echo $?                                                                                                                                            1 ↵ ganesh@ganesh-MS-7B86
1  
```

Module not found:
```
(np-test) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/os/numpy (bld_24080_lint*) » spin lint --uncommitted                                                                                                                                                          ganesh@ganesh-MS-7B86
Performing lint checks for uncommitted changes
Error: No module named 'git'. Install using linter_requirements.txt
```

### Notes
Related: #24080 