### PR TITLE
DOC: std/var: improve documentation of `ddof`

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3588,13 +3588,13 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The definition of the standard deviation of an array is not unique.
-    Assuming the input `a` is a one dimensional NumPy array and `mean` is
-    either provided as an argument or computed as ``a.mean()``, NumPy
-    computes the standard deviation of an array as::
+    There are several common variants of the array standard deviation
+    calculation. Assuming the input `a` is a one dimensional NumPy array
+    and `mean` is either provided as an argument or computed as ``a.mean()``,
+    NumPy computes the standard deviation of an array as::
 
         N = len(a)
-        d2 = abs(a - mean)**2
+        d2 = abs(a - mean)**2  # abs is for complex `a`
         var = d2.sum() / (N - ddof)  # note use of `ddof`
         std = var**0.5
 
@@ -3605,8 +3605,9 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
         \sqrt{\frac{\sum_i{|a_i - \bar{a}|^2 }}{N}}
 
-    and is sometimes (for better or for worse) called "population
-    standard deviation" or "uncorrected sample standard deviation".
+    which is sometimes called the "population standard deviation" in the field
+    of statistics because it applies the definition of standard deviation to
+    `a` as if `a` were a complete population of possible observations.
 
     Many other libraries define the standard deviation of an array
     differently, e.g.:
@@ -3615,10 +3616,16 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
         \sqrt{\frac{\sum_i{|a_i - \bar{a}|^2 }}{N - 1}}
 
-    The use of :math:`N-1` in the denominator is often called "Bessel's
-    correction", and the resulting quantity is sometimed called the "sample
-    standard deviation" or "corrected sample standard deviation". For this
-    quantity, use ``ddof=1``.
+    In statistics, the resulting quantity is sometimed called the "sample
+    standard deviation" because it treats `a` as a random sample from a larger
+    population: it computes an unbiased estimate of the variance of this
+    population from the sample, then takes the square root. The use of
+    :math:`N-1` in the denominator is often called "Bessel's correction"
+    because it corrects for bias (toward lower values) in the variance
+    estimate introduced when the sample mean of `a` is used in place of the
+    true mean of the population. (The resulting estimate of the standard
+    deviation is still biased, but less than it would have been without the
+    correction.) For this quantity, use ``ddof=1``.
 
     Note that, for complex numbers, `std` takes the absolute
     value before squaring, so that the result is always real and nonnegative.
@@ -3773,13 +3780,13 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The definition of the variance of an array is not unique.
+    There are several common variants of the array variance calculation.
     Assuming the input `a` is a one dimensional NumPy array and `mean` is
     either provided as an argument or computed as ``a.mean()``, NumPy
     computes the variance of an array as::
 
         N = len(a)
-        d2 = abs(a - mean)**2
+        d2 = abs(a - mean)**2  # abs is for complex `a`
         var = d2.sum() / (N - ddof)  # note use of `ddof`
 
     Different values of the argument `ddof` are useful in different
@@ -3789,8 +3796,9 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
         \frac{\sum_i{|a_i - \bar{a}|^2 }}{N}
 
-    and is sometimes (for better or for worse) called "population
-    variance", "uncorrected sample variance", or "biased sample variance".
+    which is sometimes called the "population variance" in the field of
+    statistics because it applies the definition of variance to `a` as if `a`
+    were a complete population of possible observations.
 
     Many other libraries define the variance of an array differently, e.g.:
 
@@ -3798,10 +3806,14 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
         \frac{\sum_i{|a_i - \bar{a}|^2}}{N - 1}
 
-    The use of :math:`N-1` in the denominator is often called "Bessel's
-    correction", and the resulting quantity is sometimed called the "sample
-    variance", "corrected sample variance", or "unbiased sample variance".
-    For this quantity, use ``ddof=1``.
+    In statistics, the resulting quantity is sometimed called the "sample
+    variance" because it treats `a` as a random sample from a larger
+    population, and it computes an unbiased estimate of the variance of this
+    population from the sample. The use of :math:`N-1` in the denominator is
+    often called "Bessel's correction" because it corrects for bias (toward
+    lower values) in the variance estimate introduced when the sample mean of
+    `a` is used in place of the true mean of the population. For this
+    quantity, use ``ddof=1``.
 
     Note that for complex numbers, the absolute value is taken before
     squaring, so that the result is always real and nonnegative.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3550,7 +3550,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     ddof : int, optional
         Means Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
