### PR TITLE
DOC: Add replacement NEP links in superseded, replaced-by fields

### DIFF
--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -146,7 +146,8 @@ thread in the mailing list archives.
 
 NEPs can also be ``Superseded`` by a different NEP, rendering the
 original obsolete.  The ``Replaced-By`` and ``Replaces`` headers
-should be added to the original and new NEPs respectively.
+containing references to the original and new NEPs, like
+``:ref:`NEP#number``` should be added respectively.
 
 Process NEPs may also have a status of ``Active`` if they are never
 meant to be completed, e.g. NEP 0 (this NEP).

--- a/doc/neps/nep-0030-duck-array-protocol.rst
+++ b/doc/neps/nep-0030-duck-array-protocol.rst
@@ -7,7 +7,7 @@ NEP 30 — Duck typing for NumPy arrays - implementation
 :Author: Peter Andreas Entschev <pentschev@nvidia.com>
 :Author: Stephan Hoyer <shoyer@google.com>
 :Status: Superseded
-:Replaced-By: 56
+:Replaced-By: :ref:`NEP56`
 :Type: Standards Track
 :Created: 2019-07-31
 :Updated: 2019-07-31

--- a/doc/neps/nep-0031-uarray.rst
+++ b/doc/neps/nep-0031-uarray.rst
@@ -8,7 +8,7 @@ NEP 31 — Context-local and global overrides of the NumPy API
 :Author: Ralf Gommers <rgommers@quansight.com>
 :Author: Peter Bell <pbell@quansight.com>
 :Status: Superseded
-:Replaced-By: 56
+:Replaced-By: :ref:`NEP56`
 :Type: Standards Track
 :Created: 2019-08-22
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/

--- a/doc/neps/nep-0037-array-module.rst
+++ b/doc/neps/nep-0037-array-module.rst
@@ -8,7 +8,7 @@ NEP 37 — A dispatch protocol for NumPy-like modules
 :Author: Hameer Abbasi
 :Author: Sebastian Berg
 :Status: Superseded
-:Replaced-By: 56
+:Replaced-By: :ref:`NEP56`
 :Type: Standards Track
 :Created: 2019-12-29
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/

--- a/doc/neps/nep-0047-array-api-standard.rst
+++ b/doc/neps/nep-0047-array-api-standard.rst
@@ -8,7 +8,7 @@ NEP 47 — Adopting the array API standard
 :Author: Stephan Hoyer <shoyer@gmail.com>
 :Author: Aaron Meurer <asmeurer@gmail.com>
 :Status: Superseded
-:Replaced-By: 56
+:Replaced-By: :ref:`NEP56`
 :Type: Standards Track
 :Created: 2021-01-21
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/

--- a/doc/neps/nep-0056-array-api-main-namespace.rst
+++ b/doc/neps/nep-0056-array-api-main-namespace.rst
@@ -8,7 +8,7 @@ NEP 56 — Array API standard support in NumPy's main namespace
 :Author: Mateusz Sokół <msokol@quansight.com>
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>
 :Status: Final
-:Replaces: 30, 31, 37, 47
+:Replaces: :ref:`NEP30`, :ref:`NEP31`, :ref:`NEP37`, :ref:`NEP47`
 :Type: Standards Track
 :Created: 2023-12-19
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/message/Z6AA5CL47NHBNEPTFWYOTSUVSRDGHYPN/

--- a/doc/neps/tools/build_index.py
+++ b/doc/neps/tools/build_index.py
@@ -75,7 +75,7 @@ def nep_metadata():
                     f'NEP {nr} has been Superseded, but has no Replaced-By tag'
                 )
 
-            replaced_by = int(tags['Replaced-By'])
+            replaced_by = int(re.findall(r'\d+', tags['Replaced-By'])[0])
             replacement_nep = neps[replaced_by]
 
             if not 'Replaces' in replacement_nep:
@@ -105,13 +105,8 @@ def nep_metadata():
 
 def parse_replaces_metadata(replacement_nep):
     """Handle :Replaces: as integer or list of integers"""
-    replaces = replacement_nep['Replaces']
-    if ' ' in replaces:
-        # Replaces multiple NEPs, should be comma-separated ints
-        replaced_neps = [int(s) for s in replaces.split(', ')]
-    else:
-        replaced_neps = [int(replaces)]
-
+    replaces = re.findall(r'\d+', replacement_nep['Replaces'])
+    replaced_neps = [int(s) for s in replaces]
     return replaced_neps
 
 


### PR DESCRIPTION
Fixes #25930

Summary of changes:
- add nep references to replaced by and replaces tags in superseded neps
- use regex expression parse nep ids for building tags from the new format of replaced-by and replaces tags
