### PR TITLE
BUG: avoid incorrect type punning in NpyString_acquire_allocators

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -328,6 +328,9 @@ NpyString_acquire_allocators(size_t n_descriptors,
         }
         int allocators_match = 0;
         for (size_t j=0; j<i; j++) {
+            if (allocators[j] == NULL) {
+                continue;
+            }
             if (((PyArray_StringDTypeObject *)descrs[i])->allocator ==
                 ((PyArray_StringDTypeObject *)descrs[j])->allocator)
             {


### PR DESCRIPTION
Fixes #25957. It may also fix the hangs on sanitizer CI too, we'll have to see.

I think merging #25943 made this more visible, but it was always buggy to do this.

The issue is that `descrs` doesn't necessarily contain only `PyArray_StringDTypeObject` instances, so it's incorrect to cast (say) a LONG descriptor to `PyArray_StringDTypeObject` in the following line.

The fix is to check for this case and skip the cast if the descriptor we want to compare with isn't a stringdtype descriptor.