### PR TITLE
BUG: fancy indexing copy

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1960,6 +1960,10 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
         tmp_arr = (PyArrayObject *)op;
     }
 
+    if (tmp_arr && solve_may_share_memory(self, tmp_arr, 1) == 1) {
+        Py_SETREF(tmp_arr, (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER));
+    }
+
     /*
      * Special case for very simple 1-d fancy indexing, which however
      * is quite common. This saves not only a lot of setup time in the
@@ -1997,10 +2001,6 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
                     PyArray_DESCR(self), PyArray_DESCR(self),
                     0, &cast_info, &transfer_flags) != NPY_SUCCEED) {
                 goto fail;
-            }
-
-            if (solve_may_share_memory(self, tmp_arr, 1) == 1) {
-                tmp_arr = (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER);
             }
 
             /* trivial_set checks the index for us */

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1999,6 +1999,10 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
                 goto fail;
             }
 
+            if (solve_may_share_memory(self, tmp_arr, 1) == 1) {
+                tmp_arr = (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER);
+            }
+
             /* trivial_set checks the index for us */
             if (mapiter_trivial_set(
                     self, ind, tmp_arr, is_aligned, &cast_info) < 0) {

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1960,7 +1960,7 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
         tmp_arr = (PyArrayObject *)op;
     }
 
-    if (tmp_arr && solve_may_share_memory(self, tmp_arr, 1) == 1) {
+    if (tmp_arr && solve_may_share_memory(self, tmp_arr, 1) != 0) {
         Py_SETREF(tmp_arr, (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER));
     }
 

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -133,6 +133,13 @@ class TestIndexing:
         b = np.array([])
         assert_raises(IndexError, a.__getitem__, b)
 
+    def test_gh_26542(self):
+        a = np.array([0, 1, 2])
+        idx = np.array([2, 1, 0])
+        a[idx] = a
+        expected = np.array([2, 1, 0])
+        assert_equal(a, expected)
+
     def test_ellipsis_index(self):
         a = np.array([[1, 2, 3],
                       [4, 5, 6],

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -140,6 +140,21 @@ class TestIndexing:
         expected = np.array([2, 1, 0])
         assert_equal(a, expected)
 
+    def test_gh_26542_2d(self):
+        a = np.array([[0, 1, 2]])
+        idx_row = np.zeros(3, dtype=int)
+        idx_col = np.array([2, 1, 0])
+        a[idx_row, idx_col] = a
+        expected = np.array([[2, 1, 0]])
+        assert_equal(a, expected)
+
+    def test_gh_26542_index_overlap(self):
+        arr = np.arange(100)
+        expected_vals = np.copy(arr[:-10])
+        arr[10:] = arr[:-10]
+        actual_vals = arr[10:]
+        assert_equal(actual_vals, expected_vals)
+
     def test_ellipsis_index(self):
         a = np.array([[1, 2, 3],
                       [4, 5, 6],


### PR DESCRIPTION
* Fixes gh-26542

* For these very simple advanced indexing cases, if the `result` and `self` arrays share the same data pointer, use a copy of `result` to assign values to `self`, otherwise the outcome of the fancy indexing suffers from mutation of `result` before the assignments are complete.