### PR TITLE
ENH: Added `changelog` spin command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -35,7 +35,7 @@ if not meson_import_dir.exists():
     required=True
 )
 @click.pass_context
-def authors(ctx, token, revision_range):
+def changelog(ctx, token, revision_range):
     """👩 Get change log for provided revision range
 
     \b

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -7,13 +7,10 @@ import pathlib
 import shutil
 import json
 import pathlib
-from github.GithubException import GithubException
-from git.exc import GitError
 
 import click
 from spin import util
 from spin.cmds import meson
-from tools.changelog import main as generate_changelog
 
 
 # Check that the meson git submodule is present
@@ -47,6 +44,14 @@ def authors(ctx, token, revision_range):
     \b
     $ spin authors -t $GH_TOKEN --revision-range v1.25.0..v1.26.0
     """
+    try:
+        from github.GithubException import GithubException
+        from git.exc import GitError
+        from tools.changelog import main as generate_changelog
+    except ModuleNotFoundError as e:
+        raise click.ClickException(
+            f"{e.msg}. Install the missing packages to use this command."
+        )
     click.secho(
         f"Generating change log for range {revision_range}",
         bold=True, fg="bright_green",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,5 +208,8 @@ cli = 'vendored-meson/meson/meson.py'
   "spin.cmds.meson.run", ".spin/cmds.py:ipython",
   ".spin/cmds.py:python", "spin.cmds.meson.gdb"
 ]
-"Documentation" = [".spin/cmds.py:docs"]
+"Documentation" = [
+  ".spin/cmds.py:docs",
+  ".spin/cmds.py:authors",
+]
 "Metrics" = [".spin/cmds.py:bench"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,6 @@ cli = 'vendored-meson/meson/meson.py'
 ]
 "Documentation" = [
   ".spin/cmds.py:docs",
-  ".spin/cmds.py:authors",
+  ".spin/cmds.py:changelog",
 ]
 "Metrics" = [".spin/cmds.py:bench"]


### PR DESCRIPTION
### Changes
- Added `changelog` spin command

### Examples:
<details>
  <summary>Regular Usage</summary>

