### PR TITLE
ENH: inherit numerical dtypes from abstract ones.

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -906,6 +906,30 @@ PyArray_DTypeMeta and PyArrayDTypeMeta_Spec
       of functions in the DType API. Slot IDs must be one of the
       DType slot IDs enumerated in :ref:`dtype-slots`.
 
+Exposed DTypes classes (``PyArray_DTypeMeta`` objects)
+------------------------------------------------------
+
+For use with promoters, NumPy exposes a number of Dtypes following the
+pattern ``PyArray_<Name>DType`` corresponding to those found in `np.dtypes`.
+
+Additionally, the three DTypes, ``PyArray_PyLongDType``,
+``PyArray_PyFloatDType``, ``PyArray_PyComplexDType`` correspond to the
+Python scalar values.  These cannot be used in all places, but do allow
+for example the common dtype operation and implementing promotion with them
+may be necessary.
+
+Further, the following abstract DTypes are defined which cover both the
+builtin NumPy ones and the python ones, and users can in principle subclass
+from them (this does not inherit any DType specific functionality):
+* ``PyArray_IntAbstractDType``
+* ``PyArray_FloatAbstractDType``
+* ``PyArray_ComplexAbstractDType``
+
+.. warning::
+    As of NumPy 2.0, the *only* valid use for these DTypes is registering a
+    promoter conveniently to e.g. match "any integers" (and subclass checks).
+    Because of this, they are not exposed to Python.
+
 
 PyUFunc_Type and PyUFuncObject
 ------------------------------

--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -227,6 +227,7 @@ def do_generate_api(targets, sources):
 
     # Check multiarray api indexes
     multiarray_api_index = genapi.merge_api_dicts(multiarray_api)
+    unused_index_max = max(multiarray_api_index.get("__unused_indices__", 0))
     genapi.check_api_dict(multiarray_api_index)
 
     numpyapi_list = genapi.get_api_functions('NUMPY_API',
@@ -277,6 +278,10 @@ def do_generate_api(targets, sources):
         extension_list.append(api_item.define_from_array_api_string())
         init_list.append(api_item.array_api_define())
         module_list.append(api_item.internal_define())
+
+    # In case we end with a "hole", append more NULLs
+    while len(init_list) <= unused_index_max:
+        init_list.append("        NULL")
 
     # Write to header
     s = h_template % ('\n'.join(module_list), '\n'.join(extension_list))

--- a/numpy/_core/code_generators/numpy_api.py
+++ b/numpy/_core/code_generators/numpy_api.py
@@ -94,6 +94,7 @@ multiarray_types_api = {
     # NOTE: The Slots 320-360 are defined in `_experimental_dtype_api.h`
     #       and filled explicitly outside the code generator as the metaclass
     #       makes them tricky to expose.  (This may be refactored.)
+    # Slot 366, 367, 368 are the abstract DTypes
     # End 2.0 API
 }
 
@@ -107,7 +108,8 @@ multiarray_funcs_api = {
          103, 115, 117, 122, 163, 164, 171, 173, 197,
          201, 202, 208, 219, 220, 221, 222, 223, 278,
          291, 293, 294, 295, 301]
-        + list(range(320, 361))  # range reserved DType class slots
+        # range/slots reserved DType classes (see _public_dtype_api_table.h):
+        + list(range(320, 361)) + [366, 367, 368]
         ),
     'PyArray_GetNDArrayCVersion':           (0,),
     # Unused slot 40, was `PyArray_SetNumericOps`

--- a/numpy/_core/include/numpy/_public_dtype_api_table.h
+++ b/numpy/_core/include/numpy/_public_dtype_api_table.h
@@ -4,6 +4,9 @@
  *
  * These definitions are only relevant for the public API and we reserve
  * the slots 320-360 in the API table generation for this (currently).
+ *
+ * TODO: This file should be consolidated with the API table generation
+ *       (although not sure the current generation is worth preserving).
  */
 #ifndef NUMPY_CORE_INCLUDE_NUMPY__PUBLIC_DTYPE_API_TABLE_H_
 #define NUMPY_CORE_INCLUDE_NUMPY__PUBLIC_DTYPE_API_TABLE_H_
@@ -69,7 +72,13 @@
 #define PyArray_DefaultIntDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[38])
 /* New non-legacy DTypes follow in the order they were added */
 #define PyArray_StringDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[39])
-/* NOTE: offset 40 is free, after that a new range will need to be used */
+
+/* NOTE: offset 40 is free */
+
+/* Need to start with a larger offset again for the abstract classes: */
+#define PyArray_IntAbstractDType (*(PyArray_DTypeMeta *)PyArray_API[366])
+#define PyArray_FloatAbstractDType (*(PyArray_DTypeMeta *)PyArray_API[367])
+#define PyArray_ComplexAbstractDType (*(PyArray_DTypeMeta *)PyArray_API[368])
 
 #endif /* NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION */
 

--- a/numpy/_core/include/numpy/_public_dtype_api_table.h
+++ b/numpy/_core/include/numpy/_public_dtype_api_table.h
@@ -61,13 +61,11 @@
 /* Object/Void */
 #define PyArray_ObjectDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[33])
 #define PyArray_VoidDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[34])
