### PR TITLE
MAINT: Update copyright to 2024 (LICENSE & DOC)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2023, NumPy Developers.
+Copyright (c) 2005-2024, NumPy Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,7 +114,7 @@ source_suffix = '.rst'
 
 # General substitutions.
 project = 'NumPy'
-copyright = '2008-2023, NumPy Developers'
+copyright = '2008-2024, NumPy Developers'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
This PR is for updating the NumPy copyright to the new year (2024).

Changed files:
- `LICENSE.txt`
- `doc/source/conf.py`

Wishing peace and good events in the new year! 😃 