### PR TITLE
BUG: support axes argument in np.linalg.tensordot

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3212,8 +3212,7 @@ def matmul(x1, x2, /):
 
 # tensordot
 
-def _tensordot_dispatcher(
-        x1, x2, /, *, offset=None, dtype=None):
+def _tensordot_dispatcher(x1, x2, /, *, axes=None):
     return (x1, x2)
 
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2307,6 +2307,7 @@ def test_tensordot():
     x = np.arange(6).reshape((2, 3))
 
     assert np.linalg.tensordot(x, x) == 55
+    assert np.linalg.tensordot(x, x, axes=[(0, 1), (0, 1)]) == 55
 
 
 def test_matmul():


### PR DESCRIPTION
This is broken at HEAD because of a typo in `_tensordot_dispatcher`:
```python
In [1]: import numpy as np

In [2]: np.__version__
Out[2]: '2.0.0.dev0+git20240106.42fef42'

In [3]: x = np.arange(6).reshape((2, 3))

In [4]: np.linalg.tensordot(x, x, axes=2)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 np.linalg.tensordot(x, x, axes=2)

TypeError: tensordot() got an unexpected keyword argument 'axes'
```