### PR TITLE
BUG: ensure that FFT routines can deal with integer and bool arrays

### DIFF
--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -57,12 +57,13 @@ def _raw_fft(a, n, axis, is_real, is_forward, norm, out=None):
     if not is_forward:
         norm = _swap_direction(norm)
 
+    real_dtype = result_type(a.real.dtype, 1.0)
     if norm is None or norm == "backward":
         fct = 1
     elif norm == "ortho":
-        fct = reciprocal(sqrt(n, dtype=a.real.dtype))
+        fct = reciprocal(sqrt(n, dtype=real_dtype))
     elif norm == "forward":
-        fct = reciprocal(n, dtype=a.real.dtype)
+        fct = reciprocal(n, dtype=real_dtype)
     else:
         raise ValueError(f'Invalid norm value {norm}; should be "backward",'
                          '"ortho" or "forward".')
@@ -81,7 +82,7 @@ def _raw_fft(a, n, axis, is_real, is_forward, norm, out=None):
 
     if out is None:
         if is_real and not is_forward:  # irfft, complex in, real output.
-            out_dtype = result_type(a.real.dtype, 1.0)
+            out_dtype = real_dtype
         else:  # Others, complex output.
             out_dtype = result_type(a.dtype, 1j)
         out = empty(a.shape[:axis] + (n_out,) + a.shape[axis+1:],

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -543,3 +543,19 @@ def test_irfft_with_n_large_regression():
                          -6.62459848, 4., -3.37540152, -0.16057669,
                          1.8819096, -20.86055364])
     assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize("fft", [
+    np.fft.fft, np.fft.ifft, np.fft.rfft, np.fft.irfft
+])
+@pytest.mark.parametrize("data", [
+    np.array([False, True, False]),
+    np.arange(10, dtype=np.uint8),
+    np.arange(5, dtype=np.int16),
+])
+def test_fft_with_integer_or_bool_input(data, fft):
+    # Regression test for gh-25819
+    result = fft(data)
+    float_data = data.astype(np.result_type(data, 1.))
+    expected = fft(float_data)
+    assert_array_equal(result, expected)


### PR DESCRIPTION
Previously, integer and bool input caused incorrect calculation of the factor (or even didn't work at all).

Fixes #25819