### PR TITLE
SIMD: Extend the enabled targets for Google Highway quicksort

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,10 @@ option('mkl-threading', type: 'string', value: 'auto',
         description: 'MKL threading method, one of: `seq`, `iomp`, `gomp`, `tbb`')
 option('disable-svml', type: 'boolean', value: false,
         description: 'Disable building against SVML')
+option('disable-highway', type: 'boolean', value: false,
+        description: 'Disables SIMD-optimized operations related to Google Highway')
+option('disable-intel-sort', type: 'boolean', value: false,
+        description: 'Disables SIMD-optimized operations related to Intel x86-simd-sort')
 option('disable-threading', type: 'boolean', value: false,
         description: 'Disable threading support (see `NPY_ALLOW_THREADS` docs)')
 option('disable-optimization', type: 'boolean', value: false,

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -802,14 +802,14 @@ foreach gen_mtargets : [
     'highway_qsort.dispatch.h',
     'src/npysort/highway_qsort.dispatch.cpp',
     use_highway ? [
-      SVE, ASIMD, VSX2, VXE
+      SVE, ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
     ] : []
   ],
   [
     'highway_qsort_16bit.dispatch.h',
     'src/npysort/highway_qsort_16bit.dispatch.cpp',
     use_highway ? [
-      ASIMDHP, VSX2, VXE
+      ASIMDHP, VSX2,  # VXE FIXME: disable VXE due to runtime segfault
     ] : []
   ],
 ]

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -82,9 +82,10 @@ cdata = configuration_data()
 cdata.set('NPY_ABI_VERSION', C_ABI_VERSION)
 cdata.set('NPY_API_VERSION', C_API_VERSION)
 
+cpu_family = host_machine.cpu_family()
 use_svml = (
   host_machine.system() == 'linux' and
-  host_machine.cpu_family() == 'x86_64' and
+  cpu_family == 'x86_64' and
   ('AVX512_SKX' in CPU_DISPATCH_NAMES or 'AVX512_SKX' in CPU_BASELINE_NAMES) and
   not get_option('disable-svml')
 )
@@ -94,10 +95,28 @@ if use_svml
     error('Missing the `SVML` git submodule! Run `git submodule update --init` to fix this.')
   endif
 endif
-if not fs.exists('src/highway/README.md')
+
+use_highway = not get_option('disable-highway')
+if use_highway and not fs.exists('src/highway/README.md')
   error('Missing the `highway` git submodule! Run `git submodule update --init` to fix this.')
 endif
-if not fs.exists('src/npysort/x86-simd-sort/README.md')
+
+if use_highway
+  highway_lib = static_library('highway',
+    [
+      # required for hwy::Abort symbol
+      'src/highway/hwy/targets.cc'
+    ],
+    cpp_args: '-DTOOLCHAIN_MISS_ASM_HWCAP_H',
+    include_directories: ['src/highway'],
+    install: false
+  )
+else
+  highway_lib = []
+endif
+
+use_intel_sort = not get_option('disable-intel-sort') and cpu_family in ['x86', 'x86_64']
+if use_intel_sort and not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
 
@@ -767,33 +786,31 @@ foreach gen_mtargets : [
   [
     'x86_simd_argsort.dispatch.h',
     'src/npysort/x86_simd_argsort.dispatch.cpp',
-    [AVX512_SKX]
+    use_intel_sort ? [AVX512_SKX] : []
   ],
   [
     'x86_simd_qsort.dispatch.h',
     'src/npysort/x86_simd_qsort.dispatch.cpp',
-    [
-      AVX512_SKX, AVX2,
-    ]
+    use_intel_sort ? [AVX512_SKX, AVX2] : []
   ],
   [
     'x86_simd_qsort_16bit.dispatch.h',
     'src/npysort/x86_simd_qsort_16bit.dispatch.cpp',
-    [AVX512_SPR, AVX512_ICL]
+    use_intel_sort ? [AVX512_SPR, AVX512_ICL] : []
   ],
   [
     'highway_qsort.dispatch.h',
     'src/npysort/highway_qsort.dispatch.cpp',
-    [
-      SVE, ASIMD,
-    ]
+    use_highway ? [
+      SVE, ASIMD, VSX2, VXE
+    ] : []
   ],
   [
     'highway_qsort_16bit.dispatch.h',
     'src/npysort/highway_qsort_16bit.dispatch.cpp',
-    [
-      ASIMDHP,
-    ]
+    use_highway ? [
+      ASIMDHP, VSX2, VXE
+    ] : []
   ],
 ]
   mtargets = mod_features.multi_targets(
@@ -1164,8 +1181,8 @@ py.extension_module('_multiarray_umath',
     'src/npymath',
     'src/umath',
   ],
-  dependencies: blas_dep,
-  link_with: [npymath_lib, multiarray_umath_mtargets.static_lib('_multiarray_umath_mtargets')],
+  dependencies: [blas_dep],
+  link_with: [npymath_lib, multiarray_umath_mtargets.static_lib('_multiarray_umath_mtargets')] + highway_lib,
   install: true,
   subdir: 'numpy/_core',
 )

--- a/numpy/_core/src/common/npstd.hpp
+++ b/numpy/_core/src/common/npstd.hpp
@@ -34,7 +34,7 @@ using std::intptr_t;
 using std::complex;
 using std::uint_fast16_t;
 using std::uint_fast32_t;
