### PR TITLE
CI: Bump azure pipeline timeout to 120 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
       displayName: 'Run 32-bit manylinux2014 Docker Build / Tests'
 
   - job: Windows
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2019'
     strategy:


### PR DESCRIPTION
Not sure if this will work, but maybe the default of 60minutes is just suddenly (correctly?) enforced.  I didn't see any note that it changed with a quick google.

Closes gh-25577