### PR TITLE
BUG: int32 and intc should both appear in sctypes

### DIFF
--- a/numpy/_core/_type_aliases.py
+++ b/numpy/_core/_type_aliases.py
@@ -93,9 +93,10 @@ for is_complex, full_name in [(False, "longdouble"), (True, "clongdouble")]:
 # Building `sctypes`
 ####################
 
-sctypes = {"int": [], "uint": [], "float": [], "complex": [], "others": []}
+sctypes = {"int": set(), "uint": set(), "float": set(),
+           "complex": set(), "others": set()}
 
-for type_info in set(typeinfo.values()):
+for type_info in typeinfo.values():
     if type_info.kind in ["M", "m"]:  # exclude timedelta and datetime
         continue
 
@@ -108,9 +109,11 @@ for type_info in set(typeinfo.values()):
         ("others", ma.generic)
     ]:
         if issubclass(concrete_type, abstract_type):
-            sctypes[type_group].append(concrete_type)
+            sctypes[type_group].add(concrete_type)
             break
 
 # sort sctype groups by bitsize
-for sctype_list in sctypes.values():
+for sctype_key in sctypes.keys():
+    sctype_list = list(sctypes[sctype_key])
     sctype_list.sort(key=lambda x: dtype(x).itemsize)
+    sctypes[sctype_key] = sctype_list

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -473,6 +473,14 @@ class TestIsDType:
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
             np.isdtype(np.int64, "int64")
 
+    def test_sctypes_complete(self):
+        # issue 26439: int32/intc were masking eachother on 32-bit builds
+        assert np.int32 in sctypes['int']
+        assert np.intc in sctypes['int']
+        assert np.int64 in sctypes['int']
+        assert np.uint32 in sctypes['uint']
+        assert np.uintc in sctypes['uint']
+        assert np.uint64 in sctypes['uint']
 
 class TestSctypeDict:
     def test_longdouble(self):


### PR DESCRIPTION
Backport of #26441.

Fix issue #26439 where in 32-bit builds `np.int32` did not appear in `sctypes`, so `np.isdtype(np.int32, 'integral')` was False.

The issue was that 
```
[t.type for t in set(typeinfo.values())]
```

is not the same as
```
set([t.type for t in typeinfo.values()])
```

The latter has more members, and is the one used now.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
