### PR TITLE
BUG: Handle `--f77flags` and `--f90flags` for `meson`

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -223,11 +223,11 @@ def _prepare_sources(mname, sources, bdir):
 def _get_flags(fc_flags):
     flag_values = []
     flag_pattern = re.compile(r"--f(77|90)flags=(.*)")
-
     for flag in fc_flags:
         match_result = flag_pattern.match(flag)
         if match_result:
             values = match_result.group(2).strip().split()
+            values = [val.strip("'\"") for val in values]
             flag_values.extend(values)
     # Hacky way to preserve order of flags
     unique_flags = list(dict.fromkeys(flag_values))

--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -28,7 +28,7 @@ class MesonTemplate:
         include_dirs: list[Path],
         object_files: list[Path],
         linker_args: list[str],
-        c_args: list[str],
+        fortran_args: list[str],
         build_type: str,
         python_exe: str,
     ):
@@ -46,12 +46,18 @@ class MesonTemplate:
             self.include_dirs = []
         self.substitutions = {}
         self.objects = object_files
+        # Convert args to '' wrapped variant for meson
+        self.fortran_args = [
+            f"'{x}'" if not (x.startswith("'") and x.endswith("'")) else x
+            for x in fortran_args
+        ]
         self.pipeline = [
             self.initialize_template,
             self.sources_substitution,
             self.deps_substitution,
             self.include_substitution,
             self.libraries_substitution,
+            self.fortran_args_substitution,
         ]
         self.build_type = build_type
         self.python_exe = python_exe
@@ -109,6 +115,14 @@ class MesonTemplate:
             [f"{self.indent}'''{inc}'''," for inc in self.include_dirs]
         )
 
+    def fortran_args_substitution(self) -> None:
+        if self.fortran_args:
+            self.substitutions["fortran_args"] = (
+                f"{self.indent}fortran_args: [{', '.join([arg for arg in self.fortran_args])}],"
+            )
+        else:
+            self.substitutions["fortran_args"] = ""
+
     def generate_meson_build(self):
         for node in self.pipeline:
             node()
@@ -126,6 +140,7 @@ class MesonBackend(Backend):
         self.build_type = (
             "debug" if any("debug" in flag for flag in self.fc_flags) else "release"
         )
+        self.fc_flags = _get_flags(self.fc_flags)
 
     def _move_exec_to_root(self, build_dir: Path):
         walk_dir = Path(build_dir) / self.meson_build_dir
@@ -203,3 +218,17 @@ def _prepare_sources(mname, sources, bdir):
         if not Path(source).suffix == ".pyf"
     ]
     return extended_sources
+
+
+def _get_flags(fc_flags):
+    flag_values = []
+    flag_pattern = re.compile(r"--f(77|90)flags=(.*)")
+
+    for flag in fc_flags:
+        match_result = flag_pattern.match(flag)
+        if match_result:
+            values = match_result.group(2).strip().split()
+            flag_values.extend(values)
+    # Hacky way to preserve order of flags
+    unique_flags = list(dict.fromkeys(flag_values))
+    return unique_flags

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -51,4 +51,5 @@ ${dep_list}
 ${lib_list}
 ${lib_dir_list}
                      ],
+${fortran_args}
                      install : true)

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -635,6 +635,7 @@ def run_compile():
         r'--((f(90)?compiler(-exec|)|compiler)=|help-compiler)')
     flib_flags = [_m for _m in sys.argv[1:] if _reg3.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in flib_flags]
+    # TODO: Once distutils is dropped completely, i.e. min_ver >= 3.12, unify into --fflags
     reg_f77_f90_flags = re.compile(r'--f(77|90)flags=')
     reg_distutils_flags = re.compile(r'--((f(77|90)exec|opt|arch)=|(debug|noopt|noarch|help-fcompiler))')
     fc_flags = [_m for _m in sys.argv[1:] if reg_f77_f90_flags.match(_m)]

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -635,10 +635,13 @@ def run_compile():
         r'--((f(90)?compiler(-exec|)|compiler)=|help-compiler)')
     flib_flags = [_m for _m in sys.argv[1:] if _reg3.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in flib_flags]
