### PR TITLE
TST: skip limited API test on nogil python build

### DIFF
--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -5,7 +5,7 @@ import sys
 import sysconfig
 import pytest
 
-from numpy.testing import IS_WASM, IS_PYPY
+from numpy.testing import IS_WASM, IS_PYPY, NOGIL_BUILD
 
 # This import is copied from random.tests.test_extending
 try:
@@ -68,10 +68,8 @@ def install_temp(tmpdir_factory):
     ),
 )
 @pytest.mark.xfail(
-    sysconfig.get_config_var("Py_GIL_DISABLED"),
-    reason=(
-        "Py_LIMITED_API is incompatible with the Python 3.6 limited API"
-    ),
+    NOGIL_BUILD,
+    reason="Py_GIL_DISABLED builds do not currently support the limited API",
 )
 @pytest.mark.skipif(IS_PYPY, reason="no support for limited API in PyPy")
 def test_limited_api(install_temp):

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -67,6 +67,12 @@ def install_temp(tmpdir_factory):
         "and Py_REF_DEBUG"
     ),
 )
+@pytest.mark.xfail(
+    sysconfig.get_config_var("Py_GIL_DISABLED"),
+    reason=(
+        "Py_LIMITED_API is incompatible with the Python 3.6 limited API"
+    ),
+)
 @pytest.mark.skipif(IS_PYPY, reason="no support for limited API in PyPy")
 def test_limited_api(install_temp):
     """Test building a third-party C extension with the limited API

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1,5 +1,4 @@
 import sys
-import sysconfig
 import pytest
 
 import textwrap
@@ -11,10 +10,9 @@ import numpy._core._multiarray_tests as _multiarray_tests
 from numpy import array, arange, nditer, all
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises,
-    IS_WASM, HAS_REFCOUNT, suppress_warnings, break_cycles
+    IS_WASM, HAS_REFCOUNT, suppress_warnings, break_cycles,
+    NOGIL_BUILD
     )
-
-NOGIL_BUILD = bool(sysconfig.get_config_var('Py_GIL_DISABLED'))
 
 def iter_multi_index(i):
     ret = []

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -39,7 +39,7 @@ __all__ = [
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
         'HAS_REFCOUNT', "IS_WASM", 'suppress_warnings', 'assert_array_compare',
         'assert_no_gc_cycles', 'break_cycles', 'HAS_LAPACK64', 'IS_PYSTON',
-        '_OLD_PROMOTION', 'IS_MUSL', '_SUPPORTS_SVE'
+        '_OLD_PROMOTION', 'IS_MUSL', '_SUPPORTS_SVE', 'NOGIL_BUILD'
         ]
 
 
@@ -68,6 +68,7 @@ _v = sysconfig.get_config_var('HOST_GNU_TYPE') or ''
 if 'musl' in _v:
     IS_MUSL = True
 
+NOGIL_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 def assert_(val, msg=''):
     """


### PR DESCRIPTION
Currently the limited API test fails on a nogil python 3.13 build:

<details>

```
In file included from ../../../../../../../../../../Users/goldbaum/Documents/numpy/build-install/usr/lib/python3.13/site-packages/numpy/_core/tests/examples/limited_api/limited_api1.c:3:
In file included from /Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/Python.h:58:
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:317:22: error: call to undeclared function '_Py_atomic_load_uint32_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    uint32_t local = _Py_atomic_load_uint32_relaxed(&ob->ob_ref_local);
                     ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:321:25: error: call to undeclared function '_Py_atomic_load_ssize_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&ob->ob_ref_shared);
                        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:392:9: error: call to undeclared function '_Py_IsOwnedByCurrentThread'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (_Py_IsOwnedByCurrentThread(ob)) {
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:432:5: error: call to undeclared function '_Py_atomic_store_ssize_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    _Py_atomic_store_ssize_relaxed(&ob->ob_size, size);
    ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:806:22: error: call to undeclared function '_Py_atomic_load_uint32_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
                     ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:812:9: error: call to undeclared function '_Py_IsOwnedByCurrentThread'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (_Py_IsOwnedByCurrentThread(op)) {
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:813:9: error: call to undeclared function '_Py_atomic_store_uint32_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, new_local);
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:816:9: error: call to undeclared function '_Py_atomic_add_ssize'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _Py_atomic_add_ssize(&op->ob_ref_shared, (1 << _Py_REF_SHARED_SHIFT));
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:900:22: error: call to undeclared function '_Py_atomic_load_uint32_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
                     ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:905:9: error: call to undeclared function '_Py_IsOwnedByCurrentThread'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (_Py_IsOwnedByCurrentThread(op)) {
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:907:9: error: call to undeclared function '_Py_atomic_store_uint32_relaxed'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
        ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:909:13: error: call to undeclared function '_Py_MergeZeroLocalRefcount'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            _Py_MergeZeroLocalRefcount(op);
            ^
/Users/goldbaum/.pyenv/versions/3.13-dev-nogil-integration/include/python3.13t/object.h:913:9: error: call to undeclared function '_Py_DecRefShared'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _Py_DecRefShared(op);
        ^
13 errors generated.
```

</details>

It may be possible to conditionally increase the required limited API version for nogil builds, but it's not clear to me if that's even supposed to work right now. Marking as an xfail for now to unblock eventually setting up nogil CI.