### PR TITLE
BUG: Disallow shadowed modulenames

### DIFF
--- a/doc/release/upcoming_changes/25181.compatibility.rst
+++ b/doc/release/upcoming_changes/25181.compatibility.rst
@@ -1,0 +1,4 @@
+``f2py`` will no longer accept ambiguous ``-m`` and ``.pyf`` CLI combinations.
+When more than one ``.pyf`` file is passed, an error is raised. When both ``-m``
+and a ``.pyf`` is passed, a warning is emitted and the ``-m`` provided name is
+ignored.

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -239,10 +239,11 @@ Other options
 ``-m <modulename>``
   Name of an extension module. Default is ``untitled``.
 
-.. warning:: Don't use this option if a signature file (``*.pyf``) is used.
+.. warning::
+   Don't use this option if a signature file (``*.pyf``) is used.
 
-.. versionchanged:: 2.0.0
-   Will ignore ``-m`` if a ``pyf`` file is provided.
+   .. versionchanged:: 1.26.3
+      Will ignore ``-m`` if a ``pyf`` file is provided.
 
 ``--[no-]lower``
   Do [not] lower the cases in ``<fortran files>``. By default, ``--lower`` is

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -450,6 +450,16 @@ def run_main(comline_list):
     f2pydir = os.path.dirname(os.path.abspath(cfuncs.__file__))
     fobjhsrc = os.path.join(f2pydir, 'src', 'fortranobject.h')
     fobjcsrc = os.path.join(f2pydir, 'src', 'fortranobject.c')
+    # gh-22819 -- begin
+    parser = make_f2py_parser()
+    args, comline_list = parser.parse_known_args(comline_list)
+    pyf_files, _ = filter_files("", "[.]pyf([.]src|)", comline_list)
+    # Checks that no existing modulename is defined in a pyf file
+    # TODO: Remove all this when scaninputline is replaced
+    if "-h" not in comline_list: # Can't check what doesn't exist yet, -h creates the pyf
+        modname = validate_modulename(pyf_files, args.module_name)
+        comline_list += ['-m', modname] # needed for the rest of scaninputline
+    # gh-22819 -- end
     files, options = scaninputline(comline_list)
     auxfuncs.options = options
     capi_maps.load_f2cmap_file(options['f2cmap_file'])
@@ -516,24 +526,30 @@ def get_prefix(module):
     p = os.path.dirname(os.path.dirname(module.__file__))
     return p
 
-def preparse_sysargv():
-    # To keep backwards bug compatibility, newer flags are handled by argparse,
-    # and `sys.argv` is passed to the rest of `f2py` as is.
+def make_f2py_parser():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--dep", action="append", dest="dependencies")
     parser.add_argument("--backend", choices=['meson', 'distutils'], default='distutils')
+    parser.add_argument("-m", dest="module_name")
+    return parser
+
+def preparse_sysargv():
+    # To keep backwards bug compatibility, newer flags are handled by argparse,
+    # and `sys.argv` is passed to the rest of `f2py` as is.
+    parser = make_f2py_parser()
 
     args, remaining_argv = parser.parse_known_args()
     sys.argv = [sys.argv[0]] + remaining_argv
 
     backend_key = args.backend
     if sys.version_info >= (3, 12) and backend_key == 'distutils':
-        outmess('Cannot use distutils backend with Python 3.12, using meson backend instead.')
+        outmess("Cannot use distutils backend with Python 3.12, using meson backend instead.\n")
         backend_key = 'meson'
 
     return {
         "dependencies": args.dependencies or [],
-        "backend": backend_key
+        "backend": backend_key,
+        "modulename": args.module_name,
     }
 
 def run_compile():
@@ -544,10 +560,10 @@ def run_compile():
 
     # Collect dependency flags, preprocess sys.argv
     argy = preparse_sysargv()
+    modulename = argy["modulename"]
     dependencies = argy["dependencies"]
     backend_key = argy["backend"]
     build_backend = f2py_build_generator(backend_key)
-
 
     i = sys.argv.index('-c')
     del sys.argv[i]
@@ -628,9 +644,7 @@ def run_compile():
     if '--quiet' in f2py_flags:
         setup_flags.append('--quiet')
 
