### PR TITLE
DOC: Correct documentation for polyfit()

### DIFF
--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -511,7 +511,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
 
         For more details, see `numpy.linalg.lstsq`.
 
-    V : ndarray, shape (M,M) or (M,M,K)
+    V : ndarray, shape (deg + 1, deg + 1) or (deg + 1, deg + 1, K)
         Present only if ``full == False`` and ``cov == True``.  The covariance
         matrix of the polynomial coefficient estimates.  The diagonal of
         this matrix are the variance estimates for each coefficient.  If y


### PR DESCRIPTION
DOC: Correcting documentation for polyfit()

When the polyfit() argument cov=True, the resulting covariance matrix of the polynomial 
coefficient estimates "V" is not of (M,M), as the current documentation states, but is size 
(deg + 1, deg + 1). Correcting this mistake.

Skipping all CI because this is a documentation correction.
[skip ci]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
