### PR TITLE
MAINT: Add ``array-api-tests`` CI stage, add ``ndarray.__array_namespace__``

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -208,6 +208,47 @@ jobs:
         cd tools
         pytest --pyargs numpy -m "not slow"
 
+  array_api_tests:
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push'
+    steps:
+    - name: Checkout NumPy
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Checkout array-api-tests
+      uses: actions/checkout@v3
+      with:
+        repository: data-apis/array-api-tests
+        ref: '83f0bcdcc5286250dbb26be5d37511702970b4dc'  # Latest commit as of 2023-11-15
+        submodules: 'true'
+        path: 'array-api-tests'
+    - name: Fix array-apis bug
+      # Temporary workaround for https://github.com/data-apis/array-api/issues/631 
+      run: |
+        sed -i -e 's/\\/\\\\/g' array-api-tests/array-api/spec/API_specification/signatures/*.py
+    - name: Set up Python
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      with:
+        python-version: '3.11'
+    - name: Install build and test dependencies from PyPI
+      run: |
+        python -m pip install -r build_requirements.txt
+        python -m pip install -r test_requirements.txt
+        python -m pip install hypothesis!=6.88.4  # 6.88.4 leads to a strange error
+        python -m pip install -r array-api-tests/requirements.txt
+    - name: Build and install NumPy
+      run: |
+        python -m pip install . -v -Csetup-args=-Dallow-noblas=true -Csetup-args=-Dcpu-baseline=none -Csetup-args=-Dcpu-dispatch=none
+    - name: Run the test suite
+      env:
+        ARRAY_API_TESTS_MODULE: numpy
+      run: |
+        cd ${GITHUB_WORKSPACE}/array-api-tests
+        pytest array_api_tests -v -W ignore::pytest.PytestDeprecationWarning -W ignore::RuntimeWarning -W ignore::DeprecationWarning --ci --max-examples=2 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/array-api-skips.txt
+
   custom_checks:
     needs: [smoke_test]
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -222,13 +222,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: data-apis/array-api-tests
-        ref: '83f0bcdcc5286250dbb26be5d37511702970b4dc'  # Latest commit as of 2023-11-15
+        ref: '9afe8c709d81f005c98d383c82ad5e1c2cd8166c'  # Latest commit as of 2023-11-24
         submodules: 'true'
         path: 'array-api-tests'
-    - name: Fix array-apis bug
-      # Temporary workaround for https://github.com/data-apis/array-api/issues/631 
-      run: |
-        sed -i -e 's/\\/\\\\/g' array-api-tests/array-api/spec/API_specification/signatures/*.py
     - name: Set up Python
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
@@ -237,7 +233,6 @@ jobs:
       run: |
         python -m pip install -r build_requirements.txt
         python -m pip install -r test_requirements.txt
-        python -m pip install hypothesis!=6.88.4  # 6.88.4 leads to a strange error
         python -m pip install -r array-api-tests/requirements.txt
     - name: Build and install NumPy
       run: |
@@ -245,9 +240,12 @@ jobs:
     - name: Run the test suite
       env:
         ARRAY_API_TESTS_MODULE: numpy
+        PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
       run: |
         cd ${GITHUB_WORKSPACE}/array-api-tests
-        pytest array_api_tests -v -W ignore::pytest.PytestDeprecationWarning -W ignore::RuntimeWarning -W ignore::DeprecationWarning --ci --max-examples=2 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/array-api-skips.txt
+        # remove once https://github.com/data-apis/array-api-tests/pull/217 is merged
+        touch pytest.ini
+        pytest array_api_tests -v -c pytest.ini --ci --max-examples=2 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/tools/ci/array-api-skips.txt
 
   custom_checks:
     needs: [smoke_test]

--- a/array-api-skips.txt
+++ b/array-api-skips.txt
@@ -1,0 +1,133 @@
+# copy not implemented
+array_api_tests/test_creation_functions.py::test_asarray_arrays
+
+# https://github.com/numpy/numpy/issues/20870
+array_api_tests/test_data_type_functions.py::test_can_cast
+
+# The return dtype for trace is not consistent in the spec
+# https://github.com/data-apis/array-api/issues/202#issuecomment-952529197
+array_api_tests/test_linalg.py::test_trace
+
+# waiting on NumPy to allow/revert distinct NaNs for np.unique
+# https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
+array_api_tests/test_set_functions.py
+
+# newaxis not included in numpy namespace as of v1.26.2
+array_api_tests/test_constants.py::test_newaxis
+
+# linalg.solve issue in numpy.array_api as of v1.26.2 (see numpy#25146)
+array_api_tests/test_linalg.py::test_solve
+
+# https://github.com/numpy/numpy/issues/21373
+array_api_tests/test_array_object.py::test_getitem
+
+# missing copy arg
+array_api_tests/test_signatures.py::test_func_signature[reshape]
+
+# https://github.com/numpy/numpy/issues/21211
+array_api_tests/test_special_cases.py::test_iop[__iadd__(x1_i is -0 and x2_i is -0) -> -0]
+# https://github.com/numpy/numpy/issues/21213
+array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
+array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
+# noted diversions from spec
+array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+array_api_tests/test_special_cases.py::test_binary[floor_divide(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+array_api_tests/test_special_cases.py::test_binary[__floordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i > 0) -> -infinity]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
+array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+
+# asarray() got an unexpected keyword argument 'copy'
+array_api_tests/test_array_object.py::test_setitem
+# array_api_tests/test_array_object.py::test_setitem_masking
+array_api_tests/test_creation_functions.py::test_asarray_scalars
+
+# astype is not defined in numpy
+array_api_tests/test_data_type_functions.py::test_astype
+
+# fft test suite is buggy as of 83f0bcdc
+array_api_tests/test_fft.py
+
+# missing isdtype and finfo return type misalignment
+array_api_tests/test_data_type_functions.py::test_finfo[float32]
+array_api_tests/test_data_type_functions.py::test_isdtype
+
+# missing names
+array_api_tests/test_has_names.py::test_has_names[linalg-cross]
+array_api_tests/test_has_names.py::test_has_names[linalg-matmul]
+array_api_tests/test_has_names.py::test_has_names[linalg-matrix_norm]
+array_api_tests/test_has_names.py::test_has_names[linalg-matrix_transpose]
+array_api_tests/test_has_names.py::test_has_names[linalg-outer]
+array_api_tests/test_has_names.py::test_has_names[linalg-svdvals]
+array_api_tests/test_has_names.py::test_has_names[linalg-tensordot]
+array_api_tests/test_has_names.py::test_has_names[linalg-vecdot]
+array_api_tests/test_has_names.py::test_has_names[linalg-vector_norm]
+array_api_tests/test_has_names.py::test_has_names[set-unique_all]
+array_api_tests/test_has_names.py::test_has_names[set-unique_counts]
+array_api_tests/test_has_names.py::test_has_names[set-unique_inverse]
+array_api_tests/test_has_names.py::test_has_names[set-unique_values]
+array_api_tests/test_has_names.py::test_has_names[manipulation-concat]
+array_api_tests/test_has_names.py::test_has_names[manipulation-permute_dims]
+array_api_tests/test_has_names.py::test_has_names[data_type-astype]
+array_api_tests/test_has_names.py::test_has_names[elementwise-acos]
+array_api_tests/test_has_names.py::test_has_names[elementwise-acosh]
+array_api_tests/test_has_names.py::test_has_names[elementwise-asin]
+array_api_tests/test_has_names.py::test_has_names[elementwise-asinh]
+array_api_tests/test_has_names.py::test_has_names[elementwise-atan]
+array_api_tests/test_has_names.py::test_has_names[elementwise-atan2]
+array_api_tests/test_has_names.py::test_has_names[elementwise-atanh]
+array_api_tests/test_has_names.py::test_has_names[elementwise-bitwise_left_shift]
+array_api_tests/test_has_names.py::test_has_names[elementwise-bitwise_invert]
+array_api_tests/test_has_names.py::test_has_names[elementwise-bitwise_right_shift]
+array_api_tests/test_has_names.py::test_has_names[elementwise-pow]
+array_api_tests/test_has_names.py::test_has_names[linear_algebra-matrix_transpose]
+array_api_tests/test_has_names.py::test_has_names[linear_algebra-vecdot]
+array_api_tests/test_has_names.py::test_has_names[array_method-to_device]
+array_api_tests/test_has_names.py::test_has_names[array_attribute-device]
+
+# missing linalg names
+array_api_tests/test_linalg.py::test_cross
+array_api_tests/test_linalg.py::test_matrix_norm
+array_api_tests/test_linalg.py::test_matrix_transpose
+array_api_tests/test_linalg.py::test_outer
+array_api_tests/test_linalg.py::test_pinv
+array_api_tests/test_linalg.py::test_svdvals
+array_api_tests/test_linalg.py::test_vecdot
+
+# missing names
+array_api_tests/test_manipulation_functions.py::test_concat
+array_api_tests/test_manipulation_functions.py::test_permute_dims
+
+# a few misalignments
+array_api_tests/test_operators_and_elementwise_functions.py
+array_api_tests/test_signatures.py
+
+# unexpected argument 'stable'
+array_api_tests/test_sorting_functions.py::test_argsort
+array_api_tests/test_sorting_functions.py::test_sort
+
+# missing aliases
+array_api_tests/test_special_cases.py::test_unary
+array_api_tests/test_special_cases.py::test_binary
+
+# asarray() got an unexpected keyword argument 'copy'
+array_api_tests/test_special_cases.py::test_iop
+
+# got an unexpected keyword argument 'correction'
+array_api_tests/test_statistical_functions.py::test_std
+array_api_tests/test_statistical_functions.py::test_var
+
+# assertionError: out.dtype=float32, but should be float64 [sum(float32)]
+array_api_tests/test_statistical_functions.py::test_sum

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -285,6 +285,8 @@ else:
     # import with `from numpy import *`.
     __future_scalars__ = {"str", "bytes", "object"}
 
+    __array_api_version__ = "2022.12"
+
     # now that numpy core module is imported, can initialize limits
     _core.getlimits._register_known_types()
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -622,6 +622,7 @@ __all__: list[str]
 __dir__: list[str]
 __version__: str
 __git_version__: str
+__array_api_version__: str
 test: PytestTester
 
 # TODO: Move placeholders to their respective module once
@@ -2461,6 +2462,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
 
     def __dlpack__(self: NDArray[number[Any]], *, stream: None = ...) -> _PyCapsule: ...
     def __dlpack_device__(self) -> tuple[int, L[0]]: ...
+
+    def __array_namespace__(self, *, api_version: str = ...) -> Any: ...
 
     def bitwise_count(
         self,

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2767,9 +2767,10 @@ array_array_namespace(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    if (strcmp(array_api_version, "2022.12") != 0) {
+    if (strcmp(array_api_version, "2021.12") != 0 &&
+            strcmp(array_api_version, "2022.12") != 0) {
         PyErr_Format(PyExc_ValueError,
-                     "Version \"%s\" of Array API is not supported.",
+                     "Version \"%s\" of the Array API Standard is not supported.",
                      array_api_version);
         return NULL;
     }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2756,6 +2756,32 @@ array_class_getitem(PyObject *cls, PyObject *args)
     return Py_GenericAlias(cls, args);
 }
 
+static PyObject *
+array_array_namespace(PyArrayObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"api_version", NULL};
+    char *array_api_version = "2022.12";
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$s:__array_namespace__", kwlist,
+                                     &array_api_version)) {
+        return NULL;
+    }
+
+    if (strcmp(array_api_version, "2022.12") != 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "Version \"%s\" of Array API is not supported.",
+                     array_api_version);
+        return NULL;
+    }
+
+    PyObject *numpy_module = PyImport_ImportModule("numpy");
+    if (numpy_module == NULL){
+        return NULL;
+    }
+
+    return numpy_module;
+}
+
 NPY_NO_EXPORT PyMethodDef array_methods[] = {
 
     /* for subtypes */
