### PR TITLE
BUG: fix reference counting error in stringdtype setup

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1796,14 +1796,14 @@ add_promoter(PyObject *numpy, const char *ufunc_name,
 
     PyObject *DType_tuple = PyTuple_New(n_dtypes);
 
-    for (size_t i=0; i<n_dtypes; i++) {
-        PyTuple_SET_ITEM(DType_tuple, i, (PyObject *)dtypes[i]);
-    }
-
-
     if (DType_tuple == NULL) {
         Py_DECREF(ufunc);
         return -1;
+    }
+
+    for (size_t i=0; i<n_dtypes; i++) {
+        Py_INCREF((PyObject *)dtypes[i]);
+        PyTuple_SET_ITEM(DType_tuple, i, (PyObject *)dtypes[i]);
     }
 
     PyObject *promoter_capsule = PyCapsule_New((void *)promoter_impl,


### PR DESCRIPTION
Backport of #26119.

`PyTuple_SET_ITEM` steals a reference, so we need to `INCREF` before calling it because we don't do that above. I think this hasn't been problematic before because the number of static references to built-in dtypes is high so it's not a problem unless this function gets called a lot.

I also moved this clause below the error check, since the error check is really for the `PyTuple_New` above.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
