### PR TITLE
DOC: Follow-up fixes for new theme

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -12,6 +12,13 @@ body {
   font-size: medium;
 }
 
+/* Making sure the navbar shows correctly in one line
+   Reduces the space between the top-left logo and the navbar section titles */
+
+.col-lg-3 {
+  width: 15%;
+}
+
 /* Version switcher colors from PyData Sphinx Theme */
 
 .version-switcher__button[data-active-version-name*="devdocs"] {
@@ -58,12 +65,10 @@ div.admonition-legacy {
   border-color: var(--pst-color-warning);
 }
 
-.admonition>.admonition-title::after,
-div.admonition>.admonition-title::after {
+div.admonition-legacy>.admonition-title::after {
   color: var(--pst-color-warning);
 }
 
-.admonition>.admonition-title,
-div.admonition>.admonition-title {
+div.admonition-legacy>.admonition-title {
   background-color: var(--pst-color-warning-bg);
 }


### PR DESCRIPTION
Fixes spacing between logo and navbar section titles, and admonition colors.

This is a follow-up to #26125 - I noticed the navbar spacing was off, and that the regular admonitions were erroneously taking colors from the legacy admonition colors.


