### PR TITLE
CI: fix wheel tags for Cirrus macOS arm64

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -81,11 +81,9 @@ macosx_arm64_task:
     micromamba activate numpydev
     micromamba install -y -c conda-forge python=3.11 2>/dev/null
     
-    ver=$(sw_vers -productVersion)
-    macos_target=$(python -c "print('14.0') if '$ver' >= '14.0' else print('11.0')")
     # Use scipy-openblas wheels
     export INSTALL_OPENBLAS=true
-    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=$macos_target INSTALL_OPENBLAS=true RUNNER_OS=macOS PKG_CONFIG_PATH=$PWD/.openblas"
+    export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET='11.0' INSTALL_OPENBLAS=true RUNNER_OS=macOS PKG_CONFIG_PATH=$PWD/.openblas"
 
     # needed for submodules
     git submodule update --init


### PR DESCRIPTION
As can be seen from for example [this log](https://cirrus-ci.com/task/5258104548360192?logs=build#L245), there was a small hiccup with gh-25945 and now wheels built with OpenBLAS are tagged as `14_0` rather than `11_0`. So simplify the logic to ensure that these wheels are tagged for 11.0

Note that this also overwrote the `14_0` nightlies on https://anaconda.org/scientific-python-nightly-wheels/numpy/files, so I'll rebuild those. 