### PR TITLE
BUG: fix issues with `newaxis` and `linalg.solve` in `numpy.array_api`

### DIFF
--- a/numpy/array_api/__init__.py
+++ b/numpy/array_api/__init__.py
@@ -125,7 +125,7 @@ __array_api_version__ = "2022.12"
 
 __all__ = ["__array_api_version__"]
 
-from ._constants import e, inf, nan, pi
+from ._constants import e, inf, nan, pi, newaxis
 
 __all__ += ["e", "inf", "nan", "pi"]
 

--- a/numpy/array_api/_constants.py
+++ b/numpy/array_api/_constants.py
@@ -4,3 +4,4 @@ e = np.e
 inf = np.inf
 nan = np.nan
 pi = np.pi
+newaxis = np.newaxis

--- a/numpy/array_api/linalg.py
+++ b/numpy/array_api/linalg.py
@@ -318,9 +318,9 @@ def _solve(a, b):
     # This does nothing currently but is left in because it will be relevant
     # when complex dtype support is added to the spec in 2022.
     signature = 'DD->D' if isComplexType(t) else 'dd->d'
-    with errstate(call=_raise_linalgerror_singular, invalid='call',
-                  over='ignore', divide='ignore', under='ignore'):
-        r = gufunc(a, b, signature=signature, extobj=extobj)
+    with np.errstate(call=_raise_linalgerror_singular, invalid='call',
+                     over='ignore', divide='ignore', under='ignore'):
+        r = gufunc(a, b, signature=signature)
 
     return wrap(r.astype(result_t, copy=False))
 


### PR DESCRIPTION
Looks like this wasn't caught before because of gaps in the test coverage (fixed for `linalg.solve` and fix ready to merge for `newaxis` in `array-api-tests`).

[skip azp] [skip cirrus] [skip circle]