### PR TITLE
BLD: Fix features.h detection for Meson builds [1.26.x Backport]

### DIFF
--- a/numpy/core/config.h.in
+++ b/numpy/core/config.h.in
@@ -12,6 +12,7 @@
 #mesondefine HAVE___DECLSPEC_THREAD_
 
 /* Optional headers */
+#mesondefine HAVE_FEATURES_H
 #mesondefine HAVE_XLOCALE_H
 #mesondefine HAVE_DLFCN_H
 #mesondefine HAVE_EXECINFO_H

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -160,8 +160,29 @@
 #undef HAVE_CACOSHL
 
 #endif  /* __GLIBC_PREREQ(2, 18) */
-#endif  /* defined(__GLIBC_PREREQ) */
+#else   /* defined(__GLIBC) */
+/* musl linux?, see issue #25092 */
 
+#undef HAVE_CASIN
+#undef HAVE_CASINF
+#undef HAVE_CASINL
+#undef HAVE_CASINH
+#undef HAVE_CASINHF
+#undef HAVE_CASINHL
+#undef HAVE_CATAN
+#undef HAVE_CATANF
+#undef HAVE_CATANL
+#undef HAVE_CATANH
+#undef HAVE_CATANHF
+#undef HAVE_CATANHL
+#undef HAVE_CACOS
+#undef HAVE_CACOSF
+#undef HAVE_CACOSL
+#undef HAVE_CACOSH
+#undef HAVE_CACOSHF
+#undef HAVE_CACOSHL
+
+#endif  /* defined(__GLIBC) */
 #endif  /* defined(HAVE_FEATURES_H) */
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_CONFIG_H_ */

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1712,6 +1712,9 @@ class TestSpecialFloats:
                     assert_raises(FloatingPointError, np.arctanh,
                                   np.array(value, dtype=dt))
 
+        # Make sure glibc < 2.18 atanh is not used, issue 25087
+        assert np.signbit(np.arctanh(-1j).real)
+
     # See: https://github.com/numpy/numpy/issues/20448
     @pytest.mark.xfail(
         _glibc_older_than("2.17"),


### PR DESCRIPTION
Fixes function blocklisting for glibc<2.18, reported in issue gh-25087.

backport of gh-25092
closes gh-25087

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
