### PR TITLE
STY: fixes Pylint `C0209` Errors (uses f-strings)

### DIFF
--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -12,7 +12,7 @@ class Records(Benchmark):
         self.formats_str = ','.join(self.formats)
         self.dtype_ = np.dtype(
             [
-                ('field_{}'.format(i), self.l50.dtype.str)
+                (f'field_{i}', self.l50.dtype.str)
                 for i in range(self.fields_number)
             ]
         )

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -506,10 +506,11 @@ class ArgPack:
         self.args = args
         self.kwargs = kwargs
     def __repr__(self):
-        return '({})'.format(', '.join(
+        joined_elements = ', '.join(
             [repr(a) for a in self.args] +
-            ['{}={}'.format(k, repr(v)) for k, v in self.kwargs.items()]
-        ))
+            [f'{k}={repr(v)}' for k, v in self.kwargs.items()]
+        )
+        return f'({joined_elements})'
 
 
 class ArgParsing(Benchmark):

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@
 # Use explicit "version_info" indexing since make cannot handle colon characters, and
 # evaluate it now to allow easier debugging when printing the variable
 
-PYVER:=$(shell python3 -c 'from sys import version_info as v; print(f"{v[0]}.{v[1]}")')
+PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".format(v[0], v[1]))')
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@
 # Use explicit "version_info" indexing since make cannot handle colon characters, and
 # evaluate it now to allow easier debugging when printing the variable
 
-PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".format(v[0], v[1]))')
+PYVER:=$(shell python3 -c 'from sys import version_info as v; print(f"{v[0]}.{v[1]}")')
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -526,7 +526,7 @@ multiplication::
         def __init__(self, value):
             self.value = value
         def __repr__(self):
-            return "MyObject({!r})".format(self.value)
+            return f"MyObject({self.value!r})"
         def __mul__(self, other):
             return MyObject(1234)
         def __rmul__(self, other):

--- a/doc/source/reference/random/bit_generators/index.rst
+++ b/doc/source/reference/random/bit_generators/index.rst
@@ -91,7 +91,7 @@ user, which is up to you.
     # If the user did not provide a seed, it should return `None`.
     seed = get_user_seed()
     ss = SeedSequence(seed)
-    print('seed = {}'.format(ss.entropy))
+    print(f'seed = {ss.entropy}')
     bg = PCG64(ss)
 
 .. end_block

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -480,7 +480,7 @@ else:
                             "\nIf you compiled yourself, more information is available at:"
                             "\nhttps://numpy.org/devdocs/building/index.html"
                             "\nOtherwise report this to the vendor "
-                            "that provided NumPy.\n\n{}\n".format(error_message))
+                            f"that provided NumPy.\n\n{error_message}\n")
                         raise RuntimeError(msg)
                 del _wn
             del w

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -407,8 +407,8 @@ else:
             import numpy.char as char
             return char.chararray
 
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute "
+                             f"{attr!r}")
 
     def __dir__():
         public_symbols = (

--- a/numpy/_core/_dtype.py
+++ b/numpy/_core/_dtype.py
@@ -289,16 +289,13 @@ def _struct_list_str(dtype):
 
         item = "("
         if title is not None:
-            item += "({!r}, {!r}), ".format(title, name)
+            item += f"({title!r}, {name!r}), "
         else:
-            item += "{!r}, ".format(name)
+            item += f"{name!r}, "
         # Special case subarray handling here
         if fld_dtype.subdtype is not None:
             base, shape = fld_dtype.subdtype
-            item += "{}, {}".format(
-                _construction_repr(base, short=True),
-                shape
-            )
+            item += f"{_construction_repr(base, short=True)}, {shape}"
         else:
             item += _construction_repr(fld_dtype, short=True)
 
@@ -320,17 +317,14 @@ def _struct_str(dtype, include_align):
 
     # If the data type isn't the default, void, show it
     if dtype.type != np.void:
-        return "({t.__module__}.{t.__name__}, {f})".format(t=dtype.type, f=sub)
+        return f"({dtype.type.__module__}.{dtype.type.__name__}, {sub})"
     else:
         return sub
 
 
 def _subarray_str(dtype):
     base, shape = dtype.subdtype
-    return "({}, {})".format(
-        _construction_repr(base, short=True),
-        shape
-    )
+    return f"({_construction_repr(base, short=True)}, {shape})"
 
 
 def _name_includes_bit_suffix(dtype):

--- a/numpy/_core/_dtype.py
+++ b/numpy/_core/_dtype.py
@@ -46,7 +46,7 @@ def __repr__(dtype):
     arg_str = _construction_repr(dtype, include_align=False)
     if dtype.isalignedstruct:
         arg_str = arg_str + ", align=True"
-    return "dtype({})".format(arg_str)
+    return f"dtype({arg_str})"
 
 
 def _unpack_field(dtype, offset, title=None):
@@ -187,9 +187,9 @@ def _datetime_metadata_str(dtype):
     if unit == 'generic':
         return ''
     elif count == 1:
-        return '[{}]'.format(unit)
+        return f'[{unit}]'
     else:
-        return '[{}{}]'.format(count, unit)
+        return f'[{count}{unit}]'
 
 
 def _struct_dict_str(dtype, includealignedflag):
@@ -367,7 +367,7 @@ def _name_get(dtype):
 
     # append bit counts
     if _name_includes_bit_suffix(dtype):
-        name += "{}".format(dtype.itemsize * 8)
+        name += f"{dtype.itemsize * 8}"
 
     # append metadata to datetimes
     if dtype.type in (np.datetime64, np.timedelta64):

--- a/numpy/_core/_dtype_ctypes.py
+++ b/numpy/_core/_dtype_ctypes.py
@@ -117,4 +117,4 @@ def dtype_from_ctypes_type(t):
         return _from_ctypes_scalar(t)
     else:
         raise NotImplementedError(
-            "Unknown ctypes type {}".format(t.__name__))
+            f"Unknown ctypes type {t.__name__}")

--- a/numpy/_core/_exceptions.py
+++ b/numpy/_core/_exceptions.py
@@ -86,12 +86,10 @@ class _UFuncInputCastingError(_UFuncCastingError):
 
     def __str__(self):
         # only show the number if more than one input exists
-        i_str = "{} ".format(self.in_i) if self.ufunc.nin != 1 else ""
+        i_str = f"{self.in_i} " if self.ufunc.nin != 1 else ""
         return (
-            "Cannot cast ufunc {!r} input {}from {!r} to {!r} with casting "
-            "rule {!r}"
-        ).format(
-            self.ufunc.__name__, i_str, self.from_, self.to, self.casting
+            f"Cannot cast ufunc {self.ufunc.__name__!r} input {i_str}from "
+            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}"
         )
 
 
@@ -104,12 +102,10 @@ class _UFuncOutputCastingError(_UFuncCastingError):
 
     def __str__(self):
         # only show the number if more than one output exists
-        i_str = "{} ".format(self.out_i) if self.ufunc.nout != 1 else ""
+        i_str = f"{self.out_i} " if self.ufunc.nout != 1 else ""
         return (
-            "Cannot cast ufunc {!r} output {}from {!r} to {!r} with casting "
-            "rule {!r}"
-        ).format(
-            self.ufunc.__name__, i_str, self.from_, self.to, self.casting
+            f"Cannot cast ufunc {self.ufunc.__name__!r} output {i_str}from "
+            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}"
         )
 
 
@@ -156,17 +152,17 @@ class _ArrayMemoryError(MemoryError):
         # format with a sensible number of digits
         if unit_i == 0:
             # no decimal point on bytes
-            return '{:.0f} {}'.format(n_units, unit_name)
+            return f'{n_units:.0f} {unit_name}'
         elif round(n_units) < 1000:
             # 3 significant figures, if none are dropped to the left of the .
-            return '{:#.3g} {}'.format(n_units, unit_name)
+            return f'{n_units:#.3g} {unit_name}'
         else:
             # just give all the digits otherwise
-            return '{:#.0f} {}'.format(n_units, unit_name)
+            return f'{n_units:#.0f} {unit_name}'
 
     def __str__(self):
         size_str = self._size_to_string(self._total_size)
         return (
-            "Unable to allocate {} for an array with shape {} and data type {}"
-            .format(size_str, self.shape, self.dtype)
+            f"Unable to allocate {size_str} for an array with "
+            f"shape {self.shape} and data type {self.dtype}"
         )

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -869,14 +869,14 @@ def _lcm(a, b):
 
 def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
     """ Format the error message for when __array_ufunc__ gives up. """
-    args_string = ', '.join(['{!r}'.format(arg) for arg in inputs] +
-                            ['{}={!r}'.format(k, v)
-                             for k, v in kwargs.items()])
+    args_string = ', '.join(
+        [f"{arg!r}" for arg in inputs] +
+        [f"{k}={v!r}" for k, v in kwargs.items()])
     args = inputs + kwargs.get('out', ())
     types_string = ', '.join(repr(type(arg).__name__) for arg in args)
-    return ('operand type(s) all returned NotImplemented from '
-            '__array_ufunc__({!r}, {!r}, {}): {}'
-            .format(ufunc, method, args_string, types_string))
+    return (
+        'operand type(s) all returned NotImplemented from __array_ufunc__'
+        f'({ufunc!r}, {method!r}, {args_string}): {types_string}')
 
 
 def array_function_errmsg_formatter(public_api, types):
@@ -905,11 +905,9 @@ def _ufunc_doc_signature_formatter(ufunc):
     elif ufunc.nout == 1:
         out_args = ', /, out=None'
     else:
