### PR TITLE
ENH: Allow strings in logical ufuncs

### DIFF
--- a/doc/release/upcoming_changes/25651.improvement.rst
+++ b/doc/release/upcoming_changes/25651.improvement.rst
@@ -1,0 +1,1 @@
+* Strings are now supported by ``any``, ``all`, and the logical ufuncs.

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -1173,17 +1173,6 @@ logical_ufunc_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
      */
     int force_object = 0;
 
-    if (signature[0] == NULL && signature[1] == NULL
-            && signature[2] != NULL && signature[2]->type_num != NPY_BOOL) {
-        /* bail out, this is _only_ to give future/deprecation warning! */
-        return -1;
-    }
-    if ((op_dtypes[0] != NULL && PyTypeNum_ISSTRING(op_dtypes[0]->type_num))
-            || PyTypeNum_ISSTRING(op_dtypes[1]->type_num)) {
-        /* bail out on strings: currently casting them to bool is too weird */
-        return -1;
-    }
-
     for (int i = 0; i < 3; i++) {
         PyArray_DTypeMeta *item;
         if (signature[i] != NULL) {


### PR DESCRIPTION
I didn't allow them because casting strings to bools made no sense at all.  But that was fixed in gh-23898.

I am very sure the deprecation is expired and I simply forgot to remove that branch also.

Closes gh-1912
