### PR TITLE
DOC: Update internal links for generator.rst and related

### DIFF
--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -2,14 +2,14 @@
 
 Random ``Generator``
 ====================
-The `~Generator` provides access to
+The `Generator` provides access to
 a wide range of distributions, and served as a replacement for
 :class:`~numpy.random.RandomState`.  The main difference between
-the two is that ``Generator`` relies on an additional BitGenerator to
+the two is that `Generator` relies on an additional BitGenerator to
 manage state and generate the random bits, which are then transformed into
 random values from useful distributions. The default BitGenerator used by
-``Generator`` is `~PCG64`.  The BitGenerator
-can be changed by passing an instantized BitGenerator to ``Generator``.
+`Generator` is `PCG64`.  The BitGenerator
+can be changed by passing an instantized BitGenerator to `Generator`.
 
 
 .. autofunction:: default_rng

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -146,7 +146,7 @@ cdef class Generator:
 
     Container for the BitGenerators.
 
-    ``Generator`` exposes a number of methods for generating random
+    `Generator` exposes a number of methods for generating random
     numbers drawn from a variety of probability distributions. In addition to
     the distribution-specific arguments, each method takes a keyword argument
     `size` that defaults to ``None``. If `size` is ``None``, then a single
@@ -159,7 +159,7 @@ cdef class Generator:
 
     **No Compatibility Guarantee**
 
-    ``Generator`` does not provide a version compatibility guarantee. In
+    `Generator` does not provide a version compatibility guarantee. In
     particular, as better algorithms evolve the bit stream may change.
 
     Parameters
@@ -171,8 +171,8 @@ cdef class Generator:
     -----
     The Python stdlib module `random` contains pseudo-random number generator
     with a number of methods that are similar to the ones available in
-    ``Generator``. It uses Mersenne Twister, and this bit generator can
-    be accessed using ``MT19937``. ``Generator``, besides being
+    `Generator`. It uses Mersenne Twister, and this bit generator can
+    be accessed using `MT19937`. `Generator`, besides being
     NumPy-aware, has the advantage that it provides a much larger number
     of probability distributions to choose from.
 
@@ -5025,11 +5025,11 @@ def default_rng(seed=None):
     
     Examples
     --------
-    ``default_rng`` is the recommended constructor for the random number class
-    ``Generator``. Here are several ways we can construct a random 
-    number generator using ``default_rng`` and the ``Generator`` class. 
+    `default_rng` is the recommended constructor for the random number class
+    `Generator`. Here are several ways we can construct a random 
+    number generator using `default_rng` and the `Generator` class. 
     
-    Here we use ``default_rng`` to generate a random float:
+    Here we use `default_rng` to generate a random float:
  
     >>> import numpy as np
     >>> rng = np.random.default_rng(12345)
@@ -5041,7 +5041,7 @@ def default_rng(seed=None):
     >>> type(rfloat)
     <class 'float'>
      
-    Here we use ``default_rng`` to generate 3 random integers between 0 
+    Here we use `default_rng` to generate 3 random integers between 0 
     (inclusive) and 10 (exclusive):
         
     >>> import numpy as np


### PR DESCRIPTION
This is a first in a sequence of future PRs to update internal links, as discussed in the triage meeting. In addition to removing double backticks on internal functions, I removed unneeded tilde ~ as well. This is a great example page to see why a tilde ~ is needed in the first paragraph of generator.rst.

I included instructions for the POSSEE team on this topic, as it's a simple way to help train them in the PR process.

I did build the docs, and verify that each link appropriately points to the correct spot. If there is any thing I can do to help speed up the review process as more of these come in, let me know. 

[skip azp] [skip actions] [skip cirrus]
