### PR TITLE
MAINT: Performance improvement of polyutils.as_series

### DIFF
--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -114,8 +114,9 @@ def as_series(alist, trim=True):
 
     """
     arrays = [np.array(a, ndmin=1, copy=False) for a in alist]
-    if min([a.size for a in arrays]) == 0:
-        raise ValueError("Coefficient array is empty")
+    for a in arrays:
+        if a.size == 0:
+            raise ValueError("Coefficient array is empty")
     if any(a.ndim != 1 for a in arrays):
         raise ValueError("Coefficient array is not 1-d")
     if trim:


### PR DESCRIPTION
This small patch provides a (small) performance improvement: For the normal (straight / no error) case the improvement is from 1 - 9%, for the error case the improvement is between 3 and 30%. The improvement highly depends on the value of the parameter.

The original code always runs through all arrays, even if it could stop at the first found with size zero.

