### PR TITLE
MAINT: Use ``_ITEMSIZE`` rather than ``_DESCR(arr)->elsize``

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1186,7 +1186,7 @@ struct PyArrayIterObject_tag {
                 _PyArray_ITER_NEXT1(_PyAIT(it)); \
         } \
         else if (_PyAIT(it)->contiguous) \
-                _PyAIT(it)->dataptr += PyArray_DESCR(_PyAIT(it)->ao)->elsize; \
+                _PyAIT(it)->dataptr += PyArray_ITEMSIZE(_PyAIT(it)->ao); \
         else if (_PyAIT(it)->nd_m1 == 1) { \
                 _PyArray_ITER_NEXT2(_PyAIT(it)); \
         } \
@@ -1239,7 +1239,7 @@ struct PyArrayIterObject_tag {
         } \
         else if (_PyAIT(it)->contiguous) \
                 _PyAIT(it)->dataptr = PyArray_BYTES(_PyAIT(it)->ao) + \
-                        __npy_ind * PyArray_DESCR(_PyAIT(it)->ao)->elsize; \
+                        __npy_ind * PyArray_ITEMSIZE(_PyAIT(it)->ao); \
         else { \
                 _PyAIT(it)->dataptr = PyArray_BYTES(_PyAIT(it)->ao); \
                 for (__npy_i = 0; __npy_i<=_PyAIT(it)->nd_m1; \

--- a/numpy/_core/src/common/array_assign.c
+++ b/numpy/_core/src/common/array_assign.c
@@ -145,7 +145,7 @@ IsUintAligned(PyArrayObject *ap)
 {
     return raw_array_is_aligned(PyArray_NDIM(ap), PyArray_DIMS(ap),
                                 PyArray_DATA(ap), PyArray_STRIDES(ap),
-                                npy_uint_alignment(PyArray_DESCR(ap)->elsize));
+                                npy_uint_alignment(PyArray_ITEMSIZE(ap)));
 }
 
 

--- a/numpy/_core/src/multiarray/array_assign_scalar.c
+++ b/numpy/_core/src/multiarray/array_assign_scalar.c
@@ -267,11 +267,11 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
          * Use a static buffer to store the aligned/cast version,
          * or allocate some memory if more space is needed.
          */
-        if ((int)sizeof(scalarbuffer) >= PyArray_DESCR(dst)->elsize) {
+        if ((int)sizeof(scalarbuffer) >= PyArray_ITEMSIZE(dst)) {
             tmp_src_data = (char *)&scalarbuffer[0];
         }
         else {
-            tmp_src_data = PyArray_malloc(PyArray_DESCR(dst)->elsize);
+            tmp_src_data = PyArray_malloc(PyArray_ITEMSIZE(dst));
             if (tmp_src_data == NULL) {
                 PyErr_NoMemory();
                 goto fail;
@@ -280,7 +280,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
         }
 
         if (PyDataType_FLAGCHK(PyArray_DESCR(dst), NPY_NEEDS_INIT)) {
-            memset(tmp_src_data, 0, PyArray_DESCR(dst)->elsize);
+            memset(tmp_src_data, 0, PyArray_ITEMSIZE(dst));
         }
 
         if (PyArray_CastRawArrays(1, src_data, tmp_src_data, 0, 0,

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -643,7 +643,7 @@ LONGDOUBLE_setitem(PyObject *op, void *ov, void *vap)
         *((npy_longdouble *)ov) = temp;
     }
     else {
-        copy_and_swap(ov, &temp, PyArray_DESCR(ap)->elsize, 1, 0,
+        copy_and_swap(ov, &temp, PyArray_ITEMSIZE(ap), 1, 0,
                       PyArray_ISBYTESWAPPED(ap));
     }
     return 0;
@@ -695,7 +695,7 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     }
 
     /* truncate if needed */
-    Py_ssize_t max_len = PyArray_DESCR(ap)->elsize >> 2;
+    Py_ssize_t max_len = PyArray_ITEMSIZE(ap) >> 2;
     Py_ssize_t actual_len = PyUnicode_GetLength(temp);
     if (actual_len < 0) {
         Py_DECREF(temp);
@@ -735,8 +735,8 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     }
 
     /* Fill in the rest of the space with 0 */
-    if (PyArray_DESCR(ap)->elsize > num_bytes) {
-        memset((char*)ov + num_bytes, 0, (PyArray_DESCR(ap)->elsize - num_bytes));
+    if (PyArray_ITEMSIZE(ap) > num_bytes) {
+        memset((char*)ov + num_bytes, 0, (PyArray_ITEMSIZE(ap) - num_bytes));
     }
     if (PyArray_ISBYTESWAPPED(ap)) {
         byte_swap_vector(ov, actual_len, 4);
@@ -756,7 +756,7 @@ STRING_getitem(void *ip, void *vap)
     PyArrayObject *ap = vap;
     /* Will eliminate NULLs at the end */
     char *ptr;
-    int size = PyArray_DESCR(ap)->elsize;
+    int size = PyArray_ITEMSIZE(ap);
 
     ptr = (char *)ip + size - 1;
     while (size > 0 && *ptr-- == '\0') {
@@ -812,13 +812,13 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
         Py_DECREF(temp);
         return -1;
     }
-    memcpy(ov, ptr, PyArray_MIN(PyArray_DESCR(ap)->elsize,len));
+    memcpy(ov, ptr, PyArray_MIN(PyArray_ITEMSIZE(ap),len));
     /*
      * If string length is smaller than room in array
      * Then fill the rest of the element size with NULL
      */
-    if (PyArray_DESCR(ap)->elsize > len) {
-        memset((char *)ov + len, 0, (PyArray_DESCR(ap)->elsize - len));
+    if (PyArray_ITEMSIZE(ap) > len) {
+        memset((char *)ov + len, 0, (PyArray_ITEMSIZE(ap) - len));
     }
     Py_DECREF(temp);
     return 0;
@@ -1037,7 +1037,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
 {
     char *ip = input;
     PyArrayObject *ap = vap;
-    int itemsize = PyArray_DESCR(ap)->elsize;
+    int itemsize = PyArray_ITEMSIZE(ap);
     int res;
     PyArray_Descr *descr = PyArray_DESCR(ap);
 
@@ -1518,9 +1518,9 @@ BOOL_to_@TOTYPE@(void *input, void *output, npy_intp n,
  *              npy_cfloat, npy_cdouble, npy_clongdouble,
  *              npy_char, npy_char, npy_char,
  *              npy_datetime, npy_timedelta)*3#
- * #oskip = 1*18,(PyArray_DESCR(aop)->elsize)*3,1*2,
- *          1*18,(PyArray_DESCR(aop)->elsize)*3,1*2,
- *          1*18,(PyArray_DESCR(aop)->elsize)*3,1*2#
+ * #oskip = 1*18,(PyArray_ITEMSIZE(aop))*3,1*2,
+ *          1*18,(PyArray_ITEMSIZE(aop))*3,1*2,
+ *          1*18,(PyArray_ITEMSIZE(aop))*3,1*2#
  */
 
 static void
@@ -1532,7 +1532,7 @@ static void
     PyArrayObject *aip = vaip;
 
     npy_intp i;
-    int skip = PyArray_DESCR(aip)->elsize;
+    int skip = PyArray_ITEMSIZE(aip);
     int oskip = @oskip@;
 
     for (i = 0; i < n; i++, ip+=skip, op+=oskip) {
@@ -1581,7 +1581,7 @@ static void
     npy_intp i;
     PyObject *temp = NULL;
     int skip = 1;
-    int oskip = PyArray_DESCR(aop)->elsize;
+    int oskip = PyArray_ITEMSIZE(aop);
     for (i = 0; i < n; i++, ip += skip, op += oskip) {
         temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
         if (temp == NULL) {
@@ -2256,7 +2256,7 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
     if (arr == NULL) {
         return;
     }
-    _basic_copyn(dst, dstride, src, sstride, n, PyArray_DESCR(arr)->elsize);
+    _basic_copyn(dst, dstride, src, sstride, n, PyArray_ITEMSIZE(arr));
     return;
 }
 
@@ -2438,7 +2438,7 @@ UNICODE_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
     if (arr == NULL) {
         return;
     }
-    itemsize = PyArray_DESCR(arr)->elsize;
+    itemsize = PyArray_ITEMSIZE(arr);
     _basic_copyn(dst, dstride, src, sstride, n, itemsize);
 
     if (swap) {
@@ -2467,7 +2467,7 @@ STRING_copyswap(char *dst, char *src, int NPY_UNUSED(swap), PyArrayObject *arr)
         return;
     }
     /* copy first if needed */
-    _basic_copy(dst, src, PyArray_DESCR(arr)->elsize);
+    _basic_copy(dst, src, PyArray_ITEMSIZE(arr));
 }
 
 static void
@@ -2479,7 +2479,7 @@ UNICODE_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
     if (arr == NULL) {
         return;
     }
-    itemsize = PyArray_DESCR(arr)->elsize;
+    itemsize = PyArray_ITEMSIZE(arr);
     _basic_copy(dst, src, itemsize);
 
     if (swap) {
@@ -2571,7 +2571,7 @@ static npy_bool
 static npy_bool
 STRING_nonzero (char *ip, PyArrayObject *ap)
 {
-    int len = PyArray_DESCR(ap)->elsize;
+    int len = PyArray_ITEMSIZE(ap);
 
     for (int i = 0; i < len; i++) {
         if (ip[i]) {
@@ -2588,7 +2588,7 @@ UNICODE_nonzero (char *ip, PyArrayObject *ap)
     if (PyArray_ISALIGNED(ap)) {
         /* go character by character */
         Py_UCS4 *chars = (Py_UCS4 *)ip;
-        int len = PyArray_DESCR(ap)->elsize / 4;
+        int len = PyArray_ITEMSIZE(ap) / 4;
         for (int i = 0; i < len; i++) {
             if (chars[i]) {
                 return NPY_TRUE;
@@ -2597,7 +2597,7 @@ UNICODE_nonzero (char *ip, PyArrayObject *ap)
     }
     else {
         /* go char/byte by char/byte, it doesn't matter where the nonzero is */
-        int len = PyArray_DESCR(ap)->elsize;
+        int len = PyArray_ITEMSIZE(ap);
         for (int i = 0; i < len; i++) {
             if (ip[i]) {
                 return NPY_TRUE;
@@ -2680,7 +2680,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
         }
         return nonz;
     }
-    len = PyArray_DESCR(ap)->elsize;
+    len = PyArray_ITEMSIZE(ap);
     for (i = 0; i < len; i++) {
         if (*ip != '\0') {
             nonz = NPY_TRUE;
@@ -2941,7 +2941,7 @@ STRING_compare(char *ip1, char *ip2, PyArrayObject *ap)
 {
     const unsigned char *c1 = (unsigned char *)ip1;
     const unsigned char *c2 = (unsigned char *)ip2;
-    const size_t len = PyArray_DESCR(ap)->elsize;
+    const size_t len = PyArray_ITEMSIZE(ap);
     int i;
 
     i = memcmp(c1, c2, len);
@@ -2961,7 +2961,7 @@ static int
 UNICODE_compare(npy_ucs4 *ip1, npy_ucs4 *ip2,
                 PyArrayObject *ap)
 {
-    int itemsize = PyArray_DESCR(ap)->elsize;
+    int itemsize = PyArray_ITEMSIZE(ap);
 
     if (itemsize < 0) {
         return 0;
@@ -3317,7 +3317,7 @@ static int
 @fname@_argmax(@type@ *ip, npy_intp n, npy_intp *max_ind, PyArrayObject *aip)
 {
     npy_intp i;
-    int elsize = PyArray_DESCR(aip)->elsize;
+    int elsize = PyArray_ITEMSIZE(aip);
     @type@ *mp = (@type@ *)PyArray_malloc(elsize);
 
     if (mp == NULL) {
@@ -3381,7 +3381,7 @@ static int
 @fname@_argmin(@type@ *ip, npy_intp n, npy_intp *min_ind, PyArrayObject *aip)
 {
     npy_intp i;
-    int elsize = PyArray_DESCR(aip)->elsize;
+    int elsize = PyArray_ITEMSIZE(aip);
     @type@ *mp = (@type@ *)PyArray_malloc(elsize);
 
     if (mp==NULL) return 0;

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -135,7 +135,7 @@ _PyArray_ArgMinMaxCommon(PyArrayObject *op,
                 "data type not ordered");
         goto fail;
     }
-    elsize = PyArray_DESCR(ap)->elsize;
+    elsize = PyArray_ITEMSIZE(ap);
     m = PyArray_DIMS(ap)[PyArray_NDIM(ap)-1];
     if (m == 0) {
         PyErr_Format(PyExc_ValueError,

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -297,7 +297,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
     ni = PyArray_SIZE(array);
     dest = PyArray_DATA(array);
-    chunk = PyArray_DESCR(array)->elsize;
+    chunk = PyArray_ITEMSIZE(array);
     mask = (PyArrayObject *)PyArray_FROM_OTF(mask0, NPY_BOOL,
                                 NPY_ARRAY_CARRAY | NPY_ARRAY_FORCECAST);
     if (mask == NULL) {

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -146,7 +146,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                     "cannot write object arrays to a file in binary mode");
             return -1;
         }
-        if (PyArray_DESCR(self)->elsize == 0) {
+        if (PyArray_ITEMSIZE(self) == 0) {
             /* For zero-width data types there's nothing to write */
             return 0;
         }
@@ -185,15 +185,15 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
              * assert_((a[-n:] == testbytes).all())
              */
             {
-                size_t maxsize = 2147483648 / (size_t)PyArray_DESCR(self)->elsize;
+                size_t maxsize = 2147483648 / (size_t)PyArray_ITEMSIZE(self);
                 size_t chunksize;
 
                 n = 0;
                 while (size > 0) {
                     chunksize = (size > maxsize) ? maxsize : size;
                     n2 = fwrite((const void *)
-                             ((char *)PyArray_DATA(self) + (n * PyArray_DESCR(self)->elsize)),
-                             (size_t) PyArray_DESCR(self)->elsize,
+                             ((char *)PyArray_DATA(self) + (n * PyArray_ITEMSIZE(self))),
+                             (size_t) PyArray_ITEMSIZE(self),
                              chunksize, fp);
                     if (n2 < chunksize) {
                         break;
@@ -205,7 +205,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             }
 #else
             n = fwrite((const void *)PyArray_DATA(self),
-                    (size_t) PyArray_DESCR(self)->elsize,
+                    (size_t) PyArray_ITEMSIZE(self),
                     (size_t) size, fp);
 #endif
             NPY_END_ALLOW_THREADS;
@@ -223,7 +223,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             NPY_BEGIN_THREADS;
             while (it->index < it->size) {
                 if (fwrite((const void *)it->dataptr,
-                            (size_t) PyArray_DESCR(self)->elsize,
+                            (size_t) PyArray_ITEMSIZE(self),
                             1, fp) < 1) {
                     NPY_END_THREADS;
                     PyErr_Format(PyExc_OSError,
@@ -376,7 +376,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
         }
         dptr = PyBytes_AS_STRING(ret);
         i = it->size;
-        elsize = PyArray_DESCR(self)->elsize;
+        elsize = PyArray_ITEMSIZE(self);
         while (i--) {
             memcpy(dptr, it->dataptr, elsize);
             dptr += elsize;

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2136,7 +2136,7 @@ PyArray_Zero(PyArrayObject *arr)
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
     }
-    zeroval = PyDataMem_NEW(PyArray_DESCR(arr)->elsize);
+    zeroval = PyDataMem_NEW(PyArray_ITEMSIZE(arr));
     if (zeroval == NULL) {
         PyErr_SetNone(PyExc_MemoryError);
         return NULL;
@@ -2182,7 +2182,7 @@ PyArray_One(PyArrayObject *arr)
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
     }
-    oneval = PyDataMem_NEW(PyArray_DESCR(arr)->elsize);
+    oneval = PyDataMem_NEW(PyArray_ITEMSIZE(arr));
     if (oneval == NULL) {
         PyErr_SetNone(PyExc_MemoryError);
         return NULL;

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -340,7 +340,7 @@ array_data_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 array_itemsize_get(PyArrayObject *self, void* NPY_UNUSED(ignored))
 {
-    return PyLong_FromLong((long) PyArray_DESCR(self)->elsize);
+    return PyLong_FromLong((long) PyArray_ITEMSIZE(self));
 }
 
 static PyObject *
@@ -406,16 +406,16 @@ array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
      */
     if (newtype->type_num == NPY_VOID &&
             PyDataType_ISUNSIZED(newtype) &&
-            newtype->elsize != PyArray_DESCR(self)->elsize) {
+            newtype->elsize != PyArray_ITEMSIZE(self)) {
         PyArray_DESCR_REPLACE(newtype);
         if (newtype == NULL) {
             return -1;
         }
-        newtype->elsize = PyArray_DESCR(self)->elsize;
+        newtype->elsize = PyArray_ITEMSIZE(self);
     }
 
     /* Changing the size of the dtype results in a shape change */
-    if (newtype->elsize != PyArray_DESCR(self)->elsize) {
+    if (newtype->elsize != PyArray_ITEMSIZE(self)) {
         /* forbidden cases */
         if (PyArray_NDIM(self) == 0) {
             PyErr_SetString(PyExc_ValueError,
@@ -434,7 +434,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
         int axis = PyArray_NDIM(self) - 1;
         if (PyArray_DIMS(self)[axis] != 1 &&
                 PyArray_SIZE(self) != 0 &&
-                PyArray_STRIDES(self)[axis] != PyArray_DESCR(self)->elsize) {
+                PyArray_STRIDES(self)[axis] != PyArray_ITEMSIZE(self)) {
             PyErr_SetString(PyExc_ValueError,
                     "To change to a dtype of a different size, the last axis "
                     "must be contiguous");
@@ -443,22 +443,22 @@ array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
 
         npy_intp newdim;
 
-        if (newtype->elsize < PyArray_DESCR(self)->elsize) {
+        if (newtype->elsize < PyArray_ITEMSIZE(self)) {
             /* if it is compatible, increase the size of the last axis */
             if (newtype->elsize == 0 ||
-                    PyArray_DESCR(self)->elsize % newtype->elsize != 0) {
+                    PyArray_ITEMSIZE(self) % newtype->elsize != 0) {
                 PyErr_SetString(PyExc_ValueError,
                         "When changing to a smaller dtype, its size must be a "
                         "divisor of the size of original dtype");
                 goto fail;
             }
-            newdim = PyArray_DESCR(self)->elsize / newtype->elsize;
+            newdim = PyArray_ITEMSIZE(self) / newtype->elsize;
             PyArray_DIMS(self)[axis] *= newdim;
             PyArray_STRIDES(self)[axis] = newtype->elsize;
         }
-        else /* newtype->elsize > PyArray_DESCR(self)->elsize */ {
+        else /* newtype->elsize > PyArray_ITEMSIZE(self) */ {
             /* if it is compatible, decrease the size of the relevant axis */
-            newdim = PyArray_DIMS(self)[axis] * PyArray_DESCR(self)->elsize;
+            newdim = PyArray_DIMS(self)[axis] * PyArray_ITEMSIZE(self);
             if ((newdim % newtype->elsize) != 0) {
                 PyErr_SetString(PyExc_ValueError,
                         "When changing to a larger dtype, its size must be a "
@@ -523,7 +523,7 @@ array_struct_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     inter->two = 2;
     inter->nd = PyArray_NDIM(self);
     inter->typekind = PyArray_DESCR(self)->kind;
-    inter->itemsize = PyArray_DESCR(self)->elsize;
+    inter->itemsize = PyArray_ITEMSIZE(self);
     inter->flags = PyArray_FLAGS(self);
     if (inter->flags & NPY_ARRAY_WARN_ON_WRITE) {
         /* Export a warn-on-write array as read-only */

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -418,7 +418,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
     }
     max_item = PyArray_SIZE(self);
     dest = PyArray_DATA(self);
-    itemsize = PyArray_DESCR(self)->elsize;
+    itemsize = PyArray_ITEMSIZE(self);
 
     int has_references = PyDataType_REFCHK(PyArray_DESCR(self));
 
@@ -710,7 +710,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
         self = obj;
     }
 
-    itemsize = PyArray_DESCR(self)->elsize;
+    itemsize = PyArray_ITEMSIZE(self);
     dest = PyArray_DATA(self);
 
     if (PyDataType_REFCHK(PyArray_DESCR(self))) {
@@ -926,7 +926,7 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
     old_data = PyArray_DATA(aop);
 
     nel = 1;
-    elsize = PyArray_DESCR(aop)->elsize;
+    elsize = PyArray_ITEMSIZE(aop);
     for(i = axis + 1; i < PyArray_NDIM(aop); i++) {
         nel *= PyArray_DIMS(aop)[i];
     }
@@ -1908,15 +1908,15 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
     size = rit->size;
     N = PyArray_DIMS(mps[0])[axis];
     rstride = PyArray_STRIDE(ret, axis);
-    maxelsize = PyArray_DESCR(mps[0])->elsize;
+    maxelsize = PyArray_ITEMSIZE(mps[0]);
     needcopy = (rstride != sizeof(npy_intp));
     for (j = 0; j < n; j++) {
         needcopy = needcopy
             || PyArray_ISBYTESWAPPED(mps[j])
             || !(PyArray_FLAGS(mps[j]) & NPY_ARRAY_ALIGNED)
-            || (PyArray_STRIDES(mps[j])[axis] != (npy_intp)PyArray_DESCR(mps[j])->elsize);
-        if (PyArray_DESCR(mps[j])->elsize > maxelsize) {
-            maxelsize = PyArray_DESCR(mps[j])->elsize;
+            || (PyArray_STRIDES(mps[j])[axis] != (npy_intp)PyArray_ITEMSIZE(mps[j]));
+        if (PyArray_ITEMSIZE(mps[j]) > maxelsize) {
+            maxelsize = PyArray_ITEMSIZE(mps[j]);
         }
     }
 
@@ -1956,7 +1956,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
             }
             for (j = 0; j < n; j++) {
                 int rcode;
-                elsize = PyArray_DESCR(mps[j])->elsize;
+                elsize = PyArray_ITEMSIZE(mps[j]);
                 astride = PyArray_STRIDES(mps[j])[axis];
                 argsort = PyArray_DESCR(mps[j])->f->argsort[NPY_STABLESORT];
                 if(argsort == NULL) {
@@ -2184,7 +2184,7 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
                   (const char *)PyArray_DATA(ap2),
                   (char *)PyArray_DATA(ret),
                   PyArray_SIZE(ap1), PyArray_SIZE(ap2),
-                  PyArray_STRIDES(ap1)[0], PyArray_DESCR(ap2)->elsize,
+                  PyArray_STRIDES(ap1)[0], PyArray_ITEMSIZE(ap2),
                   NPY_SIZEOF_INTP, ap2);
         NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
     }
@@ -2198,7 +2198,7 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
                              (char *)PyArray_DATA(ret),
                              PyArray_SIZE(ap1), PyArray_SIZE(ap2),
                              PyArray_STRIDES(ap1)[0],
-                             PyArray_DESCR(ap2)->elsize,
+                             PyArray_ITEMSIZE(ap2),
                              PyArray_STRIDES(sorter)[0], NPY_SIZEOF_INTP, ap2);
         NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
         if (error < 0) {

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -452,7 +452,7 @@ iter_subscript_Bool(PyArrayIterObject *self, PyArrayObject *ind,
     /* Get size of return array */
     count = count_boolean_trues(PyArray_NDIM(ind), PyArray_DATA(ind),
                                 PyArray_DIMS(ind), PyArray_STRIDES(ind));
-    itemsize = PyArray_DESCR(self->ao)->elsize;
+    itemsize = PyArray_ITEMSIZE(self->ao);
     PyArray_Descr *dtype = PyArray_DESCR(self->ao);
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(self->ao),
@@ -1638,7 +1638,7 @@ static char* _set_constant(PyArrayNeighborhoodIterObject* iter,
     PyArrayIterObject *ar = iter->_internal_iter;
     int storeflags, st;
 
-    ret = PyDataMem_NEW(PyArray_DESCR(ar->ao)->elsize);
+    ret = PyDataMem_NEW(PyArray_ITEMSIZE(ar->ao));
     if (ret == NULL) {
         PyErr_SetNone(PyExc_MemoryError);
         return NULL;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -546,7 +546,7 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
         }
         size = PyArray_SIZE(self);
         if (PyArray_ISONESEGMENT(self)) {
-            copyswapn(PyArray_DATA(self), PyArray_DESCR(self)->elsize, NULL, -1, size, 1, self);
+            copyswapn(PyArray_DATA(self), PyArray_ITEMSIZE(self), NULL, -1, size, 1, self);
         }
         else { /* Use iterator */
             int axis = -1;
@@ -2024,7 +2024,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         }
     }
     overflowed = npy_mul_sizes_with_overflow(
-            &nbytes, nbytes, PyArray_DESCR(self)->elsize);
+            &nbytes, nbytes, PyArray_ITEMSIZE(self));
     if (overflowed) {
         return PyErr_NoMemory();
     }
@@ -2116,7 +2116,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
             memcpy(PyArray_DIMS(self), dimensions, sizeof(npy_intp)*nd);
         }
         _array_fill_strides(PyArray_STRIDES(self), dimensions, nd,
-                               PyArray_DESCR(self)->elsize,
+                               PyArray_ITEMSIZE(self),
                                (is_f_order ? NPY_ARRAY_F_CONTIGUOUS :
                                              NPY_ARRAY_C_CONTIGUOUS),
                                &(fa->flags));
@@ -2149,8 +2149,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 /* byte-swap on pickle-read */
                 npy_intp numels = PyArray_SIZE(self);
                 PyArray_DESCR(self)->f->copyswapn(PyArray_DATA(self),
-                                        PyArray_DESCR(self)->elsize,
-                                        datastr, PyArray_DESCR(self)->elsize,
+                                        PyArray_ITEMSIZE(self),
+                                        datastr, PyArray_ITEMSIZE(self),
                                         numels, 1, self);
                 if (!(PyArray_ISEXTENDED(self) ||
                       PyArray_DESCR(self)->metadata ||

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -750,7 +750,7 @@ _signbit_set(PyArrayObject *arr)
     char byteorder;
     int elsize;
 
-    elsize = PyArray_DESCR(arr)->elsize;
+    elsize = PyArray_ITEMSIZE(arr);
     byteorder = PyArray_DESCR(arr)->byteorder;
     ptr = PyArray_DATA(arr);
     if (elsize > 1 &&
@@ -1068,7 +1068,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     }
 
     op = PyArray_DATA(out_buf);
-    os = PyArray_DESCR(out_buf)->elsize;
+    os = PyArray_ITEMSIZE(out_buf);
     axis = PyArray_NDIM(ap1)-1;
     it1 = (PyArrayIterObject *)
         PyArray_IterAllButAxis((PyObject *)ap1, &axis);
@@ -1198,7 +1198,7 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
     is1 = PyArray_STRIDES(ap1)[0];
     is2 = PyArray_STRIDES(ap2)[0];
     op = PyArray_DATA(ret);
-    os = PyArray_DESCR(ret)->elsize;
+    os = PyArray_ITEMSIZE(ret);
     ip1 = PyArray_DATA(ap1);
     ip2 = PyArray_BYTES(ap2) + n_left*is2;
     n = n - n_left;
@@ -1249,7 +1249,7 @@ static int
 _pyarray_revert(PyArrayObject *ret)
 {
     npy_intp length = PyArray_DIM(ret, 0);
-    npy_intp os = PyArray_DESCR(ret)->elsize;
+    npy_intp os = PyArray_ITEMSIZE(ret);
     char *op = PyArray_DATA(ret);
     char *sw1 = op;
     char *sw2;
@@ -1268,7 +1268,7 @@ _pyarray_revert(PyArrayObject *ret)
         copyswapn(op, os, NULL, 0, length, 1, NULL);
     }
     else {
-        char *tmp = PyArray_malloc(PyArray_DESCR(ret)->elsize);
+        char *tmp = PyArray_malloc(PyArray_ITEMSIZE(ret));
         if (tmp == NULL) {
             PyErr_NoMemory();
             return -1;
@@ -1517,7 +1517,7 @@ _prepend_ones(PyArrayObject *arr, int nd, int ndmin, NPY_ORDER order)
     PyArray_Descr *dtype;
 
     if (order == NPY_FORTRANORDER || PyArray_ISFORTRAN(arr) || PyArray_NDIM(arr) == 0) {
-        newstride = PyArray_DESCR(arr)->elsize;
+        newstride = PyArray_ITEMSIZE(arr);
     }
     else {
         newstride = PyArray_STRIDES(arr)[0] * PyArray_DIMS(arr)[0];

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1419,7 +1419,7 @@ gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
     inter->flags &= ~(NPY_ARRAY_WRITEBACKIFCOPY | NPY_ARRAY_OWNDATA);
     inter->flags |= NPY_ARRAY_NOTSWAPPED;
     inter->typekind = PyArray_DESCR(arr)->kind;
-    inter->itemsize = PyArray_DESCR(arr)->elsize;
+    inter->itemsize = PyArray_ITEMSIZE(arr);
     inter->strides = NULL;
     inter->shape = NULL;
     inter->data = PyArray_DATA(arr);

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -78,7 +78,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
     }
 
     /* Convert to number of bytes. The new count might overflow */
-    elsize = PyArray_DESCR(self)->elsize;
+    elsize = PyArray_ITEMSIZE(self);
     oldnbytes = oldsize * elsize;
     if (npy_mul_sizes_with_overflow(&newnbytes, newsize, elsize)) {
         return PyErr_NoMemory();
@@ -174,7 +174,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         }
         /* make new_strides variable */
         _array_fill_strides(new_strides, new_dimensions, new_nd,
-                            PyArray_DESCR(self)->elsize, PyArray_FLAGS(self),
+                            PyArray_ITEMSIZE(self), PyArray_FLAGS(self),
                             &(((PyArrayObject_fields *)self)->flags));
         memmove(PyArray_DIMS(self), new_dimensions, new_nd*sizeof(npy_intp));
         memmove(PyArray_STRIDES(self), new_strides, new_nd*sizeof(npy_intp));

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2309,7 +2309,7 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
             if (PyTypeNum_ISBOOL(typenum)) {
                 typenum = NPY_INTP;
             }
-            else if ((size_t)PyArray_DESCR(arr)->elsize < sizeof(npy_intp)) {
+            else if ((size_t)PyArray_ITEMSIZE(arr) < sizeof(npy_intp)) {
                 if (PyTypeNum_ISUNSIGNED(typenum)) {
                     typenum = NPY_UINTP;
                 }

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -803,7 +803,7 @@ get_elsize(PyObject *obj) {
   */
 
   if (PyArray_Check(obj)) {
-    return PyArray_DESCR((PyArrayObject *)obj)->elsize;
+    return PyArray_ITEMSIZE((PyArrayObject *)obj);
   } else if (PyBytes_Check(obj)) {
     return PyBytes_GET_SIZE(obj);
   } else if (PyUnicode_Check(obj)) {

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -130,7 +130,7 @@ F2PyGetThreadLocalCallbackPtr(char *key);
              : (F2PY_ALIGN8(intent) ? 8 : (F2PY_ALIGN16(intent) ? 16 : 1)))
 #define F2PY_CHECK_ALIGNMENT(arr, intent) \
     ARRAY_ISALIGNED(arr, F2PY_GET_ALIGNMENT(intent))
-#define F2PY_ARRAY_IS_CHARACTER_COMPATIBLE(arr) ((PyArray_DESCR(arr)->type_num == NPY_STRING && PyArray_DESCR(arr)->elsize >= 1) \
+#define F2PY_ARRAY_IS_CHARACTER_COMPATIBLE(arr) ((PyArray_DESCR(arr)->type_num == NPY_STRING && PyArray_ITEMSIZE(arr) >= 1) \
                                                  || PyArray_DESCR(arr)->type_num == NPY_UINT8)
 #define F2PY_IS_UNICODE_ARRAY(arr) (PyArray_DESCR(arr)->type_num == NPY_UNICODE)
 
@@ -156,7 +156,7 @@ dump_attrs(const PyArrayObject *arr);
      expressions. See signature-file.rst for documentation.
   */
 
-#define f2py_itemsize(var) (PyArray_DESCR((capi_ ## var ## _as_array))->elsize)
+#define f2py_itemsize(var) (PyArray_ITEMSIZE(capi_ ## var ## _as_array))
 #define f2py_size(var, ...) f2py_size_impl((PyArrayObject *)(capi_ ## var ## _as_array), ## __VA_ARGS__, -1)
 #define f2py_rank(var) var ## _Rank
 #define f2py_shape(var,dim) var ## _Dims[dim]


### PR DESCRIPTION
This is a simple cleanup, but an important step because almost all access of ``elsize`` is through an array.  Fixing these (which arguably is nicer) greatly simplifies potentially renaming ``elsize``.

---

I used the script from the other PR to create the diff and had a look over to sanity check.