### PR TITLE
BUG: fixed datetime64[ns] conversion issue in numpy.vectorize, see #25936

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2330,7 +2330,7 @@ class vectorize:
                 if char not in typecodes['All']:
                     raise ValueError("Invalid otype specified: %s" % (char,))
         elif iterable(otypes):
-            otypes = ''.join([_nx.dtype(x).char for x in otypes])
+            otypes = [_nx.dtype(x) for x in otypes]
         elif otypes is not None:
             raise ValueError("Invalid otype specification")
         self.otypes = otypes

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1901,6 +1901,13 @@ class TestVectorize:
         r = f([2])
         assert_equal(r.dtype, np.dtype('float64'))
 
+    def test_datetime_conversion(self):
+        otype = "datetime64[ns]"
+        arr = np.array(['2024-01-01', '2024-01-02', '2024-01-03'], 
+                       dtype='datetime64[ns]')
+        assert_array_equal(np.vectorize(lambda x: x, signature="(i)->(j)",
+                                        otypes=[otype])(arr), arr)
+
 
 class TestLeaks:
     class A:


### PR DESCRIPTION
This PR fixes issue #25936 where vectorize fails with otype: datetime64[ns].