### PR TITLE
MAINT: Fix GCC -Wmaybe-uninitialized warning

### DIFF
--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -1523,7 +1523,7 @@ eigh_wrapper(char JOBZ,
                            UPLO,
                            (fortran_int)dimensions[0], dispatch_scalar<typ>())) {
         LINEARIZE_DATA_t matrix_in_ld;
-        LINEARIZE_DATA_t eigenvectors_out_ld;
+        LINEARIZE_DATA_t eigenvectors_out_ld  = {}; /* silence uninitialized warning */
         LINEARIZE_DATA_t eigenvalues_out_ld;
 
         init_linearize_data(&matrix_in_ld,
@@ -2465,8 +2465,8 @@ eig_wrapper(char JOBVL,
                            (fortran_int)dimensions[0], dispatch_scalar<ftype>())) {
         LINEARIZE_DATA_t a_in;
         LINEARIZE_DATA_t w_out;
-        LINEARIZE_DATA_t vl_out;
-        LINEARIZE_DATA_t vr_out;
+        LINEARIZE_DATA_t vl_out = {}; /* silence uninitialized warning */
+        LINEARIZE_DATA_t vr_out = {}; /* silence uninitialized warning */
 
         init_linearize_data(&a_in,
                             geev_params.N, geev_params.N,


### PR DESCRIPTION
GCC is unable to verify data-dependent initialization, so help him a bit and default-initialized some data structures

Related to #26513

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
