### PR TITLE
MAINT: address improper error handling and cleanup for ``spin``

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,11 +1,7 @@
 import os
 import shutil
-import sys
-import argparse
-import tempfile
 import pathlib
 import shutil
-import json
 import pathlib
 import importlib
 import subprocess
@@ -621,16 +617,10 @@ def notes(ctx, version_override):
     )
     # towncrier build --version 2.1 --yes
     cmd = ["towncrier", "build", "--version", version, "--yes"]
-    try:
-        p = util.run(
-                cmd=cmd,
-                sys_exit=False,
-                output=True,
-                encoding="utf-8"
-            )
-    except subprocess.SubprocessError as e:
+    p = util.run(cmd=cmd, sys_exit=False, output=True, encoding="utf-8")
+    if p.returncode != 0:
         raise click.ClickException(
-            f"`towncrier` failed returned {e.returncode} with error `{e.stderr}`"
+            f"`towncrier` failed returned {p.returncode} with error `{p.stderr}`"
         )
 
     output_path = project_config['tool.towncrier.filename'].format(version=version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,8 +199,10 @@ cli = 'vendored-meson/meson/meson.py'
   ".spin/cmds.py:lint",
 ]
 "Environments" = [
-  "spin.cmds.meson.run", ".spin/cmds.py:ipython",
-  ".spin/cmds.py:python", "spin.cmds.meson.gdb",
+  "spin.cmds.meson.run",
+  ".spin/cmds.py:ipython",
+  ".spin/cmds.py:python",
+  "spin.cmds.meson.gdb",
   "spin.cmds.meson.lldb"
 ]
 "Documentation" = [


### PR DESCRIPTION
Backport of #26304.

I just came across that while trying to benchmark docs.

It seem that when this was moved from subprocess.run to spin.util run the error handling was not updated.

spin.util seem to always return a CompletedProcess and it has the stderr and return code. (tested locally by changing `towncrier` to `false`).

While at it I removed unused import and reformatted a tiny bit the pyprojet.toml to only have 1 command per line for readability.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
