### PR TITLE
CI: remove no-blas=true from spin command on macos_arm64 ci [skip act…

### DIFF
--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -102,7 +102,7 @@ macos_arm64_test_task:
     pip install -r build_requirements.txt
     pip install pytest pytest-xdist hypothesis typing_extensions
 
-    spin build -- -Dallow-noblas=true
+    spin build
     spin test -j auto
 
     ccache -s


### PR DESCRIPTION
Removes the `no-blas=True` option from the spin command on the CI for macos_arm64. This makes the run use Accelerate. This should've been removed in #25253.