### PR TITLE
BUG: Fix typings in ndarray.__getitem__

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1504,8 +1504,6 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
         | tuple[NDArray[integer[Any]] | NDArray[np.bool], ...]
     )) -> ndarray[Any, _DType_co]: ...
     @overload
-    def __getitem__(self, key: SupportsIndex | tuple[SupportsIndex, ...]) -> Any: ...
-    @overload
     def __getitem__(self, key: (
         None
         | slice


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Hello,
I have spotted that retrieving an item from a numpy.ndarray tells the static checker that the type is Any.
I suppose this is not the intended functionality, and the correct one is to obtain another ndarray.
If that is the case, this change should fix that.

Screenshot before the fix:
![image](https://github.com/numpy/numpy/assets/6832634/b2b4791c-abe3-440e-a304-675b101d1f98)

Screenshot after the fix:
![image](https://github.com/numpy/numpy/assets/6832634/99284c3b-d2bb-45a6-95d4-0d9c13687853)
