### PR TITLE
BUG: fix incorrect strcmp implementation for unequal length strings

### DIFF
--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -290,20 +290,14 @@ struct Buffer {
             tmp2++;
         }
         while (tmp1.buf < tmp1.after) {
-            if (*tmp1 < 0) {
-                return -1;
-            }
-            if (*tmp1 > 0) {
+            if (*tmp1) {
                 return 1;
             }
             tmp1++;
         }
         while (tmp2.buf < tmp2.after) {
-            if (*tmp2 < 0) {
+            if (*tmp2) {
                 return -1;
-            }
-            if (*tmp2 > 0) {
-                return 1;
             }
             tmp2++;
         }

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -157,28 +157,34 @@ class TestChar:
 
 class TestComparisons:
     def setup_method(self):
-        self.A = np.array([['abc', '123'],
-                           ['789', 'xyz']]).view(np.char.chararray)
-        self.B = np.array([['efg', '123  '],
-                           ['051', 'tuv']]).view(np.char.chararray)
+        self.A = np.array([['abc', 'abcc', '123'],
+                           ['789', 'abc', 'xyz']]).view(np.char.chararray)
+        self.B = np.array([['efg', 'efg', '123  '],
+                           ['051', 'efgg', 'tuv']]).view(np.char.chararray)
 
     def test_not_equal(self):
-        assert_array_equal((self.A != self.B), [[True, False], [True, True]])
+        assert_array_equal((self.A != self.B),
+                           [[True, True, False], [True, True, True]])
 
     def test_equal(self):
-        assert_array_equal((self.A == self.B), [[False, True], [False, False]])
+        assert_array_equal((self.A == self.B),
+                           [[False, False, True], [False, False, False]])
 
     def test_greater_equal(self):
-        assert_array_equal((self.A >= self.B), [[False, True], [True, True]])
+        assert_array_equal((self.A >= self.B),
+                           [[False, False, True], [True, False, True]])
 
     def test_less_equal(self):
-        assert_array_equal((self.A <= self.B), [[True, True], [False, False]])
+        assert_array_equal((self.A <= self.B),
+                           [[True, True, True], [False, True, False]])
 
     def test_greater(self):
-        assert_array_equal((self.A > self.B), [[False, False], [True, True]])
+        assert_array_equal((self.A > self.B),
+                           [[False, False, False], [True, False, True]])
 
     def test_less(self):
-        assert_array_equal((self.A < self.B), [[True, False], [False, False]])
+        assert_array_equal((self.A < self.B),
+                           [[True, True, False], [False, True, False]])
 
     def test_type(self):
         out1 = np.char.equal(self.A, self.B)
@@ -191,17 +197,18 @@ class TestComparisonsMixed1(TestComparisons):
 
     def setup_method(self):
         TestComparisons.setup_method(self)
-        self.B = np.array([['efg', '123  '],
-                           ['051', 'tuv']], np.str_).view(np.char.chararray)
+        self.B = np.array(
+            [['efg', 'efg', '123  '],
+             ['051', 'efgg', 'tuv']], np.str_).view(np.char.chararray)
 
 class TestComparisonsMixed2(TestComparisons):
     """Ticket #1276"""
 
     def setup_method(self):
         TestComparisons.setup_method(self)
-        self.A = np.array([['abc', '123'],
-                           ['789', 'xyz']], np.str_) \
-                            .view(np.char.chararray)
+        self.A = np.array(
+            [['abc', 'abcc', '123'],
+             ['789', 'abc', 'xyz']], np.str_).view(np.char.chararray)
 
 class TestInformation:
     def setup_method(self):


### PR DESCRIPTION
Followup for #25515, the result of `strcmp` shouldn't depend on the characters of the longer string for characters after the length of the shorter string