### PR TITLE
DOC: fix typos in numpy v2.0 documentation

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -191,7 +191,7 @@ arrays that are not 0-D, such as ``array([2])``.
    * - ``array([1], uint8) + int64(1)`` or
 
        ``array([1], uint8) + array(1, int64)``
-     - ``array([2], unit8)``
+     - ``array([2], uint8)``
      - ``array([2], int64)`` [T2]_
    * - ``array([1.], float32) + float64(1.)`` or
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -142,7 +142,7 @@ Advanced types, not listed above, are explored in section
 
 .. _canonical-python-and-c-types:
 
-Relationship Between NumPy Data Types and C Data Data Types
+Relationship Between NumPy Data Types and C Data Types
 ===========================================================
 
 NumPy provides both bit sized type names and names based on the names of C types.

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -143,7 +143,7 @@ Advanced types, not listed above, are explored in section
 .. _canonical-python-and-c-types:
 
 Relationship Between NumPy Data Types and C Data Types
-===========================================================
+======================================================
 
 NumPy provides both bit sized type names and names based on the names of C types.
 Since the definition of C types are platform dependent, this means the explicitly


### PR DESCRIPTION
This fixes some minor typos found in the new documentation