### PR TITLE
BUG: Fix undefined behavior when converting NaN float16 to datetime or timedelta

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1407,7 +1407,7 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
             t = (@type@)npy_half_to_float(*ip);
         }
 
-        *ip++;
+        ip++;
         *op++ = t;
     }
 }

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1399,7 +1399,15 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
     @type@ *op = output;
 
     while (n--) {
-        *op++ = (@type@)npy_half_to_float(*ip++);
+        @type@ t;
+        if (npy_half_isnan(*ip)) {
+            t = (@type@)NPY_DATETIME_NAT;
+        }
+        else {
+            t = (@type@)npy_half_to_float(*ip++);
+        }
+
+        *op++ = t;
     }
 }
 

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1402,6 +1402,7 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
         @type@ t;
         if (npy_half_isnan(*ip)) {
             t = (@type@)NPY_DATETIME_NAT;
+            *ip++;
         }
         else {
             t = (@type@)npy_half_to_float(*ip++);

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1402,7 +1402,7 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
         @type@ t;
         if (npy_half_isnan(*ip)) {
             t = (@type@)NPY_DATETIME_NAT;
-            *ip++;
+            ip++;
         }
         else {
             t = (@type@)npy_half_to_float(*ip++);

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1402,12 +1402,12 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
         @type@ t;
         if (npy_half_isnan(*ip)) {
             t = (@type@)NPY_DATETIME_NAT;
-            ip++;
         }
         else {
-            t = (@type@)npy_half_to_float(*ip++);
+            t = (@type@)npy_half_to_float(*ip);
         }
 
+        *ip++;
         *op++ = t;
     }
 }

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -579,7 +579,7 @@ class TestDateTime:
         assert_equal(np.datetime64(a, '[W]'), np.datetime64('NaT', '[W]'))
 
         # NaN -> NaT
-        nan = np.array([np.nan] * 8)
+        nan = np.array([np.nan] * 8 + [0])
         fnan = nan.astype('f')
         lnan = nan.astype('g')
         cnan = nan.astype('D')
@@ -587,7 +587,7 @@ class TestDateTime:
         clnan = nan.astype('G')
         hnan = nan.astype(np.half)
 
-        nat = np.array([np.datetime64('NaT')] * 8)
+        nat = np.array([np.datetime64('NaT')] * 8 + [np.datetime64(0, 'D')])
         assert_equal(nan.astype('M8[ns]'), nat)
         assert_equal(fnan.astype('M8[ns]'), nat)
         assert_equal(lnan.astype('M8[ns]'), nat)
@@ -596,7 +596,7 @@ class TestDateTime:
         assert_equal(clnan.astype('M8[ns]'), nat)
         assert_equal(hnan.astype('M8[ns]'), nat)
 
-        nat = np.array([np.timedelta64('NaT')] * 8)
+        nat = np.array([np.timedelta64('NaT')] * 8 + [np.timedelta64(0)])
         assert_equal(nan.astype('timedelta64[ns]'), nat)
         assert_equal(fnan.astype('timedelta64[ns]'), nat)
         assert_equal(lnan.astype('timedelta64[ns]'), nat)

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -585,6 +585,7 @@ class TestDateTime:
         cnan = nan.astype('D')
         cfnan = nan.astype('F')
         clnan = nan.astype('G')
+        hnan = nan.astype(np.half)
 
         nat = np.array([np.datetime64('NaT')] * 8)
         assert_equal(nan.astype('M8[ns]'), nat)
@@ -593,6 +594,7 @@ class TestDateTime:
         assert_equal(cnan.astype('M8[ns]'), nat)
         assert_equal(cfnan.astype('M8[ns]'), nat)
         assert_equal(clnan.astype('M8[ns]'), nat)
+        assert_equal(hnan.astype('M8[ns]'), nat)
 
         nat = np.array([np.timedelta64('NaT')] * 8)
         assert_equal(nan.astype('timedelta64[ns]'), nat)
@@ -601,6 +603,7 @@ class TestDateTime:
         assert_equal(cnan.astype('timedelta64[ns]'), nat)
         assert_equal(cfnan.astype('timedelta64[ns]'), nat)
         assert_equal(clnan.astype('timedelta64[ns]'), nat)
+        assert_equal(hnan.astype('timedelta64[ns]'), nat)
 
     def test_days_creation(self):
         assert_equal(np.array('1599', dtype='M8[D]').astype('i8'),


### PR DESCRIPTION
Resolves #21762.

In this change to the casting of HALF types to DATETIME or TIMEDELTA, the case in which the input is NaN is handled appropriately by casting to NaT.

I am not sure where to add additional unit tests, if any; any feedback would be appreciated.

Thank you!