### PR TITLE
BUG: Disallow string inputs for copy keyword in np.array and np.asarray

### DIFF
--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -249,6 +249,12 @@ PyArray_CopyConverter(PyObject *obj, NPY_COPYMODE *copymode) {
             return NPY_FAIL;
         }
     }
+    else if(PyUnicode_Check(obj)) {
+        PyErr_SetString(PyExc_ValueError,
+                        "strings are not allowed for 'copy' keyword. "
+                        "Use True/False/None instead.");
+        return NPY_FAIL;
+    }
     else {
         npy_bool bool_copymode;
         if (!PyArray_BoolConverter(obj, &bool_copymode)) {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -503,6 +503,14 @@ class TestArrayConstruction:
         assert_array_equal(e, [[1, 3, 7], [1, 2, 3]])
         assert_array_equal(d, [[1, 5, 3], [1,2,3]])
 
+    def test_array_copy_str(self):
+        with pytest.raises(
+            ValueError,
+            match="strings are not allowed for 'copy' keyword. "
+                  "Use True/False/None instead."
+        ):
+            np.array([1, 2, 3], copy="always")
+
     def test_array_cont(self):
         d = np.ones(10)[::2]
         assert_(np.ascontiguousarray(d).flags.c_contiguous)


### PR DESCRIPTION
Backport of #26603.

Hi @seberg,

This PR disallows any string inputs for `copy` keyword in `np.array` and `np.asarray`, and is meant to fix https://github.com/numpy/numpy/issues/26573.

This way we still allow any integer-likes and the code change isn't that convoluted (`np.array(..., copy=np.bool(True))` works but also `np.array(..., copy={})` can run though)


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
