### PR TITLE
DOC: standardize capitalization of NEP headings

### DIFF
--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -54,7 +54,7 @@ There are three kinds of NEPs:
    Any meta-NEP is also considered a Process NEP.
 
 
-NEP Workflow
+NEP workflow
 ------------
 
 The NEP process begins with a new idea for NumPy.  It is highly
@@ -97,7 +97,7 @@ to be made available as PR to the NumPy repo (making sure to appropriately
 mark the PR as a WIP).
 
 
-Review and Resolution
+Review and resolution
 ^^^^^^^^^^^^^^^^^^^^^
 
 NEPs are discussed on the mailing list.  The possible paths of the
@@ -152,7 +152,7 @@ Process NEPs may also have a status of ``Active`` if they are never
 meant to be completed, e.g. NEP 0 (this NEP).
 
 
-How a NEP becomes Accepted
+How a NEP becomes accepted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A NEP is ``Accepted`` by consensus of all interested contributors. We
@@ -220,7 +220,7 @@ to development practices and other details. The precise process followed in
 these cases will depend on the nature and purpose of the NEP being updated.
 
 
-Format and Template
+Format and template
 -------------------
 
 NEPs are UTF-8 encoded text files using the reStructuredText_ format.  Please
@@ -273,7 +273,7 @@ Discussion
 - https://mail.python.org/pipermail/numpy-discussion/2017-December/077481.html
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] This historical record is available by the normal git commands

--- a/doc/neps/nep-0001-npy-format.rst
+++ b/doc/neps/nep-0001-npy-format.rst
@@ -53,7 +53,7 @@ more complicated problems for which more complicated formats like
 HDF5 [2] are a better solution.
 
 
-Use Cases
+Use cases
 ---------
 
 - Neville Newbie has just started to pick up Python and NumPy.  He
@@ -152,7 +152,7 @@ The format explicitly *does not* need to:
   general NPY format.
 
 
-Format Specification: Version 1.0
+Format specification: version 1.0
 ---------------------------------
 
 The first 6 bytes are a magic string: exactly "\x93NUMPY".
@@ -200,7 +200,7 @@ bytes of the array.  Consumers can figure out the number of bytes
 by multiplying the number of elements given by the shape (noting
 that shape=() means there is 1 element) by dtype.itemsize.
 
-Format Specification: Version 2.0
+Format specification: version 2.0
 ---------------------------------
 
 The version 1.0 format only allowed the array header to have a

--- a/doc/neps/nep-0002-warnfix.rst
+++ b/doc/neps/nep-0002-warnfix.rst
@@ -44,7 +44,7 @@ the compilers do not generate warnings in those cases; the tag process has to
 be clean, readable, and be robust. In particular, it should not make the code
 more obscure or worse, break working code.
 
-unused parameter
+Unused parameter
 ----------------
 
 This one appears often: any python-callable C function takes two arguments,
@@ -78,12 +78,12 @@ expanded to::
 Thus avoiding any accidental use of the variable. The mangling is pure C, and
 thus portable. The per-variable warning disabling is compiler specific.
 
-signed/unsigned comparison
+Signed/unsigned comparison
 --------------------------
 
 More tricky: not always clear what to do
 
-half-initialized structures
+Half-initialized structures
 ---------------------------
 
 Just put the elements with NULL in it.

--- a/doc/neps/nep-0004-datetime-proposal3.rst
+++ b/doc/neps/nep-0004-datetime-proposal3.rst
@@ -462,7 +462,7 @@ With this, the above operation can be done as follows::
   Out[12]: array([366, 366, 366],  dtype="timedelta64[D]")
 
 
-Dtype vs time units conversions
+dtype vs time units conversions
 ===============================
 
 For changing the date/time dtype of an existing array, we propose to use

--- a/doc/neps/nep-0004-datetime-proposal3.rst
+++ b/doc/neps/nep-0004-datetime-proposal3.rst
@@ -462,7 +462,7 @@ With this, the above operation can be done as follows::
   Out[12]: array([366, 366, 366],  dtype="timedelta64[D]")
 
 
-dtype vs time units conversions
+Dtype vs time units conversions
 ===============================
 
 For changing the date/time dtype of an existing array, we propose to use

--- a/doc/neps/nep-0005-generalized-ufuncs.rst
+++ b/doc/neps/nep-0005-generalized-ufuncs.rst
@@ -1,7 +1,7 @@
 .. _NEP05:
 
 =======================================
-NEP 5 — Generalized Universal Functions
+NEP 5 — Generalized universal functions
 =======================================
 
 :Status: Final
@@ -86,7 +86,7 @@ Dimension Index
     occurrence of each name in the signature.
 
 
-Details of Signature
+Details of signature
 --------------------
 
 The signature defines "core" dimensionality of input and output
@@ -141,7 +141,7 @@ Here are some examples of signatures:
 |             |                        | and loop/broadcast over the rest. |
 +-------------+------------------------+-----------------------------------+
 
-C-API for implementing Elementary Functions
+C-API for implementing elementary functions
 -------------------------------------------
 
 The current interface remains unchanged, and ``PyUFunc_FromFuncAndData``

--- a/doc/neps/nep-0006-newbugtracker.rst
+++ b/doc/neps/nep-0006-newbugtracker.rst
@@ -1,7 +1,7 @@
 .. _NEP06:
 
 ===================================================
-NEP 6 — Replacing trac with a different bug tracker
+NEP 6 — Replacing Trac with a different bug tracker
 ===================================================
 
 :Author: David Cournapeau, Stefan van der Walt

--- a/doc/neps/nep-0006-newbugtracker.rst
+++ b/doc/neps/nep-0006-newbugtracker.rst
@@ -1,7 +1,7 @@
 .. _NEP06:
 
 ===================================================
-NEP 6 — Replacing Trac with a different bug tracker
+NEP 6 — Replacing trac with a different bug tracker
 ===================================================
 
 :Author: David Cournapeau, Stefan van der Walt
@@ -15,7 +15,7 @@ current trac limitations, and what can be done about it.
 Scenario
 ========
 
-new release
+New release
 -----------
 
 The workflow for a release is roughly as follows:
@@ -47,7 +47,7 @@ better than the actually deployed version on scipy website. Finding issues with
 patches, old patches, etc... and making reports has to be much more streamlined
 that it is now.
 
-subcomponent maintainer
+Subcomponent maintainer
 -----------------------
 
 Say you are the maintainer of scipy.foo, then you are mostly interested in

--- a/doc/neps/nep-0007-datetime-proposal.rst
+++ b/doc/neps/nep-0007-datetime-proposal.rst
@@ -505,7 +505,7 @@ With this, the above operation can be done as follows::
   Out[12]: array([366, 366, 366],  dtype="timedelta64[D]")
 
 
-dtype vs time units conversions
+Dtype vs time units conversions
 ===============================
 
 For changing the date/time dtype of an existing array, we propose to use
@@ -600,7 +600,7 @@ There is a new ufunc C-API call to set the data for a particular
 function pointer (for a particular set of data-types) to be the list of arrays
 passed in to the ufunc.
 
-Array Interface Extensions
+Array interface extensions
 --------------------------
 
 The array interface is extended to both handle datetime and timedelta
@@ -619,7 +619,7 @@ list of tuples describing a data-format can itself be a tuple of
 Final considerations
 ====================
 
-Why the fractional time and events: [3Y/12]//50
+Why the fractional time and events: [3y/12]//50
 -----------------------------------------------
 
 It is difficult to come up with enough units to satisfy every need.  For

--- a/doc/neps/nep-0007-datetime-proposal.rst
+++ b/doc/neps/nep-0007-datetime-proposal.rst
@@ -505,7 +505,7 @@ With this, the above operation can be done as follows::
   Out[12]: array([366, 366, 366],  dtype="timedelta64[D]")
 
 
-Dtype vs time units conversions
+dtype vs time units conversions
 ===============================
 
 For changing the date/time dtype of an existing array, we propose to use
@@ -619,7 +619,7 @@ list of tuples describing a data-format can itself be a tuple of
 Final considerations
 ====================
 
-Why the fractional time and events: [3y/12]//50
+Why the fractional time and events: [3Y/12]//50
 -----------------------------------------------
 
 It is difficult to come up with enough units to satisfy every need.  For

--- a/doc/neps/nep-0008-groupby_additions.rst
+++ b/doc/neps/nep-0008-groupby_additions.rst
@@ -1,7 +1,7 @@
 .. _NEP08:
 
 =============================================================
-NEP 8 —  A proposal for adding groupby functionality to NumPy
+NEP 8 —  a proposal for adding groupby functionality to NumPy
 =============================================================
 
 :Author: Travis Oliphant
@@ -21,7 +21,7 @@ describes two additional methods for ufuncs (reduceby and reducein) and
 two additional functions (segment and edges) which can help add this
 functionality.
 
-Example Use Case
+Example use case
 ================
 Suppose you have a NumPy structured array containing information about
 the number of purchases at several stores over multiple days.  To be clear, the

--- a/doc/neps/nep-0008-groupby_additions.rst
+++ b/doc/neps/nep-0008-groupby_additions.rst
@@ -1,8 +1,8 @@
 .. _NEP08:
 
-=============================================================
-NEP 8 —  a proposal for adding groupby functionality to NumPy
-=============================================================
+============================================================
+NEP 8 — a proposal for adding groupby functionality to NumPy
+============================================================
 
 :Author: Travis Oliphant
 :Contact: oliphant@enthought.com

--- a/doc/neps/nep-0008-groupby_additions.rst
+++ b/doc/neps/nep-0008-groupby_additions.rst
@@ -1,7 +1,7 @@
 .. _NEP08:
 
 ============================================================
-NEP 8 — a proposal for adding groupby functionality to NumPy
+NEP 8 — A proposal for adding groupby functionality to NumPy
 ============================================================
 
 :Author: Travis Oliphant

--- a/doc/neps/nep-0010-new-iterator-ufunc.rst
+++ b/doc/neps/nep-0010-new-iterator-ufunc.rst
@@ -1983,7 +1983,7 @@ functions.::
         ...:        composite_over_it(image1, image2))
     Out[18]: True
 
-Image compositing with numexpr
+Image compositing with NumExpr
 ------------------------------
 
 As a test of the iterator, numexpr has been enhanced to allow use of

--- a/doc/neps/nep-0010-new-iterator-ufunc.rst
+++ b/doc/neps/nep-0010-new-iterator-ufunc.rst
@@ -1,7 +1,7 @@
 .. _NEP10:
 
 ==============================================
-NEP 10 — Optimizing iterator/ufunc performance
+NEP 10 — Optimizing iterator/UFunc performance
 ==============================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
@@ -1680,7 +1680,7 @@ references, and add ``NPY_ITER_WRITEABLE_REFERENCES`` to the flags:
         return ret;
     }
 
-Python lambda ufunc example
+Python lambda UFunc example
 ---------------------------
 
 To show how the new iterator allows the definition of efficient UFunc-like

--- a/doc/neps/nep-0010-new-iterator-ufunc.rst
+++ b/doc/neps/nep-0010-new-iterator-ufunc.rst
@@ -1,7 +1,7 @@
 .. _NEP10:
 
 ==============================================
-NEP 10 — Optimizing Iterator/UFunc performance
+NEP 10 — Optimizing iterator/ufunc performance
 ==============================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
@@ -75,7 +75,7 @@ a view of the memory, adding, then reshaping back.  To further examine
 the problem and see how it isn’t always as trivial to work around,
 let’s consider simple code for working with image buffers in NumPy.
 
-Image Compositing Example
+Image compositing example
 =========================
 
 For a more realistic example, consider an image buffer.  Images are
@@ -164,7 +164,7 @@ proposed can produce, go to the example continued after the
 proposed API, near the bottom of the document.
 
 *************************
-Improving Cache-Coherency
+Improving cache-coherency
 *************************
 
 In order to get the best performance from UFunc calls, the pattern of
@@ -241,7 +241,7 @@ by adding an additional constraint.  I think the appropriate choice
 is to resolve it by picking the memory layout closest to C-contiguous,
 but still compatible with the input strides.
 
