### PR TITLE
DOC: `np.sort` doc fix contiguous axis

### DIFF
--- a/doc/release/upcoming_changes/25157.change.rst
+++ b/doc/release/upcoming_changes/25157.change.rst
@@ -1,0 +1,5 @@
+``numpy.sort`` doc fix 
+----------------------
+
+Fixed the doc of ``np.sort``
+regarding the note on optimization over contiguous axis.

--- a/doc/release/upcoming_changes/25157.change.rst
+++ b/doc/release/upcoming_changes/25157.change.rst
@@ -1,5 +1,0 @@
-``numpy.sort`` doc fix 
-----------------------
-
-Fixed the doc of ``np.sort``
-regarding the note on optimization over contiguous axis.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -925,10 +925,11 @@ def sort(a, axis=-1, kind=None, order=None):
        is actually used, even if 'mergesort' is specified. User selection
        at a finer scale is not currently available.
 
-    All the sort algorithms make temporary copies of the data when
-    sorting along any but the last axis.  Consequently, sorting along
-    the last axis is faster and uses less space than sorting along
-    any other axis.
+    For performance, ``sort`` makes a temporary copy if needed to make the data
+    `contiguous <https://numpy.org/doc/stable/glossary.html#term-contiguous>`_
+    in memory along the sort axis. For even better performance and reduced
+    memory consumption, ensure that the array is already contiguous along the
+    sort axis.
 
     The sort order for complex numbers is lexicographic. If both the real
     and imaginary parts are non-nan then the order is determined by the


### PR DESCRIPTION
Fixed the doc of [`np.sort`](https://numpy.org/doc/stable/reference/generated/numpy.sort.html) regarding the note on optimization over contiguous axis, following @mdhaber 's proposition. See #24619.