### PR TITLE
API: revert position-only 'start' in 'np.arange'

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -310,16 +310,6 @@ environment variables to interact with ``meson``. `Native files
 
 (`gh-25193 <https://github.com/numpy/numpy/pull/25193>`__)
 
-``arange``'s ``start`` argument is positional-only
---------------------------------------------------
-The first argument of ``arange`` is now positional only. This way,
-specifying a ``start`` argument as a keyword, e.g. ``arange(start=0, stop=4)``,
-raises a TypeError. Other behaviors, are unchanged so ``arange(stop=4)``,
-``arange(2, stop=4)`` and so on, are still valid and have the same meaning as
-before.
-
-(`gh-25336 <https://github.com/numpy/numpy/pull/25336>`__)
-
 
 C API changes
 =============

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1698,7 +1698,7 @@ add_newdoc('numpy._core.multiarray', 'correlate',
 
 add_newdoc('numpy._core.multiarray', 'arange',
     """
-    arange(start, / [, stop[, step,], dtype=None, *, device=None,, like=None)
+    arange(start, [, stop[, step,], dtype=None, *, device=None,, like=None)
 
     Return evenly spaced values within a given interval.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1698,7 +1698,7 @@ add_newdoc('numpy._core.multiarray', 'correlate',
 
 add_newdoc('numpy._core.multiarray', 'arange',
     """
-    arange(start, [, stop[, step,], dtype=None, *, device=None,, like=None)
+    arange([start,] stop[, step,], dtype=None, *, device=None, like=None)
 
     Return evenly spaced values within a given interval.
 

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -141,16 +141,15 @@ initialize_keywords(const char *funcname,
         }
 
         if (*name == '\0') {
-            npositional_only += 1;
             /* Empty string signals positional only */
-            if (state == '$' || npositional_only != npositional) {
+            if (state != '\0') {
                 PyErr_Format(PyExc_SystemError,
-                        "NumPy internal error: non-kwarg marked with $ "
-                        "to %s() at argument %d or positional only following "
-                        "kwarg.", funcname, nargs);
+                        "NumPy internal error: non-kwarg marked with | or $ "
+                        "to %s() at argument %d.", funcname, nargs);
                 va_end(va);
                 return -1;
             }
+            npositional_only += 1;
         }
         else {
             nkwargs += 1;

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -141,15 +141,16 @@ initialize_keywords(const char *funcname,
         }
 
         if (*name == '\0') {
+            npositional_only += 1;
             /* Empty string signals positional only */
-            if (state != '\0') {
+            if (state == '$' || npositional_only != npositional) {
                 PyErr_Format(PyExc_SystemError,
-                        "NumPy internal error: non-kwarg marked with | or $ "
-                        "to %s() at argument %d.", funcname, nargs);
+                        "NumPy internal error: non-kwarg marked with $ "
+                        "to %s() at argument %d or positional only following "
+                        "kwarg.", funcname, nargs);
                 va_end(va);
                 return -1;
             }
-            npositional_only += 1;
         }
         else {
             nkwargs += 1;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3068,7 +3068,7 @@ array_arange(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("arange", args, len_args, kwnames,
-            "|", NULL, &o_start,
+            "|start", NULL, &o_start,
             "|stop", NULL, &o_stop,
             "|step", NULL, &o_step,
             "|dtype", &PyArray_DescrConverter2, &typecode,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9471,14 +9471,9 @@ class TestArange:
         assert_raises(TypeError, np.arange, start=4)
 
     def test_start_stop_kwarg(self):
-        with pytest.raises(TypeError):
-            # Start cannot be passed as a kwarg anymore, because on it's own
-            # it would be strange.
-            np.arange(start=0, stop=3)
-
         keyword_stop = np.arange(stop=3)
         keyword_zerotostop = np.arange(0, stop=3)
-        keyword_start_stop = np.arange(3, stop=9)
+        keyword_start_stop = np.arange(start=3, stop=9)
 
         assert len(keyword_stop) == 3
         assert len(keyword_zerotostop) == 3


### PR DESCRIPTION
Closes #25743, reverts #23536

Removing the ability to use `start` as a kwarg in `np.arange(start=3, stop=5)` breaks too much even for a 2.0 release. I still am a bit confused about the motivation for the change, was it for typing or automatic signature parsing? Note that `np.arange(start=3)` raises, and `np.arange(stop=5) assumes `start=0`.

At some point we may wish to revisit this and remove _any_ use of kwargs, but that would require a long deprecation period.

Edit: any use of kwargs _for `start`, `stop`, `step`