### PR TITLE
API,BUG,DEP: treat trailing comma as a tuple and thus a structured dtype.

### DIFF
--- a/doc/release/upcoming_changes/25434.change.rst
+++ b/doc/release/upcoming_changes/25434.change.rst
@@ -1,0 +1,15 @@
+Cleanup of initialization of ``numpy.dtype`` with strings with commas
+---------------------------------------------------------------------
+The interpretation of strings with commas is changed slightly, in that a
+trailing comma will now always create a structured dtype.  E.g., where
+previously ``np.dtype("i")`` and ``np.dtype("i,")`` were treated as identical,
+now ``np.dtype("i,")`` will create a structured dtype, with a single
+field. This is analogous to ``np.dtype("i,i")`` creating a structured dtype
+with two fields, and makes the behaviour consistent with that expected of
+tuples.
+
+At the same time, the use of single number surrounded by parenthesis to
+indicate a sub-array shape, like in ``np.dtype("(2)i,")``, is deprecated.
+Instead; one should use ``np.dtype("(2,)i")`` or ``np.dtype("2i")``.
+Eventually, using a number in parentheses will raise an exception, like is the
+case for initializations without a comma, like ``np.dtype("(2)i")``.

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -149,6 +149,7 @@ _convorder = {'=': _nbo}
 def _commastring(astr):
     startindex = 0
     result = []
+    islist = False
     while startindex < len(astr):
         mo = format_re.match(astr, pos=startindex)
         try:
@@ -169,6 +170,7 @@ def _commastring(astr):
                         'format number %d of "%s" is not recognized' %
                         (len(result)+1, astr))
                 startindex = mo.end()
+                islist = True
 
         if order2 == '':
             order = order1
@@ -186,13 +188,22 @@ def _commastring(astr):
         if order in ('|', '=', _nbo):
             order = ''
         dtype = order + dtype
-        if (repeats == ''):
+        if repeats == '':
             newitem = dtype
         else:
+            if (repeats[0] == "(" and repeats[-1] == ")"
+                    and repeats[1:-1].strip() != ""
+                    and "," not in repeats):
+                warnings.warn(
+                    'Passing in a parenthesized single number for repeats '
+                    'is deprecated; pass either a single number or indicate '
+                    'a tuple with a comma, like "(2,)".', DeprecationWarning,
+                    stacklevel=2)
             newitem = (dtype, ast.literal_eval(repeats))
+
         result.append(newitem)
 
-    return result
+    return result if islist else result[0]
 
 class dummy_ctype:
 
@@ -267,7 +278,7 @@ class _ctypes:
         """
         Return the data pointer cast to a particular c-types object.
         For example, calling ``self._as_parameter_`` is equivalent to
-        ``self.data_as(ctypes.c_void_p)``. Perhaps you want to use 
+        ``self.data_as(ctypes.c_void_p)``. Perhaps you want to use
         the data as a pointer to a ctypes array of floating-point data:
         ``self.data_as(ctypes.POINTER(ctypes.c_double))``.
 
@@ -335,9 +346,9 @@ class _ctypes:
     def strides(self):
         """
         (c_intp*self.ndim): A ctypes array of length self.ndim where
