### PR TITLE
DOC: Update docstring for invert function

### DIFF
--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -1589,12 +1589,13 @@ add_newdoc('numpy._core.umath', 'invert',
     the integers in the input arrays. This ufunc implements the C/Python
     operator ``~``.
 
-    For signed integer inputs, the two's complement is returned.  In a
-    two's-complement system negative numbers are represented by the two's
-    complement of the absolute value. This is the most common method of
-    representing signed integers on computers [1]_. A N-bit
-    two's-complement system can represent every integer in the range
-    :math:`-2^{N-1}` to :math:`+2^{N-1}-1`.
+    For signed integer inputs, the bit-wise NOT of the absolute value is
+    returned. In a two's-complement system, this operation effectively flips
+    all the bits, resulting in a representation that corresponds to the
+    negative of the input plus one. This is the most common method of
+    representing signed integers on computers [1]_. A N-bit two's-complement
+    system can represent every integer in the range :math:`-2^{N-1}` to
+    :math:`+2^{N-1}-1`.
 
     Parameters
     ----------
@@ -1646,8 +1647,8 @@ add_newdoc('numpy._core.umath', 'invert',
     >>> np.binary_repr(x, width=16)
     '1111111111110010'
 
-    When using signed integer types the result is the two's complement of
-    the result for the unsigned type:
+    When using signed integer types, the result is the bit-wise NOT of
+    the unsigned type, interpreted as a signed integer:
 
     >>> np.invert(np.array([13], dtype=np.int8))
     array([-14], dtype=int8)
@@ -1666,7 +1667,8 @@ add_newdoc('numpy._core.umath', 'invert',
     >>> ~x1
     array([False,  True])
 
-    """)
+    """
+)
 
 add_newdoc('numpy._core.umath', 'isfinite',
     """

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -1667,8 +1667,7 @@ add_newdoc('numpy._core.umath', 'invert',
     >>> ~x1
     array([False,  True])
 
-    """
-)
+    """)
 
 add_newdoc('numpy._core.umath', 'isfinite',
     """


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

fixes #25747

This PR updates the docstring for the invert function to accurately describe its behavior. It removes the incorrect reference to two’s complement and clarifies that the function performs a bit-wise NOT operation.