### PR TITLE
TST: Explicitly pass NumPy path to cython during tests (also speed them up)

### DIFF
--- a/numpy/_core/tests/examples/cython/meson.build
+++ b/numpy/_core/tests/examples/cython/meson.build
@@ -14,6 +14,15 @@ npy_include_path = run_command(py, [
     'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
     ], check: true).stdout().strip()
 
+npy_path = run_command(py, [
+    '-c',
+    'import os; os.chdir(".."); import numpy; print(os.path.dirname(numpy.__file__).removesuffix("numpy"))'
+    ], check: true).stdout().strip()
+
+# TODO: This is a hack due to gh-25135, where cython may not find the right
+#       __init__.pyd file.
+add_project_arguments('-I', npy_path, language : 'cython')
+
 py.extension_module(
     'checks',
     'checks.pyx',

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -30,14 +30,14 @@ else:
 pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
 
 
-@pytest.fixture
-def install_temp(tmp_path):
+@pytest.fixture(scope='module')
+def install_temp(tmpdir_factory):
     # Based in part on test_cython from random.tests.test_extending
     if IS_WASM:
         pytest.skip("No subprocess")
 
     srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'cython')
-    build_dir = tmp_path / "build"
+    build_dir = tmpdir_factory.mktemp("cython_test") / "build"
     os.makedirs(build_dir, exist_ok=True)
     try:
         subprocess.check_call(["meson", "--version"])


### PR DESCRIPTION
This mainly injects the `-I` into the cython build in meson by fetching the actual numpy directory during the build to paper over gh-25135.

It clearly isn't a fix, since it is probably a Cython issue (or maybe an issue with the meson in-place build setup).

I also modified the building fixture to only run once, the tests are ridiculously slow otherwise (there were much fewer tests not long ago).