### PR TITLE
BUG: Handle ``iso_c_type`` mappings more consistently

### DIFF
--- a/numpy/f2py/_isocbind.py
+++ b/numpy/f2py/_isocbind.py
@@ -51,6 +51,70 @@ iso_c_binding_map = {
     }
 }
 
+isoc_c2pycode_map = {
+    'int': 'i',  # int
+    'short int': 'h',  # short int
+    'long': 'l',  # long int
+    'long long': 'q',  # long long int
+    'signed char': 'b',  # signed char
+    'size_t': 'I',  # size_t (approx unsigned int)
+    'int8_t': 'b',  # int8_t
+    'int16_t': 'h',  # int16_t
+    'int32_t': 'i',  # int32_t
+    'int64_t': 'q',  # int64_t
+    'int_least8_t': 'b',  # int_least8_t
+    'int_least16_t': 'h',  # int_least16_t
+    'int_least32_t': 'i',  # int_least32_t
+    'int_least64_t': 'q',  # int_least64_t
+    'int_fast8_t': 'b',  # int_fast8_t
+    'int_fast16_t': 'h',  # int_fast16_t
+    'int_fast32_t': 'i',  # int_fast32_t
+    'int_fast64_t': 'q',  # int_fast64_t
+    'intmax_t': 'q',  # intmax_t (approx long long)
+    'intptr_t': 'q',  # intptr_t (approx long long)
+    'ptrdiff_t': 'q',  # intptr_t (approx long long)
+    'float': 'f',  # float
+    'double': 'd',  # double
+    'long double': 'g',  # long double
+    'float _Complex': 'F',  # float  _Complex
+    'double _Complex': 'D',  # double  _Complex
+    'long double _Complex': 'G',  # long double  _Complex
+    '_Bool': '?',  #  Bool
+    'char': 'c',   # char
+}
+
+iso_c2py_map = {
+    'int': 'int',
+    'short int': 'int',                 # forced casting
+    'long': 'int',
+    'long long': 'long',
+    'signed char': 'int',           # forced casting
+    'size_t': 'int',                # approx Python int
+    'int8_t': 'int',                # forced casting
+    'int16_t': 'int',               # forced casting
+    'int32_t': 'int',
+    'int64_t': 'long',
+    'int_least8_t': 'int',          # forced casting
+    'int_least16_t': 'int',         # forced casting
+    'int_least32_t': 'int',
+    'int_least64_t': 'long',
+    'int_fast8_t': 'int',           # forced casting
+    'int_fast16_t': 'int',          # forced casting
+    'int_fast32_t': 'int',
+    'int_fast64_t': 'long',
+    'intmax_t': 'long',
+    'intptr_t': 'long',
+    'ptrdiff_t': 'long',
+    'float': 'float',
+    'double': 'float',              # forced casting
+    'long double': 'float',         # forced casting
+    'float _Complex': 'complex',     # forced casting
+    'double _Complex': 'complex',
+    'long double _Complex': 'complex', # forced casting
+    '_Bool': 'bool',
+    'char': 'bytes',                  # approx Python bytes
+}
+
 isoc_kindmap = {}
 for fortran_type, c_type_dict in iso_c_binding_map.items():
     for c_type in c_type_dict.keys():

