### PR TITLE
DOC: Set default as `-j 1` for spin docs and move `-W` to SPHINXOPTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             . venv/bin/activate
             cd doc
             # Don't use -q, show warning summary"
-            SPHINXOPTS="-n" make -e html
+            SPHINXOPTS="-W -n" make -e html
             if [[ $(find build/html -type f | wc -l) -lt 1000 ]]; then
                 echo "doc build failed: build/html is empty"
                 exit -1

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -132,8 +132,10 @@ def build(ctx, meson_args, with_scipy_openblas, jobs=None, clean=False, verbose=
 @click.option(
     '--jobs', '-j',
     metavar='N_JOBS',
-    default="auto",
-    help="Number of parallel build jobs"
+    # Avoids pydata_sphinx_theme extension warning from default="auto".
+    default="1",
+    help=("Number of parallel build jobs."
+          "Can be set to `auto` to use all cores.")
 )
 @click.pass_context
 def docs(ctx, sphinx_target, clean, first_build, jobs, *args, **kwargs):

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,7 @@ PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".fo
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= LANG=C sphinx-build
 PAPER         ?=
 DOXYGEN       ?= doxygen
@@ -25,7 +25,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
+ALLSPHINXOPTS   = -T --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
                   $(SPHINXOPTS) source
 
 .PHONY: help clean html web htmlhelp latex changes linkcheck \


### PR DESCRIPTION
This commit tries to solve two problems.
- The pydata_sphinx_theme extension warning can be avoided by setting the default `--jobs` to `1`. This matches `spin test`.
- The `-W` option is currently hardcoded in ALLSPHINXOPTS and impossible to override. This commit moves `-W` to SPHINXOPTS which allows a local machine to remove -W if needed, as described in the documentation. This adds to the discussion in PR #26125.

[skip actions] [skip azp] [skip cirrus]

### Context
While trying to build a workflow that incorporates `spin docs`, I encountered two issues. First, I noticed that the the following suggestion in the spin documentation was invalid. 
https://github.com/numpy/numpy/blob/fba4fc16a26e77ec4ce2b1900577f088b1d5a7a6/.spin/cmds.py#L142-L145
The fact that `-W` is hard coded in `ALLSPHINXOPTS` makes it impossible to remove without changing the makefile. 

The second issue is the [known](https://github.com/numpy/numpy/pull/26125#issuecomment-2112509451) error message 
```
WARNING: the pydata_sphinx_theme extension is not safe for parallel writing
WARNING: doing serial write
```
This was [fixed](https://github.com/numpy/numpy/pull/26125/commits/79e5c870743f2dc532b4f02cebbfb36efb4206b0) for those using `make` by removing `-j2` from `SPHINXOPTS`. The circle build uses `make` but new users are [directed](https://numpy.org/devdocs/dev/howto_build_docs.html) to use `spin docs`. When someone runs `SPHINXOPTS="-n" make -e html` everything works fine. When someone runs `spin docs`, the generated doc build command is 
```
LANG=C sphinx-build -b html -WT --keep-going -d build/doctrees  -j auto source build/html
```
The problem is `-j auto`.  Running `SPHINXOPTS="-j 1" spin docs` generates 
```
LANG=C sphinx-build -b html -WT --keep-going -d build/doctrees  -j 1 -j auto source build/html
```
The problem remains. Using `spin docs -j 1` instead of `SPHINXOPTS="-j 1" spin docs` works. Discovering this fix was difficult for a newcomer, as the rest of the examples in the codebase model changing SPHINXOPTS.

I set up 7 different codespace environments, and sometimes the docs would build without errors, while other times they would fail. My best guess now is that this may have to do with how many cores `-j auto` was able to access on each different codespace. 

### Further Discussion
I'd love to change something to help newcomers so they don't have to question why their doc build gives an error message (that they can ignore). Here's some options.
- Swapping the default to `1`, and later updating it back to auto when an upstream fix is found, would simplify things for newcomers. This PR follows this option. I purposefully matched the `default` and `help` from `spin test`.  
- Alternately, we could add a note in the docs wherever `spin docs` appears that adds a comment to use `spin docs -j 1` if they encounter a warning. IMHO, this makes it harder for newcomers to contribute. If anything, this PR will provide a record for people to find a fix. 
- We could test if the pydata_sphinx_theme extension is safe for parallel writing (they fixed things upstream), and then set the default based on that. This muddies up `cmds.py`, but does mean the change to `auto` will auto happen.

As for the `-W` option change, I understand why we want the doc build to throw an error on numpy/numpy.  Moving `-W` to `SPHINXOPTS` allows both upstream and local repos to set the option as needed.  
- I left `doc/neps/makefile` alone. The `-W` command is still in ALLSPHINXOPTS. I can update that file as well, if wanted. 
  