### PR TITLE
BUG: Fix F2py with meson when fortran code uses "include" statement

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -59,7 +59,7 @@ class MesonTemplate:
     def initialize_template(self) -> None:
         self.substitutions["modulename"] = self.modulename
         self.substitutions["buildtype"] = self.build_type
-        self.subsitutions["original_source_dir"] = os.getcwd()
+        self.substitutions["original_source_dir"] = os.getcwd()
 
     def sources_substitution(self) -> None:
         indent = " " * 21

--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -59,6 +59,7 @@ class MesonTemplate:
     def initialize_template(self) -> None:
         self.substitutions["modulename"] = self.modulename
         self.substitutions["buildtype"] = self.build_type
+        self.subsitutions["original_source_dir"] = os.getcwd()
 
     def sources_substitution(self) -> None:
         indent = " " * 21

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -40,7 +40,7 @@ py.extension_module('${modulename}',
 ${source_list},
                      fortranobject_c
                      ],
-                     include_directories: [inc_np],
+                     include_directories: [inc_np, '${original_source_dir}'],
                      dependencies : [
                      py_dep,
                      quadmath_dep,


### PR DESCRIPTION
This is a proposal to fix #25344 

In practice, I'm adding the current work directory to the list of  include paths.
Obviously, they are likely a nicer way to fix the issue. So do not hesistate to trash it to have something nicer/more robust/...

Thanks,

Olivier
  