### PR TITLE
MAINT: Unpin pydata-sphinx-theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,8 +35,9 @@ dependencies:
   - scipy
   - pandas
   - matplotlib
-  - pydata-sphinx-theme=0.15.2
+  - pydata-sphinx-theme>=0.15.2
   - doxygen
+  - towncrier
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe>4.33.0
   # For linting

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,7 +1,7 @@
 # doxygen required, use apt-get or dnf
 sphinx==7.2.6
 numpydoc==1.4
-pydata-sphinx-theme==0.15.2
+pydata-sphinx-theme>=0.15.2
 sphinx-design
 scipy
 matplotlib


### PR DESCRIPTION
With the more recent releases of PyData Sphinx theme containing many accessibility and usability fixes, I believe we can now relax the pin on it. 

Also adds towncrier to docs dependencies for conda to avoid an error when building the docs locally.