### PR TITLE
BUG: Fix test_impossible_feature_enable failing without BASELINE_FEAT

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -325,7 +325,6 @@ npy__cpu_check_env(int disable, const char *env) {
         ) < 0) {
             return -1;
         }
-        return 0;
     }
 
     #define NOTSUPP_BODY \

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -311,14 +311,24 @@ if __name__ == "__main__":
         err_type = "RuntimeError"
         self._expect_error(msg, err_type)
 
-        # Ensure that only the bad feature gets reported
-        feats = f"{bad_feature}, {self.BASELINE_FEAT}"
+        # Ensure that it fails even when providing garbage in addition
+        feats = f"{bad_feature}, Foobar"
         self.env['NPY_ENABLE_CPU_FEATURES'] = feats
         msg = (
             f"You cannot enable CPU features \\({bad_feature}\\), since they "
             "are not supported by your machine."
         )
         self._expect_error(msg, err_type)
+
+        if self.BASELINE_FEAT is not None:
+            # Ensure that only the bad feature gets reported
+            feats = f"{bad_feature}, {self.BASELINE_FEAT}"
+            self.env['NPY_ENABLE_CPU_FEATURES'] = feats
+            msg = (
+                f"You cannot enable CPU features \\({bad_feature}\\), since "
+                "they are not supported by your machine."
+            )
+            self._expect_error(msg, err_type)
 
 is_linux = sys.platform.startswith('linux')
 is_cygwin = sys.platform.startswith('cygwin')


### PR DESCRIPTION
If the build has no baseline features set, the test ended up setting e.g. NPY_ENABLE_CPU_FEATURES="ASIMDHP, None". This actually made the execution succeed, as the warning for decoding "None" overrode the error for the real feature. Fix the error handling there by removing the errorneous "return 0;", add a test for this, and avoid passing "None" by accident.