### PR TITLE
MAINT: fix warning about visibility tag on clang

### DIFF
--- a/numpy/fft/pocketfft/pocketfft.h
+++ b/numpy/fft/pocketfft/pocketfft.h
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include "numpy/numpyconfig.h"  // for NPY_VISIBILITY_HIDDEN
 
-NPY_VISIBILITY_HIDDEN struct cfft_plan_i;
+struct NPY_VISIBILITY_HIDDEN cfft_plan_i;
 typedef struct cfft_plan_i * cfft_plan;
 NPY_VISIBILITY_HIDDEN cfft_plan make_cfft_plan (size_t length);
 NPY_VISIBILITY_HIDDEN void destroy_cfft_plan (cfft_plan plan);
@@ -24,7 +24,7 @@ NPY_VISIBILITY_HIDDEN int cfft_backward(cfft_plan plan, double c[], double fct);
 NPY_VISIBILITY_HIDDEN int cfft_forward(cfft_plan plan, double c[], double fct);
 NPY_VISIBILITY_HIDDEN size_t cfft_length(cfft_plan plan);
 
-NPY_VISIBILITY_HIDDEN struct rfft_plan_i;
+struct NPY_VISIBILITY_HIDDEN rfft_plan_i;
 typedef struct rfft_plan_i * rfft_plan;
 NPY_VISIBILITY_HIDDEN rfft_plan make_rfft_plan (size_t length);
 NPY_VISIBILITY_HIDDEN void destroy_rfft_plan (rfft_plan plan);

--- a/numpy/fft/pocketfft/pocketfft.h
+++ b/numpy/fft/pocketfft/pocketfft.h
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include "numpy/numpyconfig.h"  // for NPY_VISIBILITY_HIDDEN
 
-struct NPY_VISIBILITY_HIDDEN cfft_plan_i;
+struct cfft_plan_i;
 typedef struct cfft_plan_i * cfft_plan;
 NPY_VISIBILITY_HIDDEN cfft_plan make_cfft_plan (size_t length);
 NPY_VISIBILITY_HIDDEN void destroy_cfft_plan (cfft_plan plan);
@@ -24,7 +24,7 @@ NPY_VISIBILITY_HIDDEN int cfft_backward(cfft_plan plan, double c[], double fct);
 NPY_VISIBILITY_HIDDEN int cfft_forward(cfft_plan plan, double c[], double fct);
 NPY_VISIBILITY_HIDDEN size_t cfft_length(cfft_plan plan);
 
-struct NPY_VISIBILITY_HIDDEN rfft_plan_i;
+struct rfft_plan_i;
 typedef struct rfft_plan_i * rfft_plan;
 NPY_VISIBILITY_HIDDEN rfft_plan make_rfft_plan (size_t length);
 NPY_VISIBILITY_HIDDEN void destroy_rfft_plan (rfft_plan plan);


### PR DESCRIPTION
This fixes a warning reported by clang:

```
In file included from ../numpy/fft/_pocketfft_umath.c:23:
../numpy/fft/pocketfft/pocketfft.h:19:1: warning: attribute 'visibility' is ignored, place it after "struct" to apply attribute to type declaration [-Wignored-attributes]
NPY_VISIBILITY_HIDDEN struct cfft_plan_i;
^
```

I don't have gcc locally so let's see if other compilers complain