### PR TITLE
TST: Skip an f2py module test on Windows

### DIFF
--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import platform
 
 import numpy as np
 import numpy.testing as npt
@@ -123,6 +124,7 @@ def test_gh26623():
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(platform.system() not in ['Linux', 'Darwin'], reason='Unsupported on this platform for now')
 def test_gh25784():
     # Compile dubious file using passed flags
     try:


### PR DESCRIPTION
Resolves (staves off) https://github.com/numpy/numpy/pull/26703#issuecomment-2171272729 by being more consistent with the rest of the F2PY testsuite.


the `util.F2PyTest` helper skips Windows tests, so the test added should also skip on Windows (https://github.com/numpy/numpy/issues/25134 again).

Looking at the logs it seems like the Windows CI is using the wrong stack though #25000 was why `quadmath` was added for Windows testers, and also `meson` detects it fine, though it fails to find it while linking. Leaving an extract from the logs here for posterity:

<details>

```
RuntimeError: Running f2py failed: ['-m', 'Blah', "--f77flags='-ffixed-form -O2'", '--f90flags="-ffixed-form -Og"', 'C:\\Users\\VSSADM~1\\AppData\\Local\\Temp\\tmpk5lopyhl\\f77fixedform.f95', '--backend', 'meson']
The Meson build system
Version: 1.4.1
Source dir: C:\Users\VssAdministrator\AppData\Local\Temp\tmp26x34xwn
Build dir: C:\Users\VssAdministrator\AppData\Local\Temp\tmp26x34xwn\bbdir
Build type: native build
Project name: Blah
Project version: 0.1
Fortran compiler for the host machine: gfortran (gcc 8.1.0 "GNU Fortran (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 8.1.0")
Fortran linker for the host machine: gfortran ld.bfd 2.30
C compiler for the host machine: cl (msvc 19.00.24247.2 "Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24247.2 for x64")
C linker for the host machine: link link 14.00.24247.2
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program C:\hostedtoolcache\windows\Python\3.11.9\x64\python.exe found: YES (C:\hostedtoolcache\windows\Python\3.11.9\x64\python.exe)
Run-time dependency python found: YES 3.11
Library quadmath found: YES
Build targets in project: 1

Found ninja-1.11.1.git.kitware.jobserver-1 at C:\hostedtoolcache\windows\Python\3.11.9\x64\Scripts\ninja.EXE
ninja: Entering directory `C:/Users/VssAdministrator/AppData/Local/Temp/tmp26x34xwn/bbdir'
[1/6] Compiling C object Blah.cp311-win_amd64.pyd.p/Blahmodule.c.obj
[2/6] Module scanner.
[3/6] Compiling C object Blah.cp311-win_amd64.pyd.p/439c03e4f3b998dc3aa6363e6ec5d442570006cf_.._.._f2py_src_fortranobject.c.obj
[4/6] Compiling Fortran object Blah.cp311-win_amd64.pyd.p/f77fixedform.f95.obj
../f77fixedform.f95:3:8:

      & x)
        1
Warning: Unused dummy argument 'x' at (1) [-Wunused-dummy-argument]
[5/6] Compiling Fortran object Blah.cp311-win_amd64.pyd.p/Blah-f2pywrappers.f.obj
[6/6] Linking target Blah.cp311-win_amd64.pyd
FAILED: Blah.cp311-win_amd64.pyd 
"link"  /MACHINE:x64 /OUT:Blah.cp311-win_amd64.pyd Blah.cp311-win_amd64.pyd.p/f77fixedform.f95.obj Blah.cp311-win_amd64.pyd.p/Blahmodule.c.obj Blah.cp311-win_amd64.pyd.p/Blah-f2pywrappers.f.obj Blah.cp311-win_amd64.pyd.p/439c03e4f3b998dc3aa6363e6ec5d442570006cf_.._.._f2py_src_fortranobject.c.obj "/LIBPATH:C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0" "/LIBPATH:C:/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0" "/LIBPATH:C:/mingw64/bin/../lib/gcc" "/LIBPATH:C:/mingw64/lib/gcc" "/LIBPATH:C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/lib/../lib" "/LIBPATH:C:/mingw64/x86_64-w64-mingw32/lib" "/LIBPATH:C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../lib" "/LIBPATH:C:/mingw64/lib" "/LIBPATH:C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/lib" "/LIBPATH:C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../.." "/release" "/nologo" "/OPT:REF" "/DLL" "/IMPLIB:Blah.cp311-win_amd64.lib" "C:\hostedtoolcache\windows\Python\3.11.9\x64\libs\python311.lib" "quadmath.lib" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib" "gfortran.lib"
LINK : fatal error LNK1181: cannot open input file 'quadmath.lib'

ninja: build stopped: subcommand failed.
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: C:\hostedtoolcache\windows\Python\3.11.9\x64\Scripts\ninja.EXE -C C:/Users/VssAdministrator/AppData/Local/Temp/tmp26x34xwn/bbdir
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\numpy\f2py\f2py2e.py", line 769, in main
    run_compile()
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\numpy\f2py\f2py2e.py", line 741, in run_compile
    builder.compile()
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\numpy\f2py\_backends\_meson.py", line 193, in compile
    self.run_meson(self.build_dir)
  File "C:\hostedtoolcache
```

</details>

The reason why it didn't show up in #26634 which uses a similar test pattern is because that raised an error in `meson`, so we handle a `RuntimeError` before trying to link the final module, while here we're trying to catch an `ImportError` but the Windows CI doesn't import any F2PY modules correctly (since it can't build them).