### PR TITLE
API: Make `encoding=None` the default in loadtxt

### DIFF
--- a/doc/release/upcoming_changes/25158.compatibility.rst
+++ b/doc/release/upcoming_changes/25158.compatibility.rst
@@ -1,0 +1,8 @@
+``loadtxt`` and ``genfromtxt`` default to ``encoding=None``
+-----------------------------------------------------------
+``loadtxt`` and ``genfromtxt`` now both default to ``encoding=None``
+which may mainly modifies how ``converters`` work.
+These will now be passed ``str`` rather than ``bytes``, pass the
+encoding explicitly to always get the new or old behavior.
+For ``genfromtxt`` the change also means that returned values will now be
+unicode strings rather than bytes.

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -370,7 +370,7 @@ single element of the wanted type.
 In the following example, the second column is converted from as string
 representing a percentage to a float between 0 and 1::
 
-   >>> convertfunc = lambda x: float(x.strip(b"%"))/100.
+   >>> convertfunc = lambda x: float(x.strip("%"))/100.
    >>> data = u"1, 2.3%, 45.\n6, 78.9%, 0"
    >>> names = ("i", "p", "n")
    >>> # General case .....

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -58,7 +58,7 @@ Quite often, a single character marks the separation between columns.  For
 example, comma-separated files (CSV) use a comma (``,``) or a semicolon
 (``;``) as delimiter::
 
-   >>> data = u"1, 2, 3\n4, 5, 6"
+   >>> data = "1, 2, 3\n4, 5, 6"
    >>> np.genfromtxt(StringIO(data), delimiter=",")
    array([[1.,  2.,  3.],
           [4.,  5.,  6.]])
@@ -74,12 +74,12 @@ defined as a given number of characters.  In that case, we need to set
 ``delimiter`` to a single integer (if all the columns have the same
 size) or to a sequence of integers (if columns can have different sizes)::
 
-   >>> data = u"  1  2  3\n  4  5 67\n890123  4"
+   >>> data = "  1  2  3\n  4  5 67\n890123  4"
    >>> np.genfromtxt(StringIO(data), delimiter=3)
    array([[  1.,    2.,    3.],
           [  4.,    5.,   67.],
           [890.,  123.,    4.]])
