### PR TITLE
DOC: Added web docs for missing ma and strings routines

### DIFF
--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -416,10 +416,25 @@ Miscellanea
 
    ma.allequal
    ma.allclose
+   ma.amax
+   ma.amin
    ma.apply_along_axis
    ma.apply_over_axes
    ma.arange
    ma.choose
+   ma.compress_nd
+   ma.convolve
+   ma.correlate
    ma.ediff1d
+   ma.flatten_mask
+   ma.flatten_structured_array
+   ma.fromflex
    ma.indices
+   ma.left_shift
+   ma.ndim
+   ma.put
+   ma.putmask
+   ma.right_shift
+   ma.round_
+   ma.take
    ma.where

--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -31,6 +31,11 @@ String operations
    :toctree: generated/
 
    add
+   center
+   capitalize
+   decode
+   encode
+   expandtabs
    ljust
    lower
    lstrip


### PR DESCRIPTION
This commit updates the routines.ma.rst file to enable web docs for several routines in the `ma` module. Similar to #23352 See #21351 for a script to locate similar items in any module.

[skip actions] [skip azp] [skip cirrus]