@@ -2980,5 +3006,11 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
     {"__dlpack_device__",
         (PyCFunction)array_dlpack_device,
         METH_NOARGS, NULL},
+
+    // For Array API compatibility
+    {"__array_namespace__",
+        (PyCFunction)array_array_namespace,
+        METH_VARARGS | METH_KEYWORDS, NULL},
+
     {NULL, NULL, 0, NULL}           /* sentinel */
 };

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2556,3 +2556,20 @@ class TestRegression:
         test_data = b'\x80\x04\x95(\x00\x00\x00\x00\x00\x00\x00\x8c\x1cnumpy.core._multiarray_umath\x94\x8c\x03add\x94\x93\x94.'  # noqa
         result = pickle.loads(test_data, encoding='bytes')
         assert result is np.add
+
+    def test__array_namespace__(self):
+        arr = np.arange(2)
+
+        xp = arr.__array_namespace__()
+        assert xp is np
+        xp = arr.__array_namespace__(api_version="2021.12")
+        assert xp is np
+        xp = arr.__array_namespace__(api_version="2022.12")
+        assert xp is np
+
+        with pytest.raises(
+            ValueError,
+            match="Version \"2023.12\" of the Array API Standard "
+                  "is not supported."
+        ):
+            arr.__array_namespace__(api_version="2023.12")

