### PR TITLE
ENH: Clarify error message for invalid array indices

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -605,7 +605,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
             /* The input was not an array, so give a general error message */
             PyErr_SetString(PyExc_IndexError,
                     "only integers, slices (`:`), ellipsis (`...`), "
-                    "numpy.newaxis (`None`) and integer or boolean "
+                    "numpy.newaxis (`None`), tuples of these objects, "
+                    "and integer or boolean "
                     "arrays are valid indices");
         }
         Py_DECREF(arr);


### PR DESCRIPTION
This enhancement updates the error message thrown during array indexing
with invalid objects. Previously, the message did not explicitly mention
that tuples of valid indexing objects are also acceptable. This could lead
to confusion, especially when debugging legacy code or for users less
familiar with NumPy's indexing rules.

The new error message now includes "tuples of these objects" to clearly
indicate that tuples containing any combination of valid indices (integers,
slices, ellipsis, numpy.newaxis, and integer or boolean arrays) are valid
indexing methods. This change aims to reduce misunderstanding and improve
the developer experience by providing more direct guidance on valid
indexing types.

See ticket #26115