### PR TITLE
DOC: Backport various documentation fixes

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -423,7 +423,7 @@ The :ref:`copy keyword behavior changes <copy-keyword-changes-2.0>` in
 * For any ``__array__`` method on a non-NumPy array-like object, ``dtype=None``
   and ``copy=None`` keywords must be added to the signature - this will work with older
   NumPy versions as well (although older numpy versions will never pass in ``copy`` keyword).
-  If the keywords are actually used in the ``__array__`` method implementation, then for:
+  If the keywords are added to the ``__array__`` signature, then for:
 
   * ``copy=True`` and any ``dtype`` value always return a new copy,
   * ``copy=None`` create a copy if required (for example by ``dtype``),

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -412,20 +412,23 @@ The :ref:`copy keyword behavior changes <copy-keyword-changes-2.0>` in
 `~numpy.asarray`, `~numpy.array` and `ndarray.__array__
 <numpy.ndarray.__array__>` may require these changes:
 
-1. Code using ``np.array(..., copy=False)`` can in most cases be changed to
-   ``np.asarray(...)``. Older code tended to use ``np.array`` like this because
-   it had less overhead than the default ``np.asarray`` copy-if-needed
-   behavior. This is no longer true, and ``np.asarray`` is the preferred function.
-2. For code that explicitly needs to pass ``None``/``False`` meaning "copy if
-   needed" in a way that's compatible with NumPy 1.x and 2.x, see
-   `scipy#20172 <https://github.com/scipy/scipy/pull/20172>`__ for an example
-   of how to do so.
-3. For any ``__array__`` method on a non-NumPy array-like object, a
-   ``copy=None`` keyword can be added to the signature - this will work with
-   older NumPy versions as well. If ``copy`` keyword is considered in
-   the ``__array__`` method implementation, then for ``copy=True`` always
-   return a new copy.
+* Code using ``np.array(..., copy=False)`` can in most cases be changed to
+  ``np.asarray(...)``. Older code tended to use ``np.array`` like this because
+  it had less overhead than the default ``np.asarray`` copy-if-needed
+  behavior. This is no longer true, and ``np.asarray`` is the preferred function.
+* For code that explicitly needs to pass ``None``/``False`` meaning "copy if
+  needed" in a way that's compatible with NumPy 1.x and 2.x, see
+  `scipy#20172 <https://github.com/scipy/scipy/pull/20172>`__ for an example
+  of how to do so.
+* For any ``__array__`` method on a non-NumPy array-like object, ``dtype=None``
+  and ``copy=None`` keywords must be added to the signature - this will work with older
+  NumPy versions as well (although older numpy versions will never pass in ``copy`` keyword).
+  If the keywords are actually used in the ``__array__`` method implementation, then for:
 
