### PR TITLE
BUG: fix spin bench not running on Windows

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -309,7 +309,7 @@ def _run_asv(cmd):
         '/usr/local/lib/ccache', '/usr/local/lib/f90cache'
     ])
     env = os.environ
-    env['PATH'] = f'EXTRA_PATH:{PATH}'
+    env['PATH'] = f'{EXTRA_PATH}{os.pathsep}{PATH}'
 
     # Control BLAS/LAPACK threads
     env['OPENBLAS_NUM_THREADS'] = '1'


### PR DESCRIPTION
Attempting to run `spin bench` on Windows platform fails with the following message:
`Error: [WinError 2] The system cannot find the file specified; aborting.`

The issue was the usage of Unix path separator in `PATH`.

However, even on Unix, `EXTRA_PATH` was erroneously not being expanded in the fstring.