### PR TITLE
MNT: add a thread_local polyfill and use it for the allocator cache

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -11,6 +11,7 @@
 #include "numpy/npy_common.h"
 #include "npy_config.h"
 #include "alloc.h"
+#include "common.h"
 
 #include <assert.h>
 #ifdef NPY_OS_LINUX
@@ -32,8 +33,8 @@ typedef struct {
     npy_uintp available; /* number of cached pointers */
     void * ptrs[NCACHE];
 } cache_bucket;
-static cache_bucket datacache[NBUCKETS];
-static cache_bucket dimcache[NBUCKETS_DIM];
+static thread_local cache_bucket datacache[NBUCKETS];
+static thread_local cache_bucket dimcache[NBUCKETS_DIM];
 
 static int _madvise_hugepage = 1;
 

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -364,4 +364,19 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
  */
 #define NPY_ITER_REDUCTION_AXIS(axis) (axis + (1 << (NPY_BITSOF_INT - 2)))
 
+#ifndef thread_local
+# if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define thread_local _Thread_local
+# elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL )
+#  define thread_local __declspec(thread)
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+# elif defined __GNUC__
+#  define thread_local __thread
+# else
+#  error "Cannot define thread_local"
+# endif
+#endif
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_COMMON_H_ */


### PR DESCRIPTION
This adds a macro to define a C11 `thread_local` keyword in a portable manner. It also uses it to mark the allocator cache as thread local, avoiding heap corruption in multithreaded tests with the GIL disabled.

Opening as a draft because I'm not sure if there are platforms this macro doesn't cover.