### PR TITLE
BUG: Raise error for negative-sized fixed-width dtype

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1813,6 +1813,11 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Parse the integer, make sure it's the rest of the string */
         elsize = (int)strtol(type + 1, &typeend, 10);
+        /* Make sure size is not negative */
+        if (elsize < 0) {
+            goto fail;
+        }
+
         if (typeend - type == len) {
 
             kind = type[0];

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -98,6 +98,8 @@ class TestBuiltin:
 
         # Make sure negative-sized dtype raises an error
         assert_raises(TypeError, np.dtype, 'S-1')
+        assert_raises(TypeError, np.dtype, 'U-1')
+        assert_raises(TypeError, np.dtype, 'V-1')
 
     def test_richcompare_invalid_dtype_equality(self):
         # Make sure objects that cannot be converted to valid

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -96,6 +96,9 @@ class TestBuiltin:
             assert_raises(TypeError, np.dtype, 'q8')
             assert_raises(TypeError, np.dtype, 'Q8')
 
+        # Make sure negative-sized dtype raises an error
+        assert_raises(TypeError, np.dtype, 'S-1')
+
     def test_richcompare_invalid_dtype_equality(self):
         # Make sure objects that cannot be converted to valid
         # dtypes results in False/True when compared to valid dtypes.

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 
 import numpy as np
 from numpy._core import umath, sctypes
-from numpy._core._exceptions import _ArrayMemoryError
 from numpy._core.numerictypes import obj2sctype
 from numpy._core.arrayprint import set_string_function
 from numpy.exceptions import AxisError
@@ -3345,7 +3344,7 @@ class TestLikeFuncs:
         assert_(type(b) is not MyNDArray)
 
         # Test invalid dtype
-        with assert_raises(_ArrayMemoryError):
+        with assert_raises(TypeError):
             a = np.array(b"abc")
             like_function(a, dtype="S-1", **fill_kwarg)
 


### PR DESCRIPTION
Solves the creation of negative-sized fixed-width dtypes, which can't be used in practice and create problems with other numpy functions (e.g. #25853).

The solution consists in checking, while parsing the dtype string argument, if the element size is negative, in which case an error is now raised.

I also added a unit test, that makes sure the error is raised. Changed another test to make sure a TypeError is raised instead of an ArrayMemoryError, since the creation of negative-sized dtypes is no longer possible.

Closes #25860.