### PR TITLE
CI: show meson-log.txt in Cirrus wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,11 +140,11 @@ tracker = "https://github.com/numpy/numpy/issues"
 # Note: the below skip command doesn't do much currently, the platforms to
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
 # `tools/ci/cirrus_wheels.yml`.
+build-frontend = "build"
 skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
 build-verbosity = "3"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
-config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_ setup-args=-Dallow-noblas=false"
-# not have it.
+config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dblas=openblas setup-args=-Dlapack=openblas setup-args=-Dblas-symbol-suffix=64_ setup-args=-Dallow-noblas=false build-dir=build"
 before-test = "pip install -r {project}/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -3,6 +3,8 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - python -m pip install cibuildwheel
   cibuildwheel_script:
     - cibuildwheel
+  always:
+    show_meson_log_script: cat build/meson-logs/meson-log.txt
   wheels_artifacts:
     path: "wheelhouse/*"
 


### PR DESCRIPTION
To do this, we need to be able to locate the log file in a fixed location, hence the need to add `build-dir=build` to the flags passed to meson-python. And to make that work, it turns out `pypa/build` is the better build front-end to use. It's also going to be the future default for `cibuildwheel`, so this change makes sense anyway.

Extracted from gh-25012, this is a standalone change that is mergeable.

[wheel build]