--- a/tools/ci/array-api-skips.txt
+++ b/tools/ci/array-api-skips.txt
@@ -1,31 +1,10 @@
 # copy not implemented
 array_api_tests/test_creation_functions.py::test_asarray_arrays
 
-# https://github.com/numpy/numpy/issues/20870
-array_api_tests/test_data_type_functions.py::test_can_cast
-
-# The return dtype for trace is not consistent in the spec
-# https://github.com/data-apis/array-api/issues/202#issuecomment-952529197
-array_api_tests/test_linalg.py::test_trace
-
 # waiting on NumPy to allow/revert distinct NaNs for np.unique
 # https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
 array_api_tests/test_set_functions.py
 
-# newaxis not included in numpy namespace as of v1.26.2
-array_api_tests/test_constants.py::test_newaxis
-
-# linalg.solve issue in numpy.array_api as of v1.26.2 (see numpy#25146)
-array_api_tests/test_linalg.py::test_solve
-
-# https://github.com/numpy/numpy/issues/21373
-array_api_tests/test_array_object.py::test_getitem
-
-# missing copy arg
-array_api_tests/test_signatures.py::test_func_signature[reshape]
-
-# https://github.com/numpy/numpy/issues/21211
-array_api_tests/test_special_cases.py::test_iop[__iadd__(x1_i is -0 and x2_i is -0) -> -0]
 # https://github.com/numpy/numpy/issues/21213
 array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
 array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
