### PR TITLE
API: Make any and all return booleans by default

### DIFF
--- a/doc/release/upcoming_changes/25712.change.rst
+++ b/doc/release/upcoming_changes/25712.change.rst
@@ -1,0 +1,8 @@
+``any`` and ``all`` return booleans for object arrays
+-----------------------------------------------------
+The ``any`` and ``all`` functions and methods now return
+booleans also for object arrays.  Previously, they did
+a reduction which behaved like the Python ``or`` and
+``and`` operators which evaluates to one of the arguments.
+You can use ``np.logical_or.reduce`` and ``np.logical_and.reduce``
+to achieve the previous behavior.

--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -17,6 +17,7 @@ from numpy._core._ufunc_config import _no_nep50_warning
 from numpy._globals import _NoValue
 
 # save those O(100) nanoseconds!
+bool_dt = mu.dtype("bool")
 umr_maximum = um.maximum.reduce
 umr_minimum = um.minimum.reduce
 umr_sum = um.add.reduce
@@ -55,12 +56,18 @@ def _prod(a, axis=None, dtype=None, out=None, keepdims=False,
     return umr_prod(a, axis, dtype, out, keepdims, initial, where)
 
 def _any(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
+    # By default, return a boolean for any and all
+    if dtype is None:
+        dtype = bool_dt
     # Parsing keyword arguments is currently fairly slow, so avoid it for now
     if where is True:
         return umr_any(a, axis, dtype, out, keepdims)
     return umr_any(a, axis, dtype, out, keepdims, where=where)
 
 def _all(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
+    # By default, return a boolean for any and all
+    if dtype is None:
+        dtype = bool_dt
     # Parsing keyword arguments is currently fairly slow, so avoid it for now
     if where is True:
         return umr_all(a, axis, dtype, out, keepdims)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2459,6 +2459,11 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     Not a Number (NaN), positive infinity and negative infinity evaluate
     to `True` because these are not equal to zero.
 
+    .. versionchanged:: 2.0
+       Before NumPy 2.0, ``any`` did not return booleans for object dtype
+       input arrays.
+       This behavior is still available via ``np.logical_or.reduce``.
+
     Examples
     --------
     >>> np.any([[True, False], [True, True]])
@@ -2564,6 +2569,11 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     -----
     Not a Number (NaN), positive infinity and negative infinity
     evaluate to `True` because these are not equal to zero.
+
+    .. versionchanged:: 2.0
+       Before NumPy 2.0, ``all`` did not return booleans for object dtype
+       input arrays.
+       This behavior is still available via ``np.logical_and.reduce``.
 
     Examples
     --------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -86,6 +86,22 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
 
 
+def _wrapreduction_any_all(obj, ufunc, method, axis, out, **kwargs):
+    # Same as above function, but dtype is always bool (but never passed on)
+    passkwargs = {k: v for k, v in kwargs.items()
+                  if v is not np._NoValue}
+
+    if type(obj) is not mu.ndarray:
+        try:
+            reduction = getattr(obj, method)
+        except AttributeError:
+            pass
+        else:
+            return reduction(axis=axis, out=out, **passkwargs)
+
+    return ufunc.reduce(obj, axis, bool, out, **passkwargs)
+
+
 def _take_dispatcher(a, indices, axis=None, out=None, mode=None):
     return (a, out)
 
@@ -2480,8 +2496,8 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (191614240, 191614240)
 
     """
-    return _wrapreduction(a, np.logical_or, 'any', axis, None, out,
-                          keepdims=keepdims, where=where)
+    return _wrapreduction_any_all(a, np.logical_or, 'any', axis, out,
+                                  keepdims=keepdims, where=where)
 
 
 def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
@@ -2572,8 +2588,8 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (28293632, 28293632, array(True)) # may vary
 
     """
-    return _wrapreduction(a, np.logical_and, 'all', axis, None, out,
-                          keepdims=keepdims, where=where)
+    return _wrapreduction_any_all(a, np.logical_and, 'all', axis, out,
+                                  keepdims=keepdims, where=where)
 
 
 def _cumsum_dispatcher(a, axis=None, dtype=None, out=None):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1879,6 +1879,19 @@ class TestMethods:
         assert_equal(a.any(where=False), False)
         assert_equal(np.any(a, where=False), False)
 
+    @pytest.mark.parametrize("dtype", ["i8", "U10", "object", "datetime64[ms]"])
+    def test_any_and_all_result_dtype(self, dtype):
+        arr = np.ones(3, dtype=dtype)
+        assert arr.any().dtype == np.bool_
+        assert arr.all().dtype == np.bool_
+
+    def test_any_and_all_object_dtype(self):
+        # (seberg) Not sure we should even allow dtype here, but it is.
+        arr = np.ones(3, dtype=object)
+        # keepdims to prevent getting a scalar.
+        assert arr.any(dtype=object, keepdims=True).dtype == object
+        assert arr.all(dtype=object, keepdims=True).dtype == object
+
     def test_compress(self):
         tgt = [[5, 6, 7, 8, 9]]
         arr = np.arange(10).reshape(2, 5)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1879,7 +1879,8 @@ class TestMethods:
         assert_equal(a.any(where=False), False)
         assert_equal(np.any(a, where=False), False)
 
-    @pytest.mark.parametrize("dtype", ["i8", "U10", "object", "datetime64[ms]"])
+    @pytest.mark.parametrize("dtype",
+            ["i8", "U10", "object", "datetime64[ms]"])
     def test_any_and_all_result_dtype(self, dtype):
         arr = np.ones(3, dtype=dtype)
         assert arr.any().dtype == np.bool_

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -251,6 +251,13 @@ class TestAll:
         assert_array_equal(np.all(y1, axis=1), [0, 0, 1])
 
 
+@pytest.mark.parametrize("dtype", ["i8", "U10", "object", "datetime64[ms]"])
+def test_any_and_all_result_dtype(dtype):
+    arr = np.ones(3, dtype=dtype)
+    assert np.any(arr).dtype == np.bool_
+    assert np.all(arr).dtype == np.bool_
+
+
 class TestCopy:
 
     def test_basic(self):


### PR DESCRIPTION
The method supports a `dtype=` argument, but I am thinking to promote `np.logical_or.reduce()` instead.

Closes gh-4352