### PR TITLE
TST: Fixture based tests for ``f2py``

### DIFF
--- a/numpy/f2py/tests/conftest.py
+++ b/numpy/f2py/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from . import util
+from numpy.testing import IS_WASM
 
 
 @pytest.fixture(scope="session")
@@ -11,6 +12,8 @@ def check_compilers():
     return checker
 
 
+@pytest.mark.slow
+@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.fixture(scope="module")
 def module_builder_factory(check_compilers):
     def build_module(spec):
@@ -32,3 +35,10 @@ def module_builder_factory(check_compilers):
             pytest.skip(f"Module build failed: {e}")
 
     return build_module
+
+
+# For generating modules from different specs
+@pytest.fixture(scope="module")
+def _mod(module_builder_factory, request):
+    spec = request.getfixturevalue(request.param)
+    return module_builder_factory(spec)

--- a/numpy/f2py/tests/conftest.py
+++ b/numpy/f2py/tests/conftest.py
@@ -25,5 +25,8 @@ def build_module(request, check_compilers):
     if needs_pyf and not (check_compilers.has_f90 or check_compilers.has_f77):
         pytest.skip("No Fortran compiler available")
 
-    test_instance.build_mod()
+    try:
+        test_instance.build_mod()
+    except:
+        pytest.skip("Module build failed")
     request.cls.module = test_instance.module

--- a/numpy/f2py/tests/conftest.py
+++ b/numpy/f2py/tests/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+from . import util
+
+
+@pytest.fixture(scope="session")
+def check_compilers():
+    checker = util.CompilerChecker()
+    checker.check_compilers()
+    if not checker.has_c:
+        pytest.skip("No C compiler available")
+    return checker
+
+@pytest.fixture(scope="class")
+def build_module(request, check_compilers):
+    test_instance = request.cls()
+    codes = test_instance.sources if test_instance.sources else []
+    needs_f77 = any(str(fn).endswith(".f") for fn in codes)
+    needs_f90 = any(str(fn).endswith(".f90") for fn in codes)
+    needs_pyf = any(str(fn).endswith(".pyf") for fn in codes)
+
+    if needs_f77 and not check_compilers.has_f77:
+        pytest.skip("No Fortran 77 compiler available")
+    if needs_f90 and not check_compilers.has_f90:
+        pytest.skip("No Fortran 90 compilers available")
+    if needs_pyf and not (check_compilers.has_f90 or check_compilers.has_f77):
+        pytest.skip("No Fortran compiler available")
+
+    test_instance.build_mod()
+    request.cls.module = test_instance.module

--- a/numpy/f2py/tests/conftest.py
+++ b/numpy/f2py/tests/conftest.py
@@ -12,8 +12,8 @@ def check_compilers():
 
 @pytest.fixture(scope="class")
 def build_module(request, check_compilers):
-    test_instance = request.cls()
-    codes = test_instance.sources if test_instance.sources else []
+    spec = request.cls.spec
+    codes = spec.sources if spec.sources else []
     needs_f77 = any(str(fn).endswith(".f") for fn in codes)
     needs_f90 = any(str(fn).endswith(".f90") for fn in codes)
     needs_pyf = any(str(fn).endswith(".pyf") for fn in codes)
@@ -26,7 +26,8 @@ def build_module(request, check_compilers):
         pytest.skip("No Fortran compiler available")
 
     try:
-        test_instance.build_mod()
+        request.cls.module = util.build_module_from_spec(spec)
     except:
         pytest.skip("Module build failed")
-    request.cls.module = test_instance.module
+
+    yield request.cls.module

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -9,9 +9,11 @@ from numpy.testing import IS_WASM
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
 @pytest.mark.usefixtures("build_module")
-class TestAbstractInterface(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "abstract_interface", "foo.f90")]
-    skip = ["add1", "add2"]
+class TestAbstractInterface:
+    spec = util.F2PyModuleSpec(
+        sources=[util.getpath("tests", "src", "abstract_interface", "foo.f90")],
+        skip=["add1", "add2"]
+    )
 
     def test_abstract_interface(self):
         assert self.module.ops_module.foo(3, 5) == (8, 13)

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -8,9 +8,9 @@ from numpy.testing import IS_WASM
 
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestAbstractInterface(util.F2PyTest):
     sources = [util.getpath("tests", "src", "abstract_interface", "foo.f90")]
-
     skip = ["add1", "add2"]
 
     def test_abstract_interface(self):

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -11,6 +11,7 @@ from numpy.testing import IS_WASM
 @pytest.mark.usefixtures("build_module")
 class TestAbstractInterface:
     spec = util.F2PyModuleSpec(
+        test_class_name="TestAbstractInterface",
         sources=[util.getpath("tests", "src", "abstract_interface", "foo.f90")],
         skip=["add1", "add2"]
     )

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -3,21 +3,19 @@ import pytest
 import textwrap
 from . import util
 from numpy.f2py import crackfortran
-from numpy.testing import IS_WASM
 
 
-@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
-@pytest.mark.slow
 @pytest.fixture(scope="module")
-def _mod(module_builder_factory):
+def abstract_interface_spec():
     spec = util.F2PyModuleSpec(
         test_class_name="TestAbstractInterface",
         sources=[util.getpath("tests", "src", "abstract_interface", "foo.f90")],
         skip=["add1", "add2"],
     )
-    return module_builder_factory(spec)
+    return spec
 
 
+@pytest.mark.parametrize("_mod", ["abstract_interface_spec"], indirect=True)
 def test_abstract_interface(_mod):
     assert _mod.ops_module.foo(3, 5) == (8, 13)
 

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -9,7 +9,7 @@ from numpy.testing import IS_WASM
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
 @pytest.mark.usefixtures("build_module")
-class TestAbstractInterface:
+class TestAbstractInterface(util.F2PyTest):
     spec = util.F2PyModuleSpec(
         test_class_name="TestAbstractInterface",
         sources=[util.getpath("tests", "src", "abstract_interface", "foo.f90")],

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -24,7 +24,7 @@ def get_testdir():
     testroot = Path(__file__).resolve().parent / "src"
     return  testroot / "array_from_pyobj"
 
-def setup_module():
+def setup_module(check_compilers):
     """
     Build the required testing extension module
 

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -6,54 +6,62 @@ from . import util
 
 
 @pytest.fixture(scope="function")
-def custom_f2cmap(request):
-    test_instance = request.instance
-    original_sources = test_instance.sources.copy()
-
-    f2cmap_src = original_sources.pop(-1)
-    f2cmap_file = tempfile.NamedTemporaryFile(delete=False)
-    with open(f2cmap_src, "rb") as f:
-        f2cmap_file.write(f.read())
-    f2cmap_file.close()
-
-    test_instance.sources = original_sources + [f2cmap_file.name]
-    test_instance.options = ["--f2cmap", f2cmap_file.name]
-
-    def cleanup_f2cmap_file():
-        os.unlink(f2cmap_file.name)
-
-    request.addfinalizer(cleanup_f2cmap_file)
-
-
-@pytest.mark.usefixtures("build_module")
-class TestAssumedShapeSumExample(util.F2PyTest):
-    spec = util.F2PyModuleSpec(
+def base_assumed_shape_spec():
+    return util.F2PyModuleSpec(
         test_class_name="TestAssumedShapeSumExample",
-        sources = [
+        sources=[
             util.getpath("tests", "src", "assumed_shape", "foo_free.f90"),
             util.getpath("tests", "src", "assumed_shape", "foo_use.f90"),
             util.getpath("tests", "src", "assumed_shape", "precision.f90"),
             util.getpath("tests", "src", "assumed_shape", "foo_mod.f90"),
             util.getpath("tests", "src", "assumed_shape", ".f2py_f2cmap"),
-        ]
+        ],
     )
 
-    @pytest.mark.slow
-    def test_all(self):
-        r = self.module.fsum([1, 2])
-        assert r == 3
-        r = self.module.sum([1, 2])
-        assert r == 3
-        r = self.module.sum_with_use([1, 2])
-        assert r == 3
 
-        r = self.module.mod.sum([1, 2])
-        assert r == 3
-        r = self.module.mod.fsum([1, 2])
-        assert r == 3
+@pytest.fixture(scope="function")
+def f2cmap_assumed_shape_spec(base_assumed_shape_spec):
+    original_sources = base_assumed_shape_spec.sources.copy()
+    f2cmap_src = original_sources.pop(-1)
+
+    f2cmap_file = tempfile.NamedTemporaryFile(delete=False)
+    with open(f2cmap_src, "rb") as f:
+        f2cmap_file.write(f.read())
+    f2cmap_file.close()
+
+    modified_spec = util.F2PyModuleSpec(
+        test_class_name="TestF2cmapOption",
+        sources=original_sources + [f2cmap_file.name],
+        options=["--f2cmap", f2cmap_file.name],
+    )
+
+    yield modified_spec
+
+    # Cleanup
+    os.unlink(f2cmap_file.name)
 
 
-class TestF2cmapOption(TestAssumedShapeSumExample):
-    @pytest.mark.usefixtures("custom_f2cmap")
-    def test_all(self):
-        super().test_all()
+@pytest.mark.slow
+@pytest.fixture(scope="function")
+def _mod(module_builder_factory, request):
+    spec = request.getfixturevalue(request.param)
+    return module_builder_factory(spec)
+
+
+@pytest.mark.parametrize(
+    "_mod",
+    ["base_assumed_shape_spec", "f2cmap_assumed_shape_spec"],
+    indirect=True,
+)
+def test_assumed_shape(_mod):
+    r = _mod.fsum([1, 2])
+    assert r == 3
+    r = _mod.sum([1, 2])
+    assert r == 3
+    r = _mod.sum_with_use([1, 2])
+    assert r == 3
+
+    r = _mod.mod.sum([1, 2])
+    assert r == 3
+    r = _mod.mod.fsum([1, 2])
+    assert r == 3

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -5,9 +5,9 @@ import tempfile
 from . import util
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def base_assumed_shape_spec():
-    return util.F2PyModuleSpec(
+    spec = util.F2PyModuleSpec(
         test_class_name="TestAssumedShapeSumExample",
         sources=[
             util.getpath("tests", "src", "assumed_shape", "foo_free.f90"),
@@ -17,9 +17,10 @@ def base_assumed_shape_spec():
             util.getpath("tests", "src", "assumed_shape", ".f2py_f2cmap"),
         ],
     )
+    return spec
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def f2cmap_assumed_shape_spec(base_assumed_shape_spec):
     original_sources = base_assumed_shape_spec.sources.copy()
     f2cmap_src = original_sources.pop(-1)
@@ -39,13 +40,6 @@ def f2cmap_assumed_shape_spec(base_assumed_shape_spec):
 
     # Cleanup
     os.unlink(f2cmap_file.name)
-
-
-@pytest.mark.slow
-@pytest.fixture(scope="function")
-def _mod(module_builder_factory, request):
-    spec = request.getfixturevalue(request.param)
-    return module_builder_factory(spec)
 
 
 @pytest.mark.parametrize(

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -27,13 +27,16 @@ def custom_f2cmap(request):
 
 @pytest.mark.usefixtures("build_module")
 class TestAssumedShapeSumExample(util.F2PyTest):
-    sources = [
-        util.getpath("tests", "src", "assumed_shape", "foo_free.f90"),
-        util.getpath("tests", "src", "assumed_shape", "foo_use.f90"),
-        util.getpath("tests", "src", "assumed_shape", "precision.f90"),
-        util.getpath("tests", "src", "assumed_shape", "foo_mod.f90"),
-        util.getpath("tests", "src", "assumed_shape", ".f2py_f2cmap"),
-    ]
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestAssumedShapeSumExample",
+        sources = [
+            util.getpath("tests", "src", "assumed_shape", "foo_free.f90"),
+            util.getpath("tests", "src", "assumed_shape", "foo_use.f90"),
+            util.getpath("tests", "src", "assumed_shape", "precision.f90"),
+            util.getpath("tests", "src", "assumed_shape", "foo_mod.f90"),
+            util.getpath("tests", "src", "assumed_shape", ".f2py_f2cmap"),
+        ]
+    )
 
     @pytest.mark.slow
     def test_all(self):

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -8,7 +8,10 @@ from numpy.testing import IS_PYPY
 @pytest.mark.slow
 @pytest.mark.usefixtures("build_module")
 class TestBlockDocString(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "block_docstring", "foo.f")]
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestBlockDocString",
+        sources=[util.getpath("tests", "src", "block_docstring", "foo.f")],
+    )
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="Fails with MinGW64 Gfortran (Issue #9673)")

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -14,9 +14,6 @@ def block_docstring_spec():
     return spec
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
-)
 @pytest.mark.xfail(IS_PYPY, reason="PyPy cannot modify tp_doc after PyType_Ready")
 @pytest.mark.parametrize(
     "_mod",

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -5,20 +5,24 @@ from . import util
 from numpy.testing import IS_PYPY, IS_WASM
 
 
-@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
-@pytest.mark.slow
 @pytest.fixture(scope="module")
-def _mod(module_builder_factory):
+def block_docstring_spec():
     spec = util.F2PyModuleSpec(
         test_class_name="TestBlockDocString",
         sources=[util.getpath("tests", "src", "block_docstring", "foo.f")],
     )
-    return module_builder_factory(spec)
+    return spec
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
-@pytest.mark.xfail(IS_PYPY,
-                   reason="PyPy cannot modify tp_doc after PyType_Ready")
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
+)
+@pytest.mark.xfail(IS_PYPY, reason="PyPy cannot modify tp_doc after PyType_Ready")
+@pytest.mark.parametrize(
+    "_mod",
+    ["block_docstring_spec"],
+    indirect=True,
+)
 def test_block_docstring(_mod):
     expected = "bar : 'i'-array(2,3)\n"
     assert _mod.block.__doc__ == expected

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -6,6 +6,7 @@ from numpy.testing import IS_PYPY
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestBlockDocString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "block_docstring", "foo.f")]
 

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -2,21 +2,23 @@ import sys
 import pytest
 from . import util
 
-from numpy.testing import IS_PYPY
+from numpy.testing import IS_PYPY, IS_WASM
 
 
+@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestBlockDocString(util.F2PyTest):
+@pytest.fixture(scope="module")
+def _mod(module_builder_factory):
     spec = util.F2PyModuleSpec(
         test_class_name="TestBlockDocString",
         sources=[util.getpath("tests", "src", "block_docstring", "foo.f")],
     )
+    return module_builder_factory(spec)
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="Fails with MinGW64 Gfortran (Issue #9673)")
-    @pytest.mark.xfail(IS_PYPY,
-                       reason="PyPy cannot modify tp_doc after PyType_Ready")
-    def test_block_docstring(self):
-        expected = "bar : 'i'-array(2,3)\n"
-        assert self.module.block.__doc__ == expected
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
+@pytest.mark.xfail(IS_PYPY,
+                   reason="PyPy cannot modify tp_doc after PyType_Ready")
+def test_block_docstring(_mod):
+    expected = "bar : 'i'-array(2,3)\n"
+    assert _mod.block.__doc__ == expected

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,234 +11,260 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestF77Callback(util.F2PyTest):
+@pytest.fixture(scope="module")
+def f77_callback_spec():
     spec = util.F2PyModuleSpec(
         test_class_name="TestF77Callback",
-        sources = [util.getpath("tests", "src", "callback", "foo.f")]
+        sources=[util.getpath("tests", "src", "callback", "foo.f")],
     )
-
-    @pytest.mark.parametrize("name", "t,t2".split(","))
-    @pytest.mark.slow
-    def test_all(self, name):
-        self.check_function(name)
-
-    @pytest.mark.xfail(IS_PYPY,
-                       reason="PyPy cannot modify tp_doc after PyType_Ready")
-    def test_docstring(self):
-        expected = textwrap.dedent("""\
-        a = t(fun,[fun_extra_args])
-
-        Wrapper for ``t``.
-
-        Parameters
-        ----------
-        fun : call-back function
-
-        Other Parameters
-        ----------------
-        fun_extra_args : input tuple, optional
-            Default: ()
-
-        Returns
-        -------
-        a : int
-
-        Notes
-        -----
-        Call-back functions::
-
-            def fun(): return a
-            Return objects:
-                a : int
-        """)
-        assert self.module.t.__doc__ == expected
-
-    def check_function(self, name):
-        t = getattr(self.module, name)
-        r = t(lambda: 4)
-        assert r == 4
-        r = t(lambda a: 5, fun_extra_args=(6, ))
-        assert r == 5
-        r = t(lambda a: a, fun_extra_args=(6, ))
-        assert r == 6
-        r = t(lambda a: 5 + a, fun_extra_args=(7, ))
-        assert r == 12
-        r = t(lambda a: math.degrees(a), fun_extra_args=(math.pi, ))
-        assert r == 180
-        r = t(math.degrees, fun_extra_args=(math.pi, ))
-        assert r == 180
-
-        r = t(self.module.func, fun_extra_args=(6, ))
-        assert r == 17
-        r = t(self.module.func0)
-        assert r == 11
-        r = t(self.module.func0._cpointer)
-        assert r == 11
-
-        class A:
-            def __call__(self):
-                return 7
-
-            def mth(self):
-                return 9
-
-        a = A()
-        r = t(a)
-        assert r == 7
-        r = t(a.mth)
-        assert r == 9
-
-    @pytest.mark.skipif(sys.platform == 'win32',
-                        reason='Fails with MinGW64 Gfortran (Issue #9673)')
-    def test_string_callback(self):
-        def callback(code):
-            if code == "r":
-                return 0
-            else:
-                return 1
-
-        f = getattr(self.module, "string_callback")
-        r = f(callback)
-        assert r == 0
-
-    @pytest.mark.skipif(sys.platform == 'win32',
-                        reason='Fails with MinGW64 Gfortran (Issue #9673)')
-    def test_string_callback_array(self):
-        # See gh-10027
-        cu1 = np.zeros((1, ), "S8")
-        cu2 = np.zeros((1, 8), "c")
-        cu3 = np.array([""], "S8")
-
-        def callback(cu, lencu):
-            if cu.shape != (lencu,):
-                return 1
-            if cu.dtype != "S8":
-                return 2
-            if not np.all(cu == b""):
-                return 3
-            return 0
-
-        f = getattr(self.module, "string_callback_array")
-        for cu in [cu1, cu2, cu3]:
-            res = f(callback, cu, cu.size)
-            assert res == 0
-
-    def test_threadsafety(self):
-        # Segfaults if the callback handling is not threadsafe
-
-        errors = []
-
-        def cb():
-            # Sleep here to make it more likely for another thread
-            # to call their callback at the same time.
-            time.sleep(1e-3)
-
-            # Check reentrancy
-            r = self.module.t(lambda: 123)
-            assert r == 123
-
-            return 42
-
-        def runner(name):
-            try:
-                for j in range(50):
-                    r = self.module.t(cb)
-                    assert r == 42
-                    self.check_function(name)
-            except Exception:
-                errors.append(traceback.format_exc())
-
-        threads = [
-            threading.Thread(target=runner, args=(arg, ))
-            for arg in ("t", "t2") for n in range(20)
-        ]
-
-        for t in threads:
-            t.start()
-
-        for t in threads:
-            t.join()
-
-        errors = "\n\n".join(errors)
-        if errors:
-            raise AssertionError(errors)
-
-    def test_hidden_callback(self):
-        try:
-            self.module.hidden_callback(2)
-        except Exception as msg:
-            assert str(msg).startswith("Callback global_f not defined")
-
-        try:
-            self.module.hidden_callback2(2)
-        except Exception as msg:
-            assert str(msg).startswith("cb: Callback global_f not defined")
-
-        self.module.global_f = lambda x: x + 1
-        r = self.module.hidden_callback(2)
-        assert r == 3
-
-        self.module.global_f = lambda x: x + 2
-        r = self.module.hidden_callback(2)
-        assert r == 4
-
-        del self.module.global_f
-        try:
-            self.module.hidden_callback(2)
-        except Exception as msg:
-            assert str(msg).startswith("Callback global_f not defined")
-
-        self.module.global_f = lambda x=0: x + 3
-        r = self.module.hidden_callback(2)
-        assert r == 5
-
-        # reproducer of gh18341
-        r = self.module.hidden_callback2(2)
-        assert r == 3
+    return spec
 
 
-@pytest.mark.usefixtures("build_module")
-class TestF90Callback(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "callback", "gh17797.f90")]
-
-    @pytest.mark.slow
-    def test_gh17797(self):
-        def incr(x):
-            return x + 123
-
-        y = np.array([1, 2, 3], dtype=np.int64)
-        r = self.module.gh17797(incr, y)
-        assert r == 123 + 1 + 2 + 3
+@pytest.fixture(scope="module")
+def f90_callback_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestF90Callback",
+        sources=[util.getpath("tests", "src", "callback", "gh17797.f90")],
+    )
+    return spec
 
 
-@pytest.mark.usefixtures("build_module")
-class TestGH18335(util.F2PyTest):
-    """The reproduction of the reported issue requires specific input that
-    extensions may break the issue conditions, so the reproducer is
-    implemented as a separate test class. Do not extend this test with
-    other tests!
+@pytest.fixture(scope="module")
+def gh18335_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestGH18335",
+        sources=[util.getpath("tests", "src", "callback", "gh18335.f90")],
+    )
+    return spec
+
+
+@pytest.fixture(scope="module")
+def gh25211_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestGH25211",
+        sources=[
+            util.getpath("tests", "src", "callback", "gh25211.f"),
+            util.getpath("tests", "src", "callback", "gh25211.pyf"),
+        ],
+        module_name="callback2",
+    )
+    return spec
+
+
+# TestF77Callback
+
+
+def check_function(mod, name):
+    t = getattr(mod, name)
+    r = t(lambda: 4)
+    assert r == 4
+    r = t(lambda a: 5, fun_extra_args=(6,))
+    assert r == 5
+    r = t(lambda a: a, fun_extra_args=(6,))
+    assert r == 6
+    r = t(lambda a: 5 + a, fun_extra_args=(7,))
+    assert r == 12
+    r = t(lambda a: math.degrees(a), fun_extra_args=(math.pi,))
+    assert r == 180
+    r = t(math.degrees, fun_extra_args=(math.pi,))
+    assert r == 180
+
+    r = t(mod.func, fun_extra_args=(6,))
+    assert r == 17
+    r = t(mod.func0)
+    assert r == 11
+    r = t(mod.func0._cpointer)
+    assert r == 11
+
+
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+@pytest.mark.parametrize("name", ["t", "t2"])
+def test_all(_mod, name):
+    check_function(_mod, name)
+
+
+@pytest.mark.xfail(IS_PYPY, reason="PyPy cannot modify tp_doc after PyType_Ready")
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+def test_docstring(_mod):
+    expected = textwrap.dedent(
+        """\
+    a = t(fun,[fun_extra_args])
+
+    Wrapper for ``t``.
+
+    Parameters
+    ----------
+    fun : call-back function
+
+    Other Parameters
+    ----------------
+    fun_extra_args : input tuple, optional
+        Default: ()
+
+    Returns
+    -------
+    a : int
+
+    Notes
+    -----
+    Call-back functions::
+
+        def fun(): return a
+        Return objects:
+            a : int
     """
-    sources = [util.getpath("tests", "src", "callback", "gh18335.f90")]
-
-    @pytest.mark.slow
-    def test_gh18335(self):
-        def foo(x):
-            x[0] += 1
-
-        r = self.module.gh18335(foo)
-        assert r == 123 + 1
+    )
+    assert _mod.t.__doc__ == expected
 
 
-@pytest.mark.usefixtures("build_module")
-class TestGH25211(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "callback", "gh25211.f"),
-               util.getpath("tests", "src", "callback", "gh25211.pyf")]
-    module_name = "callback2"
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
+)
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+def test_string_callback(_mod):
+    def callback(code):
+        if code == "r":
+            return 0
+        else:
+            return 1
 
-    def test_gh25211(self):
-        def bar(x):
-            return x*x
+    f = getattr(_mod, "string_callback")
+    r = f(callback)
+    assert r == 0
 
