### PR TITLE
MAINT: remove now-unused ``NPY_USE_C99_FORMAT``

### DIFF
--- a/numpy/_core/include/numpy/_numpyconfig.h.in
+++ b/numpy/_core/include/numpy/_numpyconfig.h.in
@@ -17,8 +17,6 @@
 #mesondefine NPY_SIZEOF_PY_LONG_LONG
 #mesondefine NPY_SIZEOF_LONGLONG
 
-#mesondefine NPY_USE_C99_FORMATS
-
 #mesondefine NPY_NO_SMP
 
 #mesondefine NPY_VISIBILITY_HIDDEN

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -495,11 +495,6 @@ endif
 # TODO: document this (search for NPY_NOSMP in C API docs)
 cdata.set10('NPY_NO_SMP', get_option('disable-threading'))
 
-# Check whether we can use inttypes (C99) formats
-if cc.has_header_symbol('inttypes.h', 'PRIdPTR')
-  cdata.set10('NPY_USE_C99_FORMATS', true)
-endif
-
 visibility_hidden = ''
 if cc.has_function_attribute('visibility:hidden') and host_machine.system() != 'cygwin'
   visibility_hidden = '__attribute__((visibility("hidden")))'


### PR DESCRIPTION
The need for this define was removed with gh-24888. A code search shows no external usages, and the few times this shows up on the issue tracker it's always defined to `1`.