### PR TITLE
ENH, BENCH: isclose runs faster by using errstate only when needed

### DIFF
--- a/benchmarks/benchmarks/bench_numeric.py
+++ b/benchmarks/benchmarks/bench_numeric.py
@@ -1,0 +1,14 @@
+from .common import Benchmark
+
+import numpy as np
+
+
+class IsClose(Benchmark):
+    params = [1, int(1e3), int(1e6)]
+
+    def setup(self, v):
+        self.a = np.random.default_rng().random(v)
+        self.b = np.random.default_rng().random(v)
+
+    def time_isclose(self, v):
+        np.isclose(self.a, self.b, atol=1e-5, rtol=1e-7)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2329,7 +2329,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     array([False,  True])
     """
     def within_tol(x, y, atol, rtol):
-        # within tol is only called with finite x and y
+        # within_tol is only called with finite x and y
         if isfinite(atol) & isfinite(rtol):
             context_manager = contextlib.nullcontext()
         else:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2347,7 +2347,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
 
     xfin = isfinite(x)
     yfin = isfinite(y)
-    if all(xfin) and all(yfin):
+    if all(xfin & yfin):
         return within_tol(x, y, atol, rtol)
     else:
         finite = xfin & yfin

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2328,8 +2328,12 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     array([False,  True])
     """
     def within_tol(x, y, atol, rtol):
-        with errstate(invalid='ignore'), _no_nep50_warning():
-            return less_equal(abs(x-y), atol + rtol * abs(y))
+        with _no_nep50_warning():
+            if isfinite(atol) & isfinite(rtol):
+                return less_equal(abs(x - y), atol + rtol * abs(y))
+            else:
+                with errstate(invalid='ignore'), _no_nep50_warning():
+                    return less_equal(abs(x-y), atol + rtol * abs(y))
 
     x = asanyarray(a)
     y = asanyarray(b)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2332,7 +2332,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
             if isfinite(atol) & isfinite(rtol):
                 return less_equal(abs(x - y), atol + rtol * abs(y))
             else:
-                with errstate(invalid='ignore'), _no_nep50_warning():
+                with errstate(invalid='ignore'):
                     return less_equal(abs(x-y), atol + rtol * abs(y))
 
     x = asanyarray(a)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Following the discussions on the issue  #16160 , I have made the following change - 

-  Replace `np.all(xfin)` and `np.all(yfin)` with `np.all(xfin & yfin)`
-  Conditionally use the `errstate(invalid='ignore')` only when needed

I have added a small benchmark for isClose, which show significant improvement for small arrays, and no statistically significant change for large arrays. 

**Before**

             ========= ============
                param1              
              --------- ------------
                  1      15.4±0.7μs 
                 1000    17.3±0.4μs 
               1000000   7.38±0.4ms 
              ========= ============

**With Change**

             ========= ============
               param1              
             --------- ------------
                 1      10.6±0.1μs 
                1000    13.0±0.2μs 
              1000000   7.10±0.3ms 
             ========= ============
