### PR TITLE
MAINT: mark temp elision address cache as thread local

### DIFF
--- a/numpy/_core/src/multiarray/temp_elide.c
+++ b/numpy/_core/src/multiarray/temp_elide.c
@@ -124,22 +124,22 @@ check_callers(int * cannot)
      * TODO some calls go over scalarmath in umath but we cannot get the base
      * address of it from multiarraymodule as it is not linked against it
      */
-    static int init = 0;
+    NPY_TLS static int init = 0;
     /*
      * measured DSO object memory start and end, if an address is located
      * inside these bounds it is part of that library so we don't need to call
      * dladdr on it (assuming linear memory)
      */
-    static void * pos_python_start;
-    static void * pos_python_end;
-    static void * pos_ma_start;
-    static void * pos_ma_end;
+    NPY_TLS static void * pos_python_start;
+    NPY_TLS static void * pos_python_end;
+    NPY_TLS static void * pos_ma_start;
+    NPY_TLS static void * pos_ma_end;
 
     /* known address storage to save dladdr calls */
-    static void * py_addr[64];
-    static void * pyeval_addr[64];
-    static npy_intp n_py_addr = 0;
-    static npy_intp n_pyeval = 0;
+    NPY_TLS static void * py_addr[64];
+    NPY_TLS static void * pyeval_addr[64];
+    NPY_TLS static npy_intp n_py_addr = 0;
+    NPY_TLS static npy_intp n_pyeval = 0;
 
     void *buffer[NPY_MAX_STACKSIZE];
     int i, nptrs;

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -36,3 +36,21 @@ def test_parallel_ufunc_execution():
         np.isnan(arr)
 
     run_threaded(func, 500)
+
+def test_temp_elision_thread_safety():
+    amid = np.ones(50000)
+    bmid = np.ones(50000)
+    alarge = np.ones(1000000)
+    blarge = np.ones(1000000)
+
+    def func(count):
+        if count % 4 == 0:
+            (amid * 2) + bmid
+        elif count % 4 == 1:
+            (amid + bmid) - 2
+        elif count % 4 == 2:
+            (alarge * 2) + blarge
+        else:
+            (alarge + blarge) - 2
+
+    run_threaded(func, 100, pass_count=True)


### PR DESCRIPTION
The basic idea of temporary elision should be thread safe in the free-threaded build but we may have to come back to this if it turns out that temporaries can be shared between threads somehow. I don't think that's possible.

The implementation of the elision check uses a cache that is not constructed in a thread safe manner. Marking the members of the cache as thread-local using the `NPY_TLS` macro should fix any thread safety issues introduced by threads simultaneously filling the cache.

I don't see any statistically significant slowdowns running the temporary elision benchmarks locally in the free-threaded CPython 3.13.0b1 build or a 3.12.3 build.