### PR TITLE
BLD, CI: revert pinning scipy-openblas

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,7 @@ jobs:
         python-version: 'pypy3.9-v7.3.12'
     - name: Setup using scipy-openblas
       run: |
-        python -m pip install "scipy-openblas32<=0.3.23.293.2" spin
+        python -m pip install scipy-openblas32 spin
         spin config-openblas --with-scipy-openblas=32
     - uses: ./.github/meson_actions
 
@@ -129,7 +129,7 @@ jobs:
         set -xe
         sudo apt update
         sudo apt install gfortran libgfortran5
-        pip install "scipy-openblas32<=0.3.23.293.2"
+        pip install scipy-openblas32
         spin config-openblas --with-scipy-openblas=32
     - name: Build a wheel
       env:

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r build_requirements.txt
-        pip install "scipy-openblas32<=0.3.23.293.2" spin
+        pip install scipy-openblas32 spin
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -55,12 +55,14 @@ jobs:
         python -m venv test_env
         source test_env/bin/activate
 
-        pip install "scipy-openblas64<=0.3.23.293.2"
+        pip install scipy-openblas64
 
         pip install -r build_requirements.txt -r test_requirements.txt
 
         # use meson to build and test 
-        spin build --with-scipy-openblas=64 -- -Duse-ilp64=true
+        # the Duse-ilp64 is not needed with scipy-openblas wheels > 0.3.24.95.0
+        # spin build --with-scipy-openblas=64 -- -Duse-ilp64=true
+        spin build --with-scipy-openblas=64
         spin test -j auto
 
     - name: Meson Log

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
-        python -m pip install "scipy-openblas32<=0.3.23.293.2"
+        python -m pip install scipy-openblas32
         spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
@@ -60,7 +60,7 @@ jobs:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        python -m pip install "scipy-openblas32<=0.3.23.293.2"
+        python -m pip install scipy-openblas32
         spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -30,12 +30,14 @@ steps:
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
     elseif ( Test-Path env:_USE_BLAS_ILP64 ) {
-        python -m pip install "scipy-openblas64<=0.3.23.293.2" spin
+        python -m pip install scipy-openblas64 spin
         spin config-openblas --with-scipy-openblas=64
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
-        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"
+        # use-ilp64 is no longer needed with scipy-openblas > 0.3.24.95.0
+        # python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"
+        python -m pip install . -v -Csetup-args="--vsenv"
     } else {
-        python -m pip install "scipy-openblas32<=0.3.23.293.2" spin
+        python -m pip install scipy-openblas32 spin
         spin config-openblas --with-scipy-openblas=32
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
         python -m pip install . -v -Csetup-args="--vsenv" 

--- a/tools/ci/run_32_bit_linux_docker.sh
+++ b/tools/ci/run_32_bit_linux_docker.sh
@@ -4,7 +4,7 @@ git config --global --add safe.directory /numpy
 cd /numpy
 /opt/python/cp39-cp39/bin/python -mvenv venv
 source venv/bin/activate
-python3 -m pip install ninja "scipy-openblas32<=0.3.23.293.2" spin
+python3 -m pip install ninja scipy-openblas32 spin
 python3 -m pip install -r test_requirements.txt
 echo CFLAGS \$CFLAGS
 spin config-openblas --with-scipy-openblas=32


### PR DESCRIPTION
Reverts #25085 

The OpenBLAS builds now have a prefix `scipy_`, in addition to the `ILP64` suffix `64_`. The prefix is automatically used when meson detect scipy-openblas via the pkg-config script. That script also adds `OPENBLAS_ILP64_NAMING_SCHEME` so meson no longer need the `use-ilp64=true` argument.