### PR TITLE
DRAFT - Change API to prepare for heap types.

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -657,7 +657,7 @@ cdef extern from "numpy/arrayobject.h":
     #object PyArray_FromArrayAttr (object, dtype, object)
     #NPY_SCALARKIND PyArray_ScalarKind (int, ndarray*)
     int PyArray_CanCoerceScalar (int, int, NPY_SCALARKIND)
-    object PyArray_NewFlagsObject (object)
+    object PyArray_NewFlagsObject (object, object)
     npy_bool PyArray_CanCastScalar (type, type)
     #int PyArray_CompareUCS4 (npy_ucs4 *, npy_ucs4 *, register size_t)
     int PyArray_RemoveSmallest (broadcast) except -1

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -576,7 +576,7 @@ cdef extern from "numpy/arrayobject.h":
     #object PyArray_FromArrayAttr (object, dtype, object)
     #NPY_SCALARKIND PyArray_ScalarKind (int, ndarray*)
     int PyArray_CanCoerceScalar (int, int, NPY_SCALARKIND)
-    object PyArray_NewFlagsObject (object)
+    object PyArray_NewFlagsObject (object, object)
     npy_bool PyArray_CanCastScalar (type, type)
     #int PyArray_CompareUCS4 (npy_ucs4 *, npy_ucs4 *, register size_t)
     int PyArray_RemoveSmallest (broadcast) except -1

--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -74,3 +74,6 @@
 
 # Version 18 (NumPy 2.0.0)
 0x00000012 = 082b496f5b37251cd9a404087915c1dc
+
+# Version 19 (NumPy 2.1.0)
+0x00000013 = 0e39fa8a8e46979e7a88ee6ef5b7a619

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -248,6 +248,7 @@ def find_functions(filename, tag='API'):
     SCANNING, STATE_DOC, STATE_RETTYPE, STATE_NAME, STATE_ARGS = list(range(5))
     state = SCANNING
     tagcomment = '/*' + tag
+    doprint = 0
     for lineno, line in enumerate(fo):
         try:
             line = line.strip()

--- a/numpy/_core/code_generators/numpy_api.py
+++ b/numpy/_core/code_generators/numpy_api.py
@@ -5,7 +5,7 @@ Each dictionary contains name -> index pair.
 
 Whenever you change one index, you break the ABI (and the ABI version number
 should be incremented). Whenever you add an item to one of the dict, the API
-needs to be updated in both numpy/core/meson.build and by adding an appropriate
+needs to be updated in both numpy/_core/meson.build and by adding an appropriate
 entry to cversion.txt (generate the hash via "python cversions.py").
 
 When adding a function, make sure to use the next integer not used as an index
