### PR TITLE
DOC: Added web docs for missing ma and strings routines

### DIFF
--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -416,10 +416,25 @@ Miscellanea
 
    ma.allequal
    ma.allclose
+   ma.amax
+   ma.amin
    ma.apply_along_axis
    ma.apply_over_axes
    ma.arange
    ma.choose
+   ma.compress_nd
+   ma.convolve
+   ma.correlate
    ma.ediff1d
+   ma.flatten_mask
+   ma.flatten_structured_array
+   ma.fromflex
    ma.indices
+   ma.left_shift
+   ma.ndim
+   ma.put
+   ma.putmask
+   ma.right_shift
+   ma.round_
+   ma.take
    ma.where

--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -31,6 +31,10 @@ String operations
    :toctree: generated/
 
    add
+   center
+   capitalize
+   decode
+   encode
    ljust
    lower
    lstrip


### PR DESCRIPTION
Backport of #26571.

This commit updates the routines.ma.rst file to enable web docs for several routines in the `ma` module. Similar to #23352 See #21351 for a script to locate similar items in any module.

[skip actions] [skip azp] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
