### PR TITLE
ENH: improve performance of lexsort for integers.

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -301,6 +301,42 @@ class Sort(Benchmark):
         np.argsort(self.arr, kind=kind)
 
 
+class LexSort(Benchmark):
+    """
+    This benchmark tests sorting multiple arrays with lexsort, for varying
+    sizes.
+    """
+    params = [
+        # Integers have a different code paths from any other type:
+        ['int64', 'float64'],
+        [2, 4],
+        [10**i for i in range(2, 7)],
+        ['mixed', 'separated', 'big']
+    ]
+    param_names = ['dtype', 'levels', 'n', 'mode']
+
+    def setup(self, dtype, levels, n, mode):
+        np.random.seed(1234)
+        # In 'big' mode, we use values large enough as to make the int-specific
+        # code path unfeasible:
+        max_val = np.iinfo(np.uint).max / 2 if mode == 'big' else 10**6
+        arr = np.random.randint(-max_val, max_val, size=(levels, n))
+        arr = arr.astype(dtype)
+        if mode == 'separated':
+            # In this mode, the array is actually the concatenation of two
+            # internally ordered sub-arrays.
+
+            # Just a ratio that is going to be roughly coprime with n:
+            point = int(n/np.pi)
+            chunks = [arr[:, :point], arr[:, point:]]
+            s_chunks = [ch[:, np.lexsort(ch)] for ch in chunks]
+            arr = np.concatenate(s_chunks, axis=1)
+
+        self.arr = arr
+
+    def time_lexsort(self, dtype, levels, n, ordered_runs):
+        np.lexsort(self.arr)
+
 class Partition(Benchmark):
     params = [
         ['float64', 'int64', 'float32', 'int32', 'int16', 'float16'],

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -434,6 +434,35 @@ def where(condition, x=None, y=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.lexsort)
+def _general_lexsort(keys, axis=None):
+    """
+    Unspecialized code path for lexsort.
+
+    Parameters
+    ----------
+    keys : (k, m, n, ...) array-like
+        The `k` keys to be sorted. The *last* key (e.g, the last
+        row if `keys` is a 2D array) is the primary sort key.
+        Each element of `keys` along the zeroth axis must be
+        an array-like object of the same shape.
+    axis : int, optional
+        Axis to be indirectly sorted. By default, sort over the last axis
+        of each sequence. Separate slices along `axis` sorted over
+        independently; see last example.
+
+    Returns
+    -------
+    indices : (m, n, ...) ndarray of ints
+        Array of indices that sort the keys along the specified axis.
+
+    """
+
+    if isinstance(keys, tuple):
+        return keys
+    else:
+        return (keys,)
+
+
 def lexsort(keys, axis=None):
     """
     lexsort(keys, axis=-1)
@@ -547,11 +576,102 @@ def lexsort(keys, axis=None):
     [1 0 3 2]
 
     """
-    if isinstance(keys, tuple):
-        return keys
-    else:
-        return (keys,)
 
+    import numpy as np
+    import warnings
+
+    if np.ndim(keys[0]) == 0:
+        # Weird case, each level is actually a scalar, to be interpreted as a
+        # level of length 1:
+        if axis:
+            msg = f"axis {axis} is out of bounds for array of dimension 0"
+            raise np.exceptions.AxisError(msg)
+        return 0
+
+    # Check the size of each level - the int fast path has overhead that makes
+    # it not convenient for less than 1000:
+    if len(keys[0]) > 1000:
+        n_layers = len(keys)
+
+        def _is_int_ndarray(a):
+            """
+            Return True if and only if a is an array of (any) integer dtype.
+            """
+            return (isinstance(a, np.ndarray) and
+                    np.issubdtype(a.dtype, np.integer))
+
+        # Check if we are only dealing with ndarrays of (any) integer type:
+        if all(_is_int_ndarray(a) for a in keys):
+            # Get extreme values for each level:
+            m_m = [[keys[i].min(), keys[i].max()]
+                         for i in range(n_layers)]
+            # ... and their difference:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                # This overflows np.int, but not np.uint, to which this is
+                # immediately casted... so it's fine.
+                ranges = np.array([(v[1] - v[0]) for v in m_m],
+                                  dtype=np.uint)
+
+            # Calculate the number of bits needed to represent values in each
+            # layer, once reparametrized between 0 and range[i] (hence
+            # ranges[i]+1 values).
+            layers_bits = np.ceil(np.log2(ranges + 1))
+            # Note that if a level is constant, it is assigned 0 bits, and it
+            # is correct, since it is irrelevant for the sorting.
+
+            # Compute cumulated bit shifts.
+            # Note that lexsort starts from the last level, so the first level
+            # is the less relevant one, and hence has offset 0 because it does
+            # not need to be shifted - each level is shifted by the number of
+            # bits required to store the previous levels:
+            offsets = np.cumsum(np.insert(layers_bits, 0, 0))
+            # The last level is shifted by offsets[-2]; offsets[-1] actually
+            # represents the bits required to store all levels.
+
+            # Check if the levels can be compressed in a single uint array:
+            if offsets[-1] <= np.iinfo(np.uint).bits:
+                # OK, we can take the fast path.
+
+                # For instance: if 3 levels have respectively 3, 6 and 1
+                # possible values, then their labels can be represented using
+                # respectively 2, 3 and 1 bits, as follows:
+                #  _ _ _ _____ _ __ __ __
+                # |0|0|0| ... |0| 0|a1|a0| -> offset 0 (first level)
+                #  — — — ————— — —— —— ——
+                # |0|0|0| ... |0|b2|b1|b0| -> offset 2 (bits for 1 level)
+                #  — — — ————— — —— —— ——
+                # |0|0|0| ... |0| 0| 0|c0| -> offset 5 (bits for levels 1-2)
+                #  ‾ ‾ ‾ ‾‾‾‾‾ ‾ ‾‾ ‾‾ ‾‾
+                # and the resulting unsigned integer representation will be:
+                #  _ _ _ _____ _ __ __ __ __ __ __
+                # |0|0|0| ... |0|c0|b2|b1|b0|a1|a0|
+                #  ‾ ‾ ‾ ‾‾‾‾‾ ‾ ‾‾ ‾‾ ‾‾ ‾‾ ‾‾ ‾‾
+
+                # We want to first subtract minima in order to obtain positive
+                # values only.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", RuntimeWarning)
+                    # The first "astype" will underflow if the initial array
+                    # has negative elements, but this is fine because adding
+                    # the shift will overflow and produce the correct result:
+                    arr = [keys[i].astype(np.uint) - m_m[i][0].astype(np.uint)
+                           for i in range(n_layers)]
+
+                # Now use offsets to shift each layer's representations:
+                reprs = [arr[i] << int(offsets[i]) for i in range(n_layers)]
+
+                # ... and combine them into a single layer:
+                shifted = np.bitwise_or.reduce(reprs)
+
+                # Sort the resulting "summary" numbers:
+                return np.argsort(shifted, axis=axis, kind='stable')
+
+    # Fall back to general code path:
+    return _general_lexsort(keys, axis=axis or -1)
+
+
+lexsort.__module__ = 'numpy'
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.can_cast)
 def can_cast(from_, to, casting=None):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5286,6 +5286,28 @@ class TestLexsort:
         assert_array_equal(idx, expected_idx)
         assert_array_equal(a[idx], np.sort(a))
 
