### PR TITLE
MAINT,BUG: Robust string meson template substitution

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -73,8 +73,8 @@ class MesonTemplate:
         self.substitutions["python"] = self.python_exe
 
     def sources_substitution(self) -> None:
-        self.substitutions["source_list"] = f",\n{self.indent}".join(
-            [f"{self.indent}'{source}'," for source in self.sources]
+        self.substitutions["source_list"] = ",\n".join(
+            [f"{self.indent}'''{source}'''," for source in self.sources]
         )
 
     def deps_substitution(self) -> None:
@@ -85,7 +85,7 @@ class MesonTemplate:
     def libraries_substitution(self) -> None:
         self.substitutions["lib_dir_declarations"] = "\n".join(
             [
-                f"lib_dir_{i} = declare_dependency(link_args : ['-L{lib_dir}'])"
+                f"lib_dir_{i} = declare_dependency(link_args : ['''-L{lib_dir}'''])"
                 for i, lib_dir in enumerate(self.library_dirs)
             ]
         )
@@ -106,7 +106,7 @@ class MesonTemplate:
 
     def include_substitution(self) -> None:
         self.substitutions["inc_list"] = f",\n{self.indent}".join(
-            [f"{self.indent}'{inc}'," for inc in self.include_dirs]
+            [f"{self.indent}'''{inc}'''," for inc in self.include_dirs]
         )
 
     def generate_meson_build(self):
@@ -114,7 +114,7 @@ class MesonTemplate:
             node()
         template = Template(self.meson_build_template())
         meson_build = template.substitute(self.substitutions)
-        meson_build = re.sub(r',,', ',', meson_build)
+        meson_build = re.sub(r",,", ",", meson_build)
         return meson_build
 
 

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -8,7 +8,7 @@ project('${modulename}',
                           ])
 fc = meson.get_compiler('fortran')
 
-py = import('python').find_installation('${python}', pure: false)
+py = import('python').find_installation('''${python}''', pure: false)
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,


### PR DESCRIPTION
*Slightly robust, see @seberg's [comment](https://github.com/numpy/numpy/issues/26107#issuecomment-2015198785). Only things which are likely to be paths are triple quoted since it is rather ugly..

Closes gh-26107. Also makes the resulting file a bit prettier (better indentation).

```meson
py = import('python').find_installation('''/home/rgoswami/micromamba/envs/numpy-dev/bin/python3''', pure: false)

las = declare_dependency(link_args : ['-llas'])
lib_dir_0 = declare_dependency(link_args : ['''-L/horastmi/ra'''])

py.extension_module('test',
                     [
                     '''test.f90''',
                     '''testmodule.c''',
                     '''test-f2pywrappers2.f90''',
                     fortranobject_c
                     ],
                     include_directories: [
                     inc_np,

                     ],
                     dependencies : [
                     py_dep,
                     quadmath_dep,
                     dependency('openblas'),
                     las,
                     lib_dir_0,
                     ],
                     install : true)
```


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
