### PR TITLE
ENH: implement stringdtype <-> timedelta roundtrip casts

### DIFF
--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -415,7 +415,7 @@ NumPyOS_ascii_isupper(char c)
  *
  * Same as tolower under C locale
  */
-static int
+NPY_NO_EXPORT int
 NumPyOS_ascii_tolower(int c)
 {
     if (c >= 'A' && c <= 'Z') {

--- a/numpy/_core/src/common/numpyos.h
+++ b/numpy/_core/src/common/numpyos.h
@@ -50,6 +50,9 @@ NumPyOS_ascii_islower(char c);
 NPY_NO_EXPORT int
 NumPyOS_ascii_isupper(char c);
 
+NPY_NO_EXPORT int
+NumPyOS_ascii_tolower(char c);
+
 /* Convert a string to an int in an arbitrary base */
 NPY_NO_EXPORT npy_longlong
 NumPyOS_strtoll(const char *str, char **endptr, int base);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2535,7 +2535,6 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         /* Parse as an integer */
         else {
             char *strend = NULL;
-
             *out = strtol(str, &strend, 10);
             if (strend - str == len) {
                 succeeded = 1;

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -1426,8 +1426,8 @@ static char *dt2s_name = "cast_Datetime_to_StringDType";
 
 static int
 string_to_timedelta(PyArrayMethod_Context *context, char *const data[],
-                                       npy_intp const dimensions[], npy_intp const strides[],
-                   NpyAuxData *NPY_UNUSED(auxdata))
+                    npy_intp const dimensions[], npy_intp const strides[],
+                    NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
@@ -1540,7 +1540,7 @@ timedelta_to_string(PyArrayMethod_Context *context, char *const data[],
             else if (NpyString_pack_null(allocator, out_pss) < 0) {
                 npy_gil_error(
                         PyExc_MemoryError,
-                        "Failed to pack string in datetime to string cast");
+                        "Failed to pack string in timedelta to string cast");
                 goto fail;
             }
         }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import itertools
 import os
 import pickle
 import string
@@ -843,6 +844,14 @@ def test_datetime_cast(dtype):
         a = np.delete(a, 3)
 
     assert_array_equal(sa, a.astype("U"))
+
+
+def test_datetime_nat_casts():
+    s = 'nat'
+    all_nats = map(''.join, itertools.product(*zip(s.upper(), s.lower())))
+    arr = np.array([''] + list(all_nats), dtype=np.dtypes.StringDType())
+    NaT = np.datetime64('NaT')
+    assert_array_equal(arr.astype('M8[s]'), np.array([NaT] * arr.size))
 
 
 def test_growing_strings(dtype):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -884,10 +884,8 @@ def test_nat_casts():
         arr = np.array([''] + all_nats, dtype=dtype)
         dt_array = arr.astype('M8[s]')
         td_array = arr.astype('m8[s]')
-        assert_array_equal(
-            dt_array, np.array([NaT_dt] * arr.size, dtype='M8[s]'))
-        assert_array_equal(
-            td_array, np.array([NaT_td] * arr.size, dtype='m8[s]'))
+        assert_array_equal(dt_array, NaT_dt)
+        assert_array_equal(td_array, NaT_td)
 
         if na_object is np._NoValue:
             output_object = 'NaT'


### PR DESCRIPTION
I missed this cast before adding stringdtype to numpy. It turns out the pandas test suite expects this round-trip cast to work.

Note that this differs from the existing casts between timedelta and unicode string, which are (IMO) useless and kind of broken:

```
In [1]: import numpy as np

In [2]: arr = np.array([123, 456], dtype='m8[s]')

In [3]: arr.astype(str)
Out[3]: array(['123 seconds', '456 seconds'], dtype='<U21')

In [4]: arr = np.array([1234567891011121314, 456], dtype='m8[s]')

In [5]: arr.astype(str)
Out[5]: array(['1234567891011121314 s', '456 seconds'], dtype='<U21')
```

Not totally sure where `"U21"` is coming from, but even if there wasn't any truncation this still wouldn't roundtrip:

```
In [6]: arr = np.array([123, 456], dtype='m8[s]')

In [7]: arr.astype(str).astype('m8[s]')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[7], line 1
----> 1 arr.astype(str).astype('m8[s]')

ValueError: Could not convert object to NumPy timedelta
```

This happens because the numpy code for parsing strings as datetimes [only supports parsing strings as integers directly](https://github.com/numpy/numpy/blob/a53b0b3777a966554add1313e22b625638282192/numpy/_core/src/multiarray/datetime.c#L2535) (side note, the use of `strtol` there is almost certainly buggy under non-C locales, it also doesn't do any overflow checking).

I've chosen here to not touch those code paths and instead always output the string representation of integers or "NaT" and leave it up to the caller to deal with the timedelta unit metadata. This has the nice property that timedeltas roundtrip automatically as long as you specify the unit:

```
In [1]: import numpy as np

In [2]: arr = np.array([1234567891011121314, 456], dtype='m8[s]')

In [3]: arr.astype(np.dtypes.StringDType())
Out[3]: array(['1234567891011121314', '456'], dtype=StringDType())

In [4]: arr.astype(np.dtypes.StringDType()).astype(arr.dtype)
Out[4]: array([1234567891011121314,                 456], dtype='timedelta64[s]')
```