### PR TITLE
CI: Add editable install tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,10 +113,10 @@ jobs:
         cd tools
         pytest --pyargs numpy -m "not slow"
 
-  full:
-    # Build a wheel, install it, then run the full test suite with code coverage
+  test-editable:
     needs: [smoke_test]
     runs-on: ubuntu-22.04
+    if: github.event_name != 'push'
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -129,26 +129,12 @@ jobs:
       run: |
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/test_requirements.txt
-    - name: Install gfortran and setup OpenBLAS (MacPython build)
+    - name: Install editable NumPy
       run: |
-        set -xe
-        sudo apt update
-        sudo apt install gfortran libgfortran5
-        python -m pip install -r requirements/ci32_requirements.txt
-        mkdir -p ./.openblas
-        python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
-
-    - name: Build a wheel
-      env:
-        PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
+        pip install -e . -v --no-build-isolation
+    - name: Run test suite
       run: |
-        python -m build --wheel --no-isolation --skip-dependency-check
-        pip install dist/numpy*.whl
-    - name: Run full test suite
-      run: |
-        cd tools
-        pytest --pyargs numpy --cov-report=html:build/coverage
-        # TODO: gcov
+        pytest numpy
 
   benchmark:
     needs: [smoke_test]
@@ -310,25 +296,3 @@ jobs:
       env:
         PYTHON_GIL: 0
 
-  test-editable:
-    needs: [smoke_test]
-    runs-on: ubuntu-22.04
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-      with:
-        python-version: '3.10'
-    - name: Install build and test dependencies from PyPI
-      run: |
-        pip install -r requirements/build_requirements.txt
-        pip install -r requirements/test_requirements.txt
-    - name: Install editable NumPy
-      run: |
-        pip install -e . -v --no-build-isolation
-    - name: Run test suite
-      run: |
-        pytest numpy

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -309,3 +309,26 @@ jobs:
     - uses: ./.github/meson_actions
       env:
         PYTHON_GIL: 0
+
+  test-editable:
+    needs: [smoke_test]
+    runs-on: ubuntu-22.04
+    if: github.event_name != 'push'
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: '3.10'
+    - name: Install build and test dependencies from PyPI
+      run: |
+        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/test_requirements.txt
+    - name: Install editable NumPy
+      run: |
+        pip install -e . -v --no-build-isolation
+    - name: Run test suite
+      run: |
+        pytest numpy


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #26337 (Or at least try... Pipelines are a pain to test.) by adding a new job `test-editable`.

I did not identify any other job that could be made with an editable install. If there's one please let me know so I can tweak that one instead of adding a new one.