### PR TITLE
ENH: print traceback after printing ABI mismatch error

### DIFF
--- a/numpy/core/_multiarray_umath.py
+++ b/numpy/core/_multiarray_umath.py
@@ -16,6 +16,7 @@ def __getattr__(attr_name):
     if attr_name in {"_ARRAY_API", "_UFUNC_API"}:
         from numpy.version import short_version, release
         import textwrap
+        import traceback
         import sys
 
         msg = textwrap.dedent(f"""
@@ -35,27 +36,21 @@ def __getattr__(attr_name):
                 the NumPy pre-release is used at build time.
                 The main way to ensure this is using no build isolation
                 and installing dependencies manually with NumPy.
-                For cibuildwheel for example, this may be achieved by using
-                the flag to pip:
-                    CIBW_BUILD_FRONTEND: pip; args: --no-build-isolation
-                installing NumPy with:
-                    pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-                in the `CIBW_BEFORE_BUILD` step.  Please compare with the
-                solutions e.g. in astropy or matplotlib for how to make this
-                conditional for nightly wheel builds using expressions.
-                If you do not worry about using pre-releases of all
-                dependencies, you can also use `--pre --extra-index-url` in the
-                build frontend (instead of build isolation).
-                This will become unnecessary as soon as NumPy 2.0 is released.
 
                 If your dependencies have the issue, check whether they
-                have nightly wheels build against NumPy 2.0.
+                build nightly wheels build against NumPy 2.0.
 
-                pybind11 note: You may see this message if using pybind11,
-                this is not problematic at pre-release time
-                it indicates the need for a new pybind11 release.
+                pybind11 note: If you see this message and do not see
+                any errors raised, it's possible this is due to a
+                package using an old version of pybind11 that should be
+                updated.
 
                 """)
+        msg += "Traceback (most recent call last):"
+        for line in traceback.format_stack()[:-1]:
+            if "frozen importlib" in line:
+                continue
+            msg += line
         # Only print the message.  This has two reasons (for now!):
         # 1. Old NumPy replaced the error here making it never actually show
         #    in practice, thus raising alone would not be helpful.


### PR DESCRIPTION
Fixes #25741.

With this change, the warning text looks like the details block below, including the traceback after printing the message. Here from using the pyarrow release wheel instead of the nightly wheel.

Without printing a traceback this error message is very confusing, especially if the error is coming from importing a dependency or a dependency of a dependency.

<details>

```

RuntimeError: module compiled against ABI version 0x1000009 but this version of numpy is 0x2000000

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0.dev0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled against NumPy 2.0.

If you are a user of the module, the easiest solution will be to
either downgrade NumPy or update the failing module (if available).

NOTE: When testing against pre-release versions of NumPy 2.0
or building nightly wheels for it, it is necessary to ensure
the NumPy pre-release is used at build time.
The main way to ensure this is using no build isolation
and installing dependencies manually with NumPy.
For cibuildwheel for example, this may be achieved by using
the flag to pip:
    CIBW_BUILD_FRONTEND: pip; args: --no-build-isolation
installing NumPy with:
    pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
in the `CIBW_BEFORE_BUILD` step.  Please compare with the
solutions e.g. in astropy or matplotlib for how to make this
conditional for nightly wheel builds using expressions.
If you do not worry about using pre-releases of all
dependencies, you can also use `--pre --extra-index-url` in the
build frontend (instead of build isolation).
This will become unnecessary as soon as NumPy 2.0 is released.

If your dependencies have the issue, check whether they
have nightly wheels build against NumPy 2.0.

pybind11 note: You may see this message if using pybind11,
this is not problematic at pre-release time
it indicates the need for a new pybind11 release.

Traceback (most recent call last):  File "<string>", line 1, in <module>
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/__init__.py", line 130, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/traitlets/config/application.py", line 1077, in launch_instance
    app.start()
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/terminal/ipapp.py", line 317, in start
    self.shell.mainloop()
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/terminal/interactiveshell.py", line 911, in mainloop
    self.interact()
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/terminal/interactiveshell.py", line 904, in interact
    self.run_cell(code, store_history=True)
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3051, in run_cell
    result = self._run_cell(
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3106, in _run_cell
    result = runner(coro)
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/async_helpers.py", line 129, in _pseudo_sync_runner
    coro.send(None)
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3311, in run_cell_async
    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3493, in run_ast_nodes
    if await self.run_code(code, result, async_=asy):
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3553, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-7dd3504c366f>", line 1, in <module>
    import pandas as pd
  File "/Users/goldbaum/Documents/pandas/pandas/__init__.py", line 48, in <module>
    from pandas.core.api import (
  File "/Users/goldbaum/Documents/pandas/pandas/core/api.py", line 9, in <module>
    from pandas.core.dtypes.dtypes import (
  File "/Users/goldbaum/Documents/pandas/pandas/core/dtypes/dtypes.py", line 24, in <module>
    from pandas._libs import (
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/pyarrow/__init__.py", line 65, in <module>
    import pyarrow.lib as _lib
  File "/Users/goldbaum/.pyenv/versions/3.11.6/lib/python3.11/site-packages/numpy/core/_multiarray_umath.py", line 61, in __getattr__
    for line in traceback.format_stack():

```

</details>