### PR TITLE
BUG: Avoid intp conversion regression in Cython 3

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -20,12 +20,14 @@ cdef extern from *:
     """
 
 
-cdef extern from "Python.h":
-    ctypedef Py_ssize_t Py_intptr_t
-
 cdef extern from "numpy/arrayobject.h":
-    ctypedef Py_intptr_t npy_intp
-    ctypedef size_t npy_uintp
+    # It would be nice to use size_t and ssize_t, but ssize_t has special
+    # implicit conversion rules, so just use "long".
+    # Note: The actual type only matters for Cython promotion, so long
+    #       is closer than int, but could lead to incorrect promotion.
+    #       (Not to worrying, and always the status-quo.)
+    ctypedef signed long npy_intp
+    ctypedef unsigned long npy_uintp
 
     cdef enum NPY_TYPES:
         NPY_BOOL

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -128,3 +128,6 @@ def get_default_integer():
     if cnp.NPY_DEFAULT_INT == cnp.NPY_INTP:
         return cnp.dtype("intp")
     return None
+
+def conv_intp(cnp.intp_t val):
+    return val

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -192,3 +192,15 @@ def test_multiiter_fields(install_temp, arrays):
             for x, y in zip(bcast.iters, checks.get_multiiter_iters(bcast))
         ]
     )
+
+
+def test_conv_intp(install_temp):
+    import checks
+
+    class myint:
+        def __int__(self):
+            return 3
+
+    # These conversion passes via `__int__`, not `__index__`:
+    assert checks.conv_intp(3.) == 3
+    assert checks.conv_intp(myint()) == 3

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3501,7 +3501,7 @@ cdef class RandomState:
             return randoms
 
         _dp = PyFloat_AsDouble(p)
-        _in = int(n)
+        _in = n
         check_constraint(_dp, 'p', CONS_BOUNDED_0_1)
         check_constraint(<double>_in, 'n', LEGACY_CONS_NON_NEGATVE_INBOUNDS_LONG)
 


### PR DESCRIPTION
In the Cython 3 `__init__.pxd` `intp` was defined to `Py_ssize_t` which is *correct*.  However, Cython has special rules for `Py_ssize_t`. It uses the `PyNumber_AsIndex` (`operator.index`) function for conversion which rejects for example floats.

Of course I prefer that behavior, but:
1. There is no great reason why `np.intp_t` should be all that special.
2. Changing it silently changes downstream (and `np.random`) behavior.

It would be awesome if Cython would allow transitioning to using `operator.index()` style coercion since you can still explicitly convert via `int()`.

Now, why the new definition to `signed long`!?  `ssize_t` doesn't work because it is *also* special, using `PyLong_AsSize_t`. It seems to me that adding signed might give this type a bit of preference in promotion, so it is is just for good sport. (It is impossible to get Cython promotion fully right.)