### PR TITLE
DOC: Backport gh-25971 and  gh-25972

### DIFF
--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -390,7 +390,7 @@ to the front of the integer name.
     This is the correct integer for lengths or indexing.  In practice this is
     normally the size of a pointer, but this is not guaranteed.
 
-    ..note::
+    .. note::
         Before NumPy 2.0, this was the same as ``Py_intptr_t``.
         While a better match, this did not match actual usage in practice.
         On the Python side, we still support ``np.dtype('p')`` to fetch a dtype

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -37,6 +37,7 @@ from numpy import ndarray, amax, amin, iscomplexobj, bool_, _NoValue, angle
 from numpy import array as narray, expand_dims, iinfo, finfo
 from numpy._core.numeric import normalize_axis_tuple
 from numpy._utils._inspect import getargspec, formatargspec
+from numpy._utils import set_module
 
 
 __all__ = [
@@ -2636,7 +2637,7 @@ class MaskedIterator:
     >>> x = np.ma.array(arange(6).reshape(2, 3))
     >>> fl = x.flat
     >>> type(fl)
-    <class 'numpy.ma.core.MaskedIterator'>
+    <class 'numpy.ma.MaskedIterator'>
     >>> for item in fl:
     ...     print(item)
     ...
@@ -2717,6 +2718,7 @@ class MaskedIterator:
         return d
 
 
+@set_module("numpy.ma")
 class MaskedArray(ndarray):
     """
     An array class with possibly masked values.
@@ -8378,7 +8380,7 @@ def asarray(a, dtype=None, order=None):
       mask=False,
       fill_value=1e+20)
     >>> type(np.ma.asarray(x))
-    <class 'numpy.ma.core.MaskedArray'>
+    <class 'numpy.ma.MaskedArray'>
 
     """
     order = order or 'C'
@@ -8425,7 +8427,7 @@ def asanyarray(a, dtype=None):
       mask=False,
       fill_value=1e+20)
     >>> type(np.ma.asanyarray(x))
-    <class 'numpy.ma.core.MaskedArray'>
+    <class 'numpy.ma.MaskedArray'>
 
     """
     # workaround for #8666, to preserve identity. Ideally the bottom line


### PR DESCRIPTION
Backport of #25971 and #25972.

- #25971 DOC: Fix a note section markup in `dtype.rst`

- #25972 DOC: Fix module setting of `MaskedArray`
  Set module of `MaskedArray` to `numpy.ma` because `numpy.ma.core.MaskedArray`
  is an internal alias not documented.

  ref: gh-13114

[skip cirrus] [skip azp] [skip actions]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
