### PR TITLE
BLD: limit scipy-openblas32 wheel to 0.3.23.293.2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,7 @@ jobs:
         python-version: 'pypy3.9-v7.3.12'
     - name: Setup using scipy-openblas
       run: |
-        python -m pip install scipy-openblas32 spin
+        python -m pip install "scipy-openblas32<=0.3.23.293.2" spin
         spin config-openblas --with-scipy-openblas=32
     - uses: ./.github/meson_actions
 
@@ -129,7 +129,7 @@ jobs:
         set -xe
         sudo apt update
         sudo apt install gfortran libgfortran5
-        pip install scipy-openblas32
+        pip install "scipy-openblas32<=0.3.23.293.2"
         spin config-openblas --with-scipy-openblas=32
     - name: Build a wheel
       env:

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r build_requirements.txt
-        pip install scipy-openblas32 spin
+        pip install "scipy-openblas32<=0.3.23.293.2" spin
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -55,7 +55,7 @@ jobs:
         python -m venv test_env
         source test_env/bin/activate
 
-        pip install scipy-openblas64
+        pip install "scipy-openblas64<=0.3.23.293.2"
 
         pip install -r build_requirements.txt -r test_requirements.txt
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
-        python -m pip install scipy-openblas32
+        python -m pip install "scipy-openblas32<=0.3.23.293.2"
         spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
@@ -60,7 +60,7 @@ jobs:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        python -m pip install scipy-openblas32
+        python -m pip install "scipy-openblas32<=0.3.23.293.2"
         spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,19 +68,7 @@ stages:
             # yum does not have a ninja package, so use the PyPI one
             docker run -v $(pwd):/numpy -e CFLAGS="-msse2 -std=c99 -UNDEBUG" \
             -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2014_i686 \
-            /bin/bash -xc " \
-            git config --global --add safe.directory /numpy && \
-            cd /numpy && \
-            /opt/python/cp39-cp39/bin/python -mvenv venv && \
-            source venv/bin/activate && \
-            python3 -m pip install ninja "scipy-openblas32\<=0.3.23.293.2" spin && \
-            python3 -m pip install -r test_requirements.txt && \
-            echo CFLAGS \$CFLAGS && \
-            spin config-openblas --with-scipy-openblas=32 && \
-            export PKG_CONFIG_PATH=/numpy/.openblas && \
-            python3 -m pip install  . && \
-            cd tools && \
-            python3 -m pytest --pyargs numpy"
+            /bin/bash -xc "source /numpy/tools/ci/run_32_bit_linux_docker.sh"
       displayName: 'Run 32-bit manylinux2014 Docker Build / Tests'
 
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
             cd /numpy && \
             /opt/python/cp39-cp39/bin/python -mvenv venv && \
             source venv/bin/activate && \
-            python3 -m pip install ninja scipy-openblas32 spin && \
+            python3 -m pip install ninja "scipy-openblas32<=0.3.23.293.2" spin && \
             python3 -m pip install -r test_requirements.txt && \
             echo CFLAGS \$CFLAGS && \
             spin config-openblas --with-scipy-openblas=32 && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
             cd /numpy && \
             /opt/python/cp39-cp39/bin/python -mvenv venv && \
             source venv/bin/activate && \
-            python3 -m pip install ninja "scipy-openblas32<=0.3.23.293.2" spin && \
+            python3 -m pip install ninja "scipy-openblas32\<=0.3.23.293.2" spin && \
             python3 -m pip install -r test_requirements.txt && \
             echo CFLAGS \$CFLAGS && \
             spin config-openblas --with-scipy-openblas=32 && \

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -30,12 +30,12 @@ steps:
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
     elseif ( Test-Path env:_USE_BLAS_ILP64 ) {
-        python -m pip install scipy-openblas64 spin
+        python -m pip install "scipy-openblas64<=0.3.23.293.2" spin
         spin config-openblas --with-scipy-openblas=64
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"
     } else {
-        python -m pip install scipy-openblas32 spin
+        python -m pip install "scipy-openblas32<=0.3.23.293.2" spin
         spin config-openblas --with-scipy-openblas=32
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
         python -m pip install . -v -Csetup-args="--vsenv" 

--- a/tools/ci/run_32_bit_linux_docker.sh
+++ b/tools/ci/run_32_bit_linux_docker.sh
@@ -1,0 +1,14 @@
+set -xe
+
+git config --global --add safe.directory /numpy
+cd /numpy
+/opt/python/cp39-cp39/bin/python -mvenv venv
+source venv/bin/activate
+python3 -m pip install ninja "scipy-openblas32<=0.3.23.293.2" spin
+python3 -m pip install -r test_requirements.txt
+echo CFLAGS \$CFLAGS
+spin config-openblas --with-scipy-openblas=32
+export PKG_CONFIG_PATH=/numpy/.openblas
+python3 -m pip install .
+cd tools
+python3 -m pytest --pyargs numpy


### PR DESCRIPTION
I am working towards adding a scipy_ prefix to all the openblas symbol names in the scipy-openblas wheels. This will allow using both the scipy-openblas wheels and another OpenBLAS library together in scipy, for instance if using a scipy compiled with the "regular" OpenBLAS together with a numpy compiled with the OpenBLAS wheels.

In order to do an ordered transition, first this PR freezes the current version of scipy-openblas32/64 used in CI here. Then I will release new scipy-openblas32 wheels with an updated scipy-openblas.pc file, that will define a `-DBLAS_SYMBOL_PREFIX=scipy_` compile-time directive. Then I will come back to here and submit a new PR that reverts this one, and makes sure the use of `BLAS_SYMBOL_PREFIX` actually works.

xref @scipy/scipy#19484

cc @rgommers