### PR TITLE
DOC: two minor fixes for DType API doc formatting

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1948,6 +1948,8 @@ code:
         Py_INCREF(loop_descrs[2]);
     }
 
+API for calling array methods
+-----------------------------
 
 Conversion
 ~~~~~~~~~~
@@ -3316,7 +3318,7 @@ Data Type Promotion and Inspection
 Custom Data Types
 -----------------
 
-..versionadded:: 2.0
+.. versionadded:: 2.0
 
 These functions allow defining custom flexible data types outside of NumPy.  See
 :ref:`NEP 42 <NEP42>` for more details about the rationale and design of the new


### PR DESCRIPTION
Reading over the docs build on the website I noticed two issues I missed looking at the docs locally in #25754 

First, the versionadded macro is broken, this fixes it.

Second, I accidentally grouped the new ArrayMethod API with the old api for calling array methods. I added a section break to separate them.