-        the basetype is the same as for the shape attribute. This ctypes 
-        array contains the strides information from the underlying array. 
-        This strides information is important for showing how many bytes 
+        the basetype is the same as for the shape attribute. This ctypes
+        array contains the strides information from the underlying array.
+        This strides information is important for showing how many bytes
         must be jumped to get to the next element in the array.
         """
         return self.strides_as(_getintp_ctype())
@@ -736,7 +747,7 @@ def __dtype_from_pep3118(stream, is_subdtype):
         #
         # Native alignment may require padding
         #
-        # Here we assume that the presence of a '@' character implicitly 
+        # Here we assume that the presence of a '@' character implicitly
         # implies that the start of the array is *already* aligned.
         #
         extra_offset = 0

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -12,6 +12,7 @@
 
 #include "npy_config.h"
 #include "npy_ctypes.h"
+#include "npy_import.h"
 #include "npy_pycompat.h"
 
 #include "_datetime.h"
@@ -717,8 +718,8 @@ _convert_from_list(PyObject *obj, int align)
  * this is the format developed by the numarray records module and implemented
  * by the format parser in that module this is an alternative implementation
  * found in the _internal.py file patterned after that one -- the approach is
- * to try to convert to a list (with tuples if any repeat information is
- * present) and then call the _convert_from_list)
+ * to convert strings like "i,i" or "i1,2i,(3,4)f4" to a list of simple dtypes or
+ * (dtype, repeat) tuples. A single tuple is expected for strings such as "(2,)i".
  *
  * TODO: Calling Python from C like this in critical-path code is not
  *       a good idea. This should all be converted to C code.
@@ -726,32 +727,31 @@ _convert_from_list(PyObject *obj, int align)
 static PyArray_Descr *
 _convert_from_commastring(PyObject *obj, int align)
 {
-    PyObject *listobj;
+    PyObject *parsed;
     PyArray_Descr *res;
-    PyObject *_numpy_internal;
+    static PyObject *_commastring = NULL;
     assert(PyUnicode_Check(obj));
-    _numpy_internal = PyImport_ImportModule("numpy._core._internal");
-    if (_numpy_internal == NULL) {
+    npy_cache_import("numpy._core._internal", "_commastring", &_commastring);
+    if (_commastring == NULL) {
         return NULL;
     }
-    listobj = PyObject_CallMethod(_numpy_internal, "_commastring", "O", obj);
-    Py_DECREF(_numpy_internal);
-    if (listobj == NULL) {
+    parsed = PyObject_CallOneArg(_commastring, obj);
+    if (parsed == NULL) {
         return NULL;
     }
-    if (!PyList_Check(listobj) || PyList_GET_SIZE(listobj) < 1) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "_commastring is not returning a list with len >= 1");
-        Py_DECREF(listobj);
-        return NULL;
+    if ((PyTuple_Check(parsed) && PyTuple_GET_SIZE(parsed) == 2)) {
+        res = _convert_from_any(parsed, align);
     }
-    if (PyList_GET_SIZE(listobj) == 1) {
-        res = _convert_from_any(PyList_GET_ITEM(listobj, 0), align);
+    else if (PyList_Check(parsed) && PyList_GET_SIZE(parsed) >= 1) {
+        res = _convert_from_list(parsed, align);
     }
     else {
-        res = _convert_from_list(listobj, align);
+        PyErr_SetString(PyExc_RuntimeError,
+                "_commastring should return a tuple with len == 2, or "
+                "a list with len >= 1");
+        res = NULL;
     }
-    Py_DECREF(listobj);
+    Py_DECREF(parsed);
     return res;
 }
 

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -851,14 +851,14 @@ def test_subarray_from_array_construction():
     # Arrays are more complex, since they "broadcast" on success:
     arr = np.array([1, 2])
 
-    res = arr.astype("(2)i,")
+    res = arr.astype("2i")
     assert_array_equal(res, [[1, 1], [2, 2]])
 
-    res = np.array(arr, dtype="(2)i,")
+    res = np.array(arr, dtype="(2,)i")
 
     assert_array_equal(res, [[1, 1], [2, 2]])
 
-    res = np.array([[(1,), (2,)], arr], dtype="(2)i,")
+    res = np.array([[(1,), (2,)], arr], dtype="2i")
     assert_array_equal(res, [[[1, 1], [2, 2]], [[1, 1], [2, 2]]])
 
     # Also try a multi-dimensional example:

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -755,7 +755,7 @@ class TestLibImports(_DeprecationTestCase):
         from numpy._core.numerictypes import maximum_sctype
         from numpy.lib.tests.test_io import TextIO
         from numpy import in1d, row_stack, trapz
-        
+
         self.assert_deprecated(lambda: safe_eval("None"))
 
         data_gen = lambda: TextIO('A,B\n0,1\n2,3')
@@ -787,3 +787,11 @@ class TestDeprecatedDTypeAliases(_DeprecationTestCase):
     def test_a_dtype_alias(self):
         self._check_for_warning(lambda: np.dtype("a"))
         self._check_for_warning(lambda: np.dtype("a10"))
+
+
+class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
+    messsage = "Passing in a parenthesized single number"
+
+    @pytest.mark.parametrize("string", ["(2)i,", "(3)3S,", "f,(2)f"])
+    def test_parenthesized_repeat_count(self, string):
+        self.assert_deprecated(np.dtype, args=(string,))

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -283,6 +283,13 @@ class TestRecord:
         assert_dtype_equal(a, b)
         assert_dtype_not_equal(a, c)
 
+    def test_init_simple_structured(self):
+        dt1 = np.dtype("i, i")
+        assert dt1.names == ("f0", "f1")
+
+        dt2 = np.dtype("i,")
+        assert dt2.names == ("f0",)
+
     def test_mutate_error(self):
         # NOTE: Mutating should be deprecated, but new API added to replace it.
         a = np.dtype("i,i")
@@ -419,11 +426,11 @@ class TestRecord:
                        'offsets':[np.dtype('intp').itemsize, 0]})
 
     @pytest.mark.parametrize(["obj", "dtype", "expected"],
-        [([], ("(2)f4,"), np.empty((0, 2), dtype="f4")),
-         (3, "(3)f4,", [3, 3, 3]),
-         (np.float64(2), "(2)f4,", [2, 2]),
+        [([], ("2f4"), np.empty((0, 2), dtype="f4")),
+         (3, "(3,)f4", [3, 3, 3]),
+         (np.float64(2), "(2,)f4", [2, 2]),
          ([((0, 1), (1, 2)), ((2,),)], '(2,2)f4', None),
-         (["1", "2"], "(2)i,", None)])
+         (["1", "2"], "2i", None)])
     def test_subarray_list(self, obj, dtype, expected):
         dtype = np.dtype(dtype)
         res = np.array(obj, dtype=dtype)
@@ -435,6 +442,17 @@ class TestRecord:
                 expected[i] = obj[i]
 
         assert_array_equal(res, expected)
+
+    def test_parenthesized_single_number(self):
+        with pytest.raises(TypeError, match="not understood"):
+            np.dtype("(2)f4")
+
+        # Deprecation also tested in
+        # test_deprecations.py::TestDeprecatedDTypeParenthesizedRepeatCount
+        # Left here to allow easy conversion to an exception check.
+        with pytest.warns(DeprecationWarning,
+                          match="parenthesized single number"):
+            np.dtype("(2)f4,")
 
     def test_comma_datetime(self):
         dt = np.dtype('M8[D],datetime64[Y],i8')

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1197,7 +1197,7 @@ class TestCreation:
         a = np.array([1, Decimal(1)])
         a = np.array([[1], [Decimal(1)]])
 
-    @pytest.mark.parametrize("dtype", [object, "O,O", "O,(3)O", "(2,3)O"])
+    @pytest.mark.parametrize("dtype", [object, "O,O", "O,(3,)O", "(2,3)O"])
     @pytest.mark.parametrize("function", [
             np.ndarray, np.empty,
             lambda shape, dtype: np.empty_like(np.empty(shape, dtype=dtype))])
@@ -1552,7 +1552,7 @@ class TestStructured:
 
     def test_structuredscalar_indexing(self):
         # test gh-7262
-        x = np.empty(shape=1, dtype="(2)3S,(2)3U")
+        x = np.empty(shape=1, dtype="(2,)3S,(2,)3U")
         assert_equal(x[["f0","f1"]][0], x[0][["f0","f1"]])
         assert_equal(x[0], x[0][()])
 

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -195,18 +195,18 @@ def test_nditer_multi_index_set():
     it.multi_index = (0, 2,)
 
     assert_equal([i for i in it], [2, 3, 4, 5])
-    
+
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 def test_nditer_multi_index_set_refcount():
     # Test if the reference count on index variable is decreased
-    
+
     index = 0
     i = np.nditer(np.array([111, 222, 333, 444]), flags=['multi_index'])
 
     start_count = sys.getrefcount(index)
     i.multi_index = (index,)
     end_count = sys.getrefcount(index)
-    
+
     assert_equal(start_count, end_count)
 
 def test_iter_best_order_multi_index_1d():
@@ -1436,9 +1436,9 @@ def test_iter_copy_casts_structured():
     # casts, which cause this to require all steps in the casting machinery
     # one level down as well as the iterator copy (which uses NpyAuxData clone)
     in_dtype = np.dtype([("a", np.dtype("i,")),
-                         ("b", np.dtype(">i,<i,>d,S17,>d,(3)f,O,i1"))])
+                         ("b", np.dtype(">i,<i,>d,S17,>d,3f,O,i1"))])
     out_dtype = np.dtype([("a", np.dtype("O")),
-                          ("b", np.dtype(">i,>i,S17,>d,>U3,(3)d,i1,O"))])
+                          ("b", np.dtype(">i,>i,S17,>d,>U3,3d,i1,O"))])
     arr = np.ones(1000, dtype=in_dtype)
 
     it = np.nditer((arr,), ["buffered", "external_loop", "refs_ok"],
@@ -1464,9 +1464,9 @@ def test_iter_copy_casts_structured():
 def test_iter_copy_casts_structured2():
     # Similar to the above, this is a fairly arcane test to cover internals
     in_dtype = np.dtype([("a", np.dtype("O,O")),
-                         ("b", np.dtype("(5)O,(3)O,(1,)O,(1,)i,(1,)O"))])
+                         ("b", np.dtype("5O,3O,(1,)O,(1,)i,(1,)O"))])
     out_dtype = np.dtype([("a", np.dtype("O")),
-                          ("b", np.dtype("O,(3)i,(4)O,(4)O,(4)i"))])
+                          ("b", np.dtype("O,3i,4O,4O,4i"))])
 
     arr = np.ones(1, dtype=in_dtype)
     it = np.nditer((arr,), ["buffered", "external_loop", "refs_ok"],
@@ -2079,7 +2079,7 @@ def test_buffered_cast_error_paths_unraisable():
     # pytest.PytestUnraisableExceptionWarning:
     code = textwrap.dedent("""
         import numpy as np
