### PR TITLE
TST: Fix test_warning_calls on Python 3.12

### DIFF
--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -5,7 +5,6 @@ all of these occurrences but should catch almost all.
 import pytest
 
 from pathlib import Path
-import sys
 import ast
 import tokenize
 import numpy
@@ -33,7 +32,7 @@ class FindFuncs(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-            if node.args[0].s == "ignore":
+            if node.args[0].value == "ignore":
                 raise AssertionError(
                     "warnings should have an appropriate stacklevel; found in "
                     "{} on line {}".format(self.__filename, node.lineno))
@@ -57,8 +56,6 @@ class FindFuncs(ast.NodeVisitor):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(sys.version_info >= (3, 12),
-                    reason="Deprecation warning in ast")
 def test_warning_calls():
     # combined "ignore" and stacklevel error
     base = Path(numpy.__file__).parent


### PR DESCRIPTION
Backport of #25628.

It currently raises a warning:
```
DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
```
AFAICT, the `value` attribute has always existed (at least in supported versions of Python 3.)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
