### PR TITLE
BUG: use PyArray_SafeCast in array_astype

### DIFF
--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -497,6 +497,13 @@ def test_create_with_copy_none(string_list):
     assert arr_view is arr
 
 
+def test_astype_copy_false():
+    orig_dt = StringDType()
+    arr = np.array(["hello", "world"], dtype=StringDType())
+    assert not arr.astype(StringDType(coerce=False), copy=False).dtype.coerce
+
+    assert arr.astype(orig_dt, copy=False).dtype is orig_dt
+
 @pytest.mark.parametrize(
     "strings",
     [


### PR DESCRIPTION
Backport of #26317.

I noticed today that passing a distinct `StringDType` instance to `astype` wasn't sufficient to actually change the dtype with `copy=False`. This fixes that issue by using `PyArray_SafeCast` instead of `PyArray_EquivTypes`.

See #26147 which introduced `PyArray_SafeCast` and fixed a similar issue.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
