### PR TITLE
BUG: linalg complex type rejection portability

### DIFF
--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -82,7 +82,7 @@ class TestAsIntegerRatio:
             [0, -7400, 14266, -7822, -8721],
             marks=[
                 pytest.mark.skipif(
-                    np.finfo(np.double) == np.finfo(np.longdouble),
+                    np.finfo(np.double).bits == np.finfo(np.longdouble).bits,
                     reason="long double is same as double"),
                 pytest.mark.skipif(
                     platform.machine().startswith("ppc"),

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -525,7 +525,8 @@ class TestConversion:
             assert_raises(OverflowError, x.__int__)
             assert_equal(len(sup.log), 1)
 
-    @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
+    @pytest.mark.skipif(np.finfo(np.double).bits ==
+                        np.finfo(np.longdouble).bits,
                         reason="long double is same as double")
     @pytest.mark.skipif(platform.machine().startswith("ppc"),
                         reason="IBM double double")

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -23,6 +23,7 @@ from numpy._utils import set_module
 from numpy._core import (
     array, asarray, zeros, empty, empty_like, intc, single, double,
     csingle, cdouble, inexact, complexfloating, newaxis, all, inf, dot,
+    clongdouble,
     add, multiply, sqrt, sum, isfinite, finfo, errstate, moveaxis, amin,
     amax, prod, abs, atleast_2d, intp, asanyarray, object_, matmul,
     swapaxes, divide, count_nonzero, isnan, sign, argsort, sort,
@@ -134,6 +135,8 @@ _complex_types_map = {single: csingle,
                       cdouble: cdouble}
 
 def _realType(t, default=double):
+    if finfo(clongdouble).bits == finfo(cdouble).bits:
+        _real_types_map[clongdouble] = cdouble
     return _real_types_map.get(t, default)
 
 def _complexType(t, default=cdouble):

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2228,3 +2228,15 @@ def test_trace():
     expected = np.array([36, 116, 196])
 
     assert_equal(actual, expected)
+
+
+@pytest.mark.skipif(np.finfo(np.clongdouble).bits == 128,
+                    reason="complex256 not supported by linalg")
+def test_linalg_complex128_pass_through():
+    # on some platforms (i.e., ARM Mac)
+    # clongdouble is the same size as cdouble
+    # and NumPy was incorrectly rejecting
+    # linalg computations under NEP50 per
+    # https://github.com/scipy/scipy/issues/19605
+    x = np.array([[1.-0.j]], dtype=np.clongdouble)
+    linalg.eigvals(x)


### PR DESCRIPTION
* on some platforms, like MacOS ARM64, `clongdouble`
has the same size as `cdouble`, so we can safely map
it to `cdouble` instead of rejecting linear algebra
computations that are perfectly tractable under NEP 50; related
to: https://github.com/scipy/scipy/issues/19605

* a small number of tests were shimmed because their skip
conditions were too strict on exact `dtype` info
object match, instead of bit size (I think this is safe to do,
but I'll let more active core devs weigh in of course)

* the new regression test is only valid on certain
platforms, so is guarded with a skip (I think linalg
rejecting `complex256` may actually be ok?)