### PR TITLE
MAINT: Remove redundant print from bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,7 +56,7 @@ body:
     label: "Runtime Environment:"
     description: |
       1. Install `threadpoolctl` (e.g. with `pip` or `conda`)
-      2. Paste the output of `import numpy; print(numpy.show_runtime())`.
+      2. Paste the output of `import numpy; numpy.show_runtime()`.
 
       Note: Only valid for NumPy 1.24 or newer.
   validations:


### PR DESCRIPTION
The bug report issue template asks to `print(np.show_runtime())`, but `np.show_runtime()` already prints its results and returns `None`, so the printing is unnecessary (and slightly noisy due to a trailing `None`).