### PR TITLE
CI: cygwin 3.9.18 stalls in pip install with progress bars

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -61,7 +61,7 @@ jobs:
         shell: "C:\\tools\\cygwin\\bin\\bash.exe -o igncr -eo pipefail {0}"
         run: |
           cd tools
-          /usr/bin/python3.9 -m pytest --pyargs numpy -n2 -m "not slow"
+          /usr/bin/python3.9 -m pytest --pyargs numpy -v -n2 -m "not slow"
       - name: Upload wheel if tests fail
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: failure()

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -49,7 +49,7 @@ jobs:
           dash -c "which python3.9; /usr/bin/python3.9 --version -V"
       - name: Build NumPy wheel
         run: |
-          dash -c "/usr/bin/python3.9 -m pip install build pytest hypothesis pytest-xdist Cython meson"
+          dash -c "/usr/bin/python3.9 -m pip install --progress-bar=off build pytest hypothesis pytest-xdist Cython meson"
           dash -c "/usr/bin/python3.9 -m build . --wheel -Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack -Csetup-args=-Dcpu-dispatch=none -Csetup-args=-Dcpu-baseline=native"
       - name: Install NumPy from wheel
         run: |


### PR DESCRIPTION
[skip azp][skip circle][skip cirrus]

Fixes #25708, apparently it is enough to disable progress bars. Maybe we should do this globally with a [`PIP_CONFIG_FILE`](https://pip.pypa.io/en/stable/topics/configuration/#pip-config-file), I doubt anyone enjoys seeing the progress reports in CI.