### PR TITLE
MNT: use pythoncapi_compat.h in npy_compat.h

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "numpy/fft/pocketfft"]
 	path = numpy/fft/pocketfft
 	url = https://github.com/mreineck/pocketfft
+[submodule "numpy/_core/src/common/pythoncapi-compat"]
+	path = numpy/_core/src/common/pythoncapi-compat
+	url = https://github.com/python/pythoncapi-compat

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -123,6 +123,11 @@ if use_intel_sort and not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
 
+if not fs.exists('src/common/pythoncapi-compat')
+  error('Missing the `pythoncapi-compat` git submodule! ' +
+        'Run `git submodule update --init` to fix this.')
+endif
+
 # Check sizes of types. Note, some of these landed in config.h before, but were
 # unused. So clean that up and only define the NPY_SIZEOF flavors rather than
 # the SIZEOF ones

--- a/numpy/_core/src/common/array_assign.c
+++ b/numpy/_core/src/common/array_assign.c
@@ -15,7 +15,7 @@
 
 #include <numpy/ndarraytypes.h>
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "shape.h"
 

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -5,8 +5,9 @@
 #include <Python.h>
 
 #include "numpy/ndarraytypes.h"
+#include "numpy/npy_2_compat.h"
 #include "npy_argparse.h"
-#include "npy_pycompat.h"
+
 #include "npy_import.h"
 
 #include "arrayfunction_override.h"
