### PR TITLE
CI: streamline macos_arm64 test

### DIFF
--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -86,12 +86,12 @@ macos_arm64_test_task:
 
   test_script: |
     brew install micromamba ccache
-    /opt/homebrew/opt/micromamba/bin/micromamba shell init -s bash -p ~/micromamba
+    micromamba shell init -s bash -p ~/micromamba
     source ~/.bash_profile
     
     micromamba create -n numpydev
     micromamba activate numpydev
-    micromamba install -y -c conda-forge compilers python=3.11
+    micromamba install -y -c conda-forge compilers python=3.11 2>/dev/null
     
     export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
     export CCACHE_DIR=$PWD/.ccache

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -71,7 +71,7 @@ macos_arm64_test_task:
   depends_on:
     - linux_aarch64_test
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+    image: ghcr.io/cirruslabs/macos-sonoma-xcode
 
   <<: *MODIFIED_CLONE
 
@@ -85,29 +85,20 @@ macos_arm64_test_task:
     folder: ~/.cache/pip
 
   test_script: |
-    brew install python@3.10 ccache
-
-    export PATH=/opt/homebrew/opt/python@3.10/libexec/bin:$PATH
+    brew install micromamba ccache
+    /opt/homebrew/opt/micromamba/bin/micromamba shell init -s bash -p ~/micromamba
+    source ~/.bash_profile
+    
+    micromamba create -n numpydev
+    micromamba activate numpydev
+    micromamba install -y -c conda-forge compilers python=3.11
+    
     export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
     export CCACHE_DIR=$PWD/.ccache
     echo "PATH=$PATH" >> $CIRRUS_ENV
 
     python --version
-
-    RUNNER_OS="macOS"
-    SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
-
-    # NOTE: OpenBLAS is not used in this job; if that's done in the future, ensure
-    # PKG_CONFIG_PATH points to the directory containing the openblas.pc file
-    # that's installed with the cibw_before_build.sh command.
-    # used for installing OpenBLAS/gfortran
-    bash tools/wheels/cibw_before_build.sh $PWD
-
-    pushd ~/
-    python -m venv numpy-dev
-    source numpy-dev/bin/activate
-    popd
-
+    
     pip install -r build_requirements.txt
     pip install pytest pytest-xdist hypothesis typing_extensions
 


### PR DESCRIPTION
This PR streamlines the cirrusci macos_arm64 testing. 

- uses micromamba instead of brew to install python
- uses micromamba to handle compiler install from conda-forge (i.e. gfortran). This is hopefully more robust for compiler installation.
- uses `macos-sonoma-xcode` image, which means that the test uses Accelerate by default (macos >=14)