### PR TITLE
MAINT: Refactor C++ Sort Operations

### DIFF
--- a/numpy/_core/src/common/npstd.hpp
+++ b/numpy/_core/src/common/npstd.hpp
@@ -35,20 +35,414 @@ using std::complex;
 using std::uint_fast16_t;
 using std::uint_fast32_t;
 using SSize = Py_ssize_t;
-/** Guard for long double.
- *
- * The C implementation defines long double as double
- * on MinGW to provide compatibility with MSVC to unify
- * one behavior under Windows OS, which makes npy_longdouble
- * not fit to be used with template specialization or overloading.
- *
- * This type will be set to `void` when `npy_longdouble` is not defined
- * as `long double`.
+/// @} cpp_core_types
+
+/// @addtogroup cpp_core_constants
+/// @{
+/// Enumerated values represents the basic 24 data types.
+enum class TypeID : char {
+    /// Represents `Bool`.
+    kBool = 0,
+    /// Represents `Byte`.
+    kByte,
+    /// Represents `UByte`.
+    kUByte,
+    /// Represents `Short`.
+    kShort,
+    /// Represents `UShort`.
+    kUShort,
+    /// Represents `Int`.
+    kInt,
+    /// Represents `UInt`.
+    kUInt,
+    /// Represents `Long`.
+    kLong,
+    /// Represents `ULong`.
+    kULong,
+    /// Represents `LongLong`.
+    kLongLong,
+    /// Represents `ULongLong`.
+    kULongLong,
+    /// Represents `Float`.
+    kFloat,
+    /// Represents `Double`.
+    kDouble,
+    /// Represents `LongDouble`.
+    kLongDouble,
+    /// Represents `CFloat`.
+    kCFloat,
+    /// Represents `CDouble`.
+    kCDouble,
+    /// Represents `CLongDouble`.
+    kCLongDouble,
+    /// Represents `Object`.
+    kObject = 17,
+    /// Represents `String`.
+    kString,
+    /// Represents `Unicode`.
+    kUnicode,
+    /// Represents `Void`.
+    kVoid,
+    /// Represents `DateTime`.
+    kDateTime,
+    /// Represents `TimeDelta`.
+    kTimeDelta,
+    /// Represents `Half`.
+    kHalf
+};
+
+/// @name Types IDs alias
+/// For lazy access to enumeration values of `TypeID`.
+/// @{
+constexpr auto kBool = TypeID::kBool;
+constexpr auto kByte = TypeID::kByte;
+constexpr auto kUByte = TypeID::kUByte;
+constexpr auto kShort = TypeID::kShort;
+constexpr auto kUShort = TypeID::kUShort;
+constexpr auto kInt = TypeID::kInt;
+constexpr auto kUInt = TypeID::kUInt;
+constexpr auto kLong = TypeID::kLong;
+constexpr auto kULong = TypeID::kULong;
+constexpr auto kLongLong = TypeID::kLongLong;
+constexpr auto kULongLong = TypeID::kULongLong;
+constexpr auto kHalf = TypeID::kHalf;
+constexpr auto kFloat = TypeID::kFloat;
+constexpr auto kDouble = TypeID::kDouble;
+constexpr auto kLongDouble = TypeID::kLongDouble;
+constexpr auto kCFloat = TypeID::kCFloat;
+constexpr auto kCDouble = TypeID::kCDouble;
+constexpr auto kCLongDouble = TypeID::kCLongDouble;
+constexpr auto kObject = TypeID::kObject;
+constexpr auto kString = TypeID::kString;
+constexpr auto kUnicode = TypeID::kUnicode;
+constexpr auto kVoid = TypeID::kVoid;
+constexpr auto kDateTime = TypeID::kDateTime;
+constexpr auto kTimeDelta = TypeID::kTimeDelta;
+/// @}
+
+/// Number of supported basic data types (24).
+constexpr int kNTypes = static_cast<int>(kHalf) + 1;
+/// Whether long double is forced or has the same precision as double.
+#if defined(WIN32) || defined(_WIN32)
+constexpr bool kLongDoubleIsDouble = true;
+#else
+constexpr bool kLongDoubleIsDouble = sizeof(long double) == sizeof(double);
+#endif
+
+template<typename T, TypeID>
+class Holder;
+class Half;
+class DateTime;
+class TimeDelta;
+class Object;
+
+namespace details {
+template<typename T>
+struct Traits;
+template<>
+struct Traits<bool> { static constexpr TypeID kID = kBool; };
+template<>
+struct Traits<Half> { static constexpr TypeID kID = kHalf; };
+template<>
+struct Traits<float> { static constexpr TypeID kID = kFloat; };
+template<>
+struct Traits<double> { static constexpr TypeID kID = kDouble; };
+template<>
+struct Traits<long double> { static constexpr TypeID kID = kLongDouble;};
+template<>
+struct Traits<complex<float>> { static constexpr TypeID kID = kCFloat; };
+template<>
+struct Traits<complex<double>> { static constexpr TypeID kID = kCDouble; };
+template<>
+struct Traits<complex<long double>> { static constexpr TypeID kID = kCLongDouble; };
+template<>
+struct Traits<Object> { static constexpr TypeID kID = kObject; };
+template<>
+struct Traits<DateTime> { static constexpr TypeID kID = kDateTime; };
+template<>
+struct Traits<TimeDelta> { static constexpr TypeID kID = kTimeDelta; };
+template<typename T, TypeID ID>
+struct Traits<Holder<T, ID>> { static constexpr TypeID kID = ID; };
+} // namespace details
+
+/// Returns TypeID based on @tparam T.
+template<typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>>>
+constexpr TypeID kTypeID = details::Traits<TBase>::kID;
+
+/// Checks whether @tparam `T` is an boolean type.
+template<typename T>
+constexpr bool kIsBool = kTypeID<T> == kBool;
+
+/// Checks whether `T` is an unsigned integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsUnsigned = ID == kUByte || ID == kUShort || ID == kUInt ||
+                             ID == kULong || ID == kULongLong;
+
+/// Checks whether `T` is an signed integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsSigned = ID == kByte || ID == kShort || ID == kInt ||
+                           ID == kLong || ID == kLongLong;
+
+/// Checks whether `T` is an integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsIntegral = kIsSigned<T> || kIsUnsigned<T>;
+
+/// Checks whether `T` is an floating-point type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsFloat = ID == kHalf || ID == kFloat ||
+                          ID == kDouble || ID == kLongDouble;
+
+/// Checks whether `T` is an complex type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsComplex = ID == kCFloat || ID == kCDouble ||
+                            ID == kCLongDouble;
+
+/// Checks whether `T` is an time type (`DateTime`, `Timedelta`).
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsTime = ID == kDateTime || ID == kTimeDelta;
+/// @} cpp_core_constants
+
+/// @addtogroup cpp_core_containers
+/// @{
+/// Class wraps builtin data types.
+/// To distinct them, and gives the room for dealing
+/// with platform compatiblty.
+template <typename T, TypeID>
+class Holder {
+  public:
+    /// initlize nothing.
+    Holder() = default;
+    /// Construct from `T`
+    constexpr Holder(const T &val) : val_(val)
+    {}
+    /// cast
+    constexpr operator T () const
+    { return val_; }
+
+  private:
+    T val_;
+};
+template<template<class> class C, typename T, TypeID ID>
+class Holder<C<T>, ID> : public C<T> {
+  public:
+    using C<T>::C;
+};
+/// @} cpp_core_containers
+
+/// @addtogroup cpp_core_types
+/// @{
+/// Signed integer with at least 8-bit width.
+using Byte = Holder<signed char, kByte>;
+/// Unsigned integer with at least 8-bit width.
+using UByte = Holder<unsigned char, kUByte>;
+/// Signed integer with at least 16-bit width.
+using Short = Holder<short, kShort>;
+/// Unsigned integer with at least 16-bit width.
+using UShort = Holder<unsigned short, kUShort>;
+/// Signed integer with at least 16-bit width.
+using Int = Holder<int, kInt>;
+/// Unsigned integer with at least 16-bit width.
+using UInt = Holder<unsigned int, kUInt>;
+/// Signed integer with at least 32-bit width.
+using Long = Holder<long, kLong>;
+/// Unsigned integer with at least 32-bit width.
+using ULong = Holder<unsigned long, kULong>;
+/// Signed integer with at least 64-bit width.
+using LongLong = Holder<long long, kLongLong>;
+/// Unsigned integer with at least 64-bit width.
+using ULongLong = Holder<unsigned long long, kULongLong>;
+/// Boolean type, stored as `Byte`.
+/// It may only be set to the values false and true.
+using Bool = std::conditional_t<sizeof(bool) == sizeof(unsigned char),
+    bool, Holder<unsigned char, kBool>>;
+/// single-precision floating-point type, compatible with IEEE-754.
+using Float = float;
+/// double-precision floating-point type, compatible with IEEE-754.
+using Double = double;
+/**
+ * Extended precision floating-point type, compatible with IEEE-754.
+ * Provides at least the same precision of `Double`.
+ * Note:
+ *  The C implementation defines long double as double
+ *  on MinGW to provide compatibility with MSVC to unify
+ *  one behavior under Windows OS.
  */
-using LongDouble = typename std::conditional<
-    !std::is_same<npy_longdouble, long double>::value,
-     void, npy_longdouble
->::type;
+using LongDouble = std::conditional_t<kLongDoubleIsDouble,
+      Holder<double, kLongDouble>, long double>;
+/// Complex type made up of two `Float` values.
+using CFloat = complex<float>;
+/// Complex type made up of two `Double` values.
+using CDouble = complex<double>;
+/// Complex type made up of two `LongDouble` values.
+using CLongDouble = std::conditional_t<kLongDoubleIsDouble,
+      Holder<complex<double>, kCLongDouble>, complex<long double>>;
+
+using String = Holder<unsigned char, kString>;
+using Unicode = Holder<uint32_t, kUnicode>;
+/** An abstract type that implements general date/time
+ * operations for types `DateTime` and `Timedelta`.
+ *
+ * This type is ensured to be 64-bits size.
+ */
+class AbstractTime {
+ public:
+    /// initlize nothing.
+    AbstractTime() = default;
+    /// Constract from int64_t
+    constexpr AbstractTime(int64_t d) : bits_(d)
+    {}
+    /// cast to int64_t.
+    constexpr operator int64_t() const
+    {
+        return bits_;
+    }
+    /// Initialize with not-a-time value.
+    constexpr static AbstractTime NaT()
+    {
+        return AbstractTime(std::numeric_limits<int64_t>::min());
+    }
+    /// @name Comparison operators
+    /// @{
+    constexpr bool operator==(const AbstractTime &r) const
+    {
+        return bits_ == r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator!=(const AbstractTime &r) const
+    {
+        return bits_ != r.bits_ || IsNaT() || r.IsNaT();
+    }
+    constexpr bool operator<(const AbstractTime &r) const
+    {
+        return bits_ < r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator>(const AbstractTime &r) const
+    {
+        return r < *this;
+    }
+    constexpr bool operator<=(const AbstractTime &r) const
+    {
+        return bits_ <= r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator>=(const AbstractTime &r) const
+    {
+        return r <= *this;
+    }
+    /// @}
+
+    /// @name Arithmetic operators
+    /// @{
+    constexpr AbstractTime operator+(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ + r.bits_);
+    }
+    constexpr AbstractTime &operator+=(const AbstractTime &r)
+    {
+        *this = (*this) + r;
+        return *this;
+    }
+    constexpr AbstractTime operator-(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ - r.bits_);
+    }
+    constexpr AbstractTime &operator-=(const AbstractTime &r)
+    {
+        *this = (*this) - r;
+        return *this;
+    }
+    constexpr AbstractTime operator*(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ * r.bits_);
+    }
+    constexpr AbstractTime &operator*=(const AbstractTime &r)
+    {
+        *this = (*this) * r;
+        return *this;
+    }
+    constexpr AbstractTime operator/(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ / r.bits_);
+    }
+    constexpr AbstractTime &operator/=(const AbstractTime &r)
+    {
+        *this = (*this) / r;
+        return *this;
+    }
+    /// @}
+
+    /// @name Properties
+    /// @{
+    constexpr bool IsNaT() const
+    {
+        return bits_ == static_cast<int64_t>(NaT());
+    }
+    constexpr bool IsFinite() const
+    {
+        return bits_ != static_cast<int64_t>(NaT());
+    }
+    /// @}
+
+  private:
+    int64_t bits_;
+};
+
+/// Holds dates or datetimes with a precision based on selectable date or time units.
+class DateTime : public AbstractTime
+{
+  public:
+    using AbstractTime::AbstractTime;
+};
+/// Holds lengths of times in integers of selectable date or time units.
+class TimeDelta : public AbstractTime
+{
+  public:
+    using AbstractTime::AbstractTime;
+};
+
+
+
+namespace details {
+template<int size, bool unsig>
+struct IntBySize;
+
+template<bool unsig>
+struct IntBySize<sizeof(uint8_t), unsig> {
+    using Type = typename std::conditional_t<
+        unsig, uint8_t, int8_t>;
+};
+template<bool unsig>
+struct IntBySize<sizeof(uint16_t), unsig> {
+    using Type = typename std::conditional_t<
+        unsig, uint16_t, int16_t>;
+};
+template<bool unsig>
+struct IntBySize<sizeof(uint32_t), unsig> {
+    using Type = typename std::conditional_t<
+        unsig, uint32_t, int32_t>;
+};
+template<bool unsig>
+struct IntBySize<sizeof(uint64_t), unsig> {
+    using Type = typename std::conditional_t<
+        unsig, uint64_t, int64_t>;
+};
+} // namespace details
+
+template <typename T>
+using MakeFixedIntegral = std::conditional_t<
+    kIsIntegral<T>, typename details::IntBySize<sizeof(T), kIsUnsigned<T>>::Type, T
+>;
+
 /// @} cpp_core_types
 
 } // namespace np

