### PR TITLE
Draft: ENH: Improve performance of np.broadcast_arrays (v2)

### DIFF
--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -867,11 +867,9 @@ class TestUfunc:
         u, v = np.broadcast_arrays(a, b)
         assert_equal(u.strides[0], 0)
         x = u + v
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        assert_array_equal(x, np.array([[0, 2], [2, 4]]))
+        with pytest.raises(ValueError, match=r"output array is read-only"):
             u += v
-            assert_equal(len(w), 1)
-            assert_(x[0, 0] != u[0, 0])
 
         # Output reduction should not be allowed.
         # See gh-15139

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -546,13 +546,12 @@ def broadcast_arrays(*args, subok=False):
     # return np.nditer(args, flags=['multi_index', 'zerosize_ok'],
     #                  order='C').itviews
 
-    args = tuple(np.array(_m, copy=None, subok=subok) for _m in args)
+    args = [np.array(_m, copy=None, subok=subok) for _m in args]
 
     shape = _broadcast_shape(*args)
 
-    if all(array.shape == shape for array in args):
-        # Common case where nothing needs to be broadcasted.
-        return args
+    result = [array if array.shape == shape
+              else _broadcast_to(array, shape, subok=subok, readonly=False)
+                              for array in args]
+    return tuple(result)
 
-    return tuple(_broadcast_to(array, shape, subok=subok, readonly=False)
-                 for array in args)

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -531,9 +531,9 @@ def broadcast_arrays(*args, subok=False):
             [5, 5, 5]])]
 
     """
-    if len(args)< 65 and not subok:
-        return np.nditer(args, flags=['multi_index', 'zerosize_ok', 'reduce_ok', 
-                                      'refs_ok'], order='C').itviews
+    if len(args) < 65 and not subok:
+        return np.nditer(args, flags=['multi_index', 'reduce_ok', 'refs_ok',
+                                      'zerosize_ok'], order='C').itviews
 
     args = [np.array(_m, copy=None, subok=subok) for _m in args]
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -580,8 +580,8 @@ def test_writeable():
     # preserve backwards compatibility
     for results in [broadcast_arrays(original,),
                     broadcast_arrays(0, original)]:
-        for result in  results:
-                assert_equal(result.flags.writeable, False)
+        for result in results:
+            assert_equal(result.flags.writeable, False)
 
     for results in [broadcast_arrays(original),
                     broadcast_arrays(0, original)]:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -341,7 +341,7 @@ def test_broadcast_shapes_raises():
         [(2, 3), (2,)],
         [(3,), (3,), (4,)],
         [(1, 3, 4), (2, 3, 3)],
-        [(1, 2), (3, 1), (3,2), (10, 5)],
+        [(1, 2), (3, 1), (3, 2), (10, 5)],
         [2, (2, 3)],
     ]
     for input_shapes in data:
@@ -578,20 +578,10 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [((False,), broadcast_arrays(original,)),
-                                  ((True, False), broadcast_arrays(0, original))]:
-        for array_is_broadcast, result in zip(is_broadcast, results):
-            # This will change to False in a future version
-            if array_is_broadcast:
-                with assert_warns(FutureWarning):
-                    assert_equal(result.flags.writeable, True)
-                with assert_warns(DeprecationWarning):
-                    result[:] = 0
-                # Warning not emitted, writing to the array resets it
-                assert_equal(result.flags.writeable, True)
-            else:
-                # No warning:
-                assert_equal(result.flags.writeable, True)
+    for results in [broadcast_arrays(original,),
+                    broadcast_arrays(0, original)]:
+        for result in  results:
+                assert_equal(result.flags.writeable, False)
 
     for results in [broadcast_arrays(original),
                     broadcast_arrays(0, original)]:
@@ -623,16 +613,10 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
-                                  ((True, False), broadcast_arrays(0, original))]:
-        for array_is_broadcast, result in zip(is_broadcast, results):
-            # This will change to False in a future version
-            if array_is_broadcast:
-                # memoryview(result, writable=True) will give warning but cannot
-                # be tested using the python API.
-                assert memoryview(result).readonly
-            else:
-                assert not memoryview(result).readonly
+    for results in [broadcast_arrays(original,),
+                    broadcast_arrays(0, original)]:
+        for result in results:
+            assert memoryview(result).readonly
 
 
 def test_reference_types():

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -578,8 +578,8 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
-                                  ( (True, False), broadcast_arrays(0, original))]:
+    for is_broadcast, results in [((False,), broadcast_arrays(original,)),
+                              ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
@@ -623,8 +623,8 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
-                              ( (True, False), broadcast_arrays(0, original))]:
+    for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
+                              ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -341,7 +341,7 @@ def test_broadcast_shapes_raises():
         [(2, 3), (2,)],
         [(3,), (3,), (4,)],
         [(1, 3, 4), (2, 3, 3)],
-        [(1, 2), (3,1), (3,2), (10, 5)],
+        [(1, 2), (3, 1), (3,2), (10, 5)],
         [2, (2, 3)],
     ]
     for input_shapes in data:
@@ -579,7 +579,7 @@ def test_writeable():
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
     for is_broadcast, results in [((False,), broadcast_arrays(original,)),
-                              ((True, False), broadcast_arrays(0, original))]:
+                                  ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
@@ -624,7 +624,7 @@ def test_writeable_memoryview():
     original = np.array([1, 2, 3])
 
     for is_broadcast, results in [((False, ), broadcast_arrays(original,)),
-                              ((True, False), broadcast_arrays(0, original))]:
+                                  ((True, False), broadcast_arrays(0, original))]:
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -578,11 +578,11 @@ def test_writeable():
 
     # but the result of broadcast_arrays needs to be writeable, to
     # preserve backwards compatibility
-    for is_broadcast, results in [(False, broadcast_arrays(original,)),
-                                  (True, broadcast_arrays(0, original))]:
-        for result in results:
+    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
+                                  ( (True, False), broadcast_arrays(0, original))]:
+        for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
-            if is_broadcast:
+            if array_is_broadcast:
                 with assert_warns(FutureWarning):
                     assert_equal(result.flags.writeable, True)
                 with assert_warns(DeprecationWarning):
@@ -623,11 +623,11 @@ def test_writeable_memoryview():
     # See gh-13929.
     original = np.array([1, 2, 3])
 
-    for is_broadcast, results in [(False, broadcast_arrays(original,)),
-                                  (True, broadcast_arrays(0, original))]:
-        for result in results:
+    for is_broadcast, results in [( (False, ), broadcast_arrays(original,)),
+                              ( (True, False), broadcast_arrays(0, original))]:
+        for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
-            if is_broadcast:
+            if array_is_broadcast:
                 # memoryview(result, writable=True) will give warning but cannot
                 # be tested using the python API.
                 assert memoryview(result).readonly


### PR DESCRIPTION
This PR uses `np.nditer` to implement `np.broadcast_arrays`. The performance is good (also see #26160):
```
main:
broadcast_arrays(*args) 1.20 us
broadcast_arrays(*args_two) 7.26 us
broadcast_arrays(*args_multi) 9.11 us

PR #26160
broadcast_arrays(*args) 1.03 us
broadcast_arrays(*args_two) 3.83 us
broadcast_arrays(*args_multi) 3.87 us

PR:
broadcast_arrays(*args) 0.89 us
broadcast_arrays(*args_two) 0.99 us
broadcast_arrays(*args_multi) 1.15 us
```

A change in behaviour is that all output of `np.broadcast_arrays` is now readonly. This might be acceptable, as writeable broadcasted arrays have been deprecated for some time:  https://github.com/numpy/numpy/pull/12609



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
