### PR TITLE
TST: work around flaky test on free-threaded build

### DIFF
--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -362,7 +362,7 @@ def test_thread_local_promotion_state():
         np._set_promotion_state("weak")
         b.wait()
         assert np._get_promotion_state() == "weak"
-        with pytest.warns(RuntimeWarning):
+        with pytest.raises(RuntimeWarning):
             np.float16(1) + 131008
 
     task1 = threading.Thread(target=legacy_no_warn)


### PR DESCRIPTION
The newly added free-threaded CI is seeing intermittent test failures caused by this test. See e.g. [this run](https://github.com/numpy/numpy/actions/runs/9192752576/job/25282577565).

This is a weird bug, from the error message, somehow a RuntimeWarning is getting created, and then during the handling of the warning, pytest doesn't see it. But only sometimes. In my test using `pytest-repeat` to repeatedly run this test I see unhandled warnings anywhere from 0% to 20% of the time. It happens more often in an optimized build of numpy than in a debug build (which is why I missed it during local testing).

This smells like a bug in either pytest or CPython and I will try to figure out what exactly is happening. For now it looks like `pytest.raises` doesn't have the same issue.