### PR TITLE
BUG: Pass newline to datasource.open() in numpy.lib.npio.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1554,7 +1554,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     if _is_string_like(fname):
         # datasource doesn't support creating a new file ...
         open(fname, 'wt').close()
-        fh = np.lib._datasource.open(fname, 'wt', encoding=encoding)
+        fh = np.lib._datasource.open(fname, 'wt', encoding=encoding, newline=newline)
         own_fh = True
     elif hasattr(fname, 'write'):
         # wrap to handle byte output streams

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1565,7 +1565,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
         fh = np.lib._datasource.open(fname, 
                                      'wt',
                                      encoding=encoding,
-                                     open_newline=newline)
+                                     newline=open_newline)
         own_fh = True
     elif hasattr(fname, 'write'):
         # wrap to handle byte output streams

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1554,7 +1554,10 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     if _is_string_like(fname):
         # datasource doesn't support creating a new file ...
         open(fname, 'wt').close()
-        fh = np.lib._datasource.open(fname, 'wt', encoding=encoding, newline=newline)
+        fh = np.lib._datasource.open(fname, 
+                                     'wt',
+                                     encoding=encoding,
+                                     newline=newline)
         own_fh = True
     elif hasattr(fname, 'write'):
         # wrap to handle byte output streams

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1548,6 +1548,14 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
                 self.write_bytes(v)
                 self.write = self.write_bytes
 
+    # _datasource.open() needs to be passed None to enable universal
+    # newlines, and this function needs to write newlines.
+    if newline is None:
+        open_newline = None
+        newline = '\n'
+    else:
+        open_newline = newline
+                
     own_fh = False
     if isinstance(fname, os_PathLike):
         fname = os_fspath(fname)
@@ -1557,7 +1565,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
         fh = np.lib._datasource.open(fname, 
                                      'wt',
                                      encoding=encoding,
-                                     newline=newline)
+                                     open_newline=newline)
         own_fh = True
     elif hasattr(fname, 'write'):
         # wrap to handle byte output streams

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1552,7 +1552,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
     # newlines, and this function needs to write newlines.
     if newline is None:
         open_newline = None
-        newline = '\n'
+        newline = os.linesep
     else:
         open_newline = newline
                 
@@ -1618,7 +1618,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
             raise ValueError('invalid fmt: %r' % (fmt,))
 
         if len(header) > 0:
-            header = header.replace('\n', '\n' + comments)
+            header = header.replace(newline, newline + comments)
             fh.write(comments + header + newline)
         if iscomplex_X:
             for row in X:
@@ -1639,7 +1639,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
                 fh.write(v)
 
         if len(footer) > 0:
