### PR TITLE
BUG: Ensure meson updates generated umath doc correctly.

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -623,8 +623,9 @@ src_umath_api_c = custom_target('__umath_generated',
 
 src_umath_doc_h = custom_target('_umath_doc_generated',
   output : '_umath_doc_generated.h',
-  input : 'code_generators/generate_umath_doc.py',
-  command: [py, '@INPUT@', '-o', '@OUTPUT@'],
+  input : ['code_generators/generate_umath_doc.py',
+           'code_generators/ufunc_docstrings.py'],
+  command: [py, '@INPUT0@', '-o', '@OUTPUT@'],
 )
 
 src_numpy_api = custom_target('__multiarray_api',


### PR DESCRIPTION
The docstrings are set in `code_generators/ufunc_docstrings.py`, so added that to the inputs for `_umath_doc_generated`.

Noticed this because when trying to add new `gufuncs` my new docstrings didn't get recognized if I did not clean the environment.