### PR TITLE
ENH: Better error message for axis=None in `np.put_along_axis` and `np.take_along_axis`

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -164,7 +164,7 @@ def take_along_axis(arr, indices, axis):
     if axis is None:
         if indices.ndim != 1:
             raise ValueError(
-                'for axis=None, `indices` should have a dimension of one.')
+                'when axis=None, `indices` must have a single dimension.')
         arr = arr.flat
         arr_shape = (len(arr),)  # flatiter has no .shape
         axis = 0
@@ -257,7 +257,7 @@ def put_along_axis(arr, indices, values, axis):
     if axis is None:
         if indices.ndim != 1:
             raise ValueError(
-                'for axis=None, `indices` should have a dimension of one.')
+                'when axis=None, `indices` must have a single dimension.')
         arr = arr.flat
         axis = 0
         arr_shape = (len(arr),)  # flatiter has no .shape

--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -162,6 +162,9 @@ def take_along_axis(arr, indices, axis):
     """
     # normalize inputs
     if axis is None:
+        if indices.ndim != 1:
+            raise ValueError(
+                'for axis=None, `indices` should have a dimension of one.')
         arr = arr.flat
         arr_shape = (len(arr),)  # flatiter has no .shape
         axis = 0
@@ -252,6 +255,9 @@ def put_along_axis(arr, indices, values, axis):
     """
     # normalize inputs
     if axis is None:
+        if indices.ndim != 1:
+            raise ValueError(
+                'for axis=None, `indices` should have a dimension of one.')
         arr = arr.flat
         axis = 0
         arr_shape = (len(arr),)  # flatiter has no .shape

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -63,6 +63,8 @@ class TestTakeAlongAxis:
         assert_raises(IndexError, take_along_axis, a, ai.astype(float), axis=1)
         # invalid axis
         assert_raises(AxisError, take_along_axis, a, ai, axis=10)
+        # invalid indices
+        assert_raises(ValueError, take_along_axis, a, ai, axis=None)
 
     def test_empty(self):
         """ Test everything is ok with empty results, even with inserted dims """
@@ -103,6 +105,21 @@ class TestPutAlongAxis:
         ai = np.arange(10, dtype=np.intp).reshape((1, 2, 5)) % 4
         put_along_axis(a, ai, 20, axis=1)
         assert_equal(take_along_axis(a, ai, axis=1), 20)
+
+    def test_invalid(self):
+        """ Test invalid inputs """
+        a_base = np.array([[10, 30, 20], [60, 40, 50]])
+        indices = np.array([[0], [1]])
+        values = np.array([[2], [1]])
+
+        # sanity check
+        a = a_base.copy()
+        put_along_axis(a, indices, values, axis=0)
+
+        # invalid indices
+        a = a_base.copy()
+        assert_raises(ValueError, put_along_axis, a, indices, values, axis=None)
+
 
 
 class TestApplyAlongAxis:

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -115,10 +115,13 @@ class TestPutAlongAxis:
         # sanity check
         a = a_base.copy()
         put_along_axis(a, indices, values, axis=0)
+        assert np.all(a == [[2, 2, 2], [1, 1, 1]])
 
         # invalid indices
         a = a_base.copy()
-        assert_raises(ValueError, put_along_axis, a, indices, values, axis=None)
+        with assert_raises(ValueError) as exc:
+            put_along_axis(a, indices, values, axis=None)
+        assert "single dimension" in str(exc.exception)
 
 
 


### PR DESCRIPTION
Fixes #26553 by adding a conditional check on indices for cases
where axis is None.
