### PR TITLE
BUG: fix reference count leak in __array__ internals

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2466,6 +2466,9 @@ PyArray_FromArrayAttr_int(
 
     if (new == NULL) {
         if (npy_ma_str_array_err_msg_substr == NULL) {
+            Py_DECREF(array_meth);
+            Py_DECREF(args);
+            Py_DECREF(kwargs);
             return NULL;
         }
         PyObject *type, *value, *traceback;
@@ -2481,6 +2484,7 @@ PyArray_FromArrayAttr_int(
                                  "__array__ should implement 'dtype' and "
                                  "'copy' keywords", 1) < 0) {
                     Py_DECREF(str_value);
+                    Py_DECREF(array_meth);
                     Py_DECREF(args);
                     Py_DECREF(kwargs);
                     return NULL;
@@ -2490,6 +2494,7 @@ PyArray_FromArrayAttr_int(
                     new = PyObject_Call(array_meth, args, kwargs);
                     if (new == NULL) {
                         Py_DECREF(str_value);
+                        Py_DECREF(array_meth);
                         Py_DECREF(args);
                         Py_DECREF(kwargs);
                         return NULL;
@@ -2500,15 +2505,16 @@ PyArray_FromArrayAttr_int(
         }
         if (new == NULL) {
             PyErr_Restore(type, value, traceback);
+            Py_DECREF(array_meth);
             Py_DECREF(args);
             Py_DECREF(kwargs);
             return NULL;
         }
     }
 
+    Py_DECREF(array_meth);
     Py_DECREF(args);
     Py_DECREF(kwargs);
-    Py_DECREF(array_meth);
 
     if (!PyArray_Check(new)) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8492,6 +8492,25 @@ class TestArrayCreationCopyArgument(object):
                                               "and 'copy' keywords")):
             np.array(a, copy=False)
 
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test__array__reference_leak(self):
+        class NotAnArray:
+            def __array__(self):
+                raise NotImplementedError()
+
+        x = NotAnArray()
+
+        refcount = sys.getrefcount(x)
+
+        try:
+            np.array(x)
+        except NotImplementedError:
+            pass
+
+        gc.collect()
+
+        assert refcount == sys.getrefcount(x)
+
     @pytest.mark.parametrize(
             "arr", [np.ones(()), np.arange(81).reshape((9, 9))])
     @pytest.mark.parametrize("order1", ["C", "F", None])


### PR DESCRIPTION
Backport of #26025.

Closes https://github.com/numpy/numpy/issues/26020.

Would very much appreciate another careful eye on this or suggestions to make the error handling less convoluted.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
