### PR TITLE
MNT: use reproducible RNG sequences in benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_clip.py
+++ b/benchmarks/benchmarks/bench_clip.py
@@ -27,7 +27,7 @@ class ClipInteger(Benchmark):
     ]
 
     def setup(self, dtype, size):
-        rnd = np.random.RandomState(12345)
+        rnd = np.random.RandomState(1301109903)
         self.array = rnd.randint(256, size=size, dtype=dtype)
         self.dataout = np.full_like(self.array, 128)
 

--- a/benchmarks/benchmarks/bench_clip.py
+++ b/benchmarks/benchmarks/bench_clip.py
@@ -11,7 +11,7 @@ class ClipFloat(Benchmark):
     ]
 
     def setup(self, dtype, size):
-        rnd = np.random.RandomState(12345)
+        rnd = np.random.RandomState(994584855)
         self.array = rnd.random(size=size).astype(dtype)
         self.dataout = np.full_like(self.array, 0.5)
 

--- a/benchmarks/benchmarks/bench_clip.py
+++ b/benchmarks/benchmarks/bench_clip.py
@@ -11,8 +11,8 @@ class ClipFloat(Benchmark):
     ]
 
     def setup(self, dtype, size):
-        rng = np.random.default_rng()
-        self.array = rng.random(size=size).astype(dtype)
+        rnd = np.random.RandomState(12345)
+        self.array = rnd.random(size=size).astype(dtype)
         self.dataout = np.full_like(self.array, 0.5)
 
     def time_clip(self, dtype, size):
@@ -27,8 +27,8 @@ class ClipInteger(Benchmark):
     ]
 
     def setup(self, dtype, size):
-        rng = np.random.default_rng()
-        self.array = rng.integers(256, size=size, dtype=dtype)
+        rnd = np.random.RandomState(12345)
+        self.array = rnd.randint(256, size=size, dtype=dtype)
         self.dataout = np.full_like(self.array, 128)
 
     def time_clip(self, dtype, size):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -159,7 +159,7 @@ class SortGenerator:
         Returns a randomly-shuffled array.
         """
         arr = np.arange(size, dtype=dtype)
-        rnd = np.random.RandomState(12345)
+        rnd = np.random.RandomState(1792364059)
         rnd.shuffle(arr)
         return arr
 

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -159,7 +159,8 @@ class SortGenerator:
         Returns a randomly-shuffled array.
         """
         arr = np.arange(size, dtype=dtype)
-        np.random.shuffle(arr)
+        rnd = np.random.RandomState(12345)
+        rnd.shuffle(arr)
         return arr
 
     @staticmethod


### PR DESCRIPTION
These three benchmarks aren't using seeded RNG sequences so the test data is not consistent from run to run. Using a seeded `RandomState` should fix that for these benchmarks.