### PR TITLE
MAINT,API: Const qualify some new API (mostly new DType API)

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1682,8 +1682,8 @@ the functions that must be implemented for each slot.
 
 .. c:type:: NPY_CASTING (PyArrayMethod_ResolveDescriptors)( \
                 struct PyArrayMethodObject_tag *method, \
-                PyArray_DTypeMeta **dtypes, \
-                PyArray_Descr **given_descrs, \
+                PyArray_DTypeMeta *const *dtypes, \
+                PyArray_Descr *const *given_descrs, \
                 PyArray_Descr **loop_descrs, \
                 npy_intp *view_offset)
 
@@ -1857,7 +1857,7 @@ Typedefs for functions that users of the ArrayMethod API can implement are
 described below.
 
 .. c:type:: int (PyArrayMethod_TraverseLoop)( \
-        void *traverse_context, PyArray_Descr *descr, char *data, \
+        void *traverse_context, const PyArray_Descr *descr, char *data, \
         npy_intp size, npy_intp stride, NpyAuxData *auxdata)
 
    A traverse loop working on a single array. This is similar to the general
@@ -1880,7 +1880,7 @@ described below.
    passed through in the future (for structured dtypes).
 
 .. c:type:: int (PyArrayMethod_GetTraverseLoop)( \
-                void *traverse_context, PyArray_Descr *descr, \
+                void *traverse_context, const PyArray_Descr *descr, \
                 int aligned, npy_intp fixed_stride, \
                 PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **out_auxdata, \
                 NPY_ARRAYMETHOD_FLAGS *flags)
@@ -1920,7 +1920,8 @@ with the rest of the ArrayMethod API.
    attempt a new search for a matching loop/promoter.
 
 .. c:type:: int (PyArrayMethod_PromoterFunction)(PyObject *ufunc, \
-                PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[], \
+                PyArray_DTypeMeta *const op_dtypes[], \
+                PyArray_DTypeMeta *const signature[], \
                 PyArray_DTypeMeta *new_op_dtypes[])
 
    Type of the promoter function, which must be wrapped into a

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3387,7 +3387,7 @@ Data Type Promotion and Inspection
 ----------------------------------
 
 .. c:function:: PyArray_DTypeMeta *PyArray_CommonDType( \
-                    PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2)
+            const PyArray_DTypeMeta *dtype1, const PyArray_DTypeMeta *dtype2)
 
    This function defines the common DType operator. Note that the common DType
    will not be ``object`` (unless one of the DTypes is ``object``). Similar to
@@ -3414,7 +3414,7 @@ Data Type Promotion and Inspection
    For example promoting ``float16`` with any other float, integer, or unsigned
    integer again gives a floating point number.
 
-.. c:function:: PyArray_Descr *PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
+.. c:function:: PyArray_Descr *PyArray_GetDefaultDescr(const PyArray_DTypeMeta *DType)
 
    Given a DType class, returns the default instance (descriptor).  This checks
    for a ``singleton`` first and only calls the ``default_descr`` function if

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -728,7 +728,7 @@ PyArrayMethod_Context and PyArrayMethod_Spec
       typedef struct {
           PyObject *caller;
           struct PyArrayMethodObject_tag *method;
-          PyArray_Descr **descriptors;
+          PyArray_Descr *const *descriptors;
       } PyArrayMethod_Context
 
    .. c:member:: PyObject *caller

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -106,7 +106,7 @@ typedef struct PyArrayMethod_Context_tag {
     struct PyArrayMethodObject_tag *method;
 
     /* Operand descriptors, filled in by resolve_descriptors */
-    PyArray_Descr **descriptors;
+    PyArray_Descr *const *descriptors;
     /* Structure may grow (this is harmless for DType authors) */
 } PyArrayMethod_Context;
 
@@ -159,9 +159,9 @@ typedef NPY_CASTING (PyArrayMethod_ResolveDescriptors)(
         /* "method" is currently opaque (necessary e.g. to wrap Python) */
         struct PyArrayMethodObject_tag *method,
         /* DTypes the method was created for */
-        PyArray_DTypeMeta **dtypes,
+        PyArray_DTypeMeta *const *dtypes,
         /* Input descriptors (instances).  Outputs may be NULL. */
-        PyArray_Descr **given_descrs,
+        PyArray_Descr *const *given_descrs,
         /* Exact loop descriptors to use, must not hold references on error */
         PyArray_Descr **loop_descrs,
         npy_intp *view_offset);
