### PR TITLE
API: Fix compat header and add new import helpers

### DIFF
--- a/doc/release/upcoming_changes/25866.c_api.rst
+++ b/doc/release/upcoming_changes/25866.c_api.rst
@@ -2,7 +2,7 @@ New C-API import functions
 --------------------------
 We have now added ``PyArray_ImportNumPyAPI`` and ``PyUFunc_ImportUFuncAPI``
 as static inline functions to import the NumPy C-API tables.
-The new functions have two advantages:
+The new functions have two advantages over `import_array` and `import_ufunc`:
 - They check whether the import was already performed and are light-weight
   if not, allowing to add them judiciously (although this is not preferable
   in most cases).

--- a/doc/release/upcoming_changes/25866.c_api.rst
+++ b/doc/release/upcoming_changes/25866.c_api.rst
@@ -1,0 +1,13 @@
+New C-API import functions
+--------------------------
+We have now added ``PyArray_ImportNumPyAPI`` and ``PyUFunc_ImportUFuncAPI``
+as static inline functions to import the NumPy C-API tables.
+The new functions have two advantages:
+- They check whether the import was already performed and are light-weight
+  if not, allowing to add them judiciously (although this is not preferable
+  in most cases).
+- The old mechanisms were macros rather than functions which included a
+  ``return`` statement.
+
+The ``PyArray_ImportNumPyAPI()`` function is included in ``npy_2_compat.h``
+for simpler backporting.

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -69,6 +69,7 @@ Note that the NumPy random API is not affected by this change.
 
 C-API Changes
 =============
+
 Some definitions were removed or replaced due to being outdated or
 unmaintainable.  Some new API definition will evaluate differently at
 runtime between NumPy 2.0 and NumPy 1.x.
@@ -81,6 +82,22 @@ used to explicitly implement different behavior on NumPy 1.x and 2.0.
 (The compat header defines it in a way compatible with such use.)
 
 Please let us know if you require additional workarounds here.
+
+Functionality moved to headers requiring ``import_numpy()``
+-----------------------------------------------------------
+If you previously included only ``ndarraytypes.h`` you may find that some
+functionality is not available anymore and requires the inclusion of
+``ndarrayobject.h`` or similar.
+This include is also needed when backporting ``npy_2_compat.h``.
+
+.. warning::
+  It is important that the ``import_array()`` mechanism is used to ensure
+  that the full NumPy API is accessible when using the ``npy_2_compat.h``
+  header.  In most cases your extension module probably already calls it.
+  However, if not we have added ``PyArray_ImportNumPyAPI()`` as a preferable
+  way to ensure the NumPy API is imported.  This function is light-weight 
+  when called multiple times so that you may insert it wherever it may be
+  needed (if you wish to avoid setting it up at module import).
 
 .. _migration_maxdims:
 

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -83,12 +83,13 @@ used to explicitly implement different behavior on NumPy 1.x and 2.0.
 
 Please let us know if you require additional workarounds here.
 
-Functionality moved to headers requiring ``import_numpy()``
+Functionality moved to headers requiring ``import_array()``
 -----------------------------------------------------------
 If you previously included only ``ndarraytypes.h`` you may find that some
 functionality is not available anymore and requires the inclusion of
 ``ndarrayobject.h`` or similar.
-This include is also needed when backporting ``npy_2_compat.h``.
+This include is also needed when vendoring ``npy_2_compat.h`` into your own
+codebase to allow use of the new definitions when compiling with NumPy 1.x.
 
 .. warning::
   It is important that the ``import_array()`` mechanism is used to ensure

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3726,7 +3726,17 @@ self-contained in a single .c file, then that is all that needs to be
 done. If, however, the extension module involves multiple files where
 the C-API is needed then some additional steps must be taken.
 
-.. c:function:: void import_array(void)
+.. c:function:: int PyArray_ImportNumPyAPI(void)
+
+    Ensures that the NumPy C-API is imported and usable.  It returns ``0``
+    on success and ``-1`` with an error set if NumPy couldn't be imported.
+    While preferable to call it once at module initialization, this function
+    is very light-weight if called multiple times.
+
+    .. versionadded:: 2.0
+        This function is backported in the ``npy_2_compat.h`` header.
+
+.. c:macro:: void import_array(void)
 
     This function must be called in the initialization section of a
     module that will make use of the C-API. It imports the module

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -431,7 +431,18 @@ Importing the API
 
 .. c:macro:: NO_IMPORT_UFUNC
 
-.. c:function:: void import_ufunc(void)
+.. c:function:: int PyUFunc_ImportUFuncAPI(void)
+
+    Ensures that the UFunc C-API is imported and usable.  It returns ``0``
+    on success and ``-1`` with an error set if NumPy couldn't be imported.
+    While preferable to call it once at module initialization, this function
+    is very light-weight if called multiple times.
+
+    .. versionadded:: 2.0
+        This function mainly checks for ``PyUFunc_API == NULL`` so it can be
+        manually backported if desired.
+
+.. c:macro:: void import_ufunc(void)
 
     These are the constants and functions for accessing the ufunc
     C-API from extension modules in precisely the same way as the

