### PR TITLE
DOC: Fix typo in NumPy 2.0 migration guide

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -140,7 +140,7 @@ deprecated member migration guideline
 ================= =======================================================================
 in1d              Use ``np.isin`` instead.
 row_stack         Use ``np.vstack`` instead (``row_stack`` was an alias for ``v_stack``).
-trapz             Use ``scipy.interpolate.trapezoid`` instead.
+trapz             Use ``scipy.integrate.trapezoid`` instead.
 ================= =======================================================================
 
 


### PR DESCRIPTION
Fixes #25143: `scipy.interpolate.trapezoid` should be `scipy.integrate.trapezoid` in the NumPy 2.0 migration guide.

P.S.: this is my first NumPy PR, I hope I did it right!