### PR TITLE
ENH: Speedup clip for floating point

### DIFF
--- a/benchmarks/benchmarks/bench_clip.py
+++ b/benchmarks/benchmarks/bench_clip.py
@@ -1,0 +1,35 @@
+from .common import Benchmark
+
+import numpy as np
+
+
+class ClipFloat(Benchmark):
+    param_names = ["dtype", "size"]
+    params = [
+        [np.float32, np.float64, np.longdouble],
+        [100, 100_000]
+    ]
+
+    def setup(self, dtype, size):
+        rng = np.random.default_rng()
+        self.array = rng.random(size=size).astype(dtype)
+        self.dataout = np.full_like(self.array, 0.5)
+
+    def time_clip(self, dtype, size):
+        np.clip(self.array, 0.125, 0.875, self.dataout)
+
+
+class ClipInteger(Benchmark):
+    param_names = ["dtype", "size"]
+    params = [
+        [np.int32, np.int64],
+        [100, 100_000]
+    ]
+
+    def setup(self, dtype, size):
+        rng = np.random.default_rng()
+        self.array = rng.integers(256, size=size, dtype=dtype)
+        self.dataout = np.full_like(self.array, 128)
+
+    def time_clip(self, dtype, size):
+        np.clip(self.array, 32, 224, self.dataout)


### PR DESCRIPTION
`np.clip` with floating point values is slower than it should be due to having to check and propagate `nans`.
This PR speeds up the operation by:
1) checking that `vmin` and `vmax` are not `nans` only once.
2) writing the clipping operation such that any `nans` in the input data will naturally propagate without having to check explicitly.

Sample output of `asv` on my laptop (WSL2 Ubuntu 22.04)
```
· Running 4 total benchmarks (2 commits * 1 environments * 2 benchmarks)
[ 0.00%] · For numpy commit bb069125 <speedup-float-clip~1> (round 1/2):
[ 0.00%] ·· Building for virtualenv-py3.10-Cython-build-packaging.....................................................
[ 0.00%] ·· Benchmarking virtualenv-py3.10-Cython-build-packaging
[12.50%] ··· Running (bench_clip.ClipFloat.time_clip--)..
[25.00%] · For numpy commit 3e1b55dc <speedup-float-clip> (round 1/2):
[25.00%] ·· Building for virtualenv-py3.10-Cython-build-packaging.
[25.00%] ·· Benchmarking virtualenv-py3.10-Cython-build-packaging
[37.50%] ··· Running (bench_clip.ClipFloat.time_clip--)..
[50.00%] · For numpy commit 3e1b55dc <speedup-float-clip> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.10-Cython-build-packaging
[62.50%] ··· bench_clip.ClipFloat.time_clip                                                                                        ok
[62.50%] ··· ================== ============= ============
             --                            size
             ------------------ --------------------------
                   dtype             100         100000
             ================== ============= ============
               numpy.float32     2.22±0.01μs   16.3±0.2μs
               numpy.float64     1.97±0.09μs    32.3±2μs
              numpy.longdouble    3.05±0.2μs    384±2μs
             ================== ============= ============

[75.00%] ··· bench_clip.ClipInteger.time_clip                                                                                      ok
[75.00%] ··· ============= ============= ============
             --                       size
             ------------- --------------------------
                 dtype          100         100000
             ============= ============= ============
              numpy.int32   2.27±0.02μs   25.2±0.3μs
              numpy.int64   2.00±0.01μs    76.7±1μs
             ============= ============= ============

[75.00%] · For numpy commit bb069125 <speedup-float-clip~1> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.10-Cython-build-packaging.
[75.00%] ·· Benchmarking virtualenv-py3.10-Cython-build-packaging
[87.50%] ··· bench_clip.ClipFloat.time_clip                                                                                        ok
[87.50%] ··· ================== ============= ============
             --                            size
             ------------------ --------------------------
                   dtype             100         100000
             ================== ============= ============
               numpy.float32     2.25±0.01μs   33.0±0.6μs
               numpy.float64     1.98±0.03μs    63.8±1μs
              numpy.longdouble   2.96±0.02μs    383±3μs
             ================== ============= ============

[100.00%] ··· bench_clip.ClipInteger.time_clip                                                                                      ok
[100.00%] ··· ============= ============= ============
              --                       size
              ------------- --------------------------
                  dtype          100         100000
              ============= ============= ============
               numpy.int32   2.28±0.01μs   24.9±0.1μs
               numpy.int64   2.01±0.03μs    75.4±2μs
              ============= ============= ============

| Change   | Before [bb069125] <speedup-float-clip~1>   | After [3e1b55dc] <speedup-float-clip>   |   Ratio | Benchmark (Parameter)                                           |
|----------|--------------------------------------------|-----------------------------------------|---------|-----------------------------------------------------------------|
| -        | 63.8±1μs                                   | 32.3±2μs                                |    0.51 | bench_clip.ClipFloat.time_clip(<class 'numpy.float64'>, 100000) |
| -        | 33.0±0.6μs                                 | 16.3±0.2μs                              |    0.49 | bench_clip.ClipFloat.time_clip(<class 'numpy.float32'>, 100000) |
```

I was not able to get `asv` to run on native Windows. 
```
(numpy-dev) C:\work\repos\numpy>spin bench -c HEAD~1 -t bench_clip
$ cd benchmarks
$ asv continuous --factor 1.05 --bench bench_clip 5aa66561f991dd40914aebedacf5ee462b8dd560 7ef941d96a2814dc0c806457560d2a996b29515b
Error: [WinError 2] The system cannot find the file specified; aborting.
```
But the gains (from other testing) were even larger because the `main` branch code was running slower on native Windows than on WSL2 to begin with (due to poorer codegen for MSVC). 
https://godbolt.org/z/TPoax4b9v