### PR TITLE
ENH: improve the error raised by ``numpy.isdtype`` 

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -360,7 +360,11 @@ def issubsctype(arg1, arg2):
     return issubclass(obj2sctype(arg1), obj2sctype(arg2))
 
 
-def _preprocess_dtype(dtype, err_msg):
+class _PreprocessDTypeError(Exception):
+    pass
+
+
+def _preprocess_dtype(dtype):
     """
     Preprocess dtype argument by:
       1. fetching type from a data type
@@ -369,7 +373,7 @@ def _preprocess_dtype(dtype, err_msg):
     if isinstance(dtype, ma.dtype):
         dtype = dtype.type
     if isinstance(dtype, ndarray) or dtype not in allTypes.values():
-        raise TypeError(f"{err_msg}, but it is a {type(dtype)}.")
+        raise _PreprocessDTypeError()
     return dtype
 
 
@@ -414,9 +418,13 @@ def isdtype(dtype, kind):
     True
 
     """
-    dtype = _preprocess_dtype(
-        dtype, err_msg="dtype argument must be a NumPy dtype"
-    )
+    try:
+        dtype = _preprocess_dtype(dtype)
+    except _PreprocessDTypeError:
+        raise TypeError(
+            "dtype argument must be a NumPy dtype, "
+            f"but it is a {type(dtype)}."
+        ) from None
 
     input_kinds = kind if isinstance(kind, tuple) else (kind,)
 
@@ -440,12 +448,20 @@ def isdtype(dtype, kind):
                 sctypes["int"] + sctypes["uint"] +
                 sctypes["float"] + sctypes["complex"]
             )
-        else:
-            kind = _preprocess_dtype(
-                kind,
-                err_msg="kind argument must be comprised of "
-                        "NumPy dtypes or strings only"
+        elif isinstance(kind, str):
+            raise ValueError(
+                "kind argument is a string, but"
+                f" {repr(kind)} is not a known kind name."
             )
+        else:
+            try:
+                kind = _preprocess_dtype(kind)
+            except _PreprocessDTypeError:
+                raise TypeError(
+                    "kind argument must be comprised of "
+                    "NumPy dtypes or strings only, "
+                    f"but is a {type(kind)}."
+                ) from None
             processed_kinds.add(kind)
 
     return dtype in processed_kinds

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -471,6 +471,8 @@ class TestIsDType:
         with assert_raises_regex(TypeError, r".*must be a NumPy dtype.*"):
             np.isdtype("int64", np.int64)
         with assert_raises_regex(TypeError, r".*kind argument must.*"):
+            np.isdtype(np.int64, 1)
+        with assert_raises_regex(ValueError, r".*not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):


### PR DESCRIPTION
Backport of #26456.

When passing an invalid string kind to `numpy.isdtype`, it raises this error:

``` python
np.isdtype(np.uint64, "integer")
# TypeError: kind argument must be comprised of NumPy dtypes or strings only, but it is a <class 'str'>.
```

That's not really helpful: we did pass in a string (as the first part of the message requires), we just passed the _wrong_ string.

Improving this is somewhat tricky: `_preprocess_dtype` is used to check both dtypes and kinds, and the only difference is the error message that is passed in. To work around that, I've added a boolean parameter to know when to change the error message.

However, this function now feels a bit weird to me, so instead we could also generate `err_msg` within `_preprocess_dtype` and just pass something like `kind="kind"` or `kind="dtype"` (I'm not attached to that name, though).

Edit: with the last two commits I changed the function to generate the error message based on the `is_kind` flag, and to raise a `ValueError` if the wrong string was passed.

* improve the error message raised by ``numpy.isdtype`` if the kind is a string

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
