### PR TITLE
DOC: fix typos and rearrange CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,16 +69,6 @@ jobs:
             ./tools/ci/test_all_newsfragments_used.py
 
       - run:
-          name: run doctests on documentation
-          command: |
-            . venv/bin/activate
-            # Note: keep these two checks separate, because they seem to
-            # influence each other through changing global state (e.g., via
-            # `np.polynomial.set_default_printstyle`)
-            python tools/refguide_check.py --rst
-            python tools/refguide_check.py --doctests
-
-      - run:
           name: build devdocs w/ref warnings
           command: |
             . venv/bin/activate
@@ -103,6 +93,16 @@ jobs:
       - store_artifacts:
           path: doc/neps/_build/html/
      #      destination: neps
+
+      - run:
+          name: run doctests on documentation
+          command: |
+            . venv/bin/activate
+            # Note: keep these two checks separate, because they seem to
+            # influence each other through changing global state (e.g., via
+            # `np.polynomial.set_default_printstyle`)
+            python tools/refguide_check.py --rst
+            python tools/refguide_check.py --doctests
 
       - persist_to_workspace:
           root: ~/repo

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -98,6 +98,7 @@ dtype/descriptor itself is attached to an array (e.g. ``arr->descr->elsize``)
 this is best replaced with ``PyArray_ITEMSIZE(arr)``.
 
 Where not possible, new accessor functions are required:
+
 * ``PyDataType_ELSIZE`` and ``PyDataType_SET_ELSIZE`` (note that the result
   is now ``npy_intp`` and not ``int``).
 * ``PyDataType_ALIGNENT``

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -60,7 +60,7 @@ and its sub-types).
     success.
 
     .. note::
-        In general, prefer the use of :c:function:`PyArray_Pack` when
+        In general, prefer the use of :c:func:`PyArray_Pack` when
         handling arbitrary Python objects.  Setitem is for example not able
         to handle arbitrary casts between different dtypes.
 
@@ -781,7 +781,7 @@ cannot not be accessed directly.
 .. versionchanged:: 2.0
     Prior to NumPy 2.0 the ABI was different but unnecessary large for user
     DTypes.  These accessors were all added in 2.0 and can be backported
-    (see :ref:`_migration_c_descr`).
+    (see :ref:`migration_c_descr`).
 
 .. c:function:: npy_intp PyDataType_ELSIZE(PyArray_Descr *descr)
 


### PR DESCRIPTION
- Move the doctest step so that even if doctests fail, we still can see artifacts (if the doc build succeeds)
- Fix a few typos

Fixes #25951