+    def test_long_int(self):
+        # gh-26434: the int fast path is only taken for levels of length > 1000
+        disorder = np.arange(1500, dtype=int)
+        np.random.shuffle(disorder)
+        a = np.arange(1500, dtype=int)[disorder]
+        # Non unique "b", so that lexsorting is not trivial:
+        b = (np.arange(1500, dtype=int) // 300)[disorder]
+        ordered = np.lexsort((a, b))
+        assert_array_equal(disorder[ordered], np.arange(1500))
+        assert_array_equal(a[ordered], np.sort(a))
+        assert_array_equal(b[ordered], np.sort(b))
+
+        # Same but with numbers too large for the int fast path, that is,
+        # levels that together need more bits than the platform uint:
+        added_bits = int(np.iinfo(np.uint).bits * 2/3)
+        a = a * 2**added_bits
+        b = b * 2**added_bits
+        ordered = np.lexsort((a, b))
+        assert_array_equal(disorder[ordered], np.arange(1500))
+        assert_array_equal(a[ordered], np.sort(a))
+        assert_array_equal(b[ordered], np.sort(b))
+
     def test_mixed(self):
         a = np.array([1, 2, 1, 3, 1, 5])
         b = np.array([0, 4, 5, 6, 2, 3], dtype='datetime64[D]')


### PR DESCRIPTION
This PR implements an alternative and more performant code path for ``lexsort`` when passed (appropriate - see below) integer ``keys``.
It does so by compressing the levels into a single array using bit shifts, and then sorting the resulting array.

The result of this is, at a glance (details below):
- ~1.75x speedup for large arrays (N>2000)
- ... but a much large speedup (e.g. 8x in my application) can be obtained thanks to the possibility of selecting the desired sorting algorithm
- ~0.75x slowdown for small arrays (N<1000)
- very small slowdown for the (rare, I think) case where ``keys`` are integers but they are too large for the new code path (as reported in the docs, this is guaranteed not to happen for instance if all values are below MAX_INT / 2L, L being the number of levels)

The application I'm referring to is [the use of ``lexsort`` inside COO sparse matrices in scipy](https://github.com/scipy/scipy/issues/20151).

The current PR was influenced by some feedback received by @ngoldbaum [in the mailing list](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/Q5EH4NJU3HEHWL6YB46KRZASRXYII2HM/). However, I did not use C, because the Python code I wrote is vectorized anyway, and writing the same code in C would take me too much time (my C skills being full of rust) resulting in less readable code.

Assuming that, despite this, the approach is of interest for numpy (if this PR is not, I guess I will make an attempt directly in scipy?),

- [ ]  I must obviously solve the problem of where to position the Python code (I don't think the current file is right, since it contains lower level code and cleanly introducing the imports I need would result in a circular import - this is why there currently is a horrible import inside the function): guidance on this will be highly appreciated
- [ ]  I must also understand why at the end of the function I need to make ``axis`` explicit, but this is related to the previous point I think
- [ ] I must ~write tests~ integrate the tests I wrote into the codebase

Few other things to note:
- the approach is similar to [the one I took](https://github.com/pandas-dev/pandas/pull/19074) in the ``MultiIndex`` engine for ``pandas``
- a previous version of this PR (before feedback from @ngoldbaum ) would allow the user to switch on or off the new code path, but indeed the checks required to establish if it is feasible add a negligible overhead
- that same version would also switch to Python ``int`` if the ``keys`` values were too big to fit inside ``uint``... but that brings a strong performance penalty over the old code path, so it makes no sense if the user doesn't have the choice
- I *think* that it would be easy to patch [the C code](https://github.com/numpy/numpy/blob/main/numpy/_core/src/multiarray/item_selection.c#L1796) as to support different sorting algorithms... at least easy for someone a bit more fluent in C, definitely not for me. If such a patch is introduced, this PR will not guarantee the 8x speedup on nearly-sorted arrays, just the ~1.75x speedup.

Below are the result of the performance tests, where
- "PR" is this branch, "base" is main (previous commit)
- "mix" refers to random arrays, "sep" to arrays where two sorted (2-level) arrays are concatenated (so on which ``stable`` sort shines, because it has linear cost)
- "sta" refers to tests with ``kind=stable`` (in the PR)
- "big" refers to arrays where values are so large that the new code path cannot be taken (and a minimum of overhead is wasted in order to determine this is the case)


Absolute scale:
![abs](https://github.com/numpy/numpy/assets/1224492/3b9a159b-bd64-49f5-bc6b-2e25b602a755)

Log scale:
![log](https://github.com/numpy/numpy/assets/1224492/97f8530e-a4bc-4a59-91c1-95f79062d67b)

Estimation of speedup ratio when the new code path is feasible:

![speedup](https://github.com/numpy/numpy/assets/1224492/c18595e8-ea90-4833-b8a2-2327a3fba4cf)

... and when it is not (note that it is never taken for N < 1000, so the loss in efficiency is overhead):

![speedup_big](https://github.com/numpy/numpy/assets/1224492/51ea3ec3-5839-4621-acbd-deb9eabd6dbe)

The code used for these tests is available [here](https://github.com/toobaz/int_lexsort/blob/main/Show%20benchmarks%20-%20PR.ipynb).

