### PR TITLE
BUG: ``PyDataMem_SetHandler`` check capsule name

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -429,7 +429,7 @@ PyDataMem_SetHandler(PyObject *handler)
     PyObject *old_handler;
     PyObject *token;
     if (!PyCapsule_IsValid(handler, MEM_HANDLER_CAPSULE_NAME)) {
-        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'")
+        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'");
         return NULL;
     }
     if (PyContextVar_Get(current_handler, NULL, &old_handler)) {

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -37,9 +37,6 @@ static cache_bucket dimcache[NBUCKETS_DIM];
 
 static int _madvise_hugepage = 1;
 
-static const char *MEM_HANDLER_CAPSULE_NAME = "mem_handler";
-
-
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with
@@ -358,7 +355,7 @@ PyDataMem_UserNEW(size_t size, PyObject *mem_handler)
 {
     void *result;
     PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -373,7 +370,7 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler)
 {
     void *result;
     PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -387,7 +384,7 @@ NPY_NO_EXPORT void
 PyDataMem_UserFREE(void *ptr, size_t size, PyObject *mem_handler)
 {
     PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         WARN_NO_RETURN(PyExc_RuntimeWarning,
                      "Could not get pointer to 'mem_handler' from PyCapsule");
@@ -402,7 +399,7 @@ PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler)
 {
     void *result;
     PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -489,7 +486,7 @@ get_handler_name(PyObject *NPY_UNUSED(self), PyObject *args)
         }
     }
     handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         Py_DECREF(mem_handler);
         return NULL;
@@ -527,7 +524,7 @@ get_handler_version(PyObject *NPY_UNUSED(self), PyObject *args)
         }
     }
     handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
-        mem_handler, MEM_HANDLER_CAPSULE_NAME);
+            mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         Py_DECREF(mem_handler);
         return NULL;

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -428,15 +428,15 @@ PyDataMem_SetHandler(PyObject *handler)
 {
     PyObject *old_handler;
     PyObject *token;
-    if (!PyCapsule_IsValid(handler, MEM_HANDLER_CAPSULE_NAME)) {
-        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'");
-        return NULL;
-    }
     if (PyContextVar_Get(current_handler, NULL, &old_handler)) {
         return NULL;
     }
     if (handler == NULL) {
         handler = PyDataMem_DefaultHandler;
+    }
+    if (!PyCapsule_IsValid(handler, MEM_HANDLER_CAPSULE_NAME)) {
+        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'");
+        return NULL;
     }
     token = PyContextVar_Set(current_handler, handler);
     if (token == NULL) {

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -37,6 +37,9 @@ static cache_bucket dimcache[NBUCKETS_DIM];
 
 static int _madvise_hugepage = 1;
 
+static const char *MEM_HANDLER_CAPSULE_NAME = "mem_handler";
+
+
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with
@@ -354,7 +357,8 @@ NPY_NO_EXPORT void *
 PyDataMem_UserNEW(size_t size, PyObject *mem_handler)
 {
     void *result;
-    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -368,7 +372,8 @@ NPY_NO_EXPORT void *
 PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler)
 {
     void *result;
-    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -381,7 +386,8 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler)
 NPY_NO_EXPORT void
 PyDataMem_UserFREE(void *ptr, size_t size, PyObject *mem_handler)
 {
-    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         WARN_NO_RETURN(PyExc_RuntimeWarning,
                      "Could not get pointer to 'mem_handler' from PyCapsule");
@@ -395,7 +401,8 @@ NPY_NO_EXPORT void *
 PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler)
 {
     void *result;
-    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    PyDataMem_Handler *handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         return NULL;
     }
@@ -421,7 +428,7 @@ PyDataMem_SetHandler(PyObject *handler)
 {
     PyObject *old_handler;
     PyObject *token;
-    if (!PyCapsule_IsValid(handler, "mem_handler")) {
+    if (!PyCapsule_IsValid(handler, MEM_HANDLER_CAPSULE_NAME)) {
         PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'")
         return NULL;
     }
@@ -481,7 +488,8 @@ get_handler_name(PyObject *NPY_UNUSED(self), PyObject *args)
             return NULL;
         }
     }
-    handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         Py_DECREF(mem_handler);
         return NULL;
@@ -518,7 +526,8 @@ get_handler_version(PyObject *NPY_UNUSED(self), PyObject *args)
             return NULL;
         }
     }