-        res = self.module.foo(bar)
-        assert res == 110
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
+)
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+def test_string_callback_array(_mod):
+    # See gh-10027
+    cu1 = np.zeros((1,), "S8")
+    cu2 = np.zeros((1, 8), "c")
+    cu3 = np.array([""], "S8")
+
+    def callback(cu, lencu):
+        if cu.shape != (lencu,):
+            return 1
+        if cu.dtype != "S8":
+            return 2
+        if not np.all(cu == b""):
+            return 3
+        return 0
+
+    f = getattr(_mod, "string_callback_array")
+    for cu in [cu1, cu2, cu3]:
+        res = f(callback, cu, cu.size)
+        assert res == 0
+
+
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+def test_threadsafety(_mod):
+    # Segfaults if the callback handling is not threadsafe
+
+    errors = []
+
+    def cb():
+        # Sleep here to make it more likely for another thread
+        # to call their callback at the same time.
+        time.sleep(1e-3)
+
+        # Check reentrancy
+        r = _mod.t(lambda: 123)
+        assert r == 123
+
+        return 42
+
+    def runner(name):
+        try:
+            for j in range(50):
+                r = _mod.t(cb)
+                assert r == 42
+                check_function(_mod, name)
+        except Exception:
+            errors.append(traceback.format_exc())
+
+    threads = [
+        threading.Thread(target=runner, args=(arg,))
+        for arg in ("t", "t2")
+        for n in range(20)
+    ]
+
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    errors = "\n\n".join(errors)
+    if errors:
+        raise AssertionError(errors)
+
+
+@pytest.mark.parametrize("_mod", ["f77_callback_spec"], indirect=True)
+def test_hidden_callback(_mod):
+    try:
+        _mod.hidden_callback(2)
+    except Exception as msg:
+        assert str(msg).startswith("Callback global_f not defined")
+
+    try:
+        _mod.hidden_callback2(2)
+    except Exception as msg:
+        assert str(msg).startswith("cb: Callback global_f not defined")
+
+    _mod.global_f = lambda x: x + 1
+    r = _mod.hidden_callback(2)
+    assert r == 3
+
+    _mod.global_f = lambda x: x + 2
+    r = _mod.hidden_callback(2)
+    assert r == 4
+
+    del _mod.global_f
+    try:
+        _mod.hidden_callback(2)
+    except Exception as msg:
+        assert str(msg).startswith("Callback global_f not defined")
+
+    _mod.global_f = lambda x=0: x + 3
+    r = _mod.hidden_callback(2)
+    assert r == 5
+
+    # reproducer of gh18341
+    r = _mod.hidden_callback2(2)
+    assert r == 3
+
+
+# TestF90Callback
+
+
+@pytest.mark.parametrize("_mod", ["f90_callback_spec"], indirect=True)
+def test_gh17797(_mod):
+    def incr(x):
+        return x + 123
+
+    y = np.array([1, 2, 3], dtype=np.int64)
+    r = _mod.gh17797(incr, y)
+    assert r == 123 + 1 + 2 + 3
+
+
+# TestGH18335
+
+
+@pytest.mark.parametrize("_mod", ["gh18335_spec"], indirect=True)
+def test_gh18335(_mod):
+    def foo(x):
+        x[0] += 1
+
+    r = _mod.gh18335(foo)
+    assert r == 123 + 1
+
+
+@pytest.mark.parametrize("_mod", ["gh25211_spec"], indirect=True)
+def test_gh25211(_mod):
+    def bar(x):
+        return x * x
+
+    res = _mod.foo(bar)
+    assert res == 110

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -121,9 +121,6 @@ def test_docstring(_mod):
     assert _mod.t.__doc__ == expected
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
-)
 @pytest.mark.parametrize("_mod", ["f77_callback_spec", "f77_tls_spec"], indirect=True)
 def test_string_callback(_mod):
     def callback(code):
@@ -137,9 +134,6 @@ def test_string_callback(_mod):
     assert r == 0
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Fails with MinGW64 Gfortran (Issue #9673)"
-)
 @pytest.mark.parametrize("_mod", ["f77_callback_spec", "f77_tls_spec"], indirect=True)
 def test_string_callback_array(_mod):
     # See gh-10027

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,6 +11,7 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 
@@ -194,15 +195,7 @@ class TestF77Callback(util.F2PyTest):
         assert r == 3
 
 
-class TestF77CallbackPythonTLS(TestF77Callback):
-    """
-    Callback tests using Python thread-local storage instead of
-    compiler-provided
-    """
-
-    options = ["-DF2PY_USE_PYTHON_TLS"]
-
-
+@pytest.mark.usefixtures("build_module")
 class TestF90Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "gh17797.f90")]
 
@@ -216,6 +209,7 @@ class TestF90Callback(util.F2PyTest):
         assert r == 123 + 1 + 2 + 3
 
 
+@pytest.mark.usefixtures("build_module")
 class TestGH18335(util.F2PyTest):
     """The reproduction of the reported issue requires specific input that
     extensions may break the issue conditions, so the reproducer is
@@ -233,6 +227,7 @@ class TestGH18335(util.F2PyTest):
         assert r == 123 + 1
 
 
+@pytest.mark.usefixtures("build_module")
 class TestGH25211(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "gh25211.f"),
                util.getpath("tests", "src", "callback", "gh25211.pyf")]

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -13,7 +13,10 @@ from . import util
 
 @pytest.mark.usefixtures("build_module")
 class TestF77Callback(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "callback", "foo.f")]
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestF77Callback",
+        sources = [util.getpath("tests", "src", "callback", "foo.f")]
+    )
 
     @pytest.mark.parametrize("name", "t,t2".split(","))
     @pytest.mark.slow

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -6,6 +6,7 @@ from numpy.f2py.tests import util
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestCharacterString(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/test-build-f2py']
     suffix = '.f90'
@@ -132,6 +133,7 @@ class TestCharacterString(util.F2PyTest):
         assert_array_equal(f(a), expected)
 
 
+@pytest.mark.usefixtures("build_module")
 class TestCharacter(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/test-build-f2py']
     suffix = '.f90'
@@ -430,6 +432,7 @@ class TestCharacter(util.F2PyTest):
         assert_equal(f(b'B'), b"B")
 
 
+@pytest.mark.usefixtures("build_module")
 class TestMiscCharacter(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/test-build-f2py']
     suffix = '.f90'
@@ -573,6 +576,7 @@ class TestMiscCharacter(util.F2PyTest):
         assert_raises(Exception, lambda: f(b'c'))
 
 
+@pytest.mark.usefixtures("build_module")
 class TestStringScalarArr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "scalar_string.f90")]
 
@@ -592,6 +596,7 @@ class TestStringScalarArr(util.F2PyTest):
             expected = '|S12'
             assert out.dtype == expected
 
+@pytest.mark.usefixtures("build_module")
 class TestStringAssumedLength(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "gh24008.f")]
 
@@ -599,6 +604,7 @@ class TestStringAssumedLength(util.F2PyTest):
         self.module.greet("joe", "bob")
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestStringOptionalInOut(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "gh24662.f90")]
 

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -85,7 +85,7 @@ def character_string_spec():
 
 @pytest.mark.parametrize("length", CHAR_STRING_LEN)
 @pytest.mark.parametrize("_mod", ["character_string_spec"], indirect=True)
-def test_input(_mod, length):
+def test_input_char_string(_mod, length):
     fsuffix = {"(*)": "star"}.get(length, length)
     f = getattr(_mod, "test_character_string" + "_input_" + fsuffix)
 
@@ -96,7 +96,7 @@ def test_input(_mod, length):
 
 @pytest.mark.parametrize("length", CHAR_STRING_LEN[:-1])
 @pytest.mark.parametrize("_mod", ["character_string_spec"], indirect=True)
-def test_output(_mod, length):
+def test_output_char_string(_mod, length):
     fsuffix = length
     f = getattr(_mod, "test_character_string" + "_output_" + fsuffix)
 
@@ -107,7 +107,7 @@ def test_output(_mod, length):
 
 @pytest.mark.parametrize("length", CHAR_STRING_LEN)
 @pytest.mark.parametrize("_mod", ["character_string_spec"], indirect=True)
-def test_array_input(_mod, length):
+def test_array_input_char_string(_mod, length):
     fsuffix = length
     f = getattr(_mod, "test_character_string" + "_array_input_" + fsuffix)
 
@@ -125,7 +125,7 @@ def test_array_input(_mod, length):
 
 @pytest.mark.parametrize("length", CHAR_STRING_LEN)
 @pytest.mark.parametrize("_mod", ["character_string_spec"], indirect=True)
-def test_array_output(_mod, length):
+def test_array_output_char_string(_mod, length):
     fsuffix = length
     f = getattr(_mod, "test_character_string" + "_array_output_" + fsuffix)
 
@@ -143,7 +143,7 @@ def test_array_output(_mod, length):
 
 @pytest.mark.parametrize("length", CHAR_STRING_LEN)
 @pytest.mark.parametrize("_mod", ["character_string_spec"], indirect=True)
-def test_2d_array_input(_mod, length):
+def test_2d_array_input_char_string(_mod, length):
     fsuffix = length
     f = getattr(_mod, "test_character_string" + "_2d_array_input_" + fsuffix)
 
@@ -282,7 +282,7 @@ def character_spec():
 
 @pytest.mark.parametrize("dtype", ["c", "S1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_input(_mod, dtype):
+def test_input_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_input")
 
     assert_equal(f(np.array("a", dtype=dtype)), ord("a"))
@@ -293,7 +293,7 @@ def test_input(_mod, dtype):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_input_varia(_mod):
+def test_input_varia_char(_mod):
     f = getattr(_mod, "test_character" + "_input")
 
     assert_equal(f("a"), ord("a"))
@@ -331,7 +331,7 @@ def test_input_varia(_mod):
 
 @pytest.mark.parametrize("dtype", ["c", "S1", "U1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_array_input(_mod, dtype):
+def test_array_input_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_array_input")
 
     assert_array_equal(
@@ -345,7 +345,7 @@ def test_array_input(_mod, dtype):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_array_input_varia(_mod):
+def test_array_input_varia_char(_mod):
     f = getattr(_mod, "test_character" + "_array_input")
     assert_array_equal(f(["a", "b", "c"]), np.array(list(map(ord, "abc")), dtype="i1"))
     assert_array_equal(
@@ -363,7 +363,7 @@ def test_array_input_varia(_mod):
 
 @pytest.mark.parametrize("dtype", ["c", "S1", "U1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_2d_array_input(_mod, dtype):
+def test_2d_array_input_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_2d_array_input")
 
     a = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=dtype, order="F")
@@ -372,7 +372,7 @@ def test_2d_array_input(_mod, dtype):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_output(_mod):
+def test_output_char(_mod):
     f = getattr(_mod, "test_character" + "_output")
 
     assert_equal(f(ord(b"a")), b"a")
@@ -380,14 +380,14 @@ def test_output(_mod):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_array_output(_mod):
+def test_array_output_char(_mod):
     f = getattr(_mod, "test_character" + "_array_output")
 
     assert_array_equal(f(list(map(ord, "abc"))), np.array(list("abc"), dtype="S1"))
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_input_output(_mod):
+def test_input_output_char(_mod):
     f = getattr(_mod, "test_character" + "_input_output")
 
     assert_equal(f(b"a"), b"a")
@@ -397,7 +397,7 @@ def test_input_output(_mod):
 
 @pytest.mark.parametrize("dtype", ["c", "S1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_inout(_mod, dtype):
+def test_inout_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_inout")
 
     a = np.array(list("abc"), dtype=dtype)
@@ -412,7 +412,7 @@ def test_inout(_mod, dtype):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_inout_varia(_mod):
+def test_inout_varia_char(_mod):
     f = getattr(_mod, "test_character" + "_inout")
     a = np.array("abc", dtype="S3")
     f(a, "A")
@@ -433,7 +433,7 @@ def test_inout_varia(_mod):
 
 @pytest.mark.parametrize("dtype", ["c", "S1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_array_inout(_mod, dtype):
+def test_array_inout_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_array_inout")
     n = np.array(["A", "B", "C"], dtype=dtype, order="F")
 
@@ -461,7 +461,7 @@ def test_array_inout(_mod, dtype):
 
 @pytest.mark.parametrize("dtype", ["c", "S1"])
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_2d_array_inout(_mod, dtype):
+def test_2d_array_inout_char(_mod, dtype):
     f = getattr(_mod, "test_character" + "_2d_array_inout")
     n = np.array([["A", "B", "C"], ["D", "E", "F"]], dtype=dtype, order="F")
     a = np.array([["a", "b", "c"], ["d", "e", "f"]], dtype=dtype, order="F")
@@ -470,7 +470,7 @@ def test_2d_array_inout(_mod, dtype):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_return(_mod):
+def test_return_char(_mod):
     f = getattr(_mod, "test_character" + "_return")
 
     assert_equal(f("a"), b"a")
@@ -478,7 +478,7 @@ def test_return(_mod):
 
 @pytest.mark.skip("fortran function returning array segfaults")
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_array_return(_mod):
+def test_array_return_char(_mod):
     f = getattr(_mod, "test_character" + "_array_return")
 
     a = np.array(list("abc"), dtype="S1")
@@ -486,7 +486,7 @@ def test_array_return(_mod):
 
 
 @pytest.mark.parametrize("_mod", ["character_spec"], indirect=True)
-def test_optional(_mod):
+def test_optional_char(_mod):
     f = getattr(_mod, "test_character" + "_optional")
 
     assert_equal(f(), b"a")

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -3,6 +3,7 @@ import numpy as np
 from . import util
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestCommonBlock(util.F2PyTest):
     sources = [util.getpath("tests", "src", "common", "block.f")]
 
@@ -13,6 +14,7 @@ class TestCommonBlock(util.F2PyTest):
         assert self.module.block.ok == np.array(3, dtype=np.int32)
 
 
+@pytest.mark.usefixtures("build_module")
 class TestCommonWithUse(util.F2PyTest):
     sources = [util.getpath("tests", "src", "common", "gh19161.f90")]
 

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -2,21 +2,30 @@ import pytest
 import numpy as np
 from . import util
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestCommonBlock(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "common", "block.f")]
+@pytest.fixture(scope="module")
+def common_block_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestCommonBlock",
+        sources = [util.getpath("tests", "src", "common", "block.f")]
+    )
+    return spec
 
-    def test_common_block(self):
-        self.module.initcb()
-        assert self.module.block.long_bn == np.array(1.0, dtype=np.float64)
-        assert self.module.block.string_bn == np.array("2", dtype="|S1")
-        assert self.module.block.ok == np.array(3, dtype=np.int32)
+@pytest.mark.parametrize("_mod", ["common_block_spec"], indirect=True)
+def test_common_block(_mod):
+    _mod.initcb()
+    assert _mod.block.long_bn == np.array(1.0, dtype=np.float64)
+    assert _mod.block.string_bn == np.array("2", dtype="|S1")
+    assert _mod.block.ok == np.array(3, dtype=np.int32)
 
 
-@pytest.mark.usefixtures("build_module")
-class TestCommonWithUse(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "common", "gh19161.f90")]
+@pytest.fixture(scope="module")
+def common_use_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestCommonWithUse",
+        sources = [util.getpath("tests", "src", "common", "gh19161.f90")]
+    )
+    return spec
 
-    def test_common_gh19161(self):
-        assert self.module.data.x == 0
+@pytest.mark.parametrize("_mod", ["common_use_spec"], indirect=True)
+def test_common_gh19161(_mod):
+    assert _mod.data.x == 0

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -12,6 +12,7 @@ import contextlib
 import io
 
 
+@pytest.mark.usefixtures("build_module")
 class TestNoSpace(util.F2PyTest):
     # issue gh-15035: add handling for endsubroutine, endfunction with no space
     # between "end" and the block name
@@ -95,6 +96,7 @@ class TestModuleProcedure():
         assert mod['vars']['seta']['attrspec'] == ['public', ]
 
 
+@pytest.mark.usefixtures("build_module")
 class TestExternal(util.F2PyTest):
     # issue gh-17859: add external attribute support
     sources = [util.getpath("tests", "src", "crackfortran", "gh17859.f")]
@@ -114,6 +116,7 @@ class TestExternal(util.F2PyTest):
         assert r == 123
 
 
+@pytest.mark.usefixtures("build_module")
 class TestCrackFortran(util.F2PyTest):
     # gh-2848: commented lines between parameters in subroutine parameter lists
     sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90")]
@@ -144,6 +147,7 @@ class TestMarkinnerspaces:
         assert markinnerspaces(r'a "b c" "d e"') == r'a "b@_@c" "d@_@e"'
 
 
+@pytest.mark.usefixtures("build_module")
 class TestDimSpec(util.F2PyTest):
     """This test suite tests various expressions that are used as dimension
     specifications.
@@ -255,7 +259,7 @@ class TestModuleDeclaration:
         assert mod[0]["vars"]["abar"]["="] == "bar('abar')"
 
 
-class TestEval(util.F2PyTest):
+class TestEval():
     def test_eval_scalar(self):
         eval_scalar = crackfortran._eval_scalar
 
@@ -265,7 +269,7 @@ class TestEval(util.F2PyTest):
         assert eval_scalar('"123"', {}) == "'123'"
 
 
-class TestFortranReader(util.F2PyTest):
+class TestFortranReader():
     @pytest.mark.parametrize("encoding",
                              ['ascii', 'utf-8', 'utf-16', 'utf-32'])
     def test_input_encoding(self, tmp_path, encoding):
@@ -281,6 +285,7 @@ class TestFortranReader(util.F2PyTest):
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestUnicodeComment(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "unicode_comment.f90")]
 
@@ -328,6 +333,7 @@ class TestNameArgsPatternBacktracking:
             good_version_of_adversary = repeated_adversary + '@)@'
             assert nameargspattern.search(good_version_of_adversary)
 
+@pytest.mark.usefixtures("build_module")
 class TestFunctionReturn(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "gh23598.f90")]
 
@@ -337,7 +343,7 @@ class TestFunctionReturn(util.F2PyTest):
         assert self.module.intproduct(3, 4) == 12
 
 
-class TestFortranGroupCounters(util.F2PyTest):
+class TestFortranGroupCounters():
     def test_end_if_comment(self):
         # gh-23533
         fpath = util.getpath("tests", "src", "crackfortran", "gh23533.f")

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -12,22 +12,6 @@ import contextlib
 import io
 
 
-@pytest.mark.usefixtures("build_module")
-class TestNoSpace(util.F2PyTest):
-    # issue gh-15035: add handling for endsubroutine, endfunction with no space
-    # between "end" and the block name
-    sources = [util.getpath("tests", "src", "crackfortran", "gh15035.f")]
-
-    def test_module(self):
-        k = np.array([1, 2, 3], dtype=np.float64)
-        w = np.array([1, 2, 3], dtype=np.float64)
-        self.module.subb(k)
-        assert np.allclose(k, w + 1)
-        self.module.subc([w, k])
-        assert np.allclose(k, w + 1)
-        assert self.module.t0("23") == b"2"
-
-
 class TestPublicPrivate:
     def test_defaultPrivate(self):
         fpath = util.getpath("tests", "src", "crackfortran", "privatemod.f90")
@@ -55,19 +39,20 @@ class TestPublicPrivate:
         fpath = util.getpath("tests", "src", "crackfortran", "accesstype.f90")
         mod = crackfortran.crackfortran([str(fpath)])
         assert len(mod) == 1
-        tt = mod[0]['vars']
-        assert set(tt['a']['attrspec']) == {'private', 'bind(c)'}
-        assert set(tt['b_']['attrspec']) == {'public', 'bind(c)'}
-        assert set(tt['c']['attrspec']) == {'public'}
+        tt = mod[0]["vars"]
+        assert set(tt["a"]["attrspec"]) == {"private", "bind(c)"}
+        assert set(tt["b_"]["attrspec"]) == {"public", "bind(c)"}
+        assert set(tt["c"]["attrspec"]) == {"public"}
 
     def test_nowrap_private_proceedures(self, tmp_path):
         fpath = util.getpath("tests", "src", "crackfortran", "gh23879.f90")
         mod = crackfortran.crackfortran([str(fpath)])
         assert len(mod) == 1
         pyf = crackfortran.crack2fortran(mod)
-        assert 'bar' not in pyf
+        assert "bar" not in pyf
 
-class TestModuleProcedure():
+
+class TestModuleProcedure:
     def test_moduleOperators(self, tmp_path):
         fpath = util.getpath("tests", "src", "crackfortran", "operators.f90")
         mod = crackfortran.crackfortran([str(fpath)])
@@ -76,54 +61,28 @@ class TestModuleProcedure():
         assert "body" in mod and len(mod["body"]) == 9
         assert mod["body"][1]["name"] == "operator(.item.)"
         assert "implementedby" in mod["body"][1]
-        assert mod["body"][1]["implementedby"] == \
-            ["item_int", "item_real"]
+        assert mod["body"][1]["implementedby"] == ["item_int", "item_real"]
         assert mod["body"][2]["name"] == "operator(==)"
         assert "implementedby" in mod["body"][2]
         assert mod["body"][2]["implementedby"] == ["items_are_equal"]
         assert mod["body"][3]["name"] == "assignment(=)"
         assert "implementedby" in mod["body"][3]
-        assert mod["body"][3]["implementedby"] == \
-            ["get_int", "get_real"]
+        assert mod["body"][3]["implementedby"] == ["get_int", "get_real"]
 
     def test_notPublicPrivate(self, tmp_path):
         fpath = util.getpath("tests", "src", "crackfortran", "pubprivmod.f90")
         mod = crackfortran.crackfortran([str(fpath)])
         assert len(mod) == 1
         mod = mod[0]
-        assert mod['vars']['a']['attrspec'] == ['private', ]
-        assert mod['vars']['b']['attrspec'] == ['public', ]
-        assert mod['vars']['seta']['attrspec'] == ['public', ]
-
-
-@pytest.mark.usefixtures("build_module")
-class TestExternal(util.F2PyTest):
-    # issue gh-17859: add external attribute support
-    sources = [util.getpath("tests", "src", "crackfortran", "gh17859.f")]
-
-    def test_external_as_statement(self):
-        def incr(x):
-            return x + 123
-
-        r = self.module.external_as_statement(incr)
-        assert r == 123
-
-    def test_external_as_attribute(self):
-        def incr(x):
-            return x + 123
-
-        r = self.module.external_as_attribute(incr)
-        assert r == 123
-
-
-@pytest.mark.usefixtures("build_module")
-class TestCrackFortran(util.F2PyTest):
-    # gh-2848: commented lines between parameters in subroutine parameter lists
-    sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90")]
-
-    def test_gh2848(self):
-        r = self.module.gh2848(1, 2)
-        assert r == (1, 2)
+        assert mod["vars"]["a"]["attrspec"] == [
+            "private",
+        ]
+        assert mod["vars"]["b"]["attrspec"] == [
+            "public",
+        ]
+        assert mod["vars"]["seta"]["attrspec"] == [
+            "public",
+        ]
 
 
 class TestMarkinnerspaces:
@@ -147,9 +106,228 @@ class TestMarkinnerspaces:
         assert markinnerspaces(r'a "b c" "d e"') == r'a "b@_@c" "d@_@e"'
 
 