-        By default `ddof` is zero.
+        By default `ddof` is zero. See Notes for details about use of `ddof`.
     keepdims : bool, optional
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -3588,24 +3588,45 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The standard deviation is the square root of the average of the squared
-    deviations from the mean, i.e., ``std = sqrt(mean(x))``, where
-    ``x = abs(a - a.mean())**2``.
+    The (sample) standard deviation is the square root of an average of the
+    squared deviations from the sample mean.
 
-    The average squared deviation is typically calculated as ``x.sum() / N``,
-    where ``N = len(x)``. If, however, `ddof` is specified, the divisor
-    ``N - ddof`` is used instead. In standard statistical practice, ``ddof=1``
-    provides an unbiased estimator of the variance of the infinite population.
-    ``ddof=0`` provides a maximum likelihood estimate of the variance for
-    normally distributed variables. The standard deviation computed in this
-    function is the square root of the estimated variance, so even with
-    ``ddof=1``, it will not be an unbiased estimate of the standard deviation
-    per se.
+    The squared deviations are calculated as ``x2 = abs(a - a.mean())**2``,
+    and the average is taken as ``x2.sum() / (N - ddof)``, where ``N`` is the
+    number of observations in the sample `a` and `ddof` is a keyword parameter.
+    The square root of this quantity is a "consistent" estimator of the
+    standard deviation of the population from which the sample was drawn: as
+    the number of observations tends toward infinity, it converges in
+    probability to the true population standard deviation.
+
+    With ``ddof=0`` (default), the resulting sample standard deviation is known
+    as the "uncorrected sample standard deviation" because it is not corrected
+    for "bias": the expected value of this sample standard deviation does not
+    equal the true population standard deviation. Nonetheless, it is a useful
+    estimator of the population standard deviation when the sample size is
+    large, and it is the maximumum likelihood estimate of the standard
+    deviation when the population is normally distributed.
+
+    Use of ``ddof=1`` is known as the "Bessel correction", and the resulting
+    average squared deviation is an unbiased estimator of the population
+    variance. The square root of this unbiased variance estimate is known as
+    the "corrected sample standard deviation" or simply *the* "sample standard
+    deviation", although it is still a biased estimate of the population
+    standard deviation.
+
+    Other values of `ddof` may have desirable properties for samples drawn from
+    certain distributions; for instance, if the population is normally
+    distributed, ``ddof=1.5`` nearly eliminates the bias. Unfortunately, there
+    is no simple, unbiased estimator of the population standard deviation that
+    is valid for all distributions, and reducing the bias often *increases* the
+    mean squared error between the sample standard deviation and population
+    standard deviation. Consequently, the "best" choice of `ddof` depends on
+    the use case and is often subjective.
 
     Note that, for complex numbers, `std` takes the absolute
     value before squaring, so that the result is always real and nonnegative.
 
-    For floating-point input, the *std* is computed using the same
+    For floating-point input, the standard deviation is computed using the same
     precision the input has. Depending on the input data, this can cause
     the results to be inaccurate, especially for float32 (see example below).
     Specifying a higher-accuracy accumulator using the `dtype` keyword can
@@ -3717,7 +3738,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     ddof : int, optional
         "Delta Degrees of Freedom": the divisor used in the calculation is
         ``N - ddof``, where ``N`` represents the number of elements. By
-        default `ddof` is zero.
+        default `ddof` is zero. See notes for details about use of `ddof`.
     keepdims : bool, optional
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -3755,15 +3776,33 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The variance is the average of the squared deviations from the mean,
-    i.e.,  ``var = mean(x)``, where ``x = abs(a - a.mean())**2``.
+    The (sample) variance is an average of the squared deviations from the
+    sample mean.
 
