### PR TITLE
DOC: update vectorize docstring for proper rendering of decorator syntax example

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2272,7 +2272,7 @@ class vectorize:
            [0., 0., 0., 1., 2., 1.]])
 
     Decorator syntax is supported.  The decorator can be called as
-    a function to provide keyword arguments.
+    a function to provide keyword arguments:
 
     >>> @np.vectorize
     ... def identity(x):


### PR DESCRIPTION
https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html

<img width="777" alt="Screen Shot 2023-10-24 at 19 53 09" src="https://github.com/numpy/numpy/assets/24984410/1ee6cc54-2167-4051-8faa-896e39b8f98b">
