### PR TITLE
BUG: ensure static_string.buf is never NULL for a non-null string

### DIFF
--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -50,7 +50,6 @@ jobs:
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions
         ASAN_OPTIONS=detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1:halt_on_error=1 \
+        UBSAN_OPTIONS=halt_on_error=0 \
         LD_PRELOAD=$(gcc --print-file-name=libasan.so) \
         python -m spin test -- -v -s
-        
-  

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -391,6 +391,7 @@ NpyString_release_allocators(size_t length, npy_string_allocator *allocators[])
     }
 }
 
+static const char * const EMPTY_STRING = "";
 
 /*NUMPY_API
  * Extract the packed contents of *packed_string* into *unpacked_string*.
@@ -427,7 +428,7 @@ NpyString_load(npy_string_allocator *allocator,
 
     else {
         size_t size = VSTRING_SIZE(string_u);
-        char *buf = NULL;
+        const char *buf = EMPTY_STRING;
         if (size > 0) {
             npy_string_arena *arena = &allocator->arena;
             if (arena == NULL) {


### PR DESCRIPTION
Right now if you do something like:

```
npy_static_string s = {0, NULL};
int is_null = NpyString_load(allocator, packed_string, &s)
```

Then it is possible to end up in a state where `s.buf` is NULL even though `is_null` is 0. It's much simpler to reason about things if that can only happen if `packed_string` is a null string.

This is causing intermittent CI failures due to UBSAN not liking this:

```
numpy/_core/tests/test_stringdtype.py::TestStringLikeCasts::test_void_casts[unset-True-strings1] ../numpy/_core/src/multiarray/stringdtype/casts.c:1464:9: runtime error: null pointer passed as argument 2, which is declared to never be null
```

See e.g. [this run](https://github.com/numpy/numpy/actions/runs/7919699189/job/21621071277). It's not at all clear to me why that run hang for six hours instead of immediately crashing and also why the error from UBSAN never gets reported in the CI output. I was able to reproduce the failure locally though.

I'm hoping that explicitly specifying that we don't want to halt on UBSAN errors will avoid confusing CI hangs like the one above, but can't confirm.