### PR TITLE
DOC: Fix wrong return type for PyArray_CastScalarToCType

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2724,7 +2724,7 @@ Array scalars
     is copied into the memory of *ctypeptr*, for all other types, the
     actual data is copied into the address pointed to by *ctypeptr*.
 
-.. c:function:: void PyArray_CastScalarToCtype( \
+.. c:function:: int PyArray_CastScalarToCtype( \
         PyObject* scalar, void* ctypeptr, PyArray_Descr* outcode)
 
     Return the data (cast to the data type indicated by *outcode*)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2732,6 +2732,8 @@ Array scalars
     *ctypeptr* (which must be large enough to handle the incoming
     memory).
 
+    Returns -1 on failure, and 0 on success.
+
 .. c:function:: PyObject* PyArray_TypeObjectFromType(int type)
 
     Returns a scalar type-object from a type-number, *type*


### PR DESCRIPTION
I was debugging some code I had in pandas, and it turned out that I assigned the return from this to an integer.

I'd thought this couldn't happen since the return type was documented as void (and I should get a compile error), but it turns out that this is actually supposed to return an int, so I ended up spending an hour debugging this lol 😭

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