--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -112,6 +112,16 @@ _import_umath(void)
         }\
     } while(0)
 
+
+static inline int
+PyUFunc_ImportUFuncAPI()
+{
+    if (NPY_UNLIKELY(PyUFunc_API == NULL)) {
+        import_umath1(-1);
+    }
+    return 0;
+}
+
 #endif
 """
 

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -31,23 +31,55 @@
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_
 
 /*
- * Allow users to use `PyArray_RUNTIME_VERSION` when vendoring the file for
- * compilation with NumPy 1.x.
- * Simply do not define when compiling with 2.x.  It must be defined later
- * as it is set during `import_array()`.
+ * New macros for accessing real and complex part of a complex number can be
+ * found in "npy_2_complexcompat.h".
  */
-#if !defined(PyArray_RUNTIME_VERSION) && NPY_ABI_VERSION < 0x02000000
+
+
+/*
+ * This header is meant to be included by downstream directly for 1.x compat.
+ * In that case we need to ensure that users first included the full headers
+ * and not just `ndarraytypes.h`.
+ */
+#ifndef NPY_FEATURE_VERSION
+  #error "The NumPy 2 compat header requires `import_array()` for which "  \
+         "the `ndarraytypes.h` header include is not sufficient.  Please "  \
+         "include it after `numpy/ndarrayobject.h` or similar.\n"  \
+         "To simplify includsion, you may use `PyArray_ImportNumPy()` " \
+         "which is defined in the compat header and is lightweight (can be)."
+#endif
+
+#if NPY_ABI_VERSION < 0x02000000
+  /*
+   * Define 2.0 feature version as it is needed below to decide whether we
+   * compile for both 1.x and 2.x (defining it gaurantees 1.x only).
+   */
+  #define NPY_2_0_API_VERSION 0x00000012
   /*
    * If we are compiling with NumPy 1.x, PyArray_RUNTIME_VERSION so we
    * pretend the `PyArray_RUNTIME_VERSION` is `NPY_FEATURE_VERSION`.
+   * This allows downstream to use `PyArray_RUNTIME_VERSION` if they need to.
    */
   #define PyArray_RUNTIME_VERSION NPY_FEATURE_VERSION
 #endif
 
+
 /*
- * New macros for accessing real and complex part of a complex number can be
- * found in "npy_2_complexcompat.h".
+ * Define a better way to call `_import_array()` to simplify backporting as
+ * we now require imports more often (necessary to make ABI flexible).
  */
+#ifdef import_array1
+
+static inline int
+PyArray_ImportNumPyAPI()
+{
+    if (NPY_UNLIKELY(PyArray_API == NULL)) {
+        import_array1(-1);
+    }
+    return 0;
+}
+
+#endif  /* import_array1 */
 
 
 /*

--- a/numpy/_core/include/numpy/ufuncobject.h
+++ b/numpy/_core/include/numpy/ufuncobject.h
@@ -273,8 +273,6 @@ typedef struct _loop1d_info {
 } PyUFunc_Loop1d;
 
 
-#include "__ufunc_api.h"
-
 #define UFUNC_PYVALS_NAME "UFUNC_PYVALS"
 
 /*
@@ -298,6 +296,8 @@ typedef struct _loop1d_info {
 #define UFUNC_NOFPE
 #endif
 #endif
+
+#include "__ufunc_api.h"
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -800,12 +800,10 @@ PyMODINIT_FUNC PyInit__umath_tests(void) {
         return NULL;
     }
 
-    import_array();
-    if (PyErr_Occurred()) {
+    if (PyArray_ImportNumPyAPI() < 0) {
         return NULL;
     }
-    import_ufunc();
-    if (PyErr_Occurred()) {
+    if (PyUFunc_ImportUFuncAPI() < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
This PR does three somewhat related things:

1. I fixed the `npy_2_compat.h` so now it should work fine when backported.
2. Add a short segment that some functionality moved (I don't want to add a full list now, since it'll grow, and it will be obvious anyway: you get a compilation error).  This includes a warning to ensure you imported the API as otherwise things may fail cryptically unfortunately.
3. The way `import_array` works is odd, as it includes the `return` statement, which IMO is terrible and misleading.  I also wanted to tell downstream they can just import array judiciously without the need to figure out importing it exactly once at import time (which clearly nicer, but may not be trivial to update in all cases).
   Thus I added `PyArray_ImportNumPyAPI` and `PyUFunc_ImportUFuncAPI` as functions, the first is back-portable since otherwise I can't suggest to use it :).

---

~I will double check the new pattern works for backporting (I assume it does, but marking as draft until I checked).~

I believe this should alleviate the main problem with the `arrfuncs` PR, although it may be that the `GETITEM` and `SETITEM` macros need to move headers still.