### PR TITLE
ENH: Add ``axis`` kwarg to np.tile

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -1214,9 +1214,11 @@ def tile(A, reps, axis=None):
     ----------
     A : array_like
         The input array.
-    reps : array_like
-        The number of repetitions of `A` along each axis.
+    reps : int or array_like
+        The number of repetitions of `A` along each axis.  If array-like,
+        length should match length of `axis` tuple
     axis : None or int or tuple of ints, optional
+        Axis or axes to tile.  Defaults to first axis
 
     Returns
     -------
@@ -1289,6 +1291,8 @@ def tile(A, reps, axis=None):
         axis, reps = (axis,), (reps,)
 
     if isinstance(axis, tuple):
+        if isinstance(reps, int):
+            reps = (reps,) * len(axis)
         if len(reps) != len(axis):
             raise ValueError("`reps` and `axis` should have the same length")
         new_reps = [1] * c.ndim

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -731,9 +731,14 @@ class TestTile:
         assert_equal(tile(a, (2, 2)), [[0, 1, 2, 0, 1, 2], [0, 1, 2, 0, 1, 2]])
         assert_equal(tile(a, (1, 2)), [[0, 1, 2, 0, 1, 2]])
         assert_equal(tile(b, 2), [[1, 2, 1, 2], [3, 4, 3, 4]])
+        assert_equal(tile(b, 2, axis=-1), [[1, 2, 1, 2], [3, 4, 3, 4]])
         assert_equal(tile(b, (2, 1)), [[1, 2], [3, 4], [1, 2], [3, 4]])
+        assert_equal(tile(b, 2, axis=0), [[1, 2], [3, 4], [1, 2], [3, 4]])
         assert_equal(tile(b, (2, 2)), [[1, 2, 1, 2], [3, 4, 3, 4],
                                        [1, 2, 1, 2], [3, 4, 3, 4]])
+        assert_equal(tile(b, (2, 2), axis=(0, 1)),
+                     [[1, 2, 1, 2], [3, 4, 3, 4],
+                      [1, 2, 1, 2], [3, 4, 3, 4]])
 
     def test_tile_one_repetition_on_array_gh4679(self):
         a = np.arange(5)

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -739,6 +739,9 @@ class TestTile:
         assert_equal(tile(b, (2, 2), axis=(0, 1)),
                      [[1, 2, 1, 2], [3, 4, 3, 4],
                       [1, 2, 1, 2], [3, 4, 3, 4]])
+        assert_equal(tile(b, 2, axis=(0, 1)),
+                     [[1, 2, 1, 2], [3, 4, 3, 4],
+                      [1, 2, 1, 2], [3, 4, 3, 4]])
 
     def test_tile_one_repetition_on_array_gh4679(self):
         a = np.arange(5)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Adds a keyword argument `axis` allowing to specify which axes to tile:

``` python
>>> A = np.arange(3)[None, :]
>>> A
[[0 1 2]]
>>> np.tile(A, (1, 2))
[[0 1 2 0 1 2]]
>>> np.tile(A, 2, axis=-1)
[[0 1 2 0 1 2]]
>>> np.tile(A, (2, 2))
[[0 1 2 0 1 2]
 [0 1 2 0 1 2]]
>>> np.tile(A, (2, 2), axis=(0, 1))
[[0 1 2 0 1 2]
 [0 1 2 0 1 2]]
```

fixes https://github.com/numpy/numpy/issues/8879

This is my first PR to numpy, so let me know if there are any issues.