### PR TITLE
DOC: Set default as ``-j 1`` for spin docs and move ``-W`` to SPHINXOPTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             . venv/bin/activate
             cd doc
             # Don't use -q, show warning summary"
-            SPHINXOPTS="-n" make -e html
+            SPHINXOPTS="-W -n" make -e html
             if [[ $(find build/html -type f | wc -l) -lt 1000 ]]; then
                 echo "doc build failed: build/html is empty"
                 exit -1

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -132,8 +132,10 @@ def build(ctx, meson_args, with_scipy_openblas, jobs=None, clean=False, verbose=
 @click.option(
     '--jobs', '-j',
     metavar='N_JOBS',
-    default="auto",
-    help="Number of parallel build jobs"
+    # Avoids pydata_sphinx_theme extension warning from default="auto".
+    default="1",
+    help=("Number of parallel build jobs."
+          "Can be set to `auto` to use all cores.")
 )
 @click.pass_context
 def docs(ctx, sphinx_target, clean, first_build, jobs, *args, **kwargs):

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,7 @@ PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".fo
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= LANG=C sphinx-build
 PAPER         ?=
 DOXYGEN       ?= doxygen
@@ -25,7 +25,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
+ALLSPHINXOPTS   = -T --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
                   $(SPHINXOPTS) source
 
 .PHONY: help clean html web htmlhelp latex changes linkcheck \


### PR DESCRIPTION
Backport of #26478.

This commit tries to solve two problems.
- The pydata_sphinx_theme extension warning can be avoided by setting the default `--jobs` to `1`. This matches `spin test`.
- The -W option is currently hardcoded in ALLSPHINXOPTS and impossible to override. This commit moves `-W` to SPHINXOPTS which allows a local machine to remove -W if needed, as described in the documentation. This adds to the discussion in PR #26125.

[skip actions] [skip azp] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
