### PR TITLE
API: Introduce ``correction`` argument for ``np.var`` and ``np.std`` [Array API]

### DIFF
--- a/doc/release/upcoming_changes/25169.new_feature.rst
+++ b/doc/release/upcoming_changes/25169.new_feature.rst
@@ -1,0 +1,7 @@
+``correction`` argument for `numpy.var` and `numpy.std`
+-------------------------------------------------------
+
+``correction`` argument was added to `numpy.var` and `numpy.std`,
+which is an Array API compatible alias for ``ddof``.
+As both arguments serve the same purpose only one of them can be
+provided at the same time.

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -99,10 +99,6 @@ functions to include additional keyword arguments from those required.
      - The definitions of ``rtol`` and ``rcond`` are the same, but their
        default values differ, making this **breaking**. See
        :ref:`array_api-linear-algebra-differences`.
-   * - ``std`` and ``var``
-     - ``correction``
-     - ``ddof``
-     -
    * - ``reshape``
      - ``shape``
      - ``newshape``

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3558,13 +3558,13 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
 
 
 def _std_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None, mean=None):
+                    keepdims=None, *, where=None, mean=None, correction=None):
     return (a, where, out, mean)
 
 
 @array_function_dispatch(_std_dispatcher)
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
-        where=np._NoValue, mean=np._NoValue):
+        where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     r"""
     Compute the standard deviation along the specified axis.
 
@@ -3592,7 +3592,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         Alternative output array in which to place the result. It must have
         the same shape as the expected output but the type (of the calculated
         values) will be cast if necessary.
-    ddof : int, optional
+    ddof : {int, float}, optional
         Means Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
         By default `ddof` is zero. See Notes for details about use of `ddof`.
@@ -3612,13 +3612,19 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
         .. versionadded:: 1.20.0
 
-    mean : array like, optional
+    mean : array_like, optional
         Provide the mean to prevent its recalculation. The mean should have
         a shape as if it was calculated with ``keepdims=True``.
         The axis for the calculation of the mean should be the same as used in
         the call to this std function.
 
         .. versionadded:: 1.26.0
+
+    correction : {int, float}, optional
+        Array API compatible name for the ``ddof`` parameter. Only one of them
+        can be provided at the same time.
+
+        .. versionadded:: 2.0.0
 
     Returns
     -------
@@ -3736,6 +3742,14 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     if mean is not np._NoValue:
         kwargs['mean'] = mean
 
+    if correction != np._NoValue:
+        if ddof != 0:
+            raise ValueError(
+                "ddof and correction can't be provided simultaneously."
+            )
+        else:
+            ddof = correction
+
     if type(a) is not mu.ndarray:
         try:
             std = a.std
@@ -3749,13 +3763,13 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 
 
 def _var_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None, mean=None):
+                    keepdims=None, *, where=None, mean=None, correction=None):
     return (a, where, out, mean)
 
 
 @array_function_dispatch(_var_dispatcher)
 def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
-        where=np._NoValue, mean=np._NoValue):
+        where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     r"""
     Compute the variance along the specified axis.
 
@@ -3784,7 +3798,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         Alternate output array in which to place the result.  It must have
         the same shape as the expected output, but the type is cast if
         necessary.
-    ddof : int, optional
+    ddof : {int, float}, optional
         "Delta Degrees of Freedom": the divisor used in the calculation is
         ``N - ddof``, where ``N`` represents the number of elements. By
         default `ddof` is zero. See notes for details about use of `ddof`.
@@ -3811,6 +3825,12 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         the call to this var function.
 
         .. versionadded:: 1.26.0
+
+    correction : {int, float}, optional
+        Array API compatible name for the ``ddof`` parameter. Only one of them
+        can be provided at the same time.
+
+        .. versionadded:: 2.0.0
 
     Returns
     -------
@@ -3926,6 +3946,14 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         kwargs['where'] = where
     if mean is not np._NoValue:
         kwargs['mean'] = mean