-@pytest.mark.usefixtures("build_module")
-class TestDimSpec(util.F2PyTest):
-    """This test suite tests various expressions that are used as dimension
+class TestModuleDeclaration:
+    def test_dependencies(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "foo_deps.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        assert mod[0]["vars"]["abar"]["="] == "bar('abar')"
+
+
+class TestEval:
+    def test_eval_scalar(self):
+        eval_scalar = crackfortran._eval_scalar
+
+        assert eval_scalar("123", {}) == "123"
+        assert eval_scalar("12 + 3", {}) == "15"
+        assert eval_scalar("a + b", dict(a=1, b=2)) == "3"
+        assert eval_scalar('"123"', {}) == "'123'"
+
+
+class TestFortranReader:
+    @pytest.mark.parametrize("encoding", ["ascii", "utf-8", "utf-16", "utf-32"])
+    def test_input_encoding(self, tmp_path, encoding):
+        # gh-635
+        f_path = tmp_path / f"input_with_{encoding}_encoding.f90"
+        with f_path.open("w", encoding=encoding) as ff:
+            ff.write(
+                """
+                     subroutine foo()
+                     end subroutine foo
+                     """
+            )
+        mod = crackfortran.crackfortran([str(f_path)])
+        assert mod[0]["name"] == "foo"
+
+
+class TestNameArgsPatternBacktracking:
+    @pytest.mark.parametrize(
+        ["adversary"],
+        [
+            ("@)@bind@(@",),
+            ("@)@bind                         @(@",),
+            ("@)@bind foo bar baz@(@",),
+        ],
+    )
+    def test_nameargspattern_backtracking(self, adversary):
+        """address ReDOS vulnerability:
+        https://github.com/numpy/numpy/issues/23338"""
+        trials_per_batch = 12
+        batches_per_regex = 4
+        start_reps, end_reps = 15, 25
+        for ii in range(start_reps, end_reps):
+            repeated_adversary = adversary * ii
+            # test times in small batches.
+            # this gives us more chances to catch a bad regex
+            # while still catching it before too long if it is bad
+            for _ in range(batches_per_regex):
+                times = []
+                for _ in range(trials_per_batch):
+                    t0 = time.perf_counter()
+                    mtch = nameargspattern.search(repeated_adversary)
+                    times.append(time.perf_counter() - t0)
+                # our pattern should be much faster than 0.2s per search
+                # it's unlikely that a bad regex will pass even on fast CPUs
+                assert np.median(times) < 0.2
+            assert not mtch
+            # if the adversary is capped with @)@, it becomes acceptable
+            # according to the old version of the regex.
+            # that should still be true.
+            good_version_of_adversary = repeated_adversary + "@)@"
+            assert nameargspattern.search(good_version_of_adversary)
+
+
+class TestFortranGroupCounters:
+    def test_end_if_comment(self):
+        # gh-23533
+        fpath = util.getpath("tests", "src", "crackfortran", "gh23533.f")
+        try:
+            crackfortran.crackfortran([str(fpath)])
+        except Exception as exc:
+            assert False, f"'crackfortran.crackfortran' raised an exception {exc}"
+
+
+class TestF77CommonBlockReader:
+    def test_gh22648(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh22648.pyf")
+        with contextlib.redirect_stdout(io.StringIO()) as stdout_f2py:
+            mod = crackfortran.crackfortran([str(fpath)])
+        assert "Mismatch" not in stdout_f2py.getvalue()
+
+
+class TestParamEval:
+    # issue gh-11612, array parameter parsing
+    def test_param_eval_nested(self):
+        v = "(/3.14, 4./)"
+        g_params = dict(
+            kind=crackfortran._kind_func,
+            selected_int_kind=crackfortran._selected_int_kind_func,
+            selected_real_kind=crackfortran._selected_real_kind_func,
+        )
+        params = {"dp": 8, "intparamarray": {1: 3, 2: 5}, "nested": {1: 1, 2: 2, 3: 3}}
+        dimspec = "(2)"
+        ret = crackfortran.param_eval(v, g_params, params, dimspec=dimspec)
+        assert ret == {1: 3.14, 2: 4.0}
+
+    def test_param_eval_nonstandard_range(self):
+        v = "(/ 6, 3, 1 /)"
+        g_params = dict(
+            kind=crackfortran._kind_func,
+            selected_int_kind=crackfortran._selected_int_kind_func,
+            selected_real_kind=crackfortran._selected_real_kind_func,
+        )
+        params = {}
+        dimspec = "(-1:1)"
+        ret = crackfortran.param_eval(v, g_params, params, dimspec=dimspec)
+        assert ret == {-1: 6, 0: 3, 1: 1}
+
+    def test_param_eval_empty_range(self):
+        v = "6"
+        g_params = dict(
+            kind=crackfortran._kind_func,
+            selected_int_kind=crackfortran._selected_int_kind_func,
+            selected_real_kind=crackfortran._selected_real_kind_func,
+        )
+        params = {}
+        dimspec = ""
+        pytest.raises(
+            ValueError, crackfortran.param_eval, v, g_params, params, dimspec=dimspec
+        )
+
+    def test_param_eval_non_array_param(self):
+        v = "3.14_dp"
+        g_params = dict(
+            kind=crackfortran._kind_func,
+            selected_int_kind=crackfortran._selected_int_kind_func,
+            selected_real_kind=crackfortran._selected_real_kind_func,
+        )
+        params = {}
+        ret = crackfortran.param_eval(v, g_params, params, dimspec=None)
+        assert ret == "3.14_dp"
+
+    def test_param_eval_too_many_dims(self):
+        v = "reshape((/ (i, i=1, 250) /), (/5, 10, 5/))"
+        g_params = dict(
+            kind=crackfortran._kind_func,
+            selected_int_kind=crackfortran._selected_int_kind_func,
+            selected_real_kind=crackfortran._selected_real_kind_func,
+        )
+        params = {}
+        dimspec = "(0:4, 3:12, 5)"
+        pytest.raises(
+            ValueError, crackfortran.param_eval, v, g_params, params, dimspec=dimspec
+        )
+
+
+@pytest.fixture(scope="module")
+def no_space_spec():
+    # issue gh-15035: add handling for endsubroutine, endfunction with no space
+    # between "end" and the block name
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestNoSpace",
+        sources=[util.getpath("tests", "src", "crackfortran", "gh15035.f")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["no_space_spec"], indirect=True)
+def test_module(_mod):
+    k = np.array([1, 2, 3], dtype=np.float64)
+    w = np.array([1, 2, 3], dtype=np.float64)
+    _mod.subb(k)
+    assert np.allclose(k, w + 1)
+    _mod.subc([w, k])
+    assert np.allclose(k, w + 1)
+    assert _mod.t0("23") == b"2"
+
+
+@pytest.fixture(scope="module")
+def external_attr_spec():
+    # issue gh-17859: add external attribute support
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestExternal",
+        sources=[util.getpath("tests", "src", "crackfortran", "gh17859.f")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["external_attr_spec"], indirect=True)
+def test_external_as_statement(_mod):
+    def incr(x):
+        return x + 123
+
+    r = _mod.external_as_statement(incr)
+    assert r == 123
+
+
+@pytest.mark.parametrize("_mod", ["external_attr_spec"], indirect=True)
+def test_external_as_attribute(_mod):
+    def incr(x):
+        return x + 123
+
+    r = _mod.external_as_attribute(incr)
+    assert r == 123
+
+
+@pytest.fixture(scope="module")
+def commentline_params_spec():
+    # gh-2848: commented lines between parameters in subroutine parameter lists
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestCrackFortranCommentLines",
+        sources=[util.getpath("tests", "src", "crackfortran", "gh2848.f90")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["commentline_params_spec"], indirect=True)
+def test_gh2848(_mod):
+    r = _mod.gh2848(1, 2)
+    assert r == (1, 2)
+
+
+@pytest.fixture(scope="module")
+def dim_expr_spec():
+    """This test spec tests various expressions that are used as dimension
     specifications.
 
     There exists two usage cases where analyzing dimensions
@@ -178,10 +356,8 @@ class TestDimSpec(util.F2PyTest):
     is linear with respect to unknown parameter.
 
     """
-
-    suffix = ".f90"
-
-    code_template = textwrap.dedent("""
+    code_template = textwrap.dedent(
+        """
       function get_arr_size_{count}(a, n) result (length)
         integer, intent(in) :: n
         integer, dimension({dimspec}), intent(out) :: a
@@ -198,216 +374,96 @@ class TestDimSpec(util.F2PyTest):
           ! print*, "a=", a
         endif
       end subroutine
-    """)
-
-    linear_dimspecs = [
-        "n", "2*n", "2:n", "n/2", "5 - n/2", "3*n:20", "n*(n+1):n*(n+5)",
-        "2*n, n"
-    ]
-    nonlinear_dimspecs = ["2*n:3*n*n+2*n"]
-    all_dimspecs = linear_dimspecs + nonlinear_dimspecs
+    """
+    )
 
     code = ""
     for count, dimspec in enumerate(all_dimspecs):
-        lst = [(d.split(":")[0] if ":" in d else "1") for d in dimspec.split(',')]
+        lst = [(d.split(":")[0] if ":" in d else "1") for d in dimspec.split(",")]
         code += code_template.format(
             count=count,
             dimspec=dimspec,
             first=", ".join(lst),
         )
-
-    @pytest.mark.parametrize("dimspec", all_dimspecs)
-    @pytest.mark.slow
-    def test_array_size(self, dimspec):
-
-        count = self.all_dimspecs.index(dimspec)
-        get_arr_size = getattr(self.module, f"get_arr_size_{count}")
-
-        for n in [1, 2, 3, 4, 5]:
-            sz, a = get_arr_size(n)
-            assert a.size == sz
-
-    @pytest.mark.parametrize("dimspec", all_dimspecs)
-    def test_inv_array_size(self, dimspec):
-
-        count = self.all_dimspecs.index(dimspec)
-        get_arr_size = getattr(self.module, f"get_arr_size_{count}")
-        get_inv_arr_size = getattr(self.module, f"get_inv_arr_size_{count}")
-
-        for n in [1, 2, 3, 4, 5]:
-            sz, a = get_arr_size(n)
-            if dimspec in self.nonlinear_dimspecs:
-                # one must specify n as input, the call we'll ensure
-                # that a and n are compatible:
-                n1 = get_inv_arr_size(a, n)
-            else:
-                # in case of linear dependence, n can be determined
-                # from the shape of a:
-                n1 = get_inv_arr_size(a)
-            # n1 may be different from n (for instance, when `a` size
-            # is a function of some `n` fraction) but it must produce
-            # the same sized array
-            sz1, _ = get_arr_size(n1)
-            assert sz == sz1, (n, n1, sz, sz1)
-
-
-class TestModuleDeclaration:
-    def test_dependencies(self, tmp_path):
-        fpath = util.getpath("tests", "src", "crackfortran", "foo_deps.f90")
-        mod = crackfortran.crackfortran([str(fpath)])
-        assert len(mod) == 1
-        assert mod[0]["vars"]["abar"]["="] == "bar('abar')"
-
-
-class TestEval():
-    def test_eval_scalar(self):
-        eval_scalar = crackfortran._eval_scalar
-
-        assert eval_scalar('123', {}) == '123'
-        assert eval_scalar('12 + 3', {}) == '15'
-        assert eval_scalar('a + b', dict(a=1, b=2)) == '3'
-        assert eval_scalar('"123"', {}) == "'123'"
-
-
-class TestFortranReader():
-    @pytest.mark.parametrize("encoding",
-                             ['ascii', 'utf-8', 'utf-16', 'utf-32'])
-    def test_input_encoding(self, tmp_path, encoding):
-        # gh-635
-        f_path = tmp_path / f"input_with_{encoding}_encoding.f90"
-        with f_path.open('w', encoding=encoding) as ff:
-            ff.write("""
-                     subroutine foo()
-                     end subroutine foo
-                     """)
-        mod = crackfortran.crackfortran([str(f_path)])
-        assert mod[0]['name'] == 'foo'
-
-
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestUnicodeComment(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "unicode_comment.f90")]
-
-    @pytest.mark.skipif(
-        (importlib.util.find_spec("charset_normalizer") is None),
-        reason="test requires charset_normalizer which is not installed",
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestDimSpec",
+        suffix = ".f90",
+        code=code,
     )
-    def test_encoding_comment(self):
-        self.module.foo(3)
+    return spec
+
+linear_dimspecs = [
+    "n",
+    "2*n",
+    "2:n",
+    "n/2",
+    "5 - n/2",
+    "3*n:20",
+    "n*(n+1):n*(n+5)",
+    "2*n, n",
+]
+nonlinear_dimspecs = ["2*n:3*n*n+2*n"]
+all_dimspecs = linear_dimspecs + nonlinear_dimspecs
+
+@pytest.mark.parametrize("dimspec", all_dimspecs)
+@pytest.mark.parametrize("_mod", ["dim_expr_spec"], indirect=True)
+def test_array_size(_mod, dimspec):
+    count = all_dimspecs.index(dimspec)
+    get_arr_size = getattr(_mod, f"get_arr_size_{count}")
+
+    for n in [1, 2, 3, 4, 5]:
+        sz, a = get_arr_size(n)
+        assert a.size == sz
+
+@pytest.mark.parametrize("dimspec", all_dimspecs)
+@pytest.mark.parametrize("_mod", ["dim_expr_spec"], indirect=True)
+def test_inv_array_size(_mod, dimspec):
+    count = all_dimspecs.index(dimspec)
+    get_arr_size = getattr(_mod, f"get_arr_size_{count}")
+    get_inv_arr_size = getattr(_mod, f"get_inv_arr_size_{count}")
+
+    for n in [1, 2, 3, 4, 5]:
+        sz, a = get_arr_size(n)
+        if dimspec in nonlinear_dimspecs:
+            # one must specify n as input, the call we'll ensure
+            # that a and n are compatible:
+            n1 = get_inv_arr_size(a, n)
+        else:
+            # in case of linear dependence, n can be determined
+            # from the shape of a:
+            n1 = get_inv_arr_size(a)
+        # n1 may be different from n (for instance, when `a` size
+        # is a function of some `n` fraction) but it must produce
+        # the same sized array
+        sz1, _ = get_arr_size(n1)
+        assert sz == sz1, (n, n1, sz, sz1)
 
 
-class TestNameArgsPatternBacktracking:
-    @pytest.mark.parametrize(
-        ['adversary'],
-        [
-            ('@)@bind@(@',),
-            ('@)@bind                         @(@',),
-            ('@)@bind foo bar baz@(@',)
-        ]
+@pytest.fixture(scope="module")
+def unicode_comment_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestUnicodeComment",
+        sources = [util.getpath("tests", "src", "crackfortran", "unicode_comment.f90")]
     )
-    def test_nameargspattern_backtracking(self, adversary):
-        '''address ReDOS vulnerability:
-        https://github.com/numpy/numpy/issues/23338'''
-        trials_per_batch = 12
-        batches_per_regex = 4
-        start_reps, end_reps = 15, 25
-        for ii in range(start_reps, end_reps):
-            repeated_adversary = adversary * ii
-            # test times in small batches.
-            # this gives us more chances to catch a bad regex
-            # while still catching it before too long if it is bad
-            for _ in range(batches_per_regex):
-                times = []
-                for _ in range(trials_per_batch):
-                    t0 = time.perf_counter()
-                    mtch = nameargspattern.search(repeated_adversary)
-                    times.append(time.perf_counter() - t0)
-                # our pattern should be much faster than 0.2s per search
-                # it's unlikely that a bad regex will pass even on fast CPUs
-                assert np.median(times) < 0.2
-            assert not mtch
-            # if the adversary is capped with @)@, it becomes acceptable
-            # according to the old version of the regex.
-            # that should still be true.
-            good_version_of_adversary = repeated_adversary + '@)@'
-            assert nameargspattern.search(good_version_of_adversary)
+    return spec
 
-@pytest.mark.usefixtures("build_module")
-class TestFunctionReturn(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "gh23598.f90")]
+@pytest.mark.skipif(
+    (importlib.util.find_spec("charset_normalizer") is None),
+    reason="test requires charset_normalizer which is not installed",
+)
+@pytest.mark.parametrize("_mod", ["unicode_comment_spec"], indirect=True)
+def test_encoding_comment(_mod):
+    _mod.foo(3)
 
-    @pytest.mark.slow
-    def test_function_rettype(self):
-        # gh-23598
-        assert self.module.intproduct(3, 4) == 12
+@pytest.fixture(scope="module")
+def func_ret_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestFunctionReturn",
+        sources = [util.getpath("tests", "src", "crackfortran", "gh23598.f90")]
+    )
+    return spec
 
-
-class TestFortranGroupCounters():
-    def test_end_if_comment(self):
-        # gh-23533
-        fpath = util.getpath("tests", "src", "crackfortran", "gh23533.f")
-        try:
-            crackfortran.crackfortran([str(fpath)])
-        except Exception as exc:
-            assert False, f"'crackfortran.crackfortran' raised an exception {exc}"
-
-
-class TestF77CommonBlockReader():
-    def test_gh22648(self, tmp_path):
-        fpath = util.getpath("tests", "src", "crackfortran", "gh22648.pyf")
-        with contextlib.redirect_stdout(io.StringIO()) as stdout_f2py:
-            mod = crackfortran.crackfortran([str(fpath)])
-        assert "Mismatch" not in stdout_f2py.getvalue()
-
-class TestParamEval():
-    # issue gh-11612, array parameter parsing
-    def test_param_eval_nested(self):
-        v = '(/3.14, 4./)'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
-        params = {'dp': 8, 'intparamarray': {1: 3, 2: 5},
-                  'nested': {1: 1, 2: 2, 3: 3}}
-        dimspec = '(2)'
-        ret = crackfortran.param_eval(v, g_params, params, dimspec=dimspec)
-        assert ret == {1: 3.14, 2: 4.0}
-
-    def test_param_eval_nonstandard_range(self):
-        v = '(/ 6, 3, 1 /)'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
-        params = {}
-        dimspec = '(-1:1)'
-        ret = crackfortran.param_eval(v, g_params, params, dimspec=dimspec)
-        assert ret == {-1: 6, 0: 3, 1: 1}
-
-    def test_param_eval_empty_range(self):
-        v = '6'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
-        params = {}
-        dimspec = ''
-        pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,
-                      dimspec=dimspec)
-
-    def test_param_eval_non_array_param(self):
-        v = '3.14_dp'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
-        params = {}
-        ret = crackfortran.param_eval(v, g_params, params, dimspec=None)
-        assert ret == '3.14_dp'
-
-    def test_param_eval_too_many_dims(self):
-        v = 'reshape((/ (i, i=1, 250) /), (/5, 10, 5/))'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
-        params = {}
-        dimspec = '(0:4, 3:12, 5)'
-        pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,
-                      dimspec=dimspec)
+@pytest.mark.parametrize("_mod", ["func_ret_spec"], indirect=True)
+def test_function_rettype(_mod):
+    # gh-23598
+    assert _mod.intproduct(3, 4) == 12

--- a/numpy/f2py/tests/test_data.py
+++ b/numpy/f2py/tests/test_data.py
@@ -6,70 +6,95 @@ from . import util
 from numpy.f2py.crackfortran import crackfortran
 
 
-@pytest.mark.usefixtures("build_module")
-class TestData(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "data_stmts.f90")]
-
-    # For gh-23276
-    @pytest.mark.slow
-    def test_data_stmts(self):
-        assert self.module.cmplxdat.i == 2
-        assert self.module.cmplxdat.j == 3
-        assert self.module.cmplxdat.x == 1.5
-        assert self.module.cmplxdat.y == 2.0
-        assert self.module.cmplxdat.pi == 3.1415926535897932384626433832795028841971693993751058209749445923078164062
-        assert self.module.cmplxdat.medium_ref_index == np.array(1.+0.j)
-        assert np.all(self.module.cmplxdat.z == np.array([3.5, 7.0]))
-        assert np.all(self.module.cmplxdat.my_array == np.array([ 1.+2.j, -3.+4.j]))
-        assert np.all(self.module.cmplxdat.my_real_array == np.array([ 1., 2., 3.]))
-        assert np.all(self.module.cmplxdat.ref_index_one == np.array([13.0 + 21.0j]))
-        assert np.all(self.module.cmplxdat.ref_index_two == np.array([-30.0 + 43.0j]))
-
-    def test_crackedlines(self):
-        mod = crackfortran(self.sources)
-        assert mod[0]['vars']['x']['='] == '1.5'
-        assert mod[0]['vars']['y']['='] == '2.0'
-        assert mod[0]['vars']['pi']['='] == '3.1415926535897932384626433832795028841971693993751058209749445923078164062d0'
-        assert mod[0]['vars']['my_real_array']['='] == '(/1.0d0, 2.0d0, 3.0d0/)'
-        assert mod[0]['vars']['ref_index_one']['='] == '(13.0d0, 21.0d0)'
-        assert mod[0]['vars']['ref_index_two']['='] == '(-30.0d0, 43.0d0)'
-        assert mod[0]['vars']['my_array']['='] == '(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)'
-        assert mod[0]['vars']['z']['='] == '(/3.5,  7.0/)'
-
-@pytest.mark.usefixtures("build_module")
-class TestDataF77(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "data_common.f")]
-
-    # For gh-23276
-    def test_data_stmts(self):
-        assert self.module.mycom.mydata == 0
-
-    def test_crackedlines(self):
-        mod = crackfortran(str(self.sources[0]))
-        print(mod[0]['vars'])
-        assert mod[0]['vars']['mydata']['='] == '0'
+def test_crackedlines_f90():
+    mod = crackfortran(util.getpath("tests", "src", "crackfortran", "data_stmts.f90"))
+    assert mod[0]['vars']['x']['='] == '1.5'
+    assert mod[0]['vars']['y']['='] == '2.0'
+    assert mod[0]['vars']['pi']['='] == '3.1415926535897932384626433832795028841971693993751058209749445923078164062d0'
+    assert mod[0]['vars']['my_real_array']['='] == '(/1.0d0, 2.0d0, 3.0d0/)'
+    assert mod[0]['vars']['ref_index_one']['='] == '(13.0d0, 21.0d0)'
+    assert mod[0]['vars']['ref_index_two']['='] == '(-30.0d0, 43.0d0)'
+    assert mod[0]['vars']['my_array']['='] == '(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)'
+    assert mod[0]['vars']['z']['='] == '(/3.5,  7.0/)'
 
 
-@pytest.mark.usefixtures("build_module")
-class TestDataMultiplierF77(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "data_multiplier.f")]
-
-    # For gh-23276
-    def test_data_stmts(self):
-        assert self.module.mycom.ivar1 == 3
-        assert self.module.mycom.ivar2 == 3
-        assert self.module.mycom.ivar3 == 2
-        assert self.module.mycom.ivar4 == 2
-        assert self.module.mycom.evar5 == 0
+def test_crackedlines_f77():
+    mod = crackfortran(util.getpath("tests", "src", "crackfortran", "data_common.f"))
+    print(mod[0]['vars'])
+    assert mod[0]['vars']['mydata']['='] == '0'
 
 
-@pytest.mark.usefixtures("build_module")
-class TestDataWithCommentsF77(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "crackfortran", "data_with_comments.f")]
+@pytest.fixture(scope="module")
+def data_test_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestData",
+        sources = [util.getpath("tests", "src", "crackfortran", "data_stmts.f90")]
+    )
+    return spec
 
-    # For gh-23276
-    def test_data_stmts(self):
-        assert len(self.module.mycom.mytab) == 3
-        assert self.module.mycom.mytab[0] == 0
-        assert self.module.mycom.mytab[1] == 4
-        assert self.module.mycom.mytab[2] == 0
+
+@pytest.mark.parametrize("_mod", ["data_test_spec"], indirect=True)
+def test_gh23276_data_stmts(_mod):
+    assert _mod.cmplxdat.i == 2
+    assert _mod.cmplxdat.j == 3
+    assert _mod.cmplxdat.x == 1.5
+    assert _mod.cmplxdat.y == 2.0
+    assert _mod.cmplxdat.pi == 3.1415926535897932384626433832795028841971693993751058209749445923078164062
+    assert _mod.cmplxdat.medium_ref_index == np.array(1.+0.j)
+    assert np.all(_mod.cmplxdat.z == np.array([3.5, 7.0]))
+    assert np.all(_mod.cmplxdat.my_array == np.array([ 1.+2.j, -3.+4.j]))
+    assert np.all(_mod.cmplxdat.my_real_array == np.array([ 1., 2., 3.]))
+    assert np.all(_mod.cmplxdat.ref_index_one == np.array([13.0 + 21.0j]))
+    assert np.all(_mod.cmplxdat.ref_index_two == np.array([-30.0 + 43.0j]))
+
+
+@pytest.fixture(scope="module")
+def data_f77_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestDataF77",
+        sources = [util.getpath("tests", "src", "crackfortran", "data_common.f")]
+    )
+    return spec
+
+
+# For gh-23276
+@pytest.mark.parametrize("_mod", ["data_f77_spec"], indirect=True)
+def test_gh23276_f77_data_stmts(_mod):
+    assert _mod.mycom.mydata == 0
+
+
+@pytest.fixture(scope="module")
+def data_f77_multiplier_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestDataMultiplierF77",
+        sources = [util.getpath("tests", "src", "crackfortran", "data_multiplier.f")]
+    )
+    return spec
+
+
+# For gh-23276
+@pytest.mark.parametrize("_mod", ["data_f77_multiplier_spec"], indirect=True)
+def test_data_stmts(_mod):
+    assert _mod.mycom.ivar1 == 3
+    assert _mod.mycom.ivar2 == 3
+    assert _mod.mycom.ivar3 == 2
+    assert _mod.mycom.ivar4 == 2
+    assert _mod.mycom.evar5 == 0
+
+
+@pytest.fixture(scope="module")
+def data_f77_comment_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestDataWithCommentsF77",
+        sources = [util.getpath("tests", "src", "crackfortran", "data_with_comments.f")]
+    )
+    return spec
+
+
+# For gh-23276
+@pytest.mark.parametrize("_mod", ["data_f77_comment_spec"], indirect=True)
+def test_comment_data_stmts(_mod):
+    assert len(_mod.mycom.mytab) == 3
+    assert _mod.mycom.mytab[0] == 0
+    assert _mod.mycom.mytab[1] == 4
+    assert _mod.mycom.mytab[2] == 0

