### PR TITLE
MAINT,API: Always export static inline version of array accessor.

### DIFF
--- a/doc/release/upcoming_changes/25789.c_api.rst
+++ b/doc/release/upcoming_changes/25789.c_api.rst
@@ -1,3 +1,3 @@
 * The C-API now only exports the static inline function versions
   of the array accessors (previously this dependent on using "deprecated API").
-  While we encourage avoiding it, if you need to use the struct fields directly.
+  While we discourage it, you can still use the struct fields directly.

--- a/doc/release/upcoming_changes/25789.c_api.rst
+++ b/doc/release/upcoming_changes/25789.c_api.rst
@@ -1,0 +1,3 @@
+* The C-API now only exports the static inline function versions
+  of the array accessors (previously this dependent on using "deprecated API").
+  While we encourage avoiding it, if you need to use the struct fields directly.

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1458,14 +1458,6 @@ PyArrayNeighborhoodIter_Next2D(PyArrayNeighborhoodIterObject* iter);
 #define PyArray_FORTRAN_IF(m) ((PyArray_CHKFLAGS(m, NPY_ARRAY_F_CONTIGUOUS) ? \
                                NPY_ARRAY_F_CONTIGUOUS : 0))
 
-#if (defined(NPY_NO_DEPRECATED_API) && (NPY_1_7_API_VERSION <= NPY_NO_DEPRECATED_API))
-/*
- * Changing access macros into functions, to allow for future hiding
- * of the internal memory layout. This later hiding will allow the 2.x series
- * to change the internal representation of arrays without affecting
- * ABI compatibility.
- */
-
 static inline int
 PyArray_NDIM(const PyArrayObject *arr)
 {
@@ -1562,34 +1554,6 @@ PyArray_SETITEM(PyArrayObject *arr, char *itemptr, PyObject *v)
     return ((PyArrayObject_fields *)arr)->descr->f->setitem(v, itemptr, arr);
 }
 
-#else
-
-/* These macros are deprecated as of NumPy 1.7. */
-#define PyArray_NDIM(obj) (((PyArrayObject_fields *)(obj))->nd)
-#define PyArray_BYTES(obj) (((PyArrayObject_fields *)(obj))->data)
-#define PyArray_DATA(obj) ((void *)((PyArrayObject_fields *)(obj))->data)
-#define PyArray_DIMS(obj) (((PyArrayObject_fields *)(obj))->dimensions)
-#define PyArray_STRIDES(obj) (((PyArrayObject_fields *)(obj))->strides)
-#define PyArray_DIM(obj,n) (PyArray_DIMS(obj)[n])
-#define PyArray_STRIDE(obj,n) (PyArray_STRIDES(obj)[n])
-#define PyArray_BASE(obj) (((PyArrayObject_fields *)(obj))->base)
-#define PyArray_DESCR(obj) (((PyArrayObject_fields *)(obj))->descr)
-#define PyArray_FLAGS(obj) (((PyArrayObject_fields *)(obj))->flags)
-#define PyArray_CHKFLAGS(m, FLAGS) \
-        ((((PyArrayObject_fields *)(m))->flags & (FLAGS)) == (FLAGS))
-#define PyArray_ITEMSIZE(obj) \
-                    (((PyArrayObject_fields *)(obj))->descr->elsize)
-#define PyArray_TYPE(obj) \
-                    (((PyArrayObject_fields *)(obj))->descr->type_num)
-#define PyArray_GETITEM(obj,itemptr) \
-        PyArray_DESCR(obj)->f->getitem((char *)(itemptr), \
-                                     (PyArrayObject *)(obj))
-
-#define PyArray_SETITEM(obj,itemptr,v) \
-        PyArray_DESCR(obj)->f->setitem((PyObject *)(v), \
-                                     (char *)(itemptr), \
-                                     (PyArrayObject *)(obj))
-#endif
 
 static inline PyArray_Descr *
 PyArray_DTYPE(PyArrayObject *arr)


### PR DESCRIPTION
While we might not hide the struct fully by default, I don't think there is a reason to not only export the static inline versions of these?

They will type check a bit nicer (might give warnings), but otherwise should only matter if you do `PyArray_NDIM(arr) = 3`.

---

Or am I missing a reason to even have this?  Seems like a relatively mild and good API change to only use the static-inline versions.