### PR TITLE
BUG: Vecdot subclasses and axis

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1176,7 +1176,7 @@ def vecdot(x1, x2, /, *, axis=-1):
             f"but they are: {x1_shape[axis]} and {x2_shape[axis]}."
         )
 
-    x1_, x2_ = np.broadcast_arrays(x1, x2)
+    x1_, x2_ = np.broadcast_arrays(x1, x2, subok=True)
     x1_ = np.moveaxis(x1_, axis, -1)
     x2_ = np.moveaxis(x2_, axis, -1)
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4057,6 +4057,9 @@ class TestVecdot:
 
         assert_array_equal(actual, expected)
 
+        actual2 = np.vecdot(arr1.T, arr2.T, axis=-2)
+        assert_array_equal(actual2, expected)
+
     def test_vecdot_complex(self):
         arr1 = np.array([1, 2j, 3])
         arr2 = np.array([1, 2, 3])

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4070,3 +4070,12 @@ class TestVecdot:
             np.vecdot(arr2, arr1),
             np.array([10+4j])
         )
+
+    def test_vecdot_subclass(self):
+        class MySubclass(np.ndarray):
+            pass
+
+        arr1 = np.arange(6).reshape((2, 3)).view(MySubclass)
+        arr2 = np.arange(3).reshape((1, 3)).view(MySubclass)
+        result = np.vecdot(arr1, arr2)
+        assert isinstance(result, MySubclass)


### PR DESCRIPTION
In #25155, a new `vecdot` function was introduced. This fixes two aspects
1. Ensure subclasses are passed through.
2. Ensure axis is interpreted as it would be for `gufunc`.

I'm not sure the latter is consistent with the array API, though if it isn't, there likely are problems elsewhere too.