-/* Abstract */
-#define PyArray_PyIntAbstractDType \
-    (*(PyArray_DTypeMeta *)(PyArray_API + 320)[35])
-#define PyArray_PyFloatAbstractDType \
-    (*(PyArray_DTypeMeta *)(PyArray_API + 320)[36])
-#define PyArray_PyComplexAbstractDType \
-    (*(PyArray_DTypeMeta *)(PyArray_API + 320)[37])
+/* Python types (used as markers for scalars) */
+#define PyArray_PyLongDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[35])
+#define PyArray_PyFloatDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[36])
+#define PyArray_PyComplexDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[37])
+/* Default integer type */
 #define PyArray_DefaultIntDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[38])
 /* New non-legacy DTypes follow in the order they were added */
 #define PyArray_StringDType (*(PyArray_DTypeMeta *)(PyArray_API + 320)[39])

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -94,6 +94,10 @@ initialize_and_map_pytypes_to_dtypes()
     if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
         return -1;
     }
+    /*
+     * Delayed assignments to avoid "error C2099: initializer is not a constant"
+     * in windows compilers.  Can hopefully be done in structs in the future.
+     */
     ((PyTypeObject *)&PyArray_PyLongDType)->tp_base =
         (PyTypeObject *)&PyArray_IntAbstractDType;
     PyArray_PyLongDType.scalar_type = &PyLong_Type;
@@ -284,9 +288,9 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
 
 
 /*
- * TODO: These abstract DTypes also carry the dual role of representing
- *       `Floating`, `Complex`, and `Integer` (both signed and unsigned).
- *       They will have to be renamed and exposed in that capacity.
+ * Define abstract numerical DTypes that all regular ones can inherit from
+ * (in arraytypes.c.src).
+ * Here, also define types corresponding to the python scalars.
  */
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
@@ -308,11 +312,13 @@ NPY_DType_Slots pylongdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PyLongDType",
+        .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .dt_slots = &pylongdtype_slots,
+    .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
@@ -335,11 +341,13 @@ NPY_DType_Slots pyfloatdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PyFloatDType",
+        .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .dt_slots = &pyfloatdtype_slots,
+    .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
@@ -362,9 +370,11 @@ NPY_DType_Slots pycomplexdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PyComplexDType",
+        .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .dt_slots = &pycomplexdtype_slots,
+    .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -21,7 +21,7 @@ int_default_descriptor(PyArray_DTypeMeta* NPY_UNUSED(cls))
 }
 
 static PyArray_Descr *
-discover_descriptor_from_pyint(
+discover_descriptor_from_pylong(
         PyArray_DTypeMeta *NPY_UNUSED(cls), PyObject *obj)
 {
     assert(PyLong_Check(obj));
@@ -94,36 +94,36 @@ initialize_and_map_pytypes_to_dtypes()
     if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyIntAbstractDType)->tp_base =
+    ((PyTypeObject *)&PyArray_PyLongDType)->tp_base =
         (PyTypeObject *)&PyArray_IntAbstractDType;
-    PyArray_PyIntAbstractDType.scalar_type = &PyLong_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyIntAbstractDType) < 0) {
+    PyArray_PyLongDType.scalar_type = &PyLong_Type;
+    if (PyType_Ready((PyTypeObject *)&PyArray_PyLongDType) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyFloatAbstractDType)->tp_base =
+    ((PyTypeObject *)&PyArray_PyFloatDType)->tp_base =
         (PyTypeObject *)&PyArray_FloatAbstractDType;
-    PyArray_PyFloatAbstractDType.scalar_type = &PyFloat_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatAbstractDType) < 0) {
+    PyArray_PyFloatDType.scalar_type = &PyFloat_Type;
+    if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatDType) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyComplexAbstractDType)->tp_base =
+    ((PyTypeObject *)&PyArray_PyComplexDType)->tp_base =
         (PyTypeObject *)&PyArray_ComplexAbstractDType;
-    PyArray_PyComplexAbstractDType.scalar_type = &PyComplex_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexAbstractDType) < 0) {
+    PyArray_PyComplexDType.scalar_type = &PyComplex_Type;
+    if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexDType) < 0) {
         return -1;
     }
 
     /* Register the new DTypes for discovery */
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyIntAbstractDType, &PyLong_Type, NPY_FALSE) < 0) {
+            &PyArray_PyLongDType, &PyLong_Type, NPY_FALSE) < 0) {
         return -1;
     }
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyFloatAbstractDType, &PyFloat_Type, NPY_FALSE) < 0) {
+            &PyArray_PyFloatDType, &PyFloat_Type, NPY_FALSE) < 0) {
         return -1;
     }
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyComplexAbstractDType, &PyComplex_Type, NPY_FALSE) < 0) {
+            &PyArray_PyComplexDType, &PyComplex_Type, NPY_FALSE) < 0) {
         return -1;
     }
 
@@ -217,7 +217,7 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             return NPY_DT_NewRef(&PyArray_DoubleDType);
         }
     }
-    else if (other == &PyArray_PyIntAbstractDType) {
+    else if (other == &PyArray_PyLongDType) {
         Py_INCREF(cls);
         return cls;
     }
@@ -273,8 +273,8 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         return res;
 
     }
-    else if (other == &PyArray_PyIntAbstractDType ||
-             other == &PyArray_PyFloatAbstractDType) {
+    else if (other == &PyArray_PyLongDType ||
+             other == &PyArray_PyFloatDType) {
         Py_INCREF(cls);
         return cls;
     }
@@ -299,20 +299,20 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
     .flags = NPY_DT_ABSTRACT,
 };
 
