### PR TITLE
MNT: disable the coercion cache for the nogil build

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -1,0 +1,15 @@
+import concurrent.futures
+
+import numpy as np
+
+
+def test_parallel_errstate_creation():
+    # if the coercion cache is enabled and not thread-safe, creating
+    # RandomState instances simultaneously leads to a data race
+    def func(seed):
+        np.random.RandomState(seed)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as tpe:
+        futures = [tpe.submit(func, i) for i in range(500)]
+        for f in futures:
+            f.result()

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -1,6 +1,12 @@
 import concurrent.futures
 
 import numpy as np
+import pytest
+
+from numpy.testing import IS_WASM
+
+if IS_WASM:
+    pytest.skip(allow_module_level=True, reason="no threading support in wasm")
 
 
 def test_parallel_errstate_creation():


### PR DESCRIPTION
This disables the coercion cache on the nogil build, but I'd like to find a benchmark that shows the benefit of this cache more than what's already in `bench_array_coercion.py` and `bench_core.py`.

I don't see any significant performance impact before or after this change, although note that I can't actually run asv in comparison mode yet in the nogil build.

When I disable this cache for the single-threaded build (e.g. set  `COERCION_CACHE_CACHE_SIZE` to 0 in both branches of the ifdef) where I *can* run asv in comparison mode, I get the following results:

```
| Change   | Before [3c09f166] <main>   | After [c981c067] <disable-coercion-cache>   |   Ratio | Benchmark (Parameter)                                               |
|----------|----------------------------|---------------------------------------------|---------|---------------------------------------------------------------------|
| +        | 219±0.6ns                  | 233±6ns                                     |    1.06 | bench_array_coercion.ArrayCoercionSmall.time_array_no_copy([1])     |
| +        | 196±0.7ns                  | 208±1ns                                     |    1.06 | bench_array_coercion.ArrayCoercionSmall.time_ascontiguousarray([1]) |
| +        | 249±3ns                    | 262±6ns                                     |    1.05 | bench_array_coercion.ArrayCoercionSmall.time_asarray_dtype([1])     |

| Change   | Before [3c09f166] <main>   | After [c981c067] <disable-coercion-cache>   |   Ratio | Benchmark (Parameter)                                                            |
|----------|----------------------------|---------------------------------------------|---------|----------------------------------------------------------------------------------|
| +        | 687±7ns                    | 732±2ns                                     |    1.07 | bench_core.StatsMethods.time_sum('bool_', 100)                                   |
| -        | 10.9±2μs                   | 10.4±0.01μs                                 |    0.95 | bench_core.CountNonzero.time_count_nonzero_axis(3, 10000, <class 'numpy.int64'>) |
| -        | 22.7±0.1μs                 | 21.6±0.4μs                                  |    0.95 | bench_core.StatsMethods.time_var('bool_', 10000)                                 |
| -        | 640±20ns                   | 602±10ns                                    |    0.94 | bench_core.StatsMethods.time_prod('uint64', 100)                                 |
| -        | 665±40ns                   | 610±4ns                                     |    0.92 | bench_core.StatsMethods.time_max('int64', 100)                                   |
| -        | 201±2ns                    | 183±0.9ns                                   |    0.91 | bench_core.Core.time_array_l1                                                    |
| -        | 7.15±2ms                   | 6.34±0.3ms                                  |    0.89 | bench_core.CountNonzero.time_count_nonzero_axis(3, 1000000, <class 'str'>)       |
```

So it does have a small, ~5% benefit for a few of the array coercion tests, but a somewhat confusing mix of performance improvements and performance hits for reduction operations, and two other 10% performance hits for creating an array from a single-element list and a benchmark for `count_nonzero` with `axis` set.

Maybe this is all just noise?