### PR TITLE
DOC: README.md: point to user-friendly OpenSSF ScoreCard display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://anaconda.org/conda-forge/numpy)
 https://stackoverflow.com/questions/tagged/numpy)
 [![Nature Paper](https://img.shields.io/badge/DOI-10.1038%2Fs41586--020--2649--2-blue)](
 https://doi.org/10.1038/s41586-020-2649-2)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/numpy/numpy/badge)](https://api.securityscorecards.dev/projects/github.com/numpy/numpy)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/numpy/numpy/badge)](https://securityscorecards.dev/viewer/?uri=github.com/numpy/numpy)
 
 
 NumPy is the fundamental package for scientific computing with Python.


### PR DESCRIPTION
When clicking currently on the OpenSSF ScoreCard badge, one sees a rather unfriendly JSON output. Linking to https://securityscorecards.dev/viewer/?uri=github.com/numpy/numpy instead is more user friendly.
