### PR TITLE
BUG: Fix typo in array-wrap code that lead to memory leak

### DIFF
--- a/numpy/_core/src/multiarray/arraywrap.c
+++ b/numpy/_core/src/multiarray/arraywrap.c
@@ -159,7 +159,7 @@ npy_apply_wrap(
         }
         else {
             /* Replace passed wrap/wrap_type (borrowed refs) with new_wrap/type. */
-            PyObject *new_wrap = PyArray_LookupSpecial_OnInstance(
+            new_wrap = PyArray_LookupSpecial_OnInstance(
                     original_out, npy_ma_str_array_wrap);
             if (new_wrap != NULL) {
                 wrap = new_wrap;
@@ -177,11 +177,13 @@ npy_apply_wrap(
      */
     if (!return_scalar && !force_wrap
             && (PyObject *)Py_TYPE(obj) == wrap_type) {
+        Py_XDECREF(new_wrap);
         Py_INCREF(obj);
         return obj;
     }
 
     if (wrap == Py_None) {
+        Py_XDECREF(new_wrap);
         Py_INCREF(obj);
         if (return_scalar) {
             /* 
@@ -239,8 +241,9 @@ npy_apply_wrap(
             wrap, arr, py_context,
             (return_scalar && PyArray_NDIM(arr) == 0) ? Py_True : Py_False,
             NULL);
-    if (res != NULL)
+    if (res != NULL) {
         goto finish;
+    }
     else if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
         goto finish;
     }

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -18,7 +18,7 @@ from numpy.testing import (
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_array_max_ulp, assert_allclose, assert_no_warnings, suppress_warnings,
     _gen_alignment_data, assert_array_almost_equal_nulp, IS_WASM, IS_MUSL,
-    IS_PYPY
+    IS_PYPY, HAS_REFCOUNT
     )
 from numpy.testing._private.utils import _glibc_older_than
 
@@ -262,6 +262,17 @@ class TestOut:
             with assert_raises(TypeError):
                 # Out argument must be tuple, since there are multiple outputs.
                 r1, r2 = np.frexp(d, out=o1, subok=subok)
+
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_out_wrap_no_leak(self):
+        # Regression test for gh-26545
+        class ArrSubclass(np.ndarray):
+            pass
+
+        arr = np.arange(10).view(ArrSubclass)
+
+        arr *= 1
+        assert sys.getrefcount(arr) == 2
 
 
 class TestComparisons:


### PR DESCRIPTION
The typo lead to the reference not being correctly XDECREF'd, there was another (almost never taken) path that was missing the decref (could use goto there also, but OK).

Also adds a regression test for the code where it was noticed.

Closes gh-26545