### PR TITLE
MAINT: avoid use of flexible array member in public header

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1298,9 +1298,11 @@ typedef struct {
          * growing structs (as of Cython 3.0.6).  It also allows NPY_MAXARGS
          * to be runtime dependent.
          */
-#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
-        PyArrayIterObject    *iters[64];  /* 64 is NPY_MAXARGS */
-#else /* not internal build */
+#if (defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD) || defined(__cplusplus)
+        /* 64 is NPY_MAXARGS for numpy 2.0 or newer. We can't use a flexible
+           array member in C++ so use the internal size there. */
+        PyArrayIterObject    *iters[64];
+#else
         PyArrayIterObject    *iters[];
 #endif
 } PyArrayMultiIterObject;


### PR DESCRIPTION
Fixes #26013 

I *think* this is how it's supposed to be spelled and only the compile time version matters.