### PR TITLE
DOC: Fix path to svg logo files

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,8 +240,8 @@ else:
 
 html_theme_options = {
   "logo": {
-      "image_light": "numpylogo.svg",
-      "image_dark": "numpylogo_dark.svg",
+      "image_light": "_static/numpylogo.svg",
+      "image_dark": "_static/numpylogo_dark.svg",
   },
   "github_url": "https://github.com/numpy/numpy",
   "collapse_navigation": True,


### PR DESCRIPTION
Fixes warning on docs build about these logos not being found (see, for example, https://app.circleci.com/pipelines/github/numpy/numpy/23533/workflows/2c117932-7461-4734-9109-fc6179ceed55/jobs/36477?invite=true#step-109-13108_85):

```
WARNING: Path to light image logo does not exist: numpylogo.svg
WARNING: Path to dark image logo does not exist: numpylogo_dark.svg
```