@@ -54,15 +33,13 @@ array_api_tests/test_array_object.py::test_setitem
 # array_api_tests/test_array_object.py::test_setitem_masking
 array_api_tests/test_creation_functions.py::test_asarray_scalars
 
-# astype is not defined in numpy
-array_api_tests/test_data_type_functions.py::test_astype
-
 # fft test suite is buggy as of 83f0bcdc
 array_api_tests/test_fft.py
 
-# missing isdtype and finfo return type misalignment
+# missing isdtype, astype and finfo return type misalignment
 array_api_tests/test_data_type_functions.py::test_finfo[float32]
 array_api_tests/test_data_type_functions.py::test_isdtype
+array_api_tests/test_data_type_functions.py::test_astype
 
 # missing names
 array_api_tests/test_has_names.py::test_has_names[linalg-cross]
@@ -81,6 +58,7 @@ array_api_tests/test_has_names.py::test_has_names[set-unique_values]
 array_api_tests/test_has_names.py::test_has_names[manipulation-concat]
 array_api_tests/test_has_names.py::test_has_names[manipulation-permute_dims]
 array_api_tests/test_has_names.py::test_has_names[data_type-astype]
+array_api_tests/test_has_names.py::test_has_names[data_type-isdtype]
 array_api_tests/test_has_names.py::test_has_names[elementwise-acos]
 array_api_tests/test_has_names.py::test_has_names[elementwise-acosh]
 array_api_tests/test_has_names.py::test_has_names[elementwise-asin]
