### PR TITLE
CI, BLD: Upgrade to Pyodide 0.26.0 for Emscripten/Pyodide CI job

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -45,13 +45,13 @@ jobs:
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     env:
-      PYODIDE_VERSION: 0.25.1
+      PYODIDE_VERSION: 0.26.0
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
       # The appropriate versions can be found in the Pyodide repodata.json
       # "info" field, or in Makefile.envs:
       # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
-      PYTHON_VERSION: 3.11.3
-      EMSCRIPTEN_VERSION: 3.1.46
+      PYTHON_VERSION: 3.12.1
+      EMSCRIPTEN_VERSION: 3.1.58
       NODE_VERSION: 18
     steps:
       - name: Checkout NumPy
@@ -75,7 +75,7 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install "pydantic<2" pyodide-build==${{ env.PYODIDE_VERSION }}
+        run: pip install pyodide-build==${{ env.PYODIDE_VERSION }}
 
       - name: Find installation for pyodide-build
         shell: python
@@ -93,7 +93,11 @@ jobs:
 
       - name: Build NumPy for Pyodide
         run: |
-          pyodide build -Cbuild-dir=build -Csetup-args="--cross-file=$PWD/tools/ci/emscripten/emscripten.meson.cross" -Csetup-args="-Dblas=none" -Csetup-args="-Dlapack=none"
+          pyodide build \
+          -Cbuild-dir=build \
+          -Csetup-args="--cross-file=$PWD/tools/ci/emscripten/emscripten.meson.cross" \
+          -Csetup-args="-Dblas=none" \
+          -Csetup-args="-Dlapack=none"
 
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This commit bumps the version of Pyodide in the out-of-tree Pyodide/WASM build for NumPy (`emscripten.yml`) to version `0.26.0`. The Python interpreter (`3.11.3` → `3.12.1`) and the Emscripten toolchain version (`3.1.46` → `3.1.58`) have been updated as well.

## What issue does this PR reference?

Closes gh-26467

## Footnotes

Pyodide version 0.26.0 on GitHub Releases: [pyodide/pyodide@`0.26.0` (release)](https://github.com/pyodide/pyodide/releases/tag/0.26.0)
Pyodide version 0.26.0 release notes and announcement: https://blog.pyodide.org/posts/0.26-release/
The most recent changes/updates to this workflow file before this PR: gh-25894, gh-26134
