### PR TITLE
MNT: replace _PyDict_GetItemStringWithError with PyDict_GetItemStringRef

### DIFF
--- a/numpy/_core/src/common/ufunc_override.c
+++ b/numpy/_core/src/common/ufunc_override.c
@@ -2,6 +2,7 @@
 #define _MULTIARRAYMODULE
 
 #include "numpy/ndarraytypes.h"
+#include "npy_pycompat.h"
 #include "get_attr_string.h"
 #include "npy_import.h"
 #include "ufunc_override.h"
@@ -99,12 +100,11 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         *out_kwd_obj = NULL;
         return -1;
     }
-    /* borrowed reference */
-    *out_kwd_obj = _PyDict_GetItemStringWithError(kwds, "out");
-    if (*out_kwd_obj == NULL) {
-        if (PyErr_Occurred()) {
-            return -1;
-        }
+    int result = PyDict_GetItemStringRef(kwds, "out", out_kwd_obj);
+    if (result == -1) {
+        return -1;
+    }
+    else if (result == 0) {
         Py_INCREF(Py_None);
         *out_kwd_obj = Py_None;
         return 0;

--- a/numpy/_core/src/common/ufunc_override.c
+++ b/numpy/_core/src/common/ufunc_override.c
@@ -118,15 +118,14 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         seq = PySequence_Fast(*out_kwd_obj,
                               "Could not convert object to sequence");
         if (seq == NULL) {
-            *out_kwd_obj = NULL;
+            Py_CLEAR(*out_kwd_obj);
             return -1;
         }
         *out_objs = PySequence_Fast_ITEMS(seq);
-        *out_kwd_obj = seq;
+        Py_SETREF(*out_kwd_obj, seq);
         return PySequence_Fast_GET_SIZE(seq);
     }
     else {
-        Py_INCREF(*out_kwd_obj);
         *out_objs = out_kwd_obj;
         return 1;
     }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -12,7 +12,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"
-
+#include "npy_pycompat.h"
 #include "npy_ctypes.h"
 
 #include "multiarraymodule.h"
@@ -2180,10 +2180,10 @@ PyArray_FromInterface(PyObject *origin)
     }
 
     /* Get type string from interface specification */
