### PR TITLE
BUG: Fix memory leaks found by valgrind

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4222,6 +4222,7 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrFromType(int type)
 {
     PyArray_Descr *ret = NULL;
+    npy_bool is_stringdtype = (type == NPY_VSTRING || type == NPY_VSTRINGLTR);
 
     if (type < 0) {
         /*
@@ -4233,7 +4234,7 @@ PyArray_DescrFromType(int type)
          */
         ret = NULL;
     }
-    else if (type == NPY_VSTRING || type == NPY_VSTRINGLTR) {
+    else if  (is_stringdtype) {
         ret = (PyArray_Descr *)new_stringdtype_instance(NULL, 1);
     }
     // builtin legacy dtypes
@@ -4280,7 +4281,7 @@ PyArray_DescrFromType(int type)
         PyErr_SetString(PyExc_ValueError,
                 "Invalid data-type for array");
     }
-    else {
+    else if (!is_stringdtype) {
         Py_INCREF(ret);
     }
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2020,6 +2020,7 @@ arraydescr_dealloc(PyArray_Descr *self)
 {
     Py_XDECREF(self->typeobj);
     if (!PyDataType_ISLEGACY(self)) {
+        Py_TYPE(self)->tp_free((PyObject *)self);
         return;
     }
     _PyArray_LegacyDescr *lself = (_PyArray_LegacyDescr *)self;

--- a/numpy/_core/src/multiarray/stringdtype/casts.c
+++ b/numpy/_core/src/multiarray/stringdtype/casts.c
@@ -894,6 +894,7 @@ string_to_pyfloat(char *in, int has_null,
                 goto fail;                                                    \
             }                                                                 \
             double dval = PyFloat_AS_DOUBLE(pyfloat_value);                   \
+            Py_DECREF(pyfloat_value);                                         \
             npy_##typename fval = (double_to_float)(dval);                    \
                                                                               \
             if (NPY_UNLIKELY(isinf_name(fval) && !(npy_isinf(dval)))) {       \


### PR DESCRIPTION
Backport of #26586.

Fixes #26581 (I think).

I'd appreciate it if @seberg could re-run valgrind with these changes to let me know if I got everything. valgrind is so slow on my laptop I didn't have the patience to wait for it to run the full stringdtype tests.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
