### PR TITLE
DOC: document workaround for deprecation of dim-2 inputs to `cross`

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1565,6 +1565,12 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
 
     Supports full broadcasting of the inputs.
 
+    Dimension-2 input arrays were deprecated in 2.0.0. If you do need this
+    functionality, you can use::
+
+        def cross2d(x, y):
+            return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
     Examples
     --------
     Vector cross-product.


### PR DESCRIPTION
Backport of #26692.

This addresses a part of gh-26620. The one-liner was verified and is likely to be used in a future `np.linalg.cross2d` function implementation, in gh-26640.

Hat tip to @seberg for coming up with the one-liner, and @bmwoodruff for working on the longer-term replacement in gh-26640.

[skip actions] [skip azp] [skip cirrus]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
