### PR TITLE
MAINT: Use `spin lint` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,6 @@ jobs:
             spin build --with-scipy-openblas=64 -j 2
 
       - run:
-          name: create release notes
-          command: |
-            . venv/bin/activate
-            VERSION=$(pip show numpy | grep Version: | cut -d ' ' -f 2 | cut -c 1-5)
-            spin notes --version-override $VERSION
-
-      - run:
           name: build devdocs w/ref warnings
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,13 @@ jobs:
             spin build --with-scipy-openblas=64 -j 2
 
       - run:
+          name: create release notes
+          command: |
+            . venv/bin/activate
+            VERSION=$(pip show numpy | grep Version: | cut -d ' ' -f 2 | cut -c 1-5)
+            spin notes --version-override $VERSION
+
+      - run:
           name: build devdocs w/ref warnings
           command: |
             . venv/bin/activate

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         BASE_REF: ${{ github.base_ref }}
       run:
-        python tools/linter.py
+        spin lint
     - name: Check Python.h is first file included
       run: |
         python tools/check_python_h_first.py

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -2,3 +2,4 @@
 cython-lint
 ruff==0.14.14
 GitPython>=3.1.30
+spin


### PR DESCRIPTION
### Changes
- use `spin lint` for CI
- ~~use spin notes for CI~~

### Testing

- Added a tmp [commit](https://github.com/numpy/numpy/pull/25103/commits/17ee666095a630605821962ffd5b73c260b0b64e) with linter errors: [failure](https://github.com/numpy/numpy/actions/runs/6859950172/job/18653011873?pr=25103#step:5:1)

### Notes
- related
  - #24080
  - https://github.com/numpy/numpy/pull/24983
  - ~~https://github.com/numpy/numpy/pull/25017~~