### PR TITLE
BUG: Avoid intp conversion regression in Cython 3 (backport)

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -21,7 +21,7 @@ cdef extern from *:
 
 
 cdef extern from "Python.h":
-    ctypedef Py_ssize_t Py_intptr_t
+    ctypedef int Py_intptr_t
 
 cdef extern from "numpy/arrayobject.h":
     ctypedef Py_intptr_t npy_intp

--- a/numpy/core/tests/examples/cython/checks.pyx
+++ b/numpy/core/tests/examples/cython/checks.pyx
@@ -30,3 +30,6 @@ def get_dt64_unit(obj):
 
 def is_integer(obj):
     return isinstance(obj, (cnp.integer, int))
+
+def conv_intp(cnp.intp_t val):
+    return val

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -122,3 +122,14 @@ def test_abstract_scalars(install_temp):
     assert checks.is_integer(1)
     assert checks.is_integer(np.int8(1))
     assert checks.is_integer(np.uint64(1))
+
+def test_conv_intp(install_temp):
+    import checks
+
+    class myint:
+        def __int__(self):
+            return 3
+
+    # These conversion passes via `__int__`, not `__index__`:
+    assert checks.conv_intp(3.) == 3
+    assert checks.conv_intp(myint()) == 3


### PR DESCRIPTION
This is the minimal backport version of https://github.com/numpy/numpy/pull/25094, which simply aligns
the Cython 2 and Cython 3 definitions.