### PR TITLE
MAINT: Propagate requirement of cython 0.29.34

### DIFF
--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -16,11 +16,11 @@ except ImportError:
 else:
     from numpy._utils import _pep440
 
-    # Cython 0.29.30 is required for Python 3.11 and there are
+    # Cython 0.29.34 is required for Python 3.11 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    required_version = "0.29.30"
+    required_version = "0.29.34"
     if _pep440.parse(cython_version) < _pep440.Version(required_version):
         # too old or wrong cython, skip the test
         cython = None

--- a/setup.py
+++ b/setup.py
@@ -329,7 +329,7 @@ def generate_cython():
     else:
         # Note: keep in sync with that in pyproject.toml
         # Update for Python 3.11
-        required_version = '0.29.30'
+        required_version = '0.29.34'
 
         if _pep440.parse(cython_version) < _pep440.Version(required_version):
             cython_path = Cython.__file__


### PR DESCRIPTION
When i build using setup.py & cython 0.29.30, my build fails while cythonizing numpy/random\bit_generator.pyx, with a syntax error for 
`ctypedef void (*random_double_fill)(bitgen_t *state, np.npy_intp count, double* out)  noexcept nogil`

This line was changed in #23709, which also increases the dependency to 0.29.34. But setup.py for example does not get the updated dependency version, so it did not complain about having only 0.29.30