### PR TITLE
BLD: Add flag to f2py to pass arbitrary linker flags.

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -166,6 +166,7 @@ Extra options (only effective with -c):
   -L/path/to/lib/ -l<libname>
   -D<define> -U<name>
   -I/path/to/include/
+  -J--arbitrary-linker-flags
   <filename>.o <filename>.so <filename>.a
 
   Using the following macros may be required with non-gcc Fortran
@@ -671,6 +672,7 @@ def run_compile():
     pyf_files, _sources = filter_files("", "[.]pyf([.]src|)", sources)
     sources = pyf_files + _sources
     modulename = validate_modulename(pyf_files, modulename)
+    linker_flags, sources = filter_files('-J', '', sources, remove_prefix=1)
     extra_objects, sources = filter_files('', '[.](o|a|so|dylib)', sources)
     include_dirs, sources = filter_files('-I', '', sources, remove_prefix=1)
     library_dirs, sources = filter_files('-L', '', sources, remove_prefix=1)
@@ -699,7 +701,7 @@ def run_compile():
     builder = build_backend(
         modulename,
         sources,
-        extra_objects,
+        linker_flags + extra_objects,
         build_dir,
         include_dirs,
         library_dirs,


### PR DESCRIPTION
The current way of doing this is by setting the LDFLAGS environment variable. 

The problem with this is that if you build your f2py module as part of a larger build system, a valid LDFLAGS for your Fortran compiler may not be a valid LDFLAGS for your C Compiler and cause, for instance, CMake tests that determine if your compiler produces good executables to fail. Also, CMake doesn't support exporting environment variables, so they must be set by some other means. 

The attached patch adds a flag '-J,' which provides a simple mechanism to resolve this issue. For instance, '-J-static-intel' will invoke the linker with the '-static-intel' flag. 