### PR TITLE
BUG: Infinite Loop in numpy.base_repr

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2142,7 +2142,7 @@ def base_repr(number, base=2, padding=0):
     elif base < 2:
         raise ValueError("Bases less than 2 not handled in base_repr.")
 
-    num = abs(number)
+    num = abs(int(number))
     res = []
     while num:
         res.append(digits[num % base])

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1970,7 +1970,7 @@ class TestBaseRepr:
         with assert_raises(ValueError):
             np.base_repr(1, 37)
 
-    def test_min_int(self):
+    def test_minimal_signed_int(self):
         assert_equal(np.base_repr(np.int8(-128)), '-10000000')
 
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1970,6 +1970,9 @@ class TestBaseRepr:
         with assert_raises(ValueError):
             np.base_repr(1, 37)
 
+    def test_min_int(self):
+        assert_equal(np.base_repr(np.int8(-128)), '-10000000')
+
 
 def _test_array_equal_parametrizations():
     """


### PR DESCRIPTION
Backport of #26162.

Fixes #26143

- Converts number to python int, before the absolute value of number is taken
- This avoids `abs(np.int8(-128))` yielding -128 and subsequently falling into an infinite loop

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
