### PR TITLE
CI: Install Lapack runtime on Cygwin.

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -31,7 +31,7 @@ jobs:
           install-dir: 'C:\tools\cygwin'
           packages: >-
             python39-devel python39-pip python-pip-wheel python-setuptools-wheel
-            liblapack-devel gcc-fortran gcc-g++ git dash cmake ninja
+            liblapack-devel liblapack0 gcc-fortran gcc-g++ git dash cmake ninja
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@8469525c8ee3eddabbd3487658621a6235b3c581 # v3
         with:


### PR DESCRIPTION
There is a missed dependency on the new lapack version: this should be a short-term workaround.

Fixes #25273. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
