### PR TITLE
MAINT: Init ``base`` in cpu_avx512_kn

### DIFF
--- a/numpy/distutils/checks/cpu_avx512_knl.c
+++ b/numpy/distutils/checks/cpu_avx512_knl.c
@@ -15,7 +15,7 @@
 
 int main(int argc, char **argv)
 {
-    int base[128]{};
+    int base[128]={};
     __m512d ad = _mm512_loadu_pd((const __m512d*)argv[argc-1]);
     /* ER */
     __m512i a = _mm512_castpd_si512(_mm512_exp2a23_pd(ad));

--- a/numpy/distutils/checks/cpu_avx512_knl.c
+++ b/numpy/distutils/checks/cpu_avx512_knl.c
@@ -15,7 +15,7 @@
 
 int main(int argc, char **argv)
 {
-    int base[128];
+    int base[128]{};
     __m512d ad = _mm512_loadu_pd((const __m512d*)argv[argc-1]);
     /* ER */
     __m512i a = _mm512_castpd_si512(_mm512_exp2a23_pd(ad));


### PR DESCRIPTION
Backport of #25383.

Fix a false negative due to a warning that `base` could be uninitialized, e.g. on GCC 12.3.0

See the output:
```
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mno-mmx -mavx512cd -mavx512er -mavx512pf -Werror'
WARN: CCompilerOpt.dist_test[636] : CCompilerOpt._dist_test_spawn[770] : Command (gcc -DNDEBUG -g -fwrapv -O3 -Wall -O3 -march=native -fno-math-errno -fPIC -O3 -march=native -fno-math-errno -fPIC -O1 -march=n
ative -fno-math-errno -fPIC -I/software/FFTW/3.3.10-GCC-12.3.0/include -I/software/FlexiBLAS/3.3.1-GCC-12.3.
0/include -I/software/FlexiBLAS/3.3.1-GCC-12.3.0/include/flexiblas -fPIC -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inump
y/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/software/Python/3.11.3-GCCcore-12.3.0/include/python3.11 -Ibui
ld/src.linux-x86_64-3.11/numpy/core/src/common -Ibuild/src.linux-x86_64-3.11/numpy/core/src/npymath -c /build/numpy/numpy-1.25.1/numpy/distutils/chec
ks/cpu_avx512_knl.c -o /build2/numpy/numpy-1.25.1/numpy/distutils/checks/cpu_avx512_knl.o -MMD -MF /tmp/easy
build-tmp/eb-xmfgsmk1/tmp6dmww85r/build/numpy/numpy-1.25.1/numpy/distutils/checks/cpu_avx512_knl.o.d -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -m
sse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mno-mmx -mavx512cd -mavx512er -mavx512pf -Werror) failed with exit status 1 output -> 
In Datei, eingebunden von /software/GCCcore/12.3.0/lib/gcc/x86_64-pc-linux-gnu/12.3.0/include/immintrin.h:53,
                 von /build/numpy/numpy-1.25.1/numpy/distutils/checks/cpu_avx512_knl.c:14:
In Funktion _mm512_mask_prefetch_i64scatter_pd,
    eingefgt von main bei /build/numpy/numpy-1.25.1/numpy/distutils/checks/cpu_avx512_knl.c:23:5:
/software/GCCcore/12.3.0/lib/gcc/x86_64-pc-linux-gnu/12.3.0/include/avx512pfintrin.h:180:3: Fehler: base knnte uninitialisiert verwendet werden [-Werror=maybe-uninitialized]
  180 |   __builtin_ia32_scatterpfqpd (__mask, (__v8di) __index, __addr, __scale,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  181 |                                __hint);
      |                                ~~~~~~~
<eingebaut>: In Funktion main:
<eingebaut>: Anmerkung: durch Argument 3 vom Typ const void * nach __builtin_ia32_scatterpfqpd, die hier deklariert wurde
/build/numpy/numpy-1.25.1/numpy/distutils/checks/cpu_avx512_knl.c:18:9: Anmerkung: base ist hier deklariert
   18 |     int base[128];
      |         ^~~~
cc1: Alle Warnungen werden als Fehler behandelt
```

Whether or not that is a false positive warning of GCC doesn't really matter as the change doesn't hurt

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
