### PR TITLE
BUG: Allow the new string dtype summation to work

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2407,6 +2407,13 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
                 out_descrs[0], out_descrs[1], out_descrs[2]);
         goto fail;
     }
+    /*
+     * After checking that they are equivalent, we enforce the use of the out
+     * one (which the user should have defined).  (Needed by string dtype)
+     */
+    Py_INCREF(out_descrs[2]);
+    Py_SETREF(out_descrs[0], out_descrs[2]);
+
     /* TODO: This really should _not_ be unsafe casting (same above)! */
     if (validate_casting(ufuncimpl, ufunc, ops, out_descrs, casting) < 0) {
         goto fail;

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -734,6 +734,18 @@ def test_ufunc_add(dtype, string_list, other_strings, use_out):
             np.add(arr1, arr2)
 
 
+def test_ufunc_add_reduce(dtype):
+    values = ["a", "this is a long string", "c"]
+    arr = np.array(values, dtype=dtype)
+    out = np.empty((), dtype=dtype)
+
+    expected = np.array("".join(values), dtype=dtype)
+    assert_array_equal(np.add.reduce(arr), expected)
+
+    np.add.reduce(arr, out=out)
+    assert_array_equal(out, expected)
+
+
 def test_add_promoter(string_list):
     arr = np.array(string_list, dtype=StringDType())
     lresult = np.array(["hello" + s for s in string_list], dtype=StringDType())


### PR DESCRIPTION
Backport of #26066.

It may be that it would be better to indicate reductions more clearly, but this seemed like an easy and explicit fix.

Does not quite close the issue, since we shouldn't promote old-style strings probably.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