--- a/numpy/f2py/tests/test_data.py
+++ b/numpy/f2py/tests/test_data.py
@@ -6,6 +6,7 @@ from . import util
 from numpy.f2py.crackfortran import crackfortran
 
 
+@pytest.mark.usefixtures("build_module")
 class TestData(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_stmts.f90")]
 
@@ -35,6 +36,7 @@ class TestData(util.F2PyTest):
         assert mod[0]['vars']['my_array']['='] == '(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)'
         assert mod[0]['vars']['z']['='] == '(/3.5,  7.0/)'
 
+@pytest.mark.usefixtures("build_module")
 class TestDataF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_common.f")]
 
@@ -48,6 +50,7 @@ class TestDataF77(util.F2PyTest):
         assert mod[0]['vars']['mydata']['='] == '0'
 
 
+@pytest.mark.usefixtures("build_module")
 class TestDataMultiplierF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_multiplier.f")]
 
@@ -60,6 +63,7 @@ class TestDataMultiplierF77(util.F2PyTest):
         assert self.module.mycom.evar5 == 0
 
 
+@pytest.mark.usefixtures("build_module")
 class TestDataWithCommentsF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_with_comments.f")]
 

--- a/numpy/f2py/tests/test_docs.py
+++ b/numpy/f2py/tests/test_docs.py
@@ -19,34 +19,40 @@ pytestmark = pytest.mark.skipif(
 def _path(*args):
     return get_docdir().joinpath(*args)
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestDocAdvanced(util.F2PyTest):
-    # options = ['--debug-capi', '--build-dir', '/tmp/build-f2py']
-    sources = [_path('asterisk1.f90'), _path('asterisk2.f90'),
-               _path('ftype.f')]
+@pytest.fixture(scope="module")
+def doc_advanced_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestDocAdvanced",
+        sources=[_path("asterisk1.f90"),
+                 _path("asterisk2.f90"),
+                 _path("ftype.f")],
+    )
+    return spec
 
-    def test_asterisk1(self):
-        foo = getattr(self.module, 'foo1')
-        assert_equal(foo(), b'123456789A12')
+@pytest.mark.parametrize("_mod", ["doc_advanced_spec"], indirect=True)
+def test_asterisk1(_mod):
+    foo = getattr(_mod, 'foo1')
+    assert_equal(foo(), b'123456789A12')
 
-    def test_asterisk2(self):
-        foo = getattr(self.module, 'foo2')
-        assert_equal(foo(2), b'12')
-        assert_equal(foo(12), b'123456789A12')
-        assert_equal(foo(20), b'123456789A123456789B')
+@pytest.mark.parametrize("_mod", ["doc_advanced_spec"], indirect=True)
+def test_asterisk2(_mod):
+    foo = getattr(_mod, 'foo2')
+    assert_equal(foo(2), b'12')
+    assert_equal(foo(12), b'123456789A12')
+    assert_equal(foo(20), b'123456789A123456789B')
 
-    def test_ftype(self):
-        ftype = self.module
-        ftype.foo()
-        assert_equal(ftype.data.a, 0)
-        ftype.data.a = 3
-        ftype.data.x = [1, 2, 3]
-        assert_equal(ftype.data.a, 3)
-        assert_array_equal(ftype.data.x,
-                           np.array([1, 2, 3], dtype=np.float32))
-        ftype.data.x[1] = 45
-        assert_array_equal(ftype.data.x,
-                           np.array([1, 45, 3], dtype=np.float32))
+@pytest.mark.parametrize("_mod", ["doc_advanced_spec"], indirect=True)
+def test_ftype(_mod):
+    ftype = _mod
+    ftype.foo()
+    assert_equal(ftype.data.a, 0)
+    ftype.data.a = 3
+    ftype.data.x = [1, 2, 3]
+    assert_equal(ftype.data.a, 3)
+    assert_array_equal(ftype.data.x,
+                       np.array([1, 2, 3], dtype=np.float32))
+    ftype.data.x[1] = 45
+    assert_array_equal(ftype.data.x,
+                       np.array([1, 45, 3], dtype=np.float32))
 
-    # TODO: implement test methods for other example Fortran codes
+# TODO: implement test methods for other example Fortran codes

--- a/numpy/f2py/tests/test_docs.py
+++ b/numpy/f2py/tests/test_docs.py
@@ -20,6 +20,7 @@ def _path(*args):
     return get_docdir().joinpath(*args)
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestDocAdvanced(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/build-f2py']
     sources = [_path('asterisk1.f90'), _path('asterisk2.f90'),

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -1,6 +1,8 @@
 from . import util
+import pytest
 import numpy as np
 
+@pytest.mark.usefixtures("build_module")
 class TestF2Cmap(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "f2cmap", "isoFortranEnvMap.f90"),

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -2,16 +2,22 @@ from . import util
 import pytest
 import numpy as np
 
-@pytest.mark.usefixtures("build_module")
-class TestF2Cmap(util.F2PyTest):
-    sources = [
-        util.getpath("tests", "src", "f2cmap", "isoFortranEnvMap.f90"),
-        util.getpath("tests", "src", "f2cmap", ".f2py_f2cmap")
-    ]
 
-    # gh-15095
-    def test_gh15095(self):
-        inp = np.ones(3)
-        out = self.module.func1(inp)
-        exp_out = 3
-        assert out == exp_out
+@pytest.fixture(scope="module")
+def f2cmap_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestF2Cmap",
+        sources=[
+            util.getpath("tests", "src", "f2cmap", "isoFortranEnvMap.f90"),
+            util.getpath("tests", "src", "f2cmap", ".f2py_f2cmap"),
+        ],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["f2cmap_spec"], indirect=True)
+def test_gh15095(_mod):
+    inp = np.ones(3)
+    out = _mod.func1(inp)
+    exp_out = 3
+    assert out == exp_out

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -3,38 +3,50 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-@pytest.mark.usefixtures("build_module")
-class TestISOC(util.F2PyTest):
-    sources = [
-        util.getpath("tests", "src", "isocintrin", "isoCtests.f90"),
-    ]
 
+@pytest.fixture(scope="module")
+def isocmap_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestISOC",
+        sources=[
+            util.getpath("tests", "src", "isocintrin", "isoCtests.f90"),
+        ],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["isocmap_spec"], indirect=True)
+def test_c_double(_mod):
     # gh-24553
-    @pytest.mark.slow
-    def test_c_double(self):
-        out = self.module.coddity.c_add(1, 2)
-        exp_out = 3
-        assert  out == exp_out
+    out = _mod.coddity.c_add(1, 2)
+    exp_out = 3
+    assert out == exp_out
 
+
+@pytest.mark.parametrize("_mod", ["isocmap_spec"], indirect=True)
+def test_bindc_function(_mod):
     # gh-9693
-    def test_bindc_function(self):
-        out = self.module.coddity.wat(1, 20)
-        exp_out = 8
-        assert  out == exp_out
+    out = _mod.coddity.wat(1, 20)
+    exp_out = 8
+    assert out == exp_out
 
-    # gh-25207
-    def test_bindc_kinds(self):
-        out = self.module.coddity.c_add_int64(1, 20)
-        exp_out = 21
-        assert  out == exp_out
 
+@pytest.mark.parametrize("_mod", ["isocmap_spec"], indirect=True)
+def test_bindc_kinds(_mod):
     # gh-25207
-    def test_bindc_add_arr(self):
-        a = np.array([1,2,3])
-        b = np.array([1,2,3])
-        out = self.module.coddity.add_arr(a, b)
-        exp_out = a*2
-        assert_allclose(out, exp_out)
+    out = _mod.coddity.c_add_int64(1, 20)
+    exp_out = 21
+    assert out == exp_out
+
+
+@pytest.mark.parametrize("_mod", ["isocmap_spec"], indirect=True)
+def test_bindc_add_arr(_mod):
+    # gh-25207
+    a = np.array([1, 2, 3])
+    b = np.array([1, 2, 3])
+    out = _mod.coddity.add_arr(a, b)
+    exp_out = a * 2
+    assert_allclose(out, exp_out)
 
 
 def test_process_f2cmap_dict():

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+@pytest.mark.usefixtures("build_module")
 class TestISOC(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "isocintrin", "isoCtests.f90"),

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -7,45 +7,49 @@ from numpy.f2py.crackfortran import (
     _selected_int_kind_func as selected_int_kind,
     _selected_real_kind_func as selected_real_kind,
 )
-from . import util
+from . import util, conftest
 
 
-@pytest.mark.usefixtures("build_module")
-class TestKind(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "kind", "foo.f90")]
+@pytest.fixture(scope="module")
+def kind_test_module(module_builder_factory):
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestKind",
+        sources=[util.getpath("tests", "src", "kind", "foo.f90")],
+    )
+    built_module = module_builder_factory(spec)
+    return built_module
 
-    @pytest.mark.skipif(sys.maxsize < 2 ** 31 + 1,
-                        reason="Fails for 32 bit machines")
-    def test_int(self):
-        """Test `int` kind_func for integers up to 10**40."""
-        selectedintkind = self.module.selectedintkind
 
-        for i in range(40):
-            assert selectedintkind(i) == selected_int_kind(
-                i
-            ), f"selectedintkind({i}): expected {selected_int_kind(i)!r} but got {selectedintkind(i)!r}"
+@pytest.mark.skipif(sys.maxsize < 2**31 + 1, reason="Fails for 32 bit machines")
+def test_int(kind_test_module):
+    """Test `int` kind_func for integers up to 10**40."""
+    selectedintkind = kind_test_module.selectedintkind
 
-    def test_real(self):
-        """
-        Test (processor-dependent) `real` kind_func for real numbers
-        of up to 31 digits precision (extended/quadruple).
-        """
-        selectedrealkind = self.module.selectedrealkind
+    for i in range(40):
+        assert selectedintkind(i) == selected_int_kind(
+            i
+        ), f"selectedintkind({i}): expected {selected_int_kind(i)!r} but got {selectedintkind(i)!r}"
 
-        for i in range(32):
-            assert selectedrealkind(i) == selected_real_kind(
-                i
-            ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
 
-    @pytest.mark.xfail(platform.machine().lower().startswith("ppc"),
-                       reason="Some PowerPC may not support full IEEE 754 precision")
-    def test_quad_precision(self):
-        """
-        Test kind_func for quadruple precision [`real(16)`] of 32+ digits .
-        """
-        selectedrealkind = self.module.selectedrealkind
+def test_real(kind_test_module):
+    """Test (processor-dependent) `real` kind_func for real numbers of up to 31 digits precision (extended/quadruple)."""
+    selectedrealkind = kind_test_module.selectedrealkind
 
-        for i in range(32, 40):
-            assert selectedrealkind(i) == selected_real_kind(
-                i
-            ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
+    for i in range(32):
+        assert selectedrealkind(i) == selected_real_kind(
+            i
+        ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
+
+
+@pytest.mark.xfail(
+    platform.machine().lower().startswith("ppc"),
+    reason="Some PowerPC may not support full IEEE 754 precision",
+)
+def test_quad_precision(kind_test_module):
+    """Test kind_func for quadruple precision [`real(16)`] of 32+ digits."""
+    selectedrealkind = kind_test_module.selectedrealkind
+
+    for i in range(32, 40):
+        assert selectedrealkind(i) == selected_real_kind(
+            i
+        ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -11,19 +11,19 @@ from . import util, conftest
 
 
 @pytest.fixture(scope="module")
-def kind_test_module(module_builder_factory):
+def kind_test_spec():
     spec = util.F2PyModuleSpec(
         test_class_name="TestKind",
         sources=[util.getpath("tests", "src", "kind", "foo.f90")],
     )
-    built_module = module_builder_factory(spec)
-    return built_module
+    return spec
 
 
 @pytest.mark.skipif(sys.maxsize < 2**31 + 1, reason="Fails for 32 bit machines")
-def test_int(kind_test_module):
+@pytest.mark.parametrize("_mod", ["kind_test_spec"], indirect=True)
+def test_int(_mod):
     """Test `int` kind_func for integers up to 10**40."""
-    selectedintkind = kind_test_module.selectedintkind
+    selectedintkind = _mod.selectedintkind
 
     for i in range(40):
         assert selectedintkind(i) == selected_int_kind(
@@ -31,9 +31,10 @@ def test_int(kind_test_module):
         ), f"selectedintkind({i}): expected {selected_int_kind(i)!r} but got {selectedintkind(i)!r}"
 
 
-def test_real(kind_test_module):
+@pytest.mark.parametrize("_mod", ["kind_test_spec"], indirect=True)
+def test_real(_mod):
     """Test (processor-dependent) `real` kind_func for real numbers of up to 31 digits precision (extended/quadruple)."""
-    selectedrealkind = kind_test_module.selectedrealkind
+    selectedrealkind = _mod.selectedrealkind
 
     for i in range(32):
         assert selectedrealkind(i) == selected_real_kind(
@@ -45,9 +46,10 @@ def test_real(kind_test_module):
     platform.machine().lower().startswith("ppc"),
     reason="Some PowerPC may not support full IEEE 754 precision",
 )
-def test_quad_precision(kind_test_module):
+@pytest.mark.parametrize("_mod", ["kind_test_spec"], indirect=True)
+def test_quad_precision(_mod):
     """Test kind_func for quadruple precision [`real(16)`] of 32+ digits."""
-    selectedrealkind = kind_test_module.selectedrealkind
+    selectedrealkind = _mod.selectedrealkind
 
     for i in range(32, 40):
         assert selectedrealkind(i) == selected_real_kind(

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -10,6 +10,7 @@ from numpy.f2py.crackfortran import (
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestKind(util.F2PyTest):
     sources = [util.getpath("tests", "src", "kind", "foo.f90")]
 

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -6,30 +6,38 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestMixed(util.F2PyTest):
-    sources = [
-        util.getpath("tests", "src", "mixed", "foo.f"),
-        util.getpath("tests", "src", "mixed", "foo_fixed.f90"),
-        util.getpath("tests", "src", "mixed", "foo_free.f90"),
-    ]
+@pytest.fixture(scope="module")
+def mixed_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestMixed",
+        sources=[
+            util.getpath("tests", "src", "mixed", "foo.f"),
+            util.getpath("tests", "src", "mixed", "foo_fixed.f90"),
+            util.getpath("tests", "src", "mixed", "foo_free.f90"),
+        ],
+    )
+    return spec
 
-    @pytest.mark.slow
-    def test_all(self):
-        assert self.module.bar11() == 11
-        assert self.module.foo_fixed.bar12() == 12
-        assert self.module.foo_free.bar13() == 13
 
-    @pytest.mark.xfail(IS_PYPY,
-                       reason="PyPy cannot modify tp_doc after PyType_Ready")
-    def test_docstring(self):
-        expected = textwrap.dedent("""\
-        a = bar11()
+@pytest.mark.parametrize("_mod", ["mixed_spec"], indirect=True)
+def test_all(_mod):
+    assert _mod.bar11() == 11
+    assert _mod.foo_fixed.bar12() == 12
+    assert _mod.foo_free.bar13() == 13
 
-        Wrapper for ``bar11``.
 
-        Returns
-        -------
-        a : int
-        """)
-        assert self.module.bar11.__doc__ == expected
+@pytest.mark.xfail(IS_PYPY, reason="PyPy cannot modify tp_doc after PyType_Ready")
+@pytest.mark.parametrize("_mod", ["mixed_spec"], indirect=True)
+def test_docstring(_mod):
+    expected = textwrap.dedent(
+        """\
+    a = bar11()
+
+    Wrapper for ``bar11``.
+
+    Returns
+    -------
+    a : int
+    """
+    )
+    assert _mod.bar11.__doc__ == expected

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -6,6 +6,7 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestMixed(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "mixed", "foo.f"),

--- a/numpy/f2py/tests/test_module_doc.py
+++ b/numpy/f2py/tests/test_module_doc.py
@@ -7,23 +7,27 @@ from . import util
 from numpy.testing import IS_PYPY
 
 
-@pytest.mark.usefixtures("build_module")
-@pytest.mark.slow
-class TestModuleDocString(util.F2PyTest):
-    sources = [
-        util.getpath("tests", "src", "module_data",
-                     "module_data_docstring.f90")
-    ]
+@pytest.fixture(scope="module")
+def modstring_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestModuleDocString",
+        sources = [
+            util.getpath("tests", "src", "module_data",
+                         "module_data_docstring.f90")
+        ],
+    )
+    return spec
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="Fails with MinGW64 Gfortran (Issue #9673)")
-    @pytest.mark.xfail(IS_PYPY,
-                       reason="PyPy cannot modify tp_doc after PyType_Ready")
-    def test_module_docstring(self):
-        assert self.module.mod.__doc__ == textwrap.dedent("""\
-                     i : 'i'-scalar
-                     x : 'i'-array(4)
-                     a : 'f'-array(2,3)
-                     b : 'f'-array(-1,-1), not allocated\x00
-                     foo()\n
-                     Wrapper for ``foo``.\n\n""")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
+@pytest.mark.xfail(IS_PYPY,
+                   reason="PyPy cannot modify tp_doc after PyType_Ready")
+@pytest.mark.parametrize("_mod", ["modstring_spec"], indirect=True)
+def test_module_docstring(_mod):
+    assert _mod.mod.__doc__ == textwrap.dedent("""\
+                 i : 'i'-scalar
+                 x : 'i'-array(4)
+                 a : 'f'-array(2,3)
+                 b : 'f'-array(-1,-1), not allocated\x00
+                 foo()\n
+                 Wrapper for ``foo``.\n\n""")

--- a/numpy/f2py/tests/test_module_doc.py
+++ b/numpy/f2py/tests/test_module_doc.py
@@ -7,6 +7,7 @@ from . import util
 from numpy.testing import IS_PYPY
 
 
+@pytest.mark.usefixtures("build_module")
 @pytest.mark.slow
 class TestModuleDocString(util.F2PyTest):
     sources = [

--- a/numpy/f2py/tests/test_module_doc.py
+++ b/numpy/f2py/tests/test_module_doc.py
@@ -18,8 +18,6 @@ def modstring_spec():
     )
     return spec
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
 @pytest.mark.xfail(IS_PYPY,
                    reason="PyPy cannot modify tp_doc after PyType_Ready")
 @pytest.mark.parametrize("_mod", ["modstring_spec"], indirect=True)

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -6,127 +6,144 @@ import numpy as np
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestParameters(util.F2PyTest):
-    # Check that intent(in out) translates as intent(inout)
-    sources = [
-        util.getpath("tests", "src", "parameter", "constant_real.f90"),
-        util.getpath("tests", "src", "parameter", "constant_integer.f90"),
-        util.getpath("tests", "src", "parameter", "constant_both.f90"),
-        util.getpath("tests", "src", "parameter", "constant_compound.f90"),
-        util.getpath("tests", "src", "parameter", "constant_non_compound.f90"),
-        util.getpath("tests", "src", "parameter", "constant_array.f90"),
-    ]
+@pytest.fixture(scope="module")
+def param_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestParameters",
+        sources=[
+            util.getpath("tests", "src", "parameter", "constant_real.f90"),
+            util.getpath("tests", "src", "parameter", "constant_integer.f90"),
+            util.getpath("tests", "src", "parameter", "constant_both.f90"),
+            util.getpath("tests", "src", "parameter", "constant_compound.f90"),
+            util.getpath("tests", "src", "parameter", "constant_non_compound.f90"),
+            util.getpath("tests", "src", "parameter", "constant_array.f90"),
+        ],
+    )
+    return spec
 
-    @pytest.mark.slow
-    def test_constant_real_single(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float32)[::2]
-        pytest.raises(ValueError, self.module.foo_single, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float32)
-        self.module.foo_single(x)
-        assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_real_single(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float32)[::2]
+    pytest.raises(ValueError, _mod.foo_single, x)
 
-    @pytest.mark.slow
-    def test_constant_real_double(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float64)[::2]
-        pytest.raises(ValueError, self.module.foo_double, x)
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float32)
+    _mod.foo_single(x)
+    assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float64)
-        self.module.foo_double(x)
-        assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
-    def test_constant_compound_int(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.int32)[::2]
-        pytest.raises(ValueError, self.module.foo_compound_int, x)
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_real_double(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float64)[::2]
+    pytest.raises(ValueError, _mod.foo_double, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.int32)
-        self.module.foo_compound_int(x)
-        assert np.allclose(x, [0 + 1 + 2 * 6, 1, 2])
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float64)
+    _mod.foo_double(x)
+    assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
-    def test_constant_non_compound_int(self):
-        # check values
-        x = np.arange(4, dtype=np.int32)
-        self.module.foo_non_compound_int(x)
-        assert np.allclose(x, [0 + 1 + 2 + 3 * 4, 1, 2, 3])
 
-    @pytest.mark.slow
-    def test_constant_integer_int(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.int32)[::2]
-        pytest.raises(ValueError, self.module.foo_int, x)
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_compound_int(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.int32)[::2]
+    pytest.raises(ValueError, _mod.foo_compound_int, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.int32)
-        self.module.foo_int(x)
-        assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.int32)
+    _mod.foo_compound_int(x)
+    assert np.allclose(x, [0 + 1 + 2 * 6, 1, 2])
 
-    @pytest.mark.slow
-    def test_constant_integer_long(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.int64)[::2]
-        pytest.raises(ValueError, self.module.foo_long, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.int64)
-        self.module.foo_long(x)
-        assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_non_compound_int(_mod):
+    # check values
+    x = np.arange(4, dtype=np.int32)
+    _mod.foo_non_compound_int(x)
+    assert np.allclose(x, [0 + 1 + 2 + 3 * 4, 1, 2, 3])
 
-    @pytest.mark.slow
-    def test_constant_both(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float64)[::2]
-        pytest.raises(ValueError, self.module.foo, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float64)
-        self.module.foo(x)
-        assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_integer_int(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.int32)[::2]
+    pytest.raises(ValueError, _mod.foo_int, x)
 
-    @pytest.mark.slow
-    def test_constant_no(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float64)[::2]
-        pytest.raises(ValueError, self.module.foo_no, x)
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.int32)
+    _mod.foo_int(x)
+    assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float64)
-        self.module.foo_no(x)
-        assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
 
-    @pytest.mark.slow
-    def test_constant_sum(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float64)[::2]
-        pytest.raises(ValueError, self.module.foo_sum, x)
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_integer_long(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.int64)[::2]
+    pytest.raises(ValueError, _mod.foo_long, x)
 
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float64)
-        self.module.foo_sum(x)
-        assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.int64)
+    _mod.foo_long(x)
+    assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    def test_constant_array(self):
-        x = np.arange(3, dtype=np.float64)
-        y = np.arange(5, dtype=np.float64)
-        z = self.module.foo_array(x, y)
-        assert np.allclose(x, [0.0, 1./10, 2./10])
-        assert np.allclose(y, [0.0, 1.*10, 2.*10, 3.*10, 4.*10])
-        assert np.allclose(z, 19.0)
 
-    def test_constant_array_any_index(self):
-        x = np.arange(6, dtype=np.float64)
-        y = self.module.foo_array_any_index(x)
-        assert np.allclose(y, x.reshape((2, 3), order='F'))
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_both(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float64)[::2]
+    pytest.raises(ValueError, _mod.foo, x)
 
-    def test_constant_array_delims(self):
-        x = self.module.foo_array_delims()
-        assert x == 9
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float64)
+    _mod.foo(x)
+    assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
 
