### PR TITLE
DOC: quantile: correct/simplify documentation

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4050,144 +4050,9 @@ def percentile(a,
 
     Notes
     -----
-    In general, the percentile at percentage level :math:`q` of a cumulative
-    distribution function :math:`F(y)=P(Y \\leq y)` with probability measure
-    :math:`P` is defined as any number :math:`x` that fulfills the
-    *coverage conditions*
-
-    .. math:: P(Y < x) \\leq q/100 \\quad\\text{and}
-              \\quad P(Y \\leq x) \\geq q/100
-
-    with random variable :math:`Y\\sim P`.
-    Sample percentiles, the result of ``percentile``, provide nonparametric
-    estimation of the underlying population counterparts, represented by the
-    unknown :math:`F`, given a data vector ``a`` of length ``n``.
-
-    One type of estimators arises when one considers :math:`F` as the empirical
-    distribution function of the data, i.e.
-    :math:`F(y) = \\frac{1}{n} \\sum_i 1_{a_i \\leq y}`.
-    Then, different methods correspond to different choices of :math:`x` that
-    fulfill the above inequalities. Methods that follow this approach are
-    ``inverted_cdf`` and ``averaged_inverted_cdf``.
-
-    A more general way to define sample percentile estimators is as follows.
-    The empirical q-percentile of ``a`` is the ``n * q/100``-th value of the
-    way from the minimum to the maximum in a sorted copy of ``a``. The values
-    and distances of the two nearest neighbors as well as the `method`
-    parameter will determine the percentile if the normalized ranking does not
-    match the location of ``n * q/100`` exactly. This function is the same as
-    the median if ``q=50``, the same as the minimum if ``q=0`` and the same
-    as the maximum if ``q=100``.
-
-    The optional `method` parameter specifies the method to use when the
-    desired percentile lies between two indexes ``i`` and ``j = i + 1``.
-    In that case, we first determine ``i + g``, a virtual index that lies
-    between ``i`` and ``j``, where  ``i`` is the floor and ``g`` is the
-    fractional part of the index. The final result is, then, an interpolation
-    of ``a[i]`` and ``a[j]`` based on ``g``. During the computation of ``g``,
-    ``i`` and ``j`` are modified using correction constants ``alpha`` and
-    ``beta`` whose choices depend on the ``method`` used. Finally, note that
-    since Python uses 0-based indexing, the code subtracts another 1 from the
-    index internally.
-
-    The following formula determines the virtual index ``i + g``, the location
-    of the percentile in the sorted sample:
-
-    .. math::
-        i + g = (q / 100) * ( n - alpha - beta + 1 ) + alpha
-
-    The different methods then work as follows
-
-    inverted_cdf:
-        method 1 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 ; then take i
-
-    averaged_inverted_cdf:
-        method 2 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 ; then average between bounds
-
-    closest_observation:
-        method 3 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 and index is odd ; then take j
-        * if g = 0 and index is even ; then take i
-
-    interpolated_inverted_cdf:
-        method 4 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 0
-        * beta = 1
-
-    hazen:
-        method 5 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 1/2
-        * beta = 1/2
-
-    weibull:
-        method 6 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 0
-        * beta = 0
-
-    linear:
-        method 7 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 1
-        * beta = 1
-
-    median_unbiased:
-        method 8 of H&F [1]_.
-        This method is probably the best method if the sample
-        distribution function is unknown (see reference).
-        This method gives continuous results using:
-
-        * alpha = 1/3
-        * beta = 1/3
-
-    normal_unbiased:
-        method 9 of H&F [1]_.
-        This method is probably the best method if the sample
-        distribution function is known to be normal.
-        This method gives continuous results using:
-
-        * alpha = 3/8
-        * beta = 3/8
-
-    lower:
-        NumPy method kept for backwards compatibility.
-        Takes ``i`` as the interpolation point.
-
-    higher:
-        NumPy method kept for backwards compatibility.
-        Takes ``j`` as the interpolation point.
-
-    nearest:
-        NumPy method kept for backwards compatibility.
-        Takes ``i`` or ``j``, whichever is nearest.
-
-    midpoint:
-        NumPy method kept for backwards compatibility.
-        Uses ``(i + j) / 2``.
-
-    For weighted percentiles, the above coverage conditions still hold. The
-    empirical cumulative distribution is simply replaced by its weighted
-    version, i.e.
-    :math:`P(Y \\leq t) = \\frac{1}{\\sum_i w_i} \\sum_i w_i 1_{x_i \\leq t}`.
-    Only ``method="inverted_cdf"`` supports weights.
-
+    The behavior of `numpy.percentile` with percentage `q` is
+    that of `numpy.quantile` with argument ``q/100``.
+    For more information, please see `numpy.quantile`.
 
     Examples
     --------
@@ -4315,7 +4180,7 @@ def quantile(a,
     a : array_like of real numbers
         Input array or object that can be converted to an array.
     q : array_like of float
-        Probability or sequence of probabilities for the quantiles to compute.
+        Probability or sequence of probabilities of the quantiles to compute.
         Values must be between 0 and 1 inclusive.
     axis : {int, tuple of int, None}, optional
         Axis or axes along which the quantiles are computed. The default is
@@ -4332,8 +4197,7 @@ def quantile(a,
     method : str, optional
         This parameter specifies the method to use for estimating the
         quantile.  There are many different methods, some unique to NumPy.
-        See the notes for explanation.  The options sorted by their R type
-        as summarized in the H&F paper [1]_ are:
+        The recommended options, numbered as they appear in [1]_, are:
 
         1. 'inverted_cdf'
         2. 'averaged_inverted_cdf'
@@ -4345,13 +4209,16 @@ def quantile(a,
         8. 'median_unbiased'
         9. 'normal_unbiased'
 
-        The first three methods are discontinuous.  NumPy further defines the
-        following discontinuous variations of the default 'linear' (7.) option:
+        The first three methods are discontinuous. For backward compatibility
+        with previous versions of NumPy, the following discontinuous variations
+        of the default 'linear' (7.) option are available:
 
         * 'lower'
         * 'higher',
         * 'midpoint'
         * 'nearest'
+
+        See Notes for details.
 
         .. versionchanged:: 1.22.0
             This argument was previously called "interpolation" and only
@@ -4400,7 +4267,64 @@ def quantile(a,
 
     Notes
     -----
-    In general, the quantile at probability level :math:`q` of a cumulative
+    Given a sample `a` from an underlying distribution, `quantile` provides a
+    nonparametric estimate of the inverse cumulative distribution function.
+
+    By default, this is done by interpolating between adjacent elements in
+    ``y``, a sorted copy of `a`::
+
+        (1-g)*y[j] + g*y[j+1]
+
+    where the index ``j`` and coefficient ``g`` are the integral and
+    fractional components of ``q * (n-1)``, and ``n`` is the number of
+    elements in the sample.
+
+    This is a special case of Equation 1 of H&F [1]_. More generally,
+
+    - ``j = (q*n + m - 1) // 1``, and
+    - ``g = (q*n + m - 1) % 1``,
+
+    where ``m`` may be defined according to several different conventions.
+    The preferred convention may be selected using the ``method`` parameter:
+
+    =============================== =============== ===============
+    ``method``                      number in H&F   ``m``
+    =============================== =============== ===============
+    ``interpolated_inverted_cdf``   4               ``0``
+    ``hazen``                       5               ``1/2``
+    ``weibull``                     6               ``q``
+    ``linear`` (default)            7               ``1 - q``
+    ``median_unbiased``             8               ``q/3 + 1/3``
+    ``normal_unbiased``             9               ``q/4 + 3/8``
+    =============================== =============== ===============
+
+    Note that indices ``j`` and ``j + 1`` are clipped to the range ``0`` to
+    ``n - 1`` when the results of the formula would be outside the allowed
+    range of non-negative indices. The ``- 1`` in the formulas for ``j`` and
+    ``g`` accounts for Python's 0-based indexing.
+
+    The table above includes only the estimators from H&F that are continuous
+    functions of probability `q` (estimators 4-9). NumPy also provides the
+    three discontinuous estimators from H&F (estimators 1-3), where ``j`` is
+    defined as above and ``m`` and ``g`` are defined as follows.
+
+    1. ``inverted_cdf``: ``m = 0`` and ``g = int(q*n > 0)``
+    2. ``averaged_inverted_cdf``: ``m = 0`` and ``g = (1 + int(q*n > 0)) / 2``
+    3. ``closest_observation``: ``m = -1/2`` and
+       ``1 - int((g == 0) & (j%2 == 0))``
+
+    For backward compatibility with previous versions of NumPy, `quantile`
+    provides four additional discontinuous estimators. Like
+    ``method='linear'``, all have ``m = 1 - q`` so that ``j = q*(n-1) // 1``,
+    but ``g`` is defined as follows.
+
+    - ``lower``: ``g = 0``
+    - ``midpoint``: ``g = 0.5``
+    - ``higher``: ``g = 1``
+    - ``nearest``: ``g = (q*(n-1) % 1) > 0.5``
+
+    **Weighted quantiles:**
+    More formally, the quantile at probability level :math:`q` of a cumulative
     distribution function :math:`F(y)=P(Y \\leq y)` with probability measure
     :math:`P` is defined as any number :math:`x` that fulfills the
     *coverage conditions*
@@ -4408,131 +4332,18 @@ def quantile(a,
     .. math:: P(Y < x) \\leq q \\quad\\text{and}\\quad P(Y \\leq x) \\geq q
 
     with random variable :math:`Y\\sim P`.
-    Sample quantiles, the result of ``quantile``, provide nonparametric
+    Sample quantiles, the result of `quantile`, provide nonparametric
     estimation of the underlying population counterparts, represented by the
-    unknown :math:`F`, given a data vector ``a`` of length ``n``.
+    unknown :math:`F`, given a data vector `a` of length ``n``.
 
-    One type of estimators arises when one considers :math:`F` as the empirical
-    distribution function of the data, i.e.
+    Some of the estimators above arise when one considers :math:`F` as the
+    empirical distribution function of the data, i.e.
     :math:`F(y) = \\frac{1}{n} \\sum_i 1_{a_i \\leq y}`.
     Then, different methods correspond to different choices of :math:`x` that
-    fulfill the above inequalities. Methods that follow this approach are
-    ``inverted_cdf`` and ``averaged_inverted_cdf``.
+    fulfill the above coverage conditions. Methods that follow this approach
+    are ``inverted_cdf`` and ``averaged_inverted_cdf``.
 
-    A more general way to define sample quantile estimators is as follows.
-    The empirical q-quantile of ``a`` is the ``n * q``-th value of the
-    way from the minimum to the maximum in a sorted copy of ``a``. The values
-    and distances of the two nearest neighbors as well as the `method`
-    parameter will determine the quantile if the normalized ranking does not
-    match the location of ``n * q`` exactly. This function is the same as
-    the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and the same
-    as the maximum if ``q=1.0``.
-
-    The optional `method` parameter specifies the method to use when the
-    desired quantile lies between two indexes ``i`` and ``j = i + 1``.
-    In that case, we first determine ``i + g``, a virtual index that lies
-    between ``i`` and ``j``, where  ``i`` is the floor and ``g`` is the
-    fractional part of the index. The final result is, then, an interpolation
-    of ``a[i]`` and ``a[j]`` based on ``g``. During the computation of ``g``,
-    ``i`` and ``j`` are modified using correction constants ``alpha`` and
-    ``beta`` whose choices depend on the ``method`` used. Finally, note that
-    since Python uses 0-based indexing, the code subtracts another 1 from the
-    index internally.
-
-    The following formula determines the virtual index ``i + g``, the location
-    of the quantile in the sorted sample:
-
-    .. math::
-        i + g = q * ( n - alpha - beta + 1 ) + alpha
-
-    The different methods then work as follows
-
-    inverted_cdf:
-        method 1 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 ; then take i
-
-    averaged_inverted_cdf:
-        method 2 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 ; then average between bounds
-
-    closest_observation:
-        method 3 of H&F [1]_.
-        This method gives discontinuous results:
-
-        * if g > 0 ; then take j
-        * if g = 0 and index is odd ; then take j
-        * if g = 0 and index is even ; then take i
-
-    interpolated_inverted_cdf:
-        method 4 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 0
-        * beta = 1
-
-    hazen:
-        method 5 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 1/2
-        * beta = 1/2
-
-    weibull:
-        method 6 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 0
-        * beta = 0
-
-    linear:
-        method 7 of H&F [1]_.
-        This method gives continuous results using:
-
-        * alpha = 1
-        * beta = 1
-
-    median_unbiased:
-        method 8 of H&F [1]_.
-        This method is probably the best method if the sample
-        distribution function is unknown (see reference).
-        This method gives continuous results using:
-
-        * alpha = 1/3
-        * beta = 1/3
-
-    normal_unbiased:
-        method 9 of H&F [1]_.
-        This method is probably the best method if the sample
-        distribution function is known to be normal.
-        This method gives continuous results using:
-
-        * alpha = 3/8
-        * beta = 3/8
-
-    lower:
-        NumPy method kept for backwards compatibility.
-        Takes ``i`` as the interpolation point.
-
-    higher:
-        NumPy method kept for backwards compatibility.
-        Takes ``j`` as the interpolation point.
-
-    nearest:
-        NumPy method kept for backwards compatibility.
-        Takes ``i`` or ``j``, whichever is nearest.
-
-    midpoint:
-        NumPy method kept for backwards compatibility.
-        Uses ``(i + j) / 2``.
-
-    **Weighted quantiles:**
-    For weighted quantiles, the above coverage conditions still hold. The
+    For weighted quantiles, the coverage conditions still hold. The
     empirical cumulative distribution is simply replaced by its weighted
     version, i.e. 
     :math:`P(Y \\leq t) = \\frac{1}{\\sum_i w_i} \\sum_i w_i 1_{x_i \\leq t}`.

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1344,7 +1344,9 @@ def nanpercentile(
 
     Notes
     -----
-    For more information please see `numpy.percentile`
+    The behavior of `numpy.nanpercentile` with percentage `q` is that of
+    `numpy.quantile` with argument ``q/100`` (ignoring nan values).
+    For more information, please see `numpy.quantile`.
 
     Examples
     --------
@@ -1532,7 +1534,9 @@ def nanquantile(
 
     Notes
     -----
-    For more information please see `numpy.quantile`
+    The behavior of `numpy.nanquantile` is the same as that of
+    `numpy.quantile` (ignoring nan values).
+    For more information, please see `numpy.quantile`.
 
     Examples
     --------


### PR DESCRIPTION
gh-24588 noted inaccuracies in the `quantile` documentation. This PR corrects these and simplifies the descriptions of the various methods. It also refers users of `percentile`, `nanquantile`, `nanpercentile` to the documentation of `quantile` to reduce redunandancy and ensure that the notes of these functions do not get out of sync.

Closes gh-24588

@lorentzenchr 