### PR TITLE
CI: Use default llvm on Windows.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,10 @@ jobs:
     - name: Install Clang-cl
       if: matrix.compiler == 'Clang-cl'
       run: |
-        choco install llvm -y --version=16.0.6
+        # llvm is preinstalled, but leave
+        # this here in case we need to pin the
+        # version at some point.
+        #choco install llvm -y
 
     - name: Install NumPy (MSVC)
       if: matrix.compiler == 'MSVC'


### PR DESCRIPTION
Backport of #26675.

`choco install llvm -y --version=16.0.6` causes and error as the default version has increase to 18.1.6.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