+
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_no(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float64)[::2]
+    pytest.raises(ValueError, _mod.foo_no, x)
+
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float64)
+    _mod.foo_no(x)
+    assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
+
+
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_sum(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float64)[::2]
+    pytest.raises(ValueError, _mod.foo_sum, x)
+
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float64)
+    _mod.foo_sum(x)
+    assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
+
+
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_array(_mod):
+    x = np.arange(3, dtype=np.float64)
+    y = np.arange(5, dtype=np.float64)
+    z = _mod.foo_array(x, y)
+    assert np.allclose(x, [0.0, 1.0 / 10, 2.0 / 10])
+    assert np.allclose(y, [0.0, 1.0 * 10, 2.0 * 10, 3.0 * 10, 4.0 * 10])
+    assert np.allclose(z, 19.0)
+
+
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_array_any_index(_mod):
+    x = np.arange(6, dtype=np.float64)
+    y = _mod.foo_array_any_index(x)
+    assert np.allclose(y, x.reshape((2, 3), order="F"))
+
+
+@pytest.mark.parametrize("_mod", ["param_spec"], indirect=True)
+def test_constant_array_delims(_mod):
+    x = _mod.foo_array_delims()
+    assert x == 9

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -6,6 +6,7 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestParameters(util.F2PyTest):
     # Check that intent(in out) translates as intent(inout)
     sources = [

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -7,6 +7,7 @@ import pytest
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestQuotedCharacter(util.F2PyTest):
     sources = [util.getpath("tests", "src", "quoted_character", "foo.f")]
 

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -7,12 +7,16 @@ import pytest
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestQuotedCharacter(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "quoted_character", "foo.f")]
+@pytest.fixture(scope="module")
+def quotedchar_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestQuotedCharacter",
+        sources = [util.getpath("tests", "src", "quoted_character", "foo.f")],
+    )
+    return spec
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="Fails with MinGW64 Gfortran (Issue #9673)")
-    @pytest.mark.slow
-    def test_quoted_character(self):
-        assert self.module.foo() == (b"'", b'"', b";", b"!", b"(", b")")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
+@pytest.mark.parametrize("_mod", ["quotedchar_spec"], indirect=True)
+def test_quoted_character(_mod):
+    assert _mod.foo() == (b"'", b'"', b";", b"!", b"(", b")")

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -15,8 +15,6 @@ def quotedchar_spec():
     )
     return spec
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="Fails with MinGW64 Gfortran (Issue #9673)")
 @pytest.mark.parametrize("_mod", ["quotedchar_spec"], indirect=True)
 def test_quoted_character(_mod):
     assert _mod.foo() == (b"'", b'"', b";", b"!", b"(", b")")

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -6,6 +6,7 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestIntentInOut(util.F2PyTest):
     # Check that intent(in out) translates as intent(inout)
     sources = [util.getpath("tests", "src", "regression", "inout.f90")]
@@ -22,6 +23,7 @@ class TestIntentInOut(util.F2PyTest):
         assert np.allclose(x, [3, 1, 2])
 
 
+@pytest.mark.usefixtures("build_module")
 class TestNegativeBounds(util.F2PyTest):
     # Check that negative bounds work correctly
     sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")]
@@ -41,6 +43,7 @@ class TestNegativeBounds(util.F2PyTest):
         assert np.allclose(rval, expval)
 
 
+@pytest.mark.usefixtures("build_module")
 class TestNumpyVersionAttribute(util.F2PyTest):
     # Check that th attribute __f2py_numpy_version__ is present
     # in the compiled module and that has the value np.__version__.

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -6,62 +6,6 @@ import numpy as np
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestIntentInOut(util.F2PyTest):
-    # Check that intent(in out) translates as intent(inout)
-    sources = [util.getpath("tests", "src", "regression", "inout.f90")]
-
-    @pytest.mark.slow
-    def test_inout(self):
-        # non-contiguous should raise error
-        x = np.arange(6, dtype=np.float32)[::2]
-        pytest.raises(ValueError, self.module.foo, x)
-
-        # check values with contiguous array
-        x = np.arange(3, dtype=np.float32)
-        self.module.foo(x)
-        assert np.allclose(x, [3, 1, 2])
-
-
-@pytest.mark.usefixtures("build_module")
-class TestNegativeBounds(util.F2PyTest):
-    # Check that negative bounds work correctly
-    sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")]
-
-    @pytest.mark.slow
-    def test_negbound(self):
-        xvec = np.arange(12)
-        xlow = -6
-        xhigh = 4
-        # Calculate the upper bound,
-        # Keeping the 1 index in mind
-        def ubound(xl, xh):
-            return xh - xl + 1
-        rval = self.module.foo(is_=xlow, ie_=xhigh,
-                        arr=xvec[:ubound(xlow, xhigh)])
-        expval = np.arange(11, dtype = np.float32)
-        assert np.allclose(rval, expval)
-
-
-@pytest.mark.usefixtures("build_module")
-class TestNumpyVersionAttribute(util.F2PyTest):
-    # Check that th attribute __f2py_numpy_version__ is present
-    # in the compiled module and that has the value np.__version__.
-    sources = [util.getpath("tests", "src", "regression", "inout.f90")]
-
-    @pytest.mark.slow
-    def test_numpy_version_attribute(self):
-
-        # Check that self.module has an attribute named "__f2py_numpy_version__"
-        assert hasattr(self.module, "__f2py_numpy_version__")
-
-        # Check that the attribute __f2py_numpy_version__ is a string
-        assert isinstance(self.module.__f2py_numpy_version__, str)
-
-        # Check that __f2py_numpy_version__ has the value numpy.__version__
-        assert np.__version__ == self.module.__f2py_numpy_version__
-
-
 def test_include_path():
     incdir = np.f2py.get_include()
     fnames_in_dir = os.listdir(incdir)
@@ -69,24 +13,105 @@ def test_include_path():
         assert fname in fnames_in_dir
 
 
-class TestModuleAndSubroutine(util.F2PyTest):
-    module_name = "example"
-    sources = [util.getpath("tests", "src", "regression", "gh25337", "data.f90"),
-               util.getpath("tests", "src", "regression", "gh25337", "use_data.f90")]
-
-    @pytest.mark.slow
-    def test_gh25337(self):
-        self.module.data.set_shift(3)
-        assert "data" in dir(self.module)
+@pytest.fixture(scope="module")
+def inout_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestIntentInOut",
+        sources = [util.getpath("tests", "src", "regression", "inout.f90")],
+    )
+    return spec
 
 
-class TestIncludeFiles(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "regression", "incfile.f90")]
-    options = [f"-I{util.getpath('tests', 'src', 'regression')}",
-               f"--include-paths {util.getpath('tests', 'src', 'regression')}"]
+@pytest.mark.parametrize("_mod", ["inout_spec"], indirect=True)
+def test_inout(_mod):
+    # non-contiguous should raise error
+    x = np.arange(6, dtype=np.float32)[::2]
+    pytest.raises(ValueError, _mod.foo, x)
 
-    @pytest.mark.slow
-    def test_gh25344(self):
-        exp = 7.0
-        res = self.module.add(3.0, 4.0)
-        assert  exp == res
+    # check values with contiguous array
+    x = np.arange(3, dtype=np.float32)
+    _mod.foo(x)
+    assert np.allclose(x, [3, 1, 2])
+
+
+@pytest.fixture(scope="module")
+def negbound_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestNegativeBounds",
+        sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["negbound_spec"], indirect=True)
+def test_negbound(_mod):
+    xvec = np.arange(12)
+    xlow = -6
+    xhigh = 4
+    # Calculate the upper bound,
+    # Keeping the 1 index in mind
+    def ubound(xl, xh):
+        return xh - xl + 1
+    rval = _mod.foo(is_=xlow, ie_=xhigh,
+                    arr=xvec[:ubound(xlow, xhigh)])
+    expval = np.arange(11, dtype = np.float32)
+    assert np.allclose(rval, expval)
+
+
+@pytest.fixture(scope="module")
+def npversion_spec():
+    # Check that th attribute __f2py_numpy_version__ is present
+    # in the compiled module and that has the value np.__version__.
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestNumpyVersionAttribute",
+        sources = [util.getpath("tests", "src", "regression", "inout.f90")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["npversion_spec"], indirect=True)
+def test_numpy_version_attribute(_mod):
+    # Check that _mod has an attribute named "__f2py_numpy_version__"
+    assert hasattr(_mod, "__f2py_numpy_version__")
+    # Check that the attribute __f2py_numpy_version__ is a string
+    assert isinstance(_mod.__f2py_numpy_version__, str)
+    # Check that __f2py_numpy_version__ has the value numpy.__version__
+    assert np.__version__ == _mod.__f2py_numpy_version__
+
+
+@pytest.fixture(scope="module")
+def mod_subrout_spec():
+    # Check that th attribute __f2py_numpy_version__ is present
+    # in the compiled module and that has the value np.__version__.
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestModuleAndSubroutine",
+        sources = [util.getpath("tests", "src", "regression", "gh25337", "data.f90"),
+                   util.getpath("tests", "src", "regression", "gh25337", "use_data.f90")],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["mod_subrout_spec"], indirect=True)
+def test_gh25337(_mod):
+    _mod.data.set_shift(3)
+    assert "data" in dir(_mod)
+
+
+@pytest.fixture(scope="module")
+def include_spec():
+    # Check that th attribute __f2py_numpy_version__ is present
+    # in the compiled module and that has the value np.__version__.
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestIncludeFiles",
+        sources = [util.getpath("tests", "src", "regression", "incfile.f90")],
+        options = [f"-I{util.getpath('tests', 'src', 'regression')}",
+                   f"--include-paths {util.getpath('tests', 'src', 'regression')}"],
+    )
+    return spec
+
+
+@pytest.mark.parametrize("_mod", ["include_spec"], indirect=True)
+def test_gh25344(_mod):
+    exp = 7.0
+    res = _mod.add(3.0, 4.0)
+    assert  exp == res

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -6,42 +6,42 @@ import platform
 
 IS_S390X = platform.machine() == "s390x"
 
+@pytest.fixture(scope="module")
+def retchar_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestF77ReturnCharacter",
+        sources = [
+            util.getpath("tests", "src", "return_character", "foo77.f"),
+            util.getpath("tests", "src", "return_character", "foo90.f90"),
+        ],
+    )
+    return spec
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestReturnCharacter(util.F2PyTest):
-    def check_function(self, t, tname):
-        if tname in ["t0", "t1", "s0", "s1"]:
-            assert t("23") == b"2"
-            r = t("ab")
-            assert r == b"a"
-            r = t(array("ab"))
-            assert r == b"a"
-            r = t(array(77, "u1"))
-            assert r == b"M"
-        elif tname in ["ts", "ss"]:
-            assert t(23) == b"23"
-            assert t("123456789abcdef") == b"123456789a"
-        elif tname in ["t5", "s5"]:
-            assert t(23) == b"23"
-            assert t("ab") == b"ab"
-            assert t("123456789abcdef") == b"12345"
-        else:
-            raise NotImplementedError
+def check_function(modcomp, tname):
+    t = getattr(modcomp, tname)
+    if tname in ["t0", "t1", "s0", "s1"]:
+        assert t("23") == b"2"
+        assert t("ab") == b"a"
+        assert t(array("ab")) == b"a"
+        assert t(array(77, "u1")) == b"M"
+    elif tname in ["ts", "ss"]:
+        assert t(23) == b"23"
+        assert t("123456789abcdef") == b"123456789a"
+    elif tname in ["t5", "s5"]:
+        assert t(23) == b"23"
+        assert t("ab") == b"ab"
+        assert t("123456789abcdef") == b"12345"
+    else:
+        raise NotImplementedError
 
+@pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
+@pytest.mark.parametrize("name", "t0,t1,t5,s0,s1,s5,ss".split(","))
+@pytest.mark.parametrize("_mod", ["retchar_spec"], indirect=True)
+def test_all_f77(_mod, name):
+    check_function(_mod, name)
 
-class TestFReturnCharacter(TestReturnCharacter):
-    sources = [
-        util.getpath("tests", "src", "return_character", "foo77.f"),
-        util.getpath("tests", "src", "return_character", "foo90.f90"),
-    ]
-
-    @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
-    @pytest.mark.parametrize("name", "t0,t1,t5,s0,s1,s5,ss".split(","))
-    def test_all_f77(self, name):
-        self.check_function(getattr(self.module, name), name)
-
-    @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
-    @pytest.mark.parametrize("name", "t0,t1,t5,ts,s0,s1,s5,ss".split(","))
-    def test_all_f90(self, name):
-        self.check_function(getattr(self.module.f90_return_char, name), name)
+@pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
+@pytest.mark.parametrize("name", "t0,t1,t5,ts,s0,s1,s5,ss".split(","))
+@pytest.mark.parametrize("_mod", ["retchar_spec"], indirect=True)
+def test_all_f90(_mod, name):
+    check_function(_mod.f90_return_char, name)

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -6,16 +6,18 @@ import platform
 
 IS_S390X = platform.machine() == "s390x"
 
+
 @pytest.fixture(scope="module")
 def retchar_spec():
     spec = util.F2PyModuleSpec(
         test_class_name="TestF77ReturnCharacter",
-        sources = [
+        sources=[
             util.getpath("tests", "src", "return_character", "foo77.f"),
             util.getpath("tests", "src", "return_character", "foo90.f90"),
         ],
     )
     return spec
+
 
 def check_function(modcomp, tname):
     t = getattr(modcomp, tname)
@@ -34,11 +36,13 @@ def check_function(modcomp, tname):
     else:
         raise NotImplementedError
 
+
 @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
 @pytest.mark.parametrize("name", "t0,t1,t5,s0,s1,s5,ss".split(","))
 @pytest.mark.parametrize("_mod", ["retchar_spec"], indirect=True)
 def test_all_f77(_mod, name):
     check_function(_mod, name)
+
 
 @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
 @pytest.mark.parametrize("name", "t0,t1,t5,ts,s0,s1,s5,ss".split(","))

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -8,6 +8,7 @@ IS_S390X = platform.machine() == "s390x"
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestReturnCharacter(util.F2PyTest):
     def check_function(self, t, tname):
         if tname in ["t0", "t1", "s0", "s1"]:

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -5,6 +5,7 @@ from . import util
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestReturnComplex(util.F2PyTest):
     def check_function(self, t, tname):
         if tname in ["t0", "t8", "s0", "s8"]:

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -4,64 +4,70 @@ from numpy import array
 from . import util
 
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestReturnComplex(util.F2PyTest):
-    def check_function(self, t, tname):
-        if tname in ["t0", "t8", "s0", "s8"]:
-            err = 1e-5
-        else:
-            err = 0.0
-        assert abs(t(234j) - 234.0j) <= err
-        assert abs(t(234.6) - 234.6) <= err
-        assert abs(t(234) - 234.0) <= err
-        assert abs(t(234.6 + 3j) - (234.6 + 3j)) <= err
-        # assert abs(t('234')-234.)<=err
-        # assert abs(t('234.6')-234.6)<=err
-        assert abs(t(-234) + 234.0) <= err
-        assert abs(t([234]) - 234.0) <= err
-        assert abs(t((234, )) - 234.0) <= err
-        assert abs(t(array(234)) - 234.0) <= err
-        assert abs(t(array(23 + 4j, "F")) - (23 + 4j)) <= err
-        assert abs(t(array([234])) - 234.0) <= err
-        assert abs(t(array([[234]])) - 234.0) <= err
-        assert abs(t(array([234]).astype("b")) + 22.0) <= err
-        assert abs(t(array([234], "h")) - 234.0) <= err
-        assert abs(t(array([234], "i")) - 234.0) <= err
-        assert abs(t(array([234], "l")) - 234.0) <= err
-        assert abs(t(array([234], "q")) - 234.0) <= err
-        assert abs(t(array([234], "f")) - 234.0) <= err
-        assert abs(t(array([234], "d")) - 234.0) <= err
-        assert abs(t(array([234 + 3j], "F")) - (234 + 3j)) <= err
-        assert abs(t(array([234], "D")) - 234.0) <= err
-
-        # pytest.raises(TypeError, t, array([234], 'S1'))
-        pytest.raises(TypeError, t, "abc")
-
-        pytest.raises(IndexError, t, [])
-        pytest.raises(IndexError, t, ())
-
-        pytest.raises(TypeError, t, t)
-        pytest.raises(TypeError, t, {})
-
-        try:
-            r = t(10**400)
-            assert repr(r) in ["(inf+0j)", "(Infinity+0j)"]
-        except OverflowError:
-            pass
+@pytest.fixture(scope="module")
+def ret_complex_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestFReturnComplex",
+        sources=[
+            util.getpath("tests", "src", "return_complex", "foo77.f"),
+            util.getpath("tests", "src", "return_complex", "foo90.f90"),
+        ],
+    )
+    return spec
 
 
-class TestFReturnComplex(TestReturnComplex):
-    sources = [
-        util.getpath("tests", "src", "return_complex", "foo77.f"),
-        util.getpath("tests", "src", "return_complex", "foo90.f90"),
-    ]
+def check_function(modcomp, tname):
+    t = getattr(modcomp, tname)
+    if tname in ["t0", "t8", "s0", "s8"]:
+        err = 1e-5
+    else:
+        err = 0.0
+    assert abs(t(234j) - 234.0j) <= err
+    assert abs(t(234.6) - 234.6) <= err
+    assert abs(t(234) - 234.0) <= err
+    assert abs(t(234.6 + 3j) - (234.6 + 3j)) <= err
+    # assert abs(t('234')-234.)<=err
+    # assert abs(t('234.6')-234.6)<=err
+    assert abs(t(-234) + 234.0) <= err
+    assert abs(t([234]) - 234.0) <= err
+    assert abs(t((234,)) - 234.0) <= err
+    assert abs(t(array(234)) - 234.0) <= err
+    assert abs(t(array(23 + 4j, "F")) - (23 + 4j)) <= err
+    assert abs(t(array([234])) - 234.0) <= err
+    assert abs(t(array([[234]])) - 234.0) <= err
+    assert abs(t(array([234]).astype("b")) + 22.0) <= err
+    assert abs(t(array([234], "h")) - 234.0) <= err
+    assert abs(t(array([234], "i")) - 234.0) <= err
+    assert abs(t(array([234], "l")) - 234.0) <= err
+    assert abs(t(array([234], "q")) - 234.0) <= err
+    assert abs(t(array([234], "f")) - 234.0) <= err
+    assert abs(t(array([234], "d")) - 234.0) <= err
+    assert abs(t(array([234 + 3j], "F")) - (234 + 3j)) <= err
+    assert abs(t(array([234], "D")) - 234.0) <= err
 
-    @pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
-    def test_all_f77(self, name):
-        self.check_function(getattr(self.module, name), name)
+    # pytest.raises(TypeError, t, array([234], 'S1'))
+    pytest.raises(TypeError, t, "abc")
 
-    @pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
-    def test_all_f90(self, name):
-        self.check_function(getattr(self.module.f90_return_complex, name),
-                            name)
+    pytest.raises(IndexError, t, [])
+    pytest.raises(IndexError, t, ())
+
+    pytest.raises(TypeError, t, t)
+    pytest.raises(TypeError, t, {})
+
+    try:
+        r = t(10**400)
+        assert repr(r) in ["(inf+0j)", "(Infinity+0j)"]
+    except OverflowError:
+        pass
+
+
+@pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
+@pytest.mark.parametrize("_mod", ["ret_complex_spec"], indirect=True)
+def test_all_f77(_mod, name):
+    check_function(_mod, name)
+
+
+@pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
+@pytest.mark.parametrize("_mod", ["ret_complex_spec"], indirect=True)
+def test_all_f90(_mod, name):
+    check_function(_mod.f90_return_complex, name)

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -5,6 +5,7 @@ from . import util
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestReturnInteger(util.F2PyTest):
     def check_function(self, t, tname):
         assert t(123) == 123

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -4,52 +4,56 @@ from numpy import array
 from . import util
 
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestReturnInteger(util.F2PyTest):
-    def check_function(self, t, tname):
-        assert t(123) == 123
-        assert t(123.6) == 123
-        assert t("123") == 123
-        assert t(-123) == -123
-        assert t([123]) == 123
-        assert t((123, )) == 123
-        assert t(array(123)) == 123
-        assert t(array(123, "b")) == 123
-        assert t(array(123, "h")) == 123
-        assert t(array(123, "i")) == 123
-        assert t(array(123, "l")) == 123
-        assert t(array(123, "B")) == 123
-        assert t(array(123, "f")) == 123
-        assert t(array(123, "d")) == 123
-
-        # pytest.raises(ValueError, t, array([123],'S3'))
-        pytest.raises(ValueError, t, "abc")
-
-        pytest.raises(IndexError, t, [])
-        pytest.raises(IndexError, t, ())
-
-        pytest.raises(Exception, t, t)
-        pytest.raises(Exception, t, {})
-
-        if tname in ["t8", "s8"]:
-            pytest.raises(OverflowError, t, 100000000000000000000000)
-            pytest.raises(OverflowError, t, 10000000011111111111111.23)
+@pytest.fixture(scope="module")
+def ret_int_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestFReturnInteger",
+        sources=[
+            util.getpath("tests", "src", "return_integer", "foo77.f"),
+            util.getpath("tests", "src", "return_integer", "foo90.f90"),
+        ],
+    )
+    return spec
 
 
-class TestFReturnInteger(TestReturnInteger):
-    sources = [
-        util.getpath("tests", "src", "return_integer", "foo77.f"),
-        util.getpath("tests", "src", "return_integer", "foo90.f90"),
-    ]
+def check_function(modcomp, tname):
+    t = getattr(modcomp, tname)
+    assert t(123) == 123
+    assert t(123.6) == 123
+    assert t("123") == 123
+    assert t(-123) == -123
+    assert t([123]) == 123
+    assert t((123,)) == 123
+    assert t(array(123)) == 123
+    assert t(array(123, "b")) == 123
+    assert t(array(123, "h")) == 123
+    assert t(array(123, "i")) == 123
+    assert t(array(123, "l")) == 123
+    assert t(array(123, "B")) == 123
+    assert t(array(123, "f")) == 123
+    assert t(array(123, "d")) == 123
 
-    @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
-    def test_all_f77(self, name):
-        self.check_function(getattr(self.module, name), name)
+    # pytest.raises(ValueError, t, array([123],'S3'))
+    pytest.raises(ValueError, t, "abc")
 
