### PR TITLE
BLD: try to fix macOS arm64 wheel build on Cirrus for 1.26.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "Cython>=0.29.34,<3.1",
-    "meson-python>=0.15.0,<0.16.0",
+    "meson-python>=0.15.0",
 ]
 
 [project]

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel
+    - python -m pip install "cibuildwheel<2.17.0"
   cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -27,16 +27,6 @@ linux_aarch64_task:
         CIRRUS_CLONE_SUBMODULES: true
         CIBW_BUILD: cp39-*
         EXPECT_CPU_FEATURES: NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM
-    - env:
-        CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp310-*
-    - env:
-        CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp311-*
-    - env:
-        CIRRUS_CLONE_SUBMODULES: true
-        CIBW_PRERELEASE_PYTHONS: True
-        CIBW_BUILD: cp312-*
 
   build_script: |
     apt update
@@ -60,9 +50,6 @@ macosx_arm64_task:
     - env:
         CIRRUS_CLONE_SUBMODULES: true
         CIBW_BUILD: cp39-*
-    - env:
-        CIRRUS_CLONE_SUBMODULES: true
-        CIBW_BUILD: cp310-* cp311-*
     - env:
         CIRRUS_CLONE_SUBMODULES: true
         CIBW_PRERELEASE_PYTHONS: True
@@ -96,76 +83,3 @@ macosx_arm64_task:
     - clang --version
   <<: *BUILD_AND_STORE_WHEELS
 
-
-######################################################################
-# Upload all wheels
-######################################################################
-
-wheels_upload_task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  # Artifacts don't seem to be persistent from task to task.
-  # Rather than upload wheels at the end of each cibuildwheel run we do a
-  # final upload here. This is because a run may be on different OS for
-  # which bash, etc, may not be present.
-  depends_on:
-    - linux_aarch64
-    - macosx_arm64
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder
-    platform: linux
-    cpu: 1
-
-  env:
-    NUMPY_STAGING_UPLOAD_TOKEN: ENCRYPTED[!5a69522ae0c2af9edb2bc1cdfeaca6292fb3666d9ecd82dca0615921834a6ce3b702352835d8bde4ea2a9ed5ef8424ac!]
-    NUMPY_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[ef04347663cfcb58d121385707e55951dc8e03b009edeed988aa4a33ba8205c54ca9980ac4da88e1adfdebff8b9d7ed4]
-
-  upload_script: |
-    apt-get update
-    apt-get install -y curl wget
-    export IS_SCHEDULE_DISPATCH="false"
-    export IS_PUSH="false"
-
-    # cron job
-    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
-      export IS_SCHEDULE_DISPATCH="true"
-    fi
-
-    # a manual build was started
-    if [[ "$CIRRUS_BUILD_SOURCE" == "api" && "$CIRRUS_COMMIT_MESSAGE" == "API build for null" ]]; then
-      export IS_SCHEDULE_DISPATCH="true"
-    fi
-
-    # only upload wheels to staging if it's a tag beginning with 'v' and you're
-    # on a maintenance branch
-    if [[ "$CIRRUS_TAG" == v* ]] && [[ $CIRRUS_TAG != *"dev0"* ]]; then
-      export IS_PUSH="true"
-    fi
-
-    if [[ $IS_PUSH == "true" ]] || [[ $IS_SCHEDULE_DISPATCH == "true" ]]; then
-        # install miniconda in the home directory. For some reason HOME isn't set by Cirrus
-        export HOME=$PWD
-
-        # install miniconda for uploading to anaconda
-        wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-        bash miniconda.sh -b -p $HOME/miniconda3
-        $HOME/miniconda3/bin/conda init bash
-        source $HOME/miniconda3/bin/activate
-        #conda install -y anaconda-client
-        # pin urllib3 until anaconda-client is fixed upstream
-        conda install -y anaconda-client 'urllib3<2.0.0'
-
-        # The name of the zip file is derived from the `wheels_artifact` line.
-        # If you change the artifact line to `myfile_artifact` then it would be
-        # called myfile.zip
-
-        curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
-        unzip wheels.zip
-
-        source ./tools/wheels/upload_wheels.sh
-        # IS_PUSH takes precedence over IS_SCHEDULE_DISPATCH
-        set_upload_vars
-
-        # Will be skipped if not a push/tag/scheduled build
-        upload_wheels
-    fi


### PR DESCRIPTION
Following up on the build failures discussed in gh-26365.