### PR TITLE
BUG: avoid incorrect stringdtype allocator sharing from array copies

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4235,7 +4235,7 @@ PyArray_DescrFromType(int type)
         ret = NULL;
     }
     else if (type == NPY_VSTRING || type == NPY_VSTRINGLTR) {
-        ret = (PyArray_Descr *)new_stringdtype_instance(NULL, 1, NULL);
+        ret = (PyArray_Descr *)new_stringdtype_instance(NULL, 1);
     }
     // builtin legacy dtypes
     else if (type < NPY_NTYPES_LEGACY) {

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -337,14 +337,16 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
         goto fail;
     }
 
-    Py_XDECREF(indices);
-    Py_XDECREF(self);
     if (out != NULL && out != obj) {
-        Py_INCREF(out);
-        PyArray_ResolveWritebackIfCopy(obj);
+        if (PyArray_ResolveWritebackIfCopy(obj) < 0) {
+            goto fail;
+        }
         Py_DECREF(obj);
+        Py_INCREF(out);
         obj = out;
     }
+    Py_XDECREF(indices);
+    Py_XDECREF(self);
     return (PyObject *)obj;
 
  fail:

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -30,7 +30,7 @@
             if (given_descrs[1] == NULL) {                                     \
                 PyArray_Descr *new =                                           \
                         (PyArray_Descr *)new_stringdtype_instance(             \
-                                NULL, 1, NULL);                                \
+                                NULL, 1);                                      \
                 if (new == NULL) {                                             \
                     return (NPY_CASTING)-1;                                    \
                 }                                                              \
@@ -121,7 +121,7 @@ string_to_string(PyArrayMethod_Context *context, char *const data[],
                 }
             }
             else if (free_and_copy(iallocator, oallocator, s, os,
-                                   "string to string cast") == -1) {
+                                   "string to string cast") < 0) {
                 goto fail;
             }
         }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -14,7 +14,7 @@ extern "C" {
 #define ALIGNOF_NPY_PACKED_STATIC_STRING _Alignof(size_t)
 
 NPY_NO_EXPORT PyObject *
-new_stringdtype_instance(PyObject *na_object, int coerce, npy_string_allocator *allocator);
+new_stringdtype_instance(PyObject *na_object, int coerce);
 
 NPY_NO_EXPORT int
 init_string_dtype(void);

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -530,7 +530,7 @@ NpyString_pack_empty(npy_packed_static_string *out)
 {
     _npy_static_string_u *out_u = (_npy_static_string_u *)out;
     unsigned char *flags = &out_u->direct_buffer.size_and_flags;
-    if (*flags == 0 || *flags & NPY_STRING_OUTSIDE_ARENA) {
+    if (*flags & NPY_STRING_OUTSIDE_ARENA) {
         // This also sets short string size to 0.
         *flags = NPY_STRING_INITIALIZED | NPY_STRING_OUTSIDE_ARENA;
     }
@@ -685,9 +685,6 @@ NpyString_dup(const npy_packed_static_string *in,
     _npy_static_string_u *in_u = (_npy_static_string_u *)in;
     char *in_buf = NULL;
     npy_string_arena *arena = &in_allocator->arena;
-    if (arena->buffer == NULL) {
-        return -1;
-    }
     int used_malloc = 0;
     if (in_allocator == out_allocator && !is_short_string(in)) {
         in_buf = in_allocator->malloc(size);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -60,7 +60,7 @@ multiply_resolve_descriptors(
 
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                odescr->na_object, odescr->coerce, NULL);
+                odescr->na_object, odescr->coerce);
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
         }
@@ -273,8 +273,7 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
                 ((PyArray_StringDTypeObject *)given_descrs[1])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[1])->coerce,
-                NULL);
+                ((PyArray_StringDTypeObject *)given_descrs[1])->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1077,8 +1076,7 @@ strip_chars_resolve_descriptors(
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
                 ((PyArray_StringDTypeObject *)given_descrs[0])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce,
-                NULL);
+                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1186,8 +1184,7 @@ strip_whitespace_resolve_descriptors(
     if (given_descrs[1] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
                 ((PyArray_StringDTypeObject *)given_descrs[0])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce,
-                NULL);
+                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1335,8 +1332,7 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     if (given_descrs[4] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
                 ((PyArray_StringDTypeObject *)given_descrs[0])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce,
-                NULL);
+                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1478,7 +1474,7 @@ static NPY_CASTING expandtabs_resolve_descriptors(
 
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                idescr->na_object, idescr->coerce, NULL);
+                idescr->na_object, idescr->coerce);
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
         }


### PR DESCRIPTION
This fixes the issue noted at https://github.com/numpy/numpy/pull/25890#issuecomment-1972309561 by @mhvk.

The problem ultimately came down to passing the `allocator` to `new_stringdtype_instance` in `stringdtype_finalize_descr`.

I originally added that because I thought it had something to do with views, and I set `array_owned=2` in that case. This was wrong, you can only ever get to this code path if you're creating a new array, so it's wrong to ever share allocators if you're calling `new_stringdtype_instance`. As a result, I removed the third argument from that function and in all call sites and made it so `array_owned` can only be 0 or 1. I also had a buggy incorrect default value of `array_owned=2`, which I delete here and leave it as zero by default (i.e. not yet owned by an array).

This revealed a small bug in the stringdtype allocator implementation. Empty uninitialized strings set via `NpyString_pack_empty` would end up marked as initialized empty strings. The fix there is to delete the check for `flags==0` before setting the initialized flag in that case. As a result there are some changes to `TestImplementation`, since now empty uninitialized strings do not have the initialized and outside arena flags set.