### PR TITLE
BUG: Use Python pickle protocol version 4 for np.save (#26388)

### DIFF
--- a/doc/release/upcoming_changes/26388.performance.rst
+++ b/doc/release/upcoming_changes/26388.performance.rst
@@ -1,0 +1,3 @@
+ * `numpy.save` now uses pickle protocol version 4 for saving arrays with
+   object dtype, which allows for pickle objects larger than 4GB and improves
+   saving speed by about 5% for large arrays.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -520,7 +520,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
         arbitrary code) and portability (pickled objects may not be loadable
         on different Python installations, for example if the stored objects
         require libraries that are not available, and not all pickled data is
-        compatible between Python 2 and Python 3).
+        compatible between different versions of Python).
         Default: True
     fix_imports : bool, optional
         Only useful in forcing objects in object arrays on Python 3 to be

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -741,7 +741,7 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
                                  "when allow_pickle=False")
         if pickle_kwargs is None:
             pickle_kwargs = {}
-        pickle.dump(array, fp, protocol=3, **pickle_kwargs)
+        pickle.dump(array, fp, protocol=4, **pickle_kwargs)
     elif array.flags.f_contiguous and not array.flags.c_contiguous:
         if isfileobj(fp):
             array.T.tofile(fp)


### PR DESCRIPTION
Backport of #26388.

* BUG: Use default Python pickle protocol version rather than outdated protocol 3

* Update default pickle of np.save to 4

* Adds document for default pickle protocol 4

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
