### PR TITLE
DOC: Try to fix the docs rendering of ``numpy.vectorize``

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2345,15 +2345,14 @@ class vectorize:
     >>> @np.vectorize
     ... def identity(x):
     ...     return x
-    ...
     >>> identity([0, 1, 2])
     array([0, 1, 2])
     >>> @np.vectorize(otypes=[float])
     ... def as_float(x):
     ...     return x
-    ...
     >>> as_float([0, 1, 2])
     array([0., 1., 2.])
+
     """
     def __init__(self, pyfunc=np._NoValue, otypes=None, doc=None,
                  excluded=None, cache=False, signature=None):


### PR DESCRIPTION
The HTML page of the documentation for the function `numpy.vectorize` appears to be broken in the last example as of today.

<img width="780" alt="image" src="https://github.com/numpy/numpy/assets/25192197/c81b9c77-a733-4fef-a244-9b2843e7aa44">

I referenced other examples in the documentation and suspect that an empty line needs to be added at the end of the example.