### PR TITLE
BUG: Restore missing asstr import

### DIFF
--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -20,6 +20,7 @@ import contextlib
 import numpy
 
 from pathlib import Path
+from numpy.compat import asstr
 from numpy._utils import asunicode
 from numpy.testing import temppath, IS_WASM
 from importlib import import_module


### PR DESCRIPTION
The user of this import was removed in the clean-up in #25111, post-2.26.

Used on: https://github.com/numpy/numpy/blob/cd29a9016c9404e6dcb7b823fe939398865f0327/numpy/f2py/tests/util.py#L335