### PR TITLE
ENH: Improve performance of np.broadcast_arrays and np.broadcast_shapes

### DIFF
--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -546,13 +546,12 @@ def broadcast_arrays(*args, subok=False):
     # return np.nditer(args, flags=['multi_index', 'zerosize_ok'],
     #                  order='C').itviews
 
-    args = tuple(np.array(_m, copy=None, subok=subok) for _m in args)
+    args = [np.array(_m, copy=None, subok=subok) for _m in args]
 
     shape = _broadcast_shape(*args)
 
-    if all(array.shape == shape for array in args):
-        # Common case where nothing needs to be broadcasted.
-        return args
+    result = [array if array.shape == shape
+              else _broadcast_to(array, shape, subok=subok, readonly=False)
+                              for array in args]
+    return tuple(result)
 
-    return tuple(_broadcast_to(array, shape, subok=subok, readonly=False)
-                 for array in args)

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -478,7 +478,7 @@ def broadcast_shapes(*args):
     >>> np.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7))
     (5, 6, 7)
     """
-    arrays = [np.empty(x, dtype=[]) for x in args]
+    arrays = [np.empty(x, dtype=bool) for x in args]
     return _broadcast_shape(*arrays)
 
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -341,7 +341,7 @@ def test_broadcast_shapes_raises():
         [(2, 3), (2,)],
         [(3,), (3,), (4,)],
         [(1, 3, 4), (2, 3, 3)],
-        [(1, 2), (3, 1), (3,2), (10, 5)],
+        [(1, 2), (3, 1), (3, 2), (10, 5)],
         [2, (2, 3)],
     ]
     for input_shapes in data:
@@ -578,8 +578,9 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [((False,), broadcast_arrays(original,)),
-                                  ((True, False), broadcast_arrays(0, original))]:
+    test_cases = [((False,), broadcast_arrays(original,)),
+                  ((True, False), broadcast_arrays(0, original))]
+    for is_broadcast, results in test_cases:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
@@ -623,8 +624,9 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
-                                  ((True, False), broadcast_arrays(0, original))]:
+    test_cases = [((False, ), broadcast_arrays(original,)),
+                  ((True, False), broadcast_arrays(0, original))]
+    for is_broadcast, results in test_cases:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -578,8 +578,8 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
-                                  ( (True, False), broadcast_arrays(0, original))]:
+    for is_broadcast, results in [((False,), broadcast_arrays(original,)),
+                              ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
@@ -623,8 +623,8 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
-                              ( (True, False), broadcast_arrays(0, original))]:
+    for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
+                              ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -341,7 +341,7 @@ def test_broadcast_shapes_raises():
         [(2, 3), (2,)],
         [(3,), (3,), (4,)],
         [(1, 3, 4), (2, 3, 3)],
-        [(1, 2), (3,1), (3,2), (10, 5)],
+        [(1, 2), (3, 1), (3,2), (10, 5)],
         [2, (2, 3)],
     ]
     for input_shapes in data:
@@ -579,7 +579,7 @@ def test_writeable():
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
     for is_broadcast, results in [((False,), broadcast_arrays(original,)),
-                              ((True, False), broadcast_arrays(0, original))]:
+                                  ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
@@ -624,7 +624,7 @@ def test_writeable_memoryview():
     original = np.array([1, 2, 3])
 
     for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
-                              ((True, False), broadcast_arrays(0, original))]:
+                                  ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -578,11 +578,11 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [(False, broadcast_arrays(original,)),
-                                  (True, broadcast_arrays(0, original))]:
-        for result in results:
+    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
+                                  ( (True, False), broadcast_arrays(0, original))]:
+        for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
-            if is_broadcast:
+            if array_is_broadcast:
                 with assert_warns(FutureWarning):
                     assert_equal(result.flags.writeable, True)
                 with assert_warns(DeprecationWarning):
@@ -623,11 +623,11 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [(False, broadcast_arrays(original,)),
-                                  (True, broadcast_arrays(0, original))]:
-        for result in results:
+    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
+                              ( (True, False), broadcast_arrays(0, original))]:
+        for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
-            if is_broadcast:
+            if array_is_broadcast:
                 # memoryview(result, writable=True) will give warning but cannot
                 # be tested using the python API.
                 assert memoryview(result).readonly


### PR DESCRIPTION
Results:
``` 
main:
broadcast_arrays(*args) 1.12 us
broadcast_arrays(*args_two) 6.98 us
broadcast_arrays(*args_multi) 9.01 us

PR:
broadcast_arrays(*args) 0.77 us
broadcast_arrays(*args_two) 3.30 us
broadcast_arrays(*args_multi) 3.72 us
```

Benchmark script:
```

import timeit
import numpy as np
from numpy import broadcast_arrays
args = (np.array([1.]), )
args_two = (np.array([1.]), np.arange(10) )
args_multi = (np.array([1.]), np.arange(10), np.arange(2, 12) )

number=100_000
dt = timeit.timeit(stmt="broadcast_arrays(*args)", globals=globals(), number=number)
print(f'broadcast_arrays(*args) {1e6*dt/number:.2f} us')
dt = timeit.timeit(stmt="broadcast_arrays(*args_two)", globals=globals(), number=number)
print(f'broadcast_arrays(*args_two) {1e6*dt/number:.2f} us')
dt = timeit.timeit(stmt="broadcast_arrays(*args_multi)", globals=globals(), number=number)
print(f'broadcast_arrays(*args_multi) {1e6*dt/number:.2f} us')
```

There are some tests failing/modified due to the results not being writable. Maybe that is ok, but I am not sure.
See [DEP: finish deprecating readonly result from numpy.broadcast_arrays](https://github.com/numpy/numpy/issues/13974) and the links in that issue.


Notes:

* The PR avoids calling `_broadcast_to` on arrays that do not require broadcasting. Also two generators are avoided.
* The performance of  `np.broadcast_arrays` matters for the argument parsing in the random distributions of `scipy.stats`.
* In the code there is a comment about possibly using `np.nditer`. Adding 
```
    if len(args)< 33 and not subok:        
        return np.nditer(args, flags=['multi_index', 'zerosize_ok', 'reduce_ok',  'refs_ok'], order='C').itviews
```
makes the method much faster, but there are two failing tests. Both related to the result of `np.nditer` being read-only (output included in the details below). I could not find an option to make the output of `np.nditer` writable.

<details>

```
_____________________________________________ test_writeable ____________________________________________

    def test_writeable():
        # broadcast_to should return a readonly array
        original = np.array([1, 2, 3])
        result = broadcast_to(original, (2, 3))
        assert_equal(result.flags.writeable, False)
        assert_raises(ValueError, result.__setitem__, slice(None), 0)

        # but the result of broadcast_arrays needs to be writeable, to
        # preserve backwards compatibility
        for is_broadcast, results in [(False, broadcast_arrays(original,)),
                                      (True, broadcast_arrays(0, original))]:
            for result in results:
                # This will change to False in a future version
                if is_broadcast:
                    with assert_warns(FutureWarning):
                        assert_equal(result.flags.writeable, True)
                    with assert_warns(DeprecationWarning):
                        result[:] = 0
                    # Warning not emitted, writing to the array resets it
                    assert_equal(result.flags.writeable, True)
                else:
                    # No warning:
>                   assert_equal(result.flags.writeable, True)
E                   AssertionError:
E                   Items are not equal:
E                    ACTUAL: False
E                    DESIRED: True

is_broadcast = False
original   = array([1, 2, 3])
result     = array([1, 2, 3])
results    = (array([1, 2, 3]),)

numpy\lib\tests\test_stride_tricks.py:594: AssertionError
_____________________________________ test_writeable_memoryview _______________________________________

    def test_writeable_memoryview():
        # The result of broadcast_arrays exports as a non-writeable memoryview
        # because otherwise there is no good way to opt in to the new behaviour
        # (i.e. you would need to set writeable to False explicitly).
        # See gh-13929.
        original = np.array([1, 2, 3])

        for is_broadcast, results in [(False, broadcast_arrays(original,)),
                                      (True, broadcast_arrays(0, original))]:
            for result in results:
                # This will change to False in a future version
                if is_broadcast:
                    # memoryview(result, writable=True) will give warning but cannot
                    # be tested using the python API.
                    assert memoryview(result).readonly
                else:
>                   assert not memoryview(result).readonly
E                   assert not True
E                    +  where True = <memory at 0x0000029E1779FB80>.readonly
E                    +    where <memory at 0x0000029E1779FB80> = memoryview(array([1, 2, 3]))

is_broadcast = False
original   = array([1, 2, 3])
result     = array([1, 2, 3])
results    = (array([1, 2, 3]),)

numpy\lib\tests\test_stride_tricks.py:635: AssertionError
===================================================================================================== short test summary info =====================================================================================================
FAILED numpy/lib/tests/test_stride_tricks.py::test_writeable - AssertionError:
FAILED numpy/lib/tests/test_stride_tricks.py::test_writeable_memoryview - assert not True
========================================================================= 2 failed, 4360 passed, 165 skipped, 6 deselected, 4 xfailed, 1 xpassed in 9.38s =========================================================================

```
</details>

The `np.broadcast_shapes` is made faster (and more memory efficient) by selecting a more efficient `dtype` for the helper arrays.
```
%timeit broadcast_shapes( (10, 10), (1,1))

MAIN: 1.39 µs ± 94.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
PR: 1.08 µs ± 7.32 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