-    handler = (PyDataMem_Handler *) PyCapsule_GetPointer(mem_handler, "mem_handler");
+    handler = (PyDataMem_Handler *) PyCapsule_GetPointer(
+        mem_handler, MEM_HANDLER_CAPSULE_NAME);
     if (handler == NULL) {
         Py_DECREF(mem_handler);
         return NULL;

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -421,6 +421,10 @@ PyDataMem_SetHandler(PyObject *handler)
 {
     PyObject *old_handler;
     PyObject *token;
+    if (!PyCapsule_IsValid(handler, "mem_handler")) {
+        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'")
+        return NULL;
+    }
     if (PyContextVar_Get(current_handler, NULL, &old_handler)) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -6,6 +6,7 @@
 #include "numpy/ndarraytypes.h"
 
 #define NPY_TRACE_DOMAIN 389047
+#define MEM_HANDLER_CAPSULE_NAME "mem_handler"
 
 NPY_NO_EXPORT PyObject *
 _get_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args));

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5234,7 +5234,8 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     /*
      * Initialize the default PyDataMem_Handler capsule singleton.
      */
-    PyDataMem_DefaultHandler = PyCapsule_New(&default_handler, "mem_handler", NULL);
+    PyDataMem_DefaultHandler = PyCapsule_New(
+            &default_handler, MEM_HANDLER_CAPSULE_NAME, NULL);
     if (PyDataMem_DefaultHandler == NULL) {
         goto err;
     }

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -47,13 +47,13 @@ def get_module(tmp_path):
              return old;
          """),
         ("set_wrong_capsule_name_data_policy", "METH_NOARGS", """
-             PyObject *secret_data =
+             PyObject *wrong_name_capsule =
                  PyCapsule_New(&secret_data_handler, "not_mem_handler", NULL);
-             if (secret_data == NULL) {
+             if (wrong_name_capsule == NULL) {
                  return NULL;
              }
-             PyObject *old = PyDataMem_SetHandler(secret_data);
-             Py_DECREF(secret_data);
+             PyObject *old = PyDataMem_SetHandler(wrong_name_capsule);
+             Py_DECREF(wrong_name_capsule);
              return old;
          """),
         ("set_old_policy", "METH_O", """

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -46,6 +46,16 @@ def get_module(tmp_path):
              Py_DECREF(secret_data);
              return old;
          """),
+        ("set_wrong_capsule_name_data_policy", "METH_NOARGS", """
+             PyObject *secret_data =
+                 PyCapsule_New(&secret_data_handler, "wrong_mem_handler", NULL);
+             if (secret_data == NULL) {
+                 return NULL;
+             }
+             PyObject *old = PyDataMem_SetHandler(secret_data);
+             Py_DECREF(secret_data);
+             return old;
+         """),
         ("set_old_policy", "METH_O", """
              PyObject *old;
              if (args != NULL && PyCapsule_CheckExact(args)) {
@@ -251,6 +261,10 @@ def test_set_policy(get_module):
     else:
         get_module.set_old_policy(orig_policy)
         assert get_handler_name() == orig_policy_name
+
+    with pytest.raises(ValueError,
+                       match="Capsule must be named 'mem_handler'"):
+        get_module.set_wrong_capsule_name_data_policy()
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -48,7 +48,7 @@ def get_module(tmp_path):
          """),
         ("set_wrong_capsule_name_data_policy", "METH_NOARGS", """
              PyObject *secret_data =
-                 PyCapsule_New(&secret_data_handler, "wrong_mem_handler", NULL);
+                 PyCapsule_New(&secret_data_handler, "not_mem_handler", NULL);
              if (secret_data == NULL) {
                  return NULL;
              }


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes https://github.com/numpy/numpy/issues/26137.

Tests capsule name and sets `PyErr` if not valid:
```c
    if (!PyCapsule_IsValid(handler, MEM_HANDLER_CAPSULE_NAME)) {
        PyErr_SetString(PyExc_ValueError, "Capsule must be named 'mem_handler'")
        return NULL;
    }
```