-        out_args = '[, {positional}], / [, out={default}]'.format(
-            positional=', '.join(
-                f'out{i+1}' for i in range(ufunc.nout)),
-            default=repr((None,)*ufunc.nout)
-        )
+        positional = ', '.join(
+                f'out{i+1}' for i in range(ufunc.nout))
+        out_args = f'[, {positional}], / [, out={repr((None,)*ufunc.nout)}]'
 
     # keyword only args depend on whether this is a gufunc
     kwargs = (
@@ -926,12 +924,7 @@ def _ufunc_doc_signature_formatter(ufunc):
         kwargs += "[, signature, axes, axis]"
 
     # join all the parts together
-    return '{name}({in_args}{out_args}, *{kwargs})'.format(
-        name=ufunc.__name__,
-        in_args=in_args,
-        out_args=out_args,
-        kwargs=kwargs
-    )
+    return f'{ufunc.__name__}({in_args}{out_args}, *{kwargs})'
 
 
 def npy_ctypes_check(cls):

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -882,8 +882,8 @@ def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
 def array_function_errmsg_formatter(public_api, types):
     """ Format the error message for when __array_ufunc__ gives up. """
     func_name = f'{public_api.__module__}.{public_api.__name__}'
-    return (f"no implementation found for '{func_name}' on types that implement "
-            f'__array_function__: {list(types)}')
+    return (f"no implementation found for '{func_name}' on types "
+            f"that implement __array_function__: {list(types)}")
 
 
 def _ufunc_doc_signature_formatter(ufunc):
@@ -907,7 +907,7 @@ def _ufunc_doc_signature_formatter(ufunc):
     else:
         out_args = '[, {positional}], / [, out={default}]'.format(
             positional=', '.join(
-                'out{}'.format(i+1) for i in range(ufunc.nout)),
+                f'out{i+1}' for i in range(ufunc.nout)),
             default=repr((None,)*ufunc.nout)
         )
 

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -881,9 +881,9 @@ def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
 
 def array_function_errmsg_formatter(public_api, types):
     """ Format the error message for when __array_ufunc__ gives up. """
-    func_name = '{}.{}'.format(public_api.__module__, public_api.__name__)
-    return ("no implementation found for '{}' on types that implement "
-            '__array_function__: {}'.format(func_name, list(types)))
+    func_name = f'{public_api.__module__}.{public_api.__name__}'
+    return (f"no implementation found for '{func_name}' on types that implement "
+            f'__array_function__: {list(types)}')
 
 
 def _ufunc_doc_signature_formatter(ufunc):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -77,7 +77,7 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     modes = ['fixed', 'unique', 'maxprec', 'maxprec_equal']
     if floatmode not in modes + [None]:
         raise ValueError("floatmode option must be one of " +
-                         ", ".join('"{}"'.format(m) for m in modes))
+                         ", ".join(f'"{m}"' for m in modes))
 
     if sign not in [None, '-', '+', ' ']:
         raise ValueError("sign option must be one of ' ', '+', or '-'")
@@ -926,7 +926,7 @@ def _none_or_positive_arg(x, name):
     if x is None:
         return -1
     if x < 0:
-        raise ValueError("{} must be >= 0".format(name))
+        raise ValueError(f"{name} must be >= 0")
     return x
 
 class FloatingFormat:
@@ -1323,7 +1323,7 @@ class _TimelikeFormat:
         if len(non_nat) < data.size:
             # data contains a NaT
             max_str_len = max(max_str_len, 5)
-        self._format = '%{}s'.format(max_str_len)
+        self._format = f'%{max_str_len}s'
         self._nat = "'NaT'".rjust(max_str_len)
 
     def _format_non_nat(self, x):
@@ -1432,9 +1432,9 @@ class StructuredVoidFormat:
             for field, format_function in zip(x, self.format_functions)
         ]
         if len(str_fields) == 1:
-            return "({},)".format(str_fields[0])
+            return f"({str_fields[0]},)".format(str_fields[0])
         else:
-            return "({})".format(", ".join(str_fields))
+            return f"({', '.join(str_fields)})"
 
 
 def _void_scalar_to_string(x, is_repr=True):
@@ -1567,7 +1567,7 @@ def _array_repr_implementation(
     if skipdtype:
         return arr_str
 
-    dtype_str = "dtype={})".format(dtype_short_repr(arr.dtype))
+    dtype_str = f"dtype={dtype_short_repr(arr.dtype)})"
 
     # compute whether we should put dtype on a new line: Do so if adding the
     # dtype would extend the last line past max_line_width.

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1434,7 +1434,8 @@ class StructuredVoidFormat:
         if len(str_fields) == 1:
             return f"({str_fields[0]},)"
         else:
-            return f"({', '.join(str_fields)})"
+            all_str_fields = ', '.join(str_fields)
+            return f"({all_str_fields})"
 
 
 def _void_scalar_to_string(x, is_repr=True):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1432,7 +1432,7 @@ class StructuredVoidFormat:
             for field, format_function in zip(x, self.format_functions)
         ]
         if len(str_fields) == 1:
-            return f"({str_fields[0]},)".format(str_fields[0])
+            return f"({str_fields[0]},)"
         else:
             return f"({', '.join(str_fields)})"
 

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -495,7 +495,7 @@ def check_api_dict(d):
                 doubled[index] = [name]
         fmt = "Same index has been used twice in api definition: {}"
         val = ''.join(
-            '\n\tindex {} -> {}'.format(index, names)
+            f'\n\tindex {index} -> {names}'
             for index, names in doubled.items() if len(names) != 1
         )
         raise ValueError(fmt.format(val))

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1478,7 +1478,7 @@ def make_ufuncs(funcdict):
         if uf.signature is None:
             sig = "NULL"
         else:
