### PR TITLE
DOC: clarify boolean index error message

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -703,8 +703,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
 
                     PyOS_snprintf(err_msg, sizeof(err_msg),
                         "boolean index did not match indexed array along "
-                        "dimension %d; dimension is %" NPY_INTP_FMT
-                        " but corresponding boolean dimension is %" NPY_INTP_FMT,
+                        "axis %d; size of axis is %" NPY_INTP_FMT
+                        " but size of corresponding boolean axis is %" NPY_INTP_FMT,
                         used_ndim, PyArray_DIM(self, used_ndim),
                         indices[i].value);
                     PyErr_SetString(PyExc_IndexError, err_msg);

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -1311,30 +1311,30 @@ class TestBooleanIndexing:
         # This used to incorrectly work (and give an array of shape (0,))
         idx1 = np.array([[False]*9])
         assert_raises_regex(IndexError,
-            "boolean index did not match indexed array along dimension 0; "
-            "dimension is 3 but corresponding boolean dimension is 1",
+            "boolean index did not match indexed array along axis 0; "
+            "size of axis is 3 but size of corresponding boolean axis is 1",
             lambda: a[idx1])
 
         # This used to incorrectly give a ValueError: operands could not be broadcast together
         idx2 = np.array([[False]*8 + [True]])
         assert_raises_regex(IndexError,
-            "boolean index did not match indexed array along dimension 0; "
-            "dimension is 3 but corresponding boolean dimension is 1",
+            "boolean index did not match indexed array along axis 0; "
+            "size of axis is 3 but size of corresponding boolean axis is 1",
             lambda: a[idx2])
 
         # This is the same as it used to be. The above two should work like this.
         idx3 = np.array([[False]*10])
         assert_raises_regex(IndexError,
-            "boolean index did not match indexed array along dimension 0; "
-            "dimension is 3 but corresponding boolean dimension is 1",
+            "boolean index did not match indexed array along axis 0; "
+            "size of axis is 3 but size of corresponding boolean axis is 1",
             lambda: a[idx3])
 
         # This used to give ValueError: non-broadcastable operand
         a = np.ones((1, 1, 2))
         idx = np.array([[[True], [False]]])
         assert_raises_regex(IndexError,
-            "boolean index did not match indexed array along dimension 1; "
-            "dimension is 1 but corresponding boolean dimension is 2",
+            "boolean index did not match indexed array along axis 1; "
+            "size of axis is 1 but size of corresponding boolean axis is 2",
             lambda: a[idx])
 
 


### PR DESCRIPTION
gh-24624 reported that the use of "dimension" in error messages like:
```
IndexError: boolean index did not match indexed array along dimension 0; 
dimension is 3 but corresponding boolean dimension is 2
```
was ambiguous because "dimension" is used to refer to two distinct concepts: both to "axis" 0 and the the "size"(or "length") of axis 0.

This PR would change the error message to:
```
IndexError: boolean index did not match indexed array along axis 0; 
size of axis is 3 but size of corresponding boolean axis is 2
```
to agree with the terminology of another `IndexError` message, e.g.:
```
IndexError: index 3 is out of bounds for axis 0 with size 2
```

Closes gh-24624

---

That said, I'm not sure if "size" is the best term for the number of elements along a given axis, e.g. `arr.shape[axis]`. I would think that "length" would be less likely to be confused with the array attribute `size`, and "length of axis" is a reasonable generalization of the concept of `len` (which is always along axis 0). "length" is also used in this context in the [NumPy glossary](https://numpy.org/doc/stable/glossary.html):
> shape: A tuple showing the length of each dimension of an ndarray.

If desired, I'd be happy to change both of these error messages to refer to the "length" of the axis rather than the "size" of the axis, and I would add terms "length of axis" and "size" to the glossary.

> length of axis - the number of elements along an axis, e.g. 
```
a = np.zeros(3, 4)
len(a) == a.shape[0] == 3  # the length of axis 0 is 3
a.shape[1] == 4  # the length of axis 1 is 4
```

> size - the total number of elements in an array; e.g., 
```
a = np.zeros(3, 4)
a.size == np.prod(a.shape) == 12  # the size of `a` is 12
```
(However, neither "length" nor "size" are defined in the glossary, and they seem used interchangably in this context throughout the documentation, so it would be a bigger project to completely standardize this.)