### PR TITLE
MAINT: Cleanup mapiter struct a bit

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1584,7 +1584,7 @@ mapiter_@name@(
     int i;
 
     /* Cached mit info */
-    int numiter = mit->numiter;
+    int num_fancy = mit->num_fancy;
     int needs_api = (flags & NPY_METH_REQUIRES_PYAPI) != 0;
     /* Constant information */
     npy_intp fancy_dims[NPY_MAXDIMS];
@@ -1602,7 +1602,7 @@ mapiter_@name@(
 #if @isget@
     iteraxis = mit->iteraxes[0];
 #endif
-    for (i = 0; i < numiter; i++) {
+    for (i = 0; i < num_fancy; i++) {
         fancy_dims[i] = mit->fancy_dims[i];
         fancy_strides[i] = mit->fancy_strides[i];
     }
@@ -1629,11 +1629,11 @@ mapiter_@name@(
 
 /**begin repeat1
  * #one_iter = 1, 0#
- * #numiter = 1, numiter#
+ * #num_fancy = 1, num_fancy#
  */
 
 #if @one_iter@
-        if (numiter == 1) {
+        if (num_fancy == 1) {
 #else
         else {
 #endif
@@ -1669,7 +1669,7 @@ mapiter_@name@(
                     count = *counter;
                     while (count--) {
                         char * self_ptr = baseoffset;
-                        for (i=0; i < @numiter@; i++) {
+                        for (i=0; i < @num_fancy@; i++) {
                             npy_intp indval = *((npy_intp*)outer_ptrs[i]);
                             assert(npy_is_aligned(outer_ptrs[i],
                                                   NPY_ALIGNOF_UINT(npy_intp)));
@@ -1760,11 +1760,11 @@ mapiter_@name@(
         }
 /**begin repeat1
  * #one_iter = 1, 0#
- * #numiter = 1, numiter#
+ * #num_fancy = 1, num_fancy#
  */
 
 #if @one_iter@
-        if (numiter == 1) {
+        if (num_fancy == 1) {
 #else
         else {
 #endif
@@ -1776,7 +1776,7 @@ mapiter_@name@(
             /* Outer iteration (safe because mit->size != 0) */
             do {
                 char * self_ptr = baseoffset;
-                for (i=0; i < @numiter@; i++) {
+                for (i=0; i < @num_fancy@; i++) {
                     npy_intp indval = *((npy_intp*)outer_ptrs[i]);
 
 #if @isget@ && @one_iter@

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1606,7 +1606,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
         goto finish;
     }
 
-    if (mit->numiter > 1 || mit->size == 0) {
+    if (mit->num_fancy > 1 || mit->size == 0) {
         /*
          * If it is one, the inner loop checks indices, otherwise
          * check indices beforehand, because it is much faster if
@@ -2282,7 +2282,7 @@ PyArray_MapIterReset(PyArrayMapIterObject *mit)
 
     baseptrs[0] = mit->baseoffset;
 
-    for (i = 0; i < mit->numiter; i++) {
+    for (i = 0; i < mit->num_fancy; i++) {
         indval = *((npy_intp*)mit->outer_ptrs[i]);
         if (indval < 0) {
             indval += mit->fancy_dims[i];
@@ -2336,7 +2336,7 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
 
             baseptr = mit->baseoffset;
 
-            for (i = 0; i < mit->numiter; i++) {
+            for (i = 0; i < mit->num_fancy; i++) {
                 indval = *((npy_intp*)mit->outer_ptrs[i]);
                 if (indval < 0) {
                     indval += mit->fancy_dims[i];
@@ -2353,7 +2353,7 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
         if (--mit->iter_count > 0) {
             baseptr = mit->baseoffset;
 
-            for (i = 0; i < mit->numiter; i++) {
+            for (i = 0; i < mit->num_fancy; i++) {
                 mit->outer_ptrs[i] += mit->outer_strides[i];
 
                 indval = *((npy_intp*)mit->outer_ptrs[i]);
@@ -2373,7 +2373,7 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
             mit->iter_count = *NpyIter_GetInnerLoopSizePtr(mit->outer);
             baseptr = mit->baseoffset;
 
-            for (i = 0; i < mit->numiter; i++) {
+            for (i = 0; i < mit->num_fancy; i++) {
                 indval = *((npy_intp*)mit->outer_ptrs[i]);
                 if (indval < 0) {
                     indval += mit->fancy_dims[i];
@@ -2590,7 +2590,7 @@ PyArray_MapIterCheckIndices(PyArrayMapIterObject *mit)
 
     NPY_BEGIN_THREADS;
 
-    for (i=0; i < mit->numiter; i++) {
+    for (i=0; i < mit->num_fancy; i++) {
         op = NpyIter_GetOperandArray(mit->outer)[i];
 
         outer_dim = mit->fancy_dims[i];
@@ -2809,17 +2809,17 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      */
     for (i=0; i < index_num; i++) {
         if (indices[i].type & HAS_FANCY) {
-            index_arrays[mit->numiter] = (PyArrayObject *)indices[i].object;
-            dtypes[mit->numiter] = intp_descr;
+            index_arrays[mit->num_fancy] = (PyArrayObject *)indices[i].object;
+            dtypes[mit->num_fancy] = intp_descr;
 
-            op_flags[mit->numiter] = (NPY_ITER_NBO |
+            op_flags[mit->num_fancy] = (NPY_ITER_NBO |
                                       NPY_ITER_ALIGNED |
                                       NPY_ITER_READONLY);
-            mit->numiter += 1;
+            mit->num_fancy += 1;
         }
     }
 
-    if (mit->numiter == 0) {
+    if (mit->num_fancy == 0) {
         /*
          * For MapIterArray, it is possible that there is no fancy index.
          * to support this case, add a dummy iterator.
@@ -2840,7 +2840,7 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         op_flags[0] = NPY_ITER_NBO | NPY_ITER_ALIGNED | NPY_ITER_READONLY;
 
         mit->fancy_dims[0] = 1;
-        mit->numiter = 1;
+        mit->num_fancy = 1;
     }
 
     /*
@@ -2944,16 +2944,13 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         npy_intp strides[NPY_MAXDIMS];
         npy_stride_sort_item strideperm[NPY_MAXDIMS];
 
-        for (i=0; i < mit->numiter; i++) {
+        for (i=0; i < mit->num_fancy; i++) {
             tmp_op_flags[i] = NPY_ITER_READONLY;
         }
 
-        Py_INCREF(extra_op_dtype);
-        mit->extra_op_dtype = extra_op_dtype;
-
         if (PyArray_SIZE(subspace) == 1) {
             /* Create an iterator, just to broadcast the arrays?! */
-            tmp_iter = NpyIter_MultiNew(mit->numiter, index_arrays,
+            tmp_iter = NpyIter_MultiNew(mit->num_fancy, index_arrays,
                                         NPY_ITER_ZEROSIZE_OK |
                                         NPY_ITER_REFS_OK |
                                         NPY_ITER_MULTI_INDEX |
@@ -3044,12 +3041,12 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
      * For a single 1-d operand, guarantee iteration order
      * (scipy used this). Note that subspace may be used.
      */
-    if ((mit->numiter == 1) && (PyArray_NDIM(index_arrays[0]) == 1)) {
+    if ((mit->num_fancy == 1) && (PyArray_NDIM(index_arrays[0]) == 1)) {
         outer_flags |= NPY_ITER_DONT_NEGATE_STRIDES;
     }
 
     /* If external array is iterated, and no subspace is needed */
-    nops = mit->numiter;
+    nops = mit->num_fancy;
 
     if (!uses_subspace) {
         outer_flags |= NPY_ITER_EXTERNAL_LOOP;
@@ -3060,25 +3057,25 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
          * NOTE: This small limitation should practically not matter.
          *       (replaces npyiter error)
          */
-        if (mit->numiter > NPY_MAXDIMS - 1) {
+        if (mit->num_fancy > NPY_MAXDIMS - 1) {
             PyErr_Format(PyExc_IndexError,
                          "when no subspace is given, the number of index "
                          "arrays cannot be above %d, but %d index arrays found",
-                         NPY_MAXDIMS - 1, mit->numiter);
+                         NPY_MAXDIMS - 1, mit->num_fancy);
             goto fail;
         }
 
         nops += 1;
-        index_arrays[mit->numiter] = extra_op;
+        index_arrays[mit->num_fancy] = extra_op;
 
-        dtypes[mit->numiter] = extra_op_dtype;
-        op_flags[mit->numiter] = (extra_op_flags |
+        dtypes[mit->num_fancy] = extra_op_dtype;
+        op_flags[mit->num_fancy] = (extra_op_flags |
                                   NPY_ITER_ALLOCATE |
                                   NPY_ITER_NO_SUBTYPE);
 
         if (extra_op) {
             /* Use the axis remapping */
-            op_axes[mit->numiter] = single_op_axis;
+            op_axes[mit->num_fancy] = single_op_axis;
             mit->outer = NpyIter_AdvancedNew(nops, index_arrays, outer_flags,
                              NPY_KEEPORDER, NPY_UNSAFE_CASTING, op_flags, dtypes,
                              mit->nd_fancy, op_axes, mit->dimensions, 0);
@@ -3115,7 +3112,7 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
     /* Get the allocated extra_op */
     if (extra_op_flags) {
         if (extra_op == NULL) {
-            mit->extra_op = NpyIter_GetOperandArray(mit->outer)[mit->numiter];
+            mit->extra_op = NpyIter_GetOperandArray(mit->outer)[mit->num_fancy];
         }
         else {
             mit->extra_op = extra_op;
@@ -3409,7 +3406,6 @@ arraymapiter_dealloc(PyArrayMapIterObject *mit)
     Py_XDECREF(mit->array);
     Py_XDECREF(mit->subspace);
     Py_XDECREF(mit->extra_op);
-    Py_XDECREF(mit->extra_op_dtype);
     if (mit->outer != NULL) {
         NpyIter_Deallocate(mit->outer);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -6183,7 +6183,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         if ((ufuncimpl->contiguous_indexed_loop != NULL) &&
                 (PyArray_NDIM(op1_array) == 1)  &&
                 (op2_array == NULL || PyArray_NDIM(op2_array) <= 1) &&
-                (iter->subspace_iter == NULL) && (iter->numiter == 1)) {
+                (iter->subspace_iter == NULL) && (iter->num_fancy == 1)) {
             res = trivial_at_loop(ufuncimpl, flags, iter, op1_array,
                         op2_array, &context);
 


### PR DESCRIPTION
This is a small followup to making MapIter private.  It renames `numiters` to `num_fancy` (because numiters only made sense many years ago).

Also reorders some fields (tried to move some less used ones to the end and clump them a bit clearer) and rewrites basically all the docs to be maybe half understandable.
(This stuff is confusing/complicated, but I think it is a lot clearer now probably)