### PR TITLE
BLD: ensure libnpymath and highway static libs use hidden visibility

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -112,7 +112,8 @@ if use_highway
     ],
     cpp_args: '-DTOOLCHAIN_MISS_ASM_HWCAP_H',
     include_directories: ['src/highway'],
-    install: false
+    install: false,
+    gnu_symbol_visibility: 'hidden',
   )
 else
   highway_lib = []
@@ -561,6 +562,7 @@ npymath_lib = static_library('npymath',
   install_dir: np_dir / '_core/lib',
   name_prefix: name_prefix_staticlib,
   name_suffix: name_suffix_staticlib,
+  gnu_symbol_visibility: 'hidden',
 )
 
 dir_separator = '/'


### PR DESCRIPTION
The effect this has is that symbols don't get re-exported as public by Python extension modules that link with these shared libraries. E.g., building on macOS arm64 with Clang changes the set of exported symbols for `_multiarray_umath` from:

```
% dyld_info -exports build/numpy/_core/_multiarray_umath.cpython-39-darwin.so
build/numpy/_core/_multiarray_umath.cpython-39-darwin.so [arm64]:
    -exports:
        offset      symbol
        0x00112BA4  _PyInit__multiarray_umath
        0x001C955C  _npy_spacingf
        0x001C95F8  _npy_spacing
        ...
        <many more _npy symbols>
```
to:
```
  build/numpy/_core/_multiarray_umath.cpython-311-darwin.so [arm64]:
    -exports:
        offset      symbol
        0x0010B8F8  _PyInit__multiarray_umath
```

This works for all compilers that support GNU-style `__attribute__((visibility("hidden"))`, which both GCC and Clang do. Tested on SciPy as well, it has the same effect there. For example, `scipy.special._ufuncs` was re-exporting all `_npy_*` symbols and after this change that is no longer the case.

Note that the `libnpyrandom` static library is left alone here. Trying to change visibility there breaks a test for CFFI, because that test is accessing private symbols. This is clearly wrong, but explicitly documented at
https://numpy.org/devdocs/reference/random/extending.html#cffi. So leaving that alone here. `libnpyrandom` isn't used by SciPy anymore and may well have zero users left, so it's not critical.