### PR TITLE
DOC: Fix license identifier for OpenBLAS

### DIFF
--- a/tools/wheels/LICENSE_linux.txt
+++ b/tools/wheels/LICENSE_linux.txt
@@ -8,7 +8,7 @@ Name: OpenBLAS
 Files: numpy.libs/libopenblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
 

--- a/tools/wheels/LICENSE_osx.txt
+++ b/tools/wheels/LICENSE_osx.txt
@@ -7,7 +7,7 @@ Name: OpenBLAS
 Files: numpy/.dylibs/libopenblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
 

--- a/tools/wheels/LICENSE_win32.txt
+++ b/tools/wheels/LICENSE_win32.txt
@@ -8,7 +8,7 @@ Name: OpenBLAS
 Files: numpy.libs\libopenblas*.dll
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
 


### PR DESCRIPTION
This fixes the SPDX license identifier for the OpenBLAS dependency. Looking at the license text itself, this clearly is BSD-3-Clause and not BSD-3-Clause-Attribution. BSD-3-Clause-Attribution usually has a fourth clause with some advertisement stuff: https://spdx.org/licenses/BSD-3-Clause-Attribution.html