### PR TITLE
MAINT: remove the now-unused ``NPY_NO_SIGNAL``

### DIFF
--- a/numpy/_core/include/numpy/_numpyconfig.h.in
+++ b/numpy/_core/include/numpy/_numpyconfig.h.in
@@ -19,7 +19,6 @@
 
 #mesondefine NPY_USE_C99_FORMATS
 
-#mesondefine NPY_NO_SIGNAL
 #mesondefine NPY_NO_SMP
 
 #mesondefine NPY_VISIBILITY_HIDDEN

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -491,9 +491,6 @@ endif
 if cc.has_header('sys/endian.h')
   cdata.set10('NPY_HAVE_SYS_ENDIAN_H', true)
 endif
-if is_windows
-  cdata.set10('NPY_NO_SIGNAL', true)
-endif
 # Command-line switch; distutils build checked for `NPY_NOSMP` env var instead
 # TODO: document this (search for NPY_NOSMP in C API docs)
 cdata.set10('NPY_NO_SMP', get_option('disable-threading'))


### PR DESCRIPTION
The `npy_interrupt.h` header that needed it was removed in gh-23919 for 2.0.0.