### PR TITLE
TST: static types are now immortal in the default build too

### DIFF
--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -11,7 +11,6 @@ from numpy import array, arange, nditer, all
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises,
     IS_WASM, HAS_REFCOUNT, suppress_warnings, break_cycles,
-    NOGIL_BUILD
     )
 
 def iter_multi_index(i):
@@ -68,8 +67,8 @@ def test_iter_refcount():
     rc2_dt = sys.getrefcount(dt)
     it2 = it.copy()
     assert_(sys.getrefcount(a) > rc2_a)
-    if not NOGIL_BUILD:
-        # np.dtype('f4') is immortal in the nogil build
+    if sys.version_info < (3, 13):
+        # np.dtype('f4') is immortal after Python 3.13
         assert_(sys.getrefcount(dt) > rc2_dt)
     it = None
     assert_equal(sys.getrefcount(a), rc2_a)


### PR DESCRIPTION
See https://github.com/python/cpython/pull/117673 for the relevant upstream PR.

Fixes a test that started failing for me when I recompiled python 3.13-dev.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
