### PR TITLE
DOC: Various documentation updates

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -19,7 +19,7 @@ Ruff plugin
 ===========
 
 Many of the changes covered in the 2.0 release notes and in this migration
-guide can be automatically adapted to in downstream code with a dedicated
+guide can be automatically adapted in downstream code with a dedicated
 `Ruff <https://docs.astral.sh/ruff/>`__ rule, namely rule
 `NPY201 <https://docs.astral.sh/ruff/rules/numpy2-deprecation/>`__.
 
@@ -43,9 +43,8 @@ NumPy 2.0 changes promotion (the result of combining dissimilar data types)
 as per :ref:`NEP 50 <NEP50>`. Please see the NEP for details on this change.
 It includes a table of example changes and a backwards compatibility section.
 
-The largest backwards compatibility change of this is that it means that
-the precision of scalars is now preserved consistently.
-Two examples are:
+The largest backwards compatibility change is that the precision of scalars
+is now preserved consistently.  Two examples are:
 
 * ``np.float32(3) + 3.`` now returns a float32 when it previously returned
   a float64.
@@ -97,7 +96,7 @@ C-API Changes
 =============
 
 Some definitions were removed or replaced due to being outdated or
-unmaintainable.  Some new API definition will evaluate differently at
+unmaintainable.  Some new API definitions will evaluate differently at
 runtime between NumPy 2.0 and NumPy 1.x.
 Some are defined in ``numpy/_core/include/numpy/npy_2_compat.h``
 (for example ``NPY_DEFAULT_INT``) which can be vendored in full or part
@@ -116,10 +115,10 @@ The ``PyArray_Descr`` struct has been changed
 One of the most impactful C-API changes is that the ``PyArray_Descr`` struct
 is now more opaque to allow us to add additional flags and have
 itemsizes not limited by the size of ``int`` as well as allow improving
-structured dtypes in the future and not burdon new dtypes with their fields.
+structured dtypes in the future and not burden new dtypes with their fields.
 
 Code which only uses the type number and other initial fields is unaffected.
-Most code will hopefull mainly access the ``->elsize`` field, when the
+Most code will hopefully mainly access the ``->elsize`` field, when the
 dtype/descriptor itself is attached to an array (e.g. ``arr->descr->elsize``)
 this is best replaced with ``PyArray_ITEMSIZE(arr)``.
 
@@ -127,7 +126,7 @@ Where not possible, new accessor functions are required:
 
 * ``PyDataType_ELSIZE`` and ``PyDataType_SET_ELSIZE`` (note that the result
   is now ``npy_intp`` and not ``int``).
-* ``PyDataType_ALIGNENT``
+* ``PyDataType_ALIGNMENT``
 * ``PyDataType_FIELDS``, ``PyDataType_NAMES``, ``PyDataType_SUBARRAY``
 * ``PyDataType_C_METADATA``
 
@@ -146,7 +145,7 @@ or adding ``npy2_compat.h`` into your code base and explicitly include it
 when compiling with NumPy 1.x (as they are new API).
 Including the file has no effect on NumPy 2.
 
-Please do not hesitate to open a NumPy issue, if you require assistence or
+Please do not hesitate to open a NumPy issue, if you require assistance or
 the provided functions are not sufficient.
 
 **Custom User DTypes:**
@@ -180,7 +179,7 @@ Functionality which previously did not require import includes:
 
 Increased maximum number of dimensions
 --------------------------------------
-The maximum number of dimensions (and arguments) was increased to 64, this
+The maximum number of dimensions (and arguments) was increased to 64. This
 affects the ``NPY_MAXDIMS`` and ``NPY_MAXARGS`` macros.
 It may be good to review their use, and we generally encourage you to
 not use these macros (especially ``NPY_MAXARGS``), so that a future version of
@@ -237,7 +236,7 @@ Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html
 Main namespace
 --------------
 
-About 100 members of the main ``np`` namespace has been deprecated, removed, or
+About 100 members of the main ``np`` namespace have been deprecated, removed, or
 moved to a new place. It was done to reduce clutter and establish only one way to
 access a given attribute. The table below shows members that have been removed:
 
@@ -247,6 +246,7 @@ removed member          migration guideline
 add_docstring           It's still available as ``np.lib.add_docstring``.
 add_newdoc              It's still available as ``np.lib.add_newdoc``.
 add_newdoc_ufunc        It's an internal function and doesn't have a replacement.
+alltrue                 Use ``all`` instead.
 asfarray                Use ``np.asarray`` with a float dtype instead.
 byte_bounds             Now it's available under ``np.lib.array_utils.byte_bounds``
 cast                    Use ``np.asarray(arr, dtype=dtype)`` instead.
