### PR TITLE
BUG: cast missing in PyPy-specific f2py code, pin spin in CI (#26534)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,7 +163,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libopenblas-dev ninja-build
-        pip install spin cython asv virtualenv packaging
+        pip install asv virtualenv packaging -r requirements/build_requirements.txt
     - name: Install NumPy
       run: |
         spin build -- -Dcpu-dispatch=none

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install build dependencies from PyPI
       run: |
-        python -m pip install spin Cython
+        python -m pip install -r requirements/build_requirements.txt
 
     - name: Install pkg-config
       run: |

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -122,7 +122,7 @@ f2py_cb_start_clock();
 #setdims#
 #ifdef PYPY_VERSION
 #define CAPI_ARGLIST_SETITEM(idx, value) PyList_SetItem((PyObject *)capi_arglist_list, idx, value)
-    capi_arglist_list = PySequence_List(capi_arglist);
+    capi_arglist_list = PySequence_List((PyObject *)capi_arglist);
     if (capi_arglist_list == NULL) goto capi_fail;
 #else
 #define CAPI_ARGLIST_SETITEM(idx, value) PyTuple_SetItem((PyObject *)capi_arglist, idx, value)


### PR DESCRIPTION
Backport of #26534.

Discovered when building SciPy with GCC14, which is more strict about casting. See pypy/pypy#4969.

* BUG: cast missing in PyPy-specific f2py code

* CI: use build_requirements.txt

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
