### PR TITLE
CI, MAINT: use `fetch-tags: true` to speed up NumPy checkouts

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,6 +1,3 @@
-# To enable this workflow on a fork, comment out:
-#
-# if: github.repository == 'numpy/numpy'
 name: Test on Cygwin
 on:
   pull_request:
@@ -18,14 +15,15 @@ permissions:
 jobs:
   cygwin_build_test:
     runs-on: windows-latest
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-tags: true
       - name: Install Cygwin
-        uses: egor-tensin/setup-cygwin@d2c752bab416d4b0662591bd366fc2686297c82d   #v4
+        uses: egor-tensin/setup-cygwin@d2c752bab416d4b0662591bd366fc2686297c82d # v4
         with:
           platform: x86_64
           install-dir: 'C:\tools\cygwin'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       pull-requests: write  # to add labels
     steps:
     - name: Label the PR

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   lint:
+    # To enable this job and subsequent jobs on a fork, comment out:
     if: github.repository == 'numpy/numpy' && github.event_name != 'push'
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -47,7 +48,8 @@ jobs:
         python tools/linter.py --branch origin/${{ github.base_ref }}
 
   smoke_test:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this job on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
@@ -55,7 +57,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
@@ -69,7 +71,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: 'pypy3.9-v7.3.12'
@@ -87,7 +89,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - name: Install debug Python
       run: |
         sudo apt-get update
@@ -116,7 +118,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
@@ -153,7 +155,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
@@ -184,7 +186,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -218,7 +220,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - name: Checkout array-api-tests
       uses: actions/checkout@v4
       with:
@@ -256,7 +258,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -54,7 +54,8 @@ permissions:
 
 jobs:
   openblas32_stable_nightly:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -66,7 +67,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -116,7 +117,7 @@ jobs:
 
 
   openblas_no_pkgconfig_fedora:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container: fedora:39
     name: "OpenBLAS (Fedora, no pkg-config, LP64/ILP64)"
@@ -128,7 +129,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Install dependencies
       run: |
@@ -151,7 +152,7 @@ jobs:
 
 
   flexiblas_fedora:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container: fedora:39
     name: "FlexiBLAS (LP64, ILP64 on Fedora)"
@@ -163,7 +164,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Install dependencies
       run: |
@@ -186,14 +187,14 @@ jobs:
 
 
   openblas_cmake:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     name: "OpenBLAS with CMake"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -214,14 +215,14 @@ jobs:
 
  
   netlib-debian:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     name: "Debian libblas/liblapack"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -243,7 +244,7 @@ jobs:
 
 
   netlib-split:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container: opensuse/tumbleweed
     name: "OpenSUSE Netlib BLAS/LAPACK"
@@ -257,7 +258,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Install PyPI dependencies
       run: |
@@ -274,14 +275,14 @@ jobs:
 
 
   mkl:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     name: "MKL (LP64, ILP64, SDL)"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -337,14 +338,14 @@ jobs:
       run: spin test -- numpy/linalg
 
   blis:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     name: "BLIS"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -373,14 +374,14 @@ jobs:
       run: spin test -- numpy/linalg
 
   atlas:
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     name: "ATLAS"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -22,13 +22,14 @@ permissions:
 
 jobs:
   gcc_sanitizers:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -19,7 +19,8 @@ permissions:
 jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc
@@ -34,11 +35,11 @@ jobs:
         # actions/checkout is used for the clone step in a container
 
         git config --global --add safe.directory $PWD 
-        
+
         if [ $GITHUB_EVENT_NAME != pull_request ]; then
             git clone --recursive --branch=$GITHUB_REF_NAME https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
             git reset --hard $GITHUB_SHA
-        else        
+        else
             git clone --recursive https://github.com/${GITHUB_REPOSITORY}.git $GITHUB_WORKSPACE
             git fetch origin $GITHUB_REF:my_ref_name
             git checkout $GITHUB_BASE_REF

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -28,7 +28,8 @@ permissions:
 
 jobs:
   linux_qemu:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
@@ -94,7 +95,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -52,7 +52,8 @@ permissions:
 
 jobs:
   baseline_only:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=none"
@@ -60,7 +61,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
@@ -77,7 +78,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.9'
@@ -141,7 +142,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: "${{ matrix.BUILD_PROP[2] }}"
@@ -155,7 +156,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'
@@ -209,7 +210,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: '3.11'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,8 @@ concurrency:
 jobs:
   x86_conda:
     name: macOS x86-64 conda
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -29,7 +30,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name:  Prepare cache dirs and timestamps
       id:    prep-ccache
@@ -102,7 +103,7 @@ jobs:
 
   accelerate:
     name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
-    if: "github.repository == 'numpy/numpy'"
+    if: github.repository == 'numpy/numpy'
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
       matrix:
@@ -114,7 +115,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -38,7 +38,8 @@ permissions:
 
 jobs:
   mypy:
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     name: "MyPy"
     runs-on: ${{ matrix.os_python[0] }}
     strategy:
@@ -51,7 +52,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
     - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: ${{ matrix.os_python[1] }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,7 +39,8 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this job and subsequent jobs on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
@@ -97,7 +98,7 @@ jobs:
           # fetch the complete history to get access to the tags.
           # A shallow clone can work when the following issue is resolved:
           # https://github.com/actions/checkout/issues/338
-          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup MSVC (32-bit)
         if: ${{ matrix.buildplat[1] == 'win32' }}
@@ -188,7 +189,7 @@ jobs:
           # fetch the complete history to get access to the tags.
           # A shallow clone can work when the following issue is resolved:
           # https://github.com/actions/checkout/issues/338
-          fetch-depth: 0
+          fetch-tags: true
       # Used to push the built wheels
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,8 @@ jobs:
   python64bit_openblas:
     name: x86-64, LP64 OpenBLAS
     runs-on: windows-2019
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this job on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     strategy:
       matrix:
         compiler: ["MSVC", "Clang-cl"]
@@ -26,7 +27,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Setup Python
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
@@ -79,13 +80,14 @@ jobs:
   msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS
     runs-on: windows-2019
-    if: "github.repository == 'numpy/numpy'"
+    # To enable this job on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Python (32-bit)
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This pull request performs the following changes:

1. It uses the `fetch-tags: true` input for the GitHub Actions checkout step for all of the workflows, which is faster and should save us some time (see [the Usage section of the documentation](https://github.com/actions/checkout?tab=readme-ov-file#usage) for `actions/checkout@v4.1.1`)
2. It de-quotes (but keeps) the condition:

```yaml
if: github.repository == 'numpy/numpy'
```

for disabling jobs on forks, wherever applicable – it removes some warnings related to the JSON schema for GitHub Actions that were being raised in my text editor; i.e., Visual Studio Code.
3. In some locations, some missing comments have been added that prompt users to comment out the condition in point 2 to run it on their forks. This has not been done for smaller jobs, and mostly for jobs with longer durations.

This was requested in the code review stage in gh-25894
