### PR TITLE
BUG: ensure passing ``np.dtype`` to itself doesn't crash

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1478,6 +1478,11 @@ PyArray_DTypeOrDescrConverterRequired(PyObject *obj, npy_dtype_info *dt_info)
     dt_info->descr = NULL;
 
     if (PyObject_TypeCheck(obj, &PyArrayDTypeMeta_Type)) {
+        if (obj == (PyObject *)&PyArrayDescr_Type) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Cannot convert np.dtype into a dtype.");
+            return NPY_FAIL;
+        }
         Py_INCREF(obj);
         dt_info->dtype = (PyArray_DTypeMeta *)obj;
         dt_info->descr = NULL;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1898,3 +1898,9 @@ def test_result_type_integers_and_unitless_timedelta64():
     td = np.timedelta64(4)
     result = np.result_type(0, td)
     assert_dtype_equal(result, td.dtype)
+
+
+def test_creating_dtype_with_dtype_class_errors():
+    # Regression test for #25031, calling `np.dtype` with itself segfaulted.
+    with pytest.raises(TypeError, match="Cannot convert np.dtype into a"):
+        np.array(np.ones(10), dtype=np.dtype)


### PR DESCRIPTION
Backport of #25042.

Happy to implement other approaches but adding a check just before the crash happens seemed simplest.

Fixes #25031.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
