### PR TITLE
BUG: Replace dots with underscores in f2py meson backend for lib identifiers

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -92,13 +92,13 @@ class MesonTemplate:
 
         self.substitutions["lib_declarations"] = "\n".join(
             [
-                f"{lib} = declare_dependency(link_args : ['-l{lib}'])"
+                f"{lib.replace('.','_')} = declare_dependency(link_args : ['-l{lib}'])"
                 for lib in self.libraries
             ]
         )
 
         self.substitutions["lib_list"] = f"\n{self.indent}".join(
-            [f"{self.indent}{lib}," for lib in self.libraries]
+            [f"{self.indent}{lib.replace('.','_')}," for lib in self.libraries]
         )
         self.substitutions["lib_dir_list"] = f"\n{self.indent}".join(
             [f"{self.indent}lib_dir_{i}," for i in range(len(self.library_dirs))]

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -108,3 +108,14 @@ class TestF90Contiuation(util.F2PyTest):
         res=self.module.testsub(x1, x2)
         assert(res[0] == 8)
         assert(res[1] == 15)
+
+def test_gh26623():
+    # Including libraries with . should not generate an incorrect meson.build
+    try:
+        aa = util.build_module(
+            [util.getpath("tests", "src", "regression", "f90continuation.f90")],
+            ["-lfoo.bar"],
+            module_name="Blah",
+        )
+    except RuntimeError as rerr:
+        assert "lparen got assign" not in str(rerr)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

As seen in #26623, if a library itself has a dot, e.g., `-lMAPL.base`, then the meson backend produces code like:
```meson
MAPL.base = declare_dependency(link_args : ['-lMAPL.base'])
```
But meson apparently sees `MAPL.base` as saying this is the `base` method in the `MAPL` type (or class?). Thus, it expects parentheses. 

So this PR uses a `replace()` call to replace all the `.` to `_` in the `lib` identifier. This has to be done both in the `declare_dependency` and in the `dependencies` bit of `py.extension_module`.

With this fix I get:
```meson
MAPL_constants = declare_dependency(link_args : ['-lMAPL.constants'])
MAPL_base = declare_dependency(link_args : ['-lMAPL.base'])
```

This seems to fix any issues in my testing, but my fear is cases I don't have. (Though perhaps libraries with dots is a rare case anyway and mainly a style used in the our code.)

Closes #26623 

---

NOTE: I tested this with Numpy 1.26.4, and I see main is now in v2 land. It would be nice to get this into a v1 tag as well if v2 is still a ways off. I could backport this to `maintenance/1.26.x` if desired.