### PR TITLE
DEP: Finalize future warning for shape=1 descriptor dropping shape

### DIFF
--- a/doc/release/upcoming_changes/25761.expired.rst
+++ b/doc/release/upcoming_changes/25761.expired.rst
@@ -1,0 +1,2 @@
+* ``np.dtype(("f8", 1)`` will now return a shape 1 subarray dtype
+  rather than a non-subarray one.

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -312,20 +312,6 @@ _convert_from_tuple(PyObject *obj, int align)
             npy_free_cache_dim_obj(shape);
             return type;
         }
-        /* (type, 1) use to be equivalent to type, but is deprecated */
-        if (shape.len == 1
-                && shape.ptr[0] == 1
-                && PyNumber_Check(val)) {
-            /* 2019-05-20, 1.17 */
-            if (DEPRECATE_FUTUREWARNING(
-                        "Passing (type, 1) or '1type' as a synonym of type is "
-                        "deprecated; in a future version of numpy, it will be "
-                        "understood as (type, (1,)) / '(1,)type'.") < 0) {
-                goto fail;
-            }
-            npy_free_cache_dim_obj(shape);
-            return type;
-        }
 
         /* validate and set shape */
         for (int i=0; i < shape.len; i++) {

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -356,14 +356,6 @@ class TestFromStringAndFileInvalidData(_DeprecationTestCase):
             assert_array_equal(res, x)
 
 
-class TestShape1Fields(_DeprecationTestCase):
-    warning_cls = FutureWarning
-
-    # 2019-05-20, 1.17.0
-    def test_shape_1_fields(self):
-        self.assert_deprecated(np.dtype, args=([('a', int, 1)],))
-
-
 class TestNonZero(_DeprecationTestCase):
     # 2019-05-26, 1.17.0
     def test_zerod(self):

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -633,10 +633,8 @@ class TestSubarray:
     def test_shape_equal(self):
         """Test some data types that are equal"""
         assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
-        # FutureWarning during deprecation period; after it is passed this
-        # should instead check that "(1)f8" == "1f8" == ("f8", 1).
-        with pytest.warns(FutureWarning):
-            assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
+        assert_dtype_equal(np.dtype('(1,)f8'), np.dtype(('f8', 1)))
+        assert np.dtype(('f8', 1)).shape == (1,)
         assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
         assert_dtype_equal(np.dtype(('<f4', (3, 2))), np.dtype(('<f4', (3, 2))))
         d = ([('a', 'f4', (1, 2)), ('b', 'f8', (3, 1))], (3, 2))


### PR DESCRIPTION
This finalizes the old FutureWarning to not drop the shape for a dtype like `("f8", 1)`.