### PR TITLE
TST: temporarily pin spin to work around issue in 0.9 release

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pkg-config
   - meson-python
   - pip
-  - spin
+  - spin=0.8 # Unpin when spin 0.9.1 is released
   - ccache
   # For testing
   - pytest


### PR DESCRIPTION
This should fix the build failures seen on mac conda CI: https://github.com/numpy/numpy/actions/runs/9099364436/job/25011771454?pr=26441

See https://github.com/scientific-python/spin/issues/193.

A fix should be out in a few days but it will take a while to propagate to conda-forge, so let's unbreak the broken CI job for now. @stefanv I'd appreciate it if you could unpin this when a release is out with a fix.