-            footer = footer.replace('\n', '\n' + comments)
+            footer = footer.replace(newline, newline + comments)
             fh.write(comments + footer + newline)
     finally:
         if own_fh:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1388,7 +1388,7 @@ def _savetxt_dispatcher(fname, X, fmt=None, delimiter=None, newline=None,
 
 
 @array_function_dispatch(_savetxt_dispatcher)
-def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
+def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline=None, header='',
             footer='', comments='# ', encoding=None):
     """
     Save an array to a text file.
@@ -1417,7 +1417,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     delimiter : str, optional
         String or character separating columns.
     newline : str, optional
-        String or character separating lines.
+        String or character separating lines.  Default is universal newline.
 
         .. versionadded:: 1.5.0
     header : str, optional

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -189,7 +189,7 @@ def savetxt(
     X: ArrayLike,
     fmt: str | Sequence[str] = ...,
     delimiter: str = ...,
-    newline: str = ...,
+    newline: None | str = ...,
     header: str = ...,
     footer: str = ...,
     comments: str = ...,

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -648,7 +648,7 @@ class TestSaveTxt:
         if iotype is StringIO:
             assert_equal(s.read(), "%f%s" % (1., os.linesep))
         else:
-            assert_equal(s.read(), b"%f%s" % (1., os.linesep))
+            assert_equal(s.read(), b"%f%s" % (1., os.linesep.encode()))
 
     @pytest.mark.skipif(sys.platform=='win32', reason="files>4GB may not work")
     @pytest.mark.slow

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -447,12 +447,13 @@ class TestSaveTxt:
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
                      err_msg='Universal newline, implicit')
+        c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=None)
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
                      err_msg='Universal newline, explicit')
 
-        # POSIX
+        # POSIX newline
         newline = b'\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)
@@ -461,7 +462,7 @@ class TestSaveTxt:
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
                      err_msg='POSIX newline')
 
-        # NT
+        # NT newline
         newline = b'\r\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)
@@ -470,7 +471,7 @@ class TestSaveTxt:
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
                      err_msg='NT newline')
 
-        # Tab
+        # Tab "newline"
         newline = b'\t'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -527,6 +527,21 @@ class TestSaveTxt:
         assert_equal(c.read(),
                      asbytes(a_txt + commentstr + test_header_footer
                             + os.linesep))
+
+    @pytest.mark.parametrize("newline", ['\n', '\r\n'])
+    def test_newline_header_footer(self, newline):
+        c = BytesIO()
+        a = np.array([(1, 2), (3, 4)], dtype=int)
+        a_txt = '1 2' + newline + '3 4' + newline
+        test_header_footer = 'Test header / footer'
+        # Test the header and footer keyword argument
+        np.savetxt(c, a, fmt='%1d', newline=newline, header=test_header_footer,
+                   footer=test_header_footer)
+        c.seek(0)
+        assert_equal(c.read(),
+                     asbytes('# ' + test_header_footer + newline
+                             + a_txt
+                             + '# ' + test_header_footer + newline))
     
     def test_file_roundtrip(self):
         with temppath() as name:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -488,18 +488,20 @@ class TestSaveTxt:
 
         c = BytesIO()
         a = np.array([(1, 2), (3, 4)], dtype=int)
+        a_txt = '1 2' + os.linesep + '3 4' + os.linesep
         test_header_footer = 'Test header / footer'
         # Test the header keyword argument
         np.savetxt(c, a, fmt='%1d', header=test_header_footer)
         c.seek(0)
         assert_equal(c.read(),
-                     asbytes('# ' + test_header_footer + '\n1 2\n3 4\n'))
+                     asbytes('# ' + test_header_footer + os.linesep
+                             + a_txt))
         # Test the footer keyword argument
         c = BytesIO()
         np.savetxt(c, a, fmt='%1d', footer=test_header_footer)
         c.seek(0)
         assert_equal(c.read(),
-                     asbytes('1 2\n3 4\n# ' + test_header_footer + '\n'))
+                     asbytes(a_txt + '# ' + test_header_footer + os.linesep))
         # Test the commentstr keyword argument used on the header
         c = BytesIO()
         commentstr = '% '
@@ -507,7 +509,8 @@ class TestSaveTxt:
                    header=test_header_footer, comments=commentstr)
         c.seek(0)
         assert_equal(c.read(),
-                     asbytes(commentstr + test_header_footer + '\n' + '1 2\n3 4\n'))
+                     asbytes(commentstr + test_header_footer + os.linesep
+                            + a_txt))
         # Test the commentstr keyword argument used on the footer
         c = BytesIO()
         commentstr = '% '
@@ -515,7 +518,8 @@ class TestSaveTxt:
                    footer=test_header_footer, comments=commentstr)
         c.seek(0)
         assert_equal(c.read(),
-                     asbytes('1 2\n3 4\n' + commentstr + test_header_footer + '\n'))
+                     asbytes(a_txt + commentstr + test_header_footer
+                            + os.linesep))
     
     def test_file_roundtrip(self):
         with temppath() as name:
@@ -623,7 +627,7 @@ class TestSaveTxt:
         s = BytesIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
-        assert_equal(s.read().decode('UTF-8'), utf8 + '\n')
+        assert_equal(s.read().decode('UTF-8'), utf8 + os.linesep)
 
     def test_unicode_stringstream(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
@@ -631,7 +635,7 @@ class TestSaveTxt:
         s = StringIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
-        assert_equal(s.read(), utf8 + '\n')
+        assert_equal(s.read(), utf8 + os.linesep)
 
     @pytest.mark.parametrize("fmt", ["%f", b"%f"])
     @pytest.mark.parametrize("iotype", [StringIO, BytesIO])
@@ -642,9 +646,9 @@ class TestSaveTxt:
         np.savetxt(s, a, fmt=fmt)
         s.seek(0)
         if iotype is StringIO:
-            assert_equal(s.read(), "%f\n" % 1.)
+            assert_equal(s.read(), "%f%s" % (1., os.linesep))
         else:
-            assert_equal(s.read(), b"%f\n" % 1.)
+            assert_equal(s.read(), b"%f%s" % (1., os.linesep))
 
     @pytest.mark.skipif(sys.platform=='win32', reason="files>4GB may not work")
     @pytest.mark.slow

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -442,12 +442,13 @@ class TestSaveTxt:
         c = BytesIO()
         
         # Native
+        newline = os.linesep.encode()
         np.savetxt(c, a, newline=None, fmt='%1d')
         c.seek(0)
-        assert_equal(c.readlines(), [b'1 2'+os.linesep.encode(), b'3 4'+os.linesep.encode()])
+        assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline])
 
         # POSIX
-        newline=b'\n'
+        newline = b'\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%1d')
         c.seek(0)
@@ -455,7 +456,7 @@ class TestSaveTxt:
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
 
         # NT
-        newline=b'\r\n'
+        newline = b'\r\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%1d')
         c.seek(0)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -443,7 +443,7 @@ class TestSaveTxt:
         
         # Native
         newline = os.linesep.encode()
-        np.savetxt(c, a, fmt='%1d', newline=None)
+        np.savetxt(c, a, fmt='%d', newline=None)
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
                      err_msg='Native newline')
@@ -451,7 +451,7 @@ class TestSaveTxt:
         # POSIX
         newline = b'\n'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d', newline=newline)
+        np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
@@ -460,7 +460,7 @@ class TestSaveTxt:
         # NT
         newline = b'\r\n'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d', newline=newline)
+        np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
@@ -469,7 +469,7 @@ class TestSaveTxt:
         # Tab
         newline = b'\t'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d', newline=newline)
+        np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline+b'3 4'+newline, ],

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -356,14 +356,15 @@ class TestSaveTxt:
         np.savetxt(c, a, fmt=fmt)
         c.seek(0)
         assert_equal(c.readlines(),
-                     [asbytes((fmt + ' ' + fmt + '\n') % (1, 2)),
-                      asbytes((fmt + ' ' + fmt + '\n') % (3, 4))])
+                     [asbytes((fmt + ' ' + fmt + os.linesep) % (1, 2)),
+                      asbytes((fmt + ' ' + fmt + os.linesep) % (3, 4))])
 
         a = np.array([[1, 2], [3, 4]], int)
         c = BytesIO()
         np.savetxt(c, a, fmt='%d')
         c.seek(0)
-        assert_equal(c.readlines(), [b'1 2\n', b'3 4\n'])
+        assert_equal(c.readlines(), [b'1 2'+os.linesep.encode(),
+                                     b'3 4'+os.linesep.encode()])
 
     def test_1D(self):
         a = np.array([1, 2, 3, 4], int)
@@ -371,7 +372,8 @@ class TestSaveTxt:
         np.savetxt(c, a, fmt='%d')
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'1\n', b'2\n', b'3\n', b'4\n'])
+        newline = os.linesep.encode()
+        assert_equal(lines, [b'1'+newline, b'2'+newline, b'3'+newline, b'4'+newline])
 
     def test_0D_3D(self):
         c = BytesIO()
@@ -383,7 +385,8 @@ class TestSaveTxt:
         c = BytesIO()
         np.savetxt(c, a, fmt='%d')
         c.seek(0)
-        assert_equal(c.readlines(), [b'1 2\n', b'3 4\n'])
+        newline = os.linesep.encode()
+        assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline])
 
     def test_structured_padded(self):
         # gh-13297
@@ -393,7 +396,8 @@ class TestSaveTxt:
         c = BytesIO()
         np.savetxt(c, a[['foo', 'baz']], fmt='%d')
         c.seek(0)
-        assert_equal(c.readlines(), [b'1 3\n', b'4 6\n'])
+        newline = os.linesep.encode()
+        assert_equal(c.readlines(), [b'1 3'+newline, b'4 6'+newline])
 
     def test_multifield_view(self):
         a = np.ones(1, dtype=[('x', 'i4'), ('y', 'i4'), ('z', 'f4')])
@@ -409,29 +413,31 @@ class TestSaveTxt:
         c = BytesIO()
         np.savetxt(c, a, delimiter=',', fmt='%d')
         c.seek(0)
-        assert_equal(c.readlines(), [b'1,2\n', b'3,4\n'])
+        newline = os.linesep.encode()
+        assert_equal(c.readlines(), [b'1,2'+newline, b'3,4'+newline])
 
     def test_format(self):
         a = np.array([(1, 2), (3, 4)])
+        newline = os.linesep.encode()
         c = BytesIO()
         # Sequence of formats
         np.savetxt(c, a, fmt=['%02d', '%3.1f'])
         c.seek(0)
-        assert_equal(c.readlines(), [b'01 2.0\n', b'03 4.0\n'])
+        assert_equal(c.readlines(), [b'01 2.0'+newline, b'03 4.0'+newline])
 
         # A single multiformat string
         c = BytesIO()
         np.savetxt(c, a, fmt='%02d : %3.1f')
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'01 : 2.0\n', b'03 : 4.0\n'])
+        assert_equal(lines, [b'01 : 2.0'+newline, b'03 : 4.0'+newline])
 
         # Specify delimiter, should be overridden
         c = BytesIO()
         np.savetxt(c, a, fmt='%02d : %3.1f', delimiter=',')
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'01 : 2.0\n', b'03 : 4.0\n'])
+        assert_equal(lines, [b'01 : 2.0'+newline, b'03 : 4.0'+newline])
 
         # Bad fmt, should raise a ValueError
         c = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -373,7 +373,8 @@ class TestSaveTxt:
         c.seek(0)
         lines = c.readlines()
         newline = os.linesep.encode()
-        assert_equal(lines, [b'1'+newline, b'2'+newline, b'3'+newline, b'4'+newline])
+        assert_equal(lines, [b'1'+newline, b'2'+newline, b'3'+newline,
+                             b'4'+newline])
 
     def test_0D_3D(self):
         c = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -446,7 +446,7 @@ class TestSaveTxt:
         np.savetxt(c, a, fmt='%1d', newline=None)
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
-                     err_msg='Native newline)
+                     err_msg='Native newline')
 
         # POSIX
         newline = b'\n'
@@ -455,7 +455,7 @@ class TestSaveTxt:
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
-                     err_msg='POSIX newline)
+                     err_msg='POSIX newline')
 
         # NT
         newline = b'\r\n'
@@ -464,7 +464,7 @@ class TestSaveTxt:
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
-                     err_msg='NT newline)
+                     err_msg='NT newline')
 
         # Tab
         newline = b'\t'
@@ -473,7 +473,7 @@ class TestSaveTxt:
         c.seek(0)
         lines = c.readlines()
         assert_equal(lines, [b'1 2'+newline+b'3 4'+newline, ],
-                     err_msg='Tab newline)
+                     err_msg='Tab newline')
     
     def test_header_footer(self):
         # Test the functionality of the header and footer keyword argument.

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -454,29 +454,32 @@ class TestSaveTxt:
                      err_msg='Universal newline, explicit')
 
         # POSIX newline
-        newline = b'\n'
+        newline = '\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
+        newline = newline.encode()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
                      err_msg='POSIX newline')
 
         # NT newline
-        newline = b'\r\n'
+        newline = '\r\n'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
+        newline = newline.encode()
         assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
                      err_msg='NT newline')
 
         # Tab "newline"
-        newline = b'\t'
+        newline = '\t'
         c = BytesIO()
         np.savetxt(c, a, fmt='%d', newline=newline)
         c.seek(0)
         lines = c.readlines()
+        newline = newline.encode()
         assert_equal(lines, [b'1 2'+newline+b'3 4'+newline, ],
                      err_msg='Tab newline')
     

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -551,10 +551,10 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)' \
+            [b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)'
              + newline,
-             b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)' \
-             + newline ])
+             b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)'
+             + newline])
 
         # One format for each real and imaginary part
         c = BytesIO()
@@ -563,9 +563,9 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00' \
+            [b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00'
              + newline,
-             b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00' \
+             b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00'
              + newline])
 
         # One format for each complex number
@@ -575,9 +575,9 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)' \ 
+            [b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)'
              + newline,
-             b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)' \
+             b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)'
              + newline])
 
     def test_complex_negative_exponent(self):
@@ -595,9 +595,9 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)' \
+            [b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)'
              + newline,
-             b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)' \
+             b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)'
              + newline])
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -441,12 +441,16 @@ class TestSaveTxt:
         a = np.array([(1, 2), (3, 4)])
         c = BytesIO()
         
-        # Native
+        # Universal newline, implicit and explicit
         newline = os.linesep.encode()
+        np.savetxt(c, a, fmt='%d')
+        c.seek(0)
+        assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
+                     err_msg='Universal newline, implicit')
         np.savetxt(c, a, fmt='%d', newline=None)
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
-                     err_msg='Native newline')
+                     err_msg='Universal newline, explicit')
 
         # POSIX
         newline = b'\n'
@@ -508,7 +512,7 @@ class TestSaveTxt:
         c.seek(0)
         assert_equal(c.read(),
                      asbytes('1 2\n3 4\n' + commentstr + test_header_footer + '\n'))
-
+    
     def test_file_roundtrip(self):
         with temppath() as name:
             a = np.array([(1, 2), (3, 4)])

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -542,6 +542,7 @@ class TestSaveTxt:
         re = np.pi
         im = np.e
         a[:] = re + 1.0j * im
+        newline = os.linesep.encode()
 
         # One format only
         c = BytesIO()
@@ -550,8 +551,10 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n',
-             b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)\n'])
+            [b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)' \
+             + newline,
+             b' ( +3.142e+00+ +2.718e+00j)  ( +3.142e+00+ +2.718e+00j)' \
+             + newline ])
 
         # One format for each real and imaginary part
         c = BytesIO()
@@ -560,8 +563,10 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n',
-             b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00\n'])
+            [b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00' \
+             + newline,
+             b'  +3.142e+00  +2.718e+00  +3.142e+00  +2.718e+00' \
+             + newline])
 
         # One format for each complex number
         c = BytesIO()
@@ -570,8 +575,10 @@ class TestSaveTxt:
         lines = c.readlines()
         assert_equal(
             lines,
-            [b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n',
-             b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)\n'])
+            [b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)' \ 
+             + newline,
+             b'(3.142e+00+2.718e+00j) (3.142e+00+2.718e+00j)' \
+             + newline])
 
     def test_complex_negative_exponent(self):
         # Previous to 1.15, some formats generated x+-yj, gh 7895
@@ -581,14 +588,17 @@ class TestSaveTxt:
         re = np.pi
         im = np.e
         a[:] = re - 1.0j * im
+        newline = os.linesep.encode()
         c = BytesIO()
         np.savetxt(c, a, fmt='%.3e')
         c.seek(0)
         lines = c.readlines()
         assert_equal(
             lines,
-            [b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)\n',
-             b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)\n'])
+            [b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)' \
+             + newline,
+             b' (3.142e+00-2.718e+00j)  (3.142e+00-2.718e+00j)' \
+             + newline])
 
 
     def test_custom_writer(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -437,6 +437,38 @@ class TestSaveTxt:
         c = BytesIO()
         assert_raises(ValueError, np.savetxt, c, a, fmt=99)
 
+    def test_newline(self):
+        a = np.array([(1, 2), (3, 4)])
+        c = BytesIO()
+        
+        # Native
+        np.savetxt(c, a, newline=None, fmt='%1d')
+        c.seek(0)
+        assert_equal(c.readlines(), [b'1 2'+os.linesep.encode(), b'3 4'+os.linesep.encode()])
+
+        # POSIX
+        newline=b'\n'
+        c = BytesIO()
+        np.savetxt(c, a, fmt='%1d')
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+
+        # NT
+        newline=b'\r\n'
+        c = BytesIO()
+        np.savetxt(c, a, fmt='%1d')
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+
+        # Tab
+        c = BytesIO()
+        np.savetxt(c, a, fmt='%1d')
+        c.seek(0)
+        lines = c.readlines()
+        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+    
     def test_header_footer(self):
         # Test the functionality of the header and footer keyword argument.
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -443,32 +443,37 @@ class TestSaveTxt:
         
         # Native
         newline = os.linesep.encode()
-        np.savetxt(c, a, newline=None, fmt='%1d')
+        np.savetxt(c, a, fmt='%1d', newline=None)
         c.seek(0)
-        assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline])
+        assert_equal(c.readlines(), [b'1 2'+newline, b'3 4'+newline],
+                     err_msg='Native newline)
 
         # POSIX
         newline = b'\n'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d')
+        np.savetxt(c, a, fmt='%1d', newline=newline)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
+                     err_msg='POSIX newline)
 
         # NT
         newline = b'\r\n'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d')
+        np.savetxt(c, a, fmt='%1d', newline=newline)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline],
+                     err_msg='NT newline)
 
         # Tab
+        newline = b'\t'
         c = BytesIO()
-        np.savetxt(c, a, fmt='%1d')
+        np.savetxt(c, a, fmt='%1d', newline=newline)
         c.seek(0)
         lines = c.readlines()
-        assert_equal(lines, [b'1 2'+newline, b'3 4'+newline])
+        assert_equal(lines, [b'1 2'+newline+b'3 4'+newline, ],
+                     err_msg='Tab newline)
     
     def test_header_footer(self):
         # Test the functionality of the header and footer keyword argument.


### PR DESCRIPTION
BUG:  Pass newline to datasource.open() in numpy.lib.npio.savetxt().

Currently, the value of newline passed to savetxt() is not respected for line endings.  Below is shown on Windows that a request for Unix-style line endings results in Windows-style line endings being written.
```
import numpy as np
x = y = z = np.arange(0.0,5.0,1.0)
np.savetxt('test.out', x, delimiter=',', newline='\n')

with open('test.out', 'rb') as fin:
    text = fin.read()
print(text)
b'0.000000000000000000e+00\r\n1.000000000000000000e+00\r\n2.000000000000000000e+00\r\n3.000000000000000000e+00\r\n4.000000000000000000e+00\r\n'
```
(Python 3.11.5, Numpy 1.24.3, problem extends back many years)

My apologies for not having thoroughly tested this trivial change.  I am supplying a quick PR to get things moving, then will have to follow up after work hours.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
