### PR TITLE
ENH: Release crackfortran as a standalone tool for parsing Fortran.

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3691,13 +3691,21 @@ def character_backward_compatibility_hook(item, parents, result,
 post_processing_hooks.append(character_backward_compatibility_hook)
 
 
-if __name__ == "__main__":
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
     files = []
     funcs = []
     f = 1
     f2 = 0
     f3 = 0
+    strictf77 = 0
+    f77modulename = 0
+    skipemptyends = 0
     showblocklist = 0
+    pyffilename = None
     for l in sys.argv[1:]:
         if l == '':
             pass
@@ -3757,6 +3765,10 @@ if __name__ == "__main__":
   statement).
 """, 0)
 
+    if len(files) == 0:
+        print('No input files specified, nothing to do')
+        sys.exit(0)
+
     postlist = crackfortran(files)
     if pyffilename:
         outmess('Writing fortran code to file %s\n' % repr(pyffilename), 0)
@@ -3765,3 +3777,6 @@ if __name__ == "__main__":
             f.write(pyf)
     if showblocklist:
         show(postlist)
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 
 [project.scripts]
 f2py = 'numpy.f2py.f2py2e:main'
+crackfortran = 'numpy.f2py.crackfortran:main'
 
 [project.entry-points.array_api]
 numpy = 'numpy.array_api'


### PR DESCRIPTION
The `crackfortran` tool is developed to be a backend for the f2py utility. However, crackfortran could also be very useful on its own.

The use of crackfortran could be demonstrated by the following example:

```
► crackfortran symbol.f90 -show
Reading fortran codes...
        Reading file 'symbol.f90' (format:free)
Post-processing...
        Block: symbol
Post-processing (stage 2)...
[{'args': ['x', 'y', 'symx', 'opt'],
  'block': 'subroutine',
  'body': [],
  'common': {'pltdat': ['model', 'ploter'], 'symbls': ['nsym', 'symbl']},
  'commonvars': ['model', 'ploter', 'nsym', 'symbl'],
  'entry': {},
  'externals': [],
  'from': 'symbol.f90',
  'implicit': None,
  'interfaced': [],
  'name': 'symbol',
  'sortvars': ['model', 'nsym', 'ploter', 'symbl', 'opt', 'x', 'y', 'symx'],
  'vars': {'model': {'attrspec': [], 'typespec': 'integer'},
           'nsym': {'attrspec': [], 'typespec': 'integer'},
           'opt': {'typespec': 'integer'},
           'ploter': {'attrspec': [], 'typespec': 'integer'},
           'symbl': {'attrspec': [],
                     'dimension': ['20', '2'],
                     'typespec': 'integer'},
           'symx': {'attrspec': [], 'dimension': ['2'], 'typespec': 'integer'},
           'x': {'typespec': 'real'},
           'y': {'typespec': 'real'}}}]
```

The tool presents the subroutine declaration statements as a JSON that can be consumed by other tools for further analysis.

Everyone who is looking for the Fortran parser should first come across crackfortran, before wasting time on many sloppy half-working parsers on the Internet. In this regard, the importance of crackfortran is currently misrepresented by keeping it in the depth of numpy internals. Therefore, this patch adds changes required to expose crackfortran as an entry point, next to f2py3 and reveal it to the world.
