### PR TITLE
API: Introduce ``PyDataType_FLAGS`` accessor for public access

### DIFF
--- a/doc/release/upcoming_changes/25816.c_api.rst
+++ b/doc/release/upcoming_changes/25816.c_api.rst
@@ -1,0 +1,7 @@
+* The dtype flags on ``PyArray_Descr`` must now be accessed through the
+  ``PyDataType_FLAGS` inline function to be compatible with both 1.x and 2.x.
+  This function is defined in ``npy_2_compat.h`` to allow backporting.
+  Most or all users should use ``PyDataType_FLAGCHK`` which is available on
+  1.x and does not require backporting.
+  *Cython* users should use Cython 3.  Otherwise access will go through Python
+  unless they use ``PyDataType_FLAGCHK`` instead.

--- a/doc/release/upcoming_changes/25816.c_api.rst
+++ b/doc/release/upcoming_changes/25816.c_api.rst
@@ -1,3 +1,6 @@
+* Due to runtime dependencies, some functionality was moved out of
+  ``numpy/ndarraytypes.h`` and is only available after including ``ndarrayobject.h``
+  (requires ``import_array()`` setup).
 * The dtype flags on ``PyArray_Descr`` must now be accessed through the
   ``PyDataType_FLAGS` inline function to be compatible with both 1.x and 2.x.
   This function is defined in ``npy_2_compat.h`` to allow backporting.

--- a/doc/release/upcoming_changes/25816.c_api.rst
+++ b/doc/release/upcoming_changes/25816.c_api.rst
@@ -1,6 +1,8 @@
-* Due to runtime dependencies, some functionality was moved out of
-  ``numpy/ndarraytypes.h`` and is only available after including ``ndarrayobject.h``
-  (requires ``import_array()`` setup).
+* Due to runtime dependencies, the definition for functionality accessing
+  the dtype flags was moved from ``numpy/ndarraytypes.h`` and is only available
+  after including ``numpy/ndarrayobject.h`` as it requires ``import_array()``.
+  This includes ``PyDataType_FLAGCHK``, ``PyDataType_REFCHK`` and
+  ``NPY_BEGIN_THREADS_DESCR``.
 * The dtype flags on ``PyArray_Descr`` must now be accessed through the
   ``PyDataType_FLAGS`` inline function to be compatible with both 1.x and 2.x.
   This function is defined in ``npy_2_compat.h`` to allow backporting.

--- a/doc/release/upcoming_changes/25816.c_api.rst
+++ b/doc/release/upcoming_changes/25816.c_api.rst
@@ -2,7 +2,7 @@
   ``numpy/ndarraytypes.h`` and is only available after including ``ndarrayobject.h``
   (requires ``import_array()`` setup).
 * The dtype flags on ``PyArray_Descr`` must now be accessed through the
