### PR TITLE
TST: Fix f2py doc test collection in editable installs

### DIFF
--- a/numpy/f2py/tests/test_docs.py
+++ b/numpy/f2py/tests/test_docs.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
@@ -6,9 +5,18 @@ from . import util
 from pathlib import Path
 
 def get_docdir():
-    # Assumes that spin is used to run tests
-    nproot = Path(__file__).resolve().parents[8]
-    return  nproot / "doc" / "source" / "f2py" / "code"
+    parents = Path(__file__).resolve().parents
+    try:
+        # Assumes that spin is used to run tests
+        nproot = parents[8]
+    except IndexError:
+        docdir = None
+    else:
+        docdir = nproot / "doc" / "source" / "f2py" / "code"
+    if docdir and docdir.is_dir():
+        return docdir
+    # Assumes that an editable install is used to run tests
+    return parents[3] / "doc" / "source" / "f2py" / "code"
 
 pytestmark = pytest.mark.skipif(
     not get_docdir().is_dir(),


### PR DESCRIPTION
When running outside `spin` and in a short directory path, the `parents[8]` causes an `IndexError` and a _very very long_ backtrace during the collection stage. This fixes that and also adds a fallback for an editable install.