+  * ``copy=True`` and any ``dtype`` value always return a new copy,
+  * ``copy=None`` create a copy if required (for example by ``dtype``),
+  * ``copy=False`` a copy must never be made. If a copy is needed to return a numpy array
+    or satisfy ``dtype``, then raise an exception (``ValueError``).
 
 Writing numpy-version-dependent code
 ------------------------------------

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -37,9 +37,8 @@ of the flexible itemsize array types (:class:`str_`,
 
    **Figure:** Hierarchy of type objects representing the array data
    types. Not shown are the two integer types :class:`intp` and
-   :class:`uintp` which just point to the integer type that holds a
-   pointer for the platform. All the number types can be obtained
-   using bit-width names as well.
+   :class:`uintp` which are used for indexing (the same as the
+   default integer since NumPy 2).
 
 
 .. TODO - use something like this instead of the diagram above, as it generates
@@ -377,21 +376,29 @@ are also provided.
 
    Alias for the signed integer type (one of `numpy.byte`, `numpy.short`,
    `numpy.intc`, `numpy.int_`, `numpy.long` and `numpy.longlong`)
-   that is the same size as a pointer.
+   that is used as a default integer and for indexing.
 
-   Compatible with the C ``intptr_t``.
+   Compatible with the C ``Py_ssize_t``.
 
-   :Character code: ``'p'``
+   :Character code: ``'n'``
+
+   .. versionchanged:: 2.0
+      Before NumPy 2, this had the same size as a pointer.  In practice this
+      is almost always identical, but the character code ``'p'`` maps to the C
+      ``intptr_t``.  The character code ``'n'`` was added in NumPy 2.0.
 
 .. attribute:: uintp
 
-   Alias for the unsigned integer type (one of `numpy.ubyte`, `numpy.ushort`,
-   `numpy.uintc`, `numpy.uint`, `numpy.ulong` and `numpy.ulonglong`)
-   that is the same size as a pointer.
+   Alias for the unsigned integer type that is the same size as ``intp``.
 
-   Compatible with the C ``uintptr_t``.
+   Compatible with the C ``size_t``.
 
-   :Character code: ``'P'``
+   :Character code: ``'N'``
+
+   .. versionchanged:: 2.0
+      Before NumPy 2, this had the same size as a pointer.  In practice this
+      is almost always identical, but the character code ``'P'`` maps to the C
+      ``uintptr_t``.  The character code ``'N'`` was added in NumPy 2.0.
 
 .. autoclass:: numpy.float16
 

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -170,14 +170,26 @@ Enumerated types
 
     .. c:enumerator:: NPY_INTP
 
-        The enumeration value for a signed integer type which is the same
-        size as a (void \*) pointer. This is the type used by all
+        The enumeration value for a signed integer of type ``Py_ssize_t``
+        (same as ``ssize_t`` if defined). This is the type used by all
         arrays of indices.
+
+        .. versionchanged:: 2.0
+            Previously, this was the same as ``intptr_t`` (same size as a
+            pointer).  In practice, this is identical except on very niche
+            platforms.
+            You can use the ``'p'`` character code for the pointer meaning.
 
     .. c:enumerator:: NPY_UINTP
 
-        The enumeration value for an unsigned integer type which is the
-        same size as a (void \*) pointer.
+        The enumeration value for an unsigned integer type that is identical
+        to a ``size_t``.
+
+        .. versionchanged:: 2.0
+            Previously, this was the same as ``uintptr_t`` (same size as a
+            pointer).  In practice, this is identical except on very niche
+            platforms.
+            You can use the ``'P'`` character code for the pointer meaning.
 
     .. c:enumerator:: NPY_MASK
 
@@ -287,14 +299,20 @@ all platforms for all the kinds of numeric types. Commonly 8-, 16-,
 types are available.
 
 
-Integer that can hold a pointer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Further integer aliases
+~~~~~~~~~~~~~~~~~~~~~~~
 
-The constants **NPY_INTP** and **NPY_UINTP** refer to an
-enumerated integer type that is large enough to hold a pointer on the
-platform. Index arrays should always be converted to **NPY_INTP**
-, because the dimension of the array is of type npy_intp.
+The constants **NPY_INTP** and **NPY_UINTP** refer to an ``Py_ssize_t``
+and ``size_t``.
+Although in practice normally true, these types are strictly speaking not
+pointer sized and the character codes ``'p'`` and ``'P'`` can be used for
+pointer sized integers.
+(Before NumPy 2, ``intp`` was pointer size, but this almost never matched
+the actual use, which is the reason for the name.)
 
+Since NumPy 2, **NPY_DEFAULT_INT** is additionally defined.
+The value of the macro is runtime dependent:  Since NumPy 2, it maps to
+``NPY_INTP`` while on earlier versions it maps to ``NPY_LONG``.
 
 C-type names
 ------------

--- a/doc/source/user/basics.dispatch.rst
+++ b/doc/source/user/basics.dispatch.rst
@@ -23,6 +23,10 @@ example that has rather narrow utility but illustrates the concepts involved.
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
 ...     def __array__(self, dtype=None, copy=None):
+...         if copy is False:
+...             raise ValueError(
+...                 "`copy=False` isn't supported. A copy is always created."
+...             )
 ...         return self._i * np.eye(self._N, dtype=dtype)
 
 Our custom array can be instantiated like:
@@ -85,6 +89,10 @@ For this example we will only handle the method ``__call__``
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
 ...     def __array__(self, dtype=None, copy=None):
+...         if copy is False:
+...             raise ValueError(
+...                 "`copy=False` isn't supported. A copy is always created."
+...             )
 ...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':
@@ -136,6 +144,10 @@ conveniently by inheriting from the mixin
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
 ...     def __array__(self, dtype=None, copy=None):
+...         if copy is False:
+...             raise ValueError(
+...                 "`copy=False` isn't supported. A copy is always created."
+...             )
 ...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':
@@ -174,6 +186,10 @@ functions to our custom variants.
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
 ...     def __array__(self, dtype=None, copy=None):
+...         if copy is False:
+...             raise ValueError(
+...                 "`copy=False` isn't supported. A copy is always created."
+...             )
 ...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':

--- a/doc/source/user/basics.interoperability.rst
+++ b/doc/source/user/basics.interoperability.rst
@@ -113,6 +113,8 @@ We can check that ``arr`` and ``new_arr`` share the same data buffer:
  array([1000, 2, 3, 4])
 
 
+.. _dunder_array.interface:
+
 The ``__array__()`` method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -948,6 +948,8 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         the other requirements (``dtype``, ``order``, etc.).
         For ``False`` it raises a ``ValueError`` if a copy cannot be avoided.
         Default: ``None``.
+
+        .. versionadded:: 2.0.0
     ${ARRAY_FUNCTION_LIKE}
 
         .. versionadded:: 1.20.0

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2956,6 +2956,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array__',
     parameter. The method returns a new array for ``copy=True``, regardless of
     ``dtype`` parameter.
 
+    A more detailed explanation of the ``__array__`` interface
+    can be found in :ref:`dunder_array.interface`.
+
     """))
 
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2945,10 +2945,11 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array__',
     """
-    a.__array__([dtype], /, *, copy=None)
+    a.__array__([dtype], *, copy=None)
 
-    For ``dtype`` parameter it returns either a new reference to self if
-    ``dtype`` is not given or a new array of provided data type if ``dtype``
+    For ``dtype`` parameter it returns a new reference to self if
+    ``dtype`` is not given or it matches array's data type.
+    A new array of provided data type is returned if ``dtype``
     is different from the current data type of the array.
     For ``copy`` parameter it returns a new reference to self if
     ``copy=False`` or ``copy=None`` and copying isn't enforced by ``dtype``

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2459,8 +2459,9 @@ check_or_clear_and_warn_error_if_due_to_copy_kwarg(PyObject *kwnames)
         Py_DECREF(type);
         Py_DECREF(value);
         Py_XDECREF(traceback);
-        if (DEPRECATE("__array__ should implement the 'dtype' and "
-                      "'copy' keyword argument") < 0) {
+        if (DEPRECATE("__array__ implementation doesn't accept a copy keyword, "
+                      "so passing copy=False failed. __array__ must implement "
+                      "'dtype' and 'copy' keyword arguments.") < 0) {
             return -1;
         }
         return 0;


### PR DESCRIPTION
Backports of #26239,  #26241,  #26245

* DOC: Update `__array__` `copy` keyword docs (26245)
* DOC: Fixup intp/uintp documentation for ssize_t/size_t changes  (26241)
* DOC: add versionadded for copy keyword in np.asarray docstring  (26239)
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
