### PR TITLE
DOC: fix typo `v_stack` in 2.0 migration guide

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -163,7 +163,7 @@ The next table presents deprecated members, which will be removed in a release a
 deprecated member migration guideline
 ================= =======================================================================
 in1d              Use ``np.isin`` instead.
-row_stack         Use ``np.vstack`` instead (``row_stack`` was an alias for ``v_stack``).
+row_stack         Use ``np.vstack`` instead (``row_stack`` was an alias for ``vstack``).
 trapz             Use ``scipy.integrate.trapezoid`` instead.
 ================= =======================================================================
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fix a small typo (`v_stack` &rarr; `vstack`).