@@ -254,6 +254,7 @@ cfloat                  Use ``np.complex128`` instead.
 clongfloat              Use ``np.clongdouble`` instead.
 compat                  There's no replacement, as Python 2 is no longer supported.
 complex\_               Use ``np.complex128`` instead.
+cumproduct              Use ``np.cumprod`` instead.
 DataSource              It's still available as ``np.lib.npyio.DataSource``.
 deprecate               Emit ``DeprecationWarning`` with ``warnings.warn`` directly,
                         or use ``typing.deprecated``.
@@ -287,6 +288,7 @@ longfloat               Use ``np.longdouble`` instead.
 lookfor                 Search NumPy's documentation directly.
 obj2sctype              Use ``np.dtype(obj).type`` instead.
 PINF                    Use ``np.inf`` instead.
+product                 Use ``np.prod`` instead.
 PZERO                   Use ``0.0`` instead.
 recfromcsv              Use ``np.genfromtxt`` with comma delimiter instead.
 recfromtxt              Use ``np.genfromtxt`` instead.
@@ -302,6 +304,7 @@ set_string_function     Use ``np.set_printoptions`` instead with a formatter
                         for custom printing of NumPy objects.
 singlecomplex           Use ``np.complex64`` instead.
 string\_                Use ``np.bytes_`` instead.
+sometrue                Use ``any`` instead.
 source                  Use ``inspect.getsource`` instead.
 tracemalloc_domain      It's now available from ``np.lib``.
 unicode\_               Use ``np.str_`` instead.

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -182,21 +182,16 @@ site-packages directory.
             $python setup.py install
             will install the module in your site-packages file.
 
-            See the distutils section of
-            'Extending and Embedding the Python Interpreter'
-            at docs.python.org for more information.
+            See the setuptools section 'Building Extension Modules'
+            at setuptools.pypa.io for more information.
         '''
 
+        from setuptools import setup, Extension
+        import numpy as np
 
-        from distutils.core import setup, Extension
+        module1 = Extension('spam', sources=['spammodule.c'])
 
-        module1 = Extension('spam', sources=['spammodule.c'],
-                                include_dirs=['/usr/local/lib'])
-
-        setup(name = 'spam',
-                version='1.0',
-                description='This is my spam package',
-                ext_modules = [module1])
+        setup(name='spam', version='1.0', ext_modules=[module1])
 
 
 Once the spam module is imported into python, you can call logit
@@ -355,8 +350,8 @@ using ``python setup.py build_ext --inplace``.
         '''
             setup.py file for single_type_logit.c
             Note that since this is a numpy extension
-            we use numpy.distutils instead of
-            distutils from the python standard library.
+            we add an include_dirs=[get_include()] so that the
+            extension is built with numpy's C/C++ header files.
 
             Calling
             $python setup.py build_ext --inplace
@@ -373,33 +368,26 @@ using ``python setup.py build_ext --inplace``.
             $python setup.py install
             will install the module in your site-packages file.
 
-            See the distutils section of
-            'Extending and Embedding the Python Interpreter'
-            at docs.python.org  and the documentation
-            on numpy.distutils for more information.
+            See the setuptools section 'Building Extension Modules'
+            at setuptools.pypa.io for more information.
         '''
 
+        from setuptools import setup, Extension
+        from numpy import get_include
 
-        def configuration(parent_package='', top_path=None):
-            from numpy.distutils.misc_util import Configuration
+        npufunc = Extension('npufunc',
+                            sources=['single_type_logit.c'],
+                            include_dirs=[get_include()])
 
-            config = Configuration('npufunc_directory',
-                                   parent_package,
-                                   top_path)
-            config.add_extension('npufunc', ['single_type_logit.c'])
+        setup(name='npufunc', version='1.0', ext_modules=[npufunc])
 
-            return config
-
-        if __name__ == "__main__":
-            from numpy.distutils.core import setup
-            setup(configuration=configuration)
 
 After the above has been installed, it can be imported and used as follows.
 
 >>> import numpy as np
 >>> import npufunc
 >>> npufunc.logit(0.5)
-0.0
+np.float64(0.0)
 >>> a = np.linspace(0,1,5)
 >>> npufunc.logit(a)
 array([       -inf, -1.09861229,  0.        ,  1.09861229,         inf])
@@ -607,8 +595,10 @@ or installed to site-packages via ``python setup.py install``.
         '''
             setup.py file for multi_type_logit.c
             Note that since this is a numpy extension
-            we use numpy.distutils instead of
-            distutils from the python standard library.
+            we add an include_dirs=[get_include()] so that the
+            extension is built with numpy's C/C++ header files.
+            Furthermore, we also have to include the npymath
+            lib for half-float d-type.
 
             Calling
             $python setup.py build_ext --inplace
