### PR TITLE
API: make arange `start` argument positional-only

### DIFF
--- a/doc/release/upcoming_changes/25336.compatibility.rst
+++ b/doc/release/upcoming_changes/25336.compatibility.rst
@@ -1,0 +1,8 @@
+``arange``'s ``start`` argyment is positional-only
+------------------------------------------------
+The first argument of ``arange`` is now positional only. This way,
+specifying a ``start`` argument as a keyword, e.g. ``arange(start=0, stop=4)``,
+raises a TypeError. Other behaviors, are unchanged so ``arange(stop=4)``,
+``arange(2, stop=4)`` and so on, are still legal and have the same meaning as
+before.
+

--- a/doc/release/upcoming_changes/25336.compatibility.rst
+++ b/doc/release/upcoming_changes/25336.compatibility.rst
@@ -1,8 +1,8 @@
-``arange``'s ``start`` argyment is positional-only
-------------------------------------------------
+``arange``'s ``start`` argument is positional-only
+--------------------------------------------------
 The first argument of ``arange`` is now positional only. This way,
 specifying a ``start`` argument as a keyword, e.g. ``arange(start=0, stop=4)``,
 raises a TypeError. Other behaviors, are unchanged so ``arange(stop=4)``,
-``arange(2, stop=4)`` and so on, are still legal and have the same meaning as
+``arange(2, stop=4)`` and so on, are still valid and have the same meaning as
 before.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1686,7 +1686,7 @@ add_newdoc('numpy._core.multiarray', 'correlate',
 
 add_newdoc('numpy._core.multiarray', 'arange',
     """
-    arange([start,] stop[, step,], dtype=None, *, device=None, like=None)
+    arange(start, / [, stop[, step,], dtype=None, *, device=None,, like=None)
 
     Return evenly spaced values within a given interval.
 

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -141,15 +141,16 @@ initialize_keywords(const char *funcname,
         }
 
         if (*name == '\0') {
+            npositional_only += 1;
             /* Empty string signals positional only */
-            if (state != '\0') {
+            if (state == '$' || npositional_only != npositional) {
                 PyErr_Format(PyExc_SystemError,
-                        "NumPy internal error: non-kwarg marked with | or $ "
-                        "to %s() at argument %d.", funcname, nargs);
+                        "NumPy internal error: non-kwarg marked with $ "
+                        "to %s() at argument %d or positional only following "
+                        "kwarg.", funcname, nargs);
                 va_end(va);
                 return -1;
             }
-            npositional_only += 1;
         }
         else {
             nkwargs += 1;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3068,7 +3068,7 @@ array_arange(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("arange", args, len_args, kwnames,
-            "|start", NULL, &o_start,
+            "", NULL, &o_start,
             "|stop", NULL, &o_stop,
             "|step", NULL, &o_step,
             "|dtype", &PyArray_DescrConverter2, &typecode,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3068,7 +3068,7 @@ array_arange(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("arange", args, len_args, kwnames,
-            "", NULL, &o_start,
+            "|", NULL, &o_start,
             "|stop", NULL, &o_stop,
             "|step", NULL, &o_step,
             "|dtype", &PyArray_DescrConverter2, &typecode,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9435,16 +9435,6 @@ class TestArange:
         assert_raises(TypeError, np.arange, dtype='int64')
         assert_raises(TypeError, np.arange, start=4)
 
-    def test_start_stop_kwarg(self):
-        keyword_stop = np.arange(stop=3)
-        keyword_zerotostop = np.arange(start=0, stop=3)
-        keyword_start_stop = np.arange(start=3, stop=9)
-
-        assert len(keyword_stop) == 3
-        assert len(keyword_zerotostop) == 3
-        assert len(keyword_start_stop) == 6
-        assert_array_equal(keyword_stop, keyword_zerotostop)
-
     def test_arange_booleans(self):
         # Arange makes some sense for booleans and works up to length 2.
         # But it is weird since `arange(2, 4, dtype=bool)` works.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9435,6 +9435,21 @@ class TestArange:
         assert_raises(TypeError, np.arange, dtype='int64')
         assert_raises(TypeError, np.arange, start=4)
 
+    def test_start_stop_kwarg(self):
+        with pytest.raises(TypeError):
+            # Start cannot be passed as a kwarg anymore, because on it's own
+            # it would be strange.
+            np.arange(start=0, stop=3)
+
+        keyword_stop = np.arange(stop=3)
+        keyword_zerotostop = np.arange(0, stop=3)
+        keyword_start_stop = np.arange(3, stop=9)
+
+        assert len(keyword_stop) == 3
+        assert len(keyword_zerotostop) == 3
+        assert len(keyword_start_stop) == 6
+        assert_array_equal(keyword_stop, keyword_zerotostop)
+
     def test_arange_booleans(self):
         # Arange makes some sense for booleans and works up to length 2.
         # But it is weird since `arange(2, 4, dtype=bool)` works.


### PR DESCRIPTION
Make `np.arange` first argument positional-only. This does break some backwards compat. This PR removes a test, which also shows typical usages this patch disallows. The weirdest one is probably `np.arange(stop=3)`, where the `start` is inferred to have a zero default. FWIW, the current `arange` sinature, `arange([start,] stop[, step,]`, where the first argument has a default value and the second does not, is not very easy to reconstruct with just pure python rules.

cross-ref https://github.com/numpy/numpy/issues/23999#issuecomment-1602380088 and https://github.com/numpy/numpy/issues/23999#issuecomment-1602491249
