### PR TITLE
ENH: Optimize np.power for integer type

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -572,17 +572,11 @@ class BinaryBench(Benchmark):
     def time_pow(self, dtype):
         np.power(self.a, self.b)
 
-    def time_pow_32(self):
-        np.power(self.a32, self.b32)
-
     def time_pow_2(self, dtype):
         np.power(self.a, 2.0)
 
     def time_pow_half(self, dtype):
         np.power(self.a, 0.5)
-
-    def time_atan2_32(self):
-        np.arctan2(self.a32, self.b32)
 
     def time_atan2(self, dtype):
         np.arctan2(self.a, self.b)
@@ -593,14 +587,14 @@ class BinaryBenchInteger(Benchmark):
 
     def setup(self, dtype):
         N = 1000000
-        self.a_i64 = np.random.randint(20, size=N).astype(dtype)
-        self.b_i64 = np.random.randint(4, size=N).astype(dtype)
+        self.a = np.random.randint(20, size=N).astype(dtype)
+        self.b = np.random.randint(4, size=N).astype(dtype)
         
     def time_pow(self, dtype):
         np.power(self.a, self.b)
 
-    def time_pow_two(self):
+    def time_pow_two(self, dtype):
         np.power(self.a, 2)
 
-    def time_pow_five(self):
+    def time_pow_five(self, dtype):
         np.power(self.a, 5)

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -566,15 +566,41 @@ class BinaryBench(Benchmark):
         N = 1000000
         self.a = np.random.rand(N).astype(dtype)
         self.b = np.random.rand(N).astype(dtype)
+        self.a_i64 = np.random.randint(20, size=N).astype(np.int64)
+        self.b_i64 = np.random.randint(4, size=N).astype(np.int64)
 
     def time_pow(self, dtype):
         np.power(self.a, self.b)
 
+    def time_pow_32(self):
+        np.power(self.a32, self.b32)
+
     def time_pow_2(self, dtype):
         np.power(self.a, 2.0)
 
-    def time_pow_half(self, dype):
+    def time_pow_half(self, dtype):
         np.power(self.a, 0.5)
+
+    def time_atan2_32(self):
+        np.arctan2(self.a32, self.b32)
 
     def time_atan2(self, dtype):
         np.arctan2(self.a, self.b)
+
+class BinaryBenchInteger(Benchmark):
+    params = [np.int32, np.int64]
+    param_names = ['dtype']
+
+    def setup(self, dtype):
+        N = 1000000
+        self.a_i64 = np.random.randint(20, size=N).astype(dtype)
+        self.b_i64 = np.random.randint(4, size=N).astype(dtype)
+        
+    def time_pow(self, dtype):
+        np.power(self.a, self.b)
+
+    def time_pow_two(self):
+        np.power(self.a, 2)
+
+    def time_pow_five(self):
+        np.power(self.a, 5)

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -566,8 +566,6 @@ class BinaryBench(Benchmark):
         N = 1000000
         self.a = np.random.rand(N).astype(dtype)
         self.b = np.random.rand(N).astype(dtype)
-        self.a_i64 = np.random.randint(20, size=N).astype(np.int64)
-        self.b_i64 = np.random.randint(4, size=N).astype(np.int64)
 
     def time_pow(self, dtype):
         np.power(self.a, self.b)

--- a/numpy/_core/src/umath/fast_loop_macros.h
+++ b/numpy/_core/src/umath/fast_loop_macros.h
@@ -90,6 +90,16 @@ abs_ptrdiff(char *a, char *b)
     BINARY_DEFS\
     BINARY_LOOP_SLIDING
 
+/** (ip1, ip2) -> (op1), for case ip2 has zero stride*/
+#define BINARY_DEFS_ZERO_STRIDE                          \
+    char *ip1 = args[0], *ip2 = args[1], *op1 = args[2]; \
+    npy_intp is1 = steps[0], os1 = steps[2];             \
+    npy_intp n = dimensions[0];                          \
+    npy_intp i;
+
+#define BINARY_LOOP_SLIDING_ZERO_STRIDE \
+    for (i = 0; i < n; i++, ip1 += is1, op1 += os1)
+
 /** (ip1, ip2) -> (op1, op2) */
 #define BINARY_LOOP_TWO_OUT\
     char *ip1 = args[0], *ip2 = args[1], *op1 = args[2], *op2 = args[3];\

--- a/numpy/_core/src/umath/fast_loop_macros.h
+++ b/numpy/_core/src/umath/fast_loop_macros.h
@@ -90,16 +90,6 @@ abs_ptrdiff(char *a, char *b)
     BINARY_DEFS\
     BINARY_LOOP_SLIDING
 