-Output Layout Selection Algorithm
+Output layout selection algorithm
 =================================
 
 The output ndarray memory layout we would like to produce is as follows:
@@ -296,7 +296,7 @@ output layout.::
     return perm
 
 *********************
-Coalescing Dimensions
+Coalescing dimensions
 *********************
 
 In many cases, the memory layout allows for the use of a one-dimensional
@@ -334,7 +334,7 @@ Here is pseudo-code for coalescing.::
                 j += 1
 
 *************************
-Inner Loop Specialization
+Inner loop specialization
 *************************
 
 Specialization is handled purely by the inner loop function, so this
@@ -371,7 +371,7 @@ constant argument may be combined with SSE when the strides match the
 data type size, and reductions can be optimized with SSE as well.
 
 **********************
-Implementation Details
+Implementation details
 **********************
 
 Except for inner loop specialization, the discussed
@@ -436,7 +436,7 @@ could adopt this enum as its preferred way of dealing with casting.
             NPY_UNSAFE_CASTING=4
     } NPY_CASTING;
 
-Iterator Rewrite
+Iterator rewrite
 ================
 
 Based on an analysis of the code, it appears that refactoring the existing
@@ -495,7 +495,7 @@ Notes for implementation:
   a wrapper around the C iterator.  This is analogous to the
   PEP 3118 design separation of Py_buffer and memoryview.
 
-Proposed Iterator Memory Layout
+Proposed iterator memory layout
 ===============================
 
 The following struct describes the iterator memory.  All items
@@ -596,7 +596,7 @@ common properties are, resulting in increased cache coherency.
 It also simplifies the iternext call, while making getcoord and
 related functions slightly more complicated.
 
-Proposed Iterator API
+Proposed iterator API
 =====================
 
 The existing iterator API includes functions like PyArrayIter_Check,
@@ -631,7 +631,7 @@ to emulate UFunc behavior in cases which don't quite fit the
 UFunc paradigm.  In particular, emulating the UFunc buffering behavior
 is not a trivial enterprise.
 
-Old -> New Iterator API Conversion
+Old -> new iterator API conversion
 ----------------------------------
 
 For the regular iterator:
@@ -672,7 +672,7 @@ For other API calls:
 ===============================  =============================================
 
 
-Iterator Pointer Type
+Iterator pointer type
 ---------------------
 
 The iterator structure is internally generated, but a type is still needed
@@ -682,7 +682,7 @@ the API.  We do this with a typedef of an incomplete struct
 ``typedef struct NpyIter_InternalOnly NpyIter;``
 
 
-Construction and Destruction
+Construction and destruction
 ----------------------------
 
 ``NpyIter* NpyIter_New(PyArrayObject* op, npy_uint32 flags, NPY_ORDER order, NPY_CASTING casting, PyArray_Descr* dtype, npy_intp a_ndim, npy_intp *axes, npy_intp buffersize)``
@@ -1415,7 +1415,7 @@ Construction and Destruction
     Fills ``niter`` flags. Sets ``outwriteflags[i]`` to 1 if
     ``op[i]`` can be written to, and to 0 if not.
 
-Functions For Iteration
+Functions for iteration
 -----------------------
 
 ``NpyIter_IterNext_Fn NpyIter_GetIterNext(NpyIter *iter, char **errmsg)``
@@ -1680,7 +1680,7 @@ references, and add ``NPY_ITER_WRITEABLE_REFERENCES`` to the flags:
         return ret;
     }
 
-Python Lambda UFunc Example
+Python lambda ufunc example
 ---------------------------
 
 To show how the new iterator allows the definition of efficient UFunc-like
@@ -1733,7 +1733,7 @@ can gain some performance from better cache behavior.::
     Out[7]: True
 
 
-Python Addition Example
+Python addition example
 -----------------------
 
 The iterator has been mostly written and exposed to Python.  To
@@ -1897,7 +1897,7 @@ Also, just to check that it's doing the same thing,::
 
     Out[22]: True
 
-Image Compositing Example Revisited
+Image compositing example revisited
 -----------------------------------
 
 For motivation, we had an example that did an 'over' composite operation
@@ -1983,7 +1983,7 @@ functions.::
         ...:        composite_over_it(image1, image2))
     Out[18]: True
 
-Image Compositing With NumExpr
+Image compositing with numexpr
 ------------------------------
 
 As a test of the iterator, numexpr has been enhanced to allow use of

--- a/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
+++ b/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
@@ -1,7 +1,7 @@
 .. _NEP11:
 
 ==================================
-NEP 11 — Deferred ufunc evaluation
+NEP 11 — Deferred UFunc evaluation
 ==================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>

--- a/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
+++ b/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
@@ -1,7 +1,7 @@
 .. _NEP11:
 
 ==================================
-NEP 11 — Deferred UFunc evaluation
+NEP 11 — Deferred ufunc evaluation
 ==================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
@@ -73,7 +73,7 @@ UFunc to evaluate on the fly.
 
 
 *******************
-Example Python Code
+Example Python code
 *******************
 
 Here's how it might be used in NumPy.::
@@ -138,7 +138,7 @@ divide by zero error?" can hopefully be avoided by recommending
 this approach.
 
 ********************************
-Proposed Deferred Evaluation API
+Proposed deferred evaluation API
 ********************************
 
 For deferred evaluation to work, the C API needs to be aware of its
@@ -216,7 +216,7 @@ The Python API would be expanded as follows.
     ``numpy.errstate``.
 
 
-Error Handling
+Error handling
 ==============
 
 Error handling is a thorny issue for deferred evaluation.  If the
@@ -232,7 +232,7 @@ only when the error state is set to ignore all, but allow user control with
 use deferred evaluation, False would mean never use it, and None would
 mean use it only when safe (i.e. the error state is set to ignore all).
 
-Interaction With UPDATEIFCOPY
+Interaction with updateifcopy
 =============================
 
 The ``NPY_UPDATEIFCOPY`` documentation states:
@@ -272,7 +272,7 @@ To deal with this issue, we make these two states mutually exclusive.
   future.  If the deferred evaluation mechanism sees this flag in
   any operand, it triggers immediate evaluation.
 
-Other Implementation Details
+Other implementation details
 ============================
 
 When a deferred array is created, it gets references to all the
@@ -288,7 +288,7 @@ This may release references to other deferred arrays contained
 in the deferred expression tree, which then
 never have to be calculated.
 
-Further Optimization
+Further optimization
 ====================
 
 Instead of conservatively disabling deferred evaluation when any

--- a/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
+++ b/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
@@ -232,7 +232,7 @@ only when the error state is set to ignore all, but allow user control with
 use deferred evaluation, False would mean never use it, and None would
 mean use it only when safe (i.e. the error state is set to ignore all).
 
-Interaction with updateifcopy
+Interaction with UPDATEIFCOPY
 =============================
 
 The ``NPY_UPDATEIFCOPY`` documentation states:

--- a/doc/neps/nep-0012-missing-data.rst
+++ b/doc/neps/nep-0012-missing-data.rst
@@ -11,7 +11,7 @@ NEP 12 — Missing data functionality in NumPy
 :Status: Deferred
 
 *****************
-Table of Contents
+Table of contents
 *****************
 
 .. contents::
@@ -53,7 +53,7 @@ solution, and with the requirement that a bit pattern to sacrifice be
 chosen in the case of the bitpattern solution.
 
 **************************
-Definition of Missing Data
+Definition of missing data
 **************************
 
 In order to be able to develop an intuition about what computation
@@ -77,7 +77,7 @@ proposed elsewhere for customizing subclass ufunc behavior with a
 _numpy_ufunc_ member function would allow a subclass with a different
 default to be created.
 
-Unknown Yet Existing Data (NA)
+Unknown yet existing data (na)
 ==============================
 
 This is the approach taken in the R project, defining a missing element
@@ -98,7 +98,7 @@ such things to the theoretical limit is probably not worth it,
 and in many cases either raising an exception or returning all
 missing values may be preferred to doing precise calculations.
 
-Data That Doesn't Exist Or Is Being Skipped (IGNORE)
+Data that doesn't exist or is being skipped (ignore)
 ====================================================
 
 Another useful interpretation is that the missing elements should be
@@ -119,7 +119,7 @@ the data as if the NA values are not part of the data set. This proposal
 defines a standard parameter "skipna=True" for this same purpose.
 
 ********************************************
-Implementation Techniques For Missing Values
+Implementation techniques for missing values
 ********************************************
 
 In addition to there being two different interpretations of missing values,
@@ -136,7 +136,7 @@ not have to worry about whether the arrays it is using have taken one
 or the other approach, the missing value semantics will be identical
 for the two implementations.
 
-Bit Patterns Signalling Missing Values (bitpattern)
+Bit patterns signalling missing values (bitpattern)
 ===================================================
 
 One or more patterns of bits, for example a NaN with
@@ -149,7 +149,7 @@ holding the value, so that value is gone.
 Additionally, for some types such as integers, a good and proper value
 must be sacrificed to enable this functionality.
 
-Boolean Masks Signalling Missing Values (mask)
+Boolean masks signalling missing values (mask)
 ==============================================
 
 A mask is a parallel array of booleans, either one byte per element or
@@ -168,7 +168,7 @@ data type, it may take on any binary pattern without affecting the
 NA behavior.
 
 *****************
-Glossary of Terms
+Glossary of terms
 *****************
 
 Because the above discussions of the different concepts and their
@@ -215,10 +215,10 @@ C API
     is usually prioritizes flexibility and high performance.
 
 ********************************
-Missing Values as Seen in Python
+Missing values as seen in Python
 ********************************
 
-Working With Missing Values
+Working with missing values
 ===========================
 
 NumPy will gain a global singleton called numpy.NA, similar to None,
@@ -336,7 +336,7 @@ A manual loop through a masked array like::
 works even with masked values, because 'a[i]' returns an NA object
 with a data type associated, that can be treated properly by the ufuncs.
 
-Accessing a Boolean Mask
+Accessing a boolean mask
 ========================
 
 The mask used to implement missing data in the masked approach is not
@@ -353,7 +353,7 @@ instead of masked and unmasked values. The functions are
 'np.isna' and 'np.isavail', which test for NA or available values
 respectively.
 
-Creating NA-Masked Arrays
+Creating na-masked arrays
 =========================
 
 The usual way to create an array with an NA mask is to pass the keyword
@@ -374,7 +374,7 @@ into the mask of another array. If this is set to True in a masked
 array, the array will create a copy of the mask so that further modifications
 to the mask will not affect the original mask from which the view was taken.
 
-NA-Masks When Constructing From Lists
+Na-masks when constructing from lists
 =====================================
 
 The initial design of NA-mask construction was to make all construction
@@ -390,7 +390,7 @@ NA-masks, and extending the NA-mask support more fully throughout NumPy seems
 much more reasonable than starting another system and ending up with two
 incomplete systems.
 
-Mask Implementation Details
+Mask implementation details
 ===========================
 
 The memory ordering of the mask will always match the ordering of
@@ -410,7 +410,7 @@ mask to that view. A data set can be viewed with multiple different
 masks simultaneously, by creating multiple views, and giving each view
 a mask.
 
-New ndarray Methods
+New ndarray methods
 ===================
 
 New functions added to the numpy namespace are::
@@ -455,7 +455,7 @@ New functions added to the ndarray are::
         >>> a.flags.maskna = True
         >>> a.flags.ownmaskna = True
 
-Element-wise UFuncs With Missing Values
+Element-wise ufuncs with missing values
 =======================================
 
 As part of the implementation, ufuncs and other operations will
@@ -491,7 +491,7 @@ like ufuncs, but deviate from their behavior. The functions logical_and
 and logical_or can be moved into standalone function objects which are
 backwards compatible with the current ufuncs.
 
-Reduction UFuncs With Missing Values
+Reduction ufuncs with missing values
 ====================================
 
 Reduction operations like 'sum', 'prod', 'min', and 'max' will operate
