### PR TITLE
MAINT: Fix build when using scipy-openblas wheels

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -230,7 +230,7 @@ python_sources = [
   'py.typed'
 ]
 
-if blas_name == 'scipy-openblas'
+if fs.exists('_distributor_init_local.py')
   python_sources += ['_distributor_init_local.py']
 endif
 


### PR DESCRIPTION
The helper file will only be created when using spin --with-scipy-openblas. When using a workflow that builds from source, the helper file is not created and the build will fail:
```
pip install scipy-openblas32
python -c 'import scipy_openblas32; print(scipy_openblas32.get_pkg_config())' > ./scipy-openblas.pc
export PKG_CONFIG_PATH=$PWD
pip install  --no-binary :numpy: numpy==1.26.5
```

This should fix the problem. Skipping CI since this problem is not hit by current CI. 