### PR TITLE
API: Add ``outer`` to ``numpy.linalg`` [Array API]

### DIFF
--- a/doc/release/upcoming_changes/25101.new_feature.rst
+++ b/doc/release/upcoming_changes/25101.new_feature.rst
@@ -1,0 +1,6 @@
+``outer`` for `numpy.linalg`
+----------------------------
+
+`numpy.linalg.outer` has been added. It computes the outer product of two vectors.
+It differs from `numpy.outer` by accepting one-dimensional arrays only.
+This function is compatible with Array API.

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -134,11 +134,8 @@ Function instead of method
 These functions are in the ``linalg`` sub-namespace in the array API, but are
 only in the top-level namespace in NumPy:
 
-- ``diagonal``
 - ``matmul`` (*)
-- ``outer``
 - ``tensordot`` (*)
-- ``trace``
 
 (*): These functions are also in the top-level namespace in the array API.
 

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -72,6 +72,7 @@ Decompositions
    :toctree: generated/
 
    linalg.cholesky
+   linalg.outer
    linalg.qr
    linalg.svd
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -873,6 +873,8 @@ def outer(a, b, out=None):
     ufunc.outer : A generalization to dimensions other than 1D and other
                   operations. ``np.multiply.outer(a.ravel(), b.ravel())``
                   is the equivalent.
+    linalg.outer : An Array API compatible variation of ``np.outer``,
+                   which accepts 1-dimensional inputs only.
     tensordot : ``np.tensordot(a.ravel(), b.ravel(), axes=((), ()))``
                 is the equivalent.
 

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -34,6 +34,7 @@ Decompositions
 --------------
 
    cholesky
+   outer
    qr
    svd
 

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -5,6 +5,7 @@ from numpy.linalg._linalg import (
     tensorinv as tensorinv,
     inv as inv,
     cholesky as cholesky,
+    outer as outer,
     eigvals as eigvals,
     eigvalsh as eigvalsh,
     pinv as pinv,

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -12,7 +12,7 @@ zgetrf, dpotrf, zpotrf, dgeqrf, zgeqrf, zungqr, dorgqr.
 __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
            'cholesky', 'eigvals', 'eigvalsh', 'pinv', 'slogdet', 'det',
            'svd', 'eig', 'eigh', 'lstsq', 'norm', 'qr', 'cond', 'matrix_rank',
-           'LinAlgError', 'multi_dot', 'trace', 'diagonal', 'cross']
+           'LinAlgError', 'multi_dot', 'trace', 'diagonal', 'cross', 'outer']
 
 import functools
 import operator
@@ -27,7 +27,7 @@ from numpy._core import (
     amax, prod, abs, atleast_2d, intp, asanyarray, object_, matmul,
     swapaxes, divide, count_nonzero, isnan, sign, argsort, sort,
     reciprocal, overrides, diagonal as _core_diagonal, trace as _core_trace,
-    cross as _core_cross,
+    cross as _core_cross, outer as _core_outer
 )
 from numpy.lib._twodim_base_impl import triu, eye
 from numpy.lib.array_utils import normalize_axis_index
@@ -814,7 +814,52 @@ def cholesky(a):
     return wrap(r.astype(result_t, copy=False))
 
 
+# outer product
+
+
+def _outer_dispatcher(x1, x2):
+    return (x1, x2)
+
+
+@array_function_dispatch(_outer_dispatcher)
+def outer(x1, x2, /):
+    """
+    Compute the outer product of two vectors.
+
+    This function is Array API compatible. Compared to ``np.outer``
+    it accepts 1-dimensional inputs only.
+
+    Parameters
+    ----------
+    x1 : (M,) array_like
+        One-dimensional input array of size ``N``.
+        Must have a numeric data type.
+    x2 : (N,) array_like
+        One-dimensional input array of size ``M``.
+        Must have a numeric data type.
+
+    Returns
+    -------
+    out : (M, N) ndarray
+        ``out[i, j] = a[i] * b[j]``
+
+    See also
+    --------
+    outer
+
+    """
+    x1 = asarray(x1)
+    x2 = asarray(x2)
+    if x1.ndim != 1 or x2.ndim != 1:
+        raise ValueError(
+            "Input arrays must be one-dimensional, but they are "
+            f"{x1.ndim=} and {x2.ndim=}."
+        )
+    return _core_outer(x1, x2, out=None)
+
+
 # QR decomposition
+
 
 def _qr_dispatcher(a, mode=None):
     return (a,)

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -10,12 +10,15 @@ from typing import (
     Generic,
 )
 
