### PR TITLE
DOC: Adding links to polynomial table.

### DIFF
--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -3,16 +3,16 @@ Using the convenience classes
 
 The convenience classes provided by the polynomial package are:
 
-============    ================
-Name            Provides
-============    ================
-Polynomial      Power series
-Chebyshev       Chebyshev series
-Legendre        Legendre series
-Laguerre        Laguerre series
-Hermite         Hermite series
-HermiteE        HermiteE series
-============    ================
+================================================    ================
+Name                                                Provides
+================================================    ================
+:class:`~numpy.polynomial.polynomial.Polynomial`    Power series
+:class:`~numpy.polynomial.chebyshev.Chebyshev`      Chebyshev series
+:class:`~numpy.polynomial.legendre.Legendre`        Legendre series
+:class:`~numpy.polynomial.laguerre.Laguerre`        Laguerre series
+:class:`~numpy.polynomial.hermite.Hermite`          Hermite series
+:class:`~numpy.polynomial.hermite_e.HermiteE`       HermiteE series
+================================================    ================
 
 The series in this context are finite sums of the corresponding polynomial
 basis functions multiplied by coefficients. For instance, a power series


### PR DESCRIPTION
I added missing links to polynomial classes table.

[skip azp] [skip actions] [skip cirrus]

Here is screenshot of the changes made.
![Screenshot 2024-05-15 193005](https://github.com/numpy/numpy/assets/103896399/f1910d3c-1a3d-4e04-9c2a-1f36ad2cf92b)
