### PR TITLE
TST: Use platform.machine() for improved portability on riscv64

### DIFF
--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -798,7 +798,7 @@ class TestBoolCmp:
         # Propagation of the RISC-V Unprivileged ISA for more details.
         # We disable the float32 sign test on riscv64 for -np.nan as the sign
         # of the NaN will be lost when it's converted to a float32.
-        if platform.processor() != 'riscv64':
+        if platform.machine() != 'riscv64':
             self.signf[3::6][self.ef[3::6]] = -np.nan
         self.signd[3::6][self.ed[3::6]] = -np.nan
         self.signf[4::6][self.ef[4::6]] = -0.

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1844,7 +1844,7 @@ class TestFPClass:
         assert_equal(np.isnan(arr_f64[::stride]), nan[::stride])
         assert_equal(np.isinf(arr_f32[::stride]), inf[::stride])
         assert_equal(np.isinf(arr_f64[::stride]), inf[::stride])
-        if platform.processor() == 'riscv64':
+        if platform.machine() == 'riscv64':
             # On RISC-V, many operations that produce NaNs, such as converting
             # a -NaN from f64 to f32, return a canonical NaN.  The canonical
             # NaNs are always positive.  See section 11.3 NaN Generation and
@@ -1881,7 +1881,7 @@ class TestFPClass:
         ncontig_out = out[1::3]
         contig_in = np.array(ncontig_in)
 
-        if platform.processor() == 'riscv64':
+        if platform.machine() == 'riscv64':
             # Disable the -np.nan signbit tests on riscv64.  See comments in
             # test_fpclass for more details.
             data_rv = np.copy(data)
@@ -1920,7 +1920,7 @@ class TestFPClass:
         finite_split = np.array(np.array_split(finite, 2))
         assert_equal(np.isnan(data_split), nan_split)
         assert_equal(np.isinf(data_split), inf_split)
-        if platform.processor() == 'riscv64':
+        if platform.machine() == 'riscv64':
             data_split_rv = np.array(np.array_split(data_rv, 2))
             assert_equal(np.signbit(data_split_rv), sign_split)
         else:


### PR DESCRIPTION
Replace `platform.processor()` with `platform.machine()` considering the latter is more portable.  More specifically, `platform.processor()` returns empty string on Arch Linux, and this PR fixes the corresponding test failure.