@@ -555,7 +555,7 @@ Since 'np.any' is the reduction for 'np.logical_or', and 'np.all'
 is the reduction for 'np.logical_and', it makes sense for them to
 have a 'skipna=' parameter like the other similar reduction functions.
 
-Parameterized NA Data Types
+Parameterized na data types
 ===========================
 
 A masked array isn't the only way to deal with missing data, and
@@ -645,7 +645,7 @@ cannot hold values, but will conform to the input types in functions like
 maps to [('a', 'NA[f4]'), ('b', 'NA[i4]')]. Thus, to view the memory
 of an 'f8' array 'arr' with 'NA[f8]', you can say arr.view(dtype='NA').
 
-Future Expansion to multi-NA Payloads
+Future expansion to multi-na payloads
 =====================================
 
 The packages SAS and Stata both support multiple different "NA" values.
@@ -782,7 +782,7 @@ to be consistent with the result of np.sum([])::
     >>> np.sum([])
     0.0
 
-Boolean Indexing
+Boolean indexing
 ================
 
 Indexing using a boolean array containing NAs does not have a consistent
@@ -814,7 +814,7 @@ R uses. That is, to produce the following::
 If, in user testing, this is found necessary for pragmatic reasons,
 the feature should be added even though it is inconsistent.
 
-PEP 3118
+Pep 3118
 ========
 
 PEP 3118 doesn't have any mask mechanism, so arrays with masks will
@@ -840,7 +840,7 @@ to do this will be to include it with supporting np.nditer, which
 is most likely going to have an enhancement to make writing missing
 value algorithms easier.
 
-Hard Masks
+Hard masks
 ==========
 
 The numpy.ma implementation has a "hardmask" feature,
@@ -854,7 +854,7 @@ arbitrary choice of C-ordering as it currently does. While this
 improves the abstraction of the array significantly, it is not
 a compatible change.
 
-Shared Masks
+Shared masks
 ============
 
 One feature of numpy.ma is called 'shared masks'.
@@ -876,7 +876,7 @@ both the mask and the data are taken simultaneously. The result
 is two views which share the same mask memory and the same data memory,
 which still preserves the missing value abstraction.
 
-Interaction With Pre-existing C API Usage
+Interaction with Pre-existing C API usage
 =========================================
 
 Making sure existing code using the C API, whether it's written in C, C++,
@@ -887,7 +887,7 @@ a few different access patterns people use to get ahold of the numpy array data,
 here we examine a few of them to see what numpy can do. These examples are
 found from doing google searches of numpy C API array access.
 
-NumPy Documentation - How to extend NumPy
+NumPy documentation - how to extend numpy
 -----------------------------------------
 
 https://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#dealing-with-array-objects
@@ -907,7 +907,7 @@ it is an ndarray and checks some flags, will silently produce incorrect results.
 of code does not provide any opportunity for numpy to say "hey, this array is special",
 so also is not compatible with future ideas of lazy evaluation, derived dtypes, etc.
 
-Tutorial From Cython Website
+Tutorial from cython website
 ----------------------------
 
 http://docs.cython.org/src/tutorial/numpy.html
@@ -937,7 +937,7 @@ PyObject_GetBuffer. This call gives numpy the opportunity to raise an
 exception if the inputs are arrays with NA-masks, something not supported
 by the Python buffer protocol.
 
-Numerical Python - JPL website
+Numerical Python - jpl website
 ------------------------------
 
 http://dsnra.jpl.nasa.gov/software/Python/numpydoc/numpy-13.html
@@ -954,7 +954,7 @@ gives numpy an opportunity to raise an exception when NA-masked arrays are used,
 so the later code will raise exceptions as desired.
 
 ************************
-C Implementation Details
+C implementation details
 ************************
 
 .. highlight:: c
@@ -1029,7 +1029,7 @@ int PyArray_AllocateMaskNA(PyArrayObject* arr, npy_bool ownmaskna, npy_bool mult
     Allocates an NA mask for the array, ensuring ownership if requested
     and using NPY_MASK instead of NPY_BOOL for the dtype if multina is True.
 
-Mask Binary Format
+Mask binary format
 ==================
 
 The format of the mask itself is designed to indicate whether an
@@ -1062,7 +1062,7 @@ The fact that this makes masks completely different from booleans, instead
 of a strict superset, is the primary reason this choice was discarded.
 
 ********************************************
-C Iterator API Changes: Iteration With Masks
+C iterator API changes: iteration with masks
 ********************************************
 
 For iteration and computation with masks, both in the context of missing
@@ -1077,7 +1077,7 @@ First we describe iteration designed for use of masks outside the
 context of missing values, then the features which include missing
 value support.
 
-Iterator Mask Features
+Iterator mask features
 ======================
 
 We add several new per-operand flags:
@@ -1116,7 +1116,7 @@ NPY_ITER_VIRTUAL
     allows for creating a "virtual mask", specifying which values
     are unmasked without ever creating a full mask array.
 
-Iterator NA-array Features
+Iterator na-array features
 ==========================
 
 We add several new per-operand flags:
@@ -1137,10 +1137,10 @@ NPY_ITER_IGNORE_MASKNA
     dtype, showing a dtype that does not support NA.
 
 ********************
-Rejected Alternative
+Rejected alternative
 ********************
 
-Parameterized Data Type Which Adds Additional Memory for the NA Flag
+Parameterized data type which adds additional memory for the na flag
 ====================================================================
 
 Another alternative to having a separate mask added to the array is

--- a/doc/neps/nep-0012-missing-data.rst
+++ b/doc/neps/nep-0012-missing-data.rst
@@ -77,7 +77,7 @@ proposed elsewhere for customizing subclass ufunc behavior with a
 _numpy_ufunc_ member function would allow a subclass with a different
 default to be created.
 
-Unknown yet existing data (na)
+Unknown yet existing data (NA)
 ==============================
 
 This is the approach taken in the R project, defining a missing element
@@ -98,7 +98,7 @@ such things to the theoretical limit is probably not worth it,
 and in many cases either raising an exception or returning all
 missing values may be preferred to doing precise calculations.
 
-Data that doesn't exist or is being skipped (ignore)
+Data that doesn't exist or is being skipped (IGNORE)
 ====================================================
 
 Another useful interpretation is that the missing elements should be
@@ -353,7 +353,7 @@ instead of masked and unmasked values. The functions are
 'np.isna' and 'np.isavail', which test for NA or available values
 respectively.
 
-Creating na-masked arrays
+Creating NA-masked arrays
 =========================
 
 The usual way to create an array with an NA mask is to pass the keyword
@@ -555,7 +555,7 @@ Since 'np.any' is the reduction for 'np.logical_or', and 'np.all'
 is the reduction for 'np.logical_and', it makes sense for them to
 have a 'skipna=' parameter like the other similar reduction functions.
 
-Parameterized na data types
+Parameterized NA data types
 ===========================
 
 A masked array isn't the only way to deal with missing data, and
@@ -645,7 +645,7 @@ cannot hold values, but will conform to the input types in functions like
 maps to [('a', 'NA[f4]'), ('b', 'NA[i4]')]. Thus, to view the memory
 of an 'f8' array 'arr' with 'NA[f8]', you can say arr.view(dtype='NA').
 
-Future expansion to multi-na payloads
+Future expansion to multi-NA payloads
 =====================================
 
 The packages SAS and Stata both support multiple different "NA" values.
@@ -814,7 +814,7 @@ R uses. That is, to produce the following::
 If, in user testing, this is found necessary for pragmatic reasons,
 the feature should be added even though it is inconsistent.
 
-Pep 3118
+PEP 3118
 ========
 
 PEP 3118 doesn't have any mask mechanism, so arrays with masks will
@@ -876,7 +876,7 @@ both the mask and the data are taken simultaneously. The result
 is two views which share the same mask memory and the same data memory,
 which still preserves the missing value abstraction.
 
-Interaction with Pre-existing C API usage
+Interaction with pre-existing C API usage
 =========================================
 
 Making sure existing code using the C API, whether it's written in C, C++,
@@ -887,7 +887,7 @@ a few different access patterns people use to get ahold of the numpy array data,
 here we examine a few of them to see what numpy can do. These examples are
 found from doing google searches of numpy C API array access.
 
-NumPy documentation - how to extend numpy
+NumPy documentation - how to extend NumPy
 -----------------------------------------
 
 https://docs.scipy.org/doc/numpy/user/c-info.how-to-extend.html#dealing-with-array-objects
@@ -907,7 +907,7 @@ it is an ndarray and checks some flags, will silently produce incorrect results.
 of code does not provide any opportunity for numpy to say "hey, this array is special",
 so also is not compatible with future ideas of lazy evaluation, derived dtypes, etc.
 
-Tutorial from cython website
+Tutorial from Cython website
 ----------------------------
 
 http://docs.cython.org/src/tutorial/numpy.html
@@ -937,7 +937,7 @@ PyObject_GetBuffer. This call gives numpy the opportunity to raise an
 exception if the inputs are arrays with NA-masks, something not supported
 by the Python buffer protocol.
 
-Numerical Python - jpl website
+Numerical Python - JPL website
 ------------------------------
 
 http://dsnra.jpl.nasa.gov/software/Python/numpydoc/numpy-13.html
@@ -1116,7 +1116,7 @@ NPY_ITER_VIRTUAL
     allows for creating a "virtual mask", specifying which values
     are unmasked without ever creating a full mask array.
 
-Iterator na-array features
+Iterator NA-array features
 ==========================
 
 We add several new per-operand flags:
@@ -1140,7 +1140,7 @@ NPY_ITER_IGNORE_MASKNA
 Rejected alternative
 ********************
 
-Parameterized data type which adds additional memory for the na flag
+Parameterized data type which adds additional memory for the NA flag
 ====================================================================
 
 Another alternative to having a separate mask added to the array is

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -1,7 +1,7 @@
 .. _NEP13:
 
 ==========================================
-NEP 13 — A mechanism for overriding ufuncs
+NEP 13 — A mechanism for overriding Ufuncs
 ==========================================
 
 .. currentmodule:: numpy
@@ -415,7 +415,7 @@ with them in ufuncs.
 
 .. _neps.ufunc-overrides.turning-ufuncs-off:
 
-Turning ufuncs off
+Turning Ufuncs off
 ------------------
 
 For some classes, Ufuncs make no sense, and, like for some other special
@@ -622,7 +622,7 @@ or NumPy's dispatch rules, but not some mixture of both at the same time.
 
 .. _neps.ufunc-overrides.list-of-operators:
 
-List of operators and NumPy ufuncs
+List of operators and NumPy Ufuncs
 ----------------------------------
 
 Here is a full list of Python binary operators and the corresponding NumPy

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -1,7 +1,7 @@
 .. _NEP13:
 
 ==========================================
-NEP 13 — A mechanism for overriding Ufuncs
+NEP 13 — A mechanism for overriding ufuncs
 ==========================================
 
 .. currentmodule:: numpy
@@ -415,7 +415,7 @@ with them in ufuncs.
 
 .. _neps.ufunc-overrides.turning-ufuncs-off:
 
-Turning Ufuncs off
+Turning ufuncs off
 ------------------
 
 For some classes, Ufuncs make no sense, and, like for some other special
@@ -622,7 +622,7 @@ or NumPy's dispatch rules, but not some mixture of both at the same time.
 
 .. _neps.ufunc-overrides.list-of-operators:
 
-List of operators and NumPy Ufuncs
+List of operators and NumPy ufuncs
 ----------------------------------
 
 Here is a full list of Python binary operators and the corresponding NumPy

--- a/doc/neps/nep-0016-abstract-array.rst
+++ b/doc/neps/nep-0016-abstract-array.rst
@@ -318,7 +318,7 @@ Links to discussion
 * https://mail.python.org/pipermail/numpy-discussion/2018-March/077767.html
 
 
-Appendix: Benchmark script
+Appendix: benchmark script
 --------------------------
 
 .. literalinclude:: nep-0016-benchmark.py

--- a/doc/neps/nep-0017-split-out-maskedarray.rst
+++ b/doc/neps/nep-0017-split-out-maskedarray.rst
@@ -118,7 +118,7 @@ After a lively discussion on the mailing list:
 - `MaskedArray` will stay where it is, at least until the new masked array
   class materializes and has been tried in the wild.
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] Subclassing ndarray,

