### PR TITLE
BUG: Don't try to grab callback modules

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -943,5 +943,5 @@ def getuseblocks(pymod):
     for inner in pymod['body']:
         for modblock in inner['body']:
             if modblock.get('use'):
-                all_uses.extend([x for x in modblock.get('use').keys()])
+                all_uses.extend([x for x in modblock.get("use").keys() if "__" not in x])
     return all_uses

--- a/numpy/f2py/tests/src/callback/gh25211.f
+++ b/numpy/f2py/tests/src/callback/gh25211.f
@@ -1,0 +1,10 @@
+      SUBROUTINE FOO(FUN,R)
+      EXTERNAL FUN
+      INTEGER I
+      REAL*8 R, FUN
+Cf2py intent(out) r
+      R = 0D0
+      DO I=-5,5
+         R = R + FUN(I)
+      ENDDO
+      END

--- a/numpy/f2py/tests/src/callback/gh25211.pyf
+++ b/numpy/f2py/tests/src/callback/gh25211.pyf
@@ -1,0 +1,18 @@
+python module __user__routines
+    interface
+        function fun(i) result (r)
+            integer :: i
+            real*8 :: r
+        end function fun
+    end interface
+end python module __user__routines
+
+python module callback2
+    interface
+        subroutine foo(f,r)
+            use __user__routines, f=>fun
+            external f
+            real*8 intent(out) :: r
+        end subroutine foo
+    end interface
+end python module callback2

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -228,3 +228,16 @@ class TestGH18335(util.F2PyTest):
 
         r = self.module.gh18335(foo)
         assert r == 123 + 1
+
+
+class TestGH25211(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "callback", "gh25211.f"),
+               util.getpath("tests", "src", "callback", "gh25211.pyf")]
+    module_name = "callback2"
+
+    def test_gh18335(self):
+        def bar(x):
+            return x*x
+
+        res = self.module.foo(bar)
+        assert res == 110


### PR DESCRIPTION
Closes gh-25211. Snuck in over at https://github.com/numpy/numpy/pull/25186.

Forgot that `f2py` has `__user__` as a "use" directive for callbacks.. 

- [X] Test SciPy locally. 
- [x] Add a test.

Thanks @tylerjereddy for the easy to track defect ^_^