### PR TITLE
BLD: unpin cibuildwheel [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,7 +116,7 @@ jobs:
           python-version: "3.x"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@7da7df1efc530f07d1945c00934b8cfd34be0d50 # v2.16.1
+        uses: pypa/cibuildwheel@0b04ab1040366101259658b355777e4ff2d16f83  # v2.16.4
         env:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}


### PR DESCRIPTION
PyPy has a new release, so we should be able to update cibuildwheel to the latest ~2.16.2~ 2.16.4 version

cc @charris