### PR TITLE
NEP: update status fields of many NEPs

### DIFF
--- a/doc/neps/meta.rst.tmpl
+++ b/doc/neps/meta.rst.tmpl
@@ -1,5 +1,5 @@
-Meta-NEPs (NEPs about NEPs or Processes)
-----------------------------------------
+Meta-NEPs (NEPs about NEPs or active Processes)
+-----------------------------------------------
 
 .. toctree::
    :maxdepth: 1

--- a/doc/neps/nep-0021-advanced-indexing.rst
+++ b/doc/neps/nep-0021-advanced-indexing.rst
@@ -6,7 +6,7 @@ NEP 21 — Simplified and explicit advanced indexing
 
 :Author: Sebastian Berg
 :Author: Stephan Hoyer <shoyer@google.com>
-:Status: Draft
+:Status: Deferred
 :Type: Standards Track
 :Created: 2015-08-27
 

--- a/doc/neps/nep-0023-backwards-compatibility.rst
+++ b/doc/neps/nep-0023-backwards-compatibility.rst
@@ -5,7 +5,7 @@ NEP 23 — Backwards compatibility and deprecation policy
 =======================================================
 
 :Author: Ralf Gommers <ralf.gommers@gmail.com>
-:Status: Final
+:Status: Active
 :Type: Process
 :Created: 2018-07-14
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2021-January/081423.html

--- a/doc/neps/nep-0030-duck-array-protocol.rst
+++ b/doc/neps/nep-0030-duck-array-protocol.rst
@@ -6,11 +6,12 @@ NEP 30 — Duck typing for NumPy arrays - implementation
 
 :Author: Peter Andreas Entschev <pentschev@nvidia.com>
 :Author: Stephan Hoyer <shoyer@google.com>
-:Status: Draft
+:Status: Superseded
+:Replaced-By: 56
 :Type: Standards Track
 :Created: 2019-07-31
 :Updated: 2019-07-31
-:Resolution:
+:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/
 
 Abstract
 --------

--- a/doc/neps/nep-0031-uarray.rst
+++ b/doc/neps/nep-0031-uarray.rst
@@ -7,9 +7,11 @@ NEP 31 — Context-local and global overrides of the NumPy API
 :Author: Hameer Abbasi <habbasi@quansight.com>
 :Author: Ralf Gommers <rgommers@quansight.com>
 :Author: Peter Bell <pbell@quansight.com>
-:Status: Draft
+:Status: Superseded
+:Replaced-By: 56
 :Type: Standards Track
 :Created: 2019-08-22
+:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/
 
 
 Abstract

--- a/doc/neps/nep-0036-fair-play.rst
+++ b/doc/neps/nep-0036-fair-play.rst
@@ -5,7 +5,7 @@ NEP 36 — Fair play
 ==================
 
 :Author: Stéfan van der Walt <stefanv@berkeley.edu>
-:Status: Accepted
+:Status: Active
 :Type: Informational
 :Created: 2019-10-24
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2021-June/081890.html

--- a/doc/neps/nep-0037-array-module.rst
+++ b/doc/neps/nep-0037-array-module.rst
@@ -7,9 +7,12 @@ NEP 37 — A dispatch protocol for NumPy-like modules
 :Author: Stephan Hoyer <shoyer@google.com>
 :Author: Hameer Abbasi
 :Author: Sebastian Berg
-:Status: Draft
+:Status: Superseded
+:Replaced-By: 56
 :Type: Standards Track
 :Created: 2019-12-29
+:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/
+
 
 Abstract
 --------

--- a/doc/neps/nep-0038-SIMD-optimizations.rst
+++ b/doc/neps/nep-0038-SIMD-optimizations.rst
@@ -5,7 +5,7 @@ NEP 38 — Using SIMD optimization instructions for performance
 =============================================================
 
 :Author: Sayed Adel, Matti Picus, Ralf Gommers
-:Status: Accepted
+:Status: Final
 :Type: Standards
 :Created: 2019-11-25
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB/#PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB

--- a/doc/neps/nep-0045-c_style_guide.rst
+++ b/doc/neps/nep-0045-c_style_guide.rst
@@ -5,7 +5,7 @@ NEP 45 — C style guide
 =================================
 
 :Author: Charles Harris <charlesr.harris@gmail.com>
-:Status: Accepted
+:Status: Active
 :Type: Process
 :Created: 2012-02-26
 :Resolution: https://github.com/numpy/numpy/issues/11911

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -5,7 +5,7 @@ NEP 46 — NumPy sponsorship guidelines
 =====================================
 
 :Author: Ralf Gommers <ralf.gommers@gmail.com>
-:Status: Accepted
+:Status: Active
 :Type: Process
 :Created: 2020-12-27
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2021-January/081424.html

