### PR TITLE
BUG: fix incorrect randomized parameterization in bench_linalg

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -72,7 +72,7 @@ class Eindot(Benchmark):
 
 
 class Linalg(Benchmark):
-    params = set(TYPES1) - set(['float16'])
+    params = sorted(list(set(TYPES1) - set(['float16'])))
     param_names = ['dtype']
 
     def setup(self, typename):


### PR DESCRIPTION
Thanks to @rgommers for spotting this.

If you don't use a sorted list here, the order ends up randomized in every python process and it seems that messes with how asv iterates over the parameters.