### PR TITLE
MNT: disable the allocator cache for nogil builds

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -96,11 +96,13 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
     assert((esz == 1 && cache == datacache) ||
            (esz == sizeof(npy_intp) && cache == dimcache));
     assert(PyGILState_Check());
+#ifndef Py_GIL_DISABLED
     if (nelem < msz) {
         if (cache[nelem].available > 0) {
             return cache[nelem].ptrs[--(cache[nelem].available)];
         }
     }
+#endif
     p = alloc(nelem * esz);
     if (p) {
 #ifdef _PyPyGC_AddMemoryPressure
@@ -131,12 +133,14 @@ _npy_free_cache(void * p, npy_uintp nelem, npy_uint msz,
                 cache_bucket * cache, void (*dealloc)(void *))
 {
     assert(PyGILState_Check());
+#ifndef Py_GIL_DISABLED
     if (p != NULL && nelem < msz) {
         if (cache[nelem].available < NCACHE) {
             cache[nelem].ptrs[cache[nelem].available++] = p;
             return;
         }
     }
+#endif
     dealloc(p);
 }
 


### PR DESCRIPTION
These caches are implicitly locked by the GIL, so in the nogil build I see use-after-free errors in tests that use python threads. See for example this ASAN error in one of the stringdtype tests that does multithreaded array mutation and access:

<details>

```
==31117==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000003010 at pc 0x000149921bbc bp 0x00016fece010 sp 0x00016fece008
READ of size 8 at 0x602000003010 thread T13
    #0 0x149921bb8 in PyArray_MultiplyList multiarraymodule.c:181
    #1 0x149999e14 in PyArray_ClearArray refcount.c:83
    #2 0x1497578c4 in array_dealloc arrayobject.c:427
    #3 0x106961118 in _PyEval_EvalFrameDefault generated_cases.c.h:4818
    #4 0x10681ac98 in method_vectorcall classobject.c:70
    #5 0x106a47364 in thread_run _threadmodule.c:337
    #6 0x1069de8b0 in pythread_wrapper thread_pthread.h:241
    #7 0x1057b8760 in asan_thread_start(void*)+0x3c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x50760)
    #8 0x186dfe030 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64+0x7030)
    #9 0xa358800186df8e38  (<unknown module>)

0x602000003010 is located 0 bytes inside of 16-byte region [0x602000003010,0x602000003020)
freed by thread T14 here:
    #0 0x1057bbb1c in free+0x90 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x53b1c)
    #1 0x14974ee18 in _npy_free_cache alloc.c:140
    #2 0x14974ef0c in npy_free_cache_dim alloc.c:204
    #3 0x149757be8 in array_dealloc arrayobject.c:452
    #4 0x1498ea800 in Py_DECREF object.h:909
    #5 0x1498ee59c in Py_XDECREF object.h:1038
    #6 0x1498fe2dc in array_assign_subscript mapping.c:2139
    #7 0x106962ccc in _PyEval_EvalFrameDefault generated_cases.c.h:5529
    #8 0x10681ac98 in method_vectorcall classobject.c:70
    #9 0x106a47364 in thread_run _threadmodule.c:337
    #10 0x1069de8b0 in pythread_wrapper thread_pthread.h:241
    #11 0x1057b8760 in asan_thread_start(void*)+0x3c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x50760)
    #12 0x186dfe030 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64+0x7030)
    #13 0x587d000186df8e38  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x1057bb9e8 in malloc+0x8c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x539e8)
    #1 0x14974e9f4 in _npy_alloc_cache alloc.c:104
    #2 0x14974eeac in npy_alloc_cache_dim alloc.c:193
    #3 0x1497e5a20 in PyArray_NewFromDescr_int ctors.c:765
    #4 0x1497e8c20 in PyArray_NewFromDescrAndBase ctors.c:1045
    #5 0x1497e8ba0 in PyArray_NewFromDescr ctors.c:1030
    #6 0x1497e912c in PyArray_NewLikeArrayWithShape ctors.c:1119
    #7 0x1497e99d8 in PyArray_NewLikeArray ctors.c:1207
    #8 0x1497b4ec0 in PyArray_NewCopy convert.c:493
    #9 0x1499107d4 in array_copy methods.c:1141
    #10 0x106824e68 in method_vectorcall_FASTCALL_KEYWORDS descrobject.c:420
    #11 0x106817e88 in PyObject_Vectorcall call.c:327
    #12 0x10695106c in _PyEval_EvalFrameDefault generated_cases.c.h:813
    #13 0x1068181b4 in PyObject_CallOneArg call.c:395
    #14 0x10687efa8 in _PyObject_GenericGetAttrWithDict object.c:1577
```

</details>

I initially thought we could keep the caching by marking the caches as thread local, but that won't work with any allocation happening in a dynamically created thread. Instead I think the only safe thing we can do without adding a mutex to access the caches is disable the cache entirely.

Happy to entertain alternative approaches.

With this change when the gil is disabled `numpy/_core/tests/test_stringdtype.py::test_threaded_access_and_mutation` goes from seg faulting every time it's executed to working every time I run it.