### PR TITLE
ENH: DType API slot for descriptor finalization before array creation

### DIFF
--- a/numpy/_core/include/numpy/_dtype_api.h
+++ b/numpy/_core/include/numpy/_dtype_api.h
@@ -5,7 +5,7 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 #define NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_
 
-#define __EXPERIMENTAL_DTYPE_API_VERSION 14
+#define __EXPERIMENTAL_DTYPE_API_VERSION 15
 
 struct PyArrayMethodObject_tag;
 
@@ -344,6 +344,7 @@ typedef int (get_traverse_loop_function)(
 #define NPY_DT_getitem 8
 #define NPY_DT_get_clear_loop 9
 #define NPY_DT_get_fill_zero_loop 10
+#define NPY_DT_finalize_descr 11
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;
@@ -418,6 +419,14 @@ typedef PyArray_DTypeMeta *(common_dtype_function)(
 typedef PyArray_Descr *(common_instance_function)(
         PyArray_Descr *dtype1, PyArray_Descr *dtype2);
 typedef PyArray_Descr *(ensure_canonical_function)(PyArray_Descr *dtype);
+/*
+ * Returns either a new reference to *dtype* or a new descriptor instance
+ * initialized with the same parameters as *dtype*. The caller cannot know
+ * which choice a dtype will make. This function is called just before the
+ * array buffer is created for a newly created array, it is not called for
+ * views and the descriptor returned by this function is attached to the array.
+ */
+typedef PyArray_Descr *(finalize_descr_function)(PyArray_Descr *dtype);
 
 /*
  * TODO: These two functions are currently only used for experimental DType

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -662,13 +662,10 @@ PyArray_NewFromDescr_int(
     finalize_descr_function *finalize =
             NPY_DT_SLOTS(NPY_DTYPE(descr))->finalize_descr;
     if (finalize != NULL && data == NULL) {
-        PyArray_Descr *finalize_descr = finalize(descr);
-        if (finalize_descr == NULL) {
-            Py_DECREF(descr);
+        Py_SETREF(descr, finalize(descr));
+        if (descr == NULL) {
             return NULL;
         }
-        /* may or may not be the same as descr */
-        Py_SETREF(descr, finalize_descr);
     }
 
     nbytes = descr->elsize;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -658,6 +658,13 @@ PyArray_NewFromDescr_int(
         return NULL;
     }
 
+    /* finalize the descriptor if the DType defines a finalization function */
+    finalize_descr_function *finalize =
+            NPY_DT_SLOTS(NPY_DTYPE(descr))->finalize_descr;
+    if (finalize != NULL && data == NULL) {
+        Py_SETREF(descr, finalize(descr));
+    }
+
     nbytes = descr->elsize;
     /*
      * Unless explicitly asked not to, we do replace dtypes in some cases.

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -662,7 +662,13 @@ PyArray_NewFromDescr_int(
     finalize_descr_function *finalize =
             NPY_DT_SLOTS(NPY_DTYPE(descr))->finalize_descr;
     if (finalize != NULL && data == NULL) {
-        Py_SETREF(descr, finalize(descr));
+        PyArray_Descr *finalize_descr = finalize(descr);
+        if (finalize_descr == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+        /* may or may not be the same as descr */
+        Py_SETREF(descr, finalize_descr);
     }
 
     nbytes = descr->elsize;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -878,6 +878,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr,
     dt_slots->common_instance = NULL;
     dt_slots->ensure_canonical = ensure_native_byteorder;
     dt_slots->get_fill_zero_loop = NULL;
