### PR TITLE
API,BUG: Allow promoters to indicate no-match and use it to fix string add promoter

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1928,6 +1928,25 @@ with the rest of the ArrayMethod API.
    operation and requested DType signatures and can mutate the signatures to
    attempt a search for a new loop or promoter that can accomplish the operation
    by casting the inputs to the "promoted" DTypes.
+   The promoter must ensure that the new DTypes are compatible with the passed
+   in, user provided, ``signature``.  It should also take care to meaningfully
+   mutate the DTypes to avoid infinite recursion.
+
+   The function must return -1 on error and 1 if it wrote ``new_op_dtypes``.
+   It may return 0 to indicate that the promoter does not apply/match.
+   However, you must still register it with meaningful DTypes to ensure NumPy
+   can unambiguously pick a best promoter when multiple match.
+
+   How well a loop/promoter matches is defined by subclass relations so that
+   ``(None, None, MyDType)`` is more specific than ``(None, None, None)``
+   but not necessarily ``(IntDType, None, None)`` since that either loop
+   is more specific in one argument (although inputs are prioritized).
+
+    .. warning::
+        Promotion (more so than loop registration) can interfere with other
+        libraries and even NumPy in principle.  If ambiguities can arise when
+        NumPy or another library adds a generic promoter, you must be
+        prepared to adept to these. It is not possible guarantee stability.
 
 .. c:function:: int PyUFunc_GiveFloatingpointErrors( \
                         const char *name, int fpe_errors)

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -770,7 +770,7 @@ promote_to_sfloat(PyUFuncObject *NPY_UNUSED(ufunc),
         Py_INCREF(new);
         new_dtypes[i] = new;
     }
-    return 0;
+    return 1;
 }
 
 

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -313,7 +313,7 @@ pyint_comparison_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_ObjectDType);
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_ObjectDType);
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_BoolDType);
-    return 0;
+    return 1;
 }
 
 

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -703,7 +703,7 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
-    return 0;
+    return 1;
 }
 
 
@@ -725,7 +725,7 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
 
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[4] = op_dtypes[0];
-    return 0;
+    return 1;
 }
 
 
@@ -779,7 +779,7 @@ string_startswith_endswith_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[4] = NPY_DT_NewRef(&PyArray_BoolDType);
-    return 0;
+    return 1;
 }
 
 
@@ -792,7 +792,7 @@ string_expandtabs_length_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = op_dtypes[0];
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
-    return 0;
+    return 1;
 }
 
 
@@ -806,7 +806,7 @@ string_expandtabs_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[2] = op_dtypes[0];
-    return 0;
+    return 1;
 }
 
 
@@ -856,7 +856,7 @@ string_center_ljust_rjust_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = op_dtypes[0];
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[3] = op_dtypes[0];
-    return 0;
+    return 1;
 }
 
 
@@ -909,7 +909,7 @@ string_zfill_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[2] = op_dtypes[0];
-    return 0;
+    return 1;
 }
 
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1047,6 +1047,12 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
                      PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
                      PyArray_DTypeMeta *new_op_dtypes[])
 {
+    if (op_dtypes[0] != &PyArray_StringDType
+            && op_dtypes[1] != &PyArray_StringDType
+            && op_dtypes[1] != &PyArray_StringDType) {
+        /* No string DType involved after all, do not apply promoter */
+        return 0;
+    }
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -769,7 +769,7 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
-    return 0;
+    return 1;
 }
 
 static NPY_CASTING
@@ -829,7 +829,7 @@ string_startswith_endswith_promoter(
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_BOOL);
-    return 0;
+    return 1;
 }
 
 static NPY_CASTING
@@ -1050,7 +1050,7 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
-    return 0;
+    return 1;
 }
 
 static NPY_CASTING
@@ -1286,7 +1286,7 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[4] = NPY_DT_NewRef(&PyArray_StringDType);
-    return 0;
+    return 1;
 }
 
 static NPY_CASTING
@@ -1909,7 +1909,7 @@ string_inputs_promoter(
         }
     }
 
-    return 0;
+    return 1;
 }
 
 static int
@@ -2040,7 +2040,7 @@ string_multiply_promoter(PyObject *ufunc_obj, PyArray_DTypeMeta *op_dtypes[],
             new_op_dtypes[i] = &PyArray_StringDType;
         }
     }
-    return 0;
+    return 1;
 }
 
 // Register a ufunc.

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -740,6 +740,12 @@ def test_add_promoter(string_list):
         assert_array_equal(arr + op, rresult)
 
 
+def test_add_promoter_reduce():
+    # Exact TypeError could change, but ensure StringDtype doesn't match
+    with pytest.raises(TypeError, match="the resolved dtypes are not"):
+        np.add.reduce(np.array(["a", "b"], dtype="U"))
+
+
 @pytest.mark.parametrize("use_out", [True, False])
 @pytest.mark.parametrize("other", [2, [2, 1, 3, 4, 1, 3]])
 @pytest.mark.parametrize(


### PR DESCRIPTION
This reorganizes the loop lookup slightly to integrate calling promoters into the actual lookup loop.  That requires a slight duplication unfortunatley, because I thought it is nicer to avoid trying to call a promoter multiple times (although of course we still may in some situations).

*The second commit just moves the code to make the diff of the first easier to read.*

Then uses that to fix the string promotion.

Closes gh-26062