-    @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
-    def test_all_f90(self, name):
-        self.check_function(getattr(self.module.f90_return_integer, name),
-                            name)
+    pytest.raises(IndexError, t, [])
+    pytest.raises(IndexError, t, ())
+
+    pytest.raises(Exception, t, t)
+    pytest.raises(Exception, t, {})
+
+    if tname in ["t8", "s8"]:
+        pytest.raises(OverflowError, t, 100000000000000000000000)
+        pytest.raises(OverflowError, t, 10000000011111111111111.23)
+
+
+@pytest.mark.parametrize("name", "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+@pytest.mark.parametrize("_mod", ["ret_int_spec"], indirect=True)
+def test_all_f77(_mod, name):
+    check_function(_mod, name)
+
+
+@pytest.mark.parametrize("name", "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+@pytest.mark.parametrize("_mod", ["ret_int_spec"], indirect=True)
+def test_all_f90(_mod, name):
+    check_function(_mod.f90_return_integer, name)

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -4,6 +4,7 @@ from numpy import array
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestReturnLogical(util.F2PyTest):
     def check_function(self, t):
         assert t(True) == 1

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -4,62 +4,67 @@ from numpy import array
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestReturnLogical(util.F2PyTest):
-    def check_function(self, t):
-        assert t(True) == 1
-        assert t(False) == 0
-        assert t(0) == 0
-        assert t(None) == 0
-        assert t(0.0) == 0
-        assert t(0j) == 0
-        assert t(1j) == 1
-        assert t(234) == 1
-        assert t(234.6) == 1
-        assert t(234.6 + 3j) == 1
-        assert t("234") == 1
-        assert t("aaa") == 1
-        assert t("") == 0
-        assert t([]) == 0
-        assert t(()) == 0
-        assert t({}) == 0
-        assert t(t) == 1
-        assert t(-234) == 1
-        assert t(10**100) == 1
-        assert t([234]) == 1
-        assert t((234, )) == 1
-        assert t(array(234)) == 1
-        assert t(array([234])) == 1
-        assert t(array([[234]])) == 1
-        assert t(array([127], "b")) == 1
-        assert t(array([234], "h")) == 1
-        assert t(array([234], "i")) == 1
-        assert t(array([234], "l")) == 1
-        assert t(array([234], "f")) == 1
-        assert t(array([234], "d")) == 1
-        assert t(array([234 + 3j], "F")) == 1
-        assert t(array([234], "D")) == 1
-        assert t(array(0)) == 0
-        assert t(array([0])) == 0
-        assert t(array([[0]])) == 0
-        assert t(array([0j])) == 0
-        assert t(array([1])) == 1
-        pytest.raises(ValueError, t, array([0, 0]))
+@pytest.fixture(scope="module")
+def ret_logical_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestFReturnLogical",
+        sources=[
+            util.getpath("tests", "src", "return_logical", "foo77.f"),
+            util.getpath("tests", "src", "return_logical", "foo90.f90"),
+        ],
+    )
+    return spec
 
 
-class TestFReturnLogical(TestReturnLogical):
-    sources = [
-        util.getpath("tests", "src", "return_logical", "foo77.f"),
-        util.getpath("tests", "src", "return_logical", "foo90.f90"),
-    ]
+def check_function(modcomp, tname):
+    t = getattr(modcomp, tname)
+    assert t(True) == 1
+    assert t(False) == 0
+    assert t(0) == 0
+    assert t(None) == 0
+    assert t(0.0) == 0
+    assert t(0j) == 0
+    assert t(1j) == 1
+    assert t(234) == 1
+    assert t(234.6) == 1
+    assert t(234.6 + 3j) == 1
+    assert t("234") == 1
+    assert t("aaa") == 1
+    assert t("") == 0
+    assert t([]) == 0
+    assert t(()) == 0
+    assert t({}) == 0
+    assert t(t) == 1
+    assert t(-234) == 1
+    assert t(10**100) == 1
+    assert t([234]) == 1
+    assert t((234,)) == 1
+    assert t(array(234)) == 1
+    assert t(array([234])) == 1
+    assert t(array([[234]])) == 1
+    assert t(array([127], "b")) == 1
+    assert t(array([234], "h")) == 1
+    assert t(array([234], "i")) == 1
+    assert t(array([234], "l")) == 1
+    assert t(array([234], "f")) == 1
+    assert t(array([234], "d")) == 1
+    assert t(array([234 + 3j], "F")) == 1
+    assert t(array([234], "D")) == 1
+    assert t(array(0)) == 0
+    assert t(array([0])) == 0
+    assert t(array([[0]])) == 0
+    assert t(array([0j])) == 0
+    assert t(array([1])) == 1
+    pytest.raises(ValueError, t, array([0, 0]))
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("name", "t0,t1,t2,t4,s0,s1,s2,s4".split(","))
-    def test_all_f77(self, name):
-        self.check_function(getattr(self.module, name))
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
-    def test_all_f90(self, name):
-        self.check_function(getattr(self.module.f90_return_logical, name))
+@pytest.mark.parametrize("name", "t0,t1,t2,t4,s0,s1,s2,s4".split(","))
+@pytest.mark.parametrize("_mod", ["ret_logical_spec"], indirect=True)
+def test_all_f77(_mod, name):
+    check_function(_mod, name)
+
+
+@pytest.mark.parametrize("name", "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+@pytest.mark.parametrize("_mod", ["ret_logical_spec"], indirect=True)
+def test_all_f90(_mod, name):
+    check_function(_mod.f90_return_logical, name)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -6,46 +6,94 @@ from numpy import array
 from . import util
 
 
-@pytest.mark.slow
-@pytest.mark.usefixtures("build_module")
-class TestReturnReal(util.F2PyTest):
-    def check_function(self, t, tname):
-        if tname in ["t0", "t4", "s0", "s4"]:
-            err = 1e-5
-        else:
-            err = 0.0
-        assert abs(t(234) - 234.0) <= err
-        assert abs(t(234.6) - 234.6) <= err
-        assert abs(t("234") - 234) <= err
-        assert abs(t("234.6") - 234.6) <= err
-        assert abs(t(-234) + 234) <= err
-        assert abs(t([234]) - 234) <= err
-        assert abs(t((234, )) - 234.0) <= err
-        assert abs(t(array(234)) - 234.0) <= err
-        assert abs(t(array(234).astype("b")) + 22) <= err
-        assert abs(t(array(234, "h")) - 234.0) <= err
-        assert abs(t(array(234, "i")) - 234.0) <= err
-        assert abs(t(array(234, "l")) - 234.0) <= err
-        assert abs(t(array(234, "B")) - 234.0) <= err
-        assert abs(t(array(234, "f")) - 234.0) <= err
-        assert abs(t(array(234, "d")) - 234.0) <= err
-        if tname in ["t0", "t4", "s0", "s4"]:
-            assert t(1e200) == t(1e300)  # inf
+@pytest.fixture(scope="module")
+def ret_creal_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestCReturnReal",
+        suffix=".pyf",
+        module_name="c_ext_return_real",
+        code="""
+    python module c_ext_return_real
+    usercode \'\'\'
+    float t4(float value) { return value; }
+    void s4(float *t4, float value) { *t4 = value; }
+    double t8(double value) { return value; }
+    void s8(double *t8, double value) { *t8 = value; }
+    \'\'\'
+    interface
+      function t4(value)
+        real*4 intent(c) :: t4,value
+      end
+      function t8(value)
+        real*8 intent(c) :: t8,value
+      end
+      subroutine s4(t4,value)
+        intent(c) s4
+        real*4 intent(out) :: t4
+        real*4 intent(c) :: value
+      end
+      subroutine s8(t8,value)
+        intent(c) s8
+        real*8 intent(out) :: t8
+        real*8 intent(c) :: value
+      end
+    end interface
+    end python module c_ext_return_real
+        """,
+    )
+    return spec
 
-        # pytest.raises(ValueError, t, array([234], 'S1'))
-        pytest.raises(ValueError, t, "abc")
 
-        pytest.raises(IndexError, t, [])
-        pytest.raises(IndexError, t, ())
+@pytest.fixture(scope="module")
+def ret_freal_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestFReturnReal",
+        sources=[
+            util.getpath("tests", "src", "return_real", "foo77.f"),
+            util.getpath("tests", "src", "return_real", "foo90.f90"),
+        ],
+    )
+    return spec
 
-        pytest.raises(Exception, t, t)
-        pytest.raises(Exception, t, {})
 
-        try:
-            r = t(10**400)
-            assert repr(r) in ["inf", "Infinity"]
-        except OverflowError:
-            pass
+def check_function(compmod, tname):
+    t = getattr(compmod, tname)
+    if tname in ["t0", "t4", "s0", "s4"]:
+        err = 1e-5
+    else:
+        err = 0.0
+    assert abs(t(234) - 234.0) <= err
+    assert abs(t(234.6) - 234.6) <= err
+    assert abs(t("234") - 234) <= err
+    assert abs(t("234.6") - 234.6) <= err
+    assert abs(t(-234) + 234) <= err
+    assert abs(t([234]) - 234) <= err
+    assert abs(t((234,)) - 234.0) <= err
+    assert abs(t(array(234)) - 234.0) <= err
+    assert abs(t(array(234).astype("b")) + 22) <= err
+    assert abs(t(array(234, "h")) - 234.0) <= err
+    assert abs(t(array(234, "i")) - 234.0) <= err
+    assert abs(t(array(234, "l")) - 234.0) <= err
+    assert abs(t(array(234, "B")) - 234.0) <= err
+    assert abs(t(array(234, "f")) - 234.0) <= err
+    assert abs(t(array(234, "d")) - 234.0) <= err
+    if tname in ["t0", "t4", "s0", "s4"]:
+        assert t(1e200) == t(1e300)  # inf
+
+    # pytest.raises(ValueError, t, array([234], 'S1'))
+    pytest.raises(ValueError, t, "abc")
+
+    pytest.raises(IndexError, t, [])
+    pytest.raises(IndexError, t, ())
+
+    pytest.raises(Exception, t, t)
+    pytest.raises(Exception, t, {})
+
+    try:
+        r = t(10**400)
+        assert repr(r) in ["inf", "Infinity"]
+    except OverflowError:
+        pass
 
 
 @pytest.mark.skipif(
@@ -53,57 +101,20 @@ class TestReturnReal(util.F2PyTest):
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
     "but not when run in isolation",
 )
-@pytest.mark.skipif(
-    np.dtype(np.intp).itemsize < 8,
-    reason="32-bit builds are buggy"
-)
-class TestCReturnReal(TestReturnReal):
-    suffix = ".pyf"
-    module_name = "c_ext_return_real"
-    code = """
-python module c_ext_return_real
-usercode \'\'\'
-float t4(float value) { return value; }
-void s4(float *t4, float value) { *t4 = value; }
-double t8(double value) { return value; }
-void s8(double *t8, double value) { *t8 = value; }
-\'\'\'
-interface
-  function t4(value)
-    real*4 intent(c) :: t4,value
-  end
-  function t8(value)
-    real*8 intent(c) :: t8,value
-  end
-  subroutine s4(t4,value)
-    intent(c) s4
-    real*4 intent(out) :: t4
-    real*4 intent(c) :: value
-  end
-  subroutine s8(t8,value)
-    intent(c) s8
-    real*8 intent(out) :: t8
-    real*8 intent(c) :: value
-  end
-end interface
-end python module c_ext_return_real
-    """
-
-    @pytest.mark.parametrize("name", "t4,t8,s4,s8".split(","))
-    def test_all(self, name):
-        self.check_function(getattr(self.module, name), name)
+@pytest.mark.skipif(np.dtype(np.intp).itemsize < 8, reason="32-bit builds are buggy")
+@pytest.mark.parametrize("name", "t4,t8,s4,s8".split(","))
+@pytest.mark.parametrize("_mod", ["ret_creal_spec"], indirect=True)
+def test_all(_mod, name):
+    check_function(_mod, name)
 
 
-class TestFReturnReal(TestReturnReal):
-    sources = [
-        util.getpath("tests", "src", "return_real", "foo77.f"),
-        util.getpath("tests", "src", "return_real", "foo90.f90"),
-    ]
+@pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
+@pytest.mark.parametrize("_mod", ["ret_freal_spec"], indirect=True)
+def test_all_f77(_mod, name):
+    check_function(_mod, name)
 
-    @pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
-    def test_all_f77(self, name):
-        self.check_function(getattr(self.module, name), name)
 
-    @pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
-    def test_all_f90(self, name):
-        self.check_function(getattr(self.module.f90_return_real, name), name)
+@pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
+@pytest.mark.parametrize("_mod", ["ret_freal_spec"], indirect=True)
+def test_all_f90(_mod, name):
+    check_function(_mod.f90_return_real, name)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -7,6 +7,7 @@ from . import util
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestReturnReal(util.F2PyTest):
     def check_function(self, t, tname):
         if tname in ["t0", "t4", "s0", "s4"]:

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -14,6 +14,7 @@ from . import util
     np.dtype(np.intp).itemsize < 8,
     reason="32-bit builds are buggy"
 )
+@pytest.mark.usefixtures("build_module")
 class TestMultiline(util.F2PyTest):
     suffix = ".pyf"
     module_name = "multiline"
@@ -48,6 +49,7 @@ end python module {module_name}
     reason="32-bit builds are buggy"
 )
 @pytest.mark.slow
+@pytest.mark.usefixtures("build_module")
 class TestCallstatement(util.F2PyTest):
     suffix = ".pyf"
     module_name = "callstatement"

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -5,42 +5,51 @@ import numpy as np
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestSizeSumExample(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "size", "foo.f90")]
+@pytest.fixture(scope="module")
+def size_sum_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestSizeSumExample",
+        sources=[
+            util.getpath("tests", "src", "size", "foo.f90"),
+        ],
+    )
+    return spec
 
-    @pytest.mark.slow
-    def test_all(self):
-        r = self.module.foo([[]])
-        assert r == [0]
 
-        r = self.module.foo([[1, 2]])
-        assert r == [3]
+@pytest.mark.parametrize("_mod", ["size_sum_spec"], indirect=True)
+def test_all(_mod):
+    r = _mod.foo([[]])
+    assert r == [0]
 
-        r = self.module.foo([[1, 2], [3, 4]])
-        assert np.allclose(r, [3, 7])
+    r = _mod.foo([[1, 2]])
+    assert r == [3]
 
-        r = self.module.foo([[1, 2], [3, 4], [5, 6]])
-        assert np.allclose(r, [3, 7, 11])
+    r = _mod.foo([[1, 2], [3, 4]])
+    assert np.allclose(r, [3, 7])
 
-    @pytest.mark.slow
-    def test_transpose(self):
-        r = self.module.trans([[]])
-        assert np.allclose(r.T, np.array([[]]))
+    r = _mod.foo([[1, 2], [3, 4], [5, 6]])
+    assert np.allclose(r, [3, 7, 11])
 
-        r = self.module.trans([[1, 2]])
-        assert np.allclose(r, [[1.], [2.]])
 
-        r = self.module.trans([[1, 2, 3], [4, 5, 6]])
-        assert np.allclose(r, [[1, 4], [2, 5], [3, 6]])
+@pytest.mark.parametrize("_mod", ["size_sum_spec"], indirect=True)
+def test_transpose(_mod):
+    r = _mod.trans([[]])
+    assert np.allclose(r.T, np.array([[]]))
 
-    @pytest.mark.slow
-    def test_flatten(self):
-        r = self.module.flatten([[]])
-        assert np.allclose(r, [])
+    r = _mod.trans([[1, 2]])
+    assert np.allclose(r, [[1.0], [2.0]])
 
-        r = self.module.flatten([[1, 2]])
-        assert np.allclose(r, [1, 2])
+    r = _mod.trans([[1, 2, 3], [4, 5, 6]])
+    assert np.allclose(r, [[1, 4], [2, 5], [3, 6]])
 
-        r = self.module.flatten([[1, 2, 3], [4, 5, 6]])
-        assert np.allclose(r, [1, 2, 3, 4, 5, 6])
+
+@pytest.mark.parametrize("_mod", ["size_sum_spec"], indirect=True)
+def test_flatten(_mod):
+    r = _mod.flatten([[]])
+    assert np.allclose(r, [])
+
+    r = _mod.flatten([[1, 2]])
+    assert np.allclose(r, [1, 2])
+
+    r = _mod.flatten([[1, 2, 3], [4, 5, 6]])
+    assert np.allclose(r, [1, 2, 3, 4, 5, 6])

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -5,6 +5,7 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestSizeSumExample(util.F2PyTest):
     sources = [util.getpath("tests", "src", "size", "foo.f90")]
 

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -5,99 +5,104 @@ import numpy as np
 from . import util
 
 
-@pytest.mark.usefixtures("build_module")
-class TestString(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "string", "char.f90")]
+def _sint(s, start=0, end=None):
+    """Return the content of a string buffer as integer value.
 
-    @pytest.mark.slow
-    def test_char(self):
-        strings = np.array(["ab", "cd", "ef"], dtype="c").T
-        inp, out = self.module.char_test.change_strings(
-            strings, strings.shape[1])
-        assert inp == pytest.approx(strings)
-        expected = strings.copy()
-        expected[1, :] = "AAA"
-        assert out == pytest.approx(expected)
-
-
-@pytest.mark.usefixtures("build_module")
-class TestDocStringArguments(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "string", "string.f")]
-
-    def test_example(self):
-        a = np.array(b"123\0\0")
-        b = np.array(b"123\0\0")
-        c = np.array(b"123")
-        d = np.array(b"123")
-
-        self.module.foo(a, b, c, d)
-
-        assert a.tobytes() == b"123\0\0"
-        assert b.tobytes() == b"B23\0\0"
-        assert c.tobytes() == b"123"
-        assert d.tobytes() == b"D23"
+    For example:
+      _sint('1234') -> 4321
+      _sint('123A') -> 17321
+    """
+    if isinstance(s, np.ndarray):
+        s = s.tobytes()
+    elif isinstance(s, str):
+        s = s.encode()
+    assert isinstance(s, bytes)
+    if end is None:
+        end = len(s)
+    i = 0
+    for j in range(start, min(end, len(s))):
+        i += s[j] * 10**j
+    return i
 
 
-@pytest.mark.usefixtures("build_module")
-class TestFixedString(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "string", "fixed_string.f90")]
+def _get_input(intent="in"):
+    if intent in ["in"]:
+        yield ""
+        yield "1"
+        yield "1234"
+        yield "12345"
+        yield b""
+        yield b"\0"
+        yield b"1"
+        yield b"\01"
+        yield b"1\0"
+        yield b"1234"
+        yield b"12345"
+    yield np.ndarray((), np.bytes_, buffer=b"")  # array(b'', dtype='|S0')
+    yield np.array(b"")  # array(b'', dtype='|S1')
+    yield np.array(b"\0")
+    yield np.array(b"1")
+    yield np.array(b"1\0")
+    yield np.array(b"\01")
+    yield np.array(b"1234")
+    yield np.array(b"123\0")
+    yield np.array(b"12345")
 
-    @staticmethod
-    def _sint(s, start=0, end=None):
-        """Return the content of a string buffer as integer value.
 
-        For example:
-          _sint('1234') -> 4321
-          _sint('123A') -> 17321
-        """
-        if isinstance(s, np.ndarray):
-            s = s.tobytes()
-        elif isinstance(s, str):
-            s = s.encode()
-        assert isinstance(s, bytes)
-        if end is None:
-            end = len(s)
-        i = 0
-        for j in range(start, min(end, len(s))):
-            i += s[j] * 10**j
-        return i
+@pytest.fixture(scope="module")
+def strn_fixed_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestStringNFixedDocstring",
+        sources=[
+            util.getpath("tests", "src", "string", "char.f90"),
+            util.getpath("tests", "src", "string", "fixed_string.f90"),
+            util.getpath("tests", "src", "string", "string.f"),
+        ],
+    )
+    return spec
 
-    def _get_input(self, intent="in"):
-        if intent in ["in"]:
-            yield ""
-            yield "1"
-            yield "1234"
-            yield "12345"
-            yield b""
-            yield b"\0"
-            yield b"1"
-            yield b"\01"
-            yield b"1\0"
-            yield b"1234"
-            yield b"12345"
-        yield np.ndarray((), np.bytes_, buffer=b"")  # array(b'', dtype='|S0')
-        yield np.array(b"")  # array(b'', dtype='|S1')
-        yield np.array(b"\0")
-        yield np.array(b"1")
-        yield np.array(b"1\0")
-        yield np.array(b"\01")
-        yield np.array(b"1234")
-        yield np.array(b"123\0")
-        yield np.array(b"12345")
 
-    def test_intent_in(self):
-        for s in self._get_input():
-            r = self.module.test_in_bytes4(s)
-            # also checks that s is not changed inplace
-            expected = self._sint(s, end=4)
-            assert r == expected, s
+@pytest.mark.parametrize("_mod", ["strn_fixed_spec"], indirect=True)
+def test_char(_mod):
+    strings = np.array(["ab", "cd", "ef"], dtype="c").T
+    inp, out = _mod.char_test.change_strings(strings, strings.shape[1])
+    assert inp == pytest.approx(strings)
+    expected = strings.copy()
+    expected[1, :] = "AAA"
+    assert out == pytest.approx(expected)
 
-    def test_intent_inout(self):
-        for s in self._get_input(intent="inout"):
-            rest = self._sint(s, start=4)
-            r = self.module.test_inout_bytes4(s)
-            expected = self._sint(s, end=4)
-            assert r == expected
 
-            # check that the rest of input string is preserved
-            assert rest == self._sint(s, start=4)
+@pytest.mark.parametrize("_mod", ["strn_fixed_spec"], indirect=True)
+def test_example(_mod):
+    a = np.array(b"123\0\0")
+    b = np.array(b"123\0\0")
+    c = np.array(b"123")
+    d = np.array(b"123")
+
+    _mod.foo(a, b, c, d)
+
+    assert a.tobytes() == b"123\0\0"
+    assert b.tobytes() == b"B23\0\0"
+    assert c.tobytes() == b"123"
+    assert d.tobytes() == b"D23"
+
+
+@pytest.mark.parametrize("_mod", ["strn_fixed_spec"], indirect=True)
+def test_intent_in(_mod):
+    for s in _get_input():
+        r = _mod.test_in_bytes4(s)
+        # also checks that s is not changed inplace
+        expected = _sint(s, end=4)
+        assert r == expected, s
+
+
+@pytest.mark.parametrize("_mod", ["strn_fixed_spec"], indirect=True)
+def test_intent_inout(_mod):
+    for s in _get_input(intent="inout"):
+        rest = _sint(s, start=4)
+        r = _mod.test_inout_bytes4(s)
+        expected = _sint(s, end=4)
+        assert r == expected
+
+        # check that the rest of input string is preserved
+        assert rest == _sint(s, start=4)

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -5,6 +5,7 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.usefixtures("build_module")
 class TestString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "char.f90")]
 
@@ -19,6 +20,7 @@ class TestString(util.F2PyTest):
         assert out == pytest.approx(expected)
 
 
+@pytest.mark.usefixtures("build_module")
 class TestDocStringArguments(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "string.f")]
 
@@ -36,6 +38,7 @@ class TestDocStringArguments(util.F2PyTest):
         assert d.tobytes() == b"D23"
 
 
+@pytest.mark.usefixtures("build_module")
 class TestFixedString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "fixed_string.f90")]
 

