### PR TITLE
[NOGIL] thread local promotion state

### DIFF
--- a/numpy/_core/config.h.in
+++ b/numpy/_core/config.h.in
@@ -8,6 +8,8 @@
 #mesondefine HAVE_FSEEKO
 #mesondefine HAVE_FALLOCATE
 #mesondefine HAVE_STRTOLD_L
+#mesondefine HAVE_THREAD_LOCAL
+#mesondefine HAVE__THREAD_LOCAL
 #mesondefine HAVE__THREAD
 #mesondefine HAVE___DECLSPEC_THREAD_
 

--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -113,14 +113,18 @@
     #define NPY_NOINLINE static
 #endif
 
-#ifdef HAVE___THREAD
+#ifdef __cplusplus
+    #define NPY_TLS thread_local
+#elif defined(HAVE_THREAD_LOCAL)
+    #define NPY_TLS thread_local
+#elif defined(HAVE__THREAD_LOCAL)
+    #define NPY_TLS _Thread_local
+#elif defined(HAVE___THREAD)
     #define NPY_TLS __thread
+#elif defined(HAVE__DECLSPEC_THREAD_)
+    #define NPY_TLS __declspec(thread)
 #else
-    #ifdef HAVE___DECLSPEC_THREAD_
-        #define NPY_TLS __declspec(thread)
-    #else
-        #define NPY_TLS
-    #endif
+    #define NPY_TLS
 #endif
 
 #ifdef WITH_CPYCHECKER_RETURNS_BORROWED_REF_ATTRIBUTE

--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -121,7 +121,7 @@
     #define NPY_TLS _Thread_local
 #elif defined(HAVE___THREAD)
     #define NPY_TLS __thread
-#elif defined(HAVE__DECLSPEC_THREAD_)
+#elif defined(HAVE___DECLSPEC_THREAD_)
     #define NPY_TLS __declspec(thread)
 #else
     #define NPY_TLS

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -244,6 +244,8 @@ endforeach
 
 # variable attributes tested via "int %s a" % attribute
 optional_variable_attributes = [
+  ['thread_local', 'HAVE_THREAD_LOCAL'],
+  ['_Thread_local', 'HAVE__THREAD_LOCAL'],
   ['__thread', 'HAVE__THREAD'],
   ['__declspec(thread)', 'HAVE___DECLSPEC_THREAD_']
 ]