-            sig = '"{}"'.format(uf.signature)
+            sig = f'"{uf.signature}"'
         fmt = textwrap.dedent("""\
             identity = {identity_expr};
             if ({has_identity} && identity == NULL) {{

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -50,11 +50,11 @@ def add_newdoc(place, name, doc):
     )
     if name[0] != '_' and name not in skip:
         if '\nx :' in doc:
-            assert '$OUT_SCALAR_1' in doc, "in {}".format(name)
+            assert '$OUT_SCALAR_1' in doc, f"in {name}"
         elif '\nx2 :' in doc or '\nx1, x2 :' in doc:
-            assert '$OUT_SCALAR_2' in doc, "in {}".format(name)
+            assert '$OUT_SCALAR_2' in doc, f"in {name}"
         else:
-            assert False, "Could not detect number of inputs in {}".format(name)
+            assert False, "Could not detect number of inputs in {name}"
 
     for k, v in subst.items():
         doc = doc.replace('$' + k, v)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -539,7 +539,7 @@ def put(a, ind, v, mode='raise'):
         put = a.put
     except AttributeError as e:
         raise TypeError("argument 1 must be numpy.ndarray, "
-                        "not {name}".format(name=type(a).__name__)) from e
+                       f"not {type(a).__name__}") from e
 
     return put(ind, v, mode=mode)
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1424,7 +1424,7 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
     if not allow_duplicate and len(set(axis)) != len(axis):
         if argname:
-            raise ValueError('repeated axis in `{}` argument'.format(argname))
+            raise ValueError(f'repeated axis in `{argname}` argument')
         else:
             raise ValueError('repeated axis')
     return axis

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -126,7 +126,7 @@ class format_parser:
         if isinstance(formats, list):
             dtype = sb.dtype(
                 [
-                    ('f{}'.format(i), format_) 
+                    (f'f{i}', format_)
                     for i, format_ in enumerate(formats)
                 ],
                 aligned,

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -469,7 +469,7 @@ def _block_format_index(index):
     """
     Convert a list of indices ``[0, 1, 2]`` into ``"arrays[0][1][2]"``.
     """
-    idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
+    idx_str = ''.join(f'[{i}]' for i in index if i is not None)
     return 'arrays' + idx_str
 
 
@@ -529,11 +529,8 @@ def _block_check_depths_match(arrays, parent_index=[]):
             if len(index) != len(first_index):
                 raise ValueError(
                     "List depths are mismatched. First element was at depth "
-                    "{}, but there is an element at depth {} ({})".format(
-                        len(first_index),
-                        len(index),
-                        _block_format_index(index)
-                    )
+                    f"{len(first_index)}, but there is an element at depth "
+                    f"{len(index)} ({_block_format_index(index)})"
                 )
             # propagate our flag that indicates an empty list at the bottom
             if index[-1] is None:
@@ -605,9 +602,9 @@ def _concatenate_shapes(shapes, axis):
     if any(shape[:axis] != first_shape_pre or
            shape[axis+1:] != first_shape_post for shape in shapes):
         raise ValueError(
-            'Mismatched array shapes in block along axis {}.'.format(axis))
+            f'Mismatched array shapes in block along axis {axis}.')
 
-    shape = (first_shape_pre + (sum(shape_at_axis),) + first_shape[axis+1:])
+    shape = first_shape_pre + (sum(shape_at_axis),) + first_shape[axis+1:]
 
     offsets_at_axis = _accumulate(shape_at_axis)
     slice_prefixes = [(slice(start, end),)
@@ -885,9 +882,7 @@ def _block_setup(arrays):
     list_ndim = len(bottom_index)
     if bottom_index and bottom_index[-1] is None:
         raise ValueError(
-            'List at {} cannot be empty'.format(
-                _block_format_index(bottom_index)
-            )
+            f'List at {_block_format_index(bottom_index)} cannot be empty'
         )
     result_ndim = max(arr_ndim, list_ndim)
     return arrays, list_ndim, result_ndim, final_size

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -799,7 +799,7 @@ class TestPrintOptions:
         c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
 
         # also make sure 1e23 is right (is between two fp numbers)
-        w = np.array(['1e{}'.format(i) for i in range(25)], dtype=np.float64)
+        w = np.array([f'1e{i}' for i in range(25)], dtype=np.float64)
         # note: we construct w from the strings `1eXX` instead of doing
         # `10.**arange(24)` because it turns out the two are not equivalent in
         # python. On some architectures `1e23 != 10.**23`.
@@ -911,10 +911,10 @@ class TestPrintOptions:
 
         styp = '<U4'
         assert_equal(repr(np.ones(3, dtype=styp)),
-            "array(['1', '1', '1'], dtype='{}')".format(styp))
-        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
+            f"array(['1', '1', '1'], dtype='{styp}')")
+        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent(f"""\
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
-                  dtype='{}')""".format(styp)))
+                  dtype='{styp}')"""))
 
     @pytest.mark.parametrize(
         ['native'],

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -509,7 +509,7 @@ class TestArray2String:
         assert_equal(a[0], text)
         text = text.item()  # use raw python strings for repr below
         # and that np.array2string puts a newline in the expected location
-        expected_repr = "[{0!r} {0!r}\n {0!r}]".format(text)
+        expected_repr = f"[{text!r} {text!r}\n {text!r}]"
         result = np.array2string(a, max_line_width=len(repr(text)) * 2 + 3)
         assert_equal(result, expected_repr)
 

--- a/numpy/_core/tests/test_conversion_utils.py
+++ b/numpy/_core/tests/test_conversion_utils.py
@@ -19,7 +19,7 @@ class StringConverterTestCase:
     warn = True
 
     def _check_value_error(self, val):
-        pattern = r'\(got {}\)'.format(re.escape(repr(val)))
+        pattern = fr'\(got {re.escape(repr(val))}\)'
         with pytest.raises(ValueError, match=pattern) as exc:
             self.conv(val)
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -488,7 +488,7 @@ class TestDateTime:
 
     def test_timedelta_nat_format(self):
         # gh-17552
-        assert_equal('NaT', '{0}'.format(np.timedelta64('nat')))
+        assert_equal('NaT', f'{np.timedelta64("nat")}')
 
     def test_timedelta_scalar_construction_units(self):
         # String construction detecting units

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -258,7 +258,7 @@ class TestFromStringAndFileInvalidData(_DeprecationTestCase):
     @pytest.mark.parametrize("invalid_str", [",invalid_data", "invalid_sep"])
     def test_deprecate_unparsable_string(self, invalid_str):
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
-        x_str = "1.51,2,3.51,4{}".format(invalid_str)
+        x_str = f"1.51,2,3.51,4{invalid_str}"
 
         self.assert_deprecated(lambda: np.fromstring(x_str, sep=","))
         self.assert_deprecated(lambda: np.fromstring(x_str, sep=",", count=5))

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1883,7 +1883,7 @@ class TestFromCTypes:
         Example: np.dtype('d,I') -> dtype([('f0', '<f8'), ('f1', '<u4')])
         """
         # gh-5645: check that np.dtype('i,L') can be used
-        pair_type = np.dtype('{},{}'.format(*pair))
+        pair_type = np.dtype(f'{pair[0]},{pair[1]}')
         expected = np.dtype([('f0', pair[0]), ('f1', pair[1])])
         assert_equal(pair_type, expected)
 

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -1238,7 +1238,7 @@ class TestEinsumPath:
         arr = np.array([[1]])
         for sp in itertools.product(['', ' '], repeat=4):
             # no error for any spacing
-            np.einsum('{}...a{}->{}...a{}'.format(*sp), arr)
+            np.einsum(f'{sp[0]}...a{sp[1]}->{sp[2]}...a{sp[3]}', arr)
 
 def test_overlap():
     a = np.arange(9, dtype=int).reshape(3, 3)

--- a/numpy/_core/tests/test_longdouble.py
+++ b/numpy/_core/tests/test_longdouble.py
@@ -285,7 +285,7 @@ def test_str_exact():
                     reason="Need strtold_l")
 def test_format():
     o = 1 + LD_INFO.eps
-    assert_("{0:.40g}".format(o) != '1')
+    assert_(f"{o:.40g}" != '1')
 
 
 @pytest.mark.skipif(longdouble_longer_than_double, reason="BUG #2376")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2405,7 +2405,7 @@ class TestMethods:
         for endianness in '<>':
             for dt in np.typecodes['Complex']:
                 arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianness + dt)
-                msg = 'byte-swapped complex argsort, dtype={0}'.format(dt)
+                msg = f'byte-swapped complex argsort, dtype={dt}'
                 assert_equal(arr.argsort(),
                              np.arange(len(arr), dtype=np.intp), msg)
 
@@ -2486,7 +2486,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array argsort with axis={0}'.format(axis)
+            msg = f'test empty array argsort with axis={axis}'
             assert_equal(np.argsort(a, axis=axis),
                          np.zeros_like(a, dtype=np.intp), msg)
         msg = 'test empty array argsort with axis=None'
@@ -2804,7 +2804,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array partition with axis={0}'.format(axis)
+            msg = f'test empty array partition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis), a, msg)
         msg = 'test empty array partition with axis=None'
         assert_equal(np.partition(a, kth, axis=None), a.ravel(), msg)
@@ -2816,7 +2816,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array argpartition with axis={0}'.format(axis)
+            msg = f'test empty array argpartition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis),
                          np.zeros_like(a, dtype=np.intp), msg)
         msg = 'test empty array argpartition with axis=None'
@@ -3706,7 +3706,7 @@ class TestMethods:
             b = np.array([7], dtype=dt)
             c = np.array([[[[[7]]]]], dtype=dt)
 
-            msg = 'dtype: {0}'.format(dt)
+            msg = f'dtype: {dt}'
             ap = complex(a)
             assert_equal(ap, a, msg)
 
@@ -3838,9 +3838,9 @@ class TestBinop:
             if array_priority is not False:
                 class_namespace["__array_priority__"] = array_priority
             for op in ops:
-                class_namespace["__{0}__".format(op)] = op_impl
-                class_namespace["__r{0}__".format(op)] = rop_impl
-                class_namespace["__i{0}__".format(op)] = iop_impl
+                class_namespace[f"__{op}__"] = op_impl
+                class_namespace[f"__r{op}__"] = rop_impl
+                class_namespace[f"__i{op}__"] = iop_impl
             if array_ufunc is not False:
                 class_namespace["__array_ufunc__"] = array_ufunc
             eval_namespace = {"base": base,
@@ -3865,7 +3865,7 @@ class TestBinop:
                 if check_scalar:
                     check_objs.append(check_objs[0][0])
                 for arr in check_objs:
-                    arr_method = getattr(arr, "__{0}__".format(op))
+                    arr_method = getattr(arr, f"__{op}__")
 
                     def first_out_arg(result):
                         if op == "divmod":
@@ -3891,7 +3891,7 @@ class TestBinop:
                             assert_raises((TypeError, Coerced),
                                           arr_method, obj, err_msg=err_msg)
                     # obj __op__ arr
-                    arr_rmethod = getattr(arr, "__r{0}__".format(op))
+                    arr_rmethod = getattr(arr, f"__r{op}__")
                     if ufunc_override_expected:
                         res = arr_rmethod(obj)
                         assert_equal(res[0], "__array_ufunc__",
@@ -3912,7 +3912,7 @@ class TestBinop:
                     # arr __iop__ obj
                     # array scalars don't have in-place operators
                     if has_inplace and isinstance(arr, np.ndarray):
-                        arr_imethod = getattr(arr, "__i{0}__".format(op))
+                        arr_imethod = getattr(arr, f"__i{op}__")
                         if inplace_override_expected:
                             assert_equal(arr_method(obj), NotImplemented,
                                          err_msg=err_msg)
@@ -9258,8 +9258,8 @@ class TestFormat:
 
     def test_0d(self):
         a = np.array(np.pi)
-        assert_equal('{:0.3g}'.format(a), '3.14')
-        assert_equal('{:0.3g}'.format(a[()]), '3.14')
+        assert_equal(f'{a:0.3g}', '3.14')
+        assert_equal(f'{a[()]:0.3g}', '3.14')
 
     def test_1d_no_format(self):
         a = np.array([np.pi])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9263,7 +9263,7 @@ class TestFormat:
 
     def test_1d_no_format(self):
         a = np.array([np.pi])
-        assert_equal('{}'.format(a), str(a))
+        assert_equal(f'{a}', str(a))
 
     def test_1d_format(self):
         # until gh-5543, ensure that the behaviour matches what it used to be

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2138,7 +2138,7 @@ class TestMethods:
                 arr = np.array([1+3.j, 2+2.j, 3+1.j], dtype=endianness + dt)
                 c = arr.copy()
                 c.sort()
-                msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
+                msg = f'byte-swapped complex sort, dtype={dt}'
                 assert_equal(c, arr, msg)
 
     @pytest.mark.parametrize('dtype', [np.bytes_, np.str_])
@@ -2225,7 +2225,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array sort with axis={0}'.format(axis)
+            msg = f'test empty array sort with axis={axis}'
             assert_equal(np.sort(a, axis=axis), a, msg)
         msg = 'test empty array sort with axis=None'
         assert_equal(np.sort(a, axis=None), a.ravel(), msg)

--- a/numpy/_core/tests/test_protocols.py
+++ b/numpy/_core/tests/test_protocols.py
@@ -24,7 +24,7 @@ def test_getattr_warning():
             return getattr(self.array, name)
 
         def __repr__(self):
-            return "<Wrapper({self.array})>".format(self=self)
+            return f"<Wrapper({self.array})>"
 
     array = Wrapper(np.arange(10))
     with pytest.raises(UserWarning, match="object got converted"):

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2124,7 +2124,7 @@ class TestRegression:
         # Ticket #4369.
         dt = np.dtype([('date', '<M8[D]'), ('val', '<f8')])
         arr = np.array([('2000-01-01', 1)], dt)
-        formatted = '{0}'.format(arr[0])
+        formatted = f'{arr[0]}'
         assert_equal(formatted, str(arr[0]))
 
     def test_deepcopy_on_0d_array(self):

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -105,7 +105,7 @@ class TestAsIntegerRatio:
                 # the values may not fit in any float type
                 pytest.skip("longdouble too small on this platform")
 
-            assert_equal(nf / df, f, "{}/{}".format(n, d))
+            assert_equal(nf / df, f, f"{n}/{d}")
 
 
 class TestIsInteger:

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -25,7 +25,7 @@ class TestRealScalars:
 
         for wants, val in zip(wanted, svals):
             for want, styp in zip(wants, styps):
-                msg = 'for str({}({}))'.format(np.dtype(styp).name, repr(val))
+                msg = f'for str({np.dtype(styp).name}({repr(val)}))'
                 assert_equal(str(styp(val)), want, err_msg=msg)
 
     def test_scalar_cutoffs(self):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3069,8 +3069,8 @@ class TestSpecialMethods:
                 # assert_equal produces truly useless error messages
                 raise AssertionError("\n".join([
                     "Bad arguments passed in ufunc call",
-                    " expected:              {}".format(expected),
-                    " __array_wrap__ got:    {}".format(w)
+                    f" expected:              {expected}"
+                    f" __array_wrap__ got:    {w}"
                 ]))
 
         # method not on the out argument

--- a/numpy/_utils/_pep440.py
+++ b/numpy/_utils/_pep440.py
@@ -172,7 +172,7 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     def __repr__(self):
-        return "<LegacyVersion({0})>".format(repr(str(self)))
+        return f"<LegacyVersion({repr(str(self))})>"
 
     @property
     def public(self):
@@ -293,7 +293,7 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:
-            raise InvalidVersion("Invalid version: '{0}'".format(version))
+            raise InvalidVersion(f"Invalid version: '{version}'")
 
         # Store the parsed out pieces of the version
         self._version = _Version(
@@ -325,14 +325,14 @@ class Version(_BaseVersion):
         )
 
     def __repr__(self):
-        return "<Version({0})>".format(repr(str(self)))
+        return f"<Version({repr(str(self))})>"
 
     def __str__(self):
         parts = []
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))
@@ -343,16 +343,17 @@ class Version(_BaseVersion):
 
         # Post-release
         if self._version.post is not None:
-            parts.append(".post{0}".format(self._version.post[1]))
+            parts.append(f".post{self._version.post[1]}")
 
         # Development release
         if self._version.dev is not None:
-            parts.append(".dev{0}".format(self._version.dev[1]))
+            parts.append(f".dev{self._version.dev[1]}")
 
         # Local version segment
         if self._version.local is not None:
+            joined_elements = '.'.join(str(x) for x in self._version.local)
             parts.append(
-                "+{0}".format(".".join(str(x) for x in self._version.local))
+                f"+{joined_elements}"
             )
 
         return "".join(parts)
@@ -367,7 +368,7 @@ class Version(_BaseVersion):
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -382,7 +382,7 @@ if ctypes is not None:
             ctype = _scalar_type_map[dtype_native]
         except KeyError as e:
             raise NotImplementedError(
-                "Converting {!r} to a ctypes type".format(dtype)
+                f"Converting {dtype!r} to a ctypes type"
             ) from None
 
         if dtype_with_endian.byteorder == '>':

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -2555,7 +2555,10 @@ class CCompilerOpt(_Config, _Distutils, _Cache, _CCompiler, _Feature, _Parse):
             target_name = '__'.join(target)
 
         wrap_path = os.path.join(output_dir, os.path.basename(dispatch_src))
-        wrap_path = "{0}.{2}{1}".format(*os.path.splitext(wrap_path), ext_name.lower())
+        wrap_path = (
+            f"{os.path.splitext(wrap_path)[0]}."
+            f"{ext_name.lower()}{os.path.splitext(wrap_path)[1]}"
+        )
         if nochange and os.path.exists(wrap_path):
             return wrap_path
 

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -53,7 +53,9 @@ class build(old_build):
     def finalize_options(self):
         build_scripts = self.build_scripts
         old_build.finalize_options(self)
-        plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info[:2])
+        plat_specifier = (
+            f".{get_platform()}-{sys.version_info[0]}.{sys.version_info[1]}"
+        )
         if build_scripts is None:
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts' + plat_specifier)

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -93,7 +93,8 @@ class build_src(build_ext.build_ext):
 
         if self.build_src is None:
             plat_specifier = (
-                f".{get_platform()}-{sys.version_info[0]}.{sys.version_info[1]}"
+                f".{get_platform()}-"
+                f"{sys.version_info[0]}.{sys.version_info[1]}"
             )
             self.build_src = os.path.join(self.build_base, 'src'+plat_specifier)
 

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -92,7 +92,9 @@ class build_src(build_ext.build_ext):
         self.data_files = self.distribution.data_files or []
 
         if self.build_src is None:
-            plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info[:2])
+            plat_specifier = (
+                f".{get_platform()}-{sys.version_info[0]}.{sys.version_info[1]}"
+            )
             self.build_src = os.path.join(self.build_base, 'src'+plat_specifier)
 
         # py_modules_dict is used in build_py.find_package_modules

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -162,7 +162,7 @@ class GnuFCompiler(FCompiler):
 
         libgfortran_dir = None
         if libgfortran_name:
-            find_lib_arg = ['-print-file-name={0}'.format(libgfortran_name)]
+            find_lib_arg = [f'-print-file-name={libgfortran_name}']
             try:
                 output = subprocess.check_output(
                                        self.compiler_f77 + find_lib_arg)

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -60,7 +60,7 @@ class IntelFCompiler(BaseIntelFCompiler):
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
         return ['-fp-model', 'strict', '-O1',
-                '-assume', 'minus0', '-{}'.format(mpopt)]
+                '-assume', 'minus0', f'-{mpopt}']
 
     def get_flags_arch(self):
         return []

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -819,7 +819,7 @@ class system_info:
         if AliasedOptionError.__doc__ is None:
             raise AliasedOptionError()
         raise AliasedOptionError(AliasedOptionError.__doc__.format(
-            section=self.section, options=f'[{', '.join(options)}]'))
+            section=self.section, options=f'[{", ".join(options)}]'))
 
 
     def has_info(self):

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -229,7 +229,7 @@ def _c_string_literal(s):
     s = s.replace('\\', r'\\')
     s = s.replace('"',  r'\"')
     s = s.replace('\n', r'\n')
-    return '"{}"'.format(s)
+    return f'"{s}"'
 
 
 def libpaths(paths, bits):
@@ -819,7 +819,7 @@ class system_info:
         if AliasedOptionError.__doc__ is None:
             raise AliasedOptionError()
         raise AliasedOptionError(AliasedOptionError.__doc__.format(
-            section=self.section, options='[{}]'.format(', '.join(options))))
+            section=self.section, options=f'[{', '.join(options)}]'))
 
 
     def has_info(self):
@@ -1971,14 +1971,14 @@ class lapack_opt_info(system_info):
         return True
 
     def _calc_info(self, name):
-        return getattr(self, '_calc_info_{}'.format(name))()
+        return getattr(self, f'_calc_info_{name}')()
 
     def calc_info(self):
         lapack_order, unknown_order = _parse_env_order(self.lapack_order, self.order_env_var_name)
         if len(unknown_order) > 0:
             raise ValueError("lapack_opt_info user defined "
                              "LAPACK order has unacceptable "
-                             "values: {}".format(unknown_order))
+                             f"values: {unknown_order}")
 
         if 'NPY_LAPACK_LIBS' in os.environ:
             # Bypass autodetection, set language to F77 and use env var linker
@@ -2142,12 +2142,12 @@ class blas_opt_info(system_info):
         return True
 
     def _calc_info(self, name):
-        return getattr(self, '_calc_info_{}'.format(name))()
+        return getattr(self, f'_calc_info_{name}')()
 
     def calc_info(self):
         blas_order, unknown_order = _parse_env_order(self.blas_order, self.order_env_var_name)
         if len(unknown_order) > 0:
-            raise ValueError("blas_opt_info user defined BLAS order has unacceptable values: {}".format(unknown_order))
+            raise ValueError(f"blas_opt_info user defined BLAS order has unacceptable values: {unknown_order}")
 
         if 'NPY_BLAS_LIBS' in os.environ:
             # Bypass autodetection, set language to F77 and use env var linker

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2148,7 +2148,7 @@ class blas_opt_info(system_info):
         blas_order, unknown_order = _parse_env_order(self.blas_order, self.order_env_var_name)
         if len(unknown_order) > 0:
             raise ValueError(
-                f"blas_opt_info user defined BLAS order "
+                "blas_opt_info user defined BLAS order "
                 f"has unacceptable values: {unknown_order}")
 
         if 'NPY_BLAS_LIBS' in os.environ:

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2147,7 +2147,9 @@ class blas_opt_info(system_info):
     def calc_info(self):
         blas_order, unknown_order = _parse_env_order(self.blas_order, self.order_env_var_name)
         if len(unknown_order) > 0:
-            raise ValueError(f"blas_opt_info user defined BLAS order has unacceptable values: {unknown_order}")
+            raise ValueError(
+                f"blas_opt_info user defined BLAS order "
+                f"has unacceptable values: {unknown_order}")
 
         if 'NPY_BLAS_LIBS' in os.environ:
             # Bypass autodetection, set language to F77 and use env var linker

--- a/numpy/distutils/tests/test_fcompiler.py
+++ b/numpy/distutils/tests/test_fcompiler.py
@@ -18,7 +18,7 @@ def test_fcompiler_flags(monkeypatch):
     flag_vars = fc.flag_vars.clone(lambda *args, **kwargs: None)
 
     for opt, envvar in customizable_flags:
-        new_flag = '-dummy-{}-flag'.format(opt)
+        new_flag = f'-dummy-{opt}-flag'
         prev_flags = getattr(flag_vars, opt)
 
         monkeypatch.setenv(envvar, new_flag)
@@ -30,7 +30,7 @@ def test_fcompiler_flags(monkeypatch):
     monkeypatch.setenv('NPY_DISTUTILS_APPEND_FLAGS', '1')
 
     for opt, envvar in customizable_flags:
-        new_flag = '-dummy-{}-flag'.format(opt)
+        new_flag = f'-dummy-{opt}-flag'
         prev_flags = getattr(flag_vars, opt)
         monkeypatch.setenv(envvar, new_flag)
         new_flags = getattr(flag_vars, opt)

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -80,8 +80,8 @@ def __getattr__(attr):
         return test
 
     else:
-        raise AttributeError("module {!r} has no attribute "
-                              "{!r}".format(__name__, attr))
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {attr!r}")
 
 
 def __dir__():

--- a/numpy/f2py/_src_pyf.py
+++ b/numpy/f2py/_src_pyf.py
@@ -165,7 +165,8 @@ def expand_sub(substr, names):
             elif num == numsubs:
                 rules[r] = rule
             else:
-                print(f"Mismatch in number of replacements (base <{base_rule}={','.join(rules[base_rule])}>) "
+                base_rules_str = ','.join(rules[base_rule])
+                print(f"Mismatch in number of replacements (base <{base_rule}={base_rules_str}>) "
                       f"for <{r}={thelist}>. Ignoring.")
     if not rules:
         return substr

--- a/numpy/f2py/_src_pyf.py
+++ b/numpy/f2py/_src_pyf.py
@@ -165,8 +165,8 @@ def expand_sub(substr, names):
             elif num == numsubs:
                 rules[r] = rule
             else:
-                print("Mismatch in number of replacements (base <{}={}>) "
-                      "for <{}={}>. Ignoring.".format(base_rule, ','.join(rules[base_rule]), r, thelist))
+                print(f"Mismatch in number of replacements (base <{base_rule}={','.join(rules[base_rule])}>) "
+                      f"for <{r}={thelist}>. Ignoring.")
     if not rules:
         return substr
 

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -152,7 +152,7 @@ def load_f2cmap_file(f2cmap_file):
     # interpreted as C 'float'. This feature is useful for F90/95 users if
     # they use PARAMETERS in type specifications.
     try:
-        outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
+        outmess(f'Reading f2cmap from {f2cmap_file!r} ...\n')
         with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
         f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map, True)

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -675,8 +675,8 @@ def split_by_unquoted(line, characters):
     r = re.compile(
         r"\A(?P<before>({single_quoted}|{double_quoted}|{not_quoted})*)"
         r"(?P<after>{char}.*)\Z".format(
-            not_quoted="[^\"'{}]".format(re.escape(characters)),
-            char="[{}]".format(re.escape(characters)),
+            not_quoted=f"[^\"'{re.escape(characters)}]",
+            char=f"[{re.escape(characters)}]",
             single_quoted=r"('([^'\\]|(\\.))*')",
             double_quoted=r'("([^"\\]|(\\.))*")'))
     m = r.match(line)
@@ -1462,7 +1462,7 @@ def analyzeline(m, case, line):
                 vdim = getdimension(vars[v])
                 matches = re.findall(r"\(.*?\)", l[1]) if vtype == 'complex' else l[1].split(',')
                 try:
-                    new_val = "(/{}/)".format(", ".join(matches)) if vdim else matches[idx]
+                    new_val = f'(/{", ".join(matches)}/)' if vdim else matches[idx]
                 except IndexError:
                     # gh-24746
                     # Runs only if above code fails. Fixes the line
@@ -1480,7 +1480,7 @@ def analyzeline(m, case, line):
                             else:
                                 expanded_list.append(match.strip())
                         matches = expanded_list
-                    new_val = "(/{}/)".format(", ".join(matches)) if vdim else matches[idx]
+                    new_val = f'(/{", ".join(matches)}/)' if vdim else matches[idx]
                 current_val = vars[v].get('=')
                 if current_val and (current_val != new_val):
                     outmess('analyzeline: changing init expression of "%s" ("%s") to "%s"\n' % (v, current_val, new_val))

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1462,7 +1462,8 @@ def analyzeline(m, case, line):
                 vdim = getdimension(vars[v])
                 matches = re.findall(r"\(.*?\)", l[1]) if vtype == 'complex' else l[1].split(',')
                 try:
-                    new_val = f'(/{", ".join(matches)}/)' if vdim else matches[idx]
+                    all_matches_str = ", ".join(matches)
+                    new_val = f'(/{all_matches_str}/)' if vdim else matches[idx]
                 except IndexError:
                     # gh-24746
                     # Runs only if above code fails. Fixes the line
@@ -1480,7 +1481,8 @@ def analyzeline(m, case, line):
                             else:
                                 expanded_list.append(match.strip())
                         matches = expanded_list
-                    new_val = f'(/{", ".join(matches)}/)' if vdim else matches[idx]
+                    all_matches_str = ", ".join(matches)
+                    new_val = f'(/{all_matches_str}/)' if vdim else matches[idx]
                 current_val = vars[v].get('=')
                 if current_val and (current_val != new_val):
                     outmess('analyzeline: changing init expression of "%s" ("%s") to "%s"\n' % (v, current_val, new_val))

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -471,10 +471,10 @@ def run_main(comline_list):
         if plist['block'] == 'python module' and '__user__' in plist['name']:
             if plist['name'] in isusedby:
                 # if not quiet:
+                joined_elements = ','.join(f'"{s}"' for s in isusedby[plist['name']])
                 outmess(
                     f'Skipping Makefile build for module "{plist["name"]}" '
-                    'which is used by {}\n'.format(
-                        ','.join(f'"{s}"' for s in isusedby[plist['name']])))
+                    f'which is used by {joined_elements}\n')
     if 'signsfile' in options:
         if options['verbose'] > 1:
             outmess(

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -161,7 +161,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
         # need to change to record how big each module is, rather than
         # relying on rebase being able to find that from the files.
         _module_list.extend(
-            glob.glob(os.path.join(d, "{:s}*".format(module_name)))
+            glob.glob(os.path.join(d, f"{module_name:s}*"))
         )
         subprocess.check_call(
             ["/usr/bin/rebase", "--database", "--oblivious", "--verbose"]

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -85,5 +85,5 @@ def __getattr__(attr):
             "Arrayterator class use numpy.lib.Arrayterator."
         )
     else:
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {attr!r}")

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -787,7 +787,9 @@ def pad(array, pad_width, mode='constant', **kwargs):
     except KeyError:
         raise ValueError(f"mode '{mode}' is not supported") from None
     if unsupported_kwargs:
-        raise ValueError(f"unsupported keyword arguments for mode '{mode}': {unsupported_kwargs}")
+        raise ValueError(
+            f"unsupported keyword arguments for "
+            f"mode '{mode}': {unsupported_kwargs}")
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -785,10 +785,9 @@ def pad(array, pad_width, mode='constant', **kwargs):
     try:
         unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
     except KeyError:
-        raise ValueError("mode '{}' is not supported".format(mode)) from None
+        raise ValueError(f"mode '{mode}' is not supported") from None
     if unsupported_kwargs:
-        raise ValueError("unsupported keyword arguments for mode '{}': {}"
-                         .format(mode, unsupported_kwargs))
+        raise ValueError(f"unsupported keyword arguments for mode '{mode}': {unsupported_kwargs}")
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -298,7 +298,7 @@ def unique(ar, return_index=False, return_inverse=False,
     orig_shape, orig_dtype = ar.shape, ar.dtype
     ar = ar.reshape(orig_shape[0], np.prod(orig_shape[1:], dtype=np.intp))
     ar = np.ascontiguousarray(ar)
-    dtype = [('f{i}'.format(i=i), ar.dtype) for i in range(ar.shape[1])]
+    dtype = [(f'f{i}', ar.dtype) for i in range(ar.shape[1])]
 
     # At this point, `ar` has shape `(n, m)`, and `dtype` is a structured
     # data type with `m` fields where each field has the data type of `ar`.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -869,7 +869,7 @@ def select(condlist, choicelist, default=0):
     for i, cond in enumerate(condlist):
         if cond.dtype.type is not np.bool:
             raise TypeError(
-                'invalid entry {} in condlist: should be boolean ndarray'.format(i))
+                f'invalid entry {i} in condlist: should be boolean ndarray')
 
     if choicelist[0].ndim == 0:
         # This may be common, so avoid the call.
@@ -2039,7 +2039,7 @@ def _parse_gufunc_signature(signature):
 
     if not re.match(_SIGNATURE, signature):
         raise ValueError(
-            'not a valid gufunc signature: {}'.format(signature))
+            f'not a valid gufunc signature: {signature}')
     return tuple([tuple(re.findall(_DIMENSION_NAME, arg))
                   for arg in re.findall(_ARGUMENT, arg_list)]
                  for arg_list in signature.split('->'))
@@ -5497,7 +5497,7 @@ def delete(arr, obj, axis=None):
             if obj.shape != (N,):
                 raise ValueError('boolean array argument obj to delete '
                                  'must be one dimensional and match the axis '
-                                 'length of {}'.format(N))
+                                 f'length of {N}')
 
             # optimization, the other branch is slower
             keep = ~obj

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2014,10 +2014,10 @@ def disp(mesg, device=None, linefeed=True):
 
 # See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
 _DIMENSION_NAME = r'\w+'
-_CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
-_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
-_ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
-_SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
+_CORE_DIMENSION_LIST = f'(?:{_DIMENSION_NAME:}(?:,{_DIMENSION_NAME:})*)?'
+_ARGUMENT = fr'\({_CORE_DIMENSION_LIST}\)'
+_ARGUMENT_LIST = f'{_ARGUMENT:}(?:,{_ARGUMENT:})*'
+_SIGNATURE = f'^{_ARGUMENT_LIST:}->{_ARGUMENT_LIST:}$'
 
 
 def _parse_gufunc_signature(signature):

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -391,7 +391,7 @@ def _get_bin_edges(a, bins, range, weights):
         # this will replace it with the number of bins calculated
         if bin_name not in _hist_bin_selectors:
             raise ValueError(
-                "{!r} is not a valid estimator for `bins`".format(bin_name))
+                f"{bin_name!r} is not a valid estimator for `bins`")
         if weights is not None:
             raise TypeError("Automated estimation of the number of "
                             "bins is not supported for weighted data")

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -321,7 +321,8 @@ def _get_outer_edges(a, range):
         first_edge, last_edge = a.min(), a.max()
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                f"autodetected range of [{first_edge}, {last_edge}] is not finite")
+                f"autodetected range of "
+                f"[{first_edge}, {last_edge}] is not finite")
 
     # expand empty range to avoid divide by zero
     if first_edge == last_edge:
@@ -1016,7 +1017,7 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
             except TypeError as e:
                 raise TypeError(
-                	f'`bins[{i}]` must be an integer, when a scalar'
+                    f'`bins[{i}]` must be an integer, when a scalar'
                 ) from e
 
             edges[i] = np.linspace(smin, smax, n + 1)
@@ -1024,7 +1025,8 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
             edges[i] = np.asarray(bins[i])
             if np.any(edges[i][:-1] > edges[i][1:]):
                 raise ValueError(
-                    f'`bins[{i}]` must be monotonically increasing, when an array')
+                    f'`bins[{i}]` must be monotonically increasing, '
+                    'when an array')
         else:
             raise ValueError(
                 f'`bins[{i}]` must be a scalar or 1d array')

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -313,7 +313,7 @@ def _get_outer_edges(a, range):
                 'max must be larger than min in range parameter.')
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                "supplied range of [{}, {}] is not finite".format(first_edge, last_edge))
+                f"supplied range of [{first_edge}, {last_edge}] is not finite")
     elif a.size == 0:
         # handle empty arrays. Can't determine range, so use 0-1.
         first_edge, last_edge = 0, 1
@@ -321,7 +321,7 @@ def _get_outer_edges(a, range):
         first_edge, last_edge = a.min(), a.max()
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                "autodetected range of [{}, {}] is not finite".format(first_edge, last_edge))
+                f"autodetected range of [{first_edge}, {last_edge}] is not finite")
 
     # expand empty range to avoid divide by zero
     if first_edge == last_edge:
@@ -1009,14 +1009,14 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
         if np.ndim(bins[i]) == 0:
             if bins[i] < 1:
                 raise ValueError(
-                    '`bins[{}]` must be positive, when an integer'.format(i))
+                    f'`bins[{i}]` must be positive, when an integer')
             smin, smax = _get_outer_edges(sample[:,i], range[i])
             try:
                 n = operator.index(bins[i])
 
             except TypeError as e:
                 raise TypeError(
-                	"`bins[{}]` must be an integer, when a scalar".format(i)
+                	f'`bins[{i}]` must be an integer, when a scalar'
                 ) from e
 
             edges[i] = np.linspace(smin, smax, n + 1)
@@ -1024,11 +1024,10 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
             edges[i] = np.asarray(bins[i])
             if np.any(edges[i][:-1] > edges[i][1:]):
                 raise ValueError(
-                    '`bins[{}]` must be monotonically increasing, when an array'
-                    .format(i))
+                    f'`bins[{i}]` must be monotonically increasing, when an array')
         else:
             raise ValueError(
-                '`bins[{}]` must be a scalar or 1d array'.format(i))
+                f'`bins[{i}]` must be a scalar or 1d array')
 
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])

--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -392,7 +392,7 @@ class AxisConcatenator:
                         continue
                     except Exception as e:
                         raise ValueError(
-                            "unknown special directive {!r}".format(item)
+                            f"unknown special directive {item!r}"
                         ) from e
                 try:
                     axis = int(item)

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -394,7 +394,7 @@ def _wrap_header(header, version):
     try:
         header_prefix = magic(*version) + struct.pack(fmt, hlen + padlen)
     except struct.error:
-        msg = "Header length {} too big for version={}".format(hlen, version)
+        msg = f"Header length {hlen} too big for version={version}"
         raise ValueError(msg) from None
 
     # Pad the header with spaces and a final newline such that the magic

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -612,7 +612,7 @@ def _read_array_header(fp, version, max_header_size=_MAX_HEADER_SIZE):
     import struct
     hinfo = _header_size_info.get(version)
     if hinfo is None:
-        raise ValueError("Invalid version {!r}".format(version))
+        raise ValueError(f"Invalid version {version!r}")
     hlength_type, encoding = hinfo
 
     hlength_str = _read_bytes(fp, struct.calcsize(hlength_type), "array header length")

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -21,7 +21,7 @@ def _binary_method(ufunc, name):
         if _disables_array_ufunc(other):
             return NotImplemented
         return ufunc(self, other)
-    func.__name__ = '__{}__'.format(name)
+    func.__name__ = f'__{name}__'
     return func
 
 
@@ -31,7 +31,7 @@ def _reflected_binary_method(ufunc, name):
         if _disables_array_ufunc(other):
             return NotImplemented
         return ufunc(other, self)
-    func.__name__ = '__r{}__'.format(name)
+    func.__name__ = f'__r{name}__'
     return func
 
 
@@ -39,7 +39,7 @@ def _inplace_binary_method(ufunc, name):
     """Implement an in-place binary method with a ufunc, e.g., __iadd__."""
     def func(self, other):
         return ufunc(self, other, out=(self,))
-    func.__name__ = '__i{}__'.format(name)
+    func.__name__ = f'__i{name}__'
     return func
 
 
@@ -54,7 +54,7 @@ def _unary_method(ufunc, name):
     """Implement a unary special method with a ufunc."""
     def func(self):
         return ufunc(self)
-    func.__name__ = '__{}__'.format(name)
+    func.__name__ = f'__{name}__'
     return func
 
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1006,7 +1006,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
         raise NotImplementedError("arr with no fields is not supported")
 
     dts, counts, offsets = zip(*fields)
-    names = ['f{}'.format(n) for n in range(n_fields)]
+    names = [f'f{n}' for n in range(n_fields)]
 
     if dtype is None:
         out_dtype = np.result_type(*[dt.base for dt in dts])
@@ -1134,7 +1134,7 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
 
     if dtype is None:
         if names is None:
-            names = ['f{}'.format(n) for n in range(n_elem)]
+            names = [f'f{n}' for n in range(n_elem)]
         out_dtype = np.dtype([(n, arr.dtype) for n in names], align=align)
         fields = _get_fields_and_offsets(out_dtype)
         dts, counts, offsets = zip(*fields)
@@ -1157,7 +1157,7 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
         if align and not out_dtype.isalignedstruct:
             raise ValueError("align was True but dtype is not aligned")
 
-    names = ['f{}'.format(n) for n in range(len(fields))]
+    names = [f'f{n}' for n in range(len(fields))]
 
     # Use a series of views and casts to convert to a structured array:
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1350,7 +1350,7 @@ def test_constant_zero_default():
 
 @pytest.mark.parametrize("mode", [1, "const", object(), None, True, False])
 def test_unsupported_mode(mode):
-    match= f"mode '{mode}' is not supported"
+    match=f"mode '{mode}' is not supported"
     with pytest.raises(ValueError, match=match):
         np.pad([1, 2, 3], 4, mode=mode)
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1338,7 +1338,7 @@ def test_kwargs(mode):
     np.pad([1, 2, 3], 1, mode, **allowed)
     # Test if prohibited keyword arguments of other modes raise an error
     for key, value in not_allowed.items():
-        match = "unsupported keyword arguments for mode '{}'".format(mode)
+        match = f"unsupported keyword arguments for mode '{mode}'"
         with pytest.raises(ValueError, match=match):
             np.pad([1, 2, 3], 1, mode, **{key: value})
 
@@ -1350,7 +1350,7 @@ def test_constant_zero_default():
 
 @pytest.mark.parametrize("mode", [1, "const", object(), None, True, False])
 def test_unsupported_mode(mode):
-    match= "mode '{}' is not supported".format(mode)
+    match= f"mode '{mode}' is not supported"
     with pytest.raises(ValueError, match=match):
         np.pad([1, 2, 3], 4, mode=mode)
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1350,7 +1350,7 @@ def test_constant_zero_default():
 
 @pytest.mark.parametrize("mode", [1, "const", object(), None, True, False])
 def test_unsupported_mode(mode):
-    match=f"mode '{mode}' is not supported"
+    match = f"mode '{mode}' is not supported"
     with pytest.raises(ValueError, match=match):
         np.pad([1, 2, 3], 4, mode=mode)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -155,7 +155,7 @@ class TestSetOps:
         # specifically, raise an appropriate
         # Exception when attempting to append or
         # prepend with an incompatible type
-        msg = 'dtype of `{}` must be compatible'.format(expected)
+        msg = f'dtype of `{expected}` must be compatible'
         with assert_raises_regex(TypeError, msg):
             ediff1d(ary=ary,
                     to_end=append,

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -452,8 +452,9 @@ class TestHistogramOptimBinNums:
             x = np.concatenate((x1, x2))
             for estimator, numbins in expectedResults.items():
                 a, b = np.histogram(x, estimator)
-                assert_equal(len(a), numbins, err_msg="For the {0} estimator "
-                             "with datasize of {1}".format(estimator, testlen))
+                assert_equal(len(a), numbins, err_msg=(
+                    f"For the {estimator} estimator "
+                    f"with datasize of {testlen}"))
 
     def test_small(self):
         """
@@ -472,8 +473,9 @@ class TestHistogramOptimBinNums:
             testdat = np.arange(testlen)
             for estimator, expbins in expectedResults.items():
                 a, b = np.histogram(testdat, estimator)
-                assert_equal(len(a), expbins, err_msg="For the {0} estimator "
-                             "with datasize of {1}".format(estimator, testlen))
+                assert_equal(len(a), expbins, err_msg=(
+                    f"For the {estimator} estimator "
+                    f"with datasize of {testlen}"))
 
     def test_incorrect_methods(self):
         """
@@ -578,8 +580,9 @@ class TestHistogramOptimBinNums:
             x = np.hstack((x1, x2, x3))
             for estimator, numbins in expectedResults.items():
                 a, b = np.histogram(x, estimator, range = (-20, 20))
-                msg = "For the {0} estimator".format(estimator)
-                msg += " with datasize of {0}".format(testlen)
+                msg = (
+                    f"For the {estimator} estimator"
+                    f" with datasize of {testlen}")
                 assert_equal(len(a), numbins, err_msg=msg)
 
     @pytest.mark.parametrize("bins", ['auto', 'fd', 'doane', 'scott',

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -182,14 +182,14 @@ class TestNDArrayOperatorsMixin:
         for op in _ALL_BINARY_OPERATORS:
             expected = wrap_array_like(op(array, 1))
             actual = op(array_like, 1)
-            err_msg = 'failed for operator {}'.format(op)
+            err_msg = f'failed for operator {op}'
             _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
 
     def test_reflected_binary_methods(self):
         for op in _ALL_BINARY_OPERATORS:
             expected = wrap_array_like(op(2, 1))
             actual = op(2, ArrayLike(1))
-            err_msg = 'failed for operator {}'.format(op)
+            err_msg = f'failed for operator {op}'
             _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
 
     def test_matmul(self):

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -316,7 +316,7 @@ class TestRecFunctions:
             return np.dtype((dt, shape))
 
         def structured(*dts):
-            return np.dtype([('x{}'.format(i), dt) for i, dt in enumerate(dts)])
+            return np.dtype([(f'x{i}', dt) for i, dt in enumerate(dts)])
 
         def inspect(dt, dtype=None):
             arr = np.zeros((), dt)

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -360,7 +360,7 @@ def main():
         patch_file = os.path.basename(fortran_file) + '.patch'
         if os.path.exists(patch_file):
             subprocess.check_call(['patch', '-u', fortran_file, patch_file])
-            print("Patched {}".format(fortran_file))
+            print(f"Patched {fortran_file}")
         try:
             runF2C(fortran_file, output_dir)
         except F2CError:

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -85,8 +85,7 @@ class FortranRoutine:
         return self._dependencies
 
     def __repr__(self):
-        return "FortranRoutine({!r}, filename={!r})".format(self.name,
-                                                            self.filename)
+        return f"FortranRoutine({self.name!r}, filename={self.filename!r})"
 
 class UnknownFortranRoutine(FortranRoutine):
     """Wrapper for a Fortran routine for which the corresponding file

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4123,8 +4123,7 @@ class MaskedArray(ndarray):
 
         # join keys with values and indentations
         result = ',\n'.join(
-            '{}{}={}'.format(indents[k], k, reprs[k])
-            for k in keys
+            f'{indents[k]}{k}={reprs[k]}' for k in keys
         )
         return prefix + result + ')'
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4054,10 +4054,7 @@ class MaskedArray(ndarray):
                 dtype=str(self.dtype)
             )
             is_structured = bool(self.dtype.names)
