### PR TITLE
DOC: Update randn() to use rng.standard_normal()

### DIFF
--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -418,7 +418,7 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
     Examples
     --------
     >>> rng = np.random.default_rng()
-    >>> arrays = [rng.standard_normal(size=(3,4)) for _ in range(10)]
+    >>> arrays = [rng.normal(size=(3,4)) for _ in range(10)]
     >>> np.stack(arrays, axis=0).shape
     (10, 3, 4)
 

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -417,7 +417,8 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
 
     Examples
     --------
-    >>> arrays = [np.random.randn(3, 4) for _ in range(10)]
+    >>> rng = np.random.default_rng()
+    >>> arrays = [rng.standard_normal(size=(3,4)) for _ in range(10)]
     >>> np.stack(arrays, axis=0).shape
     (10, 3, 4)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -324,7 +324,7 @@ def flip(m, axis=None):
            [[1, 0],
             [3, 2]]])
     >>> rng = np.random.default_rng()
-    >>> A = rng.standard_normal(size=(3,4,5))
+    >>> A = rng.normal(size=(3,4,5))
     >>> np.all(np.flip(A,2) == A[:,:,::-1,...])
     True
     """

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -323,7 +323,8 @@ def flip(m, axis=None):
             [7, 6]],
            [[1, 0],
             [3, 2]]])
-    >>> A = np.random.randn(3,4,5)
+    >>> rng = np.random.default_rng()
+    >>> A = rng.standard_normal(size=(3,4,5))
     >>> np.all(np.flip(A,2) == A[:,:,::-1,...])
     True
     """

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -973,7 +973,7 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     Examples
     --------
     >>> rng = np.random.default_rng()
-    >>> r = rng.standard_normal(size=(100,3))
+    >>> r = rng.normal(size=(100,3))
     >>> H, edges = np.histogramdd(r, bins = (5, 8, 4))
     >>> H.shape, edges[0].size, edges[1].size, edges[2].size
     ((5, 8, 4), 6, 9, 5)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -972,7 +972,8 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
     Examples
     --------
-    >>> r = np.random.randn(100,3)
+    >>> rng = np.random.default_rng()
+    >>> r = rng.standard_normal(size=(100,3))
     >>> H, edges = np.histogramdd(r, bins = (5, 8, 4))
     >>> H.shape, edges[0].size, edges[1].size, edges[2].size
     ((5, 8, 4), 6, 9, 5)

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -90,7 +90,7 @@ def fliplr(m):
            [3.,  0.,  0.]])
 
     >>> rng = np.random.default_rng()
-    >>> A = rng.standard_normal(size=(2,3,5))
+    >>> A = rng.normal(size=(2,3,5))
     >>> np.all(np.fliplr(A) == A[:,::-1,...])
     True
 
@@ -144,7 +144,7 @@ def flipud(m):
            [1.,  0.,  0.]])
 
     >>> rng = np.random.default_rng()
-    >>> A = rng.standard_normal(size=(2,3,5))
+    >>> A = rng.normal(size=(2,3,5))
     >>> np.all(np.flipud(A) == A[::-1,...])
     True
 

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -89,7 +89,8 @@ def fliplr(m):
            [0.,  2.,  0.],
            [3.,  0.,  0.]])
 
-    >>> A = np.random.randn(2,3,5)
+    >>> rng = np.random.default_rng()
+    >>> A = rng.standard_normal(size=(2,3,5))
     >>> np.all(np.fliplr(A) == A[:,::-1,...])
     True
 
@@ -142,7 +143,8 @@ def flipud(m):
            [0.,  2.,  0.],
            [1.,  0.,  0.]])
 
-    >>> A = np.random.randn(2,3,5)
+    >>> rng = np.random.default_rng()
+    >>> A = rng.standard_normal(size=(2,3,5))
     >>> np.all(np.flipud(A) == A[::-1,...])
     True
 

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -274,7 +274,8 @@ def tensorsolve(a, b, axes=None):
     --------
     >>> a = np.eye(2*3*4)
     >>> a.shape = (2*3, 4, 2, 3, 4)
-    >>> b = np.random.randn(2*3, 4)
+    >>> rng = np.random.default_rng()
+    >>> b = rng.standard_normal(size=(2*3, 4))
     >>> x = np.linalg.tensorsolve(a, b)
     >>> x.shape
     (2, 3, 4)
@@ -456,7 +457,8 @@ def tensorinv(a, ind=2):
     >>> ainv = np.linalg.tensorinv(a, ind=2)
     >>> ainv.shape
     (8, 3, 4, 6)
