### PR TITLE
MAINT: expose and use dtype classes in internal API

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -8,6 +8,7 @@
 #include "numpy/ndarraytypes.h"
 #include "numpy/arrayobject.h"
 
+#include "dtypemeta.h"
 #include "abstractdtypes.h"
 #include "array_coercion.h"
 #include "common.h"
@@ -153,12 +154,12 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
     if (NPY_DT_is_legacy(other) && other->type_num < NPY_NTYPES) {
         if (other->type_num == NPY_BOOL) {
             /* Use the default integer for bools: */
-            return PyArray_DTypeFromTypeNum(NPY_INTP);
+            return &PyArray_IntpDType;
         }
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *uint8_dt = PyArray_DTypeFromTypeNum(NPY_UINT8);
+        PyArray_DTypeMeta *uint8_dt = &PyArray_UInt8DType;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, uint8_dt);
         Py_DECREF(uint8_dt);
         if (res == NULL) {
@@ -171,7 +172,7 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
             return res;
         }
         /* Try again with `int8`, an error may have been set, though */
-        PyArray_DTypeMeta *int8_dt = PyArray_DTypeFromTypeNum(NPY_INT8);
+        PyArray_DTypeMeta *int8_dt = &PyArray_Int8DType;
         res = NPY_DT_CALL_common_dtype(other, int8_dt);
         Py_DECREF(int8_dt);
         if (res == NULL) {
@@ -184,7 +185,7 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
             return res;
         }
         /* And finally, we will try the default integer, just for sports... */
-        PyArray_DTypeMeta *default_int = PyArray_DTypeFromTypeNum(NPY_INTP);
+        PyArray_DTypeMeta *default_int = &PyArray_IntpDType;
         res = NPY_DT_CALL_common_dtype(other, default_int);
         Py_DECREF(default_int);
         if (res == NULL) {
@@ -203,7 +204,7 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     if (NPY_DT_is_legacy(other) && other->type_num < NPY_NTYPES) {
         if (other->type_num == NPY_BOOL || PyTypeNum_ISINTEGER(other->type_num)) {
             /* Use the default integer for bools and ints: */
-            return PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+            return &PyArray_DoubleDType;
         }
     }
     else if (other == &PyArray_PyIntAbstractDType) {
@@ -212,7 +213,7 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *half_dt = PyArray_DTypeFromTypeNum(NPY_HALF);
+        PyArray_DTypeMeta *half_dt = &PyArray_HalfDType;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, half_dt);
         Py_DECREF(half_dt);
         if (res == NULL) {
@@ -225,7 +226,7 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             return res;
         }
         /* Retry with double (the default float) */
-        PyArray_DTypeMeta *double_dt = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+        PyArray_DTypeMeta *double_dt = &PyArray_DoubleDType;
         res = NPY_DT_CALL_common_dtype(other, double_dt);
         Py_DECREF(double_dt);
         return res;
@@ -242,12 +243,12 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         if (other->type_num == NPY_BOOL ||
                 PyTypeNum_ISINTEGER(other->type_num)) {
             /* Use the default integer for bools and ints: */
-            return PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
+            return &PyArray_CDoubleDType;
         }
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *cfloat_dt = PyArray_DTypeFromTypeNum(NPY_CFLOAT);
+        PyArray_DTypeMeta *cfloat_dt = &PyArray_CFloatDType;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, cfloat_dt);
         Py_DECREF(cfloat_dt);
         if (res == NULL) {
@@ -260,7 +261,7 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             return res;
         }
         /* Retry with cdouble (the default complex) */
-        PyArray_DTypeMeta *cdouble_dt = PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
+        PyArray_DTypeMeta *cdouble_dt = &PyArray_CDoubleDType;
         res = NPY_DT_CALL_common_dtype(other, cdouble_dt);
         Py_DECREF(cdouble_dt);
         return res;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4386,6 +4386,8 @@ set_typeinfo(PyObject *dict)
 
     /**end repeat**/
 
