### PR TITLE
BUG: Fix reference leak in niche user old user dtypes

### DIFF
--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -305,8 +305,8 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
         NPY_DT_SLOTS(NPY_DTYPE(descr))->get_clear_loop = (
                 &npy_get_clear_void_and_legacy_user_dtype_loop);
         /* Also use the void zerofill since there may be objects */
-        NPY_DT_SLOTS(NPY_DTYPE(descr))->get_clear_loop = (
-                &npy_get_zerofill_void_and_legacy_user_dtype_loop);
+        NPY_DT_SLOTS(NPY_DTYPE(descr))->get_fill_zero_loop = (
+                (get_traverse_loop_function *)&npy_get_zerofill_void_and_legacy_user_dtype_loop);
     }
 
     return typenum;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1848,6 +1848,13 @@ class TestUserDType:
         # unnecessary restriction, but one that has been around forever:
         assert np.dtype(mytype) == np.dtype("O")
 
+        if HAS_REFCOUNT:
+            # Create an array and test that memory gets cleaned up (gh-25949)
+            o = object()
+            a = np.array([o], dtype=dt)
+            del a
+            assert sys.getrefcount(o) == 2
+
     def test_custom_structured_dtype_errors(self):
         class mytype:
             pass


### PR DESCRIPTION
Backport of #25950.

This was just a typo, add a test for the regression (checked that it triggered it).

Closes gh-25949

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
