### PR TITLE
BLD: musllinux_aarch64 [wheel build]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # Note: the below skip command doesn't do much currently, the platforms to
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
 # `tools/ci/cirrus_wheels.yml`.
-skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x *-musllinux_aarch64"
+skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
 build-verbosity = "3"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_"

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -17,7 +17,7 @@ linux_aarch64_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 2
+    cpu: 1
     memory: 8G
   matrix:
     # build in a matrix because building and testing all four wheels in a


### PR DESCRIPTION
Going to try to build `musllinux_aarch64` and `manylinux_aarch64` in a single matrix entry. This should work for cp310, cp311, cp312, but may fail on cp39 because of the `EXPECT_CPU_FEATURES` environment variable. I'm not sure why that's there, because I can't find that environment variable anywhere else in the project, and a search doesn't bring up anything either.