### PR TITLE
CI: don't use ``fetch-tags`` in wheel build jobs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,11 +103,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-          # versioneer.py requires the latest tag to be reachable. Here we
-          # fetch the complete history to get access to the tags.
-          # A shallow clone can work when the following issue is resolved:
-          # https://github.com/actions/checkout/issues/338
-          fetch-tags: true
 
       - name: Setup MSVC (32-bit)
         if: ${{ matrix.buildplat[1] == 'win32' }}
@@ -217,11 +212,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-          # versioneer.py requires the latest tag to be reachable. Here we
-          # fetch the complete history to get access to the tags.
-          # A shallow clone can work when the following issue is resolved:
-          # https://github.com/actions/checkout/issues/338
-          fetch-tags: true
       # Used to push the built wheels
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:


### PR DESCRIPTION
This failed in combination with tag-based triggers:
- issue: gh-25979
- cause: https://github.com/numpy/numpy/pull/25981#issuecomment-1987653985

More importantly, we don't need to fetch either the tags or the whole commit history, because:

(a) we don't derive the version number from the last tag, but from parsing pyproject.toml
(b) we don't use a commit count, but only yyyymmdd.git-hash

See `numpy/_build_utils/gitversion.py`

Done only in the wheel build job right now, because that's where the problem is and we're in a hurry to solve it on the 2.0.x branch. However, this change should be fine everywhere.

[skip cirrus] [skip circle] [skip azp]