### PR TITLE
MAINT: use cholesky_up gufunc for upper Cholesky decomposition

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -819,7 +819,7 @@ def cholesky(a, /, *, upper=False):
            [0.-0.j, 1.-0.j]])
 
     """
-    gufunc = _umath_linalg.cholesky_lo
+    gufunc = _umath_linalg.cholesky_up if upper else _umath_linalg.cholesky_lo
     a, wrap = _makearray(a)
     _assert_stacked_2d(a)
     _assert_stacked_square(a)
@@ -828,8 +828,6 @@ def cholesky(a, /, *, upper=False):
     with errstate(call=_raise_linalgerror_nonposdef, invalid='call',
                   over='ignore', divide='ignore', under='ignore'):
         r = gufunc(a, signature=signature)
-    if upper:
-        r = matrix_transpose(r).conj()
     return wrap(r.astype(result_t, copy=False))
 
 

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -983,11 +983,25 @@ identity_matrix(typ *matrix, size_t n)
     }
 }
 
-         /* lower/upper triangular matrix using blas (in place) */
+         /* zero the undefined part in a upper/lower triangular matrix */
+          /* Note: matrix from fortran routine, so column-major order */
 
 template<typename typ>
 static inline void
 triu_matrix(typ *matrix, size_t n)
+{
+    size_t i, j;
+    for (i = 0; i < n-1; ++i) {
+        for (j = i+1; j < n; ++j) {
+            matrix[j] = numeric_limits<typ>::zero;
+        }
+        matrix += n;
+    }
+}
+
+template<typename typ>
+static inline void
+tril_matrix(typ *matrix, size_t n)
 {
     size_t i, j;
     matrix += n;
@@ -998,7 +1012,6 @@ triu_matrix(typ *matrix, size_t n)
         matrix += n;
     }
 }
-
 
 /* -------------------------------------------------------------------------- */
                           /* Determinants */
@@ -1959,8 +1972,6 @@ cholesky(char uplo, char **args, npy_intp const *dimensions, npy_intp const *ste
     fortran_int n;
     INIT_OUTER_LOOP_2
 
-    assert(uplo == 'L');
-
     n = (fortran_int)dimensions[0];
     if (init_potrf(&params, uplo, n)) {
         LINEARIZE_DATA_t a_in, r_out;
@@ -1971,7 +1982,12 @@ cholesky(char uplo, char **args, npy_intp const *dimensions, npy_intp const *ste
             linearize_matrix(params.A, (ftyp*)args[0], &a_in);
             not_ok = call_potrf(&params);
             if (!not_ok) {
-                triu_matrix(params.A, params.N);
+                if (uplo == 'L') {
+                    tril_matrix(params.A, params.N);
+                }
+                else {
+                    triu_matrix(params.A, params.N);
+                }
                 delinearize_matrix((ftyp*)args[1], params.A, &r_out);
             } else {
                 error_occurred = 1;
@@ -1990,6 +2006,14 @@ cholesky_lo(char **args, npy_intp const *dimensions, npy_intp const *steps,
                 void *NPY_UNUSED(func))
 {
     cholesky<typ>('L', args, dimensions, steps);
+}
+
+template<typename typ>
+static void
+cholesky_up(char **args, npy_intp const *dimensions, npy_intp const *steps,
+                void *NPY_UNUSED(func))
+{
+    cholesky<typ>('U', args, dimensions, steps);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -3292,7 +3316,7 @@ using ftyp = fortran_type_t<typ>;
 
 
 /* -------------------------------------------------------------------------- */
-                 /* qr common code (modes - reduced and complete) */ 
+                 /* qr common code (modes - reduced and complete) */
 
 template<typename typ>
 struct GQR_PARAMS_t
@@ -3529,7 +3553,7 @@ init_gqr(GQR_PARAMS_t<ftyp> *params,
                    fortran_int n)
 {
     return init_gqr_common(
-        params, m, n, 
+        params, m, n,
         fortran_int_min(m, n));
 }
 
@@ -4176,6 +4200,7 @@ GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(solve);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(solve1);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(inv);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(cholesky_lo);
+GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(cholesky_up);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(svd_N);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(svd_S);
 GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(svd_A);
@@ -4390,11 +4415,21 @@ GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {
     {
         "cholesky_lo",
         "(m,m)->(m,m)",
-        "cholesky decomposition of hermitian positive-definite matrices. \n"\
-        "Broadcast to all outer dimensions. \n"\
-        "    \"(m,m)->(m,m)\" \n",
+        "cholesky decomposition of hermitian positive-definite matrices,\n"\
+        "using lower triangle. Broadcast to all outer dimensions.\n"\
+        "    \"(m,m)->(m,m)\"\n",
         4, 1, 1,
         FUNC_ARRAY_NAME(cholesky_lo),
+        equal_2_types
+    },
+    {
+        "cholesky_up",
+        "(m,m)->(m,m)",
+        "cholesky decomposition of hermitian positive-definite matrices,\n"\
+        "using upper triangle. Broadcast to all outer dimensions.\n"\
+        "    \"(m,m)->(m,m)\"\n",
+        4, 1, 1,
+        FUNC_ARRAY_NAME(cholesky_up),
         equal_2_types
     },
     {


### PR DESCRIPTION
As I was in gufunc-land anyway, thought I might as well do the follow-up of #25388, of using the actual BLAS routine for upper-triangle cholesky decomposition (rather than `.mT.conj()`, which uses extra memory).

Fixes #25457