@@ -112,7 +90,55 @@ array_api_tests/test_manipulation_functions.py::test_permute_dims
 
 # a few misalignments
 array_api_tests/test_operators_and_elementwise_functions.py
-array_api_tests/test_signatures.py
+array_api_tests/test_signatures.py::test_func_signature[std]
+array_api_tests/test_signatures.py::test_func_signature[var]
+array_api_tests/test_signatures.py::test_func_signature[unique_all]
+array_api_tests/test_signatures.py::test_func_signature[unique_counts]
+array_api_tests/test_signatures.py::test_func_signature[unique_inverse]
+array_api_tests/test_signatures.py::test_func_signature[unique_values]
+array_api_tests/test_signatures.py::test_func_signature[asarray]
+array_api_tests/test_signatures.py::test_func_signature[empty_like]
+array_api_tests/test_signatures.py::test_func_signature[eye]
+array_api_tests/test_signatures.py::test_func_signature[full]
+array_api_tests/test_signatures.py::test_func_signature[full_like]
+array_api_tests/test_signatures.py::test_func_signature[linspace]
+array_api_tests/test_signatures.py::test_func_signature[ones]
+array_api_tests/test_signatures.py::test_func_signature[ones_like]
+array_api_tests/test_signatures.py::test_func_signature[zeros_like]
+array_api_tests/test_signatures.py::test_func_signature[concat]
+array_api_tests/test_signatures.py::test_func_signature[permute_dims]
+array_api_tests/test_signatures.py::test_func_signature[reshape]
+array_api_tests/test_signatures.py::test_func_signature[argsort]
+array_api_tests/test_signatures.py::test_func_signature[sort]
+array_api_tests/test_signatures.py::test_func_signature[astype]
+array_api_tests/test_signatures.py::test_func_signature[isdtype]
+array_api_tests/test_signatures.py::test_func_signature[acos]
+array_api_tests/test_signatures.py::test_func_signature[acosh]
+array_api_tests/test_signatures.py::test_func_signature[asin]
+array_api_tests/test_signatures.py::test_func_signature[asinh]
+array_api_tests/test_signatures.py::test_func_signature[atan]
+array_api_tests/test_signatures.py::test_func_signature[atan2]
+array_api_tests/test_signatures.py::test_func_signature[atanh]
+array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
+array_api_tests/test_signatures.py::test_func_signature[bitwise_invert]
+array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
+array_api_tests/test_signatures.py::test_func_signature[pow]
+array_api_tests/test_signatures.py::test_func_signature[matrix_transpose]
+array_api_tests/test_signatures.py::test_func_signature[vecdot]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.cross]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matmul]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.cholesky]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_norm]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_rank]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_transpose]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.outer]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.pinv]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.svdvals]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.tensordot]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.vecdot]
+array_api_tests/test_signatures.py::test_extension_func_signature[linalg.vector_norm]
+array_api_tests/test_signatures.py::test_array_method_signature[__array_namespace__]
+array_api_tests/test_signatures.py::test_array_method_signature[to_device]
 
 # unexpected argument 'stable'
 array_api_tests/test_sorting_functions.py::test_argsort


### PR DESCRIPTION
Hi @rgommers @asmeurer,

This draft PR introduces `array-api-tests` CI stage. Here are some important notes:

- It's the first WIP implementation that I managed to initially run on my fork. I'm sharing it here to start the discussion.
- I [couldn't find](https://pypi.org/search/?q=array-api-tests) `array-api-tests` on PyPI, so I followed implementation in https://github.com/google/jax/pull/16099/files, where `array-api-tests` is cloned, and some issues are manually fixed (for now).
- `array-api-skips.txt` contains and disables quite a lot of tests - the rationale is to merge it first, and then, as Array API PRs arrive, enable tests gradually.
- In this PR I added `__array_namespace__` to `ndarray` class and `__array_api_version__` to the main namespace.
- `xp.bool` is required to run the tests and it can't be XFAILed, so https://github.com/numpy/numpy/pull/25080 needs to be merged before this PR **[EDIT]** Merged. 
