### PR TITLE
DOC: replace integer overflow example

### DIFF
--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -239,13 +239,13 @@ Overflow errors
 
 The fixed size of NumPy numeric types may cause overflow errors when a value
 requires more memory than available in the data type. For example, 
-`numpy.power` evaluates ``100 ** 8`` correctly for 64-bit integers,
-but gives 1874919424 (incorrect) for a 32-bit integer.
+`numpy.power` evaluates ``100 ** 9`` correctly for 64-bit integers,
+but gives -1486618624 (incorrect) for a 32-bit integer.
 
-    >>> np.power(100, 8, dtype=np.int64)
-    10000000000000000
-    >>> np.power(100, 8, dtype=np.int32)
-    1874919424
+    >>> np.power(100, 9, dtype=np.int64)
+    1000000000000000000
+    >>> np.power(100, 9, dtype=np.int32)
+    -1486618624
 
 The behaviour of NumPy and Python integer types differs significantly for
 integer overflows and may confuse users expecting NumPy integers to behave


### PR DESCRIPTION
gh-21326 noted that a positive integer raised to a positive integer power could result in a negative integer result. The suggested resolution was to add an example of this type of integer overflow to the documentation. By changing the old example of integer overflow slightly, it serves its original purpose (integer interflow can produce unexpected results) and this new purpose (the result of positive integer to positive integer can be negative).
@rossbar @melissawm 

Closes gh-21326.
