### PR TITLE
MAINT: avoid using a generic promoter for string multiply

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2103,6 +2103,7 @@ add_promoter(PyObject *numpy, const char *ufunc_name,
     PyObject *DType_tuple = PyTuple_New(n_dtypes);
 
     for (size_t i=0; i<n_dtypes; i++) {
+        Py_INCREF((PyObject *)dtypes[i]);
         PyTuple_SET_ITEM(DType_tuple, i, (PyObject *)dtypes[i]);
     }
 
@@ -2336,14 +2337,34 @@ init_stringdtype_ufuncs(PyObject *umath)
         return -1;
     }
 
+    INIT_MULTIPLY(Int8, int8);
+    INIT_MULTIPLY(Int16, int16);
+    INIT_MULTIPLY(Int32, int32);
     INIT_MULTIPLY(Int64, int64);
+    INIT_MULTIPLY(UInt8, uint8);
+    INIT_MULTIPLY(UInt16, uint16);
+    INIT_MULTIPLY(UInt32, uint32);
     INIT_MULTIPLY(UInt64, uint64);
-
-    // all other integer dtypes are handled with a generic promoter
+#if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
+    INIT_MULTIPLY(Byte, byte);
+    INIT_MULTIPLY(UByte, ubyte);
+#endif
+#if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
+    INIT_MULTIPLY(Short, short);
+    INIT_MULTIPLY(UShort, ushort);
+#endif
+#if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
+    INIT_MULTIPLY(Long, long);
+    INIT_MULTIPLY(ULong, ulong);
+#endif
+#if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
+    INIT_MULTIPLY(LongLong, longlong);
+    INIT_MULTIPLY(ULongLong, ulonglong);
+#endif
 
     PyArray_DTypeMeta *rdtypes[] = {
         &PyArray_StringDType,
-        (PyArray_DTypeMeta *)Py_None,
+        &PyArray_PyIntAbstractDType,
         &PyArray_StringDType};
 
     if (add_promoter(umath, "multiply", rdtypes, 3, string_multiply_promoter) < 0) {
@@ -2351,7 +2372,7 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *ldtypes[] = {
-        (PyArray_DTypeMeta *)Py_None,
+        &PyArray_PyIntAbstractDType,
         &PyArray_StringDType,
         &PyArray_StringDType};
 


### PR DESCRIPTION
This includes two fixes.

First, it fixes a reference counting mistake in `add_promoter`. `PyTuple_SET_ITEM` steals a reference and we need to incref the objects we pass to it.

Second, I avoid using a generic promoter for stringdtype's multiply implementation.

The main reason is to avoid this error which is triggered by the pandas tests:

```
>           result[valid] = op(self._ndarray[valid], other)
E           RuntimeError: Could not find a loop for the inputs:
E               (<class 'numpy.dtypes.StringDType'>, <class 'numpy.dtypes.StringDType'>, None)
E           The two promoters (<class 'numpy.dtypes.StringDType'>, None, <class 'numpy.dtypes.StringDType'>) and (None, <class 'numpy.dtypes.StringDType'>, <class 'numpy.dtypes.StringDType'>) matched the input equally well.  Promoters must be designed to be unambiguous.  NOTE: This indicates an error in NumPy or an extending library and should be reported.
```

Here `op` is `multiply` and the two arguments are both stringdtype arrays. IMO this should raise `UFuncTypeError` because no loop is registered for multiplying two string operands, but because there's a generic promoter we get a `RuntimeError` complaining about not being able to resolve an ambiguous promotion. This breaks a pandas test that explicitly checks for `UFuncTypeError` in this situation.

We already have all the machinery for directly defining the loops for all the integer dtypes. This is how I originally wrote it, but we switched to a generic promoter during the big code review when stringdtype was initially imported into numpy.

I tried to define promoters for all the integer dtypes, but I couldn't get that to work because of a mysterious seg fault coming from a GC pass that runs after stringdtype initialization finishes. That's how I discovered the reference counting error in `add_promoter`. Unfortunately I couldn't figure out where the seg fault came from (fixing the reference counting error didn't fix it) and I ended up deciding to go back to this approach, which I know works.

If anyone is interested in trying to figure out what's happening, try building [this branch](https://github.com/ngoldbaum/numpy/tree/int-promoters) on my fork, it should seg fault trying to import numpy.

The main down side of the approach in this PR is defining all these loops increases binary size.