### PR TITLE
MAINT: add npy_gil_error to acquire the GIL and set an error

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -987,6 +987,7 @@ endforeach
 # ------------------------------
 src_multiarray_umath_common = [
   'src/common/array_assign.c',
+  'src/common/gil_utils.c',
   'src/common/mem_overlap.c',
   'src/common/npy_argparse.c',
   'src/common/npy_hashtable.c',

--- a/numpy/_core/src/common/gil_utils.c
+++ b/numpy/_core/src/common/gil_utils.c
@@ -16,7 +16,21 @@ npy_gil_error(PyObject *type, const char *format, ...)
     NPY_ALLOW_C_API_DEF;
     NPY_ALLOW_C_API;
     if (!PyErr_Occurred()) {
+#if !defined(PYPY_VERSION)
         PyErr_FormatV(type, format, va);
+#else
+        PyObject *exc_str = PyUnicode_FromFormatV(format, va);
+        if (exc_str == NULL) {
+            // no reason to have special handling for this error case, since
+            // this function sets an error anyway
+            NPY_DISABLE_C_API;
+            va_end(va);
+            return;
+        }
+        PyErr_SetObject(type, exc_str);
+        Py_DECREF(exc_str);
+#endif
     }
     NPY_DISABLE_C_API;
+    va_end(va);
 }

--- a/numpy/_core/src/common/gil_utils.c
+++ b/numpy/_core/src/common/gil_utils.c
@@ -1,0 +1,22 @@
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <numpy/ndarraytypes.h>
+
+#include <stdarg.h>
+
+NPY_NO_EXPORT void
+npy_gil_error(PyObject *type, const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    NPY_ALLOW_C_API_DEF;
+    NPY_ALLOW_C_API;
+    if (!PyErr_Occurred()) {
+        PyErr_FormatV(type, format, va);
+    }
+    NPY_DISABLE_C_API;
+}

--- a/numpy/_core/src/common/gil_utils.h
+++ b/numpy/_core/src/common/gil_utils.h
@@ -1,0 +1,7 @@
+#ifndef NUMPY_CORE_SRC_COMMON_GIL_UTILS_H_
+#define NUMPY_CORE_SRC_COMMON_GIL_UTILS_H_
+
+NPY_NO_EXPORT void
+npy_gil_error(PyObject *type, const char *format, ...);
+
+#endif /* NUMPY_CORE_SRC_COMMON_GIL_UTILS_H_ */

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -28,6 +28,7 @@
 #include "_datetime.h"
 #include "arrayobject.h"
 #include "alloc.h"
+#include "gil_utils.h"
 
 #include "npy_longdouble.h"
 #include "numpyos.h"
@@ -3637,12 +3638,9 @@ OBJECT_dot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp 
 static int
 BOOL_fill(PyObject **buffer, npy_intp length, void *NPY_UNUSED(ignored))
 {
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
-    PyErr_SetString(PyExc_TypeError,
-            "arange() is only supported for booleans when the result has at "
-            "most length 2.");
-    NPY_DISABLE_C_API;
+    npy_gil_error(PyExc_TypeError,
+                  "arange() is only supported for booleans when the result has at "
+                  "most length 2.");
     return -1;
 }
 

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -24,7 +24,7 @@
 #include "convert_datatype.h"
 #include "dtypemeta.h"
 #include "dispatching.h"
-
+#include "gil_utils.h"
 
 /* TODO: from wrapping_array_method.c, use proper public header eventually  */
 NPY_NO_EXPORT int
@@ -274,11 +274,8 @@ check_factor(double factor) {
     if (npy_isfinite(factor) && factor != 0.) {
         return 0;
     }
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
-    PyErr_SetString(PyExc_TypeError,
-            "error raised inside the core-loop: non-finite factor!");
-    NPY_DISABLE_C_API;
+    npy_gil_error(PyExc_TypeError,
+                  "error raised inside the core-loop: non-finite factor!");
     return -1;
 }
 

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -14,6 +14,7 @@
 #include "numpy/halffloat.h"
 #include "lowlevel_strided_loops.h"
 #include "loops_utils.h"
+#include "gil_utils.h"
 
 #include "npy_pycompat.h"
 
@@ -480,11 +481,8 @@ NPY_NO_EXPORT void
 
 #if @SIGNED@
         if (in2 < 0) {
-            NPY_ALLOW_C_API_DEF
-            NPY_ALLOW_C_API;
-            PyErr_SetString(PyExc_ValueError,
-                    "Integers to negative integer powers are not allowed.");
-            NPY_DISABLE_C_API;
+            npy_gil_error(PyExc_ValueError,
+                          "Integers to negative integer powers are not allowed.");
             return;
         }
 #endif


### PR DESCRIPTION
This adds `npy_gil_error`, a helper I wrote for stringdtype/NEP 55. I'm making a PR here separately from the stringdtype PR to ease review.

This function acquires the GIL, sets an error using `PyErr_FormatV`, and releases the GIL. I've replaced all the places in NumPy that follow this pattern, ignoring a few places that do something more complicated than just setting an error.

I'm not using the fact that `npy_gil_error` is a varargs function in numpy yet, but do want to use that for stringdtype. It works locally both without any varargs and with varargs.

This is purely a refactoring and should have no user-visible impacts.