### PR TITLE
TST: remove ``TestNewBufferProtocol.test_error_too_many_dims``

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8205,33 +8205,6 @@ class TestNewBufferProtocol:
         a = np.ones((1,) * 32)
         self._check_roundtrip(a)
 
-    @pytest.mark.slow
-    def test_error_too_many_dims(self):
-        def make_ctype(shape, scalar_type):
-            t = scalar_type
-            for dim in shape[::-1]:
-                t = dim * t
-            return t
-
-        # Try constructing a memory with too many dimensions:
-        c_u8_65d = make_ctype((1,)*65, ctypes.c_uint8)
-        try:
-            m = memoryview(c_u8_65d())
-        except ValueError:
-            pytest.skip("memoryview doesn't support more dimensions")
-
-        assert_equal(m.ndim, 65)
-
-        with pytest.raises(RuntimeError, match=".*ndim"):
-            np.array(m)
-
-        # The above seems to create some deep cycles, clean them up for
-        # easier reference count debugging:
-        del c_u8_65d, m
-        for i in range(65):
-            if gc.collect() == 0:
-                break
-
     def test_error_pointer_type(self):
         # gh-6741
         m = memoryview(ctypes.pointer(ctypes.c_uint8()))


### PR DESCRIPTION
This is failing in the tests for PyPy 3.9 wheel builds, which is blocking the production of nightlies. The test doesn't really do what it was designed for and is slow, so delete it - as suggested by @seberg on gh-25334.

Closes gh-25334

[skip ci]