### PR TITLE
BUG: Adds asanyarray to start of linalg.cross

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3171,6 +3171,9 @@ def cross(x1, x2, /, *, axis=-1):
     numpy.cross
 
     """
+    x1 = asanyarray(x1)
+    x2 = asanyarray(x2)
+
     if x1.shape[axis] != 3 or x2.shape[axis] != 3:
         raise ValueError(
             "Both input arrays must be (arrays of) 3-dimensional vectors, "

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2307,6 +2307,14 @@ def test_cross():
 
     assert_equal(actual, expected)
 
+    # We test that lists are converted to arrays.
+    u = [1, 2, 3]
+    v = [4, 5, 6]
+    actual = np.linalg.cross(u, v)
+    expected = array([-3,  6, -3])
+
+    assert_equal(actual, expected)
+
     with assert_raises_regex(
         ValueError,
         r"input arrays must be \(arrays of\) 3-dimensional vectors"


### PR DESCRIPTION
Currently linalg.cross fails when given two 3D lists. This adds `asanyarray` at the start of the code,
mimicking the other Array API compatible additions. This was discussed in PR #26640, with a bug fix requested.