--- a/numpy/f2py/_isocbind.py
+++ b/numpy/f2py/_isocbind.py
@@ -9,116 +9,52 @@ terms of the NumPy License.
 
 NO WARRANTY IS EXPRESSED OR IMPLIED.  USE AT YOUR OWN RISK.
 """
+# These map to keys in c2py_map, via forced casting for now, see gh-25229
 iso_c_binding_map = {
     'integer': {
         'c_int': 'int',
-        'c_short': 'short int',
-        'c_long': 'long int',
-        'c_long_long': 'long long int',
-        'c_signed_char': 'signed char',
-        'c_size_t': 'size_t',
-        'c_int8_t': 'int8_t',
-        'c_int16_t': 'int16_t',
-        'c_int32_t': 'int32_t',
-        'c_int64_t': 'int64_t',
-        'c_int_least8_t': 'int_least8_t',
-        'c_int_least16_t': 'int_least16_t',
-        'c_int_least32_t': 'int_least32_t',
-        'c_int_least64_t': 'int_least64_t',
-        'c_int_fast8_t': 'int_fast8_t',
-        'c_int_fast16_t': 'int_fast16_t',
-        'c_int_fast32_t': 'int_fast32_t',
-        'c_int_fast64_t': 'int_fast64_t',
-        'c_intmax_t': 'intmax_t',
-        'c_intptr_t': 'intptr_t',
-        'c_ptrdiff_t': 'intptr_t',
+        'c_short': 'short',  # 'short' <=> 'int' for now
+        'c_long': 'long',  # 'long' <=> 'int' for now
+        'c_long_long': 'long_long',
+        'c_signed_char': 'signed_char',
+        'c_size_t': 'unsigned',  # size_t <=> 'unsigned' for now
+        'c_int8_t': 'signed_char',  # int8_t <=> 'signed_char' for now
+        'c_int16_t': 'short',  # int16_t <=> 'short' for now
+        'c_int32_t': 'int',  # int32_t <=> 'int' for now
+        'c_int64_t': 'long_long',
+        'c_int_least8_t': 'signed_char',  # int_least8_t <=> 'signed_char' for now
+        'c_int_least16_t': 'short',  # int_least16_t <=> 'short' for now
+        'c_int_least32_t': 'int',  # int_least32_t <=> 'int' for now
+        'c_int_least64_t': 'long_long',
+        'c_int_fast8_t': 'signed_char',  # int_fast8_t <=> 'signed_char' for now
+        'c_int_fast16_t': 'short',  # int_fast16_t <=> 'short' for now
+        'c_int_fast32_t': 'int',  # int_fast32_t <=> 'int' for now
+        'c_int_fast64_t': 'long_long',
+        'c_intmax_t': 'long_long',  # intmax_t <=> 'long_long' for now
+        'c_intptr_t': 'long',  # intptr_t <=> 'long' for now
+        'c_ptrdiff_t': 'long',  # ptrdiff_t <=> 'long' for now
     },
     'real': {
         'c_float': 'float',
         'c_double': 'double',
-        'c_long_double': 'long double'
+        'c_long_double': 'long_double'
     },
     'complex': {
-        'c_float_complex': 'float _Complex',
-        'c_double_complex': 'double _Complex',
-        'c_long_double_complex': 'long double _Complex'
+        'c_float_complex': 'complex_float',
+        'c_double_complex': 'complex_double',
+        'c_long_double_complex': 'complex_long_double'
     },
     'logical': {
-        'c_bool': '_Bool'
+        'c_bool': 'unsigned_char'  # _Bool <=> 'unsigned_char' for now
     },
     'character': {
         'c_char': 'char'
     }
 }
 
-isoc_c2pycode_map = {
-    'int': 'i',  # int
-    'short int': 'h',  # short int
-    'long': 'l',  # long int
-    'long long': 'q',  # long long int
-    'signed char': 'b',  # signed char
-    'size_t': 'I',  # size_t (approx unsigned int)
-    'int8_t': 'b',  # int8_t
-    'int16_t': 'h',  # int16_t
-    'int32_t': 'i',  # int32_t
-    'int64_t': 'q',  # int64_t
-    'int_least8_t': 'b',  # int_least8_t
-    'int_least16_t': 'h',  # int_least16_t
-    'int_least32_t': 'i',  # int_least32_t
-    'int_least64_t': 'q',  # int_least64_t
-    'int_fast8_t': 'b',  # int_fast8_t
-    'int_fast16_t': 'h',  # int_fast16_t
-    'int_fast32_t': 'i',  # int_fast32_t
-    'int_fast64_t': 'q',  # int_fast64_t
-    'intmax_t': 'q',  # intmax_t (approx long long)
-    'intptr_t': 'q',  # intptr_t (approx long long)
-    'ptrdiff_t': 'q',  # intptr_t (approx long long)
-    'float': 'f',  # float
-    'double': 'd',  # double
-    'long double': 'g',  # long double
-    'float _Complex': 'F',  # float  _Complex
-    'double _Complex': 'D',  # double  _Complex
-    'long double _Complex': 'D',  # very approximate complex
-    '_Bool': 'i',  #  Bool but not really
-    'char': 'c',   # char
-}
-
-# TODO: At some point these should be included, but then they'd need special
-# handling in cfuncs.py e.g. needs[int64_t_from_pyobj] These are not very hard
-# to add, since they all derive from the base `int_from_pyobj`, e.g. the way
-# `short_from_pyobj` and others do
+# TODO: See gh-25229
+isoc_c2pycode_map = {}
 iso_c2py_map = {}
-# iso_c2py_map = {
-#     'int': 'int',
-#     'short int': 'int',                 # forced casting
-#     'long': 'int',
-#     'long long': 'long',
-#     'signed char': 'int',           # forced casting
-#     'size_t': 'int',                # approx Python int
-#     'int8_t': 'int',                # forced casting
-#     'int16_t': 'int',               # forced casting
-#     'int32_t': 'int',
-#     'int64_t': 'long',
-#     'int_least8_t': 'int',          # forced casting
-#     'int_least16_t': 'int',         # forced casting
-#     'int_least32_t': 'int',
-#     'int_least64_t': 'long',
-#     'int_fast8_t': 'int',           # forced casting
-#     'int_fast16_t': 'int',          # forced casting
-#     'int_fast32_t': 'int',
-#     'int_fast64_t': 'long',
-#     'intmax_t': 'long',
-#     'intptr_t': 'long',
-#     'ptrdiff_t': 'long',
-#     'float': 'float',
-#     'double': 'float',              # forced casting
-#     'long double': 'float',         # forced casting
-#     'float _Complex': 'complex',     # forced casting
-#     'double _Complex': 'complex',
-#     'long double _Complex': 'complex', # forced casting
-#     '_Bool': 'bool',
-#     'char': 'bytes',                  # approx Python bytes
-# }
 
 isoc_kindmap = {}
 for fortran_type, c_type_dict in iso_c_binding_map.items():

--- a/numpy/f2py/_isocbind.py
+++ b/numpy/f2py/_isocbind.py
@@ -83,37 +83,42 @@ isoc_c2pycode_map = {
     'char': 'c',   # char
 }
 
-iso_c2py_map = {
-    'int': 'int',
-    'short int': 'int',                 # forced casting
-    'long': 'int',
-    'long long': 'long',
-    'signed char': 'int',           # forced casting
-    'size_t': 'int',                # approx Python int
-    'int8_t': 'int',                # forced casting
-    'int16_t': 'int',               # forced casting
-    'int32_t': 'int',
-    'int64_t': 'long',
-    'int_least8_t': 'int',          # forced casting
-    'int_least16_t': 'int',         # forced casting
-    'int_least32_t': 'int',
-    'int_least64_t': 'long',
-    'int_fast8_t': 'int',           # forced casting
-    'int_fast16_t': 'int',          # forced casting
-    'int_fast32_t': 'int',
-    'int_fast64_t': 'long',
-    'intmax_t': 'long',
-    'intptr_t': 'long',
-    'ptrdiff_t': 'long',
-    'float': 'float',
-    'double': 'float',              # forced casting
-    'long double': 'float',         # forced casting
-    'float _Complex': 'complex',     # forced casting
-    'double _Complex': 'complex',
-    'long double _Complex': 'complex', # forced casting
-    '_Bool': 'bool',
-    'char': 'bytes',                  # approx Python bytes
-}
+# TODO: At some point these should be included, but then they'd need special
+# handling in cfuncs.py e.g. needs[int64_t_from_pyobj] These are not very hard
+# to add, since they all derive from the base `int_from_pyobj`, e.g. the way
+# `short_from_pyobj` and others do
+iso_c2py_map = {}
+# iso_c2py_map = {
+#     'int': 'int',
+#     'short int': 'int',                 # forced casting
+#     'long': 'int',
+#     'long long': 'long',
+#     'signed char': 'int',           # forced casting
+#     'size_t': 'int',                # approx Python int
+#     'int8_t': 'int',                # forced casting
+#     'int16_t': 'int',               # forced casting
+#     'int32_t': 'int',
+#     'int64_t': 'long',
+#     'int_least8_t': 'int',          # forced casting
+#     'int_least16_t': 'int',         # forced casting
+#     'int_least32_t': 'int',
+#     'int_least64_t': 'long',
+#     'int_fast8_t': 'int',           # forced casting
+#     'int_fast16_t': 'int',          # forced casting
+#     'int_fast32_t': 'int',
+#     'int_fast64_t': 'long',
+#     'intmax_t': 'long',
+#     'intptr_t': 'long',
+#     'ptrdiff_t': 'long',
+#     'float': 'float',
+#     'double': 'float',              # forced casting
+#     'long double': 'float',         # forced casting
+#     'float _Complex': 'complex',     # forced casting
+#     'double _Complex': 'complex',
+#     'long double _Complex': 'complex', # forced casting
+#     '_Bool': 'bool',
+#     'char': 'bytes',                  # approx Python bytes
+# }
 
 isoc_kindmap = {}
 for fortran_type, c_type_dict in iso_c_binding_map.items():

--- a/numpy/f2py/_isocbind.py
+++ b/numpy/f2py/_isocbind.py
@@ -78,8 +78,8 @@ isoc_c2pycode_map = {
     'long double': 'g',  # long double
     'float _Complex': 'F',  # float  _Complex
     'double _Complex': 'D',  # double  _Complex
-    'long double _Complex': 'G',  # long double  _Complex
-    '_Bool': '?',  #  Bool
+    'long double _Complex': 'D',  # very approximate complex
+    '_Bool': 'i',  #  Bool but not really
     'char': 'c',   # char
 }
 

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -44,7 +44,7 @@ __all__ = [
     'isunsigned_long_longarray', 'isunsigned_short',
     'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess',
     'replace', 'show', 'stripcomma', 'throw_error', 'isattr_value',
-    'deep_merge', 'getuseblocks', 'process_f2cmap_dict'
+    'getuseblocks', 'process_f2cmap_dict'
 ]
 
 
@@ -892,28 +892,6 @@ def applyrules(rules, d, var={}):
             if ret[k] == []:
                 del ret[k]
     return ret
-
-def deep_merge(dict1, dict2):
-    """Recursively merge two dictionaries into a new dictionary.
-
-    Parameters:
-    - dict1: The base dictionary.
-    - dict2: The dictionary to merge into a copy of dict1.
-             If a key exists in both, the dict2 value will take precedence.
-
-    Returns:
-    - A new merged dictionary.
-    """
-    merged_dict = deepcopy(dict1)
-    for key, value in dict2.items():
-        if key in merged_dict:
-            if isinstance(merged_dict[key], dict) and isinstance(value, dict):
-                merged_dict[key] = deep_merge(merged_dict[key], value)
-            else:
-                merged_dict[key] = value
-        else:
-            merged_dict[key] = value
-    return merged_dict
 
 _f2py_module_name_match = re.compile(r'\s*python\s*module\s*(?P<name>[\w_]+)',
                                      re.I).match

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -918,7 +918,7 @@ def getuseblocks(pymod):
                 all_uses.extend([x for x in modblock.get("use").keys() if "__" not in x])
     return all_uses
 
-def process_f2cmap_dict(f2cmap_all, new_map, c2py_map):
+def process_f2cmap_dict(f2cmap_all, new_map, c2py_map, verbose = False):
     """
     Update the Fortran-to-C type mapping dictionary with new mappings and
     return a list of successfully mapped C types.
