### PR TITLE
MAINT: update all TypedDict imports [skip ci]

### DIFF
--- a/numpy/_core/_type_aliases.pyi
+++ b/numpy/_core/_type_aliases.pyi
@@ -1,5 +1,5 @@
-from typing import Any, TypedDict
-
+from typing_extensions import TypedDict
+from typing import Any
 from numpy import generic, signedinteger, unsignedinteger, floating, complexfloating
 
 class _SCTypes(TypedDict):

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal
+from typing_extensions import TypedDict
 
 from numpy import _SupportsWrite
 

--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict, SupportsIndex
-
+from typing import Any, Literal, SupportsIndex
+from typing_extensions import TypedDict
 # Using a private class is by no means ideal, but it is simply a consequence
 # of a `contextlib.context` returning an instance of aforementioned class
 from contextlib import _GeneratorContextManager

--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -6,9 +6,8 @@ from typing import (
     Any,
     TypeVar,
     Protocol,
-    TypedDict,
 )
-
+from typing_extensions import TypedDict
 import numpy as np
 from numpy import (
     ndarray,

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -5,10 +5,9 @@ from typing import (
     Union,
     TypeVar,
     Protocol,
-    TypedDict,
     runtime_checkable,
 )
-
+from typing_extensions import TypedDict
 import numpy as np
 
 from ._shape import _ShapeLike

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -1,7 +1,8 @@
 import os
 import subprocess
 from collections.abc import Iterable
-from typing import Literal as L, Any, overload, TypedDict
+from typing import Literal as L, Any, overload
+from typing_extensions import TypedDict
 
 from numpy._pytesttester import PytestTester
 

--- a/numpy/random/_mt19937.pyi
+++ b/numpy/random/_mt19937.pyi
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from numpy import uint32
 from numpy.typing import NDArray

--- a/numpy/random/_pcg64.pyi
+++ b/numpy/random/_pcg64.pyi
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 from numpy._typing import _ArrayLikeInt_co

--- a/numpy/random/_philox.pyi
+++ b/numpy/random/_philox.pyi
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from numpy import uint64
 from numpy.typing import NDArray

--- a/numpy/random/_sfc64.pyi
+++ b/numpy/random/_sfc64.pyi
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from numpy import uint64
 from numpy.random.bit_generator import BitGenerator, SeedSequence

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -4,12 +4,11 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import (
     Any,
     NamedTuple,
-    TypedDict,
     TypeVar,
     overload,
     Literal,
 )
-
+from typing_extensions import TypedDict
 from numpy import dtype, uint32, uint64
 from numpy._typing import (
     NDArray,


### PR DESCRIPTION
addresses https://github.com/numpy/numpy/issues/25206 by updating where TypedDict is imported from. This is to address an error pydantic raises when numpy_typing.DTypeLike is used in pydantic v2 BaseModels.

I'm skipping ci since this is my first PR and I'm not sure if I should skip some of the CI described here given that the change is minimal: https://numpy.org/devdocs/dev/development_workflow.html#commands-to-skip-continuous-integration