### PR TITLE
BLD: use newer openblas wheels [wheel build]

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.27.0.1
+scipy-openblas32==0.3.27.44.2

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.27.44.2
+scipy-openblas32==0.3.27.44.3

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.27.44.2
-scipy-openblas64==0.3.27.44.2
+scipy-openblas32==0.3.27.44.3
+scipy-openblas64==0.3.27.44.3

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.27.0.1
-scipy-openblas64==0.3.27.0.1
+scipy-openblas32==0.3.27.44.2
+scipy-openblas64==0.3.27.44.2


### PR DESCRIPTION
Fix wheel build failure on macos-x86_64 with newer wheels, see MacPython/openblas-libs#153. Blocking #26273.