### PR TITLE
BUG: introduce PyArray_SafeCast to fix issues around stringdtype views

### DIFF
--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -560,7 +560,7 @@ def _view_is_safe(oldtype, newtype):
         return
 
     if newtype.hasobject or oldtype.hasobject:
-        raise TypeError("Cannot change data-type for object array.")
+        raise TypeError("Cannot change data-type for array of references.")
     return
 
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -465,18 +465,18 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
     /*
      * Check for less harmful non-standard returns.  The following two returns
      * should never happen:
-     * 1. No-casting must imply a view offset of 0.
-     *    (with an exception for stringdtype)
+     * 1. No-casting must imply a view offset of 0 unless the DType
+          defines a finalization function, which implies it stores data
+          on the descriptor
      * 2. Equivalent-casting + 0 view offset is (usually) the definition
      *    of a "no" cast.  However, changing the order of fields can also
      *    create descriptors that are not equivalent but views.
      * Note that unsafe casts can have a view offset.  For example, in
      * principle, casting `<i8` to `<i4` is a cast with 0 offset.
      */
-    if (*view_offset != 0) {
-        if (from->kind != 'T' || to->kind != 'T') {
-            assert(casting != NPY_NO_CASTING);
-        }
+    if ((*view_offset != 0 &&
+         NPY_DT_SLOTS(NPY_DTYPE(from))->finalize_descr == NULL)) {
+        assert(casting != NPY_NO_CASTING);
     }
     else {
         assert(casting != NPY_EQUIV_CASTING

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -466,6 +466,7 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
      * Check for less harmful non-standard returns.  The following two returns
      * should never happen:
      * 1. No-casting must imply a view offset of 0.
+     *    (with an exception for stringdtype)
      * 2. Equivalent-casting + 0 view offset is (usually) the definition
      *    of a "no" cast.  However, changing the order of fields can also
      *    create descriptors that are not equivalent but views.
@@ -473,7 +474,9 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
      * principle, casting `<i8` to `<i4` is a cast with 0 offset.
      */
     if (*view_offset != 0) {
-        assert(casting != NPY_NO_CASTING);
+        if (from->kind != 'T' || to->kind != 'T') {
+            assert(casting != NPY_NO_CASTING);
+        }
     }
     else {
         assert(casting != NPY_EQUIV_CASTING

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -651,6 +651,35 @@ PyArray_CanCastTo(PyArray_Descr *from, PyArray_Descr *to)
 }
 
 
+/*
+ * This function returns true if the two types can be safely cast at
+ * *minimum_safety* casting level. Sets the *view_offset* if that is set
+ * for the cast. If ignore_error is set, the error indicator is cleared
+ * if there are any errors in cast setup and returns false, otherwise
+ * the error indicator is left set and returns -1.
+ */
+NPY_NO_EXPORT npy_intp
+PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
+                 npy_intp* view_offset, NPY_CASTING minimum_safety,
+                 npy_intp ignore_error)
+{
+    if (type1 == type2) {
+        *view_offset = 0;
+        return 1;
+    }
+
+    NPY_CASTING safety = PyArray_GetCastInfo(type1, type2, NULL, view_offset);
+    if (safety < 0) {
+        if (ignore_error) {
+            PyErr_Clear();
+            return 0;
+        }
+        return -1;
+    }
+    return PyArray_MinCastSafety(safety, minimum_safety) == minimum_safety;
+}
+
+
 /* Provides an ordering for the dtype 'kind' character codes */
 NPY_NO_EXPORT int
 dtype_kind_to_ordering(char kind)

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -102,6 +102,11 @@ PyArray_GetCastInfo(
         PyArray_Descr *from, PyArray_Descr *to, PyArray_DTypeMeta *to_dtype,
         npy_intp *view_offset);
 
+NPY_NO_EXPORT npy_intp
+PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
+                 npy_intp* view_offset, NPY_CASTING minimum_safety,
+                 npy_intp ignore_errors);
+
 NPY_NO_EXPORT int
 PyArray_CheckCastSafety(NPY_CASTING casting,
         PyArray_Descr *from, PyArray_Descr *to, PyArray_DTypeMeta *to_dtype);

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1913,12 +1913,10 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     }
 
     arrflags = PyArray_FLAGS(arr);
-    npy_intp view_offset;
-    npy_intp is_safe = PyArray_SafeCast(oldtype, newtype, &view_offset, NPY_NO_CASTING, 1);
-    npy_intp view_safe = (is_safe && (view_offset == 0));
 
-           /* If a guaranteed copy was requested */
-    copy = (flags & NPY_ARRAY_ENSURECOPY) ||
+
+    copy = /* If a guaranteed copy was requested */
+           (flags & NPY_ARRAY_ENSURECOPY) ||
            /* If C contiguous was requested, and arr is not */
            ((flags & NPY_ARRAY_C_CONTIGUOUS) &&
                    (!(arrflags & NPY_ARRAY_C_CONTIGUOUS))) ||
@@ -1930,8 +1928,13 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
                    (!(arrflags & NPY_ARRAY_F_CONTIGUOUS))) ||
            /* If a writeable array was requested, and arr is not */
            ((flags & NPY_ARRAY_WRITEABLE) &&
-                   (!(arrflags & NPY_ARRAY_WRITEABLE))) ||
-           !view_safe;
+                   (!(arrflags & NPY_ARRAY_WRITEABLE)));
+
+    if (!copy) {
+        npy_intp view_offset;
+        npy_intp is_safe = PyArray_SafeCast(oldtype, newtype, &view_offset, NPY_NO_CASTING, 1);
+        copy = copy || !(is_safe && (view_offset == 0));
+    }
 
     if (copy) {
         if (flags & NPY_ARRAY_ENSURENOCOPY ) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1913,6 +1913,12 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     }
 
     arrflags = PyArray_FLAGS(arr);
