### PR TITLE
BLD: use hash for mamba action 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -159,7 +159,7 @@ jobs:
           name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: ./wheelhouse/*.whl
 
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@422500192359a097648154e8db4e39bdb6c6eed7
         with:
           # for installation of anaconda-client, required for upload to
           # anaconda.org


### PR DESCRIPTION
Use full hash for mamba action.

@rgommers, note that the wheel upload aspect has not been verified to work yet. We will get confirmation once the next wheel cron job triggers.