### PR TITLE
DOC: angle: update documentation of convention when magnitude of argument is zero

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1620,8 +1620,9 @@ def angle(z, deg=False):
 
     Notes
     -----
-    Although the angle of the complex number 0 is undefined, ``numpy.angle(0)``
-    returns the value 0.
+    This function passes the imaginary and real parts of the argument to
+    `arctan2` to compute the result; consequently, it follows the convention
+    of `arctan2` when the magnitude of the argument is zero. See example.
 
     Examples
     --------
@@ -1629,6 +1630,8 @@ def angle(z, deg=False):
     array([ 0.        ,  1.57079633,  0.78539816]) # may vary
     >>> np.angle(1+1j, deg=True)                  # in degrees
     45.0
+    >>> np.angle([0., -0., complex(0., -0.), complex(-0., -0.)])  # convention
+    array([ 0.        ,  3.14159265, -0.        , -3.14159265])
 
     """
     z = asanyarray(z)


### PR DESCRIPTION
gh-21593 notes that the documentation of `np.angle` includes:

> Although the angle of the complex number 0 is undefined, numpy.angle(0) returns the value 0.

but this does not capture the behavior with other zero-magnitude arguments.  This PR adds an example
```python3
np.angle([0., -0., complex(0., -0.), complex(-0., -0.)])  # convention
# array([ 0.        ,  3.14159265, -0.        , -3.14159265])
```
and refers to `np.arctan2` (which points to C standard library `atan2` in turn)  as the source of this convention.

Closes gh-21593

