### PR TITLE
TST: Bump pytz to 2023.3.post1

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,7 @@ setuptools==59.2.0 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
 hypothesis==6.81.1
 pytest==7.4.0
-pytz==2023.3
+pytz==2023.3.post1
 pytest-cov==4.1.0
 meson
 pytest-xdist


### PR DESCRIPTION
Backport of #25629.

This version fixes the DeprecationWarning in Python 3.12:
```
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated
and scheduled for removal in a future version. Use timezone-aware
objects to represent datetimes in UTC:
datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