--- a/doc/neps/nep-0019-rng-policy.rst
+++ b/doc/neps/nep-0019-rng-policy.rst
@@ -30,7 +30,7 @@ policy to remove the obstacles that are in the way of accepting contributions
 to our random number generation capabilities.
 
 
-The Status Quo
+The status quo
 --------------
 
 Our current policy, in full:

--- a/doc/neps/nep-0020-gufunc-signature-enhancement.rst
+++ b/doc/neps/nep-0020-gufunc-signature-enhancement.rst
@@ -225,7 +225,7 @@ strongest use case. The frozen dimensions has a very simple implementation and
 its meaning is obvious. The ability to broadcast is simple too, once the
 flexible dimensions are supported.
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] Identified needs and suggestions for the implementation are not all by

--- a/doc/neps/nep-0021-advanced-indexing.rst
+++ b/doc/neps/nep-0021-advanced-indexing.rst
@@ -198,7 +198,7 @@ motivational use-cases for the general ideas and is likely a good start for
 anyone not intimately familiar with advanced indexing.
 
 
-Detailed Description
+Detailed description
 --------------------
 
 Proposed rules
@@ -652,7 +652,7 @@ Copyright
 This document is placed under the CC0 1.0 Universell (CC0 1.0) Public Domain Dedication [1]_.
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] To the extent possible under law, the person who associated CC0 

--- a/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
+++ b/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
@@ -75,7 +75,7 @@ extended to work with duck array objects. In some cases this is easy
 difficult. Here are some principles we’ve found useful so far:
 
 
-Principle 1: Focus on “full” duck arrays, but don’t rule out “partial” duck arrays
+Principle 1: focus on “full” duck arrays, but don’t rule out “partial” duck arrays
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We can distinguish between two classes:
@@ -159,7 +159,7 @@ example of what this might look like, see the documentation for
 <http://dask.pydata.org/en/latest/array-api.html#dask.array.from_array>`__.
 
 
-Principle 2: Take advantage of duck typing
+Principle 2: take advantage of duck typing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``ndarray`` has a very large API surface area::
@@ -207,7 +207,7 @@ arrays room to experiment.
 But, we do provide some more detailed advice for duck array
 implementers and consumers below.
 
-Principle 3: Focus on protocols
+Principle 3: focus on protocols
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Historically, numpy has had lots of success at interoperating with
@@ -249,7 +249,7 @@ semantics.
 Conclusion: protocols are one honking great idea – let’s do more of
 those.
 
-Principle 4: Reuse existing methods when possible
+Principle 4: reuse existing methods when possible
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It’s tempting to try to define cleaned up versions of ndarray methods
@@ -267,7 +267,7 @@ and ``__getitem__`` have the advantage of already being widely
 used/exercised by libraries that use duck arrays, and in practice, any
 serious duck array type is going to have to implement them anyway.
 
-Principle 5: Make it easy to do the right thing
+Principle 5: make it easy to do the right thing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Making duck arrays work well is going to be a community effort.

--- a/doc/neps/nep-0023-backwards-compatibility.rst
+++ b/doc/neps/nep-0023-backwards-compatibility.rst
@@ -187,7 +187,7 @@ made to indicate when the behavior changed:
 
     def argsort(self, axis=np._NoValue, ...):
         """
-        parameters
+        Parameters
         ----------
         axis : int, optional
             Axis along which to sort. If None, the default, the flattened array

--- a/doc/neps/nep-0023-backwards-compatibility.rst
+++ b/doc/neps/nep-0023-backwards-compatibility.rst
@@ -20,7 +20,7 @@ processes for individual cases where breaking backwards compatibility
 is considered.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 NumPy has a very large user base.  Those users rely on NumPy being stable
@@ -187,7 +187,7 @@ made to indicate when the behavior changed:
 
     def argsort(self, axis=np._NoValue, ...):
         """
-        Parameters
+        parameters
         ----------
         axis : int, optional
             Axis along which to sort. If None, the default, the flattened array
@@ -330,7 +330,7 @@ Discussion
 - `PR with review comments on the Dec 2020 update of this NEP <https://github.com/numpy/numpy/pull/18097>`__
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 - `Issue requesting semantic versioning <https://github.com/numpy/numpy/issues/10156>`__

--- a/doc/neps/nep-0024-missing-data-2.rst
+++ b/doc/neps/nep-0024-missing-data-2.rst
@@ -1,7 +1,7 @@
 .. _NEP24:
 
 =============================================================
-NEP 24 — Missing data functionality - alternative 1 to nep 12
+NEP 24 — Missing data functionality - alternative 1 to NEP 12
 =============================================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>, Matthew Brett <matthew.brett@gmail.com>

--- a/doc/neps/nep-0024-missing-data-2.rst
+++ b/doc/neps/nep-0024-missing-data-2.rst
@@ -1,7 +1,7 @@
 .. _NEP24:
 
 =============================================================
-NEP 24 — Missing data functionality - Alternative 1 to NEP 12
+NEP 24 — Missing data functionality - alternative 1 to nep 12
 =============================================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>, Matthew Brett <matthew.brett@gmail.com>

--- a/doc/neps/nep-0025-missing-data-3.rst
+++ b/doc/neps/nep-0025-missing-data-3.rst
@@ -1,7 +1,7 @@
 .. _NEP25:
 
 ======================================
-NEP 25 — NA support via special dtypes
+NEP 25 — Na support via special dtypes
 ======================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>
@@ -129,7 +129,7 @@ Some example use cases:
 
 .. _categorical data: http://mail.scipy.org/pipermail/numpy-discussion/2010-August/052401.html
 
-dtype C-level API extensions
+Dtype c-level API extensions
 ============================
 
 .. highlight:: c
@@ -361,7 +361,7 @@ own global singleton.) So for now we stick to scalar indexing just returning
 
 .. highlight:: python
 
-Python API for generic NA support
+Python API for generic na support
 =================================
 
 NumPy will gain a global singleton called ``numpy.NA``, similar to None, but with
@@ -411,7 +411,7 @@ values where-ever the dtype's ``isna`` function returned true. ``np.isnumber``
 is only defined for numeric dtypes, and returns True for all elements which are
 not NA, and for which ``np.isfinite`` would return True.
 
-Builtin NA dtypes
+Builtin na dtypes
 =================
 
 The above describes the generic machinery for NA support in dtypes. It's

--- a/doc/neps/nep-0025-missing-data-3.rst
+++ b/doc/neps/nep-0025-missing-data-3.rst
@@ -1,7 +1,7 @@
 .. _NEP25:
 
 ======================================
-NEP 25 — Na support via special dtypes
+NEP 25 — NA support via special dtypes
 ======================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>
@@ -129,7 +129,7 @@ Some example use cases:
 
 .. _categorical data: http://mail.scipy.org/pipermail/numpy-discussion/2010-August/052401.html
 
-Dtype c-level API extensions
+dtype C-level API extensions
 ============================
 
 .. highlight:: c
@@ -361,7 +361,7 @@ own global singleton.) So for now we stick to scalar indexing just returning
 
 .. highlight:: python
 
-Python API for generic na support
+Python API for generic NA support
 =================================
 
 NumPy will gain a global singleton called ``numpy.NA``, similar to None, but with
@@ -411,7 +411,7 @@ values where-ever the dtype's ``isna`` function returned true. ``np.isnumber``
 is only defined for numeric dtypes, and returns True for all elements which are
 not NA, and for which ``np.isfinite`` would return True.
 
-Builtin na dtypes
+Builtin NA dtypes
 =================
 
 The above describes the generic machinery for NA support in dtypes. It's

--- a/doc/neps/nep-0026-missing-data-summary.rst
+++ b/doc/neps/nep-0026-missing-data-summary.rst
@@ -1,7 +1,7 @@
 .. _NEP26:
 
 ====================================================
-NEP 26 — Summary of missing data NEPs and discussion
+NEP 26 — Summary of missing data neps and discussion
 ====================================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
@@ -88,7 +88,7 @@ the project to add missing data support to NumPy should be, and which
 kinds of problems are in scope. Let's start with the
 best understood situation where "missing data" comes into play:
 
-"Statistical missing data"
+"statistical missing data"
 --------------------------
 
 In statistics, social science, etc., "missing data" is a term of art
@@ -99,7 +99,7 @@ have a table listing the height, age, and income of a number of
 individuals, but one person did not provide their income, then we need
 some way to represent this::
 
-  Person | Height | Age | Income
+  person | height | age | income
   ------------------------------
      1   |   63   | 25  | 15000
      2   |   58   | 32  | <missing>
@@ -132,7 +132,7 @@ for floats it's a special NaN value that's distinguishable from
 other NaNs, ...) Then, they arrange that in computations, this
 value has a special semantics that we will call "NA semantics".
 
-NA Semantics
+Na semantics
 ------------
 
 The idea of NA semantics is that any computations involving NA
@@ -551,7 +551,7 @@ What **Mark** thinks, overall:
 
   * The mask approach works universally with all data types.
 
-Recommendations for Moving Forward
+Recommendations for moving forward
 ==================================
 
 **Nathaniel** thinks we should:
@@ -703,7 +703,7 @@ and I believe backing out this code because these worries would create a
 risk of reducing developer contribution.
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 :ref:`NEP12` describes Mark's NA-semantics/mask implementation/view based mask

--- a/doc/neps/nep-0026-missing-data-summary.rst
+++ b/doc/neps/nep-0026-missing-data-summary.rst
@@ -1,7 +1,7 @@
 .. _NEP26:
 
 ====================================================
-NEP 26 — Summary of missing data neps and discussion
+NEP 26 — Summary of missing data NEPs and discussion
 ====================================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
@@ -88,7 +88,7 @@ the project to add missing data support to NumPy should be, and which
 kinds of problems are in scope. Let's start with the
 best understood situation where "missing data" comes into play:
 
-"statistical missing data"
+"Statistical missing data"
 --------------------------
 
 In statistics, social science, etc., "missing data" is a term of art
@@ -99,7 +99,7 @@ have a table listing the height, age, and income of a number of
 individuals, but one person did not provide their income, then we need
 some way to represent this::
 
-  person | height | age | income
+  Person | Height | Age | Income
   ------------------------------
      1   |   63   | 25  | 15000
      2   |   58   | 32  | <missing>
@@ -132,7 +132,7 @@ for floats it's a special NaN value that's distinguishable from
 other NaNs, ...) Then, they arrange that in computations, this
 value has a special semantics that we will call "NA semantics".
 
-Na semantics
+NA semantics
 ------------
 
 The idea of NA semantics is that any computations involving NA

--- a/doc/neps/nep-0027-zero-rank-arrarys.rst
+++ b/doc/neps/nep-0027-zero-rank-arrarys.rst
@@ -21,7 +21,7 @@ NEP 27 — Zero rank arrays
     Some of the information here is dated, for instance indexing of 0-D arrays
     now is now implemented and does not error.
 
-Zero-Rank Arrays
+Zero-rank arrays
 ----------------
 
 Zero-rank arrays are arrays with shape=().  For example:
@@ -31,7 +31,7 @@ Zero-rank arrays are arrays with shape=().  For example:
     ()
 
 
-Zero-Rank Arrays and Array Scalars
+Zero-rank arrays and array scalars
 ----------------------------------
 
 Array scalars are similar to zero-rank arrays in many aspects::
@@ -54,7 +54,7 @@ However there are some important differences:
 * Array scalars are immutable
 * Array scalars have different python type for different data types
 
-Motivation for Array Scalars
+Motivation for array scalars
 ----------------------------
 
 NumPy's design decision to provide 0-d arrays and array scalars in addition to
@@ -115,7 +115,7 @@ NumPy implements a solution that is designed to have all the pros and none of th
     inherit from the three that already exist. Define equivalent
     methods and attributes for these Python scalar types.
 
