### PR TITLE
MAINT: Update URL in nep 0014 - domain change

### DIFF
--- a/doc/neps/nep-0014-dropping-python2.7-proposal.rst
+++ b/doc/neps/nep-0014-dropping-python2.7-proposal.rst
@@ -52,6 +52,6 @@ to Python3 only, see the python3-statement_.
 For more information on porting your code to run on Python 3, see the
 python3-howto_.
 
-.. _python3-statement: https://python3statement.org/
+.. _python3-statement: https://python3statement.github.io/
 
 .. _python3-howto: https://docs.python.org/3/howto/pyporting.html


### PR DESCRIPTION
See https://github.com/python3statement/python3statement.github.io/issues/292

To avoid having to pay for the domain indefinitely the devs are now redirecting toward github pages.

Be proactive and start switching domains.