### PR TITLE
Update to OpenBLAS 0.3.26

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -243,7 +243,7 @@ python_sources = [
   'version.pyi',
 ]
 
-if blas_name == 'scipy-openblas'
+if fs.exists('_distributor_init_local.py')
   python_sources += ['_distributor_init_local.py']
 endif
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.23.dev'
-OPENBLAS_LONG = 'v0.3.23-293-gc2f4bdbb'
+OPENBLAS_V = '0.3.26'
+OPENBLAS_LONG = 'v0.3.26'
 BASE_LOC = (
     'https://anaconda.org/scientific-python-nightly-wheels/openblas-libs'
 )


### PR DESCRIPTION
OpenBLAS released v0.3.26, update to use it. This also uses the newer tarball format with a single `scipy-openblas` shared object, see MacPython/openblas-libs#128. This will enable #25505 and dropping the tools/openblas_support.py script