```
~/os/numpy (bld_24080_authors*) » spin changelog -t $GH_TOKEN --revision-range v1.25.0..v1.26.0                                                                                                               1 ↵ ganesh@ganesh-MS-7B86
Generating change log for range v1.25.0..v1.26.0                                                                   
                                                                                                                                                                                                                                      
Contributors                                                                                                       
============                                                                                                       
                                                                                                                                                                                                                                      
A total of 30 people contributed to this release.  People with a "+" by their                                                                                                                                                         
names contributed a patch for the first time.                                                                      
                                                                                                                   
* @DWesl                                                                                                                                                                                                                              
* Aaron Meurer                                                                                                                                                                                                                        
* Albert Steppi +                                                                                                                                                                                                                     
* Andrew Nelson                                                                                                    
* Bas van Beek                                                                                                     
* Charles Harris                                                                                                   
* Developer-Ecosystem-Engineering                                                                                  
* Filipe Laíns +                                                                                                                                                                                                                      
* Hood Chatham                                                                                                                                                                                                                        
* Jake Vanderplas                                                                                                                                                                                                                     
* Kevin Sheppard                                                                                                                                                                                                                      
* Liang Yan +                                                                                                                                                                                                                         
* Marten van Kerkwijk                                                                                              
* Matti Picus                                                                                                      
* Melissa Weber Mendonça                                                                                           
* Namami Shanker                                                                                                                                                                                                                      
* Nathan Goldbaum                                                                                                                                                                                                                     
* Peter Hawkins                                                                                                                                                                                                                       
* Ralf Gommers                                                                                                                                                                                                                        
* Randy Eckenrode +                                                                                                
* Rohit Goswami                                                                                                    
* Sam James +                                                                                                                                                                                                                         
* Sayed Adel                                                                                                       
* Sebastian Berg                                                                                                                                                                                                                      
* Stefan van der Walt                                                                                                                                                                                                                 
* Tim Paine +
* Tyler Reddy
* Warren Weckesser
* dependabot[bot]
* matoro +

Pull requests merged                                                                                               
====================                                                                                                                                                                                                                  
                                                                                                                   
A total of 95 pull requests were merged for this release.                         
                                                                                                                   
* `#23968 <https://github.com/numpy/numpy/pull/23968>`__: MAINT: prepare 1.25.x for further development
* `#24036 <https://github.com/numpy/numpy/pull/24036>`__: BLD: Port long double identification to C for meson
* `#24037 <https://github.com/numpy/numpy/pull/24037>`__: BUG: Fix reduction ``return NULL`` to be ``goto fail``                                                                                                                      
* `#24038 <https://github.com/numpy/numpy/pull/24038>`__: BUG: Avoid undefined behavior in array.astype()
* `#24039 <https://github.com/numpy/numpy/pull/24039>`__: BUG: Ensure ``__array_ufunc__`` works without any kwargs passed
* `#24117 <https://github.com/numpy/numpy/pull/24117>`__: MAINT: Pin urllib3 to avoid anaconda-client bug.                                                                                                                            
* `#24118 <https://github.com/numpy/numpy/pull/24118>`__: TST: Pin pydantic<2 in Pyodide workflow                                                                                                                                     
* `#24119 <https://github.com/numpy/numpy/pull/24119>`__: MAINT: Bump pypa/cibuildwheel from 2.13.0 to 2.13.1 
* `#24120 <https://github.com/numpy/numpy/pull/24120>`__: MAINT: Bump actions/checkout from 3.5.2 to 3.5.3
* `#24122 <https://github.com/numpy/numpy/pull/24122>`__: BUG: Multiply or Divides using SIMD without a full vector can...
* `#24127 <https://github.com/numpy/numpy/pull/24127>`__: MAINT: testing for IS_MUSL closes #24074
* `#24128 <https://github.com/numpy/numpy/pull/24128>`__: BUG: Only replace dtype temporarily if dimensions changed 
* `#24129 <https://github.com/numpy/numpy/pull/24129>`__: MAINT: Bump actions/setup-node from 3.6.0 to 3.7.0
* `#24134 <https://github.com/numpy/numpy/pull/24134>`__: BUG: Fix private procedures in f2py modules            
* `#24146 <https://github.com/numpy/numpy/pull/24146>`__: REL: Prepare for the NumPy 1.25.1 release.                                                                                                                                  
* `#24148 <https://github.com/numpy/numpy/pull/24148>`__: MAINT: prepare 1.25.x for further development                                                                                                                               
* `#24174 <https://github.com/numpy/numpy/pull/24174>`__: ENH: Improve clang-cl compliance       
* `#24179 <https://github.com/numpy/numpy/pull/24179>`__: MAINT: Upgrade various build dependencies.
* `#24182 <https://github.com/numpy/numpy/pull/24182>`__: BLD: use ``-ftrapping-math`` with Clang on macOS                                                                                                                            
* `#24183 <https://github.com/numpy/numpy/pull/24183>`__: BUG: properly handle negative indexes in ufunc_at fast path
* `#24184 <https://github.com/numpy/numpy/pull/24184>`__: BUG: PyObject_IsTrue and PyObject_Not error handling in setflags    
* `#24185 <https://github.com/numpy/numpy/pull/24185>`__: BUG: histogram small range robust     
* `#24186 <https://github.com/numpy/numpy/pull/24186>`__: MAINT: Update meson.build files from main branch       
* `#24234 <https://github.com/numpy/numpy/pull/24234>`__: MAINT: exclude min, max and round from `np.__all__`
* `#24241 <https://github.com/numpy/numpy/pull/24241>`__: MAINT: Dependabot updates       
* `#24242 <https://github.com/numpy/numpy/pull/24242>`__: BUG: Fix the signature for np.array_api.take                                                                                                                                
* `#24243 <https://github.com/numpy/numpy/pull/24243>`__: BLD: update OpenBLAS to an intermeidate commit                                                                                                                              
* `#24244 <https://github.com/numpy/numpy/pull/24244>`__: BUG: Fix reference count leak in str(scalar).                                                                                                                               
* `#24245 <https://github.com/numpy/numpy/pull/24245>`__: BUG: fix invalid function pointer conversion error                                                                                                                          
* `#24255 <https://github.com/numpy/numpy/pull/24255>`__: BUG: Factor out slow `getenv` call used for memory policy warning
* `#24292 <https://github.com/numpy/numpy/pull/24292>`__: CI: correct URL in cirrus.star [skip cirrus]
* `#24293 <https://github.com/numpy/numpy/pull/24293>`__: BUG: Fix C types in scalartypes                  
* `#24294 <https://github.com/numpy/numpy/pull/24294>`__: BUG: do not modify the input to ufunc_at     
* `#24295 <https://github.com/numpy/numpy/pull/24295>`__: BUG: Further fixes to indexing loop and added tests                                                                                                                         
* `#24296 <https://github.com/numpy/numpy/pull/24296>`__: REL: Prepare for the NumPy 1.25.2 release.                                                                                                                                  
* `#24305 <https://github.com/numpy/numpy/pull/24305>`__: MAINT: Prepare 1.26.x branch for development                                                                                                                                
* `#24308 <https://github.com/numpy/numpy/pull/24308>`__: MAINT: Massive update of files from main for numpy 1.26                                                                                                                     
* `#24322 <https://github.com/numpy/numpy/pull/24322>`__: CI: fix wheel builds on the 1.26.x branch             
* `#24326 <https://github.com/numpy/numpy/pull/24326>`__: BLD: update openblas to newer version              
* `#24327 <https://github.com/numpy/numpy/pull/24327>`__: TYP: Trim down the ``_NestedSequence.__getitem__`` signature       
* `#24328 <https://github.com/numpy/numpy/pull/24328>`__: BUG: fix choose refcount leak      
* `#24337 <https://github.com/numpy/numpy/pull/24337>`__: TST: fix running the test suite in builds without BLAS/LAPACK
* `#24338 <https://github.com/numpy/numpy/pull/24338>`__: BUG: random: Fix generation of nan by dirichlet.
* `#24340 <https://github.com/numpy/numpy/pull/24340>`__: MAINT: Dependabot updates from main
* `#24342 <https://github.com/numpy/numpy/pull/24342>`__: MAINT: Add back NPY_RUN_MYPY_IN_TESTSUITE=1
* `#24353 <https://github.com/numpy/numpy/pull/24353>`__: MAINT: Update ``extbuild.py`` from main.
* `#24356 <https://github.com/numpy/numpy/pull/24356>`__: TST: fix distutils tests for deprecations in recent setuptools...
* `#24375 <https://github.com/numpy/numpy/pull/24375>`__: MAINT: Update cibuildwheel to version 2.15.0
* `#24381 <https://github.com/numpy/numpy/pull/24381>`__: MAINT: Fix codespaces setup.sh script
* `#24403 <https://github.com/numpy/numpy/pull/24403>`__: ENH: Vendor meson for multi-target build support
* `#24404 <https://github.com/numpy/numpy/pull/24404>`__: BLD: vendor meson-python to make the Windows builds with SIMD...
* `#24405 <https://github.com/numpy/numpy/pull/24405>`__: BLD, SIMD: The meson CPU dispatcher implementation
* `#24406 <https://github.com/numpy/numpy/pull/24406>`__: MAINT: Remove versioneer
* `#24409 <https://github.com/numpy/numpy/pull/24409>`__: REL: Prepare for the NumPy 1.26.0b1 release.
* `#24453 <https://github.com/numpy/numpy/pull/24453>`__: MAINT: Pin upper version of sphinx.
* `#24455 <https://github.com/numpy/numpy/pull/24455>`__: ENH: Add prefix to _ALIGN Macro
* `#24456 <https://github.com/numpy/numpy/pull/24456>`__: BUG: cleanup warnings [skip azp][skip circle][skip travis][skip...
* `#24460 <https://github.com/numpy/numpy/pull/24460>`__: MAINT: Upgrade to spin 0.5
* `#24495 <https://github.com/numpy/numpy/pull/24495>`__: BUG: ``asv dev`` has been removed, use ``asv run``.
* `#24496 <https://github.com/numpy/numpy/pull/24496>`__: BUG: Fix meson build failure due to unchanged inplace auto-generated...
* `#24521 <https://github.com/numpy/numpy/pull/24521>`__: BUG: fix issue with git-version script, needs a shebang to run
* `#24522 <https://github.com/numpy/numpy/pull/24522>`__: BUG: Use a default assignment for git_hash [skip ci]
* `#24524 <https://github.com/numpy/numpy/pull/24524>`__: BUG: fix NPY_cast_info error handling in choose
* `#24526 <https://github.com/numpy/numpy/pull/24526>`__: BUG: Fix common block handling in f2py
* `#24541 <https://github.com/numpy/numpy/pull/24541>`__: CI,TYP: Bump mypy to 1.4.1
* `#24542 <https://github.com/numpy/numpy/pull/24542>`__: BUG: Fix assumed length f2py regression
* `#24544 <https://github.com/numpy/numpy/pull/24544>`__: MAINT: Harmonize fortranobject
* `#24545 <https://github.com/numpy/numpy/pull/24545>`__: TYP: add kind argument to numpy.isin type specification
* `#24561 <https://github.com/numpy/numpy/pull/24561>`__: BUG: fix comparisons between masked and unmasked structured arrays
* `#24590 <https://github.com/numpy/numpy/pull/24590>`__: CI: Exclude import libraries from list of DLLs on Cygwin.
* `#24591 <https://github.com/numpy/numpy/pull/24591>`__: BLD: fix ``_umath_linalg`` dependencies
* `#24594 <https://github.com/numpy/numpy/pull/24594>`__: MAINT: Stop testing on ppc64le.
* `#24602 <https://github.com/numpy/numpy/pull/24602>`__: BLD: meson-cpu: fix SIMD support on platforms with no features
* `#24606 <https://github.com/numpy/numpy/pull/24606>`__: BUG: Change Cython ``binding`` directive to "False".
* `#24613 <https://github.com/numpy/numpy/pull/24613>`__: ENH: Adopt new macOS Accelerate BLAS/LAPACK Interfaces, including...
* `#24614 <https://github.com/numpy/numpy/pull/24614>`__: DOC: Update building docs to use Meson
* `#24615 <https://github.com/numpy/numpy/pull/24615>`__: TYP: Add the missing ``casting`` keyword to ``np.clip``
* `#24616 <https://github.com/numpy/numpy/pull/24616>`__: TST: convert cython test from setup.py to meson
* `#24617 <https://github.com/numpy/numpy/pull/24617>`__: MAINT: Fixup ``fromnumeric.pyi``
* `#24622 <https://github.com/numpy/numpy/pull/24622>`__: BUG, ENH: Fix ``iso_c_binding`` type maps and fix ``bind(c)``...
* `#24629 <https://github.com/numpy/numpy/pull/24629>`__: TYP: Allow ``binary_repr`` to accept any object implementing...
* `#24630 <https://github.com/numpy/numpy/pull/24630>`__: TYP: Explicitly declare ``dtype`` and ``generic`` hashable
* `#24637 <https://github.com/numpy/numpy/pull/24637>`__: ENH: Refactor the typing "reveal" tests using `typing.assert_type`
* `#24638 <https://github.com/numpy/numpy/pull/24638>`__: MAINT: Bump actions/checkout from 3.6.0 to 4.0.0
* `#24647 <https://github.com/numpy/numpy/pull/24647>`__: ENH: ``meson`` backend for ``f2py``
* `#24648 <https://github.com/numpy/numpy/pull/24648>`__: MAINT: Refactor partial load Workaround for Clang
* `#24653 <https://github.com/numpy/numpy/pull/24653>`__: REL: Prepare for the NumPy 1.26.0rc1 release.
* `#24659 <https://github.com/numpy/numpy/pull/24659>`__: BLD: allow specifying the long double format to avoid the runtime...
* `#24665 <https://github.com/numpy/numpy/pull/24665>`__: BLD: fix bug in random.mtrand extension, don't link libnpyrandom
* `#24675 <https://github.com/numpy/numpy/pull/24675>`__: BLD: build wheels for 32-bit Python on Windows, using MSVC
* `#24700 <https://github.com/numpy/numpy/pull/24700>`__: BLD: fix issue with compiler selection during cross compilation
* `#24701 <https://github.com/numpy/numpy/pull/24701>`__: BUG: Fix data stmt handling for complex values in f2py
* `#24707 <https://github.com/numpy/numpy/pull/24707>`__: TYP: Add annotations for the py3.12 buffer protocol
* `#24718 <https://github.com/numpy/numpy/pull/24718>`__: DOC: fix a few doc build issues on 1.26.x and update `spin docs`...
* `#24722 <https://github.com/numpy/numpy/pull/24722>`__: REL: Prepare for the NumPy 1.26.0 release
```
</details>

<details>
  <summary>Github errors</summary>

```
~/os/numpy (bld_24080_authors*) » spin changelog -t $GH_TOKEN --revision-range v1.13.0..v1.141.0                                                                                                              1 ↵ ganesh@ganesh-MS-7B86
Generating change log for range v1.13.0..v1.141.0
Error: GithubException raised with status: 401 and message: Bad credentials
```
</details>

<details>
  <summary>Git errors</summary>

```
~/os/numpy (bld_24080_authors*) » spin changelog -t $GH_TOKEN --revision-range v1.25.0..v1.261.0                                                                                                                  ganesh@ganesh-MS-7B86
Generating change log for range v1.25.0..v1.261.0
Error: Git error in command `git shortlog -s --group=author --group=trailer:co-authored-by v1.25.0..v1.261.0` with error message: 
  stderr: 'fatal: ambiguous argument 'v1.25.0..v1.261.0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]''
```
</details>

<details>
  <summary>Missing package errors</summary>

```
~/os/numpy (bld_24080_authors*) » spin changelog -t $GH_TOKEN --revision-range v1.25.0..v1.261.0                                                                                                                  ganesh@ganesh-MS-7B86
Error: No module named 'git'. Install the missing packages to use this command.
```
</details>

### Notes
related: #24080