### PR TITLE
DOC: replace autosummary for numpy.dtypes with enumerated list

### DIFF
--- a/doc/source/reference/routines.dtypes.rst
+++ b/doc/source/reference/routines.dtypes.rst
@@ -3,9 +3,69 @@
 Data type classes
 =================
 
-.. currentmodule:: numpy
+.. automodule:: numpy.dtypes
+   :no-members:
 
-.. autosummary::
-   :toctree: generated/
+Boolean
+-------
 
-   dtypes
+.. attribute:: BoolDType
+
+Bit-sized integers
+------------------
+
+.. attribute:: Int8DType
+               UInt8DType
+               Int16DType
+               UInt16DType
+               Int32DType
+               UInt32DType
+               Int64DType
+               UInt64DType
+
+C-named integers (may be aliases)
+---------------------------------
+
+.. attribute:: ByteDType
+               UByteDType
+               ShortDType
+               UShortDType
+               IntDType
+               UIntDType
+               LongDType
+               ULongDType
+               LongLongDType
+               ULongLongDType
+
+Floating point
+--------------
+
+.. attribute:: Float16DType
+               Float32DType
+               Float64DType
+               LongDoubleDType
+
+Complex
+-------
+
+.. attribute:: Complex64DType
+               Complex128DType
+               CLongDoubleDType
+
+Strings and Bytestrings
+-----------------------
+
+.. attribute:: StrDType
+               BytesDType
+
+Times
+-----
+
+.. attribute:: DateTime64DType
+               TimeDelta64DType
+
+Others
+------
+
+.. attribute:: ObjectDType
+               VoidDType

--- a/numpy/dtypes.py
+++ b/numpy/dtypes.py
@@ -20,41 +20,6 @@ NumPy scalar types.  The classes can be used in ``isinstance`` checks and can
 also be instantiated or used directly.  Direct use of these classes is not
 typical, since their scalar counterparts (e.g. ``np.float64``) or strings
 like ``"float64"`` can be used.
-
-.. list-table::
-    :header-rows: 1
-
-    * - Group
-      - DType class
-
-    * - Boolean
-      - ``BoolDType``
-
-    * - Bit-sized integers
-      - ``Int8DType``, ``UInt8DType``, ``Int16DType``, ``UInt16DType``,
-        ``Int32DType``, ``UInt32DType``, ``Int64DType``, ``UInt64DType``
-
-    * - C-named integers (may be aliases)
-      - ``ByteDType``, ``UByteDType``, ``ShortDType``, ``UShortDType``,
-        ``IntDType``, ``UIntDType``, ``LongDType``, ``ULongDType``,
-        ``LongLongDType``, ``ULongLongDType``
-
-    * - Floating point
-      - ``Float16DType``, ``Float32DType``, ``Float64DType``,
-        ``LongDoubleDType``
-
-    * - Complex
-      - ``Complex64DType``, ``Complex128DType``, ``CLongDoubleDType``
-
-    * - Strings and Bytestrings
-      - ``StrDType``, ``BytesDType``
-
-    * - Times
-      - ``DateTime64DType``, ``TimeDelta64DType``
-
-    * - Others
-      - ``ObjectDType``, ``VoidDType``
-
 """
 
 __all__ = []


### PR DESCRIPTION
Doing it this way creates cross-reference anchors for these classes without actually autogenerating docs for them.

See @rgommers' suggestion for a little context: https://github.com/numpy/numpy/pull/25656#issuecomment-1909003694