### PR TITLE
API,ENH: Change definition of complex sign

### DIFF
--- a/doc/release/upcoming_changes/25441.change.rst
+++ b/doc/release/upcoming_changes/25441.change.rst
@@ -1,0 +1,7 @@
+Change in how complex sign is calculated
+----------------------------------------
+Following the API Array standard, the complex sign is now calculated as
+``z / |z|`` (instead of the rather less logical case where the sign of
+the real part was taken, unless the real part was zero, in which case
+the sign of the imaginary part was returned).  Like for real numbers,
+zero is returned if ``z==0``.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3597,10 +3597,11 @@ add_newdoc('numpy._core.umath', 'sign',
     The `sign` function returns ``-1 if x < 0, 0 if x==0, 1 if x > 0``.  nan
     is returned for nan inputs.
 
-    For complex inputs, the `sign` function returns
-    ``sign(x.real) + 0j if x.real != 0 else sign(x.imag) + 0j``.
+    For complex inputs, the `sign` function returns ``x / abs(x)``, the
+    generalization of the above (and ``0 if x==0``).
 
-    complex(nan, 0) is returned for complex nan inputs.
+    .. versionchanged:: 2.0.0
+        Definition of complex sign changed to follow the Array API standard.
 
     Parameters
     ----------
@@ -3626,8 +3627,8 @@ add_newdoc('numpy._core.umath', 'sign',
     array([-1.,  1.])
     >>> np.sign(0)
     0
-    >>> np.sign(5-2j)
-    (1+0j)
+    >>> np.sign([3-4j, 8j])
+    array([0.6-0.8j, 0. +1.j ])
 
     """)
 

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2232,14 +2232,38 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_sign(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    /* fixme: sign of nan is currently 0 */
     UNARY_LOOP {
-        const @ftype@ in1r = ((@ftype@ *)ip1)[0];
-        const @ftype@ in1i = ((@ftype@ *)ip1)[1];
-        ((@ftype@ *)op1)[0] = CGT(in1r, in1i, 0.0, 0.0) ?  1 :
-                            (CLT(in1r, in1i, 0.0, 0.0) ? -1 :
-                            (CEQ(in1r, in1i, 0.0, 0.0) ?  0 : NPY_NAN@C@));
-        ((@ftype@ *)op1)[1] = 0;
+        const @ftype@ in_r = ((@ftype@ *)ip1)[0];
+        const @ftype@ in_i = ((@ftype@ *)ip1)[1];
+        const @ftype@ in_abs = npy_hypot@c@(in_r, in_i);
+        if (NPY_UNLIKELY(npy_isnan(in_abs))) {
+            ((@ftype@ *)op1)[0] = NPY_NAN@C@;
+            ((@ftype@ *)op1)[1] = NPY_NAN@C@;
+        }
+        else if (NPY_UNLIKELY(npy_isinf(in_abs))) {
+            if (npy_isinf(in_r)) {
+                if (npy_isinf(in_i)) {
+                    ((@ftype@ *)op1)[0] = NPY_NAN@C@;
+                    ((@ftype@ *)op1)[1] = NPY_NAN@C@;
+                }
+                else {
+                    ((@ftype@ *)op1)[0] = in_r > 0 ? 1.: -1.;
+                    ((@ftype@ *)op1)[1] = 0.;
+                }
+            }
+            else {
+                ((@ftype@ *)op1)[0] = 0.;
+                ((@ftype@ *)op1)[1] = in_i > 0 ? 1.: -1.;
+            }
+        }
+        else if (NPY_UNLIKELY(in_abs == 0)) {
+            ((@ftype@ *)op1)[0] = 0.@C@;
+            ((@ftype@ *)op1)[1] = 0.@C@;
+        }
+        else{
+            ((@ftype@ *)op1)[0] = in_r / in_abs;
+            ((@ftype@ *)op1)[1] = in_i / in_abs;
+        }
     }
 }
 

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1189,9 +1189,10 @@ class TestRegression:
     def test_sign_for_complex_nan(self):
         # Ticket 794.
         with np.errstate(invalid='ignore'):
-            C = np.array([-np.inf, -2+1j, 0, 2-1j, np.inf, np.nan])
+            C = np.array([-np.inf, -3+4j, 0, 4-3j, np.inf, np.nan])
             have = np.sign(C)
-            want = np.array([-1+0j, -1+0j, 0+0j, 1+0j, 1+0j, np.nan])
+            want = np.array([-1+0j, -0.6+0.8j, 0+0j, 0.8-0.6j, 1+0j,
+                             complex(np.nan, np.nan)])
             assert_equal(have, want)
 
     def test_for_equal_names(self):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -2836,6 +2836,28 @@ class TestSign:
             assert_equal(res, tgt)
             assert_equal(out, tgt)
 
+    def test_sign_complex(self):
+        a = np.array([
+            np.inf, -np.inf, complex(0, np.inf), complex(0, -np.inf),
+            complex(np.inf, np.inf), complex(np.inf, -np.inf),  # nan
+            np.nan, complex(0, np.nan), complex(np.nan, np.nan),  # nan
+            0.0,  # 0.
+            3.0, -3.0, -2j, 3.0+4.0j, -8.0+6.0j
+        ])
+        out = np.zeros(a.shape, a.dtype)
+        tgt = np.array([
+            1., -1., 1j, -1j,
+            ] + [complex(np.nan, np.nan)] * 5 + [
+            0.0,
+            1.0, -1.0, -1j, 0.6+0.8j, -0.8+0.6j])
+
+        with np.errstate(invalid='ignore'):
+            res = ncu.sign(a)
+            assert_equal(res, tgt)
+            res = ncu.sign(a, out)
+            assert_(res is out)
+            assert_equal(res, tgt)
+
     def test_sign_dtype_object(self):
         # In reference to github issue #6229
 


### PR DESCRIPTION
This may be controversial, but the old definition of sign for complex numbers is really useless, and if we don't change it in 2.0, when will we? Note how the code in `geomspace` is substantially simplified by using the new definition!

From the release note included:

Following the API Array standard, the complex sign is now calculated as ``z / |z|`` (instead of the rather less logical case where the sign of the real part was taken, unless the real part was zero, in which case the sign of the imaginary part was returned).  Like for real numbers, zero is returned if ``z==0``.

EDIT: after discussion on the list, the consensus seemed to be that redefining `sign` was a good idea, but that the case for `copysign` was not strong. So, that is now removed from this PR. 
~With this, it has become possible to extend ``np.copysign(x1, x2)`` to complex numbers, since it can now generally return ``|x1| * sign(x2)`` with the sign as defined above (with no special treatment for zero).~
