### PR TITLE
MAINT: Update pinned setuptools for Python < 3.12

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,6 +1,6 @@
 Cython
 wheel==0.38.1
-setuptools==59.2.0 ; python_version < '3.12'
+setuptools==65.5.1 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
 hypothesis==6.81.1
 pytest==7.4.0

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,7 +1,8 @@
 Cython
 wheel==0.38.1
-setuptools==65.5.1 ; python_version < '3.12'
-setuptools         ; python_version >= '3.12'
+#setuptools==65.5.1 ; python_version < '3.12'
+#setuptools         ; python_version >= '3.12'
+setuptools
 hypothesis==6.81.1
 pytest==7.4.0
 pytz==2023.3.post1


### PR DESCRIPTION
The is a security advisory for setuptools <= 65.5.0. This updates the pin to 65.5.1 to see if it still works.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
