### PR TITLE
ENH: add ability to use weights that align with specified axis in num…

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -421,7 +421,9 @@ def average(a, axis=None, weights=None, returned=False, *,
         If `weights=None`, then all data in `a` are assumed to have a
         weight equal to one.
         The calculation is::
+
             avg = sum(a * weights) / sum(weights)
+        
         where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -513,7 +513,8 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> np.average(data, axis=0, weights=[[1./4, 3./4], [1., 1./2]])
     Traceback (most recent call last):
         ...
-    ValueError: Weight dimensions should be consistent with specified axis.
+    ValueError: Shape of weights must be consistent
+    with shape of a along specified axis.
     """
     a = np.asanyarray(a)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -417,9 +417,12 @@ def average(a, axis=None, weights=None, returned=False, *,
         `a` contributes to the average according to its associated weight.
         The array of weights must be the same shape as `a` if no axis is
         specified, otherwise the weights must have dimensions and shape
-        consistent with `a` along the specified axis..
+        consistent with `a` along the specified axis.
         If `weights=None`, then all data in `a` are assumed to have a
         weight equal to one.
+        The calculation is::
+            avg = sum(a * weights) / sum(weights)
+        where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.
     returned : bool, optional
@@ -511,12 +514,6 @@ def average(a, axis=None, weights=None, returned=False, *,
     Traceback (most recent call last):
         ...
     ValueError: Weight dimensions should be consistent with specified axis.
-
-    >>> a = np.ones(5, dtype=np.float64)
-    >>> w = np.ones(5, dtype=np.complex64)
-    >>> avg = np.average(a, weights=w)
-    >>> print(avg.dtype)
-    complex128
     """
     a = np.asanyarray(a)
 
@@ -547,14 +544,10 @@ def average(a, axis=None, weights=None, returned=False, *,
                 raise TypeError(
                     "Axis must be specified when shapes of a and weights "
                     "differ.")
-            if wgt.ndim != len(axis):
-                raise ValueError(
-                    "Weight dimensions should be "
-                    "consistent with specified axis.")
             if wgt.shape != tuple(a.shape[ax] for ax in axis):
                 raise ValueError(
-                    "Weight shape should be "
-                    "consistent with a along specified axis.")
+                    "Shape of weights must be consistent with "
+                    "shape of a along specified axis.")
 
             # setup wgt to broadcast along axis
             wgt = wgt.transpose(np.argsort(axis))

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -492,6 +492,13 @@ def average(a, axis=None, weights=None, returned=False, *,
         ...
     TypeError: Axis must be specified when shapes of a and weights differ.
 
+    With ``keepdims=True``, the following result has shape (3, 1).
+
+    >>> np.average(data, axis=1, keepdims=True)
+    array([[0.5],
+           [2.5],
+           [4.5]])
+
     >>> data = np.arange(8).reshape((2, 2, 2))
     >>> data
     array([[[0, 1],
@@ -510,13 +517,6 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> avg = np.average(a, weights=w)
     >>> print(avg.dtype)
     complex128
-
-    With ``keepdims=True``, the following result has shape (3, 1).
-
-    >>> np.average(data, axis=1, keepdims=True)
-    array([[0.5],
-           [2.5],
-           [4.5]])
     """
     a = np.asanyarray(a)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -551,14 +551,17 @@ def average(a, axis=None, weights=None, returned=False, *,
                     "differ.")
             if np.array(axis).shape[0] != wgt.ndim:
                 raise ValueError(
-                    "Weight dimensions should be consistent with specified axis.")
+                    "Weight dimensions should be "
+                    "consistent with specified axis.")
             if not (wgt.shape == np.array(a.shape)[np.array(axis)]).all():
                 raise ValueError(
-                    "Weight shape should be consistent with a along specified axis.")
+                    "Weight shape should be "
+                    "consistent with a along specified axis.")
 
             # setup wgt to broadcast along axis
             orig_wgt_ndim = wgt.ndim
-            wgt = np.broadcast_to(wgt, (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape)
+            wgt = np.broadcast_to(wgt,
+                                  (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape)
             for i, _ax in enumerate(axis):
                 wgt = wgt.swapaxes(-orig_wgt_ndim + i, _ax)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -496,7 +496,6 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> data
     array([[[0, 1],
             [2, 3]],
-
            [[4, 5],
             [6, 7]]])
     >>> np.average(data, axis=(0, 1), weights=[[1./4, 3./4], [1., 1./2]])

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -404,7 +404,7 @@ def average(a, axis=None, weights=None, returned=False, *,
         conversion is attempted.
     axis : None or int or tuple of ints, optional
         Axis or axes along which to average `a`.  The default,
-        axis=None, will average over all of the elements of the input array.
+        `axis=None`, will average over all of the elements of the input array.
         If axis is negative it counts from the last to the first axis.
 
         .. versionadded:: 1.7.0
@@ -415,14 +415,13 @@ def average(a, axis=None, weights=None, returned=False, *,
     weights : array_like, optional
         An array of weights associated with the values in `a`. Each value in
         `a` contributes to the average according to its associated weight.
-        The weights array can either be 1-D (in which case its length must be
-        the size of `a` along the given axis) or of the same shape as `a`.
+        The array of weights must be the same shape as `a` if no axis is specified,
+        otherwise the weights must have dimensions and shape consistent with `a`
+        along the specified axis.
         If `weights=None`, then all data in `a` are assumed to have a
-        weight equal to one.  The 1-D calculation is::
-
-            avg = sum(a * weights) / sum(weights)
-
-        The only constraint on `weights` is that `sum(weights)` must not be 0.
+        weight equal to one.
+        The only constraint on the values of `weights` is that `sum(weights)`
+        must not be 0.
     returned : bool, optional
         Default is `False`. If `True`, the tuple (`average`, `sum_of_weights`)
         is returned, otherwise only the average is returned.
@@ -457,8 +456,10 @@ def average(a, axis=None, weights=None, returned=False, *,
         When all weights along axis are zero. See `numpy.ma.average` for a
         version robust to this type of error.
     TypeError
-        When the length of 1D `weights` is not the same as the shape of `a`
-        along axis.
+        When `weights` does not have the same shape as `a`, and `axis=None`.
+    ValueError
+        When `weights` does not have dimensions and shape consistent with `a`
+        along specified `axis`.
 
     See Also
     --------
@@ -491,6 +492,20 @@ def average(a, axis=None, weights=None, returned=False, *,
         ...
     TypeError: Axis must be specified when shapes of a and weights differ.
 
+    >>> data = np.arange(8).reshape((2, 2, 2))
+    >>> data
+    array([[[0, 1],
+            [2, 3]],
+
+           [[4, 5],
+            [6, 7]]])
+    >>> np.average(data, axis=(0, 1), weights=[[1./4, 3./4], [1., 1./2]])
+    array([3.4, 4.4])
+    >>> np.average(data, axis=0, weights=[[1./4, 3./4], [1., 1./2]])
+    Traceback (most recent call last):
+        ...
+    ValueError: Weight dimensions should be consistent with specified axis.
+
     >>> a = np.ones(5, dtype=np.float64)
     >>> w = np.ones(5, dtype=np.complex64)
     >>> avg = np.average(a, weights=w)
@@ -505,6 +520,10 @@ def average(a, axis=None, weights=None, returned=False, *,
            [4.5]])
     """
     a = np.asanyarray(a)
+
+    # cast axis to tuple if not already
+    if axis is not None and np.array(axis).ndim == 0:
+        axis = (axis,)
 
     if keepdims is np._NoValue:
         # Don't pass on the keepdims argument if one wasn't given.
@@ -530,16 +549,18 @@ def average(a, axis=None, weights=None, returned=False, *,
                 raise TypeError(
                     "Axis must be specified when shapes of a and weights "
                     "differ.")
-            if wgt.ndim != 1:
-                raise TypeError(
-                    "1D weights expected when shapes of a and weights differ.")
-            if wgt.shape[0] != a.shape[axis]:
+            if np.array(axis).shape[0] != wgt.ndim:
                 raise ValueError(
-                    "Length of weights not compatible with specified axis.")
+                    "Weight dimensions should be consistent with specified axis.")
+            if not (wgt.shape == np.array(a.shape)[np.array(axis)]).all():
+                raise ValueError(
+                    "Weight shape should be consistent with a along specified axis.")
 
             # setup wgt to broadcast along axis
-            wgt = np.broadcast_to(wgt, (a.ndim-1)*(1,) + wgt.shape)
-            wgt = wgt.swapaxes(-1, axis)
+            orig_wgt_ndim = wgt.ndim
+            wgt = np.broadcast_to(wgt, (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape)
+            for i, _ax in enumerate(axis):
+                wgt = wgt.swapaxes(-orig_wgt_ndim + i, _ax)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype, **keepdims_kw)
         if np.any(scl == 0.0):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -350,7 +350,8 @@ class TestAverage:
         # weights and input have different shapes but no axis is specified
         with pytest.raises(
                 TypeError,
-                match="Axis must be specified when shapes of a and weights differ"):
+                match="Axis must be specified when shapes of a "
+                      "and weights differ"):
             average(y1, weights=w1)
 
         # 2D Case

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -348,9 +348,9 @@ class TestAverage:
         assert_almost_equal(actual, desired)
 
         # weights and input have different shapes but no axis is specified
-        with assert_raises_regex(
+        with pytest.raises(
                 TypeError,
-                "Axis must be specified when shapes of a and weights differ"):
+                match="Axis must be specified when shapes of a and weights differ"):
             average(y1, weights=w1)
 
         # 2D Case
@@ -396,18 +396,17 @@ class TestAverage:
         desired = np.array([4.75, 7.75])
         assert_almost_equal(actual, desired)
 
-        # here the weights have the wrong dimensions for the specified axes
-        with np.testing.assert_raises_regex(
+        # here the weights have the wrong shape for the specified axes
+        with pytest.raises(
                 ValueError,
-                "Weight dimensions should be "
-                "consistent with specified axis"):
+                match="Shape of weights must be consistent with "
+                      "shape of a along specified axis"):
             average(y, axis=(0, 1, 2), weights=subw0)
 
-        # here the weights have the wrong shape for the specified axes
-        with np.testing.assert_raises_regex(
+        with pytest.raises(
                 ValueError,
-                "Weight shape should be "
-                "consistent with a along specified axis"):
+                match="Shape of weights must be consistent with "
+                      "shape of a along specified axis"):
             average(y, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -347,8 +347,9 @@ class TestAverage:
         desired = np.array([3., 6.])
         assert_almost_equal(actual, desired)
 
-        # This should raise an error. Can we test for that ?
-        # assert_equal(average(y1, weights=w1), 9./2.)
+        # weights and input have different shapes but no axis is specified
+        with assert_raises_regex(TypeError, "Axis must be specified when shapes of a and weights differ"):
+            average(y1, weights=w1)
 
         # 2D Case
         w2 = [[0, 0, 1], [0, 0, 2]]
@@ -372,6 +373,44 @@ class TestAverage:
         actual = np.average(x, weights=w, axis=1, keepdims=True)
         desired = np.array([[2.], [3.], [4.]])
         assert_array_equal(actual, desired)
+
+    def test_weight_and_input_dims_different(self):
+        y = np.arange(12).reshape(2, 2, 3)
+        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.]).reshape(2, 2, 3)
+
+        subw0 = w[:, :, 0]
+        actual = average(y, axis=(0, 1), weights=subw0)
+        desired = np.array([7., 8., 9.])
+        assert_almost_equal(actual, desired)
+
+        subw1 = w[1, :, :]
+        actual = average(y, axis=(1, 2), weights=subw1)
+        desired = np.array([2.25, 8.25])
+        assert_almost_equal(actual, desired)
+
+        subw2 = w[:, 0, :]
+        actual = average(y, axis=(0, 2), weights=subw2)
+        desired = np.array([4.75, 7.75])
+        assert_almost_equal(actual, desired)
+
+        # here the weights have the wrong dimensions for the specified axes
+        with np.testing.assert_raises_regex(ValueError,
+                                            "Weight dimensions should be consistent with specified axis"):
+            average(y, axis=(0, 1, 2), weights=subw0)
+
+        # here the weights have the wrong shape for the specified axes
+        with np.testing.assert_raises_regex(ValueError,
+                                            "Weight shape should be consistent with a along specified axis"):
+            average(y, axis=(0, 1), weights=subw1)
+
+        # swapping the axes should be same as transposing weights
+        actual = average(y, axis=(1, 0), weights=subw0)
+        desired = average(y, axis=(0, 1), weights=subw0.T)
+        assert_almost_equal(actual, desired)
+
+        # if average over all axes, should have float output
+        actual = average(y, axis=(0, 1, 2), weights=w)
+        assert_(actual.ndim == 0)
 
     def test_returned(self):
         y = np.array([[1, 2, 3], [4, 5, 6]])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -399,13 +399,15 @@ class TestAverage:
         # here the weights have the wrong dimensions for the specified axes
         with np.testing.assert_raises_regex(
                 ValueError,
-                "Weight dimensions should be consistent with specified axis"):
+                "Weight dimensions should be "
+                "consistent with specified axis"):
             average(y, axis=(0, 1, 2), weights=subw0)
 
         # here the weights have the wrong shape for the specified axes
         with np.testing.assert_raises_regex(
                 ValueError,
-                "Weight shape should be consistent with a along specified axis"):
+                "Weight shape should be "
+                "consistent with a along specified axis"):
             average(y, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -348,7 +348,9 @@ class TestAverage:
         assert_almost_equal(actual, desired)
 
         # weights and input have different shapes but no axis is specified
-        with assert_raises_regex(TypeError, "Axis must be specified when shapes of a and weights differ"):
+        with assert_raises_regex(
+                TypeError,
+                "Axis must be specified when shapes of a and weights differ"):
             average(y1, weights=w1)
 
         # 2D Case
@@ -376,7 +378,8 @@ class TestAverage:
 
     def test_weight_and_input_dims_different(self):
         y = np.arange(12).reshape(2, 2, 3)
-        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.]).reshape(2, 2, 3)
+        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.])\
+            .reshape(2, 2, 3)
 
         subw0 = w[:, :, 0]
         actual = average(y, axis=(0, 1), weights=subw0)