-The Need for Zero-Rank Arrays
+The need for zero-rank arrays
 -----------------------------
 
 Once the idea to use zero-rank arrays to represent scalars was rejected, it was
@@ -147,7 +147,7 @@ replaced by array scalars.  See also `A case for rank-0 arrays`_ from February
     >>> y
     array(20)
 
-Indexing of Zero-Rank Arrays
+Indexing of zero-rank arrays
 ----------------------------
 
 As of NumPy release 0.9.3, zero-rank arrays do not support any indexing::

--- a/doc/neps/nep-0028-website-redesign.rst
+++ b/doc/neps/nep-0028-website-redesign.rst
@@ -45,7 +45,7 @@ This website serves a couple of roles:
   can find their way
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 The current numpy.org website has almost no content and its design is poor.
@@ -328,7 +328,7 @@ Discussion
 - Proposal to accept this NEP: https://mail.python.org/pipermail/numpy-discussion/2019-August/079889.html
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 .. _Crowdin: https://crowdin.com/pricing#annual
 

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -269,7 +269,7 @@ Discussion
 ----------
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 Code to generate support and drop schedule tables ::

--- a/doc/neps/nep-0030-duck-array-protocol.rst
+++ b/doc/neps/nep-0030-duck-array-protocol.rst
@@ -1,7 +1,7 @@
 .. _NEP30:
 
 ======================================================
-NEP 30 — Duck typing for NumPy arrays - Implementation
+NEP 30 — Duck typing for NumPy arrays - implementation
 ======================================================
 
 :Author: Peter Andreas Entschev <pentschev@nvidia.com>

--- a/doc/neps/nep-0031-uarray.rst
+++ b/doc/neps/nep-0031-uarray.rst
@@ -31,7 +31,7 @@ NumPy API. It is intended as a comprehensive resolution to NEP-22 [3]_, and
 obviates the need to add an ever-growing list of new protocols for each new
 type of function or object that needs to become overridable.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 The primary end-goal of this NEP is to make the following possible:
@@ -96,7 +96,7 @@ such as CuPy needing to coerce to a CuPy array, for example, instead of
 a NumPy array. In simpler words, one needs things like ``np.asarray(...)`` or
 an alternative to "just work" and return duck-arrays.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 This NEP allows for global and context-local overrides, as well as
@@ -381,7 +381,7 @@ The benefits to end-users extend beyond just writing new code. Old code
 by a simple import switch and a line adding the preferred backend. This way,
 users may find it easier to port existing code to GPU or distributed computing.
 
-Related Work
+Related work
 ------------
 
 Other override mechanisms
@@ -629,7 +629,7 @@ Discussion
 * Discussion PR 3: https://github.com/numpy/numpy/pull/14389
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] uarray, A general dispatch mechanism for Python: https://uarray.readthedocs.io

--- a/doc/neps/nep-0034-infer-dtype-is-object.rst
+++ b/doc/neps/nep-0034-infer-dtype-is-object.rst
@@ -20,7 +20,7 @@ arrays via ``np.array([<ragged_nested_sequence>])`` with no ``dtype`` keyword
 argument will today default to an ``object``-dtype array. Change the behaviour to
 raise a ``ValueError`` instead.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 Users who specify lists-of-lists when creating a `numpy.ndarray` via
@@ -33,7 +33,7 @@ level have the same length) will force users who actually wish to create
 ``object`` arrays to specify that explicitly. Note that ``lists``, ``tuples``,
 and ``nd.ndarrays`` are all sequences [0]_. See for instance `issue 5303`_.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 After this change, array creation with ragged nested sequences must explicitly
@@ -70,7 +70,7 @@ all of these will be rejected:
     >>> arr = np.array([np.arange(10), [10]])
     >>> arr = np.array([[range(3), range(3), range(3)], [range(3), 0, 0]])
 
-Related Work
+Related work
 ------------
 
 `PR 14341`_ tried to raise an error when ragged nested sequences were specified
@@ -127,7 +127,7 @@ Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 have stuck. The WIP implementation in `PR 14794`_ seems to point to the
 viability of this approach.
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303

--- a/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
+++ b/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
@@ -20,7 +20,7 @@ as described by NEP 18 [1]_. The ``like=`` keyword argument will create an
 instance of the argument's type, enabling direct creation of non-NumPy arrays.
 The target array type must implement the ``__array_function__`` protocol.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 Many libraries implement the NumPy API, such as Dask for graph
@@ -86,7 +86,7 @@ of the keyword-only argument standard described in PEP-3102 [2]_ to implement
 
 .. _neps.like-kwarg.usage-and-impact:
 
-Usage and Impact
+Usage and impact
 ----------------
 
 NumPy users who don't use other arrays from downstream libraries can continue
@@ -192,7 +192,7 @@ alone. Combining Dask's internal handling of meta arrays and the proposed
 of non-NumPy arrays, which is likely the heaviest limitation Dask currently
 faces from the ``__array_function__`` protocol.
 
-Backward Compatibility
+Backward compatibility
 ----------------------
 
 This proposal does not raise any backward compatibility issues within NumPy,

--- a/doc/neps/nep-0038-SIMD-optimizations.rst
+++ b/doc/neps/nep-0038-SIMD-optimizations.rst
@@ -36,7 +36,7 @@ architectures.  The steps proposed are to:
   the possible code paths accordingly.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 Traditionally NumPy has depended on compilers to generate optimal code
@@ -85,7 +85,7 @@ specifically available CPU features at runtime, currently used for ``avx2``,
 universal intrinsics would extend the generated code to include more loop
 variants.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 The end user will be able to get a list of intrinsics available for their
@@ -238,7 +238,7 @@ When importing the ufuncs, the available compiled loops' required features are
 matched to the ones discovered. The loop with the best match is marked to be
 called by the ufunc.
 
-Related Work
+Related work
 ------------
 
 - `Pixman`_ is the library used by Cairo and X to manipulate pixels. It uses
@@ -302,7 +302,7 @@ both on the mailing list and in `gh-15228`_ and resolved as follows:
   architecture-specific code helps one architecture but harms performance
   on another? (answered in the tradeoffs_ part of the workflow).
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. _`build alternative loops`: https://github.com/numpy/numpy/blob/v1.17.4/numpy/core/code_generators/generate_umath.py#L50

--- a/doc/neps/nep-0040-legacy-datatype-impl.rst
+++ b/doc/neps/nep-0040-legacy-datatype-impl.rst
@@ -317,7 +317,7 @@ This function is used multiple places and should probably be part of
 a redesigned casting API.
 
 
-Dtype handling in universal functions
+dtype handling in universal functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Universal functions are implemented as instances of the ``numpy.UFunc`` class
@@ -436,7 +436,7 @@ As such this step may move from the dispatching step (described above) to
 the implementation-specific code described below.
 
 
-Dtype-specific implementation of the ufunc
+dtype-specific implementation of the ufunc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the correct implementation/loop is found, UFuncs currently call

--- a/doc/neps/nep-0040-legacy-datatype-impl.rst
+++ b/doc/neps/nep-0040-legacy-datatype-impl.rst
@@ -317,7 +317,7 @@ This function is used multiple places and should probably be part of
 a redesigned casting API.
 
 
-dtype handling in universal functions
+DType handling in universal functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Universal functions are implemented as instances of the ``numpy.UFunc`` class
@@ -415,7 +415,7 @@ While option 2 may be less complex to reason about it remains to be seen
 whether it is sufficient for all (or most) use cases.
 
 
-Adjustment of parametric output dtypes in ufuncs
+Adjustment of parametric output DTypes in UFuncs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A second step necessary for parametric dtypes is currently performed within
@@ -436,7 +436,7 @@ As such this step may move from the dispatching step (described above) to
 the implementation-specific code described below.
 
 
-dtype-specific implementation of the ufunc
+DType-specific implementation of the UFunc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the correct implementation/loop is found, UFuncs currently call