--- a/doc/neps/nep-0047-array-api-standard.rst
+++ b/doc/neps/nep-0047-array-api-standard.rst
@@ -11,7 +11,7 @@ NEP 47 — Adopting the array API standard
 :Replaced-By: 56
 :Type: Standards Track
 :Created: 2021-01-21
-:Resolution:
+:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/
 
 .. note::
 

--- a/doc/neps/nep-0048-spending-project-funds.rst
+++ b/doc/neps/nep-0048-spending-project-funds.rst
@@ -7,7 +7,7 @@ NEP 48 — Spending NumPy project funds
 :Author: Ralf Gommers <ralf.gommers@gmail.com>
 :Author: Inessa Pawson <inessa@albuscode.org>
 :Author: Stefan van der Walt <stefanv@berkeley.edu>
-:Status: Draft
+:Status: Active
 :Type: Informational
 :Created: 2021-02-07
 :Resolution:

--- a/doc/neps/nep-0056-array-api-main-namespace.rst
+++ b/doc/neps/nep-0056-array-api-main-namespace.rst
@@ -7,8 +7,8 @@ NEP 56 — Array API standard support in NumPy's main namespace
 :Author: Ralf Gommers <ralf.gommers@gmail.com>
 :Author: Mateusz Sokół <msokol@quansight.com>
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>
-:Status: Draft
-:Replaces: 47
+:Status: Accepted
+:Replaces: 30, 31, 37, 47
 :Type: Standards Track
 :Created: 2023-12-19
 :Resolution: TODO mailing list link (after acceptance)

--- a/doc/neps/tools/build_index.py
+++ b/doc/neps/tools/build_index.py
@@ -84,22 +84,36 @@ def nep_metadata():
                     f"no Replaces tag."
                 )
 
-            if not int(replacement_nep['Replaces']) == nr:
+            if nr not in parse_replaces_metadata(replacement_nep):
                 raise RuntimeError(
                     f'NEP {nr} is superseded by {replaced_by}, but that NEP has a '
                     f"Replaces tag of `{replacement_nep['Replaces']}`."
                 )
 
         if 'Replaces' in tags:
-            replaced_nep = int(tags['Replaces'])
-            replaced_nep_tags = neps[replaced_nep]
-            if not replaced_nep_tags['Status'] == 'Superseded':
-                raise RuntimeError(
-                    f'NEP {nr} replaces {replaced_nep}, but that NEP has not '
-                    f'been set to Superseded'
-                )
+            replaced_neps = parse_replaces_metadata(tags)
+            for nr_replaced in replaced_neps:
+                replaced_nep_tags = neps[nr_replaced]
+                if not replaced_nep_tags['Status'] == 'Superseded':
+                    raise RuntimeError(
+                        f'NEP {nr} replaces NEP {nr_replaced}, but that NEP '
+                        'has not been set to Superseded'
+                    )
 
     return {'neps': neps, 'has_provisional': has_provisional}
+
+
+def parse_replaces_metadata(replacement_nep):
+    """Handle :Replaces: as integer or list of integers"""
+    replaces = replacement_nep['Replaces']
+    if ' ' in replaces:
+        # Replaces multiple NEPs, should be comma-separated ints
+        replaced_neps = [int(s) for s in replaces.split(', ')]
+    else:
+        replaced_neps = [int(replaces)]
+
+    return replaced_neps
+
 
 meta = nep_metadata()
 


### PR DESCRIPTION
The first commit marks NEPs 30, 31, 37, and 47 as superseded (by NEP 56), and NEP 56 as accepted, since it's done and 99.x% implemented. The NEP doc build tooling needed a small update to allow the metadata in one NEP to list several others in `:Replaces:`.

The second commit updates the status of active process NEPs, marks NEP 21 as deferred, and NEP 38 as final:
 
- We marked process NEPs as Accepted/Final so far, but the intent of policy/process NEPs that still apply and can be updated when we update our development processes or project policies is that they are marked as Active, so they show up under "Meta-NEPs".  
- NEP 21 (oindex/vindex) is still considered perhaps a good idea, but hasn't been touched in many years (it's from 2015), so mark it as Deferred.
- NEP 38 (SIMD) was finished several years ago, so mark it as Final.

Overall this should give a better picture of the current state of development and thinking. There are only four NEPs left under Draft, and NEP 50 (type promotion) and NEP (C API changes for 2.0) should be moving to Accepted soon as well. I chose not to touch those, since for NEP 50 there is still a fair bit in flight, and NEP 53 seems to need some updates for what was actually implemented (at a high level, forexample a compat header rather than a separate library).

I'll send an email to the mailing list about this PR.