### PR TITLE
CI: Bump azure pipeline timeout to 120 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,7 @@ stages:
       displayName: 'Run 32-bit manylinux2014 Docker Build / Tests'
 
   - job: Windows
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2019'
     strategy:


### PR DESCRIPTION
Backport of #25582.

Not sure if this will work, but maybe the default of 60minutes is just suddenly (correctly?) enforced.  I didn't see any note that it changed with a quick google.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
