### PR TITLE
MAINT,BUG: Never import distutils above 3.12 [f2py]

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -35,6 +35,7 @@ errmess = sys.stderr.write
 # outmess=sys.stdout.write
 show = pprint.pprint
 outmess = auxfuncs.outmess
+MESON_ONLY_VER = (sys.version_info >= (3, 12))
 
 __usage__ =\
 f"""Usage:
@@ -540,9 +541,10 @@ def preparse_sysargv():
     sys.argv = [sys.argv[0]] + remaining_argv
 
     backend_key = args.backend
-    if sys.version_info >= (3, 12) and backend_key == 'distutils':
-        outmess("Cannot use distutils backend with Python 3.12, using meson backend instead.\n")
-        backend_key = 'meson'
+    if MESON_ONLY_VER and backend_key == 'distutils':
+        outmess("Cannot use distutils backend with Python>=3.12,"
+                " using meson backend instead.\n")
+        backend_key = "meson"
 
     return {
         "dependencies": args.dependencies or [],
@@ -617,21 +619,27 @@ def run_compile():
     for s in flib_flags:
         v = '--fcompiler='
         if s[:len(v)] == v:
-            from numpy.distutils import fcompiler
-            fcompiler.load_all_fcompiler_classes()
-            allowed_keys = list(fcompiler.fcompiler_class.keys())
-            nv = ov = s[len(v):].lower()
-            if ov not in allowed_keys:
-                vmap = {}  # XXX
-                try:
-                    nv = vmap[ov]
-                except KeyError:
-                    if ov not in vmap.values():
-                        print('Unknown vendor: "%s"' % (s[len(v):]))
-                nv = ov
-            i = flib_flags.index(s)
-            flib_flags[i] = '--fcompiler=' + nv
-            continue
+            if sys.version_info >= (3, 12):
+                outmess(
+                    "--fcompiler cannot be used with meson,"
+                    "set compiler with the FC environment variable\n"
+                    )
+            else:
+                from numpy.distutils import fcompiler
+                fcompiler.load_all_fcompiler_classes()
+                allowed_keys = list(fcompiler.fcompiler_class.keys())
+                nv = ov = s[len(v):].lower()
+                if ov not in allowed_keys:
+                    vmap = {}  # XXX
+                    try:
+                        nv = vmap[ov]
+                    except KeyError:
+                        if ov not in vmap.values():
+                            print('Unknown vendor: "%s"' % (s[len(v):]))
+                    nv = ov
+                i = flib_flags.index(s)
+                flib_flags[i] = '--fcompiler=' + nv
+                continue
     for s in del_list:
         i = flib_flags.index(s)
         del flib_flags[i]
@@ -719,8 +727,11 @@ def validate_modulename(pyf_files, modulename='untitled'):
 def main():
     if '--help-link' in sys.argv[1:]:
         sys.argv.remove('--help-link')
-        from numpy.distutils.system_info import show_all
-        show_all()
+        if MESON_ONLY_VER:
+            outmess("Use --dep for meson builds\n")
+        else:
+            from numpy.distutils.system_info import show_all
+            show_all()
         return
 
     if '-c' in sys.argv[1:]:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -619,7 +619,7 @@ def run_compile():
     for s in flib_flags:
         v = '--fcompiler='
         if s[:len(v)] == v:
-            if sys.version_info >= (3, 12):
+            if MESON_ONLY_VER or backend_key == 'meson':
                 outmess(
                     "--fcompiler cannot be used with meson,"
                     "set compiler with the FC environment variable\n"

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -213,7 +213,7 @@ def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
         assert "untitledmodule.c" in out
 
 
-@pytest.mark.skipif(platform.system() != 'Linux', reason='Compiler required')
+@pytest.mark.skipif((platform.system() != 'Linux') or (sys.version_info <= (3, 12)), reason='Compiler and 3.12 required')
 def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
     """Check that no distutils imports are performed on 3.12
     CLI :: --fcompiler --help-link --backend distutils
@@ -222,7 +222,7 @@ def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
     foutl = get_io_paths(hello_world_f90, mname=MNAME)
     ipath = foutl.f90inp
     monkeypatch.setattr(
-        sys, "argv", f"f2py {ipath} --backend meson -c --fcompiler=gfortran -m {MNAME}".split()
+        sys, "argv", f"f2py {ipath} -c --fcompiler=gfortran -m {MNAME}".split()
     )
     with util.switchdir(ipath.parent):
         f2pycli()
@@ -235,15 +235,14 @@ def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
         f2pycli()
         out, _ = capfd.readouterr()
         assert "Use --dep for meson builds" in out
-    if (sys.version_info >= (3, 12)):
-        MNAME = "hi2" # Needs to be different for a new -c
-        monkeypatch.setattr(
-            sys, "argv", f"f2py {ipath} -c -m {MNAME} --backend distutils".split()
-        )
-        with util.switchdir(ipath.parent):
-            f2pycli()
-            out, _ = capfd.readouterr()
-            assert "Cannot use distutils backend with Python>=3.12" in out
+    MNAME = "hi2" # Needs to be different for a new -c
+    monkeypatch.setattr(
+        sys, "argv", f"f2py {ipath} -c -m {MNAME} --backend distutils".split()
+    )
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        out, _ = capfd.readouterr()
+        assert "Cannot use distutils backend with Python>=3.12" in out
 
 
 @pytest.mark.xfail

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -213,6 +213,39 @@ def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
         assert "untitledmodule.c" in out
 
 
+@pytest.mark.skipif(platform.system() != 'Linux', reason='Compiler required')
+def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
+    """Check that no distutils imports are performed on 3.12
+    CLI :: --fcompiler --help-link --backend distutils
+    """
+    MNAME = "hi"
+    foutl = get_io_paths(hello_world_f90, mname=MNAME)
+    ipath = foutl.f90inp
+    monkeypatch.setattr(
+        sys, "argv", f"f2py {ipath} --backend meson -c --fcompiler=gfortran -m {MNAME}".split()
+    )
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        out, _ = capfd.readouterr()
+        assert "--fcompiler cannot be used with meson" in out
+    monkeypatch.setattr(
+        sys, "argv", f"f2py --help-link".split()
+    )
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        out, _ = capfd.readouterr()
+        assert "Use --dep for meson builds" in out
+    if (sys.version_info >= (3, 12)):
+        MNAME = "hi2" # Needs to be different for a new -c
+        monkeypatch.setattr(
+            sys, "argv", f"f2py {ipath} -c -m {MNAME} --backend distutils".split()
+        )
+        with util.switchdir(ipath.parent):
+            f2pycli()
+            out, _ = capfd.readouterr()
+            assert "Cannot use distutils backend with Python>=3.12" in out
+
+
 @pytest.mark.xfail
 def test_f2py_skip(capfd, retreal_f77, monkeypatch):
     """Tests that functions can be skipped


### PR DESCRIPTION
Closes gh-24838. There were two locations in `f2py` where the options passed in would trigger an import of `distutils`. This simply guards them via an `if`.
