### PR TITLE
DOC: add pickleshare to doc dependencies

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,11 +3,14 @@ sphinx>=4.5.0
 numpydoc==1.4
 pydata-sphinx-theme==0.13.3
 sphinx-design
-ipython!=8.1.0
 scipy
 matplotlib
 pandas
 breathe>4.33.0
+ipython!=8.1.0
+# Needed for ipython>=8.17
+# https://github.com/ipython/ipython/issues/14237
+pickleshare
 
 # needed to build release notes
 towncrier


### PR DESCRIPTION
Closes #25502 

IPython>=8.17 removed the dependency on pickleshare, so we need to add it back for doc building.