### PR TITLE
MAINT: default to C11 rather than C99, fix most build warnings with Clang 14

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.13.1
-Cython>=3.0
+Cython>=3.0.6
 ninja
 spin==0.8
 build

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -11,7 +11,7 @@ Recommended development setup
 Since NumPy contains parts written in C and Cython that need to be
 compiled before use, make sure you have the necessary compilers and Python
 development headers installed - see :ref:`building-from-source`. Building
-NumPy as of version ``1.17`` requires a C99 compliant compiler.
+NumPy as of version ``2.0`` requires C11 and C++17 compliant compilers.
 
 Having compiled code also means that importing NumPy from the development
 sources needs some additional steps, which are explained below.  For the rest

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',
-    'c_std=c99',
+    'c_std=c11',
     'cpp_std=c++17',
     'pkgconfig.relocatable=true',
   ],

--- a/meson.build
+++ b/meson.build
@@ -33,8 +33,8 @@ elif cc.get_id() == 'msvc'
           'when building with MSVC')
   endif
 endif
-if not cy.version().version_compare('>=0.29.34')
-  error('NumPy requires Cython >= 0.29.34')
+if not cy.version().version_compare('>=3.0.6')
+  error('NumPy requires Cython >= 3.0.6')
 endif
 
 py = import('python').find_installation(pure: false)

