### PR TITLE
BUG: Fix single to half-precision conversion on PPC64/VSX3

### DIFF
--- a/numpy/_core/src/common/half.hpp
+++ b/numpy/_core/src/common/half.hpp
@@ -59,7 +59,11 @@ class Half final {
         __vector float vf32 = vec_splats(f);
         __vector unsigned short vf16;
         __asm__ __volatile__ ("xvcvsphp %x0,%x1" : "=wa" (vf16) : "wa" (vf32));
+        #ifdef __BIG_ENDIAN__
+        bits_ = vec_extract(vf16, 1);
+        #else
         bits_ = vec_extract(vf16, 0);
+        #endif
     #else
         bits_ = half_private::FromFloatBits(BitCast<uint32_t>(f));
     #endif


### PR DESCRIPTION
  This fix respects the lane order with regards to big/little-endians.

closes #25178 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
