### PR TITLE
API: Create ``PyArray_DescrProto`` for legacy descriptor registration

### DIFF
--- a/doc/release/upcoming_changes/25792.c_api.rst
+++ b/doc/release/upcoming_changes/25792.c_api.rst
@@ -1,0 +1,8 @@
+Required changes for custom legacy user dtypes
+----------------------------------------------
+In order to improve our DTypes it is unfortunately necessary
+to break with ABI, which requires some changes for dtypes registered
+with `PyArray_RegisterDataType`.
+Please see the documentation of `PyArray_RegisterDataType` for how
+to adapt your code and achieve compatibility with both 1.x and 2.x.
+

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1104,7 +1104,39 @@ User-defined data types
 
     Initialize all function pointers and members to ``NULL``.
 
-.. c:function:: int PyArray_RegisterDataType(PyArray_Descr* dtype)
+.. c:function:: int PyArray_RegisterDataType(PyArray_DescrProto* dtype)
+
+    .. note::
+        As of NumPy 2.0 this API is considered legacy, the new DType API
+        is more powerful and provides additional flexibility.
+        The API may eventually be deprecated but support is continued for
+        the time being.
+
+        **Compiling for NumPy 1.x and 2.x**
+
+        NumPy 2.x requires passing in a ``PyArray_DescrProto`` typed struct
+        rather than a ``PyArray_Descr``.  This is necessary to allow changes.
+        To allow code to run and compile on both 1.x and 2.x you need to
+        change the type of your struct to ``PyArray_DescrProto`` and add::
+
+            /* Allow compiling on NumPy 1.x */
+            #if NPY_ABI_VERSION < 0x02000000
+            #define PyArray_DescrProto PyArray_Descr
+            #endif
+
+        for 1.x compatibility.  Further, the struct will *not* be the actual
+        descriptor anymore, only it's type number will be updated.
+        After successful registration, you must thus fetch the actual
+        dtype with:
+
+            int type_num = PyArray_RegisterDataType(&my_descr_proto);
+            if (type_num < 0) {
+                /* error */
+            }
+            PyArray_Descr *my_descr = PyArray_DescrFromType(type_num);
+
+        With these two changes, the code should compile and work on both 1.x
+        and 2.x or later.
 
     Register a data-type as a new user-defined data type for
     arrays. The type must have most of its entries filled in. This is

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -638,7 +638,35 @@ typedef struct _PyArray_Descr {
          * This was added for NumPy 2.0.0.
          */
         npy_hash_t hash;
+
 } PyArray_Descr;
