### PR TITLE
BLD: remove `-fno-strict-aliasing`, `--strip-debug` from cibuildwheel config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 musllinux-x86_64-image = "musllinux_1_1"
-environment = {CFLAGS="-fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", RUNNER_OS="Linux"}
+environment = {RUNNER_OS="Linux"}
 
 [tool.cibuildwheel.macos]
 # For universal2 wheels, we will need to fuse them manually
@@ -166,8 +166,7 @@ environment = {CFLAGS="-fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", RUNNE
 # for more info
 archs = "x86_64 arm64"
 test-skip = "*_universal2:arm64"
-# MACOS linker doesn't support stripping symbols.
-environment = {CFLAGS="-fno-strict-aliasing", RUNNER_OS="macOS"}
+environment = {RUNNER_OS="macOS"}
 
 [tool.cibuildwheel.windows]
 environment = {PKG_CONFIG_PATH="C:/opt/64/lib/pkgconfig"}


### PR DESCRIPTION
It's already included in the top-level `meson.build` file, which is more correct. See gh-25004 for where `-fno-strict-aliasing` came from.

Also clean up the `-Wl,--strip-debug` flag, it's unused since the buildtype is release and there is no debug info in the binaries.

(not triggering wheel builds, since this has been tested multiple times in gh-25012, and also in gh-25255)