@@ -947,6 +947,9 @@ def process_f2cmap_dict(f2cmap_all, new_map, c2py_map):
         types to corresponding Python types and is used to ensure that the C
         types specified in `new_map` are valid.
 
+    verbose : boolean
+        A flag used to provide information about the types mapped
+
     Returns
     -------
     tuple of (dict, list)
@@ -972,12 +975,14 @@ def process_f2cmap_dict(f2cmap_all, new_map, c2py_map):
                         % (k, k1, f2cmap_all[k][k1], v1)
                     )
                 f2cmap_all[k][k1] = v1
-                outmess('\tMapping "%s(kind=%s)" to "%s"\n' % (k, k1, v1))
+                if verbose:
+                    outmess('\tMapping "%s(kind=%s)" to "%s"\n' % (k, k1, v1))
                 f2cmap_mapped.append(v1)
             else:
-                errmess(
-                    "\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n"
-                    % (k, k1, v1, v1, list(c2py_map.keys()))
-                )
+                if verbose:
+                    errmess(
+                        "\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n"
+                        % (k, k1, v1, v1, list(c2py_map.keys()))
+                    )
 
     return f2cmap_all, f2cmap_mapped

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -920,7 +920,8 @@ def getuseblocks(pymod):
 
 def process_f2cmap_dict(f2cmap_all, new_map, c2py_map):
     """
-    Update the Fortran-to-C type mapping dictionary with new mappings.
+    Update the Fortran-to-C type mapping dictionary with new mappings and
+    return a list of successfully mapped C types.
 
     This function integrates a new mapping dictionary into an existing
     Fortran-to-C type mapping dictionary. It ensures that all keys are in
@@ -948,29 +949,35 @@ def process_f2cmap_dict(f2cmap_all, new_map, c2py_map):
 
     Returns
     -------
-    dict
-        The updated Fortran-to-C type mapping dictionary.
+    tuple of (dict, list)
+        The updated Fortran-to-C type mapping dictionary and a list of
+        successfully mapped C types.
     """
