### PR TITLE
BUG: raise error trying to coerce object arrays containing timedelta64('NaT') to StringDType

### DIFF
--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -838,22 +838,13 @@ python_builtins_are_known_scalar_types(
      * This is necessary only for python scalar classes which we discover
      * as valid DTypes.
      */
-    if (pytype == &PyFloat_Type) {
-        return 1;
-    }
-    if (pytype == &PyLong_Type) {
-        return 1;
-    }
-    if (pytype == &PyBool_Type) {
-        return 1;
-    }
-    if (pytype == &PyComplex_Type) {
-        return 1;
-    }
-    if (pytype == &PyUnicode_Type) {
-        return 1;
-    }
-    if (pytype == &PyBytes_Type) {
+    if (pytype == &PyFloat_Type ||
+        pytype == &PyLong_Type ||
+        pytype == &PyBool_Type ||
+        pytype == &PyComplex_Type ||
+        pytype == &PyUnicode_Type ||
+        pytype == &PyBytes_Type)
+    {
         return 1;
     }
     return 0;

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -554,91 +554,36 @@ stringdtype_get_clear_loop(void *NPY_UNUSED(traverse_context),
 }
 
 static int
-stringdtype_is_known_scalar_type(PyArray_DTypeMeta *NPY_UNUSED(cls),
+stringdtype_is_known_scalar_type(PyArray_DTypeMeta *cls,
                                  PyTypeObject *pytype)
 {
-    if (pytype == &PyFloat_Type) {
+    if (python_builtins_are_known_scalar_types(cls, pytype)) {
         return 1;
     }
-    if (pytype == &PyLong_Type) {
-        return 1;
-    }
-    if (pytype == &PyBool_Type) {
-        return 1;
-    }
-    if (pytype == &PyComplex_Type) {
-        return 1;
-    }
-    if (pytype == &PyUnicode_Type) {
-        return 1;
-    }
-    if (pytype == &PyBytes_Type) {
-        return 1;
-    }
-    if (pytype == &PyBoolArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyByteArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyShortArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyIntArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyLongArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyLongLongArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyUByteArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyUShortArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyUIntArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyULongArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyULongLongArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyHalfArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyFloatArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyDoubleArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyLongDoubleArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyCFloatArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyCDoubleArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyCLongDoubleArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyIntpArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyUIntpArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyDatetimeArrType_Type) {
-        return 1;
-    }
-    if (pytype == &PyTimedeltaArrType_Type) {
+    // accept every built-in numpy dtype
+    else if (pytype == &PyBoolArrType_Type ||
+             pytype == &PyByteArrType_Type ||
+             pytype == &PyShortArrType_Type ||
+             pytype == &PyIntArrType_Type ||
+             pytype == &PyLongArrType_Type ||
+             pytype == &PyLongLongArrType_Type ||
+             pytype == &PyUByteArrType_Type ||
+             pytype == &PyUShortArrType_Type ||
+             pytype == &PyUIntArrType_Type ||
+             pytype == &PyULongArrType_Type ||
+             pytype == &PyULongLongArrType_Type ||
+             pytype == &PyHalfArrType_Type ||
+             pytype == &PyFloatArrType_Type ||
+             pytype == &PyDoubleArrType_Type ||
+             pytype == &PyLongDoubleArrType_Type ||
+             pytype == &PyCFloatArrType_Type ||
+             pytype == &PyCDoubleArrType_Type ||
+             pytype == &PyCLongDoubleArrType_Type ||
+             pytype == &PyIntpArrType_Type ||
+             pytype == &PyUIntpArrType_Type ||
+             pytype == &PyDatetimeArrType_Type ||
+             pytype == &PyTimedeltaArrType_Type)
+    {
         return 1;
     }
     return 0;

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -638,6 +638,9 @@ stringdtype_is_known_scalar_type(PyArray_DTypeMeta *NPY_UNUSED(cls),
     if (pytype == &PyDatetimeArrType_Type) {
         return 1;
     }
+    if (pytype == &PyTimedeltaArrType_Type) {
+        return 1;
+    }
     return 0;
 }
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -916,6 +916,12 @@ def test_nat_casts():
                 np.array([output_object]*arr.size, dtype=dtype))
 
 
+def test_nat_conversion():
+    for nat in [np.datetime64("NaT", "s"), np.timedelta64("NaT", "s")]:
+        with pytest.raises(ValueError, match="string coercion is disabled"):
+            np.array(["a", nat], dtype=StringDType(coerce=False))
+
+
 def test_growing_strings(dtype):
     # growing a string leads to a heap allocation, this tests to make sure
     # we do that bookkeeping correctly for all possible starting cases


### PR DESCRIPTION
Backport of #26024.

Without the change to `stringdtype_is_known_scalar_type`, the second iteration of the for loop in the test would fail. Datetime already fails, so this just makes timedelta consistent with that.

I discovered this running the pandas test suite against my pandas string dtype built on StringDType.

@seberg is there maybe a better way to write `is_known_scalar_type` than using a bunch of if statements?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