-            key = '{}_{}'.format(
-                'long' if is_long else 'short',
-                'flx' if is_structured else 'std'
-            )
+            key = f"{'long' if is_long else 'short'}_{'flx' if is_structured else 'std'}"
             return _legacy_print_templates[key] % parameters
 
         prefix = f"masked_{name}("

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4054,7 +4054,8 @@ class MaskedArray(ndarray):
                 dtype=str(self.dtype)
             )
             is_structured = bool(self.dtype.names)
-            key = f"{'long' if is_long else 'short'}_{'flx' if is_structured else 'std'}"
+            key = (f"{'long' if is_long else 'short'}_"
+                   f"{'flx' if is_structured else 'std'}")
             return _legacy_print_templates[key] % parameters
 
         prefix = f"masked_{name}("

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -444,7 +444,7 @@ class ABCPolyBase(abc.ABC):
     def _repr_latex_scalar(x, parens=False):
         # TODO: we're stuck with disabling math formatting until we handle
         # exponents in this function
-        return r'\text{{{}}}'.format(pu.format_float(x, parens=parens))
+        return fr'\text{{{pu.format_float(x, parens=parens)}}}'
 
     def _format_term(self, scalar_format: Callable, off: float, scale: float):
         """ Format a single term in the expansion """

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -224,8 +224,8 @@ cdef np.ndarray int_to_array(object value, object name, object bits, object uint
         value = int(value)
         upper = int(2)**int(bits)
         if value < 0 or value >= upper:
-            raise ValueError('{name} must be positive and '
-                             'less than 2**{bits}.'.format(name=name, bits=bits))
+            raise ValueError(
+                f'{name} must be positive and less than 2**{bits}.')
 
         out = np.empty(len, dtype=dtype)
         for i in range(len):
@@ -283,7 +283,7 @@ cdef check_output(object out, object dtype, object size, bint require_c_array):
         )
     if out_array.dtype != dtype:
         raise TypeError('Supplied output array has the wrong type. '
-                        'Expected {0}, got {1}'.format(np.dtype(dtype), out_array.dtype))
+                        f'Expected {np.dtype(dtype)}, got {out_array.dtype}')
     if size is not None:
         try:
             tup_size = tuple(size)
