### PR TITLE
BLD: Make NumPy build reproducibly

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1206,8 +1206,7 @@ py.extension_module('_multiarray_umath',
     src_numpy_api[1],  # __multiarray_api.h
     src_umath_doc_h,
     npy_math_internal_h,
-  ],
-  objects: svml_objects,
+  ] + svml_objects,
   c_args: c_args_common,
   cpp_args: cpp_args_common,
   include_directories: [

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -366,7 +366,7 @@ conf_data.set('PYTHON_VERSION', py.language_version())
 # `np.show_config()`; needs some special handling for the case BLAS was found
 # but CBLAS not (and hence BLAS was also disabled)
 dependency_map = {
-  'LAPACK': lapack_dep,
+  'LAPACK': lapack,
 }
 if have_blas
   dependency_map += {'BLAS': blas}


### PR DESCRIPTION
This pull request fixes two non-deterministic build outcomes to make the NumPy build fully reproducible:

- The `__config__.py` configuration dict should take the LAPACK metainfo from  the `lapack` object, not the `lapack_dep` object, because the latter contains a (randomly) generated name of the form `depXXXXXXXXXXX`.

- If the `.s` source files for SVML support are added as `objects`, `gcc` will implicitly build them to object files with a random temporary filename of the form `ccXXXXX.o` in the linking stage. If added as source files, Meson will create the object files explicitly and assign sane, reproducible file names.
