### PR TITLE
BUG: Adds asanyarray to start of linalg.cross (#26667)

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3164,6 +3164,9 @@ def cross(x1, x2, /, *, axis=-1):
     numpy.cross
 
     """
+    x1 = asanyarray(x1)
+    x2 = asanyarray(x2)
+
     if x1.shape[axis] != 3 or x2.shape[axis] != 3:
         raise ValueError(
             "Both input arrays must be (arrays of) 3-dimensional vectors, "

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2307,6 +2307,14 @@ def test_cross():
 
     assert_equal(actual, expected)
 
+    # We test that lists are converted to arrays.
+    u = [1, 2, 3]
+    v = [4, 5, 6]
+    actual = np.linalg.cross(u, v)
+    expected = array([-3,  6, -3])
+
+    assert_equal(actual, expected)
+
     with assert_raises_regex(
         ValueError,
         r"input arrays must be \(arrays of\) 3-dimensional vectors"


### PR DESCRIPTION
Backport of #26667.

Currently linalg.cross fails when given two 3D lists. This adds `asanyarray` at the start of the code,
mimicing the other Array API compatible additions. This was discussed in PR #26640, with a bug fix requested.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
