### PR TITLE
CI: use version 0.3.26.0.2 of scipy-openblas wheels

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -565,7 +565,9 @@ def _config_openblas(blas_variant):
             fid.write(f"import {module_name}\n")
         os.makedirs(openblas_dir, exist_ok=True)
         with open(pkg_config_fname, "wt", encoding="utf8") as fid:
-            fid.write(openblas.get_pkg_config().replace("\\", "/"))
+            fid.write(
+                openblas.get_pkg_config(use_preloading=True).replace("\\", "/")
+            )
 
 
 @click.command()

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32<0.3.26
+scipy-openblas32<=0.3.26.0
 

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32<=0.3.26.0
+scipy-openblas32<=0.3.26.0.1
 

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32<=0.3.26.0.1
+scipy-openblas32==0.3.26.0.2
 

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32<=0.3.26.0
-scipy-openblas64<=0.3.26.0
+scipy-openblas32<=0.3.26.0.1
+scipy-openblas64<=0.3.26.0.1

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32<0.3.26
-scipy-openblas64<0.3.26
+scipy-openblas32<=0.3.26.0
+scipy-openblas64<=0.3.26.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32<=0.3.26.0.1
-scipy-openblas64<=0.3.26.0.1
+scipy-openblas32==0.3.26.0.2
+scipy-openblas64==0.3.26.0.2


### PR DESCRIPTION
Now that the wheel versions are pinned, try the latest version (with a single shared object).

Needed for #25505