@@ -386,44 +386,44 @@ cdef int _check_array_cons_bounded_0_1(np.ndarray val, object name) except -1:
 cdef int check_array_constraint(np.ndarray val, object name, constraint_type cons) except -1:
     if cons == CONS_NON_NEGATIVE:
         if np.any(np.logical_and(np.logical_not(np.isnan(val)), np.signbit(val))):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
         if cons == CONS_POSITIVE_NOT_NAN and np.any(np.isnan(val)):
-            raise ValueError(name + " must not be NaN")
+            raise ValueError(f"{name} must not be NaN")
         elif np.any(np.less_equal(val, 0)):
-            raise ValueError(name + " <= 0")
+            raise ValueError(f"{name} <= 0")
     elif cons == CONS_BOUNDED_0_1:
         return _check_array_cons_bounded_0_1(val, name)
     elif cons == CONS_BOUNDED_GT_0_1:
         if not np.all(np.greater(val, 0)) or not np.all(np.less_equal(val, 1)):
-            raise ValueError("{0} <= 0, {0} > 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 0, {name} > 1 or {name} contains NaNs")
     elif cons == CONS_BOUNDED_LT_0_1:
         if not np.all(np.greater_equal(val, 0)) or not np.all(np.less(val, 1)):
-            raise ValueError("{0} < 0, {0} >= 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0, {name} >= 1 or {name} contains NaNs")
     elif cons == CONS_GT_1:
         if not np.all(np.greater(val, 1)):
