### PR TITLE
CI: clean up some unused `choco install` invocations

### DIFF
--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -14,10 +14,7 @@ steps:
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
 - powershell: |
-    choco install -y --stoponfirstfailure unzip
     choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-    choco install --stoponfirstfailure ninja
-    echo "##vso[task.setvariable variable=RTOOLS43_HOME]c:\rtools43"
   displayName: 'Install utilities'
 
 - powershell: |
@@ -42,7 +39,7 @@ steps:
 - powershell: |
     cd tools  # avoid root dir to not pick up source tree
     # Get a gfortran onto the path for f2py tests
-    $env:PATH = "$env:RTOOLS43_HOME\\x86_64-w64-mingw32.static.posix\\bin;$env:PATH"
+    $env:PATH = "c:\\rtools43\\x86_64-w64-mingw32.static.posix\\bin;$env:PATH"
     If ( $env:TEST_MODE -eq "full" ) {
       pytest --pyargs numpy -rsx --junitxml=junit/test-results.xml
     } else {


### PR DESCRIPTION
Backport of #25990.

- `unzip` is (I think) a left-over from having to unzip OpenBLAS tarballs (we have wheels for that now)
- `ninja` is already installed from PyPI, it's in `test_requirements.txt`

The `rtools43` path cleanup helps readability. Rtools is already installed on the CI runner image, and only used for testing (f2py tests in "full" mode).

[skip cirrus] [skip circle] [skip actions]

xref gh-25980 for Chocolatey issues that motivated this PR.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
