### PR TITLE
ENH: improve the error raised by ``numpy.isdtype``

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -360,7 +360,7 @@ def issubsctype(arg1, arg2):
     return issubclass(obj2sctype(arg1), obj2sctype(arg2))
 
 
-def _preprocess_dtype(dtype, err_msg):
+def _preprocess_dtype(dtype, err_msg, is_kind=False):
     """
     Preprocess dtype argument by:
       1. fetching type from a data type
@@ -369,8 +369,11 @@ def _preprocess_dtype(dtype, err_msg):
     if isinstance(dtype, ma.dtype):
         dtype = dtype.type
     if isinstance(dtype, ndarray) or dtype not in allTypes.values():
-        if isinstance(dtype, str):
-            message = f"{err_msg}, but {repr(dtype)} is not a valid kind name."
+        if is_kind and isinstance(dtype, str):
+            message = (
+                "kind argument is a string, but"
+                f" {repr(dtype)} is not a known kind name."
+            )
         else:
             message = f"{err_msg}, but it is a {type(dtype)}."
         raise TypeError(message)
@@ -449,6 +452,7 @@ def isdtype(dtype, kind):
                 kind,
                 err_msg="kind argument must be comprised of "
                         "NumPy dtypes or strings only"
+                is_kind=True,
             )
             processed_kinds.add(kind)
 

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -360,7 +360,7 @@ def issubsctype(arg1, arg2):
     return issubclass(obj2sctype(arg1), obj2sctype(arg2))
 
 
-def _preprocess_dtype(dtype, is_kind=False):
+def _preprocess_dtype(dtype, err_msg):
     """
     Preprocess dtype argument by:
       1. fetching type from a data type
@@ -369,24 +369,7 @@ def _preprocess_dtype(dtype, is_kind=False):
     if isinstance(dtype, ma.dtype):
         dtype = dtype.type
     if isinstance(dtype, ndarray) or dtype not in allTypes.values():
-        if is_kind and isinstance(dtype, str):
-            message = (
-                "kind argument is a string, but"
-                f" {repr(dtype)} is not a known kind name."
-            )
-            raise ValueError(message)
-        elif is_kind:
-            message = (
-                "kind argument must be comprised of "
-                "NumPy dtypes or strings only"
-            )
-        else:
-            message = (
-                "dtype argument must be a NumPy dtype, "
-                "but it is a {type(dtype)}."
-            )
-
-        raise TypeError(message)
+        raise TypeError(f"{err_msg}, but it is a {type(dtype)}.")
     return dtype
 
 
@@ -431,7 +414,9 @@ def isdtype(dtype, kind):
     True
 
     """
-    dtype = _preprocess_dtype(dtype, is_kind=False)
+    dtype = _preprocess_dtype(
+        dtype, err_msg="dtype argument must be a NumPy dtype"
+    )
 
     input_kinds = kind if isinstance(kind, tuple) else (kind,)
 
@@ -456,7 +441,11 @@ def isdtype(dtype, kind):
                 sctypes["float"] + sctypes["complex"]
             )
         else:
-            kind = _preprocess_dtype(kind, is_kind=True)
+            kind = _preprocess_dtype(
+                kind,
+                err_msg="kind argument must be comprised of "
+                        "NumPy dtypes or strings only"
+            )
             processed_kinds.add(kind)
 
     return dtype in processed_kinds

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -440,6 +440,11 @@ def isdtype(dtype, kind):
                 sctypes["int"] + sctypes["uint"] +
                 sctypes["float"] + sctypes["complex"]
             )
+        elif isinstance(kind, str):
+            raise ValueError(
+                "kind argument is a string, but"
+                f" {repr(kind)} is not a known kind name."
+            ) from None
         else:
             kind = _preprocess_dtype(
                 kind,

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -369,7 +369,11 @@ def _preprocess_dtype(dtype, err_msg):
     if isinstance(dtype, ma.dtype):
         dtype = dtype.type
     if isinstance(dtype, ndarray) or dtype not in allTypes.values():
-        raise TypeError(f"{err_msg}, but it is a {type(dtype)}.")
+        if isinstance(dtype, str):
+            message = f"{err_msg}, but {repr(dtype)} is not a valid kind name."
+        else:
+            message = f"{err_msg}, but it is a {type(dtype)}."
+        raise TypeError(message)
     return dtype
 
 

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -452,7 +452,7 @@ def isdtype(dtype, kind):
             raise ValueError(
                 "kind argument is a string, but"
                 f" {repr(kind)} is not a known kind name."
-            ) from None
+            )
         else:
             try:
                 kind = _preprocess_dtype(kind)

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -360,7 +360,7 @@ def issubsctype(arg1, arg2):
     return issubclass(obj2sctype(arg1), obj2sctype(arg2))
 
 
-def _preprocess_dtype(dtype, err_msg, is_kind=False):
+def _preprocess_dtype(dtype, is_kind=False):
     """
     Preprocess dtype argument by:
       1. fetching type from a data type
