### PR TITLE
MAINT: declare func arg for PyUFunc_FromFunc* as const

### DIFF
--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -112,7 +112,7 @@ Functions
 ---------
 
 .. c:function:: PyObject *PyUFunc_FromFuncAndData( \
-        PyUFuncGenericFunction *func, void *const *data, const char *types, \
+        const PyUFuncGenericFunction *func, void *const *data, const char *types, \
         int ntypes, int nin, int nout, int identity, const char *name, \
         const char *doc, int unused)
 
@@ -192,7 +192,7 @@ Functions
         Unused and present for backwards compatibility of the C-API.
 
 .. c:function:: PyObject *PyUFunc_FromFuncAndDataAndSignature( \
-        PyUFuncGenericFunction *func, void *const *data, const char *types, \
+        const PyUFuncGenericFunction *func, void *const *data, const char *types, \
         int ntypes, int nin, int nout, int identity, const char *name, \
         const char *doc, int unused, const char *signature)
 
@@ -209,7 +209,7 @@ Functions
         so the passed in buffer can be freed.
 
 .. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignatureAndIdentity( \
-        PyUFuncGenericFunction *func, void **data, char *types, int ntypes, \
+        const PyUFuncGenericFunction *func, void **data, char *types, int ntypes, \
         int nin, int nout, int identity, char *name, char *doc, int unused, \
         char *signature, PyObject *identity_value)
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -303,7 +303,7 @@ the primary thing that must be changed to create your own ufunc.
         }
 
         /* This a pointer to the above function */
-        PyUFuncGenericFunction funcs[1] = {&double_logit};
+        static const PyUFuncGenericFunction funcs[1] = {&double_logit};
 
         /* These are the input and return dtypes of logit.*/
         static const char types[2] = {NPY_DOUBLE, NPY_DOUBLE};

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -951,7 +951,7 @@ cdef extern from "numpy/ufuncobject.h":
         UFUNC_FPE_UNDERFLOW
         UFUNC_FPE_INVALID
 
