### PR TITLE
DOC: Indicate order is kwarg-only for ndarray.reshape.

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3761,7 +3761,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('repeat',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('reshape',
     """
-    a.reshape(shape, /, order='C')
+    a.reshape(shape, /, *, order='C')
 
     Returns an array containing the same data with a new shape.
 


### PR DESCRIPTION
Followup to #24953 that closes #25514.