### PR TITLE
BUG: Fix module name bug in signature files [urgent] [f2py] 

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -463,9 +463,17 @@ def run_main(comline_list):
     pyf_files, _ = filter_files("", "[.]pyf([.]src|)", comline_list)
     # Checks that no existing modulename is defined in a pyf file
     # TODO: Remove all this when scaninputline is replaced
-    if "-h" not in comline_list and args.module_name: # Can't check what doesn't exist yet, -h creates the pyf
-        modname = validate_modulename(pyf_files, args.module_name)
-        comline_list += ['-m', modname] # needed for the rest of scaninputline
+    modname = "untitled"  # Default
+    if args.module_name:
+        if "-h" in comline_list:
+            modname = (
+                args.module_name
+            )  # Directly use from args when -h is present
+        else:
+            modname = validate_modulename(
+                pyf_files, args.module_name
+            )  # Validate modname when -h is not present
+    comline_list += ['-m', modname]  # needed for the rest of scaninputline
     # gh-22819 -- end
     files, options = scaninputline(comline_list)
     auxfuncs.options = options

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -339,6 +339,22 @@ def test_mod_gen_f77(capfd, hello_world_f90, monkeypatch):
     assert Path.exists(foutl.wrap77)
 
 
+def test_mod_gen_gh25263(capfd, hello_world_f77, monkeypatch):
+    """Check that pyf files are correctly generated with module structure
+    CLI :: -m <name> -h pyf_file
+    BUG: numpy-gh #20520
+    """
+    MNAME = "hi"
+    foutl = get_io_paths(hello_world_f77, mname=MNAME)
+    ipath = foutl.finp
+    monkeypatch.setattr(sys, "argv", f'f2py {ipath} -m {MNAME} -h hi.pyf'.split())
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        with Path('hi.pyf').open() as hipyf:
+            pyfdat = hipyf.read()
+            assert "python module hi" in pyfdat
+
+
 def test_lower_cmod(capfd, hello_world_f77, monkeypatch):
     """Lowers cases by flag or when -h is present
 


### PR DESCRIPTION
Backport of #25267.

Closes #25263 by more clearly demarcating the case of `-h` (signature file generation) and the other cases.

Needs a backport, @charris, since it was introduced in the backported 9140edde39d133487c3be6011100b2f93e09849a. 

* TST: Add one for gh-25263



* BUG: Handle modules correctly for F77

Closes gh-25263

---------

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