+    dt_slots->finalize_descr = NULL;
 
     if (PyTypeNum_ISSIGNED(dtype_class->type_num)) {
         /* Convert our scalars (raise on too large unsigned and NaN, etc.) */

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -59,6 +59,12 @@ typedef struct {
     */
     get_traverse_loop_function *get_fill_zero_loop;
     /*
+     * Either NULL or a function that performs finalization on a dtype, either
+     * returning that dtype or a newly created instance that has the same
+     * parameters, if any, as the operand dtype.
+     */
+    finalize_descr_function *finalize_descr;
+    /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
      */
@@ -80,7 +86,7 @@ typedef struct {
 
 // This must be updated if new slots before within_dtype_castingimpl
 // are added
-#define NPY_NUM_DTYPE_SLOTS 10
+#define NPY_NUM_DTYPE_SLOTS 11
 #define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
 #define NPY_DT_MAX_ARRFUNCS_SLOT \
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET

--- a/numpy/_core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/_core/src/multiarray/experimental_public_dtype_api.c
@@ -164,6 +164,8 @@ PyArrayInitDTypeMeta_FromSpec(
     NPY_DT_SLOTS(DType)->setitem = NULL;
     NPY_DT_SLOTS(DType)->getitem = NULL;
     NPY_DT_SLOTS(DType)->get_clear_loop = NULL;
+    NPY_DT_SLOTS(DType)->get_fill_zero_loop = NULL;
+    NPY_DT_SLOTS(DType)->finalize_descr = NULL;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
     PyType_Slot *spec_slot = spec->slots;

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -38,7 +38,7 @@ npy_fasttake_impl(
         npy_intp n, npy_intp m, npy_intp max_item,
         npy_intp nelem, npy_intp chunk,
         NPY_CLIPMODE clipmode, npy_intp itemsize, int needs_refcounting,
-        PyArray_Descr *dtype, int axis)
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype, int axis)
 {
     NPY_BEGIN_THREADS_DEF;
 
@@ -52,7 +52,7 @@ npy_fasttake_impl(
     }
     else {
         if (PyArray_GetDTypeTransferFunction(
-                1, itemsize, itemsize, dtype, dtype, 0,
+                1, itemsize, itemsize, src_dtype, dst_dtype, 0,
                 &cast_info, &flags) < 0) {
             return -1;
         }
@@ -174,44 +174,51 @@ npy_fasttake(
         npy_intp n, npy_intp m, npy_intp max_item,
         npy_intp nelem, npy_intp chunk,
         NPY_CLIPMODE clipmode, npy_intp itemsize, int needs_refcounting,
-        PyArray_Descr *dtype, int axis)
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype, int axis)
 {
     if (!needs_refcounting) {
         if (chunk == 1) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
         if (chunk == 2) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
         if (chunk == 4) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
         if (chunk == 8) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
         if (chunk == 16) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
         if (chunk == 32) {
             return npy_fasttake_impl(
                     dest, src, indices, n, m, max_item, nelem, chunk,
-                    clipmode, itemsize, needs_refcounting, dtype, axis);
+                    clipmode, itemsize, needs_refcounting, src_dtype,
+                    dst_dtype, axis);
         }
     }
 
     return npy_fasttake_impl(
             dest, src, indices, n, m, max_item, nelem, chunk,
-            clipmode, itemsize, needs_refcounting, dtype, axis);
+            clipmode, itemsize, needs_refcounting, src_dtype,
+            dst_dtype, axis);
 }
 
 
@@ -310,6 +317,8 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
     chunk = chunk * itemsize;
     char *src = PyArray_DATA(self);
     char *dest = PyArray_DATA(obj);
+    PyArray_Descr *src_descr = PyArray_DESCR(self);
+    PyArray_Descr *dst_descr = PyArray_DESCR(obj);
     needs_refcounting = PyDataType_REFCHK(PyArray_DESCR(self));
     npy_intp *indices_data = (npy_intp *)PyArray_DATA(indices);
 
@@ -322,7 +331,8 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
 
     if (npy_fasttake(
             dest, src, indices_data, n, m, max_item, nelem, chunk,
-            clipmode, itemsize, needs_refcounting, dtype, axis) < 0) {
+            clipmode, itemsize, needs_refcounting, src_descr, dst_descr,
+            axis) < 0) {
         goto fail;
     }
 

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -925,6 +925,7 @@ array_boolean_subscript(PyArrayObject *self,
     npy_intp size, itemsize;
     char *ret_data;
     PyArray_Descr *dtype;
+    PyArray_Descr *ret_dtype;
     PyArrayObject *ret;
 
     size = count_boolean_trues(PyArray_NDIM(bmask), PyArray_DATA(bmask),
@@ -935,6 +936,8 @@ array_boolean_subscript(PyArrayObject *self,
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype, 1, &size,
                                 NULL, NULL, 0, NULL);
+    /* not same as *dtype* if the DType class replaces dtypes */
+    ret_dtype = PyArray_DESCR(ret);
     if (ret == NULL) {
         return NULL;
     }
@@ -981,7 +984,7 @@ array_boolean_subscript(PyArrayObject *self,
         if (PyArray_GetDTypeTransferFunction(
                         IsUintAligned(self) && IsAligned(self),
                         fixed_strides[0], itemsize,
-                        dtype, dtype,
+                        dtype, ret_dtype,
                         0,
                         &cast_info,
                         &cast_flags) != NPY_SUCCEED) {
@@ -1051,9 +1054,9 @@ array_boolean_subscript(PyArrayObject *self,
     if (!PyArray_CheckExact(self)) {
         PyArrayObject *tmp = ret;
 
-        Py_INCREF(dtype);
+        Py_INCREF(ret_dtype);
         ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
-                Py_TYPE(self), dtype,
+                Py_TYPE(self), ret_dtype,
                 1, &size, PyArray_STRIDES(ret), PyArray_BYTES(ret),
                 PyArray_FLAGS(self), (PyObject *)self, (PyObject *)tmp);
 


### PR DESCRIPTION
This adds a new DType API slot, `NPY_DT_finalize_descr` that, when defined, numpy calls before creating a new array buffer and sets the dtype for the array to the return value.

In addition to the change to `PyArray_NewFromDescr_Int`, this also includes two changes to the boolean subscripting internals and `npy_fasttake`, where numpy assumes that input and output dtypes are the same. These are separate bugfixes but were needed to get my stringdtype arena allocator implementation working (https://github.com/numpy/numpy-user-dtypes/pull/92).