-
+using SSize = Py_ssize_t;
 /** Guard for long double.
  *
  * The C implementation defines long double as double

--- a/numpy/_core/src/npysort/heapsort.hpp
+++ b/numpy/_core/src/npysort/heapsort.hpp
@@ -1,0 +1,70 @@
+#ifndef NUMPY_SRC_COMMON_NPYSORT_HEAPSORT_HPP
+#define NUMPY_SRC_COMMON_NPYSORT_HEAPSORT_HPP
+
+#include "common.hpp"
+
+namespace np::sort {
+
+template <typename T>
+inline bool LessThan(const T &a, const T &b)
+{
+    if constexpr (std::is_floating_point_v<T>) {
+        return a < b || (b != b && a == a);
+    }
+    else if constexpr(std::is_same_v<T, Half>) {
+        bool a_nn = !a.IsNaN();
+        return b.IsNaN() ? a_nn : a_nn && a.Less(b);
+    }
+    else {
+        return a < b;
+    }
+}
+
+// NUMERIC SORTS
+template <typename T>
+inline void Heap(T *start, SSize n)
+{
+    SSize i, j, l;
+    // The array needs to be offset by one for heapsort indexing
+    T tmp, *a = start - 1;
+
+    for (l = n >> 1; l > 0; --l) {
+        tmp = a[l];
+        for (i = l, j = l << 1; j <= n;) {
+            if (j < n && LessThan(a[j], a[j + 1])) {
+                j += 1;
+            }
+            if (LessThan(tmp, a[j])) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+
+    for (; n > 1;) {
+        tmp = a[n];
+        a[n] = a[1];
+        n -= 1;
+        for (i = 1, j = 2; j <= n;) {
+            if (j < n && LessThan(a[j], a[j + 1])) {
+                j++;
+            }
+            if (LessThan(tmp, a[j])) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+}
+} // namespace np::sort
+#endif

--- a/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
@@ -2,11 +2,17 @@
 #define VQSORT_ONLY_STATIC 1
 #include "hwy/contrib/sort/vqsort-inl.h"
 
+#include "quicksort.hpp"
+
 namespace np { namespace highway { namespace qsort_simd {
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
 {
+#if HWY_HAVE_FLOAT16
     hwy::HWY_NAMESPACE::VQSortStatic(reinterpret_cast<hwy::float16_t*>(arr), size, hwy::SortAscending());
+#else
+    sort::Quick(arr, size);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, intptr_t size)
 {

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -1,0 +1,96 @@
+#ifndef NUMPY_SRC_COMMON_NPYSORT_QUICKSORT_HPP
+#define NUMPY_SRC_COMMON_NPYSORT_QUICKSORT_HPP
+
+#include "heapsort.hpp"
+#include "common.hpp"
+
+namespace np::sort {
+
+// pushing largest partition has upper bound of log2(n) space
+// we store two pointers each time
+constexpr size_t kQuickStack = sizeof(intptr_t) * 8 * 2;
+constexpr ptrdiff_t kQuickSmall = 15;
+
+// NUMERIC SORTS
+template <typename T>
+inline void Quick(T *start, SSize num)
+{
+    T vp;
+    T *pl = start;
+    T *pr = pl + num - 1;
+    T *stack[kQuickStack];
+    T **sptr = stack;
+    T *pm, *pi, *pj, *pk;
+    int depth[kQuickStack];
+    int *psdepth = depth;
+    int cdepth = BitScanReverse(static_cast<std::make_unsigned_t<SSize>>(num)) * 2;
+    for (;;) {
+        if (NPY_UNLIKELY(cdepth < 0)) {
+            Heap(pl, pr - pl + 1);
+            goto stack_pop;
+        }
+        while ((pr - pl) > kQuickSmall) {
+            // quicksort partition
+            pm = pl + ((pr - pl) >> 1);
+            if (LessThan(*pm, *pl)) {
+                std::swap(*pm, *pl);
+            }
+            if (LessThan(*pr, *pm)) {
+                std::swap(*pr, *pm);
+            }
+            if (LessThan(*pm, *pl)) {
+                std::swap(*pm, *pl);
+            }
+            vp = *pm;
+            pi = pl;
+            pj = pr - 1;
+            std::swap(*pm, *pj);
+            for (;;) {
+                do {
+                    ++pi;
+                } while (LessThan(*pi, vp));
+                do {
+                    --pj;
+                } while (LessThan(vp, *pj));
+                if (pi >= pj) {
+                    break;
+                }
+                std::swap(*pi, *pj);
+            }
+            pk = pr - 1;
+            std::swap(*pi, *pk);
+            // push largest partition on stack
+            if (pi - pl < pr - pi) {
+                *sptr++ = pi + 1;
+                *sptr++ = pr;
+                pr = pi - 1;
+            }
+            else {
+                *sptr++ = pl;
+                *sptr++ = pi - 1;
+                pl = pi + 1;
+            }
+            *psdepth++ = --cdepth;
+        }
+
+        /* insertion sort */
+        for (pi = pl + 1; pi <= pr; ++pi) {
+            vp = *pi;
+            pj = pi;
+            pk = pi - 1;
+            while (pj > pl && LessThan(vp, *pk)) {
+                *pj-- = *pk--;
+            }
+            *pj = vp;
+        }
+    stack_pop:
+        if (sptr == stack) {
+            break;
+        }
+        pr = *(--sptr);
+        pl = *(--sptr);
+        cdepth = *(--psdepth);
+    }
+}
+} // np::sort
+#endif // NUMPY_SRC_COMMON_NPYSORT_QUICK_HPP


### PR DESCRIPTION
  This patch extends CPU targets that used to build Highway's quicksort
  to cover PowerPC/VSX2 and ~IBMZ-14~. Also provides two meson options
  to disable Google-highway and Intel-simd-sort.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
