### PR TITLE
MNT: build numpy with link-time optimization in benchmarks

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -18,7 +18,7 @@
     "branches": ["HEAD"],
 
     "build_command": [
-        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+        "python -m build --wheel -C'setup-args=-Db_lto=true' -C'setup-args=-Dbuildtype=release' -o {build_cache_dir} {build_dir}"
     ],
 
     // The DVCS being used.  If not set, it will be automatically


### PR DESCRIPTION
I've been trying to benchmark a big refactor of numpy in #26607. I remembered a blog post from @vstinner years ago on python performance work, where he found turning on LTO improved reproducibility. See e.g. [this LWN summary](https://lwn.net/Articles/725114/). Can't seem to find the original blog post...

Now that we have meson, it's easy to use LTO. It also doesn't take that much more time to build numpy with LTO, at least on my ARM Macbook.

This makes benchmarks where I was seeing substantial changes in speed comparing with main have no difference at all. I haven't tried the full benchmark suite but I suspect the remaining changes will be "real" differences and not just due to code shuffling in the binary or changing size slightly.