@@ -394,13 +397,15 @@ class TestAverage:
         assert_almost_equal(actual, desired)
 
         # here the weights have the wrong dimensions for the specified axes
-        with np.testing.assert_raises_regex(ValueError,
-                                            "Weight dimensions should be consistent with specified axis"):
+        with np.testing.assert_raises_regex(
+                ValueError,
+                "Weight dimensions should be consistent with specified axis"):
             average(y, axis=(0, 1, 2), weights=subw0)
 
         # here the weights have the wrong shape for the specified axes
-        with np.testing.assert_raises_regex(ValueError,
-                                            "Weight shape should be consistent with a along specified axis"):
+        with np.testing.assert_raises_regex(
+                ValueError,
+                "Weight shape should be consistent with a along specified axis"):
             average(y, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -35,6 +35,7 @@ from numpy import ndarray, array as nxarray
 from numpy.lib.array_utils import normalize_axis_index, normalize_axis_tuple
 from numpy.lib._function_base_impl import _ureduce
 from numpy.lib._index_tricks_impl import AxisConcatenator
+from numpy._core.numeric import normalize_axis_tuple
 
 
 def issequence(seq):
@@ -539,9 +540,9 @@ def average(a, axis=None, weights=None, returned=False, *,
     weights : array_like, optional
         An array of weights associated with the values in `a`. Each value in
         `a` contributes to the average according to its associated weight.
-        The array of weights must be the same shape as `a` if no axis is specified,
-        otherwise the weights must have dimensions and shape consistent with `a`
-        along the specified axis.
+        The array of weights must be the same shape as `a` if no axis is
+        specified, otherwise the weights must have dimensions and shape
+        consistent with `a` along the specified axis.
         If `weights=None`, then all data in `a` are assumed to have a
         weight equal to one.
         The only constraint on the values of `weights` is that `sum(weights)`
@@ -630,9 +631,8 @@ def average(a, axis=None, weights=None, returned=False, *,
     a = asarray(a)
     m = getmask(a)
 
-    # cast axis to tuple if not already
-    if axis is not None and np.array(axis).ndim == 0:
-        axis = (axis,)
+    if axis is not None:
+        axis = normalize_axis_tuple(axis, a.ndim, argname="axis")
 
     if keepdims is np._NoValue:
         # Don't pass on the keepdims argument if one wasn't given.
@@ -657,22 +657,19 @@ def average(a, axis=None, weights=None, returned=False, *,
                 raise TypeError(
                     "Axis must be specified when shapes of a and weights "
                     "differ.")
-            if np.array(axis).shape[0] != wgt.ndim:
+            if wgt.ndim != len(axis):
                 raise ValueError(
                     "Weight dimensions should be "
                     "consistent with specified axis.")
-            if not (wgt.shape == np.array(a.shape)[np.array(axis)]).all():
+            if wgt.shape != tuple(a.shape[ax] for ax in axis):
                 raise ValueError(
                     "Weight shape should be "
                     "consistent with a along specified axis.")
 
             # setup wgt to broadcast along axis
-            orig_wgt_ndim = wgt.ndim
-            wgt = np.broadcast_to(wgt,
-                                  (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape,
-                                  subok=True)
-            for i, _ax in enumerate(axis):
-                wgt = wgt.swapaxes(-orig_wgt_ndim + i, _ax)
+            wgt = wgt.transpose(np.argsort(axis))
+            wgt = wgt.reshape(tuple((s if ax in axis else 1)
+                                    for ax, s in enumerate(a.shape)))
 
         if m is not nomask:
             wgt = wgt*(~a.mask)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -545,6 +545,9 @@ def average(a, axis=None, weights=None, returned=False, *,
         consistent with `a` along the specified axis.
         If `weights=None`, then all data in `a` are assumed to have a
         weight equal to one.
+        The calculation is::
+            avg = sum(a * weights) / sum(weights)
+        where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.
     returned : bool, optional
@@ -656,14 +659,10 @@ def average(a, axis=None, weights=None, returned=False, *,
                 raise TypeError(
                     "Axis must be specified when shapes of a and weights "
                     "differ.")
-            if wgt.ndim != len(axis):
-                raise ValueError(
-                    "Weight dimensions should be "
-                    "consistent with specified axis.")
             if wgt.shape != tuple(a.shape[ax] for ax in axis):
                 raise ValueError(
-                    "Weight shape should be "
-                    "consistent with a along specified axis.")
+                    "Shape of weights must be consistent with "
+                    "shape of a along specified axis.")
 
             # setup wgt to broadcast along axis
             wgt = wgt.transpose(np.argsort(axis))

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -599,7 +599,6 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> data
     array([[[0, 1],
             [2, 3]],
-
            [[4, 5],
             [6, 7]]])
     >>> np.ma.average(data, axis=(0, 1), weights=[[1./4, 3./4], [1., 1./2]])

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -611,7 +611,8 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> np.ma.average(data, axis=0, weights=[[1./4, 3./4], [1., 1./2]])
     Traceback (most recent call last):
         ...
-    ValueError: Weight dimensions should be consistent with specified axis.
+    ValueError: Shape of weights must be consistent
+    with shape of a along specified axis.
 
     >>> avg, sumweights = np.ma.average(x, axis=0, weights=[1, 2, 3],
     ...                                 returned=True)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -659,14 +659,18 @@ def average(a, axis=None, weights=None, returned=False, *,
                     "differ.")
             if np.array(axis).shape[0] != wgt.ndim:
                 raise ValueError(
-                    "Weight dimensions should be consistent with specified axis.")
+                    "Weight dimensions should be "
+                    "consistent with specified axis.")
             if not (wgt.shape == np.array(a.shape)[np.array(axis)]).all():
                 raise ValueError(
-                    "Weight shape should be consistent with a along specified axis.")
+                    "Weight shape should be "
+                    "consistent with a along specified axis.")
 
             # setup wgt to broadcast along axis
             orig_wgt_ndim = wgt.ndim
-            wgt = np.broadcast_to(wgt, (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape, subok=True)
+            wgt = np.broadcast_to(wgt,
+                                  (a.ndim - orig_wgt_ndim) * (1,) + wgt.shape,
+                                  subok=True)
             for i, _ax in enumerate(axis):
                 wgt = wgt.swapaxes(-orig_wgt_ndim + i, _ax)
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -546,7 +546,9 @@ def average(a, axis=None, weights=None, returned=False, *,
         If `weights=None`, then all data in `a` are assumed to have a
         weight equal to one.
         The calculation is::
+
             avg = sum(a * weights) / sum(weights)
+
         where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -287,13 +287,15 @@ class TestAverage:
         # here the weights have the wrong dimensions for the specified axes
         with np.testing.assert_raises_regex(
                 ValueError,
-                "Weight dimensions should be consistent with specified axis"):
+                "Weight dimensions should be "
+                "consistent with specified axis"):
             average(yma, axis=(0, 1, 2), weights=subw0)
 
         # here the weights have the wrong shape for the specified axes
         with np.testing.assert_raises_regex(
                 ValueError,
-                "Weight shape should be consistent with a along specified axis"):
+                "Weight shape should be "
+                "consistent with a along specified axis"):
             average(yma, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -251,6 +251,53 @@ class TestAverage:
         desired = masked_array([[2.], [3.], [4.]], [[False], [False], [True]])
         assert_equal(actual, desired)
 
+
+    def test_weight_and_input_dims_different(self):
+        # this test mirrors a test for np.average() in lib/test/test_function_base.py
+        y = np.arange(12).reshape(2, 2, 3)
+        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.]).reshape(2, 2, 3)
+
+        m = np.full((2, 2, 3), False)
+        yma = np.ma.array(y, mask=m)
+        subw0 = w[:, :, 0]
+
+        actual = average(yma, axis=(0, 1), weights=subw0)
+        desired = masked_array([7., 8., 9.], mask=[False, False, False])
+        assert_almost_equal(actual, desired)
+
+        m = np.full((2, 2, 3), False)
+        m[:, :, 0] = True
+        m[0, 0, 1] = True
+        yma = np.ma.array(y, mask=m)
+        actual = average(yma, axis=(0, 1), weights=subw0)
+        desired = masked_array(
+            [np.nan, 8., 9.],
+            mask=[True, False, False])
+        assert_almost_equal(actual, desired)
+
+        m = np.full((2, 2, 3), False)
+        yma = np.ma.array(y, mask=m)
+
+        subw1 = w[1, :, :]
+        actual = average(yma, axis=(1, 2), weights=subw1)
+        desired = masked_array([2.25, 8.25], mask=[False, False])
+        assert_almost_equal(actual, desired)
+
+        # here the weights have the wrong dimensions for the specified axes
+        with np.testing.assert_raises_regex(ValueError,
+                                            "Weight dimensions should be consistent with specified axis"):
+            average(yma, axis=(0, 1, 2), weights=subw0)
+
+        # here the weights have the wrong shape for the specified axes
+        with np.testing.assert_raises_regex(ValueError,
+                                            "Weight shape should be consistent with a along specified axis"):
+            average(yma, axis=(0, 1), weights=subw1)
+
+        # swapping the axes should be same as transposing weights
+        actual = average(yma, axis=(1, 0), weights=subw0)
+        desired = average(yma, axis=(0, 1), weights=subw0.T)
+        assert_almost_equal(actual, desired)
+
     def test_onintegers_with_mask(self):
         # Test average on integers with mask
         a = average(array([1, 2]))

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -284,18 +284,17 @@ class TestAverage:
         desired = masked_array([2.25, 8.25], mask=[False, False])
         assert_almost_equal(actual, desired)
 
-        # here the weights have the wrong dimensions for the specified axes
-        with np.testing.assert_raises_regex(
-                ValueError,
-                "Weight dimensions should be "
-                "consistent with specified axis"):
+        # here the weights have the wrong shape for the specified axes
+        with pytest.raises(
+                    ValueError,
+                    match="Shape of weights must be consistent with "
+                          "shape of a along specified axis"):
             average(yma, axis=(0, 1, 2), weights=subw0)
 
-        # here the weights have the wrong shape for the specified axes
-        with np.testing.assert_raises_regex(
+        with pytest.raises(
                 ValueError,
-                "Weight shape should be "
-                "consistent with a along specified axis"):
+                match="Shape of weights must be consistent with "
+                      "shape of a along specified axis"):
             average(yma, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -286,9 +286,9 @@ class TestAverage:
 
         # here the weights have the wrong shape for the specified axes
         with pytest.raises(
-                    ValueError,
-                    match="Shape of weights must be consistent with "
-                          "shape of a along specified axis"):
+                ValueError,
+                match="Shape of weights must be consistent with "
+                      "shape of a along specified axis"):
             average(yma, axis=(0, 1, 2), weights=subw0)
 
         with pytest.raises(

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -251,11 +251,12 @@ class TestAverage:
         desired = masked_array([[2.], [3.], [4.]], [[False], [False], [True]])
         assert_equal(actual, desired)
 
-
     def test_weight_and_input_dims_different(self):
-        # this test mirrors a test for np.average() in lib/test/test_function_base.py
+        # this test mirrors a test for np.average()
+        # in lib/test/test_function_base.py
         y = np.arange(12).reshape(2, 2, 3)
-        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.]).reshape(2, 2, 3)
+        w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.])\
+            .reshape(2, 2, 3)
 
         m = np.full((2, 2, 3), False)
         yma = np.ma.array(y, mask=m)