-    >>> b = np.random.randn(4, 6)
+    >>> rng = np.random.default_rng()
+    >>> b = rng.standard_normal(size=(4, 6))
     >>> np.allclose(np.tensordot(ainv, b), np.linalg.tensorsolve(a, b))
     True
 
@@ -465,7 +467,8 @@ def tensorinv(a, ind=2):
     >>> ainv = np.linalg.tensorinv(a, ind=1)
     >>> ainv.shape
     (8, 3, 24)
-    >>> b = np.random.randn(24)
+    >>> rng = np.random.default_rng()
+    >>> b = rng.standard_normal(24)
     >>> np.allclose(np.tensordot(ainv, b, 1), np.linalg.tensorsolve(a, b))
     True
 
@@ -978,7 +981,8 @@ def qr(a, mode='reduced'):
 
     Examples
     --------
-    >>> a = np.random.randn(9, 6)
+    >>> rng = np.random.default_rng()
+    >>> a = rng.standard_normal(size=(9, 6))
     >>> Q, R = np.linalg.qr(a)
     >>> np.allclose(a, np.dot(Q, R))  # a does equal QR
     True
@@ -1703,8 +1707,13 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
 
     Examples
     --------
-    >>> a = np.random.randn(9, 6) + 1j*np.random.randn(9, 6)
-    >>> b = np.random.randn(2, 7, 8, 3) + 1j*np.random.randn(2, 7, 8, 3)
+    >>> rng = np.random.default_rng()
+    >>> a_re = rng.standard_normal(size=(9, 6))
+    >>> a_im = rng.standard_normal(size=(9, 6))
+    >>> a = a_re + 1j*a_im
+    >>> b_re = rng.standard_normal(size=(2, 7, 8, 3))
+    >>> b_im = rng.standard_normal(size=(2, 7, 8, 3))
+    >>> b = b_re + 1j*b_im
 
     Reconstruction based on full SVD, 2D case:
 
@@ -2181,7 +2190,8 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
     The following example checks that ``a * a+ * a == a`` and
     ``a+ * a * a+ == a+``:
 
-    >>> a = np.random.randn(9, 6)
+    >>> rng = np.random.default_rng()
+    >>> a = rng.standard_normal(size=(9, 6))
     >>> B = np.linalg.pinv(a)
     >>> np.allclose(a, np.dot(a, np.dot(B, a)))
     True

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -275,7 +275,7 @@ def tensorsolve(a, b, axes=None):
     >>> a = np.eye(2*3*4)
     >>> a.shape = (2*3, 4, 2, 3, 4)
     >>> rng = np.random.default_rng()
-    >>> b = rng.standard_normal(size=(2*3, 4))
+    >>> b = rng.normal(size=(2*3, 4))
     >>> x = np.linalg.tensorsolve(a, b)
     >>> x.shape
     (2, 3, 4)
@@ -458,7 +458,7 @@ def tensorinv(a, ind=2):
     >>> ainv.shape
     (8, 3, 4, 6)
     >>> rng = np.random.default_rng()
-    >>> b = rng.standard_normal(size=(4, 6))
+    >>> b = rng.normal(size=(4, 6))
     >>> np.allclose(np.tensordot(ainv, b), np.linalg.tensorsolve(a, b))
     True
 
@@ -468,7 +468,7 @@ def tensorinv(a, ind=2):
     >>> ainv.shape
     (8, 3, 24)
     >>> rng = np.random.default_rng()
-    >>> b = rng.standard_normal(24)
+    >>> b = rng.normal(size=24)
     >>> np.allclose(np.tensordot(ainv, b, 1), np.linalg.tensorsolve(a, b))
     True
 
@@ -982,7 +982,7 @@ def qr(a, mode='reduced'):
     Examples
     --------
     >>> rng = np.random.default_rng()
-    >>> a = rng.standard_normal(size=(9, 6))
+    >>> a = rng.normal(size=(9, 6))
     >>> Q, R = np.linalg.qr(a)
     >>> np.allclose(a, np.dot(Q, R))  # a does equal QR
     True
@@ -1708,12 +1708,9 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     Examples
     --------
     >>> rng = np.random.default_rng()
