### PR TITLE
BUG: Fix reference leak in niche user old user dtypes

### DIFF
--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -320,7 +320,7 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
         NPY_DT_SLOTS(NPY_DTYPE(descr))->get_clear_loop = (
                 (PyArrayMethod_GetTraverseLoop *)&npy_get_clear_void_and_legacy_user_dtype_loop);
         /* Also use the void zerofill since there may be objects */
-        NPY_DT_SLOTS(NPY_DTYPE(descr))->get_clear_loop = (
+        NPY_DT_SLOTS(NPY_DTYPE(descr))->get_fill_zero_loop = (
                 (PyArrayMethod_GetTraverseLoop *)&npy_get_zerofill_void_and_legacy_user_dtype_loop);
     }
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1897,6 +1897,13 @@ class TestUserDType:
         # unnecessary restriction, but one that has been around forever:
         assert np.dtype(mytype) == np.dtype("O")
 
+        if HAS_REFCOUNT:
+            # Create an array and test that memory gets cleaned up (gh-25949)
+            o = object()
+            a = np.array([o], dtype=dt)
+            del a
+            assert sys.getrefcount(o) == 2
+
     def test_custom_structured_dtype_errors(self):
         class mytype:
             pass


### PR DESCRIPTION
This was just a typo, add a test for the regression (checked that it triggered it).

Closes gh-25949
