### PR TITLE
DOC: Remove outdated authentication instructions

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -88,9 +88,6 @@ Here's the short summary, complete TOC links are below:
 
       git push origin linspace-speedups
 
-   * Enter your GitHub username and password (repeat contributors or advanced
-     users can remove this step by connecting to GitHub with SSH).
-
    * Go to GitHub. The new branch will show up with a green Pull Request
      button. Make sure the title and message are clear, concise, and self-
      explanatory. Then click the button to submit it.


### PR DESCRIPTION
This is meant to remove GitHub authentication instructions from the NumPy documentation.

[skip azp] [skip actions] [skip cirrus]

This is a cleaned up version of https://github.com/numpy/numpy/pull/26343

Here's a snapshot of the before and after.

![Capture](https://github.com/numpy/numpy/assets/82846833/89a1b3c2-29a9-4eb3-9b8b-74f915b6e719)