-    >>> a_re = rng.standard_normal(size=(9, 6))
-    >>> a_im = rng.standard_normal(size=(9, 6))
-    >>> a = a_re + 1j*a_im
-    >>> b_re = rng.standard_normal(size=(2, 7, 8, 3))
-    >>> b_im = rng.standard_normal(size=(2, 7, 8, 3))
-    >>> b = b_re + 1j*b_im
+    >>> a = rng.normal(size=(9, 6)) + 1j*rng.normal(size=(9, 6))
+    >>> b = rng.normal(size=(2, 7, 8, 3)) + 1j*rng.normal(size=(2, 7, 8, 3))
+
 
     Reconstruction based on full SVD, 2D case:
 
@@ -2191,7 +2188,7 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
     ``a+ * a * a+ == a+``:
 
     >>> rng = np.random.default_rng()
-    >>> a = rng.standard_normal(size=(9, 6))
+    >>> a = rng.normal(size=(9, 6))
     >>> B = np.linalg.pinv(a)
     >>> np.allclose(a, np.dot(a, np.dot(B, a)))
     True

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1461,7 +1461,7 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.hermite import hermfit, hermval
     >>> x = np.linspace(-10, 10)
     >>> rng = np.random.default_rng()
-    >>> err = rng.normal(scale=1./10,size=len(x))
+    >>> err = rng.normal(scale=1./10, size=len(x))
     >>> y = hermval(x, [1, 2, 3]) + err
     >>> hermfit(x, y, 2)
     array([1.02294967, 2.00016403, 2.99994614]) # may vary

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1460,11 +1460,11 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.hermite import hermfit, hermval
     >>> x = np.linspace(-10, 10)
-    >>> rng = np.random.default_rng(seed=123)
+    >>> rng = np.random.default_rng()
     >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = hermval(x, [1, 2, 3]) + err
     >>> hermfit(x, y, 2)
