### PR TITLE
BLD,BUG: quadmath required where available [f2py]

### DIFF
--- a/doc/source/f2py/windows/index.rst
+++ b/doc/source/f2py/windows/index.rst
@@ -18,7 +18,14 @@ Broadly speaking, there are two issues working with F2PY on Windows:
 - the linking issues related to the C runtime library for building Python-C extensions.
 
 The focus of this section is to establish a guideline for developing and
-extending Fortran modules for Python natively, via F2PY on Windows. 
+extending Fortran modules for Python natively, via F2PY on Windows.
+
+Currently supported toolchains are:
+
+- Mingw-w64 C/C++/Fortran compilers
+- Intel compilers
+- Clang-cl + Flang
+- MSVC + Flang
 
 Overview
 ========

--- a/doc/source/f2py/windows/index.rst
+++ b/doc/source/f2py/windows/index.rst
@@ -6,8 +6,11 @@ F2PY and Windows
 
 .. warning::
 
-	F2PY support for Windows is not at par with Linux support, and 
-	OS specific flags can be seen via ``python -m numpy.f2py``
+	F2PY support for Windows is not always at par with Linux support
+
+.. note::
+   `ScPy's documentation`_ has some information on system-level dependencies
+   which are well tested for Fortran as well.
 
 Broadly speaking, there are two issues working with F2PY on Windows:
 
@@ -19,6 +22,7 @@ extending Fortran modules for Python natively, via F2PY on Windows.
 
 Overview
 ========
+
 From a user perspective, the most UNIX compatible Windows
 development environment is through emulation, either via the Windows Subsystem
 on Linux, or facilitated by Docker. In a similar vein, traditional
@@ -206,3 +210,4 @@ path using a hash. This needs to be added to the ``PATH`` variable.
 .. _are outdated: https://github.com/conda-forge/conda-forge.github.io/issues/1044
 .. _now deprecated: https://github.com/numpy/numpy/pull/20875
 .. _LLVM Flang: https://releases.llvm.org/11.0.0/tools/flang/docs/ReleaseNotes.html
+.. _ScPy's documentation: http://scipy.github.io/devdocs/building/index.html#system-level-dependencies

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -6,6 +6,7 @@ project('${modulename}',
                             'warning_level=1',
                             'buildtype=${buildtype}'
                           ])
+fc = meson.get_compiler('fortran')
 
 py = import('python').find_installation(pure: false)
 py_dep = py.dependency()
@@ -28,6 +29,8 @@ inc_f2py = include_directories(incdir_f2py)
 fortranobject_c = incdir_f2py / 'fortranobject.c'
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)
+# gh-25000
+quadmath_dep = fc.find_library('quadmath', required: false)
 
 py.extension_module('${modulename}',
                      [
@@ -37,6 +40,7 @@ ${source_list},
                      include_directories: [inc_np],
                      dependencies : [
                      py_dep,
+                     quadmath_dep,
 ${dep_list}
                      ],
                      install : true)


### PR DESCRIPTION
Closes gh-25000.

There's a longer explanation in the [issue comment](https://github.com/numpy/numpy/issues/25000#issuecomment-1793836602) but essentially, for the most common toolchain (`gfortran` from `rtools` and standard `python`), `quadmath` needs to be declared as an explicit dependency.

Also updates the documentation with supported compiler toolchains.