### PR TITLE
BUG: ensure empty cholesky upper does not hang.

### DIFF
--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -2,6 +2,8 @@
 """
 import warnings
 
+import pytest
+
 import numpy as np
 from numpy import linalg, arange, float64, array, dot, transpose
 from numpy.testing import (
@@ -146,3 +148,9 @@ class TestRegression:
         u_lstsq, res, rank, sv = linalg.lstsq(G, b, rcond=None)
         # check results just in case
         assert_array_almost_equal(u_lstsq, u)
+
+    @pytest.mark.parametrize("upper", [True, False])
+    def test_cholesky_empty_array(self, upper):
+        # gh-25840 - upper=True hung before.
+        res = np.linalg.cholesky(np.zeros((0, 0)), upper=upper)
+        assert res.size == 0


### PR DESCRIPTION
Fixes #25840 - the problem was that for `size_t`, `0 - 1` is a large number. Since a `fortran int` is passed in, a `ssize_t` makes more sense anyway.