### PR TITLE
DOC: add explanation of dtype to parameter values for np.append

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5760,8 +5760,11 @@ def append(arr, values, axis=None):
 
     >>> a = np.array([1, 2], dtype=int)
     >>> b = []
-    >>> np.append(a, b)
+    >>> c = np.append(a, b)
+    >>> c
     array([1., 2.])
+    >>> c.dtype
+    float64
 
     Default dtype for empty lists is `float64` thus making the output of dtype
     `float64` when appended with dtype `int64`

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5715,10 +5715,7 @@ def append(arr, values, axis=None):
         These values are appended to a copy of `arr`.  It must be of the
         correct shape (the same shape as `arr`, excluding `axis`).  If
         `axis` is not specified, `values` can be any shape and will be
-        flattened before use. If dtype of `values` is different from the
-        dtype of `arr` then their dtypes are compared to figure out the
-        common dtype they can both be safely coerced to. For e.g. `int64`
-        and `float64` can both go to `float64`.
+        flattened before use.
     axis : int, optional
         The axis along which `values` are appended.  If `axis` is not
         given, both `arr` and `values` are flattened before use.
@@ -5734,6 +5731,13 @@ def append(arr, values, axis=None):
     --------
     insert : Insert elements into an array.
     delete : Delete elements from an array.
+
+    Notes
+    -----
+    If dtype of `values` is different from the dtype of `arr` then
+    their dtypes are compared to figure out the common dtype they can
+    both be safely coerced to. For e.g. `int64` and `float64` can both
+    go to `float64`. See examples section below.
 
     Examples
     --------

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5732,13 +5732,6 @@ def append(arr, values, axis=None):
     insert : Insert elements into an array.
     delete : Delete elements from an array.
 
-    Notes
-    -----
-    If dtype of `values` is different from the dtype of `arr` then
-    their dtypes are compared to figure out the common dtype they can
-    both be safely coerced to. For e.g. `int64` and `float64` can both
-    go to `float64`. See examples section below.
-
     Examples
     --------
     >>> np.append([1, 2, 3], [[4, 5, 6], [7, 8, 9]])
@@ -5759,14 +5752,13 @@ def append(arr, values, axis=None):
     dimension(s)
 
     >>> a = np.array([1, 2], dtype=int)
-    >>> b = []
-    >>> c = np.append(a, b)
+    >>> c = np.append(a, [])
     >>> c
     array([1., 2.])
     >>> c.dtype
     float64
 
-    Default dtype for empty lists is `float64` thus making the output of dtype
+    Default dtype for empty ndarrays is `float64` thus making the output of dtype
     `float64` when appended with dtype `int64`
 
     """

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5715,8 +5715,8 @@ def append(arr, values, axis=None):
         These values are appended to a copy of `arr`.  It must be of the
         correct shape (the same shape as `arr`, excluding `axis`).  If
         `axis` is not specified, `values` can be any shape and will be
-        flattened before use. If dtype of values is different from the
-        dtype of arr then their dtypes are compared to figure out the
+        flattened before use. If dtype of `values` is different from the
+        dtype of `arr` then their dtypes are compared to figure out the
         common dtype they can both be safely coerced to. For e.g. `int64`
         and `float64` can both go to `float64`.
     axis : int, optional

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5746,12 +5746,21 @@ def append(arr, values, axis=None):
     array([[1, 2, 3],
            [4, 5, 6],
            [7, 8, 9]])
+
     >>> np.append([[1, 2, 3], [4, 5, 6]], [7, 8, 9], axis=0)
     Traceback (most recent call last):
         ...
     ValueError: all the input arrays must have same number of dimensions, but
     the array at index 0 has 2 dimension(s) and the array at index 1 has 1
     dimension(s)
+
+    >>> a = np.array([1, 2], dtype=int)
+    >>> b = []
+    >>> np.append(a, b)
+    array([1., 2.])
+
+    Default dtype for empty lists is `float64` thus making the output of dtype
+    `float64` when appended with dtype `int64`
 
     """
     arr = asanyarray(arr)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5715,7 +5715,10 @@ def append(arr, values, axis=None):
         These values are appended to a copy of `arr`.  It must be of the
         correct shape (the same shape as `arr`, excluding `axis`).  If
         `axis` is not specified, `values` can be any shape and will be
-        flattened before use.
+        flattened before use. If dtype of values is different from the
+        dtype of arr then their dtypes are compared to figure out the
+        common dtype they can both be safely coerced to. For e.g. `int64`
+        and `float64` can both go to `float64`.
     axis : int, optional
         The axis along which `values` are appended.  If `axis` is not
         given, both `arr` and `values` are flattened before use.


### PR DESCRIPTION
Improve doc strings to include explanation of `dtype` to parameter `values` for `np.append`

closes https://github.com/numpy/numpy/issues/26291