### PR TITLE
TST: run the smoke tests on more python versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
+    strategy:
+      matrix:
+        version: ["3.10", "3.11", "3.12", "3.13-dev"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -60,7 +63,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.version }}
     - uses: ./.github/meson_actions
 
   pypy:


### PR DESCRIPTION
This makes sure numpy is buildable and the not-slow test suite passes on all supported python versions. I added `3.13-dev` to support the nogil work but Python 3.13 b1 is almost due to be released. I'll disable the 3.13 test if it ends up being annoyingly noisy before the first beta release, but I suspect it'll be a net benefit to have 3.13 testing starting now.