### PR TITLE
FIX: Fixed np.load time when file is large & compressed.

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -253,14 +253,24 @@ class NpzFile(Mapping):
             bytes.close()
             if magic == format.MAGIC_PREFIX:
                 info = self.zip.NameToInfo[key]
-                assert info.compress_type == 0
-                self.zip.fp.seek(
-                    info.header_offset + len(info.FileHeader()) + 20
-                )
-                return format.read_array(self.zip.fp,
-                                         allow_pickle=self.allow_pickle,
-                                         pickle_kwargs=self.pickle_kwargs,
-                                         max_header_size=self.max_header_size)
+                if info.compress_type == 0:
+                    self.zip.fp.seek(
+                        info.header_offset + len(info.FileHeader()) + 20
+                    )
+                    return format.read_array(
+                        self.zip.fp,
+                        allow_pickle=self.allow_pickle,
+                        pickle_kwargs=self.pickle_kwargs,
+                        max_header_size=self.max_header_size
+                    )
+                else:
+                    bytes = self.zip.open(key)
+                    return format.read_array(
+                        bytes,
+                        allow_pickle=self.allow_pickle,
+                        pickle_kwargs=self.pickle_kwargs,
+                        max_header_size=self.max_header_size
+                    )
             else:
                 return self.zip.read(key)
         else:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -252,7 +252,7 @@ class NpzFile(Mapping):
             magic = bytes.read(len(format.MAGIC_PREFIX))
             bytes.close()
             if magic == format.MAGIC_PREFIX:
-                info = self.zip.NameToInfo[key]
+                info = self.zip.getinfo(key)
                 if info.compress_type == 0:
                     self.zip.fp.seek(
                         info.header_offset + len(info.FileHeader()) + 20

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -252,8 +252,12 @@ class NpzFile(Mapping):
             magic = bytes.read(len(format.MAGIC_PREFIX))
             bytes.close()
             if magic == format.MAGIC_PREFIX:
-                bytes = self.zip.open(key)
-                return format.read_array(bytes,
+                info = self.zip.NameToInfo[key]
+                assert info.compress_type == 0
+                self.zip.fp.seek(
+                    info.header_offset + len(info.FileHeader()) + 20
+                )
+                return format.read_array(self.zip.fp,
                                          allow_pickle=self.allow_pickle,
                                          pickle_kwargs=self.pickle_kwargs,
                                          max_header_size=self.max_header_size)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fixes: #26498 

Instead of passing an object of `zipfile.ZipExtFile` to `format.read_array()`, I am now passing `_io.BufferedReader` whose read() is faster.