### PR TITLE
MAINT: combine string ufuncs by passing on auxilliary data

### DIFF
--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -142,6 +142,7 @@ typedef struct {
 #define NPY_METH_unaligned_strided_loop 7
 #define NPY_METH_unaligned_contiguous_loop 8
 #define NPY_METH_contiguous_indexed_loop 9
+#define _NPY_METH_static_data 10
 
 
 /*

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -296,6 +296,9 @@ fill_arraymethod_from_slots(
             case NPY_METH_contiguous_indexed_loop:
                 meth->contiguous_indexed_loop = slot->pfunc;
                 continue;
+            case _NPY_METH_static_data:
+                meth->static_data = slot->pfunc;
+                continue;
             default:
                 break;
         }

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -45,6 +45,9 @@ typedef struct PyArrayMethodObject_tag {
     NPY_CASTING casting;
     /* default flags. The get_strided_loop function can override these */
     NPY_ARRAYMETHOD_FLAGS flags;
+    /* pointer to possible data needed inside the loop (e.g., a function pointer) */
+    void *static_data;
+    /* functions to help decide which loop to call and how to prepare for it */
     PyArrayMethod_ResolveDescriptorsWithScalar *resolve_descriptors_with_scalars;
     PyArrayMethod_ResolveDescriptors *resolve_descriptors;
     PyArrayMethod_GetLoop *get_strided_loop;


### PR DESCRIPTION
This ~is just a proof of concept to show~ shows how one can reduce the code by using loops for multiple functions. ~trying `maximum` and `minimum`~ EDIT: now all useful functions done.

~Right now, it is rather inelegant since I do not know how to pass on arbitrary data in the new array method framework... (@seberg?), so instead I base it on the name of the function. That said, at least that name was immediately useful!~ EDIT: it changes the array method so that it allows passing on aux data; this should really be a different PR!

cc @ngoldbaum

p.s. Shaves ~1500~ 55000 bytes off the (enormous) _multiarray_umath.cpython-311-x86_64-linux-gnu.so, though that is with debug symbols, etc.