--- a/doc/neps/nep-0040-legacy-datatype-impl.rst
+++ b/doc/neps/nep-0040-legacy-datatype-impl.rst
@@ -36,7 +36,7 @@ For more general information most readers should begin by reading :ref:`NEP 41 <
 and use this document only as a reference or for additional details.
 
 
-Detailed Description
+Detailed description
 --------------------
 
 This section describes some central concepts and provides a brief overview
@@ -46,7 +46,7 @@ current implementation and then follow with an "Issues and Discussion" section.
 
 .. _parametric-datatype-discussion:
 
-Parametric Datatypes
+Parametric datatypes
 ^^^^^^^^^^^^^^^^^^^^
 
 Some datatypes are inherently *parametric*. All ``np.flexible`` scalar
@@ -91,7 +91,7 @@ numerical ones, which is evident in the complicated output type discovery
 of universal functions.
 
 
-Value Based Casting
+Value based casting
 ^^^^^^^^^^^^^^^^^^^
 
 Casting is typically defined between two types:
@@ -128,7 +128,7 @@ Universal functions currently rely on safe casting semantics to decide which
 loop should be used, and thus what the output datatype will be.
 
 
-Issues and Discussion
+Issues and discussion
 """""""""""""""""""""
 
 There appears to be some agreement that the current method is
@@ -143,7 +143,7 @@ The result depends on the "minimal" representation in the context of the
 conversion (for ufuncs the context may depend on the loop order).
 
 
-The Object Datatype
+The object datatype
 ^^^^^^^^^^^^^^^^^^^
 
 The object datatype currently serves as a generic fallback for any value
@@ -189,7 +189,7 @@ These issues do not need to solved right away:
   for example a DType for ``decimal.Decimal``.
 
 
-Current ``dtype`` Implementation
+Current ``dtype`` implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Currently ``np.dtype`` is a Python class with its instances being the
@@ -220,7 +220,7 @@ datatype in the future.
 For example the ``np.clip`` function was previously implemented using
 ``PyArray_ArrFuncs`` and is now implemented as a ufunc.
 
-Discussion and Issues
+Discussion and issues
 """""""""""""""""""""
 
 A further issue with the current implementation of the functions on the dtype
@@ -246,7 +246,7 @@ However, in the long run access to these structures will probably have to
 be deprecated.
 
 
-NumPy Scalars and Type Hierarchy
+NumPy scalars and type hierarchy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As a side note to the above datatype implementation: unlike the datatypes,
@@ -268,7 +268,7 @@ For the numerical (and unicode) datatypes, they are further limited to
 native byte order.
 
 
-Current Implementation of Casting
+Current implementation of casting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 One of the main features which datatypes need to support is casting between one
@@ -317,7 +317,7 @@ This function is used multiple places and should probably be part of
 a redesigned casting API.
 
 
-DType handling in Universal functions
+Dtype handling in universal functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Universal functions are implemented as instances of the ``numpy.UFunc`` class
@@ -363,7 +363,7 @@ For user defined datatypes, the dispatching logic is similar,
 although separately implemented and limited (see discussion below).
 
 
-Issues and Discussion
+Issues and discussion
 """""""""""""""""""""
 
 It is currently only possible for user defined functions to be found/resolved
@@ -415,7 +415,7 @@ While option 2 may be less complex to reason about it remains to be seen
 whether it is sufficient for all (or most) use cases.
 
 
-Adjustment of Parametric output DTypes in UFuncs
+Adjustment of parametric output dtypes in ufuncs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A second step necessary for parametric dtypes is currently performed within
@@ -425,7 +425,7 @@ for the operation and output array.
 This step also needs to double check that all casts can be performed safely,
 which by default means that they are "same kind" casts.
 
-Issues and Discussion
+Issues and discussion
 """""""""""""""""""""
 
 Fixing the correct output dtype is currently part of the type resolution.
@@ -436,7 +436,7 @@ As such this step may move from the dispatching step (described above) to
 the implementation-specific code described below.
 
 
-DType-specific Implementation of the UFunc
+Dtype-specific implementation of the ufunc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the correct implementation/loop is found, UFuncs currently call
@@ -445,7 +445,7 @@ This may be called multiple times to do the full calculation and it has
 little or no information about the current context. It also has a void
 return value.
 
-Issues and Discussion
+Issues and discussion
 """""""""""""""""""""
 
 Parametric datatypes may require passing
@@ -498,7 +498,7 @@ In general it should be possible to provide a dtype-specific identity to the
 ufunc reduction.
 
 
-Datatype Discovery during Array Coercion
+Datatype discovery during array coercion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When calling ``np.array(...)`` to coerce a general Python object to a NumPy array,
@@ -540,7 +540,7 @@ That is:
 * Datetime64 is capable of coercing from strings and guessing the correct unit.
 
 
-Discussion and Issues
+Discussion and issues
 """""""""""""""""""""
 
 It seems probable that during normal discovery, the ``isinstance`` should rather
@@ -551,7 +551,7 @@ the normal discovery.
 
 
 
-Related Issues
+Related issues
 --------------
 
 ``np.save`` currently translates all user-defined dtypes to void dtypes.
@@ -572,7 +572,7 @@ interoperability they could be considered even if
 they are not used by NumPy itself.
 
 
-Related Work
+Related work
 ------------
 
 * Julia types are an interesting blueprint for a type hierarchy, and define

--- a/doc/neps/nep-0041-improved-dtype-support.rst
+++ b/doc/neps/nep-0041-improved-dtype-support.rst
@@ -47,7 +47,7 @@ development of both user-defined external datatypes,
 as well as new features for existing datatypes internal to NumPy.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 .. seealso::
@@ -183,7 +183,7 @@ For example ``common_dtype(a, b)`` must not be ``c`` unless ``a`` or ``b`` know
 that ``c`` exists.
 
 
-User Impact
+User impact
 -----------
 
 The current ecosystem has very few user-defined datatypes using NumPy, the
@@ -223,7 +223,7 @@ The following examples represent future user-defined datatypes we wish to enable
 These datatypes are not part the NEP and choices (e.g. choice of casting rules)
 are possibilities we wish to enable and do not represent recommendations.
 
-Simple Numerical Types
+Simple numerical types
 """"""""""""""""""""""
 
 Mainly used where memory is a consideration, lower-precision numeric types
@@ -334,7 +334,7 @@ strictly more values defined, is something that the Categorical datatype would
 need to decide. Both options should be available.
 
 
-Unit on the Datatype
+Unit on the datatype
 """"""""""""""""""""
 
 There are different ways to define Units, depending on how the internal
@@ -400,7 +400,7 @@ certain decisions before the actual calculation can start.
 Implementation
 --------------
 
-Plan to Approach the Full Refactor
+Plan to approach the full refactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To address these issues in NumPy and enable new datatypes,
@@ -563,14 +563,14 @@ possibly never, by downstream projects.
 
 
 
-Detailed Description
+Detailed description
 --------------------
 
 This section details the design decisions covered by this NEP.
 The subsections correspond to the list of design choices presented
 in the Scope section.
 
-Datatypes as Python Classes (1)
+Datatypes as Python classes (1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The current NumPy datatypes are not full scale python classes.
@@ -695,7 +695,7 @@ increase the complexity of both the design and implementation.
 A possible future path may be to instead simplify the current NumPy scalars to
 be much simpler objects which largely derive their behaviour from the datatypes.
 
-C-API for creating new Datatypes (3)
+C-API for creating new datatypes (3)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The current C-API with which users can create new datatypes
@@ -737,7 +737,7 @@ a later step in the implementation to reduce the complexity of the initial
 implementation.
 
 
-C-API Changes to the UFunc Machinery (4)
+C-API changes to the ufunc machinery (4)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Proposed changes to the UFunc machinery will be part of NEP 43.

--- a/doc/neps/nep-0041-improved-dtype-support.rst
+++ b/doc/neps/nep-0041-improved-dtype-support.rst
@@ -737,7 +737,7 @@ a later step in the implementation to reduce the complexity of the initial
 implementation.
 
 
-C-API changes to the ufunc machinery (4)
+C-API changes to the UFunc machinery (4)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Proposed changes to the UFunc machinery will be part of NEP 43.

--- a/doc/neps/nep-0042-new-dtypes.rst
+++ b/doc/neps/nep-0042-new-dtypes.rst
@@ -1,7 +1,7 @@
 .. _NEP42:
 
 ==============================================================================
-NEP 42 — New and extensible dtypes
+NEP 42 — New and extensible DTypes
 ==============================================================================
 
 :title: New and extensible DTypes
@@ -262,7 +262,7 @@ dtype instances from DType classes.
 .. _nep42_DType class:
 
 ******************************************************************************
-The dtype class
+The DType class
 ******************************************************************************
 
 This section reviews the structure underlying the proposed DType class,
@@ -463,7 +463,7 @@ We review here the operations related to casting arrays:
 
 We show how casting arrays with ``astype(new_dtype)`` will be implemented.
 
-`Common dtype` operations
+`Common DType` operations
 ==============================================================================
 
 When input types are mixed, a first step is to find a DType that can hold
@@ -984,7 +984,7 @@ important enough to be handled by NumPy using the presented methods.
     ``np.float128`` base class.
 
 
-dtype discovery during array coercion
+DType discovery during array coercion
 ==============================================================================
 
 An important step in the use of NumPy arrays is creation of the array from
@@ -1214,7 +1214,7 @@ This is a general limitation, but round-tripping is always possible if
 Public C-API
 ******************************************************************************
 
-dtype creation
+DType creation
 ==============================================================================
 
 To create a new DType the user will need to define the methods and attributes

--- a/doc/neps/nep-0042-new-dtypes.rst
+++ b/doc/neps/nep-0042-new-dtypes.rst
@@ -463,7 +463,7 @@ We review here the operations related to casting arrays:
 
 We show how casting arrays with ``astype(new_dtype)`` will be implemented.
 
-`common dtype` operations
+`Common dtype` operations
 ==============================================================================
 
 When input types are mixed, a first step is to find a DType that can hold
@@ -984,7 +984,7 @@ important enough to be handled by NumPy using the presented methods.
     ``np.float128`` base class.
 
 
-Dtype discovery during array coercion
+dtype discovery during array coercion
 ==============================================================================
 
 An important step in the use of NumPy arrays is creation of the array from
@@ -1211,10 +1211,10 @@ This is a general limitation, but round-tripping is always possible if
 .. _nep42_c-api:
 
 ******************************************************************************
-Public c-API
+Public C-API
 ******************************************************************************
 
-Dtype creation
+dtype creation
 ==============================================================================
 
 To create a new DType the user will need to define the methods and attributes
@@ -1290,7 +1290,7 @@ memory management but would allow ABI-compatible extension (the struct is
 freed again when the DType is created).
 
 
-Castingimpl
+CastingImpl
 ==============================================================================
 
 The external API for ``CastingImpl`` will be limited initially to defining:

--- a/doc/neps/nep-0042-new-dtypes.rst
+++ b/doc/neps/nep-0042-new-dtypes.rst
@@ -1,7 +1,7 @@
 .. _NEP42:
 
 ==============================================================================
-NEP 42 — New and extensible DTypes
+NEP 42 — New and extensible dtypes
 ==============================================================================
 
 :title: New and extensible DTypes
@@ -262,7 +262,7 @@ dtype instances from DType classes.
 .. _nep42_DType class:
 
 ******************************************************************************
-The DType class
+The dtype class
 ******************************************************************************
 
 This section reviews the structure underlying the proposed DType class,
@@ -463,7 +463,7 @@ We review here the operations related to casting arrays:
 
 We show how casting arrays with ``astype(new_dtype)`` will be implemented.
 
-`Common DType` operations
+`common dtype` operations
 ==============================================================================
 
 When input types are mixed, a first step is to find a DType that can hold
@@ -984,7 +984,7 @@ important enough to be handled by NumPy using the presented methods.
     ``np.float128`` base class.
 
 
-DType discovery during array coercion
+Dtype discovery during array coercion
 ==============================================================================
 
 An important step in the use of NumPy arrays is creation of the array from
@@ -1211,10 +1211,10 @@ This is a general limitation, but round-tripping is always possible if
 .. _nep42_c-api:
 
 ******************************************************************************
-Public C-API
+Public c-API
 ******************************************************************************
 
-DType creation
+Dtype creation
 ==============================================================================
 
 To create a new DType the user will need to define the methods and attributes
@@ -1290,7 +1290,7 @@ memory management but would allow ABI-compatible extension (the struct is
 freed again when the DType is created).
 
 
-CastingImpl
+Castingimpl
 ==============================================================================
 
 The external API for ``CastingImpl`` will be limited initially to defining:

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -1,7 +1,7 @@
 .. _NEP43:
 
 ==============================================================================
-NEP 43 — Enhancing the extensibility of UFuncs
+NEP 43 — Enhancing the extensibility of ufuncs
 ==============================================================================
 
 :title: Enhancing the Extensibility of UFuncs
@@ -108,7 +108,7 @@ promotion and dispatching.
 
 
 ***********************
-Backwards Compatibility
+Backwards compatibility
 ***********************
 
 The general backwards compatibility issues have also been listed
@@ -295,7 +295,7 @@ are described and motivated in details later. Briefly:
   ``class.method`` is a method, while ``class().method`` returns a "bound" method.
 
 
-Customizing Dispatching and Promotion
+Customizing dispatching and Promotion
 =====================================
 
 Finding the correct implementation when ``np.positive.resolve_impl()`` is
@@ -329,7 +329,7 @@ Where ``Integer`` is an abstract DType (compare NEP 42).
 .. _steps_of_a_ufunc_call:
 
 ****************************************************************************
-Steps involved in a UFunc call
+Steps involved in a ufunc call
 ****************************************************************************
 
 Before going into more detailed API choices, it is helpful to review the
@@ -419,7 +419,7 @@ and which are handled by NumPy:
 
 
 *****************************************************************************
-ArrayMethod
+Arraymethod
 *****************************************************************************
 
 A central proposal of this NEP is the creation of the ``ArrayMethod`` as an object
@@ -500,7 +500,7 @@ And ``flags`` stored properties, for whether:
 *Note: More information is expected to be added as necessary.*
 
 
-The call ``Context``
+The call ``context``
 ====================
 
 The "context" object is analogous to Python's ``self`` that is
@@ -584,7 +584,7 @@ fast C-functions and NumPy API creates the new ``ArrayMethod`` or
 
 .. _ArrayMethod_specs:
 
-ArrayMethod Specifications
+Arraymethod specifications
 ==========================
 
 .. highlight:: c
@@ -833,7 +833,7 @@ feature in NumPy. The error handling is further complicated by the way
 CPUs signal floating point errors.
 Both are discussed in the next section.
 
-Error Handling
+Error handling
 """"""""""""""
 
 .. highlight:: c
@@ -921,7 +921,7 @@ the ``context`` in principle.
 
 .. highlight:: python
 
-Reusing existing Loops/Implementations
+Reusing existing loops/implementations
 ======================================
 
 For many DTypes the above definition for adding additional C-level loops will be
@@ -1246,7 +1246,7 @@ power and complexity carefully and responsibly.
 
 
 ***************
-User Guidelines
+User guidelines
 ***************
 
 In general adding a promoter to a UFunc must be done very carefully.

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -1,7 +1,7 @@
 .. _NEP43:
 
 ==============================================================================
-NEP 43 — Enhancing the extensibility of ufuncs
+NEP 43 — Enhancing the extensibility of UFuncs
 ==============================================================================
 
 :title: Enhancing the Extensibility of UFuncs
@@ -329,7 +329,7 @@ Where ``Integer`` is an abstract DType (compare NEP 42).
 .. _steps_of_a_ufunc_call:
 
 ****************************************************************************
-Steps involved in a ufunc call
+Steps involved in a UFunc call
 ****************************************************************************
 
 Before going into more detailed API choices, it is helpful to review the

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -419,7 +419,7 @@ and which are handled by NumPy:
 
 
 *****************************************************************************
-Arraymethod
+ArrayMethod
 *****************************************************************************
 
 A central proposal of this NEP is the creation of the ``ArrayMethod`` as an object
@@ -500,7 +500,7 @@ And ``flags`` stored properties, for whether:
 *Note: More information is expected to be added as necessary.*
 
 
-The call ``context``
+The call ``Context``
 ====================
 
 The "context" object is analogous to Python's ``self`` that is
@@ -584,7 +584,7 @@ fast C-functions and NumPy API creates the new ``ArrayMethod`` or
 
 .. _ArrayMethod_specs:
 
-Arraymethod specifications
+ArrayMethod specifications
 ==========================
 
 .. highlight:: c

--- a/doc/neps/nep-0044-restructuring-numpy-docs.rst
+++ b/doc/neps/nep-0044-restructuring-numpy-docs.rst
@@ -19,7 +19,7 @@ This document proposes a restructuring of the NumPy Documentation, both in form
 and content, with the goal of making it more organized and discoverable for
 beginners and experienced users.
 
-Motivation and Scope
+Motivation and scope
 ====================
 
 See `here <https://numpy.org/devdocs/>`_ for the front page of the latest docs.