-/** (ip1, ip2) -> (op1), for case ip2 has zero stride*/
-#define BINARY_DEFS_ZERO_STRIDE                          \
-    char *ip1 = args[0], *ip2 = args[1], *op1 = args[2]; \
-    npy_intp is1 = steps[0], os1 = steps[2];             \
-    npy_intp n = dimensions[0];                          \
-    npy_intp i;
-
-#define BINARY_LOOP_SLIDING_ZERO_STRIDE \
-    for (i = 0; i < n; i++, ip1 += is1, op1 += os1)
-
 /** (ip1, ip2) -> (op1, op2) */
 #define BINARY_LOOP_TWO_OUT\
     char *ip1 = args[0], *ip2 = args[1], *op1 = args[2], *op2 = args[3];\

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -491,7 +491,7 @@ NPY_NO_EXPORT void
 {
     if (steps[1]==0) {
         // stride for second argument is 0
-        BINARY_DEFS_ZERO_STRIDE
+        BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
         #if @SIGNED@
             if (in2 < 0) {
@@ -504,7 +504,7 @@ NPY_NO_EXPORT void
         int first_bit = in2 & 1;
         @type@ in2start = in2 >> 1;
 
-        BINARY_LOOP_SLIDING_ZERO_STRIDE {
+        BINARY_LOOP_SLIDING {
             @type@ in1 = *(@type@ *)ip1;
 
             *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -513,7 +513,6 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;
-        @type@ out;
 
 #if @SIGNED@
         if (in2 < 0) {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -476,7 +476,11 @@ NPY_NO_EXPORT void
 {
     if (steps[1]==0) {
         // stride for second argument is 0
-        BINARY_DEFS
+        char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
+        npy_intp is1 = steps[0], os1 = steps[2];
+        npy_intp n = dimensions[0];
+        npy_intp i;
+
         @type@ in2 = *(@type@ *)ip2;
         #if @SIGNED@
                 if (in2 < 0) {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -474,6 +474,47 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 int
 NPY_NO_EXPORT void
 @TYPE@_power(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
+    if (steps[1]==0) {
+        // stride for second argument is 0
+        BINARY_DEFS
+        @type@ in2 = *(@type@ *)ip2;
+        #if @SIGNED@
+                if (in2 < 0) {
+                    npy_gil_error(PyExc_ValueError,
+                                  "Integers to negative integer powers are not allowed.");
+                    return;
+                }
+        #endif
+
+        if (in2==2) {
+            for(i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+                    @type@ in1 = *(@type@ *)ip1;
+
+                    *((@type@ *) op1) = in1 * in1;
+                }
+                return;
+        } else {
+            int first_bit = in2 & 1;
+            @type@ in2start = in2 >> 1;
+
+            for(i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+                @type@ in1 = *(@type@ *)ip1;
+                @type@ var = in2start;
+                @type@ out;
+
+                out = first_bit ? in1 : 1;
+                while (var > 0) {
+                    in1 *= in1;
+                    if (var & 1) {
+                        out *= in1;
+                    }
+                    var >>= 1;
+                }
+                *((@type@ *) op1) = out;
+            }
+        return;
+        }
+    }
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -471,6 +471,20 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 int
 }
 /**end repeat1**/
 
+static inline @type@ _@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int first_bit) {
+   // Helper method to calculate power using squared exponentiation
+   // The algorithm is partly unrolled. The second and third argument are the exponent//2 and the first bit of the exponent
+   @type@ out = first_bit ? base : 1;
+   while (exponent_two > 0) {
+        base *= base;
+        if (exponent_two & 1) {
+            out *= base;
+        }
+        exponent_two >>= 1;
+    }
+   return out;
+}
+
 NPY_NO_EXPORT void
 @TYPE@_power(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
@@ -491,18 +505,8 @@ NPY_NO_EXPORT void
 
         BINARY_LOOP_SLIDING_ZERO_STRIDE {
             @type@ in1 = *(@type@ *)ip1;
-            @type@ var = in2start;
-            @type@ out;
 
-            out = first_bit ? in1 : 1;
-            while (var > 0) {
-                in1 *= in1;
-                if (var & 1) {
-                    out *= in1;
-                }
-                var >>= 1;
-            }
-            *((@type@ *) op1) = out;
+            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
         }
         return;
     }
@@ -527,16 +531,9 @@ NPY_NO_EXPORT void
             continue;
         }
 
-        out = in2 & 1 ? in1 : 1;
+        int first_bit = in2 & 1;
         in2 >>= 1;
-        while (in2 > 0) {
-            in1 *= in1;
-            if (in2 & 1) {
-                out *= in1;
-            }
-            in2 >>= 1;
-        }
-        *((@type@ *) op1) = out;
+        *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);
     }
 }
 /**end repeat**/

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -476,12 +476,8 @@ NPY_NO_EXPORT void
 {
     if (steps[1]==0) {
         // stride for second argument is 0
-        char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
-        npy_intp is1 = steps[0], os1 = steps[2];
-        npy_intp n = dimensions[0];
-        npy_intp i;
-
-        @type@ in2 = *(@type@ *)ip2;
+        BINARY_DEFS_ZERO_STRIDE
+        const @type@ in2 = *(@type@ *)ip2;
         #if @SIGNED@
                 if (in2 < 0) {
                     npy_gil_error(PyExc_ValueError,
@@ -490,34 +486,25 @@ NPY_NO_EXPORT void
                 }
         #endif
 
-        if (in2==2) {
-            for(i = 0; i < n; i++, ip1 += is1, op1 += os1) {
-                    @type@ in1 = *(@type@ *)ip1;
+        int first_bit = in2 & 1;
+        @type@ in2start = in2 >> 1;
 
-                    *((@type@ *) op1) = in1 * in1;
+        BINARY_LOOP_SLIDING_ZERO_STRIDE {
+            @type@ in1 = *(@type@ *)ip1;
+            @type@ var = in2start;
+            @type@ out;
+
+            out = first_bit ? in1 : 1;
+            while (var > 0) {
+                in1 *= in1;
+                if (var & 1) {
+                    out *= in1;
                 }
-                return;
-        } else {
-            int first_bit = in2 & 1;
-            @type@ in2start = in2 >> 1;
-
-            for(i = 0; i < n; i++, ip1 += is1, op1 += os1) {
-                @type@ in1 = *(@type@ *)ip1;
-                @type@ var = in2start;
-                @type@ out;
-
-                out = first_bit ? in1 : 1;
-                while (var > 0) {
-                    in1 *= in1;
-                    if (var & 1) {
-                        out *= in1;
-                    }
-                    var >>= 1;
-                }
-                *((@type@ *) op1) = out;
+                var >>= 1;
             }
-        return;
+            *((@type@ *) op1) = out;
         }
+        return;
     }
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -471,7 +471,8 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 int
 }
 /**end repeat1**/
 
-static inline @type@ _@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int first_bit) {
+static inline @type@
+_@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int first_bit) {
    // Helper method to calculate power using squared exponentiation
    // The algorithm is partly unrolled. The second and third argument are the exponent//2 and the first bit of the exponent
    @type@ out = first_bit ? base : 1;
@@ -493,11 +494,11 @@ NPY_NO_EXPORT void
         BINARY_DEFS_ZERO_STRIDE
         const @type@ in2 = *(@type@ *)ip2;
         #if @SIGNED@
-                if (in2 < 0) {
-                    npy_gil_error(PyExc_ValueError,
-                                  "Integers to negative integer powers are not allowed.");
-                    return;
-                }
+            if (in2 < 0) {
+                npy_gil_error(PyExc_ValueError,
+                              "Integers to negative integer powers are not allowed.");
+                return;
+            }
         #endif
 
         int first_bit = in2 & 1;


### PR DESCRIPTION
In this PR we optimize `np.power(x, n)` for integer types and a scalar argument `n`. The current implementation is a generic binary loop for the arguments. In the case `n` is a scalar (stride 0) we can optimize the  loop. 

Micro benchmark:
```
import numpy as np
import timeit

x=np.arange(100_000)
n = 20_000

dt=timeit.timeit('x**2', globals=globals(), number=n)
print(f'x**2 {1e6*dt/n}')
dt=timeit.timeit('x**3', globals=globals(), number=n)
print(f'x**3 {1e6*dt/n}')
dt=timeit.timeit('np.power(x, 1)', globals=globals(), number=n)
print(f'power(x, 1) {1e6*dt/n}')
dt=timeit.timeit('np.power(x, 2)', globals=globals(), number=n)
print(f'power(x, 2) {1e6*dt/n}')
dt=timeit.timeit('np.power(x, 3)', globals=globals(), number=n)
print(f'power(x, 3) {1e6*dt/n}')
dt=timeit.timeit('np.power(x, 4)', globals=globals(), number=n)
print(f'power(x, 4) {1e6*dt/n}')
```
Main:
```
x**2 62.292819999856874
x**3 135.96379000227898
power(x, 1) 103.64716000040062
power(x, 2) 134.2153200006578
power(x, 3) 142.9221049998887
power(x, 4) 197.58593500009738
```
PR:
```
x**2 59.52026000013575
x**3 87.76193000085186
power(x, 1) 62.03027000010479
power(x, 2) 86.0 (estimated)
power(x, 3) 86.40300999977626
power(x, 4) 126.56257500057109

```
Notes

* We could add the special case `if (in2==2)` to improve performance. For `np.power(x, 2)` we have per loop: main 143.2 us, special case exponent 2 55.7 us, no special case about 86 us.
* Related: #9363, #6399, #22651, #7786


