### PR TITLE
TST: Re-enable int8/uint8 einsum tests

### DIFF
--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -10,12 +10,6 @@ from numpy.testing import (
     assert_raises, suppress_warnings, assert_raises_regex, assert_allclose
     )
 
-try:
-    COMPILERS = np.show_config(mode="dicts")["Compilers"]
-    USING_CLANG_CL = COMPILERS["c"]["name"] == "clang-cl"
-except TypeError:
-    USING_CLANG_CL = False
-
 # Setup for optimize einsum
 chars = 'abcdefghij'
 sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3])

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -621,23 +621,9 @@ class TestEinsum:
                            [2.])  # contig_stride0_outstride0_two
 
     def test_einsum_sums_int8(self):
-        if (
-                (sys.platform == 'darwin' and platform.machine() == 'x86_64')
-                or
-                USING_CLANG_CL
-        ):
-            pytest.xfail('Fails on macOS x86-64 and when using clang-cl '
-                         'with Meson, see gh-23838')
         self.check_einsum_sums('i1')
 
     def test_einsum_sums_uint8(self):
-        if (
-                (sys.platform == 'darwin' and platform.machine() == 'x86_64')
-                or
-                USING_CLANG_CL
-        ):
-            pytest.xfail('Fails on macOS x86-64 and when using clang-cl '
-                         'with Meson, see gh-23838')
         self.check_einsum_sums('u1')
 
     def test_einsum_sums_int16(self):


### PR DESCRIPTION
It seems #24732 fixed itself, see the following CI runs:
- [macOS intel](github.com/JuliaPoo/numpy/actions/runs/9344912430/job/25716839862)
- [windows clang-cl](github.com/JuliaPoo/numpy/actions/runs/9344767573/job/25716459859)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
