### PR TITLE
DOC: Enable web docs for numpy.trapezoid and add back links

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -71,6 +71,7 @@ Sums, products, differences
    ediff1d
    gradient
    cross
+   trapezoid
 
 Exponents and logarithms
 ------------------------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2355,6 +2355,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     ndarray.sum : Equivalent method.
     add: ``numpy.add.reduce`` equivalent function.
     cumsum : Cumulative sum of array elements.
+    trapezoid : Integration of array values using composite trapezoidal rule.
 
     mean, average
 
@@ -2681,6 +2682,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     See Also
     --------
     sum : Sum array elements.
+    trapezoid : Integration of array values using composite trapezoidal rule.
     diff : Calculate the n-th discrete difference along given axis.
 
     Notes


### PR DESCRIPTION
This PR adds back the links that were removed from `trapz` in PR #24445, finishing the migration to `trapezoid` in PR #25738. Currently, no web docs appear for `trapezoid`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
