### PR TITLE
BUG: fix handling of copy keyword argument when calling __array__

### DIFF
--- a/doc/release/upcoming_changes/25168.change.rst
+++ b/doc/release/upcoming_changes/25168.change.rst
@@ -7,3 +7,15 @@ Now `numpy.array` and `numpy.asarray` support three values for ``copy`` paramete
 * ``False`` - Never make a copy. If a copy is required a ``ValueError`` is raised.
 
 The meaning of ``False`` changed as it now raises an exception if a copy is needed.
+
+The ``__array__`` special method now takes a ``copy`` keyword argument.
+-----------------------------------------------------------------------
+
+NumPy will pass ``copy`` to the ``__array__`` special method in situations where
+it would be set to a non-default value (e.g. in a call to
+``np.asarray(some_object, copy=False)``). Currently, if an
+unexpected keyword argument error is raised after this, NumPy will print a
+warning and re-try without the ``copy`` keyword argument. Implementations of
+objects implementing the ``__array__`` protocol should accept a ``copy`` keyword
+argument with the same meaning as when passed to `numpy.array` or
+`numpy.asarray`.

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -958,7 +958,8 @@ PyArray_AdaptDescriptorToArray(
  *        (Initially it is a pointer to the user-provided head pointer).
  * @param fixed_DType User provided fixed DType class
  * @param flags Discovery flags (reporting and behaviour flags, see def.)
- * @param never_copy Specifies if a copy is allowed during array creation.
+ * @param copy Specifies the copy behavior. -1 is corresponds to copy=None,
+ *        0 to copy=False, and 1 to copy=True in the Python API.
  * @return The updated number of maximum dimensions (i.e. scalars will set
  *         this to the current dimensions).
  */
@@ -968,7 +969,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj ***coercion_cache_tail_ptr,
         PyArray_DTypeMeta *fixed_DType, enum _dtype_discovery_flags *flags,
-        int never_copy)
+        int copy)
 {
     PyArrayObject *arr = NULL;
     PyObject *seq;
@@ -1026,7 +1027,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
             requested_descr = *out_descr;
         }
         arr = (PyArrayObject *)_array_from_array_like(obj,
-                requested_descr, 0, NULL, never_copy);
+                requested_descr, 0, NULL, copy);
         if (arr == NULL) {
             return -1;
         }
