### PR TITLE
BUG: Fix moving compiled executable to root with f2py -c on Windows

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ._backend import Backend
 from string import Template
+from itertools import chain
 
 import warnings
 
@@ -83,7 +84,10 @@ class MesonBackend(Backend):
 
     def _move_exec_to_root(self, build_dir: Path):
         walk_dir = Path(build_dir) / self.meson_build_dir
-        path_objects = walk_dir.glob(f"{self.modulename}*.so")
+        path_objects = chain(
+            walk_dir.glob(f"{self.modulename}*.so"),
+            walk_dir.glob(f"{self.modulename}*.pyd"),
+        )
         for path_object in path_objects:
             shutil.move(path_object, Path.cwd())
 


### PR DESCRIPTION
Backport of #25160.

This is a follow up to #25000 (bug report) and #25073 (PR) which fixed f2py compilation under Windows using `f2py -c` by declaring `quadmath` as dependency and referring to compatible Windows toolchains in the documentation.

The f2py compile still does not work as expected under Windows as the compiled binary is not moved to the root directory after compile. This PR fixes that by searching for `*.pyd` files in addition to `*.so` files in the build directory.


*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