--- a/numpy/f2py/tests/test_symbolic.py
+++ b/numpy/f2py/tests/test_symbolic.py
@@ -32,463 +32,462 @@ from numpy.f2py.symbolic import (
 from . import util
 
 
-class TestSymbolic(util.F2PyTest):
-    def test_eliminate_quotes(self):
-        def worker(s):
-            r, d = eliminate_quotes(s)
-            s1 = insert_quotes(r, d)
-            assert s1 == s
+def test_eliminate_quotes():
+    def worker(s):
+        r, d = eliminate_quotes(s)
+        s1 = insert_quotes(r, d)
+        assert s1 == s
 
-        for kind in ["", "mykind_"]:
-            worker(kind + '"1234" // "ABCD"')
-            worker(kind + '"1234" // ' + kind + '"ABCD"')
-            worker(kind + "\"1234\" // 'ABCD'")
-            worker(kind + '"1234" // ' + kind + "'ABCD'")
-            worker(kind + '"1\\"2\'AB\'34"')
-            worker("a = " + kind + "'1\\'2\"AB\"34'")
+    for kind in ["", "mykind_"]:
+        worker(kind + '"1234" // "ABCD"')
+        worker(kind + '"1234" // ' + kind + '"ABCD"')
+        worker(kind + "\"1234\" // 'ABCD'")
+        worker(kind + '"1234" // ' + kind + "'ABCD'")
+        worker(kind + '"1\\"2\'AB\'34"')
+        worker("a = " + kind + "'1\\'2\"AB\"34'")
 
-    def test_sanity(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
+def test_sanity():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
 
-        assert x.op == Op.SYMBOL
-        assert repr(x) == "Expr(Op.SYMBOL, 'x')"
-        assert x == x
-        assert x != y
-        assert hash(x) is not None
+    assert x.op == Op.SYMBOL
+    assert repr(x) == "Expr(Op.SYMBOL, 'x')"
+    assert x == x
+    assert x != y
+    assert hash(x) is not None
 
-        n = as_number(123)
-        m = as_number(456)
-        assert n.op == Op.INTEGER
-        assert repr(n) == "Expr(Op.INTEGER, (123, 4))"
-        assert n == n
-        assert n != m
-        assert hash(n) is not None
+    n = as_number(123)
+    m = as_number(456)
+    assert n.op == Op.INTEGER
+    assert repr(n) == "Expr(Op.INTEGER, (123, 4))"
+    assert n == n
+    assert n != m
+    assert hash(n) is not None
 
-        fn = as_number(12.3)
-        fm = as_number(45.6)
-        assert fn.op == Op.REAL
-        assert repr(fn) == "Expr(Op.REAL, (12.3, 4))"
-        assert fn == fn
-        assert fn != fm
-        assert hash(fn) is not None
+    fn = as_number(12.3)
+    fm = as_number(45.6)
+    assert fn.op == Op.REAL
+    assert repr(fn) == "Expr(Op.REAL, (12.3, 4))"
+    assert fn == fn
+    assert fn != fm
+    assert hash(fn) is not None
 
-        c = as_complex(1, 2)
-        c2 = as_complex(3, 4)
-        assert c.op == Op.COMPLEX
-        assert repr(c) == ("Expr(Op.COMPLEX, (Expr(Op.INTEGER, (1, 4)),"
-                           " Expr(Op.INTEGER, (2, 4))))")
-        assert c == c
-        assert c != c2
-        assert hash(c) is not None
+    c = as_complex(1, 2)
+    c2 = as_complex(3, 4)
+    assert c.op == Op.COMPLEX
+    assert repr(c) == ("Expr(Op.COMPLEX, (Expr(Op.INTEGER, (1, 4)),"
+                       " Expr(Op.INTEGER, (2, 4))))")
+    assert c == c
+    assert c != c2
+    assert hash(c) is not None
 
-        s = as_string("'123'")
-        s2 = as_string('"ABC"')
-        assert s.op == Op.STRING
-        assert repr(s) == "Expr(Op.STRING, (\"'123'\", 1))", repr(s)
-        assert s == s
-        assert s != s2
+    s = as_string("'123'")
+    s2 = as_string('"ABC"')
+    assert s.op == Op.STRING
+    assert repr(s) == "Expr(Op.STRING, (\"'123'\", 1))", repr(s)
+    assert s == s
+    assert s != s2
 
-        a = as_array((n, m))
-        b = as_array((n, ))
-        assert a.op == Op.ARRAY
-        assert repr(a) == ("Expr(Op.ARRAY, (Expr(Op.INTEGER, (123, 4)),"
-                           " Expr(Op.INTEGER, (456, 4))))")
-        assert a == a
-        assert a != b
+    a = as_array((n, m))
+    b = as_array((n, ))
+    assert a.op == Op.ARRAY
+    assert repr(a) == ("Expr(Op.ARRAY, (Expr(Op.INTEGER, (123, 4)),"
+                       " Expr(Op.INTEGER, (456, 4))))")
+    assert a == a
+    assert a != b
 
-        t = as_terms(x)
-        u = as_terms(y)
-        assert t.op == Op.TERMS
-        assert repr(t) == "Expr(Op.TERMS, {Expr(Op.SYMBOL, 'x'): 1})"
-        assert t == t
-        assert t != u
-        assert hash(t) is not None
+    t = as_terms(x)
+    u = as_terms(y)
+    assert t.op == Op.TERMS
+    assert repr(t) == "Expr(Op.TERMS, {Expr(Op.SYMBOL, 'x'): 1})"
+    assert t == t
+    assert t != u
+    assert hash(t) is not None
 
-        v = as_factors(x)
-        w = as_factors(y)
-        assert v.op == Op.FACTORS
-        assert repr(v) == "Expr(Op.FACTORS, {Expr(Op.SYMBOL, 'x'): 1})"
-        assert v == v
-        assert w != v
-        assert hash(v) is not None
+    v = as_factors(x)
+    w = as_factors(y)
+    assert v.op == Op.FACTORS
+    assert repr(v) == "Expr(Op.FACTORS, {Expr(Op.SYMBOL, 'x'): 1})"
+    assert v == v
+    assert w != v
+    assert hash(v) is not None
 
-        t = as_ternary(x, y, z)
-        u = as_ternary(x, z, y)
-        assert t.op == Op.TERNARY
-        assert t == t
-        assert t != u
-        assert hash(t) is not None
+    t = as_ternary(x, y, z)
+    u = as_ternary(x, z, y)
+    assert t.op == Op.TERNARY
+    assert t == t
+    assert t != u
+    assert hash(t) is not None
 
-        e = as_eq(x, y)
-        f = as_lt(x, y)
-        assert e.op == Op.RELATIONAL
-        assert e == e
-        assert e != f
-        assert hash(e) is not None
+    e = as_eq(x, y)
+    f = as_lt(x, y)
+    assert e.op == Op.RELATIONAL
+    assert e == e
+    assert e != f
+    assert hash(e) is not None
 
-    def test_tostring_fortran(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-        n = as_number(123)
-        m = as_number(456)
-        a = as_array((n, m))
-        c = as_complex(n, m)
+def test_tostring_fortran():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
+    n = as_number(123)
+    m = as_number(456)
+    a = as_array((n, m))
+    c = as_complex(n, m)
 
-        assert str(x) == "x"
-        assert str(n) == "123"
-        assert str(a) == "[123, 456]"
-        assert str(c) == "(123, 456)"
+    assert str(x) == "x"
+    assert str(n) == "123"
+    assert str(a) == "[123, 456]"
+    assert str(c) == "(123, 456)"
 
-        assert str(Expr(Op.TERMS, {x: 1})) == "x"
-        assert str(Expr(Op.TERMS, {x: 2})) == "2 * x"
-        assert str(Expr(Op.TERMS, {x: -1})) == "-x"
-        assert str(Expr(Op.TERMS, {x: -2})) == "-2 * x"
-        assert str(Expr(Op.TERMS, {x: 1, y: 1})) == "x + y"
-        assert str(Expr(Op.TERMS, {x: -1, y: -1})) == "-x - y"
-        assert str(Expr(Op.TERMS, {x: 2, y: 3})) == "2 * x + 3 * y"
-        assert str(Expr(Op.TERMS, {x: -2, y: 3})) == "-2 * x + 3 * y"
-        assert str(Expr(Op.TERMS, {x: 2, y: -3})) == "2 * x - 3 * y"
+    assert str(Expr(Op.TERMS, {x: 1})) == "x"
+    assert str(Expr(Op.TERMS, {x: 2})) == "2 * x"
+    assert str(Expr(Op.TERMS, {x: -1})) == "-x"
+    assert str(Expr(Op.TERMS, {x: -2})) == "-2 * x"
+    assert str(Expr(Op.TERMS, {x: 1, y: 1})) == "x + y"
+    assert str(Expr(Op.TERMS, {x: -1, y: -1})) == "-x - y"
+    assert str(Expr(Op.TERMS, {x: 2, y: 3})) == "2 * x + 3 * y"
+    assert str(Expr(Op.TERMS, {x: -2, y: 3})) == "-2 * x + 3 * y"
+    assert str(Expr(Op.TERMS, {x: 2, y: -3})) == "2 * x - 3 * y"
 
-        assert str(Expr(Op.FACTORS, {x: 1})) == "x"
-        assert str(Expr(Op.FACTORS, {x: 2})) == "x ** 2"
-        assert str(Expr(Op.FACTORS, {x: -1})) == "x ** -1"
-        assert str(Expr(Op.FACTORS, {x: -2})) == "x ** -2"
-        assert str(Expr(Op.FACTORS, {x: 1, y: 1})) == "x * y"
-        assert str(Expr(Op.FACTORS, {x: 2, y: 3})) == "x ** 2 * y ** 3"
+    assert str(Expr(Op.FACTORS, {x: 1})) == "x"
+    assert str(Expr(Op.FACTORS, {x: 2})) == "x ** 2"
+    assert str(Expr(Op.FACTORS, {x: -1})) == "x ** -1"
+    assert str(Expr(Op.FACTORS, {x: -2})) == "x ** -2"
+    assert str(Expr(Op.FACTORS, {x: 1, y: 1})) == "x * y"
+    assert str(Expr(Op.FACTORS, {x: 2, y: 3})) == "x ** 2 * y ** 3"
 
-        v = Expr(Op.FACTORS, {x: 2, Expr(Op.TERMS, {x: 1, y: 1}): 3})
-        assert str(v) == "x ** 2 * (x + y) ** 3", str(v)
-        v = Expr(Op.FACTORS, {x: 2, Expr(Op.FACTORS, {x: 1, y: 1}): 3})
-        assert str(v) == "x ** 2 * (x * y) ** 3", str(v)
+    v = Expr(Op.FACTORS, {x: 2, Expr(Op.TERMS, {x: 1, y: 1}): 3})
+    assert str(v) == "x ** 2 * (x + y) ** 3", str(v)
+    v = Expr(Op.FACTORS, {x: 2, Expr(Op.FACTORS, {x: 1, y: 1}): 3})
+    assert str(v) == "x ** 2 * (x * y) ** 3", str(v)
 
-        assert str(Expr(Op.APPLY, ("f", (), {}))) == "f()"
-        assert str(Expr(Op.APPLY, ("f", (x, ), {}))) == "f(x)"
-        assert str(Expr(Op.APPLY, ("f", (x, y), {}))) == "f(x, y)"
-        assert str(Expr(Op.INDEXING, ("f", x))) == "f[x]"
+    assert str(Expr(Op.APPLY, ("f", (), {}))) == "f()"
+    assert str(Expr(Op.APPLY, ("f", (x, ), {}))) == "f(x)"
+    assert str(Expr(Op.APPLY, ("f", (x, y), {}))) == "f(x, y)"
+    assert str(Expr(Op.INDEXING, ("f", x))) == "f[x]"
 
-        assert str(as_ternary(x, y, z)) == "merge(y, z, x)"
-        assert str(as_eq(x, y)) == "x .eq. y"
-        assert str(as_ne(x, y)) == "x .ne. y"
-        assert str(as_lt(x, y)) == "x .lt. y"
-        assert str(as_le(x, y)) == "x .le. y"
-        assert str(as_gt(x, y)) == "x .gt. y"
-        assert str(as_ge(x, y)) == "x .ge. y"
+    assert str(as_ternary(x, y, z)) == "merge(y, z, x)"
+    assert str(as_eq(x, y)) == "x .eq. y"
+    assert str(as_ne(x, y)) == "x .ne. y"
+    assert str(as_lt(x, y)) == "x .lt. y"
+    assert str(as_le(x, y)) == "x .le. y"
+    assert str(as_gt(x, y)) == "x .gt. y"
+    assert str(as_ge(x, y)) == "x .ge. y"
 
-    def test_tostring_c(self):
-        language = Language.C
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-        n = as_number(123)
+def test_tostring_c():
+    language = Language.C
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
+    n = as_number(123)
 
-        assert Expr(Op.FACTORS, {x: 2}).tostring(language=language) == "x * x"
-        assert (Expr(Op.FACTORS, {
-            x + y: 2
-        }).tostring(language=language) == "(x + y) * (x + y)")
-        assert Expr(Op.FACTORS, {
-            x: 12
-        }).tostring(language=language) == "pow(x, 12)"
+    assert Expr(Op.FACTORS, {x: 2}).tostring(language=language) == "x * x"
+    assert (Expr(Op.FACTORS, {
+        x + y: 2
+    }).tostring(language=language) == "(x + y) * (x + y)")
+    assert Expr(Op.FACTORS, {
+        x: 12
+    }).tostring(language=language) == "pow(x, 12)"
 
-        assert as_apply(ArithOp.DIV, x,
-                        y).tostring(language=language) == "x / y"
-        assert (as_apply(ArithOp.DIV, x,
-                         x + y).tostring(language=language) == "x / (x + y)")
-        assert (as_apply(ArithOp.DIV, x - y, x +
-                         y).tostring(language=language) == "(x - y) / (x + y)")
-        assert (x + (x - y) / (x + y) +
-                n).tostring(language=language) == "123 + x + (x - y) / (x + y)"
+    assert as_apply(ArithOp.DIV, x,
+                    y).tostring(language=language) == "x / y"
+    assert (as_apply(ArithOp.DIV, x,
+                     x + y).tostring(language=language) == "x / (x + y)")
+    assert (as_apply(ArithOp.DIV, x - y, x +
+                     y).tostring(language=language) == "(x - y) / (x + y)")
+    assert (x + (x - y) / (x + y) +
+            n).tostring(language=language) == "123 + x + (x - y) / (x + y)"
 
-        assert as_ternary(x, y, z).tostring(language=language) == "(x?y:z)"
-        assert as_eq(x, y).tostring(language=language) == "x == y"
-        assert as_ne(x, y).tostring(language=language) == "x != y"
-        assert as_lt(x, y).tostring(language=language) == "x < y"
-        assert as_le(x, y).tostring(language=language) == "x <= y"
-        assert as_gt(x, y).tostring(language=language) == "x > y"
-        assert as_ge(x, y).tostring(language=language) == "x >= y"
+    assert as_ternary(x, y, z).tostring(language=language) == "(x?y:z)"
+    assert as_eq(x, y).tostring(language=language) == "x == y"
+    assert as_ne(x, y).tostring(language=language) == "x != y"
+    assert as_lt(x, y).tostring(language=language) == "x < y"
+    assert as_le(x, y).tostring(language=language) == "x <= y"
+    assert as_gt(x, y).tostring(language=language) == "x > y"
+    assert as_ge(x, y).tostring(language=language) == "x >= y"
 
-    def test_operations(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
+def test_operations():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
 
-        assert x + x == Expr(Op.TERMS, {x: 2})
-        assert x - x == Expr(Op.INTEGER, (0, 4))
-        assert x + y == Expr(Op.TERMS, {x: 1, y: 1})
-        assert x - y == Expr(Op.TERMS, {x: 1, y: -1})
-        assert x * x == Expr(Op.FACTORS, {x: 2})
-        assert x * y == Expr(Op.FACTORS, {x: 1, y: 1})
+    assert x + x == Expr(Op.TERMS, {x: 2})
+    assert x - x == Expr(Op.INTEGER, (0, 4))
+    assert x + y == Expr(Op.TERMS, {x: 1, y: 1})
+    assert x - y == Expr(Op.TERMS, {x: 1, y: -1})
+    assert x * x == Expr(Op.FACTORS, {x: 2})
+    assert x * y == Expr(Op.FACTORS, {x: 1, y: 1})
 
-        assert +x == x
-        assert -x == Expr(Op.TERMS, {x: -1}), repr(-x)
-        assert 2 * x == Expr(Op.TERMS, {x: 2})
-        assert 2 + x == Expr(Op.TERMS, {x: 1, as_number(1): 2})
-        assert 2 * x + 3 * y == Expr(Op.TERMS, {x: 2, y: 3})
-        assert (x + y) * 2 == Expr(Op.TERMS, {x: 2, y: 2})
+    assert +x == x
+    assert -x == Expr(Op.TERMS, {x: -1}), repr(-x)
+    assert 2 * x == Expr(Op.TERMS, {x: 2})
+    assert 2 + x == Expr(Op.TERMS, {x: 1, as_number(1): 2})
+    assert 2 * x + 3 * y == Expr(Op.TERMS, {x: 2, y: 3})
+    assert (x + y) * 2 == Expr(Op.TERMS, {x: 2, y: 2})
 
-        assert x**2 == Expr(Op.FACTORS, {x: 2})
-        assert (x + y)**2 == Expr(
-            Op.TERMS,
-            {
-                Expr(Op.FACTORS, {x: 2}): 1,
-                Expr(Op.FACTORS, {y: 2}): 1,
-                Expr(Op.FACTORS, {
-                    x: 1,
-                    y: 1
-                }): 2,
-            },
+    assert x**2 == Expr(Op.FACTORS, {x: 2})
+    assert (x + y)**2 == Expr(
+        Op.TERMS,
+        {
+            Expr(Op.FACTORS, {x: 2}): 1,
+            Expr(Op.FACTORS, {y: 2}): 1,
+            Expr(Op.FACTORS, {
+                x: 1,
+                y: 1
+            }): 2,
+        },
+    )
+    assert (x + y) * x == x**2 + x * y
+    assert (x + y)**2 == x**2 + 2 * x * y + y**2
+    assert (x + y)**2 + (x - y)**2 == 2 * x**2 + 2 * y**2
+    assert (x + y) * z == x * z + y * z
+    assert z * (x + y) == x * z + y * z
+
+    assert (x / 2) == as_apply(ArithOp.DIV, x, as_number(2))
+    assert (2 * x / 2) == x
+    assert (3 * x / 2) == as_apply(ArithOp.DIV, 3 * x, as_number(2))
+    assert (4 * x / 2) == 2 * x
+    assert (5 * x / 2) == as_apply(ArithOp.DIV, 5 * x, as_number(2))
+    assert (6 * x / 2) == 3 * x
+    assert ((3 * 5) * x / 6) == as_apply(ArithOp.DIV, 5 * x, as_number(2))
+    assert (30 * x**2 * y**4 / (24 * x**3 * y**3)) == as_apply(
+        ArithOp.DIV, 5 * y, 4 * x)
+    assert ((15 * x / 6) / 5) == as_apply(ArithOp.DIV, x,
+                                          as_number(2)), (15 * x / 6) / 5
+    assert (x / (5 / x)) == as_apply(ArithOp.DIV, x**2, as_number(5))
+
+    assert (x / 2.0) == Expr(Op.TERMS, {x: 0.5})
+
+    s = as_string('"ABC"')
+    t = as_string('"123"')
+
+    assert s // t == Expr(Op.STRING, ('"ABC123"', 1))
+    assert s // x == Expr(Op.CONCAT, (s, x))
+    assert x // s == Expr(Op.CONCAT, (x, s))
+
+    c = as_complex(1.0, 2.0)
+    assert -c == as_complex(-1.0, -2.0)
+    assert c + c == as_expr((1 + 2j) * 2)
+    assert c * c == as_expr((1 + 2j)**2)
+
+def test_substitute():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
+    a = as_array((x, y))
+
+    assert x.substitute({x: y}) == y
+    assert (x + y).substitute({x: z}) == y + z
+    assert (x * y).substitute({x: z}) == y * z
+    assert (x**4).substitute({x: z}) == z**4
+    assert (x / y).substitute({x: z}) == z / y
+    assert x.substitute({x: y + z}) == y + z
+    assert a.substitute({x: y + z}) == as_array((y + z, y))
+
+    assert as_ternary(x, y,
+                      z).substitute({x: y + z}) == as_ternary(y + z, y, z)
+    assert as_eq(x, y).substitute({x: y + z}) == as_eq(y + z, y)
+
+def test_fromstring():
+
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
+    f = as_symbol("f")
+    s = as_string('"ABC"')
+    t = as_string('"123"')
+    a = as_array((x, y))
+
+    assert fromstring("x") == x
+    assert fromstring("+ x") == x
+    assert fromstring("-  x") == -x
+    assert fromstring("x + y") == x + y
+    assert fromstring("x + 1") == x + 1
+    assert fromstring("x * y") == x * y
+    assert fromstring("x * 2") == x * 2
+    assert fromstring("x / y") == x / y
+    assert fromstring("x ** 2", language=Language.Python) == x**2
+    assert fromstring("x ** 2 ** 3", language=Language.Python) == x**2**3
+    assert fromstring("(x + y) * z") == (x + y) * z
+
+    assert fromstring("f(x)") == f(x)
+    assert fromstring("f(x,y)") == f(x, y)
+    assert fromstring("f[x]") == f[x]
+    assert fromstring("f[x][y]") == f[x][y]
+
+    assert fromstring('"ABC"') == s
+    assert (normalize(
+        fromstring('"ABC" // "123" ',
+                   language=Language.Fortran)) == s // t)
+    assert fromstring('f("ABC")') == f(s)
+    assert fromstring('MYSTRKIND_"ABC"') == as_string('"ABC"', "MYSTRKIND")
+
+    assert fromstring("(/x, y/)") == a, fromstring("(/x, y/)")
+    assert fromstring("f((/x, y/))") == f(a)
+    assert fromstring("(/(x+y)*z/)") == as_array(((x + y) * z, ))
+
+    assert fromstring("123") == as_number(123)
+    assert fromstring("123_2") == as_number(123, 2)
+    assert fromstring("123_myintkind") == as_number(123, "myintkind")
+
+    assert fromstring("123.0") == as_number(123.0, 4)
+    assert fromstring("123.0_4") == as_number(123.0, 4)
+    assert fromstring("123.0_8") == as_number(123.0, 8)
+    assert fromstring("123.0e0") == as_number(123.0, 4)
+    assert fromstring("123.0d0") == as_number(123.0, 8)
+    assert fromstring("123d0") == as_number(123.0, 8)
+    assert fromstring("123e-0") == as_number(123.0, 4)
+    assert fromstring("123d+0") == as_number(123.0, 8)
+    assert fromstring("123.0_myrealkind") == as_number(123.0, "myrealkind")
+    assert fromstring("3E4") == as_number(30000.0, 4)
+
+    assert fromstring("(1, 2)") == as_complex(1, 2)
+    assert fromstring("(1e2, PI)") == as_complex(as_number(100.0),
+                                                 as_symbol("PI"))
+
+    assert fromstring("[1, 2]") == as_array((as_number(1), as_number(2)))
+
+    assert fromstring("POINT(x, y=1)") == as_apply(as_symbol("POINT"),
+                                                   x,
+                                                   y=as_number(1))
+    assert fromstring(
+        'PERSON(name="John", age=50, shape=(/34, 23/))') == as_apply(
+            as_symbol("PERSON"),
+            name=as_string('"John"'),
+            age=as_number(50),
+            shape=as_array((as_number(34), as_number(23))),
         )
-        assert (x + y) * x == x**2 + x * y
-        assert (x + y)**2 == x**2 + 2 * x * y + y**2
-        assert (x + y)**2 + (x - y)**2 == 2 * x**2 + 2 * y**2
-        assert (x + y) * z == x * z + y * z
-        assert z * (x + y) == x * z + y * z
 
-        assert (x / 2) == as_apply(ArithOp.DIV, x, as_number(2))
-        assert (2 * x / 2) == x
-        assert (3 * x / 2) == as_apply(ArithOp.DIV, 3 * x, as_number(2))
-        assert (4 * x / 2) == 2 * x
-        assert (5 * x / 2) == as_apply(ArithOp.DIV, 5 * x, as_number(2))
-        assert (6 * x / 2) == 3 * x
-        assert ((3 * 5) * x / 6) == as_apply(ArithOp.DIV, 5 * x, as_number(2))
-        assert (30 * x**2 * y**4 / (24 * x**3 * y**3)) == as_apply(
-            ArithOp.DIV, 5 * y, 4 * x)
-        assert ((15 * x / 6) / 5) == as_apply(ArithOp.DIV, x,
-                                              as_number(2)), (15 * x / 6) / 5
-        assert (x / (5 / x)) == as_apply(ArithOp.DIV, x**2, as_number(5))
+    assert fromstring("x?y:z") == as_ternary(x, y, z)
 
-        assert (x / 2.0) == Expr(Op.TERMS, {x: 0.5})
+    assert fromstring("*x") == as_deref(x)
+    assert fromstring("**x") == as_deref(as_deref(x))
+    assert fromstring("&x") == as_ref(x)
+    assert fromstring("(*x) * (*y)") == as_deref(x) * as_deref(y)
+    assert fromstring("(*x) * *y") == as_deref(x) * as_deref(y)
+    assert fromstring("*x * *y") == as_deref(x) * as_deref(y)
+    assert fromstring("*x**y") == as_deref(x) * as_deref(y)
 
-        s = as_string('"ABC"')
-        t = as_string('"123"')
+    assert fromstring("x == y") == as_eq(x, y)
+    assert fromstring("x != y") == as_ne(x, y)
+    assert fromstring("x < y") == as_lt(x, y)
+    assert fromstring("x > y") == as_gt(x, y)
+    assert fromstring("x <= y") == as_le(x, y)
+    assert fromstring("x >= y") == as_ge(x, y)
 
-        assert s // t == Expr(Op.STRING, ('"ABC123"', 1))
-        assert s // x == Expr(Op.CONCAT, (s, x))
-        assert x // s == Expr(Op.CONCAT, (x, s))
+    assert fromstring("x .eq. y", language=Language.Fortran) == as_eq(x, y)
+    assert fromstring("x .ne. y", language=Language.Fortran) == as_ne(x, y)
+    assert fromstring("x .lt. y", language=Language.Fortran) == as_lt(x, y)
+    assert fromstring("x .gt. y", language=Language.Fortran) == as_gt(x, y)
+    assert fromstring("x .le. y", language=Language.Fortran) == as_le(x, y)
+    assert fromstring("x .ge. y", language=Language.Fortran) == as_ge(x, y)
 
-        c = as_complex(1.0, 2.0)
-        assert -c == as_complex(-1.0, -2.0)
-        assert c + c == as_expr((1 + 2j) * 2)
-        assert c * c == as_expr((1 + 2j)**2)
+def test_traverse():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
+    f = as_symbol("f")
 
-    def test_substitute(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-        a = as_array((x, y))
+    # Use traverse to substitute a symbol
+    def replace_visit(s, r=z):
+        if s == x:
+            return r
 
-        assert x.substitute({x: y}) == y
-        assert (x + y).substitute({x: z}) == y + z
-        assert (x * y).substitute({x: z}) == y * z
-        assert (x**4).substitute({x: z}) == z**4
-        assert (x / y).substitute({x: z}) == z / y
-        assert x.substitute({x: y + z}) == y + z
-        assert a.substitute({x: y + z}) == as_array((y + z, y))
+    assert x.traverse(replace_visit) == z
+    assert y.traverse(replace_visit) == y
+    assert z.traverse(replace_visit) == z
+    assert (f(y)).traverse(replace_visit) == f(y)
+    assert (f(x)).traverse(replace_visit) == f(z)
+    assert (f[y]).traverse(replace_visit) == f[y]
+    assert (f[z]).traverse(replace_visit) == f[z]
+    assert (x + y + z).traverse(replace_visit) == (2 * z + y)
+    assert (x +
+            f(y, x - z)).traverse(replace_visit) == (z +
+                                                     f(y, as_number(0)))
+    assert as_eq(x, y).traverse(replace_visit) == as_eq(z, y)
 
-        assert as_ternary(x, y,
-                          z).substitute({x: y + z}) == as_ternary(y + z, y, z)
-        assert as_eq(x, y).substitute({x: y + z}) == as_eq(y + z, y)
+    # Use traverse to collect symbols, method 1
+    function_symbols = set()
+    symbols = set()
 
-    def test_fromstring(self):
+    def collect_symbols(s):
+        if s.op is Op.APPLY:
+            oper = s.data[0]
+            function_symbols.add(oper)
+            if oper in symbols:
+                symbols.remove(oper)
+        elif s.op is Op.SYMBOL and s not in function_symbols:
+            symbols.add(s)
 
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-        f = as_symbol("f")
-        s = as_string('"ABC"')
-        t = as_string('"123"')
-        a = as_array((x, y))
+    (x + f(y, x - z)).traverse(collect_symbols)
+    assert function_symbols == {f}
+    assert symbols == {x, y, z}
 
-        assert fromstring("x") == x
-        assert fromstring("+ x") == x
-        assert fromstring("-  x") == -x
-        assert fromstring("x + y") == x + y
-        assert fromstring("x + 1") == x + 1
-        assert fromstring("x * y") == x * y
-        assert fromstring("x * 2") == x * 2
-        assert fromstring("x / y") == x / y
-        assert fromstring("x ** 2", language=Language.Python) == x**2
-        assert fromstring("x ** 2 ** 3", language=Language.Python) == x**2**3
-        assert fromstring("(x + y) * z") == (x + y) * z
+    # Use traverse to collect symbols, method 2
+    def collect_symbols2(expr, symbols):
+        if expr.op is Op.SYMBOL:
+            symbols.add(expr)
 
-        assert fromstring("f(x)") == f(x)
-        assert fromstring("f(x,y)") == f(x, y)
-        assert fromstring("f[x]") == f[x]
-        assert fromstring("f[x][y]") == f[x][y]
+    symbols = set()
+    (x + f(y, x - z)).traverse(collect_symbols2, symbols)
+    assert symbols == {x, y, z, f}
 
-        assert fromstring('"ABC"') == s
-        assert (normalize(
-            fromstring('"ABC" // "123" ',
-                       language=Language.Fortran)) == s // t)
-        assert fromstring('f("ABC")') == f(s)
-        assert fromstring('MYSTRKIND_"ABC"') == as_string('"ABC"', "MYSTRKIND")
+    # Use traverse to partially collect symbols
+    def collect_symbols3(expr, symbols):
+        if expr.op is Op.APPLY:
+            # skip traversing function calls
+            return expr
+        if expr.op is Op.SYMBOL:
+            symbols.add(expr)
 
-        assert fromstring("(/x, y/)") == a, fromstring("(/x, y/)")
-        assert fromstring("f((/x, y/))") == f(a)
-        assert fromstring("(/(x+y)*z/)") == as_array(((x + y) * z, ))
+    symbols = set()
+    (x + f(y, x - z)).traverse(collect_symbols3, symbols)
+    assert symbols == {x}
 
-        assert fromstring("123") == as_number(123)
-        assert fromstring("123_2") == as_number(123, 2)
-        assert fromstring("123_myintkind") == as_number(123, "myintkind")
+def test_linear_solve():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    z = as_symbol("z")
 
-        assert fromstring("123.0") == as_number(123.0, 4)
-        assert fromstring("123.0_4") == as_number(123.0, 4)
-        assert fromstring("123.0_8") == as_number(123.0, 8)
-        assert fromstring("123.0e0") == as_number(123.0, 4)
-        assert fromstring("123.0d0") == as_number(123.0, 8)
-        assert fromstring("123d0") == as_number(123.0, 8)
-        assert fromstring("123e-0") == as_number(123.0, 4)
-        assert fromstring("123d+0") == as_number(123.0, 8)
-        assert fromstring("123.0_myrealkind") == as_number(123.0, "myrealkind")
-        assert fromstring("3E4") == as_number(30000.0, 4)
+    assert x.linear_solve(x) == (as_number(1), as_number(0))
+    assert (x + 1).linear_solve(x) == (as_number(1), as_number(1))
+    assert (2 * x).linear_solve(x) == (as_number(2), as_number(0))
+    assert (2 * x + 3).linear_solve(x) == (as_number(2), as_number(3))
+    assert as_number(3).linear_solve(x) == (as_number(0), as_number(3))
+    assert y.linear_solve(x) == (as_number(0), y)
+    assert (y * z).linear_solve(x) == (as_number(0), y * z)
 
-        assert fromstring("(1, 2)") == as_complex(1, 2)
-        assert fromstring("(1e2, PI)") == as_complex(as_number(100.0),
-                                                     as_symbol("PI"))
+    assert (x + y).linear_solve(x) == (as_number(1), y)
+    assert (z * x + y).linear_solve(x) == (z, y)
+    assert ((z + y) * x + y).linear_solve(x) == (z + y, y)
+    assert (z * y * x + y).linear_solve(x) == (z * y, y)
 
-        assert fromstring("[1, 2]") == as_array((as_number(1), as_number(2)))
+    pytest.raises(RuntimeError, lambda: (x * x).linear_solve(x))
 
-        assert fromstring("POINT(x, y=1)") == as_apply(as_symbol("POINT"),
-                                                       x,
-                                                       y=as_number(1))
-        assert fromstring(
-            'PERSON(name="John", age=50, shape=(/34, 23/))') == as_apply(
-                as_symbol("PERSON"),
-                name=as_string('"John"'),
-                age=as_number(50),
-                shape=as_array((as_number(34), as_number(23))),
-            )
+def test_as_numer_denom():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    n = as_number(123)
 
-        assert fromstring("x?y:z") == as_ternary(x, y, z)
+    assert as_numer_denom(x) == (x, as_number(1))
+    assert as_numer_denom(x / n) == (x, n)
+    assert as_numer_denom(n / x) == (n, x)
+    assert as_numer_denom(x / y) == (x, y)
+    assert as_numer_denom(x * y) == (x * y, as_number(1))
+    assert as_numer_denom(n + x / y) == (x + n * y, y)
+    assert as_numer_denom(n + x / (y - x / n)) == (y * n**2, y * n - x)
 
-        assert fromstring("*x") == as_deref(x)
-        assert fromstring("**x") == as_deref(as_deref(x))
-        assert fromstring("&x") == as_ref(x)
-        assert fromstring("(*x) * (*y)") == as_deref(x) * as_deref(y)
-        assert fromstring("(*x) * *y") == as_deref(x) * as_deref(y)
-        assert fromstring("*x * *y") == as_deref(x) * as_deref(y)
-        assert fromstring("*x**y") == as_deref(x) * as_deref(y)
+def test_polynomial_atoms():
+    x = as_symbol("x")
+    y = as_symbol("y")
+    n = as_number(123)
 
-        assert fromstring("x == y") == as_eq(x, y)
-        assert fromstring("x != y") == as_ne(x, y)
-        assert fromstring("x < y") == as_lt(x, y)
-        assert fromstring("x > y") == as_gt(x, y)
-        assert fromstring("x <= y") == as_le(x, y)
-        assert fromstring("x >= y") == as_ge(x, y)
-
-        assert fromstring("x .eq. y", language=Language.Fortran) == as_eq(x, y)
-        assert fromstring("x .ne. y", language=Language.Fortran) == as_ne(x, y)
-        assert fromstring("x .lt. y", language=Language.Fortran) == as_lt(x, y)
-        assert fromstring("x .gt. y", language=Language.Fortran) == as_gt(x, y)
-        assert fromstring("x .le. y", language=Language.Fortran) == as_le(x, y)
-        assert fromstring("x .ge. y", language=Language.Fortran) == as_ge(x, y)
-
-    def test_traverse(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-        f = as_symbol("f")
-
-        # Use traverse to substitute a symbol
-        def replace_visit(s, r=z):
-            if s == x:
-                return r
-
-        assert x.traverse(replace_visit) == z
-        assert y.traverse(replace_visit) == y
-        assert z.traverse(replace_visit) == z
-        assert (f(y)).traverse(replace_visit) == f(y)
-        assert (f(x)).traverse(replace_visit) == f(z)
-        assert (f[y]).traverse(replace_visit) == f[y]
-        assert (f[z]).traverse(replace_visit) == f[z]
-        assert (x + y + z).traverse(replace_visit) == (2 * z + y)
-        assert (x +
-                f(y, x - z)).traverse(replace_visit) == (z +
-                                                         f(y, as_number(0)))
-        assert as_eq(x, y).traverse(replace_visit) == as_eq(z, y)
-
-        # Use traverse to collect symbols, method 1
-        function_symbols = set()
-        symbols = set()
-
-        def collect_symbols(s):
-            if s.op is Op.APPLY:
-                oper = s.data[0]
-                function_symbols.add(oper)
-                if oper in symbols:
-                    symbols.remove(oper)
-            elif s.op is Op.SYMBOL and s not in function_symbols:
-                symbols.add(s)
-
-        (x + f(y, x - z)).traverse(collect_symbols)
-        assert function_symbols == {f}
-        assert symbols == {x, y, z}
-
-        # Use traverse to collect symbols, method 2
-        def collect_symbols2(expr, symbols):
-            if expr.op is Op.SYMBOL:
-                symbols.add(expr)
-
-        symbols = set()
-        (x + f(y, x - z)).traverse(collect_symbols2, symbols)
-        assert symbols == {x, y, z, f}
-
-        # Use traverse to partially collect symbols
-        def collect_symbols3(expr, symbols):
-            if expr.op is Op.APPLY:
-                # skip traversing function calls
-                return expr
-            if expr.op is Op.SYMBOL:
-                symbols.add(expr)
-
-        symbols = set()
-        (x + f(y, x - z)).traverse(collect_symbols3, symbols)
-        assert symbols == {x}
-
-    def test_linear_solve(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        z = as_symbol("z")
-
-        assert x.linear_solve(x) == (as_number(1), as_number(0))
-        assert (x + 1).linear_solve(x) == (as_number(1), as_number(1))
-        assert (2 * x).linear_solve(x) == (as_number(2), as_number(0))
-        assert (2 * x + 3).linear_solve(x) == (as_number(2), as_number(3))
-        assert as_number(3).linear_solve(x) == (as_number(0), as_number(3))
-        assert y.linear_solve(x) == (as_number(0), y)
-        assert (y * z).linear_solve(x) == (as_number(0), y * z)
-
-        assert (x + y).linear_solve(x) == (as_number(1), y)
-        assert (z * x + y).linear_solve(x) == (z, y)
-        assert ((z + y) * x + y).linear_solve(x) == (z + y, y)
-        assert (z * y * x + y).linear_solve(x) == (z * y, y)
-
-        pytest.raises(RuntimeError, lambda: (x * x).linear_solve(x))
-
-    def test_as_numer_denom(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        n = as_number(123)
-
-        assert as_numer_denom(x) == (x, as_number(1))
-        assert as_numer_denom(x / n) == (x, n)
-        assert as_numer_denom(n / x) == (n, x)
-        assert as_numer_denom(x / y) == (x, y)
-        assert as_numer_denom(x * y) == (x * y, as_number(1))
-        assert as_numer_denom(n + x / y) == (x + n * y, y)
-        assert as_numer_denom(n + x / (y - x / n)) == (y * n**2, y * n - x)
-
-    def test_polynomial_atoms(self):
-        x = as_symbol("x")
-        y = as_symbol("y")
-        n = as_number(123)
-
-        assert x.polynomial_atoms() == {x}
-        assert n.polynomial_atoms() == set()
-        assert (y[x]).polynomial_atoms() == {y[x]}
-        assert (y(x)).polynomial_atoms() == {y(x)}
-        assert (y(x) + x).polynomial_atoms() == {y(x), x}
-        assert (y(x) * x[y]).polynomial_atoms() == {y(x), x[y]}
-        assert (y(x)**x).polynomial_atoms() == {y(x)}
+    assert x.polynomial_atoms() == {x}
+    assert n.polynomial_atoms() == set()
+    assert (y[x]).polynomial_atoms() == {y[x]}
+    assert (y(x)).polynomial_atoms() == {y(x)}
+    assert (y(x) + x).polynomial_atoms() == {y(x), x}
+    assert (y(x) * x[y]).polynomial_atoms() == {y(x), x[y]}
+    assert (y(x)**x).polynomial_atoms() == {y(x)}

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -3,14 +3,20 @@ import pytest
 
 from . import util
 
-@pytest.mark.usefixtures("build_module")
-class TestValueAttr(util.F2PyTest):
-    sources = [util.getpath("tests", "src", "value_attrspec", "gh21665.f90")]
 
-    # gh-21665
-    @pytest.mark.slow
-    def test_gh21665(self):
-        inp = 2
-        out = self.module.fortfuncs.square(inp)
-        exp_out = 4
-        assert out == exp_out
+@pytest.fixture(scope="module")
+def value_attr_spec():
+    spec = util.F2PyModuleSpec(
+        test_class_name="TestValueAttr",
+        sources=[util.getpath("tests", "src", "value_attrspec", "gh21665.f90")],
+    )
+    return spec
+
+
+# gh-21665
+@pytest.mark.parametrize("_mod", ["value_attr_spec"], indirect=True)
+def test_gh21665(_mod):
+    inp = 2
+    out = _mod.fortfuncs.square(inp)
+    exp_out = 4
+    assert out == exp_out

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -3,6 +3,7 @@ import pytest
 
 from . import util
 
+@pytest.mark.usefixtures("build_module")
 class TestValueAttr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "value_attrspec", "gh21665.f90")]
 

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -385,18 +385,7 @@ def build_module_from_spec(spec):
 
 
 class F2PyTest:
-    code = None
-    sources = None
-    options = []
-    skip = []
-    only = []
-    suffix = ".f"
-    module = None
-
-    @property
-    def module_name(self):
-        cls = type(self)
-        return f'_{cls.__module__.rsplit(".",1)[-1]}_{cls.__name__}_ext_module'
+    spec = None
 
 #
 # Helper functions

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -330,7 +330,7 @@ def build_meson(source_files, module_name=None, **kwargs):
 
 
 #
-# Unittest convenience
+# Build helpers
 #
 
 @dataclass
@@ -352,10 +352,6 @@ class F2PyModuleSpec:
         if not self.module_name:
             module_part = __name__.rsplit(".", 1)[-1]
             self.module_name = f"_{module_part}_{self.test_class_name}_ext_module"
-
-def create_module_spec(test_class, **kwargs):
-    return F2PyModuleSpec(test_class=test_class, **kwargs)
-
 
 def build_module_from_spec(spec):
     codes = spec.sources if spec.sources else []

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -272,17 +272,6 @@ class CompilerChecker:
 
             self.compilers_checked = True
 
-checker = CompilerChecker()
-checker.check_compilers()
-
-def has_c_compiler():
-    return checker.has_c
-
-def has_f77_compiler():
-    return checker.has_f77
-
-def has_f90_compiler():
-    return checker.has_f90
 
 #
 # Building with meson
@@ -352,41 +341,19 @@ class F2PyTest:
     only = []
     suffix = ".f"
     module = None
-    _has_c_compiler = None
-    _has_f77_compiler = None
-    _has_f90_compiler = None
 
     @property
     def module_name(self):
         cls = type(self)
         return f'_{cls.__module__.rsplit(".",1)[-1]}_{cls.__name__}_ext_module'
 
-    @classmethod
-    def setup_class(cls):
-        if sys.platform == "win32":
-            pytest.skip("Fails with MinGW64 Gfortran (Issue #9673)")
-        F2PyTest._has_c_compiler = has_c_compiler()
-        F2PyTest._has_f77_compiler = has_f77_compiler()
-        F2PyTest._has_f90_compiler = has_f90_compiler()
-
-    def setup_method(self):
+    def build_mod(self):
         if self.module is not None:
             return
 
         codes = self.sources if self.sources else []
         if self.code:
             codes.append(self.suffix)
-
-        needs_f77 = any(str(fn).endswith(".f") for fn in codes)
-        needs_f90 = any(str(fn).endswith(".f90") for fn in codes)
-        needs_pyf = any(str(fn).endswith(".pyf") for fn in codes)
-
-        if needs_f77 and not self._has_f77_compiler:
-            pytest.skip("No Fortran 77 compiler available")
-        if needs_f90 and not self._has_f90_compiler:
-            pytest.skip("No Fortran 90 compiler available")
-        if needs_pyf and not (self._has_f90_compiler or self._has_f77_compiler):
-            pytest.skip("No Fortran compiler available")
 
         # Build the module
         if self.code is not None:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -100,7 +100,7 @@ def _memoize(func):
 #
 
 
-@_memoize
+# @_memoize
 def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     """
     Compile and import a f2py module, built from the given files.
@@ -173,7 +173,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     return import_module(module_name)
 
 
-@_memoize
+# @_memoize
 def build_code(source_code,
                options=[],
                skip=[],
@@ -342,16 +342,16 @@ class F2PyModuleSpec:
     skip: list = field(default_factory=list)
     only: list = field(default_factory=list)
     suffix: str = ".f"
-    module_name: str = field(init=False)
+    module_name: str = None
 
     def __post_init__(self):
         # Obtain the module path from the current module's __name__
         # Mimicks this:
         # cls = type(self)
         # f'_{cls.__module__.rsplit(".",1)[-1]}_{cls.__name__}_ext_module'
-        module_part = __name__.rsplit(".", 1)[-1]
-        self.module_name = f"_{module_part}_{self.test_class_name}_ext_module"
-
+        if not self.module_name:
+            module_part = __name__.rsplit(".", 1)[-1]
+            self.module_name = f"_{module_part}_{self.test_class_name}_ext_module"
 
 def create_module_spec(test_class, **kwargs):
     return F2PyModuleSpec(test_class=test_class, **kwargs)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -332,6 +332,32 @@ def build_meson(source_files, module_name=None, **kwargs):
 # Unittest convenience
 #
 
+def build_module_from_spec(spec):
+    codes = spec.sources if spec.sources else []
+    if spec.code:
+        codes.append(spec.suffix)
+
+    # Build the module based on the spec
+    if spec.code is not None:
+        module = build_code(
+            spec.code,
+            options=spec.options,
+            skip=spec.skip,
+            only=spec.only,
+            suffix=spec.suffix,
+            module_name=spec.module_name,
+        )
+    elif spec.sources is not None:
+        module = build_module(
+            spec.sources,
+            options=spec.options,
+            skip=spec.skip,
+            only=spec.only,
+            module_name=spec.module_name,
+        )
+    return module
+
+
 
 class F2PyTest:
     code = None
@@ -346,35 +372,6 @@ class F2PyTest:
     def module_name(self):
         cls = type(self)
         return f'_{cls.__module__.rsplit(".",1)[-1]}_{cls.__name__}_ext_module'
-
-    def build_mod(self):
-        if self.module is not None:
-            return
-
-        codes = self.sources if self.sources else []
-        if self.code:
-            codes.append(self.suffix)
-
-        # Build the module
-        if self.code is not None:
-            self.module = build_code(
-                self.code,
-                options=self.options,
-                skip=self.skip,
-                only=self.only,
-                suffix=self.suffix,
-                module_name=self.module_name,
-            )
-
-        if self.sources is not None:
-            self.module = build_module(
-                self.sources,
-                options=self.options,
-                skip=self.skip,
-                only=self.only,
-                module_name=self.module_name,
-            )
-
 
 #
 # Helper functions


### PR DESCRIPTION
Closes #25239. Closes #25447. Draft until it is actually faster than `main`...

Currently isn't much faster (+/- 10s or so).

**Reviewer Aids**
This PR touches every one of the 900 F2PY tests. It removes the older `unittest` class style test structure in favor of a (better to cache) fixture based method. In doing so, there is a little bit of overhead (cognitively) however, the end result should be more robust than the earlier approach (which involved building a module and replacing it within a class).

Here is the basic concept, highlighting the changes from the class based design.
- The module is now returned from a specification (a special fixture which is scoped to the module)
  + This is similar to the older F2PyTest class attributes
- The compilers are only checked once per session (slight speedup)
  - As opposed to the earlier per-module check
- Instead of `self.module` a `_mod` parameter is passed which is parameterized by the `spec` returning fixture

This is possibly best seen with an example, here is a basic one:

```python
# Older
class TestStringAssumedLength(util.F2PyTest):
    sources = [util.getpath("tests", "src", "string", "gh24008.f")]

    def test_gh24008(self):
        self.module.greet("joe", "bob")
# New
@pytest.fixture(scope="module")
def string_assumed_length_spec():
    spec = util.F2PyModuleSpec(
        test_class_name="TestStringAssumedLength",
        sources=[util.getpath("tests", "src", "string", "gh24008.f")],
    )
    return spec


@pytest.mark.parametrize("_mod", ["string_assumed_length_spec"], indirect=True)
def test_gh24008(_mod):
    _mod.greet("joe", "bob")
```

Perhaps this looks a bit unweildy, but it does make parameterizations over specifications much easier:

```python
# Old, repeat the test logic in each class
@pytest.mark.slow
class TestNewCharHandling(util.F2PyTest):
    # from v1.24 onwards, gh-19388
    sources = [
        util.getpath("tests", "src", "string", "gh25286.pyf"),
        util.getpath("tests", "src", "string", "gh25286.f90")
    ]
    module_name = "_char_handling_test"

    def test_gh25286(self):
        info = self.module.charint('T')
        assert info == 2

@pytest.mark.slow
class TestBCCharHandling(util.F2PyTest):
    # SciPy style, "incorrect" bindings with a hook
    sources = [
        util.getpath("tests", "src", "string", "gh25286_bc.pyf"),
        util.getpath("tests", "src", "string", "gh25286.f90")
    ]
    module_name = "_char_handling_test"

    def test_gh25286(self):
        info = self.module.charint('T')
        assert info == 2

# New approach, just two specs to parameterize over
@pytest.fixture(scope="module")
def string_newchar_spec():
    spec = util.F2PyModuleSpec(
        test_class_name="TestNewCharHandling",
        # from v1.24 onwards, gh-19388
        sources=[
            util.getpath("tests", "src", "string", "gh25286.pyf"),
            util.getpath("tests", "src", "string", "gh25286.f90"),
        ],
        module_name="_char_handling_test",
    )
    return spec

@pytest.fixture(scope="module")
def string_bc_char_spec():
    spec = util.F2PyModuleSpec(
        test_class_name="TestBCCharHandling",
        # SciPy style, "incorrect" bindings with a hook
        sources=[
            util.getpath("tests", "src", "string", "gh25286_bc.pyf"),
            util.getpath("tests", "src", "string", "gh25286.f90"),
        ],
        module_name="_char_handling_test",
    )
    return spec

@pytest.mark.parametrize(
    "_mod", ["string_newchar_spec", "string_bc_char_spec"], indirect=True
)
def test_gh25286(_mod):
    info = _mod.charint("T")
    assert info == 2
```

Also better caching. In general it seems [more recommended](https://docs.pytest.org/en/7.1.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses) to use fixtures and `pytest` parameterization anyway.

**Notable incompatibilities**
- Test names now **must be unique** as varying parameters are not enough for `pytest` to distinguish them

Again, an example helps:

```python
# Pseudocode, would collect 2 tests
class TestBlah:
   def test_input(self):
     pass
class TestBlahTwo
   def test_input(self):
     pass
# New, will only get 1 test!!
@pytest.mark.parametrize("_mod", ["specA"], indirect=True)
def test_input(_mod):
  pass

@pytest.mark.parametrize("_mod", ["specB"], indirect=True)
def test_input(_mod):
  _mod.callable()
  pass
```

The tests should just be renamed, e.g. `test_input_spec_a` and `test_input_spec_b`.

**Checklist**
Mainly to make sure the right number of tests are collected (e.g. via `spin test -t numpy.f2py -m full -- --collect-only -k "test_value_attrspec"`).

- [x] (2) `test_abstract_interface`
- [x] (581) `test_array_from_pyobj`
- [x] (2) `test_assumed_shape`
- [x] (1) `test_block_docstring`
- [x] (17) `test_callback`
- [x] (49) `test_character`
- [x] (2) `test_common`
- [x] (50) `test_crackfortran`
- [x] (6) `test_data`
- [x] (5) `test_docs`
- [x] (2) `test_f2cmap`
- [x] (52) `test_f2py2e`
- [x] (5) `test_isoc`
- [x] (3) `test_kind`
- [x] (2) `test_mixed`
- [x] (1) `test_module_doc`
- [x] (12) `test_parameter`
- [x] (1) `test_pyf_src`
- [x] (1) `test_quoted_character`
- [x] (6) `test_regression`
- [x] (15) `test_return_character`
- [x] (16) `test_return_complex`
- [x] (20) `test_return_integer`
- [x] (18) `test_return_logical`
- [x] (20) `test_return_real`
- [x] (2) `test_semicolon_split`
- [x] (3) `test_size`
- [x] (6) `test_string`
- [x] (11) `test_symbolic`
- [x] (1) `test_value_attrspec`

