### PR TITLE
BUG: fix logic error in stringdtype maximum/minimum ufunc

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -429,7 +429,7 @@ minimum_maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
         npy_packed_static_string *sout = (npy_packed_static_string *)out;
         int cmp = _compare(in1, in2, in1_descr, in2_descr);
         if (cmp == 0 && (in1 == out || in2 == out)) {
-            continue;
+            goto next_step;
         }
         if ((cmp < 0) ^ invert) {
             // if in and out are the same address, do nothing to avoid a
@@ -449,6 +449,8 @@ minimum_maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 }
             }
         }
+
+      next_step:
         in1 += in1_stride;
         in2 += in2_stride;
         out += out_stride;

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -668,6 +668,12 @@ def test_ufuncs_minmax(string_list, ufunc_name, func, use_out):
         res = ufunc(arr, arr)
 
     assert_array_equal(uarr, res)
+    assert_array_equal(getattr(arr, ufunc_name)(), func(string_list))
+
+
+def test_max_regression():
+    arr = np.array(['y', 'y', 'z'], dtype="T")
+    assert arr.max() == 'z'
 
 
 @pytest.mark.parametrize("use_out", [True, False])


### PR DESCRIPTION
This fixes a logic error - the `continue` would skip the part of the loop that increments the array pointers by the strides.

`test_max_regression` fails on `main` but passes here.

This was discovered running the tests on my fork of pandas with stringdtype support. 