### PR TITLE
TYP: add None to ``__getitem__`` in ``numpy.array_api``

### DIFF
--- a/numpy/array_api/_array_object.py
+++ b/numpy/array_api/_array_object.py
@@ -543,7 +543,11 @@ class Array:
     def __getitem__(
         self: Array,
         key: Union[
-            int, slice, ellipsis, Tuple[Union[int, slice, ellipsis], ...], Array
+            int,
+            slice,
+            ellipsis,
+            Tuple[Union[int, slice, ellipsis, None], ...],
+            Array,
         ],
         /,
     ) -> Array:


### PR DESCRIPTION
Backport of #25022.

Add None to the getitem type hints. 

The array_api site doesn't mention it in the getitem page until the draft version however:
https://data-apis.org/array-api/draft/API_specification/generated/array_api.array.__getitem__.html

But it is mentioned in the 2021.12 version in the indexing page:

> Each None in the selection tuple must expand the dimensions of the resulting selection by one dimension of size 1. The position of the added dimension must be the same as the position of None in the selection tuple.
https://data-apis.org/array-api/2021.12/API_specification/indexing.html

Which of these pages takes priority?

- [x] Closes #24982
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
