### PR TITLE
MAINT: mark evil_global_disable_warn_O4O8_flag as thread-local

### DIFF
--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1203,7 +1203,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
  * that it is in an unpickle context instead of a normal context without
  * evil global state like we create here.
  */
-NPY_NO_EXPORT int evil_global_disable_warn_O4O8_flag = 0;
+NPY_NO_EXPORT NPY_TLS int evil_global_disable_warn_O4O8_flag = 0;
 
 /*
  * Convert a gentype (that is actually a generic kind character) and

--- a/numpy/_core/src/multiarray/conversion_utils.h
+++ b/numpy/_core/src/multiarray/conversion_utils.h
@@ -113,7 +113,7 @@ PyArray_DeviceConverterOptional(PyObject *object, NPY_DEVICE *device);
  * that it is in an unpickle context instead of a normal context without
  * evil global state like we create here.
  */
-extern NPY_NO_EXPORT int evil_global_disable_warn_O4O8_flag;
+extern NPY_NO_EXPORT NPY_TLS int evil_global_disable_warn_O4O8_flag;
 
 /*
  * Convert function which replaces np._NoValue with NULL.


### PR DESCRIPTION
I also looked at getting rid of the flag entirely but unfortunately the pickle format encodes dtype="O" as "O8" on 64 bit systems, coming from this line:

https://github.com/numpy/numpy/blob/1854f269b154aef615e90db61da339e062150ec9/numpy/_core/src/multiarray/descriptor.c#L2744

Unfortunately we didn't change that to writing just "O" instead of "O4" or "O8" when we deprecated this and added the global flag back in 2012, so we need to keep the evil global flag. I have no idea if changing how object dtypes get written to pickle files would break other things or subtly break compatibility across numpy versions.

However, we can at least make the evil global flag thread safe by marking it as a thread-local variable, just like the promotion state.

If we ever wanted to support subinterpreters, we'd need to move this state into the module state and it would no longer need to be thread-local.

You could test this by having one thread load a pickle file and another thread create e.g. an "O4" dtype simultaneously. In practice it's tricky to actually write such a test because pytest isn't thread-safe, so I can't use e.g. `pytest.warns` inside a thread.