-    modulename = 'untitled'
     sources = sys.argv[1:]
-
     for optname in ['--include_paths', '--include-paths', '--f2cmap']:
         if optname in sys.argv:
             i = sys.argv.index(optname)
@@ -638,20 +652,9 @@ def run_compile():
             del sys.argv[i + 1], sys.argv[i]
             sources = sys.argv[1:]
 
-    pyf_files = []
-    if '-m' in sys.argv:
-        i = sys.argv.index('-m')
-        modulename = sys.argv[i + 1]
-        del sys.argv[i + 1], sys.argv[i]
-        sources = sys.argv[1:]
-    else:
-        pyf_files, _sources = filter_files('', '[.]pyf([.]src|)', sources)
-        sources = pyf_files + _sources
-        for f in pyf_files:
-            modulename = auxfuncs.get_f2py_modulename(f)
-            if modulename:
-                break
-
+    pyf_files, _sources = filter_files("", "[.]pyf([.]src|)", sources)
+    sources = pyf_files + _sources
+    modulename = validate_modulename(pyf_files, modulename)
     extra_objects, sources = filter_files('', '[.](o|a|so|dylib)', sources)
     include_dirs, sources = filter_files('-I', '', sources, remove_prefix=1)
     library_dirs, sources = filter_files('-L', '', sources, remove_prefix=1)
@@ -697,6 +700,19 @@ def run_compile():
     )
 
     builder.compile()
+
+
+def validate_modulename(pyf_files, modulename='untitled'):
+    for f in pyf_files:
+        pyf_modname = auxfuncs.get_f2py_modulename(f)
+        if modulename != pyf_modname:
+            outmess(
+                f"Ignoring -m {modulename}.\n"
+                f"{f} defines {pyf_modname} to be the modulename.\n"
+            )
+            modulename = pyf_modname
+            break
+    return modulename
 
 def main():
     if '--help-link' in sys.argv[1:]:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -705,14 +705,15 @@ def run_compile():
 def validate_modulename(pyf_files, modulename='untitled'):
     if len(pyf_files) > 1:
         raise ValueError("Only one .pyf file per call")
-    pyff = pyf_files[0]
-    pyf_modname = auxfuncs.get_f2py_modulename(pyff)
-    if modulename != pyf_modname:
-        outmess(
-            f"Ignoring -m {modulename}.\n"
-            f"{pyff} defines {pyf_modname} to be the modulename.\n"
-        )
-        modulename = pyf_modname
+    if pyf_files:
+        pyff = pyf_files[0]
+        pyf_modname = auxfuncs.get_f2py_modulename(pyff)
+        if modulename != pyf_modname:
+            outmess(
+                f"Ignoring -m {modulename}.\n"
+                f"{pyff} defines {pyf_modname} to be the modulename.\n"
+            )
+            modulename = pyf_modname
     return modulename
 
 def main():

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -703,15 +703,16 @@ def run_compile():
 
 
 def validate_modulename(pyf_files, modulename='untitled'):
-    for f in pyf_files:
-        pyf_modname = auxfuncs.get_f2py_modulename(f)
-        if modulename != pyf_modname:
-            outmess(
-                f"Ignoring -m {modulename}.\n"
-                f"{f} defines {pyf_modname} to be the modulename.\n"
-            )
-            modulename = pyf_modname
-            break
+    if len(pyf_files) > 1:
+        raise ValueError("Only one .pyf file per call")
+    pyff = pyf_files[0]
+    pyf_modname = auxfuncs.get_f2py_modulename(pyff)
+    if modulename != pyf_modname:
+        outmess(
+            f"Ignoring -m {modulename}.\n"
+            f"{pyff} defines {pyf_modname} to be the modulename.\n"
+        )
+        modulename = pyf_modname
     return modulename
 
 def main():

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -456,7 +456,7 @@ def run_main(comline_list):
     pyf_files, _ = filter_files("", "[.]pyf([.]src|)", comline_list)
     # Checks that no existing modulename is defined in a pyf file
     # TODO: Remove all this when scaninputline is replaced
