### PR TITLE
MAINT: declare <ctype.h> explicitly

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 
 #include "binop_override.h"
+#include <ctype.h>
 
 /* determines if legacy mode is enabled, global set in multiarraymodule.c */
 extern int npy_legacy_print_mode;

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -10,6 +10,7 @@
 #include "common.h"  /* for error_converting */
 
 #include <math.h>
+#include <ctype.h>
 
 
 /* Relevant arithmetic exceptions */


### PR DESCRIPTION
This is added based on the build errors encountered when building numpy with Python 3.13~alpha1.

From What's new in Python 3.13:
Python.h no longer includes the <ctype.h> standard header file. If needed, it should now be included explicitly.
Source: https://docs.python.org/3.13/whatsnew/3.13.html#id5

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
