### PR TITLE
BUG: allow replacement in the dispatch cache

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.c
+++ b/numpy/_core/src/common/npy_hashtable.c
@@ -234,7 +234,7 @@ PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb,
         if (tb_item[0] != NULL && tb_item[0] != value && !replace) {
             UNLOCK_TABLE(tb);
             PyErr_SetString(PyExc_RuntimeError,
-                    "Identity cache already includes the item.");
+                    "Identity cache already includes an item with this key.");
             return -1;
         }
         tb_item[0] = value;

--- a/numpy/_core/src/common/npy_hashtable.c
+++ b/numpy/_core/src/common/npy_hashtable.c
@@ -210,10 +210,13 @@ _resize_if_necessary(PyArrayIdentityHash *tb)
  * @param value Normally a Python object, no reference counting is done.
  *        use NULL to clear an item.  If the item does not exist, no
  *        action is performed for NULL.
- * @param replace If 1, allow replacements.
+ * @param replace If 1, allow replacements. If replace is 0 an error is raised
+ *        if the stored value is different from the value to be cached. If the
+ *        value to be cached is identical to the stored value, the value to be
+ *        cached is ignored and no error is raised.
  * @returns 0 on success, -1 with a MemoryError or RuntimeError (if an item
- *        is added which is already in the cache).  The caller should avoid
- *        the RuntimeError.
+ *        is added which is already in the cache and replace is 0).  The
+ *        caller should avoid the RuntimeError.
  */
 NPY_NO_EXPORT int
 PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb,
@@ -228,7 +231,7 @@ PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb,
 
     PyObject **tb_item = find_item(tb, key);
     if (value != NULL) {
-        if (tb_item[0] != NULL && !replace) {
+        if (tb_item[0] != NULL && tb_item[0] != value && !replace) {
             UNLOCK_TABLE(tb);
             PyErr_SetString(PyExc_RuntimeError,
                     "Identity cache already includes the item.");

--- a/numpy/_core/tests/test_hashtable.py
+++ b/numpy/_core/tests/test_hashtable.py
@@ -23,8 +23,3 @@ def test_identity_hashtable(key_length, length):
 
     res = identityhash_tester(key_length, keys_vals, replace=True)
     assert res is expected
-
-    # check that ensuring one duplicate definitely raises:
-    keys_vals.insert(0, keys_vals[-2])
-    with pytest.raises(RuntimeError):
-        identityhash_tester(key_length, keys_vals)

--- a/numpy/_core/tests/test_hashtable.py
+++ b/numpy/_core/tests/test_hashtable.py
@@ -23,3 +23,13 @@ def test_identity_hashtable(key_length, length):
 
     res = identityhash_tester(key_length, keys_vals, replace=True)
     assert res is expected
+
+    if length == 1:
+        return
+
+    # add a new item with a key that is already used and a new value, this
+    # should error if replace is False, see gh-26690
+    new_key = (keys_vals[1][0], object())
+    keys_vals[0] = new_key
+    with pytest.raises(RuntimeError):
+        identityhash_tester(key_length, keys_vals)


### PR DESCRIPTION
Fixes #26690.

The test code I added raises an unhandled thread exception every time I run it using a linux x86 laptop without the change to `dispatching.c` in this PR.

Still not sure why this failure is only hit under gcc.

Here's what I think is happening: right now the locking in the dispatch cache is only internal to the cache itself. The current locking strategy allows a race condition where two threads simultaneously see the cache is empty early in dispatch and then try fill it. The second thread to fill it sees the cache is filled and raises an exception, because the `replace` parameter for `PyArrayIdentityHash_SetItem` is 0, so replacements raise an exception.

I don't think it's possible to support this replace feature without moving the lock from the dispatch cache struct to somewhere in the dispatching logic in `dispatching.c`. We'd need to lock around all the spots we check for an entry in the dispatch cache and then later insert an entry into the cache. Happy to try that approach if it turns out replacing entries in this cache is problematic for some reason. I didn't want to do that since this code is hit every time a ufunc is called so I don't want to add even larger blocks of code that need to be locked around.

In practice, I don't think it's problematic to simply replace entries when this happens, at least not any more problematic than the current approach, since the dispatch cache holds borrowed references to ArrayMethod instances.