### PR TITLE
BUG: Fix ``PyArray_FILLWBYTE`` Cython declaration

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -537,7 +537,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_FROMANY(object m, int type, int min, int max, int flags)
     object PyArray_ZEROS(int nd, npy_intp* dims, int type, int fortran)
     object PyArray_EMPTY(int nd, npy_intp* dims, int type, int fortran)
-    void PyArray_FILLWBYTE(object, int val)
+    void PyArray_FILLWBYTE(ndarray, int val)
     npy_intp PyArray_REFCOUNT(object)
     object PyArray_ContiguousFromAny(op, int, int min_depth, int max_depth)
     unsigned char PyArray_EquivArrTypes(ndarray a1, ndarray a2)

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -457,7 +457,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_FROMANY(object m, int type, int min, int max, int flags)
     object PyArray_ZEROS(int nd, npy_intp* dims, int type, int fortran)
     object PyArray_EMPTY(int nd, npy_intp* dims, int type, int fortran)
-    void PyArray_FILLWBYTE(object, int val)
+    void PyArray_FILLWBYTE(ndarray, int val)
     object PyArray_ContiguousFromAny(op, int, int min_depth, int max_depth)
     unsigned char PyArray_EquivArrTypes(ndarray a1, ndarray a2)
     bint PyArray_EquivByteorders(int b1, int b2) nogil

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -246,3 +246,11 @@ def npyiter_has_finished(it: "nditer"):
         return not (cnp.NpyIter_GetIterIndex(cit) < cnp.NpyIter_GetIterSize(cit))
     finally:
         cnp.NpyIter_Deallocate(cit)
+
+def compile_fillwithbyte():
+    # Regression test for gh-25878, mostly checks it compiles.
+    cdef cnp.npy_intp dims[2]
+    dims = (1, 2)
+    pos = cnp.PyArray_ZEROS(2, dims, cnp.NPY_UINT8, 0)
+    cnp.PyArray_FILLWBYTE(pos, 1)
+    return pos

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 import numpy as np
-from numpy.testing import IS_WASM
+from numpy.testing import assert_array_equal, IS_WASM
 
 # This import is copied from random.tests.test_extending
 try:
@@ -267,3 +267,10 @@ def test_npyiter_api(install_temp):
             for x, y in zip(checks.get_npyiter_itviews(it), it.itviews)
         ]
     )
+
+
+def test_fillwithbytes(install_temp):
+    import checks
+
+    arr = checks.compile_fillwithbyte()
+    assert_array_equal(arr, np.ones((1, 2)))


### PR DESCRIPTION
The cython declaration was never compatible with the "non deprecated" API, which didn't matter before because that was incompatible with NumPy anyway (with Cython 2).
Now it matters, and we want to enforce the new API in this case.

Cython may insert `None` and a type check here for some uses.
I would say this is fine, as it is lightweight and this is only this    
one function anyway.

Closes gh-25878

---

This seems the only affected macro, and I don't it is used a lot (using `np.zeros()` seems just more obvious typically).