+import numpy as np
 from numpy import (
     generic,
     floating,
     complexfloating,
     signedinteger,
     unsignedinteger,
+    timedelta64,
+    object_,
     int32,
     float64,
     complex128,
@@ -26,6 +29,8 @@ from numpy.linalg import LinAlgError as LinAlgError
 from numpy._typing import (
     NDArray,
     ArrayLike,
+    _ArrayLikeUnknown,
+    _ArrayLikeBool_co,
     _ArrayLikeInt_co,
     _ArrayLikeUInt_co,
     _ArrayLikeFloat_co,
@@ -139,6 +144,35 @@ def cholesky(a: _ArrayLikeInt_co) -> NDArray[float64]: ...
 def cholesky(a: _ArrayLikeFloat_co) -> NDArray[floating[Any]]: ...
 @overload
 def cholesky(a: _ArrayLikeComplex_co) -> NDArray[complexfloating[Any, Any]]: ...
+
+@overload
+def outer(x1: _ArrayLikeUnknown, x2: _ArrayLikeUnknown) -> NDArray[Any]: ...
+@overload
+def outer(x1: _ArrayLikeBool_co, x2: _ArrayLikeBool_co) -> NDArray[np.bool]: ...
+@overload
+def outer(x1: _ArrayLikeUInt_co, x2: _ArrayLikeUInt_co) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def outer(x1: _ArrayLikeInt_co, x2: _ArrayLikeInt_co) -> NDArray[signedinteger[Any]]: ...
+@overload
+def outer(x1: _ArrayLikeFloat_co, x2: _ArrayLikeFloat_co) -> NDArray[floating[Any]]: ...
+@overload
+def outer(
+    x1: _ArrayLikeComplex_co,
+    x2: _ArrayLikeComplex_co,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def outer(
+    x1: _ArrayLikeTD64_co,
+    x2: _ArrayLikeTD64_co,
+    out: None = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def outer(x1: _ArrayLikeObject_co, x2: _ArrayLikeObject_co) -> NDArray[object_]: ...
+@overload
+def outer(
+    x1: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    x2: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+) -> _ArrayType: ...
 
 @overload
 def qr(a: _ArrayLikeInt_co, mode: _ModeKind = ...) -> QRResult: ...

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1842,6 +1842,23 @@ class TestCholesky:
         assert_(isinstance(res, np.ndarray))
 
 
+class TestOuter:
+    arr1 = np.arange(3)
+    arr2 = np.arange(3)
+    expected = np.array(
+        [[0, 0, 0],
+         [0, 1, 2],
+         [0, 2, 4]]
+    )
+
+    assert_array_equal(np.linalg.outer(arr1, arr2), expected)
+
+    with assert_raises_regex(
+        ValueError, "Input arrays must be one-dimensional"
+    ):
+        np.linalg.outer(arr1[:, np.newaxis], arr2)
+
+
 def test_byteorder_check():
     # Byte order check should pass for native order
     if sys.byteorder == 'little':

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -18,6 +18,7 @@ AR_c16: npt.NDArray[np.complex128]
 AR_O: npt.NDArray[np.object_]
 AR_m: npt.NDArray[np.timedelta64]
 AR_S: npt.NDArray[np.str_]
+AR_b: npt.NDArray[np.bool]
 
 assert_type(np.linalg.tensorsolve(AR_i8, AR_i8), npt.NDArray[np.float64])
 assert_type(np.linalg.tensorsolve(AR_i8, AR_f8), npt.NDArray[np.floating[Any]])
@@ -43,6 +44,13 @@ assert_type(np.linalg.matrix_power(AR_O, 2), npt.NDArray[Any])
 assert_type(np.linalg.cholesky(AR_i8), npt.NDArray[np.float64])
 assert_type(np.linalg.cholesky(AR_f8), npt.NDArray[np.floating[Any]])
 assert_type(np.linalg.cholesky(AR_c16), npt.NDArray[np.complexfloating[Any, Any]])
+
+assert_type(np.linalg.outer(AR_i8, AR_i8), npt.NDArray[np.signedinteger[Any]])
+assert_type(np.linalg.outer(AR_f8, AR_f8), npt.NDArray[np.floating[Any]])
+assert_type(np.linalg.outer(AR_c16, AR_c16), npt.NDArray[np.complexfloating[Any, Any]])
+assert_type(np.linalg.outer(AR_b, AR_b), npt.NDArray[np.bool])
+assert_type(np.linalg.outer(AR_O, AR_O), npt.NDArray[np.object_])
+assert_type(np.linalg.outer(AR_i8, AR_m), npt.NDArray[np.timedelta64])
 
 assert_type(np.linalg.qr(AR_i8), QRResult)
 assert_type(np.linalg.qr(AR_f8), QRResult)

--- a/tools/ci/array-api-skips.txt
+++ b/tools/ci/array-api-skips.txt
@@ -45,7 +45,6 @@ array_api_tests/test_data_type_functions.py::test_astype
 array_api_tests/test_has_names.py::test_has_names[linalg-matmul]
 array_api_tests/test_has_names.py::test_has_names[linalg-matrix_norm]
 array_api_tests/test_has_names.py::test_has_names[linalg-matrix_transpose]
-array_api_tests/test_has_names.py::test_has_names[linalg-outer]
 array_api_tests/test_has_names.py::test_has_names[linalg-svdvals]
 array_api_tests/test_has_names.py::test_has_names[linalg-tensordot]
 array_api_tests/test_has_names.py::test_has_names[linalg-vecdot]
@@ -73,7 +72,6 @@ array_api_tests/test_has_names.py::test_has_names[array_attribute-device]
 # missing linalg names
 array_api_tests/test_linalg.py::test_matrix_norm
 array_api_tests/test_linalg.py::test_matrix_transpose
-array_api_tests/test_linalg.py::test_outer
 array_api_tests/test_linalg.py::test_pinv
 array_api_tests/test_linalg.py::test_svdvals
 array_api_tests/test_linalg.py::test_vecdot
@@ -120,7 +118,6 @@ array_api_tests/test_signatures.py::test_extension_func_signature[linalg.cholesk
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_norm]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_rank]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_transpose]
-array_api_tests/test_signatures.py::test_extension_func_signature[linalg.outer]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.pinv]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.svdvals]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.tensordot]


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

This PR contains next Array API compatibility change. It adds `numpy.linalg.outer` (almost the same as `numpy.outer`) with docs taken from Array API specification.
