### PR TITLE
CI/BLD: fix bash script tests for cibw

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -90,7 +90,8 @@ macosx_arm64_task:
         export INSTALL_GFORTRAN=false
     else
         export INSTALL_OPENBLAS=true
-        # scipy-openblas wheels seem to need this compiler rather than
+        # scipy-openblas tarballs need the gfortran shared object
+        # from here rather than
         # the compiler supplied by micromamba
         export INSTALL_GFORTRAN=true
     fi

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -38,7 +38,7 @@ linux_aarch64_task:
         CIBW_PRERELEASE_PYTHONS: True
         CIBW_BUILD: cp312-*
 
-  build_script: |
+  initial_setup_script: |
     apt update
     apt install -y python3-venv python-is-python3 gfortran libatlas-base-dev libgfortran5 eatmydata
     git fetch origin
@@ -74,7 +74,7 @@ macosx_arm64_task:
     PATH: /usr/local/lib:/usr/local/include:$PATH
     CIBW_ARCHS: arm64
 
-  build_script: |
+  initial_setup_script: |
     brew install micromamba
     micromamba shell init -s bash -p ~/micromamba
     source ~/.bash_profile
@@ -85,7 +85,7 @@ macosx_arm64_task:
     
     ver=$(sw_vers -productVersion)
     macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
-    if [ macos_target == '14.0' ]; then
+    if [ $macos_target == '14.0' ]; then
         export INSTALL_OPENBLAS=false
     else
         export INSTALL_OPENBLAS=true

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -74,7 +74,7 @@ macosx_arm64_task:
     PATH: /usr/local/lib:/usr/local/include:$PATH
     CIBW_ARCHS: arm64
 
-  initial_setup_script: |
+  build_script: |
     brew install micromamba
     micromamba shell init -s bash -p ~/micromamba
     source ~/.bash_profile
@@ -87,11 +87,15 @@ macosx_arm64_task:
     macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
     if [ $macos_target == '14.0' ]; then
         export INSTALL_OPENBLAS=false
+        export INSTALL_GFORTRAN=false
     else
         export INSTALL_OPENBLAS=true
+        # scipy-openblas wheels seem to need this compiler rather than
+        # the compiler supplied by micromamba
+        export INSTALL_GFORTRAN=true
     fi
 
-    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=$INSTALL_OPENBLAS INSTALL_GFORTRAN=false RUNNER_OS=macOS"
+    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=$INSTALL_OPENBLAS INSTALL_GFORTRAN=$INSTALL_GFORTRAN RUNNER_OS=macOS"
     
     # needed for submodules
     git submodule update --init

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,8 +22,8 @@ if [ -z $INSTALL_OPENBLAS ]; then
 fi
 
 # Install Openblas
-if [[ $RUNNER_OS == "Linux" || ($RUNNER_OS == "macOS" && $INSTALL_OPENBLAS) ]] ; then
-    basedir=$(python tools/openblas_support.py --use-ilp64)
+  if [[ $RUNNER_OS == "Linux" || ($RUNNER_OS == "macOS" && ("$INSTALL_OPENBLAS" = true)) ]] ; then
+      basedir=$(python tools/openblas_support.py --use-ilp64)
     if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
         # /usr/local/lib doesn't exist on cirrus-ci runners
         sudo mkdir -p /usr/local/lib /usr/local/include /usr/local/lib/cmake/openblas
@@ -57,7 +57,7 @@ if [ -z $INSTALL_GFORTRAN ]; then
     export INSTALL_GFORTRAN=true
 fi
 
-if [[ $RUNNER_OS == "macOS" && $INSTALL_GFORTRAN ]]; then
+if [[ $RUNNER_OS == "macOS" && ("$INSTALL_GFORTRAN" = true) ]]; then
     # Install same version of gfortran as the openblas-libs builds
     if [[ $PLATFORM == "macosx-arm64" ]]; then
         PLAT="arm64"

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,7 +22,7 @@ if [ -z $INSTALL_OPENBLAS ]; then
 fi
 
 # Install Openblas
-  if [[ $RUNNER_OS == "Linux" || ($RUNNER_OS == "macOS" && ("$INSTALL_OPENBLAS" = true)) ]] ; then
+if [[ $RUNNER_OS == "Linux" || ($RUNNER_OS == "macOS" && ("$INSTALL_OPENBLAS" = true)) ]] ; then
       basedir=$(python tools/openblas_support.py --use-ilp64)
     if [[ $RUNNER_OS == "macOS" && $PLATFORM == "macosx-arm64" ]]; then
         # /usr/local/lib doesn't exist on cirrus-ci runners

--- a/tools/wheels/gfortran_utils.sh
+++ b/tools/wheels/gfortran_utils.sh
@@ -169,9 +169,6 @@ if [ "$(uname)" == "Darwin" ]; then
     function install_gfortran {
         download_and_unpack_gfortran $(uname -m) native
         check_gfortran
-        if [[ "${PLAT:-}" == "universal2" || "${PLAT:-}" == "arm64" ]]; then
-            install_arm64_cross_gfortran
-        fi
     }
 
     function get_gf_lib {


### PR DESCRIPTION
This PR fixes a several logic tests in bash scripts that are used for building wheels on macOS. If we're on Sonoma we need to be using Accelerate, and the logic tests were falsely installing gfortran (which should be supplied by micromamba) and openblas which meant that that is picked up instead of Accelerate.