@@ -284,13 +285,15 @@ class TestAverage:
         assert_almost_equal(actual, desired)
 
         # here the weights have the wrong dimensions for the specified axes
-        with np.testing.assert_raises_regex(ValueError,
-                                            "Weight dimensions should be consistent with specified axis"):
+        with np.testing.assert_raises_regex(
+                ValueError,
+                "Weight dimensions should be consistent with specified axis"):
             average(yma, axis=(0, 1, 2), weights=subw0)
 
         # here the weights have the wrong shape for the specified axes
-        with np.testing.assert_raises_regex(ValueError,
-                                            "Weight shape should be consistent with a along specified axis"):
+        with np.testing.assert_raises_regex(
+                ValueError,
+                "Weight shape should be consistent with a along specified axis"):
             average(yma, axis=(0, 1), weights=subw1)
 
         # swapping the axes should be same as transposing weights


### PR DESCRIPTION
## np.average() and weight dimensionality

### Summary 
This PR intends to address the limitation that the weights supplied as an optional argument in `np.average()` can only be the same shape as the input array, or one-dimensional. With these changes, weights that have the same shape as the input array over the specified `axis` can be supplied. The PR also makes some minor improvements to the sanity checks on the weights. We have implemented the extension for both `np.average()` and `np.ma.average()`, and added tests for the new functionality (all preexisting tests pass).

