### PR TITLE
MAINT: fix thread-unsafe cache initialization in PyUFunc_TrueDivisionTypeResolver

### DIFF
--- a/numpy/_core/src/umath/ufunc_type_resolution.h
+++ b/numpy/_core/src/umath/ufunc_type_resolution.h
@@ -72,6 +72,9 @@ PyUFunc_MultiplicationTypeResolver(PyUFuncObject *ufunc,
                                    PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
+init_ufunc_type_resolution_cache();
+
+NPY_NO_EXPORT int
 PyUFunc_TrueDivisionTypeResolver(PyUFuncObject *ufunc,
                                  NPY_CASTING casting,
                                  PyArrayObject **operands,

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -31,6 +31,7 @@
 #include "stringdtype_ufuncs.h"
 #include "special_integer_comparisons.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
+#include "ufunc_type_resolution.h"
 
 /* Automatically generated code to define all ufuncs: */
 #include "funcs.inc"
@@ -343,6 +344,10 @@ int initumath(PyObject *m)
     }
 
     if (init_special_int_comparisons(d) < 0) {
+        return -1;
+    }
+
+    if (init_ufunc_type_resolution_cache() < 0) {
         return -1;
     }
 


### PR DESCRIPTION
This moves initialization for a static tuple used in the division type resolver from inside the resolver body to the initialization for the umath module.

This is only really needed for the free-threaded build of Python. Initializing globals like this during module initialization is thread safe.

No test because I can't think of a way to cause breakage from the data race. Still fixing it since I'm globally auditing usages of static globals in the codebase.