### PR TITLE
MNT: migrate PyList_GetItem usages to PyList_GetItemRef

### DIFF
--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -45,6 +45,7 @@
 #include "numpy/ndarraytypes.h"
 #include "numpy/npy_3kcompat.h"
 #include "common.h"
+#include "npy_pycompat.h"
 
 #include "dispatching.h"
 #include "dtypemeta.h"
@@ -121,8 +122,9 @@ PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
     PyObject *loops = ufunc->_loops;
     Py_ssize_t length = PyList_Size(loops);
     for (Py_ssize_t i = 0; i < length; i++) {
-        PyObject *item = PyList_GetItem(loops, i);
+        PyObject *item = PyList_GetItemRef(loops, i);
         PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
+        Py_DECREF(item);
         int cmp = PyObject_RichCompareBool(cur_DType_tuple, DType_tuple, Py_EQ);
         if (cmp < 0) {
             return -1;
@@ -1277,8 +1279,9 @@ get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype,
     PyObject *loops = ufunc->_loops;
     Py_ssize_t length = PyList_Size(loops);
     for (Py_ssize_t i = 0; i < length; i++) {
-        PyObject *item = PyList_GetItem(loops, i);
+        PyObject *item = PyList_GetItemRef(loops, i);
         PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
+        Py_DECREF(item);
         int cmp = PyObject_RichCompareBool(cur_DType_tuple,
                                            t_dtypes, Py_EQ);
         if (cmp < 0) {

--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -26,6 +26,7 @@
 
 #include "numpy/ndarraytypes.h"
 
+#include "npy_pycompat.h"
 #include "common.h"
 #include "array_method.h"
 #include "legacy_array_method.h"
@@ -250,8 +251,9 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     PyObject *loops = ufunc->_loops;
     Py_ssize_t length = PyList_Size(loops);
     for (Py_ssize_t i = 0; i < length; i++) {
-        PyObject *item = PyList_GetItem(loops, i);
+        PyObject *item = PyList_GetItemRef(loops, i);
         PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
+        Py_DECREF(item);
         int cmp = PyObject_RichCompareBool(cur_DType_tuple, wrapped_dt_tuple, Py_EQ);
         if (cmp < 0) {
             goto finish;


### PR DESCRIPTION
PEP 703 has [some discussion](https://peps.python.org/pep-0703/#borrowed-references) about why this is necessary. In short, in a GIL-less python, it's possible for `item` in all three cases to be garbage collected before the `PyTuple_GetItem` call can execute. Using `PyList_GetItemRef` ensures that can't happen.

There's still one more `PyList_GetItem` usage in a test, but it's there specifically to test C API usages that create borrowed references, so I left it alone.