### PR TITLE
ENH: optionally transpose rows and columns in A for faster & equivalent matrix_rank computation

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2047,6 +2047,9 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     near that uncertainty may be preferable. The tolerance may be absolute
     if the uncertainties are absolute rather than relative.
 
+    To speed up the computation, `A` is transposed if the number of rows in
+    each matrix is greater than the number of columns. 
+
     References
     ----------
     .. [1] MATLAB reference documentation, "Rank"

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2071,6 +2071,8 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     A = asarray(A)
     if A.ndim < 2:
         return int(not all(A == 0))
+    if A.shape[-2] < A.shape[-1]:
+        A = swapaxes(A, -2, -1)
     S = svd(A, compute_uv=False, hermitian=hermitian)
     if rtol is not None and tol is not None:
         raise ValueError("`tol` and `rtol` can't be both set.")

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2047,8 +2047,8 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     near that uncertainty may be preferable. The tolerance may be absolute
     if the uncertainties are absolute rather than relative.
 
-    To speed up the computation, `A` is transposed if the number of rows in
-    each matrix is greater than the number of columns. 
+    To speed up the computation, `A` is transposed if the number of rows is
+    greater than the number of columns by more than a factor of 200.
 
     References
     ----------
@@ -2074,7 +2074,7 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     A = asarray(A)
     if A.ndim < 2:
         return int(not all(A == 0))
-    if A.shape[-2] < A.shape[-1]:
+    if A.shape[-2]*200 < A.shape[-1]:
         A = swapaxes(A, -2, -1)
     S = svd(A, compute_uv=False, hermitian=hermitian)
     if rtol is not None and tol is not None:


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This is a simple addition to ``matrix_rank`` in the ``numpy.linalg._linalg.py`` module that optionally performs a transpose of the final two dimensions such that the matrix rank is computed with a smaller number of columns, which speeds it up but is mathematically equivalent. 

Here's some code with a test (using the original ``matrix_rank`` method):
```python
import numpy as np
import time

def check_matrix_rank(R, C, rank=None, num_tests=1, batch=1):
    rank = np.min(R, C) if rank is None else rank
    if batch==1:
        left_sv = np.random.normal(0, 1, (R, rank))
        right_sv = np.random.normal(0, 1, (rank, C))
        data = left_sv @ right_sv
    else:
        left_sv = [np.random.normal(0, 1, (R, rank)) for _ in range(batch)]
        right_sv = [np.random.normal(0, 1, (rank, C)) for _ in range(batch)]
        data = np.stack([lsv @ rsv for lsv, rsv in zip(left_sv, right_sv)])

    def message(msg, data, rank, measured_rank, duration, verbose=False):
        per_test = duration/num_tests
        if per_test < 1:
            dur_message = f"duration per measurement (ms): {1000*per_test}"
        else:
            dur_message = f"duration per measurement: {per_test}"
        if verbose:
            print(msg, 
                  "data shape:", data.shape, 
                  "expected/measured rank:", f"{rank}/{measured_rank}", 
                  dur_message)
        else:
            print(msg, dur_message)
    
    def process_data(data):
        if data.shape[-2]*200 < data.shape[-1]:
            return np.swapaxes(data, -2, -1)
        return data
    
    t = time.time()
    for _ in range(num_tests):
        measured_rank = np.linalg.matrix_rank(data)
    message("original matrix_rank:", data, rank, measured_rank, time.time() - t)
    
    t = time.time()
    for _ in range(num_tests):
        udata = process_data(data)
        measured_rank = np.linalg.matrix_rank(udata)
    message("with potential transpose:", udata, rank, measured_rank, time.time() - t)


B = 100

# asymmetric matrices
R = [10, 100]
C = [int(r*201) for r in R]
rank = [r for r in R]
num_tests = 1

print('Checks for asymmetric batched matrices:')
for r, c, rnk in zip(R, C, rank):
    print(f'Checks for R={r}, C={c}, rank={rnk}:')
    check_matrix_rank(r, c, rnk, num_tests, batch=B)
    print('')

print('')

print('Checks for asymmetric matrices (no batch):')
for r, c, rnk in zip(R, C, rank):
    print(f'Checks for R={r}, C={c}, rank={rnk}:')
    check_matrix_rank(r, c, rnk, num_tests, batch=1)
    print('')

```

### Results
Overall, there's a 1.5-2x speed up for asymmetric matrices and similar performance (or very slightly slower) for similar sized matrices). When the input is a batched set of matrices, the speed up is almost 3x. 

I'm not exactly sure how to document this because it's just a simple line to speed up the computation. I suppose there may be cases where the results differ, but that will only be numerical errors so a speed up of almost 2x for large asymmetric matrices is probably worth it. For a first pass, I just added a note in the ``matrix_rank`` method.

All tests have passed including linting on my local build.
