### PR TITLE
DOC: Improve description of ``axis`` parameter for ``np.median``

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3785,7 +3785,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         .. versionadded:: 1.9.0
 
         If a sequence of axes, the array is first flattened along the
-        given axes then the median is computed along the resulting
+        given axes, then the median is computed along the resulting
         flattened axis.
     out : ndarray, optional
         Alternative output array in which to place the result. It must
@@ -3833,13 +3833,13 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     array([[10,  7,  4],
            [ 3,  2,  1]])
     >>> np.median(a)
-    3.5
+    np.float64(3.5)
     >>> np.median(a, axis=0)
     array([6.5, 4.5, 2.5])
     >>> np.median(a, axis=1)
     array([7.,  2.])
-    >>> np.median(b, axis=(0,1), overwrite_input=True)
-    3.5
+    >>> np.median(a, axis=(0, 1))
+    np.float64(3.5)
     >>> m = np.median(a, axis=0)
     >>> out = np.zeros_like(m)
     >>> np.median(a, axis=0, out=m)
@@ -3852,7 +3852,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     >>> assert not np.all(a==b)
     >>> b = a.copy()
     >>> np.median(b, axis=None, overwrite_input=True)
-    3.5
+    np.float64(3.5)
     >>> assert not np.all(a==b)
 
     """

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3778,9 +3778,15 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     a : array_like
         Input array or object that can be converted to an array.
     axis : {int, sequence of int, None}, optional
-        Axis or axes along which the medians are computed. The default
-        is to compute the median along a flattened version of the array.
-        A sequence of axes is supported since version 1.9.0.
+        Axis or axes along which the medians are computed. The default,
+        axis=None, will compute the median along a flattened version of
+        the array.
+        
+        .. versionadded:: 1.9.0
+
+        If a sequence of axes, the array is first flattened along the
+        given axes then the median is computed along the resulting
+        flattened axis.
     out : ndarray, optional
         Alternative output array in which to place the result. It must
         have the same shape and buffer length as the expected output,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3838,6 +3838,8 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     array([6.5, 4.5, 2.5])
     >>> np.median(a, axis=1)
     array([7.,  2.])
+    >>> np.median(b, axis=(0,1), overwrite_input=True)
+    3.5
     >>> m = np.median(a, axis=0)
     >>> out = np.zeros_like(m)
     >>> np.median(a, axis=0, out=m)


### PR DESCRIPTION
This PR includes an updated docstring for `numpy.median` which clarifies the functionality of the extended axis feature, introduced in 1.9.0. 

Specifically, the description of the docstring is changed and an example is added. These help to clarify if a sequence of axes is passed, that the array is flattened along the given axes and _then_ the median is computed over the resulting flattened axis. Without this change, the functionality of passing multiple axes could be misunderstood as computing medians sequentially over the given axes (without flattening), see #25174.

Resolves #25174