### PR TITLE
DOC: ``f2py`` CLI documentation enhancements

### DIFF
--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -31,6 +31,9 @@ To scan Fortran sources and generate a signature file, use
   either specify which routines should be wrapped (in the ``only: .. :`` part)
   or which routines F2PY should ignore (in the ``skip: .. :`` part).
 
+  F2PY has no concept of a "per-file" ``skip`` or ``only`` list, so if functions
+  are listed in ``only``, no other functions will be taken from any other files.
+
 If ``<filename.pyf>`` is specified as ``stdout``, then signatures are written to
 standard output instead of a file.
 

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -115,36 +115,31 @@ finally all object and library files are linked to the extension module
 If ``<fortran files>`` does not contain a signature file, then an extension
 module is constructed by scanning all Fortran source codes for routine
 signatures, before proceeding to build the extension module.
- 
-Among other options (see below) and options described for previous modes, the
-following options can be used in this mode:
- 
-``--help-fcompiler``
-  List the available Fortran compilers.
-``--help-compiler`` **[depreciated]**
-  List the available Fortran compilers.
-``--fcompiler=<Vendor>``
-  Specify a Fortran compiler type by vendor.
-``--f77exec=<path>``
-  Specify the path to a F77 compiler
-``--fcompiler-exec=<path>`` **[depreciated]**
-  Specify the path to a F77 compiler
-``--f90exec=<path>``
-  Specify the path to a F90 compiler
-``--f90compiler-exec=<path>`` **[depreciated]**
-  Specify the path to a F90 compiler
+
+.. warning::
+   From Python 3.12 onwards, ``distutils`` has been removed. Use
+   environment variables to interact with ``meson`` instead. See its
+   `FAQ <https://mesonbuild.com/howtox.html>`__ for more information.
+
+Among other options (see below) and options described for previous modes, the following can be used.
+
+.. note::
+
+   .. versionchanged:: 1.26.0
+      There are now two separate build backends which can be used, ``distutils``
+      and ``meson``. Users are **strongly** recommended to switch to ``meson``
+      since it is the default above Python ``3.12``.
+
+Common build flags:
+
+``--backend <backend_type>``
+  Specify the build backend for the compilation process.  The supported backends
+  are ``meson`` and ``distutils``.  If not specified, defaults to ``distutils``.
+  On Python 3.12 or higher, the default is ``meson``.
 ``--f77flags=<string>``
   Specify F77 compiler flags
 ``--f90flags=<string>``
   Specify F90 compiler flags
-``--opt=<string>``
-  Specify optimization flags
-``--arch=<string>``
-  Specify architecture specific optimization flags
-``--noopt``
-  Compile without optimization flags
-``--noarch``
-  Compile without arch-dependent optimization flags
 ``--debug``
   Compile with debugging information
 ``-l<libname>``
@@ -159,13 +154,41 @@ following options can be used in this mode:
 ``-L<dir>``
   Add directory ``<dir>`` to the list of directories to be searched for
   ``-l``.
-``link-<resource>``
+
+The ``meson`` specific flags are:
+
+``--dep <dependency>`` **meson only**
+  Specify a meson dependency for the module. This may be passed multiple times
+  for multiple dependencies. Dependencies are stored in a list for further
+  processing. Example: ``--dep lapack --dep scalapack`` This will identify
+  "lapack" and "scalapack" as dependencies and remove them from argv, leaving a
+  dependencies list containing ["lapack", "scalapack"].
+
+The older ``distutils`` flags are:
+
+``--help-fcompiler`` **no meson**
+  List the available Fortran compilers.
+``--fcompiler=<Vendor>`` **no meson**
+  Specify a Fortran compiler type by vendor.
+``--f77exec=<path>`` **no meson**
+  Specify the path to a F77 compiler
+``--f90exec=<path>`` **no meson**
+  Specify the path to a F90 compiler
+``--opt=<string>`` **no meson**
+  Specify optimization flags
+``--arch=<string>`` **no meson**
+  Specify architecture specific optimization flags
+``--noopt`` **no meson**
+  Compile without optimization flags
+``--noarch`` **no meson**
+  Compile without arch-dependent optimization flags
+``link-<resource>`` **no meson**
   Link the extension module with <resource> as defined by
   ``numpy_distutils/system_info.py``. E.g. to link with optimized LAPACK
   libraries (vecLib on MacOSX, ATLAS elsewhere), use ``--link-lapack_opt``.
   See also ``--help-link`` switch.
 
-.. note:: 
+.. note::
   
   The ``f2py -c`` option must be applied either to an existing ``.pyf`` file
   (plus the source/object/library files) or one must specify the
@@ -214,6 +237,9 @@ Other options
   Name of an extension module. Default is ``untitled``.
 
 .. warning:: Don't use this option if a signature file (``*.pyf``) is used.
+
+.. versionchanged:: 2.0.0
+   Will ignore ``-m`` if a ``pyf`` file is provided.
 
 ``--[no-]lower``
   Do [not] lower the cases in ``<fortran files>``. By default, ``--lower`` is

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2398,8 +2398,6 @@ def _calc_depend_dict(vars):
 
 
 def get_sorted_names(vars):
