### PR TITLE
BLD: use homebrew gfortran

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -71,13 +71,13 @@ macosx_arm64_task:
     CIBW_ARCHS: arm64
 
   build_script: |
-    brew install micromamba
+    brew install micromamba gfortran
     micromamba shell init -s bash -p ~/micromamba
     source ~/.bash_profile
     
     micromamba create -n numpydev
     micromamba activate numpydev
-    micromamba install -y -c conda-forge compilers python=3.11 2>/dev/null
+    micromamba install -y -c conda-forge python=3.11 2>/dev/null
     
     ver=$(sw_vers -productVersion)
     macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
@@ -85,7 +85,7 @@ macosx_arm64_task:
         # Use native Accelerate
         export INSTALL_OPENBLAS=false
         export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=false RUNNER_OS=macOS"
-        export CIBW_REPAIR_WHEEL_COMMAND_MACOS=""
+        # export CIBW_REPAIR_WHEEL_COMMAND_MACOS=""
     else
         # Use scipy-openblas wheels
         export INSTALL_OPENBLAS=true


### PR DESCRIPTION
towards closes #25815.

Once the wheels are built it would be good if people could download the artifacts from the ci run and check them. I tested this locally for `cp312-cp312-macosx_14_0_arm64` and the `numpy.fft` import worked, the libc++.dylib wasn't bundled. 
Some of the f2py tests initially failed (couldn't find libgfortran5), but once l installed homebrew gfortran everything passed.