-            raise ValueError("{0} <= 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 1 or {name} contains NaNs")
     elif cons == CONS_GTE_1:
         if not np.all(np.greater_equal(val, 1)):
-            raise ValueError("{0} < 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 1 or {name} contains NaNs")
     elif cons == CONS_POISSON:
         if not np.all(np.less_equal(val, POISSON_LAM_MAX)):
-            raise ValueError("{0} value too large".format(name))
+            raise ValueError(f"{name} value too large")
         elif not np.all(np.greater_equal(val, 0.0)):
-            raise ValueError("{0} < 0 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0 or {name} contains NaNs")
     elif cons == LEGACY_CONS_POISSON:
         if not np.all(np.less_equal(val, LEGACY_POISSON_LAM_MAX)):
-            raise ValueError("{0} value too large".format(name))
+            raise ValueError(f"{name} value too large")
         elif not np.all(np.greater_equal(val, 0.0)):
-            raise ValueError("{0} < 0 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0 or {name} contains NaNs")
     elif cons == LEGACY_CONS_NON_NEGATIVE_INBOUNDS_LONG:
         # Note, we assume that array is integral:
         if not np.all(val >= 0):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
         elif not np.all(val <= int(LONG_MAX)):
             raise ValueError(
-                    name + " is out of bounds for long, consider using "
-                    "the new generator API for 64bit integers.")
+                f"{name} is out of bounds for long, consider using "
+                "the new generator API for 64bit integers.")
 
     return 0
 
