### PR TITLE
MNT: catch invalid fixed-width dtype sizes

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -6,6 +6,8 @@
 #include <Python.h>
 #include <structmember.h>
 
+#include <errno.h>
+
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
 #include "numpy/npy_math.h"
@@ -1807,14 +1809,27 @@ _convert_from_str(PyObject *obj, int align)
         /* Python byte string characters are unsigned */
         check_num = (unsigned char) type[0];
     }
-    /* A kind + size like 'f8' */
+    /* Possibly a kind + size like 'f8' but also could be 'bool' */
     else {
         char *typeend = NULL;
         int kind;
 
-        /* Parse the integer, make sure it's the rest of the string */
-        elsize = (int)strtol(type + 1, &typeend, 10);
-        if (typeend - type == len) {
+        /* Attempt to parse the integer, make sure it's the rest of the string */
+        errno = 0;
+        long result = strtol(type + 1, &typeend, 10);
+        npy_bool some_parsing_happened = !(type == typeend);
+        npy_bool entire_string_consumed = *typeend == '\0';
+        npy_bool parsing_succeeded =
+                (errno == 0) && some_parsing_happened && entire_string_consumed;
+        // make sure it doesn't overflow or go negative
+        if (result > INT_MAX || result < 0) {
+            goto fail;
+        }
+
+        elsize = (int)result;
+
+
+        if (parsing_succeeded && typeend - type == len) {
 
             kind = type[0];
             switch (kind) {
@@ -1859,6 +1874,9 @@ _convert_from_str(PyObject *obj, int align)
                         elsize = 0;
                     }
             }
+        }
+        else if (parsing_succeeded) {
+            goto fail;
         }
     }
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -15,7 +15,7 @@
 #include "npy_config.h"
 #include "npy_ctypes.h"
 #include "npy_import.h"
-#include "npy_pycompat.h"
+
 
 #include "_datetime.h"
 #include "common.h"
@@ -2038,7 +2038,6 @@ arraydescr_dealloc(PyArray_Descr *self)
 {
     Py_XDECREF(self->typeobj);
     if (!PyDataType_ISLEGACY(self)) {
-        /* non legacy dtypes must not have fields, etc. */
         Py_TYPE(self)->tp_free((PyObject *)self);
         return;
     }

--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -1462,7 +1462,7 @@ string_expandtabs_length(Buffer<enc> buf, npy_int64 tabsize)
                 line_pos = 0;
             }
         }
-        if (new_len == PY_SSIZE_T_MAX || new_len < 0) {
+        if (new_len > INT_MAX  || new_len < 0) {
             npy_gil_error(PyExc_OverflowError, "new string is too long");
             return -1;
         }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -98,6 +98,8 @@ class TestBuiltin:
 
         # Make sure negative-sized dtype raises an error
         assert_raises(TypeError, np.dtype, 'S-1')
+        assert_raises(TypeError, np.dtype, 'U-1')
+        assert_raises(TypeError, np.dtype, 'V-1')
 
     def test_richcompare_invalid_dtype_equality(self):
         # Make sure objects that cannot be converted to valid

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -96,6 +96,9 @@ class TestBuiltin:
             assert_raises(TypeError, np.dtype, 'q8')
             assert_raises(TypeError, np.dtype, 'Q8')
 
+        # Make sure negative-sized dtype raises an error
+        assert_raises(TypeError, np.dtype, 'S-1')
+
     def test_richcompare_invalid_dtype_equality(self):
         # Make sure objects that cannot be converted to valid
         # dtypes results in False/True when compared to valid dtypes.

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -231,6 +231,22 @@ class TestBuiltin:
         with pytest.raises(ValueError):
             type(np.dtype("U"))(-1)
 
+        # OverflowError on 32 bit
+        with pytest.raises((TypeError, OverflowError)):
+            # see gh-26556
+            type(np.dtype("S"))(2**61)
+
+        with pytest.raises(TypeError):
+            np.dtype("S1234hello")
+
+    def test_leading_zero_parsing(self):
+        dt1 = np.dtype('S010')
+        dt2 = np.dtype('S10')
+
+        assert dt1 == dt2
+        assert repr(dt1) == "dtype('S10')"
+        assert dt1.itemsize == 10
+
 
 class TestRecord:
     def test_equivalent_record(self):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 
 import numpy as np
 from numpy._core import umath, sctypes
-from numpy._core._exceptions import _ArrayMemoryError
 from numpy._core.numerictypes import obj2sctype
 from numpy._core.arrayprint import set_string_function
 from numpy.exceptions import AxisError
@@ -3359,7 +3358,7 @@ class TestLikeFuncs:
         assert_(type(b) is not MyNDArray)
 
         # Test invalid dtype
-        with assert_raises(_ArrayMemoryError):
+        with assert_raises(TypeError):
             a = np.array(b"abc")
             like_function(a, dtype="S-1", **fill_kwarg)
 

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -716,6 +716,7 @@ class TestMethods:
     def test_expandtabs_raises_overflow(self, dt):
         with pytest.raises(OverflowError, match="new string is too long"):
             np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), sys.maxsize)
+            np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), 2**61)
 
 
 @pytest.mark.parametrize("dt", ["U", "T"])


### PR DESCRIPTION
Backport of #26589 and #25974.

Fixes #26556 

The ultimate cause was the error checking for invalid dtype names like `'S' + str(2**61)` was incorrect. The root cause in the issue is it cast from long to int without doing any kind of overflow detection.

I also noticed another issue while I was debugging: the docs for `strtol` say that it returns 0 if the string isn't representable as an int and we need to check for that case too. It's a little tricky to do that, because we also allow types like `'S0'`, which is why the check is written in a kind of weird way with a gnarly if statement. Very open to alternative ways to write that.

Also noticed that `expandtabs` was assuming `PY_SSIZE_T_MAX` is the largest representable string, but that's wrong, it's INT_MAX because of the conversion form `long` to `int` on the result of `strtol`.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
