### PR TITLE
BUG: catch invalid fixed-width dtype sizes

### DIFF
--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -1462,7 +1462,7 @@ string_expandtabs_length(Buffer<enc> buf, npy_int64 tabsize)
                 line_pos = 0;
             }
         }
-        if (new_len == PY_SSIZE_T_MAX || new_len < 0) {
+        if (new_len > INT_MAX  || new_len < 0) {
             npy_gil_error(PyExc_OverflowError, "new string is too long");
             return -1;
         }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -236,6 +236,22 @@ class TestBuiltin:
         with pytest.raises(ValueError):
             type(np.dtype("U"))(-1)
 
+        # OverflowError on 32 bit
+        with pytest.raises((TypeError, OverflowError)):
+            # see gh-26556
+            type(np.dtype("S"))(2**61)
+
+        with pytest.raises(TypeError):
+            np.dtype("S1234hello")
+
+    def test_leading_zero_parsing(self):
+        dt1 = np.dtype('S010')
+        dt2 = np.dtype('S10')
+
+        assert dt1 == dt2
+        assert repr(dt1) == "dtype('S10')"
+        assert dt1.itemsize == 10
+
 
 class TestRecord:
     def test_equivalent_record(self):

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -716,6 +716,7 @@ class TestMethods:
     def test_expandtabs_raises_overflow(self, dt):
         with pytest.raises(OverflowError, match="new string is too long"):
             np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), sys.maxsize)
+            np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), 2**61)
 
     FILL_ERROR = "The fill character must be exactly one character long"
 


### PR DESCRIPTION
Fixes #26556 

The ultimate cause was the error checking for invalid dtype names like `'S' + str(2**61)` was incorrect. The root cause in the issue is it cast from long to int without doing any kind of overflow detection.

I also noticed another issue while I was debugging: the docs for `strtol` say that it returns 0 if the string isn't representable as an int and we need to check for that case too. It's a little tricky to do that, because we also allow types like `'S0'`, which is why the check is written in a kind of weird way with a gnarly if statement. Very open to alternative ways to write that.

Also noticed that `expandtabs` was assuming `PY_SSIZE_T_MAX` is the largest representable string, but that's wrong, it's INT_MAX because of the conversion form `long` to `int` on the result of `strtol`.