### PR TITLE
BUG: Fixes np.put receiving empty array causes endless loop

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -396,7 +396,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
     ni = PyArray_SIZE(indices);
     if ((ni > 0) && (PyArray_Size((PyObject *)self) == 0)) {
         PyErr_SetString(PyExc_IndexError, 
-                        "put: cannot do a non empty put on an empty array");
+                        "cannot replace elements of an empty array");
         return NULL;
     }
     Py_INCREF(PyArray_DESCR(self));

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -384,12 +384,6 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         return NULL;
     }
 
-    if (PyArray_Size((PyObject *)self) == 0) {
-        PyErr_SetString(PyExc_IndexError, 
-                        "put: cannot do a put on an empty array");
-        return NULL;
-    }
-
     if (PyArray_FailUnlessWriteable(self, "put: output array") < 0) {
         return NULL;
     }
@@ -400,6 +394,11 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         goto fail;
     }
     ni = PyArray_SIZE(indices);
+    if ((ni > 0) && (PyArray_Size((PyObject *)self) == 0)) {
+        PyErr_SetString(PyExc_IndexError, 
+                        "put: cannot do a non empty put on an empty array");
+        return NULL;
+    }
     Py_INCREF(PyArray_DESCR(self));
     values = (PyArrayObject *)PyArray_FromAny(values0, PyArray_DESCR(self), 0, 0,
                               NPY_ARRAY_DEFAULT | NPY_ARRAY_FORCECAST, NULL);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -384,6 +384,12 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         return NULL;
     }
 
+    if (PyArray_Size((PyObject *)self) == 0) {
+        PyErr_SetString(PyExc_IndexError, 
+                        "put: cannot do a put on an empty array");
+        return NULL;
+    }
+
     if (PyArray_FailUnlessWriteable(self, "put: output array") < 0) {
         return NULL;
     }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3506,6 +3506,7 @@ class TestMethods:
         # array is empty
         empty_array = np.asarray(list())
         assert_raises(IndexError, np.put, empty_array, 1, 1, mode="wrap")
+        assert_raises(IndexError, np.put, empty_array, 1, 1, mode="clip")
 
     def test_ravel(self):
         a = np.array([[0, 1], [2, 3]])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3501,6 +3501,12 @@ class TestMethods:
         bad_array = [1, 2, 3]
         assert_raises(TypeError, np.put, bad_array, [0, 2], 5)
 
+        # when calling np.put, make sure an 
+        # IndexError is raised if the 
+        # array is empty
+        empty_array = np.asarray(list())
+        assert_raises(IndexError, np.put, empty_array, 1, 1, mode="wrap")
+
     def test_ravel(self):
         a = np.array([[0, 1], [2, 3]])
         assert_equal(a.ravel(), [0, 1, 2, 3])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3505,8 +3505,13 @@ class TestMethods:
         # IndexError is raised if the 
         # array is empty
         empty_array = np.asarray(list())
-        assert_raises(IndexError, np.put, empty_array, 1, 1, mode="wrap")
-        assert_raises(IndexError, np.put, empty_array, 1, 1, mode="clip")
+        with pytest.raises(IndexError, 
+                            match="cannot replace elements of an empty array"):
+            np.put(empty_array, 1, 1, mode="wrap")
+        with pytest.raises(IndexError, 
+                            match="cannot replace elements of an empty array"):
+            np.put(empty_array, 1, 1, mode="clip")
+        
 
     def test_ravel(self):
         a = np.array([[0, 1], [2, 3]])


### PR DESCRIPTION
Backport of #25975.

Closes #25744.

The bug issue was in the np.put function, specifically when an empty array was passed in wrap mode, causing an endless loop. During the investigation of the bug, it was observed that a similar problem occurred when using an empty array in clip mode, resulting in a core dump.

To address both issues simultaneously, I propose the following solution: In the implementation of the put function in C, I check whether the array is empty at the beginning of the function. If it is indeed empty, the implementation should raise an IndexError, providing a more informative and accurate error handling mechanism.

  Now all these code snippets work as intended:
```python
import numpy as np 
array = np.asarray(list())
np.put(array, 1, 1, mode="wrap")`
```

```python
import numpy as np 
array = np.asarray(list())
np.put(array, 1, 1, mode="clip")`
```

```python
import numpy as np 
a = np.zeros((5, 5, 0))
a.put(100, 0)
```

I also added a unit test for this issue.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
