### PR TITLE
TYP,CI: bump mypy from 1.5.1 to 1.7.1

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os_python:
-          - [ubuntu-latest, '3.10']  # switch to 3.12-dev after mypy is upgraded (see gh-23764)
+          - [ubuntu-latest, '3.12']
           - [windows-2019, '3.11']
           - [macos-12, '3.9']
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.8.0
+  - mypy=1.7.1
   # For building docs
   - sphinx>=4.5.0
   - sphinx-design

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.5.1
+  - mypy=1.8.0
   # For building docs
   - sphinx>=4.5.0
   - sphinx-design

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,5 +25,3 @@ filterwarnings =
 # Ignore DeprecationWarnings from distutils
     ignore::DeprecationWarning:.*distutils
     ignore:\n\n  `numpy.distutils`:DeprecationWarning
-# Ignore mypy >= 0.971 DeprecationWarnings
-    ignore:path is deprecated\. Use files\(\) instead:DeprecationWarning:mypy

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,7 +14,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.5.1; platform_python_implementation != "PyPy"
+mypy==1.8.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,7 +14,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.8.0; platform_python_implementation != "PyPy"
+mypy==1.7.1; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
Bumps mypy to the latest version (~1.8.0~ 1.7.1) in addition to finally bumping the mypy ubuntu job to python 3.12.

EDIT: Downgraded to 1.7.1 as 1.8.0 is not available on conda-forge yet.