@@ -177,9 +177,9 @@ typedef NPY_CASTING (PyArrayMethod_ResolveDescriptors)(
  */
 typedef NPY_CASTING (PyArrayMethod_ResolveDescriptorsWithScalar)(
         struct PyArrayMethodObject_tag *method,
-        PyArray_DTypeMeta **dtypes,
+        PyArray_DTypeMeta *const *dtypes,
         /* Unlike above, these can have any DType and we may allow NULL. */
-        PyArray_Descr **given_descrs,
+        PyArray_Descr *const *given_descrs,
         /*
          * Input scalars or NULL.  Only ever passed for python scalars.
          * WARNING: In some cases, a loop may be explicitly selected and the
@@ -227,7 +227,7 @@ typedef int (PyArrayMethod_GetLoop)(
  */
 typedef int (PyArrayMethod_GetReductionInitial)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
-        char *initial);
+        void *initial);
 
 /*
  * The following functions are only used by the wrapping array method defined
@@ -256,8 +256,8 @@ typedef int (PyArrayMethod_GetReductionInitial)(
  *       `resolve_descriptors`, so that it can be filled there if not NULL.)
  */
 typedef int (PyArrayMethod_TranslateGivenDescriptors)(int nin, int nout,
-        PyArray_DTypeMeta *wrapped_dtypes[],
-        PyArray_Descr *given_descrs[], PyArray_Descr *new_descrs[]);
+        PyArray_DTypeMeta *const wrapped_dtypes[],
+        PyArray_Descr *const given_descrs[], PyArray_Descr *new_descrs[]);
 
 /**
  * The function to convert the actual loop descriptors (as returned by the
@@ -278,7 +278,7 @@ typedef int (PyArrayMethod_TranslateGivenDescriptors)(int nin, int nout,
  * @returns 0 on success, -1 on failure.
  */
 typedef int (PyArrayMethod_TranslateLoopDescriptors)(int nin, int nout,
-        PyArray_DTypeMeta *new_dtypes[], PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const new_dtypes[], PyArray_Descr *const given_descrs[],
         PyArray_Descr *original_descrs[], PyArray_Descr *loop_descrs[]);
 
 