-   >>> data = u"123456789\n   4  7 9\n   4567 9"
+   >>> data = "123456789\n   4  7 9\n   4567 9"
    >>> np.genfromtxt(StringIO(data), delimiter=(4, 3, 2))
    array([[1234.,   567.,    89.],
           [   4.,     7.,     9.],
@@ -94,7 +94,7 @@ individual entries are not stripped of leading nor trailing white spaces.
 This behavior can be overwritten by setting the optional argument
 ``autostrip`` to a value of ``True``::
 
-   >>> data = u"1, abc , 2\n 3, xxx, 4"
+   >>> data = "1, abc , 2\n 3, xxx, 4"
    >>> # Without autostrip
    >>> np.genfromtxt(StringIO(data), delimiter=",", dtype="|U5")
    array([['1', ' abc ', ' 2'],
@@ -114,7 +114,7 @@ string that marks the beginning of a comment.  By default,
 occur anywhere on the line.  Any character present after the comment
 marker(s) is simply ignored::
 
-   >>> data = u"""#
+   >>> data = """#
    ... # Skip me !
    ... # Skip me too !
    ... 1, 2
@@ -154,7 +154,7 @@ of lines to skip at the beginning of the file, before any other action is
 performed.  Similarly, we can skip the last ``n`` lines of the file by
 using the ``skip_footer`` attribute and giving it a value of ``n``::
 
-   >>> data = u"\n".join(str(i) for i in range(10))
+   >>> data = "\n".join(str(i) for i in range(10))
    >>> np.genfromtxt(StringIO(data),)
    array([0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.])
    >>> np.genfromtxt(StringIO(data),
@@ -178,7 +178,7 @@ integers behave the same as regular Python negative indexes.
 For example, if we want to import only the first and the last columns, we
 can use ``usecols=(0, -1)``::
 
-   >>> data = u"1 2 3\n4 5 6"
+   >>> data = "1 2 3\n4 5 6"
    >>> np.genfromtxt(StringIO(data), usecols=(0, -1))
    array([[1.,  3.],
           [4.,  6.]])
@@ -187,7 +187,7 @@ If the columns have names, we can also select which columns to import by
 giving their name to the ``usecols`` argument, either as a sequence
 of strings or a comma-separated string::
 
-   >>> data = u"1 2 3\n4 5 6"
+   >>> data = "1 2 3\n4 5 6"
    >>> np.genfromtxt(StringIO(data),
    ...               names="a, b, c", usecols=("a", "c"))
    array([(1., 3.), (4., 6.)], dtype=[('a', '<f8'), ('c', '<f8')])
@@ -371,7 +371,7 @@ In the following example, the second column is converted from as string
 representing a percentage to a float between 0 and 1::
 
    >>> convertfunc = lambda x: float(x.strip("%"))/100.
-   >>> data = u"1, 2.3%, 45.\n6, 78.9%, 0"
+   >>> data = "1, 2.3%, 45.\n6, 78.9%, 0"
    >>> names = ("i", "p", "n")
    >>> # General case .....
    >>> np.genfromtxt(StringIO(data), delimiter=",", names=names)
@@ -405,7 +405,7 @@ string into the corresponding float or into -999 if the string is empty.
 We need to explicitly strip the string from white spaces as it is not done
 by default::
 
-   >>> data = u"1, , 3\n 4, 5, 6"
+   >>> data = "1, , 3\n 4, 5, 6"
    >>> convert = lambda x: float(x.strip() or -999)
    >>> np.genfromtxt(StringIO(data), delimiter=",",
    ...               converters={1: convert})
@@ -483,7 +483,7 @@ with ``"N/A"`` in the first column and by ``"???"`` in the third column.
 We wish to transform these missing values to 0 if they occur in the first
 and second column, and to -999 if they occur in the last column::
 
-    >>> data = u"N/A, 2, 3\n4, ,???"
+    >>> data = "N/A, 2, 3\n4, ,???"
     >>> kwargs = dict(delimiter=",",
     ...               dtype=int,
     ...               names="a,b,c",

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -4279,10 +4279,10 @@ add_newdoc('numpy._core.umath', 'str_len',
     >>> a = np.array(['Grace Hopper Conference', 'Open Source Day'])
     >>> np.char.str_len(a)
     array([23, 15])
-    >>> a = np.array([u'\u0420', u'\u043e'])
+    >>> a = np.array(['\u0420', '\u043e'])
     >>> np.char.str_len(a)
     array([1, 1])
-    >>> a = np.array([['hello', 'world'], [u'\u0420', u'\u043e']])
+    >>> a = np.array([['hello', 'world'], ['\u0420', '\u043e']])
     >>> np.char.str_len(a)
     array([[5, 5], [1, 1]])
 

--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -285,10 +285,10 @@ def str_len(a):
     >>> a = np.array(['Grace Hopper Conference', 'Open Source Day'])
     >>> np.char.str_len(a)
     array([23, 15])
-    >>> a = np.array([u'\u0420', u'\u043e'])
+    >>> a = np.array(['\u0420', '\u043e'])
     >>> np.char.str_len(a)
     array([1, 1])
-    >>> a = np.array([['hello', 'world'], [u'\u0420', u'\u043e']])
+    >>> a = np.array([['hello', 'world'], ['\u0420', '\u043e']])
     >>> np.char.str_len(a)
     array([[5, 5], [1, 1]])
     """

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1976,7 +1976,7 @@ def disp(mesg, device=None, linefeed=True):
 
     >>> from io import StringIO
     >>> buf = StringIO()
-    >>> np.disp(u'"Display" in a file', device=buf)
+    >>> np.disp('"Display" in a file', device=buf)
     >>> buf.getvalue()
     '"Display" in a file\\n'
 

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -815,7 +815,7 @@ _loadtxt_chunksize = 50000
 def _read(fname, *, delimiter=',', comment='#', quote='"',
           imaginary_unit='j', usecols=None, skiplines=0,
           max_rows=None, converters=None, ndmin=None, unpack=False,
-          dtype=np.float64, encoding="bytes"):
+          dtype=np.float64, encoding=None):
     r"""
     Read a NumPy array from a text file.
     This is a helper function for loadtxt.
@@ -1073,7 +1073,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
 @set_module('numpy')
 def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             converters=None, skiprows=0, usecols=None, unpack=False,
-            ndmin=0, encoding='bytes', max_rows=None, *, quotechar=None,
+            ndmin=0, encoding=None, max_rows=None, *, quotechar=None,
             like=None):
     r"""
     Load data from a text file.
@@ -1145,6 +1145,10 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         the system default is used. The default value is 'bytes'.
 
         .. versionadded:: 1.14.0
+        .. versionchanged:: 2.0
+            Before NumPy 2, the default was ``'bytes'`` for Python 2
+            compatibility. The default is now ``None``.
+
     max_rows : int, optional
         Read `max_rows` rows of content after `skiprows` lines. The default is
         to read all the rows. Note that empty rows containing no data such as
@@ -1715,7 +1719,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                deletechars=''.join(sorted(NameValidator.defaultdeletechars)),
                replace_space='_', autostrip=False, case_sensitive=True,
                defaultfmt="f%i", unpack=None, usemask=False, loose=True,
-               invalid_raise=True, max_rows=None, encoding='bytes',
+               invalid_raise=True, max_rows=None, encoding=None,
                *, ndmin=0, like=None):
     """
     Load data from a text file, with missing values handled as specified.
@@ -1816,6 +1820,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         The default value is 'bytes'.
 
         .. versionadded:: 1.14.0
+        .. versionchanged:: 2.0
+            Before NumPy 2, the default was ``'bytes'`` for Python 2
+            compatibility. The default is now ``None``.
+
     ndmin : int, optional
         Same parameter as `loadtxt`
 

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1864,7 +1864,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     Comma delimited file with mixed dtype
 
-    >>> s = StringIO(u"1,1.3,abcde")
+    >>> s = StringIO("1,1.3,abcde")
     >>> data = np.genfromtxt(s, dtype=[('myint','i8'),('myfloat','f8'),
     ... ('mystring','S5')], delimiter=",")
     >>> data
@@ -1891,7 +1891,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     An example with fixed-width columns
 
-    >>> s = StringIO(u"11.3abcde")
+    >>> s = StringIO("11.3abcde")
     >>> data = np.genfromtxt(s, dtype=None, names=['intvar','fltvar','strvar'],
     ...     delimiter=[1,3,5])
     >>> data

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1266,7 +1266,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     array([1.e+00, 2.7e+00, 1.e+05])
 
     This idea can be extended to automatically handle values specified in
-    many different formats:
+    many different formats, such as hex values:
 
     >>> def conv(val):
     ...     try:
@@ -1274,16 +1274,14 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     ...     except ValueError:
     ...         return float.fromhex(val)
     >>> s = StringIO("1, 2.5, 3_000, 0b4, 0x1.4000000000000p+2")
-    >>> np.loadtxt(s, delimiter=",", converters=conv, encoding=None)
+    >>> np.loadtxt(s, delimiter=",", converters=conv)
     array([1.0e+00, 2.5e+00, 3.0e+03, 1.8e+02, 5.0e+00])
 
-    Note that with the default ``encoding="bytes"``, the inputs to the
-    converter function are latin-1 encoded byte strings. To deactivate the
-    implicit encoding prior to conversion, use ``encoding=None``
+    Or a format where the ``-`` sign comes after the number:
 
     >>> s = StringIO('10.01 31.25-\n19.22 64.31\n17.57- 63.94')
     >>> conv = lambda x: -float(x[:-1]) if x.endswith('-') else float(x)
-    >>> np.loadtxt(s, converters=conv, encoding=None)
+    >>> np.loadtxt(s, converters=conv)
     array([[ 10.01, -31.25],
            [ 19.22,  64.31],
            [-17.57,  63.94]])

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -693,7 +693,7 @@ class LoadTxtBase:
         c = TextIO()
         c.write(b'\xcf\x96')
         c.seek(0)
-        x = self.loadfunc(c, dtype=np.str_,
+        x = self.loadfunc(c, dtype=np.str_, encoding="bytes",
                           converters={0: lambda x: x.decode('UTF-8')})
         a = np.array([b'\xcf\x96'.decode('UTF-8')])
         assert_array_equal(x, a)
@@ -1447,7 +1447,8 @@ class TestFromTxt(LoadTxtBase):
         data = TextIO('gender age weight\nM 64.0 75.0\nF 25.0 60.0')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, dtype=None, names=True)
+            test = np.genfromtxt(data, dtype=None, names=True,
+                                 encoding='bytes')
             assert_(w[0].category is VisibleDeprecationWarning)
         control = {'gender': np.array([b'M', b'F']),
                    'age': np.array([64.0, 25.0]),
@@ -1461,7 +1462,7 @@ class TestFromTxt(LoadTxtBase):
         data = TextIO('A 64 75.0 3+4j True\nBCD 25 60.0 5+6j False')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, dtype=None)
+            test = np.genfromtxt(data, dtype=None, encoding='bytes')
             assert_(w[0].category is VisibleDeprecationWarning)
         control = [np.array([b'A', b'BCD']),
                    np.array([64, 25]),
@@ -1514,7 +1515,8 @@ M   33  21.99
         # The # is part of the first name and should be deleted automatically.
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, names=True, dtype=None)
+            test = np.genfromtxt(data, names=True, dtype=None,
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         ctrl = np.array([('M', 21, 72.1), ('F', 35, 58.33), ('M', 33, 21.99)],
                         dtype=[('gender', '|S1'), ('age', int), ('weight', float)])
@@ -1528,7 +1530,8 @@ M   33  21.99
         """)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, names=True, dtype=None)
+            test = np.genfromtxt(data, names=True, dtype=None,
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         assert_equal(test, ctrl)
 
@@ -1558,7 +1561,7 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(data, usecols=('A', 'C', 'D'),
-                                names=True, dtype=None)
+                                names=True, dtype=None, encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         control = np.array(('aaaa', 45, 9.1),
                            dtype=[('A', '|S4'), ('C', int), ('D', float)])
@@ -1579,7 +1582,7 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(data, usecols=('A', 'C', 'D'), names=True,
-                                dtype=None,
+                                dtype=None, encoding="bytes",
                                 converters={'C': lambda s: 2 * int(s)})
             assert_(w[0].category is VisibleDeprecationWarning)
         control = np.array(('aaaa', 90, 9.1),
@@ -1630,7 +1633,7 @@ M   33  21.99
                    "D02N03,10/10/2004,R 1,,7,145.55")
         kwargs = dict(
             converters={2: strip_per, 3: strip_rand}, delimiter=",",
-            dtype=None)
+            dtype=None, encoding="bytes")
         assert_raises(ConverterError, np.genfromtxt, s, **kwargs)
 
     def test_tricky_converter_bug1666(self):
@@ -1660,12 +1663,13 @@ M   33  21.99
         dtyp = [('e1','i4'),('e2','i4'),('e3','i2'),('n', 'i1')]
         conv = {0: int, 1: int, 2: int, 3: lambda r: dmap[r.decode()]}
         test = recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
-                          names=None, converters=conv)
+                          names=None, converters=conv, encoding="bytes")
         control = np.rec.array([(1,5,-1,0), (2,8,-1,1), (3,3,-2,3)], dtype=dtyp)
         assert_equal(test, control)
         dtyp = [('e1', 'i4'), ('e2', 'i4'), ('n', 'i1')]
         test = recfromcsv(TextIO(dstr,), dtype=dtyp, delimiter=',',
-                          usecols=(0, 1, 3), names=None, converters=conv)
+                          usecols=(0, 1, 3), names=None, converters=conv,
+                          encoding="bytes")
         control = np.rec.array([(1,5,0), (2,8,1), (3,3,3)], dtype=dtyp)
         assert_equal(test, control)
 
@@ -1995,7 +1999,7 @@ M   33  21.99
 
         converters = {4: lambda x: "(%s)" % x.decode()}
         kwargs = dict(delimiter=",", converters=converters,
-                      dtype=[(_, int) for _ in 'abcde'],)
+                      dtype=[(_, int) for _ in 'abcde'], encoding="bytes")
         assert_raises(ValueError, np.genfromtxt, mdata, **kwargs)
 
     def test_default_field_format(self):
@@ -2045,7 +2049,7 @@ M   33  21.99
     def test_autostrip(self):
         # Test autostrip
         data = "01/01/2003  , 1.3,   abcde"
-        kwargs = dict(delimiter=",", dtype=None)
+        kwargs = dict(delimiter=",", dtype=None, encoding="bytes")
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             mtest = np.genfromtxt(TextIO(data), **kwargs)
@@ -2179,13 +2183,15 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(TextIO("test1,testNonetherestofthedata"),
-                                 dtype=None, comments=None, delimiter=',')
+                                 dtype=None, comments=None, delimiter=',',
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         assert_equal(test[1], b'testNonetherestofthedata')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(TextIO("test1, testNonetherestofthedata"),
-                                 dtype=None, comments=None, delimiter=',')
+                                 dtype=None, comments=None, delimiter=',',
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         assert_equal(test[1], b' testNonetherestofthedata')
 
@@ -2197,7 +2203,8 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(TextIO(s),
-                                 dtype=None, comments=None, delimiter=',')
+                                 dtype=None, comments=None, delimiter=',',
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         assert_equal(test[1, 0], b"test1")
         assert_equal(test[1, 1], b"testNonethe" + latin1)
@@ -2212,7 +2219,8 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
-                                 dtype=None, comments=None, delimiter=',')
+                                 dtype=None, comments=None, delimiter=',',
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         assert_equal(test['f0'], 0)
         assert_equal(test['f1'], b"testNonethe" + latin1)
@@ -2230,7 +2238,8 @@ M   33  21.99
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             test = np.genfromtxt(TextIO(s),
-                                 dtype=None, comments=None, delimiter=',')
+                                 dtype=None, comments=None, delimiter=',',
+                                 encoding="bytes")
             assert_(w[0].category is VisibleDeprecationWarning)
         ctl = np.array([
                  [b'norm1', b'norm2', b'norm3'],
@@ -2284,7 +2293,7 @@ M   33  21.99
                 warnings.filterwarnings('always', '',
                                         VisibleDeprecationWarning)
                 test = np.genfromtxt(path, dtype=None, comments=None,
-                                     delimiter=',')
+                                     delimiter=',', encoding="bytes")
                 # Check for warning when encoding not specified.
                 assert_(w[0].category is VisibleDeprecationWarning)
             ctl = np.array([
@@ -2318,7 +2327,8 @@ M   33  21.99
     def test_recfromcsv(self):
         #
         data = TextIO('A,B\n0,1\n2,3')
-        kwargs = dict(missing_values="N/A", names=True, case_sensitive=True)
+        kwargs = dict(missing_values="N/A", names=True, case_sensitive=True,
+                      encoding="bytes")
         test = recfromcsv(data, dtype=None, **kwargs)
         control = np.array([(0, 1), (2, 3)],
                            dtype=[('A', int), ('B', int)])
@@ -2351,8 +2361,8 @@ M   33  21.99
 
         #gh-10394
         data = TextIO('color\n"red"\n"blue"')
-        test = recfromcsv(data, converters={0: lambda x: x.strip(b'\"')})
-        control = np.array([('red',), ('blue',)], dtype=[('color', (bytes, 4))])
+        test = recfromcsv(data, converters={0: lambda x: x.strip('\"')})
+        control = np.array([('red',), ('blue',)], dtype=[('color', (str, 4))])
         assert_equal(test.dtype, control.dtype)
         assert_equal(test, control)
 

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -219,9 +219,7 @@ def test_converters_negative_indices():
     txt = StringIO('1.5,2.5\n3.0,XXX\n5.5,6.0')
     conv = {-1: lambda s: np.nan if s == 'XXX' else float(s)}
     expected = np.array([[1.5, 2.5], [3.0, np.nan], [5.5, 6.0]])
-    res = np.loadtxt(
-        txt, dtype=np.float64, delimiter=",", converters=conv, encoding=None
-    )
+    res = np.loadtxt(txt, dtype=np.float64, delimiter=",", converters=conv)
     assert_equal(res, expected)
 
 
@@ -235,7 +233,6 @@ def test_converters_negative_indices_with_usecols():
         delimiter=",",
         converters=conv,
         usecols=[0, -1],
-        encoding=None,
     )
     assert_equal(res, expected)
 
@@ -313,7 +310,7 @@ def test_converter_with_structured_dtype():
 
 def test_converter_with_unicode_dtype():
     """
-    With the default 'bytes' encoding, tokens are encoded prior to being
+    With the 'bytes' encoding, tokens are encoded prior to being
     passed to the converter. This means that the output of the converter may
     be bytes instead of unicode as expected by `read_rows`.
 
@@ -323,7 +320,8 @@ def test_converter_with_unicode_dtype():
     txt = StringIO('abc,def\nrst,xyz')
     conv = bytes.upper
     res = np.loadtxt(
-            txt, dtype=np.dtype("U3"), converters=conv, delimiter=",")
+            txt, dtype=np.dtype("U3"), converters=conv, delimiter=",",
+            encoding="bytes")
     expected = np.array([['ABC', 'DEF'], ['RST', 'XYZ']])
     assert_equal(res, expected)
 
@@ -706,7 +704,7 @@ def test_byteswapping_and_unaligned(dtype, value, swap):
     full_dt = np.dtype([("a", "S1"), ("b", dtype)], align=False)
     # The above ensures that the interesting "b" field is unaligned:
     assert full_dt.fields["b"][1] == 1
-    res = np.loadtxt(data, dtype=full_dt, delimiter=",", encoding=None,
+    res = np.loadtxt(data, dtype=full_dt, delimiter=",",
                      max_rows=1)  # max-rows prevents over-allocation
     assert res["b"] == dtype.type(value)
 
@@ -1001,7 +999,7 @@ def test_str_dtype_unit_discovery_with_converter():
 
     # file-like path
     txt = StringIO("\n".join(data))
-    a = np.loadtxt(txt, dtype="U", converters=conv, encoding=None)
+    a = np.loadtxt(txt, dtype="U", converters=conv)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
 
@@ -1010,7 +1008,7 @@ def test_str_dtype_unit_discovery_with_converter():
     os.close(fd)
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
-    a = np.loadtxt(fname, dtype="U", converters=conv, encoding=None)
+    a = np.loadtxt(fname, dtype="U", converters=conv)
     os.remove(fname)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -50,7 +50,7 @@ def build_and_import_extension(
         Py_RETURN_TRUE;
     \"\"\")]
     >>> mod = build_and_import_extension("testme", functions)
-    >>> assert not mod.test_bytes(u'abc')
+    >>> assert not mod.test_bytes('abc')
     >>> assert mod.test_bytes(b'abc')
     """
     body = prologue + _make_methods(functions, modname)


### PR DESCRIPTION
This has been a very long wart that `encoding=bytes` was always the default, which means that custom converters get bytes passed which is rather tedious.

Now, changing this of course breaks some custom converters (luckily Python allow some simple things like `float()` for byte strings also.

There is an odd deprecationwarning, but for now most (not all) test failures are fixed by passing `encoding="bytes"` explicitly.

---

This one is for @rossbar to review and make a decision on.