@@ -374,8 +374,18 @@ def _preprocess_dtype(dtype, err_msg, is_kind=False):
                 "kind argument is a string, but"
                 f" {repr(dtype)} is not a known kind name."
             )
+            raise ValueError(message)
+        elif is_kind:
+            message = (
+                "kind argument must be comprised of "
+                "NumPy dtypes or strings only"
+            )
         else:
-            message = f"{err_msg}, but it is a {type(dtype)}."
+            message = (
+                "dtype argument must be a NumPy dtype, "
+                "but it is a {type(dtype)}."
+            )
+
         raise TypeError(message)
     return dtype
 
@@ -421,9 +431,7 @@ def isdtype(dtype, kind):
     True
 
     """
-    dtype = _preprocess_dtype(
-        dtype, err_msg="dtype argument must be a NumPy dtype"
-    )
+    dtype = _preprocess_dtype(dtype, is_kind=False)
 
     input_kinds = kind if isinstance(kind, tuple) else (kind,)
 
@@ -448,12 +456,7 @@ def isdtype(dtype, kind):
                 sctypes["float"] + sctypes["complex"]
             )
         else:
-            kind = _preprocess_dtype(
-                kind,
-                err_msg="kind argument must be comprised of "
-                        "NumPy dtypes or strings only"
-                is_kind=True,
-            )
+            kind = _preprocess_dtype(kind, is_kind=True)
             processed_kinds.add(kind)
 
     return dtype in processed_kinds

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -471,6 +471,8 @@ class TestIsDType:
         with assert_raises_regex(TypeError, r".*must be a NumPy dtype.*"):
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
+            np.isdtype(np.int64, 1)
+        with assert_raises_regex(ValueError, r".*not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -471,6 +471,8 @@ class TestIsDType:
         with assert_raises_regex(TypeError, r".*must be a NumPy dtype.*"):
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
+            np.isdtype(np.int64, 1)
+        with assert_raises_regex(TypeError, r".*is not a valid name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -471,8 +471,6 @@ class TestIsDType:
         with assert_raises_regex(TypeError, r".*must be a NumPy dtype.*"):
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
-            np.isdtype(np.int64, 1)
-        with assert_raises_regex(ValueError, r".*is not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -472,7 +472,7 @@ class TestIsDType:
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
             np.isdtype(np.int64, 1)
-        with assert_raises_regex(TypeError, r".*is not a known kind name.*"):
+        with assert_raises_regex(ValueError, r".*is not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -472,7 +472,7 @@ class TestIsDType:
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
             np.isdtype(np.int64, 1)
-        with assert_raises_regex(TypeError, r".*is not a valid name.*"):
+        with assert_raises_regex(TypeError, r".*is not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):


### PR DESCRIPTION
When passing an invalid string kind to `numpy.isdtype`, it raises this error:

``` python
np.isdtype(np.uint64, "integer")
# TypeError: kind argument must be comprised of NumPy dtypes or strings only, but it is a <class 'str'>.
```

That's not really helpful: we did pass in a string (as the first part of the message requires), we just passed the _wrong_ string.

Improving this is somewhat tricky: `_preprocess_dtype` is used to check both dtypes and kinds, and the only difference is the error message that is passed in. To work around that, I've added a boolean parameter to know when to change the error message.

However, this function now feels a bit weird to me, so instead we could also generate `err_msg` within `_preprocess_dtype` and just pass something like `kind="kind"` or `kind="dtype"` (I'm not attached to that name, though).

Edit: with the last two commits I changed the function to generate the error message based on the `is_kind` flag, and to raise a `ValueError` if the wrong string was passed.