### PR TITLE
ENH: Implement DLPack version 1

### DIFF
--- a/doc/release/upcoming_changes/26501.new_feature.rst
+++ b/doc/release/upcoming_changes/26501.new_feature.rst
@@ -1,0 +1,2 @@
+* NumPy now supports DLPack v1, support for older versions will
+  be deprecated in the future.

--- a/numpy/_core/src/common/dlpack/dlpack.h
+++ b/numpy/_core/src/common/dlpack/dlpack.h
@@ -200,7 +200,7 @@ typedef struct {
    * `byte_offset` field should be used to point to the beginning of the data.
    *
    * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
-   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * TVM, perhaps others) do not adhere to this 256 byte alignment requirement
    * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
    * (after which this note will be updated); at the moment it is recommended
    * to not rely on the data pointer being correctly aligned.

--- a/numpy/_core/src/common/dlpack/dlpack.h
+++ b/numpy/_core/src/common/dlpack/dlpack.h
@@ -1,5 +1,6 @@
 // Taken from:
-// https://github.com/dmlc/dlpack/blob/ca4d00ad3e2e0f410eeab3264d21b8a39397f362/include/dlpack/dlpack.h
+// https://github.com/dmlc/dlpack/blob/bbd2f4d32427e548797929af08cfe2a9cbb3cf12/include/dlpack/dlpack.h
+// but added typedef to DLManagedTensorVersioned
 /*!
  *  Copyright (c) 2017 by Contributors
  * \file dlpack.h
@@ -118,6 +119,8 @@ typedef enum {
   kDLWebGPU = 15,
   /*! \brief Qualcomm Hexagon DSP */
   kDLHexagon = 16,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
 } DLDeviceType;
 
 /*!
@@ -197,7 +200,7 @@ typedef struct {
    * `byte_offset` field should be used to point to the beginning of the data.
    *
    * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
-   * TVM, perhaps others) do not adhere to this 256 byte alignment requirement
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
    * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
    * (after which this note will be updated); at the moment it is recommended
    * to not rely on the data pointer being correctly aligned.
@@ -215,6 +218,9 @@ typedef struct {
    *   return size;
    * }
    * \endcode
+   *
+   * Note that if the tensor is of size zero, then the data pointer should be
+   * set to `NULL`.
    */
   void* data;
   /*! \brief The device of the tensor */
@@ -259,7 +265,7 @@ typedef struct DLManagedTensor {
    * \brief Destructor - this should be called
    * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
    * NULL if there is no way for the caller to provide a reasonable destructor.
-   * The destructors deletes the argument self as well.
+   * The destructor deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensor * self);
 } DLManagedTensor;
@@ -268,6 +274,14 @@ typedef struct DLManagedTensor {
 
 /*! \brief bit mask to indicate that the tensor is read only. */
 #define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
 
 /*!
  * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
@@ -279,7 +293,7 @@ typedef struct DLManagedTensor {
  *
  * \note This is the current standard DLPack exchange data structure.
  */
-struct DLManagedTensorVersioned {
+typedef struct DLManagedTensorVersioned {
   /*!
    * \brief The API and ABI version of the current managed Tensor
    */
@@ -296,7 +310,7 @@ struct DLManagedTensorVersioned {
    *
    * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
    * It can be NULL if there is no way for the caller to provide a reasonable
-   * destructor. The destructors deletes the argument self as well.
+   * destructor. The destructor deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensorVersioned *self);
   /*!
@@ -308,11 +322,12 @@ struct DLManagedTensorVersioned {
    *       stable, to ensure that deleter can be correctly called.
    *
    * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
    */
   uint64_t flags;
   /*! \brief DLTensor which is being memory managed */
   DLTensor dl_tensor;
-};
+} DLManagedTensorVersioned;
 
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C

--- a/numpy/_core/src/common/npy_dlpack.h
+++ b/numpy/_core/src/common/npy_dlpack.h
@@ -16,16 +16,17 @@
 #define NPY_DLPACK_INTERNAL_CAPSULE_NAME "numpy_dltensor"
 #define NPY_DLPACK_VERSIONED_INTERNAL_CAPSULE_NAME "numpy_dltensor_versioned"
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 array_dlpack(PyArrayObject *self, PyObject *const *args, Py_ssize_t len_args,
              PyObject *kwnames);
 
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args));
 
 
 NPY_NO_EXPORT PyObject *