-    for k, d1 in new_map.items():
-        for k1 in list(d1.keys()):
-            d1[k1.lower()] = d1.pop(k1)
-        k_lower = k.lower()
+    f2cmap_mapped = []
 
-        if k_lower not in f2cmap_all:
-            f2cmap_all[k_lower] = {}
+    new_map_lower = {}
+    for k, d1 in new_map.items():
+        d1_lower = {k1.lower(): v1 for k1, v1 in d1.items()}
+        new_map_lower[k.lower()] = d1_lower
+
+    for k, d1 in new_map_lower.items():
+        if k not in f2cmap_all:
+            f2cmap_all[k] = {}
+
         for k1, v1 in d1.items():
             if v1 in c2py_map:
-                if k1 in f2cmap_all[k_lower]:
+                if k1 in f2cmap_all[k]:
                     outmess(
                         "\tWarning: redefinition of {'%s':{'%s':'%s'->'%s'}}\n"
-                        % (k_lower, k1, f2cmap_all[k_lower][k1], v1)
+                        % (k, k1, f2cmap_all[k][k1], v1)
                     )
-                f2cmap_all[k_lower][k1] = v1
-                outmess('\tMapping "%s(kind=%s)" to "%s"\n' % (k_lower, k1, v1))
+                f2cmap_all[k][k1] = v1
+                outmess('\tMapping "%s(kind=%s)" to "%s"\n' % (k, k1, v1))
+                f2cmap_mapped.append(v1)
             else:
                 errmess(
                     "\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n"
-                    % (k_lower, k1, v1, v1, list(c2py_map.keys()))
+                    % (k, k1, v1, v1, list(c2py_map.keys()))
                 )
 
