### PR TITLE
DOC: correct PR referenced in __array_wraps__ change note

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -298,7 +298,7 @@ Deprecations
   support for implementations not accepting all three are deprecated.  Its signature
   should be ``__array_wrap__(self, arr, context=None, return_scalar=False)``
 
-  (`gh-25408 <https://github.com/numpy/numpy/pull/25408>`__)
+  (`gh-25409 <https://github.com/numpy/numpy/pull/25409>`__)
 
 * Arrays of 2-dimensional vectors for ``np.cross`` have been deprecated. Use
   arrays of 3-dimensional vectors instead.


### PR DESCRIPTION
#25409 changes `__array_wrap__` , #25408 is a declined docstring change.