### PR TITLE
BUG,MAINT: Fix __array__ bugs and simplify code

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -39,6 +39,13 @@
 
 #include "umathmodule.h"
 
+
+NPY_NO_EXPORT const char *npy_no_copy_err_msg = (
+        "Unable to avoid copy while creating an array as requested.\n"
+        "If using `np.array(obj, copy=False)` use `np.asarray(obj)` "
+        "or `copy=None` to allow NumPy to make the copy.\n"
+        "This changed in NumPy 2. The suggested fix works on all versions.");
+
 /*
  * Reading from a file or a string.
  *
@@ -1637,9 +1644,8 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
      * If we got this far, we definitely have to create a copy, since we are
      * converting either from a scalar (cache == NULL) or a (nested) sequence.
      */
-    if (flags & NPY_ARRAY_ENSURENOCOPY ) {
-        PyErr_SetString(PyExc_ValueError,
-                "Unable to avoid copy while creating an array.");
+    if (flags & NPY_ARRAY_ENSURENOCOPY) {
+        PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
         Py_DECREF(dtype);
         npy_free_coercion_cache(cache);
         return NULL;
@@ -1847,8 +1853,7 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
             && !PyArray_ElementStrides(obj)) {
         PyObject *ret;
         if (requires & NPY_ARRAY_ENSURENOCOPY) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Unable to avoid copy while creating a new array.");
+            PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             return NULL;
         }
         ret = PyArray_NewCopy((PyArrayObject *)obj, NPY_ANYORDER);
@@ -1926,8 +1931,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
 
     if (copy) {
         if (flags & NPY_ARRAY_ENSURENOCOPY ) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Unable to avoid copy while creating an array from given array.");
+            PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             Py_DECREF(newtype);
             return NULL;
         }
@@ -2405,6 +2409,63 @@ PyArray_FromInterface(PyObject *origin)
 }
 
 
+
+/*
+ * Returns -1 and an error set or 0 with the original error cleared, must
+ * be called with an error set.
+ */
+static inline int
+check_or_clear_and_warn_error_if_due_to_copy_kwarg(PyObject *kwnames)
+{
+    if (kwnames == NULL) {
+        return -1;  /* didn't pass kwnames, can't possibly be the reason */
+    }
+    if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
+        return -1;
+    }
+
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
+    if (value == NULL) {
+        PyErr_Restore(type, value, traceback);
+        return -1;
+    }
+
+    /*
+     * In most cases, if we fail, we assume the error was unrelated to the
+     * copy kwarg and simply restore the original one.
+     */
+    PyObject *str_value = PyObject_Str(value);
+    if (str_value == NULL) {
+        PyErr_Restore(type, value, traceback);
+        return -1;
+    }
+    int copy_kwarg_unsupported = PyUnicode_Contains(
+            str_value, npy_ma_str_array_err_msg_substr);
+    Py_DECREF(str_value);
+    if (copy_kwarg_unsupported == -1) {
+        PyErr_Restore(type, value, traceback);
+        return -1;
+    }
+    if (copy_kwarg_unsupported) {
+        /*
+         * TODO: As of now NumPy 2.0, the this warning is only triggered with
+         *       `copy=False` allowing downstream to not notice it.
+         */
+        Py_DECREF(type);
+        Py_DECREF(value);
+        Py_XDECREF(traceback);
+        if (DEPRECATE("__array__ should implement the 'dtype' and "
+                      "'copy' keyword argument") < 0) {
+            return -1;
+        }
+        return 0;
+    }
+    PyErr_Restore(type, value, traceback);
+    return -1;
+}
+
+
 /**
  * Check for an __array__ attribute and call it when it exists.
  *
@@ -2447,74 +2508,61 @@ PyArray_FromArrayAttr_int(
         return Py_NotImplemented;
     }
 
-    PyObject *kwargs = PyDict_New();
+    static PyObject *kwnames_is_copy = NULL;
+    if (kwnames_is_copy == NULL) {
+        kwnames_is_copy = Py_BuildValue("(s)", "copy");
+        if (kwnames_is_copy == NULL) {
+            Py_DECREF(array_meth);
+            return NULL;
+        }
+    }
+
+    Py_ssize_t nargs = 0;
+    PyObject *arguments[2];
+    PyObject *kwnames = NULL;
+
+    if (descr != NULL) {
+        arguments[0] = (PyObject *)descr;
+        nargs++;
+    }
 
     /*
      * Only if the value of `copy` isn't the default one, we try to pass it
      * along; for backwards compatibility we then retry if it fails because the
      * signature of the __array__ method being called does not have `copy`.
      */
