### PR TITLE
MAINT: Introduce NPY_FEATURE_VERSION_STRING and report it in error

### DIFF
--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -111,13 +111,15 @@ _import_array(void)
   }
   PyArray_RUNTIME_VERSION = (int)PyArray_GetNDArrayCFeatureVersion();
   if (NPY_FEATURE_VERSION > PyArray_RUNTIME_VERSION) {
-      PyErr_Format(PyExc_RuntimeError, "module compiled against "\
-             "API version 0x%%x but this version of numpy is 0x%%x . "\
-             "Check the section C-API incompatibility at the "\
-             "Troubleshooting ImportError section at "\
-             "https://numpy.org/devdocs/user/troubleshooting-importerror.html"\
-             "#c-api-incompatibility "\
-              "for indications on how to solve this problem .", \
+      PyErr_Format(PyExc_RuntimeError,
+             "module was compiled against NumPy C-API version 0x%%x "
+             "(NumPy " NPY_FEATURE_VERSION_STRING ") "
+             "but the running NumPy has C-API version 0x%%x. "
+             "Check the section C-API incompatibility at the "
+             "Troubleshooting ImportError section at "
+             "https://numpy.org/devdocs/user/troubleshooting-importerror.html"
+             "#c-api-incompatibility "
+             "for indications on how to solve this problem.",
              (int)NPY_FEATURE_VERSION, PyArray_RUNTIME_VERSION);
       return -1;
   }

--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -132,5 +132,37 @@
     #warning "Requested NumPy target lower than supported NumPy 1.15."
 #endif
 
+/*
+ * We define a human readable translation to the Python version of NumPy
+ * for error messages (and also to allow grepping the binaries for conda).
+ */
+#if NPY_FEATURE_VERSION == NPY_1_7_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.7"
+#elif NPY_FEATURE_VERSION == NPY_1_8_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.8"
+#elif NPY_FEATURE_VERSION == NPY_1_9_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.9"
+#elif NPY_FEATURE_VERSION == NPY_1_10_API_VERSION  /* also 1.11, 1.12 */
+    #define NPY_FEATURE_VERSION_STRING "1.10"
+#elif NPY_FEATURE_VERSION == NPY_1_13_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.13"
+#elif NPY_FEATURE_VERSION == NPY_1_14_API_VERSION  /* also 1.15 */
+    #define NPY_FEATURE_VERSION_STRING "1.14"
+#elif NPY_FEATURE_VERSION == NPY_1_16_API_VERSION  /* also 1.17, 1.18, 1.19 */
+    #define NPY_FEATURE_VERSION_STRING "1.16"
+#elif NPY_FEATURE_VERSION == NPY_1_20_API_VERSION  /* also 1.21 */
+    #define NPY_FEATURE_VERSION_STRING "1.20"
+#elif NPY_FEATURE_VERSION == NPY_1_22_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.22"
+#elif NPY_FEATURE_VERSION == NPY_1_23_API_VERSION  /* also 1.24 */
+    #define NPY_FEATURE_VERSION_STRING "1.23"
+#elif NPY_FEATURE_VERSION == NPY_1_25_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "1.25"
+#elif NPY_FEATURE_VERSION == NPY_2_0_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "2.0"
+#else
+    #error "Missing version string define for new NumPy version."
+#endif
+
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_NUMPYCONFIG_H_ */


### PR DESCRIPTION
This improves the error message when the API version we compiled for mismatches to include the actual Python version.  The big defines are a bit annoying, but not too bad.

This should also allow checking what a module is compiled for since:
```
strings build/numpy/_core/_rational_tests.cpython-310-darwin.so | grep "NumPy C-API"
```
Will report the error *including* the actual NumPy "python side" version we are compatible with (so that expanding that grep should be easy for extracting the interesting value.

Only modules which import NumPy will do this, I suspect that is well enough.

Closes gh-24861