+    initialize_legacy_dtypemeta_aliases(_builtin_descrs);
+
     /*
      * Add cast functions for the new types
      */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2994,8 +2994,8 @@ static int
 PyArray_InitializeStringCasts(void)
 {
     int result = -1;
-    PyArray_DTypeMeta *string = PyArray_DTypeFromTypeNum(NPY_STRING);
-    PyArray_DTypeMeta *unicode = PyArray_DTypeFromTypeNum(NPY_UNICODE);
+    PyArray_DTypeMeta *string = &PyArray_BytesDType;
+    PyArray_DTypeMeta *unicode = &PyArray_UnicodeDType;
     PyArray_DTypeMeta *other_dt = NULL;
 
     /* Add most casts as legacy ones */
@@ -3716,7 +3716,7 @@ void_to_void_get_loop(
 static int
 PyArray_InitializeVoidToVoidCast(void)
 {
-    PyArray_DTypeMeta *Void = PyArray_DTypeFromTypeNum(NPY_VOID);
+    PyArray_DTypeMeta *Void = &PyArray_VoidDType;
     PyArray_DTypeMeta *dtypes[2] = {Void, Void};
     PyType_Slot slots[] = {
             {_NPY_METH_get_loop, &void_to_void_get_loop},
@@ -3899,7 +3899,7 @@ object_to_object_get_loop(
 static int
 PyArray_InitializeObjectToObjectCast(void)
 {
-    PyArray_DTypeMeta *Object = PyArray_DTypeFromTypeNum(NPY_OBJECT);
+    PyArray_DTypeMeta *Object = &PyArray_ObjectDType;
     PyArray_DTypeMeta *dtypes[2] = {Object, Object};
     PyType_Slot slots[] = {
             {_NPY_METH_get_loop, &object_to_object_get_loop},

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -4111,10 +4111,10 @@ PyArray_InitializeDatetimeCasts()
     slots[2].slot = 0;
     slots[2].pfunc = NULL;
 
-    PyArray_DTypeMeta *datetime = PyArray_DTypeFromTypeNum(NPY_DATETIME);
-    PyArray_DTypeMeta *timedelta = PyArray_DTypeFromTypeNum(NPY_TIMEDELTA);
-    PyArray_DTypeMeta *string = PyArray_DTypeFromTypeNum(NPY_STRING);
-    PyArray_DTypeMeta *unicode = PyArray_DTypeFromTypeNum(NPY_UNICODE);
+    PyArray_DTypeMeta *datetime = &PyArray_DatetimeDType;
+    PyArray_DTypeMeta *timedelta = &PyArray_TimedeltaDType;
+    PyArray_DTypeMeta *string = &PyArray_BytesDType;
+    PyArray_DTypeMeta *unicode = &PyArray_UnicodeDType;
     PyArray_DTypeMeta *tmp = NULL;
 
     dtypes[0] = datetime;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -29,6 +29,8 @@
 
 #include <assert.h>
 
+
+
 static void
 dtypemeta_dealloc(PyArray_DTypeMeta *self) {
     /* Do not accidentally delete a statically defined DType: */
@@ -917,13 +919,13 @@ default_builtin_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
                 return cls;
             }
             else if (cls->type_num == NPY_HALF || cls->type_num == NPY_FLOAT) {
-                    return PyArray_DTypeFromTypeNum(NPY_CFLOAT);
+                    return &PyArray_CFloatDType;
             }
             else if (cls->type_num == NPY_DOUBLE) {
-                return PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
+                return &PyArray_CDoubleDType;
             }
             else if (cls->type_num == NPY_LONGDOUBLE) {
-                return PyArray_DTypeFromTypeNum(NPY_CLONGDOUBLE);
+                return &PyArray_CLongDoubleDType;
             }
         }
         else if (other == &PyArray_PyFloatAbstractDType) {
@@ -1195,7 +1197,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr,
                     void_discover_descr_from_pyobject);
             dt_slots->common_instance = void_common_instance;
             dt_slots->ensure_canonical = void_ensure_canonical;
-            dt_slots->get_fill_zero_loop = 
+            dt_slots->get_fill_zero_loop =
                     npy_get_zerofill_void_and_legacy_user_dtype_loop;
             dt_slots->get_clear_loop =
                     npy_get_clear_void_and_legacy_user_dtype_loop;
@@ -1281,6 +1283,44 @@ static PyMemberDef dtypemeta_members[] = {
     {NULL, 0, 0, 0, NULL},
 };
 
+NPY_NO_EXPORT void
+initialize_legacy_dtypemeta_aliases(PyArray_Descr **_builtin_descrs) {
+    _Bool_dtype = NPY_DTYPE(_builtin_descrs[NPY_BOOL]);
+    _Byte_dtype = NPY_DTYPE(_builtin_descrs[NPY_BYTE]);
+    _UByte_dtype = NPY_DTYPE(_builtin_descrs[NPY_UBYTE]);
+    _Short_dtype = NPY_DTYPE(_builtin_descrs[NPY_SHORT]);
+    _UShort_dtype = NPY_DTYPE(_builtin_descrs[NPY_USHORT]);
+    _Int_dtype = NPY_DTYPE(_builtin_descrs[NPY_INT]);
+    _UInt_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT]);
+    _Long_dtype = NPY_DTYPE(_builtin_descrs[NPY_LONG]);
+    _ULong_dtype = NPY_DTYPE(_builtin_descrs[NPY_ULONG]);
+    _LongLong_dtype = NPY_DTYPE(_builtin_descrs[NPY_LONGLONG]);
+    _ULongLong_dtype = NPY_DTYPE(_builtin_descrs[NPY_ULONGLONG]);
+    _Int8_dtype = NPY_DTYPE(_builtin_descrs[NPY_INT8]);
+    _UInt8_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT8]);
+    _Int16_dtype = NPY_DTYPE(_builtin_descrs[NPY_INT16]);
+    _UInt16_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT16]);
+    _Int32_dtype = NPY_DTYPE(_builtin_descrs[NPY_INT32]);
+    _UInt32_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT32]);
+    _Int64_dtype = NPY_DTYPE(_builtin_descrs[NPY_INT64]);
+    _UInt64_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT64]);
+    _Intp_dtype = NPY_DTYPE(_builtin_descrs[NPY_INTP]);
+    _UIntp_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINTP]);
+    _Half_dtype = NPY_DTYPE(_builtin_descrs[NPY_HALF]);
+    _Float_dtype = NPY_DTYPE(_builtin_descrs[NPY_FLOAT]);
+    _Double_dtype = NPY_DTYPE(_builtin_descrs[NPY_DOUBLE]);
+    _LongDouble_dtype = NPY_DTYPE(_builtin_descrs[NPY_LONGDOUBLE]);
+    _CFloat_dtype = NPY_DTYPE(_builtin_descrs[NPY_CFLOAT]);
+    _CDouble_dtype = NPY_DTYPE(_builtin_descrs[NPY_CDOUBLE]);
+    _CLongDouble_dtype = NPY_DTYPE(_builtin_descrs[NPY_CLONGDOUBLE]);
+    // NPY_STRING is the legacy python2 name
+    _Bytes_dtype = NPY_DTYPE(_builtin_descrs[NPY_STRING]);
+    _Unicode_dtype = NPY_DTYPE(_builtin_descrs[NPY_UNICODE]);
+    _Datetime_dtype = NPY_DTYPE(_builtin_descrs[NPY_DATETIME]);
+    _Timedelta_dtype = NPY_DTYPE(_builtin_descrs[NPY_TIMEDELTA]);
+    _Object_dtype = NPY_DTYPE(_builtin_descrs[NPY_OBJECT]);
+    _Void_dtype = NPY_DTYPE(_builtin_descrs[NPY_VOID]);
+}
 
 NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1299,3 +1339,38 @@ NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type = {
     .tp_new = dtypemeta_new,
     .tp_is_gc = dtypemeta_is_gc,
 };
