### PR TITLE
DEP: Deprecate 'fix_imports' flag in numpy.save

### DIFF
--- a/doc/release/upcoming_changes/26452.deprecation.rst
+++ b/doc/release/upcoming_changes/26452.deprecation.rst
@@ -1,0 +1,4 @@
+  * The `fix_imports` keyword argument in `numpy.save` is deprecated. Since
+    NumPy 1.17, `numpy.save` uses a pickle protocol that no longer supports
+    Python 2, and ignored `fix_imports` keyword. This keyword is kept only
+    for backward compatibility. It is now deprecated.

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -725,10 +725,16 @@ class TestDeprecatedSaveFixImports(_DeprecationTestCase):
     def test_deprecated(self):
         sample_args = ('a.npy', np.array(np.zeros((1024, 10))))
         self.assert_not_deprecated(np.save, args=sample_args)
-        self.assert_deprecated(np.save, args=sample_args, kwargs={'fix_imports': True})
-        self.assert_deprecated(np.save, args=sample_args, kwargs={'fix_imports': False})
+        self.assert_deprecated(np.save, args=sample_args,
+                               kwargs={'fix_imports': True})
+        self.assert_deprecated(np.save, args=sample_args,
+                               kwargs={'fix_imports': False})
         for allow_pickle in [True, False]:
-            self.assert_not_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle})
-            self.assert_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle, 'fix_imports': True})
-            self.assert_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle, 'fix_imports': False})
-    
+            self.assert_not_deprecated(np.save, args=sample_args,
+                                       kwargs={'allow_pickle': allow_pickle})
+            self.assert_deprecated(np.save, args=sample_args,
+                                   kwargs={'allow_pickle': allow_pickle,
+                                           'fix_imports': True})
+            self.assert_deprecated(np.save, args=sample_args,
+                                   kwargs={'allow_pickle': allow_pickle,
+                                           'fix_imports': False})

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -720,7 +720,7 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
 
 class TestDeprecatedSaveFixImports(_DeprecationTestCase):
     # Deprecated in Numpy 2.0, 2024-05
-    message = "Passing fix_imports into numpy.save"
+    message = "The 'fix_imports' flag is deprecated and has no effect."
     
     def test_deprecated(self):
         sample_args = ('a.npy', np.array(np.zeros((1024, 10))))

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -14,7 +14,7 @@ import sys
 import numpy as np
 from numpy.testing import (
     assert_raises, assert_warns, assert_, assert_array_equal, SkipTest,
-    KnownFailureException, break_cycles,
+    KnownFailureException, break_cycles, temppath
     )
 
 from numpy._core._multiarray_tests import fromstring_null_term_c_api
@@ -723,18 +723,19 @@ class TestDeprecatedSaveFixImports(_DeprecationTestCase):
     message = "The 'fix_imports' flag is deprecated and has no effect."
     
     def test_deprecated(self):
-        sample_args = ('a.npy', np.array(np.zeros((1024, 10))))
-        self.assert_not_deprecated(np.save, args=sample_args)
-        self.assert_deprecated(np.save, args=sample_args,
-                               kwargs={'fix_imports': True})
-        self.assert_deprecated(np.save, args=sample_args,
-                               kwargs={'fix_imports': False})
-        for allow_pickle in [True, False]:
-            self.assert_not_deprecated(np.save, args=sample_args,
-                                       kwargs={'allow_pickle': allow_pickle})
+        with temppath(suffix='.npy') as path:
+            sample_args = (path, np.array(np.zeros((1024, 10))))
+            self.assert_not_deprecated(np.save, args=sample_args)
             self.assert_deprecated(np.save, args=sample_args,
-                                   kwargs={'allow_pickle': allow_pickle,
-                                           'fix_imports': True})
+                                kwargs={'fix_imports': True})
             self.assert_deprecated(np.save, args=sample_args,
-                                   kwargs={'allow_pickle': allow_pickle,
-                                           'fix_imports': False})
+                                kwargs={'fix_imports': False})
+            for allow_pickle in [True, False]:
+                self.assert_not_deprecated(np.save, args=sample_args,
+                                        kwargs={'allow_pickle': allow_pickle})
+                self.assert_deprecated(np.save, args=sample_args,
+                                    kwargs={'allow_pickle': allow_pickle,
+                                            'fix_imports': True})
+                self.assert_deprecated(np.save, args=sample_args,
+                                    kwargs={'allow_pickle': allow_pickle,
+                                            'fix_imports': False})

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -719,7 +719,7 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
 
 
 class TestDeprecatedSaveFixImports(_DeprecationTestCase):
-    # Deprecated in Numpy 2.0, 2024-05
+    # Deprecated in Numpy 2.1, 2024-05
     message = "The 'fix_imports' flag is deprecated and has no effect."
     
     def test_deprecated(self):

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -716,3 +716,19 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
     @pytest.mark.parametrize("string", ["(2)i,", "(3)3S,", "f,(2)f"])
     def test_parenthesized_repeat_count(self, string):
         self.assert_deprecated(np.dtype, args=(string,))