@@ -32,7 +32,7 @@ are mixed). We propose the following:
 - Adding an Explanations section for key concepts and techniques that require
   deeper descriptions, some of which will be rearranged from the Reference Guide.
 
-Usage and Impact
+Usage and impact
 ================
 
 The documentation is a fundamental part of any software project, especially
@@ -168,7 +168,7 @@ So we'll aim for a new (pure Python) package, named ``numpy-datasets`` or
 how, e.g., scikit-learn ships data sets. Small data sets can be included in the
 repo, large data sets can be accessed via a downloader class or function.
 
-Related Work
+Related work
 ============
 
 Some examples of documentation organization in other projects:
@@ -230,7 +230,7 @@ Discussion around this NEP can be found on the NumPy mailing list:
 
 - https://mail.python.org/pipermail/numpy-discussion/2020-February/080419.html
 
-References and Footnotes
+References and footnotes
 ========================
 
 .. [1] `Diátaxis - A systematic framework for technical documentation authoring <https://diataxis.fr/>`_

--- a/doc/neps/nep-0045-c_style_guide.rst
+++ b/doc/neps/nep-0045-c_style_guide.rst
@@ -18,7 +18,7 @@ Abstract
 This document gives coding conventions for the C code comprising
 the C implementation of NumPy.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 The NumPy C coding conventions are based on Python
@@ -29,7 +29,7 @@ Because the NumPy conventions are very close to those in PEP 7, that PEP is
 used as a template with the NumPy additions and variations in the appropriate
 spots.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 There are many C coding conventions and it must be emphasized that the primary
@@ -246,7 +246,7 @@ NumPy style used for Python functions can also be used for documenting
 C functions, see the files in ``doc/cdoc/``.
 
 
-Related Work
+Related work
 ------------
 
 Based on Van Rossum and Warsaw, :pep:`7`

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -18,7 +18,7 @@ This NEP provides guidelines on how the NumPy project will acknowledge
 financial and in-kind support.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 In the past few years, the NumPy project has gotten significant financial
@@ -204,7 +204,7 @@ to a more suitable platform, such as `Open Collective <https://opencollective.co
 in the future, we should reconsider listing all individual donations.
 
 
-Related Work
+Related work
 ------------
 
 Here we provide a few examples of how other projects handle sponsorship
@@ -238,7 +238,7 @@ Discussion
 - `PR with review of the NEP draft <https://github.com/numpy/numpy/pull/18084>`__
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 - `Inside NumPy: preparing for the next decade <https://github.com/numpy/archive/blob/main/content/inside_numpy_presentation_SciPy2019.pdf>`__ presentation at SciPy'19 discussing the impact of the first NumPy grant.

--- a/doc/neps/nep-0047-array-api-standard.rst
+++ b/doc/neps/nep-0047-array-api-standard.rst
@@ -32,7 +32,7 @@ other array/tensor libraries that adopt this standard.
     itself.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 Python users have a wealth of choice for libraries and frameworks for
@@ -81,7 +81,7 @@ Out of scope for this NEP are:
   subsequently updated.
 
 
-Usage and Impact
+Usage and impact
 ----------------
 
 *This section will be fleshed out later, for now we refer to the use cases given
@@ -610,7 +610,7 @@ TODO - this can only be done after trying out some use cases
 Leo Fang (CuPy): *"My impression is for CuPy we could simply take this new array object and s/numpy/cupy"*
 
 
-Related Work
+Related work
 ------------
 
 :ref:`NEP37` contains a similar mechanism to retrieve a NumPy-like namespace.
@@ -673,7 +673,7 @@ Discussion
 - `PR #18585 implementing numpy.array_api
   <https://github.com/numpy/numpy/pull/18585>`_
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. _Python array API standard: https://data-apis.github.io/array-api/latest

--- a/doc/neps/nep-0048-spending-project-funds.rst
+++ b/doc/neps/nep-0048-spending-project-funds.rst
@@ -24,7 +24,7 @@ how decisions regarding spending funds get made, how funds get administered,
 and transparency around these topics.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 NumPy is a fiscally sponsored project of NumFOCUS, a 501(c)(3) nonprofit
@@ -376,7 +376,7 @@ That leaves about $25,000 in available funds at the time of writing, and
 that amount is currently growing at a rate of about $3,000/month.
 
 
-Related Work
+Related work
 ------------
 
 See references.  We assume that other open source projects have also developed
@@ -398,7 +398,7 @@ Discussion
 
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] Pauli Virtanen et al., "SciPy 1.0: fundamental algorithms for scientific

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -120,7 +120,7 @@ The version, currently 1, allows for future enhancements to the
 ``PyDataMemAllocator``. If fields are added, they must be added to the end.
 
 
-NumPy c-API functions
+NumPy C-API functions
 =====================
 
 .. c:type:: PyDataMem_Handler
@@ -178,7 +178,7 @@ NumPy c-API functions
    Return the current policy that will be used to allocate data for the
    next ``PyArrayObject``. On failure, return ``NULL``.
 
-``pydatamem_handler`` thread safety and lifetime
+``PyDataMem_Handler`` thread safety and lifetime
 ================================================
 The active handler is stored in the current :py:class:`~contextvars.Context`
 via a :py:class:`~contextvars.ContextVar`. This ensures it can be configured both

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -26,7 +26,7 @@ a performance bottleneck, custom allocation strategies to guarantee data
 alignment or pinning allocations to specialized memory hardware can enable
 hardware-specific optimizations. The other allocations remain unchanged.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 Users may wish to override the internal data memory routines with ones of their
@@ -66,7 +66,7 @@ is to create a flexible enough interface without burdening normative users.
 .. _`BPO 18835`: https://bugs.python.org/issue18835
 .. _`PEP 445`: https://www.python.org/dev/peps/pep-0445/
 
-Usage and Impact
+Usage and impact
 ----------------
 
 The new functions can only be accessed via the NumPy C-API. An example is
@@ -120,7 +120,7 @@ The version, currently 1, allows for future enhancements to the
 ``PyDataMemAllocator``. If fields are added, they must be added to the end.
 
 
-NumPy C-API functions
+NumPy c-API functions
 =====================
 
 .. c:type:: PyDataMem_Handler
@@ -178,7 +178,7 @@ NumPy C-API functions
    Return the current policy that will be used to allocate data for the
    next ``PyArrayObject``. On failure, return ``NULL``.
 
-``PyDataMem_Handler`` thread safety and lifetime
+``pydatamem_handler`` thread safety and lifetime
 ================================================
 The active handler is stored in the current :py:class:`~contextvars.Context`
 via a :py:class:`~contextvars.ContextVar`. This ensures it can be configured both
@@ -301,7 +301,7 @@ the ``sz`` argument is correct.
         }
     };
 
-Related Work
+Related work
 ------------
 
 This NEP is being tracked by the pnumpy_ project and a `comment in the PR`_
