### PR TITLE
API: Adjust ``linalg.pinv`` and ``linalg.cholesky`` to Array API

### DIFF
--- a/doc/release/upcoming_changes/25388.new_feature.rst
+++ b/doc/release/upcoming_changes/25388.new_feature.rst
@@ -1,0 +1,10 @@
+`numpy.linalg.cholesky` and `numpy.linalg.pinv` new parameters
+--------------------------------------------------------------
+
+The ``upper`` and ``rtol`` keyword parameters were added to
+`numpy.linalg.cholesky` and `numpy.lingalg.pinv`, respectively, to
+improve array API compatibility.
+
+For `numpy.linalg.pinv` if neither ``rcond`` nor ``rtol`` is specified,
+the ``rcond``'s default is used. It's planned to deprecate and remove
+``rcond`` in the future.

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -545,9 +545,6 @@ Linear algebra differences
    * - Feature
      - Type
      - Notes
-   * - ``cholesky`` includes an ``upper`` keyword argument.
-     - **Compatible**
-     -
    * - ``cross`` does not allow size 2 vectors (only size 3).
      - **Breaking**
      -

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -33,6 +33,7 @@ from numpy._core import (
     matmul as _core_matmul, matrix_transpose as _core_matrix_transpose,
     transpose as _core_transpose, vecdot as _core_vecdot,
 )
+from numpy._globals import _NoValue
 from numpy.lib._twodim_base_impl import triu, eye
 from numpy.lib.array_utils import normalize_axis_index, normalize_axis_tuple
 from numpy.linalg import _umath_linalg
@@ -721,31 +722,39 @@ def matrix_power(a, n):
 
 # Cholesky decomposition
 
+def _cholesky_dispatcher(a, /, *, upper=None):
+    return (a,)
 
-@array_function_dispatch(_unary_dispatcher)
-def cholesky(a):
+
+@array_function_dispatch(_cholesky_dispatcher)
+def cholesky(a, /, *, upper=False):
     """
     Cholesky decomposition.
 
-    Return the Cholesky decomposition, `L * L.H`, of the square matrix `a`,
-    where `L` is lower-triangular and .H is the conjugate transpose operator
-    (which is the ordinary transpose if `a` is real-valued).  `a` must be
-    Hermitian (symmetric if real-valued) and positive-definite. No
-    checking is performed to verify whether `a` is Hermitian or not.
-    In addition, only the lower-triangular and diagonal elements of `a`
-    are used. Only `L` is actually returned.
+    Return the lower or upper Cholesky decomposition, ``L * L.H`` or
+    ``U.H * U``, of the square matrix ``a``, where ``L`` is lower-triangular,
+    ``U`` is upper-triangular, and ``.H`` is the conjugate transpose operator
+    (which is the ordinary transpose if ``a`` is real-valued). ``a`` must be
+    Hermitian (symmetric if real-valued) and positive-definite. No checking is
+    performed to verify whether ``a`` is Hermitian or not. In addition, only
+    the lower or upper-triangular and diagonal elements of ``a`` are used.
+    Only ``L`` or ``U`` is actually returned.
 
     Parameters
     ----------
     a : (..., M, M) array_like
         Hermitian (symmetric if all elements are real), positive-definite
         input matrix.
+    upper : bool
+        If ``True``, the result must be the upper-triangular Cholesky factor.
+        If ``False``, the result must be the lower-triangular Cholesky factor.
+        Default: ``False``.
 
     Returns
     -------
     L : (..., M, M) array_like
-        Lower-triangular Cholesky factor of `a`.  Returns a matrix object if
-        `a` is a matrix object.
+        Lower or upper-triangular Cholesky factor of `a`. Returns a matrix
+        object if `a` is a matrix object.
 
     Raises
     ------
@@ -781,7 +790,7 @@ def cholesky(a):
 
     and then for :math:`\\mathbf{x}` in
 
-    .. math:: L.H \\mathbf{x} = \\mathbf{y}.
+    .. math:: L^{H} \\mathbf{x} = \\mathbf{y}.
 
     Examples
     --------
@@ -804,6 +813,10 @@ def cholesky(a):
     >>> np.linalg.cholesky(np.matrix(A))
     matrix([[ 1.+0.j,  0.+0.j],
             [ 0.+2.j,  1.+0.j]])
+    >>> # The upper-triangular Cholesky factor can also be obtained.
+    >>> np.linalg.cholesky(A, upper=True)
+    array([[1.-0.j, 0.-2.j],
+           [0.-0.j, 1.-0.j]])
 
     """
     gufunc = _umath_linalg.cholesky_lo
@@ -815,6 +828,8 @@ def cholesky(a):
     with errstate(call=_raise_linalgerror_nonposdef, invalid='call',
                   over='ignore', divide='ignore', under='ignore'):
         r = gufunc(a, signature=signature)
+    if upper:
+        r = matrix_transpose(r).conj()
     return wrap(r.astype(result_t, copy=False))
 
 
@@ -2067,12 +2082,12 @@ def matrix_rank(A, tol=None, hermitian=False):
 
 # Generalized inverse
 
-def _pinv_dispatcher(a, rcond=None, hermitian=None):
+def _pinv_dispatcher(a, rcond=None, hermitian=None, *, rtol=None):
     return (a,)
 
 
 @array_function_dispatch(_pinv_dispatcher)
-def pinv(a, rcond=1e-15, hermitian=False):
+def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
 
@@ -2087,17 +2102,24 @@ def pinv(a, rcond=1e-15, hermitian=False):
     ----------
     a : (..., M, N) array_like
         Matrix or stack of matrices to be pseudo-inverted.
