### PR TITLE
API: Enforce one copy for ``__array__`` when ``copy=True``

### DIFF
--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -99,7 +99,7 @@ enum _dtype_discovery_flags {
     DISCOVER_TUPLES_AS_ELEMENTS = 1 << 4,
     MAX_DIMS_WAS_REACHED = 1 << 5,
     DESCRIPTOR_WAS_SET = 1 << 6,
-    COPY_WAS_CREATED = 1 << 7,
+    COPY_WAS_CREATED_BY__ARRAY__ = 1 << 7,
 };
 
 
@@ -1028,9 +1028,9 @@ PyArray_DiscoverDTypeAndShape_Recursive(
             /* __array__ may be passed the requested descriptor if provided */
             requested_descr = *out_descr;
         }
-        int was_copied = 0;
+        int was_copied_by__array__ = 0;
         arr = (PyArrayObject *)_array_from_array_like(obj,
-                requested_descr, 0, NULL, copy, &was_copied);
+                requested_descr, 0, NULL, copy, &was_copied_by__array__);
         if (arr == NULL) {
             return -1;
         }
@@ -1038,8 +1038,8 @@ PyArray_DiscoverDTypeAndShape_Recursive(
             Py_DECREF(arr);
             arr = NULL;
         }
-        if (was_copied == 1) {
-            *flags |= COPY_WAS_CREATED;
+        if (was_copied_by__array__ == 1) {
+            *flags |= COPY_WAS_CREATED_BY__ARRAY__;
         }
     }
     if (arr != NULL) {
@@ -1231,8 +1231,8 @@ PyArray_DiscoverDTypeAndShape_Recursive(
  *        to choose a default.
  * @param copy Specifies the copy behavior. -1 is corresponds to copy=None,
  *        0 to copy=False, and 1 to copy=True in the Python API.
- * @param was_copied Set to 1 if it can be assumed that a copy was made
- *        by implementor.
+ * @param was_copied_by__array__ Set to 1 if it can be assumed that a copy was
+ *        made by implementor.
  * @return dimensions of the discovered object or -1 on error.
  *         WARNING: If (and only if) the output is a single array, the ndim
  *         returned _can_ exceed the maximum allowed number of dimensions.
@@ -1245,7 +1245,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr, int copy, int *was_copied)
+        PyArray_Descr **out_descr, int copy, int *was_copied_by__array__)
 {
     coercion_cache_obj **coercion_cache_head = coercion_cache;
     *coercion_cache = NULL;
@@ -1298,8 +1298,8 @@ PyArray_DiscoverDTypeAndShape(
         goto fail;
     }
 
-    if (was_copied != NULL && flags & COPY_WAS_CREATED) {
-        *was_copied = 1;
+    if (was_copied_by__array__ != NULL && flags & COPY_WAS_CREATED_BY__ARRAY__) {
+        *was_copied_by__array__ = 1;
     }
 
     if (NPY_UNLIKELY(flags & FOUND_RAGGED_ARRAY)) {

--- a/numpy/_core/src/multiarray/array_coercion.h
+++ b/numpy/_core/src/multiarray/array_coercion.h
@@ -40,7 +40,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr, int copy);
+        PyArray_Descr **out_descr, int copy, int *was_copied);
 
 NPY_NO_EXPORT PyObject *
 _discover_array_parameters(PyObject *NPY_UNUSED(self),

--- a/numpy/_core/src/multiarray/array_coercion.h
+++ b/numpy/_core/src/multiarray/array_coercion.h
@@ -40,7 +40,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr, int copy, int *was_copied);
+        PyArray_Descr **out_descr, int copy, int *was_copied_by__array__);
 
 NPY_NO_EXPORT PyObject *
 _discover_array_parameters(PyObject *NPY_UNUSED(self),

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -251,7 +251,7 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      */
     ndim = PyArray_DiscoverDTypeAndShape(src_object,
             PyArray_NDIM(dest), dims, &cache,
-            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, 1);
+            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, 1, NULL);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -119,7 +119,7 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, PyArray_Descr **out_dtype)
     int ndim;
 
     ndim = PyArray_DiscoverDTypeAndShape(
-            obj, maxdims, shape, &cache, NULL, NULL, out_dtype, 1);
+            obj, maxdims, shape, &cache, NULL, NULL, out_dtype, 1, NULL);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1429,6 +1429,8 @@ fail:
  * @param writeable whether the result must be writeable.
  * @param context Unused parameter, must be NULL (should be removed later).
  * @param copy Specifies the copy behavior.
