### PR TITLE
MAINT: update x86-simd-sort to latest

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -178,19 +178,19 @@ jobs:
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
     - name: Build
-      run: spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512f -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
+      run: spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
 
     - name: Meson Log
       if: always()
       run: cat build/meson-logs/meson-log.txt
 
-    - name: SIMD tests (KNM)
+    - name: SIMD tests (SKX)
       run: |
         export NUMPY_SITE=$(realpath build-install/usr/lib/python*/site-packages/)
         export PYTHONPATH="$PYTHONPATH:$NUMPY_SITE"
         cd build-install &&
-        sde -knm -- python -c "import numpy; numpy.show_config()" &&
-        sde -knm -- python -m pytest $NUMPY_SITE/numpy/_core/tests/test_simd*
+        sde -skx -- python -c "import numpy; numpy.show_config()" &&
+        sde -skx -- python -m pytest $NUMPY_SITE/numpy/_core/tests/test_simd*
 
     - name: linalg/ufunc/umath tests (TGL)
       run: |

--- a/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
@@ -2,31 +2,20 @@
 #define VQSORT_ONLY_STATIC 1
 #include "hwy/contrib/sort/vqsort-inl.h"
 
+#define DISPATCH_VQSORT(TYPE) \
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(TYPE *arr, intptr_t size) \
+{ \
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending()); \
+} \
+
 namespace np { namespace highway { namespace qsort_simd {
 
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, intptr_t size)
-{
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
+    DISPATCH_VQSORT(int32_t)
+    DISPATCH_VQSORT(uint32_t)
+    DISPATCH_VQSORT(int64_t)
+    DISPATCH_VQSORT(uint64_t)
+    DISPATCH_VQSORT(double)
+    DISPATCH_VQSORT(float)
 }
 
 } } } // np::highway::qsort_simd

--- a/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
@@ -16,6 +16,5 @@ namespace np { namespace highway { namespace qsort_simd {
     DISPATCH_VQSORT(uint64_t)
     DISPATCH_VQSORT(double)
     DISPATCH_VQSORT(float)
-}
 
 } } } // np::highway::qsort_simd

--- a/numpy/_core/src/npysort/x86_simd_argsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_argsort.dispatch.cpp
@@ -1,86 +1,57 @@
 #include "x86_simd_qsort.hpp"
 #ifndef __CYGWIN__
 
-#if defined(NPY_HAVE_AVX512_SKX)
-#include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
-#elif defined(NPY_HAVE_AVX2)
-#include "x86-simd-sort/src/avx2-32bit-half.hpp"
-#include "x86-simd-sort/src/avx2-32bit-qsort.hpp"
-#include "x86-simd-sort/src/avx2-64bit-qsort.hpp"
-#include "x86-simd-sort/src/xss-common-argsort.h"
-#endif
-
-namespace {
-template<typename T>
-void x86_argsort(T* arr, size_t* arg, npy_intp num)
-{
-#if defined(NPY_HAVE_AVX512_SKX)
-    avx512_argsort(arr, arg, num, true);
-#elif defined(NPY_HAVE_AVX2)
-    avx2_argsort(arr, arg, num, true);
-#endif
-}
-
-template<typename T>
-void x86_argselect(T* arr, size_t* arg, npy_intp kth, npy_intp num)
-{
-#if defined(NPY_HAVE_AVX512_SKX)
-    avx512_argselect(arr, arg, kth, num, true);
-#elif defined(NPY_HAVE_AVX2)
-    avx2_argselect(arr, arg, kth, num, true);
-#endif
-}
-} // anonymous
+#include "x86-simd-sort/src/x86simdsort-static-incl.h"
 
 namespace np { namespace qsort_simd {
 
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
 {
-    x86_argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
 {
-    x86_argsort(arr, reinterpret_cast<size_t*>(arg), size);
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size, true);
 }
 
 }} // namespace np::simd

--- a/numpy/_core/src/npysort/x86_simd_argsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_argsort.dispatch.cpp
@@ -3,56 +3,24 @@
 
 #include "x86-simd-sort/src/x86simdsort-static-incl.h"
 