--- a/numpy/_core/src/npysort/binsearch.cpp
+++ b/numpy/_core/src/npysort/binsearch.cpp
@@ -1,71 +1,131 @@
-/* -*- c -*- */
-
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include "numpy/ndarraytypes.h"
-#include "numpy/npy_common.h"
-
 #include "npy_binsearch.h"
-#include "npy_sort.h"
-#include "numpy_tag.h"
 
-#include <array>
-#include <functional>  // for std::less and std::less_equal
+#include "heapsort.hpp" // np::sort::LessThan()
 
-// Enumerators for the variant of binsearch
-enum arg_t
+namespace np::sort {
+
+template <bool right_side, typename T>
+inline bool BinaryCompare(const T &a, const T &b)
 {
-    noarg,
-    arg
-};
-enum side_t
+    if constexpr (right_side) {
+        return !LessThan(b, a);
+    }
+    else {
+        return LessThan(a, b);
+    }
+}
+
+template <bool right_side>
+inline bool BinaryGenericCompare(int a, int b)
 {
-    left,
-    right
-};
+    if constexpr (right_side) {
+        return a <= b;
+    }
+    else {
+        return a < b;
+    }
+}
 
-// Mapping from enumerators to comparators
-template <class Tag, side_t side>
-struct side_to_cmp;
-
-template <class Tag>
-struct side_to_cmp<Tag, left> {
-    static constexpr auto value = Tag::less;
-};
-
-template <class Tag>
-struct side_to_cmp<Tag, right> {
-    static constexpr auto value = Tag::less_equal;
-};
-
-template <side_t side>
-struct side_to_generic_cmp;
-
-template <>
-struct side_to_generic_cmp<left> {
-    using type = std::less<int>;
-};
-
-template <>
-struct side_to_generic_cmp<right> {
-    using type = std::less_equal<int>;
-};
-
-/*
- *****************************************************************************
- **                            NUMERIC SEARCHES                             **
- *****************************************************************************
- */
-template <class Tag, side_t side>
-static void
-binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
-          npy_intp key_len, npy_intp arr_str, npy_intp key_str,
-          npy_intp ret_str, PyArrayObject *)
+template <bool right_side>
+void BinaryGenericSearch(const char *arr, const char *key, char *ret, SSize arr_len,
+                         SSize key_len, SSize arr_str, SSize key_str,
+                         SSize ret_str, PyArrayObject *cmp)
 {
-    using T = typename Tag::type;
-    auto cmp = side_to_cmp<Tag, side>::value;
-    npy_intp min_idx = 0;
-    npy_intp max_idx = arr_len;
+    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
+    SSize min_idx = 0;
+    SSize max_idx = arr_len;
+    const char *last_key = key;
+
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (BinaryGenericCompare<right_side>(compare(last_key, key, cmp), 0)) {
+            max_idx = arr_len;
+        }
+        else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+
+        last_key = key;
+
+        while (min_idx < max_idx) {
+            const SSize mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const char *arr_ptr = arr + mid_idx * arr_str;
+
+            if (BinaryGenericCompare<right_side>(compare(arr_ptr, key, cmp), 0)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(SSize *)ret = min_idx;
+    }
+}
+
+template <bool right_side>
+int BinaryArgGenericSearch(const char *arr, const char *key, const char *sort, char *ret,
+                           SSize arr_len, SSize key_len, SSize arr_str,
+                           SSize key_str, SSize sort_str, SSize ret_str,
+                           PyArrayObject *cmp)
+{
+    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
+    SSize min_idx = 0;
+    SSize max_idx = arr_len;
+    const char *last_key = key;
+
+    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
+        /*
+         * Updating only one of the indices based on the previous key
+         * gives the search a big boost when keys are sorted, but slightly
+         * slows down things for purely random ones.
+         */
+        if (BinaryGenericCompare<right_side>(compare(last_key, key, cmp), 0)) {
+            max_idx = arr_len;
+        }
+        else {
+            min_idx = 0;
+            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
+        }
+
+        last_key = key;
+
+        while (min_idx < max_idx) {
+            const SSize mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const SSize sort_idx = *(SSize *)(sort + mid_idx * sort_str);
+            const char *arr_ptr;
+
+            if (sort_idx < 0 || sort_idx >= arr_len) {
+                return -1;
+            }
+
+            arr_ptr = arr + sort_idx * arr_str;
+
+            if (BinaryGenericCompare<right_side>(compare(arr_ptr, key, cmp), 0)) {
+                min_idx = mid_idx + 1;
+            }
+            else {
+                max_idx = mid_idx;
+            }
+        }
+        *(SSize *)ret = min_idx;
+    }
+    return 0;
+}
+
+template <bool right_side, typename T>
+void BinarySearch(const char *arr, const char *key, char *ret, SSize arr_len,
+                  SSize key_len, SSize arr_str, SSize key_str,
+                  SSize ret_str, PyArrayObject *)
+{
+    SSize min_idx = 0;
+    SSize max_idx = arr_len;
     T last_key_val;
 
     if (key_len == 0) {
@@ -80,7 +140,7 @@ binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (cmp(last_key_val, key_val)) {
+        if (BinaryCompare<right_side>(last_key_val, key_val)) {
             max_idx = arr_len;
         }
         else {
@@ -91,30 +151,43 @@ binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
         last_key_val = key_val;
 
         while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const SSize mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const T mid_val = *(const T *)(arr + mid_idx * arr_str);
-            if (cmp(mid_val, key_val)) {
+            if (BinaryCompare<right_side>(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
             }
             else {
                 max_idx = mid_idx;
             }
         }
-        *(npy_intp *)ret = min_idx;
+        *(SSize *)ret = min_idx;
     }
 }
 
-template <class Tag, side_t side>
-static int
-argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
-             npy_intp arr_len, npy_intp key_len, npy_intp arr_str,
-             npy_intp key_str, npy_intp sort_str, npy_intp ret_str,
-             PyArrayObject *)
+template <>
+void BinarySearch<false, void>(const char *arr, const char *key, char *ret, SSize arr_len,
+                               SSize key_len, SSize arr_str, SSize key_str,
+                               SSize ret_str, PyArrayObject *cmp)
 {
-    using T = typename Tag::type;
-    auto cmp = side_to_cmp<Tag, side>::value;
-    npy_intp min_idx = 0;
-    npy_intp max_idx = arr_len;
+    BinaryGenericSearch<false>(arr, key, ret, arr_len, key_len, arr_str, key_str, ret_str, cmp);
+}
+template <>
+void BinarySearch<true, void>(const char *arr, const char *key, char *ret, SSize arr_len,
+                               SSize key_len, SSize arr_str, SSize key_str,
+                               SSize ret_str, PyArrayObject *cmp)
+{
+    BinaryGenericSearch<true>(arr, key, ret, arr_len, key_len, arr_str, key_str, ret_str, cmp);
+}
+
+
+template <bool right_side, typename T>
+int BinaryArgSearch(const char *arr, const char *key, const char *sort, char *ret,
+                    SSize arr_len, SSize key_len, SSize arr_str,
+                    SSize key_str, SSize sort_str, SSize ret_str,
+                    PyArrayObject *)
+{
+    SSize min_idx = 0;
+    SSize max_idx = arr_len;
     T last_key_val;
 
     if (key_len == 0) {
@@ -129,7 +202,7 @@ argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (cmp(last_key_val, key_val)) {
+        if (BinaryCompare<right_side>(last_key_val, key_val)) {
             max_idx = arr_len;
         }
         else {
@@ -140,8 +213,8 @@ argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
         last_key_val = key_val;
 
         while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-            const npy_intp sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
+            const SSize mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+            const SSize sort_idx = *(SSize *)(sort + mid_idx * sort_str);
             T mid_val;
 
             if (sort_idx < 0 || sort_idx >= arr_len) {
@@ -150,254 +223,96 @@ argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
 
             mid_val = *(const T *)(arr + sort_idx * arr_str);
 
-            if (cmp(mid_val, key_val)) {
+            if (BinaryCompare<right_side>(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
             }
             else {
                 max_idx = mid_idx;
             }
         }
-        *(npy_intp *)ret = min_idx;
+        *(SSize *)ret = min_idx;
     }
     return 0;
 }
 
-/*
- *****************************************************************************
- **                             GENERIC SEARCH                              **
- *****************************************************************************
- */
-
-template <side_t side>
-static void
-npy_binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
-              npy_intp key_len, npy_intp arr_str, npy_intp key_str,
-              npy_intp ret_str, PyArrayObject *cmp)
+template <>
+int BinaryArgSearch<false, void>(const char *arr, const char *key, const char *sort, char *ret,
+                                SSize arr_len, SSize key_len, SSize arr_str,
+                                SSize key_str, SSize sort_str, SSize ret_str,
+                                PyArrayObject *cmp)
 {
-    using Cmp = typename side_to_generic_cmp<side>::type;
-    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
-    npy_intp min_idx = 0;
-    npy_intp max_idx = arr_len;
-    const char *last_key = key;
-
-    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
-        /*
-         * Updating only one of the indices based on the previous key
-         * gives the search a big boost when keys are sorted, but slightly
-         * slows down things for purely random ones.
-         */
-        if (Cmp{}(compare(last_key, key, cmp), 0)) {
-            max_idx = arr_len;
-        }
-        else {
-            min_idx = 0;
-            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
-        }
-
-        last_key = key;
-
-        while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-            const char *arr_ptr = arr + mid_idx * arr_str;
-
-            if (Cmp{}(compare(arr_ptr, key, cmp), 0)) {
-                min_idx = mid_idx + 1;
-            }
-            else {
-                max_idx = mid_idx;
-            }
-        }
-        *(npy_intp *)ret = min_idx;
-    }
+    return BinaryArgGenericSearch<false>(arr, key, sort, ret, arr_len, key_len, arr_str,
+                                         key_str, sort_str, ret_str, cmp);
+}
+template <>
+int BinaryArgSearch<true, void>(const char *arr, const char *key, const char *sort, char *ret,
+                                SSize arr_len, SSize key_len, SSize arr_str,
+                                SSize key_str, SSize sort_str, SSize ret_str,
+                                PyArrayObject *cmp)
+{
+    return BinaryArgGenericSearch<true>(arr, key, sort, ret, arr_len, key_len, arr_str,
+                                        key_str, sort_str, ret_str, cmp);
 }
 
-template <side_t side>
-static int
-npy_argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
-                 npy_intp arr_len, npy_intp key_len, npy_intp arr_str,
-                 npy_intp key_str, npy_intp sort_str, npy_intp ret_str,
-                 PyArrayObject *cmp)
-{
-    using Cmp = typename side_to_generic_cmp<side>::type;
-    PyArray_CompareFunc *compare = PyArray_DESCR(cmp)->f->compare;
-    npy_intp min_idx = 0;
-    npy_intp max_idx = arr_len;
-    const char *last_key = key;
-
-    for (; key_len > 0; key_len--, key += key_str, ret += ret_str) {
-        /*
-         * Updating only one of the indices based on the previous key
-         * gives the search a big boost when keys are sorted, but slightly
-         * slows down things for purely random ones.
-         */
-        if (Cmp{}(compare(last_key, key, cmp), 0)) {
-            max_idx = arr_len;
-        }
-        else {
-            min_idx = 0;
-            max_idx = (max_idx < arr_len) ? (max_idx + 1) : arr_len;
-        }
-
-        last_key = key;
-
-        while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-            const npy_intp sort_idx = *(npy_intp *)(sort + mid_idx * sort_str);
-            const char *arr_ptr;
-
-            if (sort_idx < 0 || sort_idx >= arr_len) {
-                return -1;
-            }
-
-            arr_ptr = arr + sort_idx * arr_str;
-
-            if (Cmp{}(compare(arr_ptr, key, cmp), 0)) {
-                min_idx = mid_idx + 1;
-            }
-            else {
-                max_idx = mid_idx;
-            }
-        }
-        *(npy_intp *)ret = min_idx;
-    }
-    return 0;
-}
-
-/*
- *****************************************************************************
- **                             GENERATOR                                   **
- *****************************************************************************
- */
-
-template <arg_t arg>
-struct binsearch_base;
-
-template <>
-struct binsearch_base<arg> {
-    using function_type = PyArray_ArgBinSearchFunc *;
-    struct value_type {
-        int typenum;
-        function_type binsearch[NPY_NSEARCHSIDES];
+template <typename ...T>
+struct BinarySearchTab {
+    PyArray_BinSearchFunc *ptrs[2][sizeof...(T)] = {
+        { BinarySearch<false, T>... },
+        { BinarySearch<true, T>... }
     };
-    template <class... Tags>
-    static constexpr std::array<value_type, sizeof...(Tags)>
-    make_binsearch_map(npy::taglist<Tags...>)
-    {
-        return std::array<value_type, sizeof...(Tags)>{
-                value_type{Tags::type_value,
-                           {(function_type)&argbinsearch<Tags, left>,
-                            (function_type)argbinsearch<Tags, right>}}...};
-    }
-    static constexpr std::array<function_type, 2> npy_map = {
-            (function_type)&npy_argbinsearch<left>,
-            (function_type)&npy_argbinsearch<right>};
-};
-constexpr std::array<binsearch_base<arg>::function_type, 2>
-        binsearch_base<arg>::npy_map;
-
-template <>
-struct binsearch_base<noarg> {
-    using function_type = PyArray_BinSearchFunc *;
-    struct value_type {
-        int typenum;
-        function_type binsearch[NPY_NSEARCHSIDES];
+    PyArray_ArgBinSearchFunc *arg_ptrs[2][sizeof...(T)] = {
+        { BinaryArgSearch<false, T>... },
+        { BinaryArgSearch<true, T>... }
     };
-    template <class... Tags>
-    static constexpr std::array<value_type, sizeof...(Tags)>
-    make_binsearch_map(npy::taglist<Tags...>)
-    {
-        return std::array<value_type, sizeof...(Tags)>{
-                value_type{Tags::type_value,
-                           {(function_type)&binsearch<Tags, left>,
-                            (function_type)binsearch<Tags, right>}}...};
-    }
-    static constexpr std::array<function_type, 2> npy_map = {
-            (function_type)&npy_binsearch<left>,
-            (function_type)&npy_binsearch<right>};
-};
-constexpr std::array<binsearch_base<noarg>::function_type, 2>
-        binsearch_base<noarg>::npy_map;
-
-// Handle generation of all binsearch variants
-template <arg_t arg>
-struct binsearch_t : binsearch_base<arg> {
-    using binsearch_base<arg>::make_binsearch_map;
-    using value_type = typename binsearch_base<arg>::value_type;
-
-    using taglist = npy::taglist<
-            /* If adding new types, make sure to keep them ordered by type num
-             */
-            npy::bool_tag, npy::byte_tag, npy::ubyte_tag, npy::short_tag,
-            npy::ushort_tag, npy::int_tag, npy::uint_tag, npy::long_tag,
-            npy::ulong_tag, npy::longlong_tag, npy::ulonglong_tag,
-            npy::float_tag, npy::double_tag, npy::longdouble_tag, 
-            npy::cfloat_tag, npy::cdouble_tag, npy::clongdouble_tag, 
-            npy::datetime_tag, npy::timedelta_tag, npy::half_tag>;
-
-    static constexpr std::array<value_type, taglist::size> map =
-            make_binsearch_map(taglist());
 };
 
-template <arg_t arg>
-constexpr std::array<typename binsearch_t<arg>::value_type,
-                     binsearch_t<arg>::taglist::size>
-        binsearch_t<arg>::map;
+static BinarySearchTab<
+    np::Bool, np::Byte, np::UByte, np::Short,
+    np::UShort, np::Int, np::UInt, np::Long,
+    np::ULong, np::LongLong, np::ULongLong,
+    np::Float, np::Double, np::LongDouble,
+    np::CFloat, np::CDouble, np::CLongDouble,
+    void/*Object*/, void/*String*/, void/*Unicode*/, void/*void*/,
+    np::DateTime, np::TimeDelta, np::Half
+> binary_search_tab;
 
-template <arg_t arg>
-static inline typename binsearch_t<arg>::function_type
-_get_binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
+template <bool arg>
+inline std::conditional_t<arg, PyArray_ArgBinSearchFunc*, PyArray_BinSearchFunc*>
+GetBinarySearchFunc(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
-    using binsearch = binsearch_t<arg>;
-    npy_intp nfuncs = binsearch::map.size();
-    npy_intp min_idx = 0;
-    npy_intp max_idx = nfuncs;
-    int type = dtype->type_num;
-
     if ((int)side >= (int)NPY_NSEARCHSIDES) {
-        return NULL;
+        return nullptr;
     }
-
-    /*
-     * It seems only fair that a binary search function be searched for
-     * using a binary search...
-     */
-    while (min_idx < max_idx) {
-        npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-
-        if (binsearch::map[mid_idx].typenum < type) {
-            min_idx = mid_idx + 1;
+    int type_id = dtype->type_num;
+    if (type_id < (int)kBool || type_id > (int)kHalf) {
+        if (!dtype->f->compare) {
+            return nullptr;
         }
-        else {
-            max_idx = mid_idx;
-        }
+        type_id = (int)kObject;
     }
-
-    if (min_idx < nfuncs && binsearch::map[min_idx].typenum == type) {
-        return binsearch::map[min_idx].binsearch[side];
+    if constexpr (arg) {
+        return binary_search_tab.arg_ptrs[side][type_id];
     }
-
-    if (dtype->f->compare) {
-        return binsearch::npy_map[side];
+    else {
+        return binary_search_tab.ptrs[side][type_id];
     }
-
-    return NULL;
 }
+
+} // namespace np::sort
 
 /*
  *****************************************************************************
  **                            C INTERFACE                                  **
  *****************************************************************************
  */
-extern "C" {
 NPY_NO_EXPORT PyArray_BinSearchFunc *
 get_binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
-    return _get_binsearch_func<noarg>(dtype, side);
+    return np::sort::GetBinarySearchFunc<false>(dtype, side);
 }
 
 NPY_NO_EXPORT PyArray_ArgBinSearchFunc *
 get_argbinsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 {
-    return _get_binsearch_func<arg>(dtype, side);
-}
+    return np::sort::GetBinarySearchFunc<true>(dtype, side);
 }

--- a/numpy/_core/src/npysort/heapsort.cpp
+++ b/numpy/_core/src/npysort/heapsort.cpp
@@ -29,19 +29,10 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include "npy_sort.h"
-#include "npysort_common.h"
-#include "numpy_tag.h"
-
-#include "npysort_heapsort.h"
 
 #include <cstdlib>
 
-#define NOT_USED NPY_UNUSED(unused)
-#define PYA_QS_STACK 100
-#define SMALL_QUICKSORT 15
-#define SMALL_MERGESORT 20
-#define SMALL_STRING 16
-
+#include "heapsort.hpp"
 
 /*
  *****************************************************************************
@@ -67,14 +58,14 @@ npy_heapsort(void *start, npy_intp num, void *varr)
     }
 
     for (l = num >> 1; l > 0; --l) {
-        GENERIC_COPY(tmp, a + l * elsize, elsize);
+        memcpy(tmp, a + l * elsize, elsize);
         for (i = l, j = l << 1; j <= num;) {
             if (j < num &&
                 cmp(a + j * elsize, a + (j + 1) * elsize, arr) < 0) {
                 ++j;
             }
             if (cmp(tmp, a + j * elsize, arr) < 0) {
-                GENERIC_COPY(a + i * elsize, a + j * elsize, elsize);
+                memcpy(a + i * elsize, a + j * elsize, elsize);
                 i = j;
                 j += j;
             }
@@ -82,12 +73,12 @@ npy_heapsort(void *start, npy_intp num, void *varr)
                 break;
             }
         }
-        GENERIC_COPY(a + i * elsize, tmp, elsize);
+        memcpy(a + i * elsize, tmp, elsize);
     }
 
     for (; num > 1;) {
-        GENERIC_COPY(tmp, a + num * elsize, elsize);
-        GENERIC_COPY(a + num * elsize, a + elsize, elsize);
+        memcpy(tmp, a + num * elsize, elsize);
+        memcpy(a + num * elsize, a + elsize, elsize);
         num -= 1;
         for (i = 1, j = 2; j <= num;) {
             if (j < num &&
@@ -95,7 +86,7 @@ npy_heapsort(void *start, npy_intp num, void *varr)
                 ++j;
             }
             if (cmp(tmp, a + j * elsize, arr) < 0) {
-                GENERIC_COPY(a + i * elsize, a + j * elsize, elsize);
+                memcpy(a + i * elsize, a + j * elsize, elsize);
                 i = j;
                 j += j;
             }
@@ -103,7 +94,7 @@ npy_heapsort(void *start, npy_intp num, void *varr)
                 break;
             }
         }
-        GENERIC_COPY(a + i * elsize, tmp, elsize);
+        memcpy(a + i * elsize, tmp, elsize);
     }
 
     free(tmp);
@@ -168,375 +159,314 @@ npy_aheapsort(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 /***************************************
  * C > C++ dispatch
  ***************************************/
-template NPY_NO_EXPORT int
-heapsort_<npy::bool_tag, npy_bool>(npy_bool *, npy_intp);
+
 NPY_NO_EXPORT int
 heapsort_bool(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::bool_tag>((npy_bool *)start, n);
+    np::sort::Heap((np::Bool *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::byte_tag, npy_byte>(npy_byte *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_byte(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::byte_tag>((npy_byte *)start, n);
+    np::sort::Heap((np::Byte *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::ubyte_tag, npy_ubyte>(npy_ubyte *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_ubyte(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::ubyte_tag>((npy_ubyte *)start, n);
+    np::sort::Heap((np::UByte *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::short_tag, npy_short>(npy_short *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_short(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::short_tag>((npy_short *)start, n);
+    np::sort::Heap((np::Short *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::ushort_tag, npy_ushort>(npy_ushort *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_ushort(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::ushort_tag>((npy_ushort *)start, n);
+    np::sort::Heap((np::UShort *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::int_tag, npy_int>(npy_int *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_int(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::int_tag>((npy_int *)start, n);
+    np::sort::Heap((np::Int *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::uint_tag, npy_uint>(npy_uint *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_uint(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::uint_tag>((npy_uint *)start, n);
+    np::sort::Heap((np::UInt *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::long_tag, npy_long>(npy_long *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_long(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::long_tag>((npy_long *)start, n);
+    np::sort::Heap((np::Long *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::ulong_tag, npy_ulong>(npy_ulong *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_ulong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::ulong_tag>((npy_ulong *)start, n);
+    np::sort::Heap((np::ULong *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::longlong_tag, npy_longlong>(npy_longlong *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_longlong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::longlong_tag>((npy_longlong *)start, n);
+    np::sort::Heap((np::LongLong *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::ulonglong_tag, npy_ulonglong>(npy_ulonglong *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_ulonglong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::ulonglong_tag>((npy_ulonglong *)start, n);
+    np::sort::Heap((np::ULongLong *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::half_tag, npy_half>(npy_half *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_half(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::half_tag>((npy_half *)start, n);
+    np::sort::Heap((np::Half *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::float_tag, npy_float>(npy_float *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_float(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::float_tag>((npy_float *)start, n);
+    np::sort::Heap((np::Float *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::double_tag, npy_double>(npy_double *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_double(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::double_tag>((npy_double *)start, n);
+    np::sort::Heap((np::Double *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::longdouble_tag, npy_longdouble>(npy_longdouble *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_longdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::longdouble_tag>((npy_longdouble *)start, n);
+    np::sort::Heap((np::LongDouble *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::cfloat_tag, npy_cfloat>(npy_cfloat *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_cfloat(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::cfloat_tag>((npy_cfloat *)start, n);
+    np::sort::Heap((np::CFloat *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::cdouble_tag, npy_cdouble>(npy_cdouble *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_cdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::cdouble_tag>((npy_cdouble *)start, n);
+    np::sort::Heap((np::CDouble *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::clongdouble_tag, npy_clongdouble>(npy_clongdouble *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_clongdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::clongdouble_tag>((npy_clongdouble *)start, n);
+    np::sort::Heap((np::CLongDouble *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::datetime_tag, npy_datetime>(npy_datetime *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_datetime(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::datetime_tag>((npy_datetime *)start, n);
+    np::sort::Heap((np::DateTime *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-heapsort_<npy::timedelta_tag, npy_timedelta>(npy_timedelta *, npy_intp);
 NPY_NO_EXPORT int
 heapsort_timedelta(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return heapsort_<npy::timedelta_tag>((npy_timedelta *)start, n);
+    np::sort::Heap((np::TimeDelta *)start, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::bool_tag, npy_bool>(npy_bool *vv, npy_intp *tosort,
-                                    npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_bool(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::bool_tag>((npy_bool *)vv, tosort, n);
+    np::sort::Heap((np::Bool *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::byte_tag, npy_byte>(npy_byte *vv, npy_intp *tosort,
-                                    npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_byte(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::byte_tag>((npy_byte *)vv, tosort, n);
+    np::sort::Heap((np::Byte *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::ubyte_tag, npy_ubyte>(npy_ubyte *vv, npy_intp *tosort,
-                                      npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_ubyte(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::ubyte_tag>((npy_ubyte *)vv, tosort, n);
+    np::sort::Heap((np::UByte *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::short_tag, npy_short>(npy_short *vv, npy_intp *tosort,
-                                      npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_short(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::short_tag>((npy_short *)vv, tosort, n);
+    np::sort::Heap((np::Short *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::ushort_tag, npy_ushort>(npy_ushort *vv, npy_intp *tosort,
-                                        npy_intp n);
 NPY_NO_EXPORT int
-aheapsort_ushort(void *vv, npy_intp *tosort, npy_intp n,
-                 void *NPY_UNUSED(varr))
+aheapsort_ushort(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::ushort_tag>((npy_ushort *)vv, tosort, n);
+    np::sort::Heap((np::UShort *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::int_tag, npy_int>(npy_int *vv, npy_intp *tosort, npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_int(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::int_tag>((npy_int *)vv, tosort, n);
+    np::sort::Heap((np::Int *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::uint_tag, npy_uint>(npy_uint *vv, npy_intp *tosort,
-                                    npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_uint(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::uint_tag>((npy_uint *)vv, tosort, n);
+    np::sort::Heap((np::UInt *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::long_tag, npy_long>(npy_long *vv, npy_intp *tosort,
-                                    npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_long(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::long_tag>((npy_long *)vv, tosort, n);
+    np::sort::Heap((np::Long *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::ulong_tag, npy_ulong>(npy_ulong *vv, npy_intp *tosort,
-                                      npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_ulong(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::ulong_tag>((npy_ulong *)vv, tosort, n);
+    np::sort::Heap((np::ULong *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::longlong_tag, npy_longlong>(npy_longlong *vv, npy_intp *tosort,
-                                            npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_longlong(void *vv, npy_intp *tosort, npy_intp n,
                    void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::longlong_tag>((npy_longlong *)vv, tosort, n);
+    np::sort::Heap((np::LongLong *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::ulonglong_tag, npy_ulonglong>(npy_ulonglong *vv,
-                                              npy_intp *tosort, npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_ulonglong(void *vv, npy_intp *tosort, npy_intp n,
                     void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::ulonglong_tag>((npy_ulonglong *)vv, tosort, n);
+    np::sort::Heap((np::ULongLong *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::half_tag, npy_half>(npy_half *vv, npy_intp *tosort,
-                                    npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_half(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::half_tag>((npy_half *)vv, tosort, n);
+    np::sort::Heap((np::Half *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::float_tag, npy_float>(npy_float *vv, npy_intp *tosort,
-                                      npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_float(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::float_tag>((npy_float *)vv, tosort, n);
+    np::sort::Heap((np::Float *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::double_tag, npy_double>(npy_double *vv, npy_intp *tosort,
-                                        npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_double(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::double_tag>((npy_double *)vv, tosort, n);
+    np::sort::Heap((np::Double *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::longdouble_tag, npy_longdouble>(npy_longdouble *vv,
-                                                npy_intp *tosort, npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_longdouble(void *vv, npy_intp *tosort, npy_intp n,
                      void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::longdouble_tag>((npy_longdouble *)vv, tosort, n);
+    np::sort::Heap((np::LongDouble *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::cfloat_tag, npy_cfloat>(npy_cfloat *vv, npy_intp *tosort,
-                                        npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_cfloat(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::cfloat_tag>((npy_cfloat *)vv, tosort, n);
+    np::sort::Heap((np::CFloat *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::cdouble_tag, npy_cdouble>(npy_cdouble *vv, npy_intp *tosort,
-                                          npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_cdouble(void *vv, npy_intp *tosort, npy_intp n,
                   void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::cdouble_tag>((npy_cdouble *)vv, tosort, n);
+    np::sort::Heap((np::CDouble *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::clongdouble_tag, npy_clongdouble>(npy_clongdouble *vv,
-                                                  npy_intp *tosort,
-                                                  npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_clongdouble(void *vv, npy_intp *tosort, npy_intp n,
                       void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::clongdouble_tag>((npy_clongdouble *)vv, tosort, n);
+    np::sort::Heap((np::CLongDouble *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::datetime_tag, npy_datetime>(npy_datetime *vv, npy_intp *tosort,
-                                            npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_datetime(void *vv, npy_intp *tosort, npy_intp n,
                    void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::datetime_tag>((npy_datetime *)vv, tosort, n);
+    np::sort::Heap((np::DateTime *)vv, tosort, n);
+    return 0;
 }
 
-template NPY_NO_EXPORT int
-aheapsort_<npy::timedelta_tag, npy_timedelta>(npy_timedelta *vv,
-                                              npy_intp *tosort, npy_intp n);
 NPY_NO_EXPORT int
 aheapsort_timedelta(void *vv, npy_intp *tosort, npy_intp n,
                     void *NPY_UNUSED(varr))
 {
-    return aheapsort_<npy::timedelta_tag>((npy_timedelta *)vv, tosort, n);
+    np::sort::Heap((np::TimeDelta *)vv, tosort, n);
+    return 0;
 }
 
 NPY_NO_EXPORT int
 heapsort_string(void *start, npy_intp n, void *varr)
 {
-    return string_heapsort_<npy::string_tag>((npy_char *)start, n, varr);
+    return np::sort::Heap((np::String*)start, n, (PyArrayObject *)varr);
 }
 NPY_NO_EXPORT int
 heapsort_unicode(void *start, npy_intp n, void *varr)
 {
-    return string_heapsort_<npy::unicode_tag>((npy_ucs4 *)start, n, varr);
+    return np::sort::Heap((np::Unicode*)start, n, (PyArrayObject *)varr);
 }
 
 NPY_NO_EXPORT int
 aheapsort_string(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
-    return string_aheapsort_<npy::string_tag>((npy_char *)vv, tosort, n, varr);
+    return np::sort::Heap((np::String*)vv, tosort, n, (PyArrayObject *)varr);
 }
 NPY_NO_EXPORT int
 aheapsort_unicode(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
-    return string_aheapsort_<npy::unicode_tag>((npy_ucs4 *)vv, tosort, n,
-                                               varr);
+    return np::sort::Heap((np::Unicode*)vv, tosort, n, (PyArrayObject *)varr);
 }

--- a/numpy/_core/src/npysort/heapsort.hpp
+++ b/numpy/_core/src/npysort/heapsort.hpp
@@ -8,17 +8,62 @@ namespace np::sort {
 template <typename T>
 inline bool LessThan(const T &a, const T &b)
 {
-    if constexpr (std::is_floating_point_v<T>) {
-        return a < b || (b != b && a == a);
-    }
-    else if constexpr(std::is_same_v<T, Half>) {
+    if constexpr(std::is_same_v<T, Half>) {
         bool a_nn = !a.IsNaN();
         return b.IsNaN() ? a_nn : a_nn && a.Less(b);
+    }
+    else if constexpr (kIsFloat<T>) {
+        return a < b || (b != b && a == a);
+    }
+    else if constexpr (kIsComplex<T>) {
+        auto a_real = a.real();
+        auto a_imag = a.imag();
+        auto b_real = b.real();
+        auto b_imag = b.imag();
+        if (a_real < b_real) {
+            return a_imag == a_imag || b_imag != b_imag;
+        }
+        else if (a_real > b_real) {
+            return b_imag != b_imag && a_imag == a_imag;
+        }
+        else if (a_real == b_real || (a_real != a_real && b_real != b_real)) {
+            return  a_imag < b_imag || (b_imag != b_imag && a_imag == a_imag);
+        }
+        else {
+            return b_real != b_real;
+        }
+    }
+    else if constexpr (kIsTime<T>) {
+        return (b.IsNaT() || static_cast<int64_t>(a) < static_cast<int64_t>(b)) && a.IsFinite();
     }
     else {
         return a < b;
     }
 }
+
+template <typename T>
+inline bool LessThan(const T *a, const T *b, SSize len)
+{
+    bool ret = false;
+    for (SSize i = 0; i < len; ++i) {
+        if (a[i] != b[i]) {
+            ret = a[i] < b[i];
+            break;
+        }
+    }
+    return ret;
+}
+
+template <typename T>
+inline void Swap(T *s1, T *s2, SSize len)
+{
+    while (len--) {
+        const T t = *s1;
+        *s1++ = *s2;
+        *s2++ = t;
+    }
+}
+
 
 // NUMERIC SORTS
 template <typename T>
@@ -66,5 +111,159 @@ inline void Heap(T *start, SSize n)
         a[i] = tmp;
     }
 }
+// Argsort
+template <typename T>
+inline void Heap(T *vv, SSize *tosort, SSize n)
+{
+    T *v = vv;
+    SSize *a, i, j, l, tmp;
+    // The arrays need to be offset by one for heapsort indexing
+    a = tosort - 1;
+
+    for (l = n >> 1; l > 0; --l) {
+        tmp = a[l];
+        for (i = l, j = l << 1; j <= n;) {
+            if (j < n && LessThan(v[a[j]], v[a[j + 1]])) {
+                j += 1;
+            }
+            if (LessThan(v[tmp], v[a[j]])) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+
+    for (; n > 1;) {
+        tmp = a[n];
+        a[n] = a[1];
+        n -= 1;
+        for (i = 1, j = 2; j <= n;) {
+            if (j < n && LessThan(v[a[j]], v[a[j + 1]])) {
+                j++;
+            }
+            if (LessThan(v[tmp], v[a[j]])) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+}
+// string sort
+template <typename T>
+inline int Heap(T *start, SSize n, PyArrayObject *arr)
+{
+    SSize arr_len = PyArray_ITEMSIZE(arr);
+    if (arr_len == 0) {
+        return 0;  /* no need for sorting if strings are empty */
+    }
+    size_t len = arr_len / sizeof(T);
+
+    T *tmp = (T *)malloc(arr_len);
+    T *a = (T *)start - len;
+    SSize i, j, l;
+
+    if (tmp == NULL) {
+        return -NPY_ENOMEM;
+    }
+
+    for (l = n >> 1; l > 0; --l) {
+        memcpy(tmp, a + l * len, arr_len);
+        for (i = l, j = l << 1; j <= n;) {
+            if (j < n && LessThan(a + j * len, a + (j + 1) * len, len))
+                j += 1;
+            if (LessThan(tmp, a + j * len, len)) {
+                memcpy(a + i * len, a + j * len, arr_len);
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        memcpy(a + i * len, tmp, arr_len);
+    }
+
+    for (; n > 1;) {
+        memcpy(tmp, a + n * len, arr_len);
+        memcpy(a + n * len, a + len, arr_len);
+        n -= 1;
+        for (i = 1, j = 2; j <= n;) {
+            if (j < n && LessThan(a + j * len, a + (j + 1) * len, len))
+                j++;
+            if (LessThan(tmp, a + j * len, len)) {
+                memcpy(a + i * len, a + j * len, arr_len);
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        memcpy(a + i * len, tmp, arr_len);
+    }
+
+    free(tmp);
+    return 0;
+}
+
+template <typename T>
+inline int Heap(T *vv, SSize *tosort, SSize n, PyArrayObject *arr)
+{
+    T *v = vv;
+    size_t len = PyArray_ITEMSIZE(arr) / sizeof(T);
+    SSize *a, i, j, l, tmp;
+
+    /* The array needs to be offset by one for heapsort indexing */
+    a = tosort - 1;
+
+    for (l = n >> 1; l > 0; --l) {
+        tmp = a[l];
+        for (i = l, j = l << 1; j <= n;) {
+            if (j < n && LessThan(v + a[j] * len, v + a[j + 1] * len, len))
+                j += 1;
+            if (LessThan(v + tmp * len, v + a[j] * len, len)) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+
+    for (; n > 1;) {
+        tmp = a[n];
+        a[n] = a[1];
+        n -= 1;
+        for (i = 1, j = 2; j <= n;) {
+            if (j < n && LessThan(v + a[j] * len, v + a[j + 1] * len, len))
+                j++;
+            if (LessThan(v + tmp * len, v + a[j] * len, len)) {
+                a[i] = a[j];
+                i = j;
+                j += j;
+            }
+            else {
+                break;
+            }
+        }
+        a[i] = tmp;
+    }
+
+    return 0;
+}
+
 } // namespace np::sort
 #endif

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -51,14 +51,14 @@
 
 #include "npy_cpu_features.h"
 #include "npy_sort.h"
-#include "npysort_common.h"
-#include "npysort_heapsort.h"
-#include "numpy_tag.h"
 #include "x86_simd_qsort.hpp"
 #include "highway_qsort.hpp"
 
 #include <cstdlib>
 #include <utility>
+
+#include "quicksort.hpp"
+
 
 #define NOT_USED NPY_UNUSED(unused)
 
@@ -77,7 +77,7 @@ template<typename T>
 inline bool quicksort_dispatch(T *start, npy_intp num)
 {
 #if !defined(__CYGWIN__)
-    using TF = typename np::meta::FixedWidth<T>::Type;
+    using TF = np::MakeFixedIntegral<T>;
     void (*dispfunc)(TF*, intptr_t) = nullptr;
     if (sizeof(T) == sizeof(uint16_t)) {
         #ifndef NPY_DISABLE_OPTIMIZATION
@@ -114,7 +114,7 @@ template<typename T>
 inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
 {
 #if !defined(__CYGWIN__)
-    using TF = typename np::meta::FixedWidth<T>::Type;
+    using TF = np::MakeFixedIntegral<T>;
     void (*dispfunc)(TF*, npy_intp*, npy_intp) = nullptr;
     #ifndef NPY_DISABLE_OPTIMIZATION
         #include "x86_simd_argsort.dispatch.h"
@@ -128,383 +128,6 @@ inline bool aquicksort_dispatch(T *start, npy_intp* arg, npy_intp num)
     (void)start; (void)arg; (void)num; // to avoid unused arg warn
     return false;
 }
-
-/*
- *****************************************************************************
- **                            NUMERIC SORTS                                **
- *****************************************************************************
- */
-
-template <typename Tag, typename type>
-static int
-quicksort_(type *start, npy_intp num)
-{
-    type vp;
-    type *pl = start;
-    type *pr = pl + num - 1;
-    type *stack[PYA_QS_STACK];
-    type **sptr = stack;
-    type *pm, *pi, *pj, *pk;
-    int depth[PYA_QS_STACK];
-    int *psdepth = depth;
-    int cdepth = npy_get_msb(num) * 2;
-
-    for (;;) {
-        if (NPY_UNLIKELY(cdepth < 0)) {
-            heapsort_<Tag>(pl, pr - pl + 1);
-            goto stack_pop;
-        }
-        while ((pr - pl) > SMALL_QUICKSORT) {
-            /* quicksort partition */
-            pm = pl + ((pr - pl) >> 1);
-            if (Tag::less(*pm, *pl)) {
-                std::swap(*pm, *pl);
-            }
-            if (Tag::less(*pr, *pm)) {
-                std::swap(*pr, *pm);
-            }
-            if (Tag::less(*pm, *pl)) {
-                std::swap(*pm, *pl);
-            }
-            vp = *pm;
-            pi = pl;
-            pj = pr - 1;
-            std::swap(*pm, *pj);
-            for (;;) {
-                do {
-                    ++pi;
-                } while (Tag::less(*pi, vp));
-                do {
-                    --pj;
-                } while (Tag::less(vp, *pj));
-                if (pi >= pj) {
-                    break;
-                }
-                std::swap(*pi, *pj);
-            }
-            pk = pr - 1;
-            std::swap(*pi, *pk);
-            /* push largest partition on stack */
-            if (pi - pl < pr - pi) {
-                *sptr++ = pi + 1;
-                *sptr++ = pr;
-                pr = pi - 1;
-            }
-            else {
-                *sptr++ = pl;
-                *sptr++ = pi - 1;
-                pl = pi + 1;
-            }
-            *psdepth++ = --cdepth;
-        }
-
-        /* insertion sort */
-        for (pi = pl + 1; pi <= pr; ++pi) {
-            vp = *pi;
-            pj = pi;
-            pk = pi - 1;
-            while (pj > pl && Tag::less(vp, *pk)) {
-                *pj-- = *pk--;
-            }
-            *pj = vp;
-        }
-    stack_pop:
-        if (sptr == stack) {
-            break;
-        }
-        pr = *(--sptr);
-        pl = *(--sptr);
-        cdepth = *(--psdepth);
-    }
-
-    return 0;
-}
-
-template <typename Tag, typename type>
-static int
-aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
-{
-    type *v = vv;
-    type vp;
-    npy_intp *pl = tosort;
-    npy_intp *pr = tosort + num - 1;
-    npy_intp *stack[PYA_QS_STACK];
-    npy_intp **sptr = stack;
-    npy_intp *pm, *pi, *pj, *pk, vi;
-    int depth[PYA_QS_STACK];
-    int *psdepth = depth;
-    int cdepth = npy_get_msb(num) * 2;
-
-    for (;;) {
-        if (NPY_UNLIKELY(cdepth < 0)) {
-            aheapsort_<Tag>(vv, pl, pr - pl + 1);
-            goto stack_pop;
-        }
-        while ((pr - pl) > SMALL_QUICKSORT) {
-            /* quicksort partition */
-            pm = pl + ((pr - pl) >> 1);
-            if (Tag::less(v[*pm], v[*pl])) {
-                std::swap(*pm, *pl);
-            }
-            if (Tag::less(v[*pr], v[*pm])) {
-                std::swap(*pr, *pm);
-            }
-            if (Tag::less(v[*pm], v[*pl])) {
-                std::swap(*pm, *pl);
-            }
-            vp = v[*pm];
-            pi = pl;
-            pj = pr - 1;
-            std::swap(*pm, *pj);
-            for (;;) {
-                do {
-                    ++pi;
-                } while (Tag::less(v[*pi], vp));
-                do {
-                    --pj;
-                } while (Tag::less(vp, v[*pj]));
-                if (pi >= pj) {
-                    break;
-                }
-                std::swap(*pi, *pj);
-            }
-            pk = pr - 1;
-            std::swap(*pi, *pk);
-            /* push largest partition on stack */
-            if (pi - pl < pr - pi) {
-                *sptr++ = pi + 1;
-                *sptr++ = pr;
-                pr = pi - 1;
-            }
-            else {
-                *sptr++ = pl;
-                *sptr++ = pi - 1;
-                pl = pi + 1;
-            }
-            *psdepth++ = --cdepth;
-        }
-
-        /* insertion sort */
-        for (pi = pl + 1; pi <= pr; ++pi) {
-            vi = *pi;
-            vp = v[vi];
-            pj = pi;
-            pk = pi - 1;
-            while (pj > pl && Tag::less(vp, v[*pk])) {
-                *pj-- = *pk--;
-            }
-            *pj = vi;
-        }
-    stack_pop:
-        if (sptr == stack) {
-            break;
-        }
-        pr = *(--sptr);
-        pl = *(--sptr);
-        cdepth = *(--psdepth);
-    }
-
-    return 0;
-}
-
-/*
- *****************************************************************************
- **                             STRING SORTS                                **
- *****************************************************************************
- */
-
-template <typename Tag, typename type>
-static int
-string_quicksort_(type *start, npy_intp num, void *varr)
-{
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    const size_t len = PyArray_ITEMSIZE(arr) / sizeof(type);
-    type *vp;
-    type *pl = start;
-    type *pr = pl + (num - 1) * len;
-    type *stack[PYA_QS_STACK], **sptr = stack, *pm, *pi, *pj, *pk;
-    int depth[PYA_QS_STACK];
-    int *psdepth = depth;
-    int cdepth = npy_get_msb(num) * 2;
-
-    /* Items that have zero size don't make sense to sort */
-    if (len == 0) {
-        return 0;
-    }
-
-    vp = (type *)malloc(PyArray_ITEMSIZE(arr));
-    if (vp == NULL) {
-        return -NPY_ENOMEM;
-    }
-
-    for (;;) {
-        if (NPY_UNLIKELY(cdepth < 0)) {
-            string_heapsort_<Tag>(pl, (pr - pl) / len + 1, varr);
-            goto stack_pop;
-        }
-        while ((size_t)(pr - pl) > SMALL_QUICKSORT * len) {
-            /* quicksort partition */
-            pm = pl + (((pr - pl) / len) >> 1) * len;
-            if (Tag::less(pm, pl, len)) {
-                Tag::swap(pm, pl, len);
-            }
-            if (Tag::less(pr, pm, len)) {
-                Tag::swap(pr, pm, len);
-            }
-            if (Tag::less(pm, pl, len)) {
-                Tag::swap(pm, pl, len);
-            }
-            Tag::copy(vp, pm, len);
-            pi = pl;
-            pj = pr - len;
-            Tag::swap(pm, pj, len);
-            for (;;) {
-                do {
-                    pi += len;
-                } while (Tag::less(pi, vp, len));
-                do {
-                    pj -= len;
-                } while (Tag::less(vp, pj, len));
-                if (pi >= pj) {
-                    break;
-                }
-                Tag::swap(pi, pj, len);
-            }
-            pk = pr - len;
-            Tag::swap(pi, pk, len);
-            /* push largest partition on stack */
-            if (pi - pl < pr - pi) {
-                *sptr++ = pi + len;
-                *sptr++ = pr;
-                pr = pi - len;
-            }
-            else {
-                *sptr++ = pl;
-                *sptr++ = pi - len;
-                pl = pi + len;
-            }
-            *psdepth++ = --cdepth;
-        }
-
-        /* insertion sort */
-        for (pi = pl + len; pi <= pr; pi += len) {
-            Tag::copy(vp, pi, len);
-            pj = pi;
-            pk = pi - len;
-            while (pj > pl && Tag::less(vp, pk, len)) {
-                Tag::copy(pj, pk, len);
-                pj -= len;
-                pk -= len;
-            }
-            Tag::copy(pj, vp, len);
-        }
-    stack_pop:
-        if (sptr == stack) {
-            break;
-        }
-        pr = *(--sptr);
-        pl = *(--sptr);
-        cdepth = *(--psdepth);
-    }
-
-    free(vp);
-    return 0;
-}
-
-template <typename Tag, typename type>
-static int
-string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, void *varr)
-{
-    type *v = vv;
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    size_t len = PyArray_ITEMSIZE(arr) / sizeof(type);
-    type *vp;
-    npy_intp *pl = tosort;
-    npy_intp *pr = tosort + num - 1;
-    npy_intp *stack[PYA_QS_STACK];
-    npy_intp **sptr = stack;
-    npy_intp *pm, *pi, *pj, *pk, vi;
-    int depth[PYA_QS_STACK];
-    int *psdepth = depth;
-    int cdepth = npy_get_msb(num) * 2;
-
-    /* Items that have zero size don't make sense to sort */
-    if (len == 0) {
-        return 0;
-    }
-
-    for (;;) {
-        if (NPY_UNLIKELY(cdepth < 0)) {
-            string_aheapsort_<Tag>(vv, pl, pr - pl + 1, varr);
-            goto stack_pop;
-        }
-        while ((pr - pl) > SMALL_QUICKSORT) {
-            /* quicksort partition */
-            pm = pl + ((pr - pl) >> 1);
-            if (Tag::less(v + (*pm) * len, v + (*pl) * len, len)) {
-                std::swap(*pm, *pl);
-            }
-            if (Tag::less(v + (*pr) * len, v + (*pm) * len, len)) {
-                std::swap(*pr, *pm);
-            }
-            if (Tag::less(v + (*pm) * len, v + (*pl) * len, len)) {
-                std::swap(*pm, *pl);
-            }
-            vp = v + (*pm) * len;
-            pi = pl;
-            pj = pr - 1;
-            std::swap(*pm, *pj);
-            for (;;) {
-                do {
-                    ++pi;
-                } while (Tag::less(v + (*pi) * len, vp, len));
-                do {
-                    --pj;
-                } while (Tag::less(vp, v + (*pj) * len, len));
-                if (pi >= pj) {
-                    break;
-                }
-                std::swap(*pi, *pj);
-            }
-            pk = pr - 1;
-            std::swap(*pi, *pk);
-            /* push largest partition on stack */
-            if (pi - pl < pr - pi) {
-                *sptr++ = pi + 1;
-                *sptr++ = pr;
-                pr = pi - 1;
-            }
-            else {
-                *sptr++ = pl;
-                *sptr++ = pi - 1;
-                pl = pi + 1;
-            }
-            *psdepth++ = --cdepth;
-        }
-
-        /* insertion sort */
-        for (pi = pl + 1; pi <= pr; ++pi) {
-            vi = *pi;
-            vp = v + vi * len;
-            pj = pi;
-            pk = pi - 1;
-            while (pj > pl && Tag::less(vp, v + (*pk) * len, len)) {
-                *pj-- = *pk--;
-            }
-            *pj = vi;
-        }
-    stack_pop:
-        if (sptr == stack) {
-            break;
-        }
-        pr = *(--sptr);
-        pl = *(--sptr);
-        cdepth = *(--psdepth);
-    }
-
-    return 0;
-}
-
 /*
  *****************************************************************************
  **                             GENERIC SORT                                **
@@ -546,18 +169,18 @@ npy_quicksort(void *start, npy_intp num, void *varr)
             /* quicksort partition */
             pm = pl + (((pr - pl) / elsize) >> 1) * elsize;
             if (cmp(pm, pl, arr) < 0) {
-                GENERIC_SWAP(pm, pl, elsize);
+                np::sort::Swap(pm, pl, elsize);
             }
             if (cmp(pr, pm, arr) < 0) {
-                GENERIC_SWAP(pr, pm, elsize);
+                np::sort::Swap(pr, pm, elsize);
             }
             if (cmp(pm, pl, arr) < 0) {
-                GENERIC_SWAP(pm, pl, elsize);
+                np::sort::Swap(pm, pl, elsize);
             }
-            GENERIC_COPY(vp, pm, elsize);
+            memcpy(vp, pm, elsize);
             pi = pl;
             pj = pr - elsize;
-            GENERIC_SWAP(pm, pj, elsize);
+            np::sort::Swap(pm, pj, elsize);
             /*
              * Generic comparisons may be buggy, so don't rely on the sentinels
              * to keep the pointers from going out of bounds.
@@ -572,10 +195,10 @@ npy_quicksort(void *start, npy_intp num, void *varr)
                 if (pi >= pj) {
                     break;
                 }
-                GENERIC_SWAP(pi, pj, elsize);
+                np::sort::Swap(pi, pj, elsize);
             }
             pk = pr - elsize;
-            GENERIC_SWAP(pi, pk, elsize);
+            np::sort::Swap(pi, pk, elsize);
             /* push largest partition on stack */
             if (pi - pl < pr - pi) {
                 *sptr++ = pi + elsize;
@@ -592,15 +215,15 @@ npy_quicksort(void *start, npy_intp num, void *varr)
 
         /* insertion sort */
         for (pi = pl + elsize; pi <= pr; pi += elsize) {
-            GENERIC_COPY(vp, pi, elsize);
+            memcpy(vp, pi, elsize);
             pj = pi;
             pk = pi - elsize;
             while (pj > pl && cmp(vp, pk, arr) < 0) {
-                GENERIC_COPY(pj, pk, elsize);
+                memcpy(pj, pk, elsize);
                 pj -= elsize;
                 pk -= elsize;
             }
-            GENERIC_COPY(pj, vp, elsize);
+            memcpy(pj, vp, elsize);
         }
     stack_pop:
         if (sptr == stack) {
@@ -646,18 +269,18 @@ npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
             if (cmp(v + (*pm) * elsize, v + (*pl) * elsize, arr) < 0) {
-                INTP_SWAP(*pm, *pl);
+                std::swap(*pm, *pl);
             }
             if (cmp(v + (*pr) * elsize, v + (*pm) * elsize, arr) < 0) {
-                INTP_SWAP(*pr, *pm);
+                std::swap(*pr, *pm);
             }
             if (cmp(v + (*pm) * elsize, v + (*pl) * elsize, arr) < 0) {
-                INTP_SWAP(*pm, *pl);
+                std::swap(*pm, *pl);
             }
             vp = v + (*pm) * elsize;
             pi = pl;
             pj = pr - 1;
-            INTP_SWAP(*pm, *pj);
+            std::swap(*pm, *pj);
             for (;;) {
                 do {
                     ++pi;
@@ -668,10 +291,10 @@ npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
                 if (pi >= pj) {
                     break;
                 }
-                INTP_SWAP(*pi, *pj);
+                std::swap(*pi, *pj);
             }
             pk = pr - 1;
-            INTP_SWAP(*pi, *pk);
+            std::swap(*pi, *pk);
             /* push largest partition on stack */
             if (pi - pl < pr - pi) {
                 *sptr++ = pi + 1;
@@ -716,81 +339,92 @@ npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
 NPY_NO_EXPORT int
 quicksort_bool(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::bool_tag>((npy_bool *)start, n);
+    np::sort::Quick((np::Bool *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_byte(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::byte_tag>((npy_byte *)start, n);
+    np::sort::Quick((np::Byte *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_ubyte(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::ubyte_tag>((npy_ubyte *)start, n);
+    np::sort::Quick((np::UByte *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_short(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_short *)start, n)) {
+    if (quicksort_dispatch((np::Short *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::short_tag>((npy_short *)start, n);
+    np::sort::Quick((np::Short *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_ushort(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_ushort *)start, n)) {
+    if (quicksort_dispatch((np::UShort *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::ushort_tag>((npy_ushort *)start, n);
+    np::sort::Quick((np::UShort *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_int(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_int *)start, n)) {
+    if (quicksort_dispatch((np::Int *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::int_tag>((npy_int *)start, n);
+    np::sort::Quick((np::Int *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_uint(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_uint *)start, n)) {
+    if (quicksort_dispatch((np::UInt *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::uint_tag>((npy_uint *)start, n);
+    np::sort::Quick((np::UInt *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_long(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_long *)start, n)) {
+    if (quicksort_dispatch((np::Long *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::long_tag>((npy_long *)start, n);
+    np::sort::Quick((np::Long *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_ulong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_ulong *)start, n)) {
+    if (quicksort_dispatch((np::ULong *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::ulong_tag>((npy_ulong *)start, n);
+    np::sort::Quick((np::ULong *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_longlong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_longlong *)start, n)) {
+    if (quicksort_dispatch((np::LongLong *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::longlong_tag>((npy_longlong *)start, n);
+    np::sort::Quick((np::LongLong *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_ulonglong(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_ulonglong *)start, n)) {
+    if (quicksort_dispatch((np::ULongLong *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::ulonglong_tag>((npy_ulonglong *)start, n);
+    np::sort::Quick((np::ULongLong *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_half(void *start, npy_intp n, void *NPY_UNUSED(varr))
@@ -798,214 +432,240 @@ quicksort_half(void *start, npy_intp n, void *NPY_UNUSED(varr))
     if (quicksort_dispatch((np::Half *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::half_tag>((npy_half *)start, n);
+    np::sort::Quick((np::Half *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_float(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_float *)start, n)) {
+    if (quicksort_dispatch((np::Float *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::float_tag>((npy_float *)start, n);
+    np::sort::Quick((np::Float *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_double(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (quicksort_dispatch((npy_double *)start, n)) {
+    if (quicksort_dispatch((np::Double *)start, n)) {
         return 0;
     }
-    return quicksort_<npy::double_tag>((npy_double *)start, n);
+    np::sort::Quick((np::Double *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_longdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::longdouble_tag>((npy_longdouble *)start, n);
+    np::sort::Quick((np::LongDouble *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_cfloat(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::cfloat_tag>((npy_cfloat *)start, n);
+    np::sort::Quick((np::CFloat *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_cdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::cdouble_tag>((npy_cdouble *)start, n);
+    np::sort::Quick((np::CDouble *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_clongdouble(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::clongdouble_tag>((npy_clongdouble *)start, n);
+    np::sort::Quick((np::CLongDouble *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_datetime(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::datetime_tag>((npy_datetime *)start, n);
+    np::sort::Quick((np::DateTime *)start, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 quicksort_timedelta(void *start, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return quicksort_<npy::timedelta_tag>((npy_timedelta *)start, n);
+    np::sort::Quick((np::TimeDelta *)start, n);
+    return 0;
 }
 
 NPY_NO_EXPORT int
 aquicksort_bool(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::bool_tag>((npy_bool *)vv, tosort, n);
+    np::sort::Quick((np::Bool *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_byte(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::byte_tag>((npy_byte *)vv, tosort, n);
+    np::sort::Quick((np::Byte *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_ubyte(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::ubyte_tag>((npy_ubyte *)vv, tosort, n);
+    np::sort::Quick((np::UByte *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_short(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::short_tag>((npy_short *)vv, tosort, n);
+    np::sort::Quick((np::Short *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_ushort(void *vv, npy_intp *tosort, npy_intp n,
                   void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::ushort_tag>((npy_ushort *)vv, tosort, n);
+    np::sort::Quick((np::UShort *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_int(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_int *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::Int *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::int_tag>((npy_int *)vv, tosort, n);
+    np::sort::Quick((np::Int *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_uint(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_uint *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::UInt *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::uint_tag>((npy_uint *)vv, tosort, n);
+    np::sort::Quick((np::UInt *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_long(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_long *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::Long *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::long_tag>((npy_long *)vv, tosort, n);
+    np::sort::Quick((np::Long *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_ulong(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_ulong *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::ULong *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::ulong_tag>((npy_ulong *)vv, tosort, n);
+    np::sort::Quick((np::ULong *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_longlong(void *vv, npy_intp *tosort, npy_intp n,
                     void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_longlong *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::LongLong *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::longlong_tag>((npy_longlong *)vv, tosort, n);
+    np::sort::Quick((np::LongLong *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_ulonglong(void *vv, npy_intp *tosort, npy_intp n,
                      void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_ulonglong *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::ULongLong *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::ulonglong_tag>((npy_ulonglong *)vv, tosort, n);
+    np::sort::Quick((np::ULongLong *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_half(void *vv, npy_intp *tosort, npy_intp n, void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::half_tag>((npy_half *)vv, tosort, n);
+    np::sort::Quick((np::Half *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_float(void *vv, npy_intp *tosort, npy_intp n,
                  void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_float *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::Float *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::float_tag>((npy_float *)vv, tosort, n);
+    np::sort::Quick((np::Float *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_double(void *vv, npy_intp *tosort, npy_intp n,
                   void *NPY_UNUSED(varr))
 {
-    if (aquicksort_dispatch((npy_double *)vv, tosort, n)) {
+    if (aquicksort_dispatch((np::Double *)vv, tosort, n)) {
         return 0;
     }
-    return aquicksort_<npy::double_tag>((npy_double *)vv, tosort, n);
+    np::sort::Quick((np::Double *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_longdouble(void *vv, npy_intp *tosort, npy_intp n,
                       void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::longdouble_tag>((npy_longdouble *)vv, tosort, n);
+    np::sort::Quick((np::LongDouble *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_cfloat(void *vv, npy_intp *tosort, npy_intp n,
                   void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::cfloat_tag>((npy_cfloat *)vv, tosort, n);
+    np::sort::Quick((np::CFloat *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_cdouble(void *vv, npy_intp *tosort, npy_intp n,
                    void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::cdouble_tag>((npy_cdouble *)vv, tosort, n);
+    np::sort::Quick((np::CDouble *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_clongdouble(void *vv, npy_intp *tosort, npy_intp n,
                        void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::clongdouble_tag>((npy_clongdouble *)vv, tosort, n);
+    np::sort::Quick((np::CLongDouble *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_datetime(void *vv, npy_intp *tosort, npy_intp n,
                     void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::datetime_tag>((npy_datetime *)vv, tosort, n);
+    np::sort::Quick((np::DateTime *)vv, tosort, n);
+    return 0;
 }
 NPY_NO_EXPORT int
 aquicksort_timedelta(void *vv, npy_intp *tosort, npy_intp n,
                      void *NPY_UNUSED(varr))
 {
-    return aquicksort_<npy::timedelta_tag>((npy_timedelta *)vv, tosort, n);
+    np::sort::Quick((np::TimeDelta *)vv, tosort, n);
+    return 0;
 }
 
 NPY_NO_EXPORT int
 quicksort_string(void *start, npy_intp n, void *varr)
 {
-    return string_quicksort_<npy::string_tag>((npy_char *)start, n, varr);
+    return np::sort::Quick((np::String*)start, n, (PyArrayObject *)varr);
 }
 NPY_NO_EXPORT int
 quicksort_unicode(void *start, npy_intp n, void *varr)
 {
-    return string_quicksort_<npy::unicode_tag>((npy_ucs4 *)start, n, varr);
+    return np::sort::Quick((np::Unicode*)start, n, (PyArrayObject *)varr);
 }
-
 NPY_NO_EXPORT int
 aquicksort_string(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
-    return string_aquicksort_<npy::string_tag>((npy_char *)vv, tosort, n,
-                                               varr);
+    return np::sort::Quick((np::String*)vv, tosort, n, (PyArrayObject *)varr);
 }
 NPY_NO_EXPORT int
 aquicksort_unicode(void *vv, npy_intp *tosort, npy_intp n, void *varr)
 {
-    return string_aquicksort_<npy::unicode_tag>((npy_ucs4 *)vv, tosort, n,
-                                                varr);
+    return np::sort::Quick((np::Unicode*)vv, tosort, n, (PyArrayObject *)varr);
 }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -92,5 +92,280 @@ inline void Quick(T *start, SSize num)
         cdepth = *(--psdepth);
     }
 }
+
+// Argsort
+template <typename T>
+inline void Quick(T *vv, SSize *tosort, SSize num)
+{
+    T *v = vv;
+    T vp;
+    SSize *pl = tosort;
+    SSize *pr = tosort + num - 1;
+    SSize *stack[kQuickStack];
+    SSize **sptr = stack;
+    SSize *pm, *pi, *pj, *pk, vi;
+    int depth[kQuickStack];
+    int *psdepth = depth;
+    int cdepth = BitScanReverse(static_cast<std::make_unsigned_t<SSize>>(num)) * 2;
+
+    for (;;) {
+        if (NPY_UNLIKELY(cdepth < 0)) {
+            Heap(vv, pl, pr - pl + 1);
+            goto stack_pop;
+        }
+        while ((pr - pl) > kQuickSmall) {
+            /* quicksort partition */
+            pm = pl + ((pr - pl) >> 1);
+            if (LessThan(v[*pm], v[*pl])) {
+                std::swap(*pm, *pl);
+            }
+            if (LessThan(v[*pr], v[*pm])) {
+                std::swap(*pr, *pm);
+            }
+            if (LessThan(v[*pm], v[*pl])) {
+                std::swap(*pm, *pl);
+            }
+            vp = v[*pm];
+            pi = pl;
+            pj = pr - 1;
+            std::swap(*pm, *pj);
+            for (;;) {
+                do {
+                    ++pi;
+                } while (LessThan(v[*pi], vp));
+                do {
+                    --pj;
+                } while (LessThan(vp, v[*pj]));
+                if (pi >= pj) {
+                    break;
+                }
+                std::swap(*pi, *pj);
+            }
+            pk = pr - 1;
+            std::swap(*pi, *pk);
+            /* push largest partition on stack */
+            if (pi - pl < pr - pi) {
+                *sptr++ = pi + 1;
+                *sptr++ = pr;
+                pr = pi - 1;
+            }
+            else {
+                *sptr++ = pl;
+                *sptr++ = pi - 1;
+                pl = pi + 1;
+            }
+            *psdepth++ = --cdepth;
+        }
+
+        /* insertion sort */
+        for (pi = pl + 1; pi <= pr; ++pi) {
+            vi = *pi;
+            vp = v[vi];
+            pj = pi;
+            pk = pi - 1;
+            while (pj > pl && LessThan(vp, v[*pk])) {
+                *pj-- = *pk--;
+            }
+            *pj = vi;
+        }
+    stack_pop:
+        if (sptr == stack) {
+            break;
+        }
+        pr = *(--sptr);
+        pl = *(--sptr);
+        cdepth = *(--psdepth);
+    }
+}
+
+template <typename T>
+inline int Quick(T *start, SSize num, PyArrayObject *arr)
+{
+    const SSize arr_len = PyArray_ITEMSIZE(arr);
+    const size_t len = arr_len / sizeof(T);
+    T *vp;
+    T *pl = start;
+    T *pr = pl + (num - 1) * len;
+    T *stack[kQuickStack], **sptr = stack, *pm, *pi, *pj, *pk;
+    int depth[kQuickStack];
+    int *psdepth = depth;
+    int cdepth = BitScanReverse(static_cast<std::make_unsigned_t<SSize>>(num)) * 2;
+
+    /* Items that have zero size don't make sense to sort */
+    if (len == 0) {
+        return 0;
+    }
+
+    vp = (T *)malloc(arr_len);
+    if (vp == NULL) {
+        return -NPY_ENOMEM;
+    }
+
+    for (;;) {
+        if (NPY_UNLIKELY(cdepth < 0)) {
+            Heap(pl, (pr - pl) / len + 1, arr);
+            goto stack_pop;
+        }
+        while ((size_t)(pr - pl) > kQuickSmall * len) {
+            /* quicksort partition */
+            pm = pl + (((pr - pl) / len) >> 1) * len;
+            if (LessThan(pm, pl, len)) {
+                Swap(pm, pl, len);
+            }
+            if (LessThan(pr, pm, len)) {
+                Swap(pr, pm, len);
+            }
+            if (LessThan(pm, pl, len)) {
+                Swap(pm, pl, len);
+            }
+            memcpy(vp, pm, arr_len);
+            pi = pl;
+            pj = pr - len;
+            Swap(pm, pj, len);
+            for (;;) {
+                do {
+                    pi += len;
+                } while (LessThan(pi, vp, len));
+                do {
+                    pj -= len;
+                } while (LessThan(vp, pj, len));
+                if (pi >= pj) {
+                    break;
+                }
+                Swap(pi, pj, len);
+            }
+            pk = pr - len;
+            Swap(pi, pk, len);
+            /* push largest partition on stack */
+            if (pi - pl < pr - pi) {
+                *sptr++ = pi + len;
+                *sptr++ = pr;
+                pr = pi - len;
+            }
+            else {
+                *sptr++ = pl;
+                *sptr++ = pi - len;
+                pl = pi + len;
+            }
+            *psdepth++ = --cdepth;
+        }
+
+        /* insertion sort */
+        for (pi = pl + len; pi <= pr; pi += len) {
+            memcpy(vp, pi, arr_len);
+            pj = pi;
+            pk = pi - len;
+            while (pj > pl && LessThan(vp, pk, len)) {
+                memcpy(pj, pk, arr_len);
+                pj -= len;
+                pk -= len;
+            }
+            memcpy(pj, vp, arr_len);
+        }
+    stack_pop:
+        if (sptr == stack) {
+            break;
+        }
+        pr = *(--sptr);
+        pl = *(--sptr);
+        cdepth = *(--psdepth);
+    }
+
+    free(vp);
+    return 0;
+}
+
+template <typename T>
+inline int Quick(T *vv, SSize *tosort, SSize num, PyArrayObject *arr)
+{
+    T *v = vv;
+    size_t len = PyArray_ITEMSIZE(arr) / sizeof(T);
+    T *vp;
+    SSize *pl = tosort;
+    SSize *pr = tosort + num - 1;
+    SSize *stack[kQuickStack];
+    SSize **sptr = stack;
+    SSize *pm, *pi, *pj, *pk, vi;
+    int depth[kQuickStack];
+    int *psdepth = depth;
+    int cdepth = BitScanReverse(static_cast<std::make_unsigned_t<SSize>>(num)) * 2;
+
+    /* Items that have zero size don't make sense to sort */
+    if (len == 0) {
+        return 0;
+    }
+
+    for (;;) {
+        if (NPY_UNLIKELY(cdepth < 0)) {
+            Heap(vv, pl, pr - pl + 1, arr);
+            goto stack_pop;
+        }
+        while ((pr - pl) > kQuickSmall) {
+            /* quicksort partition */
+            pm = pl + ((pr - pl) >> 1);
+            if (LessThan(v + (*pm) * len, v + (*pl) * len, len)) {
+                std::swap(*pm, *pl);
+            }
+            if (LessThan(v + (*pr) * len, v + (*pm) * len, len)) {
+                std::swap(*pr, *pm);
+            }
+            if (LessThan(v + (*pm) * len, v + (*pl) * len, len)) {
+                std::swap(*pm, *pl);
+            }
+            vp = v + (*pm) * len;
+            pi = pl;
+            pj = pr - 1;
+            std::swap(*pm, *pj);
+            for (;;) {
+                do {
+                    ++pi;
+                } while (LessThan(v + (*pi) * len, vp, len));
+                do {
+                    --pj;
+                } while (LessThan(vp, v + (*pj) * len, len));
+                if (pi >= pj) {
+                    break;
+                }
+                std::swap(*pi, *pj);
+            }
+            pk = pr - 1;
+            std::swap(*pi, *pk);
+            /* push largest partition on stack */
+            if (pi - pl < pr - pi) {
+                *sptr++ = pi + 1;
+                *sptr++ = pr;
+                pr = pi - 1;
+            }
+            else {
+                *sptr++ = pl;
+                *sptr++ = pi - 1;
+                pl = pi + 1;
+            }
+            *psdepth++ = --cdepth;
+        }
+
+        /* insertion sort */
+        for (pi = pl + 1; pi <= pr; ++pi) {
+            vi = *pi;
+            vp = v + vi * len;
+            pj = pi;
+            pk = pi - 1;
+            while (pj > pl && LessThan(vp, v + (*pk) * len, len)) {
+                *pj-- = *pk--;
+            }
+            *pj = vi;
+        }
+    stack_pop:
+        if (sptr == stack) {
+            break;
+        }
+        pr = *(--sptr);
+        pl = *(--sptr);
+        cdepth = *(--psdepth);
+    }
+
+    return 0;
+}
+
 } // np::sort
 #endif // NUMPY_SRC_COMMON_NPYSORT_QUICK_HPP

--- a/numpy/_core/src/umath/clip.cpp
+++ b/numpy/_core/src/umath/clip.cpp
@@ -16,145 +16,89 @@
 
 #include "fast_loop_macros.h"
 
-#include "../common/numpy_tag.h"
 
-template <class T>
-T
-_NPY_MIN(T a, T b, npy::integral_tag const &)
-{
-    return PyArray_MIN(a, b);
-}
-template <class T>
-T
-_NPY_MAX(T a, T b, npy::integral_tag const &)
-{
-    return PyArray_MAX(a, b);
-}
+#include "common.hpp"
 
-npy_half
-_NPY_MIN(npy_half a, npy_half b, npy::half_tag const &)
+namespace {
+
+template <typename T>
+inline std::enable_if_t<np::kIsComplex<T>, bool> LessThan(const T &a, const T &b)
 {
-    return npy_half_isnan(a) || npy_half_le(a, b) ? (a) : (b);
-}
-npy_half
-_NPY_MAX(npy_half a, npy_half b, npy::half_tag const &)
-{
-    return npy_half_isnan(a) || npy_half_ge(a, b) ? (a) : (b);
+    auto a_real = a.real();
+    auto a_imag = a.imag();
+    auto b_real = b.real();
+    auto b_imag = b.imag();
+    return a_real == b_real ? a_imag < b_imag : a_real < b_real;
 }
 
-template <class T>
-T
-_NPY_MIN(T a, T b, npy::floating_point_tag const &)
+template <typename T>
+inline std::enable_if_t<np::kIsComplex<T>, bool> GreatThan(const T &a, const T &b)
 {
-    return npy_isnan(a) ? (a) : PyArray_MIN(a, b);
-}
-template <class T>
-T
-_NPY_MAX(T a, T b, npy::floating_point_tag const &)
-{
-    return npy_isnan(a) ? (a) : PyArray_MAX(a, b);
+    auto a_real = a.real();
+    auto a_imag = a.imag();
+    auto b_real = b.real();
+    auto b_imag = b.imag();
+    return a_real == b_real ? a_imag > b_imag : a_real > b_real;
 }
 
-#define PyArray_CLT(p,q,suffix) (((npy_creal##suffix(p)==npy_creal##suffix(q)) ? (npy_cimag##suffix(p) < npy_cimag##suffix(q)) : \
-                               (npy_creal##suffix(p) < npy_creal##suffix(q))))
-#define PyArray_CGT(p,q,suffix) (((npy_creal##suffix(p)==npy_creal##suffix(q)) ? (npy_cimag##suffix(p) > npy_cimag##suffix(q)) : \
-                               (npy_creal##suffix(p) > npy_creal##suffix(q))))
-
-npy_cdouble
-_NPY_MIN(npy_cdouble a, npy_cdouble b, npy::complex_tag const &)
+template <typename T>
+inline T Min(const T &a, const T &b)
 {
-    return npy_isnan(npy_creal(a)) || npy_isnan(npy_cimag(a)) || PyArray_CLT(a, b,)
-                ? (a)
-                : (b);
+    if constexpr (std::is_same_v<T, np::Half>) {
+        return a.IsNaN() || a < b ? a : b;
+    }
+    else if constexpr (np::kIsFloat<T>) {
+        return std::isnan(a) || a < b  ? a : b;
+    }
+    else if constexpr (np::kIsComplex<T>) {
+        auto a_real = a.real();
+        auto a_imag = a.imag();
+        // auto b_real = b.real();
+        // auto b_imag = b.imag();
+        return std::isnan(a_real) || std::isnan(a_imag) || LessThan(a, b) ? a : b;
+    }
+    else if constexpr (np::kIsTime<T>) {
+        return a.IsNaT() || a < b ? a : b;
+    }
+    else {
+        return std::min(a, b);
+    }
 }
 
-npy_cfloat
-_NPY_MIN(npy_cfloat a, npy_cfloat b, npy::complex_tag const &)
+template <typename T>
+inline T Max(const T &a, const T &b)
 {
-    return npy_isnan(npy_crealf(a)) || npy_isnan(npy_cimagf(a)) || PyArray_CLT(a, b, f)
-                ? (a)
-                : (b);
+    if constexpr (std::is_same_v<T, np::Half>) {
+        return a.IsNaN() || a > b ?  a : b;
+    }
+    else if constexpr (np::kIsFloat<T>) {
+        return std::isnan(a) || a > b  ? a : b;
+    }
+    else if constexpr (np::kIsComplex<T>) {
+        auto a_real = a.real();
+        auto a_imag = a.imag();
+        // auto b_real = b.real();
+        // auto b_imag = b.imag();
+        return std::isnan(a_real) || std::isnan(a_imag) || GreatThan(a, b) ? a : b;
+    }
+    else if constexpr (np::kIsTime<T>) {
+        return a.IsNaT() || a > b ? a : b;
+    }
+    else {
+        return std::max(a, b);
+    }
 }
 
-npy_clongdouble
-_NPY_MIN(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
+template <typename T>
+inline T Clip(const T &x, const T &min, const T &max)
 {
-    return npy_isnan(npy_creall(a)) || npy_isnan(npy_cimagl(a)) || PyArray_CLT(a, b, l)
-                ? (a)
-                : (b);
+    return Min(Max(x, min), max);
 }
 
-npy_cdouble
-_NPY_MAX(npy_cdouble a, npy_cdouble b, npy::complex_tag const &)
+template <typename T>
+inline void Clip(T **args, np::SSize const *dimensions, np::SSize const *steps)
 {
-    return npy_isnan(npy_creal(a)) || npy_isnan(npy_cimag(a)) || PyArray_CGT(a, b,)
-                ? (a)
-                : (b);
-}
-
-npy_cfloat
-_NPY_MAX(npy_cfloat a, npy_cfloat b, npy::complex_tag const &)
-{
-    return npy_isnan(npy_crealf(a)) || npy_isnan(npy_cimagf(a)) || PyArray_CGT(a, b, f)
-                ? (a)
-                : (b);
-}
-
-npy_clongdouble
-_NPY_MAX(npy_clongdouble a, npy_clongdouble b, npy::complex_tag const &)
-{
-    return npy_isnan(npy_creall(a)) || npy_isnan(npy_cimagl(a)) || PyArray_CGT(a, b, l)
-                ? (a)
-                : (b);
-}
-#undef PyArray_CLT
-#undef PyArray_CGT
-
-template <class T>
-T
-_NPY_MIN(T a, T b, npy::date_tag const &)
-{
-    return (a) == NPY_DATETIME_NAT   ? (a)
-           : (b) == NPY_DATETIME_NAT ? (b)
-           : (a) < (b)               ? (a)
-                                     : (b);
-}
-template <class T>
-T
-_NPY_MAX(T a, T b, npy::date_tag const &)
-{
-    return (a) == NPY_DATETIME_NAT   ? (a)
-           : (b) == NPY_DATETIME_NAT ? (b)
-           : (a) > (b)               ? (a)
-                                     : (b);
-}
-
-/* generic dispatcher */
-template <class Tag, class T = typename Tag::type>
-T
-_NPY_MIN(T const &a, T const &b)
-{
-    return _NPY_MIN(a, b, Tag{});
-}
-template <class Tag, class T = typename Tag::type>
-T
-_NPY_MAX(T const &a, T const &b)
-{
-    return _NPY_MAX(a, b, Tag{});
-}
-
-template <class Tag, class T>
-T
-_NPY_CLIP(T x, T min, T max)
-{
-    return _NPY_MIN<Tag>(_NPY_MAX<Tag>((x), (min)), (max));
-}
-
-template <class Tag, class T = typename Tag::type>
-static void
-_npy_clip_(T **args, npy_intp const *dimensions, npy_intp const *steps)
-{
-    npy_intp n = dimensions[0];
+    np::SSize n = dimensions[0];
     if (steps[1] == 0 && steps[2] == 0) {
         /* min and max are constant throughout the loop, the most common case
          */
@@ -163,158 +107,152 @@ _npy_clip_(T **args, npy_intp const *dimensions, npy_intp const *steps)
         T max_val = *args[2];
 
         T *ip1 = args[0], *op1 = args[3];
-        npy_intp is1 = steps[0] / sizeof(T), os1 = steps[3] / sizeof(T);
+        np::SSize is1 = steps[0] / sizeof(T), os1 = steps[3] / sizeof(T);
 
         /* contiguous, branch to let the compiler optimize */
         if (is1 == 1 && os1 == 1) {
-            for (npy_intp i = 0; i < n; i++, ip1++, op1++) {
-                *op1 = _NPY_CLIP<Tag>(*ip1, min_val, max_val);
+            for (np::SSize i = 0; i < n; i++, ip1++, op1++) {
+                *op1 = Clip(*ip1, min_val, max_val);
             }
         }
         else {
-            for (npy_intp i = 0; i < n; i++, ip1 += is1, op1 += os1) {
-                *op1 = _NPY_CLIP<Tag>(*ip1, min_val, max_val);
+            for (np::SSize i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+                *op1 = Clip(*ip1, min_val, max_val);
             }
         }
     }
     else {
         T *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *op1 = args[3];
-        npy_intp is1 = steps[0] / sizeof(T), is2 = steps[1] / sizeof(T),
+        np::SSize is1 = steps[0] / sizeof(T), is2 = steps[1] / sizeof(T),
                  is3 = steps[2] / sizeof(T), os1 = steps[3] / sizeof(T);
-        for (npy_intp i = 0; i < n;
+        for (np::SSize i = 0; i < n;
              i++, ip1 += is1, ip2 += is2, ip3 += is3, op1 += os1)
-            *op1 = _NPY_CLIP<Tag>(*ip1, *ip2, *ip3);
+            *op1 = Clip(*ip1, *ip2, *ip3);
     }
     npy_clear_floatstatus_barrier((char *)dimensions);
 }
-
-template <class Tag>
-static void
-_npy_clip(char **args, npy_intp const *dimensions, npy_intp const *steps)
-{
-    using T = typename Tag::type;
-    return _npy_clip_<Tag>((T **)args, dimensions, steps);
-}
+} // namespace
 
 extern "C" {
+
 NPY_NO_EXPORT void
 BOOL_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
           void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::bool_tag>(args, dimensions, steps);
+    return Clip((np::Bool**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 BYTE_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
           void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::byte_tag>(args, dimensions, steps);
+    return Clip((np::Byte**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 UBYTE_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
            void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::ubyte_tag>(args, dimensions, steps);
+    return Clip((np::UByte**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 SHORT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
            void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::short_tag>(args, dimensions, steps);
+    return Clip((np::Short**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 USHORT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
             void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::ushort_tag>(args, dimensions, steps);
+    return Clip((np::UShort**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 INT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
          void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::int_tag>(args, dimensions, steps);
+    return Clip((np::Int**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 UINT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
           void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::uint_tag>(args, dimensions, steps);
+    return Clip((np::UInt**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 LONG_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
           void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::long_tag>(args, dimensions, steps);
+    return Clip((np::Long**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 ULONG_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
            void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::ulong_tag>(args, dimensions, steps);
+    return Clip((np::ULong**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 LONGLONG_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
               void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::longlong_tag>(args, dimensions, steps);
+    return Clip((np::LongLong**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 ULONGLONG_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
                void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::ulonglong_tag>(args, dimensions, steps);
+    return Clip((np::ULongLong**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 HALF_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
           void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::half_tag>(args, dimensions, steps);
+    return Clip((np::Half**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 FLOAT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
            void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::float_tag>(args, dimensions, steps);
+    return Clip((np::Float**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 DOUBLE_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
             void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::double_tag>(args, dimensions, steps);
+    return Clip((np::Double**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 LONGDOUBLE_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
                 void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::longdouble_tag>(args, dimensions, steps);
+    return Clip((np::LongDouble**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 CFLOAT_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
             void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::cfloat_tag>(args, dimensions, steps);
+    return Clip((np::CFloat**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 CDOUBLE_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
              void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::cdouble_tag>(args, dimensions, steps);
+    return Clip((np::CDouble**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 CLONGDOUBLE_clip(char **args, npy_intp const *dimensions,
                  npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::clongdouble_tag>(args, dimensions, steps);
+    return Clip((np::CLongDouble**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 DATETIME_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
               void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::datetime_tag>(args, dimensions, steps);
+    return Clip((np::DateTime**)args, dimensions, steps);
 }
 NPY_NO_EXPORT void
 TIMEDELTA_clip(char **args, npy_intp const *dimensions, npy_intp const *steps,
                void *NPY_UNUSED(func))
 {
-    return _npy_clip<npy::timedelta_tag>(args, dimensions, steps);
+    return Clip((np::TimeDelta**)args, dimensions, steps);
 }
 }


### PR DESCRIPTION
  The refactored sort operations are now encapsulated within the `np::sort` namespace and no longer rely on tags.
  This patch also introduced new C++ datatypes that cover all NumPy built-in datatypes.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
