### PR TITLE
BLD: change default of the ``allow-noblas`` option to true

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -89,7 +89,7 @@ jobs:
       env:
         TERM: xterm-256color
       run:
-        spin build -- --werror
+        spin build -- --werror -Dallow-noblas=false
 
     - name: Check build-internal dependencies
       run:
@@ -131,7 +131,7 @@ jobs:
         pip install pytest hypothesis typing_extensions
 
     - name: Build (LP64)
-      run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true
+      run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -139,7 +139,7 @@ jobs:
     - name: Build (ILP64)
       run: |
         rm -rf build
-        spin build -- -Duse-ilp64=true -Ddisable-optimization=true
+        spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -166,7 +166,7 @@ jobs:
         pip install pytest hypothesis typing_extensions
 
     - name: Build
-      run: spin build -- -Ddisable-optimization=true
+      run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -174,7 +174,7 @@ jobs:
     - name: Build (ILP64)
       run: |
         rm -rf build
-        spin build -- -Ddisable-optimization=true -Duse-ilp64=true
+        spin build -- -Ddisable-optimization=true -Duse-ilp64=true -Dallow-noblas=false
 
     - name: Test (ILP64)
       run: spin test -- numpy/linalg
@@ -201,7 +201,7 @@ jobs:
         sudo apt-get remove pkg-config
 
     - name: Build
-      run: spin build -- -Ddisable-optimization=true
+      run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -j auto -- numpy/linalg
@@ -227,7 +227,7 @@ jobs:
 
     - name: Build
       run: |
-        spin build -- -Ddisable-optimization=true
+        spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: |
@@ -303,7 +303,7 @@ jobs:
     - name: Build with defaults (LP64)
       run: |
         pkg-config --libs mkl-dynamic-lp64-seq  # check link flags
-        spin build -- -Ddisable-optimization=true
+        spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -312,7 +312,7 @@ jobs:
       run: |
         git clean -xdf > /dev/null
         pkg-config --libs mkl-dynamic-ilp64-seq
-        spin build -- -Duse-ilp64=true -Ddisable-optimization=true
+        spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -324,7 +324,7 @@ jobs:
         rm mkl*.pc
         popd
         export MKLROOT=$Python3_ROOT_DIR
-        spin build -- -Ddisable-optimization=true
+        spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -359,7 +359,7 @@ jobs:
         pkg-config --cflags blis
 
     - name: Build
-      run: spin build -- -Dblas=blis -Ddisable-optimization=true
+      run: spin build -- -Dblas=blis -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg
@@ -384,7 +384,7 @@ jobs:
         sudo apt-get install libatlas-base-dev pkg-config
 
     - name: Build
-      run: spin build -- -Dblas=blas-atlas -Dlapack=lapack-atlas -Ddisable-optimization=true
+      run: spin build -- -Dblas=blas-atlas -Dlapack=lapack-atlas -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
       run: spin test -- numpy/linalg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate numpy-dev
-        CC="ccache $CC" spin build -j2
+        CC="ccache $CC" spin build -j2 -- -Dallow-noblas=false
 
     - name: Run test suite (full)
       shell: bash -l {0}
@@ -123,14 +123,14 @@ jobs:
         pip install pytest pytest-xdist hypothesis
 
     - name: Build against Accelerate (LP64)
-      run: spin build -- -Ddisable-optimization=true
+      run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test (linalg only)
       run: spin test -j2 -- numpy/linalg
 
     - name: Build NumPy against Accelerate (ILP64)
       run: |
-        spin build -- -Duse-ilp64=true
+        spin build -- -Duse-ilp64=true -Dallow-noblas=false
 
     - name: Test (fast tests)
       run: spin test -j2

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('blas', type: 'string', value: 'auto',
         description: 'Option for BLAS library selection. By default, try to find any in the order given by `blas-order`')
 option('lapack', type: 'string', value: 'auto',
         description: 'Option for LAPACK library selection. By default, try to find any in the order given by `lapack-order`')
-option('allow-noblas', type: 'boolean', value: false,
+option('allow-noblas', type: 'boolean', value: true,
         description: 'If set to true, allow building with (slow!) internal fallback routines')
 option('blas-order', type: 'array',
         value: ['mkl', 'accelerate', 'openblas', 'flexiblas', 'blis', 'blas'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
 build-verbosity = "3"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
-config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_"
+config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_ setup-args=-Dallow-noblas=false"
 # meson has a hard dependency on ninja, and we need meson to build
 # c-extensions in tests. There is a ninja PyPI package used in
 # build_requirements.txt for macOS, windows, linux but it cannot be in


### PR DESCRIPTION
Having it set to `false` caused more disruption and complaints than the silent performance regressions for `true` ever did. So now that the dust has settled a bit on the transition to Meson, go back to the more permissive default.

The warning that is emitted when BLAS and/or LAPACK are not found is already much more visible than it was with distutils, so this new situation is still an improvement over where we were until 1.25.x.

The change to `true` was done in gh-24279, this is a partial revert. 

Closes gh-24200
Closes gh-24703