### PR TITLE
ENH: introduce a notion of "compatible" stringdtype instances

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -317,24 +317,16 @@ stringdtype_setitem(PyArray_StringDTypeObject *descr, PyObject *obj, char **data
 {
     npy_packed_static_string *sdata = (npy_packed_static_string *)dataptr;
 
-    int na_cmp = 0;
-
     // borrow reference
     PyObject *na_object = descr->na_object;
 
-    // Note there are two different na_object != NULL checks here.
-    //
-    // Do not refactor this!
-    //
     // We need the result of the comparison after acquiring the allocator, but
     // cannot use functions requiring the GIL when the allocator is acquired,
     // so we do the comparison before acquiring the allocator.
 
-    if (na_object != NULL) {
-        na_cmp = na_eq_cmp(obj, na_object);
-        if (na_cmp == -1) {
-            return -1;
-        }
+    int na_cmp = na_eq_cmp(obj, na_object);
+    if (na_cmp == -1) {
+        return -1;
     }
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -185,7 +185,7 @@ _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona)
     return na_eq_cmp(sna, ona);
 }
 
-// Currently this can only return 1 or -1, the latter indicating that the
+// Currently this can only return 0 or -1, the latter indicating that the
 // error indicator is set. Pass in out_na if you want to figure out which
 // na is valid.
 NPY_NO_EXPORT int
@@ -206,7 +206,7 @@ stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na) {
     if (out_na != NULL) {
         *out_na = na1 ? na1 : na2;
     }
-    return 1;
+    return 0;
 }
 
 /*

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -144,7 +144,7 @@ fail:
     return NULL;
 }
 
-NPY_NO_EXPORT int
+static int
 na_eq_cmp(PyObject *a, PyObject *b) {
     if (a == b) {
         // catches None and other singletons like Pandas.NA
@@ -185,39 +185,28 @@ _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona)
     return na_eq_cmp(sna, ona);
 }
 
-// currently this can only return 1 or -1, the latter indicating that the
-// error indicator is set
+// Currently this can only return 1 or -1, the latter indicating that the
+// error indicator is set. Pass in out_na if you want to figure out which
+// na is valid.
 NPY_NO_EXPORT int
-stringdtype_compatible_na(PyObject *na1, PyObject *na2) {
-    if ((na1 == NULL) != (na2 == NULL)) {
-        return 1;
-    }
+stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na) {
+    if ((na1 != NULL) && (na2 != NULL)) {
+        int na_eq = na_eq_cmp(na1, na2);
 
-    int na_eq = na_eq_cmp(na1, na2);
-
-    if (na_eq < 0) {
-        return -1;
+        if (na_eq < 0) {
+            return -1;
+        }
+        else if (na_eq == 0) {
+            PyErr_Format(PyExc_TypeError,
+                         "Cannot find a compatible null string value for "
+                         "null strings '%R' and '%R'", na1, na2);
+            return -1;
+        }
     }
-    else if (na_eq == 0) {
-        PyErr_Format(PyExc_TypeError,
-                     "Cannot find a compatible null string value for "
-                     "null strings '%R' and '%R'", na1, na2);
-        return -1;
+    if (out_na != NULL) {
+        *out_na = na1 ? na1 : na2;
     }
     return 1;
-}
-
-NPY_NO_EXPORT int
-stringdtype_compatible_settings(PyObject *na1, PyObject *na2, PyObject **out_na,
-                                int coerce1, int coerce2, int *out_coerce) {
-    int compatible = stringdtype_compatible_na(na1, na2);
-    if (compatible == -1) {
-        return -1;
-    }
-    *out_na = (na1 ? na1 : na2);
-    *out_coerce = (coerce1 && coerce2);
-
-    return 0;
 }
 
 /*
@@ -228,12 +217,10 @@ stringdtype_compatible_settings(PyObject *na1, PyObject *na2, PyObject **out_na,
 static PyArray_StringDTypeObject *
 common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dtype2)
 {
-    int out_coerce = 1;
     PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                dtype1->na_object, dtype2->na_object, &out_na_object,
-                dtype1->coerce, dtype2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                dtype1->na_object, dtype2->na_object, &out_na_object) == -1) {
         PyErr_Format(PyExc_TypeError,
                      "Cannot find common instance for incompatible dtypes "
                      "'%R' and '%R'", (PyObject *)dtype1, (PyObject *)dtype2);
@@ -241,7 +228,7 @@ common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dt
     }
 
     return (PyArray_StringDTypeObject *)new_stringdtype_instance(
-            out_na_object, out_coerce);
+            out_na_object, dtype1->coerce && dtype1->coerce);
 }
 
 /*

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -49,8 +49,12 @@ stringdtype_finalize_descr(PyArray_Descr *dtype);
 NPY_NO_EXPORT int
 _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona);
 
-NPY_NO_EXPORT PyArray_StringDTypeObject *
-common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dtype2);
+NPY_NO_EXPORT int
+stringdtype_compatible_settings(PyObject *na1, PyObject *na2, PyObject **out_na,
+                                int coerce1, int coerce2, int *out_coerce);
+
+NPY_NO_EXPORT int
+stringdtype_compatible_na(PyObject *na1, PyObject *na2);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -49,6 +49,9 @@ stringdtype_finalize_descr(PyArray_Descr *dtype);
 NPY_NO_EXPORT int
 _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona);
 
+NPY_NO_EXPORT PyArray_StringDTypeObject *
+common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dtype2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -50,11 +50,7 @@ NPY_NO_EXPORT int
 _eq_comparison(int scoerce, int ocoerce, PyObject *sna, PyObject *ona);
 
 NPY_NO_EXPORT int
-stringdtype_compatible_settings(PyObject *na1, PyObject *na2, PyObject **out_na,
-                                int coerce1, int coerce2, int *out_coerce);
-
-NPY_NO_EXPORT int
-stringdtype_compatible_na(PyObject *na1, PyObject *na2);
+stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -246,20 +246,9 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
+    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
 
-    // _eq_comparison has a short-circuit pointer comparison fast path,
-    // so no need to check here
-    int eq_res = _eq_comparison(descr1->coerce, descr2->coerce,
-                                descr1->na_object, descr2->na_object);
-
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can only do binary operations with equal StringDType "
-                        "instances.");
+    if (common_descr == NULL) {
         return (NPY_CASTING)-1;
     }
 
@@ -272,8 +261,7 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                ((PyArray_StringDTypeObject *)given_descrs[1])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[1])->coerce);
+                common_descr->na_object, common_descr->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -562,6 +550,14 @@ string_comparison_resolve_descriptors(
         PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
+    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
+    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
+    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+
+    if (common_descr == NULL) {
+        return (NPY_CASTING)-1;
+    }
+
     Py_INCREF(given_descrs[0]);
     loop_descrs[0] = given_descrs[0];
     Py_INCREF(given_descrs[1]);
@@ -788,20 +784,9 @@ string_findlike_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
+    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
 
-    // _eq_comparison has a short-circuit pointer comparison fast path,
-    // so no need to check here
-    int eq_res = _eq_comparison(descr1->coerce, descr2->coerce,
-                                descr1->na_object, descr2->na_object);
-
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can only do binary operations with equal StringDType "
-                        "instances.");
+    if (common_descr == NULL) {
         return (NPY_CASTING)-1;
     }
 
@@ -849,20 +834,9 @@ string_startswith_endswith_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
+    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
 
-    // _eq_comparison has a short-circuit pointer comparison fast path, so
-    // no need to do it here
-    int eq_res = _eq_comparison(descr1->coerce, descr2->coerce,
-                                descr1->na_object, descr2->na_object);
-
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can only do binary operations with equal StringDType "
-                        "instances.");
+    if (common_descr == NULL) {
         return (NPY_CASTING)-1;
     }
 
@@ -1060,46 +1034,6 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
     return 0;
 }
-
-static NPY_CASTING
-strip_chars_resolve_descriptors(
-        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
-        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
-        PyArray_Descr *const given_descrs[],
-        PyArray_Descr *loop_descrs[],
-        npy_intp *NPY_UNUSED(view_offset))
-{
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
-
-    // we don't actually care about the null behavior of the second argument,
-    // so no need to check if the first two descrs are equal like in
-    // binary_resolve_descriptors
-
-    Py_INCREF(given_descrs[1]);
-    loop_descrs[1] = given_descrs[1];
-
-    PyArray_Descr *out_descr = NULL;
-
-    if (given_descrs[2] == NULL) {
-        out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                ((PyArray_StringDTypeObject *)given_descrs[0])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce);
-
-        if (out_descr == NULL) {
-            return (NPY_CASTING)-1;
-        }
-    }
-    else {
-        Py_INCREF(given_descrs[2]);
-        out_descr = given_descrs[2];
-    }
-
-    loop_descrs[2] = out_descr;
-
-    return NPY_NO_CASTING;
-}
-
 
 NPY_NO_EXPORT int
 string_lrstrip_chars_strided_loop(
@@ -1309,21 +1243,10 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
     PyArray_StringDTypeObject *descr3 = (PyArray_StringDTypeObject *)given_descrs[2];
 
-    // _eq_comparison has a short-circuit pointer comparison fast path, so
-    // no need to do it here
-    int eq_res = (_eq_comparison(descr1->coerce, descr2->coerce,
-                                 descr1->na_object, descr2->na_object) &&
-                  _eq_comparison(descr1->coerce, descr3->coerce,
-                                 descr1->na_object, descr3->na_object));
+    PyArray_StringDTypeObject *common_descr = common_instance(
+            common_instance(descr1, descr2), descr3);
 
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "String replace is only supported with equal StringDType "
-                        "instances.");
+    if (common_descr == NULL) {
         return (NPY_CASTING)-1;
     }
 
@@ -1340,8 +1263,7 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 
     if (given_descrs[4] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                ((PyArray_StringDTypeObject *)given_descrs[0])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[0])->coerce);
+                common_descr->na_object, common_descr->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1588,18 +1510,9 @@ center_ljust_rjust_resolve_descriptors(
 {
     PyArray_StringDTypeObject *input_descr = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *fill_descr = (PyArray_StringDTypeObject *)given_descrs[2];
+    PyArray_StringDTypeObject *common_descr = common_instance(input_descr, fill_descr);
 
-    int eq_res = _eq_comparison(input_descr->coerce, fill_descr->coerce,
-                                input_descr->na_object, fill_descr->na_object);
-
-    if (eq_res < 0) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (eq_res != 1) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can only do text justification operations with equal"
-                        "StringDType instances.");
+    if (common_descr == NULL) {
         return (NPY_CASTING)-1;
     }
 
@@ -1614,8 +1527,7 @@ center_ljust_rjust_resolve_descriptors(
 
     if (given_descrs[3] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                ((PyArray_StringDTypeObject *)given_descrs[1])->na_object,
-                ((PyArray_StringDTypeObject *)given_descrs[1])->coerce);
+                common_descr->na_object, common_descr->coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1888,6 +1800,7 @@ fail:
     return -1;
 }
 
+
 static NPY_CASTING
 string_partition_resolve_descriptors(
         PyArrayMethodObject *self,
@@ -1901,14 +1814,23 @@ string_partition_resolve_descriptors(
                      "currently support the 'out' keyword", self->name);
         return (NPY_CASTING)-1;
     }
-    for (int i=0; i<2; i++) {
-        Py_INCREF(given_descrs[i]);
-        loop_descrs[i] = given_descrs[i];
+
+    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
+    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
+    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+
+    if (common_descr == NULL) {
+        return (NPY_CASTING)-1;
     }
-    PyArray_StringDTypeObject *adescr = (PyArray_StringDTypeObject *)given_descrs[0];
+
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+    Py_INCREF(given_descrs[1]);
+    loop_descrs[1] = given_descrs[1];
+
     for (int i=2; i<5; i++) {
         loop_descrs[i] = (PyArray_Descr *)new_stringdtype_instance(
-                adescr->na_object, adescr->coerce);
+                common_descr->na_object, common_descr->coerce);
         if (loop_descrs[i] == NULL) {
             return (NPY_CASTING)-1;
         }
@@ -2655,7 +2577,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     for (int i=0; i<3; i++) {
         if (init_ufunc(umath, strip_chars_names[i], strip_chars_dtypes,
-                       &strip_chars_resolve_descriptors,
+                       &binary_resolve_descriptors,
                        &string_lrstrip_chars_strided_loop,
                        2, 1, NPY_NO_CASTING, (NPY_ARRAYMETHOD_FLAGS) 0,
                        &strip_types[i]) < 0) {

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -246,12 +246,11 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = 1;
+    int out_coerce = descr1->coerce && descr1->coerce;
     PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                descr1->na_object, descr2->na_object, &out_na_object,
-                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -556,7 +555,7 @@ string_comparison_resolve_descriptors(
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
 
-    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object) == -1) {
+    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -786,12 +785,8 @@ string_findlike_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = 1;
-    PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                descr1->na_object, descr2->na_object, &out_na_object,
-                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -839,12 +834,8 @@ string_startswith_endswith_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = 1;
-    PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                descr1->na_object, descr2->na_object, &out_na_object,
-                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1250,18 +1241,16 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
     PyArray_StringDTypeObject *descr3 = (PyArray_StringDTypeObject *)given_descrs[2];
-    int out_coerce = 1;
+    int out_coerce = descr1->coerce && descr2->coerce && descr3->coerce;
     PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                descr1->na_object, descr2->na_object, &out_na_object,
-                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 
-    if (stringdtype_compatible_settings(
-                out_na_object, descr3->na_object, &out_na_object,
-                out_coerce, descr3->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                out_na_object, descr3->na_object, &out_na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1525,12 +1514,11 @@ center_ljust_rjust_resolve_descriptors(
 {
     PyArray_StringDTypeObject *input_descr = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *fill_descr = (PyArray_StringDTypeObject *)given_descrs[2];
-    int out_coerce = 1;
+    int out_coerce = input_descr->coerce && fill_descr->coerce;
     PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                input_descr->na_object, fill_descr->na_object, &out_na_object,
-                input_descr->coerce, fill_descr->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                input_descr->na_object, fill_descr->na_object, &out_na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1835,12 +1823,11 @@ string_partition_resolve_descriptors(
 
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = 1;
+    int out_coerce = descr1->coerce && descr2->coerce;
     PyObject *out_na_object = NULL;
 
-    if (stringdtype_compatible_settings(
-                descr1->na_object, descr2->na_object, &out_na_object,
-                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+    if (stringdtype_compatible_na(
+                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -246,9 +246,12 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                descr1->na_object, descr2->na_object, &out_na_object,
+                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -261,7 +264,7 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 
     if (given_descrs[2] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                common_descr->na_object, common_descr->coerce);
+                out_na_object, out_coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -552,9 +555,8 @@ string_comparison_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -784,9 +786,12 @@ string_findlike_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                descr1->na_object, descr2->na_object, &out_na_object,
+                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -834,9 +839,12 @@ string_startswith_endswith_resolve_descriptors(
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                descr1->na_object, descr2->na_object, &out_na_object,
+                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1242,11 +1250,18 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
     PyArray_StringDTypeObject *descr3 = (PyArray_StringDTypeObject *)given_descrs[2];
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    PyArray_StringDTypeObject *common_descr = common_instance(
-            common_instance(descr1, descr2), descr3);
+    if (stringdtype_compatible_settings(
+                descr1->na_object, descr2->na_object, &out_na_object,
+                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
+        return (NPY_CASTING)-1;
+    }
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                out_na_object, descr3->na_object, &out_na_object,
+                out_coerce, descr3->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1263,7 +1278,7 @@ replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 
     if (given_descrs[4] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                common_descr->na_object, common_descr->coerce);
+                out_na_object, out_coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1510,9 +1525,12 @@ center_ljust_rjust_resolve_descriptors(
 {
     PyArray_StringDTypeObject *input_descr = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *fill_descr = (PyArray_StringDTypeObject *)given_descrs[2];
-    PyArray_StringDTypeObject *common_descr = common_instance(input_descr, fill_descr);
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                input_descr->na_object, fill_descr->na_object, &out_na_object,
+                input_descr->coerce, fill_descr->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1527,7 +1545,7 @@ center_ljust_rjust_resolve_descriptors(
 
     if (given_descrs[3] == NULL) {
         out_descr = (PyArray_Descr *)new_stringdtype_instance(
-                common_descr->na_object, common_descr->coerce);
+                out_na_object, out_coerce);
 
         if (out_descr == NULL) {
             return (NPY_CASTING)-1;
@@ -1817,9 +1835,12 @@ string_partition_resolve_descriptors(
 
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *common_descr = common_instance(descr1, descr2);
+    int out_coerce = 1;
+    PyObject *out_na_object = NULL;
 
-    if (common_descr == NULL) {
+    if (stringdtype_compatible_settings(
+                descr1->na_object, descr2->na_object, &out_na_object,
+                descr1->coerce, descr2->coerce, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1830,7 +1851,7 @@ string_partition_resolve_descriptors(
 
     for (int i=2; i<5; i++) {
         loop_descrs[i] = (PyArray_Descr *)new_stringdtype_instance(
-                common_descr->na_object, common_descr->coerce);
+                out_na_object, out_coerce);
         if (loop_descrs[i] == NULL) {
             return (NPY_CASTING)-1;
         }

--- a/numpy/_core/tests/_natype.py
+++ b/numpy/_core/tests/_natype.py
@@ -16,7 +16,7 @@ def _create_binary_propagating_op(name, is_divmod=False):
             other is pd_NA
             or isinstance(other, (str, bytes))
             or isinstance(other, (numbers.Number, np.bool))
-            or util.is_array(other)
+            or isinstance(other, np.ndarray)
             and not other.shape
         ):
             # Need the other.shape clause to handle NumPy scalars,
@@ -27,7 +27,7 @@ def _create_binary_propagating_op(name, is_divmod=False):
             else:
                 return pd_NA
 
-        elif util.is_array(other):
+        elif isinstance(other, np.ndarray):
             out = np.empty(other.shape, dtype=object)
             out[:] = pd_NA
 
@@ -36,14 +36,14 @@ def _create_binary_propagating_op(name, is_divmod=False):
             else:
                 return out
 
-        elif is_cmp and isinstance(other, (date, time, timedelta)):
+        elif is_cmp and isinstance(other, (np.datetime64, np.timedelta64)):
             return pd_NA
 
-        elif isinstance(other, date):
+        elif isinstance(other, np.datetime64):
             if name in ["__sub__", "__rsub__"]:
                 return pd_NA
 
-        elif isinstance(other, timedelta):
+        elif isinstance(other, np.timedelta64):
             if name in ["__sub__", "__rsub__", "__add__", "__radd__"]:
                 return pd_NA
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1340,8 +1340,9 @@ def test_unset_na_coercion():
     # a dtype instance with an unset na object is compatible
     # with a dtype that has one set
 
-    # this tests uses the "add" ufunc but all ufuncs that accept more
-    # than one string argument and produce a string should behave this way
+    # this test uses the "add" and "equal" ufunc but all ufuncs that
+    # accept more than one string argument and produce a string should
+    # behave this way
     # TODO: generalize to more ufuncs
     inp = ["hello", "world"]
     arr = np.array(inp, dtype=StringDType(na_object=None))

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -228,19 +228,16 @@ def test_self_casts(dtype, dtype2, strings):
     if hasattr(dtype, "na_object") and hasattr(dtype2, "na_object"):
         na1 = dtype.na_object
         na2 = dtype2.na_object
-        if na1 is na2:
-            assert_array_equal(arr[:-1], newarr[:-1])
-        else:
-            # comparisons between arrays with distinct NA objects
-            # aren't allowed
-            if ((na1 is pd_NA or na2 is pd_NA or
-                 (na1 != na2 and not ((na1 != na1) and (na2 != na2))))):
-                with pytest.raises(TypeError):
-                    arr[:-1] == newarr[:-1]
-            else:
-                assert_array_equal(arr[:-1], newarr[:-1])
-    else:
-        assert_array_equal(arr[:-1], newarr[:-1])
+        if ((na1 is not na2 and
+             # check for pd_NA first because bool(pd_NA) is an error
+             ((na1 is pd_NA or na2 is pd_NA) or
+              # the second check is a NaN check, spelled this way
+              # to avoid errors from math.isnan and np.isnan
+              (na1 != na2 and not (na1 != na1 and na2 != na2))))):
+            with pytest.raises(TypeError):
+                arr[:-1] == newarr[:-1]
+            return
+    assert_array_equal(arr[:-1], newarr[:-1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a followup for #26198, it accomplishes the same thing I wanted in that PR.

See the change to the NEP for the details and explanation. 

In short, this relaxes the error checking in stringdtype ufuncs and changes the `common_instance` logic, allowing operations between distinct stringdtype instances as long as the result isn't ambiguous. This makes it much simpler to work with non-default stringdtype instances, since users don't need to zealously convert all ufunc arguments to the same dtype before passing them to numpy in the most common cases like passing a python string as an argument.

For all operations that take more than one string argument, we now only raise an error if the inputs have distinct na_object settings. We allow distinct `coerce` settings and just choose `coerce=False` for string outputs if any input dtype had `coerce=False` set.

Also added a test. There was one spot in the existing tests where we were doing equality comparisons between arrays with distinct na_object settings, so I updated that test to account for the behavior change.

Ideally we could get this merged in time to be included with 2.0 RC2. I'd like to have this in NumPy 2.0 because it will eliminate a lot of boilerplate argument sanitizing in pandas when it called numpy ufuncs. I totally understand if this is coming too late in the game though.