### PR TITLE
DOC: ensure that docstrings for np.ndarray.copy, np.copy and np.array all mention (or link to explanation) that object arrays are shallow-copied

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -807,10 +807,12 @@ add_newdoc('numpy._core.multiarray', 'array',
         a default ``dtype`` that can represent the values (by applying promotion
         rules when necessary.)
     copy : bool, optional
-        If true (default), then the object is copied.  Otherwise, a copy will
-        only be made if ``__array__`` returns a copy, if obj is a nested
+        If true (default), then the array data is copied. Otherwise, a copy
+        will only be made if ``__array__`` returns a copy, if obj is a nested
         sequence, or if a copy is needed to satisfy any of the other
-        requirements (``dtype``, ``order``, etc.).
+        requirements (``dtype``, ``order``, etc.). Note that any copy of
+        the data is shallow, i.e., for arrays with object dtype, the new
+        array will point to the same objects. See Examples for `ndarray.copy`.
     order : {'K', 'A', 'C', 'F'}, optional
         Specify the memory layout of the array. If object is not an array, the
         newly created array will be in C order (row major) unless 'F' is
@@ -855,6 +857,7 @@ add_newdoc('numpy._core.multiarray', 'array',
     ones : Return a new array setting values to one.
     zeros : Return a new array setting values to zero.
     full : Return a new array of given shape filled with value.
+    copy: Return an array copy of the given object.
 
 
     Notes
@@ -3362,6 +3365,29 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('copy',
 
     >>> y.flags['C_CONTIGUOUS']
     True
+
+    For arrays containing Python objects (e.g. dtype=object),
+    the copy is a shallow one. The new array will contain the
+    same object which may lead to surprises if that object can
+    be modified (is mutable):
+
+    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
+    >>> b = a.copy()
+    >>> b[2][0] = 10
+    >>> a
+    array([1, 'm', list([10, 3, 4])], dtype=object)
+
+    To ensure all elements within an ``object`` array are copied,
+    use `copy.deepcopy`:
+
+    >>> import copy
+    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
+    >>> c = copy.deepcopy(a)
+    >>> c[2][0] = 10
+    >>> c
+    array([1, 'm', list([10, 3, 4])], dtype=object)
+    >>> a
+    array([1, 'm', list([2, 3, 4])], dtype=object)
 
     """))
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -923,6 +923,10 @@ def copy(a, order='K', subok=False):
 
     >>> np.array(a, copy=True)  #doctest: +SKIP
 
+    The copy made of the data is shallow, i.e., for arrays with object dtype,
+    the new array will point to the same objects.
+    See Examples from `ndarray.copy`.
+
     Examples
     --------
     Create an array x, with a reference y and a copy z:
@@ -949,31 +953,6 @@ def copy(a, order='K', subok=False):
     >>> b[0] = 3
     >>> b
     array([3, 2, 3])
-
-    Note that np.copy is a shallow copy and will not copy object
-    elements within arrays. This is mainly important for arrays
-    containing Python objects. The new array will contain the
-    same object which may lead to surprises if that object can
-    be modified (is mutable):
-
-    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
-    >>> b = np.copy(a)
-    >>> b[2][0] = 10
-    >>> a
-    array([1, 'm', list([10, 3, 4])], dtype=object)
-
-    To ensure all elements within an ``object`` array are copied,
-    use `copy.deepcopy`:
-
-    >>> import copy
-    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
-    >>> c = copy.deepcopy(a)
-    >>> c[2][0] = 10
-    >>> c
-    array([1, 'm', list([10, 3, 4])], dtype=object)
-    >>> a
-    array([1, 'm', list([2, 3, 4])], dtype=object)
-
     """
     return array(a, order=order, subok=subok, copy=True)
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This is meant to close #25562
Despite my best effort, I couldn't manage to get a successful build of documentation locally, which I suspect has to do with a circular dependency (`numpy docs`-> `matplotlib` -> `contourpy` -> `numpy < 2.0`), but I'm unsure, so I'm opening as a draft first so I can hopefully inspect CI artifacts before opening this for review.