### PR TITLE
BLD: Add meson check to test presence of pocketfft git submodule

### DIFF
--- a/numpy/fft/meson.build
+++ b/numpy/fft/meson.build
@@ -3,6 +3,10 @@ if host_machine.system() == 'aix' or host_machine.system() == 'AIX'
   largefile_define += '-D_LARGE_FILES'
 endif
 
+if not fs.exists('pocketfft/README.md')
+  error('Missing the `pocketfft` git submodule! Run `git submodule update --init` to fix this.')
+endif
+
 py.extension_module('_pocketfft_umath',
   ['_pocketfft_umath.cpp'],
   c_args: largefile_define,


### PR DESCRIPTION
Took me some time to figure out why I was getting a new build error: 

`numpy/fft/_pocketfft_umath.cpp:24:10: fatal error: pocketfft/pocketfft_hdronly.h: No such file or directory`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
