### PR TITLE
CI, BLD, TST: Re-enable Emscripten/Pyodide CI job for NumPy

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   build-wasm-emscripten:
+    name: Build NumPy distribution for Pyodide
     runs-on: ubuntu-22.04
     if: false  # NOTE: job disabled, it needs to be moved to Meson (see gh-24603)
     # if: "github.repository == 'numpy/numpy'"
@@ -73,10 +74,9 @@ jobs:
           source .venv-pyodide/bin/activate
           pip install dist/*.whl
           python -c "import sys; print(sys.platform)"
-          # TODO: when re-enabled this workflow, install test deps differently
-          # since ninja isn't installable with pyodide
-          pip install -r requirements/test_requirements.txt
-      - name: Test
+          pip install -r requirements/emscripten_test_requirements.txt
+
+      - name: Test NumPy for Pyodide
         run: |
           source .venv-pyodide/bin/activate
           cd ..

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1,6 +1,3 @@
-# To enable this workflow on a fork, comment out:
-#
-# if: github.repository == 'numpy/numpy'
 name: Test Emscripten/Pyodide build
 
 on:
@@ -8,6 +5,9 @@ on:
     branches:
       - main
       - maintenance/**
+
+env:
+  FORCE_COLOR: 3
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,50 +20,65 @@ jobs:
   build-wasm-emscripten:
     name: Build NumPy distribution for Pyodide
     runs-on: ubuntu-22.04
-    if: false  # NOTE: job disabled, it needs to be moved to Meson (see gh-24603)
-    # if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     env:
-      PYODIDE_VERSION: 0.23.1
+      PYODIDE_VERSION: 0.25.0
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
       # The appropriate versions can be found in the Pyodide repodata.json
       # "info" field, or in Makefile.envs:
       # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
-      PYTHON_VERSION: 3.11.2
-      EMSCRIPTEN_VERSION: 3.1.32
+      PYTHON_VERSION: 3.11.3
+      EMSCRIPTEN_VERSION: 3.1.46
       NODE_VERSION: 18
     steps:
-      - name: Checkout numpy
+      - name: Checkout NumPy
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          submodules: true
-          # versioneer.py requires the latest tag to be reachable. Here we
-          # fetch the complete history to get access to the tags.
-          # A shallow clone can work when the following issue is resolved:
-          # https://github.com/actions/checkout/issues/338
-          fetch-depth: 0
+          submodules: recursive
+          # This input shall fetch tags without the need to fetch the
+          # entire VCS history, see https://github.com/actions/checkout#usage
+          fetch-tags: true
 
-      - name: set up python
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         id: setup-python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+      - name: Set up Emscripten toolchain
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install "pydantic<2" pyodide-build==$PYODIDE_VERSION
+        run: pip install "pydantic<2" pyodide-build==${{ env.PYODIDE_VERSION }}
 
-      - name: Build
+      - name: Find installation for pyodide-build
+        shell: python
         run: |
-          # Pyodide is still in the process of adding better/easier support for
-          # non-setup.py based builds.
-          cp pyproject.toml.setuppy pyproject.toml
-          CFLAGS=-g2 LDFLAGS=-g2 pyodide build
+          import os
+          import pyodide_build
+          from pathlib import Path
 
-      - name: set up node
+          pyodide_build_path = Path(pyodide_build.__file__).parent
+
+          env_file = os.getenv('GITHUB_ENV')
+
+          with open(env_file, "a") as myfile:
+              myfile.write(f"PYODIDE_BUILD_PATH={pyodide_build_path}\n")
+
+      - name: Apply patch(es) for pyodide-build installation
+        run: |
+          ls -a ${{ env.PYODIDE_BUILD_PATH }}
+          patch -d "${{ env.PYODIDE_BUILD_PATH }}" -p1 < tools/ci/emscripten/0001-do-not-set-meson-environment-variable-pyodide-gh-4502.patch
+
+      - name: Build NumPy for Pyodide
+        run: |
+          pyodide build -Cbuild-dir=build -Csetup-args="--cross-file=$PWD/tools/ci/emscripten/emscripten.meson.cross" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none"
+
+      - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -73,11 +88,10 @@ jobs:
           pyodide venv .venv-pyodide
           source .venv-pyodide/bin/activate
           pip install dist/*.whl
-          python -c "import sys; print(sys.platform)"
           pip install -r requirements/emscripten_test_requirements.txt
 
       - name: Test NumPy for Pyodide
         run: |
           source .venv-pyodide/bin/activate
           cd ..
-          python numpy/runtests.py -n -vv
+          pytest --pyargs numpy -m "not slow"

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,10 @@ pip-wheel-metadata
 *.patch
 *.diff
 
+# Do not ignore the following patches: #
+########################################
+!tools/ci/emscripten/0001-do-not-set-meson-environment-variable-pyodide-gh-4502.patch
+
 # OS generated files #
 ######################
 .DS_Store*

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -92,7 +92,8 @@ min_features = {
   'ppc64': [],
   's390x': [],
   'arm': [],
-  'aarch64': [ASIMD]
+  'aarch64': [ASIMD],
+  'wasm32': [],
 }.get(cpu_family, [])
 if host_machine.endian() == 'little' and cpu_family == 'ppc64'
   min_features = [VSX2]
@@ -106,6 +107,7 @@ max_features_dict = {
   's390x': S390X_FEATURES,
   'arm': ARM_FEATURES,
   'aarch64': ARM_FEATURES,
+  'wasm32': {},
 }.get(cpu_family, {})
 max_features = []
 foreach fet_name, fet_obj : max_features_dict

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -28,9 +28,9 @@ from numpy.exceptions import AxisError, ComplexWarning
 from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
-    assert_allclose, IS_PYPY, IS_PYSTON, HAS_REFCOUNT, assert_array_less,
-    runstring, temppath, suppress_warnings, break_cycles, _SUPPORTS_SVE,
-    assert_array_compare,
+    assert_allclose, IS_PYPY, IS_WASM, IS_PYSTON, HAS_REFCOUNT,
+    assert_array_less, runstring, temppath, suppress_warnings, break_cycles,
+    _SUPPORTS_SVE, assert_array_compare,
     )
 from numpy.testing._private.utils import requires_memory, _no_tracing
 from numpy._core.tests._locales import CommaDecimalPointLocale
@@ -8837,6 +8837,7 @@ class TestWhere:
             assert_equal(np.where(c[::-3], d[::-3], e[::-3]), r[::-3])
             assert_equal(np.where(c[1::-3], d[1::-3], e[1::-3]), r[1::-3])
 
+    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
     def test_exotic(self):
         # object
         assert_array_equal(np.where(True, None, None), np.array(None))

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -9,7 +9,7 @@ import pytest
 
 from numpy.dtypes import StringDType
 from numpy._core.tests._natype import pd_NA
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, IS_WASM
 
 
 @pytest.fixture
@@ -349,7 +349,7 @@ def _pickle_load(filename):
 
     return res
 
-
+@pytest.mark.skipif(IS_WASM, reason="no threading support in wasm")
 def test_pickle(dtype, string_list):
     arr = np.array(string_list, dtype=dtype)
 
@@ -864,6 +864,7 @@ def test_growing_strings(dtype):
     assert_array_equal(arr, uarr)
 
 
+@pytest.mark.skipif(IS_WASM, reason="no threading support in wasm")
 def test_threaded_access_and_mutation(dtype, random_string_list):
     # this test uses an RNG and may crash or cause deadlocks if there is a
     # threading bug

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -22,13 +22,6 @@ from numpy.testing import (
 from numpy.testing._private.utils import requires_memory
 
 
-import cython
-from packaging.version import parse, Version
-
-# Remove this when cython fixes https://github.com/cython/cython/issues/5411
-cython_version = parse(cython.__version__)
-BUG_5411 = Version("3.0.0a7") <= cython_version <= Version("3.0.0b3")
-
 UNARY_UFUNCS = [obj for obj in np._core.umath.__dict__.values()
                     if isinstance(obj, np.ufunc)]
 UNARY_OBJECT_UFUNCS = [uf for uf in UNARY_UFUNCS if "O->O" in uf.types]
@@ -214,9 +207,6 @@ class TestUfunc:
                    b"(S'numpy._core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
         assert_(pickle.loads(astring) is np.cos)
 
-    @pytest.mark.skipif(BUG_5411,
-        reason=("cython raises a AttributeError where it should raise a "
-                "ModuleNotFoundError"))
     @pytest.mark.skipif(IS_PYPY, reason="'is' check does not work on PyPy")
     def test_pickle_name_is_qualname(self):
         # This tests that a simplification of our ufunc pickle code will

--- a/numpy/f2py/tests/__init__.py
+++ b/numpy/f2py/tests/__init__.py
@@ -1,0 +1,8 @@
+from numpy.testing import IS_WASM
+import pytest
+
+if IS_WASM:
+    pytest.skip(
+        "WASM/Pyodide does not use or support Fortran",
+        allow_module_level=True
+    )

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -272,8 +272,9 @@ class CompilerChecker:
 
             self.compilers_checked = True
 
-checker = CompilerChecker()
-checker.check_compilers()
+if not IS_WASM:
+    checker = CompilerChecker()
+    checker.check_compilers()
 
 def has_c_compiler():
     return checker.has_c

--- a/numpy/tests/test_configtool.py
+++ b/numpy/tests/test_configtool.py
@@ -5,6 +5,8 @@ import sysconfig
 import pytest
 import numpy as np
 
+from numpy.testing import IS_WASM
+
 
 is_editable = not bool(np.__path__)
 numpy_in_sitepackages = sysconfig.get_path('platlib') in np.__file__
@@ -20,17 +22,17 @@ def check_numpyconfig(arg):
     p.check_returncode()
     return p.stdout.strip()
 
-
+@pytest.mark.skipif(IS_WASM, reason="wasm interpreter cannot start subprocess")
 def test_configtool_version():
     stdout = check_numpyconfig('--version')
     assert stdout == np.__version__
 
-
+@pytest.mark.skipif(IS_WASM, reason="wasm interpreter cannot start subprocess")
 def test_configtool_cflags():
     stdout = check_numpyconfig('--cflags')
     assert stdout.endswith(os.path.join('numpy', '_core', 'include'))
 
-
+@pytest.mark.skipif(IS_WASM, reason="wasm interpreter cannot start subprocess")
 def test_configtool_pkgconfigdir():
     stdout = check_numpyconfig('--pkgconfigdir')
     assert stdout.endswith(os.path.join('numpy', '_core', 'lib', 'pkgconfig'))

--- a/requirements/emscripten_test_requirements.txt
+++ b/requirements/emscripten_test_requirements.txt
@@ -1,0 +1,4 @@
+hypothesis==6.81.1
+pytest==7.4.0
+pytz==2023.3.post1
+pytest-xdist

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -8,7 +8,7 @@ pytest==7.4.0
 pytz==2023.3.post1
 pytest-cov==4.1.0
 meson
-ninja
+ninja; sys_platform != "emscripten"
 pytest-xdist
 # for numpy.random.test.test_extending
 cffi; python_version < '3.10'

--- a/tools/ci/emscripten/0001-do-not-set-meson-environment-variable-pyodide-gh-4502.patch
+++ b/tools/ci/emscripten/0001-do-not-set-meson-environment-variable-pyodide-gh-4502.patch
@@ -1,0 +1,55 @@
+From e08ebf0e90f632547c8ff5b396ec0c4ddd65aad4 Mon Sep 17 00:00:00 2001
+From: Gyeongjae Choi <def6488@gmail.com>
+Date: Sat, 10 Feb 2024 03:28:01 +0900
+Subject: [PATCH] Update numpy to 1.26.4 and don't set MESON env variable
+ (#4502)
+
+From meson-python 0.15, $MESON env variable is used to overwrite the meson binary
+path. We don't want that behavior.
+---
+ pypabuild.py | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/pypabuild.py b/pypabuild.py
+index 9d0107a8..6961b14e 100644
+--- a/pypabuild.py
++++ b/pypabuild.py
+@@ -40,6 +40,19 @@ AVOIDED_REQUIREMENTS = [
+     "patchelf",
+ ]
+ 
++# corresponding env variables for symlinks
++SYMLINK_ENV_VARS = {
++    "cc": "CC",
++    "c++": "CXX",
++    "ld": "LD",
++    "lld": "LLD",
++    "ar": "AR",
++    "gcc": "GCC",
++    "ranlib": "RANLIB",
++    "strip": "STRIP",
++    "gfortran": "FC",  # https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables
++}
++
+ 
+ def _gen_runner(
+     cross_build_env: Mapping[str, str],
+@@ -207,13 +220,8 @@ def make_command_wrapper_symlinks(symlink_dir: Path) -> dict[str, str]:
+             symlink_path.unlink()
+ 
+         symlink_path.symlink_to(pywasmcross_exe)
+-        if symlink == "c++":
+-            var = "CXX"
+-        elif symlink == "gfortran":
+-            var = "FC"  # https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables
+-        else:
+-            var = symlink.upper()
+-        env[var] = str(symlink_path)
++        if symlink in SYMLINK_ENV_VARS:
++            env[SYMLINK_ENV_VARS[symlink]] = str(symlink_path)
+ 
+     return env
+ 
+-- 
+2.39.3 (Apple Git-145)
+

--- a/tools/ci/emscripten/emscripten.meson.cross
+++ b/tools/ci/emscripten/emscripten.meson.cross
@@ -1,0 +1,15 @@
+# compiler paths are omitted intentionally so we can override the compiler using environment variables
+[binaries]
+exe_wrapper = 'node'
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This PR supersedes gh-24603. It adds a CI job to test NumPy v2.0.0.dev0 against a Pyodide (wasm32) runtime. Some of the key changes here are:

1. A patch has been added to the `ci/tools/emscripten/` directory based on an upstream change to Pyodide at https://github.com/pyodide/pyodide/pull/4502. This patch ensures that the correct Meson build system (i.e., `vendored-meson`) is found during the build process.
2. A new requirements file has been created that contains pure-Python dependencies that can be installed inside a Pyodide virtual environment. It has been placed in the same directory as above.
3. Some ancillary files have been added to ensure that the WASM wheel is compiled without specialised CPU instructions (SIMD, etc.) and that the build procedure does not need to build against BLAS or LAPACK, which are currently unavailable on WebAssembly.
4. Various tests have been skipped, such as:
    - All `f2py` tests, since Fortran cannot run in WASM
    - Some tests for `np.where()` that require floating point exception support
    - Some tests related to the use of subprocesses to retrieve configurations for how NumPy has been built
    - A bug in Cython, i.e., https://github.com/cython/cython/issues/5411, has now been resolved. The `import cython` line was breaking the test discovery because Cython is not supported in Pyodide in-tree yet.
    - and so on

Thanks to @rgommers and the notes provided on gh-24603, all tests pass! Here's a workflow run from my fork where they can be observed: https://github.com/agriyakhetarpal/numpy/actions/runs/8065629246