@@ -625,38 +615,31 @@ or installed to site-packages via ``python setup.py install``.
             $python setup.py install
             will install the module in your site-packages file.
 
-            See the distutils section of
-            'Extending and Embedding the Python Interpreter'
-            at docs.python.org  and the documentation
-            on numpy.distutils for more information.
+            See the setuptools section 'Building Extension Modules'
+            at setuptools.pypa.io for more information.
         '''
 
+        from setuptools import setup, Extension
+        from numpy import get_include
+        from os import path
 
-        def configuration(parent_package='', top_path=None):
-            from numpy.distutils.misc_util import Configuration, get_info
+        path_to_npymath = path.join(get_include(), '..', 'lib')
+        npufunc = Extension('npufunc',
+                            sources=['multi_type_logit.c'],
+                            include_dirs=[get_include()],
+                            # Necessary for the half-float d-type.
+                            library_dirs=[path_to_npymath],
+                            libraries=["npymath"])
 
-            #Necessary for the half-float d-type.
-            info = get_info('npymath')
+        setup(name='npufunc', version='1.0', ext_modules=[npufunc])
 
-            config = Configuration('npufunc_directory',
-                                    parent_package,
-                                    top_path)
-            config.add_extension('npufunc',
-                                    ['multi_type_logit.c'],
-                                    extra_info=info)
-
-            return config
-
-        if __name__ == "__main__":
-            from numpy.distutils.core import setup
-            setup(configuration=configuration)
 
 After the above has been installed, it can be imported and used as follows.
 
 >>> import numpy as np
 >>> import npufunc
 >>> npufunc.logit(0.5)
-0.0
+np.float64(0.0)
 >>> a = np.linspace(0,1,5)
 >>> npufunc.logit(a)
 array([       -inf, -1.09861229,  0.        ,  1.09861229,         inf])
@@ -678,13 +661,17 @@ the line
 
     .. code-block:: python
 
-        config.add_extension('npufunc', ['single_type_logit.c'])
+        npufunc = Extension('npufunc',
+                            sources=['single_type_logit.c'],
+                            include_dirs=[get_include()])
 
 is replaced with
 
     .. code-block:: python
 
-        config.add_extension('npufunc', ['multi_arg_logit.c'])
+        npufunc = Extension('npufunc',
+                            sources=['multi_arg_logit.c'],
+                            include_dirs=[get_include()])
 
 The C file is given below. The ufunc generated takes two arguments ``A``
 and ``B``. It returns a tuple whose first element is ``A * B`` and whose second
@@ -809,13 +796,17 @@ the line
 
     .. code-block:: python
 
-        config.add_extension('npufunc', ['single_type_logit.c'])
+        npufunc = Extension('npufunc',
+                            sources=['single_type_logit.c'],
+                            include_dirs=[get_include()])
 
 is replaced with
 
     .. code-block:: python
 
-        config.add_extension('npufunc', ['add_triplet.c'])
+        npufunc = Extension('npufunc',
+                            sources=['add_triplet.c'],
+                            include_dirs=[get_include()])
 
 The C file is given below.
 
@@ -892,7 +883,7 @@ The C file is given below.
             NULL
         };
 
-        PyMODINIT_FUNC PyInit_struct_ufunc_test(void)
+        PyMODINIT_FUNC PyInit_npufunc(void)
         {
             PyObject *m, *add_triplet, *d;
             PyObject *dtype_dict;


### PR DESCRIPTION
Backports of #26504, #26517, and #26566.

[skip azp] [skip azure] [skip cirrus]

commit e9fca3ee60006969d0e2c18b9e04f6a0fe6f6bc8
Author: Jules <57632293+JuliaPoo@users.noreply.github.com>
Date:   Thu May 30 20:27:28 2024 +0800

    DOC: update ufunc tutorials to use setuptools (#26566)

    * DOC: update ufunc tutorials to use setuptools

    See #22027. Currently ufunc tutorials use depreciated distutils
    which is removed in Python 3.12. In addition, I've updated the
    sample output and fixed a mistake in the last example.

commit 04cb2596fbce4a12dc88c3200b8940764c1d1711
Author: Mateusz Sokół <mat646@gmail.com>
Date:   Fri May 24 11:12:38 2024 +0200

    Add np.alltrue to migration guide [skip actions] [skip azp] [skip cirrus]

commit d05bce7388b96aaf8a3ac557228ea8cfb13daffe
Author: warren <warren.weckesser@gmail.com>
Date:   Wed May 22 14:31:45 2024 -0400

    DOC: Copy-edit numpy 2.0 migration guide.

    Fix a few typos and do a touch of copy-editing.

    [skip actions] [skip azp] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
