### PR TITLE
BUG: fix setxor1d when input arrays aren't 1D

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -686,7 +686,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
         Input arrays.
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
-        can speed up the calculation.  Default is False.
+        can speed up the calculation. If the input arrays are not 1D,
+        np.ravel is called. Default is False.
 
     Returns
     -------
@@ -705,6 +706,11 @@ def setxor1d(ar1, ar2, assume_unique=False):
     if not assume_unique:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
+    else:
+        if np.ndim(ar1) > 1:
+            ar1 = np.ravel(ar1)
+        if np.ndim(ar2) > 1:
+            ar2 = np.ravel(ar2)
 
     aux = np.concatenate((ar1, ar2))
     if aux.size == 0:

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -686,8 +686,7 @@ def setxor1d(ar1, ar2, assume_unique=False):
         Input arrays.
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
-        can speed up the calculation. If the input arrays are not 1D,
-        np.ravel is called. Default is False.
+        can speed up the calculation. Default is False.
 
     Returns
     -------
@@ -706,13 +705,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
     if not assume_unique:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
-    else:
-        if np.ndim(ar1) > 1:
-            ar1 = np.ravel(ar1)
-        if np.ndim(ar2) > 1:
-            ar2 = np.ravel(ar2)
 
-    aux = np.concatenate((ar1, ar2))
+    aux = np.concatenate((ar1, ar2), axis=None)
     if aux.size == 0:
         return aux
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -104,6 +104,14 @@ class TestSetOps:
         ec = np.array([1, 2, 3, 4, 5, 6])
         c = setxor1d(a, b)
         assert_array_equal(c, ec)
+
+        assert_array_equal([], setxor1d([], []))
+
+    def test_setxor1d_unique(self):
+        a = np.array([1, 8, 2, 3])
+        b = np.array([6, 5, 4, 8])
+
+        ec = np.array([1, 2, 3, 4, 5, 6])
         c = setxor1d(a, b, assume_unique=True)
         assert_array_equal(c, ec)
 
@@ -113,8 +121,6 @@ class TestSetOps:
         ec = np.array([1, 2, 3, 4, 5, 6])
         c = setxor1d(a, b, assume_unique=True)
         assert_array_equal(c, ec)
-
-        assert_array_equal([], setxor1d([], []))
 
     def test_ediff1d(self):
         zero_elem = np.array([])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -104,6 +104,15 @@ class TestSetOps:
         ec = np.array([1, 2, 3, 4, 5, 6])
         c = setxor1d(a, b)
         assert_array_equal(c, ec)
+        c = setxor1d(a, b, assume_unique=True)
+        assert_array_equal(c, ec)
+
+        a = np.array([[1], [8], [2], [3]])
+        b = np.array([[6, 5], [4, 8]])
+
+        ec = np.array([1, 2, 3, 4, 5, 6])
+        c = setxor1d(a, b, assume_unique=True)
+        assert_array_equal(c, ec)
 
         assert_array_equal([], setxor1d([], []))
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1394,6 +1394,11 @@ def setxor1d(ar1, ar2, assume_unique=False):
     if not assume_unique:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
+    else:
+        if np.ndim(ar1) > 1:
+            ar1 = np.ravel(ar1)
+        if np.ndim(ar2) > 1:
+            ar2 = np.ravel(ar2)
 
     aux = ma.concatenate((ar1, ar2))
     if aux.size == 0:

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1394,13 +1394,8 @@ def setxor1d(ar1, ar2, assume_unique=False):
     if not assume_unique:
         ar1 = unique(ar1)
         ar2 = unique(ar2)
-    else:
-        if np.ndim(ar1) > 1:
-            ar1 = np.ravel(ar1)
-        if np.ndim(ar2) > 1:
-            ar2 = np.ravel(ar2)
 
-    aux = ma.concatenate((ar1, ar2))
+    aux = ma.concatenate((ar1, ar2), axis=None)
     if aux.size == 0:
         return aux
     aux.sort()

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1659,6 +1659,17 @@ class TestArraySetOps:
         assert_(isinstance(test, MaskedArray))
         assert_equal(test, [1, 2, 3, 4, 5, 6])
         #
+        assert_array_equal([], setxor1d([], []))
+
+    def test_setxor1d_unique(self):
+        # Test setxor1d with assume_unique=True
+        a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])
+        b = [1, 2, 3, 4, 5]
+        test = setxor1d(a, b, assume_unique=True)
+        assert_equal(test, array([3, 4, 7, -1], mask=[0, 0, 0, 1]))
+        #
+        a = array([1, 8, 2, 3], mask=[0, 1, 0, 0])
+        b = array([6, 5, 4, 8], mask=[0, 0, 0, 1])
         test = setxor1d(a, b, assume_unique=True)
         assert_(isinstance(test, MaskedArray))
         assert_equal(test, [1, 2, 3, 4, 5, 6])
@@ -1668,8 +1679,6 @@ class TestArraySetOps:
         test = setxor1d(a, b, assume_unique=True)
         assert_(isinstance(test, MaskedArray))
         assert_equal(test, [1, 2, 3, 4, 5, 6])
-        #
-        assert_array_equal([], setxor1d([], []))
 
     def test_isin(self):
         # the tests for in1d cover most of isin's behavior

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1659,6 +1659,16 @@ class TestArraySetOps:
         assert_(isinstance(test, MaskedArray))
         assert_equal(test, [1, 2, 3, 4, 5, 6])
         #
+        test = setxor1d(a, b, assume_unique=True)
+        assert_(isinstance(test, MaskedArray))
+        assert_equal(test, [1, 2, 3, 4, 5, 6])
+        #
+        a = array([[1], [8], [2], [3]])
+        b = array([[6, 5], [4, 8]])
+        test = setxor1d(a, b, assume_unique=True)
+        assert_(isinstance(test, MaskedArray))
+        assert_equal(test, [1, 2, 3, 4, 5, 6])
+        #
         assert_array_equal([], setxor1d([], []))
 
     def test_isin(self):


### PR DESCRIPTION
See #14670.

When `assume_unique=True`, `setxor1d` attemptes to concatenate arrays with potentially incompatible dimensions. The fix implemented here calls `np.ravel` on the input arrays. The choice to call `np.ravel` instead of enforcing that the input arrays are 1D comes from the consensus in the linked issue to avoid breaking existing code.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
