### PR TITLE
BUG: Fix regression with ``f2py`` wrappers when modules and subroutines are present

### DIFF
--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -112,7 +112,7 @@ def buildhooks(pymod):
                 mfargs.append(n)
         outmess('\t\tConstructing F90 module support for "%s"...\n' %
                 (m['name']))
-        if m['name'] in usenames:
+        if m['name'] in usenames and not onlyvars:
             outmess(f"\t\t\tSkipping {m['name']} since it is in 'use'...\n")
             continue
         if onlyvars:

--- a/numpy/f2py/tests/src/regression/gh25337/data.f90
+++ b/numpy/f2py/tests/src/regression/gh25337/data.f90
@@ -1,0 +1,8 @@
+module data
+   real(8) :: shift
+contains
+   subroutine set_shift(in_shift)
+      real(8), intent(in) :: in_shift
+      shift = in_shift
+   end subroutine set_shift
+end module data

--- a/numpy/f2py/tests/src/regression/gh25337/use_data.f90
+++ b/numpy/f2py/tests/src/regression/gh25337/use_data.f90
@@ -1,0 +1,6 @@
+subroutine shift_a(dim_a, a)
+    use data, only: shift
+    integer, intent(in) :: dim_a
+    real(8), intent(inout), dimension(dim_a) :: a
+    a = a + shift
+end subroutine shift_a

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -64,3 +64,14 @@ def test_include_path():
     fnames_in_dir = os.listdir(incdir)
     for fname in ("fortranobject.c", "fortranobject.h"):
         assert fname in fnames_in_dir
+
+
+class TestModuleAndSubroutine(util.F2PyTest):
+    module_name = "example"
+    sources = [util.getpath("tests", "src", "regression", "gh25337", "data.f90"),
+               util.getpath("tests", "src", "regression", "gh25337", "use_data.f90")]
+
+    @pytest.mark.slow
+    def test_gh25337(self):
+        self.module.data.set_shift(3)
+        assert "data" in dir(self.module)


### PR DESCRIPTION
Closes #25337. A two word fix, the problem was that if a module has functions (is not an only variable module) it shouldn't be skipped.

Thanks for the report @andrea-bia.