### PR TITLE
BUG: Workaround for Intel Compiler mask conversion bug

### DIFF
--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx>=4.5.0
+sphinx==7.2.6
 numpydoc==1.4
 pydata-sphinx-theme==0.13.3
 sphinx-design


### PR DESCRIPTION
Backport of #26281.

closes #26197
  
  Encountered a specific bug with Intel Compiler when `_cvtmask64_u64` comparisons against `-1`
  trigger erroneous optimizations. This bug affects equality (`==`) and inequality (`!=`)
  comparisons crucial for operations like `np.logical_or`.
  The issue originates from the compiler’s optimizer, which mistakenly duplicates the
  last vector comparison instruction (targeting `zmm`) onto `ymm`.
  It then incorrectly performs a bitwise XOR between the masks from the duplicate and original
  instructions, leading to wrong results.
  This patch implements a workaround to bypass this behavior.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
