### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -346,7 +346,7 @@ def lint(ctx, branch, uncommitted):
     Examples:
 
     \b
-    For lint checks of your development brach with `main` or a custom branch:
+    For lint checks of your development branch with `main` or a custom branch:
 
     \b
     $ spin lint # defaults to main
@@ -467,7 +467,7 @@ def bench(ctx, tests, compare, verbose, quick, commits):
         ] + bench_args
         _run_asv(cmd)
     else:
-        # Ensure that we don't have uncommited changes
+        # Ensure that we don't have uncommitted changes
         commit_a, commit_b = [_commit_to_sha(c) for c in commits]
 
         if commit_b == 'HEAD' and _dirty_git_working_dir():

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ PAPER         ?=
 DOXYGEN       ?= doxygen
 # For merging a documentation archive into a git checkout of numpy/doc
 # Turn a tag like v1.18.0 into 1.18
-# Use sed -n -e 's/patttern/match/p' to return a blank value if no match
+# Use sed -n -e 's/pattern/match/p' to return a blank value if no match
 TAG ?= $(shell git describe --tag | sed -n -e's,v\([1-9]\.[0-9]*\)\.[0-9].*,\1,p')
 
 FILES=

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -241,7 +241,7 @@ to define string equality, will be added to a ufunc.
         nin = 1
         nout = 1
         # DTypes are stored on the BoundArrayMethod and not on the internal
-        # ArrayMethod, to reference cyles.
+        # ArrayMethod, to reference cycles.
         DTypes = (String, String, Bool)
 
         def resolve_descriptors(self: ArrayMethod, DTypes, given_descrs):

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -386,7 +386,7 @@ DTypes, and we think it would harm adoption to require users to refactor their
 DType-handling code if they want to use ``StringDType``.
 
 We also hope that in the future we might be able to add a new fixed-width text
-version of ``StringDType`` that can re-use the ``"T"`` character code with
+version of ``StringDType`` that can reuse the ``"T"`` character code with
 length or encoding modifiers. This will allow a migration to a more flexible
 text dtype for use with structured arrays and other use-cases with a fixed-width
 string is a better fit than a variable-width string.
@@ -990,11 +990,11 @@ in the array buffer as a short string.
 
 No matter where it is stored, once a string is initialized it is marked with the
 ``NPY_STRING_INITIALIZED`` flag. This lets us clearly distinguish between an
-unitialized empty string and a string that has been mutated into the empty
+uninitialized empty string and a string that has been mutated into the empty
 string.
 
 The size of the allocation is stored in the arena to allow reuse of the arena
-allocation if a string is mutated. In principle we could disallow re-use of the
+allocation if a string is mutated. In principle we could disallow reuse of the
 arena buffer and not store the sizes in the arena. This may or may not save
 memory or be more performant depending on the exact usage pattern. For now we
 are erring on the side of avoiding unnecessary heap allocations when a string is
@@ -1070,7 +1070,7 @@ by the ``StringDType`` instance attached to the array. In this example, the
 string contents are "Numpy is a very cool library", stored at offset ``0x94C``
 in the arena allocation. Note that the ``size`` is stored twice, once in the
 ``size_and_flags`` field, and once in the arena allocation. This facilitates
-re-use of the arena allocation if a string is mutated. Also note that because
+reuse of the arena allocation if a string is mutated. Also note that because
 the length of the string is small enough to fit in an ``unsigned char``, this is
 a "medium"-length string and the size requires only one byte in the arena
 allocation. An arena string larger than 255 bytes would need 8 bytes in the

--- a/doc/neps/nep-0056-array-api-main-namespace.rst
+++ b/doc/neps/nep-0056-array-api-main-namespace.rst
@@ -302,7 +302,7 @@ three types of behavior rather than two - ``copy=None`` means "copy if needed".
 an exception because they use* ``copy=False`` *explicitly in their copy but a
 copy was previously made anyway, they have to inspect their code and determine
 whether the intent of the code was the old or the new semantics (both seem
-rougly equally likely), and adapt the code as appropriate. We expect most cases
+roughly equally likely), and adapt the code as appropriate. We expect most cases
 to be* ``np.array(..., copy=False)``, *because until a few years ago that had
 lower overhead than* ``np.asarray(...)``. *This was solved though, and*
 ``np.asarray(...)`` *is idiomatic NumPy usage.*

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -213,7 +213,7 @@ added for setting the real or imaginary part.
 The underlying type remains a struct under C++ (all of the above still remains
 valid).
 
-This has implications for Cython. It is recommened to always use the native
+This has implications for Cython. It is recommended to always use the native
 typedefs ``cfloat_t``, ``cdouble_t``, ``clongdouble_t`` rather than the NumPy
 types ``npy_cfloat``, etc, unless you have to interface with C code written
 using the NumPy types. You can still write cython code using the ``c.real`` and

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -18,7 +18,7 @@ upgraded to given NumPy's
 For usage guidelines for downstream libraries and end users who want to write
 code that will work with both NumPy and other array libraries, we refer to the
 documentation of the array API standard itself and to code and
