### PR TITLE
DOC: fft: correct docs about recent deprecations

### DIFF
--- a/doc/release/upcoming_changes/25495.deprecation.rst
+++ b/doc/release/upcoming_changes/25495.deprecation.rst
@@ -2,11 +2,11 @@
 -----------------------------------------------------------------------------
 
 Using `numpy.fft.fftn`, `numpy.fft.ifftn`, `numpy.fft.rfftn`,
-`numpy.fft.irfftn`, `numpy.fft.fft2` or `numpy.fft.ifft2` with the ``s``
-parameter set to a value that is not ``None`` and the ``axes`` parameter set
-to ``None`` has been deprecated, in line with the array API standard.
-To retain current behaviour, pass a sequence [0, ..., k-1] to ``axes`` for
-an array of dimension k.
+`numpy.fft.irfftn`, `numpy.fft.fft2`, `numpy.fft.ifft2`, `numpy.fft.rfft2` or
+`numpy.fft.irfft2` with the ``s`` parameter set to a value that is not
+``None`` and the ``axes`` parameter set to ``None`` has been deprecated, in
+line with the array API standard. To retain current behaviour, pass a sequence
+[0, ..., k-1] to ``axes`` for an array of dimension k.
 
 Furthermore, passing an array to ``s`` which contains ``None`` values is
 deprecated as the parameter is documented to accept a sequence of integers

--- a/doc/release/upcoming_changes/25495.improvement.rst
+++ b/doc/release/upcoming_changes/25495.improvement.rst
@@ -2,5 +2,6 @@
 -----------------------------------------------
 
 `numpy.fft.fftn`, `numpy.fft.ifftn`, `numpy.fft.rfftn`, `numpy.fft.irfftn`,
-`numpy.fft.fft2`, and `numpy.fft.ifft2` now use the whole input array along
-the axis ``i`` if ``s[i] == -1``, in line with the array API specification.
+`numpy.fft.fft2`, `numpy.fft.ifft2`, `numpy.fft.rfft2` and `numpy.fft.irfft2`
+now use the whole input array along the axis ``i`` if ``s[i] == -1``,
+in line with the array API specification.

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -764,7 +764,7 @@ def fftn(a, s=None, axes=None, norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -899,7 +899,7 @@ def ifftn(a, s=None, axes=None, norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -1017,7 +1017,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -1026,12 +1026,12 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
         Axes over which to compute the FFT.  If not given, the last two
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
-        that a one-dimensional FFT is performed.
+        that a one-dimensional FFT is performed. Default: ``(-2, -1)``.
 
         .. deprecated:: 2.0
 
             If `s` is specified, the corresponding `axes` to be transformed
-            must be explicitly specified too.
+            must not be ``None``.
 
     norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
@@ -1143,7 +1143,7 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -1152,12 +1152,12 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
         Axes over which to compute the FFT.  If not given, the last two
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
-        that a one-dimensional FFT is performed.
+        that a one-dimensional FFT is performed. Default: ``(-2, -1)``.
 
         .. deprecated:: 2.0
 
             If `s` is specified, the corresponding `axes` to be transformed
-            must be explicitly specified too.
+            must not be ``None``.
 
     norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
@@ -1254,7 +1254,7 @@ def rfftn(a, s=None, axes=None, norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -1350,8 +1350,30 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
         Input array, taken to be real.
     s : sequence of ints, optional
         Shape of the FFT.
+
+        .. versionchanged:: 2.0
+
+            If it is ``-1``, the whole input is used (no padding/trimming).
+
+        .. deprecated:: 2.0
+
+            If `s` is not ``None``, `axes` must not be ``None`` either.
+
+        .. deprecated:: 2.0
+
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
+            values currently mean that the default value for ``n`` is used
+            in the corresponding 1-D transform, but this behaviour is
+            deprecated.
+
     axes : sequence of ints, optional
-        Axes over which to compute the FFT.
+        Axes over which to compute the FFT. Default: ``(-2, -1)``.
+
+        .. deprecated:: 2.0
+
+            If `s` is specified, the corresponding `axes` to be transformed
+            must not be ``None``.
+
     norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
@@ -1434,7 +1456,7 @@ def irfftn(a, s=None, axes=None, norm=None):
 
         .. deprecated:: 2.0
 
-            `s` must contain only ``int``s, not ``None`` values. ``None``
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
             values currently mean that the default value for ``n`` is used
             in the corresponding 1-D transform, but this behaviour is
             deprecated.
@@ -1536,9 +1558,31 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
         The input array
     s : sequence of ints, optional
         Shape of the real output to the inverse FFT.
+
+        .. versionchanged:: 2.0
+
+            If it is ``-1``, the whole input is used (no padding/trimming).
+
+        .. deprecated:: 2.0
+
+            If `s` is not ``None``, `axes` must not be ``None`` either.
+
+        .. deprecated:: 2.0
+
+            `s` must contain only ``int`` s, not ``None`` values. ``None``
+            values currently mean that the default value for ``n`` is used
+            in the corresponding 1-D transform, but this behaviour is
+            deprecated.
+
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
-        Default is the last two axes.
+        Default: ``(-2, -1)``, the last two axes.
+
+        .. deprecated:: 2.0
+
+            If `s` is specified, the corresponding `axes` to be transformed
+            must not be ``None``.
+
     norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 


### PR DESCRIPTION
Closes gh-25605, follow up to gh-25495.

- There was confusion in gh-25605 due to a wrong assumption of the default value of `axes` for `(i)fft2`. Make this more clear by specifying the default in the parameter descriptions. Also do this for `rfft2` and `irfft2`.
- Add deprecation notes where they were missing.
- Slightly improve wording
- Fix some syntax that rst was not a fan of
- Update release notes