### PR TITLE
BUG: Infinite Loop in numpy.base_repr

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2142,7 +2142,7 @@ def base_repr(number, base=2, padding=0):
     elif base < 2:
         raise ValueError("Bases less than 2 not handled in base_repr.")
 
-    num = abs(number)
+    num = abs(int(number))
     res = []
     while num:
         res.append(digits[num % base])

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1969,6 +1969,9 @@ class TestBaseRepr:
         with assert_raises(ValueError):
             np.base_repr(1, 37)
 
+    def test_min_int(self):
+        assert_equal(np.base_repr(np.int8(-128)), '-10000000')
+
 
 def _test_array_equal_parametrizations():
     """

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1969,7 +1969,7 @@ class TestBaseRepr:
         with assert_raises(ValueError):
             np.base_repr(1, 37)
 
-    def test_min_int(self):
+    def test_minimal_signed_int(self):
         assert_equal(np.base_repr(np.int8(-128)), '-10000000')
 
 


### PR DESCRIPTION
Fixes #26143

- Converts number to python int, before the absolute value of number is taken
- This avoids `abs(np.int8(-128))` yielding -128 and subsequently falling into an infinite loop