### PR TITLE
DOC: Mention ``copy=True`` for ``__array__`` method in the migration guide. 

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -422,7 +422,9 @@ The :ref:`copy keyword behavior changes <copy-keyword-changes-2.0>` in
    of how to do so.
 3. For any ``__array__`` method on a non-NumPy array-like object, a
    ``copy=None`` keyword can be added to the signature - this will work with
-   older NumPy versions as well.
+   older NumPy versions as well. If ``copy`` keyword is considered in
+   the ``__array__`` method implementation, then for ``copy=True`` always
+   return a new copy.
 
 
 Writing numpy-version-dependent code


### PR DESCRIPTION
Addresses https://github.com/numpy/numpy/issues/25941#issuecomment-2010343170

Hi @ngoldbaum,

With this PR, explicit `copy` argument is always passed to `__array__`. 
`NPY_ARRAY_ENSURECOPY` check was missing from flags processing, to cover all supported values for `copy`:

https://github.com/numpy/numpy/blob/7f1c8cbe0c6fa4e554b3b1e4d7dc2f03fababbec/numpy/_core/src/multiarray/ctors.c#L2417-L2420