### PR TITLE
MAINT: Run f2py's meson backend with the same python that ran f2py

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -4,6 +4,7 @@ import os
 import errno
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from ._backend import Backend
@@ -25,6 +26,7 @@ class MesonTemplate:
         linker_args: list[str],
         c_args: list[str],
         build_type: str,
+        python_exe: str,
     ):
         self.modulename = modulename
         self.build_template_path = (
@@ -40,6 +42,7 @@ class MesonTemplate:
             self.deps_substitution,
         ]
         self.build_type = build_type
+        self.python_exe = python_exe
 
     def meson_build_template(self) -> str:
         if not self.build_template_path.is_file():
@@ -54,6 +57,7 @@ class MesonTemplate:
     def initialize_template(self) -> None:
         self.substitutions["modulename"] = self.modulename
         self.substitutions["buildtype"] = self.build_type
+        self.substitutions["python"] = self.python_exe
 
     def sources_substitution(self) -> None:
         indent = " " * 21
@@ -115,6 +119,7 @@ class MesonBackend(Backend):
             self.flib_flags,
             self.fc_flags,
             self.build_type,
+            sys.executable,
         )
         src = meson_template.generate_meson_build()
         Path(build_dir).mkdir(parents=True, exist_ok=True)

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -8,7 +8,7 @@ project('${modulename}',
                           ])
 fc = meson.get_compiler('fortran')
 
-py = import('python').find_installation(pure: false)
+py = import('python').find_installation('${python}', pure: false)
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,


### PR DESCRIPTION
Backport of #25321.

On Debian, we sometimes have multiple Python 3 versions in the archive. When using f2py3.X, I'd expect meson to run with the same python, not the default python.

Not sure how far up the stack this should come from, I kept it simple for this PR, if someone has better ideas, they can direct me.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
