### PR TITLE
BUG: Make sure that NumPy scalars are supported by can_cast

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -1498,6 +1498,16 @@ to achieve the previous behavior.
 
 (`gh-25712 <https://github.com/numpy/numpy/pull/25712>`__)
 
+``np.can_cast`` cannot be called on Python int, float, or complex
+-----------------------------------------------------------------
+``np.can_cast`` cannot be called with Python int, float, or complex instances
+anymore.  This is because NEP 50 means that the result of ``can_cast`` must
+not depend on the value passed in.
+Unfortunately, for Python scalars whether a cast should be considered
+``"same_kind"`` or ``"safe"`` may depend on the context and value so that
+this is currently not implemented.
+In some cases, this means you may have to add a specific path for:
+``if type(obj) in (int, float, complex): ...``.
 
 
 **Content from release note snippets in doc/release/upcoming_changes:**

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -20,6 +20,7 @@
 #include "conversion_utils.h"  /* for PyArray_TypestrConvert */
 #include "templ_common.h" /* for npy_mul_sizes_with_overflow */
 #include "descriptor.h"
+#include "multiarraymodule.h"
 #include "alloc.h"
 #include "assert.h"
 #include "npy_buffer.h"
@@ -2696,7 +2697,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         Py_DECREF(ret);
         return NULL;
     }
-    obj = PyObject_GetAttrString(mod, "dtype");
+    obj = PyObject_GetAttr(mod, npy_ma_str_dtype);
     Py_DECREF(mod);
     if (obj == NULL) {
         Py_DECREF(ret);

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -19,6 +19,7 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_preserve;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_dtype;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1441,6 +1441,17 @@ class TestTypes:
             assert_(np.can_cast(fi.min, dt))
             assert_(np.can_cast(fi.max, dt))
 
+    @pytest.mark.parametrize("dtype",
+            list("?bhilqBHILQefdgFDG") + [rational])
+    def test_can_cast_scalars(self, dtype):
+        # Basic test to ensure that scalars are supported in can-cast
+        # (does not check behavior exhaustively).
+        dtype = np.dtype(dtype)
+        scalar = dtype.type(0)
+
+        assert np.can_cast(scalar, "int64") == np.can_cast(dtype, "int64")
+        assert np.can_cast(scalar, "float32", casting="unsafe")
+
 
 # Custom exception class to test exception propagation in fromiter
 class NIterError(Exception):


### PR DESCRIPTION
Backport of #26372.

The main issue here was the order of the checks, since float64 is
a subclass of float the error path was taken even though it should
not have been.

This also avoids converting to an array (which is very slow) when
possible.  I opted to use `scalar.dtype` since that may be a bit
easier for potential future user dtype.
That may not be quite ideal (I would like to not force `np.generic`
as a base-class for user scalars), but is probably pretty close
and more complicated fixes are probably not good for  backport.

Closes gh-26370

---

Also adds a `can_cast` change to the relase notes as it was missing.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
