### PR TITLE
DOC: fix np.unique release notes [skip cirrus]

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -1481,7 +1481,7 @@ the ``unique_inverse`` output is now shaped such that the input can be reconstru
 directly using ``np.take(unique, unique_inverse)`` when ``axis=None``, and
 ``np.take_along_axis(unique, unique_inverse, axis=axis)`` otherwise.
 
-(`gh-25553 <https://github.com/numpy/numpy/pull/24126>`__,
+(`gh-25553 <https://github.com/numpy/numpy/pull/25553>`__,
 `gh-25570 <https://github.com/numpy/numpy/pull/25570>`__)
 
 ``any`` and ``all`` return booleans for object arrays


### PR DESCRIPTION
Fixes an incorrect link in the numpy2.0 release notes to #25553.

Noticed when the changes introduced in that PR broke a downstream package. Caused a bit of head scratching.

Perhaps the `np.unique` docstring could do with being amended with a 'changed in 2.0' note, even if the original behaviour was considered a bug. The docstring doesn't indicate that anything was different between 1.26.4 and 2.0, so when my code broke I thought it was a bug introduced into numpy2.