-    return f2cmap_all
+    return f2cmap_all, f2cmap_mapped

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -155,7 +155,7 @@ def load_f2cmap_file(f2cmap_file):
         outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
         with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
-        f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map)
+        f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map, True)
         outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:
         errmess('Failed to apply user defined f2cmap changes: %s. Skipping.\n' % (msg))

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -14,7 +14,7 @@ import re
 import os
 from .crackfortran import markoutercomma
 from . import cb_rules
-from ._isocbind import iso_c_binding_map
+from ._isocbind import iso_c_binding_map, isoc_c2pycode_map, iso_c2py_map
 
 # The environment provided by auxfuncs.py is needed for some calls to eval.
 # As the needed functions cannot be determined by static inspection of the
@@ -126,13 +126,17 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
               'byte': {'': 'char'},
               }
 
-f2cmap_all = process_f2cmap_dict(f2cmap_all, iso_c_binding_map, c2py_map)
+# Add ISO_C handling
+c2pycode_map.update(isoc_c2pycode_map)
+c2py_map.update(iso_c2py_map)
+f2cmap_all, _ = process_f2cmap_dict(f2cmap_all, iso_c_binding_map, c2py_map)
+# End ISO_C handling
 f2cmap_default = copy.deepcopy(f2cmap_all)
 
 f2cmap_mapped = []
 
 def load_f2cmap_file(f2cmap_file):
-    global f2cmap_all
+    global f2cmap_all, f2cmap_mapped
 
     f2cmap_all = copy.deepcopy(f2cmap_default)
 
@@ -151,7 +155,7 @@ def load_f2cmap_file(f2cmap_file):
         outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
         with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
