### PR TITLE
API: adjust nD fft ``s`` param to array API

### DIFF
--- a/doc/release/upcoming_changes/25495.deprecation.rst
+++ b/doc/release/upcoming_changes/25495.deprecation.rst
@@ -1,0 +1,16 @@
+`numpy.fft` deprecations for n-D transforms with ``None`` values in arguments
+-----------------------------------------------------------------------------
+
+Using `numpy.fft.fftn`, `numpy.fft.ifftn`, `numpy.fft.rfftn`,
+`numpy.fft.irfftn`, `numpy.fft.fft2` or `numpy.fft.ifft2` with the ``s``
+parameter set to a value that is not ``None`` and the ``axes`` parameter set
+to ``None`` has been deprecated, in line with the array API standard.
+To retain current behaviour, pass a sequence [0, ..., k-1] to ``axes`` for
+an array of dimension k.
+
+Furthermore, passing an array to ``s`` which contains ``None`` values is
+deprecated as the parameter is documented to accept a sequence of integers
+in both the NumPy docs and the array API specification. To use the default
+behaviour of the corresponding 1-D transform, pass the value matching
+the default for its ``n`` parameter. To use the default behaviour for every
+axis, the ``s`` argument can be omitted.

--- a/doc/release/upcoming_changes/25495.improvement.rst
+++ b/doc/release/upcoming_changes/25495.improvement.rst
@@ -1,0 +1,6 @@
+`numpy.fft` n-D transforms allow ``s[i] == -1``
+-----------------------------------------------
+
+`numpy.fft.fftn`, `numpy.fft.ifftn`, `numpy.fft.rfftn`, `numpy.fft.irfftn`,
+`numpy.fft.fft2`, and `numpy.fft.ifft2` now use the whole input array along
+the axis ``i`` if ``s[i] == -1``, in line with the array API specification.

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -200,6 +200,34 @@ class TestFFT1D:
             tr_op = np.transpose(op(x, axes=a), a)
             assert_allclose(op_tr, tr_op, atol=1e-6)
 
+    @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
+                                    np.fft.fft2, np.fft.ifft2])
+    def test_s_negative_1(self, op):
+        x = np.arange(100).reshape(10, 10)
+        # should use the whole input array along the first axis
+        assert op(x, s=(-1, 5), axes=(0, 1)).shape == (10, 5)
+
+    @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
+                                    np.fft.rfftn, np.fft.irfftn])
+    def test_s_axes_none(self, op):
+        x = np.arange(100).reshape(10, 10)
+        with pytest.warns(match='`axes` should not be `None` if `s`'):
+            op(x, s=(-1, 5))
+
+    @pytest.mark.parametrize("op", [np.fft.fft2, np.fft.ifft2])
+    def test_s_axes_none_2D(self, op):
+        x = np.arange(100).reshape(10, 10)
+        with pytest.warns(match='`axes` should not be `None` if `s`'):
+            op(x, s=(-1, 5), axes=None)
+
+    @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
+                                    np.fft.rfftn, np.fft.irfftn,
+                                    np.fft.fft2, np.fft.ifft2])
+    def test_s_contains_none(self, op):
+        x = random((30, 20, 10))
+        with pytest.warns(match='array containing `None` values to `s`'):
+            op(x, s=(10, None, 10), axes=(0, 1, 2))
+
     def test_all_1d_norm_preserving(self):
         # verify that round-trip transforms are norm-preserving
         x = random(30)


### PR DESCRIPTION
Towards gh-25076, closes gh-14179, closes scipy/scipy#10569

scipy/scipy#10569 reported that the `s` parameter of NumPy's nD fft functions behaves differently to the equivalent in `scipy.fft`. I checked, and there are some changes needed for array API compatibility. This PR adjusts for the following lines of [the spec](https://data-apis.org/array-api/latest/extensions/generated/array_api.fft.fftn.html#array_api.fft.fftn):

> If `s[i]` is `-1`, the whole input array along the axis `i` is used (no padding/trimming).

> If `s` is not `None`, `axes` must not be `None`.

---

To be deprecated:

"If s is not None, axes must not be None."

- Current behaviour: axes is allowed to be None

s and axes should be of type Sequence[Int]

- Current behaviour: 

- https://github.com/numpy/numpy/issues/14179

New features:

"If s[i] is -1, the whole input array along the axis i is used (no padding/trimming)."

- Current behaviour: ValueError: Invalid number of FFT data points (-1) specified.