### PR TITLE
DOC: fix a small np.einsum example

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2009,7 +2009,7 @@ add_newdoc('numpy._core.multiarray', 'c_einsum',
     identifier '->' as well as the list of output subscript labels.
     This feature increases the flexibility of the function since
     summing can be disabled or forced when required. The call
-    ``np.einsum('i->', a)`` is like :py:func:`np.sum(a, axis=-1) <numpy.sum>`,
+    ``np.einsum('...i->...', a)`` is like :py:func:`np.sum(a, axis=-1) <numpy.sum>`,
     and ``np.einsum('ii->i', a)`` is like :py:func:`np.diag(a) <numpy.diag>`.
     The difference is that `einsum` does not allow broadcasting by default.
     Additionally ``np.einsum('ij,jh->ih', a, b)`` directly specifies the

--- a/numpy/_core/einsumfunc.py
+++ b/numpy/_core/einsumfunc.py
@@ -1180,7 +1180,7 @@ def einsum(*operands, out=None, optimize=False, **kwargs):
     identifier '->' as well as the list of output subscript labels.
     This feature increases the flexibility of the function since
     summing can be disabled or forced when required. The call
-    ``np.einsum('i->', a)`` is like
+    ``np.einsum('...i->...', a)`` is like
     :py:func:`np.sum(a, axis=-1) <numpy.sum>`, and ``np.einsum('ii->i', a)``
     is like :py:func:`np.diag(a) <numpy.diag>`. The difference is that
     `einsum` does not allow broadcasting by default. Additionally


### PR DESCRIPTION
"..." is required if `a` is multi-dimensional, e.g.
a = np.arange(25).reshape(5,5)

Otherwise, this error is raised:
ValueError: operand has more dimensions than subscripts given in
einstein sum, but no '...' ellipsis provided to broadcast the extra
dimensions.

[skip azp]