### PR TITLE
TST: Explicitly pass NumPy path to cython during tests (also speed them up)

### DIFF
--- a/numpy/core/tests/examples/cython/meson.build
+++ b/numpy/core/tests/examples/cython/meson.build
@@ -14,6 +14,15 @@ npy_include_path = run_command(py, [
     'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
     ], check: true).stdout().strip()
 
+npy_path = run_command(py, [
+    '-c',
+    'import os; os.chdir(".."); import numpy; print(os.path.dirname(numpy.__file__).removesuffix("numpy"))'
+    ], check: true).stdout().strip()
+
+# TODO: This is a hack due to gh-25135, where cython may not find the right
+#       __init__.pyd file.
+add_project_arguments('-I', npy_path, language : 'cython')
+
 py.extension_module(
     'checks',
     'checks.pyx',

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -28,14 +28,14 @@ else:
 pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
 
 
-@pytest.fixture
-def install_temp(tmp_path):
+@pytest.fixture(scope='module')
+def install_temp(tmpdir_factory):
     # Based in part on test_cython from random.tests.test_extending
     if IS_WASM:
         pytest.skip("No subprocess")
 
     srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'cython')
-    build_dir = tmp_path / "build"
+    build_dir = tmpdir_factory.mktemp("cython_test") / "build"
     os.makedirs(build_dir, exist_ok=True)
     try:
         subprocess.check_call(["meson", "--version"])


### PR DESCRIPTION
Backport of #25141.

This mainly injects the -I into the cython build in meson by fetching the actual numpy directory during the build to paper over gh-25135.

It clearly isn't a fix, since it is probably a Cython issue (or maybe an issue with the meson in-place build setup).

I also modified the building fixture to only run once, the tests are ridiculously slow otherwise (there were much fewer tests not long ago).



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
