### PR TITLE
BUG: Fix invalid constructor in string_fastsearch.h with C++ >= 20.

### DIFF
--- a/numpy/_core/src/umath/string_fastsearch.h
+++ b/numpy/_core/src/umath/string_fastsearch.h
@@ -60,13 +60,13 @@ struct CheckedIndexer {
     char_type *buffer;
     size_t length;
 
-    CheckedIndexer<char_type>()
+    CheckedIndexer()
     {
         buffer = NULL;
         length = 0;
     }
 
-    CheckedIndexer<char_type>(char_type *buf, size_t len)
+    CheckedIndexer(char_type *buf, size_t len)
     {
         buffer = buf;
         length = len;


### PR DESCRIPTION
Backport of #26324 in the branch 2.0.