### PR TITLE
DOC: update 2.0 docs

### DIFF
--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -276,9 +276,13 @@ Deprecations
 
 * ``np.compat`` has been deprecated, as Python 2 is no longer supported.
 
-* ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, 
+* ``numpy.int8`` and similar classes will no longer support conversion of 
+  out of bounds python integers to integer arrays. For example, 
   conversion of 255 to int8 will not return -1.
-  ``numpy.iinfo(dtype)``can be used to check the machine limits for data types. For example, ``np.iinfo(np.uint16)`` returns min = 0 and max = 65535.
+  ``numpy.iinfo(dtype)`` can be used to check the machine limits for data types. 
+  For example, ``np.iinfo(np.uint16)`` returns min = 0 and max = 65535.
+
+  ``np.array(value).astype(dtype)`` will give the desired result.
 
 
 * ``np.safe_eval`` has been deprecated. ``ast.literal_eval`` should be used instead.

--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -276,6 +276,11 @@ Deprecations
 
 * ``np.compat`` has been deprecated, as Python 2 is no longer supported.
 
+* ``numpy.int8`` will no longer support conversion of out of bounds python integers to integer arrays. For example, 
+  conversion of 255 to int8 will not return -1.
+  ``numpy.iinfo(dtype)``can be used to check the machine limits for data types. For example, ``np.iinfo(np.uint16)`` returns min = 0 and max = 65535.
+
+
 * ``np.safe_eval`` has been deprecated. ``ast.literal_eval`` should be used instead.
 
   (`gh-23830 <https://github.com/numpy/numpy/pull/23830>`__)


### PR DESCRIPTION
continuing from pr #26608 

As suggested I am creating the pr in the maintenance/2.0 branch. 

Adding the deprecation that out of bounds python integers will not be supported in numpy 2.0

And adding an example of numpy.iinfo(dtype). can be used to check the machine limits for data type. 
