### PR TITLE
MAINT: Add `npy_2_compat.h` which is designed to work also if vendored

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -32,6 +32,17 @@ NumPy version.
 
 Note that the NumPy random API is not affected by this change.
 
+C-API Changes
+=============
+Some definitions where removed or replaced due to being outdated or
+unmaintaibale.  Some new API definition will evaluate differently at
+runtime between NumPy 2.0 and NumPy 1.x.
+Some are defined in ``numpy/_core/include/numpy/npy_2_compat.h``
+(for example ``NPY_DEFAULT_INT``) which can be vendored in full or part
+to have the definitions available when compiling against NumPy 1.x.
+
+Please let us know if you require additional workarounds here.
+
 Namespace changes
 =================
 

--- a/numpy/_core/include/meson.build
+++ b/numpy/_core/include/meson.build
@@ -8,6 +8,7 @@ installed_headers = [
   'numpy/ndarrayobject.h',
   'numpy/ndarraytypes.h',
   'numpy/npy_1_7_deprecated_api.h',
+  'numpy/npy_2_compat.h',
   'numpy/npy_2_complexcompat.h',
   'numpy/npy_3kcompat.h',
   'numpy/npy_common.h',

--- a/numpy/_core/include/numpy/ndarrayobject.h
+++ b/numpy/_core/include/numpy/ndarrayobject.h
@@ -20,6 +20,11 @@ extern "C" {
 
 #include "__multiarray_api.h"
 
+/*
+ * Include any defintions which are defined differently for 1.x and 2.x
+ * (Symbols only available on 2.x are not there, but rather guarded.)
+ */
+#include "npy_2_compat.h"
 
 /* C-API that requires previous API to be defined */
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1486,13 +1486,7 @@ PyArrayNeighborhoodIter_Next2D(PyArrayNeighborhoodIterObject* iter);
 
 /* The default array type */
 #define NPY_DEFAULT_TYPE NPY_DOUBLE
-/* default integer type */
-#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
-    #define NPY_DEFAULT_INT NPY_INTP
-#else
-    #define NPY_DEFAULT_INT  \
-        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)
-#endif
+/* default integer type defined in npy_2_compat header */
 
 /*
  * All sorts of useful ways to look into a PyArrayObject. It is recommended

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -1,0 +1,55 @@
+/*
+ * This header file defines relevant features which:
+ * - Require runtime inspection depending on the NumPy version.
+ * - May be needed when compiling with an older version of NumPy to allow
+ *   a smooth transition.
+ *
+ * As such, it is shipped with NumPy 2.0, but designed to be vendored in full
+ * or parts by downstream projects.
+ *
+ * It must be included after any other includes.  `import_array()` must have
+ * been called in the scope or version dependency will misbehave, even when
+ * only `PyUFunc_` API is used.
+ *
+ * If required complicated defs (with inline functions) should be written as:
+ *
+ *     #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+ *         Simple definition when NumPy 2.0 API is guaranteed.
+ *     #else
+ *         static inline definition of a 1.x compatibility shim
+ *         #if NPY_ABI_VERSION < 0x02000000
+ *            Make 1.x compatibility shim the public API (1.x only branch)
+ *         #else
+ *             Runtime dispatched version (1.x or 2.x)
+ *         #endif
+ *     #endif
+ *
+ * An internal build always passes NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+ */
+
+#ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
+#define NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
+
+/*
+ * New macros for accessing real and complex part of a complex number can be
+ * found in "npy_2_complexcompat.h".
+ */
+
+
+/*
+ * NPY_DEFAULT_INT
+ *
+ * The default integer has changed, `NPY_DEFAULT_INT` is available at runtime
+ * for use as type number, e.g. `PyArray_DescrFromType(NPY_DEFAULT_INT)`.
+ */
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    #define NPY_DEFAULT_INT NPY_INTP
+#elif NPY_ABI_VERSION < 0x02000000
+    #define NPY_DEFAULT_INT NPY_LONG
+#else
+    #define NPY_DEFAULT_INT  \
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)
+#endif
+
+
+#endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_ */


### PR DESCRIPTION
This adds a header to define compatibility with 1.x when compiling against 2.0.  However, it is also designed so that it can be vendored by downstream to allow affected projects to compile with 1.x also.

For now, it only points to the complex macros and includes the ``NPY_DEFAULT_INT`` macro.  More things could be added though, for example, I had an initial version that "backported" ``PyUFunc_GiveFloatingPointErrors``.

---

This is a small follow-up to the default integer change PR, since it makes it more clear that `NPY_DEFAULT_INT` is runtime dependent, and what to steal if you want it when having a code-base that should be compilable in 1.x.