### PR TITLE
BUG: Fix in1d fast-path range

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -853,30 +853,16 @@ def _in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         if ar2.dtype == bool:
             ar2 = ar2.astype(np.uint8)
 
-        ar2_min = np.min(ar2)
-        ar2_max = np.max(ar2)
+        ar2_min = int(np.min(ar2))
+        ar2_max = int(np.max(ar2))
 
-        ar2_range = int(ar2_max) - int(ar2_min)
+        ar2_range = ar2_max - ar2_min
 
         # Constraints on whether we can actually use the table method:
         #  1. Assert memory usage is not too large
         below_memory_constraint = ar2_range <= 6 * (ar1.size + ar2.size)
         #  2. Check overflows for (ar2 - ar2_min); dtype=ar2.dtype
         range_safe_from_overflow = ar2_range <= np.iinfo(ar2.dtype).max
-        #  3. Check overflows for (ar1 - ar2_min); dtype=ar1.dtype
-        if ar1.size > 0:
-            ar1_min = np.min(ar1)
-            ar1_max = np.max(ar1)
-
-            # After masking, the range of ar1 is guaranteed to be
-            # within the range of ar2:
-            ar1_upper = min(int(ar1_max), int(ar2_max))
-            ar1_lower = max(int(ar1_min), int(ar2_min))
-
-            range_safe_from_overflow &= all((
-                ar1_upper - int(ar2_min) <= np.iinfo(ar1.dtype).max,
-                ar1_lower - int(ar2_min) >= np.iinfo(ar1.dtype).min
-            ))
 
         # Optimal performance is for approximately
         # log10(size) > (log10(range) - 2.27) / 0.927.
@@ -906,8 +892,8 @@ def _in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
 
             # Mask out elements we know won't work
             basic_mask = (ar1 <= ar2_max) & (ar1 >= ar2_min)
-            outgoing_array[basic_mask] = isin_helper_ar[ar1[basic_mask] -
-                                                        ar2_min]
+            outgoing_array[basic_mask] = isin_helper_ar[
+                    np.subtract(ar1[basic_mask], ar2_min, dtype=np.intp)]
 
             return outgoing_array
         elif kind == 'table':  # not range_safe_from_overflow

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -400,6 +400,7 @@ class TestSetOps:
             (np.uint16, np.uint8),
             (np.uint8, np.int16),
             (np.int16, np.uint8),
+            (np.uint64, np.int64),
         ]
     )
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
@@ -415,10 +416,8 @@ class TestSetOps:
 
         expected = np.array([True, True, False, False])
 
-        expect_failure = kind == "table" and any((
-            dtype1 == np.int8 and dtype2 == np.int16,
-            dtype1 == np.int16 and dtype2 == np.int8
-        ))
+        expect_failure = kind == "table" and (
+            dtype1 == np.int16 and dtype2 == np.int8)
 
         if expect_failure:
             with pytest.raises(RuntimeError, match="exceed the maximum"):


### PR DESCRIPTION
The code never worked when the first array was uint and the second one had negative values, NumPy 2 makes that slightly worse because the reverse is also true (the second one is uint).

I did that by just using intp.  The indexing operation has to cast anyway, so it seems unlikely that we have much of a downside in general.
Casting there seems to make one bounds check just unnecessary, so removed it.

(Yes, I guess indexing could use a buffered iterator so if both ar1 and ar2 are huge and ar1[basic_mask] is so huge it barely fits the memory, that is a  downside.  I don't think I care, but if someone does it can be modified probably)
