### PR TITLE
DOC: add versionadded for copy keyword in np.asarray docstring

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -948,6 +948,8 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         the other requirements (``dtype``, ``order``, etc.).
         For ``False`` it raises a ``ValueError`` if a copy cannot be avoided.
         Default: ``None``.
+
+        .. versionadded:: 2.0.0
     ${ARRAY_FUNCTION_LIKE}
 
         .. versionadded:: 1.20.0


### PR DESCRIPTION
Noticed this small omission while testing pyarrow's `__array__`, handy to know this is a new keyword for `asarray` in 2.0 (keyword was added in https://github.com/numpy/numpy/pull/25168)