### PR TITLE
BUG: Don't use the _Complex extension in C++ mode

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -354,16 +354,9 @@ typedef double npy_double;
 typedef Py_hash_t npy_hash_t;
 #define NPY_SIZEOF_HASH_T NPY_SIZEOF_INTP
 
-#ifdef __cplusplus
-extern "C++" {
-#endif
-#include <complex.h>
-#ifdef __cplusplus
-}
-#endif
+#if defined(__cplusplus)
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && defined(__cplusplus)
-typedef struct 
+typedef struct
 {
     double _Val[2];
 } npy_cdouble;
@@ -377,7 +370,12 @@ typedef struct
 {
     long double _Val[2];
 } npy_clongdouble;
-#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) /* && !defined(__cplusplus) */
+
+#else
+
+#include <complex.h>
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 typedef _Dcomplex npy_cdouble;
 typedef _Fcomplex npy_cfloat;
 typedef _Lcomplex npy_clongdouble;
@@ -385,6 +383,8 @@ typedef _Lcomplex npy_clongdouble;
 typedef double _Complex npy_cdouble;
 typedef float _Complex npy_cfloat;
 typedef longdouble_t _Complex npy_clongdouble;
+#endif
+
 #endif
 
 /*

--- a/numpy/_core/src/umath/clip.cpp
+++ b/numpy/_core/src/umath/clip.cpp
@@ -76,7 +76,6 @@ _NPY_MIN(npy_cfloat a, npy_cfloat b, npy::complex_tag const &)
                 : (b);
 }
 
-#if (defined(_MSC_VER) && !defined(__INTEL_COMPILER)) || NPY_SIZEOF_COMPLEX_LONGDOUBLE != NPY_SIZEOF_COMPLEX_DOUBLE
 npy_clongdouble
 _NPY_MIN(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
 {
@@ -84,7 +83,6 @@ _NPY_MIN(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
                 ? (a)
                 : (b);
 }
-#endif
 
 npy_cdouble
 _NPY_MAX(npy_cdouble a, npy_cdouble b, npy::complex_tag const &)
@@ -102,7 +100,6 @@ _NPY_MAX(npy_cfloat a, npy_cfloat b, npy::complex_tag const &)
                 : (b);
 }
 
-#if (defined(_MSC_VER) && !defined(__INTEL_COMPILER)) || NPY_SIZEOF_COMPLEX_LONGDOUBLE != NPY_SIZEOF_COMPLEX_DOUBLE
 npy_clongdouble
 _NPY_MAX(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
 {
@@ -110,7 +107,6 @@ _NPY_MAX(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
                 ? (a)
                 : (b);
 }
-#endif
 #undef PyArray_CLT
 #undef PyArray_CGT
 

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -465,35 +465,19 @@ constexpr double numeric_limits<double>::minus_one;
 const double numeric_limits<double>::ninf = -NPY_INFINITY;
 const double numeric_limits<double>::nan = NPY_NAN;
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 template<>
 struct numeric_limits<npy_cfloat> {
-static constexpr npy_cfloat one = {1.0f, 0.0f};
-static constexpr npy_cfloat zero = {0.0f, 0.0f};
-static constexpr npy_cfloat minus_one = {-1.0f, 0.0f};
+static constexpr npy_cfloat one = {1.0f};
+static constexpr npy_cfloat zero = {0.0f};
+static constexpr npy_cfloat minus_one = {-1.0f};
 static const npy_cfloat ninf;
 static const npy_cfloat nan;
 };
 constexpr npy_cfloat numeric_limits<npy_cfloat>::one;
 constexpr npy_cfloat numeric_limits<npy_cfloat>::zero;
 constexpr npy_cfloat numeric_limits<npy_cfloat>::minus_one;
-const npy_cfloat numeric_limits<npy_cfloat>::ninf = {-NPY_INFINITYF, 0.0f};
+const npy_cfloat numeric_limits<npy_cfloat>::ninf = {-NPY_INFINITYF};
 const npy_cfloat numeric_limits<npy_cfloat>::nan = {NPY_NANF, NPY_NANF};
-#else
-template<>
-struct numeric_limits<npy_cfloat> {
-static constexpr npy_cfloat one = 1.0f;
-static constexpr npy_cfloat zero = 0.0f;
-static constexpr npy_cfloat minus_one = -1.0f;
-static const npy_cfloat ninf;
-static const npy_cfloat nan;
-};
-constexpr npy_cfloat numeric_limits<npy_cfloat>::one;
-constexpr npy_cfloat numeric_limits<npy_cfloat>::zero;
-constexpr npy_cfloat numeric_limits<npy_cfloat>::minus_one;
-const npy_cfloat numeric_limits<npy_cfloat>::ninf = -NPY_INFINITYF;
-const npy_cfloat numeric_limits<npy_cfloat>::nan = NPY_NANF;
-#endif
 
 template<>
 struct numeric_limits<f2c_complex> {
@@ -509,48 +493,32 @@ constexpr f2c_complex numeric_limits<f2c_complex>::minus_one;
 const f2c_complex numeric_limits<f2c_complex>::ninf = {-NPY_INFINITYF, 0.0f};
 const f2c_complex numeric_limits<f2c_complex>::nan = {NPY_NANF, NPY_NANF};
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 template<>
 struct numeric_limits<npy_cdouble> {
-static constexpr npy_cdouble one = {1.0, 0.0};
-static constexpr npy_cdouble zero = {0.0, 0.0};
-static constexpr npy_cdouble minus_one = {-1.0, 0.0};
+static constexpr npy_cdouble one = {1.0};
+static constexpr npy_cdouble zero = {0.0};
+static constexpr npy_cdouble minus_one = {-1.0};
 static const npy_cdouble ninf;
 static const npy_cdouble nan;
 };
 constexpr npy_cdouble numeric_limits<npy_cdouble>::one;
 constexpr npy_cdouble numeric_limits<npy_cdouble>::zero;
 constexpr npy_cdouble numeric_limits<npy_cdouble>::minus_one;
-const npy_cdouble numeric_limits<npy_cdouble>::ninf = {-NPY_INFINITY, 0.0};
+const npy_cdouble numeric_limits<npy_cdouble>::ninf = {-NPY_INFINITY};
 const npy_cdouble numeric_limits<npy_cdouble>::nan = {NPY_NAN, NPY_NAN};
-#else
-template<>
-struct numeric_limits<npy_cdouble> {
-static constexpr npy_cdouble one = 1.0;
-static constexpr npy_cdouble zero = 0.0;
-static constexpr npy_cdouble minus_one = -1.0;
-static const npy_cdouble ninf;
-static const npy_cdouble nan;
-};
-constexpr npy_cdouble numeric_limits<npy_cdouble>::one;
-constexpr npy_cdouble numeric_limits<npy_cdouble>::zero;
-constexpr npy_cdouble numeric_limits<npy_cdouble>::minus_one;
-const npy_cdouble numeric_limits<npy_cdouble>::ninf = -NPY_INFINITY;
-const npy_cdouble numeric_limits<npy_cdouble>::nan = NPY_NAN;
-#endif
 
 template<>
 struct numeric_limits<f2c_doublecomplex> {
-static constexpr f2c_doublecomplex one = {1.0, 0.0};
-static constexpr f2c_doublecomplex zero = {0.0, 0.0};
-static constexpr f2c_doublecomplex minus_one = {-1.0, 0.0};
+static constexpr f2c_doublecomplex one = {1.0};
+static constexpr f2c_doublecomplex zero = {0.0};
+static constexpr f2c_doublecomplex minus_one = {-1.0};
 static const f2c_doublecomplex ninf;
 static const f2c_doublecomplex nan;
 };
 constexpr f2c_doublecomplex numeric_limits<f2c_doublecomplex>::one;
 constexpr f2c_doublecomplex numeric_limits<f2c_doublecomplex>::zero;
 constexpr f2c_doublecomplex numeric_limits<f2c_doublecomplex>::minus_one;
-const f2c_doublecomplex numeric_limits<f2c_doublecomplex>::ninf = {-NPY_INFINITY, 0.0};
+const f2c_doublecomplex numeric_limits<f2c_doublecomplex>::ninf = {-NPY_INFINITY};
 const f2c_doublecomplex numeric_limits<f2c_doublecomplex>::nan = {NPY_NAN, NPY_NAN};
 
 /*


### PR DESCRIPTION
Both header provide the same symbol and types, but there are some portability subtleties provided by <ccomplex> under C++ mode, see for instance https://godbolt.org/z/nEv1Ehsds