### PR TITLE
BUG: Use large file fallocate on 32 bit linux platforms

### DIFF
--- a/numpy/core/feature_detection_stdio.h
+++ b/numpy/core/feature_detection_stdio.h
@@ -1,6 +1,9 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <fcntl.h>
 
+#if 0 /* Only for setup_common.py, not the C compiler */
 off_t ftello(FILE *stream);
 int fseeko(FILE *stream, off_t offset, int whence);
 int fallocate(int, int, off_t, off_t);
+#endif

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -23,8 +23,9 @@
 #include "array_coercion.h"
 #include "refcount.h"
 
-int
-fallocate(int fd, int mode, off_t offset, off_t len);
+#if defined(HAVE_FALLOCATE) && defined(__linux__)
+#include <fcntl.h>
+#endif
 
 /*
  * allocate nbytes of diskspace for file fp


### PR DESCRIPTION
Using a local prototype for fallocate instead of the fcntl.h header meant that the redirect triggered by -D_FILE_OFFSET_BITS=64 was not triggered.

The prototypes in feature_detection_stdio.h should only be used by functions in setup_common.py. If they are used by the feature discovery code they might trigger false positives.

A similar but not identical PR https://github.com/numpy/numpy/pull/25631 has been pushed for master.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
