### PR TITLE
TST: fix issue with dtype conversion in `test_avx_based_ufunc`

### DIFF
--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1967,19 +1967,21 @@ class TestAVXUfuncs:
             # various array sizes to ensure masking in AVX is tested
             for size in range(1,32):
                 myfunc = getattr(np, func)
-                x_f32 = np.float32(np.random.uniform(low=minval, high=maxval,
-                    size=size))
-                x_f64 = np.float64(x_f32)
-                x_f128 = np.longdouble(x_f32)
+                x_f32 = np.random.uniform(low=minval, high=maxval,
+                                          size=size).astype(np.float32)
+                x_f64 = x_f32.astype(np.float64)
+                x_f128 = x_f32.astype(np.longdouble)
                 y_true128 = myfunc(x_f128)
                 if maxulperr == 0:
-                    assert_equal(myfunc(x_f32), np.float32(y_true128))
-                    assert_equal(myfunc(x_f64), np.float64(y_true128))
+                    assert_equal(myfunc(x_f32), y_true128.astype(np.float32))
+                    assert_equal(myfunc(x_f64), y_true128.astype(np.float64))
                 else:
-                    assert_array_max_ulp(myfunc(x_f32), np.float32(y_true128),
-                            maxulp=maxulperr)
-                    assert_array_max_ulp(myfunc(x_f64), np.float64(y_true128),
-                            maxulp=maxulperr)
+                    assert_array_max_ulp(myfunc(x_f32),
+                                         y_true128.astype(np.float32),
+                                         maxulp=maxulperr)
+                    assert_array_max_ulp(myfunc(x_f64),
+                                         y_true128.astype(np.float64),
+                                         maxulp=maxulperr)
                 # various strides to test gather instruction
                 if size > 1:
                     y_true32 = myfunc(x_f32)


### PR DESCRIPTION
This avoids a deprecation and solves CI log pollution like:

```
...
   _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
    /tmp/tmp.DASUuiWiUU/venv/lib/python3.11/site-packages/numpy/_core/tests/test_umath.py:1972: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
      x_f64 = np.float64(x_f32)

  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
    /tmp/tmp.DASUuiWiUU/venv/lib/python3.11/site-packages/numpy/_core/tests/test_umath.py:1981: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
      assert_array_max_ulp(myfunc(x_f64), np.float64(y_true128),

  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
  _core/tests/test_umath.py::TestAVXUfuncs::test_avx_based_ufunc
    /tmp/tmp.DASUuiWiUU/venv/lib/python3.11/site-packages/numpy/_core/tests/test_umath.py:1977: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
      assert_equal(myfunc(x_f64), np.float64(y_true128))
```

There are more warnings that could use cleaning, but this is the worst one. See for example [this log](https://github.com/numpy/numpy/actions/runs/7280862512/job/19840190039?pr=25440).

[skip azp] [skip cirrus] [skip circle]
