### PR TITLE
DOC: Added missing See Also sections in Polynomial module

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -670,6 +670,10 @@ def chebmulx(c):
     out : ndarray
         Array representing the result of the multiplication.
 
+    See Also
+    --------
+    chebadd, chebsub, chebmul, chebdiv, chebpow
+
     Notes
     -----
 

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -408,6 +408,10 @@ def hermemulx(c):
     out : ndarray
         Array representing the result of the multiplication.
 
+    See Also
+    --------
+    hermeadd, hermesub, hermemul, hermediv, hermepow
+
     Notes
     -----
     The multiplication uses the recursion relationship for Hermite

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -426,7 +426,7 @@ def legmulx(c):
 
     See Also
     --------
-    legadd, legmul, legdiv, legpow
+    legadd, legsub, legmul, legdiv, legpow
 
     Notes
     -----


### PR DESCRIPTION
This adds some missing "See also" sections to a few functions in the polynomial module. This gives a consistent look for the add, sub, mulx, mul, div, pow versions of all 6 types.
