### PR TITLE
TST: Skip Cython test for editable install

### DIFF
--- a/numpy/_core/tests/test_array_interface.py
+++ b/numpy/_core/tests/test_array_interface.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 import numpy as np
-from numpy.testing import extbuild, IS_WASM
+from numpy.testing import extbuild, IS_WASM, IS_EDITABLE
 
 
 @pytest.fixture
@@ -14,6 +14,8 @@ def get_module(tmp_path):
         pytest.skip('link fails on cygwin')
     if IS_WASM:
         pytest.skip("Can't build module inside Wasm")
+    if IS_EDITABLE:
+        pytest.skip("Can't build module for editable install")
 
     prologue = '''
         #include <Python.h>

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 import numpy as np
-from numpy.testing import assert_array_equal, IS_WASM
+from numpy.testing import assert_array_equal, IS_WASM, IS_EDITABLE
 
 # This import is copied from random.tests.test_extending
 try:
@@ -25,6 +25,13 @@ else:
         cython = None
 
 pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
+
+
+if IS_EDITABLE:
+    pytest.skip(
+        "Editable install doesn't support tests with a compile step",
+        allow_module_level=True
+    )
 
 
 @pytest.fixture(scope='module')

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -5,7 +5,7 @@ import sys
 import sysconfig
 import pytest
 
-from numpy.testing import IS_WASM, IS_PYPY, NOGIL_BUILD
+from numpy.testing import IS_WASM, IS_PYPY, NOGIL_BUILD, IS_EDITABLE
 
 # This import is copied from random.tests.test_extending
 try:
@@ -23,6 +23,13 @@ else:
         cython = None
 
 pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
+
+
+if IS_EDITABLE:
+    pytest.skip(
+        "Editable install doesn't support tests with a compile step",
+        allow_module_level=True
+    )
 
 
 @pytest.fixture(scope='module')

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -8,7 +8,7 @@ import warnings
 import pytest
 
 import numpy as np
-from numpy.testing import extbuild, assert_warns, IS_WASM
+from numpy.testing import extbuild, assert_warns, IS_WASM, IS_EDITABLE
 from numpy._core.multiarray import get_handler_name
 
 
@@ -28,6 +28,9 @@ def get_module(tmp_path):
         pytest.skip('link fails on cygwin')
     if IS_WASM:
         pytest.skip("Can't build module inside Wasm")
+    if IS_EDITABLE:
+        pytest.skip("Can't build module for editable install")
+
     functions = [
         ("get_default_policy", "METH_NOARGS", """
              Py_INCREF(PyDataMem_DefaultHandler);

--- a/numpy/_pyinstaller/tests/__init__.py
+++ b/numpy/_pyinstaller/tests/__init__.py
@@ -1,0 +1,16 @@
+from numpy.testing import IS_WASM, IS_EDITABLE
+import pytest
+
+
+if IS_WASM:
+    pytest.skip(
+        "WASM/Pyodide does not use or support Fortran",
+        allow_module_level=True
+    )
+
+
+if IS_EDITABLE:
+    pytest.skip(
+        "Editable install doesn't support tests with a compile step",
+        allow_module_level=True
+    )

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -1,10 +1,12 @@
 from os.path import join, sep, dirname
 
+import pytest
+
 from numpy.distutils.misc_util import (
     appendpath, minrelpath, gpaths, get_shared_lib_extension, get_info
     )
 from numpy.testing import (
-    assert_, assert_equal
+    assert_, assert_equal, IS_EDITABLE
     )
 
 ajoin = lambda *paths: join(*((sep,)+paths))
@@ -73,6 +75,10 @@ class TestSharedExtension:
         assert_(get_shared_lib_extension(is_python_ext=True))
 
 
+@pytest.mark.skipif(
+    IS_EDITABLE,
+    reason="`get_info` .ini lookup method incompatible with editable install"
+)
 def test_installed_npymath_ini():
     # Regression test for gh-7707.  If npymath.ini wasn't installed, then this
     # will give an error.

--- a/numpy/f2py/tests/__init__.py
+++ b/numpy/f2py/tests/__init__.py
@@ -1,8 +1,15 @@
-from numpy.testing import IS_WASM
+from numpy.testing import IS_WASM, IS_EDITABLE
 import pytest
 
 if IS_WASM:
     pytest.skip(
         "WASM/Pyodide does not use or support Fortran",
+        allow_module_level=True
+    )
+
+
+if IS_EDITABLE:
+    pytest.skip(
+        "Editable install doesn't support tests with a compile step",
         allow_module_level=True
     )

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -47,6 +47,10 @@ else:
 
 
 @pytest.mark.skipif(
+    'editable' in np.__path__[0],
+    reason='Editable install cannot find .pxd headers'
+)
+@pytest.mark.skipif(
         sys.platform == "win32" and sys.maxsize < 2**32,
         reason="Failing in 32-bit Windows wheel build job, skip for now"
 )

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -10,7 +10,7 @@ import textwrap
 import warnings
 
 import numpy as np
-from numpy.testing import IS_WASM
+from numpy.testing import IS_WASM, IS_EDITABLE
 
 
 try:
@@ -47,7 +47,7 @@ else:
 
 
 @pytest.mark.skipif(
-    'editable' in np.__path__[0],
+    IS_EDITABLE,
     reason='Editable install cannot find .pxd headers'
 )
 @pytest.mark.skipif(

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -39,7 +39,8 @@ __all__ = [
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
         'HAS_REFCOUNT', "IS_WASM", 'suppress_warnings', 'assert_array_compare',
         'assert_no_gc_cycles', 'break_cycles', 'HAS_LAPACK64', 'IS_PYSTON',
-        '_OLD_PROMOTION', 'IS_MUSL', '_SUPPORTS_SVE', 'NOGIL_BUILD'
+        '_OLD_PROMOTION', 'IS_MUSL', '_SUPPORTS_SVE', 'NOGIL_BUILD',
+        'IS_EDITABLE'
         ]
 
 
@@ -54,6 +55,7 @@ verbose = 0
 IS_WASM = platform.machine() in ["wasm32", "wasm64"]
 IS_PYPY = sys.implementation.name == 'pypy'
 IS_PYSTON = hasattr(sys, "pyston_version_info")
+IS_EDITABLE = not bool(np.__path__) or 'editable' in np.__path__[0]
 HAS_REFCOUNT = getattr(sys, 'getrefcount', None) is not None and not IS_PYSTON
 HAS_LAPACK64 = numpy.linalg._umath_linalg._ilp64
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = -l
-norecursedirs = doc tools numpy/linalg/lapack_lite numpy/_core/code_generators
+norecursedirs = doc tools numpy/linalg/lapack_lite numpy/_core/code_generators numpy/_core/src/common/pythoncapi-compat
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS ALLOW_UNICODE ALLOW_BYTES
 junit_family=xunit2
 


### PR DESCRIPTION
Skip testing Cython extension for editable installs due to issues identified in https://github.com/scipy/scipy/issues/20540.
