### PR TITLE
BUG: fix assert in PyArry_ConcatenateArrays with StringDType

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -467,7 +467,6 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
         if (ret == NULL) {
             return NULL;
         }
-        assert(PyArray_DESCR(ret) == descr);
     }
 
     /*

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -504,6 +504,13 @@ def test_creation_functions():
     assert np.empty(3, dtype="T")[0] == ""
 
 
+def test_concatenate(string_list):
+    sarr = np.array(string_list, dtype="T")
+    sarr_cat = np.array(string_list + string_list, dtype="T")
+
+    assert_array_equal(np.concatenate([sarr], axis=0), sarr)
+
+
 def test_create_with_copy_none(string_list):
     arr = np.array(string_list, dtype=StringDType())
     # create another stringdtype array with an arena that has a different


### PR DESCRIPTION
The test I added triggers the assert deleted in this PR on main. Originally I hit this via [pandas' usage of PyArray_Concatenate](https://github.com/pandas-dev/pandas/blob/3b48b17e52f3f3837b9ba8551c932f44633b5ff8/pandas/_libs/arrays.pyx#L189).

The assert doesn't make any sense for dtypes that replace instances, like StringDType.