### Details

Some functionalities of the `numpy.average()` function can be improved, and the treatment of weights in particular. 

Currently, `np.average()` is restricted to weights that are either 
  1. the same shape as the input array, or 
  2. one-dimensional. 

This restriction is not necessary and is disadvantageous when averaging over subdimensions the input array via supplying the `axis` argument. 

If it's possible to average over subdimensions of the input array via `axis`, then it is useful to be able to supply
weights in accordance, checking that they have the required dimensionality and shape.

Consider, for example,

```python
y = np.arange(12).reshape(2, 2, 3)
w = np.array([0., 0., 1., .5, .5, 0., 0., .5, .5, 1., 0., 0.]).reshape(2, 2, 3)
```
both the input array `y` and the weights `w` have shape `(2, 2, 3)`.

If I want to average over the whole array, that is OK:

```python
np.average(y, weights=w)

5.5
```
or over a one-dimensional subset (`axis=0`):

```python
np.average(y, axis=0 weights=w[:, 0, 1])

array([[ 6.,  7.,  8.],
       [ 9., 10., 11.]])
```
   
If, however, I want to average a subdimensions of `y` that are not one-dimensional, 
and supply weights with the same shape as the subdimensions, that is not possible:

```python
np.average(y, axis=(0, 1) weights=w[:, :, 1])

TypeError: 1D weights expected when shapes of a and weights differ.
```
Of course, I can add an extra dimension to my weights to make them the same 
shape of `y` and get around this limitation, however, depending on the shape of
`a` in the dimension that is _not_ being averaged over, that might be very 
expensive in terms of memory and perhaps prohibitively so (it was for me in one case).

This PR addresses this limitation.

Moreover, some of the checks on the weights could be improved,
for example with the previous implementation if I supplied 1d weights but a tuple for the `axis`:

```python
np.average(y, axis=(0, 1), weights=w[0, 0, :])

TypeError: tuple indices must be integers or slices, not tuple
```

This issue is not caught by one of the sanity checks and the error message does not clearly tell the user what has gone wrong.

This PR improves that as well.

The main idea was to generalise the function `np.average()`, but I ended up doing the same for `np.ma.average()` too, for completeness, even though I have relatively little experience with masked arrays.

The implementations have been tested in `lib/tests/test_function_base.py` and 
`ma/tests/test_extras.py`, respectively. The two sets of tests mirror one another. All preexisting tests pass.

I'd appreciate if people could kindly take a look at this PR and let know any
feedback they have.