+
+
+class TestDeprecatedSaveFixImports(_DeprecationTestCase):
+    # Deprecated in Numpy 2.0, 2024-05
+    message = "Passing fix_imports into numpy.save"
+    
+    def test_deprecated(self):
+        sample_args = ('a.npy', np.array(np.zeros((1024, 10))))
+        self.assert_not_deprecated(np.save, args=sample_args)
+        self.assert_deprecated(np.save, args=sample_args, kwargs={'fix_imports': True})
+        self.assert_deprecated(np.save, args=sample_args, kwargs={'fix_imports': False})
+        for allow_pickle in [True, False]:
+            self.assert_not_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle})
+            self.assert_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle, 'fix_imports': True})
+            self.assert_deprecated(np.save, args=sample_args, kwargs={'allow_pickle': allow_pickle, 'fix_imports': False})
+    

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -524,12 +524,9 @@ def save(file, arr, allow_pickle=True, fix_imports=None):
         Default: True
     fix_imports : bool, optional
         The `fix_imports` flag is deprecated and has no effect.
-        .. deprecated:: 2.0
-            Historically, this flag was used to control compatibility support
-            for objects saved in Python 3 to be loadable in Python 2. This flag
-            is ignored after NumPy 1.17, and deprecated in NumPy 2.0. It will
-            be removed in a future release.
-
+        .. deprecated:: 2.1
+            This flag is ignored since NumPy 1.17 and was only needed to
+            support loading some files in Python 2 written in Python 3.
     See Also
     --------
     savez : Save several arrays into a ``.npz`` archive
@@ -564,8 +561,10 @@ def save(file, arr, allow_pickle=True, fix_imports=None):
     # [1 2] [1 3]
     """
     if fix_imports is not None:
+        # Deprecated 2024-05-16, NumPy 2.1
         warnings.warn(
-            "The 'fix_imports' flag is deprecated and has no effect.",
+            "The 'fix_imports' flag is deprecated and has no effect. "
+            "(Deprecated in NumPy 2.1)",
             DeprecationWarning, stacklevel=2)
     if hasattr(file, 'write'):
         file_ctx = contextlib.nullcontext(file)

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -524,9 +524,11 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
         Default: True
     fix_imports : bool, optional
         The `fix_imports` flag is deprecated and has no effect.
+
         .. deprecated:: 2.1
             This flag is ignored since NumPy 1.17 and was only needed to
             support loading some files in Python 2 written in Python 3.
+
     See Also
     --------
     savez : Save several arrays into a ``.npz`` archive

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -501,7 +501,7 @@ def _save_dispatcher(file, arr, allow_pickle=None, fix_imports=None):
 
 
 @array_function_dispatch(_save_dispatcher)
-def save(file, arr, allow_pickle=True, fix_imports=True):
+def save(file, arr, allow_pickle=True, fix_imports=None):
     """
     Save an array to a binary file in NumPy ``.npy`` format.
 
@@ -523,10 +523,12 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
         compatible between different versions of Python).
         Default: True
     fix_imports : bool, optional
-        Only useful in forcing objects in object arrays on Python 3 to be
-        pickled in a Python 2 compatible way. If `fix_imports` is True, pickle
-        will try to map the new Python 3 names to the old module names used in
-        Python 2, so that the pickle data stream is readable with Python 2.
+        The `fix_imports` flag is deprecated and has no effect.
+        .. deprecated:: 2.0
+            Historically, this flag was used to control compatibility support
+            for objects saved in Python 3 to be loadable in Python 2. This flag
+            is ignored after NumPy 1.17, and deprecated in NumPy 2.0. It will
+            be removed in a future release.
 
     See Also
     --------
@@ -561,6 +563,10 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     >>> print(a, b)
     # [1 2] [1 3]
     """
+    if fix_imports is not None:
+        warnings.warn(
+            "The 'fix_imports' flag is deprecated and has no effect.",
+            DeprecationWarning, stacklevel=2)
     if hasattr(file, 'write'):
         file_ctx = contextlib.nullcontext(file)
     else:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -501,7 +501,7 @@ def _save_dispatcher(file, arr, allow_pickle=None, fix_imports=None):
 
 
 @array_function_dispatch(_save_dispatcher)
-def save(file, arr, allow_pickle=True, fix_imports=None):
+def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
     """
     Save an array to a binary file in NumPy ``.npy`` format.
 
@@ -560,7 +560,7 @@ def save(file, arr, allow_pickle=True, fix_imports=None):
     >>> print(a, b)
     # [1 2] [1 3]
     """
-    if fix_imports is not None:
+    if fix_imports is not np._NoValue:
         # Deprecated 2024-05-16, NumPy 2.1
         warnings.warn(
             "The 'fix_imports' flag is deprecated and has no effect. "


### PR DESCRIPTION
Since NumPy upgraded the pickle protocol version to 3 in version 1.17, the `fix_imports` flag is ignored by the pickle library. To reduce confusion, I propose removing this flag in a future release.

However, since many people actually use `numpy.save(..., allow_pickle=True, fix_imports=True)` as default behavior (for example, see this example: [intel/intel-extension-for-transformers](https://github.com/intel/intel-extension-for-transformers/blob/008492d471aaf9658aef94da03a81540b18256b0/examples/huggingface/pytorch/neural_engine_utils/common.py#L95)), removing the `fix_imports` keyword may break compatibility with existing code.

Following NEP 23, I suggest adding a check for the usage of the `fix_imports` keyword and emitting a `DeprecationWarning` for any usage.