@@ -432,45 +432,45 @@ cdef int check_constraint(double val, object name, constraint_type cons) except 
     cdef bint is_nan
     if cons == CONS_NON_NEGATIVE:
         if not isnan(val) and signbit(val):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
         if cons == CONS_POSITIVE_NOT_NAN and isnan(val):
-            raise ValueError(name + " must not be NaN")
+            raise ValueError(f"{name} must not be NaN")
         elif val <= 0:
-            raise ValueError(name + " <= 0")
+            raise ValueError(f"{name} <= 0")
     elif cons == CONS_BOUNDED_0_1:
         if not (val >= 0) or not (val <= 1):
-            raise ValueError("{0} < 0, {0} > 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0, {name} > 1 or {name} is NaN")
     elif cons == CONS_BOUNDED_GT_0_1:
         if not val >0 or not val <= 1:
-            raise ValueError("{0} <= 0, {0} > 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 0, {name} > 1 or {name} contains NaNs")
     elif cons == CONS_BOUNDED_LT_0_1:
         if not (val >= 0) or not (val < 1):
-            raise ValueError("{0} < 0, {0} >= 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0, {name} >= 1 or {name} is NaN")
     elif cons == CONS_GT_1:
         if not (val > 1):
-            raise ValueError("{0} <= 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} <= 1 or {name} is NaN")
     elif cons == CONS_GTE_1:
         if not (val >= 1):
-            raise ValueError("{0} < 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 1 or {name} is NaN")
     elif cons == CONS_POISSON:
         if not (val >= 0):
