### PR TITLE
TST: f2py: fix issue in test skip condition

### DIFF
--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -198,7 +198,8 @@ def test_gen_pyf_no_overwrite(capfd, hello_world_f90, monkeypatch):
             assert "Use --overwrite-signature to overwrite" in err
 
 
-@pytest.mark.skipif((platform.system() != 'Linux') and (sys.version_info <= (3, 12)), reason='Compiler and 3.12 required')
+@pytest.mark.skipif((platform.system() != 'Linux') or (sys.version_info <= (3, 12)),
+                    reason='Compiler and 3.12 required')
 def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
     """Check that modules are named correctly
 


### PR DESCRIPTION
This test was failing in the 32-bit wheel build job, the AND condition should be an OR one - test is Linux-only.

This is a follow-up to gh-25185. That PR was already backported, so this one should be backported as well.