### PR TITLE
MAINT: Drop Python 3.9

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install linter requirements
       run:
         python -m pip install -r requirements/linter_requirements.txt
@@ -60,7 +60,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - uses: ./.github/meson_actions
 
   pypy:
@@ -74,7 +74,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: 'pypy3.9-v7.3.12'
+        python-version: 'pypy3.10-v7.3.15'
     - name: Setup using scipy-openblas
       run: |
         python -m pip install -r requirements/ci_requirements.txt
@@ -121,7 +121,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install build and test dependencies from PyPI
       run: |
         pip install -r requirements/build_requirements.txt
@@ -158,7 +158,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install build and benchmarking dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -64,7 +64,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - uses: ./.github/meson_actions
       name: Build/Test
 
@@ -81,7 +81,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install GCC/8/9
       run: |
@@ -117,7 +117,7 @@ jobs:
           - [
             "without optimizations",
             "-Dallow-noblas=true -Ddisable-optimization=true",
-            "3.12-dev"
+            "3.12"
           ]
           - [
             "native",
@@ -132,7 +132,7 @@ jobs:
           - [
             "without avx512/avx2/fma3",
             "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C",
-            "3.9"
+            "3.10"
           ]
 
     env:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -48,7 +48,7 @@ jobs:
         os_python:
           - [ubuntu-latest, '3.12']
           - [windows-2019, '3.11']
-          - [macos-12, '3.9']
+          - [macos-12, '3.10']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,15 +85,15 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        python: ["cp39", "cp310", "cp311", "cp312", "pp39"]
+        python: ["cp310", "cp311", "cp312", "pp310"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
-            python: "pp39"
+            python: "pp310"
           - buildplat: [ ubuntu-20.04, musllinux_x86_64, "" ]
-            python: "pp39"
+            python: "pp310"
           - buildplat: [ macos-14, macosx_arm64, accelerate ]
-            python: "pp39"
+            python: "pp310"
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           # Build sdist on lowest supported Python
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Build sdist
         run: |
           python -m pip install -U pip build

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -14,13 +14,13 @@ Prerequisites
 
 Building NumPy requires the following installed software:
 
-1) Python__ 3.9.x or newer.
+1) Python__ 3.10.x or newer.
 
    Please note that the Python development headers also need to be installed,
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 3.0
+2) Cython >= 3.0.6
 
 3) pytest__ (optional)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.9'
+        versionSpec: '3.10'
         addToPath: true
         architecture: 'x64'
     - script: >-
@@ -57,7 +57,7 @@ stages:
       displayName: 'Run Lint Checks'
       failOnStderr: true
 
-  - job: Linux_Python_39_32bit_full_with_asserts
+  - job: Linux_Python_310_32bit_full_with_asserts
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
@@ -89,8 +89,8 @@ stages:
             TEST_MODE: full
             BITS: 64
             _USE_BLAS_ILP64: '1'
-          PyPy39-64bit-fast:
-            PYTHON_VERSION: 'pypy3.9'
+          PyPy310-64bit-fast:
+            PYTHON_VERSION: 'pypy3.10'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64

--- a/building_with_meson.md
+++ b/building_with_meson.md
@@ -1,9 +1,8 @@
 # Building with Meson
 
 _Note: this is for early adopters. It has been tested on Linux and macOS, and
-with Python 3.9-3.12. Windows will be tested soon. There is one CI job to keep
-the build stable. This may have rough edges, please open an issue if you run
-into a problem._
+with Python 3.10-3.12. There is one CI job to keep the build stable. This may
+have rough edges, please open an issue if you run into a problem._
 
 ### Developer build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [{name = "Travis E. Oliphant et al."}]
 maintainers = [
     {name = "NumPy Developers", email="numpy-discussion@python.org"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -26,7 +26,6 @@ classifiers = [
     'Programming Language :: C',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -74,6 +74,7 @@ freebsd_test_task:
 
   install_devtools_script: |
     pkg install -y git bash ninja ccache blas cblas lapack pkgconf
+    pkg install -y python311
 
   <<: *MODIFIED_CLONE
 
@@ -86,22 +87,22 @@ freebsd_test_task:
   prepare_env_script: |
     # Create a venv (the `source` command needs bash, not the default sh shell)
     chsh -s /usr/local/bin/bash
-    python -m venv .venv
+    python3.11 -m venv .venv
     source .venv/bin/activate
     # Minimal build and test requirements
-    python -m pip install -U pip
-    python -m pip install meson-python Cython pytest hypothesis
+    python3.11 -m pip install -U pip
+    python3.11 -m pip install meson-python Cython pytest hypothesis
 
   build_script: |
     chsh -s /usr/local/bin/bash
     source .venv/bin/activate
-    python -m pip install . --no-build-isolation -v -Csetup-args="-Dallow-noblas=false"
+    python3.11 -m pip install . --no-build-isolation -v -Csetup-args="-Dallow-noblas=false"
 
   test_script: |
     chsh -s /usr/local/bin/bash
     source .venv/bin/activate
     cd tools
-    python -m pytest --pyargs numpy -m "not slow"
+    python3.11 -m pytest --pyargs numpy -m "not slow"
     ccache -s
 
   on_failure:

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -25,17 +25,12 @@ linux_aarch64_task:
     # cirrus-ci task).
     - env:
         CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp39-*
-        EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
-    - env:
-        CIRRUS_CLONE_SUBMODULES: true
         CIBW_BUILD: cp310-*
     - env:
         CIRRUS_CLONE_SUBMODULES: true
         CIBW_BUILD: cp311-*
     - env:
         CIRRUS_CLONE_SUBMODULES: true
-        CIBW_PRERELEASE_PYTHONS: True
         CIBW_BUILD: cp312-*
 
   initial_setup_script: |
@@ -64,10 +59,10 @@ macosx_arm64_task:
   matrix:
     - env:
         CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp39-* cp310-*
+        CIBW_BUILD: cp310-* cp311
     - env:
         CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp311-* cp312-*
+        CIBW_BUILD: cp312-*
   env:
     PATH: /usr/local/lib:/usr/local/include:$PATH
     CIBW_ARCHS: arm64

--- a/tools/ci/run_32_bit_linux_docker.sh
+++ b/tools/ci/run_32_bit_linux_docker.sh
@@ -2,7 +2,7 @@ set -xe
 
 git config --global --add safe.directory /numpy
 cd /numpy
-/opt/python/cp39-cp39/bin/python -mvenv venv
+/opt/python/cp310-cp310/bin/python -mvenv venv
 source venv/bin/activate
 pip install -r requirements/ci32_requirements.txt
 python3 -m pip install -r requirements/test_requirements.txt


### PR DESCRIPTION
Drop Python 3.9 from the supported Python versions and CI.
Cygwin is excepted because it does not yet support 3.10.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
