### PR TITLE
BUG: add missing error handling in string to int cast internals

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -571,6 +571,9 @@ string_to_pylong(char *in, int has_null,
 {
     PyObject *val_obj = non_nullable_string_to_pystring(
             in, has_null, default_string, allocator);
+    if (val_obj == NULL) {
+        return NULL;
+    }
     // interpret as an integer in base 10
     PyObject *pylong_value = PyLong_FromUnicodeObject(val_obj, 10);
     Py_DECREF(val_obj);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -562,6 +562,10 @@ def test_sized_integer_casts(bitsize, signed):
     with pytest.raises(OverflowError):
         np.array(oob, dtype="T").astype(idtype)
 
+    with pytest.raises(ValueError):
+        np.array(["1", np.nan, "3"],
+                 dtype=StringDType(na_object=np.nan)).astype(idtype)
+
 
 @pytest.mark.parametrize("typename", ["byte", "short", "int", "longlong"])
 @pytest.mark.parametrize("signed", ["", "u"])


### PR DESCRIPTION
Backport of #26027.

We don't check for errors here, but `non_nullable_string_to_pystring` can fail and we do check for errors at all other call sites. The test I added seg faults without this error handling.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
