### PR TITLE
BUG: Fix AxisError when only one argument is provided

### DIFF
--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -175,15 +175,9 @@ class AxisError(ValueError, IndexError):
     __slots__ = ("axis", "ndim", "_msg")
 
     def __init__(self, axis, ndim=None, msg_prefix=None):
-        if ndim is msg_prefix is None:
-            # single-argument form: directly set the error message
-            self._msg = axis
-            self.axis = None
-            self.ndim = None
-        else:
-            self._msg = msg_prefix
-            self.axis = axis
-            self.ndim = ndim
+        self._msg = msg_prefix
+        self.axis = axis
+        self.ndim = ndim
 
     def __str__(self):
         axis = self.axis
@@ -192,7 +186,10 @@ class AxisError(ValueError, IndexError):
         if axis is ndim is None:
             return self._msg
         else:
-            msg = f"axis {axis} is out of bounds for array of dimension {ndim}"
+            if ndim is None:
+                msg = f"axis {axis} is out of bounds"
+            else:
+                msg = f"axis {axis} is out of bounds for array of dimension {ndim}"
             if self._msg is not None:
                 msg = f"{self._msg}: {msg}"
             return msg


### PR DESCRIPTION
Previously str(AxisError(1)) would raise 'TypeError: __str__ returned non-string (type int)'. It now results in a useful error message.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