+
+PyArray_DTypeMeta *_Bool_dtype = NULL;
+PyArray_DTypeMeta *_Byte_dtype = NULL;
+PyArray_DTypeMeta *_UByte_dtype = NULL;
+PyArray_DTypeMeta *_Short_dtype = NULL;
+PyArray_DTypeMeta *_UShort_dtype = NULL;
+PyArray_DTypeMeta *_Int_dtype = NULL;
+PyArray_DTypeMeta *_UInt_dtype = NULL;
+PyArray_DTypeMeta *_Long_dtype = NULL;
+PyArray_DTypeMeta *_ULong_dtype = NULL;
+PyArray_DTypeMeta *_LongLong_dtype = NULL;
+PyArray_DTypeMeta *_ULongLong_dtype = NULL;
+PyArray_DTypeMeta *_Int8_dtype = NULL;
+PyArray_DTypeMeta *_UInt8_dtype = NULL;
+PyArray_DTypeMeta *_Int16_dtype = NULL;
+PyArray_DTypeMeta *_UInt16_dtype = NULL;
+PyArray_DTypeMeta *_Int32_dtype = NULL;
+PyArray_DTypeMeta *_UInt32_dtype = NULL;
+PyArray_DTypeMeta *_Int64_dtype = NULL;
+PyArray_DTypeMeta *_UInt64_dtype = NULL;
+PyArray_DTypeMeta *_Intp_dtype = NULL;
+PyArray_DTypeMeta *_UIntp_dtype = NULL;
+PyArray_DTypeMeta *_Half_dtype = NULL;
+PyArray_DTypeMeta *_Float_dtype = NULL;
+PyArray_DTypeMeta *_Double_dtype = NULL;
+PyArray_DTypeMeta *_LongDouble_dtype = NULL;
+PyArray_DTypeMeta *_CFloat_dtype = NULL;
+PyArray_DTypeMeta *_CDouble_dtype = NULL;
+PyArray_DTypeMeta *_CLongDouble_dtype = NULL;
+PyArray_DTypeMeta *_Bytes_dtype = NULL;
+PyArray_DTypeMeta *_Unicode_dtype = NULL;
+PyArray_DTypeMeta *_Datetime_dtype = NULL;
+PyArray_DTypeMeta *_Timedelta_dtype = NULL;
+PyArray_DTypeMeta *_Object_dtype = NULL;
+PyArray_DTypeMeta *_Void_dtype = NULL;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -157,10 +157,6 @@ dtypemeta_wrap_legacy_descriptor(
 NPY_NO_EXPORT void
 initialize_legacy_dtypemeta_aliases(PyArray_Descr **_builtin_descrs);
 
-#ifdef __cplusplus
-}
-#endif
-
 /*
  * NumPy's builtin DTypes:
  */
