### PR TITLE
BUG: Fix invalid constructor in string_fastsearch.h with C++ >= 20.

### DIFF
--- a/numpy/_core/src/umath/string_fastsearch.h
+++ b/numpy/_core/src/umath/string_fastsearch.h
@@ -60,13 +60,13 @@ struct CheckedIndexer {
     char_type *buffer;
     size_t length;
 
-    CheckedIndexer<char_type>()
+    CheckedIndexer()
     {
         buffer = NULL;
         length = 0;
     }
 
-    CheckedIndexer<char_type>(char_type *buf, size_t len)
+    CheckedIndexer(char_type *buf, size_t len)
     {
         buffer = buf;
         length = len;


### PR DESCRIPTION
This is an error with -std=gnu++20 at least with gcc 11 to 13, and will be an explicit warning with gcc >= 14. See
https://godbolt.org/z/YdoTc7r8f

In practice, it avoids these compilation errors:

```
In file included from ../numpy/_core/src/umath/string_ufuncs.cpp:20: ../numpy/_core/src/umath/string_fastsearch.h:63:31: error: expected unqualified-id before ')' token
   63 |     CheckedIndexer<char_type>()
      |                               ^
../numpy/_core/src/umath/string_fastsearch.h:69:40: error: expected ')' before '*' token
   69 |     CheckedIndexer<char_type>(char_type *buf, size_t len)
      |                              ~         ^~
      |
```