### PR TITLE
BUG: masked array division should ignore all FPEs in mask calculation

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -877,7 +877,7 @@ class _DomainSafeDivide:
             self.tolerance = np.finfo(float).tiny
         # don't call ma ufuncs from __array_wrap__ which would fail for scalars
         a, b = np.asarray(a), np.asarray(b)
-        with np.errstate(invalid='ignore'):
+        with np.errstate(all='ignore'):
             return umath.absolute(a) * self.tolerance >= umath.absolute(b)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2584,7 +2584,7 @@ class TestUfuncs:
     def test_masked_array_underflow(self):
         x = np.arange(0, 3, 0.1)
         X = np.ma.array(x)
-        with(np.errstate(under="raise")):
+        with np.errstate(under="raise"):
             X2 = X/2.0
             np.testing.assert_array_equal(X2, x/2)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2581,6 +2581,13 @@ class TestUfuncs:
             # also check that allclose uses ma ufuncs, to avoid warning
             allclose(m, 0.5)
 
+    def test_masked_array_underflow(self):
+        x = np.arange(0, 3, 0.1)
+        X = np.ma.array(x)
+        with(np.errstate(under="raise")):
+            X2 = X/2.0
+            np.testing.assert_array_equal(X2, x/2)
+
 class TestMaskedArrayInPlaceArithmetic:
     # Test MaskedArray Arithmetic
 


### PR DESCRIPTION
This PR fixes the bug #25810 where an internal multiplication underflow occured with np.seterr(under="raise")
