### PR TITLE
TST: run macos_arm64 test on Github Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,12 +100,14 @@ jobs:
         ccache -s
 
   accelerate:
-    name: Accelerate (LP64, ILP64)
+    name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
     if: "github.repository == 'numpy/numpy'"
-    runs-on: ${{ matrix.buildplat }}
+    runs-on: ${{ matrix.build_runner[0] }}
     strategy:
       matrix:
-        buildplat: [ macos-13, macos-14 ]
+        build_runner:
+          - [ macos-13, "macos_x86_64" ]
+          - [ macos-14, "macos_arm64" ]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -118,7 +120,7 @@ jobs:
         python-version: '3.10'
 
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-      if: ${{ matrix.buildplat == 'macos-13' }}
+      if: ${{ matrix.build_runner[0] == 'macos-13' }}
       with:
         xcode-version: '14.3'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -99,6 +99,7 @@ jobs:
         conda activate numpy-dev
         ccache -s
 
+
   accelerate:
     name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
     if: "github.repository == 'numpy/numpy'"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -102,7 +102,11 @@ jobs:
   accelerate:
     name: Accelerate (LP64, ILP64)
     if: "github.repository == 'numpy/numpy'"
-    runs-on: macos-13
+    runs-on: ${{ matrix.buildplat }}
+    strategy:
+      matrix:
+        buildplat: [ macos-13, macos-14 ]
+
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -114,6 +118,7 @@ jobs:
         python-version: '3.10'
 
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      if: ${{ matrix.buildplat == 'macos-13' }}
       with:
         xcode-version: '14.3'
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1808,8 +1808,9 @@ class TestQR:
         np.csingle, np.cdouble])
     def test_stacked_inputs(self, outer_size, size, dt):
 
-        A = np.random.normal(size=outer_size + size).astype(dt)
-        B = np.random.normal(size=outer_size + size).astype(dt)
+        rng = np.random.default_rng(123)
+        A = rng.normal(size=outer_size + size).astype(dt)
+        B = rng.normal(size=outer_size + size).astype(dt)
         self.check_qr_stacked(A)
         self.check_qr_stacked(A + 1.j*B)
 

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -63,48 +63,6 @@ linux_aarch64_test_task:
     ccache -s
 
 
-macos_arm64_test_task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  depends_on:
-    - linux_aarch64_test
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode
-
-  <<: *MODIFIED_CLONE
-
-  ccache_cache:
-    folder: .ccache
-    populate_script:
-      - mkdir -p .ccache
-    fingerprint_key: ccache-macosx_arm64
-
-  pip_cache:
-    folder: ~/.cache/pip
-
-  test_script: |
-    brew install micromamba ccache
-    micromamba shell init -s bash -p ~/micromamba
-    source ~/.bash_profile
-    
-    micromamba create -n numpydev
-    micromamba activate numpydev
-    micromamba install -y -c conda-forge compilers python=3.11 2>/dev/null
-    
-    export PATH=/opt/homebrew/opt/ccache/libexec:$PATH
-    export CCACHE_DIR=$PWD/.ccache
-    echo "PATH=$PATH" >> $CIRRUS_ENV
-
-    python --version
-    
-    pip install -r requirements/build_requirements.txt
-    pip install pytest pytest-xdist hypothesis typing_extensions
-
-    spin build
-    spin test -j auto
-
-    ccache -s
-
-
 freebsd_test_task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   compute_engine_instance:


### PR DESCRIPTION
With the addition of macos-14 runners we should now be able to run macos_arm64 tests on GHA. This will reduce our usage on cirrus.