@@ -195,7 +196,7 @@ initialize_keywords(const char *funcname,
         }
         if (i >= npositional_only) {
             int i_kwarg = i - npositional_only;
-            cache->kw_strings[i_kwarg] = PyUString_InternFromString(name);
+            cache->kw_strings[i_kwarg] = PyUnicode_InternFromString(name);
             if (cache->kw_strings[i_kwarg] == NULL) {
                 va_end(va);
                 goto error;

--- a/numpy/_core/src/common/npy_longdouble.c
+++ b/numpy/_core/src/common/npy_longdouble.c
@@ -6,7 +6,7 @@
 
 #include "numpy/ndarraytypes.h"
 #include "numpy/npy_math.h"
-#include "npy_pycompat.h"
+
 #include "numpyos.h"
 
 /*

--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -2,7 +2,7 @@
 #define NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_
 
 #include "numpy/npy_3kcompat.h"
-
+#include "pythoncapi-compat/pythoncapi_compat.h"
 
 /*
  * In Python 3.10a7 (or b1), python started using the identity for the hash

--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #if defined(HAVE_STRTOLD_L) && !defined(_GNU_SOURCE)
 # define _GNU_SOURCE

--- a/numpy/_core/src/common/ucsnarrow.c
+++ b/numpy/_core/src/common/ucsnarrow.c
@@ -9,7 +9,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 #include "ctors.h"
 
 /*

--- a/numpy/_core/src/common/ufunc_override.c
+++ b/numpy/_core/src/common/ufunc_override.c
@@ -1,7 +1,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
-#include "npy_pycompat.h"
+#include "numpy/ndarraytypes.h"
 #include "get_attr_string.h"
 #include "npy_import.h"
 #include "ufunc_override.h"

--- a/numpy/_core/src/dummymodule.c
+++ b/numpy/_core/src/dummymodule.c
@@ -10,8 +10,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include "npy_pycompat.h"
-
 static struct PyMethodDef methods[] = {
     {NULL, NULL, 0, NULL}
 };

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -58,7 +58,7 @@ IsPythonScalar(PyObject * dummy, PyObject *args)
     }
 }
 
-#include "npy_pycompat.h"
+
 
 
 /** Function to test calling via ctypes */

--- a/numpy/_core/src/multiarray/array_assign_array.c
+++ b/numpy/_core/src/multiarray/array_assign_array.c
@@ -17,7 +17,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "convert_datatype.h"
 #include "methods.h"

--- a/numpy/_core/src/multiarray/array_assign_scalar.c
+++ b/numpy/_core/src/multiarray/array_assign_scalar.c
@@ -17,7 +17,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "convert_datatype.h"
 #include "methods.h"

--- a/numpy/_core/src/multiarray/array_converter.c
+++ b/numpy/_core/src/multiarray/array_converter.c
@@ -26,7 +26,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 #include "array_assign.h"
 
 #include "common.h"

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -4,7 +4,7 @@
 #include <Python.h>
 #include "structmember.h"
 
-#include "npy_pycompat.h"
+#include "numpy/ndarraytypes.h"
 #include "get_attr_string.h"
 #include "npy_import.h"
 #include "multiarraymodule.h"

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "number.h"

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -7,7 +7,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "common.h"
 
 #include "abstractdtypes.h"

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -10,7 +10,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "arraytypes.h"

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -9,7 +9,7 @@
 
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "arrayobject.h"

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -14,7 +14,7 @@
 #include "npy_config.h"
 
 #include "npy_ctypes.h"
-#include "npy_pycompat.h"
+
 #include "multiarraymodule.h"
 
 #include "common.h"

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -16,7 +16,7 @@
 #include "numpyos.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "numpy/arrayscalars.h"

--- a/numpy/_core/src/multiarray/datetime_busday.c
+++ b/numpy/_core/src/multiarray/datetime_busday.c
@@ -15,7 +15,7 @@
 #include <numpy/arrayobject.h>
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "numpy/arrayscalars.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/_core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/_core/src/multiarray/datetime_busdaycal.c
@@ -17,7 +17,7 @@
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/_core/src/multiarray/datetime_strings.c
+++ b/numpy/_core/src/multiarray/datetime_strings.c
@@ -16,7 +16,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 
 #include "numpy/arrayscalars.h"
 #include "convert_datatype.h"

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -13,7 +13,7 @@
 #include "npy_config.h"
 #include "npy_ctypes.h"
 #include "npy_import.h"
-#include "npy_pycompat.h"
+
 
 #include "_datetime.h"
 #include "common.h"

--- a/numpy/_core/src/multiarray/dragon4.h
+++ b/numpy/_core/src/multiarray/dragon4.h
@@ -38,7 +38,7 @@
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "numpy/arrayscalars.h"
 
 /* Half binary format */

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -21,7 +21,7 @@
 #include "numpy/npy_math.h"
 
 #include "lowlevel_strided_loops.h"
-#include "npy_pycompat.h"
+
 
 #include "convert_datatype.h"
 #include "ctors.h"

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -9,7 +9,7 @@
 #include <numpy/ndarraytypes.h>
 #include <numpy/arrayscalars.h>
 #include <numpy/npy_math.h>
-#include "npy_pycompat.h"
+
 #include "npy_import.h"
 
 #include "abstractdtypes.h"

--- a/numpy/_core/src/multiarray/einsum.c.src
+++ b/numpy/_core/src/multiarray/einsum.c.src
@@ -16,7 +16,7 @@
 #define _MULTIARRAYMODULE
 #include <numpy/npy_common.h>
 #include <numpy/arrayobject.h>
-#include <npy_pycompat.h>
+
 #include <array_assign.h>   //PyArray_AssignRawScalar
 
 #include <ctype.h>

--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -12,7 +12,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 #include "array_assign.h"
 
 #include "common.h"

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -9,7 +9,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "npy_import.h"
 
 #include "common.h"

--- a/numpy/_core/src/multiarray/hashdescr.c
+++ b/numpy/_core/src/multiarray/hashdescr.c
@@ -8,7 +8,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "hashdescr.h"
 

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -13,7 +13,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "multiarraymodule.h"
 #include "common.h"

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -11,7 +11,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "arrayobject.h"
 #include "iterators.h"

--- a/numpy/_core/src/multiarray/nditer_impl.h
+++ b/numpy/_core/src/multiarray/nditer_impl.h
@@ -18,7 +18,7 @@
 #include <structmember.h>
 
 #include "numpy/arrayobject.h"
-#include "npy_pycompat.h"
+
 #include "convert_datatype.h"
 
 #include "lowlevel_strided_loops.h"

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -15,7 +15,7 @@
 
 #include "numpy/arrayobject.h"
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "alloc.h"
 #include "common.h"
 #include "conversion_utils.h"

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -8,7 +8,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "npy_import.h"
 #include "common.h"
 #include "number.h"

--- a/numpy/_core/src/multiarray/refcount.c
+++ b/numpy/_core/src/multiarray/refcount.c
@@ -21,7 +21,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 /*
  * Helper function to clear a strided memory (normally or always contiguous)

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -12,7 +12,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "array_coercion.h"
 #include "ctors.h"

--- a/numpy/_core/src/multiarray/sequence.c
+++ b/numpy/_core/src/multiarray/sequence.c
@@ -10,7 +10,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "common.h"
 #include "mapping.h"

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -12,7 +12,7 @@
 
 #include "npy_config.h"
 
-#include "npy_pycompat.h"
+
 
 #include "arraywrap.h"
 #include "ctors.h"

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -34,7 +34,7 @@ maintainer email:  oliphant.travis@ieee.org
 
 #include "common.h"
 
-#include "npy_pycompat.h"
+
 
 #include "usertypes.h"
 #include "dtypemeta.h"

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -19,7 +19,7 @@
 #include "numpy/ndarrayobject.h"
 #include "numpy/npy_math.h"
 
-#include "npy_pycompat.h"
+
 
 #include "npy_config.h"
 #include "npy_cpu_features.h"

--- a/numpy/_core/src/umath/extobj.c
+++ b/numpy/_core/src/umath/extobj.c
@@ -6,7 +6,7 @@
 #include <Python.h>
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "npy_argparse.h"
 
 #include "conversion_utils.h"

--- a/numpy/_core/src/umath/funcs.inc.src
+++ b/numpy/_core/src/umath/funcs.inc.src
@@ -7,7 +7,7 @@
  */
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#include "npy_pycompat.h"
+
 #include "npy_import.h"
 
 

--- a/numpy/_core/src/umath/matmul.c.src
+++ b/numpy/_core/src/umath/matmul.c.src
@@ -14,7 +14,7 @@
 #include "numpy/halffloat.h"
 #include "lowlevel_strided_loops.h"
 
-#include "npy_pycompat.h"
+
 
 #include "npy_cblas.h"
 #include "arraytypes.h" /* For TYPE_dot functions */

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -1,5 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#define NO_IMPORT_
+#define NO_IMPORT_ARRAY
 
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -1,7 +1,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#define NO_IMPORT_ARRAY
+#define NO_IMPORT_
 
-#include "npy_pycompat.h"
+#include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
 #include "npy_import.h"
 

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -16,7 +16,7 @@
 #include "npy_config.h"
 #include "numpy/arrayobject.h"
 
-#include "npy_pycompat.h"
+
 #include "array_assign.h"
 #include "array_coercion.h"
 #include "array_method.h"

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -19,7 +19,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_import.h"
-#include "npy_pycompat.h"
+
 
 #include "numpy/halffloat.h"
 #include "templ_common.h"

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -33,7 +33,7 @@
 #include <stddef.h>
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
 #include "npy_argparse.h"
 
 #include "numpy/arrayobject.h"

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -33,9 +33,11 @@
 #endif
 
 #include "npy_config.h"
-#include "npy_pycompat.h"
+
+#include "numpy/npy_common.h"
 #include "npy_import.h"
 
+#include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
 #include "ufunc_type_resolution.h"
 #include "ufunc_object.h"

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -13,8 +13,6 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_math.h"
 
-#include "npy_pycompat.h"
-
 #include "npy_config.h"
 
 #include "npy_cblas.h"

--- a/tools/check_installed_files.py
+++ b/tools/check_installed_files.py
@@ -79,6 +79,11 @@ def get_files(dir_to_check, kind='test'):
             k: v for k, v in files.items() if not k.startswith('distutils')
         }
 
+    # ignore python files in vendored pythoncapi-compat submodule
+    files = {
+        k: v for k, v in files.items() if 'pythoncapi-compat' not in k
+    }
+
     return files
 
 


### PR DESCRIPTION
Following on from #26158 and #26159, this adds a new submodule for `pythoncapi_compat.h` and includes it in `npy_pycompat.h`. I also removed all the spots where `npy_pycompat.h` was getting included unnecessarily, probably leftovers from the python 2->3 migrations.

This doesn't actually use the new header yet, that will come in followups.