### PR TITLE
BLD: try to build most macOS wheels on GHA

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     name: macOS x86-64 conda
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
           echo github.ref ${{ github.ref }}
 
   build_wheels:
-    name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    name: Build wheel ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
@@ -73,11 +73,15 @@ jobs:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
-          - [ubuntu-20.04, manylinux_x86_64]
-          - [ubuntu-20.04, musllinux_x86_64]
-          - [macos-12, macosx_x86_64]
-          - [windows-2019, win_amd64]
-          - [windows-2019, win32]
+          - [ubuntu-20.04, manylinux_x86_64, ""]
+          - [ubuntu-20.04, musllinux_x86_64, ""]
+          - [macos-13, macosx_x86_64, openblas]
+
+          # targeting macos >= 14. Could probably build on macos-14, but it would be a cross-compile
+          - [macos-13, macosx_x86_64, accelerate]
+          - [macos-14, macosx_arm64, accelerate]  # always use accelerate
+          - [windows-2019, win_amd64, ""]
+          - [windows-2019, win32, ""]
         python: ["cp39", "cp310", "cp311", "cp312", "pp39"]
         exclude:
           # Don't build PyPy 32-bit windows
@@ -123,6 +127,27 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Setup macOS
+        if: matrix.buildplat[0] == 'macos-13' || matrix.buildplat[0] == 'macos-14'
+        run: |
+          if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
+            # macosx_arm64 and macosx_x86_64 with accelerate
+            # only target Sonoma onwards
+            CIBW="MACOSX_DEPLOYMENT_TARGET=14.0 INSTALL_OPENBLAS=false RUNNER_OS=macOS"
+            echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+
+            # the macos-13 image that's used for building the x86_64 wheel can't test
+            # a wheel with deployment target >= 14 without further work
+            echo "CIBW_TEST_SKIP=*-macosx_x86_64" >> "$GITHUB_ENV"
+          else
+            # macosx_x86_64 with OpenBLAS
+            # if INSTALL_OPENBLAS isn't specified then scipy-openblas is automatically installed
+            CIBW="RUNNER_OS=macOS"
+            PKG_CONFIG_PATH="$PWD/.openblas"
+            DYLD="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
+            echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"  
+          fi
+
       - name: Build wheels
         uses: pypa/cibuildwheel@ce3fb7832089eb3e723a0a99cab7f3eaccf074fd  # v2.16.5
         env:
@@ -131,18 +156,21 @@ jobs:
 
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
+          name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: ./wheelhouse/*.whl
 
-      - uses: conda-incubator/setup-miniconda@030178870c779d9e5e1b4e563269f3aa69b04081 # v3.0.3
+      - uses: mamba-org/setup-micromamba@v1
         with:
           # for installation of anaconda-client, required for upload to
           # anaconda.org
-          # default (and activated) environment name is test
           # Note that this step is *after* specific pythons have been used to
           # build and test the wheel
-          auto-update-conda: true
-          python-version: "3.10"
+          # for installation of anaconda-client, for upload to anaconda.org
+          # environment will be activated after creation, and in future bash steps
+          init-shell: bash
+          environment-name: upload-env
+          create-args: >-
+            anaconda-client
 
       - name: Upload wheels
         if: success()
@@ -153,7 +181,6 @@ jobs:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
           NUMPY_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
-          conda install -y anaconda-client
           source tools/wheels/upload_wheels.sh
           set_upload_vars
           # trigger an upload to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,21 +160,12 @@ PKG_CONFIG_PATH="/project/.openblas"
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/project/.openblas/lib"
 
 [tool.cibuildwheel.macos]
-# universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
-archs = "x86_64 arm64"
-test-skip = "*_universal2:arm64"
 # Not clear why the DYLD_LIBRARY_PATH is not passed through from the environment
 repair-wheel-command = [
   "export DYLD_LIBRARY_PATH=$PWD/.openblas/lib",
   "echo DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH",
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
 ]
-
-[tool.cibuildwheel.macos.environment]
-# In cibuildwheel, {project} is $PWD
-RUNNER_OS="macOS"
-PKG_CONFIG_PATH="$PWD/.openblas"
-DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
 
 [tool.cibuildwheel.windows]
 # This does not work, use CIBW_ENVIRONMENT_WINDOWS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
 # `tools/ci/cirrus_wheels.yml`.
 build-frontend = "build"
-skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x"
+skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"
@@ -160,6 +160,9 @@ PKG_CONFIG_PATH="/project/.openblas"
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/project/.openblas/lib"
 
 [tool.cibuildwheel.macos]
+# universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
+# note that universal2 wheels are not built, they're listed in the tool.cibuildwheel.skip
+# section
 # Not clear why the DYLD_LIBRARY_PATH is not passed through from the environment
 repair-wheel-command = [
   "export DYLD_LIBRARY_PATH=$PWD/.openblas/lib",

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -50,13 +50,15 @@ linux_aarch64_task:
 
 ######################################################################
 # Build macosx_arm64 natively
+#
+# macosx_arm64 for macos >= 14 used to be built here, but are now
+# built on GHA.
 ######################################################################
 
 macosx_arm64_task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   macos_instance:
     matrix:
-      image: ghcr.io/cirruslabs/macos-sonoma-xcode
       image: ghcr.io/cirruslabs/macos-monterey-xcode
 
   matrix:
@@ -81,18 +83,10 @@ macosx_arm64_task:
     
     ver=$(sw_vers -productVersion)
     macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
-    if [ $macos_target == '14.0' ]; then
-        # Use native Accelerate
-        export INSTALL_OPENBLAS=false
-        export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=false RUNNER_OS=macOS"
-        # export CIBW_REPAIR_WHEEL_COMMAND_MACOS=""
-    else
-        # Use scipy-openblas wheels
-        export INSTALL_OPENBLAS=true
-        export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=true RUNNER_OS=macOS PKG_CONFIG_PATH=$PWD/.openblas"
-    fi
+    # Use scipy-openblas wheels
+    export INSTALL_OPENBLAS=true
+    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=true RUNNER_OS=macOS PKG_CONFIG_PATH=$PWD/.openblas"
 
-    
     # needed for submodules
     git submodule update --init
     # need to obtain all the tags so setup.py can determine FULLVERSION


### PR DESCRIPTION
With this PR:

- macosx_x86_64 using OpenBLAS is built on GHA (for use on macos < 14)
- macosx_x86_64 using Accelerate is built on GHA (for use on macOS >=14)
- macosx_arm64 using Accelerate is built on GHA (for use on macOS >=14). This is transferred from CirrusCI
- macosx_arm64 using OpenBLAS is still built on CirrusCI

@rgommers @mattip 