### PR TITLE
BLD: optimize BLAS and LAPACK search order

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -130,7 +130,8 @@ jobs:
 
     - name: Build NumPy against Accelerate (ILP64)
       run: |
-        spin build -- -Duse-ilp64=true -Dallow-noblas=false
+        git clean -xdf
+        spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test (fast tests)
       run: spin test -j2

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,10 +4,10 @@ option('lapack', type: 'string', value: 'auto',
         description: 'Option for LAPACK library selection. By default, try to find any in the order given by `lapack-order`')
 option('allow-noblas', type: 'boolean', value: true,
         description: 'If set to true, allow building with (slow!) internal fallback routines')
-option('blas-order', type: 'array',
-        value: ['mkl', 'accelerate', 'openblas', 'flexiblas', 'blis', 'blas'])
-option('lapack-order', type: 'array',
-        value: ['mkl', 'accelerate', 'openblas', 'flexiblas', 'lapack'])
+option('blas-order', type: 'array', value: ['auto'],
+       description: 'Order of BLAS libraries to search for. E.g.: mkl,openblas,blis,blas')
+option('lapack-order', type: 'array', value: ['auto'],
+       description: 'Order of LAPACK libraries to search for. E.g.: mkl,openblas,lapack')
 option('use-ilp64', type: 'boolean', value: false,
        description: 'Use ILP64 (64-bit integer) BLAS and LAPACK interfaces')
 option('blas-symbol-suffix', type: 'string', value: 'auto',

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -67,6 +67,30 @@ else
   blas_interface = ['interface: lp64']
 endif
 
+
+blas_order = get_option('blas-order')
+if blas_order == ['auto']
+  blas_order = []
+  if host_machine.system() == 'darwin'
+    blas_order += 'accelerate'
+  endif
+  if host_machine.cpu_family() == 'x86_64'
+    blas_order += 'mkl'
+  endif
+  blas_order += ['openblas', 'flexiblas', 'blis', 'blas']
+endif
+lapack_order = get_option('lapack-order')
+if lapack_order == ['auto']
+  lapack_order = []
+  if host_machine.system() == 'darwin'
+    lapack_order += 'accelerate'
+  endif
+  if host_machine.cpu_family() == 'x86_64'
+    lapack_order += 'mkl'
+  endif
+  lapack_order += ['openblas', 'flexiblas', 'lapack']
+endif
+
 # MKL-specific options
 _threading_opt = get_option('mkl-threading')
 if _threading_opt == 'auto'
@@ -91,7 +115,7 @@ if blas_name == 'openblas' or blas_name == 'auto'
   endif
 endif
 if blas_name == 'auto'
-  foreach _name : get_option('blas-order')
+  foreach _name : blas_order
     if _name == 'mkl'
       blas = dependency('mkl',
         modules: ['cblas'] + blas_interface + mkl_opts,
@@ -170,7 +194,7 @@ if 'mkl' in blas.name() or blas.name() == 'accelerate' or blas_name == 'scipy-op
   lapack = blas
 else
   if lapack_name == 'auto'
-    foreach _name : get_option('lapack-order')
+    foreach _name : lapack_order
       lapack = dependency(_name, modules: ['lapack'] + blas_interface, required: false)
       if lapack.found()
         break


### PR DESCRIPTION
Avoids searching for libraries that cannot be installed for a given OS or CPU architecture. The introduction of 'auto' as the default also makes it easier to tweak this later. We reserve the right to change the behavior of 'auto' as we learn more or as support for new libraries gets added.

Also fix an issue in the macOS Accelerate CI job so the ILP64 rebuild actually happens.