### PR TITLE
MAINT: optimization and broadcasting for .replace() method for strings.

### DIFF
--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -1361,7 +1361,7 @@ def replace(a, old, new, count=None):
 
     count : int, optional
         If the optional argument `count` is given, only the first
-        `count` occurrences are replaced.
+        `count` occurrences are replaced. If negative, replace all.
 
     Returns
     -------
@@ -1385,9 +1385,10 @@ def replace(a, old, new, count=None):
     """
     a_arr = numpy.asarray(a)
     max_int64 = numpy.iinfo(numpy.int64).max
-    count = count if count is not None else max_int64
-
     counts = numpy._core.umath.count(a_arr, old, 0, max_int64)
+    if count is not None:
+        count = numpy.asarray(count)
+        counts = numpy.minimum(counts, count, where=count >= 0, out=counts)
     buffersizes = (
         numpy._core.umath.str_len(a_arr)
         + counts * (numpy._core.umath.str_len(new) -
@@ -1395,7 +1396,7 @@ def replace(a, old, new, count=None):
     )
     max_buffersize = numpy.max(buffersizes)
     out = numpy.empty(a_arr.shape, dtype=f"{a_arr.dtype.char}{max_buffersize}")
-    numpy._core.umath._replace(a_arr, old, new, count, out=out)
+    numpy._core.umath._replace(a_arr, old, new, counts, out=out)
     return out
 
 

--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -1357,16 +1357,16 @@ def replace(a, old, new, count=None):
     ----------
     a : array-like of str or unicode
 
-    old, new : str or unicode
+    old, new : scalar or array-like str or unicode
 
-    count : int, optional
+    count : scalar or array-like int
         If the optional argument `count` is given, only the first
         `count` occurrences are replaced. If negative, replace all.
 
     Returns
     -------
     out : ndarray
-        Output array of str or unicode, depending on input type
+        Output array of str or unicode, depending on input type.
 
     See Also
     --------
@@ -1383,19 +1383,24 @@ def replace(a, old, new, count=None):
     array(['The dwash was fresh', 'Thwas was it'], dtype='<U19')
     
     """
-    a_arr = numpy.asarray(a)
+    a_arr = numpy.asanyarray(a)
+    old = numpy.asanyarray(old)
+    new = numpy.asanyarray(new)
     max_int64 = numpy.iinfo(numpy.int64).max
     counts = numpy._core.umath.count(a_arr, old, 0, max_int64)
     if count is not None:
-        count = numpy.asarray(count)
-        counts = numpy.minimum(counts, count, where=count >= 0, out=counts)
+        count = numpy.asanyarray(count)
+        counts = numpy.where(count < 0, counts,
+                             numpy.minimum(counts, count))
+
     buffersizes = (
         numpy._core.umath.str_len(a_arr)
         + counts * (numpy._core.umath.str_len(new) -
                     numpy._core.umath.str_len(old))
     )
-    max_buffersize = numpy.max(buffersizes)
-    out = numpy.empty(a_arr.shape, dtype=f"{a_arr.dtype.char}{max_buffersize}")
+    # buffersizes is properly broadcast along all inputs.
+    out = numpy.empty_like(a_arr, shape=buffersizes.shape,
+                           dtype=f"{a_arr.dtype.char}{buffersizes.max()}")
     numpy._core.umath._replace(a_arr, old, new, counts, out=out)
     return out
 

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -465,6 +465,29 @@ class TestMethods:
         S4 = self.A.replace(b'3', b'', count=0)
         assert_array_equal(S4, self.A)
 
+    def test_replace_count_and_size(self):
+        a = np.array(['0123456789' * i for i in range(4)]
+                     ).view(np.char.chararray)
+        r1 = a.replace('5', 'ABCDE')
+        assert r1.dtype.itemsize == (3*10 + 3*4) * 4
+        assert_array_equal(r1, np.array(['01234ABCDE6789' * i
+                                         for i in range(4)]))
+        r2 = a.replace('5', 'ABCDE', count=1)
+        assert r2.dtype.itemsize == (3*10 + 4) * 4
+        r3 = a.replace('5', 'ABCDE', count=0)
+        assert r3.dtype.itemsize == a.dtype.itemsize
+        assert_array_equal(r3, a)
+        # Negative values mean to replace all.
+        r4 = a.replace('5', 'ABCDE', count=-1)
+        assert r4.dtype.itemsize == (3*10 + 3*4) * 4
+        assert_array_equal(r4, r1)
+        # We can do count on an element-by-element basis.
+        r5 = a.replace('5', 'ABCDE', count=[-1, -1, -1, 1])
+        assert r5.dtype.itemsize == (3*10 + 4) * 4
+        assert_array_equal(r5, np.array(
+            ['01234ABCDE6789' * i for i in range(3)]
+            + ['01234ABCDE6789' + '0123456789' * 2]))
+
     def test_rjust(self):
         assert_(issubclass(self.A.rjust(10).dtype.type, np.bytes_))
 

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -488,6 +488,17 @@ class TestMethods:
             ['01234ABCDE6789' * i for i in range(3)]
             + ['01234ABCDE6789' + '0123456789' * 2]))
 
+    def test_replace_broadcasting(self):
+        a = np.array('0,0,0').view(np.char.chararray)
+        r1 = a.replace('0', '1', count=np.arange(3))
+        assert r1.dtype == a.dtype
+        assert_array_equal(r1, np.array(['0,0,0', '1,0,0', '1,1,0']))
+        r2 = a.replace('0', [['1'], ['2']], count=np.arange(1, 4))
+        assert_array_equal(r2, np.array([['1,0,0', '1,1,0', '1,1,1'],
+                                         ['2,0,0', '2,2,0', '2,2,2']]))
+        r3 = a.replace(['0', '0,0', '0,0,0'], 'X')
+        assert_array_equal(r3, np.array(['X,X,X', 'X,0', 'X']))
+
     def test_rjust(self):
         assert_(issubclass(self.A.rjust(10).dtype.type, np.bytes_))
 


### PR DESCRIPTION
The `.replace()` methods counts the number of matches in order to know the new size. This PR passes on the resulting counts array to the replace ufunc, since if count is 0, the fast path can be taken.  Small example of time gain:
```
In [1]: a = np.array(['ABCDEFGHIJKLMNOPQRSTUVWXYZ' * 100] * 10).view(np.char.chararray)

In [2]: %timeit a.replace('0123456', '')
# This PR
33.2 µs ± 102 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# Current main
45.1 µs ± 16.9 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

p.s. As a side benefit, this also fixes a small bug in the output size calculation, which used the maximum possible number of replacements, not taking into account the requested `count`.

EDIT: the second commit ensures that all inputs properly broadcast against each other for the output, which is easy to do and seems nice to have, since the idea of these functions is to behave like ufuncs. I can separate this one off if controversial.
