### PR TITLE
BUG: Fix two errors related to not checking for failed allocations

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -936,11 +936,11 @@ array_boolean_subscript(PyArrayObject *self,
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype, 1, &size,
                                 NULL, NULL, 0, NULL);
-    /* not same as *dtype* if the DType class replaces dtypes */
-    ret_dtype = PyArray_DESCR(ret);
     if (ret == NULL) {
         return NULL;
     }
+    /* not same as *dtype* if the DType class replaces dtypes */
+    ret_dtype = PyArray_DESCR(ret);
 
     itemsize = dtype->elsize;
     ret_data = PyArray_DATA(ret);

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -198,6 +198,9 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
     /* Allocate memory for the iterator */
     iter = (NpyIter*)
                 PyObject_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
+    if (iter == NULL) {
+        return NULL;
+    }
 
     NPY_IT_TIME_POINT(c_malloc);
 


### PR DESCRIPTION
Tracking down issues in the 32bit debug run, it turned out to be a memory leak and the crashes were just memory errors that were not propagated correctly.
