### PR TITLE
BUG:Fix incorrect 'inner' method type annotation in __array_ufunc_

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1468,7 +1468,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     def __array_ufunc__(
         self,
         ufunc: ufunc,
-        method: L["__call__", "reduce", "reduceat", "accumulate", "outer", "inner"],
+        method: L["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
         *inputs: Any,
         **kwargs: Any,
     ) -> Any: ...

--- a/numpy/_typing/_ufunc.pyi
+++ b/numpy/_typing/_ufunc.pyi
@@ -39,7 +39,7 @@ class _SupportsArrayUFunc(Protocol):
     def __array_ufunc__(
         self,
         ufunc: ufunc,
-        method: Literal["__call__", "reduce", "reduceat", "accumulate", "outer", "inner"],
+        method: Literal["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
         *inputs: Any,
         **kwargs: Any,
     ) -> Any: ...

--- a/numpy/lib/mixins.pyi
+++ b/numpy/lib/mixins.pyi
@@ -17,7 +17,7 @@ class NDArrayOperatorsMixin(metaclass=ABCMeta):
     def __array_ufunc__(
         self,
         ufunc: ufunc,
-        method: L["__call__", "reduce", "reduceat", "accumulate", "outer", "inner"],
+        method: L["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
         *inputs: Any,
         **kwargs: Any,
     ) -> Any: ...


### PR DESCRIPTION
BUG:Fix incorrect 'inner' method type annotation in __array_ufunc_

Replaced the 'inner' method type annotation with 'at' in the __array_ufunc__ method signature. The 'at' method is a valid universal function method, whereas 'inner' is not recognized by NumPy's ufunc. This change corrects the static type checking issue reported in issue #25499, where using 'at' would incorrectly fail type inspection, and 'inner' would erroneously pass.

Related to issue #25499

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