-NPY_DType_Slots pyintdtype_slots = {
-    .discover_descr_from_pyobject = discover_descriptor_from_pyint,
+NPY_DType_Slots pylongdtype_slots = {
+    .discover_descr_from_pyobject = discover_descriptor_from_pylong,
     .default_descr = int_default_descriptor,
     .common_dtype = int_common_dtype,
 };
 
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PythonIntegerDType",
+        .tp_name = "numpy._PyLongDType",
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
-    .dt_slots = &pyintdtype_slots,
+    .dt_slots = &pylongdtype_slots,
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
@@ -332,9 +332,9 @@ NPY_DType_Slots pyfloatdtype_slots = {
     .common_dtype = float_common_dtype,
 };
 
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PythonFloatDType",
+        .tp_name = "numpy._PyFloatDType",
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
@@ -359,9 +359,9 @@ NPY_DType_Slots pycomplexdtype_slots = {
     .common_dtype = complex_common_dtype,
 };
 
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PythonComplexDType",
+        .tp_name = "numpy._PyComplexDType",
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,
     },},

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -94,12 +94,21 @@ initialize_and_map_pytypes_to_dtypes()
     if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
         return -1;
     }
+    ((PyTypeObject *)&PyArray_PyIntAbstractDType)->tp_base =
+        (PyTypeObject *)&PyArray_IntAbstractDType;
+    PyArray_PyIntAbstractDType.scalar_type = &PyLong_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyIntAbstractDType) < 0) {
         return -1;
     }
+    ((PyTypeObject *)&PyArray_PyFloatAbstractDType)->tp_base =
+        (PyTypeObject *)&PyArray_FloatAbstractDType;
+    PyArray_PyFloatAbstractDType.scalar_type = &PyFloat_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatAbstractDType) < 0) {
         return -1;
     }
+    ((PyTypeObject *)&PyArray_PyComplexAbstractDType)->tp_base =
+        (PyTypeObject *)&PyArray_ComplexAbstractDType;
+    PyArray_PyComplexAbstractDType.scalar_type = &PyComplex_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexAbstractDType) < 0) {
         return -1;
     }
@@ -299,14 +308,12 @@ NPY_DType_Slots pyintdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PythonIntegerDType",
-        .tp_base = (PyTypeObject *)&PyArray_IntAbstractDType,
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyintdtype_slots,
-    .scalar_type = &PyLong_Type,
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
@@ -329,14 +336,12 @@ NPY_DType_Slots pyfloatdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PythonFloatDType",
-        .tp_base = (PyTypeObject *)&PyArray_FloatAbstractDType,
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyfloatdtype_slots,
-    .scalar_type = &PyFloat_Type,
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
@@ -359,12 +364,10 @@ NPY_DType_Slots pycomplexdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._PythonComplexDType",
-        .tp_base = (PyTypeObject *)&PyArray_ComplexAbstractDType,
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pycomplexdtype_slots,
-    .scalar_type = &PyComplex_Type,
 };

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -85,6 +85,15 @@ discover_descriptor_from_pycomplex(
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes()
 {
+    if (PyType_Ready((PyTypeObject *)&PyArray_IntAbstractDType) < 0) {
+        return -1;
+    }
+    if (PyType_Ready((PyTypeObject *)&PyArray_FloatAbstractDType) < 0) {
+        return -1;
+    }
+    if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
+        return -1;
+    }
     if (PyType_Ready((PyTypeObject *)&PyArray_PyIntAbstractDType) < 0) {
         return -1;
     }
@@ -270,13 +279,7 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
  *       `Floating`, `Complex`, and `Integer` (both signed and unsigned).
  *       They will have to be renamed and exposed in that capacity.
  */
-NPY_DType_Slots pyintabstractdtype_slots = {
-    .discover_descr_from_pyobject = discover_descriptor_from_pyint,
-    .default_descr = int_default_descriptor,
-    .common_dtype = int_common_dtype,
-};
-
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._IntegerAbstractDType",
         .tp_base = &PyArrayDescr_Type,
@@ -285,18 +288,28 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
-    .dt_slots = &pyintabstractdtype_slots,
+};
+
+NPY_DType_Slots pyintdtype_slots = {
+    .discover_descr_from_pyobject = discover_descriptor_from_pyint,
+    .default_descr = int_default_descriptor,
+    .common_dtype = int_common_dtype,
+};
+
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
+        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        .tp_name = "numpy._PythonIntegerDType",
+        .tp_base = (PyTypeObject *)&PyArray_IntAbstractDType,
+        .tp_basicsize = sizeof(PyArray_Descr),
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+    },},
+    .type_num = -1,
+    .flags = NPY_DT_ABSTRACT,
+    .dt_slots = &pyintdtype_slots,
     .scalar_type = &PyLong_Type,
 };
 
-
-NPY_DType_Slots pyfloatabstractdtype_slots = {
-    .discover_descr_from_pyobject = discover_descriptor_from_pyfloat,
-    .default_descr = float_default_descriptor,
-    .common_dtype = float_common_dtype,
-};
-
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._FloatAbstractDType",
         .tp_base = &PyArrayDescr_Type,