-    rcond : (...) array_like of float
+    rcond : (...) array_like of float, optional
         Cutoff for small singular values.
         Singular values less than or equal to
         ``rcond * largest_singular_value`` are set to zero.
-        Broadcasts against the stack of matrices.
+        Broadcasts against the stack of matrices. Default: ``1e-15``.
     hermitian : bool, optional
         If True, `a` is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.
         Defaults to False.
 
         .. versionadded:: 1.17.0
+    rtol : (...) array_like of float, optional
+        Same as `rcond`, but it's an Array API compatible parameter name.
+        Only `rcond` or `rtol` can be set at a time. If none of them are
+        provided then NumPy's ``1e-15`` default is used. If ``rtol=None``
+        is passed then the API standard default is used.
+
+        .. versionadded:: 2.0.0
 
     Returns
     -------
@@ -2151,6 +2173,19 @@ def pinv(a, rcond=1e-15, hermitian=False):
 
     """
     a, wrap = _makearray(a)
+    if rcond is None:
+        if rtol is _NoValue:
+            rcond = 1e-15
+        elif rtol is None:
+            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+        else:
+            rcond = rtol
+    elif rtol is not _NoValue:
+        raise ValueError("`rtol` and `rcond` can't be both set.")
+    else:
+        # NOTE: Deprecate `rcond` in a few versions.
+        pass
+
     rcond = asarray(rcond)
     if _is_empty_2d(a):
         m, n = a.shape[-2:]

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -856,6 +856,20 @@ class TestPinvHermitian(PinvHermitianCases):
     pass
 
 
+def test_pinv_rtol_arg():
+    a = np.array([[1, 2, 3], [4, 1, 1], [2, 3, 1]])
+
+    assert_almost_equal(
+        np.linalg.pinv(a, rcond=0.5),
+        np.linalg.pinv(a, rtol=0.5),
+    )
+
+    with pytest.raises(
+        ValueError, match=r"`rtol` and `rcond` can't be both set."
+    ):
+        np.linalg.pinv(a, rcond=0.5, rtol=0.5)
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):
@@ -1846,6 +1860,16 @@ class TestCholesky:
         assert_equal(a.shape, res.shape)
         assert_(res.dtype.type is np.complex64)
         assert_(isinstance(res, np.ndarray))
+
+    def test_upper_lower_arg(self):
+        a = np.array([[1+0j, 0-2j], [0+2j, 5+0j]])
+
+        assert_equal(linalg.cholesky(a), linalg.cholesky(a, upper=False))
+
+        assert_equal(
+            linalg.cholesky(a, upper=True),
+            linalg.cholesky(a).T.conj()
+        )
 
 
 class TestOuter:

--- a/tools/ci/array-api-skips.txt
+++ b/tools/ci/array-api-skips.txt
@@ -1,9 +1,9 @@
 # copy not implemented
 array_api_tests/test_creation_functions.py::test_asarray_arrays
 
-# waiting on NumPy to allow/revert distinct NaNs for np.unique
-# https://github.com/numpy/numpy/issues/20326#issuecomment-1012380448
-array_api_tests/test_set_functions.py
+# 'unique_inverse' output array is 1-D for 0-D input
+array_api_tests/test_set_functions.py::test_unique_all
+array_api_tests/test_set_functions.py::test_unique_inverse
 
 # https://github.com/numpy/numpy/issues/21213
 array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
@@ -43,9 +43,6 @@ array_api_tests/test_data_type_functions.py::test_finfo[float32]
 array_api_tests/test_has_names.py::test_has_names[array_method-to_device]
 array_api_tests/test_has_names.py::test_has_names[array_attribute-device]
 
-# missing linalg names
-array_api_tests/test_linalg.py::test_pinv
-
 # a few misalignments
 array_api_tests/test_operators_and_elementwise_functions.py
 array_api_tests/test_signatures.py::test_func_signature[std]
@@ -62,19 +59,16 @@ array_api_tests/test_signatures.py::test_func_signature[zeros_like]
 array_api_tests/test_signatures.py::test_func_signature[reshape]
 array_api_tests/test_signatures.py::test_func_signature[argsort]
 array_api_tests/test_signatures.py::test_func_signature[sort]
-array_api_tests/test_signatures.py::test_extension_func_signature[linalg.cholesky]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_rank]
-array_api_tests/test_signatures.py::test_extension_func_signature[linalg.pinv]
 array_api_tests/test_signatures.py::test_array_method_signature[__array_namespace__]
 array_api_tests/test_signatures.py::test_array_method_signature[to_device]
 
-# unexpected argument 'stable'
-array_api_tests/test_sorting_functions.py::test_argsort
-array_api_tests/test_sorting_functions.py::test_sort
+# missing 'copy' keyword argument, 'newshape' should be named 'shape'
+array_api_tests/test_signatures.py::test_func_signature[reshape]
 
-# missing aliases
-array_api_tests/test_special_cases.py::test_unary
-array_api_tests/test_special_cases.py::test_binary
+# missing 'descending' and 'stable' keyword arguments
+array_api_tests/test_signatures.py::test_func_signature[argsort]
+array_api_tests/test_signatures.py::test_func_signature[sort]
 
 # asarray() got an unexpected keyword argument 'copy'
 array_api_tests/test_special_cases.py::test_iop


### PR DESCRIPTION
Hi @rgommers @ngoldbaum,

This PR is (one of) the last Array API compatibility changes:
1. `rtol` parameter added to `np.linalg.pinv` as an alternative to `rcond` for bc (both can't be provided at the same time) (`rtol` will still diverge from Array API wrt. default value but at least it can be passed as a keyword argument)
2. `upper` parameter added to `np.linalg.cholesky`
3. Adjusted `array-api-skips.txt` to remove redundant skips