-    """
-    """
     depend_dict = _calc_depend_dict(vars)
     names = []
     for name in list(depend_dict.keys()):
@@ -3218,11 +3216,6 @@ def true_intent_list(var):
 
 
 def vars2fortran(block, vars, args, tab='', as_interface=False):
-    """
-    TODO:
-    public sub
-    ...
-    """
     setmesstext(block)
     ret = ''
     nout = []

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -184,7 +184,6 @@ Extra options (only effective with -c):
 
 Version:     {f2py_version}
 numpy Version: {numpy_version}
-Requires:    Python 3.5 or higher.
 License:     NumPy license (see LICENSE.txt in the NumPy source code)
 Copyright 1999 - 2011 Pearu Peterson all rights reserved.
 https://web.archive.org/web/20140822061353/http://cens.ioc.ee/projects/f2py2e"""

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -63,12 +63,6 @@ Description: This program generates a Python C/API file (<modulename>module.c)
 
 Options:
 
-  --2d-numpy       Use numpy.f2py tool with NumPy support. [DEFAULT]
-  --2d-numeric     Use f2py2e tool with Numeric support.
-  --2d-numarray    Use f2py2e tool with Numarray support.
-  --g3-numpy       Use 3rd generation f2py from the separate f2py package.
-                   [NOT AVAILABLE YET]
-
   -h <filename>    Write signatures of the fortran routines to file <filename>
                    and exit. You can then edit <filename> and use it instead
                    of <fortran files>. If <filename>==stdout then the
@@ -710,23 +704,6 @@ def main():
         from numpy.distutils.system_info import show_all
         show_all()
         return
-
-    # Probably outdated options that were not working before 1.16
-    if '--g3-numpy' in sys.argv[1:]:
-        sys.stderr.write("G3 f2py support is not implemented, yet.\\n")
-        sys.exit(1)
-    elif '--2e-numeric' in sys.argv[1:]:
-        sys.argv.remove('--2e-numeric')
-    elif '--2e-numarray' in sys.argv[1:]:
-        # Note that this errors becaust the -DNUMARRAY argument is
-        # not recognized. Just here for back compatibility and the
-        # error message.
-        sys.argv.append("-DNUMARRAY")
-        sys.argv.remove('--2e-numarray')
-    elif '--2e-numpy' in sys.argv[1:]:
-        sys.argv.remove('--2e-numpy')
-    else:
-        pass
 
     if '-c' in sys.argv[1:]:
         run_compile()

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -123,20 +123,22 @@ Options:
   -v               Print f2py version ID and exit.
 
 
-build backend options (only effective with -c):
+build backend options (only effective with -c)
+[NO_MESON] is used to indicate an option not meant to be used
+with the meson backend or above Python 3.12:
 
-  --fcompiler=         Specify Fortran compiler type by vendor
-  --compiler=          Specify C compiler type (as defined by distutils)
+  --fcompiler=         Specify Fortran compiler type by vendor [NO_MESON]
+  --compiler=          Specify distutils C compiler type [NO_MESON]
 
-  --help-fcompiler     List available Fortran compilers and exit
-  --f77exec=           Specify the path to F77 compiler
-  --f90exec=           Specify the path to F90 compiler
+  --help-fcompiler     List available Fortran compilers and exit [NO_MESON]
+  --f77exec=           Specify the path to F77 compiler [NO_MESON]
+  --f90exec=           Specify the path to F90 compiler [NO_MESON]
   --f77flags=          Specify F77 compiler flags
   --f90flags=          Specify F90 compiler flags
-  --opt=               Specify optimization flags
-  --arch=              Specify architecture specific optimization flags
-  --noopt              Compile without optimization
-  --noarch             Compile without arch-dependent optimization
+  --opt=               Specify optimization flags [NO_MESON]
+  --arch=              Specify architecture specific optimization flags [NO_MESON]
+  --noopt              Compile without optimization [NO_MESON]
+  --noarch             Compile without arch-dependent optimization [NO_MESON]
   --debug              Compile with debugging information
 
   --dep                <dependency>
@@ -161,7 +163,7 @@ Extra options (only effective with -c):
                        by numpy.distutils/system_info.py. E.g. to link
                        with optimized LAPACK libraries (vecLib on MacOSX,
                        ATLAS elsewhere), use --link-lapack_opt.
-                       See also --help-link switch.
+                       See also --help-link switch. [NO_MESON]
 
   -L/path/to/lib/ -l<libname>
   -D<define> -U<name>

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -173,7 +173,6 @@ Extra options (only effective with -c):
   Using the following macros may be required with non-gcc Fortran
   compilers:
     -DPREPEND_FORTRAN -DNO_APPEND_FORTRAN -DUPPERCASE_FORTRAN
-    -DUNDERSCORE_G77
 
   When using -DF2PY_REPORT_ATEXIT, a performance report of F2PY
   interface is printed out at exit (platforms: Linux).


### PR DESCRIPTION
`f2py` CLI documentation enhancements:
- Removes 1.16 CLI arguments
- Help text for `f2py` now mentions [NO_MESON] options
- Removed an `absoft` flag from the help text
- Added basic documentation, partially addressing https://github.com/numpy/numpy/issues/24874#issuecomment-1801934282
- Closes #20520.