### PR TITLE
BUG: Fix handling of size=() in Generator.choice when a.ndim > 1.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -992,7 +992,7 @@ cdef class Generator:
         if a.ndim == 0:
             return idx
 
-        if not is_scalar and idx.ndim == 0:
+        if not is_scalar and idx.ndim == 0 and a.ndim == 1:
             # If size == () then the user requested a 0-d array as opposed to
             # a scalar object when size is None. However a[idx] is always a
             # scalar and not an array. So this makes sure the result is an

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -933,6 +933,11 @@ class TestRandomDist:
         res = hashlib.sha256(actual.view(np.int8)).hexdigest()
         assert_(choice_hash == res)
 
+    def test_choice_array_size_empty_tuple(self):
+        assert_array_equal(random.choice([[1, 2, 3]], size=()), [1, 2, 3])
+        assert_array_equal(random.choice([[1]], size=()), [1])
+        assert_array_equal(random.choice([[1]], size=(), axis=1), [1])
+
     def test_bytes(self):
         random = Generator(MT19937(self.seed))
         actual = random.bytes(10)

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -934,9 +934,13 @@ class TestRandomDist:
         assert_(choice_hash == res)
 
     def test_choice_array_size_empty_tuple(self):
+        random = Generator(MT19937(self.seed))
+        assert_array_equal(random.choice([1, 2, 3], size=()), np.array(1),
+                           strict=True)
         assert_array_equal(random.choice([[1, 2, 3]], size=()), [1, 2, 3])
-        assert_array_equal(random.choice([[1]], size=()), [1])
-        assert_array_equal(random.choice([[1]], size=(), axis=1), [1])
+        assert_array_equal(random.choice([[1]], size=()), [1], strict=True)
+        assert_array_equal(random.choice([[1]], size=(), axis=1), [1],
+                           strict=True)
 
     def test_bytes(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
Closes gh-26518.