@@ -240,5 +236,9 @@ extern PyArray_DTypeMeta *_Void_dtype;
 /* Object/Void */
 #define PyArray_ObjectDType (*(_Object_dtype))
 #define PyArray_VoidDType (*(_Void_dtype))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_DTYPEMETA_H_ */

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #include "numpy/_dtype_api.h"
 
-/* DType flags, currently private, since we may just expose functions 
+/* DType flags, currently private, since we may just expose functions
    Other publicly visible flags are in _dtype_api.h                   */
 #define NPY_DT_LEGACY 1 << 0
 
@@ -154,8 +154,91 @@ NPY_NO_EXPORT int
 dtypemeta_wrap_legacy_descriptor(
         PyArray_Descr *dtypem, const char *name, const char *alias);
 
+NPY_NO_EXPORT void
+initialize_legacy_dtypemeta_aliases(PyArray_Descr **_builtin_descrs);
+
 #ifdef __cplusplus
 }
 #endif
+
+/*
+ * NumPy's builtin DTypes:
+ */
+extern PyArray_DTypeMeta *_Bool_dtype;
+extern PyArray_DTypeMeta *_Byte_dtype;
+extern PyArray_DTypeMeta *_UByte_dtype;
+extern PyArray_DTypeMeta *_Short_dtype;
+extern PyArray_DTypeMeta *_UShort_dtype;
+extern PyArray_DTypeMeta *_Int_dtype;
+extern PyArray_DTypeMeta *_UInt_dtype;
+extern PyArray_DTypeMeta *_Long_dtype;
+extern PyArray_DTypeMeta *_ULong_dtype;
+extern PyArray_DTypeMeta *_LongLong_dtype;
+extern PyArray_DTypeMeta *_ULongLong_dtype;
+extern PyArray_DTypeMeta *_Int8_dtype;
+extern PyArray_DTypeMeta *_UInt8_dtype;
+extern PyArray_DTypeMeta *_Int16_dtype;
+extern PyArray_DTypeMeta *_UInt16_dtype;
+extern PyArray_DTypeMeta *_Int32_dtype;
+extern PyArray_DTypeMeta *_UInt32_dtype;
+extern PyArray_DTypeMeta *_Int64_dtype;
+extern PyArray_DTypeMeta *_UInt64_dtype;
+extern PyArray_DTypeMeta *_Intp_dtype;
+extern PyArray_DTypeMeta *_UIntp_dtype;
+extern PyArray_DTypeMeta *_Half_dtype;
+extern PyArray_DTypeMeta *_Float_dtype;
+extern PyArray_DTypeMeta *_Double_dtype;
+extern PyArray_DTypeMeta *_LongDouble_dtype;
+extern PyArray_DTypeMeta *_CFloat_dtype;
+extern PyArray_DTypeMeta *_CDouble_dtype;
+extern PyArray_DTypeMeta *_CLongDouble_dtype;
+extern PyArray_DTypeMeta *_Bytes_dtype;
+extern PyArray_DTypeMeta *_Unicode_dtype;
+extern PyArray_DTypeMeta *_Datetime_dtype;
+extern PyArray_DTypeMeta *_Timedelta_dtype;
+extern PyArray_DTypeMeta *_Object_dtype;
+extern PyArray_DTypeMeta *_Void_dtype;
+
+#define PyArray_BoolDType (*(_Bool_dtype))
+/* Integers */
+#define PyArray_ByteDType (*(_Byte_dtype))
+#define PyArray_UByteDType (*(_UByte_dtype))
+#define PyArray_ShortDType (*(_Short_dtype))
+#define PyArray_UShortDType (*(_UShort_dtype))
+#define PyArray_IntDType (*(_Int_dtype))
+#define PyArray_UIntDType (*(_UInt_dtype))
+#define PyArray_LongDType (*(_Long_dtype))
+#define PyArray_ULongDType (*(_ULong_dtype))
+#define PyArray_LongLongDType (*(_LongLong_dtype))
+#define PyArray_ULongLongDType (*(_ULongLong_dtype))
+/* Integer aliases */
+#define PyArray_Int8DType (*(_Int8_dtype))
+#define PyArray_UInt8DType (*(_UInt8_dtype))
+#define PyArray_Int16DType (*(_Int16_dtype))
+#define PyArray_UInt16DType (*(_UInt16_dtype))
+#define PyArray_Int32DType (*(_Int32_dtype))
+#define PyArray_UInt32DType (*(_UInt32_dtype))
+#define PyArray_Int64DType (*(_Int64_dtype))
+#define PyArray_UInt64DType (*(_UInt64_dtype))
+#define PyArray_IntpDType (*(_Intp_dtype))
+#define PyArray_UIntpDType (*(_UIntp_dtype))
+/* Floats */
+#define PyArray_HalfDType (*(_Half_dtype))
+#define PyArray_FloatDType (*(_Float_dtype))
+#define PyArray_DoubleDType (*(_Double_dtype))
+#define PyArray_LongDoubleDType (*(_LongDouble_dtype))
+/* Complex */
+#define PyArray_CFloatDType (*(_CFloat_dtype))
+#define PyArray_CDoubleDType (*(_CDouble_dtype))
+#define PyArray_CLongDoubleDType (*(_CLongDouble_dtype))
+/* String/Bytes */
+#define PyArray_BytesDType (*(_Bytes_dtype))
+#define PyArray_UnicodeDType (*(_Unicode_dtype))
+/* Datetime/Timedelta */
+#define PyArray_DatetimeDType (*(_Datetime_dtype))
+#define PyArray_TimedeltaDType (*(_Timedelta_dtype))
+/* Object/Void */
+#define PyArray_ObjectDType (*(_Object_dtype))
+#define PyArray_VoidDType (*(_Void_dtype))
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_DTYPEMETA_H_ */

