### PR TITLE
ENH: allow start-stop array for indices in reduceat

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5538,18 +5538,26 @@ add_newdoc('numpy._core', 'ufunc', ('accumulate',
 
 add_newdoc('numpy._core', 'ufunc', ('reduceat',
     """
-    reduceat($self, array, /, indices, axis=0, dtype=None, out=None)
+    reduceat($self, array, /, indices, axis=0, dtype=None, out=None, **kwargs)
     --
 
-    reduceat(array, indices, axis=0, dtype=None, out=None)
+    reduceat(array, indices, axis=0, dtype=None, out=None, initial=<no value>)
 
     Performs a (local) reduce with specified slices over a single axis.
 
-    For i in ``range(len(indices))``, `reduceat` computes
-    ``ufunc.reduce(array[indices[i]:indices[i+1]])``, which becomes the i-th
-    generalized "row" parallel to `axis` in the final result (i.e., in a
-    2-D array, for example, if `axis = 0`, it becomes the i-th row, but if
-    `axis = 1`, it becomes the i-th column).  There are three exceptions to this:
+    There are two modes for how `indices` is interpreted. If it is a tuple of
+    2 arrays (or an array with two rows), then these are interpreted as start
+    and stop values of slices over which to compute reductions, i.e., for each
+    row i, ``ufunc.reduce(array[indices[0, i]:indices[1, i]])`` is computed,
+    which becomes the i-th element along `axis` in the final result (e.g., in
+    a 2-D array, if ``axis=0``, it becomes the i-th row, but if ``axis=1``,
+    it becomes the i-th column). Like for slices, negative indices are allowed
+    for both start and stop, and the values are clipped to be between 0 and
+    the shape of the array along `axis`.
+
+    If `indices` is one-dimentional, the stop values are taken to be the
+    previous index, i.e., ``ufunc.reduce(array[indices[i]:indices[i+1]])`` is
+    computed. There are three exceptions to this:
 
     * when ``i = len(indices) - 1`` (so for the last index),
       ``indices[i+1] = array.shape[axis]``.
@@ -5557,16 +5565,16 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
       simply ``array[indices[i]]``.
     * if ``indices[i] >= len(array)`` or ``indices[i] < 0``, an error is raised.
 
-    The shape of the output depends on the size of `indices`, and may be
-    larger than `array` (this happens if ``len(indices) > array.shape[axis]``).
+    .. versionchanged:: 2.2
+       Allow indices to be a 2-D array or tuple of start, stop sequences.
 
     Parameters
     ----------
     array : array_like
         The array to act on.
-    indices : array_like
-        Paired indices, comma separated (not colon), specifying slices to
-        reduce.
+    indices : array_like or tuple of array_like
+        Start and stop index arrays, interpreted like slices, or a single
+        sequence of indices, interpreted pairwise (see above).
     axis : int, optional
         The axis along which to apply the reduceat.
     dtype : data-type code, optional
@@ -5575,11 +5583,19 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
         upcast to conserve precision for some cases, such as
         ``numpy.add.reduce`` for integer or boolean input).
     out : ndarray, None, or tuple of ndarray and None, optional
-        Location into which the result is stored.
-        If not provided or None, a freshly-allocated array is returned.
-        For consistency with ``ufunc.__call__``, if passed as a keyword
-        argument, can be Ellipses (``out=...``, which has the same effect
-        as None as an array is always returned), or a 1-element tuple.
+        A location into which the result is stored. If not provided or None,
+        a freshly-allocated array is returned. For consistency with
+        ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
+        1-element tuple.
+    initial : scalar, optional
+        The value with which to start the reduction of a slice (only supported
+        if indices are in the start, stop form).
+        If the ufunc has no identity or the dtype is object, this defaults
+        to None - otherwise it defaults to ufunc.identity.
+        If ``None`` is given, the first element of the reduction is used,
+        and an error is thrown if the reduction is empty.
+
+        .. versionadded:: 2.2
 
     Returns
     -------
@@ -5591,22 +5607,19 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
     -----
     A descriptive example:
 
-    If `array` is 1-D, the function `ufunc.accumulate(array)` is the same as
-    ``ufunc.reduceat(array, indices)[::2]`` where `indices` is
-    ``range(len(array) - 1)`` with a zero placed
-    in every other element:
-    ``indices = zeros(2 * len(array) - 1)``,
-    ``indices[1::2] = range(1, len(array))``.
+    If `array` is 1-D, the function ``ufunc.accumulate(array)`` is the same as
+    ``ufunc.reduceat(array, (np.zeros(len(a)), np.arange(1, len(array)+1)))``.
 
-    Don't be fooled by this attribute's name: `reduceat(array)` is not
-    necessarily smaller than `array`.
+    Don't be fooled by this attribute's name: ``reduceat(array)`` is not
+    necessarily smaller than `array`: the shape of the output equals the
+    length of `indices` along `axis`, which may be larger than `array`.
 
     Examples
     --------
     To take the running sum of four successive values:
 
     >>> import numpy as np
-    >>> np.add.reduceat(np.arange(8),[0,4, 1,5, 2,6, 3,7])[::2]
+    >>> np.add.reduceat(np.arange(8), ([0, 1, 2, 3], [4, 5, 6, 7]))
     array([ 6, 10, 14, 18])
 
     A 2-D example:
@@ -5627,6 +5640,14 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
      # [row3]
      # [row1 + row2 + row3 + row4]
 
+    >>> np.add.reduceat(x, ([0, 3, 1, 2, 0], [3, 4, 2, 3, 4]))
+    array([[12.,  15.,  18.,  21.],
+           [12.,  13.,  14.,  15.],
+           [ 4.,   5.,   6.,   7.],
+           [ 8.,   9.,  10.,  11.],
+           [24.,  28.,  32.,  36.]])
+
+    Here, the old method of a single index array is shorter (but not clearer):
     >>> np.add.reduceat(x, [0, 3, 1, 2, 0])
     array([[12.,  15.,  18.,  21.],
            [12.,  13.,  14.,  15.],
@@ -5634,12 +5655,13 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
            [ 8.,   9.,  10.,  11.],
            [24.,  28.,  32.,  36.]])
 
+
     ::
 
      # reduce such that result has the following two columns:
      # [col1 * col2 * col3, col4]
 
-    >>> np.multiply.reduceat(x, [0, 3], 1)
+    >>> np.multiply.reduceat(x, ([0, 3], [3, 4]), 1)
     array([[   0.,     3.],
            [ 120.,     7.],
            [ 720.,    11.],

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -46,6 +46,54 @@ count_axes(int ndim, const npy_bool *axis_flags)
     return naxes;
 }
 
+NPY_NO_EXPORT int
+get_initial_buf(PyArrayMethod_Context *context, npy_bool empty_iteration,
+                PyArray_Descr *dtype, PyObject *initial, char **initial_buf)
+{
+    /*
+     * Get the initial value (if it exists).  If the iteration is empty
+     * then we assume the reduction is also empty.  The reason is that when
+     * the outer iteration is empty we just won't use the initial value
+     * in any case.  (`np.sum(np.zeros((0, 3)), axis=0)` is a length 3
+     * reduction but has an empty result.)
+     */
+    if ((initial == NULL && context->method->get_reduction_initial == NULL)
+            || initial == Py_None) {
+        /* There is no initial value, or initial value was explicitly unset */
+        return 0;
+    }
+    /* Not all functions will need initialization, but init always: */
+    *initial_buf = PyMem_Calloc(1, dtype->elsize);
+    if (*initial_buf == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    if (initial != NULL) {
+        /* must use user provided initial value */
+        if (PyArray_Pack(dtype, *initial_buf, initial) < 0) {
+            return -1;
+        }
+    }
+    else {
+        /*
+         * Fetch initial from ArrayMethod, we pretend the reduction is
+         * empty when the iteration is.  This may be wrong, but when it is,
+         * we will not need the identity as the result is also empty.
+         */
+        int has_initial = context->method->get_reduction_initial(
+                    context, empty_iteration, *initial_buf);
+        if (has_initial < 0) {
+            return -1;
+        }
+        if (!has_initial) {
+            /* We have no initial value available, free buffer to indicate */
+            PyMem_FREE(*initial_buf);
+            *initial_buf = NULL;
+        }
+    }
+    return 0;
+}
+
 /*
  * This function initializes a result array for a reduction operation
  * which has no identity. This means it needs to copy the first element
@@ -295,49 +343,6 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     npy_bool empty_iteration = NpyIter_GetIterSize(iter) == 0;
     result = NpyIter_GetOperandArray(iter)[0];
 
-    /*
-     * Get the initial value (if it exists).  If the iteration is empty
-     * then we assume the reduction is also empty.  The reason is that when
-     * the outer iteration is empty we just won't use the initial value
-     * in any case.  (`np.sum(np.zeros((0, 3)), axis=0)` is a length 3
-     * reduction but has an empty result.)
-     */
-    if ((initial == NULL && context->method->get_reduction_initial == NULL)
-            || initial == Py_None) {
-        /* There is no initial value, or initial value was explicitly unset */
-    }
-    else {
-        /* Not all functions will need initialization, but init always: */
-        initial_buf = PyMem_Calloc(1, op_dtypes[0]->elsize);
-        if (initial_buf == NULL) {
-            PyErr_NoMemory();
-            goto fail;
-        }
-        if (initial != NULL) {
-            /* must use user provided initial value */
-            if (PyArray_Pack(op_dtypes[0], initial_buf, initial) < 0) {
-                goto fail;
-            }
-        }
-        else {
-            /*
-             * Fetch initial from ArrayMethod, we pretend the reduction is
-             * empty when the iteration is.  This may be wrong, but when it is,
-             * we will not need the identity as the result is also empty.
-             */
-            int has_initial = context->method->get_reduction_initial(
-                    context, empty_iteration, initial_buf);
-            if (has_initial < 0) {
-                goto fail;
-            }
-            if (!has_initial) {
-                /* We have no initial value available, free buffer to indicate */
-                PyMem_FREE(initial_buf);
-                initial_buf = NULL;
-            }
-        }
-    }
-
     PyArrayMethod_StridedLoop *strided_loop;
     NPY_ARRAYMETHOD_FLAGS flags;
 
@@ -355,6 +360,11 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         }
     }
     flags = PyArrayMethod_COMBINED_FLAGS(flags, NpyIter_GetTransferFlags(iter));
+
+    if (get_initial_buf(context, empty_iteration, op_dtypes[0], initial,
+                        &initial_buf) < 0) {
+        goto fail;
+    }
 
     int needs_api = (flags & NPY_METH_REQUIRES_PYAPI) != 0;
     if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {

--- a/numpy/_core/src/umath/reduction.h
+++ b/numpy/_core/src/umath/reduction.h
@@ -32,6 +32,16 @@ typedef int (PyArray_ReduceLoopFunc)(PyArrayMethod_Context *context,
         int needs_api, npy_intp skip_first_count);
 
 /*
+ * Get the initial value (if it exists), and store it in initial_buf.
+ * Exposed here only so that it can be used for reduceat in ufunc_object.c
+ *
+ * TODO: move reduceat implementation to reduce.c
+ */
+NPY_NO_EXPORT int
+get_initial_buf(PyArrayMethod_Context *context, npy_bool empty_iteration,
+                PyArray_Descr *dtype, PyObject *initial, char **initial_buf);
+
+/*
  * This function executes all the standard NumPy reduction function
  * boilerplate code, just calling the appropriate inner loop function where
  * necessary.

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2977,7 +2977,8 @@ fail:
  */
 static PyObject *
 PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
-                 PyArrayObject *out, int axis, PyArray_DTypeMeta *signature[3])
+                 PyArrayObject *out, int axis, PyArray_DTypeMeta *signature[3],
+                 PyObject* initial)
 {
     PyArrayObject *op[3];
     int op_axes_arrays[3][NPY_MAXDIMS];
@@ -2997,6 +2998,10 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     /* The reduceat indices - ind must be validated outside this call */
     npy_intp *reduceat_ind;
     npy_intp i, ind_size, red_axis_size;
+    npy_bool start_stop;
+
+    /* Buffer to use when we need an initial value */
+    char *initial_buf = NULL;
 
     const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     char *opname = "reduceat";
@@ -3007,16 +3012,35 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     NPY_BEGIN_THREADS_DEF;
 
     reduceat_ind = (npy_intp *)PyArray_DATA(ind);
-    ind_size = PyArray_DIM(ind, 0);
+    start_stop = PyArray_NDIM(ind) == 2;
+    ind_size = PyArray_DIM(ind, start_stop ? 1 : 0);
     red_axis_size = PyArray_DIM(arr, axis);
 
-    /* Check for out-of-bounds values in indices array */
-    for (i = 0; i < ind_size; ++i) {
-        if (reduceat_ind[i] < 0 || reduceat_ind[i] >= red_axis_size) {
-            PyErr_Format(PyExc_IndexError,
-                "index %" NPY_INTP_FMT " out-of-bounds in %s.%s [0, %" NPY_INTP_FMT ")",
-                reduceat_ind[i], ufunc_name, opname, red_axis_size);
-            return NULL;
+    if (start_stop) {
+        /*
+         * Adjust start and stop values to be within range (like slice).
+         * Do it in-place for convenience (ind is guaranteed to be a C-order copy).
+         */
+        for (i = 0; i < ind_size * 2; ++i) {
+            npy_intp ind = reduceat_ind[i];
+            if (ind < 0) {
+                reduceat_ind[i] = ind <= -red_axis_size ? 0 : ind + red_axis_size;
+            }
+            else if (ind > red_axis_size) {
+                reduceat_ind[i] = red_axis_size;
+            }
+
+        }
+    }
+    else {
+        /* Check for out-of-bounds values in indices array */
+        for (i = 0; i < ind_size; ++i) {
+            if (reduceat_ind[i] < 0 || reduceat_ind[i] >= red_axis_size) {
+                PyErr_Format(PyExc_IndexError,
+                    "index %" NPY_INTP_FMT " out-of-bounds in %s.%s [0, %" NPY_INTP_FMT ")",
+                    reduceat_ind[i], ufunc_name, opname, red_axis_size);
+                return NULL;
+            }
         }
     }
 
@@ -3077,7 +3101,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         if (idim == axis) {
             op_axes_arrays[0][idim] = axis;
             op_axes_arrays[1][idim] = -1;
-            op_axes_arrays[2][idim] = 0;
+            op_axes_arrays[2][idim] = start_stop ? 1 : 0;
         }
         else {
             op_axes_arrays[0][idim] = idim;
@@ -3193,6 +3217,16 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     }
 
     /*
+     * Get the initial value if we are in new start_stop mode
+     */
+    if (start_stop) {
+        if (get_initial_buf(&context, PyArray_SIZE(op[0]) == 0, descrs[0], initial,
+                            &initial_buf) < 0) {
+            goto fail;
+        }
+    }
+
+    /*
      * If the output has zero elements, return now.
      */
     if (PyArray_SIZE(op[0]) == 0) {
@@ -3205,7 +3239,6 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
         NpyIter_IterNextFunc *iternext;
         char **dataptr;
-        npy_intp count_m1;
         npy_intp stride0, stride1;
         npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
 
@@ -3219,7 +3252,6 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         dataptr = NpyIter_GetDataPtrArray(iter);
 
         /* Execute the loop with just the outer iterator */
-        count_m1 = PyArray_DIM(op[1], axis)-1;
         stride0 = 0;
         stride1 = PyArray_STRIDE(op[1], axis);
 
@@ -3235,18 +3267,33 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
         do {
             for (i = 0; i < ind_size; ++i) {
-                npy_intp start = reduceat_ind[i],
-                        end = (i == ind_size-1) ? count_m1+1 :
-                                                  reduceat_ind[i+1];
+                npy_intp start = reduceat_ind[i];
+                npy_intp end = start_stop? reduceat_ind[i + ind_size] :
+                    ((i == ind_size-1) ? PyArray_DIM(arr,axis) :
+                                         reduceat_ind[i+1]);
                 npy_intp count = end - start;
 
                 dataptr_copy[0] = dataptr[0] + stride0_ind*i;
                 dataptr_copy[1] = dataptr[1] + stride1*start;
                 dataptr_copy[2] = dataptr[0] + stride0_ind*i;
+                char *first_element;
 
                 /*
-                 * Copy the first element to start the reduction.
-                 *
+                 * Copy the initial value or the first element to start the reduction.
+                 */
+                if (start_stop && (count <= 0 || initial_buf != NULL)) {
+                    if (initial_buf == NULL) {
+                        res = -2;
+                        break;
+                    }
+                    first_element = initial_buf;
+                }
+                else {
+                    first_element = dataptr_copy[1];
+                    --count;
+                    dataptr_copy[1] += stride1;
+                }
+                /*
                  * Output (dataptr[0]) and input (dataptr[1]) may point
                  * to the same memory, e.g.
                  * np.add.reduceat(a, np.arange(len(a)), out=a).
@@ -3256,19 +3303,16 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                      * Incref before decref to avoid the possibility of
                      * the reference count being zero temporarily.
                      */
-                    Py_XINCREF(*(PyObject **)dataptr_copy[1]);
+                    Py_XINCREF(*(PyObject **)first_element);
                     Py_XDECREF(*(PyObject **)dataptr_copy[0]);
-                    *(PyObject **)dataptr_copy[0] =
-                                        *(PyObject **)dataptr_copy[1];
+                    *(PyObject **)dataptr_copy[0] = *(PyObject **)first_element;
                 }
                 else {
-                    memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                    memmove(dataptr_copy[0], first_element, itemsize);
                 }
 
-                if (count > 1) {
+                if (count > 0) {
                     /* Inner loop like REDUCE */
-                    --count;
-                    dataptr_copy[1] += stride1;
                     NPY_UF_DBG_PRINT1("iterator loop count %d\n",
                                                     (int)count);
                     res = strided_loop(&context,
@@ -3294,20 +3338,35 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         }
 
         for (i = 0; i < ind_size; ++i) {
-            npy_intp start = reduceat_ind[i],
-                    end = (i == ind_size-1) ? PyArray_DIM(arr,axis) :
-                                              reduceat_ind[i+1];
+            npy_intp start = reduceat_ind[i];
+            npy_intp end = start_stop? reduceat_ind[i + ind_size] :
+                ((i == ind_size-1) ? PyArray_DIM(arr,axis) :
+                                     reduceat_ind[i+1]);
             npy_intp count = end - start;
+            char *first_element;
 
             dataptr_copy[0] = PyArray_BYTES(op[0]) + stride0_ind*i;
             dataptr_copy[1] = PyArray_BYTES(op[1]) + stride1*start;
             dataptr_copy[2] = PyArray_BYTES(op[0]) + stride0_ind*i;
 
             /*
-             * Copy the first element to start the reduction.
-             *
-             * Output (dataptr[0]) and input (dataptr[1]) may point to
-             * the same memory, e.g.
+             * Copy the initial value or the first element to start the reduction.
+             */
+            if (start_stop && (count <= 0 || initial_buf != NULL)) {
+                if (initial_buf == NULL) {
+                    res = -2;
+                    break;
+                }
+                first_element = initial_buf;
+            }
+            else {
+                first_element = dataptr_copy[1];
+                --count;
+                dataptr_copy[1] += stride1;
+            }
+            /*
+             * Output (dataptr[0]) and input (dataptr[1]) may point
+             * to the same memory, e.g.
              * np.add.reduceat(a, np.arange(len(a)), out=a).
              */
             if (descrs[2]->type_num == NPY_OBJECT) {
@@ -3315,19 +3374,16 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                  * Incref before decref to avoid the possibility of the
                  * reference count being zero temporarily.
                  */
-                Py_XINCREF(*(PyObject **)dataptr_copy[1]);
+                Py_XINCREF(*(PyObject **)first_element);
                 Py_XDECREF(*(PyObject **)dataptr_copy[0]);
-                *(PyObject **)dataptr_copy[0] =
-                                    *(PyObject **)dataptr_copy[1];
+                *(PyObject **)dataptr_copy[0] = *(PyObject **)first_element;
             }
             else {
-                memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                memmove(dataptr_copy[0], first_element, itemsize);
             }
 
-            if (count > 1) {
+            if (count > 0) {
                 /* Inner loop like REDUCE */
-                --count;
-                dataptr_copy[1] += stride1;
                 NPY_UF_DBG_PRINT1("iterator loop count %d\n",
                                                 (int)count);
                 res = strided_loop(&context,
@@ -3342,6 +3398,10 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     }
 
 finish:
+    if (initial_buf != NULL && PyDataType_REFCHK(PyArray_DESCR(out))) {
+        PyArray_Item_XDECREF(initial_buf, PyArray_DESCR(out));
+    }
+    PyMem_FREE(initial_buf);
     NPY_AUXDATA_FREE(auxdata);
     Py_DECREF(descrs[0]);
     Py_DECREF(descrs[1]);
@@ -3357,6 +3417,12 @@ finish:
     }
 
     if (res < 0) {
+        if (res == -2) {
+            PyErr_Format(PyExc_ValueError,
+                    "empty slice encountered with reduceat operation for '%s', "
+                    "which does not have an identity. Specify 'initial'.",
+                    ufunc_name);
+        }
         Py_DECREF(out);
         return NULL;
     }
@@ -3364,6 +3430,9 @@ finish:
     return (PyObject *)out;
 
 fail:
+    if (initial_buf != NULL && PyDataType_REFCHK(PyArray_DESCR(out))) {
+        PyArray_Item_XDECREF(initial_buf, PyArray_DESCR(out));
+    }
     Py_XDECREF(out);
 
     NPY_AUXDATA_FREE(auxdata);
@@ -3498,6 +3567,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
                 "|axis", NULL, &axes_obj,
                 "|dtype", NULL, &otype_obj,
                 "|out", NULL, &out_obj,
+                "|initial", &_not_NoValue, &initial,
                 NULL, NULL, NULL) < 0) {
             goto fail;
         }
@@ -3593,10 +3663,22 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     /* Finish parsing of all parameters (no matter which reduce-like) */
     if (indices_obj) {
         PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
-
+        /* Ensure a copy so that we can change indices in-place */
         indices = (PyArrayObject *)PyArray_FromAny(indices_obj,
-                indtype, 1, 1, NPY_ARRAY_CARRAY, NULL);
+                indtype, 1, 2, NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY, NULL);
         if (indices == NULL) {
+            goto fail;
+        }
+        if (PyArray_NDIM(indices) == 2 && PyArray_DIM(indices, 0) != 2) {
+            PyErr_SetString(PyExc_ValueError,
+                            "indices should either be one-dimensional or "
+                            "two-dimensional with two rows.");
+            goto fail;
+        }
+        if (PyArray_NDIM(indices) == 1 && initial != NULL) {
+            PyErr_SetString(PyExc_ValueError,
+                            "initial values are only supported with indices "
+                            "passed in as start, step arrays.");
             goto fail;
         }
     }
@@ -3716,7 +3798,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         ret = (PyArrayObject *)PyUFunc_Reduceat(ufunc,
-                mp, indices, out, axes[0], signature);
+                mp, indices, out, axes[0], signature, initial);
         Py_SETREF(indices, NULL);
         break;
     }

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -229,8 +229,47 @@ class TestUfunc:
     def test_reduceat_shifting_sum(self):
         L = 6
         x = np.arange(L)
+        # old style
         idx = np.array(list(zip(np.arange(L - 2), np.arange(L - 2) + 2))).ravel()
         assert_array_equal(np.add.reduceat(x, idx)[::2], [1, 3, 5, 7])
+        # start, stop slices
+        idx = (np.arange(0, L-2), np.arange(2, L))
+        assert_array_equal(np.add.reduceat(x, idx), [1, 3, 5, 7])
+
+    def test_reduceat_multi_d(self):
+        # Following examples in documentation.
+        x = np.arange(16.).reshape(4, 4)
+        res = np.add.reduceat(x, ([0, 3, 1, 2, 0], [3, 4, 2, 3, 4]))
+        exp = np.array([[12., 15., 18., 21.],
+                        [12., 13., 14., 15.],
+                        [4., 5., 6., 7.],
+                        [8., 9., 10., 11.],
+                        [24., 28., 32., 36.]])
+        assert_array_equal(res, exp)
+        # old style
+        res = np.add.reduceat(x, [0, 3, 1, 2, 0])
+        assert_array_equal(res, exp)
+        res = np.multiply.reduceat(x, ([0, 3], [3, 4]), 1)
+        exp = np.array([[0., 3.], [120., 7.], [720., 11.], [2184., 15.]])
+        assert_array_equal(res, exp)
+        # old style
+        res = np.multiply.reduceat(x, [0, 3], 1)
+        assert_array_equal(res, exp)
+
+    def test_reduceat_initial(self):
+        a = np.arange(12)
+        initial = 10
+        exp = np.add.reduceat(a, ([1, 3, 5], [2, -1, 0])) + initial
+        res = np.add.reduceat(a, ([1, 3, 5], [2, -1, 0]), initial=initial)
+        assert_array_equal(res, exp)
+        # ufunc without an identity
+        res = np.minimum.reduceat(a, ([1, 3, 5], [2, -1, 0]), initial=initial)
+        assert_array_equal(res, [1, 3, 10])
+        with pytest.raises(ValueError, match="empty slice"):
+            np.minimum.reduceat(a, ([1, 3, 5], [2, -1, 0]))
+        # old style is not supported
+        with pytest.raises(ValueError, match="only supported"):
+            np.add.reduceat(a, [1, 2, 0], initial=initial)
 
     def test_all_ufunc(self):
         """Try to check presence and results of all ufuncs.
@@ -1612,7 +1651,7 @@ class TestUfunc:
         out = np.empty(4, dtype=object)
         out[:] = [[1] for i in range(4)]
         np.add.reduceat(arr, np.arange(4), out=arr)
-        np.add.reduceat(arr, np.arange(4), out=arr)
+        np.add.reduceat(arr, (np.arange(4), np.arange(4)+1), out=arr)
         assert_array_equal(arr, out)
 
         # And the same if the axis argument is used
@@ -1621,7 +1660,7 @@ class TestUfunc:
         out = np.ones((2, 4), dtype=object)
         out[0, :] = [[2] for i in range(4)]
         np.add.reduceat(arr, np.arange(4), out=arr, axis=-1)
-        np.add.reduceat(arr, np.arange(4), out=arr, axis=-1)
+        np.add.reduceat(arr, (np.arange(4), np.arange(4)+1), out=arr, axis=-1)
         assert_array_equal(arr, out)
 
     def test_object_array_reduceat_failure(self):
@@ -1632,6 +1671,14 @@ class TestUfunc:
         # But errors when None would be involved in an operation:
         with pytest.raises(TypeError):
             np.add.reduceat([1, None, 2], [0, 2])
+        # Also true for new-style
+        res = np.add.reduceat(np.array([1, None, 2], dtype=object), ([1, 2], [2, 3]))
+        assert_array_equal(res, np.array([None, 2], dtype=object))
+        with pytest.raises(TypeError):
+            np.add.reduceat([1, None, 2], ([0, 2], [2, 3]))
+        # Or when initial is given.
+        with pytest.raises(TypeError):
+            np.add.reduceat([1, None, 2], ([1, 2], [2, 3]), initial=0)
 
     def test_zerosize_reduction(self):
         # Test with default dtype and object dtype
@@ -2629,6 +2676,9 @@ class TestUfunc:
         assert_array_equal(np.add.accumulate(arr_be), np.add.accumulate(arr_le))
         assert_array_equal(
             np.add.reduceat(arr_be, [1]), np.add.reduceat(arr_le, [1]))
+        # start-stop style just to be sure.
+        assert_array_equal(np.add.reduceat(arr_be, ([1], [10])),
+                           np.add.reduceat(arr_le, ([1], [10])))
 
     def test_reducelike_out_promotes(self):
         # Check that the out argument to reductions is considered for
@@ -2666,6 +2716,11 @@ class TestUfunc:
         out = np.empty(2, dtype=arr.dtype.newbyteorder())
         expected = np.add.reduceat(arr, [0, 1])
         np.add.reduceat(arr, [0, 1], out=out)
+        assert_array_equal(expected, out)
+        # start-stop
+        out2 = np.empty(2, dtype=arr.dtype.newbyteorder())
+        out = np.add.reduceat(arr, ([0, 1], [1, 20]), out=out2)
+        assert out is out2
         assert_array_equal(expected, out)
         # And accumulate:
         out = np.empty(arr.shape, dtype=arr.dtype.newbyteorder())
@@ -2706,6 +2761,9 @@ class TestUfunc:
 
         with pytest.raises(ValueError, match="(shape|size)"):
             np.add.reduceat(arr, [0, 3], out=out)
+
+        with pytest.raises(ValueError, match="(shape|size)"):
+            np.add.reduceat(arr, ([0, 3], [3, 5]), out=out)
 
         with pytest.raises(ValueError, match="(shape|size)"):
             np.add.accumulate(arr, out=out)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4936,6 +4936,10 @@ def test_reduceat_empty():
     result = np.add.reduceat(x, [], axis=1)
     assert_equal(result.dtype, x.dtype)
     assert_equal(result.shape, (5, 0))
+    # Start-stop index
+    result = np.add.reduceat(x, ([], []), axis=0)
+    assert_equal(result.dtype, x.dtype)
+    assert_equal(result.shape, (0, 2))
 
 def test_complex_nan_comparisons():
     nans = [complex(np.nan, 0), complex(0, np.nan), complex(np.nan, np.nan)]


### PR DESCRIPTION
EDIT (2024-11-23): added tests and documentation, and move out of draft. I stuck to having start and stop be separate rows, so that one can easily pass `(start, stop)` (as in the examples). I feel that is most logical given the present structure, where one can see a single array as a start array that implies a default `stop` array. This can of course still be changed.

Rationale
---------
ufuncs have a `.reduceat` method that allows having piecewise reductions, but using an array of `indices` that is rather convoluted.  From
https://numpy.org/doc/stable/reference/generated/numpy.ufunc.reduceat.html, the `indices` are interpreted as follows:
```
For i in range(len(indices)), reduceat computes
ufunc.reduce(array[indices[i]:indices[i+1]]), which becomes the i-th
generalized "row" parallel to `axis` in the final result (i.e., <snip>).
There are three exceptions to this:

* when i = len(indices) - 1 (so for the last index), indices[i+1] = array.shape[axis].
* if indices[i] >= indices[i + 1], the i-th generalized “row” is simply array[indices[i]].
* if indices[i] >= len(array) or indices[i] < 0, an error is raised.
```

The exceptions are the main issue I have with the current definition: really, the current setup is only natural for contiguous pieces; for anything else, it requires contortion.  For instance, the documentation describes how to get a
running sum as follows:
```
np.add.reduceat(np.arange(8),[0,4, 1,5, 2,6, 3,7])[::2]
```
Note the slice at the end to remove the unwanted elements!  And note that this *omits* the last set of 4 elements -- to get this, one has to add a solitary index 4 at the end - one cannot get slices that include the last element except as the last one.

The PR arose from this unnatural way to describe slices: Why can one not just pass in the start and stop values directly?  With no exceptions, but just interpreted as slices should be.  I.e., get a running sum as,
```
np.add.reduceat(np.arange(8), ((start := np.arange(0, 8//2+1)), start+8//2))
```
Currently, the updated docstring explains the new mode as follows:
```
    There are two modes for how `indices` is interpreted. If it is a tuple of
    2 arrays (or an array with two rows), then these are interpreted as start
    and stop values of slices over which to compute reductions, i.e., for each
    row i, ``ufunc.reduce(array[indices[0, i]:indices[1, i]])`` is computed,
    which becomes the i-th element along `axis` in the final result (e.g., in
    a 2-D array, if ``axis=0``, it becomes the i-th row, but if ``axis=1``,
    it becomes the i-th column). Like for slices, negative indices are allowed
    for both start and stop, and the values are clipped to be between 0 and
    the shape of the array along `axis`.
```

The PR also adds a new `initial` keyword argument. The reason for this is that with the new layout I did not want to have the exception currently present, where if `stop < start`, one gets the value at start.  I felt it was more logical to treat this case as an empty reduction, but then it becomes necessary to able to pass in an initial value for reductions that do not have an identity, like `np.minimum` (which of course just helps make `reduceat` more similar to `reduce`).

Note that I considered requiring `slice(start, stop)`, which might be clearer.  I only did not do that since implementation-wise just having a tuple or an array with 2 columns was super easy.  I also liked that with this implementation the old way could at least in principle be described in terms of the new one, as having a default `stop` that just takes the next element of `start` (with the same exceptions as above).  I ended not describing it as such in the docstring, though.

Anyway, if in principle it is thought a good idea to make `reduceat` more flexible, the API is up for discussion.  It could require `indices=slice(start, stop)` (possibly step too), or one could allow not passing in `indices` if `start` and `stop` are present, or just add a `stop` keyword argument, whose defaults are interpreted as before.

Links
-----
- Github issue: https://github.com/numpy/numpy/issues/834
- 2011 thread: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/DX5KVE5O36MQHIEBOFK6YRH2JPRMFPVB/#I5MKK4ZPX3FA6K6H5457F4WOHYSO67NN
- 2016 thread 1: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/RI7MYBUB6S7PGXQ27ZCNLOWEPNSFMDHI/#PBIB7BEA35NE2WMI25SJJEWN7YW6W72V
- 2016 thread 2: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/RZZ3TJVB5M4UFTZKD4XDDLPT2AW3ANR6/#RZZ3TJVB5M4UFTZKD4XDDLPT2AW3ANR6
- 2017 thread: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/YKLT53KE54MKKO2FDWOYQQZGSN4EGSGU/#YKLT53KE54MKKO2FDWOYQQZGSN4EGSGU
(where I suggested adding a `slice` argument to reduce instead; also an option...)
- 2023 thread (this one): https://mail.python.org/archives/list/numpy-discussion@python.org/thread/VWDXYJW362WPNE5JLZCQNPEAQD6EIKSI/#MB4LXPBEJ5OFMPXG24PCAFTXYLQIXZSG

Old text
--------
Triggered by #834 seeing some comments again, a draft just to see how it would look to allow `reduceat` to take a set of start, stop indices (treated as slices), to make the interface a bit more easily comprehensible without making a truly new method. It also allows passing in an `initial` to deal with empty slices.

Fixes #834 

Mostly to discuss whether we want this at all, and, if so, what the API should be. So probably best not to worry too much about implementation (the duplication of code, both in `reduceat` itself and with `reduce` is large).

Sample use:
```
a = np.arange(12)
np.add.reduceat(a, ([1, 3, 5], [2, -1, 0]))
# array([ 1, 52,  0])
np.minimum.reduceat(a, ([1, 3, 5], [2, -1, 0]), initial=10)
# array([ 1,  3, 10])
np.minimum.reduceat(a, ([1, 3, 5], [2, -1, 0]))
# ValueError: empty slice encountered with reduceat operation for 'minimum', which does not have an identity. Specify 'initial'.
```
Writing it out like this, I think a different order may be useful, i.e., `np.add(a, [(1, 2), (3, -1), (5, 0)])`. The reason I picked the other one was that I liked the idea of triggering it by using `slice(start, stop)`, with both `start` and `stop` possibly arrays and a tuple of two lists was closer to that (although internally it just turns it into an array). The list of tuples suggests more a structured array with start and stop (and step?) entries.

p.s. Fairly trivially extensible to `start, stop, step`.