@@ -379,6 +379,9 @@ multiarray_funcs_api = {
     'NpyDatetime_GetDatetimeISO8601StrLen':          (310, MinVersion("2.0")),
     'NpyDatetime_MakeISO8601Datetime':               (311, MinVersion("2.0")),
     'NpyDatetime_ParseISO8601Datetime':              (312, MinVersion("2.0")),
+
+    # End 2.0 API
+    "PyArray_GetFlagsType":                 (313,),
 }
 
 ufunc_types_api = {

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -47,7 +47,8 @@ C_ABI_VERSION = '0x02000000'
 # 0x00000010 - 1.24.x
 # 0x00000011 - 1.25.x
 # 0x00000012 - 2.0.x
-C_API_VERSION = '0x00000012'
+# 0x00000013 - 2.1.x
+C_API_VERSION = '0x00000013'
 
 # Check whether we have a mismatch between the set C API VERSION and the
 # actual C API VERSION. Will raise a MismatchCAPIError if so.

--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -25,7 +25,7 @@ _UpdateContiguousFlags(PyArrayObject *ap);
  * Get New ArrayFlagsObject
  */
 NPY_NO_EXPORT PyObject *
-PyArray_NewFlagsObject(PyObject *obj)
+PyArray_NewFlagsObject(PyObject* mod, PyObject *obj)
 {
     PyObject *flagobj;
     int flags;
@@ -45,7 +45,9 @@ PyArray_NewFlagsObject(PyObject *obj)
 
         flags = PyArray_FLAGS((PyArrayObject *)obj);
     }
-    flagobj = PyArrayFlags_Type.tp_alloc(&PyArrayFlags_Type, 0);
+
+    PyTypeObject* array_flags_type = &PyArrayFlags_Type;
+    flagobj = array_flags_type->tp_alloc(array_flags_type, 0);
     if (flagobj == NULL) {
         return NULL;
     }
@@ -680,17 +682,20 @@ static PyMappingMethods arrayflags_as_mapping = {
 
 
 static PyObject *
-arrayflags_new(PyTypeObject *NPY_UNUSED(self), PyObject *args, PyObject *NPY_UNUSED(kwds))
+arrayflags_new(PyTypeObject *self, PyObject *args, PyObject *NPY_UNUSED(kwds))
 {
     PyObject *arg=NULL;
     if (!PyArg_UnpackTuple(args, "flagsobj", 0, 1, &arg)) {
         return NULL;
     }
+    PyObject *mod = PyType_GetModule(Py_TYPE(self));
+    assert(mod != NULL);
+
     if ((arg != NULL) && PyArray_Check(arg)) {
-        return PyArray_NewFlagsObject(arg);
+        return PyArray_NewFlagsObject(mod, arg);
     }
     else {
-        return PyArray_NewFlagsObject(NULL);
+        return PyArray_NewFlagsObject(mod, NULL);
     }
 }
 

--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -680,7 +680,6 @@ static PyMappingMethods arrayflags_as_mapping = {
     (objobjargproc)arrayflags_setitem,   /*mp_ass_subscript*/
 };
 
-
 static PyObject *
 arrayflags_new(PyTypeObject *self, PyObject *args, PyObject *NPY_UNUSED(kwds))
 {
@@ -699,6 +698,26 @@ arrayflags_new(PyTypeObject *self, PyObject *args, PyObject *NPY_UNUSED(kwds))
     }
 }
 
+
+static PyType_Slot arrayflags_type_slots[] = {
+    {Py_tp_dealloc, arrayflags_dealloc},
+    {Py_tp_repr, arrayflags_print},
+    {Py_mp_subscript, arrayflags_getitem},
+    {Py_mp_ass_subscript, arrayflags_setitem},
+    {Py_tp_str, arrayflags_print},
+    {Py_tp_richcompare, arrayflags_richcompare},
+    {Py_tp_getset, arrayflags_getsets},
+    {Py_tp_new, arrayflags_new},
+    {0, NULL}
+};
+
+static PyType_Spec array_flags_type_spec = {
+    .name = "numpy._core.multiarray.flagsobj",
+    .basicsize = sizeof(PyArrayFlagsObject),
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = arrayflags_type_slots,
+};
+
 NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "numpy._core.multiarray.flagsobj",
@@ -712,3 +731,15 @@ NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
     .tp_getset = arrayflags_getsets,
     .tp_new = arrayflags_new,
 };
+
+/*NUMPY_API
+ * Given an instance of the multiarray module
+ * Return the PyTypeObject of PyFlagsType.
+ *
+ * Returns NULL if an error occurs.
+ */
+NPY_NO_EXPORT PyTypeObject *
+PyArray_GetFlagsType(PyObject *NPY_UNUSED(module))
+{
+    return &PyArrayFlags_Type;
+}

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -35,7 +35,8 @@ array_ndim_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 array_flags_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    return PyArray_NewFlagsObject((PyObject *)self);
+    PyObject *mod = PyType_GetModule(Py_TYPE(self));
+    return PyArray_NewFlagsObject(mod, (PyObject *)self);
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1303,9 +1303,10 @@ gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_flags_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
-    return PyArray_NewFlagsObject(NULL);
+    PyObject *mod = PyType_GetModule(Py_TYPE(self));
+    return PyArray_NewFlagsObject(mod, NULL);
 }
 
 static PyObject *


### PR DESCRIPTION
This PR demonstrates an API change for numpy that could be used before actually migrating to heap types. 