### PR TITLE
TST: remove usage of ProcessPoolExecutor in stringdtype tests

### DIFF
--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -362,13 +362,6 @@ def test_isnan(dtype, string_list):
         assert not np.any(np.isnan(sarr))
 
 
-def _pickle_load(filename):
-    with open(filename, "rb") as f:
-        res = pickle.load(f)
-
-    return res
-
-@pytest.mark.skipif(IS_WASM, reason="no threading support in wasm")
 def test_pickle(dtype, string_list):
     arr = np.array(string_list, dtype=dtype)
 
@@ -377,15 +370,6 @@ def test_pickle(dtype, string_list):
 
     with open(f.name, "rb") as f:
         res = pickle.load(f)
-
-    assert_array_equal(res[0], arr)
-    assert res[1] == dtype
-
-    # load the pickle in a subprocess to ensure the string data are
-    # actually stored in the pickle file
-    with concurrent.futures.ProcessPoolExecutor() as executor:
-        e = executor.submit(_pickle_load, f.name)
-        res = e.result()
 
     assert_array_equal(res[0], arr)
     assert res[1] == dtype


### PR DESCRIPTION
This is an attempt to fix #25875.

The tests are hanging, not crashing, so the behavior looks like a deadlock. This is the only use of `ProcessPoolExecutor` in the numpy tests and the tests seem to hang on this test.

That said, I'm not sure why the deadlock would only happen in a build of python running under address sanitizer.

Looking at the test again, I don't think this is actually a useful thing to test, since it shouldn't matter if the pickle file is loaded in the process that saved it or not.

So since I suspect this will fix the test hangs, I think this is worth pulling in.