### PR TITLE
DOC: Update a few interpreted text to verbatim/code.

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -207,12 +207,12 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
                 represented with an equal number of fewer digits, use that
                 many digits for all elements.
     legacy : string or `False`, optional
-        If set to the string `'1.13'` enables 1.13 legacy printing mode. This
+        If set to the string ``'1.13'`` enables 1.13 legacy printing mode. This
         approximates numpy 1.13 print output by including a space in the sign
         position of floats and different behavior for 0d arrays. This also
         enables 1.21 legacy printing mode (described below).
 
-        If set to the string `'1.21'` enables 1.21 legacy printing mode. This
+        If set to the string ``'1.21'`` enables 1.21 legacy printing mode. This
         approximates numpy 1.21 print output of complex structured dtypes
         by not inserting spaces after commas that separate fields and after
         colons.
@@ -681,7 +681,7 @@ def array2string(a, max_line_width=None, precision=None,
           represented with an equal number of fewer digits, use that
           many digits for all elements.
     legacy : string or `False`, optional
-        If set to the string `'1.13'` enables 1.13 legacy printing mode. This
+        If set to the string ``'1.13'`` enables 1.13 legacy printing mode. This
         approximates numpy 1.13 print output by including a space in the sign
         position of floats and different behavior for 0d arrays. If set to
         `False`, disables legacy mode. Unrecognized strings will be ignored

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1201,10 +1201,10 @@ def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     Returns
     -------
     index_array : ndarray of ints
-        Array of indices into the array. It has the same shape as `a.shape`
+        Array of indices into the array. It has the same shape as ``a.shape``
         with the dimension along `axis` removed. If `keepdims` is set to True,
         then the size of `axis` will be 1 with the resulting array having same
-        shape as `a.shape`.
+        shape as ``a.shape``.
 
     See Also
     --------
@@ -1254,7 +1254,7 @@ def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     array([[4],
            [3]])
     >>> # Same as np.amax(x, axis=-1)
-    >>> np.take_along_axis(x, np.expand_dims(index_array, axis=-1), 
+    >>> np.take_along_axis(x, np.expand_dims(index_array, axis=-1),
     ...     axis=-1).squeeze(axis=-1)
     array([4, 3])
 

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -94,7 +94,7 @@ class _Config:
         "maxopt": str or None
             utilized for target's policy '$maxopt' and the value should
             contains the maximum acceptable optimization by the compiler.
-            e.g. in gcc `'-O3'`
+            e.g. in gcc ``'-O3'``
 
         **Notes**:
             * case-sensitive for compiler names and flags
@@ -104,8 +104,8 @@ class _Config:
 
     conf_min_features : dict
         A dictionary defines the used CPU features for
-        argument option `'min'`, the key represent the CPU architecture
-        name e.g. `'x86'`. Default values provide the best effort
+        argument option ``'min'``, the key represent the CPU architecture
+        name e.g. ``'x86'``. Default values provide the best effort
         on wide range of users platforms.
 
         **Note**: case-sensitive for architecture names.

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -780,7 +780,7 @@ class StringConverter:
             value.
         missing_values : {sequence of str, None}, optional
             Sequence of strings indicating a missing value. If ``None``, then
-            the existing `missing_values` are cleared. The default is `''`.
+            the existing `missing_values` are cleared. The default is ``''``.
         locked : bool, optional
             Whether the StringConverter should be locked to prevent
             automatic upgrade or not. Default is False.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1386,13 +1386,13 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         case `delimiter` is ignored. For complex `X`, the legal options
         for `fmt` are:
 
-        * a single specifier, `fmt='%.4e'`, resulting in numbers formatted
-          like `' (%s+%sj)' % (fmt, fmt)`
+        * a single specifier, ``fmt='%.4e'``, resulting in numbers formatted
+          like ``' (%s+%sj)' % (fmt, fmt)``
         * a full string specifying every real and imaginary part, e.g.
-          `' %.4e %+.4ej %.4e %+.4ej %.4e %+.4ej'` for 3 columns
+          ``' %.4e %+.4ej %.4e %+.4ej %.4e %+.4ej'`` for 3 columns
         * a list of specifiers, one per column - in this case, the real
           and imaginary part must have separate specifiers,
-          e.g. `['%.3e + %.3ej', '(%.15e%+.15ej)']` for 2 columns
+          e.g. ``['%.3e + %.3ej', '(%.15e%+.15ej)']`` for 2 columns
     delimiter : str, optional
         String or character separating columns.
     newline : str, optional


### PR DESCRIPTION
Single backticks are meant to reference another object and sphinx/docutils is trying to fond those.

In the current sphinx theme those are rendered in italic.

For all those I assume what was meant is actually code, or verbatim.