@@ -1173,7 +1174,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         max_dims = PyArray_DiscoverDTypeAndShape_Recursive(
                 objects[i], curr_dims + 1, max_dims,
                 out_descr, out_shape, coercion_cache_tail_ptr, fixed_DType,
-                flags, never_copy);
+                flags, copy);
 
         if (max_dims < 0) {
             return -1;
@@ -1213,7 +1214,8 @@ PyArray_DiscoverDTypeAndShape_Recursive(
  *        The result may be unchanged (remain NULL) when converting a
  *        sequence with no elements. In this case it is callers responsibility
  *        to choose a default.
- * @param never_copy Specifies that a copy is not allowed.
+ * @param copy Specifies the copy behavior. -1 is corresponds to copy=None,
+ *        0 to copy=False, and 1 to copy=True in the Python API.
  * @return dimensions of the discovered object or -1 on error.
  *         WARNING: If (and only if) the output is a single array, the ndim
  *         returned _can_ exceed the maximum allowed number of dimensions.
@@ -1226,7 +1228,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr, int never_copy)
+        PyArray_Descr **out_descr, int copy)
 {
     coercion_cache_obj **coercion_cache_head = coercion_cache;
     *coercion_cache = NULL;
@@ -1273,7 +1275,7 @@ PyArray_DiscoverDTypeAndShape(
 
     int ndim = PyArray_DiscoverDTypeAndShape_Recursive(
             obj, 0, max_dims, out_descr, out_shape, &coercion_cache,
-            fixed_DType, &flags, never_copy);
+            fixed_DType, &flags, copy);
     if (ndim < 0) {
         goto fail;
     }

--- a/numpy/_core/src/multiarray/array_coercion.h
+++ b/numpy/_core/src/multiarray/array_coercion.h
@@ -40,7 +40,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr, int never_copy);
+        PyArray_Descr **out_descr, int copy);
 
 NPY_NO_EXPORT PyObject *
 _discover_array_parameters(PyObject *NPY_UNUSED(self),

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -251,7 +251,7 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      */
     ndim = PyArray_DiscoverDTypeAndShape(src_object,
             PyArray_NDIM(dest), dims, &cache,
-            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, 0);
+            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, 1);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -119,7 +119,7 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, PyArray_Descr **out_dtype)
     int ndim;
 
     ndim = PyArray_DiscoverDTypeAndShape(
-            obj, maxdims, shape, &cache, NULL, NULL, out_dtype, 0);
+            obj, maxdims, shape, &cache, NULL, NULL, out_dtype, 1);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2465,18 +2465,16 @@ PyArray_FromArrayAttr_int(
     new = PyObject_Call(array_meth, args, kwargs);
 
     if (new == NULL) {
-        PyObject *errmsg_substr = PyUnicode_FromString(
-                "__array__() got an unexpected keyword argument 'copy'");
-        if (errmsg_substr == NULL) {
+        if (npy_ma_str_array_err_msg_substr == NULL) {
             return NULL;
         }
         PyObject *type, *value, *traceback;
         PyErr_Fetch(&type, &value, &traceback);
-        if (PyUnicode_Check(value) && PyUnicode_Contains(value, errmsg_substr) > 0) {
+        if ((PyUnicode_Check(value) &&
+             PyUnicode_Contains(value, npy_ma_str_array_err_msg_substr) > 0)) {
             Py_DECREF(type);
             Py_XDECREF(value);
             Py_XDECREF(traceback);
-            Py_DECREF(errmsg_substr);
             if (PyErr_WarnEx(PyExc_UserWarning,
                              "__array__ should implement 'dtype' and 'copy' keywords", 1) < 0) {
                 return NULL;
@@ -2491,7 +2489,6 @@ PyArray_FromArrayAttr_int(
             }
         } else {
             PyErr_Restore(type, value, traceback);
-            Py_DECREF(errmsg_substr);
             Py_DECREF(kwargs);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/ctors.h
+++ b/numpy/_core/src/multiarray/ctors.h
@@ -51,7 +51,7 @@ PyArray_New(
 NPY_NO_EXPORT PyObject *
 _array_from_array_like(PyObject *op,
         PyArray_Descr *requested_dtype, npy_bool writeable, PyObject *context,
-        int never_copy);
+        int copy);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
@@ -82,7 +82,7 @@ PyArray_FromInterface(PyObject *input);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr_int(
-        PyObject *op, PyArray_Descr *descr, int never_copy);
+        PyObject *op, PyArray_Descr *descr, int copy);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4787,7 +4787,7 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_convert = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_preserve = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_convert_if_no_array = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_cpu = NULL;
-
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_err_msg_substr = NULL;
 
 static int
 intern_strings(void)
@@ -4863,6 +4863,11 @@ intern_strings(void)
     }
     npy_ma_str_cpu = PyUnicode_InternFromString("cpu");
     if (npy_ma_str_cpu == NULL) {
+        return -1;
+    }
+    npy_ma_str_array_err_msg_substr = PyUnicode_InternFromString(
+            "__array__() got an unexpected keyword argument 'copy'");
+    if (npy_ma_str_array_err_msg_substr == NULL) {
         return -1;
     }
     return 0;

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -19,5 +19,6 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_preserve;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */


### PR DESCRIPTION
Closes #25916.

This applies @rgommers draft changes from the issue description and adds a couple more fixes on top.

* Replaces internal usages of `never_copy` with `copy` that can be `-1` (corresponding to `None`), `0` (`False`), and `1` (`True`). This allows the array coercion machinery and `PyArray_FromArrayAttr_int` to support passing `copy=True` (although right now that will never happen).

* Only passes a copy keyword if copy is not the default value.

* Fixes a bug in checking for the error message

* Removes an incorrect usage of `Py_SetRef` (sorry about suggesting that in the first place 😬 )

* Fixes some reference counting issues

* Tests that the old deprecated calling convention still works.