### PR TITLE
BLD: restore 'setup-args=-Duse-ilp64=true' in cibuildwheel [wheel build]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ build-frontend = "build"
 skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
-config-settings = "setup-args=-Dallow-noblas=false build-dir=build"
+config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 


### PR DESCRIPTION
Fixes line changed in #25505 

Motivated by [this comment](https://github.com/numpy/numpy/pull/25505/files#r1485069976), cc @rgommers