### PR TITLE
DOC: minor improvement to the partition() docstrings

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2883,7 +2883,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('T',
 add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
     """
     View of the matrix transposed array.
-    
+
     The matrix transpose is the transpose of the last two dimensions, even
     if the array is of higher dimension.
 
@@ -2893,7 +2893,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
     ------
     ValueError
         If the array is of dimension less than 2.
-        
+
     Examples
     --------
     >>> a = np.array([[1, 2], [3, 4]])
@@ -2903,7 +2903,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
     >>> a.mT
     array([[1, 3],
            [2, 4]])
-           
+
     >>> a = np.arange(8).reshape((2, 2, 2))
     >>> a
     array([[[0, 1],
@@ -2917,7 +2917,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
     <BLANKLINE>
            [[4, 6],
             [5, 7]]])
-    
+
     """))
 ##############################################################################
 #
@@ -4112,11 +4112,12 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
     """
     a.partition(kth, axis=-1, kind='introselect', order=None)
 
-    Rearranges the elements in the array in such a way that the value of the
-    element in kth position is in the position it would be in a sorted array.
-    All elements smaller than the kth element are moved before this element and
-    all equal or greater are moved behind it. The ordering of the elements in
-    the two partitions is undefined.
+    Partially sorts the elements in the array in such a way that the value of
+    the element in k-th position is in the position it would be in a sorted
+    array. In the output array, all elements smaller than the k-th element
+    are located to the left of this element and all equal or greater are
+    located to its right. The ordering of the elements in the two partitions
+    on the either side of the k-th element in the output array is undefined.
 
     .. versionadded:: 1.8.0
 
@@ -4929,7 +4930,7 @@ add_newdoc('numpy._core', 'ufunc', ('identity',
     """
     The identity value.
 
-    Data attribute containing the identity element for the ufunc, 
+    Data attribute containing the identity element for the ufunc,
     if it has one. If it does not, the attribute value is None.
 
     Examples
@@ -4953,7 +4954,7 @@ add_newdoc('numpy._core', 'ufunc', ('nargs',
 
     Notes
     -----
-    Typically this value will be one more than what you might expect 
+    Typically this value will be one more than what you might expect
     because all ufuncs take  the optional "out" argument.
 
     Examples
@@ -5919,7 +5920,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('fields',
     If present, the optional title can be any object (if it is a string
     or unicode then it will also be a key in the fields dictionary,
     otherwise it's meta-data). Notice also that the first two elements
-    of the tuple can be passed directly as arguments to the 
+    of the tuple can be passed directly as arguments to the
     ``ndarray.getfield`` and ``ndarray.setfield`` methods.
 
     See Also

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -697,13 +697,13 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     """
     Return a partitioned copy of an array.
 
-    Creates a copy of the array with its elements rearranged in such a
-    way that the value of the element in k-th position is in the position
-    the value would be in a sorted array.  In the partitioned array, all
-    elements before the k-th element are less than or equal to that
-    element, and all the elements after the k-th element are greater than
-    or equal to that element.  The ordering of the elements in the two
-    partitions is undefined.
+    Creates a copy of the array and partially sorts it in such a way that
+    the value of the element in k-th position is in the position it would be
+    in a sorted array. In the output array, all elements smaller than the k-th
+    element are located to the left of this element and all equal or greater
+    are located to its right. The ordering of the elements in the two
+    partitions on the either side of the k-th element in the output array is
+    undefined.
 
     .. versionadded:: 1.8.0
 
@@ -884,7 +884,7 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     >>> x = np.array([[3, 4, 2], [1, 3, 1]])
     >>> index_array = np.argpartition(x, kth=1, axis=-1)
     >>> # below is the same as np.partition(x, kth=1)
-    >>> np.take_along_axis(x, index_array, axis=-1)  
+    >>> np.take_along_axis(x, index_array, axis=-1)
     array([[2, 3, 4],
            [1, 1, 3]])
 
@@ -1364,7 +1364,7 @@ def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     array([[2],
            [0]])
     >>> # Same as np.amax(x, axis=-1)
-    >>> np.take_along_axis(x, np.expand_dims(index_array, axis=-1), 
+    >>> np.take_along_axis(x, np.expand_dims(index_array, axis=-1),
     ...     axis=-1).squeeze(axis=-1)
     array([2, 0])
 
@@ -1437,7 +1437,7 @@ def searchsorted(a, v, side='left', sorter=None):
     As of NumPy 1.4.0 `searchsorted` works with real/complex arrays containing
     `nan` values. The enhanced sort order is documented in `sort`.
 
-    This function uses the same algorithm as the builtin python 
+    This function uses the same algorithm as the builtin python
     `bisect.bisect_left` (``side='left'``) and `bisect.bisect_right`
     (``side='right'``) functions, which is also vectorized
     in the `v` argument.
@@ -2371,7 +2371,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
         return res
 
     return _wrapreduction(
-        a, np.add, 'sum', axis, dtype, out, 
+        a, np.add, 'sum', axis, dtype, out,
         keepdims=keepdims, initial=initial, where=where
     )
 


### PR DESCRIPTION
This is a very minor modification of the description of `np.partition`. Normally no one would bother, but I couldn't understand it after two reads and found that more people were as confused as myself on stack overflow: https://stackoverflow.com/questions/41484104/how-does-np-partition-interpret-the-argument-kth

So.. in the new description I try to mention "partially sorted" and be more explicit about "k-th element of the new array".
My editor removed some blank spaces as well and I hope that is okay.
