### PR TITLE
DOC: Update documentation to reference SSH

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -88,8 +88,8 @@ Here's the short summary, complete TOC links are below:
 
       git push origin linspace-speedups
 
-   * Enter your GitHub username and password (repeat contributors or advanced
-     users can remove this step by connecting to GitHub with SSH).
+   * Sign in to your GitHub account (repeat contributors or advanced
+     users can connect via SSH for added convinience).
 
    * Go to GitHub. The new branch will show up with a green Pull Request
      button. Make sure the title and message are clear, concise, and self-

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -87,9 +87,13 @@ Here's the short summary, complete TOC links are below:
    * Push your changes back to your fork on GitHub::
 
       git push origin linspace-speedups
+  
+   * Go to GitHub. The new branch will show up with a green Pull Request
+     button. Make sure the title and message are clear, concise, and self-
+     explanatory. Then click the button to submit it.
 
-   * If your commit introduces a new feature or changes functionality, consider sharing
-     your changes on the `mailing list`_ to explain your changes. For bug fixes, documentation
+   * If your commit introduces a new feature or changes functionality, post
+     on the `mailing list`_ to explain your changes. For bug fixes, documentation
      updates, etc., this is generally not necessary, though if you do not get
      any reaction, do feel free to ask for review.
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -88,15 +88,8 @@ Here's the short summary, complete TOC links are below:
 
       git push origin linspace-speedups
 
-   * Sign in to your GitHub account (repeat contributors or advanced
-     users can connect via SSH for added convinience).
-
-   * Go to GitHub. The new branch will show up with a green Pull Request
-     button. Make sure the title and message are clear, concise, and self-
-     explanatory. Then click the button to submit it.
-
-   * If your commit introduces a new feature or changes functionality, post on
-     the `mailing list`_ to explain your changes. For bug fixes, documentation
+   * If your commit introduces a new feature or changes functionality, consider sharing
+     your changes on the `mailing list`_ to explain your changes. For bug fixes, documentation
      updates, etc., this is generally not necessary, though if you do not get
      any reaction, do feel free to ask for review.
 


### PR DESCRIPTION
ENH: Update documentation to reference SSH

I've updated the documentation in numpy/doc/source/dev/index.rst.
This change reflects the current authentication methods using SSH keys. 
This pull request replaces outdated references to GitHub Usernames and Passwords.
This change improves the clarity and accuracy of the documentation

I'd appreciate it if @bmwoodruff and @InessaPawson could review these changes.
See #26343