### PR TITLE
API: Shrink MultiIterObject and make `NPY_MAXARGS` a runtime macro

### DIFF
--- a/doc/release/upcoming_changes/25271.c_api.rst
+++ b/doc/release/upcoming_changes/25271.c_api.rst
@@ -1,0 +1,11 @@
+``NPY_MAXARGS`` not constant and ``PyArrayMultiIterObject`` size change
+-----------------------------------------------------------------------
+Since ``NPY_MAXARGS`` was increased, it is now a runtime constant and not
+compiletime constant anymore.
+We expect almost no users to notice this.  But if used for stack allocations
+it now must be replaced with a custom constant using ``NPY_MAXARGS`` as an
+additional runtime check.
+
+The ``sizeof(PyArrayMultiIterObject)`` does now not include the full size
+of the object.  We expect nobody to notice this change.  It was necessary
+to avoid issues with Cython.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3429,10 +3429,12 @@ Other constants
 
     The maximum number of array arguments that can be used in some
     functions.  This used to be 32 before NumPy 2 and is now 64.
+    To continue to allow using it as a check whether a number of arguments
+    is compatible ufuncs, this macro is now runtime dependent.
 
     .. note::
-        You should never use this.  We may remove it in future versions of
-        NumPy.
+        We discourage any use of ``NPY_MAXARGS`` that isn't explicitly tied
+        to checking for known NumPy limitations.
 
 .. c:macro:: NPY_FALSE
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -45,7 +45,7 @@
 #define NPY_MAXDIMS 64
 /* We cannot change this as it would break ABI: */
 #define NPY_MAXDIMS_LEGACY_ITERS 32
-#define NPY_MAXARGS 64
+/* NPY_MAXARGS is version dependent and defined in npy_2_compat.h */
 
 /* Used for Converter Functions "O&" code in ParseTuple */
 #define NPY_FAIL 0
@@ -1239,7 +1239,18 @@ typedef struct {
         npy_intp             index;                   /* current index */
         int                  nd;                      /* number of dims */
         npy_intp             dimensions[NPY_MAXDIMS_LEGACY_ITERS]; /* dimensions */
-        PyArrayIterObject    *iters[NPY_MAXARGS];     /* iterators */
+        /*
+         * Space for the indivdual iterators, do not specify size publically
+         * to allow changing it more easily.
+         * One reason is that Cython uses this for checks and only allows
+         * growing structs (as of Cython 3.0.6).  It also allows NPY_MAXARGS
+         * to be runtime dependent.
+         */
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+        PyArrayIterObject    *iters[64];  /* 64 is NPY_MAXARGS */
+#else /* not internal build */
+        PyArrayIterObject    *iters[];
+#endif
 } PyArrayMultiIterObject;
 
 #define _PyMIT(m) ((PyArrayMultiIterObject *)(m))

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -76,4 +76,14 @@
 #endif
 
 
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    #define NPY_MAXARGS 64
+#elif NPY_ABI_VERSION < 0x02000000
+    #define NPY_MAXARGS 32
+#else
+    #define NPY_MAXARGS  \
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? 64 : 32)
+#endif
+
+
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_ */


### PR DESCRIPTION
Cython is OK with increased sizes, but doesn't like shrinking an object size.  We should fix this (providing a size to compare with in the `pyd` maybe).  But just not including the end of the object here publically is totally fine...

This makes `NPY_MAXARGS` also a *runtime* constant, since the presumably only user (`numexpr`) should be better off with that anyway.  Yes, they need to change the code to hard-code the maximum, but they also need the NumPy cap from us anyway.

This is needed, because Cython breaks for sklearn which uses `numpy.broadcast` AKA `PyArrayMultiIterObject`.

---

@ngoldbaum this is an unfortuante quick followup on the MAXDIMS bump, as it breaks sklearn compiling (and maybe some others).