### PR TITLE
BLD: In 1.26.x, do not upper-bound the meson-python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "Cython>=0.29.34,<3.1",
-    "meson-python>=0.15.0,<0.16.0",
+    "meson-python>=0.15.0",
 ]
 
 [project]


### PR DESCRIPTION
Allows building with the just-released meson-python 0.16.0.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
The `main` and `maintenance/2.0.x` branches already lack an upper bound on the `meson-python` version, e.g.:

https://github.com/numpy/numpy/blob/50a705cb9c6f4c755c9793f719d35ebdfe574978/pyproject.toml#L4

I tested this in Fedora by building an [updated `python-meson-python` package](https://src.fedoraproject.org/rpms/python-meson-python/pull-request/4) and test-rebuilding the [`numpy` package](https://src.fedoraproject.org/rpms/numpy) with this PR applied as a patch.