### PR TITLE
TYP: Fix ``fromrecords`` type hint and bump mypy to 1.10.0.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.7.1
+  - mypy=1.10.0
   # For building docs
   - sphinx>=4.5.0
   - sphinx-design

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -174,7 +174,7 @@ def fromrecords(
     dtype: None = ...,
     shape: None | _ShapeLike = ...,
     *,
-    formats: DTypeLike,
+    formats: DTypeLike = ...,
     names: None | str | Sequence[str] = ...,
     titles: None | str | Sequence[str] = ...,
     aligned: bool = ...,

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -15,7 +15,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.7.1; platform_python_implementation != "PyPy"
+mypy==1.10.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
Backport of #26377 and #26426.

### gh-26377
  TYP: Fix incorrect type hint for creating a recarray from fromrecords.
  Closes #26376.
### gh-26426
  TYP,TST: Bump mypy to 1.10.0
  Bumps mypy to the latest 1.10.0 release.
  No further changes were required to the typing test suite, which is always nice.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
