### PR TITLE
DOC: Visually divide main license and bundled licenses in wheels

### DIFF
--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -5,7 +5,7 @@ PLATFORM=$(PYTHONPATH=tools python -c "import openblas_support; print(openblas_s
 
 # Update license
 echo "" >> $PROJECT_DIR/LICENSE.txt
-echo ""----" >> $PROJECT_DIR/LICENSE.txt
+echo "----" >> $PROJECT_DIR/LICENSE.txt
 echo "" >> $PROJECT_DIR/LICENSE.txt
 cat $PROJECT_DIR/LICENSES_bundled.txt >> $PROJECT_DIR/LICENSE.txt
 if [[ $RUNNER_OS == "Linux" ]] ; then

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -4,6 +4,9 @@ PROJECT_DIR="$1"
 PLATFORM=$(PYTHONPATH=tools python -c "import openblas_support; print(openblas_support.get_plat())")
 
 # Update license
+echo "" >> $PROJECT_DIR/LICENSE.txt
+echo ""----" >> $PROJECT_DIR/LICENSE.txt
+echo "" >> $PROJECT_DIR/LICENSE.txt
 cat $PROJECT_DIR/LICENSES_bundled.txt >> $PROJECT_DIR/LICENSE.txt
 if [[ $RUNNER_OS == "Linux" ]] ; then
     cat $PROJECT_DIR/tools/wheels/LICENSE_linux.txt >> $PROJECT_DIR/LICENSE.txt


### PR DESCRIPTION
This fixes #24998 by introducing some whitespace:

```
OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

----

The NumPy repository and source distributions bundle several libraries that are
compatibly licensed.  We list these here.
```
