### PR TITLE
TST: PyPy needs another gc.collect on latest versions

### DIFF
--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -443,3 +443,4 @@ def test_owner_is_base(get_module):
     with pytest.warns(UserWarning, match='warn_on_free'):
         del a
         gc.collect()
+        gc.collect()


### PR DESCRIPTION
In running NumPy against latest PyPy, I noticed it needs another `gc.collect` to successfully collect `a` in the test.