### PR TITLE
BUG: Ensure correct handling of multidimensional q by nanquantile

### DIFF
--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1655,10 +1655,10 @@ def _nanquantile_ureduce_func(
         # convention.
         if q.ndim != 0:
             #GH-25731
-            num_dims = len(a.shape)+len(q.shape)-1
-            new_axes = list(range(len(q.shape), num_dims))
-            new_axes[axis:axis] = range(len(q.shape)) 
-            result = np.moveaxis(result, 
+            num_dims = a.ndim + q.ndim - 1
+            new_axes = list(range(q.ndim, num_dims))
+            new_axes[axis:axis] = range(q.ndim)
+            result = np.moveaxis(result,
                                  source=range(num_dims), destination=new_axes)
     if out is not None:
         out[...] = result

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1265,14 +1265,22 @@ class TestNanFunctions_Quantile:
                      np.nanpercentile(ar, q=[50], axis=1, **w_args))
         assert_equal(np.nanquantile(ar, q=[0.25, 0.5, 0.75], axis=1, **w_args),
                      np.nanpercentile(ar, q=[25, 50, 75], axis=1, **w_args))
-    
-    @pytest.mark.parametrize(argnames='axis', 
-        argvalues=[1, (1, ), 2, (0, 2), -1, (-1, -2)])
-    def test_consistency_with_quantile(self, axis):
-        a = np.arange(42).reshape(3, 7, 2).astype(float)
+
+    @pytest.mark.parametrize(argnames='axis',
+         argvalues=[None, 0, 1, (1, ), 2, (0, 2), -1, (-1, -2)])
+    @pytest.mark.parametrize(argnames='shape',
+                             argvalues=[(42, ), (3, 7, 2)])
+    def test_consistency_with_quantile(self, shape, axis):
+        a = np.arange(np.prod(shape)).reshape(shape).astype(float)
+        if a.ndim == 1 and axis not in (None, 0, -1):
+            pytest.skip(f"Skipping test for {a.ndim}-D array"
+                        f" with incompatible axis {axis}")
+
         q = np.full((3, 2), 0.5)
-        assert_equal(np.nanquantile(a, q, axis=axis).shape, 
-                      np.quantile(a, q, axis=axis).shape)
+        assert_equal(np.nanquantile(a, q, axis=axis).shape,
+                     np.quantile(a, q, axis=axis).shape)
+        assert_equal(np.nanquantile(a, q, axis=axis),
+                     np.quantile(a, q, axis=axis))
 
     def test_basic(self):
         x = np.arange(8) * 0.5

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1266,22 +1266,14 @@ class TestNanFunctions_Quantile:
         assert_equal(np.nanquantile(ar, q=[0.25, 0.5, 0.75], axis=1, **w_args),
                      np.nanpercentile(ar, q=[25, 50, 75], axis=1, **w_args))
     
-    def test_consistency_with_quantile(self):
+    @pytest.mark.parametrize(argnames='axis', 
+        argvalues=[1, (1, ), 2, (0, 2), -1, (-1, -2)])
+    def test_consistency_with_quantile(self, axis):
         a = np.arange(42).reshape(3, 7, 2).astype(float)
         q = np.full((3, 2), 0.5)
-        assert_equal(np.nanquantile(a, q, axis=1).shape, 
-                      np.quantile(a, q, axis=1).shape)
-        assert_almost_equal(np.nanquantile(a, q, axis=1).shape, 
-                      np.quantile(a, q, axis=1).shape)
-        assert_equal(np.nanquantile(a, q, axis=2).shape, 
-                      np.quantile(a, q, axis=2).shape)
-        assert_almost_equal(np.nanquantile(a, q, axis=2).shape, 
-                              np.quantile(a, q, axis=2).shape) 
-        assert_equal(np.nanquantile(a, q, axis=(0, 2)).shape, 
-                      np.quantile(a, q, axis=(0, 2)).shape)
-        assert_almost_equal(np.nanquantile(a, q, axis=(0, 2)).shape,
-                              np.quantile(a, q, axis=(0, 2)).shape)
-
+        assert_equal(np.nanquantile(a, q, axis=axis).shape, 
+                      np.quantile(a, q, axis=axis).shape)
+        
     def test_basic(self):
         x = np.arange(8) * 0.5
         assert_equal(np.nanquantile(x, 0), 0.)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1265,6 +1265,20 @@ class TestNanFunctions_Quantile:
                      np.nanpercentile(ar, q=[50], axis=1, **w_args))
         assert_equal(np.nanquantile(ar, q=[0.25, 0.5, 0.75], axis=1, **w_args),
                      np.nanpercentile(ar, q=[25, 50, 75], axis=1, **w_args))
