### PR TITLE
BUG: adapt cython files to new complex declarations (#26080)

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -214,6 +214,13 @@ added for setting the real or imaginary part.
 The underlying type remains a struct under C++ (all of the above still remains
 valid).
 
+This has implications for Cython. It is recommened to always use the native
+typedefs ``cfloat_t``, ``cdouble_t``, ``clongdouble_t`` rather than the NumPy
+types ``npy_cfloat``, etc, unless you have to interface with C code written
+using the NumPy types. You can still write cython code using the ``c.real`` and
+``c.imag`` attributes (using the native typedefs), but you can no longer use
+in-place operators ``c.imag += 1`` in Cython's c++ mode.
+
 
 Changes to namespaces
 =====================

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -68,36 +68,28 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef long double  npy_float128
 
     ctypedef struct npy_cfloat:
-        float real
-        float imag
+        pass
 
     ctypedef struct npy_cdouble:
-        double real
-        double imag
+        pass
 
     ctypedef struct npy_clongdouble:
-        long double real
-        long double imag
+        pass
 
     ctypedef struct npy_complex64:
-        float real
-        float imag
+        pass
 
     ctypedef struct npy_complex128:
-        double real
-        double imag
+        pass
 
     ctypedef struct npy_complex160:
-        long double real
-        long double imag
+        pass
 
     ctypedef struct npy_complex192:
-        long double real
-        long double imag
+        pass
 
     ctypedef struct npy_complex256:
-        long double real
-        long double imag
+        pass
 
     ctypedef struct PyArray_Dims:
         npy_intp *ptr
@@ -562,7 +554,6 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_ZEROS(int nd, npy_intp* dims, int type, int fortran)
     object PyArray_EMPTY(int nd, npy_intp* dims, int type, int fortran)
     void PyArray_FILLWBYTE(ndarray, int val)
-    npy_intp PyArray_REFCOUNT(object)
     object PyArray_ContiguousFromAny(op, int, int min_depth, int max_depth)
     unsigned char PyArray_EquivArrTypes(ndarray a1, ndarray a2)
     bint PyArray_EquivByteorders(int b1, int b2) nogil
@@ -808,11 +799,10 @@ ctypedef npy_double     float_t
 ctypedef npy_double     double_t
 ctypedef npy_longdouble longdouble_t
 
-ctypedef npy_cfloat      cfloat_t
-ctypedef npy_cdouble     cdouble_t
-ctypedef npy_clongdouble clongdouble_t
-
-ctypedef npy_cdouble     complex_t
+ctypedef float complex       cfloat_t
+ctypedef double complex      cdouble_t
+ctypedef double complex      complex_t
+ctypedef long double complex clongdouble_t
 
 cdef inline object PyArray_MultiIterNew1(a):
     return PyArray_MultiIterNew(1, <void*>a)
@@ -850,6 +840,7 @@ cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct npy_datetimestruct:
         int64_t year
         int32_t month, day, hour, min, sec, us, ps, as
+
 
 cdef extern from "numpy/arrayscalars.h":
 

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -254,3 +254,11 @@ def compile_fillwithbyte():
     pos = cnp.PyArray_ZEROS(2, dims, cnp.NPY_UINT8, 0)
     cnp.PyArray_FILLWBYTE(pos, 1)
     return pos
+
+def inc2_cfloat_struct(cnp.ndarray[cnp.cfloat_t] arr):
+    # This works since we compile in C mode, it will fail in cpp mode
+    arr[1].real += 1
+    arr[1].imag += 1
+    # This works in both modes
+    arr[1].real = arr[1].real + 1
+    arr[1].imag = arr[1].imag + 1

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -61,9 +61,13 @@ def install_temp(tmpdir_factory):
                               )
     try:
         subprocess.check_call(["meson", "compile", "-vv"], cwd=build_dir)
-    except subprocess.CalledProcessError as p:
-        print(f"{p.stdout=}")
-        print(f"{p.stderr=}")
+    except subprocess.CalledProcessError:
+        print("----------------")
+        print("meson build failed when doing")
+        print(f"'meson setup --native-file {native_file} {srcdir}'")
+        print(f"'meson compile -vv'")
+        print(f"in {build_dir}")
+        print("----------------")
         raise
 
     sys.path.append(str(build_dir))
@@ -274,3 +278,11 @@ def test_fillwithbytes(install_temp):
 
     arr = checks.compile_fillwithbyte()
     assert_array_equal(arr, np.ones((1, 2)))
+
+
+def test_complex(install_temp):
+    from checks import inc2_cfloat_struct
+    
+    arr = np.array([0, 10+10j], dtype="F")
+    inc2_cfloat_struct(arr)
+    assert arr[1] == (12 + 12j)


### PR DESCRIPTION
Backport of #26080.

Fixes #26029 

- declare `npy_cfloat` and friends as empty structs
- declare `cfloat_t` and friends as `ctypedef float complex cfloat_t`, without being directly connected to `npy_cfloat`. This allows still using `.imag` and `.real` attributes, which Cython wraps with macros
- add a test for #26029, it passes since we use C compilation for cython. The inplace `+=` will fail on C++.
- resync the two cython `pxd` files. At what point do we declare NumPy requires Cython3?

I checked that scipy and cython can use the `pxd` file.

Edit: I checked on linux, I did not check MSVC
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
