### PR TITLE
DOC: add autosummary API reference for DType clases.

### DIFF
--- a/doc/source/reference/routines.dtypes.rst
+++ b/doc/source/reference/routines.dtypes.rst
@@ -1,6 +1,6 @@
 .. _routines.dtypes:
 
-Data Type Classes
+Data type classes
 =================
 
 .. currentmodule:: numpy

--- a/doc/source/reference/routines.dtypes.rst
+++ b/doc/source/reference/routines.dtypes.rst
@@ -1,0 +1,11 @@
+.. _routines.dtypes:
+
+Data Type Classes
+=================
+
+.. currentmodule:: numpy
+
+.. autosummary::
+   :toctree: generated/
+
+   dtypes


### PR DESCRIPTION
This was supposed to be included in #25507 and was mistakenly left out, introducing some reference warnings.

The net effect of this PR should be to add a new docs page available at `reference/generated/numpy.dtypes.html`, linked to by another page at `reference/routines.dtypes.html`.

Note that this introduces *new* reference warnings, due to an issue with how the descriptor and dtypemeta classes are implemented in C, [as explained here](https://github.com/numpy/numpy/pull/25507#issuecomment-1872218294):

> One wrinkle I noticed looking at the docs build, this introduces some new reference warnings that I can't easily fix:
> ```
> /Users/goldbaum/Documents/numpy/build-install/usr/local/lib/python3.11/site-packages/numpy/dtypes.py:docstring of numpy.dtypes.BytesDType:87: 
>  WARNING: autosummary: stub file not found 'numpy.dtypes.BytesDType.type'. Check your autosummary_generate setting.
> ```
>And similar warnings for all of the other DType classes. I think that's happening is that both the dtype metaclass and dtype class share a python attribute named `type`, and the way we've implemented the python inheritance for this in C (perhaps also somehow combined with the use of `T_OBJECT` to define the attribute) is confusing sphinx. If I change dtypemeta to use a `scalar_type` python-level name, that fixes the sphinx issue, but that seems like a more invasive risky change that I want to take on in this PR.

I would personally rather have these spurious reference warnings in the build and also be able to cross-reference the DType classes elsewhere in the docs, but please let me know if we'd rather not introduce the new reference warnings and we need a more permanent fix.