--- a/numpy/_core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/_core/src/multiarray/experimental_public_dtype_api.c
@@ -17,7 +17,6 @@
 #include "umathmodule.h"
 #include "abstractdtypes.h"
 
-
 int
 PyArrayInitDTypeMeta_FromSpec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
@@ -186,47 +185,47 @@ _get_experimental_dtype_api(PyObject *NPY_UNUSED(mod), PyObject *arg)
             /* NumPy's builtin DTypes (starting at offset 10 going to 41) */
     };
     if (experimental_api_table[10] == NULL) {
-        experimental_api_table[10] = PyArray_DTypeFromTypeNum(NPY_BOOL);
+        experimental_api_table[10] = &PyArray_BoolDType;
         /* Integers */
-        experimental_api_table[11] = PyArray_DTypeFromTypeNum(NPY_BYTE);
-        experimental_api_table[12] = PyArray_DTypeFromTypeNum(NPY_UBYTE);
-        experimental_api_table[13] = PyArray_DTypeFromTypeNum(NPY_SHORT);
-        experimental_api_table[14] = PyArray_DTypeFromTypeNum(NPY_USHORT);
-        experimental_api_table[15] = PyArray_DTypeFromTypeNum(NPY_INT);
-        experimental_api_table[16] = PyArray_DTypeFromTypeNum(NPY_UINT);
-        experimental_api_table[17] = PyArray_DTypeFromTypeNum(NPY_LONG);
-        experimental_api_table[18] = PyArray_DTypeFromTypeNum(NPY_ULONG);
-        experimental_api_table[19] = PyArray_DTypeFromTypeNum(NPY_LONGLONG);
-        experimental_api_table[20] = PyArray_DTypeFromTypeNum(NPY_ULONGLONG);
+        experimental_api_table[11] = &PyArray_ByteDType;
+        experimental_api_table[12] = &PyArray_UByteDType;
+        experimental_api_table[13] = &PyArray_ShortDType;
+        experimental_api_table[14] = &PyArray_UShortDType;
+        experimental_api_table[15] = &PyArray_IntDType;
+        experimental_api_table[16] = &PyArray_UIntDType;
+        experimental_api_table[17] = &PyArray_LongDType;
+        experimental_api_table[18] = &PyArray_ULongDType;
+        experimental_api_table[19] = &PyArray_LongLongDType;
+        experimental_api_table[20] = &PyArray_ULongLongDType;
         /* Integer aliases */
-        experimental_api_table[21] = PyArray_DTypeFromTypeNum(NPY_INT8);
-        experimental_api_table[22] = PyArray_DTypeFromTypeNum(NPY_UINT8);
-        experimental_api_table[23] = PyArray_DTypeFromTypeNum(NPY_INT16);
-        experimental_api_table[24] = PyArray_DTypeFromTypeNum(NPY_UINT16);
-        experimental_api_table[25] = PyArray_DTypeFromTypeNum(NPY_INT32);
-        experimental_api_table[26] = PyArray_DTypeFromTypeNum(NPY_UINT32);
-        experimental_api_table[27] = PyArray_DTypeFromTypeNum(NPY_INT64);
-        experimental_api_table[28] = PyArray_DTypeFromTypeNum(NPY_UINT64);
-        experimental_api_table[29] = PyArray_DTypeFromTypeNum(NPY_INTP);
-        experimental_api_table[30] = PyArray_DTypeFromTypeNum(NPY_UINTP);
+        experimental_api_table[21] = &PyArray_Int8DType;
+        experimental_api_table[22] = &PyArray_UInt8DType;
+        experimental_api_table[23] = &PyArray_Int16DType;
+        experimental_api_table[24] = &PyArray_UInt16DType;
+        experimental_api_table[25] = &PyArray_Int32DType;
+        experimental_api_table[26] = &PyArray_UInt32DType;
+        experimental_api_table[27] = &PyArray_Int64DType;
+        experimental_api_table[28] = &PyArray_UInt64DType;
+        experimental_api_table[29] = &PyArray_IntpDType;
+        experimental_api_table[30] = &PyArray_UIntpDType;
         /* Floats */
-        experimental_api_table[31] = PyArray_DTypeFromTypeNum(NPY_HALF);
-        experimental_api_table[32] = PyArray_DTypeFromTypeNum(NPY_FLOAT);
-        experimental_api_table[33] = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
-        experimental_api_table[34] = PyArray_DTypeFromTypeNum(NPY_LONGDOUBLE);
+        experimental_api_table[31] = &PyArray_HalfDType;
+        experimental_api_table[32] = &PyArray_FloatDType;
+        experimental_api_table[33] = &PyArray_DoubleDType;
+        experimental_api_table[34] = &PyArray_LongDoubleDType;
         /* Complex */
-        experimental_api_table[35] = PyArray_DTypeFromTypeNum(NPY_CFLOAT);
-        experimental_api_table[36] = PyArray_DTypeFromTypeNum(NPY_CDOUBLE);
-        experimental_api_table[37] = PyArray_DTypeFromTypeNum(NPY_CLONGDOUBLE);
+        experimental_api_table[35] = &PyArray_CFloatDType;
+        experimental_api_table[36] = &PyArray_CDoubleDType;
+        experimental_api_table[37] = &PyArray_CLongDoubleDType;
         /* String/Bytes */
-        experimental_api_table[38] = PyArray_DTypeFromTypeNum(NPY_STRING);
-        experimental_api_table[39] = PyArray_DTypeFromTypeNum(NPY_UNICODE);
+        experimental_api_table[38] = &PyArray_BytesDType;
+        experimental_api_table[39] = &PyArray_UnicodeDType;
         /* Datetime/Timedelta */
-        experimental_api_table[40] = PyArray_DTypeFromTypeNum(NPY_DATETIME);
-        experimental_api_table[41] = PyArray_DTypeFromTypeNum(NPY_TIMEDELTA);
+        experimental_api_table[40] = &PyArray_DatetimeDType;
+        experimental_api_table[41] = &PyArray_TimedeltaDType;
         /* Object and Structured */
-        experimental_api_table[42] = PyArray_DTypeFromTypeNum(NPY_OBJECT);
-        experimental_api_table[43] = PyArray_DTypeFromTypeNum(NPY_VOID);
+        experimental_api_table[42] = &PyArray_ObjectDType;
+        experimental_api_table[43] = &PyArray_VoidDType;
         /* Abstract */
         experimental_api_table[44] = &PyArray_PyIntAbstractDType;
         experimental_api_table[45] = &PyArray_PyFloatAbstractDType;

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -486,7 +486,7 @@ sfloat_init_casts(void)
     spec.name = "float_to_sfloat_cast";
     /* Technically, it is just a copy currently so this is fine: */
     spec.flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
-    PyArray_DTypeMeta *double_DType = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+    PyArray_DTypeMeta *double_DType = &PyArray_DoubleDType;
     Py_DECREF(double_DType);  /* immortal anyway */
     dtypes[0] = double_DType;
 
@@ -518,7 +518,7 @@ sfloat_init_casts(void)
 
     spec.name = "sfloat_to_bool_cast";
     dtypes[0] = &PyArray_SFloatDType;
-    dtypes[1] = PyArray_DTypeFromTypeNum(NPY_BOOL);
+    dtypes[1] = &PyArray_BoolDType;
     Py_DECREF(dtypes[1]);  /* immortal anyway */
 
     if (PyArray_AddCastingImplementation_FromSpec(&spec, 0)) {
@@ -756,7 +756,7 @@ sfloat_add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
     if (ufunc == NULL) {
         return -1;
     }
-    PyArray_DTypeMeta *double_dt = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+    PyArray_DTypeMeta *double_dt = &PyArray_DoubleDType;
     PyArray_DTypeMeta *wrapped_dtypes[3] = {double_dt, double_dt, double_dt};
     int res = PyUFunc_AddWrappingLoop(
         ufunc, dtypes, wrapped_dtypes, &translate_given_descrs_to_double,
@@ -848,7 +848,7 @@ sfloat_init_ufuncs(void) {
     /*
      * Add a promoter for both directions of multiply with double.
      */
-    PyArray_DTypeMeta *double_DType = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+    PyArray_DTypeMeta *double_DType = &PyArray_DoubleDType;
     Py_DECREF(double_DType);  /* immortal anyway */
 
     PyArray_DTypeMeta *promoter_dtypes[3] = {

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -1143,7 +1143,7 @@ object_only_ufunc_promoter(PyUFuncObject *ufunc,
         PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    PyArray_DTypeMeta *object_DType = PyArray_DTypeFromTypeNum(NPY_OBJECT);
+    PyArray_DTypeMeta *object_DType = &PyArray_ObjectDType;
 
     for (int i = 0; i < ufunc->nargs; i++) {
         if (signature[i] == NULL) {
@@ -1195,7 +1195,7 @@ logical_ufunc_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
         }
         else {
             /* Always override to boolean */
-            item = PyArray_DTypeFromTypeNum(NPY_BOOL);
+            item = &PyArray_BoolDType;
             if (op_dtypes[i] != NULL && op_dtypes[i]->type_num == NPY_OBJECT) {
                 force_object = 1;
             }
@@ -1219,7 +1219,7 @@ logical_ufunc_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
         if (signature[i] != NULL) {
             continue;
         }
-        Py_SETREF(new_op_dtypes[i], PyArray_DTypeFromTypeNum(NPY_OBJECT));
+        Py_SETREF(new_op_dtypes[i], &PyArray_ObjectDType);
     }
     return 0;
 }

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -310,9 +310,9 @@ pyint_comparison_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = PyArray_DTypeFromTypeNum(NPY_OBJECT);
-    new_op_dtypes[1] = PyArray_DTypeFromTypeNum(NPY_OBJECT);
-    new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_BOOL);
+    new_op_dtypes[0] = &PyArray_ObjectDType;
+    new_op_dtypes[1] = &PyArray_ObjectDType;
+    new_op_dtypes[2] = &PyArray_BoolDType;
     return 0;
 }
 
@@ -413,7 +413,7 @@ init_special_int_comparisons(PyObject *umath)
 {
     int res = -1;
     PyObject *info = NULL, *promoter = NULL;
-    PyArray_DTypeMeta *Bool = PyArray_DTypeFromTypeNum(NPY_BOOL);
+    PyArray_DTypeMeta *Bool = &PyArray_BoolDType;
 
     /* All loops have a boolean out DType (others filled in later) */
     PyArray_DTypeMeta *dtypes[] = {NULL, NULL, Bool};

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -796,8 +796,8 @@ string_find_rfind_count_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = op_dtypes[0];
     Py_INCREF(op_dtypes[1]);
     new_op_dtypes[1] = op_dtypes[1];
-    new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_INT64);
-    new_op_dtypes[3] = PyArray_DTypeFromTypeNum(NPY_INT64);
+    new_op_dtypes[2] = &PyArray_Int64DType;
+    new_op_dtypes[3] = &PyArray_Int64DType;
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
     return 0;
 }
@@ -812,9 +812,9 @@ string_startswith_endswith_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = op_dtypes[0];
     Py_INCREF(op_dtypes[1]);
     new_op_dtypes[1] = op_dtypes[1];
-    new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_INT64);
-    new_op_dtypes[3] = PyArray_DTypeFromTypeNum(NPY_INT64);
-    new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_BOOL);
+    new_op_dtypes[2] = &PyArray_Int64DType;
+    new_op_dtypes[3] = &PyArray_Int64DType;
+    new_op_dtypes[4] = &PyArray_BoolDType;
     return 0;
 }
 
