### PR TITLE
DOC: in ufuncs ``dtype`` is not ignored when ``out`` is passed

### DIFF
--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -80,9 +80,8 @@ an integer (or Boolean) data-type and smaller than the size of the
    array([ 0., 28., 80.])
 
 Finally, the *out* keyword allows you to
-provide an output array (for single-output ufuncs, which are currently the only
-ones supported; for future extension, however, a tuple with a single argument
-can be passed in). If *out* is given, the *dtype* argument is ignored.
+provide an output array (or a tuple of output arrays for multi-output ufuncs).
+If *out* is given, the *dtype* argument is only used for the internal computations.
 Considering ``x`` from the previous example::
 
    >>> y = np.zeros(3, dtype=int)


### PR DESCRIPTION
The documentation stated that the "dtype" argument was not playing any role when an "out" argument is given. However, that's incorrect, and both arguments are used. If dtype has a smaller range than the dtype of out, it can affect the result.

Example:
```
>>> outi16 = np.empty((1,), numpy.uint16)
>>> np.add.reduce([[200, 200]], axis=1, out=outi16)
array([400], dtype=uint16)
>>> np.add.reduce([[200, 200]], axis=1, out=outi16, dtype=numpy.uint8)
array([144], dtype=uint16)
```