### PR TITLE
ENH: add new wheel builds using Accelerate on macOS >=14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,8 @@ build-frontend = "build"
 skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
 build-verbosity = "3"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
-config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_ setup-args=-Dallow-noblas=false build-dir=build"
+# The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
+config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"
 before-test = "pip install -r {project}/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
@@ -152,14 +153,11 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 musllinux-x86_64-image = "musllinux_1_1"
+# RUNNER_OS is a GitHub Actions specific env var; define it here so it works on Cirrus CI too
 environment = {RUNNER_OS="Linux"}
 
 [tool.cibuildwheel.macos]
-# For universal2 wheels, we will need to fuse them manually
-# instead of going through cibuildwheel
-# This is because cibuildwheel tries to make a fat wheel
-# https://github.com/multi-build/multibuild/blame/devel/README.rst#L541-L565
-# for more info
+# universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
 archs = "x86_64 arm64"
 test-skip = "*_universal2:arm64"
 environment = {RUNNER_OS="macOS"}

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -20,7 +20,7 @@ linux_aarch64_task:
     architecture: arm64
     platform: linux
     cpu: 1
-    memory: 8G
+    memory: 4G
   matrix:
     # build in a matrix because building and testing all four wheels in a
     # single task takes longer than 60 mins (the default time limit for a
@@ -57,7 +57,10 @@ linux_aarch64_task:
 macosx_arm64_task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+    matrix:
+      image: ghcr.io/cirruslabs/macos-sonoma-xcode
+      image: ghcr.io/cirruslabs/macos-monterey-xcode
+
   matrix:
     - env:
         CIRRUS_CLONE_SUBMODULES: true
@@ -70,31 +73,41 @@ macosx_arm64_task:
         CIBW_PRERELEASE_PYTHONS: True
         CIBW_BUILD: cp312-*
   env:
-    PATH: /opt/homebrew/opt/python@3.10/bin:/usr/local/lib:/usr/local/include:$PATH
+    PATH: /usr/local/lib:/usr/local/include:$PATH
     CIBW_ARCHS: arm64
-    # Specifying CIBW_ENVIRONMENT_MACOS overrides pyproject.toml, so include
-    # all the settings from there, otherwise they're lost.
-    # SDKROOT needs to be set for repackaged conda-forge gfortran compilers
-    # supplied by isuruf.
-    # Find out SDKROOT via `xcrun --sdk macosx --show-sdk-path`
-    CIBW_ENVIRONMENT_MACOS: >
-      RUNNER_OS=macOS
-      SDKROOT=/Applications/Xcode-14.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk
-      LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-  build_script:
-    - brew install python@3.10
-    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
-    - which python
+  build_script: |
+    brew install micromamba
+    micromamba shell init -s bash -p ~/micromamba
+    source ~/.bash_profile
+    
+    micromamba create -n numpydev
+    micromamba activate numpydev
+    micromamba install -y -c conda-forge compilers python=3.11 2>/dev/null
+    
+    ver=$(sw_vers -productVersion)
+    macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
+    if [ macos_target == '14.0' ]; then
+        export INSTALL_OPENBLAS=false
+    else
+        export INSTALL_OPENBLAS=true
+    fi
+
+    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=$INSTALL_OPENBLAS INSTALL_GFORTRAN=false RUNNER_OS=macOS"
+    
     # needed for submodules
-    - git submodule update --init
+    git submodule update --init
     # need to obtain all the tags so setup.py can determine FULLVERSION
-    - git fetch origin
-    - uname -m
-    - python -c "import platform;print(platform.python_version());print(platform.system());print(platform.machine())"
-    - clang --version
-  <<: *BUILD_AND_STORE_WHEELS
+    git fetch origin
+    uname -m
+    python -c "import platform;print(platform.python_version());print(platform.system());print(platform.machine())"
+    clang --version
 
+    python -m pip install cibuildwheel
+    cibuildwheel
+
+  wheels_artifacts:
+    path: "wheelhouse/*"
 
 ######################################################################
 # Upload all wheels

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -16,8 +16,13 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     cat $PROJECT_DIR/tools/wheels/LICENSE_win32.txt >> $PROJECT_DIR/LICENSE.txt
 fi
 
+# the macos_arm64 build might set this variable
+if [ -z $INSTALL_OPENBLAS ]; then
+    export INSTALL_OPENBLAS=true
+fi
+
 # Install Openblas
-if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]] ; then
+if [[ $RUNNER_OS == "Linux" || ($RUNNER_OS == "macOS" && $INSTALL_OPENBLAS) ]] ; then
     basedir=$(python tools/openblas_support.py --use-ilp64)
     if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
         # /usr/local/lib doesn't exist on cirrus-ci runners
@@ -47,11 +52,17 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
     fi
 fi
 
-if [[ $RUNNER_OS == "macOS" ]]; then
+# the macos_arm64 build might set this variable
+if [ -z $INSTALL_GFORTRAN ]; then
+    export INSTALL_GFORTRAN=true
+fi
+
+if [[ $RUNNER_OS == "macOS" && $INSTALL_GFORTRAN ]]; then
     # Install same version of gfortran as the openblas-libs builds
     if [[ $PLATFORM == "macosx-arm64" ]]; then
         PLAT="arm64"
     fi
+
     source $PROJECT_DIR/tools/wheels/gfortran_utils.sh
     install_gfortran
     pip install "delocate==0.10.4"


### PR DESCRIPTION
@rgommers alternative to #25012.

EDIT: the new Accelerate-based wheels weigh in at about 5.0 MB, which is impressively small compared to the OpenBLAS arm64 wheels at ~14 MB and the OpenBLAS x86-64 wheels at ~21 MB.