### PR TITLE
BLD: fix uninitialized variable warnings from simd/neon/memory.h

### DIFF
--- a/numpy/_core/src/common/simd/neon/memory.h
+++ b/numpy/_core/src/common/simd/neon/memory.h
@@ -52,7 +52,7 @@ NPYV_IMPL_NEON_MEM(f64, double)
  ***************************/
 NPY_FINLINE npyv_s32 npyv_loadn_s32(const npy_int32 *ptr, npy_intp stride)
 {
-    int32x4_t a;
+    int32x4_t a = vdupq_n_s32(0);
     a = vld1q_lane_s32((const int32_t*)ptr,            a, 0);
     a = vld1q_lane_s32((const int32_t*)ptr + stride,   a, 1);
     a = vld1q_lane_s32((const int32_t*)ptr + stride*2, a, 2);


### PR DESCRIPTION
The warning was this, repeated many times:
```
In file included from ../numpy/_core/src/common/simd/neon/neon.h:76:
../numpy/_core/src/common/simd/neon/memory.h:56:56: warning: variable 'a' is uninitialized when used here [-Wuninitialized]
    a = vld1q_lane_s32((const int32_t*)ptr,            a, 0);
                                                       ^
```

I think the way I initialized the variable is idiomatic, but please double check (@Mousius or @seiko2plus?)  since I'm not too familiar with this stuff.

Closes gh-25461