-    attr = _PyDict_GetItemStringWithError(iface, "typestr");
-    if (attr == NULL) {
+    int result = PyDict_GetItemStringRef(iface, "typestr", &attr);
+    if (result <= 0) {
         Py_DECREF(iface);
-        if (!PyErr_Occurred()) {
+        if (result == 0) {
             PyErr_SetString(PyExc_ValueError,
                     "Missing __array_interface__ typestr");
         }
@@ -2207,43 +2207,47 @@ PyArray_FromInterface(PyObject *origin)
      * the 'descr' attribute.
      */
     if (dtype->type_num == NPY_VOID) {
-        PyObject *descr = _PyDict_GetItemStringWithError(iface, "descr");
-        if (descr == NULL && PyErr_Occurred()) {
+        PyObject *descr = NULL;
+        result = PyDict_GetItemStringRef(iface, "descr", &descr);
+        if (result == -1) {
             goto fail;
         }
         PyArray_Descr *new_dtype = NULL;
-        if (descr != NULL) {
+        if (result == 1) {
             int is_default = _is_default_descr(descr, attr);
             if (is_default < 0) {
+                Py_DECREF(descr);
                 goto fail;
             }
             if (!is_default) {
                 if (PyArray_DescrConverter2(descr, &new_dtype) != NPY_SUCCEED) {
+                    Py_DECREF(descr);
                     goto fail;
                 }
                 if (new_dtype != NULL) {
-                    Py_DECREF(dtype);
-                    dtype = new_dtype;
+                    Py_SETREF(dtype, new_dtype);
                 }
             }
-
         }
-
+        Py_DECREF(descr);
     }
+    Py_CLEAR(attr);
 
     /* Get shape tuple from interface specification */
-    attr = _PyDict_GetItemStringWithError(iface, "shape");
-    if (attr == NULL) {
-        if (PyErr_Occurred()) {
-            return NULL;
-        }
+    result = PyDict_GetItemStringRef(iface, "shape", &attr);
+    if (result < 0) {
+        return NULL;
+    }
+    if (result == 0) {
         /* Shape must be specified when 'data' is specified */
-        PyObject *data = _PyDict_GetItemStringWithError(iface, "data");
-        if (data == NULL && PyErr_Occurred()) {
+        int result = PyDict_ContainsString(iface, "data");
+        if (result < 0) {
+            Py_DECREF(attr);
             return NULL;
         }
-        else if (data != NULL) {
+        else if (result == 1) {
             Py_DECREF(iface);
+            Py_DECREF(attr);
             PyErr_SetString(PyExc_ValueError,
                     "Missing __array_interface__ shape");
             return NULL;
@@ -2271,10 +2275,11 @@ PyArray_FromInterface(PyObject *origin)
             }
         }
     }
+    Py_CLEAR(attr);
 
     /* Get data buffer from interface specification */
-    attr = _PyDict_GetItemStringWithError(iface, "data");
-    if (attr == NULL && PyErr_Occurred()){
+    result = PyDict_GetItemStringRef(iface, "data", &attr);
+    if (result == -1){
         return NULL;
     }
 
@@ -2337,20 +2342,24 @@ PyArray_FromInterface(PyObject *origin)
         PyBuffer_Release(&view);
 
         /* Get offset number from interface specification */
-        attr = _PyDict_GetItemStringWithError(iface, "offset");
-        if (attr == NULL && PyErr_Occurred()) {
+        PyObject *offset = NULL;
+        result = PyDict_GetItemStringRef(iface, "offset", &offset);
+        if (result == -1) {
             goto fail;
         }
-        else if (attr) {
-            npy_longlong num = PyLong_AsLongLong(attr);
+        else if (result == 1) {
+            npy_longlong num = PyLong_AsLongLong(offset);
             if (error_converting(num)) {
                 PyErr_SetString(PyExc_TypeError,
                         "__array_interface__ offset must be an integer");
+                Py_DECREF(offset);
                 goto fail;
             }
             data += num;
+            Py_DECREF(offset);
         }
     }
+    Py_CLEAR(attr);
 
     ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
             &PyArray_Type, dtype,
@@ -2376,21 +2385,23 @@ PyArray_FromInterface(PyObject *origin)
             goto fail;
         }
     }
-    attr = _PyDict_GetItemStringWithError(iface, "strides");
-    if (attr == NULL && PyErr_Occurred()){
+    result = PyDict_GetItemStringRef(iface, "strides", &attr);
+    if (result == -1){
         return NULL;
     }
-    if (attr != NULL && attr != Py_None) {
+    if (result == 1 && attr != Py_None) {
         if (!PyTuple_Check(attr)) {
             PyErr_SetString(PyExc_TypeError,
                     "strides must be a tuple");
             Py_DECREF(ret);
+            Py_DECREF(attr);
             goto fail;
         }
         if (n != PyTuple_GET_SIZE(attr)) {
             PyErr_SetString(PyExc_ValueError,
                     "mismatch in length of strides and shape");
             Py_DECREF(ret);
+            Py_DECREF(attr);
             goto fail;
         }
         for (i = 0; i < n; i++) {
@@ -2398,18 +2409,21 @@ PyArray_FromInterface(PyObject *origin)
             strides[i] = PyArray_PyIntAsIntp(tmp);
             if (error_converting(strides[i])) {
                 Py_DECREF(ret);
+                Py_DECREF(attr);
                 goto fail;
             }
         }
         if (n) {
             memcpy(PyArray_STRIDES(ret), strides, n*sizeof(npy_intp));
         }
+        Py_DECREF(attr);
     }
     PyArray_UpdateFlags(ret, NPY_ARRAY_UPDATE_ALL);
     Py_DECREF(iface);
     return (PyObject *)ret;
 
  fail:
+    Py_XDECREF(attr);
     Py_XDECREF(dtype);
     Py_XDECREF(iface);
     return NULL;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2394,14 +2394,12 @@ PyArray_FromInterface(PyObject *origin)
             PyErr_SetString(PyExc_TypeError,
                     "strides must be a tuple");
             Py_DECREF(ret);
-            Py_DECREF(attr);
             goto fail;
         }
         if (n != PyTuple_GET_SIZE(attr)) {
             PyErr_SetString(PyExc_ValueError,
                     "mismatch in length of strides and shape");
             Py_DECREF(ret);
-            Py_DECREF(attr);
             goto fail;
         }
         for (i = 0; i < n; i++) {
@@ -2409,7 +2407,6 @@ PyArray_FromInterface(PyObject *origin)
             strides[i] = PyArray_PyIntAsIntp(tmp);
             if (error_converting(strides[i])) {
                 Py_DECREF(ret);
-                Py_DECREF(attr);
                 goto fail;
             }
         }

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -8,7 +8,7 @@
 #include "numpy/arrayobject.h"
 
 #include "npy_config.h"
-
+#include "npy_pycompat.h"
 #include "npy_import.h"
 #include "common.h"
 #include "number.h"
@@ -60,24 +60,24 @@ array_inplace_matrix_multiply(PyArrayObject *m1, PyObject *m2);
  * Those not present will not be changed
  */
 
-/* FIXME - macro contains a return */
-#define SET(op)   temp = _PyDict_GetItemStringWithError(dict, #op); \
-    if (temp == NULL && PyErr_Occurred()) { \
+/* FIXME - macro contains returns  */
+#define SET(op) \
+    res = PyDict_GetItemStringRef(dict, #op, &temp); \
+    if (res == -1) { \
         return -1; \
     } \
-    else if (temp != NULL) { \
+    else if (res == 1) { \
         if (!(PyCallable_Check(temp))) { \
             return -1; \
         } \
-        Py_INCREF(temp); \
-        Py_XDECREF(n_ops.op); \
-        n_ops.op = temp; \
+        Py_XSETREF(n_ops.op, temp); \
     }
 
 NPY_NO_EXPORT int
 _PyArray_SetNumericOps(PyObject *dict)
 {
     PyObject *temp = NULL;
+    int res;
     SET(add);
     SET(subtract);
     SET(multiply);

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -68,6 +68,7 @@ array_inplace_matrix_multiply(PyArrayObject *m1, PyObject *m2);
     } \
     else if (res == 1) { \
         if (!(PyCallable_Check(temp))) { \
+            Py_DECREF(temp); \
             return -1; \
         } \
         Py_XSETREF(n_ops.op, temp); \

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -4,7 +4,7 @@
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
 #include "npy_import.h"
-
+#include "npy_pycompat.h"
 #include "override.h"
 #include "ufunc_override.h"
 
@@ -148,18 +148,16 @@ static int
 normalize_signature_keyword(PyObject *normal_kwds)
 {
     /* If the keywords include `sig` rename to `signature`. */
-    PyObject* obj = _PyDict_GetItemStringWithError(normal_kwds, "sig");
-    if (obj == NULL && PyErr_Occurred()) {
+    PyObject* obj = NULL;
+    int result = PyDict_GetItemStringRef(normal_kwds, "sig", &obj);
+    if (result == -1) {
         return -1;
     }
-    if (obj != NULL) {
-        /*
-         * No INCREF or DECREF needed: got a borrowed reference above,
-         * and, unlike e.g. PyList_SetItem, PyDict_SetItem INCREF's it.
-         */
+    if (result == 1) {
         if (PyDict_SetItemString(normal_kwds, "signature", obj) < 0) {
             return -1;
         }
+        Py_DECREF(obj);
         if (PyDict_DelItemString(normal_kwds, "sig") < 0) {
             return -1;
         }

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -155,6 +155,7 @@ normalize_signature_keyword(PyObject *normal_kwds)
     }
     if (result == 1) {
         if (PyDict_SetItemString(normal_kwds, "signature", obj) < 0) {
+            Py_DECREF(obj);
             return -1;
         }
         Py_DECREF(obj);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -33,7 +33,7 @@
 #include <stddef.h>
 
 #include "npy_config.h"
-
+#include "npy_pycompat.h"
 #include "npy_argparse.h"
 
 #include "numpy/arrayobject.h"
@@ -142,8 +142,10 @@ PyUFunc_clearfperr()
 NPY_NO_EXPORT int
 set_matmul_flags(PyObject *d)
 {
-    PyObject *matmul = _PyDict_GetItemStringWithError(d, "matmul");
-    if (matmul == NULL) {
+    PyObject *matmul = NULL;
+    int result = PyDict_GetItemStringRef(d, "matmul", &matmul);
+    if (result <= 0) {
+        // caller sets an error if one isn't already set
         return -1;
     }
     /*
@@ -162,6 +164,7 @@ set_matmul_flags(PyObject *d)
                                          NPY_ITER_UPDATEIFCOPY |
                                          NPY_UFUNC_DEFAULT_OUTPUT_FLAGS) &
                                          ~NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+    Py_DECREF(matmul);
     return 0;
 }
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -21,6 +21,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 #include "abstract.h"
 
 #include "numpy/npy_math.h"
@@ -303,29 +304,32 @@ int initumath(PyObject *m)
      * TODO: This should probably be done at a better place, or even in the
      *       code generator directly.
      */
-    s = _PyDict_GetItemStringWithError(d, "logical_and");
-    if (s == NULL) {
+    int res = PyDict_GetItemStringRef(d, "logical_and", &s);
+    if (res <= 0) {
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
         return -1;
     }
+    Py_DECREF(s);
 
-    s = _PyDict_GetItemStringWithError(d, "logical_or");
-    if (s == NULL) {
+    res = PyDict_GetItemStringRef(d, "logical_or", &s);
+    if (res <= 0) {
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
         return -1;
     }
+    Py_DECREF(s);
 
-    s = _PyDict_GetItemStringWithError(d, "logical_xor");
-    if (s == NULL) {
+    res = PyDict_GetItemStringRef(d, "logical_xor", &s);
+    if (res <= 0) {
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
         return -1;
     }
+    Py_DECREF(s);
 
     if (init_string_ufuncs(d) < 0) {
         return -1;

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -309,6 +309,7 @@ int initumath(PyObject *m)
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
+        Py_DECREF(s);
         return -1;
     }
     Py_DECREF(s);
@@ -318,6 +319,7 @@ int initumath(PyObject *m)
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
+        Py_DECREF(s);
         return -1;
     }
     Py_DECREF(s);
@@ -327,6 +329,7 @@ int initumath(PyObject *m)
         return -1;
     }
     if (install_logical_ufunc_promoter(s) < 0) {
+        Py_DECREF(s);
         return -1;
     }
     Py_DECREF(s);


### PR DESCRIPTION
Replaces all usages of the private `_PyDict_GetItemStringWithError` Python C API function with `PyDict_GetItemStringRef`. The latter is available in the python 3.13 C API and via `python-capicompat` in older python versions.

The new function has the same [semantics as `PyDict_GetItemRef`](https://docs.python.org/3.13/c-api/dict.html#c.PyDict_GetItemRef) but takes a UTF-8 C string instead of a python object. Like `_PyDict_GetItemStringWithError`, it does not suppress errors. It also has the nice improvement that the return type is now int and it signals success or failure. This lets me re-structure control flow a bit and avoid `PyErr_Occurred()` calls.

I used the new `PyDict_ContainsString` function if all we care about is whether a key is in the dict. I also used `Py_SETREF` in a few places that were using the unsafe decref then set pattern.

See #26159 for the relevant tracking issue.