### PR TITLE
Test: add spin to test_requirements

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -83,6 +83,7 @@ Before running the tests, first install the test dependencies::
 
     $ python -m pip install -r requirements/test_requirements.txt
     $ python -m pip install asv # only for running benchmarks
+    $ python -m pip install spin # utility for running the tests
 
 To build the development version of NumPy and run tests, spawn
 interactive shells with the Python import paths properly set up etc., use the

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -3,6 +3,7 @@ wheel==0.38.1
 #setuptools==65.5.1 ; python_version < '3.12'
 #setuptools         ; python_version >= '3.12'
 setuptools
+spin
 hypothesis==6.81.1
 pytest==7.4.0
 pytz==2023.3.post1


### PR DESCRIPTION
I was following the documentation with context to running the tests for numpy: https://github.com/numpy/numpy/blob/fba4fc16a26e77ec4ce2b1900577f088b1d5a7a6/doc/source/dev/development_environment.rst?plain=1#L91-L95
Test requirements didn't indicate that spin was needed.  I amended test-requirements with spin.  