### PR TITLE
BLD: cp313 [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,7 +85,7 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        python: ["cp310", "cp311", "cp312", "pp310"]
+        python: ["cp310", "cp311", "cp312", "pp310", "cp313"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -50,5 +50,5 @@ EOF
 fi
 if [[ $RUNNER_OS == "Windows" ]]; then
     # delvewheel is the equivalent of delocate/auditwheel for windows.
-    python -m pip install delvewheel
+    python -m pip install delvewheel wheel
 fi


### PR DESCRIPTION
Might need to be backported. I noticed that the windows wheels builds in main aren't working. The repair script needs the wheels package to be installed.