+#define DISPATCH_ARG_METHODS(TYPE) \
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(TYPE* arr, npy_intp* arg, npy_intp num, npy_intp kth) \
+{ \
+    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num, true); \
+} \
+template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(TYPE* arr, npy_intp *arg, npy_intp size) \
+{ \
+    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size, true); \
+} \
+
 namespace np { namespace qsort_simd {
 
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint32_t *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(int64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(uint64_t*arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(float *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSelect)(double *arr, npy_intp* arg, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::argselect(arr, reinterpret_cast<size_t*>(arg), kth, num, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int32_t *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint32_t *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(int64_t *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(uint64_t *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(float *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(ArgQSort)(double *arr, npy_intp *arg, npy_intp size)
-{
-    x86simdsortStatic::argsort(arr, reinterpret_cast<size_t*>(arg), size, true);
-}
+    DISPATCH_ARG_METHODS(uint32_t)
+    DISPATCH_ARG_METHODS(int32_t)
+    DISPATCH_ARG_METHODS(float)
+    DISPATCH_ARG_METHODS(uint64_t)
+    DISPATCH_ARG_METHODS(int64_t)
+    DISPATCH_ARG_METHODS(double)
 
 }} // namespace np::simd
 

--- a/numpy/_core/src/npysort/x86_simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort.dispatch.cpp
@@ -1,89 +1,57 @@
 #include "x86_simd_qsort.hpp"
 #ifndef __CYGWIN__
 
-#if defined(NPY_HAVE_AVX512_SKX)
-    #include "x86-simd-sort/src/avx512-32bit-qsort.hpp"
-    #include "x86-simd-sort/src/avx512-64bit-qsort.hpp"
-    #include "x86-simd-sort/src/avx512-64bit-argsort.hpp"
-#elif defined(NPY_HAVE_AVX2)
-    #include "x86-simd-sort/src/avx2-32bit-qsort.hpp"
-    #include "x86-simd-sort/src/avx2-64bit-qsort.hpp"
-#endif
-
-namespace {
-template<typename T>
-void x86_qsort(T* arr, npy_intp num)
-{
-#if defined(NPY_HAVE_AVX512_SKX)
-    avx512_qsort(arr, num, true);
-#elif defined(NPY_HAVE_AVX2)
-    avx2_qsort(arr, num, true);
-#endif
-}
-
-template<typename T>
-void x86_qselect(T* arr, npy_intp num, npy_intp kth)
-{
-#if defined(NPY_HAVE_AVX512_SKX)
-    avx512_qselect(arr, kth, num, true);
-#elif defined(NPY_HAVE_AVX2)
-    avx2_qselect(arr, kth, num, true);
-#endif
-}
-} // anonymous
+#include "x86-simd-sort/src/x86simdsort-static-incl.h"
 
 namespace np { namespace qsort_simd {
-#if defined(NPY_HAVE_AVX512_SKX) || defined(NPY_HAVE_AVX2)
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint32_t *arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int64_t*arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint64_t*arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(float *arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_intp kth)
 {
-    x86_qselect(arr, num, kth);
+    x86simdsortStatic::qselect(arr, kth, num, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num, true);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, npy_intp num)
 {
-    x86_qsort(arr, num);
+    x86simdsortStatic::qsort(arr, num, true);
 }
-#endif // NPY_HAVE_AVX512_SKX || NPY_HAVE_AVX2
-
 }} // namespace np::qsort_simd
 
 #endif // __CYGWIN__

--- a/numpy/_core/src/npysort/x86_simd_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort.dispatch.cpp
@@ -3,55 +3,23 @@
 
 #include "x86-simd-sort/src/x86simdsort-static-incl.h"
 
+#define DISPATCH_SORT_METHODS(TYPE) \
+template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(TYPE *arr, npy_intp num, npy_intp kth) \
+{ \
+    x86simdsortStatic::qselect(arr, kth, num, true); \
+} \
+template<> void NPY_CPU_DISPATCH_CURFX(QSort)(TYPE *arr, npy_intp num) \
+{ \
+    x86simdsortStatic::qsort(arr, num, true); \
+} \
+
 namespace np { namespace qsort_simd {
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int32_t *arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint32_t *arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int64_t*arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint64_t*arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(float *arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(double *arr, npy_intp num, npy_intp kth)
-{
-    x86simdsortStatic::qselect(arr, kth, num, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int32_t *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint32_t *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int64_t *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint64_t *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(float *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num, true);
-}
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(double *arr, npy_intp num)
-{
-    x86simdsortStatic::qsort(arr, num, true);
-}
+    DISPATCH_SORT_METHODS(uint32_t)
+    DISPATCH_SORT_METHODS(int32_t)
+    DISPATCH_SORT_METHODS(float)
+    DISPATCH_SORT_METHODS(uint64_t)
+    DISPATCH_SORT_METHODS(int64_t)
+    DISPATCH_SORT_METHODS(double)
 }} // namespace np::qsort_simd
 
 #endif // __CYGWIN__

--- a/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
@@ -13,7 +13,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_int
 #if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
 #else
-    avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true);
+    avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true, false);
 #endif
 }
 
@@ -35,7 +35,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, npy_intp size)
 #if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qsort(reinterpret_cast<_Float16*>(arr), size, true);
 #else
-    avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size, true);
+    avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size, true, false);
 #endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, npy_intp size)

--- a/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
@@ -2,6 +2,13 @@
 #ifndef __CYGWIN__
 
 #include "x86-simd-sort/src/x86simdsort-static-incl.h"
+/*
+ * MSVC doesn't set the macro __AVX512VBMI2__ which is required for the 16-bit
+ * functions and therefore we need to manually include this file here
+ */
+#ifdef _MSC_VER
+#include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
+#endif
 
 namespace np { namespace qsort_simd {
 

--- a/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
@@ -1,23 +1,17 @@
 #include "x86_simd_qsort.hpp"
 #ifndef __CYGWIN__
 
-#if defined(NPY_HAVE_AVX512_SPR)
-    #include "x86-simd-sort/src/avx512fp16-16bit-qsort.hpp"
-    #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
-#elif defined(NPY_HAVE_AVX512_ICL)
-    #include "x86-simd-sort/src/avx512-16bit-qsort.hpp"
-#endif
+#include "x86-simd-sort/src/x86simdsort-static-incl.h"
 
 namespace np { namespace qsort_simd {
 
 /*
  * QSelect dispatch functions:
  */
-#if defined(NPY_HAVE_AVX512_ICL) || defined(NPY_HAVE_AVX512_SPR)
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
-    avx512_qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
+    x86simdsortStatic::qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
 #else
     avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true);
 #endif
@@ -25,12 +19,12 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_int
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
 {
-    avx512_qselect(arr, kth, num);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_intp kth)
 {
-    avx512_qselect(arr, kth, num);
+    x86simdsortStatic::qselect(arr, kth, num);
 }
 
 /*
@@ -39,20 +33,19 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, npy_intp size)
 {
 #if defined(NPY_HAVE_AVX512_SPR)
-    avx512_qsort(reinterpret_cast<_Float16*>(arr), size, true);
+    x86simdsortStatic::qsort(reinterpret_cast<_Float16*>(arr), size, true);
 #else
     avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size, true);
 #endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, npy_intp size)
 {
-    avx512_qsort(arr, size);
+    x86simdsortStatic::qsort(arr, size);
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, npy_intp size)
 {
-    avx512_qsort(arr, size);
+    x86simdsortStatic::qsort(arr, size);
 }
-#endif // NPY_HAVE_AVX512_ICL || SPR
 
 }} // namespace np::qsort_simd
 


### PR DESCRIPTION
latest version simplifies the use of static avx512 and avx2 sort, argsort, partition and argpartition functions. No difference in performance or algorithms.  

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
