### PR TITLE
BUG: ufunc api: update multiarray_umath import path

### DIFF
--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -37,6 +37,10 @@ _import_umath(void)
   if (numpy == NULL && PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
     PyErr_Clear();
     numpy = PyImport_ImportModule("numpy._core._multiarray_umath");
+    if (numpy == NULL && PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
+      PyErr_Clear();
+      numpy = PyImport_ImportModule("numpy.core._multiarray_umath");
+    }
   }
 
   if (numpy == NULL) {

--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -36,7 +36,7 @@ _import_umath(void)
   PyObject *numpy = PyImport_ImportModule("numpy._core._multiarray_umath");
   if (numpy == NULL && PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
     PyErr_Clear();
-    numpy = PyImport_ImportModule("numpy.core._multiarray_umath");
+    numpy = PyImport_ImportModule("numpy._core._multiarray_umath");
   }
 
   if (numpy == NULL) {


### PR DESCRIPTION
The `import_umath` utility raises a DeprecationWarning in in the nightly numpy releases; I believe this should fix the issue.