### PR TITLE
DOC: Added clean_dirs to spin docs to remove generated folders

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -161,6 +161,21 @@ def docs(ctx, sphinx_target, clean, first_build, jobs, *args, **kwargs):
     """
     meson.docs.ignore_unknown_options = True
 
+    # See https://github.com/scientific-python/spin/pull/199
+    # Can be changed when spin updates to 0.11, and moved to pyproject.toml
+    if clean:
+        clean_dirs = [
+            './doc/build/',
+            './doc/source/reference/generated',
+            './doc/source/reference/random/bit_generators/generated',
+            './doc/source/reference/random/generated',
+        ]
+
+        for target_dir in clean_dirs:
+            if os.path.isdir(target_dir):
+                print(f"Removing {target_dir!r}")
+                shutil.rmtree(target_dir)
+
     # Run towncrier without staging anything for commit. This is the way to get
     # release notes snippets included in a local doc build.
     cmd = ['towncrier', 'build', '--version', '2.x.y', '--keep', '--draft']


### PR DESCRIPTION
Using `spin docs --clean` currently only removes `doc/build`. This adds the other folders that are captured with `make --clean`. When numpy updates spin from 0.8 to >=0.10, this can be moved to pyproject.toml with supported functionality.
I'd love to have the same functionality as `make --clean` with `spin docs --clean` (I hit that issue today). 
Apparently, it's [now a feature in spin](https://github.com/scientific-python/spin/pull/199) (as of two weeks ago). With numpy still on `spin=0.8`, I adapted a bit of code from that pull request to provide a stop-gap until we update spin. 

The command `make --clean` removes (at least) three folders with `generated`. 
https://github.com/numpy/numpy/blob/977a7659abc2e56716419b2442d5160e08949b24/doc/Makefile#L51-L53
After a fresh build, running
```
find doc -name generated -type d -prune -print
```
yields (those in build are omitted)
```
./doc/source/reference/generated
./doc/source/reference/random/bit_generators/generated
./doc/source/reference/random/generated
```

@ngoldbaum , you were referenced directly in the PR on spin, so I figure you might have some interest in this issue.

On a side note, I haven't had any issues running spin without this change, until I created `cross2d`. Then everything broke when I went to a new branch and didn't want to use `cross2d` any more. I didn't want to invoke `git clean -xdf` and figured there had to be a simpler way. Turns out spin 0.8 doesn't have the functionality.