### PR TITLE
BUG: enable linking of external libraries in the f2py Meson backend

### DIFF
--- a/doc/source/f2py/buildtools/distutils-to-meson.rst
+++ b/doc/source/f2py/buildtools/distutils-to-meson.rst
@@ -163,6 +163,27 @@ Here, ``meson`` can actually be used to set dependencies more robustly.
     of dependencies. They can be `customized further <https://mesonbuild.com/Dependencies.html>`_
     to use CMake or other systems to resolve dependencies.
 
+1.2.5 Libraries
+^^^^^^^^^^^^^^^
+
+Both ``meson`` and ``distutils`` are capable of linking against libraries.
+
+.. tab-set::
+
+  .. tab-item:: Distutils
+    :sync: distutils
+
+    .. code-block:: bash
+
+      python -m numpy.f2py -c fib.f90 -m fib --backend distutils -lmylib -L/path/to/mylib
+
+  .. tab-item:: Meson
+    :sync: meson
+
+    .. code-block:: bash
+
+      python -m numpy.f2py -c fib.f90 -m fib --backend meson -lmylib -L/path/to/mylib
+
 1.3 Customizing builds
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -32,6 +32,9 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 # gh-25000
 quadmath_dep = fc.find_library('quadmath', required: false)
 
+${lib_declarations}
+${lib_dir_declarations}
+
 py.extension_module('${modulename}',
                      [
 ${source_list},
@@ -42,5 +45,7 @@ ${source_list},
                      py_dep,
                      quadmath_dep,
 ${dep_list}
+${lib_list}
+${lib_dir_list}
                      ],
                      install : true)


### PR DESCRIPTION
The current state of the f2py meson code fails to transmit external libraries necessary for linking. In contrast, the previous distutils backend successfully achieved this functionality.
I tried to add few lines of code to bring back the functionality

