### PR TITLE
REL: Prepare for the NumPy 1.26.3 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -85,6 +85,8 @@ Allan Haldane <allan.haldane@gmail.com> <ealloc@gmail.com>
 Al-Baraa El-Hag <a.elhag01@gmail.com> <48454648+a-elhag@users.noreply.github.com>
 Alok Singhal <gandalf013@gmail.com> Alok Singhal <alok@merfinllc.com>
 Alyssa Quek <alyssaquek@gmail.com>
+Andrea Bianchi<andrea_bianchi@outlook.com>
+Andrea Bianchi<andrea_bianchi@outlook.com> andrea-bia <andrea-bia@users.noreply.github.com>
 Ankit Dwivedi <adwivedi@microsoft.com>
 Ankit Dwivedi <adwivedi@microsoft.com> <ankit_dwivedi@outlook.com>
 Amir Sarabadani <ladsgroup@gmail.com>
@@ -301,6 +303,8 @@ Jerome Kelleher <jerome.kelleher@ed.ac.uk>
 Jessé Pires <jesserocha@alunos.utfpr.edu.br>
 Jessi J Zhao <35235453+jessijzhao@users.noreply.github.com>
 João Fontes Gonçalves <jfontesgoncalves@gmail.com>
+Johann Rohwer <j.m.rohwer@gmail.com>
+Johann Rohwer <j.m.rohwer@gmail.com> jmrohwer <jmrohwer@users.noreply.github.com>
 Johnathon Cusick <jonathan.cusick09@gmail.com>
 Jhong-Ken Chen (陳仲肯) <kenny.kuo.fs@gmail.com>
 Jhong-Ken Chen (陳仲肯) <kenny.kuo.fs@gmail.com> <37182101+kennychenfs@users.noreply.github.com>

--- a/doc/changelog/1.26.3-changelog.rst
+++ b/doc/changelog/1.26.3-changelog.rst
@@ -1,30 +1,3 @@
-.. currentmodule:: numpy
-
-==========================
-NumPy 1.26.3 Release Notes
-==========================
-
-NumPy 1.26.3 is a maintenance release that fixes bugs and regressions
-discovered after the 1.26.2 release. The most notable changes are the f2py bug
-fixes. The Python versions supported by this release are 3.9-3.12.
-
-
-Compatibility
-=============
-
-``f2py`` will no longer accept ambiguous ``-m`` and ``.pyf`` CLI combinations.
-When more than one ``.pyf`` file is passed, an error is raised. When both ``-m``
-and a ``.pyf`` is passed, a warning is emitted and the ``-m`` provided name is
-ignored.
-
-
-Improvements
-============
-
-``f2py`` now handles ``common`` blocks which have ``kind`` specifications from
-modules. This further expands the usability of intrinsics like
-``iso_fortran_env`` and ``iso_c_binding``.
-
 
 Contributors
 ============
@@ -51,9 +24,9 @@ names contributed a patch for the first time.
 * Thomas A Caswell
 * matoro
 
-
 Pull requests merged
 ====================
+
 A total of 42 pull requests were merged for this release.
 
 * `#25130 <https://github.com/numpy/numpy/pull/25130>`__: MAINT: prepare 1.26.x for further development
@@ -98,4 +71,3 @@ A total of 42 pull requests were merged for this release.
 * `#25489 <https://github.com/numpy/numpy/pull/25489>`__: MAINT: Update ``numpy/f2py/_backends`` from main.
 * `#25490 <https://github.com/numpy/numpy/pull/25490>`__: MAINT: Easy updates of ``f2py/*.py`` from main.
 * `#25491 <https://github.com/numpy/numpy/pull/25491>`__: MAINT: Update crackfortran.py and f2py2e.py from main
-

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -5,6 +5,7 @@ all of these occurrences but should catch almost all.
 import pytest
 
 from pathlib import Path
+import sys
 import ast
 import tokenize
 import numpy
@@ -56,6 +57,8 @@ class FindFuncs(ast.NodeVisitor):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(sys.version_info >= (3, 12),
+                    reason="Deprecation warning in ast")
 def test_warning_calls():
     # combined "ignore" and stacklevel error
     base = Path(numpy.__file__).parent


### PR DESCRIPTION
- Create 1.26.3-changelog.rst
- Update 1.26.3-notes.rst
- Update .mailmap
- Skip test that fails on internal Python 3.12 bug.

[wheel build]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
