### PR TITLE
CI: allow job matrixes to run all jobs even when one fails

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -58,6 +58,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         USE_NIGHTLY_OPENBLAS: [false, true]
     env:

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         BUILD_PROP:
           - [

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -111,6 +111,7 @@ jobs:
     if: github.event_name != 'push'
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         BUILD_PROP:
           - [

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11"]
 
@@ -106,6 +107,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
+      fail-fast: false
       matrix:
         build_runner:
           - [ macos-13, "macos_x86_64" ]

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -43,6 +43,7 @@ jobs:
     name: "MyPy"
     runs-on: ${{ matrix.os_python[0] }}
     strategy:
+      fail-fast: false
       matrix:
         os_python:
           - [ubuntu-latest, '3.12']

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,7 @@ jobs:
     # To enable this job on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     strategy:
+      fail-fast: false
       matrix:
         compiler: ["MSVC", "Clang-cl"]
     steps:


### PR DESCRIPTION
It is annoying to have CI jobs canceled when another job in the matrix fails. This adds `fail-fast: false` to all the github CI matrixes.

I discovered this when looking at the OpenBLAS nightly build failures, which canceled the other non-nightly job in the matrix.