### PR TITLE
Re-enable GCC 13 in the NumPy test pipeline for Intel tests

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -170,6 +170,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt update
         sudo apt install -y g++-13
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1
@@ -224,6 +225,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt update
         sudo apt install -y g++-13
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1


### PR DESCRIPTION
The GCC 13 repository has been removed from GitHub Actions, as announced at [this issue](https://github.com/actions/runner-images/issues/9679). Use the mitigation method suggested in the announcement to re-enable GCC 13 in the NumPy test pipeline for Intel tests.