### PR TITLE
MAINT: add a C alias for the default integer DType

### DIFF
--- a/numpy/_core/include/numpy/experimental_dtype_api.h
+++ b/numpy/_core/include/numpy/experimental_dtype_api.h
@@ -330,6 +330,7 @@ PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
 #define PyArray_PyIntAbstractDType (*(PyArray_DTypeMeta *)__experimental_dtype_api_table[44])
 #define PyArray_PyFloatAbstractDType (*(PyArray_DTypeMeta *)__experimental_dtype_api_table[45])
 #define PyArray_PyComplexAbstractDType (*(PyArray_DTypeMeta *)__experimental_dtype_api_table[46])
+#define PyArray_DefaultIntDType (*(PyArray_DTypeMeta *)__experimental_dtype_api_table[47])
 
 /*
  * ********************************

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1306,6 +1306,7 @@ initialize_legacy_dtypemeta_aliases(PyArray_Descr **_builtin_descrs) {
     _UInt64_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINT64]);
     _Intp_dtype = NPY_DTYPE(_builtin_descrs[NPY_INTP]);
     _UIntp_dtype = NPY_DTYPE(_builtin_descrs[NPY_UINTP]);
+    _DefaultInt_dtype = NPY_DTYPE(_builtin_descrs[NPY_DEFAULT_INT]);
     _Half_dtype = NPY_DTYPE(_builtin_descrs[NPY_HALF]);
     _Float_dtype = NPY_DTYPE(_builtin_descrs[NPY_FLOAT]);
     _Double_dtype = NPY_DTYPE(_builtin_descrs[NPY_DOUBLE]);
@@ -1361,6 +1362,7 @@ PyArray_DTypeMeta *_Int64_dtype = NULL;
 PyArray_DTypeMeta *_UInt64_dtype = NULL;
 PyArray_DTypeMeta *_Intp_dtype = NULL;
 PyArray_DTypeMeta *_UIntp_dtype = NULL;
+PyArray_DTypeMeta *_DefaultInt_dtype = NULL;
 PyArray_DTypeMeta *_Half_dtype = NULL;
 PyArray_DTypeMeta *_Float_dtype = NULL;
 PyArray_DTypeMeta *_Double_dtype = NULL;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -181,6 +181,7 @@ extern PyArray_DTypeMeta *_Int64_dtype;
 extern PyArray_DTypeMeta *_UInt64_dtype;
 extern PyArray_DTypeMeta *_Intp_dtype;
 extern PyArray_DTypeMeta *_UIntp_dtype;
+extern PyArray_DTypeMeta *_DefaultInt_dtype;
 extern PyArray_DTypeMeta *_Half_dtype;
 extern PyArray_DTypeMeta *_Float_dtype;
 extern PyArray_DTypeMeta *_Double_dtype;
@@ -218,6 +219,7 @@ extern PyArray_DTypeMeta *_Void_dtype;
 #define PyArray_UInt64DType (*(_UInt64_dtype))
 #define PyArray_IntpDType (*(_Intp_dtype))
 #define PyArray_UIntpDType (*(_UIntp_dtype))
+#define PyArray_DefaultIntDType (*(_DefaultInt_dtype))
 /* Floats */
 #define PyArray_HalfDType (*(_Half_dtype))
 #define PyArray_FloatDType (*(_Float_dtype))

--- a/numpy/_core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/_core/src/multiarray/experimental_public_dtype_api.c
@@ -144,7 +144,7 @@ _PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
 NPY_NO_EXPORT PyObject *
 _get_experimental_dtype_api(PyObject *NPY_UNUSED(mod), PyObject *arg)
 {
-    static void *experimental_api_table[47] = {
+    static void *experimental_api_table[48] = {
             &PyUFunc_AddLoopFromSpec,
             &PyUFunc_AddPromoter,
             &PyArrayDTypeMeta_Type,
@@ -203,6 +203,7 @@ _get_experimental_dtype_api(PyObject *NPY_UNUSED(mod), PyObject *arg)
         experimental_api_table[44] = &PyArray_PyIntAbstractDType;
         experimental_api_table[45] = &PyArray_PyFloatAbstractDType;
         experimental_api_table[46] = &PyArray_PyComplexAbstractDType;
+        experimental_api_table[47] = &PyArray_DefaultIntDType;
     }
 
     char *env = getenv("NUMPY_EXPERIMENTAL_DTYPE_API");


### PR DESCRIPTION
While implementing stringdtype ufuncs, I noticed that this alias is missing from the DType class aliases we make available in the internal API and experimental API.

This isn't a proper dtype, but it's useful to have as a name available when writing ufuncs and promoters, in the same way that one would use `NPY_DEFAULT_INT` in the legacy ufunc API.

I didn't increment the experimental API version number because it's going away soon and this just extends the table.