### PR TITLE
DOC: Add documentation explaining our promotion rules

### DIFF
--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -41,7 +41,7 @@ Numerical dtypes come in four "kinds" with a natural hierarchy.
 3. float (``float``)
 4. complex (``complex``)
 
-In addition to kind, NumPy dtypes also have an associated precision, specified
+In addition to kind, NumPy numerical dtypes also have an associated precision, specified
 in bits. Together, the kind and precision specify the dtype. For example, a
 ``uint8`` is an unsigned integer stored using 8 bits.
 
@@ -55,9 +55,10 @@ may be unexpected:
    example, the result of an operation involving ``int64`` and ``float16``
    is ``float64``.
 2. When mixing unsigned and signed integers with the same precision, the
-   result will have a *higher* precision than either inputs. For instance,
-   the result of an operation involving ``int64`` and ``uint64`` is
-   ``float64``.
+   result will has *higher* precision than either inputs. Additionally,
+   if one of them has 64bit precision already, no higher precision integer
+   is available and for example an operation involving ``int64`` and ``uint64``
+   gives ``float64``.
 
 Please see the `Numerical promotion` section and image below for details
 on both.

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -1,0 +1,246 @@
+.. currentmodule:: numpy
+
+.. _arrays.promotion:
+
+****************************
+Data type promotion in NumPy
+****************************
+
+When mixing two different data types NumPy has to find the correct dtype for
+the result of the operation.  This step is referred *promotion* or finding
+the common dtype.
+In most you do not have to know much about the details of promotion since
+the promotion step generally ensures that the result of:
+1. Combining multiple arrays e.g. with ``np.concatenate``
+2. The evaluation of any mathematical operation
+
+will return in a result that either matches its input dtypes or has a higher
+precision.
+The ``dtype`` of the result can be found using the `result_type` and
+`promote_types` functions for most (but not all) operations.
+
+These are examples, for howNumPy behaves for both arrays and scalar
+operations.  Here the result matches the input:
+
+  >>> np.int8(1) + np.int8(1)
+  np.int8(2)
+
+While mixing two different ``dtypes`` normally results in the larger of both:
+
+  >>> np.int8(4) + np.int64(8)
+  np.int64(12)
+  >>> np.int16(3) + np.float64(3)
+  np.float64(6.0)
+
+In the majority of cases, this should not lead to surprises.
+However, especially if you work with non-default datatypes like low
+precision integers or floats or unsigned integers there are some details
+of NumPy promotion rules which may be relevant to know.
+These detailed rules also do not always match those of many other languages.[#hist-reasons]_
+
+For Numerical values, you can think of promotion happening in three kinds:
+``unsigned integers < signed integers < float < complex``,
+where the result will always be the highest kind of any of the inputs.
+Further, the result will always have a precision higher or equivalent than
+any of the inputs which leads to two some examples which may be unexpected:
+1. When mixing floating point numbers and integers, the integer ``dtype`` may
+   force the result to a higher precision floating point.
+2. When mixing unsigned and signed integers, the result will be a higher
+   precision than both inputs.  And an unfortunate surprise is that
+   ``int64`` and ``uint64`` can return floating point values.
+
+Please see the `Numerical promotion` section and image below for details
+on both.
+
+Detailed behavior of Python scalars
+-----------------------------------
+Since NumPy 2.0,[#NEP50]_ an important case in our promotion rules is that while
+NumPy usually never loses precision, it explicitly allows this for the Python
+numerical scalars of type ``int``, ``float``, and ``complex``.
+
+Python integers have arbitrary precision, and float and complex numbers
+have the same precision as NumPy's `float64` and `complex128`.
+However, unlike NumPy arrays and scalars, they do not have an explicit
+``dtype`` attached.  Because of this, NumPy assigns them the "kind" but
+ignores their actual precision when working with arrays of a lower precision
+dtype you do not expect this to change the result:
+
+  >>> arr_float32 = np.array([1, 2.5, 2.1], dtype="float32")
+  >>> arr_float32 + 10.0
+  array([4. , 5.5, 5.1], dtype=float32)
+  >>> arr_int16 = np.array([3, 5, 7], dtype="int16")
+  >>> arr_int16 + 10
+  array([13, 15, 17], dtype=int16)
+
+In both cases the result precision is dictated only by the NumPy dtype.
+And because of that, the ``arr_float32 + 3.0`` behaves the same as
+``arr_float32 + np.float32(3.0)`` and ``arr_int16 + 10`` is found via
+``arr_int16 + np.int16(10.)``.
+Although, when mixing NumPy integers and Python ``float`` or ``complex``
+the result always gives the default ``float64`` or ``complex128``:
+
+  >> np.int16(1) + 1.0
+  np.float64(2.0)
+
+Users should be aware that while the above is typically convenient, it can
+also lead to surprising behaviors when working with low precision data types.
+
+First, since the Python value is converted to a NumPy one, operations can
+fail with an error when the result seems obvious.
+``np.int8(1) + 1000`` cannot reasonably return an ``int8`` result when the
+``1000`` cannot be stored as an ``int8`` at all.
+In this case, an error is raised for integers:
+
+  >>> np.int8(1) + 1000
+  Traceback (most recent call last):
+    ...
+  OverflowError: Python integer 1000 out of bounds for int8
+  >>> np.int64(1) * 10**100
+  Traceback (most recent call last):
+  ...
+  OverflowError: Python int too large to convert to C long
+
+And overflows are possible for floating points:
+
+  >>> np.float32(1) + 1e300
+  RuntimeWarning: overflow encountered in cast
+  np.float32(inf)
+
+Second, since the Python float or integer precision is always ignored, a low
+precision NumPy scalar will keep using it's lower precision unless explicitly
+converted to a Python scalar via ``int()``, ``float()``, or ``scalar.item()``
+or to a higher precision NumPy dtype.
+This lower precision may be detrimental to some calculations or lead to
+incorrect results especially for integer overflows:
+
+  >>> np.int8(100) + 100
+  RuntimeWarning: overflow encountered in scalar add
+  np.int8(-56)
+
+Overflows and gives an unexpected result.  NumPy gives a warning for scalars
+but not for arrays: ``np.array(100, dtype="uint8") + 100`` will *not* warn.
+
+Numerical promotion
+-------------------
+
+The following images shows the numerical promotion rules with the kinds
+on the vertical axes and the precision on the horizontal one.
+
+.. figure:: figures/nep-0050-promotion-no-fonts.svg
+    :figclass: align-center
+
+Promotion is always found along the lines in the schema from left to right
+and down to up.
+With the following specific rules or observations:
+1. When a Python ``float`` or ``complex`` interacts with a NumPy integer
+   the result will be ``float64`` or ``complex128`` (yellow border).
+   NumPy booleans will also be cast to the default integer.[#default-int]
+2. The precision is drawn such that ``float16 < int16 < uint16`` because
+   large ``uint16`` do not fit ``int16`` and large ``int16`` will lose precision
+   when stored in a ``float16``.
+   This pattern however is broken since NumPy always considers ``float64``
+   and ``complex128`` to be acceptable promotion results for any integer
+   value.
+3. A special case the above leads to is that NumPy will promote many
+   combinations of signed and unsigned integers to ``float64`` because no
+   integer dtype can hold both inputs.
+   This can unfortunately be 
+
+The precision here comes from the bit size of the numerical value but
+an ``int32`` cannot always be stored in a ``float32`` without loss of
+precision, this leads to the 
+
+
+Notable or special promotion behaviors
+--------------------------------------
+
+In NumPy promotion refers to what specific functions do with the result and
+in some cases, this means that NumPy may deviate from what the `np.result_type`
+would give.
+
+Behavior of ``sum`` and ``prod``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**``np.sum`` and ``np.prod``:** Will alway return the default integer type
+when summing over integer values (or booleans).  This is usually an ``int64``.
+The reason for this is that integer summations are otherwise very likely
+to overflow and give confusing results.
+This rule also applies to the underlying ``np.add.reduce``, ``np.multiply.reduce``
+and other reduction methods.
+
+Notable behavior with NumPy or Python integer scalars
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NumPy promotion refers to the result dtype and operation precision,
+but the operation will sometimes dictate that result.
+Division always returns floating point values and comparison always booleans.
+
+This leads to some special behaviors which may appear as "exceptions" to
+the rules:
+* NumPy comparisons with Python integers or mixed precision integers always
+  return the correct result.  The inputs will never be cast in a way which
+  loses precision.
+* Equality comparisons between types which cannot be promoted will be
+  considered all ``False`` (equality) or all ``True`` (not-equal).
+* Unary math functions like ``np.sin`` that always return floating point
+  values, accept any Python integer input by converting it to ``float64``.
+* Division always returns floating point values and thus also allows divisions
+  between any NumPy integer with any Python integer value by casting both
+  to ``float64``.
+
+It should be noted that while these exceptions can apply to more functions,
+NumPy may choose to not implement them in all such cases.
+
+Promotion of non-numerical datatypes
+------------------------------------
+
+NumPy extends the promotion to non-numerical types, although in most cases
+promotion is not well defined and simply rejected.
+
+The following rules apply:
+* NumPy byte strings (``np.bytes_``) can be promoted to unicode strings
+  (``np.str_``).  A ``result_type``
+* For some purposes NumPy will promote almost any other datatype to strings.
+  This applies to array creation or concatenation.
+* The array constructers like ``np.array()`` will use ``object`` dtype when
+  there is no viable promotion.
+* Structured dtypes can promote when their field names and order matches.
+  In that case all fields are promoted individually.
+* NumPy ``timedelta`` can in some cases promote with integers.
+
+.. note::
+    Some of these rules describe the state as of NumPy 2.0 and details
+    may be surprising and are under consideration to be change in the future.
+    However, changes always have to be weighed against backwards compatibility
+    concerns.
+
+Details of promoted ``dtype`` instances
+---------------------------------------
+The above promotion mainly refers to the behavior when mixing different DType
+classes.
+A ``dtype`` instance attached to an array can carry additional information
+such as byte-order, metadata, string length, or exact structured dtype layout.
+
+While the string length or field names of a structured dtype are important,
+NumPy considers byte-order, metadata, and the exact layout of a structured
+dtype as storage details.
+During promotion NumPy does *not* take these storage details into account:
+* Byte-order is converted to native byte-order.
+* Metadata attached to the dtype may or may not be preserved.
+* Resulting structured dtypes will be packed (but aligned if inputs were).
+
+This behaviors is the best behavior for most programs where storage details
+are not relevant to the final results, but the use of incorrect byte-order
+could drastically slow down evaluation.
+
+
+.. [#hist-reasons]: To a large degree, this may just be for choices made early
+   on in NumPy's predecessors even.  You may find some more details also in
+   `NEP 50 <NEP50>`.
+
+.. [#NEP50]: See also `NEP 50 <NEP50>` which changed the rules for NumPy 2.0.
+   previous versions of NumPy would sometimes return higher precision results
+   based on the input value of Python scalars.
+   Further, previous versions of NumPy would typically ignore the higher
+   precision of NumPy scalars or 0-D arrays for promotion purposes.
+
+.. [#default-int]: The default integer is marked as ``int64`` in the schema
+   but is ``int32`` on 32bit platforms.  However, normal PCs are 64bit.

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -67,7 +67,7 @@ dtype you do not expect this to change the result:
 
   >>> arr_float32 = np.array([1, 2.5, 2.1], dtype="float32")
   >>> arr_float32 + 10.0
-  array([4. , 5.5, 5.1], dtype=float32)
+  array([11. , 12.5, 12.1], dtype=float32)
   >>> arr_int16 = np.array([3, 5, 7], dtype="int16")
   >>> arr_int16 + 10
   array([13, 15, 17], dtype=int16)
@@ -103,8 +103,8 @@ In this case, an error is raised for integers:
 And overflows are possible for floating points:
 
   >>> np.float32(1) + 1e300
-  RuntimeWarning: overflow encountered in cast
   np.float32(inf)
+  ... RuntimeWarning: overflow encountered in cast
 
 Second, since the Python float or integer precision is always ignored, a low
 precision NumPy scalar will keep using it's lower precision unless explicitly
@@ -114,8 +114,8 @@ This lower precision may be detrimental to some calculations or lead to
 incorrect results especially for integer overflows:
 
   >>> np.int8(100) + 100
-  RuntimeWarning: overflow encountered in scalar add
   np.int8(-56)
+  ... RuntimeWarning: overflow encountered in scalar add
 
 Overflows and gives an unexpected result.  NumPy gives a warning for scalars
 but not for arrays: ``np.array(100, dtype="uint8") + 100`` will *not* warn.
@@ -130,11 +130,16 @@ on the vertical axes and the precision on the horizontal one.
     :figclass: align-center
 
 Promotion is always found along the lines in the schema from left to right
-and down to up.
-With the following specific rules or observations:
+and down to up.  The final result dtype will smallest kind and precision
+(i.e. down and left) which is still equal or higher in both kind and precision
+while following the (green) lines.
+
+Note the following specific rules and observations:
 1. When a Python ``float`` or ``complex`` interacts with a NumPy integer
    the result will be ``float64`` or ``complex128`` (yellow border).
    NumPy booleans will also be cast to the default integer.[#default-int]
+   This is not relevant when additionally NumPy floating point values are
+   involved.
 2. The precision is drawn such that ``float16 < int16 < uint16`` because
    large ``uint16`` do not fit ``int16`` and large ``int16`` will lose precision
    when stored in a ``float16``.

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -55,7 +55,7 @@ may be unexpected:
    example, the result of an operation involving ``int64`` and ``float16``
    is ``float64``.
 2. When mixing unsigned and signed integers with the same precision, the
-   result will has *higher* precision than either inputs. Additionally,
+   result will have *higher* precision than either inputs. Additionally,
    if one of them has 64bit precision already, no higher precision integer
    is available and for example an operation involving ``int64`` and ``uint64``
    gives ``float64``.
@@ -97,7 +97,7 @@ or ``complex``, the result always has type ``float64`` or ``complex128``:
   >> np.int16(1) + 1.0
   np.float64(2.0)
 
-However, these rules can also lead to surprising behaviors when working with
+However, these rules can also lead to surprising behavior when working with
 low precision dtypes.
 
 First, since the Python value is converted to a NumPy one before the operation
@@ -135,7 +135,7 @@ e.g., ``np.array(100, dtype="uint8") + 100`` will *not* warn.
 Numerical promotion
 -------------------
 
-The following images shows the numerical promotion rules with the kinds
+The following image shows the numerical promotion rules with the kinds
 on the vertical axis and the precision on the horizontal axis.
 
 .. figure:: figures/nep-0050-promotion-no-fonts.svg
@@ -161,13 +161,9 @@ Note the following specific rules and observations:
    unsigned integers to ``float64``.  A higher kind is used here because no
    signed integer dtype is sufficiently precise to hold a ``uint64``.
 
-The precision here comes from the bit size of the numerical value but
-an ``int32`` cannot always be stored in a ``float32`` without loss of
-precision, this leads to the 
 
-
-Notable or special promotion behaviors
---------------------------------------
+Exceptions to the general promotion rules
+-----------------------------------------
 
 In NumPy promotion refers to what specific functions do with the result and
 in some cases, this means that NumPy may deviate from what the `np.result_type`
@@ -179,8 +175,8 @@ Behavior of ``sum`` and ``prod``
 when summing over integer values (or booleans).  This is usually an ``int64``.
 The reason for this is that integer summations are otherwise very likely
 to overflow and give confusing results.
-This rule also applies to the underlying ``np.add.reduce``, ``np.multiply.reduce``
-and other reduction methods.
+This rule also applies to the underlying ``np.add.reduce`` and
+``np.multiply.reduce``.
 
 Notable behavior with NumPy or Python integer scalars
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,8 +184,7 @@ NumPy promotion refers to the result dtype and operation precision,
 but the operation will sometimes dictate that result.
 Division always returns floating point values and comparison always booleans.
 
-This leads to some special behaviors which may appear as "exceptions" to
-the rules:
+This leads to what may appear as "exceptions" to the rules:
 * NumPy comparisons with Python integers or mixed precision integers always
   return the correct result.  The inputs will never be cast in a way which
   loses precision.
@@ -212,7 +207,8 @@ promotion is not well defined and simply rejected.
 
 The following rules apply:
 * NumPy byte strings (``np.bytes_``) can be promoted to unicode strings
-  (``np.str_``).  The promotion takes into account the length of both.
+  (``np.str_``).  However, casting the bytes to unicode will fail for
+  non-ascii characters.
 * For some purposes NumPy will promote almost any other datatype to strings.
   This applies to array creation or concatenation.
 * The array constructers like ``np.array()`` will use ``object`` dtype when
@@ -222,17 +218,15 @@ The following rules apply:
 * NumPy ``timedelta`` can in some cases promote with integers.
 
 .. note::
-    Some of these rules describe the state as of NumPy 2.0 and details
-    may be surprising and are under consideration to be change in the future.
-    However, changes always have to be weighed against backwards compatibility
-    concerns.
-    Please raise an issue if you have particular ideas about how promotion
-    should work
+    Some of these rules are somewhat surprising, and are being considered for
+    change in the future. However, any backward-incompatible changes have to
+    be weighed against the risks of breaking existing code. Please raise an
+    issue if you have particular ideas about how promotion should work.
 
 Details of promoted ``dtype`` instances
 ---------------------------------------
-The above promotion mainly refers to the behavior when mixing different DType
-classes.
+The above discussion has mainly dealt with the behavior when mixing different
+DType classes.
 A ``dtype`` instance attached to an array can carry additional information
 such as byte-order, metadata, string length, or exact structured dtype layout.
 
@@ -245,15 +239,15 @@ During promotion NumPy does *not* take these storage details into account:
 * Resulting structured dtypes will be packed (but aligned if inputs were).
 
 This behaviors is the best behavior for most programs where storage details
-are not relevant to the final results, but the use of incorrect byte-order
+are not relevant to the final results and where the use of incorrect byte-order
 could drastically slow down evaluation.
 
 
 .. [#hist-reasons]: To a large degree, this may just be for choices made early
-   on in NumPy's predecessors even.  For more details, see `NEP 50 <NEP50>`.
+   on in NumPy's predecessors.  For more details, see `NEP 50 <NEP50>`.
 
 .. [#NEP50]: See also `NEP 50 <NEP50>` which changed the rules for NumPy 2.0.
-   previous versions of NumPy would sometimes return higher precision results
+   Previous versions of NumPy would sometimes return higher precision results
    based on the input value of Python scalars.
    Further, previous versions of NumPy would typically ignore the higher
    precision of NumPy scalars or 0-D arrays for promotion purposes.

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -158,10 +158,9 @@ Note the following specific rules and observations:
    This pattern however is broken since NumPy always considers ``float64``
    and ``complex128`` to be acceptable promotion results for any integer
    value.
-3. A special case the above leads to is that NumPy will promote many
+3. A special case that the above leads to is that NumPy promotes many
    combinations of signed and unsigned integers to ``float64`` because no
    integer dtype can hold both inputs.
-   This can unfortunately be 
 
 The precision here comes from the bit size of the numerical value but
 an ``int32`` cannot always be stored in a ``float32`` without loss of
@@ -203,18 +202,18 @@ the rules:
   between any NumPy integer with any Python integer value by casting both
   to ``float64``.
 
-It should be noted that while these exceptions can apply to more functions,
-NumPy may choose to not implement them in all such cases.
+In principle, some of these exceptions may make sense for other functions.
+Please raise an issue if you feel this is the case.
 
 Promotion of non-numerical datatypes
 ------------------------------------
 
-NumPy extends the promotion to non-numerical types, although in most cases
+NumPy extends the promotion to non-numerical types, although in many cases
 promotion is not well defined and simply rejected.
 
 The following rules apply:
 * NumPy byte strings (``np.bytes_``) can be promoted to unicode strings
-  (``np.str_``).  A ``result_type``
+  (``np.str_``).  The promotion takes into account the length of both.
 * For some purposes NumPy will promote almost any other datatype to strings.
   This applies to array creation or concatenation.
 * The array constructers like ``np.array()`` will use ``object`` dtype when
@@ -228,6 +227,8 @@ The following rules apply:
     may be surprising and are under consideration to be change in the future.
     However, changes always have to be weighed against backwards compatibility
     concerns.
+    Please raise an issue if you have particular ideas about how promotion
+    should work
 
 Details of promoted ``dtype`` instances
 ---------------------------------------
@@ -250,8 +251,7 @@ could drastically slow down evaluation.
 
 
 .. [#hist-reasons]: To a large degree, this may just be for choices made early
-   on in NumPy's predecessors even.  You may find some more details also in
-   `NEP 50 <NEP50>`.
+   on in NumPy's predecessors even.  For more details, see `NEP 50 <NEP50>`.
 
 .. [#NEP50]: See also `NEP 50 <NEP50>` which changed the rules for NumPy 2.0.
    previous versions of NumPy would sometimes return higher precision results

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -141,10 +141,9 @@ on the vertical axis and the precision on the horizontal axis.
 .. figure:: figures/nep-0050-promotion-no-fonts.svg
     :figclass: align-center
 
-Promotion is always found along the lines in the schema from left to right
-and down to up.  The final result dtype will smallest kind and precision
-(i.e. down and left) which is still equal or higher in both kind and precision
-while following the (green) lines.
+The input dtype with the higher kind determines the kind of the result dtype.
+The result dtype has a precision as low as possible without appearing to the
+left of either input dtype in the diagram.
 
 Note the following specific rules and observations:
 1. When a Python ``float`` or ``complex`` interacts with a NumPy integer
@@ -158,9 +157,9 @@ Note the following specific rules and observations:
    This pattern however is broken since NumPy always considers ``float64``
    and ``complex128`` to be acceptable promotion results for any integer
    value.
-3. A special case that the above leads to is that NumPy promotes many
-   combinations of signed and unsigned integers to ``float64`` because no
-   integer dtype can hold both inputs.
+3. A special case is that NumPy promotes many combinations of signed and
+   unsigned integers to ``float64``.  A higher kind is used here because no
+   signed integer dtype is sufficiently precise to hold a ``uint64``.
 
 The precision here comes from the bit size of the numerical value but
 an ``int32`` cannot always be stored in a ``float32`` without loss of

--- a/doc/source/reference/arrays.rst
+++ b/doc/source/reference/arrays.rst
@@ -41,6 +41,7 @@ of also more complicated arrangements of data.
    arrays.ndarray
    arrays.scalars
    arrays.dtypes
+   arrays.promotion
    arrays.nditer
    arrays.classes
    maskedarray

--- a/doc/source/reference/figures/nep-0050-promotion-no-fonts.svg
+++ b/doc/source/reference/figures/nep-0050-promotion-no-fonts.svg
@@ -1,0 +1,1471 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="346.21313mm"
+   height="138.47121mm"
+   viewBox="0 0 346.21313 138.47116"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="nep-0050-promotion-no-fonts.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata125">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     id="namedview109"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     fit-margin-right="1"
+     lock-margins="true"
+     fit-margin-top="1"
+     fit-margin-left="1"
+     fit-margin-bottom="1"
+     inkscape:zoom="1.1024096"
+     inkscape:cx="643.13663"
+     inkscape:cy="60.322406"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="powerclip"
+       id="path-effect4411"
+       is_visible="true"
+       lpeversion="1"
+       inverse="true"
+       flatten="false"
+       hide_clip="false"
+       message="Use fill-rule evenodd on &lt;b&gt;fill and stroke&lt;/b&gt; dialog if no flatten result after convert clip to paths." />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.625;stroke-linejoin:round"
+         id="path55505" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path55487" />
+    </marker>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3010">
+      <ellipse
+         style="display:none;fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+         id="ellipse3012"
+         cx="48.04174"
+         cy="138.30666"
+         rx="21.353086"
+         ry="7.1176949" />
+      <path
+         id="lpe_path-effect3014"
+         style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+         class="powerclip"
+         d="M 42.339369,84.989221 H 105.46443 V 167.47381 H 42.339369 Z m 27.937395,53.317439 a 22.235023,7.4619589 0 0 0 -22.235024,-7.46196 22.235023,7.4619589 0 0 0 -22.235023,7.46196 22.235023,7.4619589 0 0 0 22.235023,7.46195 22.235023,7.4619589 0 0 0 22.235024,-7.46195 z" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5608">
+      <ellipse
+         style="display:none;fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:0.749999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+         id="ellipse5610"
+         cx="48.04174"
+         cy="138.30666"
+         rx="22.235023"
+         ry="7.4619589" />
+      <path
+         id="lpe_path-effect5612"
+         style="fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:0.749999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+         class="powerclip"
+         d="M 42.339369,84.989221 H 105.46443 V 167.47381 H 42.339369 Z m 27.937395,53.317439 a 22.235023,7.4619589 0 0 0 -22.235024,-7.46196 22.235023,7.4619589 0 0 0 -22.235023,7.46196 22.235023,7.4619589 0 0 0 22.235023,7.46195 22.235023,7.4619589 0 0 0 22.235024,-7.46195 z" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4407">
+      <path
+         id="lpe_path-effect4411"
+         style="fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+         class="powerclip"
+         d="m 54.183708,85.237775 h 11 v 81.654565 h -11 z m 18.72963,53.068885 a 24.871597,8.4035168 0 0 0 -24.871598,-8.40352 24.871597,8.4035168 0 0 0 -24.871597,8.40352 24.871597,8.4035168 0 0 0 24.871597,8.40351 24.871597,8.4035168 0 0 0 24.871598,-8.40351 z" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(215.26911,-51.42495)">
+    <path
+       style="fill:none;fill-opacity:0.482353;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.795245"
+       d="M 59.683708,161.89234 V 90.237775"
+       id="path1886"
+       sodipodi:nodetypes="cc"
+       clip-path="url(#clipPath4407)" />
+    <path
+       id="rect27474"
+       style="fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:128.863;stroke-opacity:1"
+       d="m -181.78548,52.42495 h 307.32963 c 2.4377,0 4.40019,1.962483 4.40019,4.400186 v 17.531895 c 0,2.437703 -1.96249,4.400186 -4.40019,4.400186 h -307.32963 c -2.43771,0 -4.40019,-1.962483 -4.40019,-4.400186 V 56.825136 c 0,-2.437703 1.96248,-4.400186 4.40019,-4.400186 z" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.741176"
+       d="M 59.683708,114.4133 48.607336,138.30666 8.429198,162.2584 m 51.25451,-47.8451 -63.4414082,24.21428 -39.9012598,23.1813 28.100481,-46.5597 -78.491938,47.71915 27.310068,-47.71915 -39.201961,22.46163"
+       id="path51595"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 48.607336,162.14732 H -153.07677"
+       id="path98273" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 48.607336,138.30666 H -153.07677"
+       id="path98096" />
+    <path
+       id="ellipse18346"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -76.025944,162.14732 a 18.448826,6.1496081 0 0 1 -18.448826,6.14961 18.448826,6.1496081 0 0 1 -18.44883,-6.14961 18.448826,6.1496081 0 0 1 18.44883,-6.1496 18.448826,6.1496081 0 0 1 18.448826,6.1496 z" />
+    <path
+       id="ellipse11160"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -87.59296,138.30666 a 18.448826,6.1496081 0 0 1 -18.44883,6.1496 18.448826,6.1496081 0 0 1 -18.44882,-6.1496 18.448826,6.1496081 0 0 1 18.44882,-6.14961 18.448826,6.1496081 0 0 1 18.44883,6.14961 z" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 99.851673,114.4661 H -153.07677"
+       id="path98094" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.741176"
+       d="M -15.558479,90.754771 V 115.24918"
+       id="path53983" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 99.851673,90.625336 H -153.07677"
+       id="path97397" />
+    <path
+       id="ellipse1674"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 3.5621271,90.625336 a 18.448826,6.1496081 0 0 1 -18.4488261,6.149608 18.448826,6.1496081 0 0 1 -18.448826,-6.149608 18.448826,6.1496081 0 0 1 18.448826,-6.149608 18.448826,6.1496081 0 0 1 18.4488261,6.149608 z" />
+    <path
+       style="fill:none;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.741176"
+       d="M -153.07677,91.853869 V 153.30979"
+       id="path54445" />
+    <g
+       id="g50892"
+       transform="translate(-33.400505,2.4455707)"
+       style="stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       id="g49473"
+       transform="translate(17.781365,2.4455707)"
+       style="stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       aria-label="complex64"
+       id="text1678"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -27.304993,91.582913 q 0.194119,0 0.362005,-0.0682 0.167886,-0.0682 0.320033,-0.173132 l 0.272815,0.377743 q -0.181003,0.15477 -0.440702,0.25183 -0.257075,0.09444 -0.532513,0.09444 -0.424962,0 -0.729256,-0.178379 -0.30167,-0.181003 -0.461686,-0.503659 -0.157394,-0.325279 -0.157394,-0.760734 0,-0.422338 0.160017,-0.752864 0.162639,-0.333149 0.466933,-0.524644 0.304294,-0.194119 0.731879,-0.194119 0.556122,0 0.960098,0.33315 l -0.270191,0.369874 q -0.16264,-0.112799 -0.333149,-0.17051 -0.17051,-0.06033 -0.346266,-0.06033 -0.330525,0 -0.53776,0.241336 -0.207234,0.241337 -0.207234,0.758111 0,0.519398 0.209857,0.739748 0.209858,0.220351 0.532514,0.220351 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1500" />
+      <path
+         d="m -24.382733,89.151187 q 0.608588,0 0.928621,0.396107 0.320032,0.396106 0.320032,1.057158 0,0.440701 -0.1469,0.768603 -0.144277,0.327903 -0.424962,0.511528 -0.278061,0.181003 -0.679414,0.181003 -0.605964,0 -0.92862,-0.39086 -0.322656,-0.393483 -0.322656,-1.065028 0,-0.430208 0.144277,-0.758111 0.1469,-0.330525 0.427585,-0.514151 0.280685,-0.186249 0.682037,-0.186249 z m 0,0.456441 q -0.317409,0 -0.477426,0.243959 -0.160016,0.241337 -0.160016,0.758111 0,0.516775 0.157393,0.760734 0.160017,0.241336 0.477426,0.241336 0.31741,0 0.474803,-0.243959 0.160017,-0.24396 0.160017,-0.763357 0,-0.511528 -0.157394,-0.752865 -0.157393,-0.243959 -0.474803,-0.243959 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1502" />
+      <path
+         d="m -20.434793,89.151187 q 0.157393,0 0.283308,0.0682 0.125914,0.0682 0.196741,0.241337 0.07345,0.170509 0.07345,0.474802 v 2.059229 h -0.52202 V 90.01685 q 0,-0.217727 -0.03148,-0.312163 -0.02886,-0.09444 -0.15477,-0.09444 -0.09968,0 -0.204611,0.06296 -0.102306,0.06033 -0.204612,0.209858 v 2.111693 h -0.474802 V 90.01685 q 0,-0.217727 -0.03148,-0.312163 -0.02886,-0.09444 -0.15477,-0.09444 -0.102306,0 -0.204611,0.06296 -0.102306,0.06033 -0.204612,0.209858 v 2.111693 h -0.524644 v -2.770121 h 0.443325 l 0.03935,0.299047 q 0.118045,-0.165263 0.254452,-0.267569 0.139031,-0.104929 0.338396,-0.104929 0.157393,0 0.285931,0.0787 0.128538,0.07607 0.188872,0.275438 0.118045,-0.157393 0.262322,-0.254452 0.144277,-0.09968 0.346265,-0.09968 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1504" />
+      <path
+         d="m -17.845682,89.151187 q 0.367251,0 0.587601,0.181003 0.220351,0.178379 0.320033,0.506281 0.09968,0.32528 0.09968,0.765981 0,0.422338 -0.120668,0.752864 -0.120668,0.330526 -0.359381,0.519398 -0.23609,0.188872 -0.587601,0.188872 -0.435455,0 -0.703024,-0.306917 v 1.301117 l -0.587601,0.06558 v -3.900729 h 0.511528 l 0.03673,0.356758 q 0.157393,-0.212481 0.364628,-0.320033 0.207234,-0.110176 0.438078,-0.110176 z m -0.16264,0.453818 q -0.196742,0 -0.348888,0.118045 -0.149524,0.118045 -0.25183,0.278061 v 1.295871 q 0.207235,0.30954 0.548254,0.30954 0.296423,0 0.451194,-0.238713 0.15477,-0.238713 0.15477,-0.760734 0,-0.532514 -0.139031,-0.76598 -0.136408,-0.23609 -0.414469,-0.23609 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1506" />
+      <path
+         d="m -14.831609,88.112392 v 3.126879 q 0,0.191495 0.115422,0.272815 0.118045,0.0787 0.304293,0.0787 0.118045,0 0.225597,-0.02361 0.110176,-0.02623 0.212481,-0.0682 l 0.149524,0.409222 q -0.123292,0.06296 -0.304294,0.110176 -0.178379,0.04722 -0.409222,0.04722 -0.417092,0 -0.650559,-0.23609 -0.230843,-0.23609 -0.230843,-0.642689 v -2.641583 h -0.836808 v -0.432832 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1508" />
+      <path
+         d="m -12.413007,90.79857 q 0.02623,0.427585 0.238713,0.61908 0.215105,0.191495 0.516775,0.191495 0.201988,0 0.37512,-0.06296 0.175756,-0.06296 0.351512,-0.178379 l 0.254452,0.351511 q -0.194118,0.157394 -0.453817,0.25183 -0.259699,0.09444 -0.556122,0.09444 -0.432832,0 -0.731879,-0.183626 -0.296424,-0.183625 -0.451194,-0.511528 -0.152147,-0.327902 -0.152147,-0.758111 0,-0.417092 0.152147,-0.744994 0.152147,-0.330526 0.435455,-0.522021 0.283307,-0.194119 0.676791,-0.194119 0.550876,0 0.870909,0.369875 0.322656,0.369874 0.322656,1.015186 0,0.07083 -0.0052,0.141654 -0.0026,0.0682 -0.0079,0.120668 z m 0.661052,-1.211928 q -0.275438,0 -0.45644,0.196742 -0.181003,0.196741 -0.207235,0.613833 h 1.282755 q -0.0079,-0.39086 -0.167886,-0.600717 -0.157393,-0.209858 -0.451194,-0.209858 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1510" />
+      <path
+         d="m -9.3438475,91.994759 h -0.6505587 l 0.9942006,-1.461134 -0.8840253,-1.308987 H -9.20744 l 0.5666157,0.975838 0.5666156,-0.975838 h 0.6453123 l -0.8656628,1.285378 0.9968238,1.484743 h -0.689907 l -0.6794141,-1.130608 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1512" />
+      <path
+         d="m -5.283109,88.301264 q 0.2203505,0 0.403976,0.06033 0.1862486,0.05771 0.3410186,0.160017 l -0.2282202,0.377743 q -0.2334666,-0.152146 -0.5141512,-0.152146 -0.3724973,0 -0.5928479,0.346265 -0.2203505,0.343642 -0.2413362,0.944359 0.1705093,-0.225597 0.3803669,-0.325279 0.2124809,-0.102306 0.451194,-0.102306 0.2806846,0 0.511528,0.131161 0.2334666,0.128538 0.3724973,0.388237 0.1390307,0.257075 0.1390307,0.642689 0,0.388236 -0.1573932,0.679414 -0.15477,0.291177 -0.4249618,0.453817 -0.2701917,0.160017 -0.6138336,0.160017 -0.4538171,0 -0.7318785,-0.225597 -0.2754382,-0.225597 -0.4013528,-0.621704 -0.1259146,-0.396106 -0.1259146,-0.907634 0,-0.603341 0.1705094,-1.054535 0.1731325,-0.453817 0.4931654,-0.703023 0.320033,-0.251829 0.7686037,-0.251829 z m -0.1232914,1.749688 q -0.2151041,0 -0.3961063,0.115422 -0.178379,0.115422 -0.3069168,0.306917 0.010493,0.587601 0.1600165,0.868286 0.1521467,0.278061 0.4957886,0.278061 0.3016704,0 0.4485708,-0.225597 0.1495235,-0.22822 0.1495235,-0.595471 0,-0.417092 -0.1495235,-0.582355 -0.1495236,-0.165263 -0.4013528,-0.165263 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1514" />
+      <path
+         d="m -1.5319106,89.736166 v 0.967968 h 0.4302082 v 0.45644 h -0.4302082 v 0.834185 H -2.095903 l -0.00262,-0.834185 h -1.5031054 v -0.409222 l 1.0414186,-2.450088 0.4957887,0.196742 -0.9233736,2.206128 h 0.891895 l 0.070827,-0.967968 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1516" />
+    </g>
+    <g
+       id="g4360">
+      <g
+         id="g4342">
+        <path
+           id="rect2223"
+           style="fill:#ffdc86;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+           d="m -171.56111,84.475945 h 36.96869 c 2.56347,0 4.6272,2.063728 4.6272,4.627193 v 3.044612 c 0,2.563466 -2.06373,4.627194 -4.6272,4.627194 h -36.96869 c -2.56347,0 -4.6272,-2.063728 -4.6272,-4.627194 v -3.044612 c 0,-2.563465 2.06373,-4.627193 4.6272,-4.627193 z" />
+        <g
+           aria-label="Python complex"
+           id="text9259"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+          <path
+             d="m -173.0955,90.623864 v 1.370895 h -0.49363 V 88.32966 h 1.08189 q 0.34783,0 0.6036,0.08185 0.25832,0.07929 0.42712,0.22763 0.16881,0.148343 0.25065,0.358069 0.0844,0.209727 0.0844,0.468049 0,0.255764 -0.0895,0.468048 -0.0895,0.212284 -0.26344,0.365742 -0.17136,0.153459 -0.42713,0.240418 -0.2532,0.0844 -0.58569,0.0844 z m 0,-0.393877 h 0.58826 q 0.21228,0 0.37341,-0.05627 0.16369,-0.05627 0.27367,-0.156016 0.11253,-0.102306 0.1688,-0.242976 0.0563,-0.14067 0.0563,-0.309474 0,-0.350397 -0.2174,-0.547335 -0.21484,-0.196939 -0.65475,-0.196939 h -0.58826 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1449" />
+          <path
+             d="m -169.83452,92.759493 q -0.023,0.05115 -0.0588,0.08184 -0.0333,0.03069 -0.10486,0.03069 h -0.33761 l 0.47317,-1.028171 -1.0691,-2.439989 h 0.39388 q 0.0588,0 0.0921,0.03069 0.0358,0.02813 0.0486,0.06394 l 0.69312,1.631774 q 0.0205,0.05883 0.0384,0.115094 0.0179,0.05371 0.0307,0.112536 0.0333,-0.115094 0.0767,-0.230187 l 0.67265,-1.629217 q 0.0153,-0.04092 0.0512,-0.0665 0.0384,-0.02813 0.0844,-0.02813 h 0.36063 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1451" />
+          <path
+             d="m -167.19248,92.035681 q -0.30692,0 -0.47317,-0.171362 -0.16368,-0.171362 -0.16368,-0.493625 v -1.585736 h -0.31204 q -0.0409,0 -0.0691,-0.02302 -0.0281,-0.02558 -0.0281,-0.07673 v -0.181593 l 0.42457,-0.05371 0.10486,-0.800542 q 0.008,-0.03836 0.0332,-0.06138 0.0281,-0.02558 0.0716,-0.02558 h 0.23019 v 0.892616 h 0.74938 v 0.329936 h -0.74938 v 1.555045 q 0,0.163689 0.0793,0.242976 0.0793,0.07929 0.20461,0.07929 0.0716,0 0.12277,-0.0179 0.0537,-0.02046 0.0921,-0.04348 0.0384,-0.02302 0.0639,-0.04092 0.0281,-0.02046 0.0486,-0.02046 0.0358,0 0.0639,0.04348 l 0.133,0.217399 q -0.11765,0.109978 -0.2839,0.173919 -0.16625,0.06138 -0.34272,0.06138 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1453" />
+          <path
+             d="m -166.15408,91.994759 v -3.767404 h 0.45781 v 1.524353 q 0.16625,-0.176477 0.3683,-0.28134 0.20206,-0.107421 0.4655,-0.107421 0.21228,0 0.37341,0.07161 0.16369,0.06906 0.27111,0.199496 0.10998,0.127882 0.16625,0.309474 0.0563,0.181593 0.0563,0.40155 v 1.649678 h -0.45782 v -1.649678 q 0,-0.294129 -0.13556,-0.45526 -0.13299,-0.163689 -0.40666,-0.163689 -0.20461,0 -0.38109,0.09719 -0.17392,0.09719 -0.31971,0.263437 v 1.908 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1455" />
+          <path
+             d="m -162.20765,89.362947 q 0.2839,0 0.51153,0.09463 0.22763,0.09463 0.38876,0.268552 0.16113,0.173919 0.24553,0.42201 0.087,0.245534 0.087,0.549893 0,0.306917 -0.087,0.55245 -0.0844,0.245534 -0.24553,0.419453 -0.16113,0.17392 -0.38876,0.268553 -0.22763,0.09207 -0.51153,0.09207 -0.28646,0 -0.51664,-0.09207 -0.22763,-0.09463 -0.38877,-0.268553 -0.16113,-0.173919 -0.24809,-0.419453 -0.0844,-0.245533 -0.0844,-0.55245 0,-0.304359 0.0844,-0.549893 0.087,-0.248091 0.24809,-0.42201 0.16114,-0.17392 0.38877,-0.268552 0.23018,-0.09463 0.51664,-0.09463 z m 0,2.312107 q 0.38364,0 0.57291,-0.255764 0.18927,-0.258322 0.18927,-0.718697 0,-0.462933 -0.18927,-0.721255 -0.18927,-0.258321 -0.57291,-0.258321 -0.19438,0 -0.34017,0.0665 -0.14323,0.0665 -0.24042,0.191823 -0.0946,0.125325 -0.14322,0.309475 -0.046,0.181592 -0.046,0.41178 0,0.460375 0.18926,0.718697 0.19183,0.255764 0.58059,0.255764 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1457" />
+          <path
+             d="m -160.3994,91.994759 v -2.59089 h 0.27366 q 0.0972,0 0.12021,0.09463 l 0.0358,0.28134 q 0.16881,-0.186707 0.37853,-0.301801 0.20973,-0.115094 0.4834,-0.115094 0.21228,0 0.37341,0.07161 0.16369,0.06906 0.27111,0.199496 0.10998,0.127882 0.16625,0.309474 0.0563,0.181593 0.0563,0.40155 v 1.649678 h -0.45782 v -1.649678 q 0,-0.294129 -0.13556,-0.45526 -0.13299,-0.163689 -0.40666,-0.163689 -0.20461,0 -0.38109,0.09719 -0.17392,0.09719 -0.3197,0.263437 v 1.908 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1459" />
+          <path
+             d="m -152.9557,91.582913 q 0.19412,0 0.362,-0.0682 0.16789,-0.0682 0.32004,-0.173132 l 0.27281,0.377743 q -0.181,0.15477 -0.4407,0.25183 -0.25707,0.09444 -0.53251,0.09444 -0.42496,0 -0.72926,-0.178379 -0.30167,-0.181003 -0.46168,-0.503659 -0.1574,-0.325279 -0.1574,-0.760734 0,-0.422338 0.16002,-0.752864 0.16264,-0.333149 0.46693,-0.524644 0.3043,-0.194119 0.73188,-0.194119 0.55612,0 0.9601,0.33315 l -0.27019,0.369874 q -0.16264,-0.112799 -0.33315,-0.17051 -0.17051,-0.06033 -0.34627,-0.06033 -0.33052,0 -0.53776,0.241336 -0.20723,0.241337 -0.20723,0.758111 0,0.519398 0.20986,0.739748 0.20985,0.220351 0.53251,0.220351 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1461" />
+          <path
+             d="m -150.03344,89.151187 q 0.60859,0 0.92862,0.396107 0.32003,0.396106 0.32003,1.057158 0,0.440701 -0.1469,0.768603 -0.14427,0.327903 -0.42496,0.511528 -0.27806,0.181003 -0.67941,0.181003 -0.60597,0 -0.92862,-0.39086 -0.32266,-0.393483 -0.32266,-1.065028 0,-0.430208 0.14428,-0.758111 0.1469,-0.330525 0.42758,-0.514151 0.28069,-0.186249 0.68204,-0.186249 z m 0,0.456441 q -0.31741,0 -0.47743,0.243959 -0.16001,0.241337 -0.16001,0.758111 0,0.516775 0.15739,0.760734 0.16002,0.241336 0.47743,0.241336 0.31741,0 0.4748,-0.243959 0.16002,-0.24396 0.16002,-0.763357 0,-0.511528 -0.1574,-0.752865 -0.15739,-0.243959 -0.4748,-0.243959 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1463" />
+          <path
+             d="m -146.0855,89.151187 q 0.15739,0 0.28331,0.0682 0.12591,0.0682 0.19674,0.241337 0.0734,0.170509 0.0734,0.474802 v 2.059229 h -0.52202 V 90.01685 q 0,-0.217727 -0.0315,-0.312163 -0.0289,-0.09444 -0.15477,-0.09444 -0.0997,0 -0.20461,0.06296 -0.10231,0.06033 -0.20461,0.209858 v 2.111693 h -0.47481 V 90.01685 q 0,-0.217727 -0.0315,-0.312163 -0.0289,-0.09444 -0.15477,-0.09444 -0.1023,0 -0.20461,0.06296 -0.1023,0.06033 -0.20461,0.209858 v 2.111693 h -0.52464 v -2.770121 h 0.44332 l 0.0393,0.299047 q 0.11805,-0.165263 0.25445,-0.267569 0.13903,-0.104929 0.3384,-0.104929 0.15739,0 0.28593,0.0787 0.12854,0.07607 0.18887,0.275438 0.11805,-0.157393 0.26232,-0.254452 0.14428,-0.09968 0.34627,-0.09968 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1465" />
+          <path
+             d="m -143.49639,89.151187 q 0.36725,0 0.5876,0.181003 0.22035,0.178379 0.32003,0.506281 0.0997,0.32528 0.0997,0.765981 0,0.422338 -0.12067,0.752864 -0.12067,0.330526 -0.35938,0.519398 -0.23609,0.188872 -0.5876,0.188872 -0.43546,0 -0.70303,-0.306917 v 1.301117 l -0.5876,0.06558 v -3.900729 h 0.51153 l 0.0367,0.356758 q 0.1574,-0.212481 0.36463,-0.320033 0.20724,-0.110176 0.43808,-0.110176 z m -0.16264,0.453818 q -0.19674,0 -0.34889,0.118045 -0.14952,0.118045 -0.25183,0.278061 v 1.295871 q 0.20724,0.30954 0.54826,0.30954 0.29642,0 0.45119,-0.238713 0.15477,-0.238713 0.15477,-0.760734 0,-0.532514 -0.13903,-0.76598 -0.13641,-0.23609 -0.41447,-0.23609 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1467" />
+          <path
+             d="m -140.48232,88.112392 v 3.126879 q 0,0.191495 0.11543,0.272815 0.11804,0.0787 0.30429,0.0787 0.11804,0 0.2256,-0.02361 0.11017,-0.02623 0.21248,-0.0682 l 0.14952,0.409222 q -0.12329,0.06296 -0.30429,0.110176 -0.17838,0.04722 -0.40923,0.04722 -0.41709,0 -0.65055,-0.23609 -0.23085,-0.23609 -0.23085,-0.642689 v -2.641583 h -0.8368 v -0.432832 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1469" />
+          <path
+             d="m -138.06371,90.79857 q 0.0262,0.427585 0.23871,0.61908 0.2151,0.191495 0.51677,0.191495 0.20199,0 0.37512,-0.06296 0.17576,-0.06296 0.35152,-0.178379 l 0.25445,0.351511 q -0.19412,0.157394 -0.45382,0.25183 -0.2597,0.09444 -0.55612,0.09444 -0.43283,0 -0.73188,-0.183626 -0.29642,-0.183625 -0.45119,-0.511528 -0.15215,-0.327902 -0.15215,-0.758111 0,-0.417092 0.15215,-0.744994 0.15214,-0.330526 0.43545,-0.522021 0.28331,-0.194119 0.67679,-0.194119 0.55088,0 0.87091,0.369875 0.32266,0.369874 0.32266,1.015186 0,0.07083 -0.005,0.141654 -0.003,0.0682 -0.008,0.120668 z m 0.66105,-1.211928 q -0.27544,0 -0.45644,0.196742 -0.181,0.196741 -0.20724,0.613833 h 1.28276 q -0.008,-0.39086 -0.16789,-0.600717 -0.15739,-0.209858 -0.45119,-0.209858 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1471" />
+          <path
+             d="m -134.99455,91.994759 h -0.65056 l 0.9942,-1.461134 -0.88403,-1.308987 h 0.67679 l 0.56662,0.975838 0.56662,-0.975838 h 0.64531 l -0.86566,1.285378 0.99682,1.484743 h -0.68991 l -0.67941,-1.130608 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1473" />
+        </g>
+      </g>
+      <g
+         id="g4348">
+        <path
+           id="rect12259"
+           style="fill:#ffdc86;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+           d="m -171.56111,108.3166 h 36.96869 c 2.56347,0 4.6272,2.06373 4.6272,4.62719 v 3.04461 c 0,2.56347 -2.06373,4.6272 -4.6272,4.6272 h -36.96869 c -2.56347,0 -4.6272,-2.06373 -4.6272,-4.6272 v -3.04461 c 0,-2.56346 2.06373,-4.62719 4.6272,-4.62719 z" />
+        <g
+           aria-label="Python float"
+           id="text12263"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+          <path
+             d="m -173.0955,114.4015 v 1.37089 h -0.49363 v -3.6651 h 1.08189 q 0.34783,0 0.6036,0.0818 0.25832,0.0793 0.42712,0.22763 0.16881,0.14834 0.25065,0.35807 0.0844,0.20972 0.0844,0.46805 0,0.25576 -0.0895,0.46804 -0.0895,0.21229 -0.26344,0.36575 -0.17136,0.15346 -0.42713,0.24042 -0.2532,0.0844 -0.58569,0.0844 z m 0,-0.39388 h 0.58826 q 0.21228,0 0.37341,-0.0563 0.16369,-0.0563 0.27367,-0.15601 0.11253,-0.10231 0.1688,-0.24298 0.0563,-0.14067 0.0563,-0.30947 0,-0.3504 -0.2174,-0.54734 -0.21484,-0.19694 -0.65475,-0.19694 h -0.58826 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1477" />
+          <path
+             d="m -169.83452,116.53713 q -0.023,0.0511 -0.0588,0.0818 -0.0333,0.0307 -0.10486,0.0307 h -0.33761 l 0.47317,-1.02817 -1.0691,-2.43999 h 0.39388 q 0.0588,0 0.0921,0.0307 0.0358,0.0281 0.0486,0.0639 l 0.69312,1.63177 q 0.0205,0.0588 0.0384,0.11509 0.0179,0.0537 0.0307,0.11254 0.0333,-0.11509 0.0767,-0.23019 l 0.67265,-1.62921 q 0.0153,-0.0409 0.0512,-0.0665 0.0384,-0.0281 0.0844,-0.0281 h 0.36063 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1479" />
+          <path
+             d="m -167.19248,115.81331 q -0.30692,0 -0.47317,-0.17136 -0.16368,-0.17136 -0.16368,-0.49362 v -1.58574 h -0.31204 q -0.0409,0 -0.0691,-0.023 -0.0281,-0.0256 -0.0281,-0.0767 v -0.18159 l 0.42457,-0.0537 0.10486,-0.80054 q 0.008,-0.0384 0.0332,-0.0614 0.0281,-0.0256 0.0716,-0.0256 h 0.23019 v 0.89262 h 0.74938 v 0.32993 h -0.74938 v 1.55505 q 0,0.16369 0.0793,0.24297 0.0793,0.0793 0.20461,0.0793 0.0716,0 0.12277,-0.0179 0.0537,-0.0205 0.0921,-0.0435 0.0384,-0.023 0.0639,-0.0409 0.0281,-0.0205 0.0486,-0.0205 0.0358,0 0.0639,0.0435 l 0.133,0.2174 q -0.11765,0.10998 -0.2839,0.17392 -0.16625,0.0614 -0.34272,0.0614 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1481" />
+          <path
+             d="m -166.15408,115.77239 v -3.7674 h 0.45781 v 1.52435 q 0.16625,-0.17648 0.3683,-0.28134 0.20206,-0.10742 0.4655,-0.10742 0.21228,0 0.37341,0.0716 0.16369,0.0691 0.27111,0.1995 0.10998,0.12788 0.16625,0.30947 0.0563,0.1816 0.0563,0.40155 v 1.64968 h -0.45782 v -1.64968 q 0,-0.29412 -0.13556,-0.45526 -0.13299,-0.16368 -0.40666,-0.16368 -0.20461,0 -0.38109,0.0972 -0.17392,0.0972 -0.31971,0.26343 v 1.908 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1483" />
+          <path
+             d="m -162.20765,113.14058 q 0.2839,0 0.51153,0.0946 0.22763,0.0946 0.38876,0.26856 0.16113,0.17392 0.24553,0.42201 0.087,0.24553 0.087,0.54989 0,0.30692 -0.087,0.55245 -0.0844,0.24553 -0.24553,0.41945 -0.16113,0.17392 -0.38876,0.26855 -0.22763,0.0921 -0.51153,0.0921 -0.28646,0 -0.51664,-0.0921 -0.22763,-0.0946 -0.38877,-0.26855 -0.16113,-0.17392 -0.24809,-0.41945 -0.0844,-0.24553 -0.0844,-0.55245 0,-0.30436 0.0844,-0.54989 0.087,-0.24809 0.24809,-0.42201 0.16114,-0.17392 0.38877,-0.26856 0.23018,-0.0946 0.51664,-0.0946 z m 0,2.31211 q 0.38364,0 0.57291,-0.25577 0.18927,-0.25832 0.18927,-0.71869 0,-0.46294 -0.18927,-0.72126 -0.18927,-0.25832 -0.57291,-0.25832 -0.19438,0 -0.34017,0.0665 -0.14323,0.0665 -0.24042,0.19182 -0.0946,0.12533 -0.14322,0.30948 -0.046,0.18159 -0.046,0.41178 0,0.46037 0.18926,0.71869 0.19183,0.25577 0.58059,0.25577 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1485" />
+          <path
+             d="m -160.3994,115.77239 v -2.59089 h 0.27366 q 0.0972,0 0.12021,0.0946 l 0.0358,0.28134 q 0.16881,-0.18671 0.37853,-0.30181 0.20973,-0.11509 0.4834,-0.11509 0.21228,0 0.37341,0.0716 0.16369,0.0691 0.27111,0.1995 0.10998,0.12788 0.16625,0.30947 0.0563,0.1816 0.0563,0.40155 v 1.64968 h -0.45782 v -1.64968 q 0,-0.29412 -0.13556,-0.45526 -0.13299,-0.16368 -0.40666,-0.16368 -0.20461,0 -0.38109,0.0972 -0.17392,0.0972 -0.3197,0.26343 v 1.908 z"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+             id="path1487" />
+          <path
+             d="m -152.60681,111.82445 q 0.25445,0 0.45382,0.0446 0.20198,0.042 0.37249,0.11542 l -0.17313,0.4066 q -0.13903,-0.0577 -0.29118,-0.0839 -0.14952,-0.0262 -0.30429,-0.0262 -0.53514,0 -0.53514,0.4302 v 0.49055 h 0.926 l -0.063,0.43283 h -0.86304 v 2.13792 h -0.58498 v -2.13792 h -0.62957 v -0.43283 h 0.62957 v -0.49579 q 0,-0.39349 0.29118,-0.63745 0.29118,-0.24395 0.77123,-0.24395 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1489" />
+          <path
+             d="m -149.92589,111.89003 v 3.12687 q 0,0.1915 0.11542,0.27282 0.11805,0.0787 0.3043,0.0787 0.11804,0 0.22559,-0.0236 0.11018,-0.0262 0.21249,-0.0682 l 0.14952,0.40923 q -0.12329,0.063 -0.30429,0.11017 -0.17838,0.0472 -0.40923,0.0472 -0.41709,0 -0.65056,-0.23609 -0.23084,-0.23609 -0.23084,-0.64269 v -2.64158 h -0.83681 v -0.43283 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1491" />
+          <path
+             d="m -146.88558,112.92882 q 0.60858,0 0.92862,0.39611 0.32003,0.3961 0.32003,1.05716 0,0.4407 -0.1469,0.7686 -0.14428,0.3279 -0.42496,0.51153 -0.27806,0.181 -0.67942,0.181 -0.60596,0 -0.92862,-0.39086 -0.32265,-0.39348 -0.32265,-1.06503 0,-0.43021 0.14427,-0.75811 0.1469,-0.33052 0.42759,-0.51415 0.28068,-0.18625 0.68204,-0.18625 z m 0,0.45644 q -0.31741,0 -0.47743,0.24396 -0.16002,0.24134 -0.16002,0.75811 0,0.51678 0.1574,0.76074 0.16001,0.24133 0.47742,0.24133 0.31741,0 0.47481,-0.24396 0.16001,-0.24396 0.16001,-0.76335 0,-0.51153 -0.15739,-0.75287 -0.15739,-0.24396 -0.4748,-0.24396 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1493" />
+          <path
+             d="m -142.73041,115.09298 q 0,0.16526 0.0498,0.23871 0.0498,0.0735 0.16002,0.11018 l -0.13116,0.39873 q -0.20461,-0.0236 -0.35414,-0.1128 -0.1469,-0.0892 -0.22035,-0.27019 -0.15214,0.19411 -0.38561,0.29117 -0.23347,0.0944 -0.49841,0.0944 -0.42234,0 -0.6663,-0.23609 -0.24396,-0.23871 -0.24396,-0.62433 0,-0.43807 0.34102,-0.67416 0.34102,-0.23609 0.97584,-0.23609 h 0.3961 v -0.18101 q 0,-0.27019 -0.16264,-0.38561 -0.16264,-0.11805 -0.45381,-0.11805 -0.13641,0 -0.33053,0.0367 -0.19412,0.0341 -0.4066,0.10755 l -0.14428,-0.41447 q 0.2597,-0.0971 0.50891,-0.14165 0.2492,-0.0472 0.46168,-0.0472 0.55613,0 0.82894,0.24658 0.27544,0.24659 0.27544,0.68204 z m -1.20143,0.31741 q 0.17837,0 0.34888,-0.0944 0.17051,-0.0944 0.27544,-0.26494 v -0.61121 h -0.32528 q -0.41447,0 -0.59284,0.13903 -0.17838,0.1364 -0.17838,0.37774 0,0.45382 0.47218,0.45382 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1495" />
+          <path
+             d="m -139.38581,115.62549 q -0.15215,0.0971 -0.36463,0.1574 -0.21248,0.0603 -0.44332,0.0603 -0.48267,0 -0.7345,-0.24921 -0.24921,-0.25183 -0.24921,-0.66105 v -1.5031 h -0.61646 v -0.42759 h 0.61646 v -0.61908 l 0.5876,-0.0708 v 0.68991 h 0.93387 l -0.0656,0.42759 h -0.86829 v 1.49786 q 0,0.22297 0.11018,0.33314 0.1128,0.10756 0.36725,0.10756 0.15214,0 0.27806,-0.0367 0.12854,-0.0367 0.23609,-0.0944 z"
+             style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+             id="path1497" />
+        </g>
+      </g>
+    </g>
+    <path
+       id="rect13393"
+       style="fill:#ffdc86;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -171.56111,132.15694 h 36.96869 c 2.56347,0 4.6272,2.06372 4.6272,4.62719 v 26.88561 c 0,2.56347 -2.06373,4.6272 -4.6272,4.6272 h -36.96869 c -2.56347,0 -4.6272,-2.06373 -4.6272,-4.6272 v -26.88561 c 0,-2.56347 2.06373,-4.62719 4.6272,-4.62719 z" />
+    <g
+       aria-label="Python int"
+       id="text13397"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -173.0955,150.48058 v 1.37089 h -0.49363 v -3.6651 h 1.08189 q 0.34783,0 0.6036,0.0819 0.25832,0.0793 0.42712,0.22763 0.16881,0.14834 0.25065,0.35807 0.0844,0.20972 0.0844,0.46804 0,0.25577 -0.0895,0.46805 -0.0895,0.21229 -0.26344,0.36575 -0.17136,0.15345 -0.42713,0.24041 -0.2532,0.0844 -0.58569,0.0844 z m 0,-0.39388 h 0.58826 q 0.21228,0 0.37341,-0.0563 0.16369,-0.0563 0.27367,-0.15601 0.11253,-0.10231 0.1688,-0.24298 0.0563,-0.14067 0.0563,-0.30948 0,-0.35039 -0.2174,-0.54733 -0.21484,-0.19694 -0.65475,-0.19694 h -0.58826 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1428" />
+      <path
+         d="m -169.83452,152.61621 q -0.023,0.0512 -0.0588,0.0818 -0.0333,0.0307 -0.10486,0.0307 h -0.33761 l 0.47317,-1.02817 -1.0691,-2.43999 h 0.39388 q 0.0588,0 0.0921,0.0307 0.0358,0.0281 0.0486,0.0639 l 0.69312,1.63178 q 0.0205,0.0588 0.0384,0.11509 0.0179,0.0537 0.0307,0.11254 0.0333,-0.1151 0.0767,-0.23019 l 0.67265,-1.62922 q 0.0153,-0.0409 0.0512,-0.0665 0.0384,-0.0281 0.0844,-0.0281 h 0.36063 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1430" />
+      <path
+         d="m -167.19248,151.89239 q -0.30692,0 -0.47317,-0.17136 -0.16368,-0.17136 -0.16368,-0.49362 v -1.58574 h -0.31204 q -0.0409,0 -0.0691,-0.023 -0.0281,-0.0256 -0.0281,-0.0767 v -0.18159 l 0.42457,-0.0537 0.10486,-0.80054 q 0.008,-0.0384 0.0332,-0.0614 0.0281,-0.0256 0.0716,-0.0256 h 0.23019 v 0.89261 h 0.74938 v 0.32994 h -0.74938 v 1.55505 q 0,0.16368 0.0793,0.24297 0.0793,0.0793 0.20461,0.0793 0.0716,0 0.12277,-0.0179 0.0537,-0.0205 0.0921,-0.0435 0.0384,-0.023 0.0639,-0.0409 0.0281,-0.0205 0.0486,-0.0205 0.0358,0 0.0639,0.0435 l 0.133,0.2174 q -0.11765,0.10998 -0.2839,0.17392 -0.16625,0.0614 -0.34272,0.0614 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1432" />
+      <path
+         d="m -166.15408,151.85147 v -3.7674 h 0.45781 v 1.52435 q 0.16625,-0.17648 0.3683,-0.28134 0.20206,-0.10742 0.4655,-0.10742 0.21228,0 0.37341,0.0716 0.16369,0.0691 0.27111,0.1995 0.10998,0.12788 0.16625,0.30947 0.0563,0.1816 0.0563,0.40155 v 1.64968 h -0.45782 v -1.64968 q 0,-0.29413 -0.13556,-0.45526 -0.13299,-0.16369 -0.40666,-0.16369 -0.20461,0 -0.38109,0.0972 -0.17392,0.0972 -0.31971,0.26344 v 1.908 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1434" />
+      <path
+         d="m -162.20765,149.21966 q 0.2839,0 0.51153,0.0946 0.22763,0.0946 0.38876,0.26855 0.16113,0.17392 0.24553,0.42201 0.087,0.24554 0.087,0.5499 0,0.30691 -0.087,0.55245 -0.0844,0.24553 -0.24553,0.41945 -0.16113,0.17392 -0.38876,0.26855 -0.22763,0.0921 -0.51153,0.0921 -0.28646,0 -0.51664,-0.0921 -0.22763,-0.0946 -0.38877,-0.26855 -0.16113,-0.17392 -0.24809,-0.41945 -0.0844,-0.24554 -0.0844,-0.55245 0,-0.30436 0.0844,-0.5499 0.087,-0.24809 0.24809,-0.42201 0.16114,-0.17392 0.38877,-0.26855 0.23018,-0.0946 0.51664,-0.0946 z m 0,2.31211 q 0.38364,0 0.57291,-0.25577 0.18927,-0.25832 0.18927,-0.71869 0,-0.46294 -0.18927,-0.72126 -0.18927,-0.25832 -0.57291,-0.25832 -0.19438,0 -0.34017,0.0665 -0.14323,0.0665 -0.24042,0.19182 -0.0946,0.12532 -0.14322,0.30948 -0.046,0.18159 -0.046,0.41178 0,0.46037 0.18926,0.71869 0.19183,0.25577 0.58059,0.25577 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1436" />
+      <path
+         d="m -160.3994,151.85147 v -2.59089 h 0.27366 q 0.0972,0 0.12021,0.0946 l 0.0358,0.28134 q 0.16881,-0.1867 0.37853,-0.3018 0.20973,-0.11509 0.4834,-0.11509 0.21228,0 0.37341,0.0716 0.16369,0.0691 0.27111,0.1995 0.10998,0.12788 0.16625,0.30947 0.0563,0.1816 0.0563,0.40155 v 1.64968 h -0.45782 v -1.64968 q 0,-0.29413 -0.13556,-0.45526 -0.13299,-0.16369 -0.40666,-0.16369 -0.20461,0 -0.38109,0.0972 -0.17392,0.0972 -0.3197,0.26344 v 1.908 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Lato;-inkscape-font-specification:Lato"
+         id="path1438" />
+      <path
+         d="m -153.18654,147.72514 q 0.17313,0 0.27806,0.10493 0.10755,0.10493 0.10755,0.26233 0,0.15739 -0.10755,0.26494 -0.10493,0.10755 -0.27806,0.10755 -0.16789,0 -0.27544,-0.10755 -0.10755,-0.10755 -0.10755,-0.26494 0,-0.1574 0.10755,-0.26233 0.10755,-0.10493 0.27544,-0.10493 z m 0.40922,1.35621 v 2.33991 h 0.75286 v 0.43021 h -2.1694 v -0.43021 h 0.82894 v -1.9097 h -0.80271 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1440" />
+      <path
+         d="m -151.14306,151.85147 v -2.77012 h 0.50628 l 0.0446,0.35938 q 0.17314,-0.20986 0.40923,-0.32003 0.23609,-0.1128 0.48529,-0.1128 0.38824,0 0.57973,0.21773 0.19412,0.21772 0.19412,0.60596 v 2.01988 h -0.5876 v -1.7287 q 0,-0.35938 -0.0735,-0.51153 -0.0708,-0.15477 -0.32265,-0.15477 -0.20199,0 -0.36988,0.12592 -0.16526,0.12329 -0.27806,0.28068 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1442" />
+      <path
+         d="m -145.68153,151.70457 q -0.15214,0.0971 -0.36462,0.15739 -0.21248,0.0603 -0.44333,0.0603 -0.48267,0 -0.7345,-0.24921 -0.2492,-0.25183 -0.2492,-0.66105 v -1.50311 h -0.61646 v -0.42758 h 0.61646 v -0.61908 l 0.5876,-0.0708 v 0.68991 h 0.93386 l -0.0656,0.42758 h -0.86828 v 1.49786 q 0,0.22298 0.11017,0.33315 0.1128,0.10755 0.36725,0.10755 0.15215,0 0.27806,-0.0367 0.12854,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1444" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:0.482353;stroke:#00b200;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.795245"
+       d="M 112.03144,112.64983 V 89.989221"
+       id="path1279" />
+    <path
+       id="path866"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 129.91874,90.625336 a 18.448826,6.1496081 0 0 1 -18.44882,6.149608 18.448826,6.1496081 0 0 1 -18.448829,-6.149608 18.448826,6.1496081 0 0 1 18.448829,-6.149608 18.448826,6.1496081 0 0 1 18.44882,6.149608 z" />
+    <g
+       aria-label="clongdouble"
+       id="text1588"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 95.912947,91.582913 q 0.194118,0 0.362004,-0.0682 0.167886,-0.0682 0.320033,-0.173132 l 0.272815,0.377743 q -0.181002,0.15477 -0.440701,0.25183 -0.257076,0.09444 -0.532514,0.09444 -0.424962,0 -0.729255,-0.178379 -0.301671,-0.181003 -0.461687,-0.503659 -0.157393,-0.325279 -0.157393,-0.760734 0,-0.422338 0.160016,-0.752864 0.16264,-0.333149 0.466933,-0.524644 0.304294,-0.194119 0.731879,-0.194119 0.556123,0 0.960099,0.33315 l -0.270192,0.369874 q -0.16264,-0.112799 -0.333149,-0.17051 -0.170509,-0.06033 -0.346265,-0.06033 -0.330526,0 -0.53776,0.241336 -0.207235,0.241337 -0.207235,0.758111 0,0.519398 0.209858,0.739748 0.209857,0.220351 0.532514,0.220351 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1404" />
+      <path
+         d="m 98.942759,88.112392 v 3.126879 q 0,0.191495 0.115422,0.272815 0.118045,0.0787 0.304293,0.0787 0.118045,0 0.225597,-0.02361 0.110175,-0.02623 0.212481,-0.0682 l 0.149524,0.409222 q -0.123292,0.06296 -0.304294,0.110176 -0.178379,0.04722 -0.409222,0.04722 -0.417092,0 -0.650559,-0.23609 -0.230844,-0.23609 -0.230844,-0.642689 V 88.545224 H 97.51835 v -0.432832 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1406" />
+      <path
+         d="m 101.98306,89.151187 q 0.60859,0 0.92862,0.396107 0.32004,0.396106 0.32004,1.057158 0,0.440701 -0.1469,0.768603 -0.14428,0.327903 -0.42497,0.511528 -0.27806,0.181003 -0.67941,0.181003 -0.60596,0 -0.92862,-0.39086 -0.32266,-0.393483 -0.32266,-1.065028 0,-0.430208 0.14428,-0.758111 0.1469,-0.330525 0.42759,-0.514151 0.28068,-0.186249 0.68203,-0.186249 z m 0,0.456441 q -0.31741,0 -0.47742,0.243959 -0.16002,0.241337 -0.16002,0.758111 0,0.516775 0.15739,0.760734 0.16002,0.241336 0.47743,0.241336 0.31741,0 0.4748,-0.243959 0.16002,-0.24396 0.16002,-0.763357 0,-0.511528 -0.15739,-0.752865 -0.1574,-0.243959 -0.47481,-0.243959 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1408" />
+      <path
+         d="m 104.0213,91.994759 v -2.770121 h 0.50628 l 0.0446,0.359381 q 0.17314,-0.209858 0.40923,-0.320033 0.23609,-0.112799 0.48529,-0.112799 0.38824,0 0.57973,0.217728 0.19412,0.217727 0.19412,0.605964 v 2.01988 h -0.5876 v -1.728703 q 0,-0.359381 -0.0734,-0.511528 -0.0708,-0.15477 -0.32265,-0.15477 -0.20199,0 -0.36988,0.125915 -0.16526,0.123291 -0.27806,0.280684 v 1.988402 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1410" />
+      <path
+         d="m 109.5012,88.873126 0.15739,0.487919 q -0.16526,0.05509 -0.36463,0.07345 -0.19674,0.01836 -0.4407,0.01836 0.24921,0.110175 0.37512,0.283308 0.12592,0.170509 0.12592,0.419715 0,0.270192 -0.13116,0.482673 -0.13116,0.21248 -0.37775,0.333149 -0.24396,0.120668 -0.58235,0.120668 -0.12067,0 -0.20986,-0.01049 -0.0866,-0.01049 -0.17051,-0.0341 -0.12329,0.08132 -0.12329,0.22822 0,0.08394 0.0682,0.146901 0.0708,0.06033 0.27807,0.06033 h 0.48267 q 0.29642,0 0.52202,0.102305 0.22822,0.09968 0.35676,0.275438 0.13116,0.173133 0.13116,0.393483 0,0.414469 -0.35676,0.642689 -0.35676,0.228221 -1.0283,0.228221 -0.47743,0 -0.74762,-0.09706 -0.26757,-0.09706 -0.37774,-0.288555 -0.11018,-0.191495 -0.11018,-0.469556 h 0.52727 q 0,0.1469 0.0551,0.241336 0.0577,0.09444 0.21248,0.139031 0.15477,0.04722 0.44594,0.04722 0.43284,0 0.61121,-0.107552 0.17838,-0.104929 0.17838,-0.296424 0,-0.17051 -0.1469,-0.262322 -0.1469,-0.08919 -0.39348,-0.08919 h -0.4748 q -0.39349,0 -0.57711,-0.160016 -0.181,-0.160017 -0.181,-0.372498 0,-0.299047 0.30954,-0.501035 -0.24921,-0.131161 -0.36463,-0.317409 -0.1128,-0.188872 -0.1128,-0.456441 0,-0.2938 0.1469,-0.514151 0.1469,-0.220351 0.4066,-0.343642 0.26232,-0.123291 0.60334,-0.123291 0.33315,0.0026 0.55612,-0.0341 0.22298,-0.03673 0.38824,-0.09968 0.16789,-0.06558 0.33315,-0.1469 z m -1.27226,0.684661 q -0.28069,0 -0.42234,0.160016 -0.14166,0.157393 -0.14166,0.411846 0,0.262322 0.14428,0.422338 0.14428,0.157394 0.42759,0.157394 0.2597,0 0.3961,-0.152147 0.13903,-0.152147 0.13903,-0.432832 0,-0.566615 -0.543,-0.566615 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1412" />
+      <path
+         d="m 111.94341,88.046812 0.5876,0.06558 v 3.882367 h -0.51677 l -0.042,-0.341019 q -0.14166,0.196741 -0.3384,0.304294 -0.19674,0.107552 -0.4407,0.107552 -0.35676,0 -0.5876,-0.181003 -0.22822,-0.183625 -0.34102,-0.511528 -0.1128,-0.327902 -0.1128,-0.763357 0,-0.422338 0.13116,-0.750241 0.13116,-0.330526 0.37512,-0.519398 0.24396,-0.188872 0.5876,-0.188872 0.42759,0 0.69778,0.301671 z m -0.54301,1.555569 q -0.29642,0 -0.46168,0.246583 -0.16527,0.24396 -0.16527,0.760734 0,0.529891 0.14953,0.768604 0.15214,0.23609 0.42496,0.23609 0.19936,0 0.34626,-0.115422 0.1469,-0.115422 0.24921,-0.278061 v -1.311611 q -0.10231,-0.1469 -0.23871,-0.225597 -0.13641,-0.08132 -0.3043,-0.08132 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1414" />
+      <path
+         d="m 114.57449,89.151187 q 0.60859,0 0.92862,0.396107 0.32003,0.396106 0.32003,1.057158 0,0.440701 -0.1469,0.768603 -0.14427,0.327903 -0.42496,0.511528 -0.27806,0.181003 -0.67941,0.181003 -0.60597,0 -0.92862,-0.39086 -0.32266,-0.393483 -0.32266,-1.065028 0,-0.430208 0.14428,-0.758111 0.1469,-0.330525 0.42758,-0.514151 0.28069,-0.186249 0.68204,-0.186249 z m 0,0.456441 q -0.31741,0 -0.47742,0.243959 -0.16002,0.241337 -0.16002,0.758111 0,0.516775 0.15739,0.760734 0.16002,0.241336 0.47743,0.241336 0.31741,0 0.4748,-0.243959 0.16002,-0.24396 0.16002,-0.763357 0,-0.511528 -0.1574,-0.752865 -0.15739,-0.243959 -0.4748,-0.243959 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1416" />
+      <path
+         d="m 117.20033,89.224638 v 1.935936 q 0,0.246583 0.0971,0.351512 0.0997,0.104929 0.29904,0.104929 0.18888,0 0.36463,-0.112799 0.17576,-0.112798 0.27806,-0.275438 v -2.00414 h 0.58761 v 2.770121 h -0.50629 l -0.0367,-0.354135 q -0.15477,0.207234 -0.39086,0.31741 -0.23609,0.107552 -0.48267,0.107552 -0.40398,0 -0.60072,-0.220351 -0.19674,-0.222974 -0.19674,-0.61121 v -2.009387 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1418" />
+      <path
+         d="m 120.34819,89.555163 q 0.14165,-0.188871 0.33577,-0.296423 0.19412,-0.107553 0.42496,-0.107553 0.36463,0 0.59022,0.181003 0.22823,0.178379 0.33315,0.506281 0.10756,0.32528 0.10756,0.765981 0,0.422338 -0.12592,0.752864 -0.12591,0.330526 -0.3725,0.519398 -0.24396,0.188872 -0.60334,0.188872 -0.46431,0 -0.72925,-0.343642 l -0.0315,0.272815 h -0.51678 v -3.882367 l 0.58761,-0.06558 z m 0.543,2.061852 q 0.29905,0 0.46169,-0.24396 0.16526,-0.243959 0.16526,-0.76598 0,-0.532514 -0.14952,-0.76598 -0.1469,-0.23609 -0.41972,-0.23609 -0.19674,0 -0.34888,0.118045 -0.14953,0.118045 -0.25183,0.278061 v 1.295871 q 0.0971,0.149524 0.23346,0.23609 0.13903,0.08394 0.30954,0.08394 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1420" />
+      <path
+         d="m 124.12562,88.112392 v 3.126879 q 0,0.191495 0.11542,0.272815 0.11804,0.0787 0.30429,0.0787 0.11805,0 0.2256,-0.02361 0.11017,-0.02623 0.21248,-0.0682 l 0.14952,0.409222 q -0.12329,0.06296 -0.30429,0.110176 -0.17838,0.04722 -0.40922,0.04722 -0.41709,0 -0.65056,-0.23609 -0.23084,-0.23609 -0.23084,-0.642689 v -2.641583 h -0.83681 v -0.432832 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1422" />
+      <path
+         d="m 126.54422,90.79857 q 0.0262,0.427585 0.23871,0.61908 0.21511,0.191495 0.51678,0.191495 0.20198,0 0.37512,-0.06296 0.17575,-0.06296 0.35151,-0.178379 l 0.25445,0.351511 q -0.19412,0.157394 -0.45382,0.25183 -0.25969,0.09444 -0.55612,0.09444 -0.43283,0 -0.73188,-0.183626 -0.29642,-0.183625 -0.45119,-0.511528 -0.15215,-0.327902 -0.15215,-0.758111 0,-0.417092 0.15215,-0.744994 0.15215,-0.330526 0.43545,-0.522021 0.28331,-0.194119 0.67679,-0.194119 0.55088,0 0.87091,0.369875 0.32266,0.369874 0.32266,1.015186 0,0.07083 -0.005,0.141654 -0.003,0.0682 -0.008,0.120668 z m 0.66105,-1.211928 q -0.27544,0 -0.45644,0.196742 -0.181,0.196741 -0.20723,0.613833 h 1.28275 q -0.008,-0.39086 -0.16789,-0.600717 -0.15739,-0.209858 -0.45119,-0.209858 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1424" />
+    </g>
+    <path
+       id="ellipse1668"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+       d="M 78.557575,90.625336 A 18.448826,6.1496081 0 0 1 60.108749,96.774944 18.448826,6.1496081 0 0 1 41.659924,90.625336 18.448826,6.1496081 0 0 1 60.108749,84.475728 18.448826,6.1496081 0 0 1 78.557575,90.625336 Z" />
+    <g
+       aria-label="complex128"
+       id="text1672"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 46.103407,91.582913 q 0.194118,0 0.362004,-0.0682 0.167886,-0.0682 0.320033,-0.173132 l 0.272815,0.377743 q -0.181002,0.15477 -0.440701,0.25183 -0.257076,0.09444 -0.532514,0.09444 -0.424961,0 -0.729255,-0.178379 -0.30167,-0.181003 -0.461687,-0.503659 -0.157393,-0.325279 -0.157393,-0.760734 0,-0.422338 0.160016,-0.752864 0.16264,-0.333149 0.466934,-0.524644 0.304293,-0.194119 0.731878,-0.194119 0.556123,0 0.960099,0.33315 l -0.270192,0.369874 q -0.16264,-0.112799 -0.333149,-0.17051 -0.170509,-0.06033 -0.346265,-0.06033 -0.330526,0 -0.53776,0.241336 -0.207235,0.241337 -0.207235,0.758111 0,0.519398 0.209858,0.739748 0.209858,0.220351 0.532514,0.220351 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1382" />
+      <path
+         d="m 49.025667,89.151187 q 0.608587,0 0.92862,0.396107 0.320033,0.396106 0.320033,1.057158 0,0.440701 -0.1469,0.768603 -0.144277,0.327903 -0.424962,0.511528 -0.278061,0.181003 -0.679414,0.181003 -0.605964,0 -0.92862,-0.39086 -0.322656,-0.393483 -0.322656,-1.065028 0,-0.430208 0.144277,-0.758111 0.1469,-0.330525 0.427585,-0.514151 0.280684,-0.186249 0.682037,-0.186249 z m 0,0.456441 q -0.31741,0 -0.477426,0.243959 -0.160017,0.241337 -0.160017,0.758111 0,0.516775 0.157394,0.760734 0.160016,0.241336 0.477426,0.241336 0.31741,0 0.474803,-0.243959 0.160016,-0.24396 0.160016,-0.763357 0,-0.511528 -0.157393,-0.752865 -0.157393,-0.243959 -0.474803,-0.243959 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1384" />
+      <path
+         d="m 52.973607,89.151187 q 0.157393,0 0.283307,0.0682 0.125915,0.0682 0.196742,0.241337 0.07345,0.170509 0.07345,0.474802 v 2.059229 H 53.005085 V 90.01685 q 0,-0.217727 -0.03148,-0.312163 -0.02886,-0.09444 -0.154771,-0.09444 -0.09968,0 -0.204611,0.06296 -0.102305,0.06033 -0.204611,0.209858 v 2.111693 H 51.934811 V 90.01685 q 0,-0.217727 -0.03148,-0.312163 -0.02886,-0.09444 -0.154771,-0.09444 -0.102305,0 -0.204611,0.06296 -0.102305,0.06033 -0.204611,0.209858 v 2.111693 h -0.524644 v -2.770121 h 0.443324 l 0.03935,0.299047 q 0.118044,-0.165263 0.254452,-0.267569 0.139031,-0.104929 0.338395,-0.104929 0.157394,0 0.285931,0.0787 0.128538,0.07607 0.188872,0.275438 0.118045,-0.157393 0.262322,-0.254452 0.144278,-0.09968 0.346266,-0.09968 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1386" />
+      <path
+         d="m 55.562717,89.151187 q 0.367251,0 0.587602,0.181003 0.22035,0.178379 0.320033,0.506281 0.09968,0.32528 0.09968,0.765981 0,0.422338 -0.120668,0.752864 -0.120668,0.330526 -0.359381,0.519398 -0.23609,0.188872 -0.587602,0.188872 -0.435454,0 -0.703023,-0.306917 v 1.301117 l -0.587601,0.06558 v -3.900729 h 0.511528 l 0.03673,0.356758 q 0.157393,-0.212481 0.364627,-0.320033 0.207235,-0.110176 0.438078,-0.110176 z m -0.162639,0.453818 q -0.196742,0 -0.348889,0.118045 -0.149523,0.118045 -0.251829,0.278061 v 1.295871 q 0.207234,0.30954 0.548253,0.30954 0.296424,0 0.451194,-0.238713 0.15477,-0.238713 0.15477,-0.760734 0,-0.532514 -0.139031,-0.76598 -0.136407,-0.23609 -0.414468,-0.23609 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1388" />
+      <path
+         d="m 58.576791,88.112392 v 3.126879 q 0,0.191495 0.115421,0.272815 0.118045,0.0787 0.304294,0.0787 0.118045,0 0.225597,-0.02361 0.110175,-0.02623 0.212481,-0.0682 l 0.149523,0.409222 q -0.123291,0.06296 -0.304293,0.110176 -0.178379,0.04722 -0.409223,0.04722 -0.417092,0 -0.650558,-0.23609 -0.230844,-0.23609 -0.230844,-0.642689 v -2.641583 h -0.836807 v -0.432832 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1390" />
+      <path
+         d="m 60.995393,90.79857 q 0.02623,0.427585 0.238713,0.61908 0.215104,0.191495 0.516775,0.191495 0.201988,0 0.37512,-0.06296 0.175756,-0.06296 0.351512,-0.178379 l 0.254452,0.351511 q -0.194118,0.157394 -0.453817,0.25183 -0.259699,0.09444 -0.556123,0.09444 -0.432831,0 -0.731878,-0.183626 -0.296424,-0.183625 -0.451194,-0.511528 -0.152147,-0.327902 -0.152147,-0.758111 0,-0.417092 0.152147,-0.744994 0.152146,-0.330526 0.435454,-0.522021 0.283308,-0.194119 0.676791,-0.194119 0.550876,0 0.870909,0.369875 0.322657,0.369874 0.322657,1.015186 0,0.07083 -0.0052,0.141654 -0.0026,0.0682 -0.0079,0.120668 z m 0.661052,-1.211928 q -0.275439,0 -0.456441,0.196742 -0.181002,0.196741 -0.207234,0.613833 h 1.282755 q -0.0079,-0.39086 -0.167886,-0.600717 -0.157394,-0.209858 -0.451194,-0.209858 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1392" />
+      <path
+         d="m 64.064552,91.994759 h -0.650559 l 0.994201,-1.461134 -0.884025,-1.308987 h 0.676791 l 0.566615,0.975838 0.566616,-0.975838 h 0.645312 l -0.865663,1.285378 0.996824,1.484743 h -0.689907 l -0.679414,-1.130608 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1394" />
+      <path
+         d="m 69.116868,91.533072 v 0.461687 h -2.190389 v -0.461687 h 0.884025 v -2.555017 l -0.797459,0.490542 -0.251829,-0.411845 1.112245,-0.682038 h 0.519398 v 3.158358 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1396" />
+      <path
+         d="m 70.911144,88.301264 q 0.367251,0 0.624326,0.139031 0.257076,0.136407 0.39086,0.369874 0.136408,0.230843 0.136408,0.514151 0,0.238713 -0.08394,0.466933 -0.08132,0.225597 -0.264946,0.477426 -0.181002,0.249206 -0.480049,0.556123 -0.299047,0.304294 -0.731879,0.697777 h 1.64476 l -0.0682,0.47218 h -2.250723 v -0.445948 q 0.487919,-0.469556 0.802705,-0.797459 0.31741,-0.327903 0.495789,-0.566616 0.181002,-0.238713 0.254452,-0.430208 0.07345,-0.194118 0.07345,-0.393483 0,-0.272815 -0.15477,-0.430208 -0.15477,-0.157393 -0.430208,-0.157393 -0.243959,0 -0.409222,0.08919 -0.16264,0.08919 -0.322656,0.288554 l -0.38299,-0.291177 q 0.21248,-0.270192 0.487919,-0.414469 0.275438,-0.144277 0.668921,-0.144277 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1398" />
+      <path
+         d="m 75.33651,89.237754 q 0,0.262322 -0.152147,0.451194 -0.152147,0.188872 -0.451194,0.354134 0.359381,0.160017 0.5535,0.4066 0.194118,0.246582 0.194118,0.569239 0,0.291177 -0.152147,0.52989 -0.152147,0.23609 -0.440701,0.377744 -0.285931,0.139031 -0.695153,0.139031 -0.406599,0 -0.689907,-0.139031 -0.280685,-0.139031 -0.427585,-0.372497 -0.144277,-0.23609 -0.144277,-0.522021 0,-0.322656 0.191495,-0.5535 0.191495,-0.230843 0.511528,-0.37512 -0.285931,-0.152147 -0.422339,-0.341019 -0.136407,-0.191495 -0.136407,-0.493166 0,-0.322656 0.165263,-0.53776 0.167886,-0.215104 0.427585,-0.322656 0.259698,-0.107552 0.540383,-0.107552 0.296424,0 0.5535,0.104929 0.257075,0.104929 0.414468,0.312163 0.160017,0.207235 0.160017,0.519398 z m -1.691977,0.0341 q 0,0.178379 0.08132,0.288554 0.08132,0.110175 0.23609,0.186249 0.15477,0.07607 0.375121,0.149523 0.225597,-0.136407 0.327902,-0.278061 0.102306,-0.141654 0.102306,-0.351512 0,-0.243959 -0.144277,-0.39086 -0.144277,-0.1469 -0.414469,-0.1469 -0.267568,0 -0.417092,0.141654 -0.1469,0.141654 -0.1469,0.401353 z m 1.235536,1.749688 q 0,-0.220351 -0.104928,-0.351512 -0.102306,-0.131161 -0.296424,-0.22035 -0.194119,-0.08919 -0.46431,-0.183626 -0.199365,0.102306 -0.341019,0.278062 -0.141654,0.175755 -0.141654,0.469556 0,0.278061 0.167886,0.443324 0.167886,0.16264 0.501035,0.16264 0.335773,0 0.506282,-0.173132 0.173132,-0.173133 0.173132,-0.424962 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1400" />
+    </g>
+    <path
+       id="ellipse6006"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 129.91874,114.46599 a 18.448826,6.1496081 0 0 1 -18.44882,6.14961 18.448826,6.1496081 0 0 1 -18.448829,-6.14961 18.448826,6.1496081 0 0 1 18.448829,-6.14961 18.448826,6.1496081 0 0 1 18.44882,6.14961 z" />
+    <g
+       aria-label="longdouble"
+       id="text6010"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 97.456706,111.95304 v 3.12688 q 0,0.19149 0.115422,0.27281 0.118045,0.0787 0.304293,0.0787 0.118045,0 0.225597,-0.0236 0.110175,-0.0262 0.212481,-0.0682 l 0.149524,0.40923 q -0.123292,0.063 -0.304294,0.11017 -0.178379,0.0472 -0.409222,0.0472 -0.417092,0 -0.650559,-0.23609 -0.230844,-0.23609 -0.230844,-0.64269 v -2.64158 h -0.836807 v -0.43283 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1360" />
+      <path
+         d="m 100.49701,112.99183 q 0.60859,0 0.92862,0.39611 0.32003,0.3961 0.32003,1.05716 0,0.4407 -0.1469,0.7686 -0.14427,0.3279 -0.42496,0.51153 -0.27806,0.181 -0.67941,0.181 -0.605966,0 -0.928622,-0.39086 -0.322656,-0.39348 -0.322656,-1.06503 0,-0.43021 0.144277,-0.75811 0.1469,-0.33052 0.427585,-0.51415 0.280686,-0.18625 0.682036,-0.18625 z m 0,0.45644 q -0.31741,0 -0.47743,0.24396 -0.160012,0.24134 -0.160012,0.75811 0,0.51678 0.157392,0.76074 0.16002,0.24133 0.47743,0.24133 0.31741,0 0.4748,-0.24396 0.16002,-0.24396 0.16002,-0.76335 0,-0.51153 -0.1574,-0.75287 -0.15739,-0.24396 -0.4748,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1362" />
+      <path
+         d="m 102.53525,115.8354 v -2.77012 h 0.50628 l 0.0446,0.35938 q 0.17313,-0.20985 0.40922,-0.32003 0.23609,-0.1128 0.4853,-0.1128 0.38824,0 0.57973,0.21773 0.19412,0.21773 0.19412,0.60596 v 2.01988 h -0.5876 v -1.7287 q 0,-0.35938 -0.0734,-0.51153 -0.0708,-0.15477 -0.32266,-0.15477 -0.20199,0 -0.36987,0.12592 -0.16526,0.12329 -0.27806,0.28068 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1364" />
+      <path
+         d="m 108.01515,112.71377 0.15739,0.48792 q -0.16526,0.0551 -0.36463,0.0734 -0.19674,0.0184 -0.4407,0.0184 0.24921,0.11018 0.37512,0.28331 0.12592,0.17051 0.12592,0.41972 0,0.27019 -0.13117,0.48267 -0.13116,0.21248 -0.37774,0.33315 -0.24396,0.12067 -0.58235,0.12067 -0.12067,0 -0.20986,-0.0105 -0.0866,-0.0105 -0.17051,-0.0341 -0.12329,0.0813 -0.12329,0.22822 0,0.0839 0.0682,0.1469 0.0708,0.0603 0.27806,0.0603 h 0.48267 q 0.29643,0 0.52203,0.1023 0.22822,0.0997 0.35675,0.27544 0.13116,0.17313 0.13116,0.39348 0,0.41447 -0.35675,0.64269 -0.35676,0.22822 -1.02831,0.22822 -0.47742,0 -0.74761,-0.0971 -0.26757,-0.0971 -0.37775,-0.28855 -0.11017,-0.1915 -0.11017,-0.46956 h 0.52726 q 0,0.1469 0.0551,0.24134 0.0577,0.0944 0.21248,0.13903 0.15477,0.0472 0.44595,0.0472 0.43283,0 0.61121,-0.10756 0.17838,-0.10492 0.17838,-0.29642 0,-0.17051 -0.1469,-0.26232 -0.1469,-0.0892 -0.39348,-0.0892 h -0.47481 q -0.39348,0 -0.5771,-0.16002 -0.18101,-0.16001 -0.18101,-0.37249 0,-0.29905 0.30954,-0.50104 -0.2492,-0.13116 -0.36462,-0.31741 -0.1128,-0.18887 -0.1128,-0.45644 0,-0.2938 0.1469,-0.51415 0.1469,-0.22035 0.4066,-0.34364 0.26232,-0.12329 0.60334,-0.12329 0.33315,0.003 0.55612,-0.0341 0.22297,-0.0367 0.38824,-0.0997 0.16788,-0.0656 0.33315,-0.1469 z m -1.27227,0.68466 q -0.28068,0 -0.42233,0.16002 -0.14166,0.15739 -0.14166,0.41184 0,0.26233 0.14428,0.42234 0.14428,0.1574 0.42758,0.1574 0.2597,0 0.39611,-0.15215 0.13903,-0.15215 0.13903,-0.43283 0,-0.56662 -0.54301,-0.56662 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1366" />
+      <path
+         d="m 110.45736,111.88746 0.5876,0.0656 v 3.88236 h -0.51678 l -0.042,-0.34102 q -0.14165,0.19675 -0.33839,0.3043 -0.19674,0.10755 -0.4407,0.10755 -0.35676,0 -0.58761,-0.181 -0.22822,-0.18363 -0.34101,-0.51153 -0.1128,-0.3279 -0.1128,-0.76336 0,-0.42234 0.13116,-0.75024 0.13116,-0.33052 0.37512,-0.5194 0.24396,-0.18887 0.5876,-0.18887 0.42759,0 0.69778,0.30167 z m -0.54301,1.55557 q -0.29642,0 -0.46169,0.24658 -0.16526,0.24396 -0.16526,0.76073 0,0.52989 0.14952,0.76861 0.15215,0.23609 0.42497,0.23609 0.19936,0 0.34626,-0.11543 0.1469,-0.11542 0.24921,-0.27806 v -1.31161 q -0.10231,-0.1469 -0.23872,-0.22559 -0.1364,-0.0813 -0.30429,-0.0813 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1368" />
+      <path
+         d="m 113.08844,112.99183 q 0.60859,0 0.92862,0.39611 0.32003,0.3961 0.32003,1.05716 0,0.4407 -0.1469,0.7686 -0.14427,0.3279 -0.42496,0.51153 -0.27806,0.181 -0.67941,0.181 -0.60597,0 -0.92862,-0.39086 -0.32266,-0.39348 -0.32266,-1.06503 0,-0.43021 0.14428,-0.75811 0.1469,-0.33052 0.42758,-0.51415 0.28069,-0.18625 0.68204,-0.18625 z m 0,0.45644 q -0.31741,0 -0.47743,0.24396 -0.16001,0.24134 -0.16001,0.75811 0,0.51678 0.15739,0.76074 0.16002,0.24133 0.47743,0.24133 0.31741,0 0.4748,-0.24396 0.16002,-0.24396 0.16002,-0.76335 0,-0.51153 -0.1574,-0.75287 -0.15739,-0.24396 -0.4748,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1370" />
+      <path
+         d="m 115.71428,113.06528 v 1.93594 q 0,0.24658 0.097,0.35151 0.0997,0.10493 0.29905,0.10493 0.18887,0 0.36463,-0.1128 0.17575,-0.1128 0.27806,-0.27544 v -2.00414 h 0.5876 v 2.77012 h -0.50628 l -0.0367,-0.35413 q -0.15477,0.20723 -0.39086,0.31741 -0.23609,0.10755 -0.48268,0.10755 -0.40397,0 -0.60071,-0.22035 -0.19675,-0.22297 -0.19675,-0.61121 v -2.00939 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1372" />
+      <path
+         d="m 118.86213,113.39581 q 0.14166,-0.18887 0.33578,-0.29643 0.19411,-0.10755 0.42496,-0.10755 0.36462,0 0.59022,0.181 0.22822,0.17838 0.33315,0.50629 0.10755,0.32528 0.10755,0.76598 0,0.42234 -0.12591,0.75286 -0.12592,0.33053 -0.3725,0.5194 -0.24396,0.18887 -0.60334,0.18887 -0.46431,0 -0.72926,-0.34364 l -0.0315,0.27281 h -0.51678 v -3.88236 l 0.5876,-0.0656 z m 0.54301,2.06185 q 0.29905,0 0.46169,-0.24396 0.16526,-0.24396 0.16526,-0.76598 0,-0.53251 -0.14952,-0.76598 -0.1469,-0.23609 -0.41972,-0.23609 -0.19674,0 -0.34889,0.11804 -0.14952,0.11805 -0.25183,0.27807 v 1.29587 q 0.0971,0.14952 0.23347,0.23609 0.13903,0.0839 0.30954,0.0839 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1374" />
+      <path
+         d="m 122.63956,111.95304 v 3.12688 q 0,0.19149 0.11543,0.27281 0.11804,0.0787 0.30429,0.0787 0.11804,0 0.2256,-0.0236 0.11017,-0.0262 0.21248,-0.0682 l 0.14952,0.40923 q -0.12329,0.063 -0.30429,0.11017 -0.17838,0.0472 -0.40923,0.0472 -0.41709,0 -0.65055,-0.23609 -0.23085,-0.23609 -0.23085,-0.64269 v -2.64158 h -0.83681 v -0.43283 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1376" />
+      <path
+         d="m 125.05817,114.63921 q 0.0262,0.42759 0.23871,0.61908 0.2151,0.1915 0.51677,0.1915 0.20199,0 0.37512,-0.063 0.17576,-0.063 0.35152,-0.17838 l 0.25445,0.35152 q -0.19412,0.15739 -0.45382,0.25182 -0.2597,0.0944 -0.55612,0.0944 -0.43283,0 -0.73188,-0.18363 -0.29642,-0.18362 -0.45119,-0.51152 -0.15215,-0.32791 -0.15215,-0.75811 0,-0.4171 0.15215,-0.745 0.15214,-0.33052 0.43545,-0.52202 0.28331,-0.19412 0.67679,-0.19412 0.55088,0 0.87091,0.36988 0.32266,0.36987 0.32266,1.01518 0,0.0708 -0.005,0.14166 -0.003,0.0682 -0.008,0.12066 z m 0.66105,-1.21192 q -0.27544,0 -0.45644,0.19674 -0.18101,0.19674 -0.20724,0.61383 h 1.28276 q -0.008,-0.39086 -0.16789,-0.60072 -0.15739,-0.20985 -0.45119,-0.20985 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1378" />
+    </g>
+    <path
+       id="ellipse6012"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+       d="m 78.557575,114.46599 a 18.448826,6.1496081 0 0 1 -18.448826,6.14961 18.448826,6.1496081 0 0 1 -18.448825,-6.14961 18.448826,6.1496081 0 0 1 18.448825,-6.14961 18.448826,6.1496081 0 0 1 18.448826,6.14961 z" />
+    <g
+       aria-label="float64"
+       id="text6018"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 51.175394,112.22767 q 0.254452,0 0.453817,0.0446 0.201988,0.042 0.372497,0.11542 l -0.173132,0.4066 q -0.139031,-0.0577 -0.291178,-0.0839 -0.149523,-0.0262 -0.304293,-0.0262 -0.535137,0 -0.535137,0.4302 v 0.49055 h 0.925997 l -0.06296,0.43283 h -0.863039 v 2.13792 H 50.11299 v -2.13792 h -0.629573 v -0.43283 h 0.629573 v -0.49579 q 0,-0.39348 0.291177,-0.63744 0.291178,-0.24396 0.771227,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1344" />
+      <path
+         d="m 53.856318,112.29325 v 3.12688 q 0,0.19149 0.115422,0.27281 0.118044,0.0787 0.304293,0.0787 0.118045,0 0.225597,-0.0236 0.110175,-0.0262 0.212481,-0.0682 l 0.149524,0.40923 q -0.123292,0.063 -0.304294,0.11017 -0.178379,0.0472 -0.409222,0.0472 -0.417093,0 -0.650559,-0.23609 -0.230844,-0.23609 -0.230844,-0.64269 v -2.64158 h -0.836807 v -0.43283 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1346" />
+      <path
+         d="m 56.896623,113.33204 q 0.608587,0 0.92862,0.39611 0.320033,0.3961 0.320033,1.05716 0,0.4407 -0.1469,0.7686 -0.144278,0.3279 -0.424962,0.51153 -0.278061,0.181 -0.679414,0.181 -0.605964,0 -0.92862,-0.39086 -0.322656,-0.39348 -0.322656,-1.06503 0,-0.43021 0.144277,-0.75811 0.1469,-0.33052 0.427585,-0.51415 0.280684,-0.18625 0.682037,-0.18625 z m 0,0.45644 q -0.31741,0 -0.477426,0.24396 -0.160017,0.24134 -0.160017,0.75811 0,0.51678 0.157394,0.76074 0.160016,0.24133 0.477426,0.24133 0.317409,0 0.474803,-0.24396 0.160016,-0.24396 0.160016,-0.76335 0,-0.51153 -0.157393,-0.75287 -0.157393,-0.24396 -0.474803,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1348" />
+      <path
+         d="m 61.051796,115.4962 q 0,0.16526 0.04984,0.23871 0.04984,0.0734 0.160016,0.11018 l -0.131161,0.39873 q -0.204611,-0.0236 -0.354135,-0.1128 -0.1469,-0.0892 -0.22035,-0.27019 -0.152147,0.19412 -0.385614,0.29117 -0.233466,0.0944 -0.498412,0.0944 -0.422338,0 -0.666298,-0.23609 -0.243959,-0.23871 -0.243959,-0.62433 0,-0.43807 0.341019,-0.67416 0.341018,-0.23609 0.975838,-0.23609 h 0.396106 v -0.18101 q 0,-0.27019 -0.16264,-0.38561 -0.162639,-0.11804 -0.453817,-0.11804 -0.136407,0 -0.330526,0.0367 -0.194118,0.0341 -0.406599,0.10755 l -0.144277,-0.41447 q 0.259699,-0.097 0.508905,-0.14165 0.249206,-0.0472 0.461687,-0.0472 0.556122,0 0.828937,0.24659 0.275438,0.24658 0.275438,0.68203 z m -1.201435,0.31741 q 0.178379,0 0.348889,-0.0944 0.170509,-0.0944 0.275438,-0.26494 v -0.61121 h -0.325279 q -0.414469,0 -0.592848,0.13903 -0.178379,0.13641 -0.178379,0.37774 0,0.45382 0.472179,0.45382 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1350" />
+      <path
+         d="m 64.396396,116.02871 q -0.152147,0.0971 -0.364628,0.1574 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25182 -0.249206,-0.66105 v -1.5031 h -0.616457 v -0.42759 h 0.616457 v -0.61908 l 0.587601,-0.0708 v 0.6899 h 0.933867 l -0.06558,0.42759 h -0.868286 v 1.49786 q 0,0.22297 0.110176,0.33315 0.112798,0.10755 0.367251,0.10755 0.152146,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1352" />
+      <path
+         d="m 66.552676,112.48212 q 0.22035,0 0.403976,0.0603 0.186249,0.0577 0.341019,0.16002 l -0.228221,0.37774 q -0.233466,-0.15214 -0.514151,-0.15214 -0.372497,0 -0.592848,0.34626 -0.22035,0.34364 -0.241336,0.94436 0.170509,-0.2256 0.380367,-0.32528 0.212481,-0.1023 0.451194,-0.1023 0.280684,0 0.511528,0.13116 0.233467,0.12853 0.372497,0.38823 0.139031,0.25708 0.139031,0.64269 0,0.38824 -0.157393,0.67942 -0.15477,0.29117 -0.424962,0.45381 -0.270192,0.16002 -0.613834,0.16002 -0.453817,0 -0.731878,-0.2256 -0.275438,-0.22559 -0.401353,-0.6217 -0.125915,-0.39611 -0.125915,-0.90763 0,-0.60334 0.17051,-1.05454 0.173132,-0.45382 0.493165,-0.70302 0.320033,-0.25183 0.768604,-0.25183 z m -0.123291,1.74969 q -0.215105,0 -0.396107,0.11542 -0.178379,0.11542 -0.306917,0.30692 0.01049,0.5876 0.160017,0.86828 0.152147,0.27806 0.495789,0.27806 0.30167,0 0.44857,-0.22559 0.149524,-0.22822 0.149524,-0.59548 0,-0.41709 -0.149524,-0.58235 -0.149523,-0.16526 -0.401352,-0.16526 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1354" />
+      <path
+         d="m 70.303872,113.91702 v 0.96797 h 0.430209 v 0.45644 h -0.430209 v 0.83418 H 69.73988 l -0.0026,-0.83418 h -1.503106 v -0.40922 l 1.041419,-2.45009 0.495789,0.19674 -0.923374,2.20613 h 0.891895 l 0.07083,-0.96797 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1356" />
+    </g>
+    <path
+       id="ellipse6020"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 3.5621271,114.46599 a 18.448826,6.1496081 0 0 1 -18.4488261,6.14961 18.448826,6.1496081 0 0 1 -18.448826,-6.14961 18.448826,6.1496081 0 0 1 18.448826,-6.14961 18.448826,6.1496081 0 0 1 18.4488261,6.14961 z" />
+    <g
+       aria-label="float32"
+       id="text6024"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -23.740044,112.22767 q 0.254453,0 0.453817,0.0446 0.201988,0.042 0.372498,0.11542 l -0.173133,0.4066 q -0.139031,-0.0577 -0.291177,-0.0839 -0.149524,-0.0262 -0.304294,-0.0262 -0.535137,0 -0.535137,0.4302 v 0.49055 h 0.925997 l -0.06296,0.43283 h -0.86304 v 2.13792 h -0.584978 v -2.13792 h -0.629573 v -0.43283 h 0.629573 v -0.49579 q 0,-0.39348 0.291177,-0.63744 0.291178,-0.24396 0.771227,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1328" />
+      <path
+         d="m -21.05912,112.29325 v 3.12688 q 0,0.19149 0.115422,0.27281 0.118045,0.0787 0.304293,0.0787 0.118045,0 0.225597,-0.0236 0.110176,-0.0262 0.212481,-0.0682 l 0.149524,0.40923 q -0.123292,0.063 -0.304294,0.11017 -0.178379,0.0472 -0.409222,0.0472 -0.417092,0 -0.650559,-0.23609 -0.230843,-0.23609 -0.230843,-0.64269 v -2.64158 h -0.836808 v -0.43283 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1330" />
+      <path
+         d="m -18.018815,113.33204 q 0.608587,0 0.92862,0.39611 0.320033,0.3961 0.320033,1.05716 0,0.4407 -0.1469,0.7686 -0.144277,0.3279 -0.424962,0.51153 -0.278061,0.181 -0.679414,0.181 -0.605964,0 -0.92862,-0.39086 -0.322656,-0.39348 -0.322656,-1.06503 0,-0.43021 0.144277,-0.75811 0.1469,-0.33052 0.427585,-0.51415 0.280685,-0.18625 0.682037,-0.18625 z m 0,0.45644 q -0.317409,0 -0.477426,0.24396 -0.160016,0.24134 -0.160016,0.75811 0,0.51678 0.157393,0.76074 0.160016,0.24133 0.477426,0.24133 0.31741,0 0.474803,-0.24396 0.160016,-0.24396 0.160016,-0.76335 0,-0.51153 -0.157393,-0.75287 -0.157393,-0.24396 -0.474803,-0.24396 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1332" />
+      <path
+         d="m -13.863641,115.4962 q 0,0.16526 0.04984,0.23871 0.04984,0.0734 0.160016,0.11018 l -0.131161,0.39873 q -0.204611,-0.0236 -0.354134,-0.1128 -0.146901,-0.0892 -0.220351,-0.27019 -0.152147,0.19412 -0.385613,0.29117 -0.233467,0.0944 -0.498412,0.0944 -0.422339,0 -0.666298,-0.23609 -0.24396,-0.23871 -0.24396,-0.62433 0,-0.43807 0.341019,-0.67416 0.341018,-0.23609 0.975838,-0.23609 h 0.396106 v -0.18101 q 0,-0.27019 -0.16264,-0.38561 -0.162639,-0.11804 -0.453817,-0.11804 -0.136407,0 -0.330525,0.0367 -0.194119,0.0341 -0.4066,0.10755 l -0.144277,-0.41447 q 0.259699,-0.097 0.508905,-0.14165 0.249206,-0.0472 0.461687,-0.0472 0.556123,0 0.828938,0.24659 0.275438,0.24658 0.275438,0.68203 z m -1.201435,0.31741 q 0.178379,0 0.348888,-0.0944 0.170509,-0.0944 0.275438,-0.26494 v -0.61121 h -0.325279 q -0.414469,0 -0.592848,0.13903 -0.178379,0.13641 -0.178379,0.37774 0,0.45382 0.47218,0.45382 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1334" />
+      <path
+         d="m -10.519042,116.02871 q -0.152147,0.0971 -0.364628,0.1574 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25182 -0.249206,-0.66105 v -1.5031 h -0.616457 v -0.42759 h 0.616457 v -0.61908 l 0.587602,-0.0708 v 0.6899 h 0.933866 l -0.06558,0.42759 H -11.7231 v 1.49786 q 0,0.22297 0.110175,0.33315 0.112798,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1336" />
+      <path
+         d="m -8.7352591,112.48212 q 0.3593812,0 0.61908,0.12591 0.2596989,0.12592 0.3987296,0.33315 0.1390307,0.20724 0.1390307,0.45644 0,0.33578 -0.2072345,0.55875 -0.2046112,0.22297 -0.511528,0.2938 0.225597,0.0236 0.4144689,0.12591 0.1914951,0.10231 0.3042936,0.29118 0.1154217,0.18887 0.1154217,0.4748 0,0.30954 -0.1626397,0.56137 -0.1626397,0.24921 -0.4564404,0.39611 -0.2938007,0.1469 -0.6925302,0.1469 -0.3410187,0 -0.6505587,-0.12591 -0.3069169,-0.12592 -0.5220209,-0.38037 l 0.3593812,-0.31479 q 0.15477,0.181 0.3593812,0.26757 0.2072344,0.0866 0.427585,0.0866 0.3357722,0 0.5325137,-0.17314 0.1967416,-0.17575 0.1967416,-0.48529 0,-0.35151 -0.1941183,-0.49054 -0.1941184,-0.14166 -0.5036584,-0.14166 h -0.3121632 l 0.068204,-0.43283 H -8.79297 q 0.2544524,0 0.4433243,-0.13903 0.1914951,-0.14165 0.1914951,-0.43283 0,-0.26232 -0.1810022,-0.40398 -0.178379,-0.14427 -0.4433243,-0.14427 -0.2282202,0 -0.403976,0.0839 -0.1757558,0.0839 -0.3462651,0.24134 l -0.3121632,-0.33315 q 0.238713,-0.2256 0.5167744,-0.33578 0.2780614,-0.11017 0.5928479,-0.11017 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1338" />
+      <path
+         d="m -5.5769105,112.48212 q 0.3672509,0 0.6243265,0.13903 0.2570756,0.13641 0.3908599,0.36987 0.1364075,0.23085 0.1364075,0.51415 0,0.23872 -0.083943,0.46694 -0.08132,0.2256 -0.2649453,0.47742 -0.1810022,0.24921 -0.4800494,0.55613 -0.2990471,0.30429 -0.7318785,0.69777 h 1.6447593 l -0.068204,0.47218 h -2.2507233 v -0.44594 q 0.487919,-0.46956 0.8027055,-0.79746 0.3174097,-0.32791 0.4957887,-0.56662 0.1810022,-0.23871 0.2544524,-0.43021 0.07345,-0.19412 0.07345,-0.39348 0,-0.27282 -0.15477,-0.43021 -0.1547701,-0.15739 -0.4302082,-0.15739 -0.2439595,0 -0.4092224,0.0892 -0.1626397,0.0892 -0.3226562,0.28855 l -0.3829902,-0.29118 q 0.2124809,-0.27019 0.4879191,-0.41446 0.2754381,-0.14428 0.6689212,-0.14428 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1340" />
+    </g>
+    <path
+       id="ellipse9494"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -47.799046,114.46599 a 18.448826,6.1496081 0 0 1 -18.448825,6.14961 18.448826,6.1496081 0 0 1 -18.448826,-6.14961 18.448826,6.1496081 0 0 1 18.448826,-6.14961 18.448826,6.1496081 0 0 1 18.448825,6.14961 z" />
+    <g
+       id="g27273"
+       transform="translate(4.583686,-3.6978503)">
+      <g
+         aria-label="float16"
+         id="text9498"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+        <path
+           d="m -79.759665,115.92552 q 0.254453,0 0.453817,0.0446 0.201988,0.042 0.372498,0.11543 l -0.173133,0.4066 q -0.13903,-0.0577 -0.291177,-0.084 -0.149524,-0.0262 -0.304294,-0.0262 -0.535137,0 -0.535137,0.43021 v 0.49054 h 0.925997 l -0.06296,0.43283 h -0.86304 v 2.13793 h -0.584978 v -2.13793 h -0.629573 v -0.43283 h 0.629573 v -0.49579 q 0,-0.39348 0.291177,-0.63744 0.291178,-0.24396 0.771227,-0.24396 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1312" />
+        <path
+           d="m -77.078741,115.9911 v 3.12688 q 0,0.19149 0.115422,0.27281 0.118045,0.0787 0.304294,0.0787 0.118044,0 0.225597,-0.0236 0.110175,-0.0262 0.21248,-0.0682 l 0.149524,0.40922 q -0.123291,0.063 -0.304294,0.11018 -0.178379,0.0472 -0.409222,0.0472 -0.417092,0 -0.650559,-0.23609 -0.230843,-0.23609 -0.230843,-0.64269 v -2.64158 h -0.836808 v -0.43283 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1314" />
+        <path
+           d="m -74.038436,117.0299 q 0.608588,0 0.92862,0.3961 0.320033,0.39611 0.320033,1.05716 0,0.4407 -0.1469,0.7686 -0.144277,0.32791 -0.424962,0.51153 -0.278061,0.181 -0.679414,0.181 -0.605964,0 -0.92862,-0.39086 -0.322656,-0.39348 -0.322656,-1.06502 0,-0.43021 0.144277,-0.75811 0.1469,-0.33053 0.427585,-0.51416 0.280685,-0.18624 0.682037,-0.18624 z m 0,0.45644 q -0.317409,0 -0.477426,0.24396 -0.160016,0.24133 -0.160016,0.75811 0,0.51677 0.157393,0.76073 0.160016,0.24134 0.477426,0.24134 0.31741,0 0.474803,-0.24396 0.160017,-0.24396 0.160017,-0.76336 0,-0.51153 -0.157394,-0.75286 -0.157393,-0.24396 -0.474803,-0.24396 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1316" />
+        <path
+           d="m -69.883262,119.19405 q 0,0.16527 0.04984,0.23872 0.04984,0.0734 0.160016,0.11017 l -0.131161,0.39873 q -0.204611,-0.0236 -0.354134,-0.1128 -0.146901,-0.0892 -0.220351,-0.27019 -0.152147,0.19412 -0.385613,0.29118 -0.233467,0.0944 -0.498412,0.0944 -0.422339,0 -0.666298,-0.23609 -0.24396,-0.23871 -0.24396,-0.62432 0,-0.43808 0.341019,-0.67417 0.341019,-0.23609 0.975838,-0.23609 h 0.396106 v -0.181 q 0,-0.27019 -0.162639,-0.38562 -0.16264,-0.11804 -0.453818,-0.11804 -0.136407,0 -0.330525,0.0367 -0.194119,0.0341 -0.4066,0.10756 l -0.144277,-0.41447 q 0.259699,-0.0971 0.508905,-0.14166 0.249206,-0.0472 0.461687,-0.0472 0.556123,0 0.828938,0.24658 0.275438,0.24658 0.275438,0.68204 z m -1.201435,0.31741 q 0.178379,0 0.348888,-0.0944 0.170509,-0.0944 0.275438,-0.26495 v -0.61121 h -0.325279 q -0.414469,0 -0.592848,0.13903 -0.178379,0.13641 -0.178379,0.37774 0,0.45382 0.47218,0.45382 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1318" />
+        <path
+           d="m -66.538663,119.72657 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.2492 -0.249206,-0.25183 -0.249206,-0.66105 v -1.50311 h -0.616456 v -0.42758 h 0.616456 v -0.61908 l 0.587602,-0.0708 v 0.68991 h 0.933866 l -0.06558,0.42758 h -0.868286 v 1.49786 q 0,0.22297 0.110175,0.33315 0.112799,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1320" />
+        <path
+           d="m -63.390805,119.41178 v 0.46169 h -2.19039 v -0.46169 h 0.884026 v -2.55502 l -0.797459,0.49055 -0.251829,-0.41185 1.112245,-0.68204 h 0.519398 v 3.15836 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1322" />
+        <path
+           d="m -61.234527,116.17997 q 0.220351,0 0.403976,0.0603 0.186249,0.0577 0.341019,0.16001 l -0.22822,0.37775 q -0.233467,-0.15215 -0.514152,-0.15215 -0.372497,0 -0.592848,0.34626 -0.22035,0.34365 -0.241336,0.94436 0.170509,-0.22559 0.380367,-0.32528 0.212481,-0.1023 0.451194,-0.1023 0.280685,0 0.511528,0.13116 0.233467,0.12854 0.372497,0.38824 0.139031,0.25707 0.139031,0.64269 0,0.38823 -0.157393,0.67941 -0.15477,0.29118 -0.424962,0.45382 -0.270192,0.16001 -0.613834,0.16001 -0.453817,0 -0.731878,-0.22559 -0.275438,-0.2256 -0.401353,-0.62171 -0.125914,-0.3961 -0.125914,-0.90763 0,-0.60334 0.170509,-1.05454 0.173133,-0.45381 0.493165,-0.70302 0.320033,-0.25183 0.768604,-0.25183 z m -0.123291,1.74969 q -0.215104,0 -0.396107,0.11542 -0.178379,0.11542 -0.306916,0.30692 0.01049,0.5876 0.160016,0.86828 0.152147,0.27807 0.495789,0.27807 0.30167,0 0.44857,-0.2256 0.149524,-0.22822 0.149524,-0.59547 0,-0.41709 -0.149524,-0.58236 -0.149523,-0.16526 -0.401352,-0.16526 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1324" />
+      </g>
+    </g>
+    <path
+       id="ellipse11140"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:#ffdc86;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:3.75;stroke-opacity:1"
+       d="m 66.490566,138.30666 a 18.448826,6.1496081 0 0 1 -18.448826,6.1496 18.448826,6.1496081 0 0 1 -18.448825,-6.1496 18.448826,6.1496081 0 0 1 18.448825,-6.14961 18.448826,6.1496081 0 0 1 18.448826,6.14961 z" />
+    <g
+       aria-label="int64"
+       id="text11146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 41.624044,135.54975 q 0.173132,0 0.278061,0.10492 0.107552,0.10493 0.107552,0.26233 0,0.15739 -0.107552,0.26494 -0.104929,0.10755 -0.278061,0.10755 -0.167887,0 -0.275439,-0.10755 -0.107552,-0.10755 -0.107552,-0.26494 0,-0.1574 0.107552,-0.26233 0.107552,-0.10492 0.275439,-0.10492 z m 0.409222,1.3562 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828938 v -1.9097 h -0.802706 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1300" />
+      <path
+         d="m 43.667525,139.67607 v -2.77012 h 0.506281 l 0.0446,0.35938 q 0.173133,-0.20986 0.409223,-0.32003 0.236089,-0.1128 0.485295,-0.1128 0.388237,0 0.579732,0.21773 0.194118,0.21772 0.194118,0.60596 v 2.01988 h -0.587601 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369874,0.12592 -0.165263,0.12329 -0.278062,0.28068 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1302" />
+      <path
+         d="m 49.129063,139.52917 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.5031 h -0.616457 v -0.42759 h 0.616457 v -0.61908 l 0.587601,-0.0708 v 0.68991 h 0.933867 l -0.06558,0.42759 h -0.868286 v 1.49785 q 0,0.22298 0.110176,0.33315 0.112798,0.10756 0.36725,0.10756 0.152147,0 0.278062,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1304" />
+      <path
+         d="m 51.285342,135.98258 q 0.22035,0 0.403976,0.0603 0.186249,0.0577 0.341019,0.16002 l -0.228221,0.37774 q -0.233466,-0.15215 -0.514151,-0.15215 -0.372497,0 -0.592848,0.34627 -0.22035,0.34364 -0.241336,0.94436 0.170509,-0.2256 0.380367,-0.32528 0.212481,-0.10231 0.451194,-0.10231 0.280685,0 0.511528,0.13116 0.233467,0.12854 0.372497,0.38824 0.139031,0.25708 0.139031,0.64269 0,0.38824 -0.157393,0.67941 -0.15477,0.29118 -0.424962,0.45382 -0.270192,0.16002 -0.613834,0.16002 -0.453817,0 -0.731878,-0.2256 -0.275438,-0.2256 -0.401353,-0.6217 -0.125915,-0.39611 -0.125915,-0.90764 0,-0.60334 0.17051,-1.05453 0.173132,-0.45382 0.493165,-0.70302 0.320033,-0.25183 0.768604,-0.25183 z m -0.123291,1.74968 q -0.215105,0 -0.396107,0.11543 -0.178379,0.11542 -0.306917,0.30691 0.01049,0.5876 0.160017,0.86829 0.152147,0.27806 0.495789,0.27806 0.30167,0 0.44857,-0.2256 0.149524,-0.22822 0.149524,-0.59547 0,-0.41709 -0.149524,-0.58235 -0.149523,-0.16527 -0.401352,-0.16527 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1306" />
+      <path
+         d="m 55.03654,137.41748 v 0.96797 h 0.430208 v 0.45644 H 55.03654 v 0.83418 h -0.563992 l -0.0026,-0.83418 h -1.503106 v -0.40923 l 1.041419,-2.45008 0.495789,0.19674 -0.923374,2.20613 h 0.891895 l 0.07083,-0.96797 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1308" />
+    </g>
+    <path
+       id="ellipse11148"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 15.129392,138.30666 a 18.448826,6.1496081 0 0 1 -18.4488257,6.1496 18.448826,6.1496081 0 0 1 -18.4488263,-6.1496 18.448826,6.1496081 0 0 1 18.4488263,-6.14961 18.448826,6.1496081 0 0 1 18.4488257,6.14961 z" />
+    <g
+       id="g27258"
+       transform="translate(19.576118,-7.1774646)">
+      <g
+         aria-label="int32"
+         id="text11152"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+        <path
+           d="m -29.233237,142.7272 q 0.173132,0 0.278061,0.10493 0.107552,0.10493 0.107552,0.26233 0,0.15739 -0.107552,0.26494 -0.104929,0.10755 -0.278061,0.10755 -0.167886,0 -0.275438,-0.10755 -0.107552,-0.10755 -0.107552,-0.26494 0,-0.1574 0.107552,-0.26233 0.107552,-0.10493 0.275438,-0.10493 z m 0.409222,1.35621 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828938 v -1.9097 h -0.802706 v -0.43021 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1288" />
+        <path
+           d="m -27.189756,146.85353 v -2.77012 h 0.506282 l 0.04459,0.35938 q 0.173133,-0.20986 0.409223,-0.32003 0.23609,-0.1128 0.485296,-0.1128 0.388236,0 0.579731,0.21773 0.194119,0.21772 0.194119,0.60596 v 2.01988 h -0.587602 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369874,0.12592 -0.165263,0.12329 -0.278061,0.28068 v 1.9884 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1290" />
+        <path
+           d="m -21.728218,146.70663 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.50311 h -0.616457 v -0.42758 h 0.616457 v -0.61908 l 0.587602,-0.0708 v 0.68991 h 0.933866 l -0.06558,0.42758 h -0.868286 v 1.49786 q 0,0.22298 0.110175,0.33315 0.112798,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1292" />
+        <path
+           d="m -19.944436,143.16004 q 0.359381,0 0.61908,0.12591 0.259699,0.12592 0.398729,0.33315 0.139031,0.20723 0.139031,0.45644 0,0.33577 -0.207234,0.55875 -0.204611,0.22297 -0.511528,0.2938 0.225597,0.0236 0.414469,0.12591 0.191495,0.10231 0.304293,0.29118 0.115422,0.18887 0.115422,0.4748 0,0.30954 -0.16264,0.56137 -0.16264,0.24921 -0.45644,0.39611 -0.293801,0.1469 -0.69253,0.1469 -0.341019,0 -0.650559,-0.12592 -0.306917,-0.12591 -0.522021,-0.38036 l 0.359381,-0.31479 q 0.15477,0.181 0.359381,0.26757 0.207235,0.0866 0.427585,0.0866 0.335773,0 0.532514,-0.17313 0.196742,-0.17575 0.196742,-0.48529 0,-0.35152 -0.194119,-0.49055 -0.194118,-0.14165 -0.503658,-0.14165 h -0.312163 l 0.0682,-0.43283 h 0.220351 q 0.254452,0 0.443324,-0.13903 0.191495,-0.14166 0.191495,-0.43283 0,-0.26233 -0.181002,-0.40398 -0.178379,-0.14428 -0.443324,-0.14428 -0.22822,0 -0.403976,0.0839 -0.175756,0.0839 -0.346265,0.24133 l -0.312163,-0.33315 q 0.238713,-0.22559 0.516774,-0.33577 0.278061,-0.11017 0.592848,-0.11017 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1294" />
+        <path
+           d="m -16.786086,143.16004 q 0.367251,0 0.624327,0.13903 0.257076,0.1364 0.39086,0.36987 0.136407,0.23084 0.136407,0.51415 0,0.23872 -0.08394,0.46694 -0.08132,0.22559 -0.264945,0.47742 -0.181002,0.24921 -0.480049,0.55612 -0.299048,0.3043 -0.731879,0.69778 h 1.644759 l -0.0682,0.47218 h -2.250724 v -0.44595 q 0.487919,-0.46955 0.802706,-0.79746 0.317409,-0.3279 0.495788,-0.56661 0.181003,-0.23871 0.254453,-0.43021 0.07345,-0.19412 0.07345,-0.39348 0,-0.27282 -0.15477,-0.43021 -0.15477,-0.15739 -0.430208,-0.15739 -0.24396,0 -0.409223,0.0892 -0.162639,0.0892 -0.322656,0.28855 l -0.38299,-0.29118 q 0.212481,-0.27019 0.487919,-0.41447 0.275438,-0.14427 0.668921,-0.14427 z"
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+           id="path1296" />
+      </g>
+    </g>
+    <path
+       id="ellipse11154"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -36.231785,138.30666 a 18.448826,6.1496081 0 0 1 -18.448826,6.1496 18.448826,6.1496081 0 0 1 -18.448825,-6.1496 18.448826,6.1496081 0 0 1 18.448825,-6.14961 18.448826,6.1496081 0 0 1 18.448826,6.14961 z" />
+    <g
+       aria-label="int16"
+       id="text11158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -61.093059,135.54975 q 0.173133,0 0.278062,0.10492 0.107552,0.10493 0.107552,0.26233 0,0.15739 -0.107552,0.26494 -0.104929,0.10755 -0.278062,0.10755 -0.167886,0 -0.275438,-0.10755 -0.107552,-0.10755 -0.107552,-0.26494 0,-0.1574 0.107552,-0.26233 0.107552,-0.10492 0.275438,-0.10492 z m 0.409223,1.3562 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828937 v -1.9097 h -0.802705 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1276" />
+      <path
+         d="m -59.049577,139.67607 v -2.77012 h 0.506281 l 0.0446,0.35938 q 0.173133,-0.20986 0.409223,-0.32003 0.236089,-0.1128 0.485295,-0.1128 0.388237,0 0.579732,0.21773 0.194118,0.21772 0.194118,0.60596 v 2.01988 h -0.587601 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369874,0.12592 -0.165263,0.12329 -0.278062,0.28068 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1278" />
+      <path
+         d="m -53.588039,139.52917 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.5031 h -0.616457 v -0.42759 h 0.616457 v -0.61908 l 0.587601,-0.0708 v 0.68991 h 0.933867 l -0.06558,0.42759 h -0.868286 v 1.49785 q 0,0.22298 0.110176,0.33315 0.112798,0.10756 0.36725,0.10756 0.152147,0 0.278062,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1280" />
+      <path
+         d="m -50.440183,139.21438 v 0.46169 h -2.190389 v -0.46169 h 0.884025 v -2.55501 l -0.797459,0.49054 -0.251829,-0.41185 1.112246,-0.68203 h 0.519397 v 3.15835 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1282" />
+      <path
+         d="m -48.283902,135.98258 q 0.22035,0 0.403975,0.0603 0.186249,0.0577 0.341019,0.16002 l -0.22822,0.37774 q -0.233467,-0.15215 -0.514151,-0.15215 -0.372498,0 -0.592848,0.34627 -0.220351,0.34364 -0.241336,0.94436 0.170509,-0.2256 0.380367,-0.32528 0.21248,-0.10231 0.451194,-0.10231 0.280684,0 0.511528,0.13116 0.233466,0.12854 0.372497,0.38824 0.139031,0.25708 0.139031,0.64269 0,0.38824 -0.157394,0.67941 -0.15477,0.29118 -0.424961,0.45382 -0.270192,0.16002 -0.613834,0.16002 -0.453817,0 -0.731879,-0.2256 -0.275438,-0.2256 -0.401352,-0.6217 -0.125915,-0.39611 -0.125915,-0.90764 0,-0.60334 0.170509,-1.05453 0.173133,-0.45382 0.493166,-0.70302 0.320033,-0.25183 0.768604,-0.25183 z m -0.123292,1.74968 q -0.215104,0 -0.396106,0.11543 -0.178379,0.11542 -0.306917,0.30691 0.01049,0.5876 0.160016,0.86829 0.152147,0.27806 0.495789,0.27806 0.301671,0 0.448571,-0.2256 0.149523,-0.22822 0.149523,-0.59547 0,-0.41709 -0.149523,-0.58235 -0.149524,-0.16527 -0.401353,-0.16527 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1284" />
+    </g>
+    <g
+       aria-label="int8"
+       id="text11164"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -110.89867,135.54975 q 0.17313,0 0.27806,0.10492 0.10755,0.10493 0.10755,0.26233 0,0.15739 -0.10755,0.26494 -0.10493,0.10755 -0.27806,0.10755 -0.16789,0 -0.27544,-0.10755 -0.10755,-0.10755 -0.10755,-0.26494 0,-0.1574 0.10755,-0.26233 0.10755,-0.10492 0.27544,-0.10492 z m 0.40922,1.3562 v 2.33991 h 0.75287 v 0.43021 h -2.16941 v -0.43021 h 0.82894 v -1.9097 h -0.8027 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1267" />
+      <path
+         d="m -108.85519,139.67607 v -2.77012 h 0.50628 l 0.0446,0.35938 q 0.17313,-0.20986 0.40922,-0.32003 0.23609,-0.1128 0.4853,-0.1128 0.38823,0 0.57973,0.21773 0.19412,0.21772 0.19412,0.60596 v 2.01988 h -0.5876 v -1.7287 q 0,-0.35938 -0.0734,-0.51153 -0.0708,-0.15477 -0.32266,-0.15477 -0.20199,0 -0.36988,0.12592 -0.16526,0.12329 -0.27806,0.28068 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1269" />
+      <path
+         d="m -103.39365,139.52917 q -0.15215,0.0971 -0.36463,0.15739 -0.21248,0.0603 -0.44332,0.0603 -0.48267,0 -0.7345,-0.24921 -0.24921,-0.25183 -0.24921,-0.66105 v -1.5031 h -0.61646 v -0.42759 h 0.61646 v -0.61908 l 0.5876,-0.0708 v 0.68991 h 0.93387 l -0.0656,0.42759 h -0.86829 v 1.49785 q 0,0.22298 0.11018,0.33315 0.1128,0.10756 0.36725,0.10756 0.15214,0 0.27806,-0.0367 0.12854,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1271" />
+      <path
+         d="m -100.32187,136.91907 q 0,0.26232 -0.15214,0.45119 -0.15215,0.18887 -0.4512,0.35414 0.35938,0.16001 0.5535,0.40659 0.19412,0.24659 0.19412,0.56924 0,0.29118 -0.15215,0.52989 -0.15214,0.23609 -0.4407,0.37775 -0.28593,0.13903 -0.69515,0.13903 -0.4066,0 -0.68991,-0.13903 -0.28068,-0.13903 -0.42758,-0.3725 -0.14428,-0.23609 -0.14428,-0.52202 0,-0.32266 0.1915,-0.5535 0.19149,-0.23084 0.51152,-0.37512 -0.28593,-0.15215 -0.42234,-0.34102 -0.1364,-0.19149 -0.1364,-0.49317 0,-0.32265 0.16526,-0.53776 0.16789,-0.2151 0.42758,-0.32265 0.2597,-0.10755 0.54039,-0.10755 0.29642,0 0.5535,0.10493 0.25707,0.10492 0.41447,0.31216 0.16001,0.20723 0.16001,0.5194 z m -1.69197,0.0341 q 0,0.17838 0.0813,0.28855 0.0813,0.11018 0.23609,0.18625 0.15477,0.0761 0.37512,0.14952 0.22559,-0.1364 0.3279,-0.27806 0.1023,-0.14165 0.1023,-0.35151 0,-0.24396 -0.14427,-0.39086 -0.14428,-0.1469 -0.41447,-0.1469 -0.26757,0 -0.41709,0.14166 -0.1469,0.14165 -0.1469,0.40135 z m 1.23553,1.74969 q 0,-0.22035 -0.10493,-0.35152 -0.1023,-0.13116 -0.29642,-0.22035 -0.19412,-0.0892 -0.46431,-0.18362 -0.19936,0.1023 -0.34102,0.27806 -0.14165,0.17576 -0.14165,0.46956 0,0.27806 0.16788,0.44332 0.16789,0.16264 0.50104,0.16264 0.33577,0 0.50628,-0.17313 0.17313,-0.17313 0.17313,-0.42496 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1273" />
+    </g>
+    <path
+       id="ellipse18326"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 78.057575,162.14732 a 18.448826,6.1496081 0 0 1 -18.448826,6.14961 18.448826,6.1496081 0 0 1 -18.448825,-6.14961 18.448826,6.1496081 0 0 1 18.448825,-6.1496 18.448826,6.1496081 0 0 1 18.448826,6.1496 z" />
+    <g
+       aria-label="uint64"
+       id="text18332"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m 51.14888,160.74662 v 1.93593 q 0,0.24659 0.09706,0.35152 0.09968,0.10493 0.299047,0.10493 0.188872,0 0.364628,-0.1128 0.175756,-0.1128 0.278061,-0.27544 v -2.00414 h 0.587602 v 2.77012 h -0.506282 l -0.03672,-0.35414 q -0.15477,0.20724 -0.39086,0.31741 -0.23609,0.10756 -0.482673,0.10756 -0.403976,0 -0.600717,-0.22035 -0.196742,-0.22298 -0.196742,-0.61122 v -2.00938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1253" />
+      <path
+         d="m 54.813511,159.39041 q 0.173133,0 0.278062,0.10493 0.107552,0.10493 0.107552,0.26232 0,0.1574 -0.107552,0.26495 -0.104929,0.10755 -0.278062,0.10755 -0.167886,0 -0.275438,-0.10755 -0.107552,-0.10755 -0.107552,-0.26495 0,-0.15739 0.107552,-0.26232 0.107552,-0.10493 0.275438,-0.10493 z m 0.409223,1.35621 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828937 v -1.9097 h -0.802705 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1255" />
+      <path
+         d="m 56.856993,163.51674 v -2.77012 h 0.506281 l 0.0446,0.35938 q 0.173133,-0.20986 0.409222,-0.32003 0.23609,-0.1128 0.485296,-0.1128 0.388237,0 0.579732,0.21773 0.194118,0.21772 0.194118,0.60596 v 2.01988 h -0.587601 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369874,0.12591 -0.165263,0.12329 -0.278062,0.28069 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1257" />
+      <path
+         d="m 62.31853,163.36984 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.50311 h -0.616456 v -0.42758 h 0.616456 v -0.61908 l 0.587602,-0.0708 v 0.68991 h 0.933866 l -0.06558,0.42758 h -0.868286 v 1.49786 q 0,0.22298 0.110175,0.33315 0.112799,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1259" />
+      <path
+         d="m 64.47481,159.82324 q 0.220351,0 0.403976,0.0603 0.186249,0.0577 0.341019,0.16001 l -0.22822,0.37775 q -0.233467,-0.15215 -0.514151,-0.15215 -0.372498,0 -0.592848,0.34627 -0.220351,0.34364 -0.241337,0.94436 0.17051,-0.2256 0.380367,-0.32528 0.212481,-0.10231 0.451194,-0.10231 0.280685,0 0.511528,0.13116 0.233467,0.12854 0.372498,0.38824 0.13903,0.25707 0.13903,0.64269 0,0.38823 -0.157393,0.67941 -0.15477,0.29118 -0.424962,0.45382 -0.270191,0.16002 -0.613833,0.16002 -0.453817,0 -0.731879,-0.2256 -0.275438,-0.2256 -0.401353,-0.6217 -0.125914,-0.39611 -0.125914,-0.90764 0,-0.60334 0.170509,-1.05453 0.173133,-0.45382 0.493166,-0.70303 0.320033,-0.25183 0.768603,-0.25183 z m -0.123291,1.74969 q -0.215104,0 -0.396106,0.11542 -0.178379,0.11543 -0.306917,0.30692 0.01049,0.5876 0.160016,0.86829 0.152147,0.27806 0.495789,0.27806 0.30167,0 0.448571,-0.2256 0.149523,-0.22822 0.149523,-0.59547 0,-0.41709 -0.149523,-0.58235 -0.149524,-0.16527 -0.401353,-0.16527 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1261" />
+      <path
+         d="m 68.226009,161.25815 v 0.96796 h 0.430208 v 0.45644 h -0.430208 v 0.83419 h -0.563993 l -0.0026,-0.83419 h -1.503105 v -0.40922 l 1.041418,-2.45009 0.495789,0.19675 -0.923374,2.20612 h 0.891895 l 0.07083,-0.96796 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1263" />
+    </g>
+    <path
+       id="ellipse18334"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m 26.696402,162.14732 a 18.448826,6.1496081 0 0 1 -18.4488262,6.14961 18.448826,6.1496081 0 0 1 -18.4488258,-6.14961 18.448826,6.1496081 0 0 1 18.4488258,-6.1496 18.448826,6.1496081 0 0 1 18.4488262,6.1496 z" />
+    <g
+       aria-label="uint32"
+       id="text18338"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -0.13228297,160.74662 v 1.93593 q 0,0.24659 0.09705916,0.35152 0.09968239,0.10493 0.29904715,0.10493 0.18887188,0 0.36462766,-0.1128 0.17575578,-0.1128 0.27806139,-0.27544 v -2.00414 H 1.4941138 v 2.77012 H 0.98783222 l -0.0367251,-0.35414 q -0.15477002,0.20724 -0.39085987,0.31741 -0.23608986,0.10756 -0.48267259,0.10756 -0.40397597,0 -0.60071752,-0.22035 -0.19674154,-0.22298 -0.19674154,-0.61122 v -2.00938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1239" />
+      <path
+         d="m 3.5323487,159.39041 q 0.1731325,0 0.2780614,0.10493 0.107552,0.10493 0.107552,0.26232 0,0.1574 -0.107552,0.26495 -0.1049289,0.10755 -0.2780614,0.10755 -0.1678861,0 -0.2754382,-0.10755 -0.107552,-0.10755 -0.107552,-0.26495 0,-0.15739 0.107552,-0.26232 0.1075521,-0.10493 0.2754382,-0.10493 z m 0.4092224,1.35621 v 2.33991 h 0.7528643 v 0.43021 H 2.525032 v -0.43021 h 0.8289377 v -1.9097 H 2.5512642 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1241" />
+      <path
+         d="m 5.57583,163.51674 v -2.77012 h 0.5062816 l 0.044595,0.35938 q 0.1731326,-0.20986 0.4092224,-0.32003 0.2360899,-0.1128 0.4852958,-0.1128 0.3882367,0 0.5797318,0.21773 0.1941183,0.21772 0.1941183,0.60596 v 2.01988 H 7.2074732 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.070827,-0.15477 -0.3226561,-0.15477 -0.201988,0 -0.3698741,0.12591 -0.1652629,0.12329 -0.2780614,0.28069 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1243" />
+      <path
+         d="m 11.037367,163.36984 q -0.152147,0.0971 -0.364627,0.15739 -0.212481,0.0603 -0.443325,0.0603 -0.4826723,0 -0.7345014,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 V 161.1742 H 8.6292508 v -0.42758 h 0.6164568 v -0.61908 l 0.5876014,-0.0708 v 0.68991 h 0.933867 l -0.06558,0.42758 H 9.833309 v 1.49786 q 0,0.22298 0.1101753,0.33315 0.1127987,0.10755 0.3672507,0.10755 0.152147,0 0.278062,-0.0367 0.128537,-0.0367 0.236089,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1245" />
+      <path
+         d="m 12.82115,159.82324 q 0.359381,0 0.61908,0.12592 0.259699,0.12591 0.39873,0.33315 0.139031,0.20723 0.139031,0.45644 0,0.33577 -0.207235,0.55874 -0.204611,0.22298 -0.511528,0.2938 0.225597,0.0236 0.414469,0.12592 0.191495,0.10231 0.304294,0.29118 0.115421,0.18887 0.115421,0.4748 0,0.30954 -0.162639,0.56137 -0.16264,0.24921 -0.456441,0.39611 -0.293801,0.1469 -0.69253,0.1469 -0.341019,0 -0.650559,-0.12592 -0.306917,-0.12591 -0.522021,-0.38037 l 0.359382,-0.31478 q 0.15477,0.181 0.359381,0.26757 0.207234,0.0866 0.427585,0.0866 0.335772,0 0.532513,-0.17313 0.196742,-0.17576 0.196742,-0.4853 0,-0.35151 -0.194118,-0.49054 -0.194119,-0.14165 -0.503659,-0.14165 h -0.312163 l 0.0682,-0.43283 h 0.22035 q 0.254453,0 0.443325,-0.13903 0.191495,-0.14166 0.191495,-0.43284 0,-0.26232 -0.181002,-0.40397 -0.178379,-0.14428 -0.443325,-0.14428 -0.22822,0 -0.403976,0.0839 -0.175755,0.084 -0.346265,0.24134 l -0.312163,-0.33315 q 0.238713,-0.2256 0.516774,-0.33577 0.278062,-0.11018 0.592848,-0.11018 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1247" />
+      <path
+         d="m 15.979501,159.82324 q 0.367251,0 0.624326,0.13903 0.257076,0.13641 0.39086,0.36988 0.136408,0.23084 0.136408,0.51415 0,0.23871 -0.08394,0.46693 -0.08132,0.2256 -0.264946,0.47743 -0.181002,0.24921 -0.480049,0.55612 -0.299047,0.3043 -0.731879,0.69778 h 1.64476 l -0.0682,0.47218 h -2.250723 v -0.44595 q 0.487919,-0.46956 0.802705,-0.79746 0.31741,-0.3279 0.495789,-0.56661 0.181002,-0.23872 0.254452,-0.43021 0.07345,-0.19412 0.07345,-0.39348 0,-0.27282 -0.15477,-0.43021 -0.15477,-0.1574 -0.430208,-0.1574 -0.243959,0 -0.409222,0.0892 -0.16264,0.0892 -0.322656,0.28856 l -0.382991,-0.29118 q 0.212481,-0.27019 0.48792,-0.41447 0.275438,-0.14428 0.668921,-0.14428 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1249" />
+    </g>
+    <path
+       id="ellipse18340"
+       style="fill:#8cc9e1;fill-opacity:1;stroke:none;stroke-width:6.819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:13.638, 13.638;stroke-dashoffset:34.095"
+       d="m -24.664776,162.14732 a 18.448826,6.1496081 0 0 1 -18.448826,6.14961 18.448826,6.1496081 0 0 1 -18.448826,-6.14961 18.448826,6.1496081 0 0 1 18.448826,-6.1496 18.448826,6.1496081 0 0 1 18.448826,6.1496 z" />
+    <g
+       aria-label="uint16"
+       id="text18344"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -51.568222,160.74662 v 1.93593 q 0,0.24659 0.09706,0.35152 0.09968,0.10493 0.299047,0.10493 0.188872,0 0.364628,-0.1128 0.175755,-0.1128 0.278061,-0.27544 v -2.00414 h 0.587601 v 2.77012 h -0.506281 l -0.03672,-0.35414 q -0.15477,0.20724 -0.39086,0.31741 -0.23609,0.10756 -0.482673,0.10756 -0.403976,0 -0.600717,-0.22035 -0.196742,-0.22298 -0.196742,-0.61122 v -2.00938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1225" />
+      <path
+         d="m -47.903591,159.39041 q 0.173133,0 0.278062,0.10493 0.107552,0.10493 0.107552,0.26232 0,0.1574 -0.107552,0.26495 -0.104929,0.10755 -0.278062,0.10755 -0.167886,0 -0.275438,-0.10755 -0.107552,-0.10755 -0.107552,-0.26495 0,-0.15739 0.107552,-0.26232 0.107552,-0.10493 0.275438,-0.10493 z m 0.409223,1.35621 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828937 v -1.9097 h -0.802705 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1227" />
+      <path
+         d="m -45.860109,163.51674 v -2.77012 h 0.506281 l 0.0446,0.35938 q 0.173133,-0.20986 0.409222,-0.32003 0.23609,-0.1128 0.485296,-0.1128 0.388237,0 0.579732,0.21773 0.194118,0.21772 0.194118,0.60596 v 2.01988 h -0.587601 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369875,0.12591 -0.165262,0.12329 -0.278061,0.28069 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1229" />
+      <path
+         d="m -40.398572,163.36984 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.50311 h -0.616457 v -0.42758 h 0.616457 v -0.61908 l 0.587602,-0.0708 v 0.68991 h 0.933866 l -0.06558,0.42758 h -0.868286 v 1.49786 q 0,0.22298 0.110175,0.33315 0.112798,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1231" />
+      <path
+         d="m -37.250714,163.05505 v 0.46169 h -2.19039 v -0.46169 h 0.884026 v -2.55501 l -0.797459,0.49054 -0.251829,-0.41185 1.112245,-0.68204 h 0.519398 v 3.15836 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1233" />
+      <path
+         d="m -35.094434,159.82324 q 0.22035,0 0.403976,0.0603 0.186249,0.0577 0.341019,0.16001 l -0.228221,0.37775 q -0.233466,-0.15215 -0.514151,-0.15215 -0.372497,0 -0.592848,0.34627 -0.22035,0.34364 -0.241336,0.94436 0.170509,-0.2256 0.380367,-0.32528 0.212481,-0.10231 0.451194,-0.10231 0.280685,0 0.511528,0.13116 0.233467,0.12854 0.372497,0.38824 0.139031,0.25707 0.139031,0.64269 0,0.38823 -0.157393,0.67941 -0.15477,0.29118 -0.424962,0.45382 -0.270192,0.16002 -0.613834,0.16002 -0.453817,0 -0.731878,-0.2256 -0.275438,-0.2256 -0.401353,-0.6217 -0.125915,-0.39611 -0.125915,-0.90764 0,-0.60334 0.17051,-1.05453 0.173132,-0.45382 0.493165,-0.70303 0.320033,-0.25183 0.768604,-0.25183 z m -0.123291,1.74969 q -0.215105,0 -0.396107,0.11542 -0.178379,0.11543 -0.306917,0.30692 0.01049,0.5876 0.160017,0.86829 0.152147,0.27806 0.495789,0.27806 0.30167,0 0.44857,-0.2256 0.149524,-0.22822 0.149524,-0.59547 0,-0.41709 -0.149524,-0.58235 -0.149523,-0.16527 -0.401352,-0.16527 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1235" />
+    </g>
+    <g
+       aria-label="uint8"
+       id="text18350"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.11528px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -101.37383,160.74662 v 1.93593 q 0,0.24659 0.0971,0.35152 0.0997,0.10493 0.29905,0.10493 0.18887,0 0.36463,-0.1128 0.17575,-0.1128 0.27806,-0.27544 v -2.00414 h 0.587601 v 2.77012 h -0.506281 l -0.0367,-0.35414 q -0.15477,0.20724 -0.39086,0.31741 -0.23608,0.10756 -0.48267,0.10756 -0.40397,0 -0.60072,-0.22035 -0.19674,-0.22298 -0.19674,-0.61122 v -2.00938 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1214" />
+      <path
+         d="m -97.709194,159.39041 q 0.173133,0 0.278062,0.10493 0.107552,0.10493 0.107552,0.26232 0,0.1574 -0.107552,0.26495 -0.104929,0.10755 -0.278062,0.10755 -0.167886,0 -0.275438,-0.10755 -0.107552,-0.10755 -0.107552,-0.26495 0,-0.15739 0.107552,-0.26232 0.107552,-0.10493 0.275438,-0.10493 z m 0.409223,1.35621 v 2.33991 h 0.752864 v 0.43021 h -2.169403 v -0.43021 h 0.828937 v -1.9097 h -0.802705 v -0.43021 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1216" />
+      <path
+         d="m -95.665712,163.51674 v -2.77012 h 0.506281 l 0.0446,0.35938 q 0.173133,-0.20986 0.409222,-0.32003 0.23609,-0.1128 0.485296,-0.1128 0.388237,0 0.579732,0.21773 0.194118,0.21772 0.194118,0.60596 v 2.01988 h -0.587601 v -1.7287 q 0,-0.35938 -0.07345,-0.51153 -0.07083,-0.15477 -0.322656,-0.15477 -0.201988,0 -0.369875,0.12591 -0.165262,0.12329 -0.278061,0.28069 v 1.9884 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1218" />
+      <path
+         d="m -90.204175,163.36984 q -0.152147,0.0971 -0.364628,0.15739 -0.212481,0.0603 -0.443324,0.0603 -0.482673,0 -0.734502,-0.24921 -0.249206,-0.25183 -0.249206,-0.66105 v -1.50311 h -0.616457 v -0.42758 h 0.616457 v -0.61908 l 0.587602,-0.0708 v 0.68991 h 0.933866 l -0.06558,0.42758 h -0.868286 v 1.49786 q 0,0.22298 0.110175,0.33315 0.112798,0.10755 0.367251,0.10755 0.152147,0 0.278061,-0.0367 0.128538,-0.0367 0.23609,-0.0944 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1220" />
+      <path
+         d="m -87.132391,160.75973 q 0,0.26233 -0.152147,0.4512 -0.152146,0.18887 -0.451194,0.35413 0.359382,0.16002 0.5535,0.4066 0.194118,0.24658 0.194118,0.56924 0,0.29118 -0.152146,0.52989 -0.152147,0.23609 -0.440702,0.37775 -0.285931,0.13903 -0.695153,0.13903 -0.406599,0 -0.689907,-0.13903 -0.280685,-0.13904 -0.427585,-0.3725 -0.144277,-0.23609 -0.144277,-0.52202 0,-0.32266 0.191495,-0.5535 0.191495,-0.23085 0.511528,-0.37512 -0.285931,-0.15215 -0.422338,-0.34102 -0.136408,-0.1915 -0.136408,-0.49317 0,-0.32265 0.165263,-0.53776 0.167886,-0.2151 0.427585,-0.32265 0.259699,-0.10756 0.540383,-0.10756 0.296424,0 0.5535,0.10493 0.257076,0.10493 0.414469,0.31217 0.160016,0.20723 0.160016,0.51939 z m -1.691977,0.0341 q 0,0.17837 0.08132,0.28855 0.08132,0.11018 0.23609,0.18625 0.15477,0.0761 0.37512,0.14952 0.225597,-0.13641 0.327903,-0.27806 0.102305,-0.14165 0.102305,-0.35151 0,-0.24396 -0.144277,-0.39086 -0.144277,-0.1469 -0.414469,-0.1469 -0.267568,0 -0.417092,0.14165 -0.1469,0.14166 -0.1469,0.40136 z m 1.235537,1.74968 q 0,-0.22035 -0.104929,-0.35151 -0.102306,-0.13116 -0.296424,-0.22035 -0.194118,-0.0892 -0.46431,-0.18362 -0.199365,0.1023 -0.341019,0.27806 -0.141654,0.17575 -0.141654,0.46955 0,0.27807 0.167887,0.44333 0.167886,0.16264 0.501035,0.16264 0.335772,0 0.506281,-0.17313 0.173133,-0.17314 0.173133,-0.42497 z"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:5.11528px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';stroke-width:0.264583"
+         id="path1222" />
+    </g>
+    <g
+       aria-label="DType “kind”"
+       transform="rotate(-90)"
+       id="text30437"
+       style="font-size:10.5833px;line-height:1.25;font-family:Lato;-inkscape-font-specification:Lato;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -149.15096,-209.967 q 0,0.85196 -0.26987,1.55046 -0.26988,0.69849 -0.762,1.19591 -0.49212,0.49741 -1.18533,0.77258 -0.68791,0.26987 -1.52399,0.26987 h -2.83104 v -7.58293 h 2.83104 q 0.83608,0 1.52399,0.27516 0.69321,0.26988 1.18533,0.77259 0.49212,0.49741 0.762,1.19591 0.26987,0.6985 0.26987,1.55045 z m -1.05304,0 q 0,-0.6985 -0.1905,-1.24883 -0.19049,-0.55033 -0.53974,-0.93133 -0.34925,-0.381 -0.84667,-0.58208 -0.49741,-0.20108 -1.11124,-0.20108 h -1.80446 v 5.92135 h 1.80446 q 0.61383,0 1.11124,-0.20108 0.49742,-0.20108 0.84667,-0.57679 0.34925,-0.381 0.53974,-0.93133 0.1905,-0.55033 0.1905,-1.24883 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1191" />
+      <path
+         d="m -142.89624,-213.76111 v 0.86254 h -2.45532 v 6.72039 h -1.02129 v -6.72039 h -2.46062 v -0.86254 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1193" />
+      <path
+         d="m -141.277,-204.59597 q -0.0476,0.10583 -0.1217,0.16933 -0.0688,0.0635 -0.21696,0.0635 h -0.6985 l 0.97895,-2.12724 -2.2119,-5.04824 h 0.81491 q 0.12171,0 0.1905,0.0635 0.0741,0.0582 0.10054,0.13229 l 1.43404,3.37608 q 0.0423,0.1217 0.0794,0.23812 0.037,0.11112 0.0635,0.23283 0.0688,-0.23812 0.15875,-0.47625 l 1.39171,-3.37078 q 0.0318,-0.0847 0.10583,-0.13758 0.0794,-0.0582 0.17462,-0.0582 h 0.74613 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1195" />
+      <path
+         d="m -137.45643,-204.36314 v -7.17548 h 0.5662 q 0.20109,0 0.24871,0.19579 l 0.0794,0.635 q 0.34396,-0.41804 0.78846,-0.67204 0.4445,-0.254 1.016,-0.254 0.46566,0 0.84137,0.17992 0.37571,0.17462 0.64029,0.52387 0.26458,0.34396 0.40746,0.85725 0.14287,0.51329 0.14287,1.18004 0,0.59266 -0.15875,1.10595 -0.15875,0.508 -0.46037,0.88371 -0.29633,0.37041 -0.73025,0.58737 -0.42862,0.21167 -0.96837,0.21167 -0.49213,0 -0.84667,-0.16404 -0.34924,-0.16405 -0.61912,-0.46567 v 2.37066 z m 2.39182,-6.50873 q -0.46037,0 -0.80962,0.21167 -0.34396,0.21166 -0.635,0.59795 v 2.59291 q 0.254,0.34925 0.56092,0.49212 0.3122,0.14288 0.6932,0.14288 0.75142,0 1.15358,-0.53446 0.40217,-0.53445 0.40217,-1.52399 0,-0.52388 -0.0952,-0.89958 -0.09,-0.37571 -0.26458,-0.61384 -0.17463,-0.24341 -0.42863,-0.35454 -0.254,-0.11112 -0.57679,-0.11112 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1197" />
+      <path
+         d="m -129.32847,-211.62328 q 0.48154,0 0.889,0.16404 0.41275,0.15875 0.70908,0.46566 0.30162,0.30163 0.47096,0.75142 0.16933,0.44449 0.16933,1.01599 0,0.22225 -0.0476,0.29634 -0.0476,0.0741 -0.17991,0.0741 h -3.58245 q 0.0106,0.508 0.13758,0.8837 0.127,0.37571 0.34925,0.62971 0.22225,0.24871 0.52917,0.37571 0.30691,0.12171 0.68791,0.12171 0.35454,0 0.60854,-0.0794 0.25929,-0.0847 0.4445,-0.17992 0.18521,-0.0952 0.30692,-0.17462 0.127,-0.0847 0.21695,-0.0847 0.11642,0 0.17992,0.09 l 0.26458,0.34396 q -0.17462,0.21166 -0.41804,0.37041 -0.24341,0.15346 -0.52387,0.254 -0.27517,0.10054 -0.5715,0.14817 -0.29633,0.0529 -0.58737,0.0529 -0.55563,0 -1.02658,-0.18521 -0.46567,-0.1905 -0.80962,-0.55033 -0.33867,-0.36513 -0.52917,-0.89958 -0.1905,-0.53446 -0.1905,-1.22767 0,-0.56091 0.16933,-1.04774 0.17463,-0.48683 0.49742,-0.84138 0.32279,-0.35983 0.78845,-0.56091 0.46567,-0.20637 1.04775,-0.20637 z m 0.0212,0.6932 q -0.68262,0 -1.07421,0.39688 -0.39158,0.39158 -0.48683,1.09008 h 2.93158 q 0,-0.32809 -0.0953,-0.59796 -0.09,-0.27517 -0.26988,-0.47096 -0.17462,-0.20108 -0.42862,-0.30691 -0.254,-0.11113 -0.57679,-0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1199" />
+      <path
+         d="m -123.45475,-211.20524 z m 0.381,0 q -0.22225,-0.37571 -0.30163,-0.78846 -0.0794,-0.41804 -0.0159,-0.8255 0.0635,-0.40745 0.26458,-0.77787 0.20108,-0.37571 0.53446,-0.67204 l 0.28574,0.17992 q 0.0794,0.0529 0.0688,0.13229 -0.005,0.0741 -0.0476,0.11641 -0.13758,0.16934 -0.23812,0.41275 -0.0952,0.24342 -0.12171,0.52388 -0.0265,0.27516 0.0265,0.57149 0.0529,0.29634 0.21695,0.5715 0.0688,0.11113 0.037,0.20109 -0.0265,0.0847 -0.127,0.12699 z m 1.60866,0 q -0.22225,-0.37571 -0.30163,-0.78846 -0.0794,-0.41804 -0.0159,-0.8255 0.0635,-0.40745 0.26458,-0.77787 0.20108,-0.37571 0.53446,-0.67204 l 0.28575,0.17992 q 0.0794,0.0529 0.0688,0.13229 -0.005,0.0741 -0.0476,0.11641 -0.13758,0.16934 -0.23812,0.41275 -0.0952,0.24342 -0.12171,0.52388 -0.0265,0.27516 0.0265,0.57149 0.0529,0.29634 0.21696,0.5715 0.0688,0.11113 0.037,0.20109 -0.0265,0.0847 -0.127,0.12699 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1201" />
+      <path
+         d="m -118.41182,-213.97278 v 4.58786 h 0.24342 q 0.10583,0 0.17462,-0.0265 0.0741,-0.0317 0.15346,-0.12171 l 1.69333,-1.81504 q 0.0741,-0.09 0.15346,-0.13758 0.0847,-0.0529 0.22225,-0.0529 h 0.85195 l -1.97378,2.10079 q -0.14288,0.17991 -0.30692,0.28045 0.0952,0.0635 0.16933,0.14817 0.0794,0.0794 0.14817,0.18521 l 2.09549,2.64582 h -0.84137 q -0.12171,0 -0.21166,-0.037 -0.0847,-0.0423 -0.14817,-0.14816 l -1.76212,-2.19604 q -0.0794,-0.11112 -0.15875,-0.14287 -0.0741,-0.037 -0.23283,-0.037 h -0.26988 v 2.56116 h -0.9472 v -7.7946 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1203" />
+      <path
+         d="m -112.98788,-211.53862 v 5.36044 h -0.94192 v -5.36044 z m 0.20108,-1.68274 q 0,0.13758 -0.0582,0.25929 -0.0529,0.11641 -0.14816,0.21166 -0.09,0.09 -0.21696,0.14288 -0.12171,0.0529 -0.25929,0.0529 -0.13759,0 -0.25929,-0.0529 -0.11642,-0.0529 -0.20638,-0.14288 -0.09,-0.0953 -0.14287,-0.21166 -0.0529,-0.12171 -0.0529,-0.25929 0,-0.13759 0.0529,-0.25929 0.0529,-0.127 0.14287,-0.21696 0.09,-0.0952 0.20638,-0.14817 0.1217,-0.0529 0.25929,-0.0529 0.13758,0 0.25929,0.0529 0.127,0.0529 0.21696,0.14817 0.0952,0.09 0.14816,0.21696 0.0582,0.1217 0.0582,0.25929 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1205" />
+      <path
+         d="m -111.44272,-206.17818 v -5.36044 h 0.5662 q 0.20109,0 0.24871,0.19579 l 0.0741,0.58208 q 0.34925,-0.38629 0.78317,-0.62441 0.43391,-0.23812 1.00012,-0.23812 0.43921,0 0.77258,0.14816 0.33867,0.14288 0.56091,0.41275 0.22755,0.26458 0.34396,0.64029 0.11642,0.37571 0.11642,0.83079 v 3.41311 h -0.94721 v -3.41311 q 0,-0.60854 -0.28045,-0.94191 -0.27517,-0.33867 -0.84138,-0.33867 -0.42333,0 -0.78845,0.20108 -0.35983,0.20109 -0.66146,0.54504 v 3.94757 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1207" />
+      <path
+         d="m -101.66377,-206.17818 q -0.20108,0 -0.254,-0.19579 l -0.0847,-0.65087 q -0.34396,0.41804 -0.78846,0.67204 -0.43921,0.24871 -1.0107,0.24871 -0.46038,0 -0.83609,-0.17463 -0.3757,-0.17991 -0.64029,-0.52387 -0.26458,-0.34396 -0.40745,-0.85725 -0.14288,-0.51329 -0.14288,-1.18004 0,-0.59266 0.15875,-1.10066 0.15875,-0.51329 0.45508,-0.889 0.29634,-0.3757 0.72496,-0.58737 0.43392,-0.21696 0.97366,-0.21696 0.49213,0 0.84138,0.16933 0.35454,0.16405 0.6297,0.46567 v -2.97391 h 0.94192 v 7.7946 z m -1.83091,-0.68791 q 0.46567,0 0.80962,-0.21167 0.34925,-0.21166 0.64029,-0.59795 v -2.58762 q -0.26458,-0.34925 -0.5715,-0.49212 -0.30691,-0.14288 -0.68791,-0.14288 -0.74612,0 -1.14829,0.53446 -0.40216,0.53445 -0.40216,1.52399 0,0.52388 0.09,0.89958 0.09,0.37042 0.26459,0.61384 0.17462,0.23812 0.42862,0.34924 0.254,0.11113 0.57679,0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1209" />
+      <path
+         d="m -99.806404,-211.19995 z m 0.846664,-3.06916 q 0.22225,0.37571 0.301624,0.79375 0.07938,0.41804 0.01588,0.8255 -0.0635,0.40745 -0.264582,0.78316 -0.201083,0.37571 -0.534457,0.66675 l -0.285749,-0.18521 q -0.07937,-0.0476 -0.07408,-0.12171 0.01058,-0.0794 0.05292,-0.127 0.137583,-0.16933 0.232833,-0.40745 0.100541,-0.24342 0.127,-0.51859 0.03175,-0.28045 -0.02646,-0.57679 -0.05292,-0.29633 -0.216957,-0.57149 -0.06879,-0.11113 -0.04233,-0.1958 0.03175,-0.09 0.132291,-0.13229 z m 1.608662,0 q 0.222249,0.37571 0.301624,0.79375 0.07937,0.41804 0.01587,0.8255 -0.0635,0.40745 -0.264583,0.78316 -0.201082,0.37571 -0.534456,0.66675 l -0.285749,-0.18521 q -0.07937,-0.0476 -0.07408,-0.12171 0.01058,-0.0794 0.05292,-0.127 0.137583,-0.16933 0.232833,-0.40745 0.100541,-0.24342 0.126999,-0.51859 0.03175,-0.28045 -0.02646,-0.57679 -0.05292,-0.29633 -0.216958,-0.57149 -0.06879,-0.11113 -0.04233,-0.1958 0.03175,-0.09 0.132291,-0.13229 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1211" />
+    </g>
+    <g
+       aria-label="DType precision"
+       id="text35573"
+       style="font-size:10.5833px;line-height:1.25;font-family:Lato;-inkscape-font-specification:Lato;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+      <path
+         d="m -59.01314,183.29229 q 0,0.85196 -0.269875,1.55046 -0.269874,0.6985 -0.761997,1.19591 -0.492124,0.49742 -1.18533,0.77258 -0.687914,0.26988 -1.523995,0.26988 h -2.831033 v -7.58294 h 2.831033 q 0.836081,0 1.523995,0.27517 0.693206,0.26987 1.18533,0.77258 0.492123,0.49741 0.761997,1.19591 0.269875,0.6985 0.269875,1.55045 z m -1.053039,0 q 0,-0.69849 -0.190499,-1.24882 -0.1905,-0.55034 -0.539748,-0.93134 -0.349249,-0.38099 -0.846664,-0.58208 -0.497416,-0.20108 -1.111247,-0.20108 h -1.804452 v 5.92136 h 1.804452 q 0.613831,0 1.111247,-0.20109 0.497415,-0.20108 0.846664,-0.57679 0.349248,-0.38099 0.539748,-0.93133 0.190499,-0.55033 0.190499,-1.24883 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1162" />
+      <path
+         d="m -52.758421,179.49818 v 0.86254 h -2.455326 v 6.7204 h -1.021288 v -6.7204 h -2.460617 v -0.86254 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1164" />
+      <path
+         d="m -51.13918,188.66332 q -0.04762,0.10583 -0.121708,0.16933 -0.06879,0.0635 -0.216957,0.0635 h -0.698498 l 0.978955,-2.12724 -2.211909,-5.04824 h 0.814914 q 0.121708,0 0.190499,0.0635 0.07408,0.0582 0.100541,0.1323 l 1.434038,3.37607 q 0.04233,0.12171 0.07937,0.23812 0.03704,0.11113 0.0635,0.23283 0.06879,-0.23812 0.15875,-0.47624 l 1.391704,-3.37078 q 0.03175,-0.0847 0.105833,-0.13759 0.07937,-0.0582 0.174624,-0.0582 h 0.746123 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1166" />
+      <path
+         d="m -47.318617,188.89615 v -7.17548 h 0.566207 q 0.201083,0 0.248707,0.1958 l 0.07937,0.63499 q 0.343957,-0.41804 0.788456,-0.67204 0.444499,-0.254 1.015997,-0.254 0.465665,0 0.841372,0.17992 0.375707,0.17463 0.64029,0.52387 0.264582,0.34396 0.407457,0.85725 0.142874,0.51329 0.142874,1.18004 0,0.59266 -0.158749,1.10595 -0.15875,0.508 -0.460374,0.88371 -0.296332,0.37042 -0.730247,0.58737 -0.428624,0.21167 -0.968372,0.21167 -0.492124,0 -0.846664,-0.16404 -0.349249,-0.16404 -0.619123,-0.46567 v 2.37066 z m 2.391826,-6.50873 q -0.460373,0 -0.809622,0.21167 -0.343958,0.21166 -0.634998,0.59795 v 2.59291 q 0.253999,0.34925 0.560915,0.49213 0.312207,0.14287 0.693206,0.14287 0.751414,0 1.153579,-0.53446 0.402166,-0.53445 0.402166,-1.52399 0,-0.52387 -0.09525,-0.89958 -0.08996,-0.37571 -0.264582,-0.61383 -0.174625,-0.24342 -0.428624,-0.35454 -0.253999,-0.11113 -0.57679,-0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1168" />
+      <path
+         d="m -39.190651,181.63601 q 0.48154,0 0.888997,0.16404 0.412748,0.15875 0.709081,0.46566 0.301624,0.30163 0.470957,0.75142 0.169332,0.4445 0.169332,1.016 0,0.22224 -0.04762,0.29633 -0.04763,0.0741 -0.179916,0.0741 h -3.582447 q 0.01058,0.508 0.137583,0.88371 0.126999,0.3757 0.349248,0.6297 0.22225,0.24871 0.529165,0.37571 0.306916,0.12171 0.687915,0.12171 0.35454,0 0.60854,-0.0794 0.25929,-0.0847 0.444498,-0.17991 0.185208,-0.0952 0.306916,-0.17463 0.126999,-0.0847 0.216958,-0.0847 0.116416,0 0.179916,0.0899 l 0.264582,0.34396 q -0.174624,0.21167 -0.41804,0.37042 -0.243416,0.15345 -0.523874,0.254 -0.275165,0.10054 -0.571498,0.14816 -0.296332,0.0529 -0.587373,0.0529 -0.555623,0 -1.02658,-0.18521 -0.465665,-0.1905 -0.809622,-0.55033 -0.338666,-0.36512 -0.529165,-0.89958 -0.1905,-0.53446 -0.1905,-1.22766 0,-0.56092 0.169333,-1.04775 0.174624,-0.48683 0.497415,-0.84137 0.322791,-0.35983 0.788456,-0.56092 0.465665,-0.20637 1.047747,-0.20637 z m 0.02117,0.6932 q -0.682623,0 -1.074205,0.39688 -0.391582,0.39158 -0.486831,1.09008 h 2.931574 q 0,-0.32808 -0.09525,-0.59796 -0.08996,-0.27516 -0.269874,-0.47096 -0.174625,-0.20108 -0.428624,-0.30691 -0.253999,-0.11113 -0.57679,-0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1170" />
+      <path
+         d="m -33.089395,188.89615 v -7.17548 h 0.566206 q 0.201083,0 0.248708,0.1958 l 0.07937,0.63499 q 0.343957,-0.41804 0.788455,-0.67204 0.444499,-0.254 1.015997,-0.254 0.465665,0 0.841372,0.17992 0.375708,0.17463 0.64029,0.52387 0.264583,0.34396 0.407457,0.85725 0.142875,0.51329 0.142875,1.18004 0,0.59266 -0.15875,1.10595 -0.158749,0.508 -0.460373,0.88371 -0.296333,0.37042 -0.730248,0.58737 -0.428624,0.21167 -0.968372,0.21167 -0.492123,0 -0.846664,-0.16404 -0.349249,-0.16404 -0.619123,-0.46567 v 2.37066 z m 2.391825,-6.50873 q -0.460373,0 -0.809622,0.21167 -0.343957,0.21166 -0.634998,0.59795 v 2.59291 q 0.253999,0.34925 0.560915,0.49213 0.312207,0.14287 0.693206,0.14287 0.751414,0 1.15358,-0.53446 0.402165,-0.53445 0.402165,-1.52399 0,-0.52387 -0.09525,-0.89958 -0.08996,-0.37571 -0.264582,-0.61383 -0.174625,-0.24342 -0.428624,-0.35454 -0.253999,-0.11113 -0.57679,-0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1172" />
+      <path
+         d="m -27.157465,187.08112 v -5.36045 h 0.539749 q 0.153457,0 0.211666,0.0582 0.05821,0.0582 0.07937,0.20109 l 0.05821,0.81491 q 0.254,-0.55033 0.624415,-0.85725 0.375707,-0.31221 0.910164,-0.31221 0.169333,0 0.322791,0.0371 0.158749,0.037 0.280457,0.11641 l -0.06879,0.70379 q -0.03175,0.13229 -0.15875,0.13229 -0.07408,0 -0.216958,-0.0317 -0.142874,-0.0318 -0.32279,-0.0318 -0.253999,0 -0.455082,0.0794 -0.201083,0.0741 -0.359832,0.22225 -0.153458,0.14287 -0.275166,0.35454 -0.121708,0.21166 -0.222249,0.48683 v 3.38666 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1174" />
+      <path
+         d="m -21.326085,181.63601 q 0.481541,0 0.888998,0.16404 0.412748,0.15875 0.709081,0.46566 0.301624,0.30163 0.470956,0.75142 0.169333,0.4445 0.169333,1.016 0,0.22224 -0.04763,0.29633 -0.04762,0.0741 -0.179916,0.0741 h -3.582447 q 0.01058,0.508 0.137583,0.88371 0.127,0.3757 0.349249,0.6297 0.222249,0.24871 0.529165,0.37571 0.306916,0.12171 0.687915,0.12171 0.35454,0 0.608539,-0.0794 0.259291,-0.0847 0.444499,-0.17991 0.185208,-0.0952 0.306916,-0.17463 0.126999,-0.0847 0.216957,-0.0847 0.116417,0 0.179916,0.0899 l 0.264583,0.34396 q -0.174625,0.21167 -0.41804,0.37042 -0.243416,0.15345 -0.523874,0.254 -0.275166,0.10054 -0.571498,0.14816 -0.296332,0.0529 -0.587373,0.0529 -0.555623,0 -1.02658,-0.18521 -0.465665,-0.1905 -0.809623,-0.55033 -0.338665,-0.36512 -0.529165,-0.89958 -0.190499,-0.53446 -0.190499,-1.22766 0,-0.56092 0.169333,-1.04775 0.174624,-0.48683 0.497415,-0.84137 0.322791,-0.35983 0.788456,-0.56092 0.465665,-0.20637 1.047746,-0.20637 z m 0.02117,0.6932 q -0.682623,0 -1.074205,0.39688 -0.391582,0.39158 -0.486832,1.09008 h 2.931574 q 0,-0.32808 -0.09525,-0.59796 -0.08996,-0.27516 -0.269875,-0.47096 -0.174624,-0.20108 -0.428623,-0.30691 -0.253999,-0.11113 -0.57679,-0.11113 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1176" />
+      <path
+         d="m -14.203524,182.67317 q -0.04233,0.0582 -0.08467,0.09 -0.04233,0.0318 -0.116417,0.0318 -0.07937,0 -0.174624,-0.0635 -0.09525,-0.0688 -0.238124,-0.14817 -0.137583,-0.0794 -0.343958,-0.14287 -0.201082,-0.0688 -0.497415,-0.0688 -0.396873,0 -0.698497,0.14287 -0.301624,0.13758 -0.507999,0.40217 -0.201083,0.26458 -0.306916,0.64029 -0.100541,0.3757 -0.100541,0.84137 0,0.48683 0.111125,0.86783 0.111124,0.37571 0.312207,0.635 0.206374,0.254 0.492124,0.39158 0.29104,0.13229 0.650872,0.13229 0.343958,0 0.566207,-0.0794 0.222249,-0.0847 0.365124,-0.18521 0.148166,-0.10054 0.243416,-0.17992 0.100541,-0.0847 0.195791,-0.0847 0.116416,0 0.179916,0.0899 l 0.264582,0.34396 q -0.174624,0.21696 -0.396873,0.37042 -0.22225,0.15345 -0.48154,0.25929 -0.254,0.10054 -0.534457,0.14816 -0.280458,0.0476 -0.571498,0.0476 -0.502707,0 -0.936622,-0.18521 -0.428624,-0.18521 -0.746123,-0.53446 -0.317499,-0.35454 -0.497415,-0.86783 -0.179916,-0.51329 -0.179916,-1.16945 0,-0.59796 0.164041,-1.10596 0.169333,-0.50799 0.486832,-0.87312 0.32279,-0.37041 0.788456,-0.57679 0.470956,-0.20637 1.079496,-0.20637 0.566207,0 0.99483,0.18521 0.433916,0.17991 0.76729,0.51329 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1178" />
+      <path
+         d="m -11.885794,181.72067 v 5.36045 h -0.941914 v -5.36045 z m 0.201082,-1.68274 q 0,0.13758 -0.05821,0.25929 -0.05292,0.11642 -0.148166,0.21167 -0.08996,0.0899 -0.216958,0.14287 -0.121708,0.0529 -0.25929,0.0529 -0.137583,0 -0.259291,-0.0529 -0.116417,-0.0529 -0.206375,-0.14287 -0.08996,-0.0953 -0.142874,-0.21167 -0.05292,-0.12171 -0.05292,-0.25929 0,-0.13758 0.05292,-0.25929 0.05292,-0.127 0.142874,-0.21696 0.08996,-0.0952 0.206375,-0.14816 0.121708,-0.0529 0.259291,-0.0529 0.137582,0 0.25929,0.0529 0.127,0.0529 0.216958,0.14816 0.09525,0.09 0.148166,0.21696 0.05821,0.12171 0.05821,0.25929 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1180" />
+      <path
+         d="m -7.2185616,182.60438 q -0.0635,0.11642 -0.1957911,0.11642 -0.079375,0 -0.1799161,-0.0582 -0.1005413,-0.0582 -0.2487075,-0.127 -0.1428746,-0.0741 -0.3439573,-0.13229 -0.2010827,-0.0635 -0.4762484,-0.0635 -0.2381243,0 -0.4286237,0.0635 -0.1904994,0.0582 -0.3280823,0.16404 -0.1322912,0.10583 -0.2063743,0.24871 -0.068791,0.13758 -0.068791,0.30162 0,0.20637 0.1164163,0.34396 0.121708,0.13758 0.317499,0.23812 0.1957911,0.10054 0.4444986,0.17992 0.2487076,0.0741 0.5079984,0.16404 0.2645825,0.0847 0.51329,0.1905 0.2487076,0.10583 0.4444986,0.26458 0.1957911,0.15875 0.3122074,0.39158 0.1217079,0.22754 0.1217079,0.55033 0,0.37042 -0.1322912,0.68792 -0.1322913,0.31221 -0.3915821,0.54504 -0.2592909,0.22754 -0.634998,0.35983 -0.3757072,0.13229 -0.8678306,0.13229 -0.5609149,0 -1.0159967,-0.17991 -0.4550818,-0.18521 -0.7725808,-0.47096 l 0.222249,-0.35983 q 0.04233,-0.0688 0.100542,-0.10584 0.05821,-0.037 0.148166,-0.037 0.09525,0 0.201082,0.0741 0.1058334,0.0741 0.2539996,0.16404 0.1534578,0.09 0.3704155,0.16404 0.2169576,0.0741 0.5397483,0.0741 0.2751658,0 0.4815401,-0.0688 0.2063743,-0.0741 0.3439572,-0.19579 0.1375829,-0.12171 0.2010827,-0.28046 0.068791,-0.15875 0.068791,-0.33866 0,-0.22225 -0.121708,-0.36513 -0.1164163,-0.14816 -0.3122073,-0.24871 -0.1957911,-0.10583 -0.4497902,-0.17991 -0.2487076,-0.0794 -0.5132901,-0.16404 -0.2592908,-0.0847 -0.51329,-0.1905 -0.2487075,-0.11113 -0.4444983,-0.27517 -0.195791,-0.16404 -0.317499,-0.40216 -0.116417,-0.24342 -0.116417,-0.58738 0,-0.30691 0.127,-0.58737 0.127,-0.28575 0.370416,-0.49742 0.2434154,-0.21695 0.5979559,-0.34395 0.3545406,-0.127 0.8096225,-0.127 0.5291649,0 0.9472053,0.16933 0.423332,0.16404 0.7302477,0.45508 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1182" />
+      <path
+         d="m -4.763251,181.72067 v 5.36045 h -0.9419137 v -5.36045 z m 0.2010827,-1.68274 q 0,0.13758 -0.058208,0.25929 -0.052917,0.11642 -0.1481662,0.21167 -0.089958,0.0899 -0.2169576,0.14287 -0.1217079,0.0529 -0.2592908,0.0529 -0.1375829,0 -0.2592909,-0.0529 -0.1164163,-0.0529 -0.2063743,-0.14287 -0.089958,-0.0953 -0.1428746,-0.21167 -0.052917,-0.12171 -0.052917,-0.25929 0,-0.13758 0.052917,-0.25929 0.052916,-0.127 0.1428746,-0.21696 0.089958,-0.0952 0.2063743,-0.14816 0.121708,-0.0529 0.2592909,-0.0529 0.1375829,0 0.2592908,0.0529 0.1269996,0.0529 0.2169576,0.14816 0.09525,0.09 0.1481662,0.21696 0.058208,0.12171 0.058208,0.25929 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1184" />
+      <path
+         d="m -0.95855723,181.63601 q 0.58737313,0 1.05832997,0.19579 0.47095683,0.19579 0.80433077,0.55562 0.33337389,0.35983 0.50799839,0.87312 0.1799161,0.508 0.1799161,1.13771 0,0.635 -0.1799161,1.143 -0.1746245,0.50799 -0.50799839,0.86783 -0.33337394,0.35983 -0.80433077,0.55562 -0.47095684,0.1905 -1.05832997,0.1905 -0.59266477,0 -1.06891327,-0.1905 -0.4709568,-0.19579 -0.8043308,-0.55562 -0.3333739,-0.35984 -0.51329,-0.86783 -0.1746244,-0.508 -0.1746244,-1.143 0,-0.62971 0.1746244,-1.13771 0.1799161,-0.51329 0.51329,-0.87312 0.333374,-0.35983 0.8043308,-0.55562 0.4762485,-0.19579 1.06891327,-0.19579 z m 0,4.78365 q 0.79374747,0 1.18532956,-0.52917 0.39158209,-0.53445 0.39158209,-1.48695 0,-0.95779 -0.39158209,-1.49224 -0.39158209,-0.53446 -1.18532956,-0.53446 -0.40216537,0 -0.70378947,0.13758 -0.2963323,0.13758 -0.497415,0.39688 -0.1957911,0.25929 -0.2963324,0.64029 -0.09525,0.3757 -0.09525,0.85195 0,0.9525 0.3915821,1.48695 0.3968737,0.52917 1.20120447,0.52917 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1186" />
+      <path
+         d="m 2.7826369,187.08112 v -5.36045 h 0.5662065 q 0.2010827,0 0.2487076,0.1958 l 0.074083,0.58208 q 0.3492489,-0.38629 0.7831641,-0.62442 0.4339153,-0.23812 1.0001219,-0.23812 0.4392069,0 0.7725808,0.14816 0.3386656,0.14288 0.5609149,0.41275 0.227541,0.26459 0.3439573,0.64029 0.1164163,0.37571 0.1164163,0.83079 v 3.41312 H 6.301584 V 183.668 q 0,-0.60854 -0.2804574,-0.94191 -0.2751658,-0.33867 -0.8413723,-0.33867 -0.423332,0 -0.7884558,0.20109 -0.3598322,0.20108 -0.6614563,0.54503 v 3.94758 z"
+         style="font-size:10.5833px;stroke-width:0.264583"
+         id="path1188" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
+       d="M -89.46727,176.53412 H 29.674668"
+       id="path55402" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend)"
+       d="M -202.54791,166.48316 V 87.745517"
+       id="path55752" />
+    <g
+       id="g955"
+       transform="translate(11.46753,-1.7989611)">
+      <path
+         id="rect80903"
+         style="opacity:0.779541;fill:#00b200;fill-opacity:0.255768;stroke:#00b200;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:128.863;stroke-opacity:1"
+         d="m -97.191238,57.390038 h 35.016891 v 20 h -35.016891 z" />
+      <g
+         aria-label="Promotionpaths"
+         id="text65310"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="m -93.249542,63.327627 v 1.7018 h -0.612775 v -4.549775 h 1.343025 q 0.4318,0 0.7493,0.1016 0.320675,0.09842 0.530225,0.282575 0.20955,0.18415 0.31115,0.4445 0.104775,0.26035 0.104775,0.581025 0,0.3175 -0.111125,0.581025 -0.111125,0.263525 -0.327025,0.454025 -0.212725,0.1905 -0.530225,0.29845 -0.314325,0.104775 -0.727075,0.104775 z m 0,-0.48895 h 0.73025 q 0.263525,0 0.46355,-0.06985 0.2032,-0.06985 0.339725,-0.193675 0.1397,-0.127 0.20955,-0.301625 0.06985,-0.174625 0.06985,-0.384175 0,-0.434975 -0.269875,-0.67945 -0.2667,-0.244475 -0.8128,-0.244475 h -0.73025 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1135" />
+        <path
+           d="m -90.242832,65.029427 v -3.216275 h 0.32385 q 0.09207,0 0.127,0.03493 0.03493,0.03492 0.04763,0.12065 l 0.03492,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.225425,-0.187325 0.5461,-0.187325 0.1016,0 0.193675,0.02222 0.09525,0.02222 0.168275,0.06985 l -0.04127,0.422275 q -0.01905,0.07937 -0.09525,0.07937 -0.04445,0 -0.130175,-0.01905 -0.08572,-0.01905 -0.193675,-0.01905 -0.1524,0 -0.27305,0.04762 -0.12065,0.04445 -0.2159,0.13335 -0.09207,0.08573 -0.1651,0.212725 -0.07303,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1137" />
+        <path
+           d="m -86.705894,61.762352 q 0.352425,0 0.635,0.117475 0.282575,0.117475 0.4826,0.333375 0.200025,0.2159 0.3048,0.523875 0.10795,0.3048 0.10795,0.682625 0,0.381 -0.10795,0.6858 -0.104775,0.3048 -0.3048,0.5207 -0.200025,0.2159 -0.4826,0.333375 -0.282575,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.282575,-0.117475 -0.4826,-0.333375 -0.200025,-0.2159 -0.307975,-0.5207 -0.104775,-0.3048 -0.104775,-0.6858 0,-0.377825 0.104775,-0.682625 0.10795,-0.307975 0.307975,-0.523875 0.200025,-0.2159 0.4826,-0.333375 0.28575,-0.117475 0.64135,-0.117475 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.320675 0.23495,-0.892175 0,-0.574675 -0.23495,-0.89535 -0.23495,-0.320675 -0.7112,-0.320675 -0.2413,0 -0.422275,0.08255 -0.1778,0.08255 -0.29845,0.238125 -0.117475,0.155575 -0.1778,0.384175 -0.05715,0.225425 -0.05715,0.511175 0,0.5715 0.23495,0.892175 0.238125,0.3175 0.720725,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1139" />
+        <path
+           d="m -84.461172,65.029427 v -3.216275 h 0.339725 q 0.12065,0 0.149225,0.117475 l 0.04127,0.3302 q 0.1778,-0.219075 0.40005,-0.358775 0.22225,-0.1397 0.51435,-0.1397 0.32385,0 0.523875,0.180975 0.2032,0.180975 0.2921,0.48895 0.06985,-0.174625 0.1778,-0.301625 0.111125,-0.127 0.24765,-0.20955 0.136525,-0.08255 0.288925,-0.12065 0.155575,-0.0381 0.314325,-0.0381 0.254,0 0.45085,0.08255 0.200025,0.07937 0.33655,0.23495 0.1397,0.155575 0.212725,0.384175 0.07303,0.225425 0.07303,0.517525 v 2.047875 h -0.568325 v -2.047875 q 0,-0.377825 -0.1651,-0.5715 -0.1651,-0.19685 -0.47625,-0.19685 -0.1397,0 -0.2667,0.0508 -0.123825,0.04763 -0.219075,0.142875 -0.09525,0.09525 -0.1524,0.2413 -0.05397,0.142875 -0.05397,0.333375 v 2.047875 h -0.568325 v -2.047875 q 0,-0.38735 -0.155575,-0.57785 -0.155575,-0.1905 -0.454025,-0.1905 -0.20955,0 -0.38735,0.1143 -0.1778,0.111125 -0.327025,0.3048 v 2.397125 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1141" />
+        <path
+           d="m -77.882583,61.762352 q 0.352425,0 0.635,0.117475 0.282575,0.117475 0.4826,0.333375 0.200025,0.2159 0.3048,0.523875 0.10795,0.3048 0.10795,0.682625 0,0.381 -0.10795,0.6858 -0.104775,0.3048 -0.3048,0.5207 -0.200025,0.2159 -0.4826,0.333375 -0.282575,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.282575,-0.117475 -0.4826,-0.333375 -0.200025,-0.2159 -0.307975,-0.5207 -0.104775,-0.3048 -0.104775,-0.6858 0,-0.377825 0.104775,-0.682625 0.10795,-0.307975 0.307975,-0.523875 0.200025,-0.2159 0.4826,-0.333375 0.28575,-0.117475 0.64135,-0.117475 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.320675 0.23495,-0.892175 0,-0.574675 -0.23495,-0.89535 -0.23495,-0.320675 -0.7112,-0.320675 -0.2413,0 -0.422275,0.08255 -0.1778,0.08255 -0.29845,0.238125 -0.117475,0.155575 -0.1778,0.384175 -0.05715,0.225425 -0.05715,0.511175 0,0.5715 0.23495,0.892175 0.238125,0.3175 0.720725,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1143" />
+        <path
+           d="m -76.006166,65.029427 z m 1.298575,0.0508 q -0.381,0 -0.587375,-0.212725 -0.2032,-0.212725 -0.2032,-0.612775 v -1.9685 h -0.38735 q -0.0508,0 -0.08573,-0.02857 -0.03492,-0.03175 -0.03492,-0.09525 v -0.225425 l 0.52705,-0.06667 0.130175,-0.993775 q 0.0095,-0.04763 0.04127,-0.0762 0.03493,-0.03175 0.0889,-0.03175 h 0.28575 v 1.108075 h 2.2225 v 3.152775 h -0.56515 v -2.7432 h -1.65735 v 1.9304 q 0,0.2032 0.09842,0.301625 0.09843,0.09842 0.254,0.09842 0.0889,0 0.1524,-0.02222 0.06668,-0.0254 0.1143,-0.05398 0.04762,-0.02857 0.07937,-0.0508 0.03493,-0.0254 0.06033,-0.0254 0.04445,0 0.07937,0.05398 l 0.1651,0.269875 q -0.14605,0.136525 -0.352425,0.2159 -0.206375,0.0762 -0.42545,0.0762 z m 2.136775,-4.29895 q 0,0.08255 -0.03493,0.155575 -0.03175,0.06985 -0.0889,0.123825 -0.05397,0.05398 -0.127,0.08573 -0.07303,0.03175 -0.155575,0.03175 -0.08255,0 -0.155575,-0.03175 -0.06985,-0.03175 -0.123825,-0.08573 -0.05398,-0.05398 -0.08573,-0.123825 -0.03175,-0.07303 -0.03175,-0.155575 0,-0.08255 0.03175,-0.155575 0.03175,-0.0762 0.08573,-0.130175 0.05397,-0.05715 0.123825,-0.0889 0.07303,-0.03175 0.155575,-0.03175 0.08255,0 0.155575,0.03175 0.07303,0.03175 0.127,0.0889 0.05715,0.05397 0.0889,0.130175 0.03493,0.07303 0.03493,0.155575 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1145" />
+        <path
+           d="m -70.427696,61.762352 q 0.352425,0 0.635,0.117475 0.282575,0.117475 0.4826,0.333375 0.200025,0.2159 0.3048,0.523875 0.10795,0.3048 0.10795,0.682625 0,0.381 -0.10795,0.6858 -0.104775,0.3048 -0.3048,0.5207 -0.200025,0.2159 -0.4826,0.333375 -0.282575,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.282575,-0.117475 -0.4826,-0.333375 -0.200025,-0.2159 -0.307975,-0.5207 -0.104775,-0.3048 -0.104775,-0.6858 0,-0.377825 0.104775,-0.682625 0.10795,-0.307975 0.307975,-0.523875 0.200025,-0.2159 0.4826,-0.333375 0.28575,-0.117475 0.64135,-0.117475 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.320675 0.23495,-0.892175 0,-0.574675 -0.23495,-0.89535 -0.23495,-0.320675 -0.7112,-0.320675 -0.2413,0 -0.422275,0.08255 -0.1778,0.08255 -0.29845,0.238125 -0.117475,0.155575 -0.1778,0.384175 -0.05715,0.225425 -0.05715,0.511175 0,0.5715 0.23495,0.892175 0.238125,0.3175 0.720725,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1147" />
+        <path
+           d="m -68.182975,65.029427 v -3.216275 h 0.339725 q 0.12065,0 0.149225,0.117475 l 0.04445,0.34925 q 0.20955,-0.231775 0.4699,-0.37465 0.26035,-0.142875 0.600075,-0.142875 0.263525,0 0.46355,0.0889 0.2032,0.08572 0.33655,0.24765 0.136525,0.15875 0.206375,0.384175 0.06985,0.225425 0.06985,0.498475 v 2.047875 H -66.0716 v -2.047875 q 0,-0.365125 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396875,0.327025 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1149" />
+        <path
+           d="m -86.939249,74.405202 v -4.3053 h 0.339725 q 0.12065,0 0.149225,0.117475 l 0.04762,0.381 q 0.206375,-0.250825 0.473075,-0.403225 0.2667,-0.1524 0.6096,-0.1524 0.2794,0 0.504825,0.10795 0.225425,0.104775 0.384175,0.314325 0.15875,0.206375 0.244475,0.51435 0.08573,0.307975 0.08573,0.708025 0,0.3556 -0.09525,0.663575 -0.09525,0.3048 -0.276225,0.530225 -0.1778,0.22225 -0.43815,0.352425 -0.257175,0.127 -0.581025,0.127 -0.295275,0 -0.508,-0.09842 -0.20955,-0.09843 -0.371475,-0.2794 v 1.4224 z m 1.4351,-3.90525 q -0.276225,0 -0.485775,0.127 -0.206375,0.127 -0.381,0.358775 v 1.55575 q 0.1524,0.20955 0.33655,0.295275 0.187325,0.08572 0.415925,0.08572 0.45085,0 0.69215,-0.320675 0.2413,-0.320675 0.2413,-0.9144 0,-0.314325 -0.05715,-0.53975 -0.05398,-0.225425 -0.15875,-0.3683 -0.104775,-0.14605 -0.257175,-0.212725 -0.1524,-0.06668 -0.346075,-0.06668 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1151" />
+        <path
+           d="m -81.335379,73.316177 q -0.08255,0 -0.127,-0.0254 -0.04445,-0.02858 -0.06985,-0.10795 l -0.0635,-0.301625 q -0.127,0.1143 -0.250825,0.206375 -0.12065,0.0889 -0.254,0.1524 -0.130175,0.06033 -0.282575,0.09208 -0.149225,0.03493 -0.333375,0.03493 -0.187325,0 -0.352425,-0.0508 -0.1651,-0.05397 -0.288925,-0.15875 -0.12065,-0.104775 -0.193675,-0.263525 -0.06985,-0.161925 -0.06985,-0.381 0,-0.1905 0.104775,-0.365125 0.104775,-0.1778 0.339725,-0.314325 0.23495,-0.136525 0.612775,-0.22225 0.377825,-0.0889 0.9271,-0.1016 v -0.250825 q 0,-0.37465 -0.161925,-0.56515 -0.161925,-0.193675 -0.473075,-0.193675 -0.20955,0 -0.352425,0.05398 -0.1397,0.0508 -0.244475,0.117475 -0.1016,0.0635 -0.1778,0.117475 -0.07303,0.0508 -0.14605,0.0508 -0.05715,0 -0.09843,-0.02857 -0.04127,-0.03175 -0.06985,-0.0762 l -0.1016,-0.180975 q 0.2667,-0.257175 0.574675,-0.384175 0.307975,-0.127 0.682625,-0.127 0.269875,0 0.479425,0.0889 0.20955,0.0889 0.352425,0.24765 0.142875,0.15875 0.2159,0.384175 0.07303,0.225425 0.07303,0.4953 v 2.0574 z m -1.21285,-0.346075 q 0.149225,0 0.27305,-0.02858 0.123825,-0.03175 0.231775,-0.08572 0.111125,-0.05715 0.20955,-0.136525 0.1016,-0.08255 0.19685,-0.18415 v -0.66675 q -0.390525,0.0127 -0.66675,0.0635 -0.27305,0.04762 -0.447675,0.127 -0.17145,0.07937 -0.250825,0.187325 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.04127,0.219075 0.04127,0.09208 0.111125,0.1524 0.07302,0.05715 0.168275,0.08573 0.09843,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1153" />
+        <path
+           d="m -79.277982,73.366977 q -0.381,0 -0.587375,-0.212725 -0.2032,-0.212725 -0.2032,-0.612775 v -1.9685 h -0.38735 q -0.0508,0 -0.08573,-0.02857 -0.03492,-0.03175 -0.03492,-0.09525 v -0.225425 l 0.52705,-0.06668 0.130175,-0.993775 q 0.0095,-0.04762 0.04127,-0.0762 0.03493,-0.03175 0.0889,-0.03175 h 0.28575 v 1.108075 h 0.930275 v 0.409575 h -0.930275 v 1.9304 q 0,0.2032 0.09842,0.301625 0.09843,0.09842 0.254,0.09842 0.0889,0 0.1524,-0.02222 0.06668,-0.0254 0.1143,-0.05398 0.04762,-0.02857 0.07937,-0.0508 0.03493,-0.0254 0.06033,-0.0254 0.04445,0 0.07937,0.05398 l 0.1651,0.269875 q -0.14605,0.136525 -0.352425,0.2159 -0.206375,0.0762 -0.42545,0.0762 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1155" />
+        <path
+           d="m -77.988935,73.316177 v -4.676775 h 0.568325 v 1.8923 q 0.206375,-0.219075 0.4572,-0.34925 0.250825,-0.13335 0.57785,-0.13335 0.263525,0 0.46355,0.0889 0.2032,0.08572 0.33655,0.24765 0.136525,0.15875 0.206375,0.384175 0.06985,0.225425 0.06985,0.498475 v 2.047875 h -0.568325 v -2.047875 q 0,-0.365125 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396875,0.327025 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1157" />
+        <path
+           d="m -72.572394,70.630127 q -0.0381,0.06985 -0.117475,0.06985 -0.04762,0 -0.10795,-0.03493 -0.06032,-0.03493 -0.149225,-0.0762 -0.08572,-0.04445 -0.206375,-0.07937 -0.12065,-0.0381 -0.28575,-0.0381 -0.142875,0 -0.257175,0.0381 -0.1143,0.03493 -0.19685,0.09842 -0.07937,0.0635 -0.123825,0.149225 -0.04127,0.08255 -0.04127,0.180975 0,0.123825 0.06985,0.206375 0.07303,0.08255 0.1905,0.142875 0.117475,0.06033 0.2667,0.10795 0.149225,0.04445 0.3048,0.09843 0.15875,0.0508 0.307975,0.1143 0.149225,0.0635 0.2667,0.15875 0.117475,0.09525 0.187325,0.23495 0.07303,0.136525 0.07303,0.3302 0,0.22225 -0.07937,0.41275 -0.07937,0.187325 -0.23495,0.327025 -0.155575,0.136525 -0.381,0.2159 -0.225425,0.07937 -0.5207,0.07937 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.111125 -0.46355,-0.282575 l 0.13335,-0.2159 q 0.0254,-0.04127 0.06033,-0.0635 0.03493,-0.02223 0.0889,-0.02223 0.05715,0 0.12065,0.04445 0.0635,0.04445 0.1524,0.09842 0.09207,0.05398 0.22225,0.09843 0.130175,0.04445 0.32385,0.04445 0.1651,0 0.288925,-0.04127 0.123825,-0.04445 0.206375,-0.117475 0.08255,-0.07303 0.12065,-0.168275 0.04127,-0.09525 0.04127,-0.2032 0,-0.13335 -0.07303,-0.219075 -0.06985,-0.0889 -0.187325,-0.149225 -0.117475,-0.0635 -0.269875,-0.10795 -0.149225,-0.04763 -0.307975,-0.09843 -0.155575,-0.0508 -0.307975,-0.1143 -0.149225,-0.06668 -0.2667,-0.1651 -0.117475,-0.09843 -0.1905,-0.2413 -0.06985,-0.14605 -0.06985,-0.352425 0,-0.18415 0.0762,-0.352425 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.130175 0.358775,-0.206375 0.212725,-0.0762 0.485775,-0.0762 0.3175,0 0.568325,0.1016 0.254,0.09843 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1159" />
+      </g>
+    </g>
+    <g
+       id="g2471"
+       transform="translate(-59.573056,-101.10613)">
+      <path
+         id="rect14959"
+         style="fill:#8cc9e1;fill-opacity:1;stroke:#ffd876;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:128.863;stroke-opacity:1"
+         d="M 53.441502,156.69722 H 173.85506 v 20 H 53.441502 Z" />
+      <g
+         aria-label="Minimum Python scalarprecision when other is integral/boolean"
+         id="text20753"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="m 83.569984,162.64592 q 0.0381,0.0762 0.07303,0.16193 0.03492,0.0825 0.06985,0.1651 0.03175,-0.0857 0.06668,-0.16828 0.03493,-0.0857 0.0762,-0.16192 l 1.54305,-2.79718 q 0.0381,-0.073 0.08255,-0.0889 0.04762,-0.0159 0.130175,-0.0159 h 0.454025 v 4.54977 h -0.53975 v -3.34327 q 0,-0.0667 0.0032,-0.14288 0.0032,-0.0762 0.0095,-0.15557 l -1.558925,2.8448 q -0.07303,0.14287 -0.22225,0.14287 h -0.0889 q -0.149225,0 -0.22225,-0.14287 l -1.59385,-2.85433 q 0.0095,0.0825 0.0127,0.16193 0.0063,0.0794 0.0063,0.14605 v 3.34327 h -0.53975 v -4.54977 h 0.454025 q 0.08255,0 0.127,0.0159 0.04445,0.0159 0.08572,0.0889 l 1.571625,2.80035 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1023" />
+        <path
+           d="m 87.643494,161.0743 v 3.21627 h -0.56515 v -3.21627 z m 0.12065,-1.00965 q 0,0.0825 -0.03493,0.15557 -0.03175,0.0698 -0.0889,0.127 -0.05398,0.054 -0.130175,0.0857 -0.07303,0.0317 -0.155575,0.0317 -0.08255,0 -0.155575,-0.0317 -0.06985,-0.0318 -0.123825,-0.0857 -0.05398,-0.0572 -0.08572,-0.127 -0.03175,-0.073 -0.03175,-0.15557 0,-0.0825 0.03175,-0.15558 0.03175,-0.0762 0.08572,-0.13017 0.05397,-0.0572 0.123825,-0.0889 0.07303,-0.0317 0.155575,-0.0317 0.08255,0 0.155575,0.0317 0.0762,0.0317 0.130175,0.0889 0.05715,0.054 0.0889,0.13017 0.03493,0.073 0.03493,0.15558 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1025" />
+        <path
+           d="m 88.570593,164.29057 v -3.21627 h 0.339725 q 0.12065,0 0.149225,0.11747 l 0.04445,0.34925 q 0.20955,-0.23177 0.4699,-0.37465 0.26035,-0.14287 0.600075,-0.14287 0.263525,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.136525,0.15875 0.206375,0.38417 0.06985,0.22543 0.06985,0.49848 v 2.04787 h -0.568325 v -2.04787 q 0,-0.36513 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396875,0.32702 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1027" />
+        <path
+           d="m 92.710784,161.0743 v 3.21627 h -0.56515 v -3.21627 z m 0.12065,-1.00965 q 0,0.0825 -0.03493,0.15557 -0.03175,0.0698 -0.0889,0.127 -0.05398,0.054 -0.130175,0.0857 -0.07303,0.0317 -0.155575,0.0317 -0.08255,0 -0.155575,-0.0317 -0.06985,-0.0318 -0.123825,-0.0857 -0.05398,-0.0572 -0.08572,-0.127 -0.03175,-0.073 -0.03175,-0.15557 0,-0.0825 0.03175,-0.15558 0.03175,-0.0762 0.08572,-0.13017 0.05397,-0.0572 0.123825,-0.0889 0.07303,-0.0317 0.155575,-0.0317 0.08255,0 0.155575,0.0317 0.0762,0.0317 0.130175,0.0889 0.05715,0.054 0.0889,0.13017 0.03493,0.073 0.03493,0.15558 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1029" />
+        <path
+           d="m 93.637882,164.29057 v -3.21627 h 0.339725 q 0.12065,0 0.149225,0.11747 l 0.04128,0.3302 q 0.1778,-0.21907 0.40005,-0.35877 0.22225,-0.1397 0.51435,-0.1397 0.32385,0 0.523875,0.18097 0.2032,0.18098 0.2921,0.48895 0.06985,-0.17462 0.1778,-0.30162 0.111125,-0.127 0.24765,-0.20955 0.136525,-0.0825 0.288925,-0.12065 0.155575,-0.0381 0.314325,-0.0381 0.254,0 0.45085,0.0825 0.200025,0.0794 0.33655,0.23495 0.1397,0.15557 0.212725,0.38417 0.07303,0.22543 0.07303,0.51753 v 2.04787 h -0.568325 v -2.04787 q 0,-0.37783 -0.1651,-0.5715 -0.1651,-0.19685 -0.47625,-0.19685 -0.1397,0 -0.2667,0.0508 -0.123825,0.0476 -0.219075,0.14287 -0.09525,0.0952 -0.1524,0.2413 -0.05398,0.14288 -0.05398,0.33338 v 2.04787 h -0.568325 v -2.04787 q 0,-0.38735 -0.155575,-0.57785 -0.155575,-0.1905 -0.454025,-0.1905 -0.20955,0 -0.38735,0.1143 -0.1778,0.11112 -0.327025,0.3048 v 2.39712 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1031" />
+        <path
+           d="m 99.394146,161.0743 v 2.05105 q 0,0.36512 0.1651,0.56515 0.168275,0.20002 0.511174,0.20002 0.24765,0 0.46673,-0.11747 0.21907,-0.11748 0.40322,-0.32703 v -2.37172 h 0.56515 v 3.21627 h -0.33655 q -0.12065,0 -0.1524,-0.11747 l -0.0444,-0.34608 q -0.20955,0.23178 -0.4699,0.37465 -0.26035,0.1397 -0.596899,0.1397 -0.263525,0 -0.466725,-0.0857 -0.200025,-0.0889 -0.33655,-0.24765 -0.136525,-0.15875 -0.206375,-0.38418 -0.06667,-0.22542 -0.06667,-0.49847 v -2.05105 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1033" />
+        <path
+           d="m 102.40087,164.29057 v -3.21627 h 0.33972 q 0.12065,0 0.14923,0.11747 l 0.0413,0.3302 q 0.1778,-0.21907 0.40005,-0.35877 0.22225,-0.1397 0.51435,-0.1397 0.32385,0 0.52388,0.18097 0.2032,0.18098 0.2921,0.48895 0.0699,-0.17462 0.1778,-0.30162 0.11112,-0.127 0.24765,-0.20955 0.13652,-0.0825 0.28892,-0.12065 0.15558,-0.0381 0.31433,-0.0381 0.254,0 0.45085,0.0825 0.20002,0.0794 0.33655,0.23495 0.1397,0.15557 0.21272,0.38417 0.073,0.22543 0.073,0.51753 v 2.04787 h -0.56833 v -2.04787 q 0,-0.37783 -0.1651,-0.5715 -0.1651,-0.19685 -0.47625,-0.19685 -0.1397,0 -0.2667,0.0508 -0.12382,0.0476 -0.21907,0.14287 -0.0952,0.0952 -0.1524,0.2413 -0.054,0.14288 -0.054,0.33338 v 2.04787 h -0.56832 v -2.04787 q 0,-0.38735 -0.15558,-0.57785 -0.15557,-0.1905 -0.45402,-0.1905 -0.20955,0 -0.38735,0.1143 -0.1778,0.11112 -0.32703,0.3048 v 2.39712 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1035" />
+        <path
+           d="m 109.99545,162.58877 v 1.7018 h -0.61278 v -4.54977 h 1.34303 q 0.4318,0 0.7493,0.1016 0.32067,0.0984 0.53022,0.28257 0.20955,0.18415 0.31115,0.4445 0.10478,0.26035 0.10478,0.58103 0,0.3175 -0.11113,0.58102 -0.11112,0.26353 -0.32702,0.45403 -0.21273,0.1905 -0.53023,0.29845 -0.31432,0.10477 -0.72707,0.10477 z m 0,-0.48895 h 0.73025 q 0.26352,0 0.46355,-0.0699 0.2032,-0.0699 0.33972,-0.19367 0.1397,-0.127 0.20955,-0.30163 0.0699,-0.17462 0.0699,-0.38417 0,-0.43498 -0.26987,-0.67945 -0.2667,-0.24448 -0.8128,-0.24448 h -0.73025 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1037" />
+        <path
+           d="m 114.04356,165.2399 q -0.0286,0.0635 -0.073,0.1016 -0.0413,0.0381 -0.13017,0.0381 h -0.4191 l 0.58737,-1.27635 -1.32715,-3.02895 h 0.48895 q 0.073,0 0.1143,0.0381 0.0444,0.0349 0.0603,0.0794 l 0.86042,2.02565 q 0.0254,0.073 0.0476,0.14288 0.0222,0.0667 0.0381,0.1397 0.0413,-0.14288 0.0952,-0.28575 l 0.83502,-2.02248 q 0.0191,-0.0508 0.0635,-0.0825 0.0476,-0.0349 0.10478,-0.0349 h 0.44767 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1039" />
+        <path
+           d="m 117.32333,164.34137 q -0.381,0 -0.58738,-0.21272 -0.2032,-0.21273 -0.2032,-0.61278 v -1.9685 h -0.38735 q -0.0508,0 -0.0857,-0.0286 -0.0349,-0.0317 -0.0349,-0.0952 v -0.22543 l 0.52705,-0.0667 0.13018,-0.99378 q 0.01,-0.0476 0.0413,-0.0762 0.0349,-0.0318 0.0889,-0.0318 h 0.28575 v 1.10808 h 0.93028 v 0.40957 h -0.93028 v 1.9304 q 0,0.2032 0.0984,0.30163 0.0984,0.0984 0.254,0.0984 0.0889,0 0.1524,-0.0222 0.0667,-0.0254 0.1143,-0.054 0.0476,-0.0286 0.0794,-0.0508 0.0349,-0.0254 0.0603,-0.0254 0.0444,0 0.0794,0.054 l 0.1651,0.26987 q -0.14605,0.13653 -0.35242,0.2159 -0.20638,0.0762 -0.42545,0.0762 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1041" />
+        <path
+           d="m 118.61237,164.29057 v -4.67677 h 0.56833 v 1.8923 q 0.20637,-0.21908 0.4572,-0.34925 0.25082,-0.13335 0.57785,-0.13335 0.26352,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.13652,0.15875 0.20637,0.38417 0.0699,0.22543 0.0699,0.49848 v 2.04787 h -0.56832 v -2.04787 q 0,-0.36513 -0.16828,-0.56515 -0.1651,-0.2032 -0.50482,-0.2032 -0.254,0 -0.47308,0.12065 -0.2159,0.12065 -0.39687,0.32702 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1043" />
+        <path
+           d="m 123.51139,161.0235 q 0.35242,0 0.635,0.11747 0.28257,0.11748 0.4826,0.33338 0.20002,0.2159 0.3048,0.52387 0.10795,0.3048 0.10795,0.68263 0,0.381 -0.10795,0.6858 -0.10478,0.3048 -0.3048,0.5207 -0.20003,0.2159 -0.4826,0.33337 -0.28258,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.28258,-0.11747 -0.4826,-0.33337 -0.20003,-0.2159 -0.30798,-0.5207 -0.10477,-0.3048 -0.10477,-0.6858 0,-0.37783 0.10477,-0.68263 0.10795,-0.30797 0.30798,-0.52387 0.20002,-0.2159 0.4826,-0.33338 0.28575,-0.11747 0.64135,-0.11747 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.32068 0.23495,-0.89218 0,-0.57467 -0.23495,-0.89535 -0.23495,-0.32067 -0.7112,-0.32067 -0.2413,0 -0.42228,0.0825 -0.1778,0.0826 -0.29845,0.23812 -0.11747,0.15558 -0.1778,0.38418 -0.0571,0.22542 -0.0571,0.51117 0,0.5715 0.23495,0.89218 0.23813,0.3175 0.72073,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1045" />
+        <path
+           d="m 125.75611,164.29057 v -3.21627 h 0.33973 q 0.12065,0 0.14922,0.11747 l 0.0445,0.34925 q 0.20955,-0.23177 0.4699,-0.37465 0.26035,-0.14287 0.60008,-0.14287 0.26352,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.13652,0.15875 0.20637,0.38417 0.0699,0.22543 0.0699,0.49848 v 2.04787 h -0.56832 v -2.04787 q 0,-0.36513 -0.16828,-0.56515 -0.1651,-0.2032 -0.50482,-0.2032 -0.254,0 -0.47308,0.12065 -0.2159,0.12065 -0.39687,0.32702 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1047" />
+        <path
+           d="m 132.79824,161.60452 q -0.0381,0.0699 -0.11747,0.0699 -0.0476,0 -0.10795,-0.0349 -0.0603,-0.0349 -0.14923,-0.0762 -0.0857,-0.0445 -0.20637,-0.0794 -0.12065,-0.0381 -0.28575,-0.0381 -0.14288,0 -0.25718,0.0381 -0.1143,0.0349 -0.19685,0.0984 -0.0794,0.0635 -0.12382,0.14922 -0.0413,0.0825 -0.0413,0.18098 0,0.12382 0.0699,0.20637 0.073,0.0826 0.1905,0.14288 0.11748,0.0603 0.2667,0.10795 0.14923,0.0445 0.3048,0.0984 0.15875,0.0508 0.30798,0.1143 0.14922,0.0635 0.2667,0.15875 0.11747,0.0952 0.18732,0.23495 0.073,0.13653 0.073,0.3302 0,0.22225 -0.0794,0.41275 -0.0794,0.18733 -0.23495,0.32703 -0.15557,0.13652 -0.381,0.2159 -0.22542,0.0794 -0.5207,0.0794 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.11112 -0.46355,-0.28257 l 0.13335,-0.2159 q 0.0254,-0.0413 0.0603,-0.0635 0.0349,-0.0222 0.0889,-0.0222 0.0572,0 0.12065,0.0444 0.0635,0.0445 0.1524,0.0984 0.0921,0.054 0.22225,0.0984 0.13017,0.0444 0.32385,0.0444 0.1651,0 0.28892,-0.0413 0.12383,-0.0444 0.20638,-0.11748 0.0825,-0.073 0.12065,-0.16827 0.0413,-0.0952 0.0413,-0.2032 0,-0.13335 -0.073,-0.21908 -0.0699,-0.0889 -0.18733,-0.14922 -0.11747,-0.0635 -0.26987,-0.10795 -0.14923,-0.0476 -0.30798,-0.0984 -0.15557,-0.0508 -0.30797,-0.1143 -0.14923,-0.0667 -0.2667,-0.1651 -0.11748,-0.0984 -0.1905,-0.2413 -0.0699,-0.14605 -0.0699,-0.35242 0,-0.18415 0.0762,-0.35243 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.13017 0.35877,-0.20637 0.21273,-0.0762 0.48578,-0.0762 0.3175,0 0.56832,0.1016 0.254,0.0984 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1049" />
+        <path
+           d="m 135.91291,161.6458 q -0.0254,0.0349 -0.0508,0.054 -0.0254,0.019 -0.0699,0.019 -0.0476,0 -0.10477,-0.0381 -0.0572,-0.0413 -0.14288,-0.0889 -0.0825,-0.0476 -0.20637,-0.0857 -0.12065,-0.0413 -0.29845,-0.0413 -0.23813,0 -0.4191,0.0857 -0.18098,0.0826 -0.3048,0.2413 -0.12065,0.15875 -0.18415,0.38417 -0.0603,0.22543 -0.0603,0.50483 0,0.2921 0.0667,0.5207 0.0667,0.22542 0.18732,0.381 0.12383,0.1524 0.29528,0.23495 0.17462,0.0794 0.39052,0.0794 0.20638,0 0.33973,-0.0476 0.13335,-0.0508 0.21907,-0.11113 0.0889,-0.0603 0.14605,-0.10795 0.0603,-0.0508 0.11748,-0.0508 0.0699,0 0.10795,0.054 l 0.15875,0.20637 q -0.10478,0.13018 -0.23813,0.22225 -0.13335,0.0921 -0.28892,0.15558 -0.1524,0.0603 -0.32068,0.0889 -0.16827,0.0286 -0.3429,0.0286 -0.30162,0 -0.56197,-0.11112 -0.25718,-0.11113 -0.44768,-0.32068 -0.1905,-0.21272 -0.29845,-0.5207 -0.10795,-0.30797 -0.10795,-0.70167 0,-0.35878 0.0984,-0.66358 0.1016,-0.3048 0.2921,-0.52387 0.19367,-0.22225 0.47307,-0.34608 0.28258,-0.12382 0.6477,-0.12382 0.33973,0 0.5969,0.11112 0.26035,0.10795 0.46038,0.30798 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1051" />
+        <path
+           d="m 138.75136,164.29057 q -0.0825,0 -0.127,-0.0254 -0.0444,-0.0286 -0.0699,-0.10795 l -0.0635,-0.30162 q -0.127,0.1143 -0.25083,0.20637 -0.12065,0.0889 -0.254,0.1524 -0.13017,0.0603 -0.28257,0.0921 -0.14923,0.0349 -0.33338,0.0349 -0.18732,0 -0.35242,-0.0508 -0.1651,-0.054 -0.28893,-0.15875 -0.12065,-0.10477 -0.19367,-0.26352 -0.0699,-0.16193 -0.0699,-0.381 0,-0.1905 0.10477,-0.36513 0.10478,-0.1778 0.33973,-0.31432 0.23495,-0.13653 0.61277,-0.22225 0.37783,-0.0889 0.9271,-0.1016 v -0.25083 q 0,-0.37465 -0.16192,-0.56515 -0.16193,-0.19367 -0.47308,-0.19367 -0.20955,0 -0.35242,0.054 -0.1397,0.0508 -0.24448,0.11748 -0.1016,0.0635 -0.1778,0.11747 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.0286 -0.0413,-0.0318 -0.0699,-0.0762 l -0.1016,-0.18098 q 0.2667,-0.25717 0.57467,-0.38417 0.30798,-0.127 0.68263,-0.127 0.26987,0 0.47942,0.0889 0.20955,0.0889 0.35243,0.24765 0.14287,0.15875 0.2159,0.38417 0.073,0.22543 0.073,0.4953 v 2.0574 z m -1.21285,-0.34607 q 0.14922,0 0.27305,-0.0286 0.12382,-0.0317 0.23177,-0.0857 0.11113,-0.0571 0.20955,-0.13653 0.1016,-0.0825 0.19685,-0.18415 v -0.66675 q -0.39052,0.0127 -0.66675,0.0635 -0.27305,0.0476 -0.44767,0.127 -0.17145,0.0794 -0.25083,0.18733 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.21907 0.0413,0.0921 0.11112,0.1524 0.073,0.0572 0.16828,0.0857 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1053" />
+        <path
+           d="m 140.4468,159.6138 v 4.67677 h -0.56515 v -4.67677 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1055" />
+        <path
+           d="m 143.40589,164.29057 q -0.0825,0 -0.127,-0.0254 -0.0444,-0.0286 -0.0699,-0.10795 l -0.0635,-0.30162 q -0.127,0.1143 -0.25082,0.20637 -0.12065,0.0889 -0.254,0.1524 -0.13018,0.0603 -0.28258,0.0921 -0.14922,0.0349 -0.33337,0.0349 -0.18733,0 -0.35243,-0.0508 -0.1651,-0.054 -0.28892,-0.15875 -0.12065,-0.10477 -0.19368,-0.26352 -0.0699,-0.16193 -0.0699,-0.381 0,-0.1905 0.10478,-0.36513 0.10477,-0.1778 0.33972,-0.31432 0.23495,-0.13653 0.61278,-0.22225 0.37782,-0.0889 0.9271,-0.1016 v -0.25083 q 0,-0.37465 -0.16193,-0.56515 -0.16192,-0.19367 -0.47307,-0.19367 -0.20955,0 -0.35243,0.054 -0.1397,0.0508 -0.24447,0.11748 -0.1016,0.0635 -0.1778,0.11747 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.0286 -0.0413,-0.0318 -0.0699,-0.0762 l -0.1016,-0.18098 q 0.2667,-0.25717 0.57468,-0.38417 0.30797,-0.127 0.68262,-0.127 0.26988,0 0.47943,0.0889 0.20955,0.0889 0.35242,0.24765 0.14288,0.15875 0.2159,0.38417 0.073,0.22543 0.073,0.4953 v 2.0574 z m -1.21285,-0.34607 q 0.14923,0 0.27305,-0.0286 0.12383,-0.0317 0.23178,-0.0857 0.11112,-0.0571 0.20955,-0.13653 0.1016,-0.0825 0.19685,-0.18415 v -0.66675 q -0.39053,0.0127 -0.66675,0.0635 -0.27305,0.0476 -0.44768,0.127 -0.17145,0.0794 -0.25082,0.18733 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.21907 0.0413,0.0921 0.11113,0.1524 0.073,0.0572 0.16827,0.0857 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1057" />
+        <path
+           d="m 144.51714,164.29057 v -3.21627 h 0.32385 q 0.0921,0 0.127,0.0349 0.0349,0.0349 0.0476,0.12065 l 0.0349,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.22543,-0.18732 0.5461,-0.18732 0.1016,0 0.19368,0.0222 0.0952,0.0222 0.16827,0.0699 l -0.0413,0.42228 q -0.019,0.0794 -0.0952,0.0794 -0.0445,0 -0.13018,-0.019 -0.0857,-0.0191 -0.19367,-0.0191 -0.1524,0 -0.27305,0.0476 -0.12065,0.0445 -0.2159,0.13335 -0.0921,0.0857 -0.1651,0.21272 -0.073,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1059" />
+        <path
+           d="m 57.973187,173.66634 v -4.3053 h 0.339725 q 0.12065,0 0.149225,0.11748 l 0.04763,0.381 q 0.206375,-0.25083 0.473075,-0.40323 0.2667,-0.1524 0.6096,-0.1524 0.2794,0 0.504825,0.10795 0.225425,0.10478 0.384175,0.31433 0.15875,0.20637 0.244475,0.51435 0.08572,0.30797 0.08572,0.70802 0,0.3556 -0.09525,0.66358 -0.09525,0.3048 -0.276225,0.53022 -0.1778,0.22225 -0.43815,0.35243 -0.257175,0.127 -0.581025,0.127 -0.295275,0 -0.508,-0.0984 -0.20955,-0.0984 -0.371475,-0.2794 v 1.4224 z m 1.4351,-3.90525 q -0.276225,0 -0.485775,0.127 -0.206375,0.127 -0.381,0.35878 v 1.55575 q 0.1524,0.20955 0.33655,0.29527 0.187325,0.0857 0.415925,0.0857 0.45085,0 0.69215,-0.32068 0.2413,-0.32067 0.2413,-0.9144 0,-0.31432 -0.05715,-0.53975 -0.05398,-0.22542 -0.15875,-0.3683 -0.104775,-0.14605 -0.257175,-0.21272 -0.1524,-0.0667 -0.346075,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1061" />
+        <path
+           d="m 61.532357,172.57732 v -3.21628 h 0.32385 q 0.09208,0 0.127,0.0349 0.03493,0.0349 0.04762,0.12065 l 0.03493,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.225425,-0.18733 0.5461,-0.18733 0.1016,0 0.193675,0.0222 0.09525,0.0222 0.168275,0.0699 l -0.04128,0.42227 q -0.01905,0.0794 -0.09525,0.0794 -0.04445,0 -0.130175,-0.019 -0.08573,-0.019 -0.193675,-0.019 -0.1524,0 -0.27305,0.0476 -0.12065,0.0445 -0.2159,0.13335 -0.09208,0.0857 -0.1651,0.21273 -0.07303,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1063" />
+        <path
+           d="m 65.031195,169.31024 q 0.288925,0 0.5334,0.0984 0.24765,0.0952 0.42545,0.2794 0.180975,0.18097 0.282575,0.45085 0.1016,0.2667 0.1016,0.6096 0,0.13335 -0.02857,0.1778 -0.02858,0.0444 -0.10795,0.0444 H 64.08822 q 0.0063,0.3048 0.08255,0.53022 0.0762,0.22543 0.20955,0.37783 0.13335,0.14922 0.3175,0.22542 0.18415,0.073 0.41275,0.073 0.212725,0 0.365125,-0.0476 0.155575,-0.0508 0.2667,-0.10795 0.111125,-0.0572 0.18415,-0.10477 0.0762,-0.0508 0.130175,-0.0508 0.06985,0 0.10795,0.054 l 0.15875,0.20638 q -0.104775,0.127 -0.250825,0.22225 -0.14605,0.0921 -0.314325,0.1524 -0.1651,0.0603 -0.3429,0.0889 -0.1778,0.0317 -0.352425,0.0317 -0.333375,0 -0.61595,-0.11113 -0.2794,-0.1143 -0.485775,-0.3302 -0.2032,-0.21907 -0.3175,-0.53975 -0.1143,-0.32067 -0.1143,-0.7366 0,-0.33655 0.1016,-0.62865 0.104775,-0.2921 0.29845,-0.50482 0.193675,-0.2159 0.473075,-0.33655 0.2794,-0.12383 0.62865,-0.12383 z m 0.0127,0.41593 q -0.409575,0 -0.644525,0.23812 -0.23495,0.23495 -0.2921,0.65405 h 1.75895 q 0,-0.19685 -0.05715,-0.35877 -0.05398,-0.1651 -0.161925,-0.28258 -0.104775,-0.12065 -0.257175,-0.18415 -0.1524,-0.0667 -0.346075,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1065" />
+        <path
+           d="m 69.304745,169.93254 q -0.0254,0.0349 -0.0508,0.054 -0.0254,0.019 -0.06985,0.019 -0.04762,0 -0.104775,-0.0381 -0.05715,-0.0413 -0.142875,-0.0889 -0.08255,-0.0476 -0.206375,-0.0857 -0.12065,-0.0413 -0.29845,-0.0413 -0.238125,0 -0.4191,0.0857 -0.180975,0.0825 -0.3048,0.2413 -0.12065,0.15875 -0.18415,0.38418 -0.06033,0.22542 -0.06033,0.50482 0,0.2921 0.06668,0.5207 0.06667,0.22543 0.187325,0.381 0.123825,0.1524 0.295275,0.23495 0.174625,0.0794 0.390525,0.0794 0.206375,0 0.339725,-0.0476 0.13335,-0.0508 0.219075,-0.11112 0.0889,-0.0603 0.14605,-0.10795 0.06033,-0.0508 0.117475,-0.0508 0.06985,0 0.10795,0.054 l 0.15875,0.20638 q -0.104775,0.13017 -0.238125,0.22225 -0.13335,0.0921 -0.288925,0.15557 -0.1524,0.0603 -0.320675,0.0889 -0.168275,0.0286 -0.3429,0.0286 -0.301625,0 -0.561975,-0.11113 -0.257175,-0.11112 -0.447675,-0.32067 -0.1905,-0.21273 -0.29845,-0.5207 -0.10795,-0.30798 -0.10795,-0.70168 0,-0.35877 0.09842,-0.66357 0.1016,-0.3048 0.2921,-0.52388 0.193675,-0.22225 0.473075,-0.34607 0.282575,-0.12383 0.6477,-0.12383 0.339725,0 0.5969,0.11113 0.26035,0.10795 0.460375,0.30797 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1067" />
+        <path
+           d="m 70.695389,169.36104 v 3.21628 h -0.56515 v -3.21628 z m 0.12065,-1.00965 q 0,0.0825 -0.03493,0.15558 -0.03175,0.0699 -0.0889,0.127 -0.05398,0.054 -0.130175,0.0857 -0.07303,0.0317 -0.155575,0.0317 -0.08255,0 -0.155575,-0.0317 -0.06985,-0.0318 -0.123825,-0.0857 -0.05398,-0.0572 -0.08573,-0.127 -0.03175,-0.073 -0.03175,-0.15558 0,-0.0825 0.03175,-0.15557 0.03175,-0.0762 0.08573,-0.13018 0.05397,-0.0572 0.123825,-0.0889 0.07303,-0.0318 0.155575,-0.0318 0.08255,0 0.155575,0.0318 0.0762,0.0317 0.130175,0.0889 0.05715,0.054 0.0889,0.13018 0.03493,0.073 0.03493,0.15557 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1069" />
+        <path
+           d="m 73.495737,169.89127 q -0.0381,0.0699 -0.117475,0.0699 -0.04763,0 -0.10795,-0.0349 -0.06033,-0.0349 -0.149225,-0.0762 -0.08572,-0.0444 -0.206375,-0.0794 -0.12065,-0.0381 -0.28575,-0.0381 -0.142875,0 -0.257175,0.0381 -0.1143,0.0349 -0.19685,0.0984 -0.07937,0.0635 -0.123825,0.14923 -0.04127,0.0825 -0.04127,0.18097 0,0.12383 0.06985,0.20638 0.07302,0.0825 0.1905,0.14287 0.117475,0.0603 0.2667,0.10795 0.149225,0.0444 0.3048,0.0984 0.15875,0.0508 0.307975,0.1143 0.149225,0.0635 0.2667,0.15875 0.117475,0.0952 0.187325,0.23495 0.07303,0.13652 0.07303,0.3302 0,0.22225 -0.07937,0.41275 -0.07937,0.18732 -0.23495,0.32702 -0.155575,0.13653 -0.381,0.2159 -0.225425,0.0794 -0.5207,0.0794 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.11113 -0.46355,-0.28258 l 0.13335,-0.2159 q 0.0254,-0.0413 0.06032,-0.0635 0.03493,-0.0222 0.0889,-0.0222 0.05715,0 0.12065,0.0445 0.0635,0.0444 0.1524,0.0984 0.09207,0.054 0.22225,0.0984 0.130175,0.0445 0.32385,0.0445 0.1651,0 0.288925,-0.0413 0.123825,-0.0445 0.206375,-0.11747 0.08255,-0.073 0.12065,-0.16828 0.04127,-0.0952 0.04127,-0.2032 0,-0.13335 -0.07302,-0.21907 -0.06985,-0.0889 -0.187325,-0.14923 -0.117475,-0.0635 -0.269875,-0.10795 -0.149225,-0.0476 -0.307975,-0.0984 -0.155575,-0.0508 -0.307975,-0.1143 -0.149225,-0.0667 -0.2667,-0.1651 -0.117475,-0.0984 -0.1905,-0.2413 -0.06985,-0.14605 -0.06985,-0.35243 0,-0.18415 0.0762,-0.35242 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.13018 0.358775,-0.20638 0.212725,-0.0762 0.485775,-0.0762 0.3175,0 0.568325,0.1016 0.254,0.0984 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1071" />
+        <path
+           d="m 74.968929,169.36104 v 3.21628 h -0.56515 v -3.21628 z m 0.12065,-1.00965 q 0,0.0825 -0.03493,0.15558 -0.03175,0.0699 -0.0889,0.127 -0.05398,0.054 -0.130175,0.0857 -0.07303,0.0317 -0.155575,0.0317 -0.08255,0 -0.155575,-0.0317 -0.06985,-0.0318 -0.123825,-0.0857 -0.05398,-0.0572 -0.08572,-0.127 -0.03175,-0.073 -0.03175,-0.15558 0,-0.0825 0.03175,-0.15557 0.03175,-0.0762 0.08572,-0.13018 0.05397,-0.0572 0.123825,-0.0889 0.07303,-0.0318 0.155575,-0.0318 0.08255,0 0.155575,0.0318 0.0762,0.0317 0.130175,0.0889 0.05715,0.054 0.0889,0.13018 0.03493,0.073 0.03493,0.15557 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1073" />
+        <path
+           d="m 77.251752,169.31024 q 0.352425,0 0.635,0.11748 0.282575,0.11747 0.4826,0.33337 0.200025,0.2159 0.3048,0.52388 0.10795,0.3048 0.10795,0.68262 0,0.381 -0.10795,0.6858 -0.104775,0.3048 -0.3048,0.5207 -0.200025,0.2159 -0.4826,0.33338 -0.282575,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.282575,-0.11748 -0.4826,-0.33338 -0.200025,-0.2159 -0.307975,-0.5207 -0.104775,-0.3048 -0.104775,-0.6858 0,-0.37782 0.104775,-0.68262 0.10795,-0.30798 0.307975,-0.52388 0.200025,-0.2159 0.4826,-0.33337 0.28575,-0.11748 0.64135,-0.11748 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.32067 0.23495,-0.89217 0,-0.57468 -0.23495,-0.89535 -0.23495,-0.32068 -0.7112,-0.32068 -0.2413,0 -0.422275,0.0825 -0.1778,0.0825 -0.29845,0.23813 -0.117475,0.15557 -0.1778,0.38417 -0.05715,0.22543 -0.05715,0.51118 0,0.5715 0.23495,0.89217 0.238125,0.3175 0.720725,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1075" />
+        <path
+           d="m 79.496474,172.57732 v -3.21628 h 0.339725 q 0.12065,0 0.149225,0.11748 l 0.04445,0.34925 q 0.20955,-0.23178 0.4699,-0.37465 0.26035,-0.14288 0.600075,-0.14288 0.263525,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.136525,0.15875 0.206375,0.38418 0.06985,0.22542 0.06985,0.49847 v 2.04788 h -0.568325 v -2.04788 q 0,-0.36512 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396875,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1077" />
+        <path
+           d="m 84.19228,169.36104 h 0.4445 q 0.06668,0 0.111125,0.0349 0.04762,0.0349 0.0635,0.0825 l 0.61595,2.0701 q 0.0254,0.11112 0.04762,0.21907 0.02222,0.10478 0.0381,0.20955 0.0254,-0.10477 0.05715,-0.20955 0.03175,-0.10795 0.06668,-0.21907 l 0.67945,-2.0828 q 0.01587,-0.0476 0.05397,-0.0794 0.04127,-0.0317 0.09843,-0.0317 h 0.24765 q 0.0635,0 0.104775,0.0317 0.04127,0.0318 0.05715,0.0794 l 0.663575,2.0828 q 0.03175,0.11112 0.06033,0.21907 0.02857,0.10795 0.05397,0.21273 0.01905,-0.10478 0.04127,-0.20955 0.0254,-0.10795 0.05398,-0.22225 l 0.62865,-2.0701 q 0.01587,-0.0508 0.06033,-0.0825 0.04445,-0.0349 0.104775,-0.0349 h 0.42545 l -1.0414,3.21628 H 87.48158 q -0.08255,0 -0.1143,-0.10795 l -0.7112,-2.18123 q -0.0254,-0.073 -0.04127,-0.14605 -0.01588,-0.0762 -0.03175,-0.14922 -0.01588,0.073 -0.03493,0.14922 -0.01587,0.0762 -0.0381,0.14923 l -0.7239,2.17805 q -0.02858,0.10795 -0.127,0.10795 h -0.42545 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1079" />
+        <path
+           d="m 89.523103,172.57732 v -4.67678 h 0.568325 v 1.8923 q 0.206374,-0.21907 0.457199,-0.34925 0.250825,-0.13335 0.57785,-0.13335 0.263525,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.136525,0.15875 0.206375,0.38418 0.06985,0.22542 0.06985,0.49847 v 2.04788 h -0.568325 v -2.04788 q 0,-0.36512 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396874,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1081" />
+        <path
+           d="m 94.384017,169.31024 q 0.288925,0 0.5334,0.0984 0.24765,0.0952 0.42545,0.2794 0.180975,0.18097 0.282575,0.45085 0.1016,0.2667 0.1016,0.6096 0,0.13335 -0.02858,0.1778 -0.02857,0.0444 -0.10795,0.0444 h -2.149475 q 0.0063,0.3048 0.08255,0.53022 0.0762,0.22543 0.20955,0.37783 0.13335,0.14922 0.3175,0.22542 0.18415,0.073 0.41275,0.073 0.212725,0 0.365125,-0.0476 0.155575,-0.0508 0.2667,-0.10795 0.111125,-0.0572 0.18415,-0.10477 0.0762,-0.0508 0.130175,-0.0508 0.06985,0 0.10795,0.054 l 0.15875,0.20638 q -0.104775,0.127 -0.250825,0.22225 -0.14605,0.0921 -0.314325,0.1524 -0.1651,0.0603 -0.3429,0.0889 -0.1778,0.0317 -0.352425,0.0317 -0.333375,0 -0.61595,-0.11113 -0.2794,-0.1143 -0.485775,-0.3302 -0.2032,-0.21907 -0.3175,-0.53975 -0.1143,-0.32067 -0.1143,-0.7366 0,-0.33655 0.1016,-0.62865 0.104775,-0.2921 0.29845,-0.50482 0.193675,-0.2159 0.473075,-0.33655 0.2794,-0.12383 0.62865,-0.12383 z m 0.0127,0.41593 q -0.409575,0 -0.644525,0.23812 -0.23495,0.23495 -0.2921,0.65405 h 1.75895 q 0,-0.19685 -0.05715,-0.35877 -0.05397,-0.1651 -0.161925,-0.28258 -0.104775,-0.12065 -0.257175,-0.18415 -0.1524,-0.0667 -0.346075,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1083" />
+        <path
+           d="m 96.419194,172.57732 v -3.21628 h 0.339725 q 0.12065,0 0.149225,0.11748 l 0.04445,0.34925 q 0.20955,-0.23178 0.4699,-0.37465 0.26035,-0.14288 0.600075,-0.14288 0.263525,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.136525,0.15875 0.206375,0.38418 0.06985,0.22542 0.06985,0.49847 v 2.04788 h -0.568325 v -2.04788 q 0,-0.36512 -0.168275,-0.56515 -0.1651,-0.2032 -0.504825,-0.2032 -0.254,0 -0.473075,0.12065 -0.2159,0.12065 -0.396875,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1085" />
+        <path
+           d="m 102.9438,169.31024 q 0.35242,0 0.635,0.11748 0.28257,0.11747 0.4826,0.33337 0.20002,0.2159 0.3048,0.52388 0.10795,0.3048 0.10795,0.68262 0,0.381 -0.10795,0.6858 -0.10478,0.3048 -0.3048,0.5207 -0.20003,0.2159 -0.4826,0.33338 -0.28258,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.28258,-0.11748 -0.4826,-0.33338 -0.20003,-0.2159 -0.30798,-0.5207 -0.10477,-0.3048 -0.10477,-0.6858 0,-0.37782 0.10477,-0.68262 0.10795,-0.30798 0.30798,-0.52388 0.20002,-0.2159 0.4826,-0.33337 0.28575,-0.11748 0.64135,-0.11748 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.32067 0.23495,-0.89217 0,-0.57468 -0.23495,-0.89535 -0.23495,-0.32068 -0.7112,-0.32068 -0.2413,0 -0.42228,0.0825 -0.1778,0.0825 -0.29845,0.23813 -0.11747,0.15557 -0.1778,0.38417 -0.0572,0.22543 -0.0572,0.51118 0,0.5715 0.23495,0.89217 0.23813,0.3175 0.72073,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1087" />
+        <path
+           d="m 106.11879,172.62812 q -0.381,0 -0.58737,-0.21273 -0.2032,-0.21272 -0.2032,-0.61277 v -1.9685 h -0.38735 q -0.0508,0 -0.0857,-0.0286 -0.0349,-0.0318 -0.0349,-0.0953 v -0.22542 l 0.52705,-0.0667 0.13017,-0.99377 q 0.01,-0.0476 0.0413,-0.0762 0.0349,-0.0317 0.0889,-0.0317 h 0.28575 v 1.10807 h 0.93027 v 0.40958 h -0.93027 v 1.9304 q 0,0.2032 0.0984,0.30162 0.0984,0.0984 0.254,0.0984 0.0889,0 0.1524,-0.0222 0.0667,-0.0254 0.1143,-0.054 0.0476,-0.0286 0.0794,-0.0508 0.0349,-0.0254 0.0603,-0.0254 0.0444,0 0.0794,0.054 l 0.1651,0.26988 q -0.14605,0.13652 -0.35243,0.2159 -0.20637,0.0762 -0.42545,0.0762 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1089" />
+        <path
+           d="m 107.40784,172.57732 v -4.67678 h 0.56832 v 1.8923 q 0.20638,-0.21907 0.4572,-0.34925 0.25083,-0.13335 0.57785,-0.13335 0.26353,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.13653,0.15875 0.20638,0.38418 0.0699,0.22542 0.0699,0.49847 v 2.04788 h -0.56833 v -2.04788 q 0,-0.36512 -0.16827,-0.56515 -0.1651,-0.2032 -0.50483,-0.2032 -0.254,0 -0.47307,0.12065 -0.2159,0.12065 -0.39688,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1091" />
+        <path
+           d="m 112.26876,169.31024 q 0.28892,0 0.5334,0.0984 0.24765,0.0952 0.42545,0.2794 0.18097,0.18097 0.28257,0.45085 0.1016,0.2667 0.1016,0.6096 0,0.13335 -0.0286,0.1778 -0.0286,0.0444 -0.10795,0.0444 h -2.14948 q 0.006,0.3048 0.0826,0.53022 0.0762,0.22543 0.20955,0.37783 0.13335,0.14922 0.3175,0.22542 0.18415,0.073 0.41275,0.073 0.21273,0 0.36513,-0.0476 0.15557,-0.0508 0.2667,-0.10795 0.11112,-0.0572 0.18415,-0.10477 0.0762,-0.0508 0.13017,-0.0508 0.0699,0 0.10795,0.054 l 0.15875,0.20638 q -0.10477,0.127 -0.25082,0.22225 -0.14605,0.0921 -0.31433,0.1524 -0.1651,0.0603 -0.3429,0.0889 -0.1778,0.0317 -0.35242,0.0317 -0.33338,0 -0.61595,-0.11113 -0.2794,-0.1143 -0.48578,-0.3302 -0.2032,-0.21907 -0.3175,-0.53975 -0.1143,-0.32067 -0.1143,-0.7366 0,-0.33655 0.1016,-0.62865 0.10478,-0.2921 0.29845,-0.50482 0.19368,-0.2159 0.47308,-0.33655 0.2794,-0.12383 0.62865,-0.12383 z m 0.0127,0.41593 q -0.40958,0 -0.64453,0.23812 -0.23495,0.23495 -0.2921,0.65405 h 1.75895 q 0,-0.19685 -0.0572,-0.35877 -0.054,-0.1651 -0.16192,-0.28258 -0.10478,-0.12065 -0.25718,-0.18415 -0.1524,-0.0667 -0.34607,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1093" />
+        <path
+           d="m 114.30393,172.57732 v -3.21628 h 0.32385 q 0.0921,0 0.127,0.0349 0.0349,0.0349 0.0476,0.12065 l 0.0349,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.22542,-0.18733 0.5461,-0.18733 0.1016,0 0.19367,0.0222 0.0952,0.0222 0.16828,0.0699 l -0.0413,0.42227 q -0.019,0.0794 -0.0952,0.0794 -0.0445,0 -0.13017,-0.019 -0.0857,-0.019 -0.19368,-0.019 -0.1524,0 -0.27305,0.0476 -0.12065,0.0445 -0.2159,0.13335 -0.0921,0.0857 -0.1651,0.21273 -0.073,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1095" />
+        <path
+           d="m 118.70445,169.36104 v 3.21628 h -0.56515 v -3.21628 z m 0.12065,-1.00965 q 0,0.0825 -0.0349,0.15558 -0.0318,0.0699 -0.0889,0.127 -0.054,0.054 -0.13017,0.0857 -0.073,0.0317 -0.15558,0.0317 -0.0825,0 -0.15557,-0.0317 -0.0699,-0.0318 -0.12383,-0.0857 -0.054,-0.0572 -0.0857,-0.127 -0.0318,-0.073 -0.0318,-0.15558 0,-0.0825 0.0318,-0.15557 0.0318,-0.0762 0.0857,-0.13018 0.054,-0.0572 0.12383,-0.0889 0.073,-0.0318 0.15557,-0.0318 0.0825,0 0.15558,0.0318 0.0762,0.0317 0.13017,0.0889 0.0572,0.054 0.0889,0.13018 0.0349,0.073 0.0349,0.15557 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1097" />
+        <path
+           d="m 121.5048,169.89127 q -0.0381,0.0699 -0.11748,0.0699 -0.0476,0 -0.10795,-0.0349 -0.0603,-0.0349 -0.14922,-0.0762 -0.0857,-0.0444 -0.20638,-0.0794 -0.12065,-0.0381 -0.28575,-0.0381 -0.14287,0 -0.25717,0.0381 -0.1143,0.0349 -0.19685,0.0984 -0.0794,0.0635 -0.12383,0.14923 -0.0413,0.0825 -0.0413,0.18097 0,0.12383 0.0699,0.20638 0.073,0.0825 0.1905,0.14287 0.11747,0.0603 0.2667,0.10795 0.14922,0.0444 0.3048,0.0984 0.15875,0.0508 0.30797,0.1143 0.14923,0.0635 0.2667,0.15875 0.11748,0.0952 0.18733,0.23495 0.073,0.13652 0.073,0.3302 0,0.22225 -0.0794,0.41275 -0.0794,0.18732 -0.23495,0.32702 -0.15558,0.13653 -0.381,0.2159 -0.22543,0.0794 -0.5207,0.0794 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.11113 -0.46355,-0.28258 l 0.13335,-0.2159 q 0.0254,-0.0413 0.0603,-0.0635 0.0349,-0.0222 0.0889,-0.0222 0.0572,0 0.12065,0.0445 0.0635,0.0444 0.1524,0.0984 0.0921,0.054 0.22225,0.0984 0.13018,0.0445 0.32385,0.0445 0.1651,0 0.28893,-0.0413 0.12382,-0.0445 0.20637,-0.11747 0.0825,-0.073 0.12065,-0.16828 0.0413,-0.0952 0.0413,-0.2032 0,-0.13335 -0.073,-0.21907 -0.0699,-0.0889 -0.18732,-0.14923 -0.11748,-0.0635 -0.26988,-0.10795 -0.14922,-0.0476 -0.30797,-0.0984 -0.15558,-0.0508 -0.30798,-0.1143 -0.14922,-0.0667 -0.2667,-0.1651 -0.11747,-0.0984 -0.1905,-0.2413 -0.0699,-0.14605 -0.0699,-0.35243 0,-0.18415 0.0762,-0.35242 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.13018 0.35878,-0.20638 0.21272,-0.0762 0.48577,-0.0762 0.3175,0 0.56833,0.1016 0.254,0.0984 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1099" />
+        <path
+           d="m 124.60358,169.36104 v 3.21628 h -0.56515 v -3.21628 z m 0.12065,-1.00965 q 0,0.0825 -0.0349,0.15558 -0.0318,0.0699 -0.0889,0.127 -0.054,0.054 -0.13018,0.0857 -0.073,0.0317 -0.15557,0.0317 -0.0825,0 -0.15558,-0.0317 -0.0699,-0.0318 -0.12382,-0.0857 -0.054,-0.0572 -0.0857,-0.127 -0.0318,-0.073 -0.0318,-0.15558 0,-0.0825 0.0318,-0.15557 0.0318,-0.0762 0.0857,-0.13018 0.054,-0.0572 0.12382,-0.0889 0.073,-0.0318 0.15558,-0.0318 0.0825,0 0.15557,0.0318 0.0762,0.0317 0.13018,0.0889 0.0572,0.054 0.0889,0.13018 0.0349,0.073 0.0349,0.15557 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1101" />
+        <path
+           d="m 125.53067,172.57732 v -3.21628 h 0.33973 q 0.12065,0 0.14922,0.11748 l 0.0444,0.34925 q 0.20955,-0.23178 0.4699,-0.37465 0.26035,-0.14288 0.60008,-0.14288 0.26352,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.13652,0.15875 0.20637,0.38418 0.0699,0.22542 0.0699,0.49847 v 2.04788 h -0.56832 v -2.04788 q 0,-0.36512 -0.16828,-0.56515 -0.1651,-0.2032 -0.50482,-0.2032 -0.254,0 -0.47308,0.12065 -0.2159,0.12065 -0.39687,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1103" />
+        <path
+           d="m 130.01693,172.62812 q -0.381,0 -0.58737,-0.21273 -0.2032,-0.21272 -0.2032,-0.61277 v -1.9685 h -0.38735 q -0.0508,0 -0.0857,-0.0286 -0.0349,-0.0318 -0.0349,-0.0953 v -0.22542 l 0.52705,-0.0667 0.13017,-0.99377 q 0.01,-0.0476 0.0413,-0.0762 0.0349,-0.0317 0.0889,-0.0317 h 0.28575 v 1.10807 h 0.93027 v 0.40958 h -0.93027 v 1.9304 q 0,0.2032 0.0984,0.30162 0.0984,0.0984 0.254,0.0984 0.0889,0 0.1524,-0.0222 0.0667,-0.0254 0.1143,-0.054 0.0476,-0.0286 0.0794,-0.0508 0.0349,-0.0254 0.0603,-0.0254 0.0444,0 0.0794,0.054 l 0.1651,0.26988 q -0.14605,0.13652 -0.35243,0.2159 -0.20637,0.0762 -0.42545,0.0762 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1105" />
+        <path
+           d="m 132.62361,169.31024 q 0.28892,0 0.5334,0.0984 0.24765,0.0952 0.42545,0.2794 0.18097,0.18097 0.28257,0.45085 0.1016,0.2667 0.1016,0.6096 0,0.13335 -0.0286,0.1778 -0.0286,0.0444 -0.10795,0.0444 h -2.14948 q 0.006,0.3048 0.0825,0.53022 0.0762,0.22543 0.20955,0.37783 0.13335,0.14922 0.3175,0.22542 0.18415,0.073 0.41275,0.073 0.21273,0 0.36513,-0.0476 0.15557,-0.0508 0.2667,-0.10795 0.11112,-0.0572 0.18415,-0.10477 0.0762,-0.0508 0.13017,-0.0508 0.0698,0 0.10795,0.054 l 0.15875,0.20638 q -0.10477,0.127 -0.25082,0.22225 -0.14605,0.0921 -0.31433,0.1524 -0.1651,0.0603 -0.3429,0.0889 -0.1778,0.0317 -0.35242,0.0317 -0.33338,0 -0.61595,-0.11113 -0.2794,-0.1143 -0.48578,-0.3302 -0.2032,-0.21907 -0.3175,-0.53975 -0.1143,-0.32067 -0.1143,-0.7366 0,-0.33655 0.1016,-0.62865 0.10478,-0.2921 0.29845,-0.50482 0.19368,-0.2159 0.47308,-0.33655 0.2794,-0.12383 0.62865,-0.12383 z m 0.0127,0.41593 q -0.40958,0 -0.64453,0.23812 -0.23495,0.23495 -0.2921,0.65405 h 1.75895 q 0,-0.19685 -0.0572,-0.35877 -0.054,-0.1651 -0.16192,-0.28258 -0.10478,-0.12065 -0.25718,-0.18415 -0.1524,-0.0667 -0.34607,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1107" />
+        <path
+           d="m 135.77955,169.30707 q 0.20955,0 0.39053,0.0476 0.18097,0.0444 0.3302,0.13335 h 0.87312 v 0.20955 q 0,0.10478 -0.13335,0.13335 l -0.36512,0.0508 q 0.10795,0.20638 0.10795,0.46038 0,0.23495 -0.0921,0.42862 -0.0889,0.1905 -0.24765,0.32703 -0.15875,0.13652 -0.381,0.20955 -0.22225,0.073 -0.4826,0.073 -0.2286,0 -0.42862,-0.054 -0.1016,0.0635 -0.15558,0.13652 -0.0508,0.073 -0.0508,0.14288 0,0.1143 0.0921,0.17462 0.0953,0.0571 0.24765,0.0825 0.1524,0.0254 0.34607,0.0317 0.19685,0.006 0.40005,0.0222 0.20638,0.0127 0.40005,0.0476 0.19685,0.0349 0.34925,0.1143 0.1524,0.0794 0.24448,0.21908 0.0953,0.1397 0.0953,0.36195 0,0.20637 -0.10478,0.40005 -0.1016,0.19367 -0.29527,0.3429 -0.19368,0.1524 -0.47625,0.2413 -0.2794,0.0921 -0.63183,0.0921 -0.35242,0 -0.61595,-0.0699 -0.26352,-0.0699 -0.43815,-0.18732 -0.17462,-0.11748 -0.26352,-0.27305 -0.0857,-0.1524 -0.0857,-0.32068 0,-0.23812 0.14923,-0.40322 0.14922,-0.1651 0.4064,-0.26353 -0.14288,-0.0635 -0.22543,-0.16827 -0.0825,-0.10795 -0.0825,-0.28893 0,-0.0699 0.0254,-0.14287 0.0254,-0.0762 0.0762,-0.14923 0.054,-0.073 0.13018,-0.1397 0.0762,-0.0667 0.1778,-0.11747 -0.23813,-0.13335 -0.37148,-0.3556 -0.13335,-0.22225 -0.13335,-0.51435 0,-0.23495 0.0889,-0.42545 0.0921,-0.19368 0.254,-0.32703 0.16193,-0.13652 0.38418,-0.20955 0.22542,-0.073 0.49212,-0.073 z m 1.01918,3.44487 q 0,-0.11747 -0.0667,-0.1905 -0.0667,-0.073 -0.18097,-0.1143 -0.11113,-0.0413 -0.26035,-0.0571 -0.14923,-0.0191 -0.3175,-0.0286 -0.1651,-0.01 -0.33655,-0.0191 -0.17145,-0.01 -0.3302,-0.0317 -0.1778,0.0825 -0.2921,0.20637 -0.11113,0.12383 -0.11113,0.29528 0,0.10795 0.054,0.20002 0.0571,0.0952 0.17145,0.16193 0.1143,0.0699 0.28575,0.10795 0.17462,0.0413 0.40957,0.0413 0.2286,0 0.40958,-0.0413 0.18097,-0.0413 0.3048,-0.11748 0.127,-0.0762 0.19367,-0.18097 0.0667,-0.10478 0.0667,-0.23178 z m -1.01918,-1.74625 q 0.17145,0 0.30163,-0.0476 0.13017,-0.0476 0.21907,-0.13335 0.0889,-0.0857 0.13335,-0.2032 0.0444,-0.12065 0.0444,-0.26353 0,-0.29527 -0.18097,-0.4699 -0.1778,-0.17462 -0.51753,-0.17462 -0.3429,0 -0.52387,0.17462 -0.1778,0.17463 -0.1778,0.4699 0,0.14288 0.0445,0.26353 0.0476,0.11747 0.13652,0.2032 0.0889,0.0857 0.21908,0.13335 0.13017,0.0476 0.30162,0.0476 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1109" />
+        <path
+           d="m 137.96077,172.57732 v -3.21628 h 0.32385 q 0.0921,0 0.127,0.0349 0.0349,0.0349 0.0476,0.12065 l 0.0349,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.22542,-0.18733 0.5461,-0.18733 0.1016,0 0.19367,0.0222 0.0953,0.0222 0.16828,0.0699 l -0.0413,0.42227 q -0.019,0.0794 -0.0952,0.0794 -0.0445,0 -0.13017,-0.019 -0.0857,-0.019 -0.19368,-0.019 -0.1524,0 -0.27305,0.0476 -0.12065,0.0445 -0.2159,0.13335 -0.0921,0.0857 -0.1651,0.21273 -0.073,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1111" />
+        <path
+           d="m 142.26605,172.57732 q -0.0825,0 -0.127,-0.0254 -0.0444,-0.0286 -0.0699,-0.10795 l -0.0635,-0.30163 q -0.127,0.1143 -0.25083,0.20638 -0.12065,0.0889 -0.254,0.1524 -0.13017,0.0603 -0.28257,0.0921 -0.14923,0.0349 -0.33338,0.0349 -0.18732,0 -0.35242,-0.0508 -0.1651,-0.054 -0.28893,-0.15875 -0.12065,-0.10478 -0.19367,-0.26353 -0.0699,-0.16192 -0.0699,-0.381 0,-0.1905 0.10477,-0.36512 0.10478,-0.1778 0.33973,-0.31433 0.23495,-0.13652 0.61277,-0.22225 0.37783,-0.0889 0.9271,-0.1016 v -0.25082 q 0,-0.37465 -0.16192,-0.56515 -0.16193,-0.19368 -0.47308,-0.19368 -0.20955,0 -0.35242,0.054 -0.1397,0.0508 -0.24448,0.11747 -0.1016,0.0635 -0.1778,0.11748 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.0286 -0.0413,-0.0317 -0.0699,-0.0762 l -0.1016,-0.18097 q 0.2667,-0.25718 0.57467,-0.38418 0.30798,-0.127 0.68263,-0.127 0.26987,0 0.47942,0.0889 0.20955,0.0889 0.35243,0.24765 0.14287,0.15875 0.2159,0.38418 0.073,0.22542 0.073,0.4953 v 2.0574 z m -1.21285,-0.34608 q 0.14922,0 0.27305,-0.0286 0.12382,-0.0318 0.23177,-0.0857 0.11113,-0.0572 0.20955,-0.13652 0.1016,-0.0825 0.19685,-0.18415 v -0.66675 q -0.39052,0.0127 -0.66675,0.0635 -0.27305,0.0476 -0.44767,0.127 -0.17145,0.0794 -0.25083,0.18732 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.21908 0.0413,0.0921 0.11112,0.1524 0.073,0.0572 0.16828,0.0857 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1113" />
+        <path
+           d="m 143.9615,167.90054 v 4.67678 h -0.56515 v -4.67678 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1115" />
+        <path
+           d="m 145.18704,172.64399 q -0.0413,0.11113 -0.13018,0.1651 -0.0857,0.054 -0.1778,0.054 h -0.23812 l 1.90817,-4.75298 q 0.0381,-0.1016 0.1143,-0.15557 0.0794,-0.054 0.18098,-0.054 h 0.2413 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1117" />
+        <path
+           d="m 147.74608,172.57732 v -4.67678 h 0.56833 v 1.92723 q 0.20002,-0.23813 0.4572,-0.37783 0.25717,-0.1397 0.59055,-0.1397 0.28257,0 0.508,0.10795 0.2286,0.10795 0.38735,0.31433 0.15875,0.2032 0.2413,0.4953 0.0857,0.2921 0.0857,0.65722 0,0.39053 -0.0952,0.7112 -0.0953,0.32068 -0.27622,0.54928 -0.1778,0.22542 -0.43498,0.35242 -0.25717,0.12383 -0.57785,0.12383 -0.3175,0 -0.53657,-0.11748 -0.2159,-0.12065 -0.37783,-0.33972 l -0.0286,0.2921 q -0.0254,0.12065 -0.14605,0.12065 z m 1.42875,-2.81623 q -0.27622,0 -0.4826,0.127 -0.20637,0.127 -0.37782,0.35878 v 1.55575 q 0.15557,0.20955 0.33972,0.29527 0.18733,0.0857 0.40958,0.0857 0.45402,0 0.69532,-0.32068 0.2413,-0.32067 0.2413,-0.95567 0,-0.59055 -0.2159,-0.86678 -0.21272,-0.2794 -0.6096,-0.2794 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1119" />
+        <path
+           d="m 152.65781,169.31024 q 0.35242,0 0.635,0.11748 0.28257,0.11747 0.4826,0.33337 0.20002,0.2159 0.3048,0.52388 0.10795,0.3048 0.10795,0.68262 0,0.381 -0.10795,0.6858 -0.10478,0.3048 -0.3048,0.5207 -0.20003,0.2159 -0.4826,0.33338 -0.28258,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.28258,-0.11748 -0.4826,-0.33338 -0.20003,-0.2159 -0.30798,-0.5207 -0.10477,-0.3048 -0.10477,-0.6858 0,-0.37782 0.10477,-0.68262 0.10795,-0.30798 0.30798,-0.52388 0.20002,-0.2159 0.4826,-0.33337 0.28575,-0.11748 0.64135,-0.11748 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.32067 0.23495,-0.89217 0,-0.57468 -0.23495,-0.89535 -0.23495,-0.32068 -0.7112,-0.32068 -0.2413,0 -0.42228,0.0825 -0.1778,0.0825 -0.29845,0.23813 -0.11747,0.15557 -0.1778,0.38417 -0.0571,0.22543 -0.0571,0.51118 0,0.5715 0.23495,0.89217 0.23813,0.3175 0.72073,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1121" />
+        <path
+           d="m 156.25826,169.31024 q 0.35242,0 0.635,0.11748 0.28257,0.11747 0.4826,0.33337 0.20002,0.2159 0.3048,0.52388 0.10795,0.3048 0.10795,0.68262 0,0.381 -0.10795,0.6858 -0.10478,0.3048 -0.3048,0.5207 -0.20003,0.2159 -0.4826,0.33338 -0.28258,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.28258,-0.11748 -0.4826,-0.33338 -0.20003,-0.2159 -0.30798,-0.5207 -0.10477,-0.3048 -0.10477,-0.6858 0,-0.37782 0.10477,-0.68262 0.10795,-0.30798 0.30798,-0.52388 0.20002,-0.2159 0.4826,-0.33337 0.28575,-0.11748 0.64135,-0.11748 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.32067 0.23495,-0.89217 0,-0.57468 -0.23495,-0.89535 -0.23495,-0.32068 -0.7112,-0.32068 -0.2413,0 -0.42228,0.0825 -0.1778,0.0825 -0.29845,0.23813 -0.11747,0.15557 -0.1778,0.38417 -0.0572,0.22543 -0.0572,0.51118 0,0.5715 0.23495,0.89217 0.23813,0.3175 0.72073,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1123" />
+        <path
+           d="m 159.08717,167.90054 v 4.67678 h -0.56515 v -4.67678 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1125" />
+        <path
+           d="m 161.31919,169.31024 q 0.28892,0 0.5334,0.0984 0.24765,0.0952 0.42545,0.2794 0.18097,0.18097 0.28257,0.45085 0.1016,0.2667 0.1016,0.6096 0,0.13335 -0.0286,0.1778 -0.0286,0.0444 -0.10795,0.0444 h -2.14948 q 0.006,0.3048 0.0826,0.53022 0.0762,0.22543 0.20955,0.37783 0.13335,0.14922 0.3175,0.22542 0.18415,0.073 0.41275,0.073 0.21273,0 0.36513,-0.0476 0.15557,-0.0508 0.2667,-0.10795 0.11112,-0.0572 0.18415,-0.10477 0.0762,-0.0508 0.13017,-0.0508 0.0699,0 0.10795,0.054 l 0.15875,0.20638 q -0.10477,0.127 -0.25082,0.22225 -0.14605,0.0921 -0.31433,0.1524 -0.1651,0.0603 -0.3429,0.0889 -0.1778,0.0317 -0.35242,0.0317 -0.33338,0 -0.61595,-0.11113 -0.2794,-0.1143 -0.48578,-0.3302 -0.2032,-0.21907 -0.3175,-0.53975 -0.1143,-0.32067 -0.1143,-0.7366 0,-0.33655 0.1016,-0.62865 0.10478,-0.2921 0.29845,-0.50482 0.19368,-0.2159 0.47308,-0.33655 0.2794,-0.12383 0.62865,-0.12383 z m 0.0127,0.41593 q -0.40958,0 -0.64453,0.23812 -0.23495,0.23495 -0.2921,0.65405 h 1.75895 q 0,-0.19685 -0.0572,-0.35877 -0.054,-0.1651 -0.16192,-0.28258 -0.10478,-0.12065 -0.25718,-0.18415 -0.1524,-0.0667 -0.34607,-0.0667 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1127" />
+        <path
+           d="m 165.39906,172.57732 q -0.0825,0 -0.127,-0.0254 -0.0445,-0.0286 -0.0699,-0.10795 l -0.0635,-0.30163 q -0.127,0.1143 -0.25083,0.20638 -0.12065,0.0889 -0.254,0.1524 -0.13017,0.0603 -0.28257,0.0921 -0.14923,0.0349 -0.33338,0.0349 -0.18732,0 -0.35242,-0.0508 -0.1651,-0.054 -0.28893,-0.15875 -0.12065,-0.10478 -0.19367,-0.26353 -0.0699,-0.16192 -0.0699,-0.381 0,-0.1905 0.10477,-0.36512 0.10478,-0.1778 0.33973,-0.31433 0.23495,-0.13652 0.61277,-0.22225 0.37783,-0.0889 0.9271,-0.1016 v -0.25082 q 0,-0.37465 -0.16192,-0.56515 -0.16193,-0.19368 -0.47308,-0.19368 -0.20955,0 -0.35242,0.054 -0.1397,0.0508 -0.24448,0.11747 -0.1016,0.0635 -0.1778,0.11748 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.0286 -0.0413,-0.0317 -0.0699,-0.0762 l -0.1016,-0.18097 q 0.2667,-0.25718 0.57467,-0.38418 0.30798,-0.127 0.68263,-0.127 0.26987,0 0.47942,0.0889 0.20955,0.0889 0.35243,0.24765 0.14287,0.15875 0.2159,0.38418 0.073,0.22542 0.073,0.4953 v 2.0574 z m -1.21285,-0.34608 q 0.14922,0 0.27305,-0.0286 0.12382,-0.0318 0.23177,-0.0857 0.11113,-0.0572 0.20955,-0.13652 0.1016,-0.0825 0.19685,-0.18415 v -0.66675 q -0.39052,0.0127 -0.66675,0.0635 -0.27305,0.0476 -0.44767,0.127 -0.17145,0.0794 -0.25083,0.18732 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.21908 0.0413,0.0921 0.11112,0.1524 0.073,0.0572 0.16828,0.0857 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1129" />
+        <path
+           d="m 166.51031,172.57732 v -3.21628 h 0.33973 q 0.12065,0 0.14922,0.11748 l 0.0445,0.34925 q 0.20955,-0.23178 0.4699,-0.37465 0.26035,-0.14288 0.60008,-0.14288 0.26352,0 0.46355,0.0889 0.2032,0.0857 0.33655,0.24765 0.13652,0.15875 0.20637,0.38418 0.0699,0.22542 0.0699,0.49847 v 2.04788 h -0.56832 v -2.04788 q 0,-0.36512 -0.16828,-0.56515 -0.1651,-0.2032 -0.50482,-0.2032 -0.254,0 -0.47308,0.12065 -0.2159,0.12065 -0.39687,0.32703 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1131" />
+      </g>
+    </g>
+    <g
+       id="g961"
+       transform="translate(-3.7473145e-6,-1.7989611)">
+      <path
+         id="rect10573"
+         style="fill:#ffdc86;fill-opacity:1;stroke:#ffdc86;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:128.863;stroke-opacity:1"
+         d="m -175.85457,57.390038 h 45.5556 v 20 h -45.5556 z" />
+      <g
+         aria-label="Python scalars"
+         id="text10579"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Medium';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           d="m -172.21403,67.482114 v 1.7018 h -0.61277 v -4.549775 h 1.34302 q 0.4318,0 0.7493,0.1016 0.32068,0.09843 0.53023,0.282575 0.20955,0.18415 0.31115,0.4445 0.10477,0.26035 0.10477,0.581025 0,0.3175 -0.11112,0.581025 -0.11113,0.263525 -0.32703,0.454025 -0.21272,0.1905 -0.53022,0.29845 -0.31433,0.104775 -0.72708,0.104775 z m 0,-0.48895 h 0.73025 q 0.26353,0 0.46355,-0.06985 0.2032,-0.06985 0.33973,-0.193675 0.1397,-0.127 0.20955,-0.301625 0.0698,-0.174625 0.0698,-0.384175 0,-0.434975 -0.26988,-0.67945 -0.2667,-0.244475 -0.8128,-0.244475 h -0.73025 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path995" />
+        <path
+           d="m -168.16592,70.133239 q -0.0286,0.0635 -0.073,0.1016 -0.0413,0.0381 -0.13018,0.0381 h -0.4191 l 0.58738,-1.27635 -1.32715,-3.02895 h 0.48895 q 0.073,0 0.1143,0.0381 0.0445,0.03493 0.0603,0.07937 l 0.86043,2.02565 q 0.0254,0.07303 0.0476,0.142875 0.0222,0.06667 0.0381,0.1397 0.0413,-0.142875 0.0952,-0.28575 l 0.83503,-2.022475 q 0.019,-0.0508 0.0635,-0.08255 0.0476,-0.03493 0.10477,-0.03493 h 0.44768 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path997" />
+        <path
+           d="m -164.88615,69.234714 q -0.381,0 -0.58737,-0.212725 -0.2032,-0.212725 -0.2032,-0.612775 v -1.9685 h -0.38735 q -0.0508,0 -0.0857,-0.02858 -0.0349,-0.03175 -0.0349,-0.09525 v -0.225425 l 0.52705,-0.06668 0.13017,-0.993775 q 0.01,-0.04762 0.0413,-0.0762 0.0349,-0.03175 0.0889,-0.03175 h 0.28575 v 1.108075 h 0.93027 v 0.409575 h -0.93027 v 1.9304 q 0,0.2032 0.0984,0.301625 0.0984,0.09842 0.254,0.09842 0.0889,0 0.1524,-0.02223 0.0667,-0.0254 0.1143,-0.05397 0.0476,-0.02858 0.0794,-0.0508 0.0349,-0.0254 0.0603,-0.0254 0.0444,0 0.0794,0.05398 l 0.1651,0.269875 q -0.14605,0.136525 -0.35243,0.2159 -0.20637,0.0762 -0.42545,0.0762 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path999" />
+        <path
+           d="m -163.5971,69.183914 v -4.676775 h 0.56832 v 1.8923 q 0.20638,-0.219075 0.4572,-0.34925 0.25083,-0.13335 0.57785,-0.13335 0.26353,0 0.46355,0.0889 0.2032,0.08572 0.33655,0.24765 0.13653,0.15875 0.20638,0.384175 0.0699,0.225425 0.0699,0.498475 v 2.047875 h -0.56833 v -2.047875 q 0,-0.365125 -0.16827,-0.56515 -0.1651,-0.2032 -0.50483,-0.2032 -0.254,0 -0.47307,0.12065 -0.2159,0.12065 -0.39688,0.327025 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1001" />
+        <path
+           d="m -158.69808,65.916839 q 0.35242,0 0.635,0.117475 0.28257,0.117475 0.4826,0.333375 0.20002,0.2159 0.3048,0.523875 0.10795,0.3048 0.10795,0.682625 0,0.381 -0.10795,0.6858 -0.10478,0.3048 -0.3048,0.5207 -0.20003,0.2159 -0.4826,0.333375 -0.28258,0.1143 -0.635,0.1143 -0.3556,0 -0.64135,-0.1143 -0.28258,-0.117475 -0.4826,-0.333375 -0.20003,-0.2159 -0.30798,-0.5207 -0.10477,-0.3048 -0.10477,-0.6858 0,-0.377825 0.10477,-0.682625 0.10795,-0.307975 0.30798,-0.523875 0.20002,-0.2159 0.4826,-0.333375 0.28575,-0.117475 0.64135,-0.117475 z m 0,2.8702 q 0.47625,0 0.7112,-0.3175 0.23495,-0.320675 0.23495,-0.892175 0,-0.574675 -0.23495,-0.89535 -0.23495,-0.320675 -0.7112,-0.320675 -0.2413,0 -0.42228,0.08255 -0.1778,0.08255 -0.29845,0.238125 -0.11747,0.155575 -0.1778,0.384175 -0.0572,0.225425 -0.0572,0.511175 0,0.5715 0.23495,0.892175 0.23813,0.3175 0.72073,0.3175 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1003" />
+        <path
+           d="m -156.45336,69.183914 v -3.216275 h 0.33972 q 0.12065,0 0.14923,0.117475 l 0.0444,0.34925 q 0.20955,-0.231775 0.4699,-0.37465 0.26035,-0.142875 0.60007,-0.142875 0.26353,0 0.46355,0.0889 0.2032,0.08572 0.33655,0.24765 0.13653,0.15875 0.20638,0.384175 0.0699,0.225425 0.0699,0.498475 v 2.047875 h -0.56833 v -2.047875 q 0,-0.365125 -0.16827,-0.56515 -0.1651,-0.2032 -0.50483,-0.2032 -0.254,0 -0.47307,0.12065 -0.2159,0.12065 -0.39688,0.327025 v 2.36855 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1005" />
+        <path
+           d="m -149.41123,66.497864 q -0.0381,0.06985 -0.11748,0.06985 -0.0476,0 -0.10795,-0.03493 -0.0603,-0.03492 -0.14922,-0.0762 -0.0857,-0.04445 -0.20638,-0.07937 -0.12065,-0.0381 -0.28575,-0.0381 -0.14287,0 -0.25717,0.0381 -0.1143,0.03493 -0.19685,0.09843 -0.0794,0.0635 -0.12383,0.149225 -0.0413,0.08255 -0.0413,0.180975 0,0.123825 0.0699,0.206375 0.073,0.08255 0.1905,0.142875 0.11747,0.06032 0.2667,0.10795 0.14922,0.04445 0.3048,0.09842 0.15875,0.0508 0.30797,0.1143 0.14923,0.0635 0.2667,0.15875 0.11748,0.09525 0.18733,0.23495 0.073,0.136525 0.073,0.3302 0,0.22225 -0.0794,0.41275 -0.0794,0.187325 -0.23495,0.327025 -0.15558,0.136525 -0.381,0.2159 -0.22543,0.07937 -0.5207,0.07937 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.111125 -0.46355,-0.282575 l 0.13335,-0.2159 q 0.0254,-0.04127 0.0603,-0.0635 0.0349,-0.02223 0.0889,-0.02223 0.0572,0 0.12065,0.04445 0.0635,0.04445 0.1524,0.09843 0.0921,0.05397 0.22225,0.09842 0.13018,0.04445 0.32385,0.04445 0.1651,0 0.28893,-0.04128 0.12382,-0.04445 0.20637,-0.117475 0.0826,-0.07302 0.12065,-0.168275 0.0413,-0.09525 0.0413,-0.2032 0,-0.13335 -0.073,-0.219075 -0.0699,-0.0889 -0.18732,-0.149225 -0.11748,-0.0635 -0.26988,-0.10795 -0.14922,-0.04762 -0.30797,-0.09842 -0.15558,-0.0508 -0.30798,-0.1143 -0.14922,-0.06668 -0.2667,-0.1651 -0.11747,-0.09842 -0.1905,-0.2413 -0.0699,-0.14605 -0.0699,-0.352425 0,-0.18415 0.0762,-0.352425 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.130175 0.35878,-0.206375 0.21272,-0.0762 0.48577,-0.0762 0.3175,0 0.56833,0.1016 0.254,0.09843 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1007" />
+        <path
+           d="m -146.29656,66.539139 q -0.0254,0.03493 -0.0508,0.05397 -0.0254,0.01905 -0.0699,0.01905 -0.0476,0 -0.10478,-0.0381 -0.0572,-0.04128 -0.14287,-0.0889 -0.0825,-0.04762 -0.20638,-0.08572 -0.12065,-0.04127 -0.29845,-0.04127 -0.23812,0 -0.4191,0.08572 -0.18097,0.08255 -0.3048,0.2413 -0.12065,0.15875 -0.18415,0.384175 -0.0603,0.225425 -0.0603,0.504825 0,0.2921 0.0667,0.5207 0.0667,0.225425 0.18733,0.381 0.12382,0.1524 0.29527,0.23495 0.17463,0.07937 0.39053,0.07937 0.20637,0 0.33972,-0.04763 0.13335,-0.0508 0.21908,-0.111125 0.0889,-0.06032 0.14605,-0.10795 0.0603,-0.0508 0.11747,-0.0508 0.0699,0 0.10795,0.05398 l 0.15875,0.206375 q -0.10477,0.130175 -0.23812,0.22225 -0.13335,0.09207 -0.28893,0.155575 -0.1524,0.06033 -0.32067,0.0889 -0.16828,0.02858 -0.3429,0.02858 -0.30163,0 -0.56198,-0.111125 -0.25717,-0.111125 -0.44767,-0.320675 -0.1905,-0.212725 -0.29845,-0.5207 -0.10795,-0.307975 -0.10795,-0.701675 0,-0.358775 0.0984,-0.663575 0.1016,-0.3048 0.2921,-0.523875 0.19368,-0.22225 0.47308,-0.346075 0.28257,-0.123825 0.6477,-0.123825 0.33972,0 0.5969,0.111125 0.26035,0.10795 0.46037,0.307975 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1009" />
+        <path
+           d="m -143.45812,69.183914 q -0.0825,0 -0.127,-0.0254 -0.0445,-0.02858 -0.0699,-0.10795 l -0.0635,-0.301625 q -0.127,0.1143 -0.25083,0.206375 -0.12065,0.0889 -0.254,0.1524 -0.13017,0.06032 -0.28257,0.09207 -0.14923,0.03493 -0.33338,0.03493 -0.18732,0 -0.35242,-0.0508 -0.1651,-0.05398 -0.28893,-0.15875 -0.12065,-0.104775 -0.19367,-0.263525 -0.0699,-0.161925 -0.0699,-0.381 0,-0.1905 0.10477,-0.365125 0.10478,-0.1778 0.33973,-0.314325 0.23495,-0.136525 0.61277,-0.22225 0.37783,-0.0889 0.9271,-0.1016 v -0.250825 q 0,-0.37465 -0.16192,-0.56515 -0.16193,-0.193675 -0.47308,-0.193675 -0.20955,0 -0.35242,0.05398 -0.1397,0.0508 -0.24448,0.117475 -0.1016,0.0635 -0.1778,0.117475 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.02858 -0.0413,-0.03175 -0.0699,-0.0762 l -0.1016,-0.180975 q 0.2667,-0.257175 0.57467,-0.384175 0.30798,-0.127 0.68263,-0.127 0.26987,0 0.47942,0.0889 0.20955,0.0889 0.35243,0.24765 0.14287,0.15875 0.2159,0.384175 0.073,0.225425 0.073,0.4953 v 2.0574 z m -1.21285,-0.346075 q 0.14922,0 0.27305,-0.02858 0.12382,-0.03175 0.23177,-0.08572 0.11113,-0.05715 0.20955,-0.136525 0.1016,-0.08255 0.19685,-0.18415 v -0.66675 q -0.39052,0.0127 -0.66675,0.0635 -0.27305,0.04762 -0.44767,0.127 -0.17145,0.07937 -0.25083,0.187325 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.219075 0.0413,0.09207 0.11112,0.1524 0.073,0.05715 0.16828,0.08572 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1011" />
+        <path
+           d="m -141.76267,64.507139 v 4.676775 h -0.56515 v -4.676775 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1013" />
+        <path
+           d="m -138.80358,69.183914 q -0.0825,0 -0.127,-0.0254 -0.0445,-0.02858 -0.0699,-0.10795 l -0.0635,-0.301625 q -0.127,0.1143 -0.25083,0.206375 -0.12065,0.0889 -0.254,0.1524 -0.13017,0.06032 -0.28257,0.09207 -0.14923,0.03493 -0.33338,0.03493 -0.18732,0 -0.35242,-0.0508 -0.1651,-0.05398 -0.28893,-0.15875 -0.12065,-0.104775 -0.19367,-0.263525 -0.0699,-0.161925 -0.0699,-0.381 0,-0.1905 0.10477,-0.365125 0.10478,-0.1778 0.33973,-0.314325 0.23495,-0.136525 0.61277,-0.22225 0.37783,-0.0889 0.9271,-0.1016 v -0.250825 q 0,-0.37465 -0.16192,-0.56515 -0.16193,-0.193675 -0.47308,-0.193675 -0.20955,0 -0.35242,0.05398 -0.1397,0.0508 -0.24448,0.117475 -0.1016,0.0635 -0.1778,0.117475 -0.073,0.0508 -0.14605,0.0508 -0.0572,0 -0.0984,-0.02858 -0.0413,-0.03175 -0.0699,-0.0762 l -0.1016,-0.180975 q 0.2667,-0.257175 0.57467,-0.384175 0.30798,-0.127 0.68263,-0.127 0.26987,0 0.47942,0.0889 0.20955,0.0889 0.35243,0.24765 0.14287,0.15875 0.2159,0.384175 0.073,0.225425 0.073,0.4953 v 2.0574 z m -1.21285,-0.346075 q 0.14922,0 0.27305,-0.02858 0.12382,-0.03175 0.23177,-0.08572 0.11113,-0.05715 0.20955,-0.136525 0.1016,-0.08255 0.19685,-0.18415 v -0.66675 q -0.39052,0.0127 -0.66675,0.0635 -0.27305,0.04762 -0.44767,0.127 -0.17145,0.07937 -0.25083,0.187325 -0.0762,0.10795 -0.0762,0.2413 0,0.127 0.0413,0.219075 0.0413,0.09207 0.11112,0.1524 0.073,0.05715 0.16828,0.08572 0.0984,0.0254 0.20955,0.0254 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1015" />
+        <path
+           d="m -137.69234,69.183914 v -3.216275 h 0.32385 q 0.0921,0 0.127,0.03493 0.0349,0.03492 0.0476,0.12065 l 0.0349,0.48895 q 0.1524,-0.3302 0.37465,-0.51435 0.22543,-0.187325 0.5461,-0.187325 0.1016,0 0.19368,0.02223 0.0952,0.02222 0.16827,0.06985 l -0.0413,0.422275 q -0.019,0.07937 -0.0952,0.07937 -0.0445,0 -0.13018,-0.01905 -0.0857,-0.01905 -0.19367,-0.01905 -0.1524,0 -0.27305,0.04762 -0.12065,0.04445 -0.2159,0.13335 -0.0921,0.08573 -0.1651,0.212725 -0.073,0.127 -0.13335,0.2921 v 2.032 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1017" />
+        <path
+           d="m -133.5077,66.497864 q -0.0381,0.06985 -0.11747,0.06985 -0.0476,0 -0.10795,-0.03493 -0.0603,-0.03492 -0.14923,-0.0762 -0.0857,-0.04445 -0.20637,-0.07937 -0.12065,-0.0381 -0.28575,-0.0381 -0.14288,0 -0.25718,0.0381 -0.1143,0.03493 -0.19685,0.09843 -0.0794,0.0635 -0.12382,0.149225 -0.0413,0.08255 -0.0413,0.180975 0,0.123825 0.0698,0.206375 0.073,0.08255 0.1905,0.142875 0.11748,0.06032 0.2667,0.10795 0.14923,0.04445 0.3048,0.09842 0.15875,0.0508 0.30798,0.1143 0.14922,0.0635 0.2667,0.15875 0.11747,0.09525 0.18732,0.23495 0.073,0.136525 0.073,0.3302 0,0.22225 -0.0794,0.41275 -0.0794,0.187325 -0.23495,0.327025 -0.15557,0.136525 -0.381,0.2159 -0.22542,0.07937 -0.5207,0.07937 -0.33655,0 -0.6096,-0.10795 -0.27305,-0.111125 -0.46355,-0.282575 l 0.13335,-0.2159 q 0.0254,-0.04127 0.0603,-0.0635 0.0349,-0.02223 0.0889,-0.02223 0.0571,0 0.12065,0.04445 0.0635,0.04445 0.1524,0.09843 0.0921,0.05397 0.22225,0.09842 0.13017,0.04445 0.32385,0.04445 0.1651,0 0.28892,-0.04128 0.12383,-0.04445 0.20638,-0.117475 0.0825,-0.07302 0.12065,-0.168275 0.0413,-0.09525 0.0413,-0.2032 0,-0.13335 -0.073,-0.219075 -0.0699,-0.0889 -0.18733,-0.149225 -0.11747,-0.0635 -0.26987,-0.10795 -0.14923,-0.04762 -0.30798,-0.09842 -0.15557,-0.0508 -0.30797,-0.1143 -0.14923,-0.06668 -0.2667,-0.1651 -0.11748,-0.09842 -0.1905,-0.2413 -0.0699,-0.14605 -0.0699,-0.352425 0,-0.18415 0.0762,-0.352425 0.0762,-0.17145 0.22225,-0.29845 0.14605,-0.130175 0.35877,-0.206375 0.21273,-0.0762 0.48578,-0.0762 0.3175,0 0.56832,0.1016 0.254,0.09843 0.43815,0.27305 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:Lato;-inkscape-font-specification:Lato;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1019" />
+      </g>
+    </g>
+    <g
+       id="g4482">
+      <g
+         aria-label="integral"
+         transform="rotate(-90)"
+         id="text1272"
+         style="font-size:10.5833px;line-height:1.25;font-family:Lato;-inkscape-font-specification:Lato;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+        <path
+           d="m -166.14416,-194.62909 v 5.36044 h -0.94192 v -5.36044 z m 0.20108,-1.68274 q 0,0.13758 -0.0582,0.25929 -0.0529,0.11641 -0.14817,0.21166 -0.0899,0.09 -0.21695,0.14288 -0.12171,0.0529 -0.25929,0.0529 -0.13759,0 -0.25929,-0.0529 -0.11642,-0.0529 -0.20638,-0.14288 -0.09,-0.0952 -0.14287,-0.21166 -0.0529,-0.12171 -0.0529,-0.25929 0,-0.13759 0.0529,-0.25929 0.0529,-0.127 0.14287,-0.21696 0.09,-0.0952 0.20638,-0.14817 0.1217,-0.0529 0.25929,-0.0529 0.13758,0 0.25929,0.0529 0.127,0.0529 0.21695,0.14817 0.0952,0.09 0.14817,0.21696 0.0582,0.1217 0.0582,0.25929 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path962" />
+        <path
+           d="m -164.599,-189.26865 v -5.36044 h 0.5662 q 0.20108,0 0.24871,0.19579 l 0.0741,0.58209 q 0.34925,-0.3863 0.78317,-0.62442 0.43391,-0.23812 1.00012,-0.23812 0.43921,0 0.77258,0.14816 0.33867,0.14288 0.56091,0.41275 0.22755,0.26458 0.34396,0.64029 0.11642,0.37571 0.11642,0.83079 v 3.41311 h -0.94721 v -3.41311 q 0,-0.60854 -0.28045,-0.94191 -0.27517,-0.33867 -0.84138,-0.33867 -0.42333,0 -0.78845,0.20108 -0.35984,0.20109 -0.66146,0.54504 v 3.94757 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path964" />
+        <path
+           d="m -157.12194,-189.18398 q -0.635,0 -0.97895,-0.35454 -0.33867,-0.35454 -0.33867,-1.02129 v -3.28082 h -0.64558 q -0.0847,0 -0.14287,-0.0476 -0.0582,-0.0529 -0.0582,-0.15875 v -0.3757 l 0.87841,-0.11113 0.21696,-1.65628 q 0.0159,-0.0794 0.0688,-0.127 0.0582,-0.0529 0.14817,-0.0529 h 0.47625 v 1.84679 h 1.55045 v 0.68262 h -1.55045 v 3.21732 q 0,0.33867 0.16404,0.50271 0.16404,0.16404 0.42333,0.16404 0.14816,0 0.254,-0.037 0.11112,-0.0423 0.1905,-0.09 0.0794,-0.0476 0.13229,-0.0847 0.0582,-0.0423 0.10054,-0.0423 0.0741,0 0.13229,0.09 l 0.27517,0.44979 q -0.24342,0.22754 -0.58738,0.35983 -0.34395,0.127 -0.70908,0.127 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path966" />
+        <path
+           d="m -152.7775,-194.71375 q 0.48154,0 0.889,0.16404 0.41275,0.15875 0.70908,0.46566 0.30162,0.30163 0.47096,0.75142 0.16933,0.4445 0.16933,1.01599 0,0.22225 -0.0476,0.29634 -0.0476,0.0741 -0.17992,0.0741 h -3.58245 q 0.0106,0.508 0.13759,0.8837 0.12699,0.37571 0.34924,0.62971 0.22225,0.24871 0.52917,0.37571 0.30691,0.12171 0.68791,0.12171 0.35454,0 0.60854,-0.0794 0.25929,-0.0847 0.4445,-0.17991 0.18521,-0.0952 0.30692,-0.17463 0.127,-0.0847 0.21696,-0.0847 0.11641,0 0.17991,0.09 l 0.26458,0.34396 q -0.17462,0.21167 -0.41804,0.37041 -0.24341,0.15346 -0.52387,0.254 -0.27517,0.10055 -0.5715,0.14817 -0.29633,0.0529 -0.58737,0.0529 -0.55562,0 -1.02658,-0.18521 -0.46567,-0.1905 -0.80962,-0.55033 -0.33867,-0.36513 -0.52917,-0.89958 -0.1905,-0.53446 -0.1905,-1.22767 0,-0.56091 0.16933,-1.04774 0.17463,-0.48683 0.49742,-0.84137 0.32279,-0.35984 0.78846,-0.56092 0.46566,-0.20637 1.04774,-0.20637 z m 0.0212,0.6932 q -0.68262,0 -1.07421,0.39688 -0.39158,0.39158 -0.48683,1.09008 h 2.93158 q 0,-0.32809 -0.0953,-0.59796 -0.09,-0.27517 -0.26988,-0.47096 -0.17462,-0.20108 -0.42862,-0.30691 -0.254,-0.11113 -0.57679,-0.11113 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path968" />
+        <path
+           d="m -147.5176,-194.71905 q 0.34925,0 0.65087,0.0794 0.30163,0.0741 0.55034,0.22225 h 1.4552 v 0.34925 q 0,0.17462 -0.22225,0.22225 l -0.60854,0.0847 q 0.17992,0.34396 0.17992,0.76729 0,0.39158 -0.15346,0.71438 -0.14817,0.31749 -0.41275,0.54503 -0.26458,0.22755 -0.635,0.34925 -0.37041,0.12171 -0.80433,0.12171 -0.381,0 -0.71437,-0.09 -0.16933,0.10584 -0.25929,0.22754 -0.0847,0.12171 -0.0847,0.23813 0,0.1905 0.15346,0.29104 0.15875,0.0952 0.41275,0.13758 0.254,0.0423 0.57679,0.0529 0.32808,0.0106 0.66675,0.037 0.34395,0.0212 0.66674,0.0794 0.32809,0.0582 0.58208,0.19049 0.254,0.1323 0.40746,0.36513 0.15875,0.23283 0.15875,0.60325 0,0.34395 -0.17462,0.66674 -0.16934,0.3228 -0.49213,0.5715 -0.32279,0.254 -0.79374,0.40217 -0.46567,0.15346 -1.05304,0.15346 -0.58738,0 -1.02658,-0.11642 -0.43921,-0.11642 -0.73025,-0.31221 -0.29104,-0.19579 -0.43921,-0.45508 -0.14287,-0.254 -0.14287,-0.53446 0,-0.39687 0.24871,-0.67204 0.2487,-0.27516 0.67733,-0.4392 -0.23813,-0.10584 -0.37571,-0.28046 -0.13758,-0.17992 -0.13758,-0.48154 0,-0.11642 0.0423,-0.23812 0.0423,-0.127 0.127,-0.24871 0.09,-0.12171 0.21696,-0.23283 0.127,-0.11113 0.29633,-0.1958 -0.39687,-0.22224 -0.61912,-0.59266 -0.22225,-0.37042 -0.22225,-0.85725 0,-0.39158 0.14816,-0.70908 0.15346,-0.32279 0.42334,-0.54504 0.26987,-0.22754 0.64029,-0.34925 0.3757,-0.12171 0.8202,-0.12171 z m 1.69862,5.74144 q 0,-0.19579 -0.11112,-0.31749 -0.11113,-0.12171 -0.30163,-0.1905 -0.18521,-0.0688 -0.43391,-0.0952 -0.24871,-0.0317 -0.52917,-0.0476 -0.27516,-0.0159 -0.56091,-0.0318 -0.28575,-0.0159 -0.55033,-0.0529 -0.29634,0.13758 -0.48684,0.34395 -0.1852,0.20638 -0.1852,0.49213 0,0.17991 0.09,0.33337 0.0952,0.15875 0.28575,0.26987 0.1905,0.11642 0.47625,0.17992 0.29104,0.0688 0.68262,0.0688 0.381,0 0.68263,-0.0688 0.30162,-0.0688 0.508,-0.19579 0.21166,-0.127 0.32279,-0.30163 0.11112,-0.17462 0.11112,-0.38629 z m -1.69862,-2.9104 q 0.28575,0 0.50271,-0.0794 0.21696,-0.0794 0.36512,-0.22225 0.14817,-0.14287 0.22225,-0.33866 0.0741,-0.20109 0.0741,-0.43921 0,-0.49212 -0.30162,-0.78316 -0.29633,-0.29104 -0.86254,-0.29104 -0.5715,0 -0.87312,0.29104 -0.29633,0.29104 -0.29633,0.78316 0,0.23812 0.0741,0.43921 0.0794,0.19579 0.22754,0.33866 0.14817,0.14288 0.36512,0.22225 0.21696,0.0794 0.50271,0.0794 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path970" />
+        <path
+           d="m -143.88225,-189.26865 v -5.36044 h 0.53975 q 0.15345,0 0.21166,0.0582 0.0582,0.0582 0.0794,0.20108 l 0.0582,0.81492 q 0.25399,-0.55033 0.62441,-0.85725 0.37571,-0.31221 0.91016,-0.31221 0.16934,0 0.32279,0.037 0.15875,0.037 0.28046,0.11642 l -0.0688,0.70379 q -0.0318,0.13229 -0.15875,0.13229 -0.0741,0 -0.21696,-0.0317 -0.14287,-0.0318 -0.32279,-0.0318 -0.254,0 -0.45508,0.0794 -0.20108,0.0741 -0.35983,0.22225 -0.15346,0.14287 -0.27517,0.35454 -0.1217,0.21166 -0.22225,0.48683 v 3.38665 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path972" />
+        <path
+           d="m -136.70681,-189.26865 q -0.13758,0 -0.21166,-0.0423 -0.0741,-0.0476 -0.11642,-0.17992 l -0.10583,-0.5027 q -0.21167,0.1905 -0.41804,0.34395 -0.20108,0.14817 -0.42333,0.254 -0.21696,0.10055 -0.47096,0.15346 -0.24871,0.0582 -0.55562,0.0582 -0.31221,0 -0.58738,-0.0847 -0.27516,-0.0899 -0.48154,-0.26458 -0.20108,-0.17462 -0.32279,-0.43921 -0.11641,-0.26987 -0.11641,-0.63499 0,-0.3175 0.17462,-0.60854 0.17463,-0.29634 0.56621,-0.52388 0.39158,-0.22754 1.02129,-0.37041 0.6297,-0.14817 1.54516,-0.16933 v -0.41805 q 0,-0.62441 -0.26988,-0.94191 -0.26987,-0.32279 -0.78845,-0.32279 -0.34925,0 -0.58737,0.09 -0.23284,0.0847 -0.40746,0.19579 -0.16933,0.10583 -0.29633,0.19579 -0.12171,0.0847 -0.24342,0.0847 -0.0952,0 -0.16404,-0.0476 -0.0688,-0.0529 -0.11642,-0.127 l -0.16933,-0.30162 q 0.4445,-0.42863 0.95779,-0.64029 0.51329,-0.21167 1.1377,-0.21167 0.44979,0 0.79904,0.14817 0.34925,0.14817 0.58738,0.41275 0.23812,0.26458 0.35983,0.64029 0.12171,0.3757 0.12171,0.82549 v 3.42899 z m -2.02141,-0.57679 q 0.24871,0 0.45509,-0.0476 0.20637,-0.0529 0.38629,-0.14288 0.1852,-0.0952 0.34925,-0.22754 0.16933,-0.13758 0.32808,-0.30691 v -1.11125 q -0.65087,0.0212 -1.11125,0.10583 -0.45508,0.0794 -0.74612,0.21167 -0.28575,0.13229 -0.41804,0.31221 -0.127,0.17991 -0.127,0.40216 0,0.21167 0.0688,0.36513 0.0688,0.15345 0.18521,0.254 0.12171,0.0952 0.28046,0.14287 0.16404,0.0423 0.34924,0.0423 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path974" />
+        <path
+           d="m -133.88107,-197.06325 v 7.7946 h -0.94191 v -7.7946 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path976" />
+      </g>
+      <g
+         aria-label="inexact"
+         transform="rotate(-90)"
+         id="text1654"
+         style="font-size:10.5833px;line-height:1.25;font-family:Lato;-inkscape-font-specification:Lato;letter-spacing:0px;word-spacing:0px;stroke-width:0.264583">
+        <path
+           d="m -118.07937,-194.84076 v 5.36044 h -0.94192 v -5.36044 z m 0.20108,-1.68274 q 0,0.13758 -0.0582,0.25929 -0.0529,0.11642 -0.14817,0.21166 -0.09,0.09 -0.21695,0.14288 -0.12171,0.0529 -0.2593,0.0529 -0.13758,0 -0.25929,-0.0529 -0.11641,-0.0529 -0.20637,-0.14288 -0.09,-0.0952 -0.14287,-0.21166 -0.0529,-0.12171 -0.0529,-0.25929 0,-0.13758 0.0529,-0.25929 0.0529,-0.127 0.14287,-0.21696 0.09,-0.0952 0.20637,-0.14817 0.12171,-0.0529 0.25929,-0.0529 0.13759,0 0.2593,0.0529 0.127,0.0529 0.21695,0.14817 0.0953,0.09 0.14817,0.21696 0.0582,0.12171 0.0582,0.25929 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path979" />
+        <path
+           d="m -116.53422,-189.48032 v -5.36044 h 0.56621 q 0.20108,0 0.24871,0.19579 l 0.0741,0.58209 q 0.34925,-0.3863 0.78317,-0.62442 0.43391,-0.23812 1.00012,-0.23812 0.4392,0 0.77258,0.14816 0.33866,0.14288 0.56091,0.41275 0.22754,0.26458 0.34396,0.64029 0.11642,0.37571 0.11642,0.83079 v 3.41311 h -0.94721 v -3.41311 q 0,-0.60854 -0.28046,-0.94191 -0.27516,-0.33867 -0.84137,-0.33867 -0.42333,0 -0.78845,0.20108 -0.35984,0.20109 -0.66146,0.54504 v 3.94757 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path981" />
+        <path
+           d="m -108.43271,-194.92542 q 0.48154,0 0.88899,0.16404 0.41275,0.15875 0.70908,0.46566 0.30163,0.30163 0.47096,0.75142 0.16933,0.4445 0.16933,1.01599 0,0.22225 -0.0476,0.29634 -0.0476,0.0741 -0.17992,0.0741 h -3.58244 q 0.0106,0.508 0.13758,0.8837 0.127,0.37571 0.34925,0.62971 0.22225,0.24871 0.52916,0.37571 0.30692,0.12171 0.68792,0.12171 0.35454,0 0.60854,-0.0794 0.25929,-0.0847 0.4445,-0.17991 0.1852,-0.0952 0.30691,-0.17463 0.127,-0.0847 0.21696,-0.0847 0.11642,0 0.17992,0.09 l 0.26458,0.34396 q -0.17463,0.21167 -0.41804,0.37042 -0.24342,0.15345 -0.52388,0.25399 -0.27516,0.10055 -0.57149,0.14817 -0.29634,0.0529 -0.58738,0.0529 -0.55562,0 -1.02658,-0.18521 -0.46566,-0.1905 -0.80962,-0.55033 -0.33867,-0.36513 -0.52916,-0.89958 -0.1905,-0.53446 -0.1905,-1.22767 0,-0.56091 0.16933,-1.04774 0.17462,-0.48683 0.49741,-0.84137 0.32279,-0.35984 0.78846,-0.56092 0.46566,-0.20637 1.04775,-0.20637 z m 0.0212,0.6932 q -0.68262,0 -1.0742,0.39688 -0.39158,0.39158 -0.48683,1.09008 h 2.93157 q 0,-0.32809 -0.0952,-0.59796 -0.09,-0.27517 -0.26987,-0.47096 -0.17463,-0.20108 -0.42863,-0.30691 -0.254,-0.11113 -0.57679,-0.11113 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path983" />
+        <path
+           d="m -103.85544,-192.22668 -1.80445,-2.61408 h 0.90487 q 0.11642,0 0.16933,0.037 0.0529,0.037 0.0952,0.10584 l 1.31233,2.01082 q 0.0476,-0.14816 0.13758,-0.29633 l 1.15358,-1.69333 q 0.0476,-0.0741 0.10054,-0.11641 0.0582,-0.0476 0.13759,-0.0476 h 0.86783 l -1.80445,2.56116 1.87853,2.79928 h -0.90487 q -0.11642,0 -0.18521,-0.0582 -0.0635,-0.0635 -0.10583,-0.13759 l -1.34937,-2.10078 q -0.037,0.15346 -0.11113,0.27516 l -1.24883,1.82562 q -0.0529,0.0741 -0.11641,0.13759 -0.0582,0.0582 -0.16404,0.0582 h -0.84138 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path985" />
+        <path
+           d="m -96.431264,-189.48032 q -0.137583,0 -0.211666,-0.0423 -0.07408,-0.0476 -0.116416,-0.17992 l -0.105833,-0.5027 q -0.211666,0.1905 -0.41804,0.34396 -0.201083,0.14816 -0.423332,0.25399 -0.216958,0.10055 -0.470957,0.15346 -0.248708,0.0582 -0.555623,0.0582 -0.312208,0 -0.587374,-0.0847 -0.275165,-0.0899 -0.48154,-0.26458 -0.201085,-0.17462 -0.322795,-0.43921 -0.11641,-0.26987 -0.11641,-0.63499 0,-0.3175 0.17462,-0.60854 0.174627,-0.29634 0.566209,-0.52388 0.391582,-0.22754 1.021289,-0.37041 0.629706,-0.14817 1.545161,-0.16933 v -0.41805 q 0,-0.62441 -0.269874,-0.94191 -0.269874,-0.32279 -0.788455,-0.32279 -0.349249,0 -0.587374,0.09 -0.232832,0.0847 -0.407457,0.19579 -0.169332,0.10583 -0.296332,0.19579 -0.121708,0.0847 -0.243416,0.0847 -0.09525,0 -0.164041,-0.0476 -0.06879,-0.0529 -0.116416,-0.127 l -0.169333,-0.30162 q 0.444498,-0.42863 0.957788,-0.64029 0.51329,-0.21167 1.137705,-0.21167 0.44979,0 0.799039,0.14817 0.349249,0.14817 0.587373,0.41275 0.238125,0.26458 0.359833,0.64029 0.121708,0.3757 0.121708,0.82549 v 3.42899 z m -2.02141,-0.57679 q 0.248708,0 0.455082,-0.0476 0.206374,-0.0529 0.38629,-0.14288 0.185208,-0.0952 0.349249,-0.22754 0.169333,-0.13758 0.328082,-0.30691 v -1.11125 q -0.650872,0.0212 -1.111246,0.10583 -0.455082,0.0794 -0.746123,0.21167 -0.285749,0.13229 -0.41804,0.31221 -0.127,0.17991 -0.127,0.40216 0,0.21167 0.06879,0.36513 0.06879,0.15345 0.185208,0.254 0.121708,0.0952 0.280457,0.14287 0.164041,0.0423 0.349249,0.0423 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path987" />
+        <path
+           d="m -90.848578,-193.88826 q -0.04233,0.0582 -0.08467,0.09 -0.04233,0.0318 -0.116417,0.0318 -0.07937,0 -0.174624,-0.0635 -0.09525,-0.0688 -0.238124,-0.14817 -0.137583,-0.0794 -0.343957,-0.14287 -0.201083,-0.0688 -0.497416,-0.0688 -0.396873,0 -0.698497,0.14287 -0.301624,0.13758 -0.507999,0.40217 -0.201082,0.26458 -0.306915,0.64029 -0.100542,0.3757 -0.100542,0.84137 0,0.48683 0.111125,0.86783 0.111125,0.37571 0.312207,0.635 0.206375,0.254 0.492124,0.39158 0.29104,0.13229 0.650873,0.13229 0.343957,0 0.566206,-0.0794 0.222249,-0.0847 0.365124,-0.1852 0.148166,-0.10054 0.243416,-0.17992 0.100541,-0.0847 0.195791,-0.0847 0.116416,0 0.179916,0.09 l 0.264583,0.34396 q -0.174625,0.21696 -0.396874,0.37042 -0.22225,0.15345 -0.48154,0.25929 -0.254,0.10054 -0.534457,0.14816 -0.280457,0.0476 -0.571498,0.0476 -0.502707,0 -0.936622,-0.18521 -0.428624,-0.18521 -0.746123,-0.53446 -0.317499,-0.35454 -0.497415,-0.86783 -0.179916,-0.51329 -0.179916,-1.16945 0,-0.59796 0.164041,-1.10596 0.169333,-0.508 0.486832,-0.87312 0.322791,-0.37042 0.788456,-0.57679 0.470957,-0.20637 1.079496,-0.20637 0.566207,0 0.99483,0.1852 0.433916,0.17992 0.76729,0.51329 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path989" />
+        <path
+           d="m -87.879971,-189.39565 q -0.634998,0 -0.978956,-0.35454 -0.338665,-0.35454 -0.338665,-1.02129 v -3.28082 h -0.645582 q -0.08467,0 -0.142874,-0.0476 -0.05821,-0.0529 -0.05821,-0.15875 v -0.3757 l 0.878414,-0.11113 0.216957,-1.65628 q 0.01588,-0.0794 0.06879,-0.127 0.05821,-0.0529 0.148166,-0.0529 h 0.476248 v 1.84679 h 1.550454 v 0.68262 h -1.550454 v 3.21732 q 0,0.33867 0.164042,0.50271 0.164041,0.16404 0.423332,0.16404 0.148166,0 0.253999,-0.037 0.111124,-0.0423 0.190499,-0.09 0.07937,-0.0476 0.132291,-0.0847 0.05821,-0.0423 0.100542,-0.0423 0.07408,0 0.132291,0.09 l 0.275166,0.44979 q -0.243416,0.22754 -0.587373,0.35983 -0.343958,0.127 -0.709081,0.127 z"
+           style="font-size:10.5833px;stroke-width:0.264583"
+           id="path991" />
+      </g>
+    </g>
+    <path
+       style="fill:#666666;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:12, 6;stroke-dashoffset:0;stroke-opacity:1"
+       d="M -195.08166,125.8553 H 119.44831"
+       id="path937"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>


### PR DESCRIPTION
This adds a dedicated page about promotion rules.

---

Please don't hesitate to rip it apart, I haven't tried to really iterate yet, but I think it would be useful to get feedback.  (Also don't hesitate to push changes/fixes!)

My thought was to try and not dwell too long on the technical details, but start with the things that I thought are more interesting to very new users.  That might mean the plot (taken from the NEP, but without the text), may be a little bit underexplained.

There is also the question if more examples would be relevant, although I don't really want to overdo it (in the NEP the big table is important, for a new user with fresh eyes, I am not quite sure what is.)

I need to figure out if we have any docs that need to be removed/refer here (beyond `result_type, `promote_types`, and maybe the release note/migration guide as a link).

*Doctest will probably fail for now, and references might be bad... let's fix it as we iterate*

---

@mdhaber maybe you can have a look?