### PR TITLE
BLD: push a tag builds a wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,6 +26,9 @@ on:
     branches:
       - main
       - maintenance/**
+  push:
+    tags:
+      - v*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Backport of #25981.

See #25979.

The logic here is that:

1. `Push`ing to a maintenance branch [starts a CI run](https://github.com/numpy/numpy/blob/main/.github/workflows/wheels.yml#L28).
2. If the `github.ref` starts with `refs/tags/v` and doesn't end with `dev0` then the [wheel builder runs](https://github.com/numpy/numpy/blob/main/.github/workflows/wheels.yml#L67)
3. This [sets](https://github.com/numpy/numpy/blob/3b246c6488cf246d488bbe5726ca58dc26b6ea74/.github/workflows/wheels.yml#L94) the `IS_PUSH` variable.
4. When it comes to the [upload step](https://github.com/numpy/numpy/blob/3b246c6488cf246d488bbe5726ca58dc26b6ea74/.github/workflows/wheels.yml#L184), then the wheels are uploaded to [multibuild-wheels-staging](https://github.com/numpy/numpy/blob/3b246c6488cf246d488bbe5726ca58dc26b6ea74/tools/wheels/upload_wheels.sh#L21).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
