### PR TITLE
MAINT: install all-string promoter for multiply

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2339,6 +2339,18 @@ init_stringdtype_ufuncs(PyObject *umath)
     INIT_MULTIPLY(Int64, int64);
     INIT_MULTIPLY(UInt64, uint64);
 
+    // This is needed so the generic promoters defined after this don't match
+    // for np.multiply(string_array, string_array)
+
+    PyArray_DTypeMeta *hdtypes[] = {
+        &PyArray_StringDType,
+        &PyArray_StringDType,
+        &PyArray_StringDType};
+
+    if (add_promoter(umath, "multiply", hdtypes, 3, string_multiply_promoter) < 0) {
+        return -1;
+    }
+
     // all other integer dtypes are handled with a generic promoter
 
     PyArray_DTypeMeta *rdtypes[] = {

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -765,6 +765,12 @@ def test_multiply_reduce():
     assert res == val * np.prod(repeats)
 
 
+def test_multiply_two_string_raises():
+    arr = np.array(["hello", "world"])
+    with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+        np.multiply(arr, arr)
+
+
 @pytest.mark.parametrize("use_out", [True, False])
 @pytest.mark.parametrize("other", [2, [2, 1, 3, 4, 1, 3]])
 @pytest.mark.parametrize(


### PR DESCRIPTION
Sorry for the noise related to the two PRs I already opened for this today. 

I think this one is a minimal solution to my issue. The test I add in this PR raises a `RuntimeError` from the code path that tries to find the best promoter before this PR.

I had to add this promoter before the other two because of https://github.com/numpy/numpy/issues/26104.