### PR TITLE
BUG: remove vestiges of array_api [wheel build]

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -367,8 +367,8 @@ else:
             import numpy.char as char
             return char
         elif attr == "array_api":
-            import numpy.array_api as array_api
-            return array_api
+            raise AttributeError("`numpy.array_api` is not available from "
+                                 "numpy 2.0 onwards")
         elif attr == "core":
             import numpy.core as core
             return core

--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -142,13 +142,6 @@ class PytestTester:
                 # so fetch module for suppression here.
                 from numpy.distutils import cpuinfo
 
-        with warnings.catch_warnings(record=True):
-            # Ignore the warning from importing the array_api submodule. This
-            # warning is done on import, so it would break pytest collection,
-            # but importing it early here prevents the warning from being
-            # issued when it imported again.
-            import numpy.array_api
-
         # Filter out annoying import messages. Want these in both develop and
         # release mode.
         pytest_args += [


### PR DESCRIPTION
Fixes #25923 by removing unneeded work-around for `array_api` warning.

This is only seen in wheel building, since only there do we do `numpy.test()`