@@ -262,7 +264,7 @@ foreach optional_attr: optional_variable_attributes
       return 0;
     }
   '''
-  if cc.compiles(code)
+  if cc.compiles(code, name: optional_attr[0])
     cdata.set10(optional_attr[1], true)
   endif
 endforeach

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -274,9 +274,9 @@ static int
 #endif
             ) {
         PyArray_Descr *descr = PyArray_DescrFromType(NPY_@TYPE@);
-
-        if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION || (
-                    npy_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN
+        int promotion_state = get_npy_promotion_state();
+        if (promotion_state == NPY_USE_LEGACY_PROMOTION || (
+                    get_npy_promotion_state() == NPY_USE_WEAK_PROMOTION_AND_WARN
                         && !npy_give_promotion_warnings())) {
             /*
              * This path will be taken both for the "promotion" case such as

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -276,8 +276,8 @@ static int
         PyArray_Descr *descr = PyArray_DescrFromType(NPY_@TYPE@);
         int promotion_state = get_npy_promotion_state();
         if (promotion_state == NPY_USE_LEGACY_PROMOTION || (
-                    get_npy_promotion_state() == NPY_USE_WEAK_PROMOTION_AND_WARN
-                        && !npy_give_promotion_warnings())) {
+                    promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN
+                    && !npy_give_promotion_warnings())) {
             /*
              * This path will be taken both for the "promotion" case such as
              * `uint8_arr + 123` as well as the assignment case.

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -51,11 +51,22 @@ NPY_NO_EXPORT npy_intp REQUIRED_STR_LEN[] = {0, 3, 5, 10, 10, 20, 20, 20, 20};
 /*
  * Whether or not legacy value-based promotion/casting is used.
  */
-NPY_NO_EXPORT int npy_promotion_state = NPY_USE_LEGACY_PROMOTION;
+
 NPY_NO_EXPORT PyObject *NO_NEP50_WARNING_CTX = NULL;
 NPY_NO_EXPORT PyObject *npy_DTypePromotionError = NULL;
 NPY_NO_EXPORT PyObject *npy_UFuncNoLoopError = NULL;
 
+NPY_NO_EXPORT NPY_TLS int npy_promotion_state = NPY_USE_LEGACY_PROMOTION;
+
+NPY_NO_EXPORT int
+get_npy_promotion_state() {
+    return npy_promotion_state;
+}
+
+NPY_NO_EXPORT void
+set_npy_promotion_state(int new_promotion_state) {
+    npy_promotion_state = new_promotion_state;
+}
 
 static PyObject *
 PyArray_GetGenericToVoidCastingImpl(void);
@@ -100,13 +111,14 @@ npy_give_promotion_warnings(void)
 
 NPY_NO_EXPORT PyObject *
 npy__get_promotion_state(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(arg)) {
-    if (npy_promotion_state == NPY_USE_WEAK_PROMOTION) {
+    int promotion_state = get_npy_promotion_state();
+    if (promotion_state == NPY_USE_WEAK_PROMOTION) {
         return PyUnicode_FromString("weak");
     }
-    else if (npy_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN) {
+    else if (promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN) {
         return PyUnicode_FromString("weak_and_warn");
     }
-    else if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+    else if (promotion_state == NPY_USE_LEGACY_PROMOTION) {
         return PyUnicode_FromString("legacy");
     }
     PyErr_SetString(PyExc_SystemError, "invalid promotion state!");
@@ -123,14 +135,15 @@ npy__set_promotion_state(PyObject *NPY_UNUSED(mod), PyObject *arg)
                 "must be a string.");
         return NULL;
     }
+    int new_promotion_state;
     if (PyUnicode_CompareWithASCIIString(arg, "weak") == 0) {
-        npy_promotion_state = NPY_USE_WEAK_PROMOTION;
+        new_promotion_state = NPY_USE_WEAK_PROMOTION;
     }
     else if (PyUnicode_CompareWithASCIIString(arg, "weak_and_warn") == 0) {
-        npy_promotion_state = NPY_USE_WEAK_PROMOTION_AND_WARN;
+        new_promotion_state = NPY_USE_WEAK_PROMOTION_AND_WARN;
     }
     else if (PyUnicode_CompareWithASCIIString(arg, "legacy") == 0) {
-        npy_promotion_state = NPY_USE_LEGACY_PROMOTION;
+        new_promotion_state = NPY_USE_LEGACY_PROMOTION;
     }
     else {
         PyErr_Format(PyExc_TypeError,
@@ -138,6 +151,7 @@ npy__set_promotion_state(PyObject *NPY_UNUSED(mod), PyObject *arg)
                 "'weak', 'legacy', or 'weak_and_warn' but got '%.100S'", arg);
         return NULL;
     }
+    set_npy_promotion_state(new_promotion_state);
     Py_RETURN_NONE;
 }
 
@@ -930,7 +944,7 @@ PyArray_CanCastArrayTo(PyArrayObject *arr, PyArray_Descr *to,
         to = NULL;
     }
 
-    if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+    if (get_npy_promotion_state() == NPY_USE_LEGACY_PROMOTION) {
         /*
          * If it's a scalar, check the value.  (This only currently matters for
          * numeric types and for `to == NULL` it can't be numeric.)
@@ -1954,10 +1968,11 @@ PyArray_CheckLegacyResultType(
         npy_intp ndtypes, PyArray_Descr **dtypes)
 {
     PyArray_Descr *ret = NULL;
-    if (npy_promotion_state == NPY_USE_WEAK_PROMOTION) {
+    int promotion_state = get_npy_promotion_state();
+    if (promotion_state == NPY_USE_WEAK_PROMOTION) {
         return 0;
     }
-    if (npy_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN
+    if (promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN
             && !npy_give_promotion_warnings()) {
         return 0;
     }
@@ -2054,12 +2069,13 @@ PyArray_CheckLegacyResultType(
         Py_DECREF(ret);
         return 0;
     }
-    if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+
+    if (promotion_state == NPY_USE_LEGACY_PROMOTION) {
         Py_SETREF(*new_result, ret);
         return 0;
     }
 
-    assert(npy_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN);
+    assert(promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN);
     if (PyErr_WarnFormat(PyExc_UserWarning, 1,
             "result dtype changed due to the removal of value-based "
             "promotion from NumPy. Changed from %S to %S.",

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -56,7 +56,7 @@ NPY_NO_EXPORT PyObject *NO_NEP50_WARNING_CTX = NULL;
 NPY_NO_EXPORT PyObject *npy_DTypePromotionError = NULL;
 NPY_NO_EXPORT PyObject *npy_UFuncNoLoopError = NULL;
 
-NPY_NO_EXPORT NPY_TLS int npy_promotion_state = NPY_USE_LEGACY_PROMOTION;
+static NPY_TLS int npy_promotion_state = NPY_USE_LEGACY_PROMOTION;
 
 NPY_NO_EXPORT int
 get_npy_promotion_state() {

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -12,7 +12,8 @@ extern NPY_NO_EXPORT npy_intp REQUIRED_STR_LEN[];
 #define NPY_USE_LEGACY_PROMOTION 0
 #define NPY_USE_WEAK_PROMOTION 1
 #define NPY_USE_WEAK_PROMOTION_AND_WARN 2
-extern NPY_NO_EXPORT int npy_promotion_state;
+
+extern NPY_NO_EXPORT NPY_TLS int npy_promotion_state;
 extern NPY_NO_EXPORT PyObject *NO_NEP50_WARNING_CTX;
 extern NPY_NO_EXPORT PyObject *npy_DTypePromotionError;
 extern NPY_NO_EXPORT PyObject *npy_UFuncNoLoopError;
@@ -136,6 +137,12 @@ simple_cast_resolve_descriptors(
 
 NPY_NO_EXPORT int
 PyArray_InitializeCasts(void);
+
+NPY_NO_EXPORT int
+get_npy_promotion_state();
+
+NPY_NO_EXPORT void
+set_npy_promotion_state(int new_promotion_state);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -13,7 +13,6 @@ extern NPY_NO_EXPORT npy_intp REQUIRED_STR_LEN[];
 #define NPY_USE_WEAK_PROMOTION 1
 #define NPY_USE_WEAK_PROMOTION_AND_WARN 2
 
-extern NPY_NO_EXPORT NPY_TLS int npy_promotion_state;
 extern NPY_NO_EXPORT PyObject *NO_NEP50_WARNING_CTX;
 extern NPY_NO_EXPORT PyObject *npy_DTypePromotionError;
 extern NPY_NO_EXPORT PyObject *npy_UFuncNoLoopError;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3493,7 +3493,7 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self),
          * TODO: `PyArray_IsScalar` should not be required for new dtypes.
          *       weak-promotion branch is in practice identical to dtype one.
          */
-        if (npy_promotion_state == NPY_USE_WEAK_PROMOTION) {
+        if (get_npy_promotion_state() == NPY_USE_WEAK_PROMOTION) {
             PyObject *descr = PyObject_GetAttr(from_obj, npy_ma_str_dtype);
             if (descr == NULL) {
                 goto finish;

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -963,7 +963,7 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
             *may_need_deferring = NPY_TRUE;
         }
         if (!IS_SAFE(NPY_DOUBLE, NPY_@TYPE@)) {
-            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+            if (get_npy_promotion_state() != NPY_USE_WEAK_PROMOTION) {
                 /* Legacy promotion and weak-and-warn not handled here */
                 return PROMOTION_REQUIRED;
             }
@@ -986,7 +986,7 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
              * long -> (c)longdouble is safe, so `OTHER_IS_UNKNOWN_OBJECT` will
              * be returned below for huge integers.
              */
-            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+            if (get_npy_promotion_state() != NPY_USE_WEAK_PROMOTION) {
                 /* Legacy promotion and weak-and-warn not handled here */
                 return PROMOTION_REQUIRED;
             }
@@ -996,7 +996,7 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
         long val = PyLong_AsLongAndOverflow(value, &overflow);
         if (overflow) {
             /* handle as if "unsafe" */
-            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+            if (get_npy_promotion_state() != NPY_USE_WEAK_PROMOTION) {
                 return OTHER_IS_UNKNOWN_OBJECT;
             }
             return CONVERT_PYSCALAR;
@@ -1018,7 +1018,7 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
             *may_need_deferring = NPY_TRUE;
         }
         if (!IS_SAFE(NPY_CDOUBLE, NPY_@TYPE@)) {
-            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+            if (get_npy_promotion_state() != NPY_USE_WEAK_PROMOTION) {
                 /* Legacy promotion and weak-and-warn not handled here */
                 return PROMOTION_REQUIRED;
             }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -670,7 +670,7 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
 
         // TODO: Is this equivalent/better by removing the logic which enforces
         //       that we always use weak promotion in the core?
-        if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+        if (get_npy_promotion_state() == NPY_USE_LEGACY_PROMOTION) {
             continue;  /* Skip use of special dtypes */
         }
 
@@ -6073,8 +6073,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
     PyArray_Descr *operation_descrs[NPY_MAXARGS] = {NULL};
 
     /* This entry-point to promotion lives in the NEP 50 future: */
-    int original_promotion_state = npy_promotion_state;
-    npy_promotion_state = NPY_USE_WEAK_PROMOTION;
+    int original_promotion_state = get_npy_promotion_state();
+    set_npy_promotion_state(NPY_USE_WEAK_PROMOTION);
 
     npy_bool promoting_pyscalars = NPY_FALSE;
     npy_bool allow_legacy_promotion = NPY_TRUE;
@@ -6261,7 +6261,7 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
     Py_DECREF(capsule);
 
   finish:
-    npy_promotion_state = original_promotion_state;
+    set_npy_promotion_state(original_promotion_state);
 
     Py_XDECREF(result_dtype_tuple);
     for (int i = 0; i < ufunc->nargs; i++) {

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -1965,10 +1965,12 @@ linear_search_type_resolver(PyUFuncObject *self,
 
     ufunc_name = ufunc_get_name_cstr(self);
 
-    assert(npy_promotion_state != NPY_USE_WEAK_PROMOTION_AND_WARN);
+    int promotion_state = get_npy_promotion_state();
+
+    assert(promotion_state != NPY_USE_WEAK_PROMOTION_AND_WARN);
     /* Always "use" with new promotion in case of Python int/float/complex */
     int use_min_scalar;
-    if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+    if (promotion_state == NPY_USE_LEGACY_PROMOTION) {
         use_min_scalar = should_use_min_scalar(nin, op, 0, NULL);
     }
     else {
@@ -2167,10 +2169,12 @@ type_tuple_type_resolver(PyUFuncObject *self,
 
     ufunc_name = ufunc_get_name_cstr(self);
 
-    assert(npy_promotion_state != NPY_USE_WEAK_PROMOTION_AND_WARN);
+    int promotion_state = get_npy_promotion_state();
+
+    assert(promotion_state != NPY_USE_WEAK_PROMOTION_AND_WARN);
     /* Always "use" with new promotion in case of Python int/float/complex */
     int use_min_scalar;
-    if (npy_promotion_state == NPY_USE_LEGACY_PROMOTION) {
+    if (promotion_state == NPY_USE_LEGACY_PROMOTION) {
         use_min_scalar = should_use_min_scalar(nin, op, 0, NULL);
     }
     else {

--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -5,6 +5,8 @@ is adopted in the main test suite.  A few may be moved elsewhere.
 """
 
 import operator
+import threading
+import warnings
 
 import numpy as np
 
@@ -340,3 +342,31 @@ def test_oob_creation(sctype, create):
 
     assert create(sctype, iinfo.min) == iinfo.min
     assert create(sctype, iinfo.max) == iinfo.max
+
+
+def test_thread_local_promotion_state():
+    b = threading.Barrier(2)
+    def legacy_no_warn():
+        np._set_promotion_state("legacy")
+        b.wait()
+        assert np._get_promotion_state() == "legacy"
+        # turn warnings into errors, this should not warn with
+        # legacy promotion state
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            np.float16(1) + 131008
+
+    def weak_warn():
+        np._set_promotion_state("weak")
+        b.wait()
+        assert np._get_promotion_state() == "weak"
+        with pytest.warns(RuntimeWarning):
+            np.float16(1) + 131008
+
+    task1 = threading.Thread(target=legacy_no_warn)
+    task2 = threading.Thread(target=weak_warn)
+
+    task1.start()
+    task2.start()
+    task1.join()
+    task2.join()

--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -346,6 +346,7 @@ def test_oob_creation(sctype, create):
 
 def test_thread_local_promotion_state():
     b = threading.Barrier(2)
+
     def legacy_no_warn():
         np._set_promotion_state("legacy")
         b.wait()

--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -344,6 +344,7 @@ def test_oob_creation(sctype, create):
     assert create(sctype, iinfo.max) == iinfo.max
 
 
+@pytest.mark.skipif(IS_WASM, reason="wasm doesn't have support for threads")
 def test_thread_local_promotion_state():
     b = threading.Barrier(2)
 


### PR DESCRIPTION
This makes the promotion state a thread local variable and mediates access to it via getter and setter functions.

In order to use it I extended the existing `NPY_TLS` macro to also check for some C11/C23 possibilities. This macro is public - is it problematic to update it? A github search indicates it's not used much. I'm not sure if the macro works on all supported platforms, let's see. I don't think there are any supported platforms or compilers that are not covered by one of the spellings for thread-local storage I added to the meson config but please let me know if you're aware of any issues.

I decided to mark this variable as thread-local irrespective of the GIL setting. I don't think marking these variables as thread-local adds any overhead. Are there any benchmarks that might be sensitive to overhead in setting or getting the promotion state?

The test I added reliably fails before the promotion state in the nogil build on `main`.