### PR TITLE
DOC: Fix ``pareto`` docstring and example

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2023,12 +2023,20 @@ cdef class Generator:
         -----
         The probability density for the Pareto distribution is
 
-        .. math:: p(x) = \\frac{a}{(x+1)^{a+1}}
+        .. math:: p(x) = \\frac{am^a}{x^{a+1}}
 
-        where :math:`a>0`. This corresponds to the Pareto II distribution 
-        and can be seen as Pareto I distribution with shape `a` and
-        scale 1 shifted by -1.
-
+        where :math:`a` is the shape and :math:`m` the scale.
+        
+        The Pareto distribution, named after the Italian economist
+        Vilfredo Pareto, is a power law probability distribution
+        useful in many real world problems.  Outside the field of
+        economics it is generally referred to as the Bradford
+        distribution. Pareto developed the distribution to describe
+        the distribution of wealth in an economy.  It has also found
+        use in insurance, web page access statistics, oil field sizes,
+        and many other problems, including the download frequency for
+        projects in Sourceforge [1]_.  It is one of the so-called
+        "fat-tailed" distributions.
 
         References
         ----------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -444,7 +444,8 @@ cdef class Generator:
         agents and the average time between customer calls is 4 minutes.
 
         >>> n = 10000
-        >>> time_between_calls = np.random.default_rng().exponential(scale=4, size=n)
+        >>> rng = np.random.default_rng()
+        >>> time_between_calls = rng.exponential(scale=4, size=n)
 
         What is the probability that a customer will call in the next 
         4 to 5 minutes? 
@@ -505,7 +506,8 @@ cdef class Generator:
         --------
         Output a 3x8000 array:
 
-        >>> n = np.random.default_rng().standard_exponential((3, 8000))
+        >>> rng = np.random.default_rng()
+        >>> n = rng.standard_exponential((3, 8000))
 
         """
         _dtype = np.dtype(dtype)
@@ -668,7 +670,8 @@ cdef class Generator:
 
         Examples
         --------
-        >>> np.random.default_rng().bytes(10)
+        >>> rng = np.random.default_rng()
+        >>> rng.bytes(10)
         b'\\xfeC\\x9b\\x86\\x17\\xf2\\xa1\\xafcp' # random
 
         """
@@ -994,7 +997,8 @@ cdef class Generator:
         --------
         Draw samples from the distribution:
 
-        >>> s = np.random.default_rng().uniform(-1,0,1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.uniform(-1,0,1000)
 
         All values are within the given interval:
 
@@ -1007,7 +1011,7 @@ cdef class Generator:
         probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 15, density=True)
+        >>> count, bins, _ = plt.hist(s, 15, density=True)
         >>> plt.plot(bins, np.ones_like(bins), linewidth=2, color='r')
         >>> plt.show()
 
@@ -1189,7 +1193,8 @@ cdef class Generator:
         Draw samples from the distribution:
 
         >>> mu, sigma = 0, 0.1 # mean and standard deviation
-        >>> s = np.random.default_rng().normal(mu, sigma, 1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.normal(mu, sigma, 1000)
 
         Verify the mean and the variance:
 
@@ -1203,7 +1208,7 @@ cdef class Generator:
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 30, density=True)
+        >>> count, bins, _ = plt.hist(s, 30, density=True)
         >>> plt.plot(bins, 1/(sigma * np.sqrt(2 * np.pi)) *
         ...                np.exp( - (bins - mu)**2 / (2 * sigma**2) ),
         ...          linewidth=2, color='r')
@@ -1212,7 +1217,8 @@ cdef class Generator:
         Two-by-four array of samples from the normal distribution with
         mean 3 and standard deviation 2.5:
 
-        >>> np.random.default_rng().normal(3, 2.5, size=(2, 4))
+        >>> rng = np.random.default_rng()
+        >>> rng.normal(3, 2.5, size=(2, 4))
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random
                [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]])  # random
 
@@ -1285,14 +1291,15 @@ cdef class Generator:
         Draw samples from the distribution:
 
         >>> shape, scale = 2., 1. # mean and width
