### PR TITLE
BUG: fix reference counting error in wrapping_method_resolve_descriptors

### DIFF
--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -54,7 +54,7 @@ wrapping_method_resolve_descriptors(
             self->wrapped_meth, self->wrapped_dtypes,
             orig_given_descrs, orig_loop_descrs, view_offset);
     for (int i = 0; i < nargs; i++) {
-        Py_XDECREF(orig_given_descrs);
+        Py_XDECREF(orig_given_descrs[i]);
     }
     if (casting < 0) {
         return -1;
@@ -62,7 +62,7 @@ wrapping_method_resolve_descriptors(
     int res = self->translate_loop_descrs(
             nin, nout, dtypes, given_descrs, orig_loop_descrs, loop_descrs);
     for (int i = 0; i < nargs; i++) {
-        Py_DECREF(orig_given_descrs);
+        Py_DECREF(orig_loop_descrs[i]);
     }
     if (res < 0) {
         return -1;


### PR DESCRIPTION
It looks like this copy/paste error has been here for two years!

This was found in the nogil python build, which may find other reference counting bugs that a more forgiving GIL implementation wasn't bothered by.