-    object PyUFunc_FromFuncAndData(PyUFuncGenericFunction *,
+    object PyUFunc_FromFuncAndData(const PyUFuncGenericFunction *,
           void **, char *, int, int, int, int, char *, char *, int)
     int PyUFunc_RegisterLoopForType(ufunc, int,
                                     PyUFuncGenericFunction, int *, void *) except -1
@@ -1002,7 +1002,7 @@ cdef extern from "numpy/ufuncobject.h":
     int PyUFunc_ReplaceLoopBySignature \
         (ufunc, PyUFuncGenericFunction, int *, PyUFuncGenericFunction *)
     object PyUFunc_FromFuncAndDataAndSignature \
-             (PyUFuncGenericFunction *, void **, char *, int, int, int,
+             (const PyUFuncGenericFunction *, void **, char *, int, int, int,
               int, char *, char *, int, char *)
 
     int _import_umath() except -1

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -866,7 +866,7 @@ cdef extern from "numpy/ufuncobject.h":
         UFUNC_FPE_UNDERFLOW
         UFUNC_FPE_INVALID
 
-    object PyUFunc_FromFuncAndData(PyUFuncGenericFunction *,
+    object PyUFunc_FromFuncAndData(const PyUFuncGenericFunction *,
           void **, char *, int, int, int, int, char *, char *, int)
     int PyUFunc_RegisterLoopForType(ufunc, int,
                                     PyUFuncGenericFunction, int *, void *) except -1
@@ -917,7 +917,7 @@ cdef extern from "numpy/ufuncobject.h":
     int PyUFunc_ReplaceLoopBySignature \
         (ufunc, PyUFuncGenericFunction, int *, PyUFuncGenericFunction *)
     object PyUFunc_FromFuncAndDataAndSignature \
-             (PyUFuncGenericFunction *, void **, char *, int, int, int,
+             (const PyUFuncGenericFunction *, void **, char *, int, int, int,
               int, char *, char *, int, char *)
 
     int _import_umath() except -1

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1446,7 +1446,7 @@ def make_arrays(funcdict):
             signames = ', '.join(siglist)
             datanames = ', '.join(datalist)
             code1list.append(
-                "static PyUFuncGenericFunction %s_functions[] = {%s};"
+                "static const PyUFuncGenericFunction %s_functions[] = {%s};"
                 % (name, funcnames))
             code1list.append("static void * %s_data[] = {%s};"
                             % (name, datanames))

--- a/numpy/_core/src/umath/_operand_flag_tests.c
+++ b/numpy/_core/src/umath/_operand_flag_tests.c
@@ -33,7 +33,7 @@ inplace_add(char **args, npy_intp const *dimensions, npy_intp const *steps, void
 
 
 /*This a pointer to the above function*/
-PyUFuncGenericFunction funcs[1] = {&inplace_add};
+static const PyUFuncGenericFunction funcs[1] = {&inplace_add};
 
 /* These are the input and return dtypes of logit.*/
 static char types[2] = {NPY_INTP, NPY_INTP};

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -1345,7 +1345,7 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         static const char types[3] = {type,type,type}; \
         static void* data[1] = {0}; \
         PyObject* ufunc = PyUFunc_FromFuncAndData( \
-            (PyUFuncGenericFunction*)func, data,(char*)types, \
+            func, data,(char*)types, \
             1,2,1,PyUFunc_One,(char*)#name,(char*)doc,0); \
         if (!ufunc) { \
             goto fail; \

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -421,28 +421,28 @@ defdict = {
 
 */
 
-static PyUFuncGenericFunction always_error_functions[] = { always_error_loop };
+static const PyUFuncGenericFunction always_error_functions[] = { always_error_loop };
 static void *always_error_data[] = { (void *)NULL };
 static char always_error_signatures[] = { NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction inner1d_functions[] = { INTP_inner1d, DOUBLE_inner1d };
+static const PyUFuncGenericFunction inner1d_functions[] = { INTP_inner1d, DOUBLE_inner1d };
 static void *inner1d_data[] = { (void *)NULL, (void *)NULL };
 static char inner1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction innerwt_functions[] = { INTP_innerwt, DOUBLE_innerwt };
+static const PyUFuncGenericFunction innerwt_functions[] = { INTP_innerwt, DOUBLE_innerwt };
 static void *innerwt_data[] = { (void *)NULL, (void *)NULL };
 static char innerwt_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction matrix_multiply_functions[] = { INTP_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
+static const PyUFuncGenericFunction matrix_multiply_functions[] = { INTP_matrix_multiply, FLOAT_matrix_multiply, DOUBLE_matrix_multiply };
 static void *matrix_multiply_data[] = { (void *)NULL, (void *)NULL, (void *)NULL };
 static char matrix_multiply_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP,  NPY_FLOAT, NPY_FLOAT, NPY_FLOAT,  NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction cross1d_functions[] = { INTP_cross1d, DOUBLE_cross1d };
+static const PyUFuncGenericFunction cross1d_functions[] = { INTP_cross1d, DOUBLE_cross1d };
 static void *cross1d_data[] = { (void *)NULL, (void *)NULL };
 static char cross1d_signatures[] = { NPY_INTP, NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE };
-static PyUFuncGenericFunction euclidean_pdist_functions[] =
+static const PyUFuncGenericFunction euclidean_pdist_functions[] =
                             { FLOAT_euclidean_pdist, DOUBLE_euclidean_pdist };
 static void *eucldiean_pdist_data[] = { (void *)NULL, (void *)NULL };
 static char euclidean_pdist_signatures[] = { NPY_FLOAT, NPY_FLOAT,
                                              NPY_DOUBLE, NPY_DOUBLE };
 
-static PyUFuncGenericFunction cumsum_functions[] = { INTP_cumsum, DOUBLE_cumsum };
+static const PyUFuncGenericFunction cumsum_functions[] = { INTP_cumsum, DOUBLE_cumsum };
 static void *cumsum_data[] = { (void *)NULL, (void *)NULL };
 static char cumsum_signatures[] = { NPY_INTP, NPY_INTP, NPY_DOUBLE, NPY_DOUBLE };
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4628,7 +4628,7 @@ PyUFunc_ReplaceLoopBySignature(PyUFuncObject *func,
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndData(PyUFuncGenericFunction *func, void *const *data,
+PyUFunc_FromFuncAndData(const PyUFuncGenericFunction *func, void *const *data,
                         const char *types, int ntypes,
                         int nin, int nout, int identity,
                         const char *name, const char *doc, int unused)
@@ -4639,7 +4639,7 @@ PyUFunc_FromFuncAndData(PyUFuncGenericFunction *func, void *const *data,
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void *const *data,
+PyUFunc_FromFuncAndDataAndSignature(const PyUFuncGenericFunction *func, void *const *data,
                                      const char *types, int ntypes,
                                      int nin, int nout, int identity,
                                      const char *name, const char *doc,
@@ -4652,7 +4652,7 @@ PyUFunc_FromFuncAndDataAndSignature(PyUFuncGenericFunction *func, void *const *d
 
 /*UFUNC_API*/
 NPY_NO_EXPORT PyObject *
-PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, void *const *data,
+PyUFunc_FromFuncAndDataAndSignatureAndIdentity(const PyUFuncGenericFunction *func, void *const *data,
                                      const char *types, int ntypes,
                                      int nin, int nout, int identity,
                                      const char *name, const char *doc,

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -36,7 +36,7 @@
 #include "__umath_generated.c"
 
 
-static PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
+static const PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
 
 static int
 object_ufunc_type_resolver(PyUFuncObject *ufunc,
@@ -142,7 +142,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
     doc = "dynamic ufunc based on a python function";
 
     self = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignatureAndIdentity(
-            (PyUFuncGenericFunction *)pyfunc_functions, data,
+            pyfunc_functions, data,
             types, /* ntypes */ 1, nin, nout, identity ? PyUFunc_IdentityValue : PyUFunc_None,
             str, doc, /* unused */ 0, NULL, identity);
 

--- a/numpy/fft/_pocketfft_umath.cpp
+++ b/numpy/fft/_pocketfft_umath.cpp
@@ -292,7 +292,7 @@ irfft_loop(char **args, npy_intp const *dimensions, npy_intp const *steps, void 
     return;
 }
 
-static PyUFuncGenericFunction fft_functions[] = {
+static const PyUFuncGenericFunction fft_functions[] = {
     wrap_legacy_cpp_ufunc<fft_loop<npy_double>>,
     wrap_legacy_cpp_ufunc<fft_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<fft_loop<npy_longdouble>>
@@ -313,12 +313,12 @@ static void *ifft_data[] = {
     (void*)&pocketfft::BACKWARD
 };
 
-static PyUFuncGenericFunction rfft_n_even_functions[] = {
+static const PyUFuncGenericFunction rfft_n_even_functions[] = {
     wrap_legacy_cpp_ufunc<rfft_n_even_loop<npy_double>>,
     wrap_legacy_cpp_ufunc<rfft_n_even_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<rfft_n_even_loop<npy_longdouble>>
 };
-static PyUFuncGenericFunction rfft_n_odd_functions[] = {
+static const PyUFuncGenericFunction rfft_n_odd_functions[] = {
     wrap_legacy_cpp_ufunc<rfft_n_odd_loop<npy_double>>,
     wrap_legacy_cpp_ufunc<rfft_n_odd_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<rfft_n_odd_loop<npy_longdouble>>
@@ -329,7 +329,7 @@ static char rfft_types[] = {
     NPY_LONGDOUBLE, NPY_LONGDOUBLE, NPY_CLONGDOUBLE
 };
 
-static PyUFuncGenericFunction irfft_functions[] = {
+static const PyUFuncGenericFunction irfft_functions[] = {
     wrap_legacy_cpp_ufunc<irfft_loop<npy_double>>,
     wrap_legacy_cpp_ufunc<irfft_loop<npy_float>>,
     wrap_legacy_cpp_ufunc<irfft_loop<npy_longdouble>>

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -4134,14 +4134,14 @@ static void *array_of_nulls[] = {
 #define FUNC_ARRAY_NAME(NAME) NAME ## _funcs
 
 #define GUFUNC_FUNC_ARRAY_REAL(NAME)                    \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                 \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         FLOAT_ ## NAME,                                 \
         DOUBLE_ ## NAME                                 \
     }
 
 #define GUFUNC_FUNC_ARRAY_REAL_COMPLEX(NAME)            \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                 \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         FLOAT_ ## NAME,                                 \
         DOUBLE_ ## NAME,                                \
@@ -4149,7 +4149,7 @@ static void *array_of_nulls[] = {
         CDOUBLE_ ## NAME                                \
     }
 #define GUFUNC_FUNC_ARRAY_REAL_COMPLEX_(NAME)            \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                  \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         NAME<npy_float, npy_float>,                                 \
         NAME<npy_double, npy_double>,                                \
@@ -4157,7 +4157,7 @@ static void *array_of_nulls[] = {
         NAME<npy_cdouble, npy_double>                                \
     }
 #define GUFUNC_FUNC_ARRAY_REAL_COMPLEX__(NAME)            \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                   \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         NAME<npy_float>,                                 \
         NAME<npy_double>,                                \
@@ -4169,7 +4169,7 @@ static void *array_of_nulls[] = {
  * That kernel is disabled
  */
 #define GUFUNC_FUNC_ARRAY_EIG(NAME)                     \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                 \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         NAME<fortran_complex,fortran_real>,                                 \
         NAME<fortran_doublecomplex,fortran_doublereal>,                                \
@@ -4181,13 +4181,13 @@ static void *array_of_nulls[] = {
  * in Python, so they are not implemented here.
  */
 #define GUFUNC_FUNC_ARRAY_QR(NAME)                      \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                 \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         DOUBLE_ ## NAME,                                \
         CDOUBLE_ ## NAME                                \
     }
 #define GUFUNC_FUNC_ARRAY_QR__(NAME)                      \
-    static PyUFuncGenericFunction                       \
+    static const PyUFuncGenericFunction                   \
     FUNC_ARRAY_NAME(NAME)[] = {                         \
         NAME<npy_double>,                                \
         NAME<npy_cdouble>                                \
@@ -4310,7 +4310,7 @@ typedef struct gufunc_descriptor_struct {
     int ntypes;
     int nin;
     int nout;
-    PyUFuncGenericFunction *funcs;
+    const PyUFuncGenericFunction *funcs;
     char *types;
 } GUFUNC_DESCRIPTOR_t;
 


### PR DESCRIPTION
Declare the `func` argument of `PyUFunc_FromFuncAndData` and related functions as `const PyUFuncGenericFunction *func` to signify that Numpy does not modify the array provided by the user.

This simplifies writing C extensions that use the Numpy C API because developers will typically declare loop function arrays as `static const PyUFuncGenericFunction[]`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
