### PR TITLE
MAINT: Private device struct shouldn't be in public header

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -322,10 +322,6 @@ typedef enum {
     NPY_BUSDAY_RAISE
 } NPY_BUSDAY_ROLL;
 
-/* Device enum for Array API compatibility */
-typedef enum {
-        NPY_DEVICE_CPU = 0,
-} NPY_DEVICE;
 
 /************************************************************
  * NumPy Auxiliary Data for inner loops, sort functions, etc.

--- a/numpy/_core/src/multiarray/conversion_utils.h
+++ b/numpy/_core/src/multiarray/conversion_utils.h
@@ -85,6 +85,10 @@ PyArray_SelectkindConverter(PyObject *obj, NPY_SELECTKIND *selectkind);
 NPY_NO_EXPORT int
 PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags);
 
+typedef enum {
+        NPY_DEVICE_CPU = 0,
+} NPY_DEVICE;
+
 /*
  * Device string converter.
  */


### PR DESCRIPTION
Just move the struct, it shouldn't have been there.
