### PR TITLE
CI, BLD: Push NumPy's Emscripten/Pyodide wheels nightly to Anaconda.org PyPI index

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -21,8 +21,10 @@ on:
   workflow_dispatch:
     inputs:
       push_wheels:
+        # Can be 'true' or 'false'. Default is 'false'.
+        # Warning: this will overwrite existing wheels.
         description: >
-          Push wheels to Anaconda.org if the build is successful, can be 'true' or 'false'. Default is 'false'. Warning: this will overwrite existing wheels.
+          Push wheels to Anaconda.org if the build succeeds
         required: false
         default: 'false'
 

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -5,6 +5,26 @@ on:
     branches:
       - main
       - maintenance/**
+  # Note: this workflow gets triggered on the same schedule as the
+  # wheels.yml workflow, with the exception that this workflow runs
+  # the test suite for the Pyodide wheel too, prior to uploading it.
+  #
+  # Run on schedule to upload to Anaconda.org
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    - cron: "42 2 * * SUN,WED"
+  workflow_dispatch:
+    inputs:
+      push_wheels:
+        description: >
+          Push wheels to Anaconda.org if the build is successful, can be 'true' or 'false'. Default is 'false'. Warning: this will overwrite existing wheels.
+        required: false
+        default: 'false'
 
 env:
   FORCE_COLOR: 3
@@ -90,3 +110,15 @@ jobs:
           source .venv-pyodide/bin/activate
           cd ..
           pytest --pyargs numpy -m "not slow"
+
+        # Push to https://anaconda.org/scientific-python-nightly-wheels/numpy
+        # WARNING: this job will overwrite any existing WASM wheels.
+      - name: Push to Anaconda PyPI index
+        if: >-
+          (github.repository == 'numpy/numpy') &&
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
+          (github.event_name == 'schedule')
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # v0.5.0
+        with:
+          artifacts_path: dist/
+          anaconda_nightly_upload_token: ${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds a schedule to push WASM wheels that are compiled via the Emscripten toolchain and Pyodide ecosystem to NumPy's PyPI-like index on Anaconda.org at https://anaconda.org/scientific-python-nightly-wheels/numpy.

## Key changes

1. The addition of a schedule to the job, which is the same as the schedule that `wheels.yml` runs on
2. A `workflow_dispatch:` trigger has been added to push the wheels manually if needed
    a. The input is false by default to not accidentally upload and subsequently overwrite any existing wheels.
4. A step has been added that runs after the tests run and succeed, which uses the `NUMPY_NIGHTLY_UPLOAD_TOKEN` repository secret. These uploads will not be attempted on forks or on workflow run contexts outside of the provided condition(s) in this newly added step.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
