### PR TITLE
DOC: Improve np.histogram documentation

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -687,27 +687,27 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     a : array_like
         Input data. The histogram is computed over the flattened array.
     bins : int or sequence of scalars or str, optional
-        If `bins` is an int, it defines the number of equal-width
-        bins in the given range (10, by default). If `bins` is a
+        If ``bins`` is an int, it defines the number of equal-width
+        bins in the given range (10, by default). If ``bins`` is a
         sequence, it defines a monotonically increasing array of bin edges,
         including the rightmost edge, allowing for non-uniform bin widths.
 
         .. versionadded:: 1.11.0
 
-        If `bins` is a string, it defines the method used to calculate the
-        optimal bin width, as defined by `histogram_bin_edges`.
+        If ``bins`` is a string, it defines the method used to calculate the
+        optimal bin width, as defined by ``histogram_bin_edges``.
 
     range : (float, float), optional
         The lower and upper range of the bins.  If not provided, range
         is simply ``(a.min(), a.max())``.  Values outside the range are
         ignored. The first element of the range must be less than or
-        equal to the second. `range` affects the automatic bin
+        equal to the second. ``range`` affects the automatic bin
         computation as well. While bin width is computed to be optimal
-        based on the actual data within `range`, the bin count will fill
+        based on the actual data within ``range``, the bin count will fill
         the entire range including portions containing no data.
     weights : array_like, optional
-        An array of weights, of the same shape as `a`.  Each value in
-        `a` only contributes its associated weight towards the bin count
+        An array of weights, of the same shape as ``a``.  Each value in
+        ``a`` only contributes its associated weight towards the bin count
         (instead of 1). If `density` is True, the weights are
         normalized, so that the integral of the density over the range
         remains 1.
@@ -724,7 +724,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     Returns
     -------
     hist : array
-        The values of the histogram. See `density` and `weights` for a
+        The values of the histogram. See ``density`` and ``weights`` for a
         description of the possible semantics.
     bin_edges : array of dtype float
         Return the bin edges ``(length(hist)+1)``.
@@ -737,7 +737,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     Notes
     -----
     All but the last (righthand-most) bin is half-open.  In other words,
-    if `bins` is::
+    if ``bins`` is::
 
       [1, 2, 3, 4]
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -711,6 +711,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
         (instead of 1). If `density` is True, the weights are
         normalized, so that the integral of the density over the range
         remains 1.
+        Please note that the ``dtype`` of ``weights`` will dictate the
+        ``dtype`` of the returned accumulator (``hist``).
     density : bool, optional
         If ``False``, the result will contain the number of samples in
         each bin. If ``True``, the result is the value of the


### PR DESCRIPTION
# Improving `np.histogram`'s documentation

It was not documented that the dtype of the output of `np.histogram`'s depends on the dtype of the weights parameter.

Closes #25385 
Closes #23681 
Closes #16616 

Skipping all CI because this is a documentation correction:
[skip ci]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
