### PR TITLE
MAINT: expose PyUFunc_AddPromoter in the internal ufunc API

### DIFF
--- a/numpy/_core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/_core/src/multiarray/experimental_public_dtype_api.c
@@ -16,6 +16,7 @@
 #include "common_dtype.h"
 #include "umathmodule.h"
 #include "abstractdtypes.h"
+#include "dispatching.h"
 
 int
 PyArrayInitDTypeMeta_FromSpec(
@@ -115,9 +116,6 @@ PyArrayInitDTypeMeta_FromSpec(
 NPY_NO_EXPORT int
 PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate);
 
-NPY_NO_EXPORT int
-PyUFunc_AddLoopFromSpec(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate);
-
 
 /*
  * Function is defined in umath/wrapping_array_method.c
@@ -128,31 +126,6 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
         PyArray_DTypeMeta *new_dtypes[], PyArray_DTypeMeta *wrapped_dtypes[],
         translate_given_descrs_func *translate_given_descrs,
         translate_loop_descrs_func *translate_loop_descrs);
-
-
-static int
-PyUFunc_AddPromoter(
-        PyObject *ufunc, PyObject *DType_tuple, PyObject *promoter)
-{
-    if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
-        PyErr_SetString(PyExc_TypeError,
-                "ufunc object passed is not a ufunc!");
-        return -1;
-    }
-    if (!PyCapsule_CheckExact(promoter)) {
-        PyErr_SetString(PyExc_TypeError,
-                "promoter must (currently) be a PyCapsule.");
-        return -1;
-    }
-    if (PyCapsule_GetPointer(promoter, "numpy._ufunc_promoter") == NULL) {
-        return -1;
-    }
-    PyObject *info = PyTuple_Pack(2, DType_tuple, promoter);
-    if (info == NULL) {
-        return -1;
-    }
-    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
-}
 
 
 /*

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -1291,3 +1291,27 @@ get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype,
     Py_DECREF(t_dtypes);
     Py_RETURN_NONE;
 }
+
+NPY_NO_EXPORT int
+PyUFunc_AddPromoter(
+        PyObject *ufunc, PyObject *DType_tuple, PyObject *promoter)
+{
+    if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
+        PyErr_SetString(PyExc_TypeError,
+                "ufunc object passed is not a ufunc!");
+        return -1;
+    }
+    if (!PyCapsule_CheckExact(promoter)) {
+        PyErr_SetString(PyExc_TypeError,
+                "promoter must (currently) be a PyCapsule.");
+        return -1;
+    }
+    if (PyCapsule_GetPointer(promoter, "numpy._ufunc_promoter") == NULL) {
+        return -1;
+    }
+    PyObject *info = PyTuple_Pack(2, DType_tuple, promoter);
+    if (info == NULL) {
+        return -1;
+    }
+    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+}

--- a/numpy/_core/src/umath/dispatching.h
+++ b/numpy/_core/src/umath/dispatching.h
@@ -51,6 +51,11 @@ object_only_ufunc_promoter(PyUFuncObject *ufunc,
 NPY_NO_EXPORT int
 install_logical_ufunc_promoter(PyObject *ufunc);
 
+NPY_NO_EXPORT int
+PyUFunc_AddPromoter(
+        PyObject *ufunc, PyObject *DType_tuple, PyObject *promoter);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This moves the implementation of `PyUFunc_AddPromoter` into `dispatching.c` and exposes it in the corresponding internal header. I use this function in `StringDType` and am issuing this PR separately from the main stringdtype PR to ease review of both.