### PR TITLE
ENH: Warn if ``mmap_mode`` is passed to ``np.load`` on zip-files

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -468,7 +468,9 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         if magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
             # warn if user passed `mmap_mode`
             if mmap_mode is not None:
-                warnings.warn("`mmap_mode` with zip-files (e.g. .npz) is unsupported")
+                warnings.warn(
+                    "`mmap_mode` with zip-files (e.g. .npz) is unsupported"
+                )
             # zip-file (assume .npz)
             # Potentially transfer file ownership to NpzFile
             stack.pop_all()

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -466,6 +466,9 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         # to seek past the beginning of the file
         fid.seek(-min(N, len(magic)), 1)  # back-up
         if magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
+            # warn if user passed `mmap_mode`
+            if mmap_mode is not None:
+                warnings.warn("`mmap_mode` with zip-files (e.g. .npz) is unsupported")
             # zip-file (assume .npz)
             # Potentially transfer file ownership to NpzFile
             stack.pop_all()


### PR DESCRIPTION
`mmap_mode` is unused on zip-files, which is confusing when slicing .npz files isn't faster than loading the whole array.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
