### PR TITLE
TST: attempt to fix intel SDE SIMD CI

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -174,7 +174,7 @@ jobs:
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
     - name: Build
-      run: spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
+      run: CC=gcc-13 CXX=g++-13 spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
 
     - name: Meson Log
       if: always()
@@ -224,7 +224,7 @@ jobs:
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
     - name: Build
-      run: spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_spr
+      run: CC=gcc-13 CXX=g++-13 spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_spr
 
     - name: Meson Log
       if: always()

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -170,10 +170,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y g++-13
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1
         python -m pip install -r requirements/build_requirements.txt
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
@@ -224,10 +220,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y g++-13
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1
         python -m pip install -r requirements/build_requirements.txt
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -152,7 +152,7 @@ jobs:
 
   intel_sde_avx512:
     needs: [baseline_only]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -206,7 +206,7 @@ jobs:
 
   intel_sde_spr:
     needs: [baseline_only]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:


### PR DESCRIPTION
It looks like the gcc-13 setup on the ubuntu 22.04 runners was removed today: https://github.com/actions/runner-images/pull/9854.

Let's see if switching to 24.04 lets us install a sufficiently new gcc without breaking anything else.