### PR TITLE
MAINT: Make PyArrayMultiIterObject struct "smaller"

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -1286,7 +1286,7 @@ PyArrayMultiIter_Type and PyArrayMultiIterObject
           npy_intp index;
           int nd;
           npy_intp dimensions[NPY_MAXDIMS_LEGACY_ITERS];
-          PyArrayIterObject *iters[NPY_MAXDIMS_LEGACY_ITERS];
+          PyArrayIterObject *iters[];
       } PyArrayMultiIterObject;
 
    .. c:macro: PyObject_HEAD

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1298,10 +1298,15 @@ typedef struct {
          * growing structs (as of Cython 3.0.6).  It also allows NPY_MAXARGS
          * to be runtime dependent.
          */
-#if (defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD) || defined(__cplusplus)
-        /* 64 is NPY_MAXARGS for numpy 2.0 or newer. We can't use a flexible
-           array member in C++ so use the internal size there. */
+#if (defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD)
         PyArrayIterObject    *iters[64];
+#elif defined(__cplusplus)
+        /*
+         * C++ doesn't stricly support flexible members and gives compilers
+         * warnings (pedantic only), so we lie.  We can't make it 64 because
+         * then Cython is unhappy (larger struct at runtime is OK smaller not).
+         */
+        PyArrayIterObject    *iters[32];
 #else
         PyArrayIterObject    *iters[];
 #endif


### PR DESCRIPTION
This inverts the lie, on C++ we claim the struct is only fixed to 32 iterators, while in reality such a limit doesn't exist.

The reason is that Cython is unhappy if it finds a smaller struct at runtime (on NumPy 1.x).

If there is more oddities around this, we could probably even detect Cython...

Closes gh-26060

---

To be clear, I think it is totally fine to lie, nobody should be using C++ `new` for these, the only thing is that `iters[40]` access could be used in principle at runtime, but I suspect that doesn't matter...