-    
+
         it = np.nditer((np.array(1, dtype="i"),), op_dtypes=["S1"],
                        op_flags=["writeonly"], casting="unsafe", flags=["buffered"])
         buf = next(it)
@@ -3032,7 +3032,7 @@ def test_object_iter_cleanup():
     class T:
         def __bool__(self):
             raise TypeError("Ambiguous")
-    assert_raises(TypeError, np.logical_or.reduce, 
+    assert_raises(TypeError, np.logical_or.reduce,
                              np.array([T(), T()], dtype='O'))
 
 def test_object_iter_cleanup_reduce():

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1481,7 +1481,7 @@ class TestRegression:
 
         x = np.array([1, 2, 3], dtype=np.dtype('<i4'))
         assert_equal(
-            sha256(x).hexdigest(), 
+            sha256(x).hexdigest(),
             '4636993d3e1da4e9d6b8f87b79e8f7c6d018580d52661950eabc3845c5897a4d'
         )
 
@@ -1941,7 +1941,7 @@ class TestRegression:
              'invalid'),
 
             # different 8-bit code point in KOI8-R vs latin1
-            (np.bytes_(b'\x9c'),  
+            (np.bytes_(b'\x9c'),
              b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'S1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'|'\np5\nNNNI1\nI1\nI0\ntp6\nbS'\\x9c'\np7\ntp8\nRp9\n.",  # noqa
              'different'),
         ]
