### PR TITLE
DOC: Improve example on array broadcasting

### DIFF
--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -665,11 +665,11 @@ behave just like slicing).
 
 .. rubric:: Example
 
-Suppose ``x.shape`` is (10, 20, 30) and ``ind`` is a (2, 3, 4)-shaped
+Suppose ``x.shape`` is (10, 20, 30) and ``ind`` is a (2, 5, 2)-shaped
 indexing :class:`intp` array, then ``result = x[..., ind, :]`` has
-shape (10, 2, 3, 4, 30) because the (20,)-shaped subspace has been
-replaced with a (2, 3, 4)-shaped broadcasted indexing subspace. If
-we let *i, j, k* loop over the (2, 3, 4)-shaped subspace then
+shape (10, 2, 5, 2, 30) because the (20,)-shaped subspace has been
+replaced with a (2, 5, 2)-shaped broadcasted indexing subspace. If
+we let *i, j, k* loop over the (2, 5, 2)-shaped subspace then
 ``result[..., i, j, k, :] = x[..., ind[i, j, k], :]``. This example
 produces the same result as :meth:`x.take(ind, axis=-2) <ndarray.take>`.
 


### PR DESCRIPTION
The earlier version of doc, it read indexing an array of shape (10, 20, 30)
with an index shaped (2, 3, 4) but it will throw an IndexError because
the (20,)-shaped subspace cannot be replaced with (2, 3, 4) shaped
broadcasted index subspace.

I updated the example by replacing (2, 3, 4) with (2, 5, 2) to make
the index compatible with the subspace.
