### PR TITLE
DOC: empty: standardize notes about uninitialized values

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1216,13 +1216,13 @@ add_newdoc('numpy._core.multiarray', 'empty',
     zeros : Return a new array setting values to zero.
     full : Return a new array of given shape filled with value.
 
-
     Notes
     -----
-    `empty`, unlike `zeros`, does not set the array values to zero,
-    and may therefore be marginally faster.  On the other hand, it requires
-    the user to manually set all the values in the array, and should be
-    used with caution.
+    Unlike other array creation functions (e.g. `zeros`, `ones`, `full`),
+    `empty` does not initialize the values of the array, and may therefore be
+    marginally faster. However, the values stored in the newly allocated array
+    are arbitrary. For reproducible behavior, be sure to set each element of
+    the array before reading.
 
     Examples
     --------

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -129,9 +129,11 @@ def empty_like(prototype, dtype=None, order=None, subok=None, shape=None):
 
     Notes
     -----
-    This function does *not* initialize the returned array; to do that use
-    `zeros_like` or `ones_like` instead.  It may be marginally faster than
-    the functions that do set the array values.
+    Unlike other array creation functions (e.g. `zeros_like`, `ones_like`,
+    `full_like`), `empty_like` does not initialize the values of the array,
+    and may therefore be marginally faster. However, the values stored in the
+    newly allocated array are arbitrary. For reproducible behavior, be sure
+    to set each element of the array before reading.
 
     Examples
     --------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -122,6 +122,15 @@ def masked_all(shape, dtype=float):
     --------
     masked_all_like : Empty masked array modelled on an existing array.
 
+    Notes
+    -----
+    Unliked other masked array creation functions (e.g. `numpy.ma.zeros`,
+    `numpy.ma.ones`, `numpy.ma.full`), `masked_all` does not initialize the
+    values of the array, and may therefore be marginally faster. However,
+    the values stored in the newly allocated array are arbitrary. For
+    reproducible behavior, be sure to set each element of the array before
+    reading.
+
     Examples
     --------
     >>> import numpy.ma as ma
@@ -176,6 +185,15 @@ def masked_all_like(arr):
     See Also
     --------
     masked_all : Empty masked array with all elements masked.
+
+    Notes
+    -----
+    Unliked other masked array creation functions (e.g. `numpy.ma.zeros_like`,
+    `numpy.ma.ones_like`, `numpy.ma.full_like`), `masked_all_like` does not
+    initialize the values of the array, and may therefore be marginally
+    faster. However, the values stored in the newly allocated array are
+    arbitrary. For reproducible behavior, be sure to set each element of the
+    array before reading.
 
     Examples
     --------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -124,7 +124,7 @@ def masked_all(shape, dtype=float):
 
     Notes
     -----
-    Unliked other masked array creation functions (e.g. `numpy.ma.zeros`,
+    Unlike other masked array creation functions (e.g. `numpy.ma.zeros`,
     `numpy.ma.ones`, `numpy.ma.full`), `masked_all` does not initialize the
     values of the array, and may therefore be marginally faster. However,
     the values stored in the newly allocated array are arbitrary. For
@@ -188,7 +188,7 @@ def masked_all_like(arr):
 
     Notes
     -----
-    Unliked other masked array creation functions (e.g. `numpy.ma.zeros_like`,
+    Unlike other masked array creation functions (e.g. `numpy.ma.zeros_like`,
     `numpy.ma.ones_like`, `numpy.ma.full_like`), `masked_all_like` does not
     initialize the values of the array, and may therefore be marginally
     faster. However, the values stored in the newly allocated array are

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -37,14 +37,17 @@ def empty(shape, dtype=None, order='C'):
 
     See Also
     --------
-    empty_like, zeros
+    numpy.empty : Equivalent array function.
+    matlib.zeros : Return a matrix of zeros.
+    matlib.ones : Return a matrix of ones.
 
     Notes
     -----
-    `empty`, unlike `zeros`, does not set the matrix values to zero,
-    and may therefore be marginally faster.  On the other hand, it requires
-    the user to manually set all the values in the array, and should be
-    used with caution.
+    Unlike other matrix creation functions (e.g. `matlib.zeros`,
+    `matlib.ones`), `matlib.empty` does not initialize the values of the
+    matrix, and may therefore be marginally faster. However, the values
+    stored in the newly allocated matrix are arbitrary. For reproducible
+    behavior, be sure to set each element of the matrix before reading.
 
     Examples
     --------


### PR DESCRIPTION
gh-21482 reported that some functions similar to `np.empty` were missing notes about uninitialized values. This PR standardizes the note about uninititalized values for functions I could find that were similar to `np.empty`. (If I missed any, LMK.)

Closes gh-21482