### PR TITLE
MAINT: Fix some typos

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3869,7 +3869,7 @@ the C-API is needed then some additional steps must be taken.
     .. code-block:: c
 
         #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
-        #include numpy/arrayobject.h
+        #include <numpy/arrayobject.h>
 
     On the other hand, coolhelper.c would contain at the top:
 
@@ -3877,7 +3877,7 @@ the C-API is needed then some additional steps must be taken.
 
         #define NO_IMPORT_ARRAY
         #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
-        #include numpy/arrayobject.h
+        #include <numpy/arrayobject.h>
 
     You can also put the common two last lines into an extension-local
     header file as long as you make sure that NO_IMPORT_ARRAY is

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -46,7 +46,7 @@
   #error "The NumPy 2 compat header requires `import_array()` for which "  \
          "the `ndarraytypes.h` header include is not sufficient.  Please "  \
          "include it after `numpy/ndarrayobject.h` or similar.\n"  \
-         "To simplify includsion, you may use `PyArray_ImportNumPy()` " \
+         "To simplify inclusion, you may use `PyArray_ImportNumPy()` " \
          "which is defined in the compat header and is lightweight (can be)."
 #endif
 


### PR DESCRIPTION
Backport of #26263 and #26264

1. MAINT: fix typo in `numpy_2_compat.h`

2. MAINT: fix typo in documentatin #include example

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
