### PR TITLE
TST: skip flaky test in test_histogram

### DIFF
--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -395,8 +395,9 @@ class TestHistogram:
         edges = histogram_bin_edges(arr, bins='auto', range=(0, 1))
         assert_array_equal(edges, e)
 
-    @requires_memory(free_bytes=1e10)
-    @pytest.mark.slow
+    # @requires_memory(free_bytes=1e10)
+    # @pytest.mark.slow
+    @pytest.mark.skip(reason="Bad memory reports lead to OOM in ci testing")
     def test_big_arrays(self):
         sample = np.zeros([100000000, 3])
         xbins = 400


### PR DESCRIPTION
Closes #25058 
xref #19491

Like in [test_linalg.py](https://github.com/numpy/numpy/blob/ade16e84d2d19750ca17145b3028d375c0f25f54/numpy/linalg/tests/test_linalg.py#L2168), the `requires_memory` check is not reliable in CI and is causing OOM failures.