### PR TITLE
BUG: fixes for three related stringdtype issues (#26436)

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1580,7 +1580,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
 
             if (PyArray_GetDTypeTransferFunction(is_aligned,
                     itemsize, itemsize,
-                    PyArray_DESCR(self), PyArray_DESCR(self),
+                    PyArray_DESCR(self), PyArray_DESCR((PyArrayObject *)result),
                     0, &cast_info, &transfer_flags) != NPY_SUCCEED) {
                 goto finish;
             }

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -395,6 +395,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
+    int has_nan_na = descr->has_nan_na;
     const npy_static_string *default_string = &descr->default_string;
 
     npy_intp N = dimensions[0];
@@ -415,8 +416,13 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
         }
         else if (is_null) {
             if (has_null && !has_string_na) {
-                // numpy treats NaN as truthy, following python
-                *out = NPY_TRUE;
+                if (has_nan_na) {
+                    // numpy treats NaN as truthy, following python
+                    *out = NPY_TRUE;
+                }
+                else {
+                    *out = NPY_FALSE;
+                }
             }
             else {
                 *out = (npy_bool)(default_string->size == 0);

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -416,8 +416,23 @@ fail:
 // PyArray_NonzeroFunc
 // Unicode strings are nonzero if their length is nonzero.
 npy_bool
-nonzero(void *data, void *NPY_UNUSED(arr))
+nonzero(void *data, void *arr)
 {
+    PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)PyArray_DESCR(arr);
+    int has_null = descr->na_object != NULL;
+    int has_nan_na = descr->has_nan_na;
+    int has_string_na = descr->has_string_na;
+    if (has_null && NpyString_isnull((npy_packed_static_string *)data)) {
+        if (!has_string_na) {
+            if (has_nan_na) {
+                // numpy treats NaN as truthy, following python
+                return 1;
+            }
+            else {
+                return 0;
+            }
+        }
+    }
     return NpyString_size((npy_packed_static_string *)data) != 0;
 }
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -40,13 +40,17 @@ def na_object(request):
     return request.param
 
 
-@pytest.fixture()
-def dtype(na_object, coerce):
+def get_dtype(na_object, coerce=True):
     # explicit is check for pd_NA because != with pd_NA returns pd_NA
     if na_object is pd_NA or na_object != "unset":
         return StringDType(na_object=na_object, coerce=coerce)
     else:
         return StringDType(coerce=coerce)
+
+
+@pytest.fixture()
+def dtype(na_object, coerce):
+    return get_dtype(na_object, coerce)
 
 
 # second copy for cast tests to do a cartesian product over dtypes
@@ -472,10 +476,40 @@ def test_sort(dtype, strings):
         ["", "a", "😸", "ááðfáíóåéë"],
     ],
 )
-def test_nonzero(strings):
-    arr = np.array(strings, dtype="T")
-    is_nonzero = np.array([i for i, item in enumerate(arr) if len(item) != 0])
+def test_nonzero(strings, na_object):
+    dtype = get_dtype(na_object)
+    arr = np.array(strings, dtype=dtype)
+    is_nonzero = np.array(
+        [i for i, item in enumerate(strings) if len(item) != 0])
     assert_array_equal(arr.nonzero()[0], is_nonzero)
+
+    if na_object is not pd_NA and na_object == 'unset':
+        return
+
+    strings_with_na = np.array(strings + [na_object], dtype=dtype)
+    is_nan = np.isnan(np.array([dtype.na_object], dtype=dtype))[0]
+
+    if is_nan:
+        assert strings_with_na.nonzero()[0][-1] == 4
+    else:
+        assert strings_with_na.nonzero()[0][-1] == 3
+
+    # check that the casting to bool and nonzero give consistent results
+    assert_array_equal(strings_with_na[strings_with_na.nonzero()],
+                       strings_with_na[strings_with_na.astype(bool)])
+
+
+def test_where(string_list, na_object):
+    dtype = get_dtype(na_object)
+    a = np.array(string_list, dtype=dtype)
+    b = a[::-1]
+    res = np.where([True, False, True, False, True, False], a, b)
+    assert_array_equal(res, [a[0], b[1], a[2], b[3], a[4], b[5]])
+
+
+def test_fancy_indexing(string_list):
+    sarr = np.array(string_list, dtype="T")
+    assert_array_equal(sarr, sarr[np.arange(sarr.shape[0])])
 
 
 def test_creation_functions():


### PR DESCRIPTION
Backport of #26436.

Fixes #26420.

While working on the issue with `where` found in #26240, I noticed two other related issues. Since the fix for where depends on the other two fixes, I figured it would make sense to send them all as one PR.

First, it turns out that advanced indexing was broken for indexing any entry in an array that needs a heap allocation. On current main, this leads to errors or segfaults:

```
>>> import numpy as np
>>> a = np.array(["a", "c", "h"*25], dtype=np.dtypes.StringDType(na_object=None))
>>> a[[1,2]]
... elide traceback ...
MemoryError: Failed to load string in StringDType getitem
```

The fix is to properly set the output descriptor in the casting setup in `array_subscript`.

Second, I noticed that the `nonzero` function completely ignores nulls. I also noticed that the string to bool cast assumed all nulls are truthy and ignored the existence of nulls like `None` that should be falsey, following the behavior of object array:

```
>>> import numpy as np
>>> np.nonzero(np.array(['hello', np.nan, 'world'], dtype=object))
(array([0, 1, 2]),)
>>> np.nonzero(np.array(['hello', None, 'world'], dtype=object))
(array([0, 2]),)
```

This updates both `nonzero` and the string to bool cast to account for this and makes sure they behave identically.

Finally, the issue with `where` is also caused by not setting the input and output descriptors properly in the cast setup in `PyArray_Where`. The casting code here dates back to https://github.com/numpy/numpy/pull/23770, which was before stringdtype had an arena allocator. With the arena allocator, we need to be more careful about bookkeeping on input and output descriptors. This means we also need to setup a separate cast for the second input descriptor.

Also adds tests for all three fixed issues.

* BUG: fix broken fancy indexing for stringdtype

* BUG: fix incorrect casting for stringdtype in PyArray_Where

* BUG: ensure casting to bool and nonzero treats null strings the same way

* MNT: refactor so itemsizes are correct

* MNT: refactor so trivial copy check aligns with casting setup

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
