### PR TITLE
Revert "MAINT: Pin scipy-openblas version."

### DIFF
--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -55,7 +55,7 @@ jobs:
         python -m venv test_env
         source test_env/bin/activate
 
-        pip install "scipy-openblas64<=0.3.23.293.2"
+        pip install scipy-openblas64
 
         pip install -r build_requirements.txt -r test_requirements.txt
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
-        python -m pip install "scipy-openblas32<=0.3.23.293.2"
+        python -m pip install scipy-openblas32
         spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
@@ -60,7 +60,7 @@ jobs:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        python -m pip install "scipy-openblas32<=0.3.23.293.2"
+        python -m pip install scipy-openblas32
         spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -24,20 +24,8 @@ steps:
   displayName: 'Install utilities'
 
 - powershell: |
-    $ErrorActionPreference = "Stop"
-    mkdir  C:/opt/openblas/openblas_dll
-    mkdir  C:/opt/32/lib/pkgconfig
-    mkdir  C:/opt/64/lib/pkgconfig
-    $target=$(python -c "import tools.openblas_support as obs; plat=obs.get_plat(); ilp64=obs.get_ilp64(); target=f'openblas_{plat}.zip'; obs.download_openblas(target, plat, ilp64);print(target)")
-    unzip -o -d c:/opt/ $target
-    echo "##vso[task.setvariable variable=PKG_CONFIG_PATH]c:/opt/64/lib/pkgconfig"
-    copy C:/opt/64/bin/*.dll C:/opt/openblas/openblas_dll
-  displayName: 'Download / Install OpenBLAS'
-
-- powershell: |
-    # Note: ensure the `pip install .` command remains the last one here, to
-    # avoid "green on failure" issues
-    python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
+    # Note: ensure the `pip install .` command remains the last one here,
+    # to avoid "green on failure" issues
     If ( Test-Path env:DISABLE_BLAS ) {
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
@@ -45,24 +33,16 @@ steps:
         python -m pip install scipy-openblas64 spin
         spin config-openblas --with-scipy-openblas=64
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
-        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"
-    } else {
+        # use-ilp64 is no longer needed with scipy-openblas > 0.3.24.95.0
+        # python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"
         python -m pip install . -v -Csetup-args="--vsenv"
+    } else {
+        python -m pip install scipy-openblas32 spin
+        spin config-openblas --with-scipy-openblas=32
+        $env:PKG_CONFIG_PATH="$pwd/.openblas"
+        python -m pip install . -v -Csetup-args="--vsenv" 
     }
   displayName: 'Build NumPy'
-
-- powershell: |
-    # copy from c:/opt/openblas/openblas_dll to numpy/../numpy.libs to ensure it can
-    # get loaded when numpy is imported (no RPATH on Windows)
-    $target = $(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")
-    mkdir $target/numpy.libs
-    copy C:/opt/openblas/openblas_dll/*.dll $target/numpy.libs
-  displayName: 'Copy OpenBLAS DLL to site-packages'
-
-- script: |
-    python -m pip install threadpoolctl
-    python tools/openblas_support.py --check_version
-  displayName: 'Check OpenBLAS version'
 
 - powershell: |
     cd tools  # avoid root dir to not pick up source tree

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -42,7 +42,7 @@ steps:
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none" -Csetup-args="-Dallow-noblas=true"
     }
     elseif ( Test-Path env:NPY_USE_BLAS_ILP64 ) {
-        python -m pip install "scipy-openblas64<=0.3.23.293.2" spin
+        python -m pip install scipy-openblas64 spin
         spin config-openblas --with-scipy-openblas=64
         $env:PKG_CONFIG_PATH="$pwd/.openblas"
         python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Duse-ilp64=true"


### PR DESCRIPTION
This reverts commit fc324e360fd1eb0ab32a5ff30c0023029d70e6ea in order to reproduce
ci failures with unpinned openblas.

@mattip has made some fixes that allows tests to pass. 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
