### PR TITLE
DOC: Add missing methods to numpy.strings docs 

### DIFF
--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -32,6 +32,7 @@ String operations
 
    add
    lstrip
+   replace
    rstrip
    strip
 

--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -31,10 +31,22 @@ String operations
    :toctree: generated/
 
    add
+   ljust
+   lower
    lstrip
+   mod
+   multiply
+   partition
    replace
+   rjust
+   rpartition
    rstrip
    strip
+   swapcase
+   title
+   translate
+   upper
+   zfill
 
 Comparison
 ----------
@@ -61,11 +73,17 @@ String information
    count
    endswith
    find
+   index
+   isalnum
    isalpha
    isdecimal
    isdigit
+   islower
    isnumeric
    isspace
+   istitle
+   isupper
    rfind
+   rindex
    startswith
    str_len

--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -36,10 +36,8 @@ String operations
    lstrip
    mod
    multiply
-   partition
    replace
    rjust
-   rpartition
    rstrip
    strip
    swapcase


### PR DESCRIPTION
Backport of #26391.

Hopefully I'm not missing anything else.

I think I've got everything under dir(np.strings) that's public (not prefixed with _)

[skip azp] [skip actions] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