-    The mean is typically calculated as ``x.sum() / N``, where ``N = len(x)``.
-    If, however, `ddof` is specified, the divisor ``N - ddof`` is used
-    instead.  In standard statistical practice, ``ddof=1`` provides an
-    unbiased estimator of the variance of a hypothetical infinite population.
-    ``ddof=0`` provides a maximum likelihood estimate of the variance for
-    normally distributed variables.
+    The squared deviations are calculated as ``x2 = abs(a - a.mean())**2``,
+    and the average is taken as ``x2.sum() / (N - ddof)``, where ``N`` is the
+    number of observations in the sample `a` and `ddof` is a keyword parameter.
+    This is a "consistent" estimator of the variance of the population from
+    which the sample was drawn: as the number of observations tends toward
+    infinity, it converges in probability to the true population variance.
+
+    With ``ddof=0`` (default), the resulting sample variance is known as the
+    "uncorrected sample variance" because it is not corrected for "bias": the
+    expected value of this sample variance does not equal the true population
+    variance. Nonetheless, it is a useful estimator of the population variance
+    when the sample size is large, and it is the maximumum likelihood estimate
+    of the variance when the population is normally distributed.
+
+    Use of ``ddof=1`` is known as the "Bessel correction", and the resulting
+    "corrected sample variance" (or simple *the* "sample variance") is an
+    unbiased estimator of the population variance. Other values of `ddof` may
+    have desirable properties for samples drawn from certain distributions;
+    for instance, if the population is normally distributed, ``ddof=1.5``
+    nearly eliminates the bias. Unfortunately, there is no simple, unbiased
+    estimator of the population variance that is valid for all distributions,
+    and reducing the bias often *increases* the mean squared error between the
+    sample variance and population variance. Consequently, the "best" choice of
+    `ddof` depends on the use case and is often subjective.
 
     Note that for complex numbers, the absolute value is taken before
     squaring, so that the result is always real and nonnegative.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3588,40 +3588,37 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The (sample) standard deviation is the square root of an average of the
-    squared deviations from the sample mean.
+    The definition of the standard deviation of an array is not unique.
+    Assuming the input `a` is a one dimensional NumPy array and `mean` is
+    either provided as an argument or computed as ``a.mean()``, NumPy
+    computes the standard deviation of an array as::
 
-    The squared deviations are calculated as ``x2 = abs(a - a.mean())**2``,
-    and the average is taken as ``x2.sum() / (N - ddof)``, where ``N`` is the
-    number of observations in the sample `a` and `ddof` is a keyword parameter.
-    The square root of this quantity is a "consistent" estimator of the
-    standard deviation of the population from which the sample was drawn: as
-    the number of observations tends toward infinity, it converges in
-    probability to the true population standard deviation.
+        N = len(a)
+        d2 = abs(a - mean)**2
+        var = d2.sum() / (N - ddof)  # note use of `ddof`
+        std = var**0.5
 
-    With ``ddof=0`` (default), the resulting sample standard deviation is known
-    as the "uncorrected sample standard deviation" because it is not corrected
-    for "bias": the expected value of this sample standard deviation does not
-    equal the true population standard deviation. Nonetheless, it is a useful
-    estimator of the population standard deviation when the sample size is
-    large, and it is the maximumum likelihood estimate of the standard
-    deviation when the population is normally distributed.
+    Different values of the argument `ddof` are useful in different
+    contexts. NumPy's default ``ddof=0`` corresponds with the expression::
 
-    Use of ``ddof=1`` is known as the "Bessel correction", and the resulting
-    average squared deviation is an unbiased estimator of the population
-    variance. The square root of this unbiased variance estimate is known as
-    the "corrected sample standard deviation" or simply *the* "sample standard
-    deviation", although it is still a biased estimate of the population
-    standard deviation.
+    .. math::
 
-    Other values of `ddof` may have desirable properties for samples drawn from
-    certain distributions; for instance, if the population is normally
-    distributed, ``ddof=1.5`` nearly eliminates the bias. Unfortunately, there
-    is no simple, unbiased estimator of the population standard deviation that
-    is valid for all distributions, and reducing the bias often *increases* the
-    mean squared error between the sample standard deviation and population
-    standard deviation. Consequently, the "best" choice of `ddof` depends on
-    the use case and is often subjective.
+        \sqrt{\frac{\sum_i{|a_i - \bar{a}|^2 }}{N}}
+
+    and is sometimes (for better or for worse) called "population
+    standard deviation" or "uncorrected sample standard deviation".
+
+    Many other libraries define the standard deviation of an array
+    differently, e.g.::
+
+    .. math::
+
+        \sqrt{\frac{\sum_i{|a_i - \bar{a}|^2 }}{N - 1}}
+
+    The use of :math:`N-1` in the denominator is often called "Bessel's
+    correction", and the resulting quantity is sometimed called the "sample
+    standard deviation" or "corrected sample standard deviation". For this
+    quantity, use ``ddof=1``.
 
     Note that, for complex numbers, `std` takes the absolute
     value before squaring, so that the result is always real and nonnegative.
