### PR TITLE
TST: skip rather than xfail a few tests to address CI log pollution

### DIFF
--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -190,7 +190,7 @@ class TestNonarrayArgs:
 
     @pytest.mark.parametrize('val, ndigits', [
         pytest.param(2**31 - 1, -1,
-            marks=pytest.mark.xfail(reason="Out of range of int32")
+            marks=pytest.mark.skip(reason="Out of range of int32")
         ),
         (2**31 - 1, 1-math.ceil(math.log10(2**31 - 1))),
         (2**31 - 1, -math.ceil(math.log10(2**31 - 1)))

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -560,7 +560,7 @@ def test_debugcapi(capfd, hello_world_f90, monkeypatch):
             assert r"#define DEBUGCFUNCS" in ocmod.read()
 
 
-@pytest.mark.xfail(reason="Consistently fails on CI.")
+@pytest.mark.skip(reason="Consistently fails on CI; noisy so skip not xfail.")
 def test_debugcapi_bld(hello_world_f90, monkeypatch):
     """Ensures that debugging wrappers work
 
@@ -732,7 +732,7 @@ def test_version(capfd, monkeypatch):
         assert np.__version__ == out.strip()
 
 
-@pytest.mark.xfail(reason="Consistently fails on CI.")
+@pytest.mark.skip(reason="Consistently fails on CI; noisy so skip not xfail.")
 def test_npdistop(hello_world_f90, monkeypatch):
     """
     CLI :: -c


### PR DESCRIPTION
When problematic tests get xfailed, they still run. In our regular CI jobs we run tests in a way that picks up the `pytest.ini` file in the root of the repo - that is used to silence noise from such tests. In the wheel build jobs, this silencing doesn't happen and hence pytest prints warnings it sees at the bottom of the test output. In the current wheel builds, this is ~2 pages of warnings.

The solution is straightforward: skip these tests instead (there's not much point continuing to run them anyway).

For the `f2py` tests I also tried using the `capfd` and `capsys` fixtures, as is done for other tests. However, a problem is that you must use one or the other, you can't use both. This may make it impossible to capture everything.

Note that I skipped CI because noise isn't visible there anyway. The improvement can be verified easily locally by deleting `pytest.ini` and then running these tests (e.g., `spin test -- numpy/f2py/tests/test_f2py2e.py`.

Output from a recent CI log:

<details>

```
=============================== warnings summary ===============================
../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127
../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127
../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127
../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127
../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127
  /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127: DeprecationWarning: 
  
    `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
    of the deprecation of `distutils` itself. It will be removed for
    Python >= 3.12. For older Python versions it will remain present.
    It is recommended to use `setuptools < 60.0` for those Python versions.
    For more details, see:
      https://numpy.org/devdocs/reference/distutils_status_migration.html 
  
  
    return _bootstrap._gcd_import(name[level:], package, level)
../venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66
../venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66
../venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66
../venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66
../venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/setuptools/_distutils/msvccompiler.py:66: DeprecationWarning: msvccompiler is deprecated and slated to be removed in the future. Please discontinue use or file an issue with pypa/distutils describing your use case.
    warnings.warn(
f2py/tests/test_f2py2e.py::test_debugcapi_bld
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/setuptools/sandbox.py:13: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources
f2py/tests/test_f2py2e.py::test_debugcapi_bld
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/distutils/command/build_ext.py:8: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
    from distutils.dep_util import newer_group
f2py/tests/test_f2py2e.py::test_debugcapi_bld
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/distutils/command/build_clib.py:11: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
    from distutils.dep_util import newer_group
f2py/tests/test_f2py2e.py::test_debugcapi_bld
f2py/tests/test_f2py2e.py::test_debugcapi_bld
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/distutils/command/build_src.py:10: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
    from distutils.dep_util import newer_group, newer
f2py/tests/test_f2py2e.py::test_debugcapi_bld
f2py/tests/test_f2py2e.py::test_npdistop
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/f2py/f2py2e.py:718: VisibleDeprecationWarning: distutils has been deprecated since NumPy 1.26.xUse the Meson backend instead, or generate wrapperswithout -c and use a custom build script
    builder = build_backend(
f2py/tests/test_f2py2e.py::test_debugcapi_bld
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
  !!
  
          ********************************************************************************
          Please avoid running ``setup.py`` directly.
          Instead, use pypa/build, pypa/installer or other
          standards-based tools.
  
          See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
          ********************************************************************************
  
  !!
    self.initialize_options()
f2py/tests/test_f2py2e.py: 4 warnings
distutils/tests/test_fcompiler_gnu.py: 10 warnings
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/distutils/fcompiler/gnu.py:276: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(v) >= "4":
f2py/tests/test_f2py2e.py: 8 warnings
distutils/tests/test_fcompiler_gnu.py: 10 warnings
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/setuptools/_distutils/version.py:345: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)
f2py/tests/test_f2py2e.py::test_debugcapi_bld
f2py/tests/test_f2py2e.py::test_debugcapi_bld
f2py/tests/test_f2py2e.py::test_npdistop
f2py/tests/test_f2py2e.py::test_npdistop
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/distutils/ccompiler.py:672: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    version = LooseVersion(version)
_core/tests/test_numeric.py::TestNonarrayArgs::test_dunder_round_edgecases[2147483647--1]
  /private/var/folders/zt/b4_8gf3n2wn8ylvm8wy7svc00000gn/T/cibw-run-_x5a49kc/cp39-macosx_arm64/venv-test/lib/python3.9/site-packages/numpy/_core/tests/test_numeric.py:199: RuntimeWarning: invalid value encountered in cast
    assert_equal(round(val, ndigits), round(np.int32(val), ndigits))
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

</details>