### PR TITLE
DOC: Follow-up fixes for new theme

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -12,6 +12,13 @@ body {
   font-size: medium;
 }
 
+/* Making sure the navbar shows correctly in one line
+   Reduces the space between the top-left logo and the navbar section titles */
+
+.col-lg-3 {
+  width: 15%;
+}
+
 /* Version switcher colors from PyData Sphinx Theme */
 
 .version-switcher__button[data-active-version-name*="devdocs"] {
@@ -58,12 +65,10 @@ div.admonition-legacy {
   border-color: var(--pst-color-warning);
 }
 
-.admonition>.admonition-title::after,
-div.admonition>.admonition-title::after {
+div.admonition-legacy>.admonition-title::after {
   color: var(--pst-color-warning);
 }
 
-.admonition>.admonition-title,
-div.admonition>.admonition-title {
+div.admonition-legacy>.admonition-title {
   background-color: var(--pst-color-warning-bg);
 }


### PR DESCRIPTION
Backport of #26311.

Fixes spacing between logo and navbar section titles, and admonition colors.

[skip azp] [skip cirrus] [skip actions]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
