### PR TITLE
BUILD: check for scipy-doctest, remove it from requirements

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -320,6 +320,7 @@ def check_docs(ctx, pytest_args, n_jobs, verbose, *args, **kwargs):
 
     """  # noqa: E501
     try:
+        # prevent obscure error later
         import scipy_doctest
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError("scipy-doctest not installed") from e

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -319,6 +319,10 @@ def check_docs(ctx, pytest_args, n_jobs, verbose, *args, **kwargs):
        from the top-level `__init__.py` file.
 
     """  # noqa: E501
+    try:
+        import scipy_doctest
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError("scipy-doctest not installed") from e
     if (not pytest_args):
         pytest_args = ('numpy',)
 

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -5,7 +5,6 @@ wheel==0.38.1
 setuptools
 hypothesis==6.81.1
 pytest==7.4.0
-scipy-doctest
 pytz==2023.3.post1
 pytest-cov==4.1.0
 meson


### PR DESCRIPTION
Fixes #26688 

The scipy-doctest package requires NumPy, so do not put it in the requirements file for numpy.

Also check that scipy-doctest is installed before starting to run `spin check-docs`.