+    unsigned char viewable = PyArray_ViewableTypes(oldtype, newtype);
+    if (viewable < 0) {
+        Py_DECREF(newtype);
+        return NULL;
+    }
+
            /* If a guaranteed copy was requested */
     copy = (flags & NPY_ARRAY_ENSURECOPY) ||
            /* If C contiguous was requested, and arr is not */
@@ -1927,7 +1933,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
            /* If a writeable array was requested, and arr is not */
            ((flags & NPY_ARRAY_WRITEABLE) &&
                    (!(arrflags & NPY_ARRAY_WRITEABLE))) ||
-           !PyArray_ViewableTypes(oldtype, newtype);
+           !viewable;
 
     if (copy) {
         if (flags & NPY_ARRAY_ENSURENOCOPY ) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1927,7 +1927,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
            /* If a writeable array was requested, and arr is not */
            ((flags & NPY_ARRAY_WRITEABLE) &&
                    (!(arrflags & NPY_ARRAY_WRITEABLE))) ||
-           !PyArray_EquivTypes(oldtype, newtype);
+           !PyArray_ViewableTypes(oldtype, newtype);
 
     if (copy) {
         if (flags & NPY_ARRAY_ENSURENOCOPY ) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1933,7 +1933,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     if (!copy) {
         npy_intp view_offset;
         npy_intp is_safe = PyArray_SafeCast(oldtype, newtype, &view_offset, NPY_NO_CASTING, 1);
-        copy = copy || !(is_safe && (view_offset == 0));
+        copy = copy || !(is_safe && (view_offset != NPY_MIN_INTP));
     }
 
     if (copy) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1933,7 +1933,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     if (!copy) {
         npy_intp view_offset;
         npy_intp is_safe = PyArray_SafeCast(oldtype, newtype, &view_offset, NPY_NO_CASTING, 1);
-        copy = copy || !(is_safe && (view_offset != NPY_MIN_INTP));
+        copy = !(is_safe && (view_offset != NPY_MIN_INTP));
     }
 
     if (copy) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1913,11 +1913,9 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     }
 
     arrflags = PyArray_FLAGS(arr);
-    unsigned char viewable = PyArray_ViewableTypes(oldtype, newtype);
-    if (viewable < 0) {
-        Py_DECREF(newtype);
-        return NULL;
-    }
+    npy_intp view_offset;
+    npy_intp is_safe = PyArray_SafeCast(oldtype, newtype, &view_offset, NPY_NO_CASTING, 1);
+    npy_intp view_safe = (is_safe && (view_offset == 0));
 
            /* If a guaranteed copy was requested */
     copy = (flags & NPY_ARRAY_ENSURECOPY) ||
@@ -1933,7 +1931,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
            /* If a writeable array was requested, and arr is not */
            ((flags & NPY_ARRAY_WRITEABLE) &&
                    (!(arrflags & NPY_ARRAY_WRITEABLE))) ||
-           !viewable;
+           !view_safe;
 
     if (copy) {
         if (flags & NPY_ARRAY_ENSURENOCOPY ) {

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1464,33 +1464,6 @@ PyArray_EquivTypes(PyArray_Descr *type1, PyArray_Descr *type2)
 }
 
 
-/*
- * This function returns true if the two types can be safely cast at
- * *minimum_safety* casting level. Sets the view_offset if that is set
- * for the cast. If ignore_error is 1, errors in cast setup are ignored.
- */
-NPY_NO_EXPORT npy_intp
-PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
-                 npy_intp* view_offset, NPY_CASTING minimum_safety,
-                 npy_intp ignore_error)
-{
-    if (type1 == type2) {
-        *view_offset = 0;
-        return 1;
-    }
-
-    NPY_CASTING safety = PyArray_GetCastInfo(type1, type2, NULL, view_offset);
-    if (safety < 0) {
-        if (ignore_error) {
-            PyErr_Clear();
-            return 0;
-        }
-        return -1;
-    }
-    return PyArray_MinCastSafety(safety, minimum_safety) == minimum_safety;
-}
-
-
 /*NUMPY_API*/
 NPY_NO_EXPORT unsigned char
 PyArray_EquivTypenums(int typenum1, int typenum2)

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1489,15 +1489,38 @@ PyArray_EquivTypes(PyArray_Descr *type1, PyArray_Descr *type2)
 NPY_NO_EXPORT unsigned char
 PyArray_ViewableTypes(PyArray_Descr *type1, PyArray_Descr *type2)
 {
-    if (!PyArray_EquivTypes(type1, type2)) {
+    if (type1 == type2) {
+        return 1;
+    }
+
+    if (Py_TYPE(Py_TYPE(type1)) == &PyType_Type) {
+        /*
+         * 2021-12-17: This case is nonsense and should be removed eventually!
+         *
+         * boost::python has/had a bug effectively using EquivTypes with
+         * `type(arbitrary_obj)`.  That is clearly wrong as that cannot be a
+         * `PyArray_Descr *`.  We assume that `type(type(type(arbitrary_obj))`
+         * is always in practice `type` (this is the type of the metaclass),
+         * but for our descriptors, `type(type(descr))` is DTypeMeta.
+         *
+         * In that case, we just return False.  There is a possibility that
+         * this actually _worked_ effectively (returning 1 sometimes).
+         * We ignore that possibility for simplicity; it really is not our bug.
+         */
         return 0;
     }
-    // a view of a stringdtype array has a corrupt arena, unless
-    // type1 and type2 are exactly the same object
-    if ((type1 != type2) && (type1->kind == 'T')) {
+
+    npy_intp view_offset;
+    NPY_CASTING safety = PyArray_GetCastInfo(type1, type2, NULL, &view_offset);
+    if (safety < 0) {
+        PyErr_Clear();
         return 0;
     }
-    return 1;
+    if (view_offset != 0) {
+        return 0;
+    }
+    /* If casting is "no casting" this dtypes are considered equivalent. */
+    return PyArray_MinCastSafety(safety, NPY_NO_CASTING) == NPY_NO_CASTING;
 }
 
 
@@ -1628,7 +1651,11 @@ _array_fromobject_generic(
 
         /* One more chance for faster exit if user specified the dtype. */
         oldtype = PyArray_DESCR(oparr);
-        if (PyArray_ViewableTypes(oldtype, dtype)) {
+        unsigned char viewable = PyArray_ViewableTypes(oldtype, dtype);
+        if (viewable < 0) {
+            goto finish;
+        }
+        if (viewable) {
             if (copy != NPY_COPY_ALWAYS && STRIDING_OK(oparr, order)) {
                 if (oldtype == dtype) {
                     Py_INCREF(op);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1593,7 +1593,7 @@ _array_fromobject_generic(
         oldtype = PyArray_DESCR(oparr);
         npy_intp view_offset;
         npy_intp is_safe = PyArray_SafeCast(oldtype, dtype, &view_offset, NPY_NO_CASTING, 1);
-        npy_intp view_safe = (is_safe && (view_offset == 0));
+        npy_intp view_safe = (is_safe && (view_offset != NPY_MIN_INTP));
         if (view_safe) {
             if (copy != NPY_COPY_ALWAYS && STRIDING_OK(oparr, order)) {
                 if (oldtype == dtype) {

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1481,6 +1481,26 @@ PyArray_EquivTypes(PyArray_Descr *type1, PyArray_Descr *type2)
 }
 
 
+/*
+ * This function returns true if a view can be safely created
+ * between the two types. This implies that PyArray_EquivTypes
+ * is true as well.
+ */
+NPY_NO_EXPORT unsigned char
+PyArray_ViewableTypes(PyArray_Descr *type1, PyArray_Descr *type2)
+{
+    if (!PyArray_EquivTypes(type1, type2)) {
+        return 0;
+    }
+    // a view of a stringdtype array has a corrupt arena, unless
+    // type1 and type2 are exactly the same object
+    if ((type1 != type2) && (type1->kind == 'T')) {
+        return 0;
+    }
+    return 1;
+}
+
+
 /*NUMPY_API*/
 NPY_NO_EXPORT unsigned char
 PyArray_EquivTypenums(int typenum1, int typenum2)
@@ -1608,7 +1628,7 @@ _array_fromobject_generic(
 
         /* One more chance for faster exit if user specified the dtype. */
         oldtype = PyArray_DESCR(oparr);
-        if (PyArray_EquivTypes(oldtype, dtype)) {
+        if (PyArray_ViewableTypes(oldtype, dtype)) {
             if (copy != NPY_COPY_ALWAYS && STRIDING_OK(oparr, order)) {
                 if (oldtype == dtype) {
                     Py_INCREF(op);

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -21,9 +21,4 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
 
-NPY_NO_EXPORT npy_intp
-PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
-                 npy_intp* view_offset, NPY_CASTING minimum_safety,
-                 npy_intp ignore_errors);
-
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -21,7 +21,9 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
 
-NPY_NO_EXPORT unsigned char
-PyArray_ViewableTypes(PyArray_Descr *type1, PyArray_Descr *type2);
+NPY_NO_EXPORT npy_intp
+PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
+                 npy_intp* view_offset, NPY_CASTING minimum_safety,
+                 npy_intp ignore_errors);
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -21,4 +21,7 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
 
+NPY_NO_EXPORT unsigned char
+PyArray_ViewableTypes(PyArray_Descr *type1, PyArray_Descr *type2);
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -80,7 +80,9 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
     }
 
     // views are only legal between descriptors that share allocators (e.g. the same object)
-    *view_offset = descr0->allocator != descr1->allocator;
+    if (descr0->allocator == descr1->allocator) {
+        *view_offset = 0;
+    };
 
     return NPY_NO_CASTING;
 }

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -79,7 +79,8 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
         return NPY_UNSAFE_CASTING;
     }
 
-    *view_offset = 0;
+    // views are only legal between descriptors that share allocators (e.g. the same object)
+    *view_offset = descr0->allocator != descr1->allocator;
 
     return NPY_NO_CASTING;
 }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -62,7 +62,6 @@
 #include "legacy_array_method.h"
 #include "abstractdtypes.h"
 #include "mapping.h"
-#include "multiarraymodule.h"
 
 /* TODO: Only for `NpyIter_GetTransferFlags` until it is public */
 #define NPY_ITERATOR_IMPLEMENTATION_CODE

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -476,8 +476,13 @@ def test_creation_functions():
 
 def test_create_with_copy_none(string_list):
     arr = np.array(string_list, dtype=StringDType())
+    # create another stringdtype array with an arena that has a different
+    # in-memory layout than the first array
     arr_rev = np.array(string_list[::-1], dtype=StringDType())
 
+    # this should create a copy and the resulting array
+    # shouldn't share an allocator or arena with arr_rev, despite
+    # explicitly passing arr_rev.dtype
     arr_copy = np.array(arr, copy=None, dtype=arr_rev.dtype)
     np.testing.assert_array_equal(arr, arr_copy)
     assert arr_copy.base is None
@@ -485,6 +490,7 @@ def test_create_with_copy_none(string_list):
     with pytest.raises(ValueError, match="Unable to avoid copy"):
         np.array(arr, copy=False, dtype=arr_rev.dtype)
 
+    # because we're using arr's dtype instance, the view is safe
     arr_view = np.array(arr, copy=None, dtype=arr.dtype)
     np.testing.assert_array_equal(arr, arr)
     np.testing.assert_array_equal(arr_view[::-1], arr_rev)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -474,6 +474,23 @@ def test_creation_functions():
     assert np.empty(3, dtype="T")[0] == ""
 
 
+def test_create_with_copy_none(string_list):
+    arr = np.array(string_list, dtype=StringDType())
+    arr_rev = np.array(string_list[::-1], dtype=StringDType())
+
+    arr_copy = np.array(arr, copy=None, dtype=arr_rev.dtype)
+    np.testing.assert_array_equal(arr, arr_copy)
+    assert arr_copy.base is None
+
+    with pytest.raises(ValueError, match="Unable to avoid copy"):
+        np.array(arr, copy=False, dtype=arr_rev.dtype)
+
+    arr_view = np.array(arr, copy=None, dtype=arr.dtype)
+    np.testing.assert_array_equal(arr, arr)
+    np.testing.assert_array_equal(arr_view[::-1], arr_rev)
+    assert arr_view is arr
+
+
 @pytest.mark.parametrize(
     "strings",
     [


### PR DESCRIPTION
Backport of #26147.

Fixes #26140.

This is a minimal implementation of a new function that generalizes PyArray_EquivTypes.



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