@@ -305,18 +318,28 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
-    .dt_slots = &pyfloatabstractdtype_slots,
+};
+
+NPY_DType_Slots pyfloatdtype_slots = {
+    .discover_descr_from_pyobject = discover_descriptor_from_pyfloat,
+    .default_descr = float_default_descriptor,
+    .common_dtype = float_common_dtype,
+};
+
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
+        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        .tp_name = "numpy._PythonFloatDType",
+        .tp_base = (PyTypeObject *)&PyArray_FloatAbstractDType,
+        .tp_basicsize = sizeof(PyArray_Descr),
+       .tp_flags = Py_TPFLAGS_DEFAULT,
+    },},
+    .type_num = -1,
+    .flags = NPY_DT_ABSTRACT,
+    .dt_slots = &pyfloatdtype_slots,
     .scalar_type = &PyFloat_Type,
 };
 
-
-NPY_DType_Slots pycomplexabstractdtype_slots = {
-    .discover_descr_from_pyobject = discover_descriptor_from_pycomplex,
-    .default_descr = complex_default_descriptor,
-    .common_dtype = complex_common_dtype,
-};
-
-NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._ComplexAbstractDType",
         .tp_base = &PyArrayDescr_Type,
@@ -325,6 +348,23 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
-    .dt_slots = &pycomplexabstractdtype_slots,
+};
+
+NPY_DType_Slots pycomplexdtype_slots = {
+    .discover_descr_from_pyobject = discover_descriptor_from_pycomplex,
+    .default_descr = complex_default_descriptor,
+    .common_dtype = complex_common_dtype,
+};
+
+NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
+        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        .tp_name = "numpy._PythonComplexDType",
+        .tp_base = (PyTypeObject *)&PyArray_ComplexAbstractDType,
+        .tp_basicsize = sizeof(PyArray_Descr),
+         .tp_flags = Py_TPFLAGS_DEFAULT,
+    },},
+    .type_num = -1,
+    .flags = NPY_DT_ABSTRACT,
+    .dt_slots = &pycomplexdtype_slots,
     .scalar_type = &PyComplex_Type,
 };

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -294,7 +294,7 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
  */
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._IntegerAbstractDType",
+        .tp_name = "numpy.dtypes._IntegerAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -311,7 +311,7 @@ NPY_DType_Slots pylongdtype_slots = {
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PyLongDType",
+        .tp_name = "numpy.dtypes._PyLongDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -323,7 +323,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._FloatAbstractDType",
+        .tp_name = "numpy.dtypes._FloatAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -340,7 +340,7 @@ NPY_DType_Slots pyfloatdtype_slots = {
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PyFloatDType",
+        .tp_name = "numpy.dtypes._PyFloatDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -352,7 +352,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._ComplexAbstractDType",
+        .tp_name = "numpy.dtypes._ComplexAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -369,7 +369,7 @@ NPY_DType_Slots pycomplexdtype_slots = {
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
-        .tp_name = "numpy._PyComplexDType",
+        .tp_name = "numpy.dtypes._PyComplexDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -312,7 +312,6 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
         .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
-    .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyintdtype_slots,
 };
 
@@ -340,7 +339,6 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
        .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
-    .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyfloatdtype_slots,
 };
 
@@ -368,6 +366,5 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
          .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
-    .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pycomplexdtype_slots,
 };

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -85,18 +85,12 @@ discover_descriptor_from_pycomplex(
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes()
 {
-    ((PyTypeObject *)&PyArray_PyIntAbstractDType)->tp_base = &PyArrayDescr_Type;
-    PyArray_PyIntAbstractDType.scalar_type = &PyLong_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyIntAbstractDType) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyFloatAbstractDType)->tp_base = &PyArrayDescr_Type;
-    PyArray_PyFloatAbstractDType.scalar_type = &PyFloat_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatAbstractDType) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyComplexAbstractDType)->tp_base = &PyArrayDescr_Type;
-    PyArray_PyComplexAbstractDType.scalar_type = &PyComplex_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexAbstractDType) < 0) {
         return -1;
     }
@@ -285,12 +279,14 @@ NPY_DType_Slots pyintabstractdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyIntAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._IntegerAbstractDType",
+        .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
         .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyintabstractdtype_slots,
+    .scalar_type = &PyLong_Type,
 };
 
 
@@ -303,12 +299,14 @@ NPY_DType_Slots pyfloatabstractdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._FloatAbstractDType",
+        .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
        .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pyfloatabstractdtype_slots,
+    .scalar_type = &PyFloat_Type,
 };
 
 
@@ -321,10 +319,12 @@ NPY_DType_Slots pycomplexabstractdtype_slots = {
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
         .tp_name = "numpy._ComplexAbstractDType",
+        .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
          .tp_flags = Py_TPFLAGS_DEFAULT,
     },},
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
     .dt_slots = &pycomplexabstractdtype_slots,
+    .scalar_type = &PyComplex_Type,
 };

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -14,6 +14,9 @@ extern "C" {
  * may be necessary to make them (partially) public, to allow user-defined
  * dtypes to perform value based casting.
  */
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_IntAbstractDType;
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_FloatAbstractDType;
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_ComplexAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyIntAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyFloatAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyComplexAbstractDType;

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -17,9 +17,9 @@ extern "C" {
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_IntAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_FloatAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_ComplexAbstractDType;
-NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyIntAbstractDType;
-NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyFloatAbstractDType;
-NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyComplexAbstractDType;
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyLongDType;
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyFloatDType;
+NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyComplexDType;
 
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes(void);
@@ -51,8 +51,8 @@ npy_mark_tmp_array_if_pyscalar(
             && (PyArray_ISINTEGER(arr) || PyArray_ISOBJECT(arr))) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_INT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyIntAbstractDType);
-            Py_SETREF(*dtype, &PyArray_PyIntAbstractDType);
+            Py_INCREF(&PyArray_PyLongDType);
+            Py_SETREF(*dtype, &PyArray_PyLongDType);
         }
         return 1;
     }