@@ -303,7 +303,7 @@ typedef int (PyArrayMethod_TranslateLoopDescriptors)(int nin, int nout,
  *
  */
 typedef int (PyArrayMethod_TraverseLoop)(
-        void *traverse_context, PyArray_Descr *descr, char *data,
+        void *traverse_context, const PyArray_Descr *descr, char *data,
         npy_intp size, npy_intp stride, NpyAuxData *auxdata);
 
 
@@ -317,7 +317,7 @@ typedef int (PyArrayMethod_TraverseLoop)(
  *
  */
 typedef int (PyArrayMethod_GetTraverseLoop)(
-        void *traverse_context, PyArray_Descr *descr,
+        void *traverse_context, const PyArray_Descr *descr,
         int aligned, npy_intp fixed_stride,
         PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **out_auxdata,
         NPY_ARRAYMETHOD_FLAGS *flags);
@@ -334,7 +334,7 @@ typedef int (PyArrayMethod_GetTraverseLoop)(
  * (There are potential use-cases, these are currently unsupported.)
  */
 typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[]);
 
 /*

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -220,19 +220,19 @@ DESCR_ACCESSOR(C_METADATA, c_metadata, NpyAuxData *, 1)
 #if !(defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)
 #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
     static inline PyArray_ArrFuncs *
-    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    PyDataType_GetArrFuncs(const PyArray_Descr *descr)
     {
         return _PyDataType_GetArrFuncs(descr);
     }
 #elif NPY_ABI_VERSION < 0x02000000
     static inline PyArray_ArrFuncs *
-    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    PyDataType_GetArrFuncs(const PyArray_Descr *descr)
     {
         return descr->f;
     }
 #else
     static inline PyArray_ArrFuncs *
-    PyDataType_GetArrFuncs(PyArray_Descr *descr)
+    PyDataType_GetArrFuncs(const PyArray_Descr *descr)
     {
         if (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION) {
             return _PyDataType_GetArrFuncs(descr);

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -59,8 +59,8 @@
 static NPY_CASTING
 default_resolve_descriptors(
         PyArrayMethodObject *method,
-        PyArray_DTypeMeta **dtypes,
-        PyArray_Descr **input_descrs,
+        PyArray_DTypeMeta *const *dtypes,
+        PyArray_Descr *const *input_descrs,
         PyArray_Descr **output_descrs,
         npy_intp *view_offset)
 {
@@ -139,7 +139,7 @@ npy_default_get_strided_loop(
         PyArrayMethod_StridedLoop **out_loop, NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     PyArrayMethodObject *meth = context->method;
     *flags = meth->flags & NPY_METH_RUNTIME_FLAGS;
     *out_transferdata = NULL;

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2440,8 +2440,8 @@ PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
 NPY_NO_EXPORT NPY_CASTING
 legacy_same_dtype_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[2]),
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -2483,7 +2483,7 @@ legacy_cast_get_strided_loop(
         PyArrayMethod_StridedLoop **out_loop, NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     int out_needs_api = 0;
 
     *flags = context->method->flags & NPY_METH_RUNTIME_FLAGS;
@@ -2507,8 +2507,8 @@ legacy_cast_get_strided_loop(
 NPY_NO_EXPORT NPY_CASTING
 simple_cast_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -2548,7 +2548,7 @@ get_byteswap_loop(
         PyArrayMethod_StridedLoop **out_loop, NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     assert(descrs[0]->kind == descrs[1]->kind);
     assert(descrs[0]->elsize == descrs[1]->elsize);
     int itemsize = descrs[0]->elsize;
@@ -2727,8 +2727,8 @@ PyArray_InitializeNumericCasts(void)
 static int
 cast_to_string_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -2879,8 +2879,8 @@ add_other_to_and_from_string_cast(
 NPY_NO_EXPORT NPY_CASTING
 string_to_string_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[2]),
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -2932,7 +2932,7 @@ string_to_string_get_loop(
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
     int unicode_swap = 0;
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
 
     assert(NPY_DTYPE(descrs[0]) == NPY_DTYPE(descrs[1]));
     *flags = context->method->flags & NPY_METH_RUNTIME_FLAGS;
@@ -3033,7 +3033,7 @@ PyArray_InitializeStringCasts(void)
  */
 static NPY_CASTING
 cast_to_void_dtype_class(
-        PyArray_Descr **given_descrs, PyArray_Descr **loop_descrs,
+        PyArray_Descr *const *given_descrs, PyArray_Descr **loop_descrs,
         npy_intp *view_offset)
 {
     /* `dtype="V"` means unstructured currently (compare final path) */
@@ -3058,8 +3058,8 @@ cast_to_void_dtype_class(
 static NPY_CASTING
 nonstructured_to_structured_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[2]),
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -3251,8 +3251,8 @@ PyArray_GetGenericToVoidCastingImpl(void)
 static NPY_CASTING
 structured_to_nonstructured_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -3521,8 +3521,8 @@ can_cast_fields_safety(
 static NPY_CASTING
 void_to_void_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset)
 {
@@ -3720,8 +3720,8 @@ PyArray_InitializeVoidToVoidCast(void)
 static NPY_CASTING
 object_to_any_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -3794,8 +3794,8 @@ PyArray_GetObjectToGenericCastingImpl(void)
 static NPY_CASTING
 any_to_object_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *NPY_UNUSED(view_offset))
 {

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -109,8 +109,8 @@ PyArray_CheckCastSafety(NPY_CASTING casting,
 NPY_NO_EXPORT NPY_CASTING
 legacy_same_dtype_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset);
 
@@ -124,8 +124,8 @@ legacy_cast_get_strided_loop(
 NPY_NO_EXPORT NPY_CASTING
 simple_cast_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[2],
-        PyArray_Descr *input_descrs[2],
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const input_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *view_offset);
 

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -3780,7 +3780,7 @@ time_to_time_get_loop(
 {
     int requires_wrap = 0;
     int inner_aligned = aligned;
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     PyArray_DatetimeMetaData *meta1 = get_datetime_metadata_from_dtype(descrs[0]);
@@ -3929,7 +3929,7 @@ datetime_to_string_get_loop(
         PyArrayMethod_StridedLoop **out_loop, NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     *flags = context->method->flags & NPY_METH_RUNTIME_FLAGS;
 
     if (descrs[1]->type_num == NPY_STRING) {
@@ -3989,7 +3989,7 @@ string_to_datetime_cast_get_loop(
         PyArrayMethod_StridedLoop **out_loop, NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     *flags = context->method->flags & NPY_METH_RUNTIME_FLAGS;
 
     if (descrs[0]->type_num == NPY_STRING) {

--- a/numpy/_core/src/multiarray/dtype_traversal.c
+++ b/numpy/_core/src/multiarray/dtype_traversal.c
@@ -32,7 +32,7 @@
 
 
 typedef int get_traverse_func_function(
-        void *traverse_context, PyArray_Descr *dtype, int aligned,
+        void *traverse_context, const PyArray_Descr *dtype, int aligned,
         npy_intp stride, NPY_traverse_info *clear_info,
         NPY_ARRAYMETHOD_FLAGS *flags);
 
@@ -42,7 +42,7 @@ typedef int get_traverse_func_function(
 
 static int
 get_clear_function(
-        void *traverse_context, PyArray_Descr *dtype, int aligned,
+        void *traverse_context, const PyArray_Descr *dtype, int aligned,
         npy_intp stride, NPY_traverse_info *clear_info,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
@@ -99,7 +99,7 @@ PyArray_GetClearFunction(
 
 static int
 get_zerofill_function(
-        void *traverse_context, PyArray_Descr *dtype, int aligned,
+        void *traverse_context, const PyArray_Descr *dtype, int aligned,
         npy_intp stride, NPY_traverse_info *zerofill_info,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
@@ -136,7 +136,7 @@ get_zerofill_function(
 
 static int
 clear_object_strided_loop(
-        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        void *NPY_UNUSED(traverse_context), const PyArray_Descr *NPY_UNUSED(descr),
         char *data, npy_intp size, npy_intp stride,
         NpyAuxData *NPY_UNUSED(auxdata))
 {
@@ -156,7 +156,7 @@ clear_object_strided_loop(
 
 NPY_NO_EXPORT int
 npy_get_clear_object_strided_loop(
-        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        void *NPY_UNUSED(traverse_context), const PyArray_Descr *NPY_UNUSED(descr),
         int NPY_UNUSED(aligned), npy_intp NPY_UNUSED(fixed_stride),
         PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **out_auxdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
@@ -171,7 +171,7 @@ npy_get_clear_object_strided_loop(
 
 static int
 fill_zero_object_strided_loop(
-        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        void *NPY_UNUSED(traverse_context), const PyArray_Descr *NPY_UNUSED(descr),
         char *data, npy_intp size, npy_intp stride,
         NpyAuxData *NPY_UNUSED(auxdata))
 {
@@ -188,7 +188,7 @@ fill_zero_object_strided_loop(
 
 NPY_NO_EXPORT int
 npy_object_get_fill_zero_loop(void *NPY_UNUSED(traverse_context),
-                              PyArray_Descr *NPY_UNUSED(descr),
+                              const PyArray_Descr *NPY_UNUSED(descr),
                               int NPY_UNUSED(aligned),
                               npy_intp NPY_UNUSED(fixed_stride),
                               PyArrayMethod_TraverseLoop **out_loop,
@@ -275,7 +275,7 @@ fields_traverse_data_clone(NpyAuxData *data)
 
 static int
 traverse_fields_function(
-        void *traverse_context, _PyArray_LegacyDescr *NPY_UNUSED(descr),
+        void *traverse_context, const _PyArray_LegacyDescr *NPY_UNUSED(descr),
         char *data, npy_intp N, npy_intp stride,
         NpyAuxData *auxdata)
 {
@@ -315,7 +315,7 @@ traverse_fields_function(
 
 static int
 get_fields_traverse_function(
-        void *traverse_context, _PyArray_LegacyDescr *dtype, int NPY_UNUSED(aligned),
+        void *traverse_context, const _PyArray_LegacyDescr *dtype, int NPY_UNUSED(aligned),
         npy_intp stride, PyArrayMethod_TraverseLoop **out_func,
         NpyAuxData **out_auxdata, NPY_ARRAYMETHOD_FLAGS *flags,
         get_traverse_func_function *get_traverse_func)
@@ -431,14 +431,14 @@ subarray_traverse_data_clone(NpyAuxData *data)
 
 static int
 traverse_subarray_func(
-        void *traverse_context, PyArray_Descr *NPY_UNUSED(descr),
+        void *traverse_context, const PyArray_Descr *NPY_UNUSED(descr),
         char *data, npy_intp N, npy_intp stride,
         NpyAuxData *auxdata)
 {
     subarray_traverse_data *subarr_data = (subarray_traverse_data *)auxdata;
 
     PyArrayMethod_TraverseLoop *func = subarr_data->info.func;
-    PyArray_Descr *sub_descr = subarr_data->info.descr;
+    const PyArray_Descr *sub_descr = subarr_data->info.descr;
     npy_intp sub_N = subarr_data->count;
     NpyAuxData *sub_auxdata = subarr_data->info.auxdata;
     npy_intp sub_stride = sub_descr->elsize;
@@ -456,7 +456,7 @@ traverse_subarray_func(
 
 static int
 get_subarray_traverse_func(
-        void *traverse_context, PyArray_Descr *dtype, int aligned,
+        void *traverse_context, const PyArray_Descr *dtype, int aligned,
         npy_intp size, npy_intp stride, PyArrayMethod_TraverseLoop **out_func,
         NpyAuxData **out_auxdata, NPY_ARRAYMETHOD_FLAGS *flags,
         get_traverse_func_function *get_traverse_func)
@@ -493,7 +493,7 @@ get_subarray_traverse_func(
 
 static int
 clear_no_op(
-        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        void *NPY_UNUSED(traverse_context), const PyArray_Descr *NPY_UNUSED(descr),
         char *NPY_UNUSED(data), npy_intp NPY_UNUSED(size),
         npy_intp NPY_UNUSED(stride), NpyAuxData *NPY_UNUSED(auxdata))
 {
@@ -502,7 +502,7 @@ clear_no_op(
 
 NPY_NO_EXPORT int
 npy_get_clear_void_and_legacy_user_dtype_loop(
-        void *traverse_context, _PyArray_LegacyDescr *dtype, int aligned,
+        void *traverse_context, const _PyArray_LegacyDescr *dtype, int aligned,
         npy_intp stride, PyArrayMethod_TraverseLoop **out_func,
         NpyAuxData **out_auxdata, NPY_ARRAYMETHOD_FLAGS *flags)
 {
@@ -569,7 +569,7 @@ npy_get_clear_void_and_legacy_user_dtype_loop(
 
 static int
 zerofill_fields_function(
-        void *traverse_context, _PyArray_LegacyDescr *descr,
+        void *traverse_context, const _PyArray_LegacyDescr *descr,
         char *data, npy_intp N, npy_intp stride,
         NpyAuxData *auxdata)
 {
@@ -598,7 +598,7 @@ zerofill_fields_function(
  */
 NPY_NO_EXPORT int
 npy_get_zerofill_void_and_legacy_user_dtype_loop(
-        void *traverse_context, _PyArray_LegacyDescr *dtype, int aligned,
+        void *traverse_context, const _PyArray_LegacyDescr *dtype, int aligned,
         npy_intp stride, PyArrayMethod_TraverseLoop **out_func,
         NpyAuxData **out_auxdata, NPY_ARRAYMETHOD_FLAGS *flags)
 {

--- a/numpy/_core/src/multiarray/dtype_traversal.h
+++ b/numpy/_core/src/multiarray/dtype_traversal.h
@@ -7,14 +7,14 @@
 
 NPY_NO_EXPORT int
 npy_get_clear_object_strided_loop(
-        void *traverse_context, PyArray_Descr *descr, int aligned,
+        void *traverse_context, const PyArray_Descr *descr, int aligned,
         npy_intp fixed_stride,
         PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **out_traversedata,
         NPY_ARRAYMETHOD_FLAGS *flags);
 
 NPY_NO_EXPORT int
 npy_get_clear_void_and_legacy_user_dtype_loop(
-        void *traverse_context, _PyArray_LegacyDescr *descr, int aligned,
+        void *traverse_context, const _PyArray_LegacyDescr *descr, int aligned,
         npy_intp fixed_stride,
         PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **out_traversedata,
         NPY_ARRAYMETHOD_FLAGS *flags);
@@ -23,14 +23,14 @@ npy_get_clear_void_and_legacy_user_dtype_loop(
 
 NPY_NO_EXPORT int
 npy_object_get_fill_zero_loop(
-        void *NPY_UNUSED(traverse_context), PyArray_Descr *NPY_UNUSED(descr),
+        void *NPY_UNUSED(traverse_context), const PyArray_Descr *NPY_UNUSED(descr),
         int NPY_UNUSED(aligned), npy_intp NPY_UNUSED(fixed_stride),
         PyArrayMethod_TraverseLoop **out_loop, NpyAuxData **NPY_UNUSED(out_auxdata),
         NPY_ARRAYMETHOD_FLAGS *flags);
 
 NPY_NO_EXPORT int
 npy_get_zerofill_void_and_legacy_user_dtype_loop(
-        void *traverse_context, _PyArray_LegacyDescr *dtype, int aligned,
+        void *traverse_context, const _PyArray_LegacyDescr *dtype, int aligned,
         npy_intp stride, PyArrayMethod_TraverseLoop **out_func,
         NpyAuxData **out_auxdata, NPY_ARRAYMETHOD_FLAGS *flags);
 
@@ -40,7 +40,7 @@ npy_get_zerofill_void_and_legacy_user_dtype_loop(
 typedef struct {
     PyArrayMethod_TraverseLoop *func;
     NpyAuxData *auxdata;
-    PyArray_Descr *descr;
+    const PyArray_Descr *descr;
 } NPY_traverse_info;
 
 

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1400,7 +1400,7 @@ PyArray_DTypeMeta *_Void_dtype = NULL;
  * for convenience as we are allowed to access the `DType` slots directly.
  */
 NPY_NO_EXPORT PyArray_ArrFuncs *
-_PyDataType_GetArrFuncs(PyArray_Descr *descr)
+_PyDataType_GetArrFuncs(const PyArray_Descr *descr)
 {
     return PyDataType_GetArrFuncs(descr);
 }

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -261,7 +261,7 @@ extern PyArray_DTypeMeta PyArray_StringDType;
 
 /* Internal version see dtypmeta.c for more information. */
 static inline PyArray_ArrFuncs *
-PyDataType_GetArrFuncs(PyArray_Descr *descr)
+PyDataType_GetArrFuncs(const PyArray_Descr *descr)
 {
     return &NPY_DT_SLOTS(NPY_DTYPE(descr))->f;
 }

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -156,7 +156,7 @@ unicode_to_string(PyArrayMethod_Context *context, char *const data[],
                   npy_intp const dimensions[], npy_intp const strides[],
                   NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     PyArray_StringDTypeObject *sdescr = (PyArray_StringDTypeObject *)descrs[1];
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
@@ -1672,7 +1672,7 @@ void_to_string(PyArrayMethod_Context *context, char *const data[],
                npy_intp const dimensions[], npy_intp const strides[],
                NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
@@ -1802,7 +1802,7 @@ bytes_to_string(PyArrayMethod_Context *context, char *const data[],
                 npy_intp const dimensions[], npy_intp const strides[],
                 NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArray_Descr **descrs = context->descriptors;
+    PyArray_Descr *const *descrs = context->descriptors;
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -517,7 +517,7 @@ stringdtype_ensure_canonical(PyArray_StringDTypeObject *self)
 
 static int
 stringdtype_clear_loop(void *NPY_UNUSED(traverse_context),
-                       PyArray_Descr *descr, char *data, npy_intp size,
+                       const PyArray_Descr *descr, char *data, npy_intp size,
                        npy_intp stride, NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_StringDTypeObject *sdescr = (PyArray_StringDTypeObject *)descr;

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -318,7 +318,7 @@ NpyString_acquire_allocator(PyArray_StringDTypeObject *descr)
  */
 NPY_NO_EXPORT void
 NpyString_acquire_allocators(size_t n_descriptors,
-                             PyArray_Descr *descrs[],
+                             PyArray_Descr *const descrs[],
                              npy_string_allocator *allocators[])
 {
     for (size_t i=0; i<n_descriptors; i++) {

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -286,7 +286,7 @@ NpyString_free_allocator(npy_string_allocator *allocator)
  * allocator mutex is held, as doing so may cause deadlocks.
  */
 NPY_NO_EXPORT npy_string_allocator *
-NpyString_acquire_allocator(PyArray_StringDTypeObject *descr)
+NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
 {
     if (!PyThread_acquire_lock(descr->allocator->allocator_lock, NOWAIT_LOCK)) {
         PyThread_acquire_lock(descr->allocator->allocator_lock, WAIT_LOCK);

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -653,8 +653,8 @@ add_sfloats_resolve_descriptors(
  */
 static int
 translate_given_descrs_to_double(
-        int nin, int nout, PyArray_DTypeMeta *wrapped_dtypes[],
-        PyArray_Descr *given_descrs[], PyArray_Descr *new_descrs[])
+        int nin, int nout, PyArray_DTypeMeta *const wrapped_dtypes[],
+        PyArray_Descr *const given_descrs[], PyArray_Descr *new_descrs[])
 {
     assert(nin == 2 && nout == 1);
     for (int i = 0; i < 3; i++) {
@@ -671,8 +671,8 @@ translate_given_descrs_to_double(
 
 static int
 translate_loop_descrs(
-        int nin, int nout, PyArray_DTypeMeta *new_dtypes[],
-        PyArray_Descr *given_descrs[],
+        int nin, int nout, PyArray_DTypeMeta *const new_dtypes[],
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *NPY_UNUSED(original_descrs[]),
         PyArray_Descr *loop_descrs[])
 {

--- a/numpy/_core/src/umath/legacy_array_method.c
+++ b/numpy/_core/src/umath/legacy_array_method.c
@@ -104,8 +104,8 @@ generic_wrapped_legacy_loop(PyArrayMethod_Context *NPY_UNUSED(context),
  */
 NPY_NO_EXPORT NPY_CASTING
 wrapped_legacy_resolve_descriptors(PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *NPY_UNUSED(given_descrs[]),
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const NPY_UNUSED(given_descrs[]),
         PyArray_Descr *NPY_UNUSED(loop_descrs[]),
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -123,8 +123,8 @@ wrapped_legacy_resolve_descriptors(PyArrayMethodObject *NPY_UNUSED(self),
 static NPY_CASTING
 simple_legacy_resolve_descriptors(
         PyArrayMethodObject *method,
-        PyArray_DTypeMeta **dtypes,
-        PyArray_Descr **given_descrs,
+        PyArray_DTypeMeta *const *dtypes,
+        PyArray_Descr *const *given_descrs,
         PyArray_Descr **output_descrs,
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -246,7 +246,7 @@ get_wrapped_legacy_ufunc_loop(PyArrayMethod_Context *context,
 static int
 copy_cached_initial(
         PyArrayMethod_Context *context, npy_bool NPY_UNUSED(reduction_is_empty),
-        char *initial)
+        void *initial)
 {
     memcpy(initial, context->method->legacy_initial,
            context->descriptors[0]->elsize);
@@ -266,7 +266,7 @@ copy_cached_initial(
 static int
 get_initial_from_ufunc(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
-        char *initial)
+        void *initial)
 {
     if (context->caller == NULL
             || !PyObject_TypeCheck(context->caller, &PyUFunc_Type)) {

--- a/numpy/_core/src/umath/legacy_array_method.h
+++ b/numpy/_core/src/umath/legacy_array_method.h
@@ -28,7 +28,7 @@ get_wrapped_legacy_ufunc_loop(PyArrayMethod_Context *context,
 
 NPY_NO_EXPORT NPY_CASTING
 wrapped_legacy_resolve_descriptors(PyArrayMethodObject *,
-        PyArray_DTypeMeta **, PyArray_Descr **, PyArray_Descr **, npy_intp *);
+        PyArray_DTypeMeta *const *, PyArray_Descr *const *, PyArray_Descr **, npy_intp *);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -587,8 +587,8 @@ string_zfill_loop(PyArrayMethod_Context *context,
 static NPY_CASTING
 string_addition_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[3],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -615,8 +615,8 @@ string_addition_resolve_descriptors(
 static NPY_CASTING
 string_multiply_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[3],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -649,8 +649,8 @@ string_multiply_resolve_descriptors(
 static NPY_CASTING
 string_strip_whitespace_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
-        PyArray_Descr *given_descrs[2],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[2]),
+        PyArray_Descr *const given_descrs[2],
         PyArray_Descr *loop_descrs[2],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -669,8 +669,8 @@ string_strip_whitespace_resolve_descriptors(
 static NPY_CASTING
 string_strip_chars_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[3],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -693,7 +693,7 @@ string_strip_chars_resolve_descriptors(
 
 static int
 string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -709,7 +709,7 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
 
 static int
 string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -732,8 +732,8 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 string_replace_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[5]),
-        PyArray_Descr *given_descrs[5],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[5]),
+        PyArray_Descr *const given_descrs[5],
         PyArray_Descr *loop_descrs[5],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -769,7 +769,7 @@ string_replace_resolve_descriptors(
 
 static int
 string_startswith_endswith_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -785,7 +785,7 @@ string_startswith_endswith_promoter(PyObject *NPY_UNUSED(ufunc),
 
 static int
 string_expandtabs_length_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -798,7 +798,7 @@ string_expandtabs_length_promoter(PyObject *NPY_UNUSED(ufunc),
 
 static int
 string_expandtabs_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -813,8 +813,8 @@ string_expandtabs_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 string_expandtabs_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[3],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -846,7 +846,7 @@ string_expandtabs_resolve_descriptors(
 
 static int
 string_center_ljust_rjust_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -863,8 +863,8 @@ string_center_ljust_rjust_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 string_center_ljust_rjust_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[5],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[5],
         PyArray_Descr *loop_descrs[5],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -901,7 +901,7 @@ string_center_ljust_rjust_resolve_descriptors(
 
 static int
 string_zfill_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     Py_INCREF(op_dtypes[0]);
@@ -916,8 +916,8 @@ string_zfill_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 string_zfill_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[3]),
-        PyArray_Descr *given_descrs[3],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -43,7 +43,7 @@
 static NPY_CASTING
 multiply_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *dtypes[], PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const dtypes[], PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     PyArray_Descr *ldescr = given_descrs[0];
@@ -239,8 +239,8 @@ static int multiply_left_strided_loop(
 
 static NPY_CASTING
 binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-                           PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-                           PyArray_Descr *given_descrs[],
+                           PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+                           PyArray_Descr *const given_descrs[],
                            PyArray_Descr *loop_descrs[],
                            npy_intp *NPY_UNUSED(view_offset))
 {
@@ -556,7 +556,8 @@ fail:
 static NPY_CASTING
 string_comparison_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]), PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     Py_INCREF(given_descrs[0]);
@@ -602,7 +603,8 @@ string_isnan_strided_loop(PyArrayMethod_Context *context, char *const data[],
 static NPY_CASTING
 string_bool_output_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]), PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     Py_INCREF(given_descrs[0]);
@@ -615,7 +617,8 @@ string_bool_output_resolve_descriptors(
 static NPY_CASTING
 string_intp_output_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]), PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     Py_INCREF(given_descrs[0]);
@@ -761,7 +764,8 @@ fail:
 
 static int
 string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
@@ -775,8 +779,8 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 string_findlike_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -821,7 +825,8 @@ string_findlike_resolve_descriptors(
 static int
 string_startswith_endswith_promoter(
         PyObject *NPY_UNUSED(ufunc),
-        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
@@ -835,8 +840,8 @@ string_startswith_endswith_promoter(
 static NPY_CASTING
 string_startswith_endswith_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -1044,7 +1049,8 @@ fail:
 
 static int
 all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
-                     PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+                     PyArray_DTypeMeta *const op_dtypes[],
+                     PyArray_DTypeMeta *const signature[],
                      PyArray_DTypeMeta *new_op_dtypes[])
 {
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
@@ -1056,8 +1062,8 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
 static NPY_CASTING
 strip_chars_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -1171,8 +1177,8 @@ fail:
 static NPY_CASTING
 strip_whitespace_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -1278,7 +1284,8 @@ string_lrstrip_whitespace_strided_loop(
 
 static int
 string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
-                        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+                        PyArray_DTypeMeta *const op_dtypes[],
+                        PyArray_DTypeMeta *const signature[],
                         PyArray_DTypeMeta *new_op_dtypes[])
 {
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
@@ -1291,8 +1298,8 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
 
 static NPY_CASTING
 replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-                            PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-                            PyArray_Descr *given_descrs[],
+                            PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+                            PyArray_Descr *const given_descrs[],
                             PyArray_Descr *loop_descrs[],
                             npy_intp *NPY_UNUSED(view_offset))
 {
@@ -1459,8 +1466,8 @@ string_replace_strided_loop(
 
 static NPY_CASTING expandtabs_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *NPY_UNUSED(dtypes[]),
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
@@ -1574,7 +1581,7 @@ string_expandtabs_strided_loop(PyArrayMethod_Context *context,
 static NPY_CASTING
 center_ljust_rjust_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *dtypes[], PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const dtypes[], PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
     PyArray_StringDTypeObject *input_descr = (PyArray_StringDTypeObject *)given_descrs[0];
@@ -1881,8 +1888,8 @@ fail:
 
 NPY_NO_EXPORT int
 string_inputs_promoter(
-        PyObject *ufunc_obj, PyArray_DTypeMeta *op_dtypes[],
-        PyArray_DTypeMeta *signature[],
+        PyObject *ufunc_obj, PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[],
         PyArray_DTypeMeta *final_dtype,
         PyArray_DTypeMeta *result_dtype)
@@ -1914,8 +1921,8 @@ string_inputs_promoter(
 
 static int
 string_object_bool_output_promoter(
-        PyObject *ufunc, PyArray_DTypeMeta *op_dtypes[],
-        PyArray_DTypeMeta *signature[],
+        PyObject *ufunc, PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     return string_inputs_promoter(
@@ -1925,8 +1932,8 @@ string_object_bool_output_promoter(
 
 static int
 string_unicode_bool_output_promoter(
-        PyObject *ufunc, PyArray_DTypeMeta *op_dtypes[],
-        PyArray_DTypeMeta *signature[],
+        PyObject *ufunc, PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
     return string_inputs_promoter(
@@ -2007,8 +2014,9 @@ is_integer_dtype(PyArray_DTypeMeta *DType)
 
 
 static int
-string_multiply_promoter(PyObject *ufunc_obj, PyArray_DTypeMeta *op_dtypes[],
-                         PyArray_DTypeMeta *signature[],
+string_multiply_promoter(PyObject *ufunc_obj,
+                         PyArray_DTypeMeta *const op_dtypes[],
+                         PyArray_DTypeMeta *const signature[],
                          PyArray_DTypeMeta *new_op_dtypes[])
 {
     PyUFuncObject *ufunc = (PyUFuncObject *)ufunc_obj;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -1011,9 +1011,11 @@ try_trivial_single_output_loop(PyArrayMethod_Context *context,
  */
 static inline int
 validate_casting(PyArrayMethodObject *method, PyUFuncObject *ufunc,
-        PyArrayObject *ops[], PyArray_Descr *descriptors[],
+        PyArrayObject *ops[], PyArray_Descr *const descriptors_const[],
         NPY_CASTING casting)
 {
+    /* Cast away const to not change old public `PyUFunc_ValidateCasting`. */
+    PyArray_Descr **descriptors = (PyArray_Descr **)descriptors_const;
     if (method->resolve_descriptors == &wrapped_legacy_resolve_descriptors) {
         /*
          * In this case the legacy type resolution was definitely called
@@ -1091,7 +1093,7 @@ execute_ufunc_loop(PyArrayMethod_Context *context, int masked,
     NpyIter *iter = NpyIter_AdvancedNew(nop + masked, op,
                         iter_flags,
                         order, NPY_UNSAFE_CASTING,
-                        op_flags, context->descriptors,
+                        op_flags, (PyArray_Descr **)context->descriptors,
                         -1, NULL, NULL, buffersize);
     if (iter == NULL) {
         return -1;
@@ -6243,7 +6245,7 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
     context->descriptors = call_info->_descrs;
     for (int i=0; i < ufunc->nargs; i++) {
         Py_INCREF(operation_descrs[i]);
-        context->descriptors[i] = operation_descrs[i];
+        ((PyArray_Descr **)context->descriptors)[i] = operation_descrs[i];
     }
 
     result = PyTuple_Pack(2, result_dtype_tuple, capsule);

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -226,7 +226,7 @@ NPY_NO_EXPORT int
 PyUFunc_ValidateCasting(PyUFuncObject *ufunc,
                             NPY_CASTING casting,
                             PyArrayObject **operands,
-                            PyArray_Descr **dtypes)
+                            PyArray_Descr *const *dtypes)
 {
     int i, nin = ufunc->nin, nop = nin + ufunc->nout;
 
@@ -1471,7 +1471,7 @@ PyUFunc_TrueDivisionTypeResolver(PyUFuncObject *ufunc,
 
 static int
 find_userloop(PyUFuncObject *ufunc,
-                PyArray_Descr **dtypes,
+                PyArray_Descr *const *dtypes,
                 PyUFuncGenericFunction *out_innerloop,
                 void **out_innerloopdata)
 {
@@ -1535,7 +1535,7 @@ find_userloop(PyUFuncObject *ufunc,
 
 NPY_NO_EXPORT int
 PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
-                                PyArray_Descr **dtypes,
+                                PyArray_Descr *const *dtypes,
                                 PyUFuncGenericFunction *out_innerloop,
                                 void **out_innerloopdata,
                                 int *out_needs_api)

--- a/numpy/_core/src/umath/ufunc_type_resolution.h
+++ b/numpy/_core/src/umath/ufunc_type_resolution.h
@@ -134,7 +134,7 @@ type_tuple_type_resolver(PyUFuncObject *self,
 
 NPY_NO_EXPORT int
 PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
-                                       PyArray_Descr **dtypes,
+                                       PyArray_Descr *const *dtypes,
                                        PyUFuncGenericFunction *out_innerloop,
                                        void **out_innerloopdata,
                                        int *out_needs_api);

--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -36,8 +36,8 @@
 static NPY_CASTING
 wrapping_method_resolve_descriptors(
         PyArrayMethodObject *self,
-        PyArray_DTypeMeta *dtypes[],
-        PyArray_Descr *given_descrs[],
+        PyArray_DTypeMeta *const dtypes[],
+        PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *view_offset)
 {
@@ -158,8 +158,8 @@ wrapping_method_get_loop(
     auxdata->orig_context.caller = context->caller;
 
     if (context->method->translate_given_descrs(
-            nin, nout, context->method->wrapped_dtypes,
-            context->descriptors, auxdata->orig_context.descriptors) < 0) {
+            nin, nout, context->method->wrapped_dtypes, context->descriptors,
+            (PyArray_Descr **)auxdata->orig_context.descriptors) < 0) {
         NPY_AUXDATA_FREE((NpyAuxData *)auxdata);
         return -1;
     }


### PR DESCRIPTION
This is a bit of a churn PR, the changes are:
* A few trivial additions of `const` as in `func(const PyArray_Descr *)`.  The additions are just OK always.
* Things like `resolve_descriptors` and also the `PyArray_MethodContext` now use `PyArray_Descr *const *` for arrays of descriptors that must not be changed by the user.

I like the second one for the most part, since it protects users from changing the wrong argument.  The downside is that for functions which get it as an input, things are less clear cut.  For the string allocator one it should use const to match.  But for type promotion, I didn't add the const because it seemed obnoxious to cast to avoid the compiler warning.  So users may have to cast in the opposite direction (e.g. in a promoter).

---

**This is no ABI change, and should only be a visible API change for NumPy 2.0 only functions (new DType API)**