### PR TITLE
MAINT: Print towncrier output file location

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -592,7 +592,8 @@ def notes(ctx, version_override):
     \b
     $ spin notes
     """
-    version = version_override or util.get_config()['project.version']
+    project_config = util.get_config()
+    version = version_override or project_config['project.version']
 
     click.secho(
         f"Generating release notes for NumPy {version}",
@@ -605,6 +606,10 @@ def notes(ctx, version_override):
             f"please install `towncrier` to use this command"
         )
 
+    click.secho(
+        f"Reading upcoming changes from {project_config['tool.towncrier.directory']}",
+        bold=True, fg="bright_yellow"
+    )
     # towncrier build --version 2.1 --yes
     cmd = ["towncrier", "build", "--version", version, "--yes"]
     try:
@@ -618,8 +623,12 @@ def notes(ctx, version_override):
         raise click.ClickException(
             f"`towncrier` failed returned {e.returncode} with error `{e.stderr}`"
         )
-    output = p.stdout
-    click.secho(output)
+
+    output_path = project_config['tool.towncrier.filename'].format(version=version)
+    click.secho(
+        f"Release notes successfully written to {output_path}",
+        bold=True, fg="bright_yellow"
+    )
 
     click.secho(
         "Verifying consumption of all news fragments",


### PR DESCRIPTION
### Changes
- Print towncrier output file location

### Testing
```
~/os/numpy (maint_25017_follow) » spin notes                                                                                                                                                                    ganesh@ganesh-MS-7B86
Generating release notes for NumPy 2.0.0.dev0
Reading upcoming changes from doc/release/upcoming_changes/
$ towncrier build --version 2.0.0.dev0 --yes
Loading template...
Finding news fragments...
Rendering news fragments...
Writing to newsfile...
Staging newsfile...
Removing the following files:
/home/ganesh/os/numpy/doc/release/upcoming_changes/24532.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24946.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24877.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24775.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24858.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24634.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24540.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24854.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24680.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24770.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24868.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24445.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24945.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24922.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24555.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24818.deprecation.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24717.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24224.change.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24053.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24587.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24376.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24887.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24931.improvement.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24477.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24807.python_removal.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/24420.new_feature.rst
/home/ganesh/os/numpy/doc/release/upcoming_changes/19355.new_feature.rst
Removing news fragments...
Done!
Release notes successfully written to doc/source/release/2.0.0.dev0-notes.rst <------------ NEW!
Verifying consumption of all news fragments

```

Follow up from: #25017