### PR TITLE
DOC: add CI and NEP commit acronyms

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -166,12 +166,14 @@ Standard acronyms to start the commit message with are::
    BENCH: changes to the benchmark suite
    BLD: change related to building numpy
    BUG: bug fix
+   CI: continuous integration
    DEP: deprecate something, or remove a deprecated object
    DEV: development tool or utility
    DOC: documentation
    ENH: enhancement
    MAINT: maintenance commit (refactoring, typos, etc.)
    MNT: alias for MAINT
+   NEP: NumPy enhancement proposals
    REL: related to releasing numpy
    REV: revert an earlier commit
    STY: style fix (whitespace, PEP8)


### PR DESCRIPTION
[skip actions][skip azp][skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes #26649.

Adds CI and NEP as standard commit acronyms in the [Development Workflow](https://numpy.org/devdocs/dev/development_workflow.html) page.