-        f2cmap_all = process_f2cmap_dict(f2cmap_all, d, c2py_map)
+        f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map)
         outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:
         errmess('Failed to apply user defined f2cmap changes: %s. Skipping.\n' % (msg))

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -24,7 +24,7 @@ from .auxfuncs import *
 __all__ = [
     'getctype', 'getstrlength', 'getarrdims', 'getpydocsign',
     'getarrdocsign', 'getinit', 'sign2map', 'routsign2map', 'modsign2map',
-    'cb_sign2map', 'cb_routsign2map', 'common_sign2map'
+    'cb_sign2map', 'cb_routsign2map', 'common_sign2map', 'process_f2cmap_dict'
 ]
 
 
@@ -126,7 +126,7 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
               'byte': {'': 'char'},
               }
 
-f2cmap_all = deep_merge(f2cmap_all, iso_c_binding_map)
+f2cmap_all = process_f2cmap_dict(f2cmap_all, iso_c_binding_map, c2py_map)
 f2cmap_default = copy.deepcopy(f2cmap_all)
 
 f2cmap_mapped = []
@@ -151,29 +151,11 @@ def load_f2cmap_file(f2cmap_file):
         outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
         with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
-        for k, d1 in d.items():
-            for k1 in d1.keys():
-                d1[k1.lower()] = d1[k1]
-            d[k.lower()] = d[k]
-        for k in d.keys():
-            if k not in f2cmap_all:
-                f2cmap_all[k] = {}
-            for k1 in d[k].keys():
-                if d[k][k1] in c2py_map:
-                    if k1 in f2cmap_all[k]:
-                        outmess(
-                            "\tWarning: redefinition of {'%s':{'%s':'%s'->'%s'}}\n" % (k, k1, f2cmap_all[k][k1], d[k][k1]))
-                    f2cmap_all[k][k1] = d[k][k1]
-                    outmess('\tMapping "%s(kind=%s)" to "%s"\n' %
-                            (k, k1, d[k][k1]))
-                    f2cmap_mapped.append(d[k][k1])
-                else:
-                    errmess("\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n" % (
-                        k, k1, d[k][k1], d[k][k1], list(c2py_map.keys())))
+        f2cmap_all = process_f2cmap_dict(f2cmap_all, d, c2py_map)
         outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:
-        errmess(
-            'Failed to apply user defined f2cmap changes: %s. Skipping.\n' % (msg))
+        errmess('Failed to apply user defined f2cmap changes: %s. Skipping.\n' % (msg))
+
 
 cformat_map = {'double': '%g',
                'float': '%g',

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -822,6 +822,8 @@ character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
 }
 """
 
+# TODO: These should be dynamically generated, too many mapped to int things,
+# see note in _isocbind.py
 needs['char_from_pyobj'] = ['int_from_pyobj']
 cfuncs['char_from_pyobj'] = """
 static int

--- a/numpy/f2py/tests/src/isocintrin/isoCtests.f90
+++ b/numpy/f2py/tests/src/isocintrin/isoCtests.f90
@@ -20,4 +20,15 @@
         integer(c_int64_t), intent(out) :: c
         c = a + b
       end subroutine c_add_int64
+      ! gh-25207
+      subroutine add_arr(A, B, C)
+         integer(c_int64_t), intent(in) :: A(3)
+         integer(c_int64_t), intent(in) :: B(3)
+         integer(c_int64_t), intent(out) :: C(3)
+         integer :: j
+
+         do j = 1, 3
+            C(j) = A(j)+B(j)
+         end do
+      end subroutine
   end module coddity

--- a/numpy/f2py/tests/src/isocintrin/isoCtests.f90
+++ b/numpy/f2py/tests/src/isocintrin/isoCtests.f90
@@ -1,5 +1,5 @@
   module coddity
-    use iso_c_binding, only: c_double, c_int
+    use iso_c_binding, only: c_double, c_int, c_int64_t
     implicit none
     contains
       subroutine c_add(a, b, c) bind(c, name="c_add")
@@ -14,4 +14,10 @@
 
           z = x + 7
       end function wat
+      ! gh-25207
+      subroutine c_add_int64(a, b, c) bind(c)
+        integer(c_int64_t), intent(in) :: a, b
+        integer(c_int64_t), intent(out) :: c
+        c = a + b
+      end subroutine c_add_int64
   end module coddity

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -29,14 +29,16 @@ class TestISOC(util.F2PyTest):
 
 def test_process_f2cmap_dict():
     from numpy.f2py.auxfuncs import process_f2cmap_dict
