### PR TITLE
MAINT: Remove unnnecessary size argument in StringDType initializer

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6922,7 +6922,7 @@ add_newdoc('numpy._core.numerictypes', 'character',
 
 add_newdoc('numpy._core.multiarray', 'StringDType',
     """
-    StringDType(/, size, *, na_object=np._NoValue, coerce=True)
+    StringDType(*, na_object=np._NoValue, coerce=True)
 
     Create a StringDType instance.
 
@@ -6931,10 +6931,6 @@ add_newdoc('numpy._core.multiarray', 'StringDType',
 
     Parameters
     ----------
-    size: integer
-        An optional positional-only size parameter. This is ignored and
-        provided only so that code that creates fixed-width strings with a size
-        will also work correctly with StringDType.
     na_object : object, optional
         Object used to represent missing data. If unset, the array will not
         use a missing data sentinel.

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -685,14 +685,13 @@ static PyType_Slot PyArray_StringDType_Slots[] = {
 static PyObject *
 stringdtype_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwds)
 {
-    static char *kwargs_strs[] = {"", "coerce", "na_object", NULL};
+    static char *kwargs_strs[] = {"coerce", "na_object", NULL};
 
-    long size = 0;
     PyObject *na_object = NULL;
     int coerce = 1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|l$pO&:StringDType",
-                                     kwargs_strs, &size, &coerce,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$pO&:StringDType",
+                                     kwargs_strs, &coerce,
                                      _not_NoValue, &na_object)) {
         return NULL;
     }

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -79,6 +79,8 @@ def _to_bytes_or_str_array(result, output_dtype_like):
         # in losing shape information
         return result.astype(output_dtype_like.dtype)
     ret = np.asarray(result.tolist())
+    if isinstance(output_dtype_like.dtype, np.dtypes.StringDType):
+        return ret.astype(type(output_dtype_like.dtype))
     return ret.astype(type(output_dtype_like.dtype)(_get_num_chars(ret)))
 
 
@@ -632,8 +634,12 @@ def ljust(a, width, fillchar=' '):
     size = int(np.max(width_arr.flat))
     if np.issubdtype(a_arr.dtype, np.bytes_):
         fillchar = np._utils.asbytes(fillchar)
+    if isinstance(a_arr.dtype, np.dtypes.StringDType):
+        res_dtype = a_arr.dtype
+    else:
+        res_dtype = type(a_arr.dtype)(size)
     return _vec_string(
-        a_arr, type(a_arr.dtype)(size), 'ljust', (width_arr, fillchar))
+        a_arr, res_dtype, 'ljust', (width_arr, fillchar))
 
 
 def rjust(a, width, fillchar=' '):
@@ -666,15 +672,19 @@ def rjust(a, width, fillchar=' '):
     >>> a = np.array(['aAaAaA', '  aA  ', 'abBABba'])
     >>> np.strings.rjust(a, width=3)
     array(['aAa', '  a', 'abB'], dtype='<U3')
-    
+
     """
     a_arr = np.asarray(a)
     width_arr = np.asarray(width)
     size = int(np.max(width_arr.flat))
     if np.issubdtype(a_arr.dtype, np.bytes_):
         fillchar = np._utils.asbytes(fillchar)
+    if isinstance(a_arr.dtype, np.dtypes.StringDType):
+        res_dtype = a_arr.dtype
+    else:
+        res_dtype = type(a_arr.dtype)(size)
     return _vec_string(
-        a_arr, type(a_arr.dtype)(size), 'rjust', (width_arr, fillchar))
+        a_arr, res_dtype, 'rjust', (width_arr, fillchar))
 
 
 def lstrip(a, chars=None):


### PR DESCRIPTION
This is one of the followup tasks from #25693.

This argument was needed during stringdtype development so that I could hook into the string manipulation functions from the old `np.char` namespace.

Now that `StringDType` is in numpy we can remove the argument to make the API simpler.