### PR TITLE
BUG: Fix two errors related to not checking for failed allocations

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -198,6 +198,9 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
     /* Allocate memory for the iterator */
     iter = (NpyIter*)
                 PyObject_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
+    if (iter == NULL) {
+        return NULL;
+    }
 
     NPY_IT_TIME_POINT(c_malloc);
 


### PR DESCRIPTION
Backport of #25425.

Tracking down issues in the 32bit debug run, it turned out to be a memory leak and the crashes were just memory errors that were not propagated correctly.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
