### PR TITLE
BUG: add exception to searchsorted incompatible inputs

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1513,7 +1513,7 @@ def searchsorted(a, v, side='left', sorter=None):
     try:
         np.less.resolve_dtypes((dtype_a, dtype_v, None))
     except UFuncTypeError:
-        raise ValueError(
+        raise TypeError(
                 f"Incompatible types for searching: a ({dtype_a}) and v"
                 f" ({dtype_v})")
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 from .._utils import set_module
+from ._exceptions import UFuncTypeError
 from . import multiarray as mu
 from . import overrides
 from . import umath as um
@@ -1507,6 +1508,14 @@ def searchsorted(a, v, side='left', sorter=None):
     array([0, 5, 1, 2])
 
     """
+    dtype_a = np.asarray(a).dtype
+    dtype_v = np.asarray(v).dtype
+    try:
+        np.less.resolve_dtypes((dtype_a, dtype_v, None))
+    except UFuncTypeError:
+        raise ValueError(
+                f"Incompatible types for searching: a ({dtype_a}) and v"
+                f" ({dtype_v})")
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)
 
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1508,8 +1508,10 @@ def searchsorted(a, v, side='left', sorter=None):
     array([0, 5, 1, 2])
 
     """
-    dtype_a = np.asarray(a).dtype
-    dtype_v = np.asarray(v).dtype
+    a = np.asanyarray(a)
+    v = np.asanyarray(v)
+    dtype_a = a.dtype
+    dtype_v = v.dtype
     try:
         np.less.resolve_dtypes((dtype_a, dtype_v, None))
     except UFuncTypeError:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2774,9 +2774,9 @@ class TestMethods:
         assert_(not isinstance(a.searchsorted(b, 'right', s), A))
 
     def test_searchsorted_incompatible_inputs(self):
-        assert_raises(ValueError, np.searchsorted, [1, 2, 3], ["1"])
-        assert_raises(ValueError, np.searchsorted, ["1", "2", "3"], [2])
-        assert_raises(ValueError, np.searchsorted, [b"1", b"2", b"3"], 1)
+        assert_raises(TypeError, np.searchsorted, [1, 2, 3], ["1"])
+        assert_raises(TypeError, np.searchsorted, ["1", "2", "3"], [2])
+        assert_raises(TypeError, np.searchsorted, [b"1", b"2", b"3"], 1)
 
     @pytest.mark.parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2773,6 +2773,11 @@ class TestMethods:
         assert_(not isinstance(a.searchsorted(b, 'left', s), A))
         assert_(not isinstance(a.searchsorted(b, 'right', s), A))
 
+    def test_searchsorted_incompatible_inputs(self):
+        assert_raises(ValueError, np.searchsorted, [1, 2, 3], ["1"])
+        assert_raises(ValueError, np.searchsorted, ["1", "2", "3"], [2])
+        assert_raises(ValueError, np.searchsorted, [b"1", b"2", b"3"], 1)
+
     @pytest.mark.parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):
         # Test out of range values in kth raise an error, gh-5469


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes https://github.com/numpy/numpy/issues/24032 by throwing an exception when `searchsorted` receives incompatible types