### PR TITLE
MAINT: Make bitfield integers unsigned

### DIFF
--- a/numpy/_core/src/_simd/_simd_inc.h.src
+++ b/numpy/_core/src/_simd/_simd_inc.h.src
@@ -105,19 +105,19 @@ typedef struct
     // type name compatible with python style
     const char *pyname;
     // returns '1' if the type represent a unsigned integer
-    int is_unsigned:1;
+    unsigned int is_unsigned:1;
     // returns '1' if the type represent a signed integer
-    int is_signed:1;
+    unsigned int is_signed:1;
     // returns '1' if the type represent a single or double precision
-    int is_float:1;
+    unsigned int is_float:1;
     // returns '1' if the type represent a boolean
-    int is_bool:1;
+    unsigned int is_bool:1;
     // returns '1' if the type represent a sequence
-    int is_sequence:1;
+    unsigned int is_sequence:1;
     // returns '1' if the type represent a scalar
-    int is_scalar:1;
+    unsigned int is_scalar:1;
     // returns '1' if the type represent a vector
-    int is_vector:1;
+    unsigned int is_vector:1;
     // returns the len of multi-vector if the type represent x2 or x3 vector
     // otherwise returns 0, e.g. returns 2 if data type is simd_data_vu8x2
     int is_vectorx;


### PR DESCRIPTION
I am getting a lot of compile warnings recently.  Not sure exactly why, but one source here is that the 1 we store is cast to -1 for a signed integer bitfield.  Making it explicitly unsigned quenches the warning and seems easiest.

---

This was just the easiest.  I have two other sources of warnings:
* Headers which are included in places but were once designed to be more stand-alone and thus redefine things like `NpyAuxData`.  I would have thought that is fine in C, but I am getting requires C11 warning.
* Unused simd functions, I think because on my target (M1) some fallback implementations are really guaranteed to not be used.