-    f2cmap_all = {'integer': {'8': 'long_long'}}
-    new_map = {'INTEGER': {'4': 'int'}}
-    c2py_map = {'int': 'int', 'long_long': 'long'}
 
-    expected_result = {'integer': {'8': 'long_long', '4': 'int'}}
+    f2cmap_all = {"integer": {"8": "rubbish_type"}}
+    new_map = {"INTEGER": {"4": "int"}}
+    c2py_map = {"int": "int", "rubbish_type": "long"}
+
+    exp_map, exp_maptyp = ({"integer": {"8": "rubbish_type", "4": "int"}}, ["int"])
 
     # Call the function
-    result = process_f2cmap_dict(f2cmap_all, new_map, c2py_map)
+    res_map, res_maptyp = process_f2cmap_dict(f2cmap_all, new_map, c2py_map)
 
     # Assert the result is as expected
-    assert result == expected_result
+    assert res_map == exp_map
+    assert res_maptyp == exp_maptyp

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -1,6 +1,7 @@
 from . import util
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 class TestISOC(util.F2PyTest):
     sources = [
@@ -25,6 +26,14 @@ class TestISOC(util.F2PyTest):
         out = self.module.coddity.c_add_int64(1, 20)
         exp_out = 21
         assert  out == exp_out
+
+    # gh-25207
+    def test_bindc_add_arr(self):
+        a = np.array([1,2,3])
+        b = np.array([1,2,3])
+        out = self.module.coddity.add_arr(a, b)
+        exp_out = a*2
+        assert_allclose(out, exp_out)
 
 
 def test_process_f2cmap_dict():

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -25,3 +25,18 @@ class TestISOC(util.F2PyTest):
         out = self.module.coddity.c_add_int64(1, 20)
         exp_out = 21
         assert  out == exp_out
+
+
+def test_process_f2cmap_dict():
+    from numpy.f2py.auxfuncs import process_f2cmap_dict
+    f2cmap_all = {'integer': {'8': 'long_long'}}
+    new_map = {'INTEGER': {'4': 'int'}}
+    c2py_map = {'int': 'int', 'long_long': 'long'}
+
+    expected_result = {'integer': {'8': 'long_long', '4': 'int'}}
+
+    # Call the function
+    result = process_f2cmap_dict(f2cmap_all, new_map, c2py_map)
+
+    # Assert the result is as expected
+    assert result == expected_result

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -19,3 +19,9 @@ class TestISOC(util.F2PyTest):
         out = self.module.coddity.wat(1, 20)
         exp_out = 8
         assert  out == exp_out
+
+    # gh-25207
+    def test_bindc_kinds(self):
+        out = self.module.coddity.c_add_int64(1, 20)
+        exp_out = 21
+        assert  out == exp_out


### PR DESCRIPTION
Closes #25207. This one could use a backport. Needs:
- [x] Scoping TODOs (can't rewrite the entire `cfuncs` here)
- [x] Tests
- [x] Check that SciPy builds

As discussed below, there were basically two deficiencies:
- Type maps were not propagated
- Fortran types (`iso_c_binding`) were mapped to ignored C types
  - This is the default behavior, but is silent and the maps are done to basic (lowest precision) corresponding types

This PR fixes (pragmatically) both these deficiences, for the first problem, the fix is a simple refactor and cleanup.

The second issue is a little trickier. For now, the pragmatic solution (as done by users anyway) is to map the `iso_c_binding` kinds to supported `f2py` types, i.e. to one of:

```python
c2py_map = {'double': 'float',
            'float': 'float',                          # forced casting
            'long_double': 'float',                    # forced casting
            'char': 'int',                             # forced casting
            'signed_char': 'int',                      # forced casting
            'unsigned_char': 'int',                    # forced casting
            'short': 'int',                            # forced casting
            'unsigned_short': 'int',                   # forced casting
            'int': 'int',                              # forced casting
            'long': 'int',
            'long_long': 'long',
            'unsigned': 'int',                         # forced casting
            'complex_float': 'complex',                # forced casting
            'complex_double': 'complex',
            'complex_long_double': 'complex',          # forced casting
            'string': 'string',
            'character': 'bytes',
            }
```

Pending a more complete overhaul of the generated bindings (tracked in #25229, which @Pranavchiku is also looking into) this is the optimal bugfix for #25207.