+
+    if correction != np._NoValue:
+        if ddof != 0:
+            raise ValueError(
+                "ddof and correction can't be provided simultaneously."
+            )
+        else:
+            ddof = correction
 
     if type(a) is not mu.ndarray:
         try:

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -946,10 +946,12 @@ def std(
     axis: None = ...,
     dtype: None = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: Literal[False] = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co = ...,
+    correction: int | float = ...,
 ) -> floating[Any]: ...
 @overload
 def std(
@@ -957,10 +959,12 @@ def std(
     axis: None | _ShapeLike = ...,
     dtype: None = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> Any: ...
 @overload
 def std(
@@ -968,10 +972,12 @@ def std(
     axis: None = ...,
     dtype: _DTypeLike[_SCT] = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: Literal[False] = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> _SCT: ...
 @overload
 def std(
@@ -979,10 +985,12 @@ def std(
     axis: None | _ShapeLike = ...,
     dtype: DTypeLike = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> Any: ...
 @overload
 def std(
@@ -990,10 +998,12 @@ def std(
     axis: None | _ShapeLike = ...,
     dtype: DTypeLike = ...,
     out: _ArrayType = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> _ArrayType: ...
 
 @overload
@@ -1002,10 +1012,12 @@ def var(
     axis: None = ...,
     dtype: None = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: Literal[False] = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co = ...,
+    correction: int | float = ...,
 ) -> floating[Any]: ...
 @overload
 def var(
@@ -1013,10 +1025,12 @@ def var(
     axis: None | _ShapeLike = ...,
     dtype: None = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> Any: ...
 @overload
 def var(
@@ -1024,10 +1038,12 @@ def var(
     axis: None = ...,
     dtype: _DTypeLike[_SCT] = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: Literal[False] = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> _SCT: ...
 @overload
 def var(
@@ -1035,10 +1051,12 @@ def var(
     axis: None | _ShapeLike = ...,
     dtype: DTypeLike = ...,
     out: None = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> Any: ...
 @overload
 def var(
@@ -1046,10 +1064,12 @@ def var(
     axis: None | _ShapeLike = ...,
     dtype: DTypeLike = ...,
     out: _ArrayType = ...,
-    ddof: float = ...,
+    ddof: int | float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
+    mean: _ArrayLikeComplex_co | _ArrayLikeObject_co = ...,
+    correction: int | float = ...,
 ) -> _ArrayType: ...
 
 max = amax

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3085,6 +3085,22 @@ class TestStdVar:
         assert_almost_equal(np.std(self.A, ddof=2)**2,
                             self.real_var * len(self.A) / (len(self.A) - 2))
 
+    def test_correction(self):
+        assert_almost_equal(
+            np.var(self.A, correction=1), np.var(self.A, ddof=1)
+        )
+        assert_almost_equal(
+            np.std(self.A, correction=1), np.std(self.A, ddof=1)
+        )
+
+        err_msg = "ddof and correction can't be provided simultaneously."
+
+        with assert_raises_regex(ValueError, err_msg):
+            np.var(self.A, ddof=1, correction=0)
+
+        with assert_raises_regex(ValueError, err_msg):
+            np.std(self.A, ddof=1, correction=1)
+
     def test_out_scalar(self):
         d = np.arange(10)
         out = np.array(0.)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -439,6 +439,22 @@ class TestNanFunctions_NumberTypes:
         else:
             assert out.dtype == tgt.dtype
 
+    @pytest.mark.parametrize(
+        "nanfunc", [np.nanvar, np.nanstd]
+    )
+    def test_nanfunc_correction(self, mat, dtype, nanfunc):
+        mat = mat.astype(dtype)
+        assert_almost_equal(
+            nanfunc(mat, correction=0.5), nanfunc(mat, ddof=0.5)
+        )
+
+        err_msg = "ddof and correction can't be provided simultaneously."
+        with assert_raises_regex(ValueError, err_msg):
+            nanfunc(mat, ddof=0.5, correction=0.5)
+
+        with assert_raises_regex(ValueError, err_msg):
+            nanfunc(mat, ddof=1, correction=0)
+
 
 class SharedNanFunctionsTestsMixin:
     def test_mutation(self):

--- a/tools/ci/array-api-skips.txt
+++ b/tools/ci/array-api-skips.txt
@@ -73,9 +73,5 @@ array_api_tests/test_signatures.py::test_func_signature[sort]
 # asarray() got an unexpected keyword argument 'copy'
 array_api_tests/test_special_cases.py::test_iop
 
-# got an unexpected keyword argument 'correction'
-array_api_tests/test_statistical_functions.py::test_std
-array_api_tests/test_statistical_functions.py::test_var
-
 # assertionError: out.dtype=float32, but should be float64 [sum(float32)]
 array_api_tests/test_statistical_functions.py::test_sum


### PR DESCRIPTION
This PR contains next Array API compatibility change. 
It adds `correction` argument to `np.var` and `np.std` (and also `np.nanvar` and `np.nanstd`), which is an Array API compatible name for `ddof`.