@@ -2091,7 +2091,7 @@ class TestRegression:
         assert_array_equal(arr2, data_back)
 
     def test_structured_count_nonzero(self):
-        arr = np.array([0, 1]).astype('i4, (2)i4')[:1]
+        arr = np.array([0, 1]).astype('i4, 2i4')[:1]
         count = np.count_nonzero(arr)
         assert_equal(count, 0)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -928,7 +928,7 @@ class TestLoadTxt(LoadTxtBase):
         with pytest.raises(TypeError,
                 match="If a structured dtype .*. But 1 usecols were given and "
                       "the number of fields is 3."):
-            np.loadtxt(["1,1\n"], dtype="i,(2)i", usecols=[0], delimiter=",")
+            np.loadtxt(["1,1\n"], dtype="i,2i", usecols=[0], delimiter=",")
 
     def test_fancy_dtype(self):
         c = TextIO()

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2432,7 +2432,7 @@ class TestFillingValues:
     def test_fillvalue_bytes_or_str(self):
         # Test whether fill values work as expected for structured dtypes
         # containing bytes or str.  See issue #7259.
-        a = empty(shape=(3, ), dtype="(2)3S,(2)3U")
+        a = empty(shape=(3, ), dtype="(2,)3S,(2,)3U")
         assert_equal(a["f0"].fill_value, default_fill_value(b"spam"))
         assert_equal(a["f1"].fill_value, default_fill_value("eggs"))
 


### PR DESCRIPTION
Previously, `np.dtype("i")` and `np.dtype("i,")` were treated as identical, even though `np.dtype("i,i")` creates a structured dtype with two fields.  Now, `np.dtype("i,")` will create a structured dtype as well, with a single field.

At the same time, the use of `np.dtype("(2)i,")` to create a subarray with 2 elements is deprecated; one should use `np.dtype("(2,)i")` or `np.dtype("2i")` instead.  This is consistent with `np.dtype("(2)i")` raising an exception; in that sense, the previously allowed usage was a bug.

fixes #25429 

