### PR TITLE
DOC: Update 2.0 release notes

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -277,6 +277,8 @@ Deprecations
 * ``np.compat`` has been deprecated, as Python 2 is no longer supported.
 
 * ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, conversion of 255 to int8 will not return -1.
+  ``numpy.iinfo(dtype)``can be used to check the machine limits for data types. For example, ``np.iinfo(np.uint16)`` returns min = 0 and max = 65535.
+
   ``np.array(value).astype(dtype)`` will give the desired result.
 
 * ``np.safe_eval`` has been deprecated. ``ast.literal_eval`` should be used instead.

--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -276,7 +276,8 @@ Deprecations
 
 * ``np.compat`` has been deprecated, as Python 2 is no longer supported.
 
-* ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, conversion of 255 to int8 will not return -1.
+* ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, 
+  conversion of 255 to int8 will not return -1.
   ``numpy.iinfo(dtype)``can be used to check the machine limits for data types. For example, ``np.iinfo(np.uint16)`` returns min = 0 and max = 65535.
 
   ``np.array(value).astype(dtype)`` will give the desired result.

--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -276,6 +276,9 @@ Deprecations
 
 * ``np.compat`` has been deprecated, as Python 2 is no longer supported.
 
+* ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, conversion of 255 to int8 will not return -1.
+  ``np.array(value).astype(dtype)`` will give the desired result.
+
 * ``np.safe_eval`` has been deprecated. ``ast.literal_eval`` should be used instead.
 
   (`gh-23830 <https://github.com/numpy/numpy/pull/23830>`__)


### PR DESCRIPTION
Adding the deprecation that out of bounds python integers will not be supported in numpy 2.0 
For example the conversion of 255 under numpy.int8 in arrays will return an error.