### PR TITLE
BUG: Disallow shadowed modulenames

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -654,6 +654,9 @@ def run_compile():
     pyf_files, _sources = filter_files('', '[.]pyf([.]src|)', sources)
     sources = pyf_files + _sources
 
+    if len(pyf_files) > 1:
+        raise RuntimeError("Only one .pyf file is allowed per compilation.")
+
     for f in pyf_files:
         pyf_modulename = auxfuncs.get_f2py_modulename(f)
         if pyf_modulename:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -644,19 +644,28 @@ def run_compile():
             del sys.argv[i + 1], sys.argv[i]
             sources = sys.argv[1:]
 
-    pyf_files = []
+    m_flag_modulename = None
     if '-m' in sys.argv:
         i = sys.argv.index('-m')
-        modulename = sys.argv[i + 1]
+        m_flag_modulename = sys.argv[i + 1]
         del sys.argv[i + 1], sys.argv[i]
         sources = sys.argv[1:]
-    else:
-        pyf_files, _sources = filter_files('', '[.]pyf([.]src|)', sources)
-        sources = pyf_files + _sources
-        for f in pyf_files:
-            modulename = auxfuncs.get_f2py_modulename(f)
-            if modulename:
-                break
+
+    pyf_files, _sources = filter_files('', '[.]pyf([.]src|)', sources)
+    sources = pyf_files + _sources
+
+    for f in pyf_files:
+        pyf_modulename = auxfuncs.get_f2py_modulename(f)
+        if pyf_modulename:
+            modulename = pyf_modulename
+            if m_flag_modulename:
+                outmess(f"INFO: {m_flag_modulename} from -m ignored, "
+                        f"using {modulename} from .pyf file\n")
+            break
+
+    if not pyf_files or not modulename:
+        if m_flag_modulename:
+            modulename = m_flag_modulename
 
     extra_objects, sources = filter_files('', '[.](o|a|so|dylib)', sources)
     include_dirs, sources = filter_files('-I', '', sources, remove_prefix=1)


### PR DESCRIPTION
Closes #22819.

Enforces the following:
- Warns (but doesn't break, for BC) when `-m` is passed with a `.pyf` in a `-c` call, the name is ignored and taken from the `.pyf` file (the only logical option)
- Each `-c` run will only produce **one** `python` module, so there can only be **one** `.pyf` file

There already is a [note in the documentation](https://numpy.org/doc/stable/f2py/usage.html#other-options), but this is a much better solution (and also paves the way for #25111).