-    if "-h" not in comline_list: # Can't check what doesn't exist yet, -h creates the pyf
+    if "-h" not in comline_list and args.module_name: # Can't check what doesn't exist yet, -h creates the pyf
         modname = validate_modulename(pyf_files, args.module_name)
         comline_list += ['-m', modname] # needed for the rest of scaninputline
     # gh-22819 -- end

--- a/numpy/f2py/tests/src/cli/gh_22819.pyf
+++ b/numpy/f2py/tests/src/cli/gh_22819.pyf
@@ -1,0 +1,6 @@
+python module test_22819
+    interface
+        subroutine hello()
+        end subroutine hello
+    end interface
+end python module test_22819

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -126,6 +126,19 @@ def test_gh22819_cli(capfd, gh22819_cli, monkeypatch):
         assert "blah-f2pywrappers.f" not in gen_paths
         assert "test_22819-f2pywrappers.f" in gen_paths
         assert "test_22819module.c" in gen_paths
+        assert "Ignoring blah"
+
+
+def test_gh22819_many_pyf(capfd, gh22819_cli, monkeypatch):
+    """Only one .pyf file allowed
+    gh-22819
+    CLI :: .pyf files
+    """
+    ipath = Path(gh22819_cli)
+    monkeypatch.setattr(sys, "argv", f"f2py -m blah {ipath} hello.pyf".split())
+    with util.switchdir(ipath.parent):
+        with pytest.raises(ValueError, match="Only one .pyf file per call"):
+            f2pycli()
 
 
 def test_gh23598_warn(capfd, gh23598_warn, monkeypatch):

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -72,6 +72,15 @@ def gh23598_warn(tmpdir_factory):
 
 
 @pytest.fixture(scope="session")
+def gh22819_cli(tmpdir_factory):
+    """F90 file for testing disallowed CLI arguments in ghff819"""
+    fdat = util.getpath("tests", "src", "cli", "gh_22819.pyf").read_text()
+    fn = tmpdir_factory.getbasetemp() / "gh_22819.pyf"
+    fn.write_text(fdat, encoding="ascii")
+    return fn
+
+
+@pytest.fixture(scope="session")
 def hello_world_f77(tmpdir_factory):
     """Generates a single f77 file for testing"""
     fdat = util.getpath("tests", "src", "cli", "hi77.f").read_text()
@@ -98,6 +107,25 @@ def f2cmap_f90(tmpdir_factory):
     fn.write_text(fdat, encoding="ascii")
     fmap.write_text(f2cmap, encoding="ascii")
     return fn
+
+
+def test_gh22819_cli(capfd, gh22819_cli, monkeypatch):
+    """Check that module names are handled correctly
+    gh-22819
+    Essentially, the -m name cannot be used to import the module, so the module
+    named in the .pyf needs to be used instead
+
+    CLI :: -m and a .pyf file
+    """
+    ipath = Path(gh22819_cli)
+    monkeypatch.setattr(sys, "argv", f"f2py -m blah {ipath}".split())
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        gen_paths = [item.name for item in ipath.parent.rglob("*") if item.is_file()]
+        assert "blahmodule.c" not in gen_paths # shouldn't be generated
+        assert "blah-f2pywrappers.f" not in gen_paths
+        assert "test_22819-f2pywrappers.f" in gen_paths
+        assert "test_22819module.c" in gen_paths
 
 
 def test_gh23598_warn(capfd, gh23598_warn, monkeypatch):


### PR DESCRIPTION
This is a better version of #25114. 
Closes https://github.com/numpy/numpy/issues/22819. Closes #25182.
Enforces the following:
- Warns (but doesn't break, for BC) when `-m` is passed with a `.pyf` in a `-c` call, the name is ignored and taken from the `.pyf` file (the only logical option)
- Each `-c` run will only produce **one** `python` module, so there can only be **one** `.pyf` file
- Will **not** write out ambiguous wrapper files when `-m` is passed without `-c` and `.pyf` files are present (**new**, #25182)

For the last point `-m blah` is internally replaced with `-m modname` from the `.pyf` file, so no additional (incorrect) wrappers are produced.

There already is a [note in the documentation](https://numpy.org/doc/stable/f2py/usage.html#other-options), but this is a much better solution (and also paves the way for #25111). The documentation could probably use an update, and since this is technically a user facing change it might need a release note.