### PR TITLE
DOC: Plot exact distributions in logistic, logseries and weibull example

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2141,14 +2141,13 @@ cdef class Generator:
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> x = np.arange(1,100.)/50.
-        >>> def weib(x,n,a):
+        >>> def weibull(x, n, a):
         ...     return (a / n) * (x / n)**(a - 1) * np.exp(-(x / n)**a)
-
         >>> count, bins, ignored = plt.hist(rng.weibull(5.,1000))
-        >>> x = np.arange(1,100.)/50.
-        >>> scale = count.max()/weib(x, 1., 5.).max()
-        >>> plt.plot(x, weib(x, 1., 5.)*scale)
+        >>> x = np.linspace(0, 2, 1000)
+        >>> bin_spacing = np.mean(np.diff(bins))
+        >>> plt.plot(x, weibull(x, 1., 5.) * bin_spacing * s.size, label='Weibull PDF')
+        >>> plt.legend()
         >>> plt.show()
 
         """
@@ -2527,14 +2526,16 @@ cdef class Generator:
         >>> rng = np.random.default_rng()
         >>> s = rng.logistic(loc, scale, 10000)
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, bins=50)
+        >>> count, bins, ignored = plt.hist(s, bins=50, label='Sampled data')
 
-        #   plot against distribution
+        #   plot sampled data against the exact distribution
 
-        >>> def logist(x, loc, scale):
+        >>> def logistic(x, loc, scale):
         ...     return np.exp((loc-x)/scale)/(scale*(1+np.exp((loc-x)/scale))**2)
-        >>> lgst_val = logist(bins, loc, scale)
-        >>> plt.plot(bins, lgst_val * count.max() / lgst_val.max())
+        >>> logistic_values  = logistic(bins, loc, scale)
+        >>> bin_spacing = np.mean(np.diff(bins))
+        >>> plt.plot(bins, logistic_values  * bin_spacing * s.size, label='Logistic PDF')
+        >>> plt.legend()
         >>> plt.show()
 
         """
@@ -3579,14 +3580,16 @@ cdef class Generator:
         >>> a = .6
         >>> s = np.random.default_rng().logseries(a, 10000)
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s)
+        >>> bins = np.arange(-.5, max(s)+.5 )
+        >>> count, bins, ignored = plt.hist(s, bins=bins, label='Sample count')
 
         #   plot against distribution
 
         >>> def logseries(k, p):
         ...     return -p**k/(k*np.log(1-p))
-        >>> plt.plot(bins, logseries(bins, a) * count.max()/
-        ...          logseries(bins, a).max(), 'r')
+        >>> centres = np.arange(0)
+        >>> plt.plot(bins, logseries(bins, a) * s.size, 'r', label='logseries PMF')
+        >>> plt.legend()
         >>> plt.show()
 
         """

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2143,7 +2143,7 @@ cdef class Generator:
         >>> import matplotlib.pyplot as plt
         >>> def weibull(x, n, a):
         ...     return (a / n) * (x / n)**(a - 1) * np.exp(-(x / n)**a)
-        >>> count, bins, ignored = plt.hist(rng.weibull(5.,1000))
+        >>> count, bins, ignored = plt.hist(rng.weibull(5., 1000))
         >>> x = np.linspace(0, 2, 1000)
         >>> bin_spacing = np.mean(np.diff(bins))
         >>> plt.plot(x, weibull(x, 1., 5.) * bin_spacing * s.size, label='Weibull PDF')
@@ -3580,15 +3580,15 @@ cdef class Generator:
         >>> a = .6
         >>> s = np.random.default_rng().logseries(a, 10000)
         >>> import matplotlib.pyplot as plt
-        >>> bins = np.arange(-.5, max(s)+.5 )
+        >>> bins = np.arange(-.5, max(s) + .5 )
         >>> count, bins, ignored = plt.hist(s, bins=bins, label='Sample count')
 
         #   plot against distribution
 
         >>> def logseries(k, p):
         ...     return -p**k/(k*np.log(1-p))
-        >>> centres = np.arange(0)
-        >>> plt.plot(bins, logseries(bins, a) * s.size, 'r', label='logseries PMF')
+        >>> centres = np.arange(1, max(s) + 1)
+        >>> plt.plot(centres, logseries(centres, a) * s.size, 'r', label='logseries PMF')
         >>> plt.legend()
         >>> plt.show()
 


### PR DESCRIPTION
In the docstrings examples of several distributions of the random number generator the PDF or PMF was plotted with the incorrect scale. In this PR we use the correct scaling and add legends to the plots.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
