### PR TITLE
MAINT: updated instructions to get MachAr byte pattern

### DIFF
--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -146,13 +146,11 @@ _MACHAR_PARAMS = {
         title = _title_fmt.format('half'))}
 
 # Key to identify the floating point type.  Key is result of
-# ftype('-0.1').newbyteorder('<').tobytes()
 #
-# 20230201 - use (ftype(-1.0) / ftype(10.0)).newbyteorder('<').tobytes()
-#            instead because stold may have deficiencies on some platforms.
-# 20340511 - use
-#            v = (np.longdouble(-1.0) / np.longdouble(10.0))
-#            v.view(v.dtype.newbyteorder('<')).tobytes()
+#    ftype = np.longdouble        # or float64, float32, etc.
+#    v = (ftype(-1.0) / ftype(10.0))
+#    v.view(v.dtype.newbyteorder('<')).tobytes()
+#
 # See:
 # https://perl5.git.perl.org/perl.git/blob/3118d7d684b56cbeb702af874f4326683c45f045:/Configure
 

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -151,6 +151,7 @@ _MACHAR_PARAMS = {
 #    v = (ftype(-1.0) / ftype(10.0))
 #    v.view(v.dtype.newbyteorder('<')).tobytes()
 #
+# Uses division to work around deficiencies in strtold on some platforms.
 # See:
 # https://perl5.git.perl.org/perl.git/blob/3118d7d684b56cbeb702af874f4326683c45f045:/Configure
 

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -150,6 +150,9 @@ _MACHAR_PARAMS = {
 #
 # 20230201 - use (ftype(-1.0) / ftype(10.0)).newbyteorder('<').tobytes()
 #            instead because stold may have deficiencies on some platforms.
+# 20340511 - use
+#            v = (np.longdouble(-1.0) / np.longdouble(10.0))
+#            v.view(v.dtype.newbyteorder('<')).tobytes()
 # See:
 # https://perl5.git.perl.org/perl.git/blob/3118d7d684b56cbeb702af874f4326683c45f045:/Configure
 


### PR DESCRIPTION
With numpy 2 the approach to get the byte pattern for a given dtype has changed slightly. This adds a comment to remind a developer what approach should be used.