-            raise ValueError("{0} < 0 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0 or {name} is NaN")
         elif not (val <= POISSON_LAM_MAX):
             raise ValueError(name + " value too large")
     elif cons == LEGACY_CONS_POISSON:
         if not (val >= 0):
-            raise ValueError("{0} < 0 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0 or {name} is NaN")
         elif not (val <= LEGACY_POISSON_LAM_MAX):
-            raise ValueError(name + " value too large")
+            raise ValueError(f"{name} value too large")
     elif cons == LEGACY_CONS_NON_NEGATIVE_INBOUNDS_LONG:
         # Note: Assume value is integral (double of LONG_MAX should work out)
         if val < 0:
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
         elif val > LONG_MAX:
             raise ValueError(
-                    name + " is out of bounds for long, consider using "
-                    "the new generator API for 64bit integers.")
+                f"{name} is out of bounds for long, consider using "
+                "the new generator API for 64bit integers.")
 
     return 0
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -204,13 +204,14 @@ cdef class Generator:
         self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
         self.lock = bit_generator.lock
 
-    def __repr__(self):
-        return self.__str__() + ' at 0x{:X}'.format(id(self))
+    def __repr__(self) -> str:
+        return f'{self.__str__()} at 0x{id(self):X}'
 
-    def __str__(self):
-        _str = self.__class__.__name__
-        _str += '(' + self.bit_generator.__class__.__name__ + ')'
-        return _str
+    def __str__(self) -> str:
+        return (
+            f'{self.__class__.__name__}'
+            f'({self.bit_generator.__class__.__name__})'
+        )
 
     # Pickling support:
     def __getstate__(self):

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -305,7 +305,7 @@ cdef class SeedSequence():
         elif not isinstance(entropy, (int, np.integer, list, tuple, range,
                                       np.ndarray)):
             raise TypeError('SeedSequence expects int or sequence of ints for '
-                            'entropy not {}'.format(entropy))
+                            f'entropy not {entropy}')
         self.entropy = entropy
         self.spawn_key = tuple(spawn_key)
         self.pool_size = pool_size

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -189,13 +189,14 @@ cdef class RandomState:
 
         self._initialize_bit_generator(bit_generator)
 
-    def __repr__(self):
-        return self.__str__() + ' at 0x{:X}'.format(id(self))
+    def __repr__(self) -> str:
+        return f'{self.__str__()} at 0x{id(self):X}'
 
-    def __str__(self):
-        _str = self.__class__.__name__
-        _str += '(' + self._bit_generator.__class__.__name__ + ')'
-        return _str
+    def __str__(self) -> str:
+        return (
+            f'{self.__class__.__name__}'
+            f'({self._bit_generator.__class__.__name__})'
+        )
 
     # Pickling support:
     def __getstate__(self):
@@ -1387,17 +1388,22 @@ cdef class RandomState:
 
         """
         if high is None:
-            warnings.warn(("This function is deprecated. Please call "
-                           "randint(1, {low} + 1) instead".format(low=low)),
-                          DeprecationWarning)
+            warnings.warn(
+                (
+                    "This function is deprecated. Please call "
+                    f"randint(1, {low} + 1) instead"
+                ),
+                DeprecationWarning)
             high = low
             low = 1
 
         else:
-            warnings.warn(("This function is deprecated. Please call "
-                           "randint({low}, {high} + 1) "
-                           "instead".format(low=low, high=high)),
-                          DeprecationWarning)
+            warnings.warn(
+                (
+                    "This function is deprecated. Please call "
+                    f"randint({low}, {high} + 1) instead"
+                ),
+                DeprecationWarning)
 
         return self.randint(low, int(high) + 1, size=size, dtype='l')
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2502,21 +2502,17 @@ def _assert_no_gc_cycles_context(name=None):
 
     if n_objects_in_cycles:
         name_str = f' when calling {name}' if name is not None else ''
+        joined_elements = ''.join(
+            "\n  {} object with id={}:\n    {}".format(
+                type(o).__name__,
+                id(o),
+                pprint.pformat(o).replace('\n', '\n    ')
+            ) for o in objects_in_cycles
+        )
         raise AssertionError(
-            "Reference cycles were found{}: {} objects were collected, "
-            "of which {} are shown below:{}"
-            .format(
-                name_str,
-                n_objects_in_cycles,
-                len(objects_in_cycles),
-                ''.join(
-                    "\n  {} object with id={}:\n    {}".format(
-                        type(o).__name__,
-                        id(o),
-                        pprint.pformat(o).replace('\n', '\n    ')
-                    ) for o in objects_in_cycles
-                )
-            )
+            f"Reference cycles were found{name_str}: {n_objects_in_cycles} "
+            f"objects were collected, of which {len(objects_in_cycles)} are "
+            f"shown below:{joined_elements}"
         )
 
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2510,7 +2510,8 @@ def _assert_no_gc_cycles_context(name=None):
                 n_objects_in_cycles,
                 len(objects_in_cycles),
                 ''.join(
-                    f"\n  {type(o).__name__} object with id={id(o)}:\n    {pprint.pformat(o).replace('\n', '\n    ')}"
+                    (f"\n  {type(o).__name__} object with id={id(o)}:\n    "
+                     f"{pprint.pformat(o).replace('\n', '\n    ')}")
                     for o in objects_in_cycles
                 )
             )

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2510,11 +2510,8 @@ def _assert_no_gc_cycles_context(name=None):
                 n_objects_in_cycles,
                 len(objects_in_cycles),
                 ''.join(
-                    "\n  {} object with id={}:\n    {}".format(
-                        type(o).__name__,
-                        id(o),
-                        pprint.pformat(o).replace('\n', '\n    ')
-                    ) for o in objects_in_cycles
+                    f"\n  {type(o).__name__} object with id={id(o)}:\n    {pprint.pformat(o).replace('\n', '\n    ')}"
+                    for o in objects_in_cycles
                 )
             )
         )

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -832,8 +832,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
             n_elements = flagged.size if flagged.ndim != 0 else reduced.size
             percent_mismatch = 100 * n_mismatch / n_elements
             remarks = [
-                'Mismatched elements: {} / {} ({:.3g}%)'.format(
-                    n_mismatch, n_elements, percent_mismatch)]
+                f'Mismatched elements: {n_mismatch} '
+                f'/ {n_elements} ({percent_mismatch:.3g}%)']
 
             with errstate(all='ignore'):
                 # ignore errors for non-numeric types

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2510,9 +2510,11 @@ def _assert_no_gc_cycles_context(name=None):
                 n_objects_in_cycles,
                 len(objects_in_cycles),
                 ''.join(
-                    (f"\n  {type(o).__name__} object with id={id(o)}:\n    "
-                     f"{pprint.pformat(o).replace('\n', '\n    ')}")
-                    for o in objects_in_cycles
+                    "\n  {} object with id={}:\n    {}".format(
+                        type(o).__name__,
+                        id(o),
+                        pprint.pformat(o).replace('\n', '\n    ')
+                    ) for o in objects_in_cycles
                 )
             )
         )

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -387,7 +387,7 @@ def test_all_modules_are_expected_2():
 
     if unexpected_members:
         raise AssertionError("Found unexpected object(s) that look like "
-                             "modules: {}".format(unexpected_members))
+                            f"modules: {unexpected_members}")
 
 
 def test_api_importable():
@@ -413,7 +413,7 @@ def test_api_importable():
 
     if module_names:
         raise AssertionError("Modules in the public API that cannot be "
-                             "imported: {}".format(module_names))
+                            f"imported: {module_names}")
 
     for module_name in PUBLIC_ALIASED_MODULES:
         try:
@@ -423,7 +423,7 @@ def test_api_importable():
 
     if module_names:
         raise AssertionError("Modules in the public API that were not "
-                             "found: {}".format(module_names))
+                            f"found: {module_names}")
 
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings('always', category=DeprecationWarning)
@@ -435,7 +435,7 @@ def test_api_importable():
     if module_names:
         raise AssertionError("Modules that are not really public but looked "
                              "public and can not be imported: "
-                             "{}".format(module_names))
+                             f"{module_names}")
 
 
 @pytest.mark.xfail(

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -35,7 +35,7 @@ class FindFuncs(ast.NodeVisitor):
             if node.args[0].value == "ignore":
                 raise AssertionError(
                     "warnings should have an appropriate stacklevel; found in "
-                    "{} on line {}".format(self.__filename, node.lineno))
+                    f"{self.__filename} on line {node.lineno}")
 
         if p.ls[-1] == 'warn' and (
                 len(p.ls) == 1 or p.ls[-2] == 'warnings'):
@@ -52,7 +52,7 @@ class FindFuncs(ast.NodeVisitor):
                 return
             raise AssertionError(
                 "warnings should have an appropriate stacklevel; found in "
-                "{} on line {}".format(self.__filename, node.lineno))
+                f"{self.__filename} on line {node.lineno}")
 
 
 @pytest.mark.slow

--- a/tools/swig/test/testFarray.py
+++ b/tools/swig/test/testFarray.py
@@ -13,7 +13,9 @@ else:          BadListError = ValueError
 
 # Add the distutils-generated build directory to the python search path and then
 # import the extension module
-libDir = "lib.{}-{}.{}".format(get_platform(), *sys.version_info[:2])
+libDir = (
+    f"lib.{get_platform()}-{sys.version_info[0]}.{sys.version_info[1]}"
+)
 sys.path.insert(0, os.path.join("build", libDir))
 import Farray
 


### PR DESCRIPTION
I went through the `numpy` repository and updated all of the strings using `'{}'.format()` to be equivalent f-strings, resolving the [Pylint `C0209`](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/consider-using-f-string.html) linting errors that were prevalent throughout the repository.  In terms of the functionality of the code, nothing was changed, but the code has been updated to meet more current Python style standards ([see Pylint `C0209` for more details](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/consider-using-f-string.html)).

Resolves #26278 