@@ -3776,33 +3773,35 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
     Notes
     -----
-    The (sample) variance is an average of the squared deviations from the
-    sample mean.
+    The definition of the variance of an array is not unique.
+    Assuming the input `a` is a one dimensional NumPy array and `mean` is
+    either provided as an argument or computed as ``a.mean()``, NumPy
+    computes the variance of an array as::
 
-    The squared deviations are calculated as ``x2 = abs(a - a.mean())**2``,
-    and the average is taken as ``x2.sum() / (N - ddof)``, where ``N`` is the
-    number of observations in the sample `a` and `ddof` is a keyword parameter.
-    This is a "consistent" estimator of the variance of the population from
-    which the sample was drawn: as the number of observations tends toward
-    infinity, it converges in probability to the true population variance.
+        N = len(a)
+        d2 = abs(a - mean)**2
+        var = d2.sum() / (N - ddof)  # note use of `ddof`
 
-    With ``ddof=0`` (default), the resulting sample variance is known as the
-    "uncorrected sample variance" because it is not corrected for "bias": the
-    expected value of this sample variance does not equal the true population
-    variance. Nonetheless, it is a useful estimator of the population variance
-    when the sample size is large, and it is the maximumum likelihood estimate
-    of the variance when the population is normally distributed.
+    Different values of the argument `ddof` are useful in different
+    contexts. NumPy's default ``ddof=0`` corresponds with the expression::
 
-    Use of ``ddof=1`` is known as the "Bessel correction", and the resulting
-    "corrected sample variance" (or simple *the* "sample variance") is an
-    unbiased estimator of the population variance. Other values of `ddof` may
-    have desirable properties for samples drawn from certain distributions;
-    for instance, if the population is normally distributed, ``ddof=1.5``
-    nearly eliminates the bias. Unfortunately, there is no simple, unbiased
-    estimator of the population variance that is valid for all distributions,
-    and reducing the bias often *increases* the mean squared error between the
-    sample variance and population variance. Consequently, the "best" choice of
-    `ddof` depends on the use case and is often subjective.
+    .. math::
+
+        \frac{\sum_i{|a_i - \bar{a}|^2 }}{N}
+
+    and is sometimes (for better or for worse) called "population
+    variance", "uncorrected sample variance", or "biased sample variance".
+
+    Many other libraries define the variance of an array differently, e.g.::
+
+    .. math::
+
+        \frac{\sum_i{|a_i - \bar{a}|^2}}{N - 1}
+
+    The use of :math:`N-1` in the denominator is often called "Bessel's
+    correction", and the resulting quantity is sometimed called the "sample
+    variance", "corrected sample variance", or "unbiased sample variance".
+    For this quantity, use ``ddof=1``.
 
     Note that for complex numbers, the absolute value is taken before
     squaring, so that the result is always real and nonnegative.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3599,7 +3599,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         std = var**0.5
 
     Different values of the argument `ddof` are useful in different
-    contexts. NumPy's default ``ddof=0`` corresponds with the expression::
+    contexts. NumPy's default ``ddof=0`` corresponds with the expression:
 
     .. math::
 
@@ -3609,7 +3609,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     standard deviation" or "uncorrected sample standard deviation".
 
     Many other libraries define the standard deviation of an array
-    differently, e.g.::
+    differently, e.g.:
 
     .. math::
 
@@ -3783,7 +3783,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         var = d2.sum() / (N - ddof)  # note use of `ddof`
 
     Different values of the argument `ddof` are useful in different
-    contexts. NumPy's default ``ddof=0`` corresponds with the expression::
+    contexts. NumPy's default ``ddof=0`` corresponds with the expression:
 
     .. math::
 
@@ -3792,7 +3792,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     and is sometimes (for better or for worse) called "population
     variance", "uncorrected sample variance", or "biased sample variance".
 
-    Many other libraries define the variance of an array differently, e.g.::
+    Many other libraries define the variance of an array differently, e.g.:
 
     .. math::
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3589,9 +3589,9 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     Notes
     -----
     There are several common variants of the array standard deviation