-  ``PyDataType_FLAGS` inline function to be compatible with both 1.x and 2.x.
+  ``PyDataType_FLAGS`` inline function to be compatible with both 1.x and 2.x.
   This function is defined in ``npy_2_compat.h`` to allow backporting.
   Most or all users should use ``PyDataType_FLAGCHK`` which is available on
   1.x and does not require backporting.

--- a/doc/release/upcoming_changes/25816.change.rst
+++ b/doc/release/upcoming_changes/25816.change.rst
@@ -1,0 +1,6 @@
+* The ``dtype.flags`` value was previously usually stored as a
+  signed integer.  This means that the aligned dtype struct flag
+  lead to neagtive flags being set (-128 rather than ``128``).
+  This flag is now stored usigned (positive).
+  Code which checks flags manually may need to adapt.  This
+  may include code compiled with Cython 2.

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -29,6 +29,81 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef signed long npy_intp
     ctypedef unsigned long npy_uintp
 
+    ctypedef unsigned char      npy_bool
+
+    ctypedef signed char      npy_byte
+    ctypedef signed short     npy_short
+    ctypedef signed int       npy_int
+    ctypedef signed long      npy_long
+    ctypedef signed long long npy_longlong
+
+    ctypedef unsigned char      npy_ubyte
+    ctypedef unsigned short     npy_ushort
+    ctypedef unsigned int       npy_uint
+    ctypedef unsigned long      npy_ulong
+    ctypedef unsigned long long npy_ulonglong
+
+    ctypedef float        npy_float
+    ctypedef double       npy_double
+    ctypedef long double  npy_longdouble
+
+    ctypedef signed char        npy_int8
+    ctypedef signed short       npy_int16
+    ctypedef signed int         npy_int32
+    ctypedef signed long long   npy_int64
+    ctypedef signed long long   npy_int96
+    ctypedef signed long long   npy_int128
+
+    ctypedef unsigned char      npy_uint8
+    ctypedef unsigned short     npy_uint16
+    ctypedef unsigned int       npy_uint32
+    ctypedef unsigned long long npy_uint64
+    ctypedef unsigned long long npy_uint96
+    ctypedef unsigned long long npy_uint128
+
+    ctypedef float        npy_float32
+    ctypedef double       npy_float64
+    ctypedef long double  npy_float80
+    ctypedef long double  npy_float96
+    ctypedef long double  npy_float128
+
+    ctypedef struct npy_cfloat:
+        float real
+        float imag
+
+    ctypedef struct npy_cdouble:
+        double real
+        double imag
+
+    ctypedef struct npy_clongdouble:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex64:
+        float real
+        float imag
+
+    ctypedef struct npy_complex128:
+        double real
+        double imag
+
+    ctypedef struct npy_complex160:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex192:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex256:
+        long double real
+        long double imag
+
+    ctypedef struct PyArray_Dims:
+        npy_intp *ptr
+        int len
+
+
     cdef enum NPY_TYPES:
         NPY_BOOL
         NPY_BYTE
@@ -213,7 +288,6 @@ cdef extern from "numpy/arrayobject.h":
         # PyArray_IsNativeByteOrder(dtype.byteorder) instead of
         # directly accessing this field.
         cdef char byteorder
-        cdef char flags
         cdef int type_num
         cdef int itemsize "elsize"
         cdef int alignment
@@ -223,6 +297,12 @@ cdef extern from "numpy/arrayobject.h":
         # valid (the pointer can be NULL). Most users should access
         # this field via the inline helper method PyDataType_SHAPE.
         cdef PyArray_ArrayDescr* subarray
+
+        @property
+        cdef inline npy_uint64 flags(self) nogil:
+            """The data types flags."""
+            return PyDataType_FLAGS(self)
+
 
     ctypedef class numpy.flatiter [object PyArrayIterObject, check_size ignore]:
         # Use through macros
@@ -321,79 +401,6 @@ cdef extern from "numpy/arrayobject.h":
             """
             return PyArray_BYTES(self)
 
-    ctypedef unsigned char      npy_bool
-
-    ctypedef signed char      npy_byte
-    ctypedef signed short     npy_short
-    ctypedef signed int       npy_int
-    ctypedef signed long      npy_long
-    ctypedef signed long long npy_longlong
-
-    ctypedef unsigned char      npy_ubyte
-    ctypedef unsigned short     npy_ushort
-    ctypedef unsigned int       npy_uint
-    ctypedef unsigned long      npy_ulong
-    ctypedef unsigned long long npy_ulonglong
-
-    ctypedef float        npy_float
-    ctypedef double       npy_double
-    ctypedef long double  npy_longdouble
-
-    ctypedef signed char        npy_int8
-    ctypedef signed short       npy_int16
-    ctypedef signed int         npy_int32
-    ctypedef signed long long   npy_int64
-    ctypedef signed long long   npy_int96
-    ctypedef signed long long   npy_int128
-
-    ctypedef unsigned char      npy_uint8
-    ctypedef unsigned short     npy_uint16
-    ctypedef unsigned int       npy_uint32
-    ctypedef unsigned long long npy_uint64
-    ctypedef unsigned long long npy_uint96
-    ctypedef unsigned long long npy_uint128
-
-    ctypedef float        npy_float32
-    ctypedef double       npy_float64
-    ctypedef long double  npy_float80
-    ctypedef long double  npy_float96
-    ctypedef long double  npy_float128
-
-    ctypedef struct npy_cfloat:
-        float real
-        float imag
-
-    ctypedef struct npy_cdouble:
-        double real
-        double imag
-
-    ctypedef struct npy_clongdouble:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex64:
-        float real
-        float imag
-
-    ctypedef struct npy_complex128:
-        double real
-        double imag
-
-    ctypedef struct npy_complex160:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex192:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex256:
-        long double real
-        long double imag
-
-    ctypedef struct PyArray_Dims:
-        npy_intp *ptr
-        int len
 
     int _import_array() except -1
     # A second definition so _import_array isn't marked as used when we use it here.
@@ -462,6 +469,7 @@ cdef extern from "numpy/arrayobject.h":
     bint PyDataType_ISOBJECT(dtype) nogil
     bint PyDataType_HASFIELDS(dtype) nogil
     bint PyDataType_HASSUBARRAY(dtype) nogil
+    npy_uint64 PyDataType_FLAGS(dtype) nogil
 
     bint PyArray_ISBOOL(ndarray) nogil
     bint PyArray_ISUNSIGNED(ndarray) nogil

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -24,6 +24,81 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef Py_intptr_t npy_intp
     ctypedef size_t npy_uintp
 
+    ctypedef unsigned char      npy_bool
+
+    ctypedef signed char      npy_byte
+    ctypedef signed short     npy_short
+    ctypedef signed int       npy_int
+    ctypedef signed long      npy_long
+    ctypedef signed long long npy_longlong
+
+    ctypedef unsigned char      npy_ubyte
+    ctypedef unsigned short     npy_ushort
+    ctypedef unsigned int       npy_uint
+    ctypedef unsigned long      npy_ulong
+    ctypedef unsigned long long npy_ulonglong
+
+    ctypedef float        npy_float
+    ctypedef double       npy_double
+    ctypedef long double  npy_longdouble
+
+    ctypedef signed char        npy_int8
+    ctypedef signed short       npy_int16
+    ctypedef signed int         npy_int32
+    ctypedef signed long long   npy_int64
+    ctypedef signed long long   npy_int96
+    ctypedef signed long long   npy_int128
+
+    ctypedef unsigned char      npy_uint8
+    ctypedef unsigned short     npy_uint16
+    ctypedef unsigned int       npy_uint32
+    ctypedef unsigned long long npy_uint64
+    ctypedef unsigned long long npy_uint96
+    ctypedef unsigned long long npy_uint128
+
+    ctypedef float        npy_float32
+    ctypedef double       npy_float64
+    ctypedef long double  npy_float80
+    ctypedef long double  npy_float96
+    ctypedef long double  npy_float128
+
+    ctypedef struct npy_cfloat:
+        float real
+        float imag
+
+    ctypedef struct npy_cdouble:
+        double real
+        double imag
+
+    ctypedef struct npy_clongdouble:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex64:
+        float real
+        float imag
+
+    ctypedef struct npy_complex128:
+        double real
+        double imag
+
+    ctypedef struct npy_complex160:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex192:
+        long double real
+        long double imag
+
+    ctypedef struct npy_complex256:
+        long double real
+        long double imag
+
+    ctypedef struct PyArray_Dims:
+        npy_intp *ptr
+        int len
+
+
     cdef enum NPY_TYPES:
         NPY_BOOL
         NPY_BYTE
@@ -208,7 +283,8 @@ cdef extern from "numpy/arrayobject.h":
         # PyArray_IsNativeByteOrder(dtype.byteorder) instead of
         # directly accessing this field.
         cdef char byteorder
-        cdef char flags
+        # Flags are not directly accessible on Cython <3. Use PyDataType_FLAGS.
+        # cdef char flags
         cdef int type_num
         cdef int itemsize "elsize"
         cdef int alignment
@@ -248,81 +324,6 @@ cdef extern from "numpy/arrayobject.h":
             dtype descr  # deprecated since NumPy 1.7 !
             PyObject* base #  NOT PUBLIC, DO NOT USE !
 
-
-
-    ctypedef unsigned char      npy_bool
-
-    ctypedef signed char      npy_byte
-    ctypedef signed short     npy_short
-    ctypedef signed int       npy_int
-    ctypedef signed long      npy_long
-    ctypedef signed long long npy_longlong
-
-    ctypedef unsigned char      npy_ubyte
-    ctypedef unsigned short     npy_ushort
-    ctypedef unsigned int       npy_uint
-    ctypedef unsigned long      npy_ulong
-    ctypedef unsigned long long npy_ulonglong
-
-    ctypedef float        npy_float
-    ctypedef double       npy_double
-    ctypedef long double  npy_longdouble
-
-    ctypedef signed char        npy_int8
-    ctypedef signed short       npy_int16
-    ctypedef signed int         npy_int32
-    ctypedef signed long long   npy_int64
-    ctypedef signed long long   npy_int96
-    ctypedef signed long long   npy_int128
-
-    ctypedef unsigned char      npy_uint8
-    ctypedef unsigned short     npy_uint16
-    ctypedef unsigned int       npy_uint32
-    ctypedef unsigned long long npy_uint64
-    ctypedef unsigned long long npy_uint96
-    ctypedef unsigned long long npy_uint128
-
-    ctypedef float        npy_float32
-    ctypedef double       npy_float64
-    ctypedef long double  npy_float80
-    ctypedef long double  npy_float96
-    ctypedef long double  npy_float128
-
-    ctypedef struct npy_cfloat:
-        float real
-        float imag
-
-    ctypedef struct npy_cdouble:
-        double real
-        double imag
-
-    ctypedef struct npy_clongdouble:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex64:
-        float real
-        float imag
-
-    ctypedef struct npy_complex128:
-        double real
-        double imag
-
-    ctypedef struct npy_complex160:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex192:
-        long double real
-        long double imag
-
-    ctypedef struct npy_complex256:
-        long double real
-        long double imag
-
-    ctypedef struct PyArray_Dims:
-        npy_intp *ptr
-        int len
 
     int _import_array() except -1
     # A second definition so _import_array isn't marked as used when we use it here.
@@ -388,6 +389,7 @@ cdef extern from "numpy/arrayobject.h":
     bint PyDataType_ISOBJECT(dtype) nogil
     bint PyDataType_HASFIELDS(dtype) nogil
     bint PyDataType_HASSUBARRAY(dtype) nogil
+    npy_uint64 PyDataType_FLAGS(dtype) nogil
 
     bint PyArray_ISBOOL(ndarray) nogil
     bint PyArray_ISUNSIGNED(ndarray) nogil

--- a/numpy/_core/include/numpy/ndarrayobject.h
+++ b/numpy/_core/include/numpy/ndarrayobject.h
@@ -237,6 +237,28 @@ NPY_TITLE_KEY_check(PyObject *key, PyObject *value)
 #define DEPRECATE(msg) PyErr_WarnEx(PyExc_DeprecationWarning,msg,1)
 #define DEPRECATE_FUTUREWARNING(msg) PyErr_WarnEx(PyExc_FutureWarning,msg,1)
 
+
+/*
+ * These macros unfortunately require runtime version checks and are only
+ * defined in `npy_2_compat.h`.  For that reasons they cannot be part of
+ * `ndarraytypes.h` which tries to be self contained.
+ */
+
+#define PyDataType_FLAGCHK(dtype, flag) \
+        ((PyDataType_FLAGS(dtype) & (flag)) == (flag))
+
+#define PyDataType_REFCHK(dtype) \
+        PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)
+
+#define NPY_BEGIN_THREADS_DESCR(dtype) \
+        do {if (!(PyDataType_FLAGCHK((dtype), NPY_NEEDS_PYAPI))) \
+                NPY_BEGIN_THREADS;} while (0);
+
+#define NPY_END_THREADS_DESCR(dtype) \
+        do {if (!(PyDataType_FLAGCHK((dtype), NPY_NEEDS_PYAPI))) \
+                NPY_END_THREADS; } while (0);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -572,8 +572,11 @@ typedef struct {
                                 NPY_ITEM_IS_POINTER | NPY_ITEM_REFCOUNT | \
                                 NPY_NEEDS_INIT | NPY_NEEDS_PYAPI)
 
+/* Actual definition in npy_2_compat.h due to version dependenc */
+static inline npy_uint64 PyDataType_FLAGS(const struct _PyArray_Descr *dtype);
+
 #define PyDataType_FLAGCHK(dtype, flag) \
-        (((dtype)->flags & (flag)) == (flag))
+        ((PyDataType_FLAGS(dtype) & (flag)) == (flag))
 
 #define PyDataType_REFCHK(dtype) \
         PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -572,15 +572,6 @@ typedef struct {
                                 NPY_ITEM_IS_POINTER | NPY_ITEM_REFCOUNT | \
                                 NPY_NEEDS_INIT | NPY_NEEDS_PYAPI)
 
-/* Actual definition in npy_2_compat.h due to version dependenc */
-static inline npy_uint64 PyDataType_FLAGS(const struct _PyArray_Descr *dtype);
-
-#define PyDataType_FLAGCHK(dtype, flag) \
-        ((PyDataType_FLAGS(dtype) & (flag)) == (flag))
-
-#define PyDataType_REFCHK(dtype) \
-        PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)
-
 typedef struct _PyArray_Descr {
         PyObject_HEAD
         /*
@@ -1012,13 +1003,6 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_BEGIN_THREADS_THRESHOLDED(loop_size) do { if ((loop_size) > 500) \
                 { _save = PyEval_SaveThread();} } while (0);
 
-#define NPY_BEGIN_THREADS_DESCR(dtype) \
-        do {if (!(PyDataType_FLAGCHK((dtype), NPY_NEEDS_PYAPI))) \
-                NPY_BEGIN_THREADS;} while (0);
-
-#define NPY_END_THREADS_DESCR(dtype) \
-        do {if (!(PyDataType_FLAGCHK((dtype), NPY_NEEDS_PYAPI))) \
-                NPY_END_THREADS; } while (0);
 
 #define NPY_ALLOW_C_API_DEF  PyGILState_STATE __save__;
 #define NPY_ALLOW_C_API      do {__save__ = PyGILState_Ensure();} while (0);
@@ -1675,6 +1659,10 @@ PyArray_CLEARFLAGS(PyArrayObject *arr, int flags)
 #define PyDataType_ISUNSIZED(dtype) ((dtype)->elsize == 0 && \
                                       !PyDataType_HASFIELDS(dtype))
 #define PyDataType_MAKEUNSIZED(dtype) ((dtype)->elsize = 0)
+/*
+ * PyDataType_FLAGS, PyDataType_FLACHK, and PyDataType_REFCHK require
+ * npy_2_compat.h and are not defined here.
+ */
 
 #define PyArray_ISBOOL(obj) PyTypeNum_ISBOOL(PyArray_TYPE(obj))
 #define PyArray_ISUNSIGNED(obj) PyTypeNum_ISUNSIGNED(PyArray_TYPE(obj))
@@ -1918,5 +1906,14 @@ typedef struct {
  * #endif
  */
 #undef NPY_DEPRECATED_INCLUDES
+
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+    /*
+     * we use ndarraytypes.h alone sometimes, but some functions from
+     * npy_2_compat.h are forward declared here, so ensure we have them.
+     * (external libraries must eventually include `ndarrayobject.h`)
+     */
+    #include "npy_2_compat.h"
+#endif
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NDARRAYTYPES_H_ */

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -78,7 +78,7 @@
     static inline npy_uint64
     PyDataType_FLAGS(const PyArray_Descr *dtype)
     {
-        return dtype->flags;
+        return (unsigned char)dtype->flags;
     }
 #elif NPY_ABI_VERSION < 0x02000000
     #define NPY_DEFAULT_INT NPY_LONG
@@ -88,7 +88,7 @@
     static inline npy_uint64
     PyDataType_FLAGS(const PyArray_Descr *dtype)
     {
-        return dtype->flags;
+        return (unsigned char)dtype->flags;
     }
 
     /* Aliases of 2.x names to 1.x only equivalent names */
@@ -107,10 +107,10 @@
     {
         if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
             // TODO: This will change to a semi-private 2.0 struct name
-            return ((PyArray_Descr *)dtype)->flags;
+            return (unsigned char)((PyArray_Descr *)dtype)->flags;
         }
         else {
-            return ((PyArray_DescrProto *)dtype)->flags;
+            return (unsigned char)((PyArray_DescrProto *)dtype)->flags;
         }
     }
 #endif

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -74,10 +74,22 @@
     #define NPY_DEFAULT_INT NPY_INTP
     #define NPY_RAVEL_AXIS NPY_MIN_INT
     #define NPY_MAXARGS 64
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        return dtype->flags;
+    }
 #elif NPY_ABI_VERSION < 0x02000000
     #define NPY_DEFAULT_INT NPY_LONG
     #define NPY_RAVEL_AXIS 32
     #define NPY_MAXARGS 32
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        return dtype->flags;
+    }
 
     /* Aliases of 2.x names to 1.x only equivalent names */
     #define NPY_NTYPES NPY_NTYPES_LEGACY
@@ -89,6 +101,18 @@
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? -1 : 32)
     #define NPY_MAXARGS  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? 64 : 32)
+
+    static inline npy_uint64
+    PyDataType_FLAGS(const PyArray_Descr *dtype)
+    {
+        if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
+            // TODO: This will change to a semi-private 2.0 struct name
+            return ((PyArray_Descr *)dtype)->flags;
+        }
+        else {
+            return ((PyArray_DescrProto *)dtype)->flags;
+        }
+    }
 #endif
 
 

--- a/numpy/_core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/_core/src/multiarray/einsum_sumprod.c.src
@@ -12,7 +12,7 @@
 #define _MULTIARRAYMODULE
 
 #include <numpy/npy_common.h>
-#include <numpy/npy_2_compat.h>  /* for NPY_NTYPES_LEGACY */
+#include <numpy/ndarraytypes.h>  /* for NPY_NTYPES_LEGACY */
 #include <numpy/halffloat.h>
 
 #include "einsum_sumprod.h"

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -133,6 +133,10 @@ def conv_intp(cnp.intp_t val):
     return val
 
 
+def get_dtype_flags(cnp.dtype dtype):
+    return dtype.flags
+
+
 cdef cnp.NpyIter* npyiter_from_nditer_obj(object it):
     """A function to create a NpyIter struct from a nditer object.
 

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -196,6 +196,12 @@ def test_multiiter_fields(install_temp, arrays):
     )
 
 
+def test_dtype_flags(install_temp):
+    import checks
+    dtype = np.dtype("i,O")  # dtype with somewhat interesting flags
+    assert dtype.flags == checks.get_dtype_flags(dtype)
+
+
 def test_conv_intp(install_temp):
     import checks
 


### PR DESCRIPTION
The flags are too small at 8 bits, so create a new uint64 accessor function for public use.  Internally, we can keep using flags just fine (since we don't need version specific handling).

Cython 2 will end up going through python to get the flags so make a note of that in the release notes.

---

Another relatively small preparatory step for opening up `PyArray_Descr` to serious changes.  This moves flags specifically to be an inline function and exposes it as such to Cython.

*Note: I wanted to use `npy_uint64` (up for discussion), which is why I had to move the type definition block to the beginning.  But that seemed very reasonable in either case.*