### PR TITLE
BUG: Fix -fsanitize=alignment issue in numpy/_core/src/multiarray/arraytypes.c.src

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -2856,7 +2856,7 @@ OBJECT_nonzero (PyObject **ip, PyArrayObject *ap)
     }
     else {
         PyObject *obj;
-        memcpy(&obj, ip, sizeof(obj));
+        memcpy(&obj, (void *)ip, sizeof(obj));
         if (obj == NULL) {
             return NPY_FALSE;
         }


### PR DESCRIPTION
OBJECT_nonzero may be called with misaligned pointers, manifesting as a -fsanitize=alignment failure. This is UB per C11 6.3.2.3

> A pointer to an object type may be converted to a pointer to a different object type. If the resulting pointer is not correctly aligned) for the referenced type, the behavior is undefined.

Nevertheless, Clang only checks alignment when the unaligned pointer is accessed. https://lists.llvm.org/pipermail/llvm-dev/2016-January/094012.html Call memcpy with unaligned arguments instead to work with new Clang (https://github.com/llvm/llvm-project/pull/67766).

Change originally by @maskray