### PR TITLE
fix: allclose returns True when one array is empty and the other has size 0

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2298,7 +2298,10 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     True
 
     """
-    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    res = isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+    if res.size == 0:
+        return False
+    res = all(res)
     return builtins.bool(res)
 
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2299,7 +2299,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
 
     """
     res = isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
-    if res.size == 0:
+    if res.size == 0 and not asanyarray(a).size == asanyarray(b).size == 0:
         return False
     res = all(res)
     return builtins.bool(res)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8335,7 +8335,8 @@ def allclose(a, b, masked_equal=True, rtol=1e-5, atol=1e-8):
 
     d = filled(less_equal(absolute(x - y), atol + rtol * absolute(y)),
                masked_equal)
-
+    if d.size == 0:
+        return False
     return np.all(d)
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8335,7 +8335,7 @@ def allclose(a, b, masked_equal=True, rtol=1e-5, atol=1e-8):
 
     d = filled(less_equal(absolute(x - y), atol + rtol * absolute(y)),
                masked_equal)
-    if d.size == 0:
+    if d.size == 0 and not asanyarray(x).size == asanyarray(y).size == 0:
         return False
     return np.all(d)
 


### PR DESCRIPTION
Fix the following behaviors:

```python
assert np.allclose([], [1.1], rtol=1e-07, atol=1e-6) == True  # I think this should be False
assert np.allclose([], [[1.1]], rtol=1e-07, atol=1e-6) == True
```