### PR TITLE
TST: Fix test_warning_calls on Python 3.12

### DIFF
--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -32,7 +32,7 @@ class FindFuncs(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-            if node.args[0].s == "ignore":
+            if node.args[0].value == "ignore":
                 raise AssertionError(
                     "warnings should have an appropriate stacklevel; found in "
                     "{} on line {}".format(self.__filename, node.lineno))


### PR DESCRIPTION
It currently raises a warning:
```
DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
```
AFAICT, the `value` attribute has always existed (at least in supported versions of Python 3.)