-    _reg4 = re.compile(
-        r'--((f(77|90)(flags|exec)|opt|arch)=|(debug|noopt|noarch|help-fcompiler))')
-    fc_flags = [_m for _m in sys.argv[1:] if _reg4.match(_m)]
-    sys.argv = [_m for _m in sys.argv if _m not in fc_flags]
+    reg_f77_f90_flags = re.compile(r'--f(77|90)flags=')
+    reg_distutils_flags = re.compile(r'--((f(77|90)exec|opt|arch)=|(debug|noopt|noarch|help-fcompiler))')
+    fc_flags = [_m for _m in sys.argv[1:] if reg_f77_f90_flags.match(_m)]
+    distutils_flags = [_m for _m in sys.argv[1:] if reg_distutils_flags.match(_m)]
+    if not (MESON_ONLY_VER or backend_key == 'meson'):
+        fc_flags.extend(distutils_flags)
+    sys.argv = [_m for _m in sys.argv if _m not in (fc_flags + distutils_flags)]
 
     del_list = []
     for s in flib_flags:

--- a/numpy/f2py/tests/src/regression/f77fixedform.f95
+++ b/numpy/f2py/tests/src/regression/f77fixedform.f95
@@ -1,0 +1,5 @@
+C This is an invalid file, but it does compile with -ffixed-form
+      subroutine mwe(
+     & x)
+          real x
+      end subroutine mwe

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -130,8 +130,8 @@ def test_gh25784():
             [util.getpath("tests", "src", "regression", "f77fixedform.f95")],
             options=[
                 # Meson will collect and dedup these to pass to fortran_args:
-                "--f77flags='-ffixed-form'",
-                "--f90flags='-ffixed-form'",
+                "--f77flags='-ffixed-form -O2'",
+                "--f90flags=\"-ffixed-form -Og\"",
             ],
             module_name="Blah",
         )

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -109,6 +109,7 @@ class TestF90Contiuation(util.F2PyTest):
         assert(res[0] == 8)
         assert(res[1] == 15)
 
+@pytest.mark.slow
 def test_gh26623():
     # Including libraries with . should not generate an incorrect meson.build
     try:
@@ -119,3 +120,20 @@ def test_gh26623():
         )
     except RuntimeError as rerr:
         assert "lparen got assign" not in str(rerr)
+
+
+@pytest.mark.slow
+def test_gh25784():
+    # Compile dubious file using passed flags
+    try:
+        aa = util.build_module(
+            [util.getpath("tests", "src", "regression", "f77fixedform.f95")],
+            options=[
+                # Meson will collect and dedup these to pass to fortran_args:
+                "--f77flags='-ffixed-form'",
+                "--f90flags='-ffixed-form'",
+            ],
+            module_name="Blah",
+        )
+    except ImportError as rerr:
+        assert "unknown_subroutine_" in str(rerr)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -121,7 +121,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
         dst_sources.append(dst)
 
         base, ext = os.path.splitext(dst)
-        if ext in (".f90", ".f", ".c", ".pyf"):
+        if ext in (".f90", ".f95", ".f", ".c", ".pyf"):
             f2py_sources.append(dst)
 
     assert f2py_sources


### PR DESCRIPTION
Closes #25784. Background and notes:
- Although the CLI was passing `fc_flags` to the Meson backend they weren't being used
- The behavior currently is to (redundantly) collect the unique set of flags passed via either `--f77flags` or `--f90flags`
  - They all map to `fortran_args` for the `meson.build` (`distutils` used to have separate handling for the two cases)
  - Eventually these should be merged into a single `--fflags` argument (basically since they're now redundant post-distutils)
    - This is likely only when we have 3.12 as the lowest supported version, since `distutils` will need to have both CLI options
- The test is specially crafted to get an error without `-ffixed-form` but is otherwise junk
  - Adding a continuation character at the end of the line as well will both get `f2py` and `gfortran` to compile without `-ffixed-form`
  - Or putting the same code in a `.f` file, thereby signalling to F2PY that this is a Fortran 77 file

It does make sense to handle `fortran_args` this way though, since it is more robust than setting `FFLAGS` (which anyway won't work due to a `meson` bug, https://github.com/mesonbuild/meson/pull/13327).