### PR TITLE
ENH: Support exotic installation of nvfortran

### DIFF
--- a/numpy/distutils/fcompiler/nv.py
+++ b/numpy/distutils/fcompiler/nv.py
@@ -14,7 +14,7 @@ class NVHPCFCompiler(FCompiler):
 
     compiler_type = 'nv'
     description = 'NVIDIA HPC SDK'
-    version_pattern = r'\s*(nvfortran|(pg(f77|f90|fortran)) \(aka nvfortran\)) (?P<version>[\d.-]+).*'
+    version_pattern = r'\s*(nvfortran|.+ \(aka nvfortran\)) (?P<version>[\d.-]+).*'
 
     executables = {
         'version_cmd': ["<F90>", "-V"],


### PR DESCRIPTION
The current `fcompiler` implementation for NVHPC Fortran compiler fails with exotic NVHPC installations.
This change allows support for custom installations where the Fortran compiler command is not called `nvfortran`, e.g. when using a wrapper.
The `aka nvfortran` part in the pattern is actually enough to garantee that it is the NVHPC Fortran compiler.
