### PR TITLE
MAINT: handle ``NPY_ALLOW_THREADS`` and related build option better

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4032,14 +4032,11 @@ variables), the GIL should be released so that other Python threads
 can run while the time-consuming calculations are performed. This can
 be accomplished using two groups of macros. Typically, if one macro in
 a group is used in a code block, all of them must be used in the same
-code block. Currently, :c:data:`NPY_ALLOW_THREADS` is defined to the
-python-defined :c:data:`WITH_THREADS` constant unless the environment
-variable ``NPY_NOSMP`` is set in which case
-:c:data:`NPY_ALLOW_THREADS` is defined to be 0.
+code block. :c:data:`NPY_ALLOW_THREADS` is true (defined as ``1``) unless the
+build option ``-Ddisable-threading`` is set to ``true`` - in which case
+:c:data:`NPY_ALLOW_THREADS` is false (``0``).
 
 .. c:macro:: NPY_ALLOW_THREADS
-
-.. c:macro:: WITH_THREADS
 
 Group 1
 ^^^^^^^

--- a/numpy/_core/include/numpy/_numpyconfig.h.in
+++ b/numpy/_core/include/numpy/_numpyconfig.h.in
@@ -17,6 +17,11 @@
 #mesondefine NPY_SIZEOF_PY_LONG_LONG
 #mesondefine NPY_SIZEOF_LONGLONG
 
+/*
+ * Defined to 1 or 0. Note that Pyodide hardcodes NPY_NO_SMP (and other defines
+ * in this header) for better cross-compilation, so don't rename them without a
+ * good reason.
+ */
 #mesondefine NPY_NO_SMP
 
 #mesondefine NPY_VISIBILITY_HIDDEN

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -8,8 +8,8 @@
 
 #define NPY_NO_EXPORT NPY_VISIBILITY_HIDDEN
 
-/* Only use thread if configured in config and python supports it */
-#if defined WITH_THREAD && !NPY_NO_SMP
+/* Always allow threading unless it was explicitly disabled at build time */
+#if !NPY_NO_SMP
         #define NPY_ALLOW_THREADS 1
 #else
         #define NPY_ALLOW_THREADS 0

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -491,8 +491,8 @@ endif
 if cc.has_header('sys/endian.h')
   cdata.set10('NPY_HAVE_SYS_ENDIAN_H', true)
 endif
-# Command-line switch; distutils build checked for `NPY_NOSMP` env var instead
-# TODO: document this (search for NPY_NOSMP in C API docs)
+# Build-time option to disable threading is stored and exposed in numpyconfig.h
+# Note: SMP is an old acronym for threading (Symmetric/Shared-memory MultiProcessing)
 cdata.set10('NPY_NO_SMP', get_option('disable-threading'))
 
 visibility_hidden = ''

--- a/numpy/_core/src/common/python_xerbla.c
+++ b/numpy/_core/src/common/python_xerbla.c
@@ -28,22 +28,16 @@ CBLAS_INT BLAS_FUNC(xerbla)(char *srname, CBLAS_INT *info)
         char buf[sizeof(format) + 6 + 4];   /* 6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
-#ifdef WITH_THREAD
         PyGILState_STATE save;
-#endif
 
         while( len<6 && srname[len]!='\0' )
                 len++;
         while( len && srname[len-1]==' ' )
                 len--;
-#ifdef WITH_THREAD
         save = PyGILState_Ensure();
-#endif
         PyOS_snprintf(buf, sizeof(buf), format, len, srname, (int)*info);
         PyErr_SetString(PyExc_ValueError, buf);
-#ifdef WITH_THREAD
         PyGILState_Release(save);
-#endif
 
         return 0;
 }

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -28,22 +28,16 @@ CBLAS_INT BLAS_FUNC(xerbla)(char *srname, CBLAS_INT *info)
         char buf[sizeof(format) + 6 + 4];   /* 6 for name, 4 for param. num. */
 
         int len = 0; /* length of subroutine name*/
-#ifdef WITH_THREAD
         PyGILState_STATE save;
-#endif
 
         while( len<6 && srname[len]!='\0' )
                 len++;
         while( len && srname[len-1]==' ' )
                 len--;
-#ifdef WITH_THREAD
         save = PyGILState_Ensure();
-#endif
         PyOS_snprintf(buf, sizeof(buf), format, len, srname, (int)*info);
         PyErr_SetString(PyExc_ValueError, buf);
-#ifdef WITH_THREAD
         PyGILState_Release(save);
-#endif
 
         return 0;
 }


### PR DESCRIPTION
The option to disable threading in CPython was removed a long time ago (see https://github.com/python/cpython/pull/3385); `WITH_THREAD` was kept defined for backwards compatibility, but can never change - so best to remove checking for it.

The docs still mentioned the old `NPY_NOSMP` environment variable, support for which was removed with the move to Meson. Instead, there is a `disable-threading` build option, so document that.
