### PR TITLE
CI: make chocolatey fail when a dependency doesn't install

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: pkg-config-for-win
         run: |
-          choco install -y --no-progress --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+          choco install -y --no-progress --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
           $CIBW = "${{ github.workspace }}/.openblas"
           # pkgconfig needs a complete path, and not just "./openblas since the
           # build is run in a tmp dir (?)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install pkg-config
       run: |
-        choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+        choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
         echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
         
 

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -14,9 +14,9 @@ steps:
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
 - powershell: |
-    choco install unzip -y
-    choco install -y --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-    choco install ninja
+    choco install -y --stoponfirstfailure unzip
+    choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+    choco install --stoponfirstfailure ninja
     echo "##vso[task.setvariable variable=RTOOLS43_HOME]c:\rtools43"
   displayName: 'Install utilities'
 


### PR DESCRIPTION
c.f. https://github.com/numpy/numpy/issues/25849#issuecomment-1953170002

The default is to continue installation even if a dependency fails to install.