### PR TITLE
BUG: three string ufunc bugs, one leading to segfault

### DIFF
--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -109,7 +109,7 @@ struct Buffer {
     {
         Buffer<enc> old = *this;
         operator++();
-        return old; 
+        return old;
     }
 
     inline Buffer<enc>&
@@ -124,7 +124,7 @@ struct Buffer {
     {
         Buffer<enc> old = *this;
         operator--();
-        return old; 
+        return old;
     }
 
     inline npy_ucs4
@@ -151,14 +151,16 @@ struct Buffer {
     inline Buffer<enc>
     buffer_memchr(npy_ucs4 ch, int len)
     {
+        Buffer<enc> newbuf = *this;
         switch (enc) {
         case ENCODING::ASCII:
-            buf = (char *) memchr(buf, ch, len);
-            return *this;
+            newbuf.buf = (char *) memchr(buf, ch, len);
+            break;
         case ENCODING::UTF32:
-            buf = (char *) wmemchr((wchar_t *) buf, ch, len);
-            return *this;
+            newbuf.buf = (char *) wmemchr((wchar_t *) buf, ch, len);
+            break;
         }
+        return newbuf;
     }
 
     inline int

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -365,7 +365,7 @@ string_replace(Buffer<enc> buf1, Buffer<enc> buf2, Buffer<enc> buf3, npy_int64 c
         buf1 += len2;
 
         time--;
-        pos = findslice_for_replace(buf1, len1, buf2, len2);
+        pos = findslice_for_replace(buf1, end1 - buf1, buf2, len2);
     }
 
     buf1.buffer_memcpy(out, end1 - buf1);

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -213,6 +213,10 @@ class TestInformation:
                            ['12345', 'MixedCase'],
                            ['123 \t 345 \0 ', 'UPPER']]) \
                             .view(np.char.chararray)
+        # Array with longer strings, > MEMCHR_CUT_OFF in code.
+        self.C = (np.array(['ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                            '01234567890123456789012345'])
+                  .view(np.char.chararray))
 
     def test_len(self):
         assert_(issubclass(np.char.str_len(self.A).dtype.type, np.integer))
@@ -240,12 +244,24 @@ class TestInformation:
 
         assert_raises(TypeError, fail)
 
-    def test_find(self):
-        assert_(issubclass(self.A.find('a').dtype.type, np.integer))
-        assert_array_equal(self.A.find('a'), [[1, -1], [-1, 6], [-1, -1]])
-        assert_array_equal(self.A.find('3'), [[-1, -1], [2, -1], [2, -1]])
-        assert_array_equal(self.A.find('a', 0, 2), [[1, -1], [-1, -1], [-1, -1]])
-        assert_array_equal(self.A.find(['1', 'P']), [[-1, -1], [0, -1], [0, 1]])
+    @pytest.mark.parametrize(
+        "dtype, encode",
+        [("U", str),
+         ("S", lambda x: x.encode('ascii')),
+         ])
+    def test_find(self, dtype, encode):
+        A = self.A.astype(dtype)
+        assert_(issubclass(A.find(encode('a')).dtype.type, np.integer))
+        assert_array_equal(A.find(encode('a')),
+                           [[1, -1], [-1, 6], [-1, -1]])
+        assert_array_equal(A.find(encode('3')),
+                           [[-1, -1], [2, -1], [2, -1]])
+        assert_array_equal(A.find(encode('a'), 0, 2),
+                           [[1, -1], [-1, -1], [-1, -1]])
+        assert_array_equal(A.find([encode('1'), encode('P')]),
+                           [[-1, -1], [0, -1], [0, 1]])
+        C = self.C.astype(dtype)
+        assert_array_equal(C.find(encode('M')), [12, -1])
 
     def test_index(self):
 

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -454,6 +454,16 @@ class TestMethods:
                [b'12########## \t ##########45 \x00 ', b'UPPER']]
         assert_(issubclass(R.dtype.type, np.bytes_))
         assert_array_equal(R, tgt)
+        # Test special cases that should just return the input array,
+        # since replacements are not possible or do nothing.
+        S1 = self.A.replace(b'A very long byte string, longer than A', b'')
+        assert_array_equal(S1, self.A)
+        S2 = self.A.replace(b'', b'')
+        assert_array_equal(S2, self.A)
+        S3 = self.A.replace(b'3', b'3')
+        assert_array_equal(S3, self.A)
+        S4 = self.A.replace(b'3', b'', count=0)
+        assert_array_equal(S4, self.A)
 
     def test_rjust(self):
         assert_(issubclass(self.A.rjust(10).dtype.type, np.bytes_))

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2578,3 +2578,14 @@ class TestRegression:
         # gh-25295
         for _ in range(1000):
             np.isclose(np.int64(2), np.int64(2), atol=1e-15, rtol=1e-300)
+
+    def test_replace_regression(self):
+        # gh-25513 segfault
+        carr = np.char.chararray((2,), itemsize=25)
+        test_strings = [b'  4.52173913043478315E+00',
+                        b'  4.95652173913043548E+00']
+        carr[:] = test_strings
+        out = carr.replace(b"E", b"D")
+        expected = np.char.chararray((2,), itemsize=25)
+        expected[:] = [s.replace(b"E", b"D") for s in test_strings]
+        assert_array_equal(out, expected)


### PR DESCRIPTION
#25171 added string ufuncs, but unfortunately did not properly update the rather sparse test suite for `chararray`, in particular failing to test the various fast paths that were created. While one bug was fixed in #25484, not all were: as noted in #25513, the present version causes segfaults in `astropy`. It turned out there were multiple mistakes:
1. The `memchr` version of `findchar` always returns 0 for the offset;
2. In replacements, the length of the remaining buffer is not tracked, leading to buffer overflow.
3. The fast-track code for "no replacement possible" gives empty strings instead of a copy of the input;
These 3 commits fix those bugs, adding tests to avoid regressions.

I note that this only increases test coverage for these cases; a larger addition seems warranted.

Fixes #25513

EDIT: ordering changed.