@@ -332,7 +332,7 @@ with a ``context`` field like :c:type:`PyMemAllocatorEx` but with a different
 signature for ``free``.
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] Each NEP must either be explicitly labeled as placed in the public domain (see

--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -267,7 +267,7 @@ arrays that are not 0-D, such as ``array([2])``.
          precision, which is ``complex128``.
 
 
-Motivation and Scope
+Motivation and scope
 ====================
 
 The motivation for changing the behaviour with respect to inspecting the value
@@ -311,7 +311,7 @@ overflow in the result,
 we believe that the proposal follows the "principle of least surprise".
 
 
-Usage and Impact
+Usage and impact
 ================
 
 This NEP is expected to be implemented with **no** transition period that warns
@@ -589,7 +589,7 @@ result will be different::
     np.add(uint8_arr, np.array([4], dtype=np.int64)).dtype == np.int64
 
 
-Proposed Weak Promotion
+Proposed weak promotion
 -----------------------
 
 This proposal uses a "weak scalar" logic.  This means that Python ``int``, ``float``,
@@ -611,7 +611,7 @@ At no time is the value used to decide the result of this promotion.  The value 
 considered when it is converted to the new dtype; this may raise an error.
 
 
-Related Work
+Related work
 ============
 
 Different Python projects that fill a similar space to NumPy prefer the weakly
@@ -796,7 +796,7 @@ Discussion
 * https://mail.python.org/archives/list/numpy-discussion@python.org/thread/NA3UBE3XAUTXFYBX6HPIOCNCTNF3PWSZ/#T5WAYQPRMI5UCK7PKPCE3LGK7AQ5WNGH
 * Poll about the desired future behavior: https://discuss.scientific-python.org/t/poll-future-numpy-behavior-when-mixing-arrays-numpy-scalars-and-python-scalars/202
 
-References and Footnotes
+References and footnotes
 ========================
 
 .. [1] Each NEP must either be explicitly labeled as placed in the public domain (see

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -34,7 +34,7 @@ more important for users once :ref:`NEP 50 <NEP50>` is adopted.
 These changes do lead to smaller incompatible and infrastructure changes
 related to array printing.
 
-Motivation and Scope
+Motivation and scope
 ====================
 
 This NEP proposes to change the representation of the following
@@ -79,7 +79,7 @@ Not only do we expect the change to help users better understand and be
 reminded of the differences between NumPy and Python scalars, but we also
 believe that the awareness will greatly help debugging.
 
-Usage and Impact
+Usage and impact
 ================
 
 Most user code should not be impacted by the change, but users will now
@@ -164,7 +164,7 @@ information.
 To allow this, a new semi-public ``np.core.array_print.get_formatter()`` will
 be introduced to expand the current functionality (see Implementation).
 
-Effects on Masked Arrays and Records
+Effects on masked arrays and records
 ------------------------------------
 Some other parts of NumPy will indirectly be changed.  Masked arrays
 ``fill_value`` will be adapted to only include the full scalar information
@@ -220,7 +220,7 @@ This choice is made since ``int64`` is generally the more useful
 information for users, but the type name itself must be precise.
 
 
-Related Work
+Related work
 ============
 
 A PR to only change the representation of booleans was previously
@@ -334,7 +334,7 @@ Discussion
   the representation of all (or at least most) NumPy scalars.
 
 
-References and Footnotes
+References and footnotes
 ========================
 
 .. [1] https://github.com/numpy/numpy/issues/12950

--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -23,7 +23,7 @@ and functions that have better alternatives. Furthermore, each function is meant
 to be accessible from only one place, so all duplicates also need to be dropped.
 
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 NumPy has a large API surface that evolved organically over many years:
@@ -97,7 +97,7 @@ Out of scope for this NEP are:
 - Introducing new functionality or performance enhancements.
 
 
-Usage and Impact
+Usage and impact
 ----------------
 
 A key principle of this API refactor is to ensure that, when code has been
@@ -299,7 +299,7 @@ actual gain. We arrived at this conclusion for such items:
 - Removing ``.repeat`` and ``.ctypes`` from ``ndarray`` object.
 
 
-Related Work
+Related work
 ------------
 
 A clear split between public and private API was recently established
@@ -351,7 +351,7 @@ Discussion
 
 - `gh-24507: Overhaul of the np.lib namespace <https://github.com/numpy/numpy/issues/24507>`__
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 

--- a/doc/neps/nep-0053-c-abi-evolution.rst
+++ b/doc/neps/nep-0053-c-abi-evolution.rst
@@ -1,7 +1,7 @@
 .. _NEP53:
 
 ===============================================
-NEP 53 — Evolving the NumPy C-API for NumPy 2.0
+NEP 53 — Evolving the NumPy c-API for numpy 2.0
 ===============================================
 
 :Author: Sebastian Berg <sebastianb@nvidia.com>
@@ -43,7 +43,7 @@ The implementation of this NEP consists would consist of two steps:
    * require some downstream code changes to adapt to changed API.
 
 
-Motivation and Scope
+Motivation and scope
 ====================
 
 The NumPy API conists of more than 300 functions and numerous macros.
@@ -85,7 +85,7 @@ we expect that this is unnecessary and that the provisions introduced here:
 should allow to add such an API also in a minor release.
 
 
-Usage and Impact
+Usage and impact
 ================
 
 Backwards compatible builds
@@ -114,7 +114,7 @@ should be necessary at most for a hand-full of users worldwide.
 This mechanism is much the same as the `Python limited API`_ since NumPy's
 C-API has a similar need for ABI stability.
 
-Breaking the C-API and changing the ABI
+Breaking the c-API and changing the ABI
 ---------------------------------------
 
 NumPy has too many functions, many of which are aliases.  The following
@@ -163,7 +163,7 @@ making it generally safe for NumPy 2.0 change.
 (One can imagine code that wants to know the actual runtime value.
 We have not seen such code in practice, but it would need to be adjusted.)
 
-Impact on Cython users
+Impact on cython users
 ----------------------
 
 Cython users may use the NumPy C-API via ``cimport numpy as cnp``.
@@ -299,7 +299,7 @@ Discussion
 
 
 
-References and Footnotes
+References and footnotes
 ========================
 
 .. [1] Each NEP must either be explicitly labeled as placed in the public domain (see

--- a/doc/neps/nep-0053-c-abi-evolution.rst
+++ b/doc/neps/nep-0053-c-abi-evolution.rst
@@ -1,7 +1,7 @@
 .. _NEP53:
 
 ===============================================
-NEP 53 — Evolving the NumPy c-API for numpy 2.0
+NEP 53 — Evolving the NumPy C-API for NumPy 2.0
 ===============================================
 
 :Author: Sebastian Berg <sebastianb@nvidia.com>
@@ -114,7 +114,7 @@ should be necessary at most for a hand-full of users worldwide.
 This mechanism is much the same as the `Python limited API`_ since NumPy's
 C-API has a similar need for ABI stability.
 
-Breaking the c-API and changing the ABI
+Breaking the C-API and changing the ABI
 ---------------------------------------
 
 NumPy has too many functions, many of which are aliases.  The following
@@ -163,7 +163,7 @@ making it generally safe for NumPy 2.0 change.
 (One can imagine code that wants to know the actual runtime value.
 We have not seen such code in practice, but it would need to be adjusted.)
 
-Impact on cython users
+Impact on Cython users
 ----------------------
 
 Cython users may use the NumPy C-API via ``cimport numpy as cnp``.

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -1,7 +1,7 @@
 .. _NEP55:
 
 =========================================================
-NEP 55 — Add a UTF-8 Variable-Width String DType to NumPy
+NEP 55 — Add a utf-8 variable-width string dtype to NumPy
 =========================================================
 
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>
@@ -28,7 +28,7 @@ memory usage, and usability improvements for NumPy users, including:
 * A more intuitive user-facing API for working with arrays of Python strings,
   without a need to think about the in-memory array representation.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 First, we will describe how the current state of support for string or
@@ -37,7 +37,7 @@ discussion about this topic. Finally, we will describe the scope of the proposed
 changes to NumPy as well as changes that are explicitly out of scope of this
 proposal.
 
-History of String Support in Numpy
+History of string support in Numpy
 **********************************
 
 Support in NumPy for textual data evolved organically in response to early user
@@ -72,7 +72,7 @@ bytestrings as the data type for *all* python ``bytes`` data, and a default
 string type with an in-memory representation that consumes four times as much
 memory as needed for ASCII or mostly-ASCII data.
 
-Problems with Fixed-Width Strings
+Problems with fixed-width strings
 *********************************
 
 Both existing string DTypes represent fixed-width sequences, allowing storage of
@@ -96,7 +96,7 @@ encoded variable-width string arrays [1]_. This is unfortunate, since ``object``
 arrays have no type guarantees, necessitating expensive sanitization passes and
 operations using object arrays cannot release the GIL.
 
-Previous Discussions
+Previous discussions
 --------------------
 
 The project last discussed this topic in depth in 2017, when Julian Taylor
@@ -170,7 +170,7 @@ data. We are attempting to avoid resolving the disagreement described in
 :ref:`NEP 26<NEP26>` and this proposal does not require or preclude adding a
 missing data sentinel or bitflag-based missing data support in the future.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 The DType is intended as a drop-in replacement for object string arrays. This
@@ -306,7 +306,7 @@ discuss our plan for the string manipulation functions in ``np.char``. Finally
 we describe out plan to update the ``npy`` and ``npz`` file formats to support
 writing sidecar data.
 
-Python API for ``StringDType``
+Python API for ``stringdtype``
 ******************************
 
 The new DType will be accessible via the ``np.dtypes`` namespace:
@@ -377,7 +377,7 @@ DTypes in the integer range available in the ``NPY_TYPES`` enum.
 
 .. _memory:
 
-Memory layout and Managing Heap Allocations
+Memory layout and managing heap allocations
 *******************************************
 
 Since NumPy has no first-class support for ragged arrays, there is no way for a
@@ -723,7 +723,7 @@ variable-width string data from an untrusted source.
 For cases where pickle support is required, support for pickling and unpickling
 string arrays will also be implemented.
 
-Related Work
+Related work
 ------------
 
 The main comparable prior art in the Python ecosystem is PyArrow arrays, which
@@ -832,7 +832,7 @@ Discussion
 - https://mail.python.org/archives/list/numpy-discussion@python.org/thread/IHSVBZ7DWGMTOD6IEMURN23XM2BYM3RG/
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] https://github.com/pandas-dev/pandas/pull/52711

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -1,7 +1,7 @@
 .. _NEP55:
 
 =========================================================
-NEP 55 — Add a UTF-8 variable-width string dtype to NumPy
+NEP 55 — Add a UTF-8 variable-width string DType to NumPy
 =========================================================
 
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -1,7 +1,7 @@
 .. _NEP55:
 
 =========================================================
-NEP 55 — Add a utf-8 variable-width string dtype to NumPy
+NEP 55 — Add a UTF-8 variable-width string dtype to NumPy
 =========================================================
 
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>
@@ -306,7 +306,7 @@ discuss our plan for the string manipulation functions in ``np.char``. Finally
 we describe out plan to update the ``npy`` and ``npz`` file formats to support
 writing sidecar data.
 
-Python API for ``stringdtype``
+Python API for ``StringDType``
 ******************************
 
 The new DType will be accessible via the ``np.dtypes`` namespace:

--- a/doc/neps/nep-template.rst
+++ b/doc/neps/nep-template.rst
@@ -1,5 +1,5 @@
 =================================
-NEP x — Template and instructions
+NEP X — Template and instructions
 =================================
 
 :Author: <list of authors' real names and optionally, email addresses>

--- a/doc/neps/nep-template.rst
+++ b/doc/neps/nep-template.rst
@@ -1,5 +1,5 @@
 =================================
-NEP X — Template and instructions
+NEP x — Template and instructions
 =================================
 
 :Author: <list of authors' real names and optionally, email addresses>
@@ -16,7 +16,7 @@ The abstract should be a short description of what the NEP will achieve.
 
 Note that the — in the title is an elongated dash, not -.
 
-Motivation and Scope
+Motivation and scope
 --------------------
 
 This section describes the need for the proposed change. It should describe
@@ -24,7 +24,7 @@ the existing problem, who it affects, what it is trying to solve, and why.
 This section should explicitly address the scope of and key requirements for
 the proposed change.
 
-Usage and Impact
+Usage and impact
 ----------------
 
 This section describes how users of NumPy will use features described in this
@@ -53,7 +53,7 @@ It should include examples of how the new functionality would be used,
 intended use-cases and pseudo-code illustrating its use.
 
 
-Related Work
+Related work
 ------------
 
 This section should list relevant and/or similar technologies, possibly in other
@@ -90,7 +90,7 @@ regarding the NEP:
 - This includes links to mailing list threads or relevant GitHub issues.
 
 
-References and Footnotes
+References and footnotes
 ------------------------
 
 .. [1] Each NEP must either be explicitly labeled as placed in the public domain (see


### PR DESCRIPTION
More toward gh-16261.

gh-16261 reported that documentation headings currently have inconsistent capitalization schemes and should be standardized. gh-25016 fixed this for `rst` files except release notes and NEPS. This PR adjusts the NEPs.

The case of 'numpy', 'blas', 'scipy', 'python', 'lapack', 'fortran', 'api', 'pypi', 'cpu', 'abi', 'pr', 'github', 'ssh', 'git', 'f77', 'numba', 'f2py', 'cffi', 'bitgenerator', 'simd', 'swig', 'csv', 'ascii', 'json', 'dataframe', 'ieee', 'matlab', 'pyfort', ' c ', and 'nep' are unchanged. (Perhaps it would be a good idea to check the capitalization of some of these words throughout the documentation, but that is a different issue.)

<details>
Minimally modified version of script in gh-25016.

```python3
import os
import sys


def process(content):
    headings = set('#*=-^"')
    preserve = {'numpy', 'blas', 'scipy', 'python', 'lapack', 'fortran',
                'api', 'pypi', 'cpu', 'abi', 'pr', 'github', 'ssh', 'git',
                'f77', 'numba', 'f2py', 'cffi', 'bitgenerator', 'simd',
                'swig', 'csv', 'ascii', 'json', 'dataframe', 'ieee',
                'matlab', 'pyfort', ' c ', 'nep'}

    for i in range(1, len(content)):
        stripped = content[i].strip()
        x = set(stripped)
        if len(stripped) > 3 and not (x - headings):
            text = content[i-1]
            lower = text.lower()

            k = 0
            if text.startswith('NEP'):
                k = text.find(' — ') + 3

            sentence = lower[:k] + lower[k].upper() + lower[k+1:]

            for word in preserve:
                j = lower.find(word.lower())
                if j < 0:
                    continue
                word = text[j:j+len(word)]
                sentence = sentence[:j] + word + sentence[j + len(word):]

            content[i-1] = sentence

    return content


walk_dir = '/Users/matthaberland/Desktop/numpy'

print('walk_dir = ' + walk_dir)

# If your current working directory may change during script execution, it's
# recommended to immediately convert program arguments to an absolute path.
# Then the variable root below will be an absolute path as well. Example:
# walk_dir = os.path.abspath(walk_dir)
print('walk_dir (absolute) = ' + os.path.abspath(walk_dir))

skips = {''}

for root, subdirs, files in os.walk(walk_dir):
    print('--\nroot = ' + root)

    for filename in files:
        file_path = os.path.join(root, filename)

        # skips = {'vendored-meson', 'doc/source/release/', 'doc/neps/nep-'}
        skips = {'doc/neps/nep-'}

        skip = False
        for word in skips:
            if word in file_path:
                skip = True

        if not skip:
            continue

        print('\t- file %s (full path: %s)' % (filename, file_path))

        if file_path.endswith('.rst'):
            with open(file_path, 'r') as f:
                f_content = f.readlines()
                f_content = process(f_content)
            with open(file_path, 'w') as f:
                f.writelines(f_content)
                # list_file.write(('The file %s contains:\n' % filename).encode('utf-8'))
                # list_file.write(f_content)
                # list_file.write(b'\n')
```

</details>