### PR TITLE
TST: account for immortal objects in test_iter_refcount

### DIFF
--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1,4 +1,5 @@
 import sys
+import sysconfig
 import pytest
 
 import textwrap
@@ -13,6 +14,7 @@ from numpy.testing import (
     IS_WASM, HAS_REFCOUNT, suppress_warnings, break_cycles
     )
 
+NOGIL_BUILD = bool(sysconfig.get_config_var('Py_GIL_DISABLED'))
 
 def iter_multi_index(i):
     ret = []
@@ -68,7 +70,9 @@ def test_iter_refcount():
     rc2_dt = sys.getrefcount(dt)
     it2 = it.copy()
     assert_(sys.getrefcount(a) > rc2_a)
-    assert_(sys.getrefcount(dt) > rc2_dt)
+    if not NOGIL_BUILD:
+        # np.dtype('f4') is immortal in the nogil build
+        assert_(sys.getrefcount(dt) > rc2_dt)
     it = None
     assert_equal(sys.getrefcount(a), rc2_a)
     assert_equal(sys.getrefcount(dt), rc2_dt)


### PR DESCRIPTION
Per PEP 703, objects that are automatically immortal in the nogil build include:

> Some objects, such as interned strings, small integers, statically allocated PyTypeObjects, and the True, False, and None objects stay alive for the lifetime of the program.

That means `np.dtype('f4')` is immortal, because all the legacy descriptors are declared statically:

https://github.com/numpy/numpy/blob/ffb23cd626bc1f7d09aed257e28142346661a915/numpy/_core/src/multiarray/arraytypes.c.src#L4042-L4053

As far as I can tell, this is the only test in the test suite that depends on INCREF or DECREF for a built-in dtype not being a no-op.

The spelling I've used to detect the nogil build is also what CPython uses internally: https://github.com/python/cpython/blob/7ecd55d604a8fa287c1d131cac14d10260be826b/Lib/test/support/__init__.py#L839