--- a/numpy/_core/src/multiarray/einsum.c.src
+++ b/numpy/_core/src/multiarray/einsum.c.src
@@ -402,11 +402,6 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
         }
         /* A repeated label, find the original one and merge them. */
         else {
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
             int i = icombinemap[idim + label];
 
             icombinemap[idim] = -1;
@@ -419,9 +414,6 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
                 return NULL;
             }
             new_strides[i] += stride;
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
         }
     }
 

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2367,6 +2367,7 @@ PyArray_Compress(PyArrayObject *self, PyObject *condition, int axis,
  * even though it uses 64 bit types its faster than the bytewise sum on 32 bit
  * but a 32 bit type version would make it even faster on these platforms
  */
+#if !NPY_SIMD
 static inline npy_intp
 count_nonzero_bytes_384(const npy_uint64 * w)
 {
@@ -2407,6 +2408,7 @@ count_nonzero_bytes_384(const npy_uint64 * w)
 
     return r;
 }
+#endif
 
 #if NPY_SIMD
 /* Count the zero bytes between `*d` and `end`, updating `*d` to point to where to keep counting from. */

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -518,7 +518,7 @@ _get_partition_func(int type, NPY_SELECTKIND which)
     npy_intp i;
     npy_intp ntypes = partition_t::map.size();
 
-    if (which >= NPY_NSELECTS) {
+    if ((int)which < 0 || (int)which >= NPY_NSELECTS) {
         return NULL;
     }
     for (i = 0; i < ntypes; i++) {

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -215,7 +215,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 //###############################################################################
 
 /********************************************************************************
- ** op intrinics
+ ** op intrinsics
  ********************************************************************************/
 
 #if NPY_SIMD_F32
@@ -295,61 +295,6 @@ NPY_FINLINE npyv_f64
 simd_csquare_f64(npyv_f64 x)
 { return simd_cmul_f64(x, x); }
 #endif
-
-/**begin repeat
- * #type = npy_float, npy_double#
- * #sfx = f32, f64#
- * #bsfx = b32, b64#
- * #usfx = b32, u64#
- * #VECTOR = NPY_SIMD_F32, NPY_SIMD_F64#
- * #is_double = 0, 1#
- * #c = f, #
- * #INF = NPY_INFINITYF, NPY_INFINITY#
- * #NAN = NPY_NANF, NPY_NAN#
- */
-#if @VECTOR@
-NPY_FINLINE npyv_@sfx@
-simd_cabsolute_@sfx@(npyv_@sfx@ re, npyv_@sfx@ im)
-{
-    const npyv_@sfx@ inf = npyv_setall_@sfx@(@INF@);
-    const npyv_@sfx@ nan = npyv_setall_@sfx@(@NAN@);
-
-    re = npyv_abs_@sfx@(re);
-    im = npyv_abs_@sfx@(im);
-    /*
-     * If real or imag = INF, then convert it to inf + j*inf
-     * Handles: inf + j*nan, nan + j*inf
-     */
-    npyv_@bsfx@ re_infmask = npyv_cmpeq_@sfx@(re, inf);
-    npyv_@bsfx@ im_infmask = npyv_cmpeq_@sfx@(im, inf);
-    im = npyv_select_@sfx@(re_infmask, inf, im);
-    re = npyv_select_@sfx@(im_infmask, inf, re);
-    /*
-     * If real or imag = NAN, then convert it to nan + j*nan
-     * Handles: x + j*nan, nan + j*x
-     */
-    npyv_@bsfx@ re_nnanmask = npyv_notnan_@sfx@(re);
-    npyv_@bsfx@ im_nnanmask = npyv_notnan_@sfx@(im);
-    im = npyv_select_@sfx@(re_nnanmask, im, nan);
-    re = npyv_select_@sfx@(im_nnanmask, re, nan);
-
-    npyv_@sfx@ larger  = npyv_max_@sfx@(re, im);
-    npyv_@sfx@ smaller = npyv_min_@sfx@(im, re);
-    /*
-     * Calculate div_mask to prevent 0./0. and inf/inf operations in div
-     */
-    npyv_@bsfx@ zeromask = npyv_cmpeq_@sfx@(larger, npyv_zero_@sfx@());
-    npyv_@bsfx@ infmask = npyv_cmpeq_@sfx@(smaller, inf);
-    npyv_@bsfx@ div_mask = npyv_not_@bsfx@(npyv_or_@bsfx@(zeromask, infmask));
-
-    npyv_@sfx@ ratio = npyv_ifdivz_@sfx@(div_mask, smaller, larger);
-    npyv_@sfx@ hypot = npyv_sqrt_@sfx@(
-        npyv_muladd_@sfx@(ratio, ratio, npyv_setall_@sfx@(1.0@c@)
-    ));
-    return npyv_mul_@sfx@(hypot, larger);
-}
-#endif // VECTOR
-/**end repeat**/
 
 /********************************************************************************
  ** Defining ufunc inner functions

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -1804,12 +1804,6 @@ static PyObject *
 }
 /**end repeat**/
 
-#if __GNUC__ < 10
-    /* At least GCC 9.2 issues spurious warnings for arg2 below. */
-    #pragma GCC diagnostic push  /* matching pop after function and repeat */
-    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 /**begin repeat
  * #oper = le, ge, lt, gt, eq, ne#
  * #op = <=, >=, <, >, ==, !=#
@@ -1940,10 +1934,6 @@ static PyObject*
 
 #undef IS_@name@
 /**end repeat**/
-
-#if __GNUC__ < 10
-    #pragma GCC diagnostic pop
-#endif
 
 
 /**begin repeat

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -99,6 +99,7 @@ get_min_max(int typenum, long long *min, unsigned long long *max)
             *max = NPY_MAX_ULONGLONG;
             break;
         default:
+            *max = 0;
             assert(0);
     }
 }

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -34,6 +34,8 @@ static const char* umath_linalg_version_string = "0.1.5";
  *                        Debugging support                                 *
  ****************************************************************************
  */
+#define _UMATH_LINALG_DEBUG 0
+
 #define TRACE_TXT(...) do { fprintf (stderr, __VA_ARGS__); } while (0)
 #define STACK_TRACE do {} while (0)
 #define TRACE\
@@ -46,7 +48,7 @@ static const char* umath_linalg_version_string = "0.1.5";
         STACK_TRACE;                            \
     } while (0)
 
-#if 0
+#if _UMATH_LINALG_DEBUG
 #if defined HAVE_EXECINFO_H
 #include <execinfo.h>
 #elif defined HAVE_LIBUNWIND_H
@@ -574,6 +576,7 @@ init_linearize_data(LINEARIZE_DATA_t *lin_data,
         lin_data, rows, columns, row_strides, column_strides, columns);
 }
 
+#if _UMATH_LINALG_DEBUG
 static inline void
 dump_ufunc_object(PyUFuncObject* ufunc)
 {
@@ -651,7 +654,7 @@ dump_matrix(const char* name,
         TRACE_TXT(" |\n");
     }
 }
-
+#endif
 
 /*
  *****************************************************************************
@@ -760,12 +763,6 @@ update_pointers(npy_uint8** bases, ptrdiff_t* offsets, size_t count)
     }
 }
 
-
-/* disable -Wmaybe-uninitialized as there is some code that generate false
-   positives with this warning
-*/
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
 /*
  *****************************************************************************
@@ -2926,7 +2923,7 @@ using basetyp = basetype_t<typ>;
                    (fortran_int)dimensions[0],
                    (fortran_int)dimensions[1],
 dispatch_scalar<typ>())) {
-        LINEARIZE_DATA_t a_in, u_out, s_out, v_out;
+        LINEARIZE_DATA_t a_in, u_out = {}, s_out = {}, v_out = {};
         fortran_int min_m_n = params.M < params.N ? params.M : params.N;
 
         init_linearize_data(&a_in, params.N, params.M, steps[1], steps[0]);
@@ -4081,8 +4078,6 @@ dispatch_scalar<typ>{});
     set_fp_invalid_or_clear(error_occurred);
 }
 
-#pragma GCC diagnostic pop
-
 /* -------------------------------------------------------------------------- */
               /* gufunc registration  */
 
@@ -4548,7 +4543,7 @@ addUfuncs(PyObject *dictionary) {
         if (f == NULL) {
             return -1;
         }
-#if 0
+#if _UMATH_LINALG_DEBUG
         dump_ufunc_object((PyUFuncObject*) f);
 #endif
         int ret = PyDict_SetItemString(dictionary, d->name, f);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.15.0",
-    "Cython>=3.0",
+    "Cython>=3.0.6",  # keep in sync with version check in meson.build
 ]
 
 [project]


### PR DESCRIPTION
The large number of build warnings on macOS was getting annoying, so I dug in and solved all but a handful of them (it was 51, now there are 5 left). Those last ones were tricky to address, and silencing `-Wunused-function` didn't seem quite right.

One main cause of warnings was the use of C11 features. Rather than trying to change that code, it made sense to start requiring C11 explicitly. The biggest change in C11 was to make previously-mandatory C99 features like `complex.h` and complex types optional - and we were already allowing that of course, because MSVC doesn't support complex types. Since all compilers we care about support C11, and the `typedef` redefinitions that we use in multiple places are a C11-only feature, documenting that C11 is what we require see and compiling with `-std=c11` seems fine.

This PR also cleans up uses of `#pragma GCC diagnostic`. Those should be avoided, especially for `-Wmaybe-uninitialized`, because Clang also looks at these pragmas and emits warnings when it doesn't understand them (and `-Wmaybe-uninitialized` doesn't exist there). There are usually better ways to deal with the problem, like changing the code that emits the warnings.

~Finally worth pointing out is one odd bug in `loops_minmax.dispatch.c.src` which disabled rather than enabled some code that was meant to run on Arm only. This was clearly a typo; tests all seem to pass; I didn't investigate performance.~

