### PR TITLE
DOC: Add note about np.char & np.strings in 2.0 migration guide

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -287,6 +287,16 @@ setitem                 Use ``arr[index] = value`` instead.
 ======================  ========================================================
 
 
+Strings namespace
+-----------------
+
+A new ``np.strings`` namespace has been created, where most of the string
+operations are implemented as ufuncs. The old ``np.char`` namespace still is
+available, and, wherever possible, uses the new ufuncs for greater performance.
+We recommend using the ``np.strings`` methods going forward. The ``np.char``
+namespace may be deprecated in the future.
+
+
 Ruff plugin
 -----------
 


### PR DESCRIPTION
Related to #25142.

The release notes already mention the creation of `np.strings` and the fact that `np.char` uses the new ufuncs from #25463. Adding a note to the migration guide as well suggesting to move to using `np.strings` methods for string manipulation.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
