### PR TITLE
DOC: fix docstring example in f2py.get_include

### DIFF
--- a/doc/source/f2py/f2py-examples.rst
+++ b/doc/source/f2py/f2py-examples.rst
@@ -219,7 +219,7 @@ multi-step extension module generation. In this case, after running
 
 .. code-block:: python
 
-	python -m numpy.f2py myroutine.f90 -h myroutine.pyf
+	python -m numpy.f2py myroutine.f90 -m myroutine -h myroutine.pyf
 
 the following signature file is generated:
 

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -53,13 +53,13 @@ def get_include():
     process. For a module ``mymod``:
 
     * Step 1: run ``python -m numpy.f2py mymod.pyf --quiet``. This
-      generates ``_mymodmodule.c`` and (if needed)
-      ``_fblas-f2pywrappers.f`` files next to ``mymod.pyf``.
+      generates ``mymodmodule.c`` and (if needed)
+      ``mymod-f2pywrappers.f`` files next to ``mymod.pyf``.
     * Step 2: build your Python extension module. This requires the
       following source files:
 
-      * ``_mymodmodule.c``
-      * ``_mymod-f2pywrappers.f`` (if it was generated in Step 1)
+      * ``mymodmodule.c``
+      * ``mymod-f2pywrappers.f`` (if it was generated in Step 1)
       * ``fortranobject.c``
 
     See Also


### PR DESCRIPTION
Small fix docstring of the f2py.get_include method

- `mymod-f2pywrappers.f` instead of `fblas-f2pywrappers.f`
- get rid of the underscore

Default behavior of

```bash
python -m numpy.f2py mymod.pyf --quiet
```

when using the `mymod.pyf`

```python
python module mymod ! in 
    interface  ! in :mymod
        subroutine mymod(...) ! in :mymod:mymod.f
        ...
        end subroutine mymod
    end interface 
end python module mymod
```

Remark: The underscore ` _mymod*.*` only occurs when using `_mymod` in `mymod.pyf`

```python
python module _mymod ! in 
    interface  ! in :mymod
        subroutine mymod(...) ! in :mymod:mymod.f
        ...
        end subroutine mymod
    end interface 
end python module mymod
```