### PR TITLE
BUG: use print to actually output something

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,7 +131,7 @@ jobs:
         sudo apt install gfortran libgfortran5
         python -m pip install -r requirements/ci32_requirements.txt
         mkdir -p ./.openblas
-        python -c"import scipy_openblas32 as ob32; ob32.get_pkg_config()" > ./.openblas/scipy-openblas.pc
+        python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
 
     - name: Build a wheel
       env:
@@ -193,7 +193,7 @@ jobs:
         set -xe
         python -m pip install -r requirements/ci_requirements.txt
         mkdir -p ./.openblas
-        python -c"import scipy_openblas64 as ob64; ob64.get_pkg_config()" > ./.openblas/scipy-openblas.pc
+        python -c"import scipy_openblas64 as ob64; print(ob64.get_pkg_config())" > ./.openblas/scipy-openblas.pc
     - name: Build a wheel via an sdist
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -101,13 +101,9 @@ jobs:
       run:
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy')
     - name: Ensure scipy-openblas
-      shell: python
       run: |
-        import numpy
-        deps = numpy.show_config('dicts')['Build Dependencies']
-        assert "blas" in deps
-        assert deps["blas"]["version"].split(".") > ["0", "3", "26"]
-        
+        set -ex
+        spin python tools/check_openblas_version.py 0.3.26
 
     - name: Test
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -81,7 +81,7 @@ jobs:
             python -m pip install -r requirements/ci32_requirements.txt
         fi
         mkdir -p ./.openblas
-        python -c"import scipy_openblas32 as ob32; ob32.get_pkg_config()" > ./.openblas/scipy-openblas.pc
+        python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
         echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $GITHUB_ENV
 
     - name: Build

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -83,6 +83,8 @@ jobs:
         mkdir -p ./.openblas
         python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
         echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $GITHUB_ENV
+        ld_library_path=$(python -c"import scipy_openblas32 as ob32; print(ob32.get_lib_dir())")
+        echo "LD_LIBRARY_PATH=$ld_library_path" >> $GITHUB_ENV
 
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
@@ -98,12 +100,19 @@ jobs:
     - name: Check installed test and stub files
       run:
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy')
+    - name: Ensure scipy-openblas
+      shell: python
+      run: |
+        import numpy
+        deps = numpy.show_config('dicts')['Build Dependencies']
+        assert "blas" in deps
+        assert deps["blas"]["version"].split(".") > ["0", "3", "26"]
+        
 
     - name: Test
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
-        LD_LIBRARY_PATH: "/usr/local/lib/"  # to find libopenblas.so.0
 
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions

--- a/tools/check_openblas_version.py
+++ b/tools/check_openblas_version.py
@@ -1,6 +1,8 @@
 """
-Check the blas version is blas and is higher than min_version
 usage: check_openblas_version.py <min_version>
+
+Check the blas version is blas from scipy-openblas and is higher than
+min_version
 example: check_openblas_version.py 0.3.26
 """
 
@@ -13,5 +15,5 @@ deps = numpy.show_config('dicts')['Build Dependencies']
 assert "blas" in deps
 print("Build Dependencies: blas")
 pprint.pprint(deps["blas"])
-print(f"Checking verions >= {version}")
 assert deps["blas"]["version"].split(".") >= version.split(".")
+assert deps["blas"]["name"] == "scipy-openblas"

--- a/tools/check_openblas_version.py
+++ b/tools/check_openblas_version.py
@@ -5,9 +5,13 @@ example: check_openblas_version.py 0.3.26
 """
 
 import numpy
+import pprint
 import sys
 
 version = sys.argv[1]
 deps = numpy.show_config('dicts')['Build Dependencies']
 assert "blas" in deps
-assert deps["blas"]["version"].split(".") > version.split(".")
+print("Build Dependencies: blas")
+pprint.pprint(deps["blas"])
+print(f"Checking verions >= {version}")
+assert deps["blas"]["version"].split(".") >= version.split(".")

--- a/tools/check_openblas_version.py
+++ b/tools/check_openblas_version.py
@@ -1,0 +1,13 @@
+"""
+Check the blas version is blas and is higher than min_version
+usage: check_openblas_version.py <min_version>
+example: check_openblas_version.py 0.3.26
+"""
+
+import numpy
+import sys
+
+version = sys.argv[1]
+deps = numpy.show_config('dicts')['Build Dependencies']
+assert "blas" in deps
+assert deps["blas"]["version"].split(".") > version.split(".")


### PR DESCRIPTION
The transition to using scipy-openblas wheels instead of tarballs is only partially working. Building wheels and using "spin" works, but the other workflows were missing a `print()` statement to actually create a pkg-config file. CI worked by chance since the images come with a pre-installed `libopenblas-dev` package. But looking at which openblas is found, the version is not correct.

This should fix the problem.