### PR TITLE
MAINT: Disable warnings for items imported by pybind11

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -1,3 +1,5 @@
+from numpy._core import _internal
+
 # Build a new array from the information in a pickle.
 # Note that the name numpy.core._internal._reconstruct is embedded in
 # pickles of ndarrays made with NumPy before release 1.0
@@ -7,6 +9,10 @@ def _reconstruct(subtype, shape, dtype):
     from numpy import ndarray
     return ndarray.__new__(subtype, shape, dtype)
 
+
+# Pybind11 (in versions <= 2.11.1) imports _dtype_from_pep3118 from the
+# _internal submodule, therefore it must be importable without a warning.
+_dtype_from_pep3118 = _internal._dtype_from_pep3118
 
 def __getattr__(attr_name):
     from numpy._core import _internal

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -5,6 +5,11 @@ from numpy._core import multiarray
 for item in ["_reconstruct", "scalar"]:
     globals()[item] = getattr(multiarray, item)
 
+# Pybind11 (in versions <= 2.11.1) imports _ARRAY_API from the multiarray
+# submodule as a part of NumPy initialization, therefore it must be importable
+# without a warning.
+_ARRAY_API = multiarray._ARRAY_API
+
 def __getattr__(attr_name):
     from numpy._core import multiarray
     from ._utils import _raise_warning


### PR DESCRIPTION
Hi! 
Here I remove deprecation warnings for `numpy.core.multiarray._ARRAY_API` and `numpy.core._internal._dtype_from_pep3118` that cause SciPy's CI error when using numpy nighlty.

These two `core` members are used in existing versions of pybind11 (it's already addressed in pybind's main branch).

(https://github.com/pybind/pybind11/blob/8a099e44b3d5f85b20f05828d919d2332a8de841/include/pybind11/numpy.h#L266)

Full discussion: https://github.com/scipy/scipy/pull/19255#issuecomment-1774226273