+
+
+
+/*
+ * Umodified PyArray_Descr struct identical to NumPy 1.x.  This struct is
+ * used as a prototype for registering a new legacy DType.
+ * It is also used to access the fields in user code running on 1.x.
+ */
+typedef struct {
+        PyObject_HEAD
+        PyTypeObject *typeobj;
+        char kind;
+        char type;
+        char byteorder;
+        char flags;
+        int type_num;
+        int elsize;
+        int alignment;
+        struct _arr_descr *subarray;
+        PyObject *fields;
+        PyObject *names;
+        PyArray_ArrFuncs *f;
+        PyObject *metadata;
+        NpyAuxData *c_metadata;
+        npy_hash_t hash;
+} PyArray_DescrProto;
+
 
 typedef struct _arr_descr {
         PyArray_Descr *base;

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -79,8 +79,9 @@
     #define NPY_RAVEL_AXIS 32
     #define NPY_MAXARGS 32
 
-    /* Renamed in 2.x */
+    /* Aliases of 2.x names to 1.x only equivalent names */
     #define NPY_NTYPES NPY_NTYPES_LEGACY
+    #define PyArray_DescrProto PyArray_Descr
 #else
     #define NPY_DEFAULT_INT  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -495,9 +495,9 @@ fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
 static PyObject *
 create_custom_field_dtype(PyObject *NPY_UNUSED(mod), PyObject *args)
 {
+    PyArray_DescrProto proto;
     PyArray_Descr *dtype;
     PyTypeObject *scalar_type;
-    PyTypeObject *original_type = NULL;
     int error_path;
 
     if (!PyArg_ParseTuple(args, "O!O!i",
@@ -518,38 +518,44 @@ create_custom_field_dtype(PyObject *NPY_UNUSED(mod), PyObject *args)
         return NULL;
     }
 
-    /* Copy and then appropriate this dtype */
-    original_type = Py_TYPE(dtype);
-    dtype = PyArray_DescrNew(dtype);
-    if (dtype == NULL) {
-        return NULL;
-    }
+    /* Set all fields, mostly copying them from the passed in dtype: */
+    Py_SET_TYPE(&proto, Py_TYPE(dtype));
+    proto.typeobj = scalar_type;
+    proto.kind = dtype->kind;
+    proto.type = dtype->type;
+    proto.byteorder = dtype->byteorder;
+    proto.flags = dtype->flags;
+    proto.type_num = dtype->type_num;
+    proto.elsize = dtype->elsize;
+    proto.alignment = dtype->alignment;
+    proto.subarray = dtype->subarray;
+    proto.fields = dtype->fields;
+    proto.names = dtype->names;
+    proto.f = dtype->f;
+    proto.metadata = dtype->metadata;
+    proto.c_metadata = dtype->c_metadata;
 
-    Py_INCREF(scalar_type);
-    Py_SETREF(dtype->typeobj, scalar_type);
     if (error_path == 1) {
         /* Test that we reject this, if fields was not already set */
-        Py_SETREF(dtype->fields, NULL);
+        proto.fields = NULL;
     }
     else if (error_path == 2) {
         /*
          * Test that we reject this if the type is not set to something that
          * we are pretty sure can be safely replaced.
          */
-        Py_SET_TYPE(dtype, scalar_type);
+        Py_SET_TYPE(&proto, scalar_type);
     }
     else if (error_path != 0) {
         PyErr_SetString(PyExc_ValueError,
                 "invalid error argument to test function.");
     }
-    if (PyArray_RegisterDataType(dtype) < 0) {
-        /* Fix original type in the error_path == 2 case and delete it */
-        Py_SET_TYPE(dtype, original_type);
-        Py_DECREF(dtype);
+    int new_typenum = PyArray_RegisterDataType(&proto);
+    if (new_typenum < 0) {
         return NULL;
     }
-    Py_INCREF(dtype);  /* hold on to the original (leaks a reference) */
-    return (PyObject *)dtype;
+
+    return (PyObject *)PyArray_DescrFromType(new_typenum);
 }
 
 

--- a/numpy/_core/src/multiarray/usertypes.h
+++ b/numpy/_core/src/multiarray/usertypes.h
@@ -13,7 +13,7 @@ PyArray_RegisterCanCast(PyArray_Descr *descr, int totype,
                         NPY_SCALARKIND scalar);
 
 NPY_NO_EXPORT int
-PyArray_RegisterDataType(PyArray_Descr *descr);
+PyArray_RegisterDataType(PyArray_DescrProto *descr);
 
 NPY_NO_EXPORT int
 PyArray_RegisterCastFunc(PyArray_Descr *descr, int totype,

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -888,7 +888,7 @@ static PyArray_ArrFuncs npyrational_arrfuncs;
 
 typedef struct { char c; rational r; } align_test;
 
-PyArray_Descr npyrational_descr = {
+PyArray_DescrProto npyrational_descr_proto = {
     PyObject_HEAD_INIT(0)
     &PyRational_Type,       /* typeobj */
     'V',                    /* kind */
@@ -1159,15 +1159,16 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     npyrational_arrfuncs.fill = npyrational_fill;
     npyrational_arrfuncs.fillwithscalar = npyrational_fillwithscalar;
     /* Left undefined: scanfunc, fromstr, sort, argsort */
-    Py_SET_TYPE(&npyrational_descr, &PyArrayDescr_Type);
-    npy_rational = PyArray_RegisterDataType(&npyrational_descr);
+    Py_SET_TYPE(&npyrational_descr_proto, &PyArrayDescr_Type);
+    npy_rational = PyArray_RegisterDataType(&npyrational_descr_proto);
     if (npy_rational<0) {
         goto fail;
     }
+    PyArray_Descr *npyrational_descr = PyArray_DescrFromType(npy_rational);
 
     /* Support dtype(rational) syntax */
     if (PyDict_SetItemString(PyRational_Type.tp_dict, "dtype",
-                             (PyObject*)&npyrational_descr) < 0) {
+                             (PyObject*)npyrational_descr) < 0) {
         goto fail;
     }
 
@@ -1188,17 +1189,17 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     #define REGISTER_INT_CASTS(bits) \
         REGISTER_CAST(npy_int##bits, rational, \
                       PyArray_DescrFromType(NPY_INT##bits), npy_rational, 1) \
-        REGISTER_CAST(rational, npy_int##bits, &npyrational_descr, \
+        REGISTER_CAST(rational, npy_int##bits, npyrational_descr, \
                       NPY_INT##bits, 0)
     REGISTER_INT_CASTS(8)
     REGISTER_INT_CASTS(16)
     REGISTER_INT_CASTS(32)
     REGISTER_INT_CASTS(64)
-    REGISTER_CAST(rational,float,&npyrational_descr,NPY_FLOAT,0)
-    REGISTER_CAST(rational,double,&npyrational_descr,NPY_DOUBLE,1)
+    REGISTER_CAST(rational,float,npyrational_descr,NPY_FLOAT,0)
+    REGISTER_CAST(rational,double,npyrational_descr,NPY_DOUBLE,1)
     REGISTER_CAST(npy_bool,rational, PyArray_DescrFromType(NPY_BOOL),
                   npy_rational,1)
-    REGISTER_CAST(rational,npy_bool,&npyrational_descr,NPY_BOOL,0)
+    REGISTER_CAST(rational,npy_bool,npyrational_descr,NPY_BOOL,0)
 
     /* Register ufuncs */
     #define REGISTER_UFUNC(name,...) { \
@@ -1307,14 +1308,14 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
                 PyUFunc_None,(char*)"test_add_rationals",
                 (char*)"add two matrices of rationals and return rational matrix",0);
-        PyArray_Descr* types[3] = {&npyrational_descr,
-                                    &npyrational_descr,
-                                    &npyrational_descr};
+        PyArray_Descr* types[3] = {npyrational_descr,
+                                    npyrational_descr,
+                                    npyrational_descr};
 
         if (!ufunc) {
             goto fail;
         }
-        if (PyUFunc_RegisterLoopForDescr((PyUFuncObject*)ufunc, &npyrational_descr,
+        if (PyUFunc_RegisterLoopForDescr((PyUFuncObject*)ufunc, npyrational_descr,
                 rational_ufunc_test_add_rationals, types, 0) < 0) {
             goto fail;
         }


### PR DESCRIPTION
First step, force users of registered dtypes to slightly change their code in order to free up changing our `descr` struct.