### PR TITLE
API: Remove PyArray_REFCNT and NPY_REFCOUNT

### DIFF
--- a/doc/release/upcoming_changes/25156.c_api_removal.rst
+++ b/doc/release/upcoming_changes/25156.c_api_removal.rst
@@ -1,0 +1,1 @@
+* ``PyArray_REFCNT`` and ``NPY_REFCOUNT`` are removed. Use ``Py_REFCNT`` instead.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3453,10 +3453,6 @@ Miscellaneous Macros
     Returns the minimum of *a* and *b*. If (*a*) or (*b*) are
     expressions they are evaluated twice.
 
-.. c:function:: npy_intp PyArray_REFCOUNT(PyObject* op)
-
-    Returns the reference count of any Python object.
-
 .. c:function:: void PyArray_DiscardWritebackIfCopy(PyArrayObject* obj)
 
     If ``obj->flags`` has :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`, this function

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -460,7 +460,6 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_ZEROS(int nd, npy_intp* dims, int type, int fortran)
     object PyArray_EMPTY(int nd, npy_intp* dims, int type, int fortran)
     void PyArray_FILLWBYTE(object, int val)
-    npy_intp PyArray_REFCOUNT(object)
     object PyArray_ContiguousFromAny(op, int, int min_depth, int max_depth)
     unsigned char PyArray_EquivArrTypes(ndarray a1, ndarray a2)
     bint PyArray_EquivByteorders(int b1, int b2) nogil

--- a/numpy/_core/include/numpy/ndarrayobject.h
+++ b/numpy/_core/include/numpy/ndarrayobject.h
@@ -103,10 +103,6 @@ extern "C" {
 
 #define PyArray_FILLWBYTE(obj, val) memset(PyArray_DATA(obj), val, \
                                            PyArray_NBYTES(obj))
-#ifndef PYPY_VERSION
-#define PyArray_REFCOUNT(obj) (((PyObject *)(obj))->ob_refcnt)
-#define NPY_REFCOUNT PyArray_REFCOUNT
-#endif
 #define NPY_MAX_ELSIZE (2 * NPY_SIZEOF_LONGDOUBLE)
 
 #define PyArray_ContiguousFromAny(op, type, min_depth, max_depth) \

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -105,7 +105,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
                     "Use the np.resize function or refcheck=False");
             return NULL;
 #else
-            refcnt = PyArray_REFCOUNT(self);
+            refcnt = Py_REFCNT(self);
 #endif /* PYPY_VERSION */
         }
         else {


### PR DESCRIPTION
These don't really make sense, even less as public API.