-    array([1.02294967, 2.00016403, 2.99994614])
+    array([1.02294967, 2.00016403, 2.99994614]) # may vary
 
     """
     return pu._fit(hermvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1460,10 +1460,11 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.hermite import hermfit, hermval
     >>> x = np.linspace(-10, 10)
-    >>> err = np.random.randn(len(x))/10
+    >>> rng = np.random.default_rng(seed=123)
+    >>> err = rng.standard_normal(size=(len(x)))/10
     >>> y = hermval(x, [1, 2, 3]) + err
     >>> hermfit(x, y, 2)
-    array([1.0218, 1.9986, 2.9999]) # may vary
+    array([1.02294967, 2.00016403, 2.99994614]) # may vary
 
     """
     return pu._fit(hermvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1461,10 +1461,10 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.hermite import hermfit, hermval
     >>> x = np.linspace(-10, 10)
     >>> rng = np.random.default_rng(seed=123)
-    >>> err = rng.standard_normal(size=(len(x)))/10
+    >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = hermval(x, [1, 2, 3]) + err
     >>> hermfit(x, y, 2)
-    array([1.02294967, 2.00016403, 2.99994614]) # may vary
+    array([1.02294967, 2.00016403, 2.99994614])
 
     """
     return pu._fit(hermvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1388,10 +1388,10 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.hermite_e import hermefit, hermeval
     >>> x = np.linspace(-10, 10)
     >>> rng = np.random.default_rng(seed=123)
-    >>> err = rng.standard_normal(size=(len(x)))/10
+    >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = hermeval(x, [1, 2, 3]) + err
     >>> hermefit(x, y, 2)
-    array([1.02284196, 2.00032805, 2.99978457]) # may vary
+    array([1.02284196, 2.00032805, 2.99978457])
 
     """
     return pu._fit(hermevander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1387,11 +1387,11 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.hermite_e import hermefit, hermeval
     >>> x = np.linspace(-10, 10)
-    >>> np.random.seed(123)
-    >>> err = np.random.randn(len(x))/10
+    >>> rng = np.random.default_rng(seed=123)
+    >>> err = rng.standard_normal(size=(len(x)))/10
     >>> y = hermeval(x, [1, 2, 3]) + err
     >>> hermefit(x, y, 2)
-    array([ 1.01690445,  1.99951418,  2.99948696]) # may vary
+    array([1.02284196, 2.00032805, 2.99978457]) # may vary
 
     """
     return pu._fit(hermevander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1388,7 +1388,7 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.hermite_e import hermefit, hermeval
     >>> x = np.linspace(-10, 10)
     >>> rng = np.random.default_rng()
-    >>> err = rng.normal(scale=1./10,size=len(x))
+    >>> err = rng.normal(scale=1./10, size=len(x))
     >>> y = hermeval(x, [1, 2, 3]) + err
     >>> hermefit(x, y, 2)
     array([1.02284196, 2.00032805, 2.99978457]) # may vary

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1387,11 +1387,11 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.hermite_e import hermefit, hermeval
     >>> x = np.linspace(-10, 10)
-    >>> rng = np.random.default_rng(seed=123)
+    >>> rng = np.random.default_rng()
     >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = hermeval(x, [1, 2, 3]) + err
     >>> hermefit(x, y, 2)
-    array([1.02284196, 2.00032805, 2.99978457])
+    array([1.02284196, 2.00032805, 2.99978457]) # may vary
 
     """
     return pu._fit(hermevander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1442,7 +1442,7 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.laguerre import lagfit, lagval
     >>> x = np.linspace(0, 10)
     >>> rng = np.random.default_rng()
-    >>> err = rng.normal(scale=1./10,size=len(x))
+    >>> err = rng.normal(scale=1./10, size=len(x))
     >>> y = lagval(x, [1, 2, 3]) + err
     >>> lagfit(x, y, 2)
     array([1.00578369, 1.99417356, 2.99827656]) # may vary

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1441,11 +1441,11 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.laguerre import lagfit, lagval
     >>> x = np.linspace(0, 10)
-    >>> rng = np.random.default_rng(seed=123)
+    >>> rng = np.random.default_rng()
     >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = lagval(x, [1, 2, 3]) + err
     >>> lagfit(x, y, 2)
-    array([1.00578369, 1.99417356, 2.99827656])
+    array([1.00578369, 1.99417356, 2.99827656]) # may vary
 
     """
     return pu._fit(lagvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1442,10 +1442,10 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial.laguerre import lagfit, lagval
     >>> x = np.linspace(0, 10)
     >>> rng = np.random.default_rng(seed=123)
-    >>> err = rng.standard_normal(size=(len(x)))/10
+    >>> err = rng.normal(scale=1./10,size=len(x))
     >>> y = lagval(x, [1, 2, 3]) + err
     >>> lagfit(x, y, 2)
-    array([1.00578369, 1.99417356, 2.99827656]) # may vary
+    array([1.00578369, 1.99417356, 2.99827656])
 
     """
     return pu._fit(lagvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1441,10 +1441,11 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial.laguerre import lagfit, lagval
     >>> x = np.linspace(0, 10)
-    >>> err = np.random.randn(len(x))/10
+    >>> rng = np.random.default_rng(seed=123)
+    >>> err = rng.standard_normal(size=(len(x)))/10
     >>> y = lagval(x, [1, 2, 3]) + err
     >>> lagfit(x, y, 2)
-    array([ 0.96971004,  2.00193749,  3.00288744]) # may vary
+    array([1.00578369, 1.99417356, 2.99827656]) # may vary
 
     """
     return pu._fit(lagvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1443,14 +1443,14 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     --------
     >>> from numpy.polynomial import polynomial as P
     >>> x = np.linspace(-1,1,51)  # x "data": [-1, -0.96, ..., 0.96, 1]
-    >>> rng = np.random.default_rng(seed=123)
+    >>> rng = np.random.default_rng()
     >>> err = rng.normal(size=len(x))
     >>> y = x**3 - x + err  # x^3 - x + Gaussian noise
     >>> c, stats = P.polyfit(x,y,3,full=True)
     >>> c # c[0], c[1] approx. -1, c[2] should be approx. 0, c[3] approx. 1
-    array([ 0.23111996, -1.02785049, -0.2241444 ,  1.08405657])
+    array([ 0.23111996, -1.02785049, -0.2241444 ,  1.08405657]) # may vary
     >>> stats # note the large SSR, explaining the rather poor results
-    [array([48.312088]),
+    [array([48.312088]),                                        # may vary
      4,
      array([1.38446749, 1.32119158, 0.50443316, 0.28853036]),
      1.1324274851176597e-14]

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1441,27 +1441,31 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
 
     Examples
     --------
-    >>> np.random.seed(123)
     >>> from numpy.polynomial import polynomial as P
     >>> x = np.linspace(-1,1,51)  # x "data": [-1, -0.96, ..., 0.96, 1]
-    >>> y = x**3 - x + np.random.randn(len(x))  # x^3 - x + Gaussian noise
+    >>> rng = np.random.default_rng(seed=123)
+    >>> err = rng.standard_normal(size=len(x))
+    >>> y = x**3 - x + err  # x^3 - x + Gaussian noise
     >>> c, stats = P.polyfit(x,y,3,full=True)
-    >>> np.random.seed(123)
-    >>> c # c[0], c[2] should be approx. 0, c[1] approx. -1, c[3] approx. 1
-    array([ 0.01909725, -1.30598256, -0.00577963,  1.02644286])  # may vary
+    >>> c # c[0], c[1] approx. -1, c[2] should be approx. 0, c[3] approx. 1
+    array([ 0.23111996, -1.02785049, -0.2241444 ,  1.08405657]) # may vary
     >>> stats # note the large SSR, explaining the rather poor results
-     [array([ 38.06116253]), 4, array([ 1.38446749,  1.32119158,  0.50443316, # may vary
-              0.28853036]), 1.1324274851176597e-014]
+    [array([48.312088]),                                      # may vary
+     4,                                                       # may vary
+     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]), # may vary
+     1.1324274851176597e-14]                                  # may vary
 
     Same thing without the added noise
 
     >>> y = x**3 - x
     >>> c, stats = P.polyfit(x,y,3,full=True)
-    >>> c # c[0], c[2] should be "very close to 0", c[1] ~= -1, c[3] ~= 1
-    array([-6.36925336e-18, -1.00000000e+00, -4.08053781e-16,  1.00000000e+00])
+    >>> c # c[0], c[1] ~= -1, c[2] should be "very close to 0", c[3] ~= 1
+    array([-6.73496154e-17, -1.00000000e+00,  0.00000000e+00,  1.00000000e+00])
     >>> stats # note the minuscule SSR
-    [array([  7.46346754e-31]), 4, array([ 1.38446749,  1.32119158, # may vary
-               0.50443316,  0.28853036]), 1.1324274851176597e-014]
+    [array([8.79579319e-31]),                                 # may vary
+     4,                                                       # may vary
+     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]), # may vary
+     1.1324274851176597e-14]                                  # may vary
 
     """
     return pu._fit(polyvander, x, y, deg, rcond, full, w)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1444,16 +1444,16 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     >>> from numpy.polynomial import polynomial as P
     >>> x = np.linspace(-1,1,51)  # x "data": [-1, -0.96, ..., 0.96, 1]
     >>> rng = np.random.default_rng(seed=123)
-    >>> err = rng.standard_normal(size=len(x))
+    >>> err = rng.normal(size=len(x))
     >>> y = x**3 - x + err  # x^3 - x + Gaussian noise
     >>> c, stats = P.polyfit(x,y,3,full=True)
     >>> c # c[0], c[1] approx. -1, c[2] should be approx. 0, c[3] approx. 1
-    array([ 0.23111996, -1.02785049, -0.2241444 ,  1.08405657]) # may vary
+    array([ 0.23111996, -1.02785049, -0.2241444 ,  1.08405657])
     >>> stats # note the large SSR, explaining the rather poor results
-    [array([48.312088]),                                      # may vary
-     4,                                                       # may vary
-     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]), # may vary
-     1.1324274851176597e-14]                                  # may vary
+    [array([48.312088]),
+     4,
+     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]),
+     1.1324274851176597e-14]
 
     Same thing without the added noise
 