@@ -60,8 +60,8 @@ npy_mark_tmp_array_if_pyscalar(
              && PyArray_TYPE(arr) == NPY_DOUBLE) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_FLOAT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyFloatAbstractDType);
-            Py_SETREF(*dtype, &PyArray_PyFloatAbstractDType);
+            Py_INCREF(&PyArray_PyFloatDType);
+            Py_SETREF(*dtype, &PyArray_PyFloatDType);
         }
         return 1;
     }
@@ -69,8 +69,8 @@ npy_mark_tmp_array_if_pyscalar(
              && PyArray_TYPE(arr) == NPY_CDOUBLE) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_COMPLEX;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyComplexAbstractDType);
-            Py_SETREF(*dtype, &PyArray_PyComplexAbstractDType);
+            Py_INCREF(&PyArray_PyComplexDType);
+            Py_SETREF(*dtype, &PyArray_PyComplexDType);
         }
         return 1;
     }

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -226,10 +226,10 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
         DType = Py_None;
     }
     else if (pytype == &PyFloat_Type) {
-        DType = (PyObject *)&PyArray_PyFloatAbstractDType;
+        DType = (PyObject *)&PyArray_PyFloatDType;
     }
     else if (pytype == &PyLong_Type) {
-        DType = (PyObject *)&PyArray_PyIntAbstractDType;
+        DType = (PyObject *)&PyArray_PyLongDType;
     }
     else {
         DType = PyDict_GetItem(_global_pytype_to_type_dict,

--- a/numpy/_core/src/multiarray/array_converter.c
+++ b/numpy/_core/src/multiarray/array_converter.c
@@ -351,8 +351,8 @@ array_converter_result_type(PyArrayArrayConverterObject *self,
                     "extra_dtype and ensure_inexact are mutually exclusive.");
             goto finish;
         }
-        Py_INCREF(&PyArray_PyFloatAbstractDType);
-        dt_info.dtype = &PyArray_PyFloatAbstractDType;
+        Py_INCREF(&PyArray_PyFloatDType);
+        dt_info.dtype = &PyArray_PyFloatDType;
     }
 
     if (dt_info.dtype != NULL) {

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -18,6 +18,7 @@
 
 #include "npy_config.h"
 #include "npy_sort.h"
+#include "abstractdtypes.h"
 #include "common.h"
 #include "ctors.h"
 #include "convert_datatype.h"
@@ -4351,10 +4352,16 @@ set_typeinfo(PyObject *dict)
      *         CFloat, CDouble, CLongDouble,
      *         Object, String, Unicode, Void,
      *         Datetime, Timedelta#
+     * #scls = PyArrayDescr_Type,
+     *         PyArray_PyIntAbstractDType*10,
+     *         PyArray_PyFloatAbstractDType*4,
+     *         PyArray_PyComplexAbstractDType*3,
+     *         PyArrayDescr_Type*6 #
      */
     if (dtypemeta_wrap_legacy_descriptor(
             _builtin_descrs[NPY_@NAME@],
             &_Py@Name@_ArrFuncs,
+            (PyTypeObject *)&@scls@,
             "numpy.dtypes." NPY_@NAME@_Name "DType",
 #ifdef NPY_@NAME@_alias
             "numpy.dtypes." NPY_@NAME@_Alias "DType"

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4353,9 +4353,9 @@ set_typeinfo(PyObject *dict)
      *         Object, String, Unicode, Void,
      *         Datetime, Timedelta#
      * #scls = PyArrayDescr_Type,
-     *         PyArray_PyIntAbstractDType*10,
-     *         PyArray_PyFloatAbstractDType*4,
-     *         PyArray_PyComplexAbstractDType*3,
+     *         PyArray_IntAbstractDType*10,
+     *         PyArray_FloatAbstractDType*4,
+     *         PyArray_ComplexAbstractDType*3,
      *         PyArrayDescr_Type*6 #
      */
     if (dtypemeta_wrap_legacy_descriptor(

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -48,7 +48,7 @@ _array_find_python_scalar_type(PyObject *op)
     }
     else if (PyLong_Check(op)) {
         return NPY_DT_CALL_discover_descr_from_pyobject(
-                &PyArray_PyIntAbstractDType, op);
+                &PyArray_PyLongDType, op);
     }
     return NULL;
 }

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -1796,17 +1796,17 @@ PyArray_ResultType(
         all_descriptors[i_all] = NULL;  /* no descriptor for py-scalars */
         if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_INT) {
             /* This could even be an object dtype here for large ints */
-            all_DTypes[i_all] = &PyArray_PyIntAbstractDType;
+            all_DTypes[i_all] = &PyArray_PyLongDType;
             if (PyArray_TYPE(arrs[i]) != NPY_LONG) {
                 /* Not a "normal" scalar, so we cannot avoid the legacy path */
                 all_pyscalar = 0;
             }
         }
         else if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_FLOAT) {
-            all_DTypes[i_all] = &PyArray_PyFloatAbstractDType;
+            all_DTypes[i_all] = &PyArray_PyFloatDType;
         }
         else if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_COMPLEX) {
-            all_DTypes[i_all] = &PyArray_PyComplexAbstractDType;
+            all_DTypes[i_all] = &PyArray_PyComplexDType;
         }
         else {
             all_descriptors[i_all] = PyArray_DTYPE(arrs[i]);

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -914,9 +914,10 @@ default_builtin_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     if (NPY_UNLIKELY(!NPY_DT_is_legacy(other))) {
         /*
          * Deal with the non-legacy types we understand: python scalars.
-         * These have lower priority than the concrete inexact types, but
-         * can change the type of the result (complex, float, int).
-         * If our own type if not numerical, signal not implemented.
+         * These may have lower priority than the concrete inexact types,
+         * but can change the type of the result (complex, float, int).
+         * If our own DType is not numerical or has lower priority (e.g.
+         * integer but abstract one is float), signal not implemented.
          */
         if (other == &PyArray_PyComplexDType) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)) {

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1063,8 +1063,9 @@ object_common_dtype(
  * @returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-dtypemeta_wrap_legacy_descriptor(_PyArray_LegacyDescr *descr,
-        PyArray_ArrFuncs *arr_funcs, const char *name, const char *alias)
+dtypemeta_wrap_legacy_descriptor(
+    _PyArray_LegacyDescr *descr, PyArray_ArrFuncs *arr_funcs,
+    PyTypeObject *dtype_super_class, const char *name, const char *alias)
 {
     int has_type_set = Py_TYPE(descr) == &PyArrayDescr_Type;
 
@@ -1118,7 +1119,7 @@ dtypemeta_wrap_legacy_descriptor(_PyArray_LegacyDescr *descr,
             .tp_name = NULL,  /* set below */
             .tp_basicsize = sizeof(_PyArray_LegacyDescr),
             .tp_flags = Py_TPFLAGS_DEFAULT,
-            .tp_base = &PyArrayDescr_Type,
+            .tp_base = NULL,  /* set below */
             .tp_new = (newfunc)legacy_dtype_default_new,
             .tp_doc = (
                 "DType class corresponding to the scalar type and dtype of "
@@ -1131,11 +1132,12 @@ dtypemeta_wrap_legacy_descriptor(_PyArray_LegacyDescr *descr,
         /* Further fields are not common between DTypes */
     };
     memcpy(dtype_class, &prototype, sizeof(PyArray_DTypeMeta));
-    /* Fix name of the Type*/
+    /* Fix name and superclass of the Type*/
     ((PyTypeObject *)dtype_class)->tp_name = name;
+    ((PyTypeObject *)dtype_class)->tp_base = dtype_super_class,
     dtype_class->dt_slots = dt_slots;
 
-    /* Let python finish the initialization (probably unnecessary) */
+    /* Let python finish the initialization */
     if (PyType_Ready((PyTypeObject *)dtype_class) < 0) {
         Py_DECREF(dtype_class);
         return -1;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -918,7 +918,7 @@ default_builtin_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
          * can change the type of the result (complex, float, int).
          * If our own type if not numerical, signal not implemented.
          */
-        if (other == &PyArray_PyComplexAbstractDType) {
+        if (other == &PyArray_PyComplexDType) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)) {
                 Py_INCREF(cls);
                 return cls;
@@ -933,14 +933,14 @@ default_builtin_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
                 return NPY_DT_NewRef(&PyArray_CLongDoubleDType);
             }
         }
-        else if (other == &PyArray_PyFloatAbstractDType) {
+        else if (other == &PyArray_PyFloatDType) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)
                     || PyTypeNum_ISFLOAT(cls->type_num)) {
                 Py_INCREF(cls);
                 return cls;
             }
         }
-        else if (other == &PyArray_PyIntAbstractDType) {
+        else if (other == &PyArray_PyLongDType) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)
                     || PyTypeNum_ISFLOAT(cls->type_num)
                     || PyTypeNum_ISINTEGER(cls->type_num)

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -155,8 +155,8 @@ python_builtins_are_known_scalar_types(
 
 NPY_NO_EXPORT int
 dtypemeta_wrap_legacy_descriptor(
-        _PyArray_LegacyDescr *descr, PyArray_ArrFuncs *arr_funcs,
-        const char *name, const char *alias);
+    _PyArray_LegacyDescr *descr, PyArray_ArrFuncs *arr_funcs,
+    PyTypeObject *dtype_super_class, const char *name, const char *alias);
 
 NPY_NO_EXPORT void
 initialize_legacy_dtypemeta_aliases(_PyArray_LegacyDescr **_builtin_descrs);

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -175,4 +175,9 @@ _fill_dtype_api(void *full_api_table[])
     api_table[38] = &PyArray_DefaultIntDType;
     /* Non-legacy DTypes that are built in to NumPy */
     api_table[39] = &PyArray_StringDType;
+
+    /* Abstract ones added directly: */
+    full_api_table[366] = &PyArray_IntAbstractDType;
+    full_api_table[367] = &PyArray_FloatAbstractDType;
+    full_api_table[368] = &PyArray_ComplexAbstractDType;
 }

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -169,9 +169,9 @@ _fill_dtype_api(void *full_api_table[])
     api_table[33] = &PyArray_ObjectDType;
     api_table[34] = &PyArray_VoidDType;
     /* Abstract */
-    api_table[35] = &PyArray_PyIntAbstractDType;
-    api_table[36] = &PyArray_PyFloatAbstractDType;
-    api_table[37] = &PyArray_PyComplexAbstractDType;
+    api_table[35] = &PyArray_PyLongDType;
+    api_table[36] = &PyArray_PyFloatDType;
+    api_table[37] = &PyArray_PyComplexDType;
     api_table[38] = &PyArray_DefaultIntDType;
     /* Non-legacy DTypes that are built in to NumPy */
     api_table[39] = &PyArray_StringDType;

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -306,7 +306,8 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
     descr->type_num = typenum;
     /* update prototype to notice duplicate registration */
     descr_proto->type_num = typenum;
-    if (dtypemeta_wrap_legacy_descriptor(descr, descr_proto->f, name, NULL) < 0) {
+    if (dtypemeta_wrap_legacy_descriptor(
+            descr, descr_proto->f, &PyArrayDescr_Type, name, NULL) < 0) {
         descr->type_num = -1;
         NPY_NUMUSERTYPES--;
         /* Override the type, it might be wrong and then decref crashes */

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -589,8 +589,7 @@ _make_new_typetup(
             none_count++;
         }
         else {
-            if (!NPY_DT_is_legacy(signature[i])
-                    || NPY_DT_is_abstract(signature[i])) {
+            if (!NPY_DT_is_legacy(signature[i])) {
                 /*
                  * The legacy type resolution can't deal with these.
                  * This path will return `None` or so in the future to

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -177,7 +177,7 @@ resolve_descriptors_with_scalars(
 {
     int value_range = 0;
 
-    npy_bool first_is_pyint = dtypes[0] == &PyArray_PyIntAbstractDType;
+    npy_bool first_is_pyint = dtypes[0] == &PyArray_PyLongDType;
     int arr_idx = first_is_pyint? 1 : 0;
     int scalar_idx = first_is_pyint? 0 : 1;
     PyObject *scalar = input_scalars[scalar_idx];
@@ -327,7 +327,7 @@ template<COMP comp>
 static int
 add_dtype_loops(PyObject *umath, PyArrayMethod_Spec *spec, PyObject *info)
 {
-    PyArray_DTypeMeta *PyInt = &PyArray_PyIntAbstractDType;
+    PyArray_DTypeMeta *PyInt = &PyArray_PyLongDType;
 
     PyObject *name = PyUnicode_FromString(comp_name(comp));
     if (name == nullptr) {
@@ -441,7 +441,7 @@ init_special_int_comparisons(PyObject *umath)
      * `np.equal(2, 4)` (with two python integers) use an object loop.
      */
     PyObject *dtype_tuple = PyTuple_Pack(3,
-            &PyArray_PyIntAbstractDType, &PyArray_PyIntAbstractDType, Bool);
+            &PyArray_PyLongDType, &PyArray_PyLongDType, Bool);
     if (dtype_tuple == NULL) {
         goto finish;
     }

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2044,7 +2044,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *rdtypes[] = {
         &PyArray_StringDType,
-        &PyArray_PyIntAbstractDType,
+        &PyArray_IntAbstractDType,
         &PyArray_StringDType};
 
     if (add_promoter(umath, "multiply", rdtypes, 3, string_multiply_promoter) < 0) {
@@ -2052,7 +2052,7 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *ldtypes[] = {
-        &PyArray_PyIntAbstractDType,
+        &PyArray_IntAbstractDType,
         &PyArray_StringDType,
         &PyArray_StringDType};
 
@@ -2072,7 +2072,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *findlike_promoter_dtypes[] = {
         &PyArray_StringDType, &PyArray_UnicodeDType,
-        &PyArray_PyIntAbstractDType, &PyArray_PyIntAbstractDType,
+        &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
         &PyArray_DefaultIntDType,
     };
 
@@ -2113,7 +2113,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *startswith_endswith_promoter_dtypes[] = {
         &PyArray_StringDType, &PyArray_UnicodeDType,
-        &PyArray_PyIntAbstractDType, &PyArray_PyIntAbstractDType,
+        &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
         &PyArray_BoolDType,
     };
 
@@ -2209,7 +2209,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *replace_promoter_pyint_dtypes[] = {
         &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_UnicodeDType,
-        &PyArray_PyIntAbstractDType, &PyArray_StringDType,
+        &PyArray_IntAbstractDType, &PyArray_StringDType,
     };
 
     if (add_promoter(umath, "_replace", replace_promoter_pyint_dtypes, 5,

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2044,7 +2044,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *rdtypes[] = {
         &PyArray_StringDType,
-        (PyArray_DTypeMeta *)Py_None,
+        &PyArray_PyIntAbstractDType,
         &PyArray_StringDType};
 
     if (add_promoter(umath, "multiply", rdtypes, 3, string_multiply_promoter) < 0) {
@@ -2052,7 +2052,7 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *ldtypes[] = {
-        (PyArray_DTypeMeta *)Py_None,
+        &PyArray_PyIntAbstractDType,
         &PyArray_StringDType,
         &PyArray_StringDType};
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1639,7 +1639,7 @@ string_unicode_bool_output_promoter(
 static int
 is_integer_dtype(PyArray_DTypeMeta *DType)
 {
-    if (DType == &PyArray_PyIntAbstractDType) {
+    if (DType == &PyArray_PyLongDType) {
         return 1;
     }
     else if (DType == &PyArray_Int8DType) {

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2040,18 +2040,6 @@ init_stringdtype_ufuncs(PyObject *umath)
     INIT_MULTIPLY(Int64, int64);
     INIT_MULTIPLY(UInt64, uint64);
 
-    // This is needed so the generic promoters defined after this don't match
-    // for np.multiply(string_array, string_array)
-
-    PyArray_DTypeMeta *hdtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType};
-
-    if (add_promoter(umath, "multiply", hdtypes, 3, string_multiply_promoter) < 0) {
-        return -1;
-    }
-
     // all other integer dtypes are handled with a generic promoter
 
     PyArray_DTypeMeta *rdtypes[] = {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4065,17 +4065,15 @@ resolve_descriptors(int nop,
                 original_dtypes[i] = PyArray_DTYPE(operands[i]);
                 Py_INCREF(original_dtypes[i]);
             }
-            if (i < nin
-                    && NPY_DT_is_abstract(signature[i])
-                    && inputs_tup != NULL) {
-                /*
-                 * TODO: We may wish to allow any scalar here.  Checking for
-                 *       abstract assumes this works out for Python scalars,
-                 *       which is the important case (especially for now).
-                 *
-                 * One possible check would be `DType->type == type(obj)`.
-                 */
-                input_scalars[i] = PyTuple_GET_ITEM(inputs_tup, i);
+            /*
+             * Check whether something is a scalar of the given type.
+             * We leave it to resolve_descriptors_with_scalars to deal
+             * with, e.g., only doing something special for python scalars.
+             */
+            if (i < nin && inputs_tup != NULL) {
+                PyObject *input = PyTuple_GET_ITEM(inputs_tup, i);
+                input_scalars[i] = signature[i]->scalar_type == Py_TYPE(input) ?
+                    input : NULL;
             }
             else {
                 input_scalars[i] = NULL;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -6119,8 +6119,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_INT);
-            Py_INCREF(&PyArray_PyIntAbstractDType);
-            DTypes[i] = &PyArray_PyIntAbstractDType;
+            Py_INCREF(&PyArray_PyLongDType);
+            DTypes[i] = &PyArray_PyLongDType;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == (PyObject *)&PyFloat_Type) {
@@ -6130,8 +6130,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_FLOAT);
-            Py_INCREF(&PyArray_PyFloatAbstractDType);
-            DTypes[i] = &PyArray_PyFloatAbstractDType;
+            Py_INCREF(&PyArray_PyFloatDType);
+            DTypes[i] = &PyArray_PyFloatDType;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == (PyObject *)&PyComplex_Type) {
@@ -6141,8 +6141,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_COMPLEX);
-            Py_INCREF(&PyArray_PyComplexAbstractDType);
-            DTypes[i] = &PyArray_PyComplexAbstractDType;
+            Py_INCREF(&PyArray_PyComplexDType);
+            DTypes[i] = &PyArray_PyComplexDType;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == Py_None) {

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1268,7 +1268,28 @@ def test_binary(string_array, unicode_array, function_name, args):
         assert 0
 
 
-def test_strip(string_array, unicode_array):
+@pytest.mark.parametrize("function, expected", [
+    (np.strings.find, [[2, -1], [1, -1]]),
+    (np.strings.startswith, [[False, False], [True, False]])])
+@pytest.mark.parametrize("start, stop", [
+    (1, 4),
+    (np.int8(1), np.int8(4)),
+    (np.array([1, 1], dtype='u2'), np.array([4, 4], dtype='u2'))])
+def test_non_default_start_stop(function, start, stop, expected):
+    a = np.array([["--🐍--", "--🦜--"],
+                  ["-🐍---", "-🦜---"]], "T")
+    indx = function(a, "🐍", start, stop)
+    assert_array_equal(indx, expected)
+
+
+@pytest.mark.parametrize("count", [2, np.int8(2), np.array([2, 2], 'u2')])
+def test_replace_non_default_repeat(count):
+    a = np.array(["🐍--", "🦜-🦜-"], "T")
+    result = np.strings.replace(a, "🦜-", "🦜†", count)
+    assert_array_equal(result, np.array(["🐍--", "🦜†🦜†"], "T"))
+
+
+def test_strip_ljust_rjust_consistency(string_array, unicode_array):
     rjs = np.char.rjust(string_array, 1000)
     rju = np.char.rjust(unicode_array, 1000)
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2972,6 +2972,13 @@ class TestLowlevelAPIAccess:
         with pytest.raises(TypeError):
             np.add.resolve_dtypes((i4, f4, None), casting="no")
 
+    def test_resolve_dtypes_comparison(self):
+        i4 = np.dtype("i4")
+        i8 = np.dtype("i8")
+        b = np.dtype("?")
+        r = np.equal.resolve_dtypes((i4, i8, None))
+        assert r == (i8, i8, b)
+
     def test_weird_dtypes(self):
         S0 = np.dtype("S0")
         # S0 is often converted by NumPy to S1, but not here:


### PR DESCRIPTION
Backport of #26116.

I couldn't quite stand how we are working around not having abstract dtypes by adding weird promotors in #26105, so thought one should just make them, especially since (as I found out) all the basic infrastructure is there.

So, this let's all numerical legacy dtypes inherit from the abstract types defined for python `int`, `float` and `complex`. This follows what was mentioned to be the plan all along in the comments in `abstractdtype`, though it does not yet change the names throughout, since I wanted to be sure first I'm not barking up the wrong tree (it took the better part of the day already, mostly to realize that the abstract dtypes better inherit from `PyArrayDescr_Type`, otherwise nothing works).

Anyway, with this, the `StringDType` multiplication promotors are now their logical selves, the work-around can be removed, and everything works.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
