### PR TITLE
ENH: add a pkg-config file and a `numpy-config` script

### DIFF
--- a/doc/release/upcoming_changes/25730.new_feature.rst
+++ b/doc/release/upcoming_changes/25730.new_feature.rst
@@ -1,0 +1,9 @@
+configtool and pkg-config support
+---------------------------------
+
+A new ``numpy-config`` CLI script is available that can be queried for the
+NumPy version and for compile flags needed to use the NumPy C API. This will
+allow build systems to better support the use of NumPy as a dependency.
+Also, a ``numpy.pc`` pkg-config file is now included inside an installed
+``numpy`` package. In order to find its location for use with
+``PKG_CONFIG_PATH``, use ``numpy-config --pkgconfigdir``.

--- a/numpy/_configtool.py
+++ b/numpy/_configtool.py
@@ -1,0 +1,39 @@
+import argparse
+from pathlib import Path
+import sys
+
+from .version import __version__
+from .lib._utils_impl import get_include
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="Print the version and exit.",
+    )
+    parser.add_argument(
+        "--cflags",
+        action="store_true",
+        help="Compile flag needed when using the NumPy headers.",
+    )
+    parser.add_argument(
+        "--pkgconfigdir",
+        action="store_true",
+        help=("Print the pkgconfig directory in which `numpy.pc` is stored "
+              "(useful for setting $PKG_CONFIG_PATH)."),
+    )
+    args = parser.parse_args()
+    if not sys.argv[1:]:
+        parser.print_help()
+    if args.cflags:
+        print("-I" + get_include())
+    if args.pkgconfigdir:
+        _path = Path(get_include()) / '..' / 'lib' / 'pkgconfig'
+        print(_path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -646,6 +646,23 @@ src_ufunc_api = custom_target('__ufunc_api',
   install_tag: 'devel'
 )
 
+# Write out pkg-config file
+# -------------------------
+
+# Note: we can't use Meson's built-in pkgconfig module, because we have to
+# install numpy.pc within site-packages rather than in its normal location.
+cdata_numpy_pc = configuration_data()
+cdata_numpy_pc.set('version', meson.project_version())
+
+# Note: keep install path in sync with numpy/_configtool.py
+_numpy_pc = configure_file(
+  input: 'numpy.pc.in',
+  output: 'numpy.pc',
+  configuration: cdata_numpy_pc,
+  install: true,
+  install_dir: np_dir / '_core/lib/pkgconfig',
+  install_tag: 'devel'
+)
 
 # Set common build flags for C and C++ code
 # -----------------------------------------

--- a/numpy/_core/numpy.pc.in
+++ b/numpy/_core/numpy.pc.in
@@ -1,0 +1,7 @@
+prefix=${pcfiledir}/../..
+includedir=${prefix}/include
+
+Name: numpy
+Description: NumPy is the fundamental package for scientific computing with Python.
+Version: @version@
+Cflags: -I${includedir}

--- a/numpy/lib/_utils_impl.py
+++ b/numpy/lib/_utils_impl.py
@@ -75,18 +75,29 @@ def get_include():
     """
     Return the directory that contains the NumPy \\*.h header files.
 
-    Extension modules that need to compile against NumPy should use this
+    Extension modules that need to compile against NumPy may need to use this
     function to locate the appropriate include directory.
 
     Notes
     -----
-    When using ``distutils``, for example in ``setup.py``::
+    When using ``setuptools``, for example in ``setup.py``::
 
         import numpy as np
         ...
         Extension('extension_name', ...
-                include_dirs=[np.get_include()])
+                  include_dirs=[np.get_include()])
         ...
+
+    Note that a CLI tool ``numpy-config`` was introduced in NumPy 2.0, using
+    that is likely preferred for build systems other than ``setuptools``::
+
+        $ numpy-config --cflags
+        -I/path/to/site-packages/numpy/_core/include
+
+        # Or rely on pkg-config:
+        $ export PKG_CONFIG_PATH=$(numpy-config --pkgconfigdir)
+        $ pkg-config --cflags
+        -I/path/to/site-packages/numpy/_core/include
 
     """
     import numpy

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -226,6 +226,7 @@ python_sources = [
   '__init__.pxd',
   '__init__.py',
   '__init__.pyi',
+  '_configtool.py',
   '_distributor_init.py',
   '_globals.py',
   '_pytesttester.py',

--- a/numpy/tests/test_configtool.py
+++ b/numpy/tests/test_configtool.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import sysconfig
+
+import pytest
+import numpy as np
+
+
+is_editable = not bool(np.__path__)
+numpy_in_sitepackages = sysconfig.get_path('platlib') in np.__file__
+# We only expect to have a `numpy-config` available if NumPy was installed via
+# a build frontend (and not `spin` for example)
+if not (numpy_in_sitepackages or is_editable):
+    pytest.skip("`numpy-config` not expected to be installed",
+                allow_module_level=True)
+
+
+def check_numpyconfig(arg):
+    p = subprocess.run(['numpy-config', arg], capture_output=True, text=True)
+    p.check_returncode()
+    return p.stdout.strip()
+
+
+def test_configtool_version():
+    stdout = check_numpyconfig('--version')
+    assert stdout == np.__version__
+
+
+def test_configtool_cflags():
+    stdout = check_numpyconfig('--cflags')
+    assert stdout.endswith(os.path.join('numpy', '_core', 'include'))
+
+
+def test_configtool_pkgconfigdir():
+    stdout = check_numpyconfig('--pkgconfigdir')
+    assert stdout.endswith(os.path.join('numpy', '_core', 'lib', 'pkgconfig'))
+
+    if not is_editable:
+        # Also check that the .pc file actually exists (unless we're using an
+        # editable install, then it'll be hiding in the build dir)
+        assert os.path.exists(os.path.join(stdout, 'numpy.pc'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 
 [project.scripts]
 f2py = 'numpy.f2py.f2py2e:main'
+numpy-config = 'numpy._configtool:main'
 
 [project.entry-points.array_api]
 numpy = 'numpy.array_api'


### PR DESCRIPTION
This will make it much easier to support getting at the location for headers and to support using numpy as a dependency in downstream build config files. It should enable removing the complexity of importing numpy and parsing the output of calling `np.get_include` and co. manually. Instead, things should work transparently with (in the Meson case): `dependency('numpy')`. CMake is also able to consume pkg-config files and/or a config tool.

Note that the `numpy.pc` file may or may not be installable in the standard location expected by pkg-config. By default in a wheel it isn't; distros are in principle able to target the correct location (however, no flag to do so is added here, it can be done by hand only right now).

The advantage of the `numpy-config` tool is that it goes into the scripts directory (i.e., `site-packages/bin`) and hence is always available. The advantage of the pkg-config file is that it works without running Python, and hence is better for cross-compiling.

Support for getting at the numpy/f2py/src directory isn't included here, because that isn't a regular include directory but rather includes a source file. And hence a compile arg `-I/path/to/numpy/f2py/src` is not enough. How to better support that requires some more thought. In its current form, this should already help most packages using the NumPy C API.


The `numpy.pc` file can be used with Meson directly, without needing an upstream change. To do so, try:
```bash
$ export PKG_CONFIG_PATH=$(numpy-config --pkgconfigdir)
$ numpy-config --version
2.0.0.dev0+git20240126.3e7b299
$ numpy-config --cflags
-I/home/rgommers/mambaforge/envs/scipy-dev/lib/python3.10/site-packages/numpy/_core/include
```

To add `numpy-config` support to Meson does require an upstream change, but it's a straightforward ~12 LoC diff: https://github.com/mesonbuild/meson/compare/master...rgommers:meson:add-numpy-dependency?expand=1

I wanted to get this in for 2.0.0, since that may be the lowest supported version for quite a while. Having this in will allow most downstream projects to drop their verbose handling of NumPy include paths completely.

@eli-schwartz maybe you want to have a look at this?