### PR TITLE
TST: marks on a fixture have no effect

### DIFF
--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -72,8 +72,6 @@ def strip_func(match: re.Match[str]) -> str:
     return match.groups()[1]
 
 
-@pytest.mark.slow
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.fixture(scope="module", autouse=True)
 def run_mypy() -> None:
     """Clears the cache and run mypy before running any of the typing tests.


### PR DESCRIPTION
Apparently applying a mark to a fixture is a no-op and has emitted a [deprecation warning on pytest>=7.4](https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function). With pytest-8.0 collection is failing. The new version was released just a little while ago.

I wonder why we did not see this warning before it became a failure. xref #25503