### PR TITLE
DOC: backport doc changes to numpy.vectorize [skip ci]

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2268,18 +2268,19 @@ class vectorize:
            [0., 0., 0., 1., 2., 1.]])
 
     Decorator syntax is supported.  The decorator can be called as
-    a function to provide keyword arguments.
-    >>>@np.vectorize
-    ...def identity(x):
-    ...    return x
+    a function to provide keyword arguments:
+
+    >>> @np.vectorize
+    ... def identity(x):
+    ...     return x
     ...
-    >>>identity([0, 1, 2])
+    >>> identity([0, 1, 2])
     array([0, 1, 2])
-    >>>@np.vectorize(otypes=[float])
-    ...def as_float(x):
-    ...    return x
+    >>> @np.vectorize(otypes=[float])
+    ... def as_float(x):
+    ...     return x
     ...
-    >>>as_float([0, 1, 2])
+    >>> as_float([0, 1, 2])
     array([0., 1., 2.])
     """
     def __init__(self, pyfunc=np._NoValue, otypes=None, doc=None,


### PR DESCRIPTION
Continuation of #26600, targetting maintenance/1.26.x

@singularitti

I backported changes from #23990, even though this is not really necessary since I don't think we will be rerendering the docs. Also see numpy/doc#23 to fix the rendered docs manually