### PR TITLE
ENH: Enable 16-bit VQSort routines on AArch64

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -787,6 +787,13 @@ foreach gen_mtargets : [
       ASIMD,
     ]
   ],
+  [
+    'highway_qsort_16bit.dispatch.h',
+    'src/npysort/highway_qsort_16bit.dispatch.cpp',
+    [
+      ASIMDHP,
+    ]
+  ],
 ]
   mtargets = mod_features.multi_targets(
     gen_mtargets[0], multiarray_gen_headers + gen_mtargets[1],

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -11,6 +11,13 @@ namespace np { namespace highway { namespace qsort_simd {
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 
+
+#ifndef NPY_DISABLE_OPTIMIZATION
+    #include "highway_qsort_16bit.dispatch.h"
+#endif
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
+
 } } } // np::highway::qsort_simd
 
 #endif // NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP

--- a/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
@@ -1,0 +1,20 @@
+#include "highway_qsort.hpp"
+#define VQSORT_ONLY_STATIC 1
+#include "hwy/contrib/sort/vqsort-inl.h"
+
+namespace np { namespace highway { namespace qsort_simd {
+
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
+{
+    hwy::HWY_NAMESPACE::VQSortStatic(reinterpret_cast<hwy::float16_t*>(arr), size, hwy::SortAscending());
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, intptr_t size)
+{
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
+}
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
+{
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
+}
+
+} } } // np::highway::qsort_simd

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -81,9 +81,14 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
     void (*dispfunc)(TF*, intptr_t) = nullptr;
     if (sizeof(T) == sizeof(uint16_t)) {
         #ifndef NPY_DISABLE_OPTIMIZATION
-            #include "x86_simd_qsort_16bit.dispatch.h"
+            #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
+                #include "x86_simd_qsort_16bit.dispatch.h"
+                NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
+            #else
+                #include "highway_qsort_16bit.dispatch.h"
+                NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSort, <TF>);
+            #endif
         #endif
-        NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
     }
     else if (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
         #ifndef NPY_DISABLE_OPTIMIZATION


### PR DESCRIPTION
Following the enablement of VQSort, this enables the 16-bit routines, which improves the performance quite a bit:

```
| Change   | Before [895c7520] <highway-vqsort-16~1>   | After [5abc0cac] <highway-vqsort-16>   |   Ratio | Benchmark (Parameter)                                                          |
|----------|-------------------------------------------|----------------------------------------|---------|--------------------------------------------------------------------------------|
| +        | 63.1±0.1μs                                | 79.7±4μs                               |    1.26 | bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 100))   |
| +        | 35.8±0.01μs                               | 41.5±6μs                               |    1.16 | bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 1000))  |
| +        | 652±1μs                                   | 695±5μs                                |    1.07 | bench_function_base.Sort.time_sort('heap', 'float16', ('sorted_block', 1000))  |
| +        | 728±0.5μs                                 | 767±2μs                                |    1.05 | bench_function_base.Sort.time_sort('heap', 'float16', ('random',))             |
| +        | 681±1μs                                   | 716±4μs                                |    1.05 | bench_function_base.Sort.time_sort('heap', 'float16', ('sorted_block', 100))   |
| +        | 49.8±0.1μs                                | 52.3±0.05μs                            |    1.05 | bench_function_base.Sort.time_sort('quick', 'int16', ('ordered',))             |
| -        | 58.9±0.05μs                               | 55.9±0.2μs                             |    0.95 | bench_function_base.Sort.time_sort('heap', 'float16', ('reversed',))           |
| -        | 59.0±0.03μs                               | 55.7±0.02μs                            |    0.95 | bench_function_base.Sort.time_sort('heap', 'float16', ('uniform',))            |
| -        | 81.6±0.2μs                                | 52.6±0.03μs                            |    0.64 | bench_function_base.Sort.time_sort('quick', 'int16', ('reversed',))            |
| -        | 135±0.05μs                                | 59.7±0.1μs                             |    0.44 | bench_function_base.Sort.time_sort('quick', 'float16', ('ordered',))           |
| -        | 251±0.9μs                                 | 55.2±0.03μs                            |    0.22 | bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 1000))   |
| -        | 340±1μs                                   | 59.2±0.05μs                            |    0.17 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 1000)) |
| -        | 312±0.6μs                                 | 52.8±0.04μs                            |    0.17 | bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 10))     |
| -        | 329±0.7μs                                 | 52.7±0.06μs                            |    0.16 | bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 100))    |
| -        | 413±0.8μs                                 | 57.6±0.02μs                            |    0.14 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 10))   |
| -        | 407±0.6μs                                 | 56.8±0.05μs                            |    0.14 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 100))  |
| -        | 376±0.6μs                                 | 52.8±0.05μs                            |    0.14 | bench_function_base.Sort.time_sort('quick', 'int16', ('random',))              |
| -        | 471±1μs                                   | 56.9±0.06μs                            |    0.12 | bench_function_base.Sort.time_sort('quick', 'float16', ('random',))            |
| -        | 49.6±0.01μs                               | 2.15±0.02μs                            |    0.04 | bench_function_base.Sort.time_sort('quick', 'int16', ('uniform',))             |
| -        | 153±0.08μs                                | 4.28±0.02μs                            |    0.03 | bench_function_base.Sort.time_sort('quick', 'float16', ('reversed',))          |
| -        | 143±1μs                                   | 4.28±0.02μs                            |    0.03 | bench_function_base.Sort.time_sort('quick', 'float16', ('uniform',))           |
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