-from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj);
+from_dlpack(PyObject *NPY_UNUSED(self),
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 
 #endif

--- a/numpy/_core/src/common/npy_dlpack.h
+++ b/numpy/_core/src/common/npy_dlpack.h
@@ -6,12 +6,15 @@
 
 // Part of the Array API specification.
 #define NPY_DLPACK_CAPSULE_NAME "dltensor"
+#define NPY_DLPACK_VERSIONED_CAPSULE_NAME "dltensor_versioned"
 #define NPY_DLPACK_USED_CAPSULE_NAME "used_dltensor"
+#define NPY_DLPACK_VERSIONED_USED_CAPSULE_NAME "used_dltensor_versioned"
 
 // Used internally by NumPy to store a base object
 // as it has to release a reference to the original
 // capsule.
 #define NPY_DLPACK_INTERNAL_CAPSULE_NAME "numpy_dltensor"
+#define NPY_DLPACK_VERSIONED_INTERNAL_CAPSULE_NAME "numpy_dltensor_versioned"
 
 PyObject *
 array_dlpack(PyArrayObject *self, PyObject *const *args, Py_ssize_t len_args,

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -8,9 +8,14 @@
 #include "numpy/arrayobject.h"
 #include "npy_argparse.h"
 #include "npy_dlpack.h"
+#include "multiarraymodule.h"
 
+
+/*
+ * Deleter for a NumPy exported dlpack DLManagedTensor(Versioned).
+ */
 static void
-array_dlpack_deleter(DLManagedTensor *self)
+array_dlpack_deleter(DLManagedTensorVersioned *self)
 {
     /*
      * Leak the pyobj if not initialized.  This can happen if we are running
@@ -32,16 +37,40 @@ array_dlpack_deleter(DLManagedTensor *self)
     PyGILState_Release(state);
 }
 
-/* This is exactly as mandated by dlpack */
-static void dlpack_capsule_deleter(PyObject *self) {
-    if (PyCapsule_IsValid(self, NPY_DLPACK_USED_CAPSULE_NAME)) {
+/* TODO: Basically same as above until dlpack v0 is removed: */
+static void
+array_dlpack_deleter_unversioned(DLManagedTensor *self)
+{
+    if (!Py_IsInitialized()) {
         return;
     }
 
-    DLManagedTensor *managed =
-        (DLManagedTensor *)PyCapsule_GetPointer(self, NPY_DLPACK_CAPSULE_NAME);
+    PyGILState_STATE state = PyGILState_Ensure();
+
+    PyArrayObject *array = (PyArrayObject *)self->manager_ctx;
+    PyMem_Free(self);
+    Py_XDECREF(array);
+
+    PyGILState_Release(state);
+}
+
+
+/*
+ * Deleter for a DLPack capsule wrapping a DLManagedTensor(Versioed).
+ *
+ * This is exactly as mandated by dlpack
+ */
+static void
+dlpack_capsule_deleter(PyObject *self) {
+    if (PyCapsule_IsValid(self, NPY_DLPACK_VERSIONED_USED_CAPSULE_NAME)) {
+        return;
+    }
+
+    DLManagedTensorVersioned *managed =
+        (DLManagedTensorVersioned *)PyCapsule_GetPointer(
+            self, NPY_DLPACK_VERSIONED_CAPSULE_NAME);
     if (managed == NULL) {
-        PyErr_WriteUnraisable(self);
+        PyErr_WriteUnraisable(NULL);
         return;
     }
     /*
@@ -53,18 +82,41 @@ static void dlpack_capsule_deleter(PyObject *self) {
     }
 }
 
-/* used internally, almost identical to dlpack_capsule_deleter() */
-static void array_dlpack_internal_capsule_deleter(PyObject *self)
-{
-    /* an exception may be in-flight, we must save it in case we create another one */
-    PyObject *type, *value, *traceback;
-    PyErr_Fetch(&type, &value, &traceback);
+/* TODO: Basically same as above until dlpack v0 is removed: */
+static void
+dlpack_capsule_deleter_unversioned(PyObject *self) {
+    if (PyCapsule_IsValid(self, NPY_DLPACK_USED_CAPSULE_NAME)) {
+        return;
+    }
 
     DLManagedTensor *managed =
-        (DLManagedTensor *)PyCapsule_GetPointer(self, NPY_DLPACK_INTERNAL_CAPSULE_NAME);
+        (DLManagedTensor *)PyCapsule_GetPointer(self, NPY_DLPACK_CAPSULE_NAME);
     if (managed == NULL) {
-        PyErr_WriteUnraisable(self);
-        goto done;
+        PyErr_WriteUnraisable(NULL);
+        return;
+    }
+
+    if (managed->deleter) {
+        managed->deleter(managed);
+    }
+}
+
+
+/*
+ * Deleter for the capsule used as a `base` in `from_dlpack`.
+ *
+ * This is almost identical to the above used internally as the base for our array
+ * so that we can consume (rename) the original capsule.
+ */
+static void
+array_dlpack_internal_capsule_deleter(PyObject *self)
+{
+    DLManagedTensorVersioned *managed =
+        (DLManagedTensorVersioned *)PyCapsule_GetPointer(
+            self, NPY_DLPACK_VERSIONED_CAPSULE_NAME);
+    if (managed == NULL) {
+        PyErr_WriteUnraisable(NULL);
+        return;
     }
     /*
      *  the spec says the deleter can be NULL if there is no way for the caller
@@ -75,9 +127,23 @@ static void array_dlpack_internal_capsule_deleter(PyObject *self)
         /* TODO: is the deleter allowed to set a python exception? */
         assert(!PyErr_Occurred());
     }
+}
 
-done:
-    PyErr_Restore(type, value, traceback);
+/* TODO: Basically same as above until dlpack v0 is removed: */
+static void
+array_dlpack_internal_capsule_deleter_unversioned(PyObject *self)
+{
+    DLManagedTensor *managed =
+        (DLManagedTensor *)PyCapsule_GetPointer(self, NPY_DLPACK_CAPSULE_NAME);
+    if (managed == NULL) {
+        PyErr_WriteUnraisable(NULL);
+        return;
+    }
+
+    if (managed->deleter) {
+        managed->deleter(managed);
+        assert(!PyErr_Occurred());
+    }
 }
 
 
@@ -99,8 +165,16 @@ array_get_dl_device(PyArrayObject *self) {
     // The outer if is due to the fact that NumPy arrays are on the CPU
     // by default (if not created from DLPack).
     if (PyCapsule_IsValid(base, NPY_DLPACK_INTERNAL_CAPSULE_NAME)) {
-        DLManagedTensor *managed = PyCapsule_GetPointer(
+        DLManagedTensor *managed = (DLManagedTensor *)PyCapsule_GetPointer(
                 base, NPY_DLPACK_INTERNAL_CAPSULE_NAME);
+        if (managed == NULL) {
+            return ret;
+        }
+        return managed->dl_tensor.device;
+    }
+    else if (PyCapsule_IsValid(base, NPY_DLPACK_VERSIONED_INTERNAL_CAPSULE_NAME)) {
+        DLManagedTensorVersioned *managed = (DLManagedTensorVersioned *)PyCapsule_GetPointer(
+                base, NPY_DLPACK_VERSIONED_INTERNAL_CAPSULE_NAME);
         if (managed == NULL) {
             return ret;
         }
@@ -110,30 +184,14 @@ array_get_dl_device(PyArrayObject *self) {
 }
 
 
-PyObject *
-array_dlpack(PyArrayObject *self,
-        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+/*
+ * Fill the dl_tensor struct from the `self` array.
+ * This struct could be versioned, but as of now is not.
+ */
+static int
+fill_dl_tensor_information(
+    DLTensor *dl_tensor, PyArrayObject *self)
 {
-    PyObject *stream = Py_None;
-    NPY_PREPARE_ARGPARSER;
-    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
-            "$stream", NULL, &stream, NULL, NULL, NULL)) {
-        return NULL;
-    }
-
-    if (stream != Py_None) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "NumPy only supports stream=None.");
-        return NULL;
-    }
-
-    if ( !(PyArray_FLAGS(self) & NPY_ARRAY_WRITEABLE)) {
-        PyErr_SetString(PyExc_BufferError,
-            "Cannot export readonly array since signalling readonly "
-            "is unsupported by DLPack.");
-        return NULL;
-    }
-
     npy_intp itemsize = PyArray_ITEMSIZE(self);
     int ndim = PyArray_NDIM(self);
     npy_intp *strides = PyArray_STRIDES(self);
@@ -145,7 +203,7 @@ array_dlpack(PyArrayObject *self,
                 PyErr_SetString(PyExc_BufferError,
                         "DLPack only supports strides which are a multiple of "
                         "itemsize.");
-                return NULL;
+                return -1;
             }
         }
     }
@@ -156,7 +214,7 @@ array_dlpack(PyArrayObject *self,
     if (PyDataType_ISBYTESWAPPED(dtype)) {
         PyErr_SetString(PyExc_BufferError,
                 "DLPack only supports native byte order.");
-            return NULL;
+            return -1;
     }
 
     managed_dtype.bits = 8 * itemsize;
@@ -178,7 +236,7 @@ array_dlpack(PyArrayObject *self,
             PyErr_SetString(PyExc_BufferError,
                     "DLPack only supports IEEE floating point types "
                     "without padding (longdouble typically is not IEEE).");
-            return NULL;
+            return -1;
         }
         managed_dtype.code = kDLFloat;
     }
@@ -189,7 +247,7 @@ array_dlpack(PyArrayObject *self,
             PyErr_SetString(PyExc_BufferError,
                     "DLPack only supports IEEE floating point types "
                     "without padding (longdouble typically is not IEEE).");
-            return NULL;
+            return -1;
         }
         managed_dtype.code = kDLComplex;
     }
@@ -197,24 +255,13 @@ array_dlpack(PyArrayObject *self,
         PyErr_SetString(PyExc_BufferError,
                 "DLPack only supports signed/unsigned integers, float "
                 "and complex dtypes.");
-        return NULL;
+        return -1;
     }
 
     DLDevice device = array_get_dl_device(self);
     if (PyErr_Occurred()) {
-        return NULL;
+        return -1;
     }
-
-    // ensure alignment
-    int offset = sizeof(DLManagedTensor) % sizeof(void *);
-    void *ptr = PyMem_Malloc(sizeof(DLManagedTensor) + offset +
-        (sizeof(int64_t) * ndim * 2));
-    if (ptr == NULL) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-
-    DLManagedTensor *managed = ptr;
 
     /*
      * Note: the `dlpack.h` header suggests/standardizes that `data` must be
@@ -229,34 +276,90 @@ array_dlpack(PyArrayObject *self,
      * that NumPy MUST use `byte_offset` to adhere to the standard (as
      * specified in the header)!
      */
-    managed->dl_tensor.data = PyArray_DATA(self);
-    managed->dl_tensor.byte_offset = 0;
-    managed->dl_tensor.device = device;
-    managed->dl_tensor.dtype = managed_dtype;
+    dl_tensor->data = PyArray_DATA(self);
+    dl_tensor->byte_offset = 0;
+    dl_tensor->device = device;
+    dl_tensor->dtype = managed_dtype;
 
-    int64_t *managed_shape_strides = (int64_t *)((char *)ptr +
-        sizeof(DLManagedTensor) + offset);
-
-    int64_t *managed_shape = managed_shape_strides;
-    int64_t *managed_strides = managed_shape_strides + ndim;
     for (int i = 0; i < ndim; ++i) {
-        managed_shape[i] = shape[i];
+        dl_tensor->shape[i] = shape[i];
         // Strides in DLPack are items; in NumPy are bytes.
-        managed_strides[i] = strides[i] / itemsize;
+        dl_tensor->strides[i] = strides[i] / itemsize;
     }
 
-    managed->dl_tensor.ndim = ndim;
-    managed->dl_tensor.shape = managed_shape;
-    managed->dl_tensor.strides = NULL;
-    if (PyArray_SIZE(self) != 1 && !PyArray_IS_C_CONTIGUOUS(self)) {
-        managed->dl_tensor.strides = managed_strides;
+    dl_tensor->ndim = ndim;
+    if (PyArray_IS_C_CONTIGUOUS(self)) {
+        /* No need to pass strides, so just NULL it again */
+        dl_tensor->strides = NULL;
     }
-    managed->dl_tensor.byte_offset = 0;
-    managed->manager_ctx = self;
-    managed->deleter = array_dlpack_deleter;
+    dl_tensor->byte_offset = 0;
 
-    PyObject *capsule = PyCapsule_New(managed, NPY_DLPACK_CAPSULE_NAME,
-            dlpack_capsule_deleter);
+    return 0;
+}
+
+
+static PyObject *
+create_dlpack_capsule(PyArrayObject *self, int versioned)
+{
+    int ndim = PyArray_NDIM(self);
+
+    /*
+     * We align shape and strides at the end but need to align them, offset
+     * gives the offset of the shape (and strides) including the struct size.
+     */
+    size_t align = sizeof(int64_t);
+    size_t struct_size = (
+        versioned ? sizeof(DLManagedTensorVersioned) : sizeof(DLManagedTensor));
+
+    size_t offset = (struct_size + align - 1) / align * align;
+    void *ptr = PyMem_Malloc(offset + (sizeof(int64_t) * ndim * 2));
+    if (ptr == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    DLTensor *dl_tensor;
+    PyCapsule_Destructor capsule_deleter;
+    const char *capsule_name;
+
+    if (versioned) {
+        DLManagedTensorVersioned *managed = (DLManagedTensorVersioned *)ptr;
+        capsule_name = NPY_DLPACK_VERSIONED_CAPSULE_NAME;
+        capsule_deleter = (PyCapsule_Destructor)dlpack_capsule_deleter;
+        managed->deleter = array_dlpack_deleter;
+        managed->manager_ctx = self;
+
+        dl_tensor = &managed->dl_tensor;
+
+        /* The versioned tensor has additional fields that we need to set */
+        managed->version.major = 1;
+        managed->version.minor = 0;
+
+        managed->flags = 0;
+        if (!PyArray_CHKFLAGS(self, NPY_ARRAY_WRITEABLE)) {
+            managed->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
+        }
+    }
+    else {
+        DLManagedTensor *managed = (DLManagedTensor *)ptr;
+        capsule_name = NPY_DLPACK_CAPSULE_NAME;
+        capsule_deleter = (PyCapsule_Destructor)dlpack_capsule_deleter_unversioned;
+        managed->deleter = array_dlpack_deleter_unversioned;
+        managed->manager_ctx = self;
+
+        dl_tensor = &managed->dl_tensor;
+    }
+
+    dl_tensor->shape = (int64_t *)((char *)ptr + offset);
+    /* Note that strides may be set to NULL later if C-contiguous */
+    dl_tensor->strides = dl_tensor->shape + ndim;
+
+    if (fill_dl_tensor_information(dl_tensor, self) < 0) {
+        PyMem_Free(ptr);
+        return NULL;
+    }
+
+    PyObject *capsule = PyCapsule_New(ptr, capsule_name, capsule_deleter);
     if (capsule == NULL) {
         PyMem_Free(ptr);
         return NULL;
@@ -264,7 +367,60 @@ array_dlpack(PyArrayObject *self,
 
     // the capsule holds a reference
     Py_INCREF(self);
+
     return capsule;
+}
+
+
+PyObject *
+array_dlpack(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    PyObject *stream = Py_None;
+    PyObject *max_version = Py_None;
+    long major_version = 0;
+    NPY_PREPARE_ARGPARSER;
+    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
+            "$stream", NULL, &stream,
+            "$max_version", NULL, &max_version,
+            NULL, NULL, NULL)) {
+        return NULL;
+    }
+
+    if (max_version != Py_None) {
+        if (!PyTuple_Check(max_version) || PyTuple_GET_SIZE(max_version) != 2) {
+            PyErr_SetString(PyExc_TypeError,
+                    "max_version must be None or a tuple with two elements.");
+            return NULL;
+        }
+        major_version = PyLong_AsLong(PyTuple_GET_ITEM(max_version, 0));
+        if (major_version == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
+    }
+
+    if (stream != Py_None) {
+        PyErr_SetString(PyExc_RuntimeError,
+                "NumPy only supports stream=None.");
+        return NULL;
+    }
+
+    if (major_version < 1 && !(PyArray_FLAGS(self) & NPY_ARRAY_WRITEABLE)) {
+        PyErr_SetString(PyExc_BufferError,
+            "Cannot export readonly array since signalling readonly "
+            "is unsupported by DLPack (supported by newer DLPack version).");
+        return NULL;
+    }
+
+    /*
+     * TODO: The versioned and non-versioned structs of DLPack are very
+     * similar but not ABI compatible so that the function called here requires
+     * branching (templating didn't seem worthwhile).
+     *
+     * Version 0 support should be deprecated in NumPy 2.1 and the branches
+     * can then be removed again.
+     */
+    return create_dlpack_capsule(self, major_version >= 1);
 }
 
 PyObject *
@@ -279,22 +435,78 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args))
 
 NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
-    PyObject *capsule = PyObject_CallMethod((PyObject *)obj->ob_type,
-            "__dlpack__", "O", obj);
+    static PyObject *kwnames = NULL;
+    static PyObject *max_version = NULL;
+
+    if (kwnames == NULL) {
+        kwnames = Py_BuildValue("(s)", "max_version");
+        if (kwnames == NULL) {
+            return NULL;
+        }
+    }
+    if (max_version == NULL) {
+        max_version = Py_BuildValue("(i,i)", 1, 0);
+        if (max_version == NULL) {
+            return NULL;
+        }
+    }
+
+    PyObject *args[2] = {obj, max_version};
+    Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+
+    PyObject *capsule = PyObject_VectorcallMethod(
+            npy_ma_str___dlpack__, args, nargsf, kwnames);
     if (capsule == NULL) {
-        return NULL;
+        /*
+         * TODO: This path should be deprecated in NumPy 2.1.  Once deprecated
+         * the below code can be simplified w.r.t. to versioned/unversioned.
+         */
+        if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+            /* max_version may be unsupported, try without kwargs */
+            PyErr_Clear();
+            capsule = PyObject_VectorcallMethod(
+                npy_ma_str___dlpack__, args, nargsf, NULL);
+        }
+        if (capsule == NULL) {
+            return NULL;
+        }
     }
 
-    DLManagedTensor *managed =
-        (DLManagedTensor *)PyCapsule_GetPointer(capsule,
-        NPY_DLPACK_CAPSULE_NAME);
+    void *managed_ptr;
+    DLTensor dl_tensor;
+    int readonly;
+    int versioned = PyCapsule_IsValid(capsule, NPY_DLPACK_VERSIONED_CAPSULE_NAME);
+    if (versioned) {
+        managed_ptr = PyCapsule_GetPointer(capsule, NPY_DLPACK_VERSIONED_CAPSULE_NAME);
+        DLManagedTensorVersioned *managed = (DLManagedTensorVersioned *)managed_ptr;
+        if (managed == NULL) {
+            Py_DECREF(capsule);
+            return NULL;
+        }
 
-    if (managed == NULL) {
-        Py_DECREF(capsule);
-        return NULL;
+        if (managed->version.major > 1) {
+            PyErr_SetString(PyExc_BufferError,
+                "from_dlpack(): the exported DLPack major version is too "
+                "high to be imported by this version of NumPy.");
+            Py_DECREF(capsule);
+            return NULL;
+        }
+
+        dl_tensor = managed->dl_tensor;
+        readonly = (managed->flags & DLPACK_FLAG_BITMASK_READ_ONLY) != 0;
+    }
+    else {
+        managed_ptr = PyCapsule_GetPointer(capsule, NPY_DLPACK_CAPSULE_NAME);
+        DLManagedTensor *managed = (DLManagedTensor *)managed_ptr;
+        if (managed == NULL) {
+            Py_DECREF(capsule);
+            return NULL;
+        }
+        dl_tensor = managed->dl_tensor;
+        readonly = 0;
     }
 
-    const int ndim = managed->dl_tensor.ndim;
+    const int ndim = dl_tensor.ndim;
     if (ndim > NPY_MAXDIMS) {
         PyErr_SetString(PyExc_RuntimeError,
                 "maxdims of DLPack tensor is higher than the supported "
@@ -303,7 +515,7 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
         return NULL;
     }
 
-    DLDeviceType device_type = managed->dl_tensor.device.device_type;
+    DLDeviceType device_type = dl_tensor.device.device_type;
     if (device_type != kDLCPU &&
             device_type != kDLCUDAHost &&
             device_type != kDLROCMHost &&
@@ -314,7 +526,7 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
         return NULL;
     }
 
-    if (managed->dl_tensor.dtype.lanes != 1) {
+    if (dl_tensor.dtype.lanes != 1) {
         PyErr_SetString(PyExc_RuntimeError,
                 "Unsupported lanes in DLTensor dtype.");
         Py_DECREF(capsule);
@@ -322,9 +534,9 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
     }
 
     int typenum = -1;
-    const uint8_t bits = managed->dl_tensor.dtype.bits;
+    const uint8_t bits = dl_tensor.dtype.bits;
     const npy_intp itemsize = bits / 8;
-    switch (managed->dl_tensor.dtype.code) {
+    switch (dl_tensor.dtype.code) {
     case kDLBool:
         if (bits == 8) {
             typenum = NPY_BOOL;
@@ -376,15 +588,14 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
     npy_intp strides[NPY_MAXDIMS];
 
     for (int i = 0; i < ndim; ++i) {
-        shape[i] = managed->dl_tensor.shape[i];
+        shape[i] = dl_tensor.shape[i];
         // DLPack has elements as stride units, NumPy has bytes.
-        if (managed->dl_tensor.strides != NULL) {
-            strides[i] = managed->dl_tensor.strides[i] * itemsize;
+        if (dl_tensor.strides != NULL) {
+            strides[i] = dl_tensor.strides[i] * itemsize;
         }
     }
 
-    char *data = (char *)managed->dl_tensor.data +
-            managed->dl_tensor.byte_offset;
+    char *data = (char *)dl_tensor.data + dl_tensor.byte_offset;
 
     PyArray_Descr *descr = PyArray_DescrFromType(typenum);
     if (descr == NULL) {
@@ -393,15 +604,27 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
     }
 
     PyObject *ret = PyArray_NewFromDescr(&PyArray_Type, descr, ndim, shape,
-            managed->dl_tensor.strides != NULL ? strides : NULL, data, 0, NULL);
+            dl_tensor.strides != NULL ? strides : NULL, data, 0, NULL);
     if (ret == NULL) {
         Py_DECREF(capsule);
         return NULL;
     }
+    if (readonly) {
+        PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
+    }
 
-    PyObject *new_capsule = PyCapsule_New(managed,
+    PyObject *new_capsule;
+    if (versioned) {
+        new_capsule = PyCapsule_New(managed_ptr,
+            NPY_DLPACK_VERSIONED_INTERNAL_CAPSULE_NAME,
+            (PyCapsule_Destructor)array_dlpack_internal_capsule_deleter);
+    }
+    else {
+        new_capsule = PyCapsule_New(managed_ptr,
             NPY_DLPACK_INTERNAL_CAPSULE_NAME,
-            array_dlpack_internal_capsule_deleter);
+            (PyCapsule_Destructor)array_dlpack_internal_capsule_deleter_unversioned);
+    }
+
     if (new_capsule == NULL) {
         Py_DECREF(capsule);
         Py_DECREF(ret);
@@ -414,7 +637,10 @@ from_dlpack(PyObject *NPY_UNUSED(self), PyObject *obj) {
         return NULL;
     }
 
-    if (PyCapsule_SetName(capsule, NPY_DLPACK_USED_CAPSULE_NAME) < 0) {
+    const char *new_name = (
+        versioned ? NPY_DLPACK_VERSIONED_USED_CAPSULE_NAME
+                  : NPY_DLPACK_USED_CAPSULE_NAME);
+    if (PyCapsule_SetName(capsule, new_name) < 0) {
         Py_DECREF(capsule);
         Py_DECREF(ret);
         return NULL;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -297,7 +297,7 @@ fill_dl_tensor_information(
 
 static PyObject *
 create_dlpack_capsule(
-        PyArrayObject *self, int versioned, DLDevice *result_device)
+        PyArrayObject *self, int versioned, DLDevice *result_device, int copied)
 {
     int ndim = PyArray_NDIM(self);
 
@@ -336,6 +336,9 @@ create_dlpack_capsule(
         managed->flags = 0;
         if (!PyArray_CHKFLAGS(self, NPY_ARRAY_WRITEABLE)) {
             managed->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
+        }
+        if (copied) {
+            managed->flags |= DLPACK_FLAG_BITMASK_IS_COPIED;
         }
     }
     else {
@@ -470,7 +473,8 @@ array_dlpack(PyArrayObject *self,
      * can then be removed again.
      */
     PyObject *res = create_dlpack_capsule(
-            self, major_version >= 1, &result_device);
+            self, major_version >= 1, &result_device,
+            copy_mode == NPY_COPY_ALWAYS);
     Py_DECREF(self);
 
     return res;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -15,7 +15,7 @@
 /*
  * Deleter for a NumPy exported dlpack DLManagedTensor(Versioned).
  */
-NPY_NO_EXPORT static void
+static void
 array_dlpack_deleter(DLManagedTensorVersioned *self)
 {
     /*
@@ -476,7 +476,7 @@ array_dlpack(PyArrayObject *self,
     return res;
 }
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args))
 {
     DLDevice device = array_get_dl_device(self);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4604,7 +4604,7 @@ static struct PyMethodDef array_module_methods[] = {
         METH_NOARGS,
         "Give a warning on reload and big warning in sub-interpreters."},
     {"from_dlpack", (PyCFunction)from_dlpack,
-        METH_O, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4795,6 +4795,7 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_convert_if_no_array = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_cpu = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_dtype = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_err_msg_substr = NULL;
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str___dlpack__ = NULL;
 
 static int
 intern_strings(void)
@@ -4879,6 +4880,10 @@ intern_strings(void)
     npy_ma_str_array_err_msg_substr = PyUnicode_InternFromString(
             "__array__() got an unexpected keyword argument 'copy'");
     if (npy_ma_str_array_err_msg_substr == NULL) {
+        return -1;
+    }
+    npy_ma_str___dlpack__ = PyUnicode_InternFromString("__dlpack__");
+    if (npy_ma_str___dlpack__ == NULL) {
         return -1;
     }
     return 0;

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -21,5 +21,6 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_convert_if_no_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_cpu;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_dtype;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_err_msg_substr;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str___dlpack__;
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -7,9 +7,10 @@ from numpy.testing import assert_array_equal, IS_PYPY
 
 class TestDLPack:
     @pytest.mark.skipif(IS_PYPY, reason="PyPy can't get refcounts.")
-    def test_dunder_dlpack_refcount(self):
+    @pytest.mark.parametrize(max_version, [(0, 0), None, (1, 0), (100, 3)])
+    def test_dunder_dlpack_refcount(self, max_version):
         x = np.arange(5)
-        y = x.__dlpack__()
+        y = x.__dlpack__(max_version=max_version)
         assert sys.getrefcount(x) == 3
         del y
         assert sys.getrefcount(x) == 2

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -7,8 +7,9 @@ from numpy.testing import assert_array_equal, IS_PYPY
 
 def new_and_old_dlpack():
     yield np.arange(5)
-    # Support only old version:
+
     class OldDLPack(np.ndarray):
+        # Support only the "old" version
         def __dlpack__(self, stream=None):
             return super().__dlpack__(stream=None)
 


### PR DESCRIPTION
This implements DLPack version 1 to close gh-26411.

Note that I had first tried to use C++ templating to avoid the duplication, but in the end the additional complexity of it didn't really seem worthwhile compared to duplicating the few functions.

Although a lot is just moved around, this is an unfortunately large diff.  The new and old code paths should be (mostly) tested, but the nature of dlpack is that it is hard to test interaction with others (e.g. gpu failure paths).

I decided to always pass device/copy as `None` to simplify the call sites.

It does fix a few smaller issues as well.