### PR TITLE
DEP: Finalize future warning move in lstsq default

### DIFF
--- a/doc/release/upcoming_changes/25721.deprecation.rst
+++ b/doc/release/upcoming_changes/25721.deprecation.rst
@@ -1,0 +1,6 @@
+``np.linalg.lstsq`` now defaults to new ``rcond`` value
+-------------------------------------------------------
+`~numpy.linalg.lstsq` now uses the new rcond value of the machine precision
+times ``max(M, N)``.  Previously, the machine precision was used but a
+FutureWarning was given to notify that this change will happen eventually.
+That old behavior can still be achieved by passing ``rcond=-1``.

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2366,7 +2366,7 @@ def _lstsq_dispatcher(a, b, rcond=None):
 
 
 @array_function_dispatch(_lstsq_dispatcher)
-def lstsq(a, b, rcond="warn"):
+def lstsq(a, b, rcond=None):
     r"""
     Return the least-squares solution to a linear matrix equation.
 
@@ -2392,13 +2392,12 @@ def lstsq(a, b, rcond="warn"):
         For the purposes of rank determination, singular values are treated
         as zero if they are smaller than `rcond` times the largest singular
         value of `a`.
+        The default uses the machine precision times ``max(M, N)``.  Passing
+        ``-1`` will use machine precision.
 
-        .. versionchanged:: 1.14.0
-           If not set, a FutureWarning is given. The previous default
-           of ``-1`` will use the machine precision as `rcond` parameter,
-           the new default will use the machine precision times `max(M, N)`.
-           To silence the warning and use the new default, use ``rcond=None``,
-           to keep using the old behavior, use ``rcond=-1``.
+        .. versionchanged:: 2.0
+            Previously, the default was ``-1``, but a warning was given that
+            this would change.
 
     Returns
     -------
@@ -2449,7 +2448,7 @@ def lstsq(a, b, rcond="warn"):
            [ 2.,  1.],
            [ 3.,  1.]])
 
-    >>> m, c = np.linalg.lstsq(A, y, rcond=None)[0]
+    >>> m, c = np.linalg.lstsq(A, y)[0]
     >>> m, c
     (1.0 -0.95) # may vary
 
@@ -2476,17 +2475,6 @@ def lstsq(a, b, rcond="warn"):
     t, result_t = _commonType(a, b)
     result_real_t = _realType(result_t)
 
-    # Determine default rcond value
-    if rcond == "warn":
-        # 2017-08-19, 1.14.0
-        warnings.warn("`rcond` parameter will change to the default of "
-                      "machine precision times ``max(M, N)`` where M and N "
-                      "are the input matrix dimensions.\n"
-                      "To use the future default and silence this warning "
-                      "we advise to pass `rcond=None`, to keep using the old, "
-                      "explicitly pass `rcond=-1`.",
-                      FutureWarning, stacklevel=2)
-        rcond = -1
     if rcond is None:
         rcond = finfo(t).eps * max(n, m)
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -964,23 +964,20 @@ class LstsqCases(LinalgSquareTestCase, LinalgNonsquareTestCase):
 
 
 class TestLstsq(LstsqCases):
-    def test_future_rcond(self):
+    def test_rcond(self):
         a = np.array([[0., 1.,  0.,  1.,  2.,  0.],
                       [0., 2.,  0.,  0.,  1.,  0.],
                       [1., 0.,  1.,  0.,  0.,  4.],
                       [0., 0.,  0.,  2.,  3.,  0.]]).T
 
         b = np.array([1, 0, 0, 0, 0, 0])
-        with suppress_warnings() as sup:
-            w = sup.record(FutureWarning, "`rcond` parameter will change")
-            x, residuals, rank, s = linalg.lstsq(a, b)
-            assert_(rank == 4)
-            x, residuals, rank, s = linalg.lstsq(a, b, rcond=-1)
-            assert_(rank == 4)
-            x, residuals, rank, s = linalg.lstsq(a, b, rcond=None)
-            assert_(rank == 3)
-            # Warning should be raised exactly once (first command)
-            assert_(len(w) == 1)
+
+        x, residuals, rank, s = linalg.lstsq(a, b, rcond=-1)
+        assert_(rank == 4)
+        x, residuals, rank, s = linalg.lstsq(a, b)
+        assert_(rank == 3)
+        x, residuals, rank, s = linalg.lstsq(a, b, rcond=None)
+        assert_(rank == 3)
 
     @pytest.mark.parametrize(["m", "n", "n_rhs"], [
         (4, 2, 2),


### PR DESCRIPTION
NumPy 2.0 is clearly the (long overdue) time to do this...

Closes gh-11015