### PR TITLE
MAINT: Fix sneaky typo [f2py]

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -561,6 +561,8 @@ def run_compile():
     # Collect dependency flags, preprocess sys.argv
     argy = preparse_sysargv()
     modulename = argy["modulename"]
+    if modulename is None:
+        modulename = 'untitled'
     dependencies = argy["dependencies"]
     backend_key = argy["backend"]
     build_backend = f2py_build_generator(backend_key)

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -1,6 +1,7 @@
 import textwrap, re, sys, subprocess, shlex
 from pathlib import Path
 from collections import namedtuple
+import platform
 
 import pytest
 
@@ -195,6 +196,20 @@ def test_gen_pyf_no_overwrite(capfd, hello_world_f90, monkeypatch):
             f2pycli()  # Refuse to overwrite
             _, err = capfd.readouterr()
             assert "Use --overwrite-signature to overwrite" in err
+
+
+@pytest.mark.skipif((platform.system() != 'Linux') and (sys.version_info <= (3, 12)), reason='Compiler and 3.12 required')
+def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
+    """Check that modules are named correctly
+
+    CLI :: defaults
+    """
+    ipath = Path(hello_world_f90)
+    monkeypatch.setattr(sys, "argv", f"f2py --backend meson -c {ipath}".split())
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        out, _ = capfd.readouterr()
+        assert "untitledmodule.c" in out
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
Sorry, this should have been part of #25181. Currently `f2py -c` will try to create `Nonemodule` instead of `untitledmodule`.

cc @mattip 