@@ -1462,10 +1462,10 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     >>> c # c[0], c[1] ~= -1, c[2] should be "very close to 0", c[3] ~= 1
     array([-6.73496154e-17, -1.00000000e+00,  0.00000000e+00,  1.00000000e+00])
     >>> stats # note the minuscule SSR
-    [array([8.79579319e-31]),                                 # may vary
-     4,                                                       # may vary
-     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]), # may vary
-     1.1324274851176597e-14]                                  # may vary
+    [array([8.79579319e-31]),
+     4,
+     array([1.38446749, 1.32119158, 0.50443316, 0.28853036]),
+     1.1324274851176597e-14]
 
     """
     return pu._fit(polyvander, x, y, deg, rcond, full, w)


### PR DESCRIPTION
Updates all references to `randn` to use `standard_normal` from Generator. I left the matlib versions alone.
In a few spots I added `seed=123`.
I left the `# may vary` tag on those examples.
This tag could be removed with the guaranteed same output now. I had to reformat a few chunks of longer code and output.

[skip actions] [skip azp] [skip cirrus]

This PR stems from a [Slack discussion](https://numpy-team.slack.com/archives/CM8C6PE67/p1715718898610159).  

I tested removing the `# may vary` tag with `python tools/refguide_check.py --doctests`, and things worked fine.  I obtained the same outputs on a dev build on Linux, and an old pip installed numpy on Windows. Should I remove the `# may very` tag?  

I'm planning on replacing other instances of `random` to use the updated modules. This was just replacing `randn`. I'll incorporate feedback from this PR in those.