### PR TITLE
DOC: add `setbufsize` example

### DIFF
--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -167,6 +167,18 @@ def setbufsize(size):
     size : int
         Size of buffer.
 
+    Returns
+    -------
+    bufsize : int
+        Previous size of ufunc buffer in bytes.
+
+    Examples
+    --------
+    >>> np.setbufsize(4096)
+    8192
+    >>> np.getbufsize()
+    4096
+
     """
     old = _get_extobj_dict()["bufsize"]
     extobj = _make_extobj(bufsize=size)

--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -174,10 +174,16 @@ def setbufsize(size):
 
     Examples
     --------
-    >>> np.setbufsize(4096)
+    When exiting a `numpy.errstate` context manager the bufsize is restored:
+
+    >>> with np.errstate():
+    ...     np.setbufsize(4096)
+    ...     print(np.getbufsize())
+    ...
     8192
-    >>> np.getbufsize()
     4096
+    >>> np.getbufsize()
+    8192
 
     """
     old = _get_extobj_dict()["bufsize"]


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Add example for getbufsize for https://github.com/numpy/numpy/issues/21351

[skip actions][skip azp][skip cirrus]

This function also returns the previous bufsize value. I think that this return value should be removed.