### PR TITLE
BUG: Add external library handling for meson [f2py]

### DIFF
--- a/doc/source/f2py/buildtools/distutils-to-meson.rst
+++ b/doc/source/f2py/buildtools/distutils-to-meson.rst
@@ -163,6 +163,27 @@ Here, ``meson`` can actually be used to set dependencies more robustly.
     of dependencies. They can be `customized further <https://mesonbuild.com/Dependencies.html>`_
     to use CMake or other systems to resolve dependencies.
 
+1.2.5 Libraries
+^^^^^^^^^^^^^^^
+
+Both ``meson`` and ``distutils`` are capable of linking against libraries.
+
+.. tab-set::
+
+  .. tab-item:: Distutils
+    :sync: distutils
+
+    .. code-block:: bash
+
+      python -m numpy.f2py -c fib.f90 -m fib --backend distutils -lmylib -L/path/to/mylib
+
+  .. tab-item:: Meson
+    :sync: meson
+
+    .. code-block:: bash
+
+      python -m numpy.f2py -c fib.f90 -m fib --backend meson -lmylib -L/path/to/mylib
+
 1.3 Customizing builds
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -21,6 +21,8 @@ class MesonTemplate:
         modulename: str,
         sources: list[Path],
         deps: list[str],
+        libraries: list[str],
+        library_dirs: list[Path],
         object_files: list[Path],
         linker_args: list[str],
         c_args: list[str],
@@ -32,12 +34,15 @@ class MesonTemplate:
         )
         self.sources = sources
         self.deps = deps
+        self.libraries = libraries
+        self.library_dirs = library_dirs
         self.substitutions = {}
         self.objects = object_files
         self.pipeline = [
             self.initialize_template,
             self.sources_substitution,
             self.deps_substitution,
+            self.libraries_substitution,
         ]
         self.build_type = build_type
 
@@ -65,6 +70,29 @@ class MesonTemplate:
         indent = " " * 21
         self.substitutions["dep_list"] = f",\n{indent}".join(
             [f"dependency('{dep}')" for dep in self.deps]
+        )
+
+    def libraries_substitution(self) -> None:
+        self.substitutions["lib_dir_declarations"] = "\n".join(
+            [
+                f"lib_dir_{i} = declare_dependency(link_args : ['-L{lib_dir}'])"
+                for i, lib_dir in enumerate(self.library_dirs)
+            ]
+        )
+
+        self.substitutions["lib_declarations"] = "\n".join(
+            [
+                f"{lib} = declare_dependency(link_args : ['-l{lib}'])"
+                for lib in self.libraries
+            ]
+        )
+
+        indent = " " * 21
+        self.substitutions["lib_list"] = f"\n{indent}".join(
+            [f"{lib}," for lib in self.libraries]
+        )
+        self.substitutions["lib_dir_list"] = f"\n{indent}".join(
+            [f"lib_dir_{i}," for i in range(len(self.library_dirs))]
         )
 
     def generate_meson_build(self):
@@ -111,6 +139,8 @@ class MesonBackend(Backend):
             self.modulename,
             self.sources,
             self.dependencies,
+            self.libraries,
+            self.library_dirs,
             self.extra_objects,
             self.flib_flags,
             self.fc_flags,

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -32,6 +32,9 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 # gh-25000
 quadmath_dep = fc.find_library('quadmath', required: false)
 
+${lib_declarations}
+${lib_dir_declarations}
+
 py.extension_module('${modulename}',
                      [
 ${source_list},
@@ -42,5 +45,7 @@ ${source_list},
                      py_dep,
                      quadmath_dep,
 ${dep_list}
+${lib_list}
+${lib_dir_list}
                      ],
                      install : true)


### PR DESCRIPTION
Backport of #25297.

The current state of the f2py meson code fails to transmit external libraries necessary for linking. In contrast, the previous distutils backend successfully achieved this functionality.
I tried to add few lines of code to bring back the functionality

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
