### PR TITLE
TST: PyPy needs another gc.collect on latest versions

### DIFF
--- a/numpy/core/tests/test_mem_policy.py
+++ b/numpy/core/tests/test_mem_policy.py
@@ -440,3 +440,4 @@ def test_owner_is_base(get_module):
     with pytest.warns(UserWarning, match='warn_on_free'):
         del a
         gc.collect()
+        gc.collect()


### PR DESCRIPTION
Backport of #25257.

In running NumPy against latest PyPy, I noticed it needs another `gc.collect` to successfully collect `a` in the test.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
