### PR TITLE
DOC: Skip API documentation for numpy.distutils with Python 3.12 and later

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -143,6 +143,10 @@ default_role = "autolink"
 # for source files.
 exclude_dirs = []
 
+exclude_patterns = []
+if sys.version_info[:2] >= (3, 12):
+    exclude_patterns += ["reference/distutils.rst"]
+
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = False
 


### PR DESCRIPTION
Backport of #26476.

[skip cirrus] [skip actions] [skip azp]

Starting with Python 3.12, the lack of a `distutils` module makes the documentation build fail with

```
WARNING: Failed to import numpy.distutils.misc_util.
Possible hints:
* AttributeError: module 'numpy' has no attribute 'distutils'
* ModuleNotFoundError: No module named 'numpy.distutils'

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/generate.py",
line 503, in generate_autosummary_docs
    name, obj, parent, modname = import_by_name(entry.name)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/__init__.py",
line 655, in import_by_name
    raise ImportExceptionGroup('no module named %s' % ' or
'.join(tried), exceptions)
sphinx.ext.autosummary.ImportExceptionGroup: no module named
numpy.distutils.ccompiler

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/__init__.py",
line 814, in process_generate_options
    generate_autosummary_docs(genfiles, suffix=suffix, base_path=app.srcdir,
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/generate.py",
line 508, in generate_autosummary_docs
    name, obj, parent, modname = import_ivar_by_name(entry.name)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/__init__.py",
line 712, in import_ivar_by_name
    real_name, obj, parent, modname = import_by_name(name, prefixes)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sphinx/ext/autosummary/__init__.py",
line 655, in import_by_name
    raise ImportExceptionGroup('no module named %s' % ' or
'.join(tried), exceptions)
sphinx.ext.autosummary.ImportExceptionGroup: no module named numpy.distutils

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/cmd/build.py", line 293,
in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/sphinx/application.py", line
271, in __init__
    self._init_builder()
  File "/usr/lib/python3/dist-packages/sphinx/application.py", line
342, in _init_builder
    self.events.emit('builder-inited')
  File "/usr/lib/python3/dist-packages/sphinx/events.py", line 108, in emit
    raise ExtensionError(__("Handler %r for event %r threw an exception") %
sphinx.errors.ExtensionError: Handler <function
process_generate_options at 0x7f03020f05e0> for event 'builder-inited'
threw an exception (exception: no module named numpy.distutils)

Extension error (sphinx.ext.autosummary):
```

This PR excludes the offending source file from the Sphinx build if built with Python 3.12 or later.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