-    calculation. Assuming the input `a` is a one dimensional NumPy array
-    and `mean` is either provided as an argument or computed as ``a.mean()``,
-    NumPy computes the standard deviation of an array as::
+    calculation. Assuming the input `a` is a one-dimensional NumPy array
+    and ``mean`` is either provided as an argument or computed as
+    ``a.mean()``, NumPy computes the standard deviation of an array as::
 
         N = len(a)
         d2 = abs(a - mean)**2  # abs is for complex `a`
@@ -3617,15 +3617,15 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         \sqrt{\frac{\sum_i{|a_i - \bar{a}|^2 }}{N - 1}}
 
     In statistics, the resulting quantity is sometimed called the "sample
-    standard deviation" because it treats `a` as a random sample from a larger
-    population: it computes an unbiased estimate of the variance of this
-    population from the sample, then takes the square root. The use of
-    :math:`N-1` in the denominator is often called "Bessel's correction"
-    because it corrects for bias (toward lower values) in the variance
-    estimate introduced when the sample mean of `a` is used in place of the
-    true mean of the population. (The resulting estimate of the standard
-    deviation is still biased, but less than it would have been without the
-    correction.) For this quantity, use ``ddof=1``.
+    standard deviation" because if `a` is a random sample from a larger
+    population, this calculation provides the square root of an unbiased
+    estimate of the variance of the population. The use of :math:`N-1` in the
+    denominator is often called "Bessel's correction" because it corrects for
+    bias (toward lower values) in the variance estimate introduced when the
+    sample mean of `a` is used in place of the true mean of the population.
+    The resulting estimate of the standard deviation is still biased, but less
+    than it would have been without the correction. For this quantity, use
+    ``ddof=1``.
 
     Note that, for complex numbers, `std` takes the absolute
     value before squaring, so that the result is always real and nonnegative.
@@ -3781,7 +3781,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     Notes
     -----
     There are several common variants of the array variance calculation.
-    Assuming the input `a` is a one dimensional NumPy array and `mean` is
+    Assuming the input `a` is a one-dimensional NumPy array and ``mean`` is
     either provided as an argument or computed as ``a.mean()``, NumPy
     computes the variance of an array as::
 
@@ -3807,13 +3807,13 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         \frac{\sum_i{|a_i - \bar{a}|^2}}{N - 1}
 
     In statistics, the resulting quantity is sometimed called the "sample
-    variance" because it treats `a` as a random sample from a larger
-    population, and it computes an unbiased estimate of the variance of this
-    population from the sample. The use of :math:`N-1` in the denominator is
-    often called "Bessel's correction" because it corrects for bias (toward
-    lower values) in the variance estimate introduced when the sample mean of
-    `a` is used in place of the true mean of the population. For this
-    quantity, use ``ddof=1``.
+    variance" because if `a` is a random sample from a larger population,
+    this calculation provides an unbiased estimate of the variance of the
+    population.  The use of :math:`N-1` in the denominator is often called
+    "Bessel's correction" because it corrects for bias (toward lower values)
+    in the variance estimate introduced when the sample mean of `a` is used
+    in place of the true mean of the population. For this quantity, use
+    ``ddof=1``.
 
     Note that for complex numbers, the absolute value is taken before
     squaring, so that the result is always real and nonnegative.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3520,7 +3520,7 @@ def _std_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
 @array_function_dispatch(_std_dispatcher)
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue, mean=np._NoValue):
-    """
+    r"""
     Compute the standard deviation along the specified axis.
 
     Returns the standard deviation, a measure of the spread of a distribution,
@@ -3704,7 +3704,7 @@ def _var_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
 @array_function_dispatch(_var_dispatcher)
 def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue, mean=np._NoValue):
-    """
+    r"""
     Compute the variance along the specified axis.
 
     Returns the variance of the array elements, a measure of the spread of a


### PR DESCRIPTION
gh-21670 reported that the documentation of `np.var` and `np.std` should include important terms like "sample variance"/"sample standard deviation" and "Bessel correction" to help users choose the appropriate `ddof` for their application. (It also reported a misunderstanding about how the "mean" was calculated, but this appears to have been ameliorated with the word "average" since the issue was opened.)

This PR goes a bit beyond that, giving a summary of factors that might go into the choice of `ddof`. 

Closes gh-21670. 

@steppi thought you might like to weigh in here.
