### PR TITLE
BUG: Include broadcasting for ``rtol`` argument in ``matrix_rank``

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2068,18 +2068,23 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     >>> matrix_rank(np.zeros((4,)))
     0
     """
+    if rtol is not None and tol is not None:
+        raise ValueError("`tol` and `rtol` can't be both set.")
+
     A = asarray(A)
     if A.ndim < 2:
         return int(not all(A == 0))
     S = svd(A, compute_uv=False, hermitian=hermitian)
-    if rtol is not None and tol is not None:
-        raise ValueError("`tol` and `rtol` can't be both set.")
-    if rtol is None:
-        rtol = max(A.shape[-2:]) * finfo(S.dtype).eps
+
     if tol is None:
+        if rtol is None:
+            rtol = max(A.shape[-2:]) * finfo(S.dtype).eps
+        else:
+            rtol = asarray(rtol)[..., newaxis]
         tol = S.max(axis=-1, keepdims=True) * rtol
     else:
         tol = asarray(tol)[..., newaxis]
+
     return count_nonzero(S > tol, axis=-1)
 
 

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -154,3 +154,10 @@ class TestRegression:
         # gh-25840 - upper=True hung before.
         res = np.linalg.cholesky(np.zeros((0, 0)), upper=upper)
         assert res.size == 0
+
+    @pytest.mark.parametrize("rtol", [0.0, [0.0] * 4, np.zeros((4,))])
+    def test_matrix_rank_rtol_argument(self, rtol):
+        # gh-25877
+        x = np.zeros((4, 3, 2))
+        res = np.linalg.matrix_rank(x, rtol=rtol)
+        assert res.shape == (4,)


### PR DESCRIPTION
Hi @asmeurer,

This PR fixes broadcasting of `rtol` argument in `matrix_rank` function that you pointed out in https://github.com/numpy/numpy/pull/25437#discussion_r1500043325.