### PR TITLE
BUG: fix incorrect error handling for dtype('a') deprecation

### DIFF
--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1341,13 +1341,19 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             break;
 
         case NPY_DEPRECATED_STRINGLTR2:
-            DEPRECATE(
-                "Data type alias `a` was removed in NumPy 2.0. "
-                "Use `S` alias instead."
-            );
-            newtype = NPY_STRING;
+        {
+            /*
+             * raise a deprecation warning, which might be an exception
+             * if warnings are errors, so leave newtype unset in that
+             * case
+             */
+            int ret = DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
+                                "Use the 'S' alias instead.");
+            if (ret == 0) {
+                newtype = NPY_STRING;
+            }
             break;
-
+        }
         case NPY_UNICODELTR:
             newtype = NPY_UNICODE;
             break;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1828,10 +1828,10 @@ _convert_from_str(PyObject *obj, int align)
                     break;
 
                 case NPY_DEPRECATED_STRINGLTR2:
-                    DEPRECATE(
-                        "Data type alias `a` was removed in NumPy 2.0. "
-                        "Use `S` alias instead."
-                    );
+                    if (DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
+                                  "Use the 'S' alias instead.") < 0) {
+                        return NULL;
+                    }
                     check_num = NPY_STRING;
                     break;
 
@@ -1900,10 +1900,10 @@ _convert_from_str(PyObject *obj, int align)
         }
 
         if (strcmp(type, "a") == 0) {
-            DEPRECATE(
-                "Data type alias `a` was removed in NumPy 2.0. "
-                "Use `S` alias instead."
-            );
+            if (DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
+                          "Use the 'S' alias instead.") < 0) {
+                return NULL;
+            }
         }
 
         /*

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -670,18 +670,22 @@ class TestLibImports(_DeprecationTestCase):
 
 class TestDeprecatedDTypeAliases(_DeprecationTestCase):
 
-    @staticmethod
-    def _check_for_warning(func):
+    def _check_for_warning(self, func):
         with warnings.catch_warnings(record=True) as caught_warnings:
             func()
         assert len(caught_warnings) == 1
         w = caught_warnings[0]
         assert w.category is DeprecationWarning
-        assert "alias `a` was removed in NumPy 2.0" in str(w.message)
+        assert "alias 'a' was deprecated in NumPy 2.0" in str(w.message)
 
     def test_a_dtype_alias(self):
-        self._check_for_warning(lambda: np.dtype("a"))
-        self._check_for_warning(lambda: np.dtype("a10"))
+        for dtype in ["a", "a10"]:
+            f = lambda: np.dtype(dtype)
+            self._check_for_warning(f)
+            self.assert_deprecated(f)
+            f = lambda: np.array(["hello", "world"]).astype("a10")
+            self._check_for_warning(f)
+            self.assert_deprecated(f)
 
 
 class TestDeprecatedArrayWrap(_DeprecationTestCase):


### PR DESCRIPTION
Fixes #26521 