### PR TITLE
BLD: improve detection of Netlib libblas/libcblas/liblapack

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -20,9 +20,12 @@ name: BLAS tests (Linux)
 #   - openblas_cmake:
 #         Tests whether OpenBLAS LP64 is detected correctly when only CMake
 #         and not pkg-config is installed.
-#   - netlib:
-#         Installs vanilla blas/lapack, which is the last option tried in
-#         auto-detection.
+#   - netlib-debian:
+#         Installs libblas/liblapack, which in Debian contains libcblas within
+#         libblas.
+#   - netlib-split:
+#         Installs vanilla Netlib blas/lapack with separate libcblas, which is
+#         the last option tried in auto-detection.
 #   - mkl:
 #         Tests MKL installed from PyPI (because easiest/fastest, if broken) in
 #         3 ways: both LP64 and ILP64 via pkg-config, and then using the
@@ -204,10 +207,10 @@ jobs:
       run: spin test -j auto -- numpy/linalg
 
  
-  netlib:
+  netlib-debian:
     if: "github.repository == 'numpy/numpy'"
     runs-on: ubuntu-latest
-    name: "Netlib BLAS/LAPACK"
+    name: "Debian libblas/liblapack"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -229,6 +232,37 @@ jobs:
     - name: Test
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions
+        spin test -j auto -- numpy/linalg
+
+
+  netlib-split:
+    if: "github.repository == 'numpy/numpy'"
+    runs-on: ubuntu-latest
+    container: opensuse/tumbleweed
+    name: "OpenSUSE Netlib BLAS/LAPACK"
+    steps:
+    - name: Install system dependencies
+      run: |
+        # No blas.pc on OpenSUSE as of Nov 2023, so no need to install pkg-config.
+        # If it is needed in the future, use install name `pkgconf-pkg-config`
+        zypper install -y git gcc-c++ python3-pip python3-devel blas cblas lapack
+
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install PyPI dependencies
+      run: |
+        pip install --break-system-packages -r build_requirements.txt
+
+    - name: Build
+      run: |
+        spin build -- -Dblas=blas -Dlapack=lapack -Ddisable-optimization=true -Dallow-noblas=false
+
+    - name: Test
+      run: |
+        pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions
         spin test -j auto -- numpy/linalg
 
 

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -127,7 +127,7 @@ freebsd_test_task:
     memory: 4G
 
   install_devtools_script: |
-    pkg install -y git bash ninja ccache
+    pkg install -y git bash ninja ccache blas cblas lapack pkgconf
 
   <<: *MODIFIED_CLONE
 
@@ -149,7 +149,7 @@ freebsd_test_task:
   build_script: |
     chsh -s /usr/local/bin/bash
     source .venv/bin/activate
-    python -m pip install . --no-build-isolation -v -Csetup-args="-Dallow-noblas=true"
+    python -m pip install . --no-build-isolation -v -Csetup-args="-Dallow-noblas=false"
 
   test_script: |
     chsh -s /usr/local/bin/bash
@@ -157,3 +157,7 @@ freebsd_test_task:
     cd tools
     python -m pytest --pyargs numpy -m "not slow"
     ccache -s
+
+  on_failure:
+    debug_script: |
+      cat build/meson-logs/meson-log.txt


### PR DESCRIPTION
Changes:
- Add proper dependencies for Netlib BLAS and LAPACK, using both pkg-config and system (custom) detection
- Also improve the MKL and OpenBLAS detection, so there is less logged in `meson-log.txt`
- Add a CI job for split `libblas`, `libcblas` and `liblapack` in an OpenSUSE container
- Add `blas`, `cblas` and `lapack` to the FreeBSD CI job

Closes gh-25028
Closes gh-25041
Also address the issue for conda-forge with split `libblas`/`libcblas` encountered in https://github.com/conda-forge/numpy-feedstock/pull/302.