+ * @param was_copied Set to 1 if it can be assumed that a copy was made
+ *        by implementor.
  *
  * @returns The array object, Py_NotImplemented if op is not array-like,
  *          or NULL with an error set. (A new reference to Py_NotImplemented
@@ -1437,7 +1439,7 @@ fail:
 NPY_NO_EXPORT PyObject *
 _array_from_array_like(PyObject *op,
         PyArray_Descr *requested_dtype, npy_bool writeable, PyObject *context,
-        int copy) {
+        int copy, int *was_copied) {
     PyObject* tmp;
 
     /*
@@ -1485,7 +1487,7 @@ _array_from_array_like(PyObject *op,
     }
 
     if (tmp == Py_NotImplemented) {
-        tmp = PyArray_FromArrayAttr_int(op, requested_dtype, copy);
+        tmp = PyArray_FromArrayAttr_int(op, requested_dtype, copy, was_copied);
         if (tmp == NULL) {
             return NULL;
         }
@@ -1572,13 +1574,16 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
 
     // Default is copy = None
     int copy = -1;
+    int was_copied = 0;
 
     if (flags & NPY_ARRAY_ENSURENOCOPY) {
         copy = 0;
+    } else if (flags & NPY_ARRAY_ENSURECOPY) {
+        copy = 1;
     }
 
     ndim = PyArray_DiscoverDTypeAndShape(
-            op, NPY_MAXDIMS, dims, &cache, in_DType, in_descr, &dtype, copy);
+            op, NPY_MAXDIMS, dims, &cache, in_DType, in_descr, &dtype, copy, &was_copied);
 
     if (ndim < 0) {
         return NULL;
@@ -1615,6 +1620,10 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         assert(cache->converted_obj == op);
         arr = (PyArrayObject *)(cache->arr_or_sequence);
         /* we may need to cast or assert flags (e.g. copy) */
+        if (was_copied == 1 && flags & NPY_ARRAY_ENSURECOPY) {
+            flags = flags & ~NPY_ARRAY_ENSURECOPY;
+            flags = flags | NPY_ARRAY_ENSURENOCOPY;
+        }
         PyObject *res = PyArray_FromArray(arr, dtype, flags);
         npy_unlink_coercion_cache(cache);
         return res;
@@ -1937,7 +1946,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
     }
 
     if (copy) {
-        if (flags & NPY_ARRAY_ENSURENOCOPY ) {
+        if (flags & NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             Py_DECREF(newtype);
             return NULL;
@@ -2486,12 +2495,14 @@ check_or_clear_and_warn_error_if_due_to_copy_kwarg(PyObject *kwnames)
  *        NOTE: For copy == -1 it passes `op.__array__(copy=None)`,
  *              for copy == 0, `op.__array__(copy=False)`, and
  *              for copy == 1, `op.__array__(copy=True).
+ * @param was_copied Set to 1 if it can be assumed that a copy was made
+ *        by implementor.
  * @returns NotImplemented if `__array__` is not defined or a NumPy array
  *          (or subclass).  On error, return NULL.
  */
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr_int(
-        PyObject *op, PyArray_Descr *descr, int copy)
+        PyObject *op, PyArray_Descr *descr, int copy, int *was_copied)
 {
     PyObject *new;
     PyObject *array_meth;
@@ -2578,10 +2589,11 @@ PyArray_FromArrayAttr_int(
         Py_DECREF(new);
         return NULL;
     }
-    if (must_copy_but_copy_kwarg_unimplemented) {
-        /* TODO: As of NumPy 2.0 this path is only reachable by C-API. */
-        Py_SETREF(new, PyArray_NewCopy((PyArrayObject *)new, NPY_KEEPORDER));
+    if (was_copied != NULL && copy == 1 && must_copy_but_copy_kwarg_unimplemented == 0) {
+        /* We can assume that a copy was made */
+        *was_copied = 1;
     }
+
     return new;
 }
 
@@ -2596,7 +2608,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
         return NULL;
     }
 
-    return PyArray_FromArrayAttr_int(op, typecode, 0);
+    return PyArray_FromArrayAttr_int(op, typecode, 0, NULL);
 }
 
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1622,9 +1622,8 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         assert(cache->converted_obj == op);
         arr = (PyArrayObject *)(cache->arr_or_sequence);
         /* we may need to cast or assert flags (e.g. copy) */
-        if (was_copied_by__array__ == 1 && flags & NPY_ARRAY_ENSURECOPY) {
+        if (was_copied_by__array__ == 1) {
             flags = flags & ~NPY_ARRAY_ENSURECOPY;
-            flags = flags | NPY_ARRAY_ENSURENOCOPY;
         }
         PyObject *res = PyArray_FromArray(arr, dtype, flags);
         npy_unlink_coercion_cache(cache);
@@ -2591,6 +2590,7 @@ PyArray_FromArrayAttr_int(PyObject *op, PyArray_Descr *descr, int copy,
         Py_DECREF(new);
         return NULL;
     }
+    /* TODO: Remove was_copied_by__array__ argument */
     if (was_copied_by__array__ != NULL && copy == 1 &&
         must_copy_but_copy_kwarg_unimplemented == 0) {
         /* We can assume that a copy was made */

--- a/numpy/_core/src/multiarray/ctors.h
+++ b/numpy/_core/src/multiarray/ctors.h
@@ -54,7 +54,7 @@ PyArray_New(
 NPY_NO_EXPORT PyObject *
 _array_from_array_like(PyObject *op,
         PyArray_Descr *requested_dtype, npy_bool writeable, PyObject *context,
-        int copy);
+        int copy, int *was_copied);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
@@ -85,7 +85,7 @@ PyArray_FromInterface(PyObject *input);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr_int(
-        PyObject *op, PyArray_Descr *descr, int copy);
+        PyObject *op, PyArray_Descr *descr, int copy, int *was_copied);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode,

--- a/numpy/_core/src/multiarray/ctors.h
+++ b/numpy/_core/src/multiarray/ctors.h
@@ -54,7 +54,7 @@ PyArray_New(
 NPY_NO_EXPORT PyObject *
 _array_from_array_like(PyObject *op,
         PyArray_Descr *requested_dtype, npy_bool writeable, PyObject *context,
-        int copy, int *was_copied);
+        int copy, int *was_copied_by__array__);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
@@ -84,8 +84,8 @@ NPY_NO_EXPORT PyObject *
 PyArray_FromInterface(PyObject *input);
 
 NPY_NO_EXPORT PyObject *
-PyArray_FromArrayAttr_int(
-        PyObject *op, PyArray_Descr *descr, int copy, int *was_copied);
+PyArray_FromArrayAttr_int(PyObject *op, PyArray_Descr *descr, int copy,
+                          int *was_copied_by__array__);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode,

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -54,7 +54,9 @@ def arraylikes():
             self.a = a
 
         def __array__(self, dtype=None, copy=None):
-            return self.a
+            if dtype is None:
+                return self.a
+            return self.a.astype(dtype)
 
     yield param(ArrayDunder, id="__array__")
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8490,7 +8490,7 @@ class TestArrayCreationCopyArgument(object):
         # As of NumPy 2.1, explicitly passing copy=True does trigger passing
         # it to __array__ (deprecation warning is triggered).
         with pytest.warns(DeprecationWarning,
-                          match="__array__.*should implement.*'copy'"):
+                          match="__array__.*must implement.*'copy'"):
             arr = np.array(a, copy=True)
         assert_array_equal(arr, base_arr)
         assert arr is not base_arr
@@ -8535,7 +8535,7 @@ class TestArrayCreationCopyArgument(object):
         arr_random = ArrayRandom()
         second_copy = np.array(arr_random, copy=True, order="F")
         assert arr_random.true_passed
-        assert not second_copy is copy_arr
+        assert second_copy is not copy_arr
 
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test__array__reference_leak(self):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8502,7 +8502,6 @@ class TestArrayCreationCopyArgument(object):
                     match=r"Unable to avoid copy(.|\n)*numpy_2_0_migration_guide.html"):
                 np.array(a, copy=False)
 
-    @pytest.mark.skipif(IS_PYPY, reason="PyPy copies differently")
     def test___array__copy_once(self):
         size = 100
         base_arr = np.zeros((size, size))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8532,6 +8532,11 @@ class TestArrayCreationCopyArgument(object):
         _ = np.array([arr_random], copy=True)
         assert not arr_random.true_passed
 
+        arr_random = ArrayRandom()
+        second_copy = np.array(arr_random, copy=True, order="F")
+        assert arr_random.true_passed
+        assert not second_copy is copy_arr
+
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test__array__reference_leak(self):
         class NotAnArray:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8452,10 +8452,9 @@ class TestArrayCreationCopyArgument(object):
         for copy in self.true_vals:
             res = np.array(arr, copy=copy)
             assert_array_equal(res, base_arr)
-            # An additional copy is currently forced by numpy in this case,
-            # you could argue, numpy does not trust the ArrayLike. This
-            # may be open for change:
-            assert res is not base_arr
+            # An additional copy is no longer forced by NumPy in this case.
+            # NumPy trusts the ArrayLike made a copy:
+            assert res is base_arr
 
         for copy in self.if_needed_vals + self.false_vals:
             res = np.array(arr, copy=copy)
@@ -8488,9 +8487,11 @@ class TestArrayCreationCopyArgument(object):
         assert_array_equal(arr, base_arr)
         assert arr is base_arr
 
-        # As of NumPy 2, explicitly passing copy=True does not trigger passing
-        # it to __array__ (deprecation warning is not triggered).
-        arr = np.array(a, copy=True)
+        # As of NumPy 2.1, explicitly passing copy=True does trigger passing
+        # it to __array__ (deprecation warning is triggered).
+        with pytest.warns(DeprecationWarning,
+                          match="__array__.*should implement.*'copy'"):
+            arr = np.array(a, copy=True)
         assert_array_equal(arr, base_arr)
         assert arr is not base_arr
 
@@ -8501,10 +8502,41 @@ class TestArrayCreationCopyArgument(object):
                     match=r"Unable to avoid copy(.|\n)*numpy_2_0_migration_guide.html"):
                 np.array(a, copy=False)
 
+    @pytest.mark.skipif(IS_PYPY, reason="PyPy copies differently")
+    def test___array__copy_once(self):
+        size = 100
+        base_arr = np.zeros((size, size))
+        copy_arr = np.zeros((size, size))
+
+        class ArrayRandom:
+            def __init__(self):
+                self.true_passed = False
+
+            def __array__(self, dtype=None, copy=None):
+                if copy:
+                    self.true_passed = True
+                    return copy_arr
+                else:
+                    return base_arr
+
+        arr_random = ArrayRandom()
+        first_copy = np.array(arr_random, copy=True)
+        assert arr_random.true_passed
+        assert first_copy is copy_arr
+
+        arr_random = ArrayRandom()
+        no_copy = np.array(arr_random, copy=False)
+        assert not arr_random.true_passed
+        assert no_copy is base_arr
+
+        arr_random = ArrayRandom()
+        _ = np.array([arr_random], copy=True)
+        assert not arr_random.true_passed
+
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test__array__reference_leak(self):
         class NotAnArray:
-            def __array__(self):
+            def __array__(self, dtype=None, copy=None):
                 raise NotImplementedError()
 
         x = NotAnArray()

--- a/numpy/_core/tests/test_protocols.py
+++ b/numpy/_core/tests/test_protocols.py
@@ -35,8 +35,8 @@ def test_array_called():
     class Wrapper:
         val = '0' * 100
 
-        def __array__(self, result=None, copy=None):
-            return np.array([self.val], dtype=object)
+        def __array__(self, dtype=None, copy=None):
+            return np.array([self.val], dtype=dtype, copy=copy)
 
 
     wrapped = Wrapper()


### PR DESCRIPTION
Addresses: https://github.com/numpy/numpy/issues/26208

Hi @seberg @ngoldbaum,

This PR enables passing `copy=True` to `def __array__(...)` and prevents NumPy from making another copy once it can assume that `copy=True` was successfully passed and the copy was made by the implementor. 

Following https://github.com/numpy/numpy/issues/26208#issuecomment-2037252734 I implemented it with a `copy_indicator` that is set to `1`, which later is used to decide whether `NPY_ARRAY_ENSURECOPY` flag can be removed. 

I added a test `test___array__copy_once` that checks if only one copy is made with `np.array(my_arr, copy=True)`. Without `copy_indicator` the test fails as `np.array(my_arr, copy=True)` doubles delta RSS (I used `psutil` package and added it as another test dependency).

I assumed that we want to prevent making implicit copies with `__array__`. Therefore the user is also responsible for properly implementing `dtype` argument.

```python
class MyArray:
    def __array__(self, dtype=None, copy=None):
        return np.array([1,2,3], dtype=int)

my_arr = MyArray()
np.array(my_arr, dtype=float)  # Error! Produced ndarray has incorrect dtype! `__array__` should use dtype arg
```