-        >>> s = np.random.default_rng().standard_gamma(shape, 1000000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.standard_gamma(shape, 1000000)
 
         Display the histogram of the samples, along with
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
         >>> import scipy.special as sps  # doctest: +SKIP
-        >>> count, bins, ignored = plt.hist(s, 50, density=True)
+        >>> count, bins, _ = plt.hist(s, 50, density=True)
         >>> y = bins**(shape-1) * ((np.exp(-bins/scale))/  # doctest: +SKIP
         ...                       (sps.gamma(shape) * scale**shape))
         >>> plt.plot(bins, y, linewidth=2, color='r')  # doctest: +SKIP
@@ -1373,14 +1380,15 @@ cdef class Generator:
         Draw samples from the distribution:
 
         >>> shape, scale = 2., 2.  # mean=4, std=2*sqrt(2)
-        >>> s = np.random.default_rng().gamma(shape, scale, 1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.gamma(shape, scale, 1000)
 
         Display the histogram of the samples, along with
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
         >>> import scipy.special as sps  # doctest: +SKIP
-        >>> count, bins, ignored = plt.hist(s, 50, density=True)
+        >>> count, bins, _ = plt.hist(s, 50, density=True)
         >>> y = bins**(shape-1)*(np.exp(-bins/scale) /  # doctest: +SKIP
         ...                      (sps.gamma(shape)*scale**shape))
         >>> plt.plot(bins, y, linewidth=2, color='r')  # doctest: +SKIP
@@ -1463,7 +1471,8 @@ cdef class Generator:
 
         >>> dfnum = 1. # between group degrees of freedom
         >>> dfden = 48. # within groups degrees of freedom
-        >>> s = np.random.default_rng().f(dfnum, dfden, 1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.f(dfnum, dfden, 1000)
 
         The lower bound for the top 1% of the samples is :
 
@@ -1617,7 +1626,8 @@ cdef class Generator:
 
         Examples
         --------
-        >>> np.random.default_rng().chisquare(2,4)
+        >>> rng = np.random.default_rng()
+        >>> rng.chisquare(2,4)
         array([ 1.89920014,  9.00867716,  3.13710533,  5.62318272]) # random
 
         """
@@ -1762,7 +1772,8 @@ cdef class Generator:
         Draw samples and plot the distribution:
 
         >>> import matplotlib.pyplot as plt
-        >>> s = np.random.default_rng().standard_cauchy(1000000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.standard_cauchy(1000000)
         >>> s = s[(s>-25) & (s<25)]  # truncate distribution so it plots well
         >>> plt.hist(s, bins=100)
         >>> plt.show()
@@ -1854,7 +1865,8 @@ cdef class Generator:
         degrees of freedom.
 
         >>> import matplotlib.pyplot as plt
-        >>> s = np.random.default_rng().standard_t(10, size=1000000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.standard_t(10, size=1000000)
         >>> h = plt.hist(s, bins=100, density=True)
 
         Does our t statistic land in one of the two critical regions found at 
@@ -1941,7 +1953,8 @@ cdef class Generator:
         Draw samples from the distribution:
 
         >>> mu, kappa = 0.0, 4.0 # mean and dispersion
-        >>> s = np.random.default_rng().vonmises(mu, kappa, 1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.vonmises(mu, kappa, 1000)
 
         Display the histogram of the samples, along with
         the probability density function:
@@ -2010,20 +2023,11 @@ cdef class Generator:
         -----
         The probability density for the Pareto distribution is
 
-        .. math:: p(x) = \\frac{am^a}{x^{a+1}}
+        .. math:: p(x) = \\frac{a}{(x+1)^{a+1}}
 
-        where :math:`a` is the shape and :math:`m` the scale.
-
-        The Pareto distribution, named after the Italian economist
-        Vilfredo Pareto, is a power law probability distribution
-        useful in many real world problems.  Outside the field of
-        economics it is generally referred to as the Bradford
-        distribution. Pareto developed the distribution to describe
-        the distribution of wealth in an economy.  It has also found
-        use in insurance, web page access statistics, oil field sizes,
-        and many other problems, including the download frequency for
-        projects in Sourceforge [1]_.  It is one of the so-called
-        "fat-tailed" distributions.
+        where :math:`a>0`. This corresponds to the Pareto II distribution 
+        and can be seen as Pareto I distribution with shape `a` and
+        scale 1 shifted by -1.
 
 
         References
@@ -2040,15 +2044,16 @@ cdef class Generator:
         --------
         Draw samples from the distribution:
 
-        >>> a, m = 3., 2.  # shape and mode
-        >>> s = (np.random.default_rng().pareto(a, 1000) + 1) * m
+        >>> a = 3
+        >>> rng = np.random.default_rng()
+        >>> s = (rng.pareto(a, 1000) + 1)
 
         Display the histogram of the samples, along with the probability
         density function:
 
         >>> import matplotlib.pyplot as plt
         >>> count, bins, _ = plt.hist(s, 100, density=True)
-        >>> fit = a*m**a / bins**(a+1)
+        >>> fit = a**a / bins**(a+1)
         >>> plt.plot(bins, max(count)*fit/max(fit), linewidth=2, color='r')
         >>> plt.show()
 
@@ -2143,7 +2148,7 @@ cdef class Generator:
         >>> import matplotlib.pyplot as plt
         >>> def weibull(x, n, a):
         ...     return (a / n) * (x / n)**(a - 1) * np.exp(-(x / n)**a)
-        >>> count, bins, ignored = plt.hist(rng.weibull(5., 1000))
+        >>> count, bins, _ = plt.hist(rng.weibull(5., 1000))
         >>> x = np.linspace(0, 2, 1000)
         >>> bin_spacing = np.mean(np.diff(bins))
         >>> plt.plot(x, weibull(x, 1., 5.) * bin_spacing * s.size, label='Weibull PDF')
@@ -2221,7 +2226,7 @@ cdef class Generator:
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, bins=30)
+        >>> count, bins, _ = plt.hist(s, bins=30)
         >>> x = np.linspace(0, 1, 100)
         >>> y = a*x**(a-1.)
         >>> normed_y = samples*np.diff(bins)[0]*y
@@ -2319,13 +2324,14 @@ cdef class Generator:
         Draw samples from the distribution
 
         >>> loc, scale = 0., 1.
-        >>> s = np.random.default_rng().laplace(loc, scale, 1000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.laplace(loc, scale, 1000)
 
         Display the histogram of the samples, along with
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 30, density=True)
+        >>> count, bins, _ = plt.hist(s, 30, density=True)
         >>> x = np.arange(-8., 8., .01)
         >>> pdf = np.exp(-abs(x-loc)/scale)/(2.*scale)
         >>> plt.plot(x, pdf)
@@ -2429,7 +2435,7 @@ cdef class Generator:
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 30, density=True)
+        >>> count, bins, _ = plt.hist(s, 30, density=True)
         >>> plt.plot(bins, (1/beta)*np.exp(-(bins - mu)/beta)
         ...          * np.exp( -np.exp( -(bins - mu) /beta) ),
         ...          linewidth=2, color='r')
@@ -2444,7 +2450,7 @@ cdef class Generator:
         ...    a = rng.normal(mu, beta, 1000)
         ...    means.append(a.mean())
         ...    maxima.append(a.max())
-        >>> count, bins, ignored = plt.hist(maxima, 30, density=True)
+        >>> count, bins, _ = plt.hist(maxima, 30, density=True)
         >>> beta = np.std(maxima) * np.sqrt(6) / np.pi
         >>> mu = np.mean(maxima) - 0.57721*beta
         >>> plt.plot(bins, (1/beta)*np.exp(-(bins - mu)/beta)
@@ -2526,7 +2532,7 @@ cdef class Generator:
         >>> rng = np.random.default_rng()
         >>> s = rng.logistic(loc, scale, 10000)
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, bins=50, label='Sampled data')
+        >>> count, bins, _ = plt.hist(s, bins=50, label='Sampled data')
 
         #   plot sampled data against the exact distribution
 
@@ -2616,7 +2622,7 @@ cdef class Generator:
         the probability density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 100, density=True, align='mid')
+        >>> count, bins, _ = plt.hist(s, 100, density=True, align='mid')
 
         >>> x = np.linspace(min(bins), max(bins), 10000)
         >>> pdf = (np.exp(-(np.log(x) - mu)**2 / (2 * sigma**2))
@@ -2639,7 +2645,7 @@ cdef class Generator:
         ...    b.append(np.prod(a))
 
         >>> b = np.array(b) / np.min(b) # scale values to be positive
-        >>> count, bins, ignored = plt.hist(b, 100, density=True, align='mid')
+        >>> count, bins, _ = plt.hist(b, 100, density=True, align='mid')
         >>> sigma = np.std(np.log(b))
         >>> mu = np.mean(np.log(b))
 
@@ -2784,7 +2790,8 @@ cdef class Generator:
         Draw values from the distribution and plot the histogram:
 
         >>> import matplotlib.pyplot as plt
-        >>> h = plt.hist(np.random.default_rng().wald(3, 2, 100000), bins=200, density=True)
+        >>> rng = np.random.default_rng()
+        >>> h = plt.hist(rng.wald(3, 2, 100000), bins=200, density=True)
         >>> plt.show()
 
         """
@@ -2851,7 +2858,8 @@ cdef class Generator:
         Draw values from the distribution and plot the histogram:
 
         >>> import matplotlib.pyplot as plt
-        >>> h = plt.hist(np.random.default_rng().triangular(-3, 0, 8, 100000), bins=200,
+        >>> rng = np.random.default_rng()
+        >>> h = plt.hist(rng.triangular(-3, 0, 8, 100000), bins=200,
         ...              density=True)
         >>> plt.show()
 
@@ -3118,7 +3126,8 @@ cdef class Generator:
         for each successive well, that is what is the probability of a
         single success after drilling 5 wells, after 6 wells, etc.?
 
-        >>> s = np.random.default_rng().negative_binomial(1, 0.1, 100000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.negative_binomial(1, 0.1, 100000)
         >>> for i in range(1, 11): # doctest: +SKIP
         ...    probability = sum(s<i) / 100000.
         ...    print(i, "wells drilled, probability of one success =", probability)
@@ -3221,7 +3230,7 @@ cdef class Generator:
         Display histogram of the sample:
 
         >>> import matplotlib.pyplot as plt
-        >>> count, bins, ignored = plt.hist(s, 14, density=True)
+        >>> count, bins, _ = plt.hist(s, 14, density=True)
         >>> plt.show()
 
         Draw each 100 values for lambda 100 and 500:
@@ -3293,7 +3302,8 @@ cdef class Generator:
 
         >>> a = 4.0
         >>> n = 20000
-        >>> s = np.random.default_rng().zipf(a, size=n)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.zipf(a, size=n)
 
         Display the histogram of the samples, along with
         the expected histogram based on the probability
@@ -3360,7 +3370,8 @@ cdef class Generator:
         Draw ten thousand values from the geometric distribution,
         with the probability of an individual success equal to 0.35:
 
-        >>> z = np.random.default_rng().geometric(p=0.35, size=10000)
+        >>> rng = np.random.default_rng()
+        >>> z = rng.geometric(p=0.35, size=10000)
 
         How many trials succeeded after a single run?
 
@@ -3578,10 +3589,11 @@ cdef class Generator:
         Draw samples from the distribution:
 
         >>> a = .6
-        >>> s = np.random.default_rng().logseries(a, 10000)
+        >>> rng = np.random.default_rng()
+        >>> s = rng.logseries(a, 10000)
         >>> import matplotlib.pyplot as plt
         >>> bins = np.arange(-.5, max(s) + .5 )
-        >>> count, bins, ignored = plt.hist(s, bins=bins, label='Sample count')
+        >>> count, bins, _ = plt.hist(s, bins=bins, label='Sample count')
 
         #   plot against distribution
 
@@ -3680,7 +3692,8 @@ cdef class Generator:
         Diagonal covariance means that points are oriented along x or y-axis:
 
         >>> import matplotlib.pyplot as plt
-        >>> x, y = np.random.default_rng().multivariate_normal(mean, cov, 5000).T
+        >>> rng = np.random.default_rng()
+        >>> x, y = rng.multivariate_normal(mean, cov, 5000).T
         >>> plt.plot(x, y, 'x')
         >>> plt.axis('equal')
         >>> plt.show()
@@ -4369,7 +4382,8 @@ cdef class Generator:
         average length, but allowing some variation in the relative sizes of
         the pieces.
 
-        >>> s = np.random.default_rng().dirichlet((10, 5, 3), 20).transpose()
+        >>> rng = np.random.default_rng() 
+        >>> s = rng.dirichlet((10, 5, 3), 20).transpose()
 
         >>> import matplotlib.pyplot as plt
         >>> plt.barh(range(20), s[0])

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2023,12 +2023,20 @@ cdef class Generator:
         -----
         The probability density for the Pareto distribution is
 
-        .. math:: p(x) = \\frac{a}{(x+1)^{a+1}}
+        .. math:: p(x) = \\frac{am^a}{x^{a+1}}
 
-        where :math:`a>0`. This corresponds to the Pareto II distribution 
-        and can be seen as Pareto I distribution with shape `a` and
-        scale 1 shifted by -1.
+        where :math:`a` is the shape and :math:`m` the scale.
 
+        The Pareto distribution, named after the Italian economist
+        Vilfredo Pareto, is a power law probability distribution
+        useful in many real world problems.  Outside the field of
+        economics it is generally referred to as the Bradford
+        distribution. Pareto developed the distribution to describe
+        the distribution of wealth in an economy.  It has also found
+        use in insurance, web page access statistics, oil field sizes,
+        and many other problems, including the download frequency for
+        projects in Sourceforge [1]_.  It is one of the so-called
+        "fat-tailed" distributions.
 
         References
         ----------


### PR DESCRIPTION
Closes #22701 and changes all instances of ``count, bins, ignored = plt.hist(s, 30, density=True)`` to ``count, bins, _ = plt.hist(s, 30, density=True)`` to  and all instances of ``s = np.random.default_rng().distribution(...)``to
```
rng = np.random.default_rng()
s = rng. distribution(...)
```