@@ -897,10 +897,9 @@ static int
 init_comparison(PyObject *umath)
 {
     int res = -1;
-    /* NOTE: This should receive global symbols? */
-    PyArray_DTypeMeta *String = PyArray_DTypeFromTypeNum(NPY_STRING);
-    PyArray_DTypeMeta *Unicode = PyArray_DTypeFromTypeNum(NPY_UNICODE);
-    PyArray_DTypeMeta *Bool = PyArray_DTypeFromTypeNum(NPY_BOOL);
+    PyArray_DTypeMeta *String = &PyArray_BytesDType;
+    PyArray_DTypeMeta *Unicode = &PyArray_UnicodeDType;
+    PyArray_DTypeMeta *Bool = &PyArray_BoolDType;
 
     /* We start with the string loops: */
     PyArray_DTypeMeta *dtypes[] = {String, String, Bool};
@@ -994,10 +993,10 @@ init_ufunc(PyObject *umath, const char *name, const char *specname, int nin, int
 
     for (int i = 0; i < nin+nout; i++) {
         if (typenums[i] == NPY_OBJECT && enc == ENCODING::UTF32) {
-            dtypes[i] = PyArray_DTypeFromTypeNum(NPY_UNICODE);
+            dtypes[i] = &PyArray_UnicodeDType;
         }
         else if (typenums[i] == NPY_OBJECT && enc == ENCODING::ASCII) {
-            dtypes[i] = PyArray_DTypeFromTypeNum(NPY_STRING);
+            dtypes[i] = &PyArray_BytesDType;
         }
         else {
             dtypes[i] = PyArray_DTypeFromTypeNum(typenums[i]);


### PR DESCRIPTION
This adds the dtype classes that have been present in the experimental DType API for a while to the internal API to allow these nicer names to be used inside NumPy. I also replaced all the usages of `DTypeFromTypeNum(NPY_SOME_TYPE)` with these aliases.