-    int copy_passed = 0;
     if (copy != -1) {
-        copy_passed = 1;
-        PyObject *copy_obj = copy == 1 ? Py_True : Py_False;
-        PyDict_SetItemString(kwargs, "copy", copy_obj);
+        kwnames = kwnames_is_copy;
+        arguments[nargs] = copy == 1 ? Py_True : Py_False;
     }
-    PyObject *args = descr != NULL ? PyTuple_Pack(1, descr) : PyTuple_New(0);
 
-    new = PyObject_Call(array_meth, args, kwargs);
-
+    int must_copy_but_copy_kwarg_unimplemented = 0;
+    new = PyObject_Vectorcall(array_meth, arguments, nargs, kwnames);
     if (new == NULL) {
-        if (npy_ma_str_array_err_msg_substr == NULL) {
+        if (check_or_clear_and_warn_error_if_due_to_copy_kwarg(kwnames) < 0) {
+            /* Error was not cleared (or a new error set) */
             Py_DECREF(array_meth);
-            Py_DECREF(args);
-            Py_DECREF(kwargs);
             return NULL;
         }
-        PyObject *type, *value, *traceback;
-        PyErr_Fetch(&type, &value, &traceback);
-        if (value != NULL) {
-            PyObject *str_value = PyObject_Str(value);
-            if (PyUnicode_Contains(
-                        str_value, npy_ma_str_array_err_msg_substr) > 0) {
-                Py_DECREF(type);
-                Py_DECREF(value);
-                Py_XDECREF(traceback);
-                if (PyErr_WarnEx(PyExc_UserWarning,
-                                 "__array__ should implement 'dtype' and "
-                                 "'copy' keywords", 1) < 0) {
-                    Py_DECREF(str_value);
-                    Py_DECREF(array_meth);
-                    Py_DECREF(args);
-                    Py_DECREF(kwargs);
-                    return NULL;
-                }
-                if (copy_passed) { /* try again */
-                    PyDict_DelItemString(kwargs, "copy");
-                    new = PyObject_Call(array_meth, args, kwargs);
-                    if (new == NULL) {
-                        Py_DECREF(str_value);
-                        Py_DECREF(array_meth);
-                        Py_DECREF(args);
-                        Py_DECREF(kwargs);
-                        return NULL;
-                    }
-                }
-            }
-            Py_DECREF(str_value);
-        }
-        if (new == NULL) {
-            PyErr_Restore(type, value, traceback);
+        if (copy == 0) {
+            /* Cannot possibly avoid a copy, so error out. */
+            PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             Py_DECREF(array_meth);
-            Py_DECREF(args);
-            Py_DECREF(kwargs);
+            return NULL;
+        }
+        /*
+         * The seems to have been due to passing copy.  We try to see
+         * more precisely what the message is and may try again.
+         */
+        must_copy_but_copy_kwarg_unimplemented = 1;
+        new = PyObject_Vectorcall(array_meth, arguments, nargs, NULL);
+        if (new == NULL) {
+            Py_DECREF(array_meth);
             return NULL;
         }
     }
 
     Py_DECREF(array_meth);
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
 
     if (!PyArray_Check(new)) {
         PyErr_SetString(PyExc_ValueError,
@@ -2522,6 +2570,10 @@ PyArray_FromArrayAttr_int(
                         "producing an array");
         Py_DECREF(new);
         return NULL;
+    }
+    if (must_copy_but_copy_kwarg_unimplemented) {
+        /* TODO: As of NumPy 2.0 this path is only reachable by C-API. */
+        Py_SETREF(new, PyArray_NewCopy((PyArrayObject *)new, NPY_KEEPORDER));
     }
     return new;
 }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -42,9 +42,9 @@
 
 NPY_NO_EXPORT const char *npy_no_copy_err_msg = (
         "Unable to avoid copy while creating an array as requested.\n"
-        "If using `np.array(obj, copy=False)` use `np.asarray(obj)` "
-        "to allow NumPy to make a copy when needed.\n"
-        "This changed in NumPy 2. The suggested fix works on all versions.");
+        "If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` "
+        "to allow a copy when needed (no behavior change in NumPy 1.x).\n"
+        "For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.");
 
 /*
  * Reading from a file or a string.

--- a/numpy/_core/src/multiarray/ctors.h
+++ b/numpy/_core/src/multiarray/ctors.h
@@ -1,6 +1,9 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_CTORS_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_CTORS_H_
 
+extern NPY_NO_EXPORT const char *npy_no_copy_err_msg;
+
+
 NPY_NO_EXPORT PyObject *
 PyArray_NewFromDescr(
         PyTypeObject *subtype, PyArray_Descr *descr, int nd,

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -980,8 +980,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(self);
             return ret;
         } else { // copy == NPY_COPY_NEVER
-            PyErr_SetString(PyExc_ValueError,
-                            "Unable to avoid copy while creating an array from given array.");
+            PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             Py_DECREF(self);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1586,8 +1586,7 @@ _array_fromobject_generic(
             }
             else {
                 if (copy == NPY_COPY_NEVER) {
-                    PyErr_SetString(PyExc_ValueError,
-                            "Unable to avoid copy while creating a new array.");
+                    PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
                     goto finish;
                 }
                 ret = (PyArrayObject *)PyArray_NewCopy(oparr, order);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8498,7 +8498,7 @@ class TestArrayCreationCopyArgument(object):
         # an error:
         with pytest.warns(DeprecationWarning, match="__array__.*'copy'"):
             with pytest.raises(ValueError,
-                    match=r"Unable to avoid copy(.|\n)*changed in NumPy 2"):
+                    match=r"Unable to avoid copy(.|\n)*numpy_2_0_migration_guide.html"):
                 np.array(a, copy=False)
 
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8488,9 +8488,18 @@ class TestArrayCreationCopyArgument(object):
         assert_array_equal(arr, base_arr)
         assert arr is base_arr
 
-        with pytest.warns(UserWarning, match=("should implement 'dtype' "
-                                              "and 'copy' keywords")):
-            np.array(a, copy=False)
+        # As of NumPy 2, explicitly passing copy=True does not trigger passing
+        # it to __array__ (deprecation warning is not triggered).
+        arr = np.array(a, copy=True)
+        assert_array_equal(arr, base_arr)
+        assert arr is not base_arr
+
+        # And passing copy=False gives a deprecation warning, but also raises
+        # an error:
+        with pytest.warns(DeprecationWarning, match="__array__.*'copy'"):
+            with pytest.raises(ValueError,
+                    match=r"Unable to avoid copy(.|\n)*changed in NumPy 2"):
+                np.array(a, copy=False)
 
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test__array__reference_leak(self):


### PR DESCRIPTION
This fixes that the UserWarning is incorrect, it needs to be a DeprecationWarning (it does not related to end-users). Instead, include the information about `copy=None` into the error message.

It also fixes a bug:  If `copy=` kwarg is unsupported we cannot guarantee no-copy, so we should raise, or did we discuss to "just warn"?

That is also a latent bug: When `copy=True` and the fallback path is taken, then we must make a copy to be on the safe side.

Fixes a couple of smaller error checking bugs.  Vectorcall allows for simpler code, I think.  The speed improvement is only around 10%, since there are other larger overheads anyway.

---

Or am I forgetting a discussion for why `UserWarning` makes sense @ngoldbaum and @mtsokol?