### PR TITLE
DOC: document workaround for deprecation of dim-2 inputs to `cross`

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1565,6 +1565,12 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
     Supports full broadcasting of the inputs.
 
+    Dimension-2 input arrays were deprecated in 2.0.0. If you do need this
+    functionality, you can use::
+
+        def cross2d(x, y):
+            return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
     Examples
     --------
     Vector cross-product.


### PR DESCRIPTION
This addresses a part of gh-26620. The one-liner was verified and is likely to be used in a future `np.linalg.cross2d` function implementation, in gh-26640.

Hat tip to @seberg for coming up with the one-liner, and @bmwoodruff for working on the longer-term replacement in gh-26640.