### PR TITLE
TYP,TST: Bump mypy to 1.10.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.7.1
+  - mypy=1.10.0
   # For building docs
   - sphinx>=4.5.0
   - sphinx-design

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -15,7 +15,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.7.1; platform_python_implementation != "PyPy"
+mypy==1.10.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
Bumps mypy to the latest 1.10.0 release.

No further changes were required to the typing test suite, which is always nice.