### PR TITLE
CI: pin cygwin python to 3.9.16-1 [skip cirrus][skip azp][skip circle]

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -30,7 +30,7 @@ jobs:
           platform: x86_64
           install-dir: 'C:\tools\cygwin'
           packages: >-
-            python39-devel=3.9.16-1 python39-pip python-pip-wheel
+            python39=3.9.16-1 python39-devel=3.9.16-1 python39-pip python-pip-wheel
             python-setuptools-wheel liblapack-devel liblapack0 gcc-fortran
             gcc-g++ git dash cmake ninja
       - name: Set Windows PATH

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -25,15 +25,16 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Install Cygwin
-        uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401 # v4
+        uses: egor-tensin/setup-cygwin@d2c752bab416d4b0662591bd366fc2686297c82d   #v4
         with:
           platform: x86_64
           install-dir: 'C:\tools\cygwin'
           packages: >-
-            python39-devel python39-pip python-pip-wheel python-setuptools-wheel
-            liblapack-devel liblapack0 gcc-fortran gcc-g++ git dash cmake ninja
+            python39-devel=3.9.16-1 python39-pip python-pip-wheel
+            python-setuptools-wheel liblapack-devel liblapack0 gcc-fortran
+            gcc-g++ git dash cmake ninja
       - name: Set Windows PATH
-        uses: egor-tensin/cleanup-path@8469525c8ee3eddabbd3487658621a6235b3c581 # v3
+        uses: egor-tensin/cleanup-path@f04bc953e6823bf491cc0bdcff959c630db1b458 # v4.0.1
         with:
           dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
       - name: Verify that bash is Cygwin bash


### PR DESCRIPTION
Closes #25708 by pinning cygwin to 3.9.16-1, which does not time out. Replaces #25714. Related to https://github.com/gitpython-developers/GitPython/pull/1814. 