-developer-focused documention in SciPy and scikit-learn.
+developer-focused documentation in SciPy and scikit-learn.
 
 Note that in order to use standard-complaint code with older NumPy versions
 (< 2.0), the `array-api-compat

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -823,7 +823,7 @@ cannot not be accessed directly.
 
 .. c:function:: PyArray_ArrayDescr *PyDataType_SUBARRAY(PyArray_Descr *descr)
 
-    Information about a subarray dtype eqivalent to the Python `np.dtype.base`
+    Information about a subarray dtype equivalent to the Python `np.dtype.base`
     and `np.dtype.shape`.
 
     If this is non- ``NULL``, then this data-type descriptor is a
@@ -3975,7 +3975,7 @@ the C-API is needed then some additional steps must be taken.
     behavior as NumPy 1.x.
 
     .. note::
-        Windows never had shared visbility although you can use this macro
+        Windows never had shared visibility although you can use this macro
         to achieve it.  We generally discourage sharing beyond shared boundary
         lines since importing the array API includes NumPy version checks.
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -307,10 +307,10 @@ code:
 
 .. code-block:: c
 
-    doub = PyArray_DescrFromType(NPY_DOUBLE);
-    PyArray_RegisterCastFunc(doub, NPY_FLOAT,
+    d = PyArray_DescrFromType(NPY_DOUBLE);
+    PyArray_RegisterCastFunc(d, NPY_FLOAT,
          (PyArray_VectorUnaryFunc *)double_to_float);
-    Py_DECREF(doub);
+    Py_DECREF(d);
 
 
 Registering coercion rules

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -202,13 +202,13 @@ foreach opt_name, conf : parse_options
         endif
       endforeach
     else
-      filterd = []
+      filtered = []
       foreach fet : result
         if fet not in accumulate
-          filterd += fet
+          filtered += fet
         endif
       endforeach
-      result = filterd
+      result = filtered
     endif # append
   endforeach # tok : tokens
   if ignored.length() > 0

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1302,7 +1302,7 @@ typedef struct {
         PyArrayIterObject    *iters[64];
 #elif defined(__cplusplus)
         /*
-         * C++ doesn't stricly support flexible members and gives compilers
+         * C++ doesn't strictly support flexible members and gives compilers
          * warnings (pedantic only), so we lie.  We can't make it 64 because
          * then Cython is unhappy (larger struct at runtime is OK smaller not).
          */

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -53,7 +53,7 @@
 #if NPY_ABI_VERSION < 0x02000000
   /*
    * Define 2.0 feature version as it is needed below to decide whether we
-   * compile for both 1.x and 2.x (defining it gaurantees 1.x only).
+   * compile for both 1.x and 2.x (defining it guarantees 1.x only).
    */
   #define NPY_2_0_API_VERSION 0x00000012
   /*

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -162,48 +162,48 @@ class memmap(ndarray):
 
     Load the memmap and verify data was stored:
 
-    >>> newfp = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
-    >>> newfp
+    >>> fp_new = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
+    >>> fp_new
     memmap([[  0.,   1.,   2.,   3.],
             [  4.,   5.,   6.,   7.],
             [  8.,   9.,  10.,  11.]], dtype=float32)
 
     Read-only memmap:
 
-    >>> fpr = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
-    >>> fpr.flags.writeable
+    >>> fp_ro = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
+    >>> fp_ro.flags.writeable
     False
 
     Copy-on-write memmap:
 
-    >>> fpc = np.memmap(filename, dtype='float32', mode='c', shape=(3,4))
-    >>> fpc.flags.writeable
+    >>> fp_cow = np.memmap(filename, dtype='float32', mode='c', shape=(3,4))
+    >>> fp_cow.flags.writeable
     True
 
     It's possible to assign to copy-on-write array, but values are only
     written into the memory copy of the array, and not written to disk:
 
-    >>> fpc
+    >>> fp_cow
     memmap([[  0.,   1.,   2.,   3.],
             [  4.,   5.,   6.,   7.],
             [  8.,   9.,  10.,  11.]], dtype=float32)
-    >>> fpc[0,:] = 0
-    >>> fpc
+    >>> fp_cow[0,:] = 0
+    >>> fp_cow
     memmap([[  0.,   0.,   0.,   0.],
             [  4.,   5.,   6.,   7.],
             [  8.,   9.,  10.,  11.]], dtype=float32)
 
     File on disk is unchanged:
 
-    >>> fpr
+    >>> fp_ro
     memmap([[  0.,   1.,   2.,   3.],
             [  4.,   5.,   6.,   7.],
             [  8.,   9.,  10.,  11.]], dtype=float32)
 
     Offset into a memmap:
 
-    >>> fpo = np.memmap(filename, dtype='float32', mode='r', offset=16)
-    >>> fpo
+    >>> fp_offset = np.memmap(filename, dtype='float32', mode='r', offset=16)
+    >>> fp_offset
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 
     """

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1147,17 +1147,17 @@ def tensordot(a, b, axes=2):
 
     # Move the axes to sum over to the end of "a"
     # and to the front of "b"
-    notin = [k for k in range(nda) if k not in axes_a]
-    newaxes_a = notin + axes_a
+    not_in = [k for k in range(nda) if k not in axes_a]
+    newaxes_a = not_in + axes_a
     N2 = math.prod(as_[axis] for axis in axes_a)
-    newshape_a = (math.prod([as_[ax] for ax in notin]), N2)
-    olda = [as_[axis] for axis in notin]
+    newshape_a = (math.prod([as_[ax] for ax in not_in]), N2)
+    olda = [as_[axis] for axis in not_in]
 
-    notin = [k for k in range(ndb) if k not in axes_b]
-    newaxes_b = axes_b + notin
+    not_in = [k for k in range(ndb) if k not in axes_b]
+    newaxes_b = axes_b + not_in
     N2 = math.prod(bs[axis] for axis in axes_b)
-    newshape_b = (N2, math.prod([bs[ax] for ax in notin]))
-    oldb = [bs[axis] for axis in notin]
+    newshape_b = (N2, math.prod([bs[ax] for ax in not_in]))
+    oldb = [bs[axis] for axis in not_in]
 
     at = a.transpose(newaxes_a).reshape(newshape_a)
     bt = b.transpose(newaxes_b).reshape(newshape_b)

--- a/numpy/_core/src/_simd/_simd_vector.inc
+++ b/numpy/_core/src/_simd/_simd_vector.inc
@@ -92,7 +92,7 @@ static PyTypeObject PySIMDVectorType = {
  * miss-align load variable of 256/512-bit vector from non-aligned
  * 256/512-bit stack pointer.
  *
- * check the following links for more clearification:
+ * check the following links for more clarification:
  * https://github.com/numpy/numpy/pull/18330#issuecomment-821539919
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001
  */

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1185,7 +1185,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
     }
 
     /*
-     * For a sequence we need to make a copy of the final aggreate anyway.
+     * For a sequence we need to make a copy of the final aggregate anyway.
      * There's no need to pass explicit `copy=True`, so we switch
      * to `copy=None` (copy if needed).
      */

--- a/numpy/_core/src/multiarray/common_dtype.c
+++ b/numpy/_core/src/multiarray/common_dtype.c
@@ -131,7 +131,7 @@ reduce_dtypes_to_most_knowledgeable(
         }
 
         if (res == (PyArray_DTypeMeta *)Py_NotImplemented) {
-            /* guess at other being more "knowledgable" */
+            /* guess at other being more "knowledgeable" */
             PyArray_DTypeMeta *tmp = dtypes[low];
             dtypes[low] = dtypes[high];
             dtypes[high] = tmp;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1401,7 +1401,7 @@ PyArray_DTypeMeta *_Void_dtype = NULL;
  * This function is exposed with an underscore "privately" because the
  * public version is a static inline function which only calls the function
  * on 2.x but directly accesses the `descr` struct on 1.x.
- * Once 1.x backwards compatibility is gone, it shoudl be exported without
+ * Once 1.x backwards compatibility is gone, it should be exported without
  * the underscore directly.
  * Internally, we define a private inline function `PyDataType_GetArrFuncs`
  * for convenience as we are allowed to access the `DType` slots directly.

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -293,7 +293,7 @@ get_loop(PyArrayMethod_Context *context,
 
 
 /*
- * Machinery to add the python integer to NumPy intger comparsisons as well
+ * Machinery to add the python integer to NumPy integer comparsisons as well
  * as a special promotion to special case Python int with Python int
  * comparisons.
  */

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -63,7 +63,7 @@ __all__ = [
     # _vec_string - Will probably not become ufuncs
     "mod", "decode", "encode", "translate",
 
-    # Removed from namespace until behavior has been crystalized
+    # Removed from namespace until behavior has been crystallized
     # "join", "split", "rsplit", "splitlines",
 ]
 

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -223,7 +223,7 @@ class TestGeomspace:
         assert_allclose(y, [-5, 3j])
 
     def test_complex_shortest_path(self):
-        # test the shortest logorithmic spiral is used, see gh-25644
+        # test the shortest logarithmic spiral is used, see gh-25644
         x = 1.2 + 3.4j
         y = np.exp(1j*(np.pi-.1)) * x
         z = np.geomspace(x, y, 5)

--- a/numpy/_core/tests/test_half.py
+++ b/numpy/_core/tests/test_half.py
@@ -49,7 +49,7 @@ class TestHalf:
         # Convert from float32 back to float16
         with np.errstate(invalid='ignore'):
             b = np.array(self.all_f32, dtype=float16)
-        # avoid testing NaNs due to differ bits wither Q/SNaNs
+        # avoid testing NaNs due to differ bits with Q/SNaNs
         b_nn = b == b
         assert_equal(self.all_f16[b_nn].view(dtype=uint16),
                      b[b_nn].view(dtype=uint16))

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -534,8 +534,8 @@ class TestIndexing:
     def test_indexing_array_negative_strides(self):
         # From gh-8264,
         # core dumps if negative strides are used in iteration
-        arro = np.zeros((4, 4))
-        arr = arro[::-1, ::-1]
+        arr0 = np.zeros((4, 4))
+        arr = arr0[::-1, ::-1]
 
         slices = (slice(None), [0, 1, 2, 3])
         arr[slices] = 10

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4810,8 +4810,8 @@ class TestArgmax:
         assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
         assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
 
-        padd = np.repeat(np.min(arr), 513)
-        rarr = np.concatenate((arr, padd))
+        arr_ = np.repeat(np.min(arr), 513)
+        rarr = np.concatenate((arr, arr_))
         rpos = pos
         assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
         assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
@@ -4953,8 +4953,8 @@ class TestArgmin:
         assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
         assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)
 
-        padd = np.repeat(np.max(arr), 513)
-        rarr = np.concatenate((arr, padd))
+        arr_ = np.repeat(np.max(arr), 513)
+        rarr = np.concatenate((arr, arr_))
         rpos = pos
         assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
         assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -476,7 +476,7 @@ class TestIsDType:
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):
-        # issue 26439: int32/intc were masking eachother on 32-bit builds
+        # issue 26439: int32/intc were masking each other on 32-bit builds
         assert np.int32 in sctypes['int']
         assert np.intc in sctypes['int']
         assert np.int64 in sctypes['int']

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1931,7 +1931,7 @@ class TestRegression:
         # encoding='latin1' work correctly.
 
         # Python2 output for pickle.dumps(...)
-        datas = [
+        data_samples = [
             # (original, python2_pickle, koi8r_validity)
             (np.str_('\u6bd2'),
              b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\nI0\ntp6\nbS'\\xd2k\\x00\\x00'\np7\ntp8\nRp9\n.",  # noqa
@@ -1946,7 +1946,7 @@ class TestRegression:
              b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n(S'S1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'|'\np5\nNNNI1\nI1\nI0\ntp6\nbS'\\x9c'\np7\ntp8\nRp9\n.",  # noqa
              'different'),
         ]
-        for original, data, koi8r_validity in datas:
+        for original, data, koi8r_validity in data_samples:
             result = pickle.loads(data, encoding='latin1')
             assert_equal(result, original)
 

--- a/numpy/_core/tests/test_simd.py
+++ b/numpy/_core/tests/test_simd.py
@@ -156,8 +156,8 @@ class _SIMD_BOOL(_Test_Utility):
         assert vand == data_and
 
         data_or = [a | b for a, b in zip(data_a, data_b)]
-        vor = getattr(self, "or")(vdata_a, vdata_b)
-        assert vor == data_or
+        vor = getattr(self, "or")(vdata_a, vdata_b)  # codespell-ignore
+        assert vor == data_or  # codespell-ignore
 
         data_xor = [a ^ b for a, b in zip(data_a, data_b)]
         vxor = getattr(self, "xor")(vdata_a, vdata_b)
@@ -900,8 +900,8 @@ class _SIMD_ALL(_Test_Utility):
         broadcast_zero = self.zero()
         assert broadcast_zero == [0] * self.nlanes
         for i in range(1, 10):
-            broadcasti = self.setall(i)
-            assert broadcasti == [i] * self.nlanes
+            broadcast_i = self.setall(i)
+            assert broadcast_i == [i] * self.nlanes
 
         data_a, data_b = self._data(), self._data(reverse=True)
         vdata_a, vdata_b = self.load(data_a), self.load(data_b)
@@ -1058,8 +1058,8 @@ class _SIMD_ALL(_Test_Utility):
         assert vxor == data_xor
 
         data_or  = cast_data([a | b for a, b in zip(data_cast_a, data_cast_b)])
-        vor  = cast(getattr(self, "or")(vdata_a, vdata_b))
-        assert vor == data_or
+        vor  = cast(getattr(self, "or")(vdata_a, vdata_b))  # codespell-ignore   
+        assert vor == data_or  # codespell-ignore
 
         data_and = cast_data([a & b for a, b in zip(data_cast_a, data_cast_b)])
         vand = cast(getattr(self, "and")(vdata_a, vdata_b))

--- a/numpy/_core/tests/test_simd.py
+++ b/numpy/_core/tests/test_simd.py
@@ -1057,8 +1057,8 @@ class _SIMD_ALL(_Test_Utility):
         vxor = cast(self.xor(vdata_a, vdata_b))
         assert vxor == data_xor
 
-        data_or  = cast_data([a | b for a, b in zip(data_cast_a, data_cast_b)])
-        vor  = cast(getattr(self, "or")(vdata_a, vdata_b))  # codespell-ignore   
+        data_or = cast_data([a | b for a, b in zip(data_cast_a, data_cast_b)])
+        vor = cast(getattr(self, "or")(vdata_a, vdata_b))  # codespell-ignore
         assert vor == data_or  # codespell-ignore
 
         data_and = cast_data([a & b for a, b in zip(data_cast_a, data_cast_b)])

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -2931,7 +2931,7 @@ class TestMinMax:
 
     def test_reduce_reorder(self):
         # gh 10370, 11029 Some compilers reorder the call to npy_getfloatstatus
-        # and put it before the call to an intrisic function that causes
+        # and put it before the call to an intrinsic function that causes
         # invalid status to be set. Also make sure warnings are not emitted
         for n in (2, 4, 8, 16, 32):
             for dt in (np.float32, np.float16, np.complex64):

--- a/numpy/_pyinstaller/hook-numpy.py
+++ b/numpy/_pyinstaller/hook-numpy.py
@@ -18,7 +18,7 @@ if is_pure_conda:
     # communal Conda bin directory. DLLs from NumPy's dependencies must also be
     # collected to capture MKL, OpenBlas, OpenMP, etc.
     from PyInstaller.utils.hooks import conda_support
-    datas = conda_support.collect_dynamic_libs("numpy", dependencies=True)
+    data_samples = conda_support.collect_dynamic_libs("numpy", dependencies=True)
 
 # Submodules PyInstaller cannot detect.  `_dtype_ctypes` is only imported
 # from C and `_multiarray_tests` is used in tests (which are not packed).

--- a/numpy/_pyinstaller/hook-numpy.py
+++ b/numpy/_pyinstaller/hook-numpy.py
@@ -18,7 +18,7 @@ if is_pure_conda:
     # communal Conda bin directory. DLLs from NumPy's dependencies must also be
     # collected to capture MKL, OpenBlas, OpenMP, etc.
     from PyInstaller.utils.hooks import conda_support
-    data_samples = conda_support.collect_dynamic_libs("numpy", dependencies=True)
+    _ = conda_support.collect_dynamic_libs("numpy", dependencies=True)
 
 # Submodules PyInstaller cannot detect.  `_dtype_ctypes` is only imported
 # from C and `_multiarray_tests` is used in tests (which are not packed).

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -1005,9 +1005,10 @@ class _CCompiler:
             for attr, rgex, cexpr in section:
                 setattr(self, attr, False)
 
-        for detect, searchin in ((detect_arch, platform), (detect_compiler, compiler_info)):
+        for detect, search_in in ((detect_arch, platform), 
+                                  (detect_compiler, compiler_info)):
             for attr, rgex, cexpr in detect:
-                if rgex and not re.match(rgex, searchin, re.IGNORECASE):
+                if rgex and not re.match(rgex, search_in, re.IGNORECASE):
                     continue
                 if cexpr and not self.cc_test_cexpr(cexpr):
                     continue
@@ -1969,7 +1970,7 @@ class _Parse:
             if ch in ('+', '-'):
                 self.dist_fatal(
                     "+/- are 'not' allowed from target's groups or @targets, "
-                    "only from cpu_baseline and cpu_dispatch parms"
+                    "only from cpu_baseline and cpu_dispatch params"
                 )
             elif ch == '$':
                 if multi_target is not None:

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1420,7 +1420,7 @@ class Configuration:
         """Apply glob to paths and prepend local_path if needed.
 
         Applies glob.glob(...) to each path in the sequence (if needed) and
-        pre-pends the local_path if needed. Because this is called on all
+        prepends the local_path if needed. Because this is called on all
         source lists, this allows wildcard characters to be specified in lists
         of sources for extension modules and libraries and scripts and allows
         path-names be relative to the source directory.

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -370,7 +370,7 @@ def read_config(pkgname, dirs=None):
         return v
 
 # TODO:
-#   - implements version comparison (modversion + atleast)
+#   - implements version comparison (modversion + at least)
 
 # pkg-config simple emulator - useful for debugging, and maybe later to query
 # the system

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1736,7 +1736,7 @@ class lapack_src_info(system_info):
         '''  # [c|z]*.f
         #######
         sclaux = laux + ' econd '                  # s*.f
-        dzlaux = laux + ' secnd '                  # d*.f
+        dzlaux = laux + ' secnd '                  # d*.f  codespell-ignore
         slasrc = lasrc + sd_lasrc                  # s*.f
         dlasrc = lasrc + sd_lasrc                  # d*.f
         clasrc = lasrc + cz_lasrc + ' srot srscl '  # c*.f

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -148,7 +148,7 @@ _cast_dict['CHARACTER'] = ['CHARACTER']
 
 # 32 bit system malloc typically does not provide the alignment required by
 # 16 byte long double types this means the inout intent cannot be satisfied
-# and several tests fail as the alignment flag can be randomly true or fals
+# and several tests fail as the alignment flag can be randomly true or false
 # when numpy gains an aligned allocator the tests could be enabled again
 #
 # Furthermore, on macOS ARM64, LONGDOUBLE is an alias for DOUBLE.

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -675,7 +675,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
                 raise ValueError("the number of data points must exceed order "
                                  "to scale the covariance matrix")
             # note, this used to be: fac = resids / (len(x) - order - 2.0)
-            # it was deciced that the "- 2" (originally justified by "Bayesian
+            # it was decided that the "- 2" (originally justified by "Bayesian
             # uncertainty analysis") is not what the user expects
             # (see gh-11196 and gh-11197)
             fac = resids / (len(x) - order)

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2974,7 +2974,7 @@ def _multi_dot_three(A, B, C, out=None):
 
 def _multi_dot_matrix_chain_order(arrays, return_costs=False):
     """
-    Return a np.array that encodes the optimal order of mutiplications.
+    Return a np.array that encodes the optimal order of multiplications.
 
     The optimal order array is then used by `_multi_dot()` to do the
     multiplication.

--- a/numpy/linalg/lapack_lite/f2c_blas.c
+++ b/numpy/linalg/lapack_lite/f2c_blas.c
@@ -4909,7 +4909,7 @@ L20:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -9801,7 +9801,7 @@ L40:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -14401,7 +14401,7 @@ L40:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -19986,7 +19986,7 @@ L20:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of

--- a/numpy/linalg/lapack_lite/f2c_c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_c_lapack.c
@@ -2759,10 +2759,10 @@ L50:
 
     The problem is solved in three steps:
     (1) Reduce the coefficient matrix A to bidiagonal form with
-        Householder tranformations, reducing the original problem
+        Householder transformations, reducing the original problem
         into a "bidiagonal least squares problem" (BLS)
     (2) Solve the BLS using a divide and conquer approach.
-    (3) Apply back all the Householder tranformations to solve
+    (3) Apply back all the Householder transformations to solve
         the original least squares problem.
 
     The effective rank of A is determined by treating as zero those
@@ -9768,7 +9768,7 @@ L80:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine SLAED2.
 
@@ -9995,7 +9995,7 @@ L80:
 	    return 0;
 	}
 
-/*     Prepare the INDXQ sorting premutation. */
+/*     Prepare the INDXQ sorting permutation. */
 
 	n1 = k;
 	n2 = *n - k;
@@ -10563,7 +10563,7 @@ L100:
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
             (*)       (initial value of H)*U  = U*(final value of H)
-                    where U is an orthognal matrix.    The final
+                    where U is an orthogonal matrix.    The final
                     value of H is upper Hessenberg and triangular in
                     rows and columns INFO+1 through IHI.
 
@@ -14509,7 +14509,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -16624,7 +16624,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====

--- a/numpy/linalg/lapack_lite/f2c_c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_c_lapack.c
@@ -10558,7 +10558,7 @@ L100:
                     If INFO .GT. 0 and WANTT is .FALSE., then on exit,
                     the remaining unconverged eigenvalues are the
                     eigenvalues of the upper Hessenberg matrix
-                    rows and columns ILO thorugh INFO of the final,
+                    rows and columns ILO through INFO of the final,
                     output value of H.
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit

--- a/numpy/linalg/lapack_lite/f2c_d_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_d_lapack.c
@@ -13604,7 +13604,7 @@ L50:
                     If INFO .GT. 0 and WANTT is .FALSE., then on exit,
                     the remaining unconverged eigenvalues are the
                     eigenvalues of the upper Hessenberg matrix rows
-                    and columns ILO thorugh INFO of the final, output
+                    and columns ILO through INFO of the final, output
                     value of H.
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
@@ -28481,7 +28481,7 @@ L100:
 
     UPLO  (input) CHARACTER*1
           On entry, UPLO specifies whether the input bidiagonal matrix
-          is upper or lower bidiagonal, and wether it is square are
+          is upper or lower bidiagonal, and whether it is square are
           not.
              UPLO = 'U' or 'u'   B is upper bidiagonal.
              UPLO = 'L' or 'l'   B is lower bidiagonal.

--- a/numpy/linalg/lapack_lite/f2c_d_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_d_lapack.c
@@ -4127,7 +4127,7 @@ L50:
         Householder transformations, reducing the original problem
         into a "bidiagonal least squares problem" (BLS)
     (2) Solve the BLS using a divide and conquer approach.
-    (3) Apply back all the Householder tranformations to solve
+    (3) Apply back all the Householder transformations to solve
         the original least squares problem.
 
     The effective rank of A is determined by treating as zero those
@@ -9176,7 +9176,7 @@ L140:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine DLAED2.
 
@@ -11646,7 +11646,7 @@ L60:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine DLAED8.
 
@@ -12172,7 +12172,7 @@ L30:
 /* L40: */
     }
 
-/*     Calculate the allowable deflation tolerence */
+/*     Calculate the allowable deflation tolerance */
 
     imax = idamax_(n, &z__[1], &c__1);
     jmax = idamax_(n, &d__[1], &c__1);
@@ -13097,7 +13097,7 @@ L120:
 
     T must be in Schur canonical form, that is, block upper triangular
     with 1-by-1 and 2-by-2 diagonal blocks; each 2-by-2 diagonal block
-    has its diagonal elemnts equal and its off-diagonal elements of
+    has its diagonal elements equal and its off-diagonal elements of
     opposite sign.
 
     Arguments
@@ -13609,7 +13609,7 @@ L50:
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
             (*)       (initial value of H)*U  = U*(final value of H)
-                    where U is an orthognal matrix.    The final
+                    where U is an orthogonal matrix.    The final
                     value of H is upper Hessenberg and triangular in
                     rows and columns INFO+1 through IHI.
 
@@ -18032,7 +18032,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -20271,7 +20271,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -24434,7 +24434,7 @@ L10:
 
        The first stage consists of deflating the size of the problem
        when there are multiple singular values or when there are zeros in
-       the Z vector.  For each such occurence the dimension of the
+       the Z vector.  For each such occurrence the dimension of the
        secular equation problem is reduced by one.  This stage is
        performed by the routine DLASD2.
 
@@ -26902,7 +26902,7 @@ L240:
 
           The first stage consists of deflating the size of the problem
           when there are multiple singular values or if there is a zero
-          in the Z vector. For each such occurence the dimension of the
+          in the Z vector. For each such occurrence the dimension of the
           secular equation problem is reduced by one. This stage is
           performed by the routine DLASD7.
 
@@ -27460,7 +27460,7 @@ L240:
 /* L50: */
     }
 
-/*     Calculate the allowable deflation tolerence */
+/*     Calculate the allowable deflation tolerance */
 
     eps = EPSILON;
 /* Computing MAX */
@@ -31388,7 +31388,7 @@ L80:
     =====================================================================
 
 
-       Test the input paramters.
+       Test the input parameters.
 */
 
     /* Parameter adjustments */

--- a/numpy/linalg/lapack_lite/f2c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_lapack.c
@@ -61,7 +61,7 @@ integer ieeeck_(integer *ispec, real *zero, real *one)
     =========
 
     ISPEC   (input) INTEGER
-            Specifies whether to test just for inifinity arithmetic
+            Specifies whether to test just for infinity arithmetic
             or whether to test for infinity and NaN arithmetic.
             = 0: Verify infinity arithmetic only.
             = 1: Verify infinity and NaN arithmetic.

--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -13561,7 +13561,7 @@ L50:
                     If INFO .GT. 0 and WANTT is .FALSE., then on exit,
                     the remaining unconverged eigenvalues are the
                     eigenvalues of the upper Hessenberg matrix rows
-                    and columns ILO thorugh INFO of the final, output
+                    and columns ILO through INFO of the final, output
                     value of H.
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
@@ -28373,7 +28373,7 @@ L100:
 
     UPLO  (input) CHARACTER*1
           On entry, UPLO specifies whether the input bidiagonal matrix
-          is upper or lower bidiagonal, and wether it is square are
+          is upper or lower bidiagonal, and whether it is square are
           not.
              UPLO = 'U' or 'u'   B is upper bidiagonal.
              UPLO = 'L' or 'l'   B is lower bidiagonal.

--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -4102,7 +4102,7 @@ L50:
         Householder transformations, reducing the original problem
         into a "bidiagonal least squares problem" (BLS)
     (2) Solve the BLS using a divide and conquer approach.
-    (3) Apply back all the Householder tranformations to solve
+    (3) Apply back all the Householder transformations to solve
         the original least squares problem.
 
     The effective rank of A is determined by treating as zero those
@@ -9145,7 +9145,7 @@ L140:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine SLAED2.
 
@@ -11610,7 +11610,7 @@ L60:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine SLAED8.
 
@@ -12136,7 +12136,7 @@ L30:
 /* L40: */
     }
 
-/*     Calculate the allowable deflation tolerence */
+/*     Calculate the allowable deflation tolerance */
 
     imax = isamax_(n, &z__[1], &c__1);
     jmax = isamax_(n, &d__[1], &c__1);
@@ -13055,7 +13055,7 @@ L120:
 
     T must be in Schur canonical form, that is, block upper triangular
     with 1-by-1 and 2-by-2 diagonal blocks; each 2-by-2 diagonal block
-    has its diagonal elemnts equal and its off-diagonal elements of
+    has its diagonal elements equal and its off-diagonal elements of
     opposite sign.
 
     Arguments
@@ -13566,7 +13566,7 @@ L50:
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
             (*)       (initial value of H)*U  = U*(final value of H)
-                    where U is an orthognal matrix.    The final
+                    where U is an orthogonal matrix.    The final
                     value of H is upper Hessenberg and triangular in
                     rows and columns INFO+1 through IHI.
 
@@ -17968,7 +17968,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -20194,7 +20194,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -24345,7 +24345,7 @@ L10:
 
        The first stage consists of deflating the size of the problem
        when there are multiple singular values or when there are zeros in
-       the Z vector.  For each such occurence the dimension of the
+       the Z vector.  For each such occurrence the dimension of the
        secular equation problem is reduced by one.  This stage is
        performed by the routine SLASD2.
 
@@ -26805,7 +26805,7 @@ L240:
 
           The first stage consists of deflating the size of the problem
           when there are multiple singular values or if there is a zero
-          in the Z vector. For each such occurence the dimension of the
+          in the Z vector. For each such occurrence the dimension of the
           secular equation problem is reduced by one. This stage is
           performed by the routine SLASD7.
 
@@ -27361,7 +27361,7 @@ L240:
 /* L50: */
     }
 
-/*     Calculate the allowable deflation tolerence */
+/*     Calculate the allowable deflation tolerance */
 
     eps = slamch_("Epsilon");
 /* Computing MAX */
@@ -31271,7 +31271,7 @@ L80:
     =====================================================================
 
 
-       Test the input paramters.
+       Test the input parameters.
 */
 
     /* Parameter adjustments */

--- a/numpy/linalg/lapack_lite/f2c_z_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_z_lapack.c
@@ -2781,10 +2781,10 @@ L50:
 
     The problem is solved in three steps:
     (1) Reduce the coefficient matrix A to bidiagonal form with
-        Householder tranformations, reducing the original problem
+        Householder transformations, reducing the original problem
         into a "bidiagonal least squares problem" (BLS)
     (2) Solve the BLS using a divide and conquer approach.
-    (3) Apply back all the Householder tranformations to solve
+    (3) Apply back all the Householder transformations to solve
         the original least squares problem.
 
     The effective rank of A is determined by treating as zero those
@@ -9826,7 +9826,7 @@ L80:
 
           The first stage consists of deflating the size of the problem
           when there are multiple eigenvalues or if there is a zero in
-          the Z vector.  For each such occurence the dimension of the
+          the Z vector.  For each such occurrence the dimension of the
           secular equation problem is reduced by one.  This stage is
           performed by the routine DLAED2.
 
@@ -10053,7 +10053,7 @@ L80:
 	    return 0;
 	}
 
-/*     Prepare the INDXQ sorting premutation. */
+/*     Prepare the INDXQ sorting permutation. */
 
 	n1 = k;
 	n2 = *n - k;
@@ -10624,7 +10624,7 @@ L100:
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit
             (*)       (initial value of H)*U  = U*(final value of H)
-                    where U is an orthognal matrix.    The final
+                    where U is an orthogonal matrix.    The final
                     value of H is upper Hessenberg and triangular in
                     rows and columns INFO+1 through IHI.
 
@@ -14582,7 +14582,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====
@@ -16718,7 +16718,7 @@ L60:
 		}
 
 /*
-                ==== Use up to NS of the smallest magnatiude
+                ==== Use up to NS of the smallest magnitude
                 .    shifts.  If there aren't NS shifts available,
                 .    then use them all, possibly dropping one to
                 .    make the number of shifts even. ====

--- a/numpy/linalg/lapack_lite/f2c_z_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_z_lapack.c
@@ -10619,7 +10619,7 @@ L100:
                     If INFO .GT. 0 and WANTT is .FALSE., then on exit,
                     the remaining unconverged eigenvalues are the
                     eigenvalues of the upper Hessenberg matrix
-                    rows and columns ILO thorugh INFO of the final,
+                    rows and columns ILO through INFO of the final,
                     output value of H.
 
                     If INFO .GT. 0 and WANTT is .TRUE., then on exit

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -270,7 +270,8 @@ class TestMaskedArray:
 
     def test_unknown_keyword_parameter(self):
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            MaskedArray([1, 2, 3], maks=[0, 1, 0])  # `mask` is misspelled.
+            # `mask` is misspelled.
+            MaskedArray([1, 2, 3], maks=[0, 1, 0])  # codespell-ignore
 
     def test_asarray(self):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1798,9 +1798,9 @@ class TestShapeBase:
         assert_equal(b.mask.shape, b.data.shape)
 
     def test_shape_scalar(self):
-        # the atleast and diagflat function should work with scalars
+        # the at least and diagflat function should work with scalars
         # GitHub issue #3367
-        # Additionally, the atleast functions should accept multiple scalars
+        # Additionally, the at least functions should accept multiple scalars
         # correctly
         b = atleast_1d(1.0)
         assert_equal(b.shape, (1,))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css,.mailmap,./doc/changelog,./doc/source/release/*-notes.rst'
+skip = '.git*,*.pdf,*.svg,*.css,.mailmap,./doc/changelog,./doc/source/release/*-notes.rst,recarray_from_file.fits'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
 # Assume that capitalized shortish (up to 10) Word is a name - skip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,5 +222,5 @@ check-hidden = true
 # Assume that capitalized shortish (up to 10) Word is a name - skip
 # Skip all shortish (up to 5) ACRONYMS
 ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
-# some common hits
-ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse'
+# some common hits and some "questionable" and false positives (rare words)
+ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse,implementor'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,8 @@ cli = 'vendored-meson/meson/meson.py'
 skip = '.git*,*.pdf,*.svg,*.css,lapack_lite'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
-ignore-regex = '"worl"|.*codespell-ignore.*'
+# Assume that capitalized shortish (up to 10) Word is a name - skip
+# Skip all shortish (up to 5) ACRONYMS
+ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*'
 # some common hits
 ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,4 +223,4 @@ check-hidden = true
 # Skip all shortish (up to 5) ACRONYMS
 ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
 # some common hits and some "questionable" and false positives (rare words)
-ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse,implementor'
+ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse,implementor,arange,aranges'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,3 +213,10 @@ cli = 'vendored-meson/meson/meson.py'
   ".spin/cmds.py:notes",
 ]
 "Metrics" = [".spin/cmds.py:bench"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.pdf,*.svg,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,11 +216,11 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css,.mailmap'
+skip = '.git*,*.pdf,*.svg,*.css,.mailmap,./doc/changelog'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
 # Assume that capitalized shortish (up to 10) Word is a name - skip
 # Skip all shortish (up to 5) ACRONYMS
 ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
 # some common hits
-ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig'
+ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,5 +218,7 @@ cli = 'vendored-meson/meson/meson.py'
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.pdf,*.svg,*.css,lapack_lite'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# some cases + pragma to add to line to ignore entire line
+ignore-regex = '"worl"|.*codespell-ignore.*'
+# some common hits
+ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,11 +216,11 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css,lapack_lite,.mailmap'
+skip = '.git*,*.pdf,*.svg,*.css,.mailmap'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
 # Assume that capitalized shortish (up to 10) Word is a name - skip
 # Skip all shortish (up to 5) ACRONYMS
 ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
 # some common hits
-ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo'
+ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,11 +216,11 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css,lapack_lite'
+skip = '.git*,*.pdf,*.svg,*.css,lapack_lite,.mailmap'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
 # Assume that capitalized shortish (up to 10) Word is a name - skip
 # Skip all shortish (up to 5) ACRONYMS
-ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*'
+ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
 # some common hits
 ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css,.mailmap,./doc/changelog'
+skip = '.git*,*.pdf,*.svg,*.css,.mailmap,./doc/changelog,./doc/source/release/*-notes.rst'
 check-hidden = true
 # some cases + pragma to add to line to ignore entire line
 # Assume that capitalized shortish (up to 10) Word is a name - skip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,4 +223,8 @@ check-hidden = true
 # Skip all shortish (up to 5) ACRONYMS
 ignore-regex = '"worl"|https://citeseerx\.ist\.psu\.edu|\b([A-Z][a-z]{1,9}|[A-Z]{1,5})\b|.*codespell-ignore.*|/seh/'
 # some common hits and some "questionable" and false positives (rare words)
-ignore-words-list = 'nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,recuse,implementor,arange,aranges'
+ignore-words-list = """
+  nd,nin,numers,numer,inout,ccompiler,fo,CCompiler,dout,
+  ans,ser,ot,asign,siz,alow,fro,delimitor,alo,dum,desig,
+  recuse,implementor,arange,aranges
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ cli = 'vendored-meson/meson/meson.py'
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.pdf,*.svg,*.css'
+skip = '.git*,*.pdf,*.svg,*.css,lapack_lite'
 check-hidden = true
 # ignore-regex = ''
 # ignore-words-list = ''

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -1,5 +1,5 @@
 # This script is used by .github/workflows/wheels.yml to run the full test
-# suite, checks for lincense inclusion and that the openblas version is correct.
+# suite, checks for license inclusion and that the openblas version is correct.
 set -xe
 
 PROJECT_DIR="$1"


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

- There were numerous commits where `codespell` was used "manually" to fixup some of the typos.
- https://github.com/numpy/numpy/issues/13694 still contemplates idea of running `codespell` on PRs
- An early attempt to introduce codespell CI was abandoned: https://github.com/numpy/numpy/pull/19594 -- IMHO now is better time!

- I did `lapack_lite` last in the separate commits if there is desire to not touch it (although I saw commits fixing typos in it as well).
- I did some variable renames to take them away from "close to a typo" form, might be worth having a look and suggesting alternative names.
- I did fix older changelogs as I think there is no point to cherish typos in them, but they could also be ignored.