### PR TITLE
BUG: Use large file fallocate on 32 bit linux platforms

### DIFF
--- a/numpy/_core/feature_detection_stdio.h
+++ b/numpy/_core/feature_detection_stdio.h
@@ -1,6 +1,3 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <fcntl.h>
-
-off_t ftello(FILE *stream);
-int fseeko(FILE *stream, off_t offset, int whence);
-int fallocate(int, int, off_t, off_t);

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -23,8 +23,9 @@
 #include "array_coercion.h"
 #include "refcount.h"
 
-int
-fallocate(int fd, int mode, off_t offset, off_t len);
+#if defined(HAVE_FALLOCATE) && defined(__linux__)
+#include <fcntl.h>
+#endif
 
 /*
  * allocate nbytes of diskspace for file fp


### PR DESCRIPTION
In spite of all of the [required preprocessor directives set](https://github.com/numpy/numpy/blob/0a4b2b83eaf3479f352a7fe5a4b378a169ab48f0/numpy/meson.build#L49) to use UNIX Large File Support, [multiarray/convert.c](https://github.com/numpy/numpy/blob/0a4b2b83eaf3479f352a7fe5a4b378a169ab48f0/numpy/_core/src/multiarray/convert.c#L26) still used the `fallocate` version with 32bit `offset_t`, at least with glibc.

glibc provides both 32bit and 64bit `fallocate` by silently using the `fallocate64` symbol instead of `fallocate` when `-D_FILE_OFFSET_BITS=64` is set.  Using a local prototype for `fallocate` instead of the `fcntl.h` header in `multiarray/convert.c` circumvented the glibc redirect. 

A similar but not identical PR #25630 has been pushed for 1.26.X.