### PR TITLE
ENH: Added `notes` command for spin

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -33,24 +33,6 @@ def _get_numpy_tools(filename):
     return module
 
 
-def _get_numpy_version():
-    cwd = pathlib.Path.cwd()
-    try:
-        site_packages = meson._set_pythonpath()
-    except FileNotFoundError:
-        return None
-
-    p = util.run(
-        ['python', '-c', 'import numpy as np; print(np.__version__)'],
-        cwd=site_packages,
-        echo=False,
-        output=False
-    )
-
-    os.chdir(cwd)
-
-    return p.stdout.strip().decode('ascii')
-
 @click.command()
 @click.option(
     "-t", "--token",
@@ -590,19 +572,19 @@ def _config_openblas(blas_variant):
 
 @click.command()
 @click.option(
-    "-v", "--version",
+    "-v", "--version-override",
     help="NumPy version of release",
     required=False
 )
 @click.pass_context
-def notes(ctx, version):
+def notes(ctx, version_override):
     """🎉 Generate release notes and validate
 
     \b
     Example:
 
     \b
-    $ spin notes --version 2.0
+    $ spin notes --version-override 2.0
 
     \b
     To automatically pick the version
@@ -610,11 +592,10 @@ def notes(ctx, version):
     \b
     $ spin notes
     """
-    if not version:
-        if not (version := _get_numpy_version()):
-            raise click.ClickException(
-                "Unable to determine NumPy version automatically"
-            )
+    if not version_override:
+        version = util.get_config()['project']['version']
+    else:
+        version = version_override
 
     click.secho(
         f"Generating release notes for NumPy {version}",

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -8,6 +8,7 @@ import shutil
 import json
 import pathlib
 import importlib
+import subprocess
 
 import click
 from spin import util
@@ -567,3 +568,81 @@ def _config_openblas(blas_variant):
         os.makedirs(openblas_dir, exist_ok=True)
         with open(pkg_config_fname, "wt", encoding="utf8") as fid:
             fid.write(openblas.get_pkg_config().replace("\\", "/"))
+
+
+@click.command()
+@click.option(
+    "-v", "--version",
+    help="NumPy version of release",
+    required=False
+)
+@click.pass_context
+def notes(ctx, version):
+    """🎉 Generate release notes and validate
+
+    \b
+    Example:
+
+    \b
+    $ spin notes --version 2.0
+
+    \b
+    To automatically pick the version
+
+    \b
+    $ spin notes
+    """
+    if not version:
+        cmd = ["pip", "show", "numpy"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+        output, error = p.communicate()
+        if error:
+            raise click.ClickException(
+                f"`pip show numpy` returned error: {error}"
+            )
+        import re
+        version_match = re.search(r'Version: (.*)', output)
+        if not version_match:
+            raise click.ClickException(
+                "Unable to determine NumPy version through pip info"
+            )
+        version = version_match.group(1)
+        click.secho(
+            f"Using inferred version {version}"
+        )
+
+    click.secho(
+        f"Generating release notes for NumPy {version}",
+        bold=True, fg="bright_green",
+    )
+
+    # Check if `towncrier` is installed
+    if not shutil.which("towncrier"):
+        raise click.ClickException(
+            f"please install `towncrier` to use this command"
+        )
+
+    # towncrier build --version 2.1 --yes
+    cmd = ["towncrier", "build", "--version", version, "--yes"]
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+    except subprocess.SubprocessError as e:
+        raise click.ClickException(
+            f"`towncrier` failed returned {e.returncode} with error `{e.stderr}`"
+        )
+    output, _ = p.communicate()
+    click.secho(output)
+
+    click.secho(
+        "Verifying consumption of all news fragments",
+        bold=True, fg="bright_green",
+    )
+
+    try:
+        test_notes = _get_numpy_tools(pathlib.Path('ci', 'test_all_newsfragments_used.py'))
+    except ModuleNotFoundError as e:
+        raise click.ClickException(
+            f"{e.msg}. Install the missing packages to use this command."
+        )
+
+    test_notes.main()

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -592,10 +592,7 @@ def notes(ctx, version_override):
     \b
     $ spin notes
     """
-    if not version_override:
-        version = util.get_config()['project']['version']
-    else:
-        version = version_override
+    version = version_override or util.get_config()['project.version']
 
     click.secho(
         f"Generating release notes for NumPy {version}",
@@ -611,12 +608,17 @@ def notes(ctx, version_override):
     # towncrier build --version 2.1 --yes
     cmd = ["towncrier", "build", "--version", version, "--yes"]
     try:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+        p = util.run(
+                cmd=cmd,
+                sys_exit=False,
+                output=True,
+                encoding="utf-8"
+            )
     except subprocess.SubprocessError as e:
         raise click.ClickException(
             f"`towncrier` failed returned {e.returncode} with error `{e.stderr}`"
         )
-    output, _ = p.communicate()
+    output = p.stdout
     click.secho(output)
 
     click.secho(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,5 +204,6 @@ cli = 'vendored-meson/meson/meson.py'
 "Documentation" = [
   ".spin/cmds.py:docs",
   ".spin/cmds.py:changelog",
+  ".spin/cmds.py:notes",
 ]
 "Metrics" = [".spin/cmds.py:bench"]

--- a/tools/ci/test_all_newsfragments_used.py
+++ b/tools/ci/test_all_newsfragments_used.py
@@ -4,13 +4,18 @@ import sys
 import toml
 import os
 
-path = toml.load("pyproject.toml")["tool"]["towncrier"]["directory"]
+def main():
+    path = toml.load("pyproject.toml")["tool"]["towncrier"]["directory"]
 
-fragments = os.listdir(path)
-fragments.remove("README.rst")
-fragments.remove("template.rst")
+    fragments = os.listdir(path)
+    fragments.remove("README.rst")
+    fragments.remove("template.rst")
 
-if fragments:
-    print("The following files were not found by towncrier:")
-    print("    " + "\n    ".join(fragments))
-    sys.exit(1)
+    if fragments:
+        print("The following files were not found by towncrier:")
+        print("    " + "\n    ".join(fragments))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Changes
- Added a notes command for spin
- Created `main` to support imports in `test_all_newsfragments_used.py`

### Testing
</details>

<details>
  <summary> Generate notes with version</summary>

```py
~/os/numpy (bld_24080_notes) » spin notes --version-override 2.0                                                                                                                     ganesh@ganesh-MS-7B86
Generating release notes for NumPy 2.0
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
Removing news fragments...
Removing the following files:
/home/ganesh/os/numpy/doc/release/upcoming_changes/24532.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24946.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24877.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24775.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24858.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24634.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24540.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24854.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24680.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24770.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24445.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24945.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24922.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24818.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24717.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24053.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24587.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24376.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24887.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24931.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24477.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24807.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24420.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/19355.new_feature.rst
Done!

Verifying consumption of all news fragments

```
</details>

---

</details>

<details>
  <summary> Auto detect version</summary>

```py
~/os/numpy (bld_24080_notes*) » spin notes                                                                                                                                  ganesh@ganesh-MS-7B86
Using inferred version 1.26.1
Generating release notes for NumPy 1.26.1
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
Removing news fragments...
Removing the following files:
/home/ganesh/os/numpy/doc/release/upcoming_changes/24532.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24946.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24877.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24775.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24858.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24634.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24540.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24854.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24680.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24770.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24445.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24945.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24922.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24818.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24717.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24053.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24587.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24376.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24887.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24931.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24477.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24807.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24420.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/19355.new_feature.rst
Done!

Verifying consumption of all news fragments
```
</details>

---

</details>

<details>
  <summary> `towncrier` not found </summary>

```py
~/os/numpy (bld_24080_notes*) » spin notes                                                                                                                                  ganesh@ganesh-MS-7B86
Using inferred version 1.26.1
Generating release notes for NumPy 1.26.1
Error: please install `towncrier` to use this command

```
</details>

---

</details>

<details>
  <summary> Auto version detection failed</summary>

```py
~/os/numpy (bld_24080_notes*) » spin notes                                                                                                                                  ganesh@ganesh-MS-7B86
Error: `pip show numpy` returned error: WARNING: Package(s) not found: numpy

```
</details>

### Notes
Related: #24080
