### PR TITLE
MAINT: utilize ufunc API const correctness internally

### DIFF
--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1450,7 +1450,7 @@ def make_arrays(funcdict):
                 % (name, funcnames))
             code1list.append("static void * %s_data[] = {%s};"
                             % (name, datanames))
-            code1list.append("static char %s_signatures[] = {%s};"
+            code1list.append("static const char %s_signatures[] = {%s};"
                             % (name, signames))
             uf.empty = False
         else:

--- a/numpy/_core/src/umath/_operand_flag_tests.c
+++ b/numpy/_core/src/umath/_operand_flag_tests.c
@@ -36,9 +36,9 @@ inplace_add(char **args, npy_intp const *dimensions, npy_intp const *steps, void
 PyUFuncGenericFunction funcs[1] = {&inplace_add};
 
 /* These are the input and return dtypes of logit.*/
-static char types[2] = {NPY_INTP, NPY_INTP};
+static const char types[2] = {NPY_INTP, NPY_INTP};
 
-static void *data[1] = {NULL};
+static void *const data[1] = {NULL};
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -1273,8 +1273,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     {
         int types2[3] = {npy_rational,npy_rational,npy_rational};
         PyObject* gufunc = PyUFunc_FromFuncAndDataAndSignature(0,0,0,0,2,1,
-            PyUFunc_None,(char*)"matrix_multiply",
-            (char*)"return result of multiplying two matrices of rationals",
+            PyUFunc_None,"matrix_multiply",
+            "return result of multiplying two matrices of rationals",
             0,"(m,n),(n,p)->(m,p)");
         if (!gufunc) {
             goto fail;
@@ -1291,8 +1291,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         int types3[3] = {NPY_INT64,NPY_INT64,npy_rational};
 
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
-                PyUFunc_None,(char*)"test_add",
-                (char*)"add two matrices of int64 and return rational matrix",0);
+                PyUFunc_None,"test_add",
+                "add two matrices of int64 and return rational matrix",0);
         if (!ufunc) {
             goto fail;
         }
@@ -1306,8 +1306,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     /* Create test ufunc with rational types using RegisterLoopForDescr */
     {
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,2,1,
-                PyUFunc_None,(char*)"test_add_rationals",
-                (char*)"add two matrices of rationals and return rational matrix",0);
+                PyUFunc_None,"test_add_rationals",
+                "add two matrices of rationals and return rational matrix",0);
         PyArray_Descr* types[3] = {npyrational_descr,
                                     npyrational_descr,
                                     npyrational_descr};
@@ -1326,7 +1326,7 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     #define NEW_UNARY_UFUNC(name,type,doc) { \
         int types[2] = {npy_rational,type}; \
         PyObject* ufunc = PyUFunc_FromFuncAndData(0,0,0,0,1,1, \
-            PyUFunc_None,(char*)#name,(char*)doc,0); \
+            PyUFunc_None,#name,doc,0); \
         if (!ufunc) { \
             goto fail; \
         } \
@@ -1345,8 +1345,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         static const char types[3] = {type,type,type}; \
         static void* data[1] = {0}; \
         PyObject* ufunc = PyUFunc_FromFuncAndData( \
-            (PyUFuncGenericFunction*)func, data,(char*)types, \
-            1,2,1,PyUFunc_One,(char*)#name,(char*)doc,0); \
+            (PyUFuncGenericFunction*)func, data,types, \
+            1,2,1,PyUFunc_One,#name,doc,0); \
         if (!ufunc) { \
             goto fail; \
         } \

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -422,29 +422,29 @@ defdict = {
 */
 
 static PyUFuncGenericFunction always_error_functions[] = { always_error_loop };
-static void *always_error_data[] = { (void *)NULL };
-static char always_error_signatures[] = { NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static void *const always_error_data[] = { (void *)NULL };
+static const char always_error_signatures[] = { NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction inner1d_functions[] = { INTP_inner1d, DOUBLE_inner1d };
-static void *inner1d_data[] = { (void *)NULL, (void *)NULL };
-static char inner1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static void *const inner1d_data[] = { (void *)NULL, (void *)NULL };
+static const char inner1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction innerwt_functions[] = { INTP_innerwt, DOUBLE_innerwt };
-static void *innerwt_data[] = { (void *)NULL, (void *)NULL };
-static char innerwt_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static void *const innerwt_data[] = { (void *)NULL, (void *)NULL };
+static const char innerwt_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction matrix_multiply_functions[] = { INTP_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
-static void *matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
-static char matrix_multiply_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static void *const matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
+static const char matrix_multiply_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction cross1d_functions[] = { INTP_cross1d, DOUBLE_cross1d };
-static void *cross1d_data[] = { (void *)NULL, (void *)NULL };
-static char cross1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
+static void *const cross1d_data[] = { (void *)NULL, (void *)NULL };
+static const char cross1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
 static PyUFuncGenericFunction euclidean_pdist_functions[] =
                             { FLOAT_euclidean_pdist, DOUBLE_euclidean_pdist };
-static void *eucldiean_pdist_data[] = { (void *)NULL, (void *)NULL };
-static char euclidean_pdist_signatures[] = { NPY_FLOAT, NPY_FLOAT,
+static void *const eucldiean_pdist_data[] = { (void *)NULL, (void *)NULL };
+static const char euclidean_pdist_signatures[] = { NPY_FLOAT, NPY_FLOAT,
                                              NPY_DOUBLE, NPY_DOUBLE };
 
 static PyUFuncGenericFunction cumsum_functions[] = { INTP_cumsum, DOUBLE_cumsum };
-static void *cumsum_data[] = { (void *)NULL, (void *)NULL };
-static char cumsum_signatures[] = { NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE };
+static void *const cumsum_data[] = { (void *)NULL, (void *)NULL };
+static const char cumsum_signatures[] = { NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE };
 
 
 static int

--- a/numpy/fft/_pocketfft_umath.cpp
+++ b/numpy/fft/_pocketfft_umath.cpp
@@ -297,17 +297,17 @@ static PyUFuncGenericFunction fft_functions[] = {
     wrap_legacy_cpp_ufunc<fft_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<fft_loop<npy_longdouble>>
 };
-static char fft_types[] = {
+static const char fft_types[] = {
     NPY_CDOUBLE, NPY_DOUBLE, NPY_CDOUBLE,
     NPY_CFLOAT, NPY_FLOAT, NPY_CFLOAT,
     NPY_CLONGDOUBLE, NPY_LONGDOUBLE, NPY_CLONGDOUBLE
 };
-static void *fft_data[] = {
+static void *const fft_data[] = {
     (void*)&pocketfft::FORWARD,
     (void*)&pocketfft::FORWARD,
     (void*)&pocketfft::FORWARD
 };
-static void *ifft_data[] = {
+static void *const ifft_data[] = {
     (void*)&pocketfft::BACKWARD,
     (void*)&pocketfft::BACKWARD,
     (void*)&pocketfft::BACKWARD
@@ -323,7 +323,7 @@ static PyUFuncGenericFunction rfft_n_odd_functions[] = {
     wrap_legacy_cpp_ufunc<rfft_n_odd_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<rfft_n_odd_loop<npy_longdouble>>
 };
-static char rfft_types[] = {
+static const char rfft_types[] = {
     NPY_DOUBLE, NPY_DOUBLE, NPY_CDOUBLE,
     NPY_FLOAT, NPY_FLOAT, NPY_CFLOAT,
     NPY_LONGDOUBLE, NPY_LONGDOUBLE, NPY_CLONGDOUBLE
@@ -334,7 +334,7 @@ static PyUFuncGenericFunction irfft_functions[] = {
     wrap_legacy_cpp_ufunc<irfft_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<irfft_loop<npy_longdouble>>
 };
-static char irfft_types[] = {
+static const char irfft_types[] = {
     NPY_CDOUBLE, NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_FLOAT, NPY_FLOAT,
     NPY_CLONGDOUBLE, NPY_LONGDOUBLE, NPY_LONGDOUBLE

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -4215,14 +4215,14 @@ GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(lstsq);
 GUFUNC_FUNC_ARRAY_EIG(eig);
 GUFUNC_FUNC_ARRAY_EIG(eigvals);
 
-static char equal_2_types[] = {
+static const char equal_2_types[] = {
     NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_CFLOAT,
     NPY_CDOUBLE, NPY_CDOUBLE
 };
 
-static char equal_3_types[] = {
+static const char equal_3_types[] = {
     NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_CFLOAT, NPY_CFLOAT,
@@ -4230,47 +4230,47 @@ static char equal_3_types[] = {
 };
 
 /* second result is logdet, that will always be a REAL */
-static char slogdet_types[] = {
+static const char slogdet_types[] = {
     NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_CFLOAT, NPY_FLOAT,
     NPY_CDOUBLE, NPY_CDOUBLE, NPY_DOUBLE
 };
 
-static char eigh_types[] = {
+static const char eigh_types[] = {
     NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_FLOAT, NPY_CFLOAT,
     NPY_CDOUBLE, NPY_DOUBLE, NPY_CDOUBLE
 };
 
-static char eighvals_types[] = {
+static const char eighvals_types[] = {
     NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_FLOAT,
     NPY_CDOUBLE, NPY_DOUBLE
 };
 
-static char eig_types[] = {
+static const char eig_types[] = {
     NPY_FLOAT, NPY_CFLOAT, NPY_CFLOAT,
     NPY_DOUBLE, NPY_CDOUBLE, NPY_CDOUBLE,
     NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE
 };
 
-static char eigvals_types[] = {
+static const char eigvals_types[] = {
     NPY_FLOAT, NPY_CFLOAT,
     NPY_DOUBLE, NPY_CDOUBLE,
     NPY_CDOUBLE, NPY_CDOUBLE
 };
 
-static char svd_1_1_types[] = {
+static const char svd_1_1_types[] = {
     NPY_FLOAT, NPY_FLOAT,
     NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT, NPY_FLOAT,
     NPY_CDOUBLE, NPY_DOUBLE
 };
 
-static char svd_1_3_types[] = {
+static const char svd_1_3_types[] = {
     NPY_FLOAT,   NPY_FLOAT,   NPY_FLOAT,  NPY_FLOAT,
     NPY_DOUBLE,  NPY_DOUBLE,  NPY_DOUBLE, NPY_DOUBLE,
     NPY_CFLOAT,  NPY_CFLOAT,  NPY_FLOAT,  NPY_CFLOAT,
@@ -4278,25 +4278,25 @@ static char svd_1_3_types[] = {
 };
 
 /* A, tau */
-static char qr_r_raw_types[] = {
+static const char qr_r_raw_types[] = {
     NPY_DOUBLE,  NPY_DOUBLE,
     NPY_CDOUBLE, NPY_CDOUBLE,
 };
 
 /* A, tau, q */
-static char qr_reduced_types[] = {
+static const char qr_reduced_types[] = {
     NPY_DOUBLE,  NPY_DOUBLE,  NPY_DOUBLE,
     NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE,
 };
 
 /* A, tau, q */
-static char qr_complete_types[] = {
+static const char qr_complete_types[] = {
     NPY_DOUBLE,  NPY_DOUBLE,  NPY_DOUBLE,
     NPY_CDOUBLE, NPY_CDOUBLE, NPY_CDOUBLE,
 };
 
 /*  A,           b,           rcond,      x,           resid,      rank,    s,        */
-static char lstsq_types[] = {
+static const char lstsq_types[] = {
     NPY_FLOAT,   NPY_FLOAT,   NPY_FLOAT,  NPY_FLOAT,   NPY_FLOAT,  NPY_INT, NPY_FLOAT,
     NPY_DOUBLE,  NPY_DOUBLE,  NPY_DOUBLE, NPY_DOUBLE,  NPY_DOUBLE, NPY_INT, NPY_DOUBLE,
     NPY_CFLOAT,  NPY_CFLOAT,  NPY_FLOAT,  NPY_CFLOAT,  NPY_FLOAT,  NPY_INT, NPY_FLOAT,
@@ -4311,7 +4311,7 @@ typedef struct gufunc_descriptor_struct {
     int nin;
     int nout;
     PyUFuncGenericFunction *funcs;
-    char *types;
+    const char *types;
 } GUFUNC_DESCRIPTOR_t;
 
 GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {


### PR DESCRIPTION
When internally defining ufuncs, declare data and types as const to take advantage of the const correctness of the API. See #23847.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