+    
+    def test_consistency_with_quantile(self):
+        a = np.arange(42).reshape(3, 7, 2).astype(float)
+        q = np.full((3, 2), 0.5)
+        assert_equal(np.nanquantile(np.ones((3,4)), q=np.full((1,2),0.5), axis=1).shape,
+                      np.quantile(np.ones((3,4)), q=np.full((1,2),0.5), axis=1).shape)
+        assert_equal(np.nanquantile(a, q, axis=2).shape,
+                      np.quantile(a, q, axis=2).shape)
+        assert_almost_equal(np.nanquantile(a, q, axis=2).shape,
+                              np.quantile(a, q, axis=2).shape) 
+        assert_equal(np.nanquantile(a, q, axis=(0,2)).shape,
+                      np.quantile(a, q, axis=(0,2)).shape)
+        assert_almost_equal(np.nanquantile(a, q, axis=(0,2)).shape,
+                              np.quantile(a, q, axis=(0,2)).shape)
 
     def test_basic(self):
         x = np.arange(8) * 0.5

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1269,16 +1269,18 @@ class TestNanFunctions_Quantile:
     def test_consistency_with_quantile(self):
         a = np.arange(42).reshape(3, 7, 2).astype(float)
         q = np.full((3, 2), 0.5)
-        assert_equal(np.nanquantile(np.ones((3,4)), q=np.full((1,2),0.5), axis=1).shape,
-                      np.quantile(np.ones((3,4)), q=np.full((1,2),0.5), axis=1).shape)
-        assert_equal(np.nanquantile(a, q, axis=2).shape,
+        assert_equal(np.nanquantile(a, q, axis=1).shape, 
+                      np.quantile(a, q, axis=1).shape)
+        assert_almost_equal(np.nanquantile(a, q, axis=1).shape, 
+                      np.quantile(a, q, axis=1).shape)
+        assert_equal(np.nanquantile(a, q, axis=2).shape, 
                       np.quantile(a, q, axis=2).shape)
-        assert_almost_equal(np.nanquantile(a, q, axis=2).shape,
+        assert_almost_equal(np.nanquantile(a, q, axis=2).shape, 
                               np.quantile(a, q, axis=2).shape) 
-        assert_equal(np.nanquantile(a, q, axis=(0,2)).shape,
-                      np.quantile(a, q, axis=(0,2)).shape)
-        assert_almost_equal(np.nanquantile(a, q, axis=(0,2)).shape,
-                              np.quantile(a, q, axis=(0,2)).shape)
+        assert_equal(np.nanquantile(a, q, axis=(0, 2)).shape, 
+                      np.quantile(a, q, axis=(0, 2)).shape)
+        assert_almost_equal(np.nanquantile(a, q, axis=(0, 2)).shape,
+                              np.quantile(a, q, axis=(0, 2)).shape)
 
     def test_basic(self):
         x = np.arange(8) * 0.5


### PR DESCRIPTION
Fixes #25731.
Key changes applied to the following function `def _nanquantile_ureduce_func()` in `/numpy/lib/_nanfunctions_impl.py`
In particular the results from `result = _nanquantile_1d(part, q, overwrite_input, method, weights=wgt)` were not being reshaped properly. Tests passed on local plus contributed additional test to `numpy/lib/tests/test_nanfunctions.py` to validate consistent behavior between quantile and nanquantile. 
Some additional details included below to facilitate code-review.
Original behavior that was highlighted in #25731.

```
a = np.ones((3, 4))
q = np.full((1, 2), 0.5)
 
print(np.quantile(a, q, axis=1).shape)
# (1, 2, 3)  correct
print(np.nanquantile(a, q, axis=1).shape)
# (1, 3, 2) mangled up
```
To ensure consistent behavior with `np.quantile/np.percentile` the axes contributed by `q` should end up at the beginning of the result. 

The key issue was `def _nanquantile_ureduce_func()` in `/numpy/lib/_nanfunctions_impl.py`.  All the computations seem correct (in my understanding), up untill `result = _nanquantile_1d(part, q, overwrite_input, method, weights=wgt)`. After this, the `result` was being reshaped using `result = np.moveaxis(result, axis, 0)`. This resulted in the mangled up shape highlighted in the original bug.

The proposed solution explicitly computes the locations of axis, before applying `np.moveaxis`
```
num_dims = len(a.shape)+len(q.shape)-1
new_axes = list(range(len(q.shape), num_dims))
new_axes[axis:axis] = range(len(q.shape)) 
result = np.moveaxis(result, source=range(num_dims), destination=new_axes)
```
Now, the return values and shapes of `np.nanquantile` are consistent with `np.quantile`. This has been verified using newly contributed tests included in `test_consistency_with_quantile` in `numpy/lib/tests/test_nanfunctions.py`. Furthermore, all pre-existing tests pass. 