### PR TITLE
CI: Add more skip conditions

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,7 +1,3 @@
-# To enable this workflow on a fork, comment out:
-#
-# if: github.repository == 'numpy/numpy'
-
 name: CircleCI artifact redirector
 
 on: [status]
@@ -9,9 +5,32 @@ on: [status]
 permissions: read-all
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[circle skip]') && !contains(github.event.head_commit.message, '[skip circle]')  && github.event.context == 'ci/circleci: build'"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[circle skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip circle]') &&
+      github.event.context == 'ci/circleci: build'
     name: Run CircleCI artifacts redirector
     permissions:
       statuses: write

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -21,7 +21,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   circleci_artifacts_redirector_job:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,9 +24,32 @@ permissions:
   contents: read
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[codeql skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip codeql]')
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -16,13 +16,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message
@@ -34,7 +34,6 @@ jobs:
           echo github.ref ${{ github.ref }}
   cygwin_build_test:
     runs-on: windows-latest
-    # To enable this workflow on a fork, comment out:
     needs: get_commit_tags
     if: >-
       !contains(needs.get_commit_tags.outputs.message, '[cygwin skip]') &&

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -13,10 +13,32 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   cygwin_build_test:
     runs-on: windows-latest
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[cygwin skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip cygwin]')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -29,7 +29,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   cygwin_build_test:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -39,11 +39,32 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   build-wasm-emscripten:
     name: Build NumPy distribution for Pyodide
     runs-on: ubuntu-22.04
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[wasm skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip wasm]')
     env:
       PYODIDE_VERSION: 0.26.0
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -55,7 +55,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   build-wasm-emscripten:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,13 +30,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   lint:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,6 +27,25 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   lint:
     # To enable this job and subsequent jobs on a fork, comment out:
     if: github.repository == 'numpy/numpy' && github.event_name != 'push'
@@ -48,8 +67,10 @@ jobs:
         python tools/linter.py --branch origin/${{ github.base_ref }}
 
   smoke_test:
-    # To enable this job on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[linux skip]') && !contains(github.event.head_commit.message, '[skip linux]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[linux skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip linux]')
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,7 @@ jobs:
 
   smoke_test:
     # To enable this job on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[linux skip]') && !contains(github.event.head_commit.message, '[skip linux]')"
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -56,13 +56,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -69,7 +69,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   openblas32_stable_nightly:

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -55,7 +55,7 @@ permissions:
 jobs:
   openblas32_stable_nightly:
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
 
 
   openblas_no_pkgconfig_fedora:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     container: fedora:39
     name: "OpenBLAS (Fedora, no pkg-config, LP64/ILP64)"
@@ -153,7 +153,7 @@ jobs:
 
 
   flexiblas_fedora:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     container: fedora:39
     name: "FlexiBLAS (LP64, ILP64 on Fedora)"
@@ -188,7 +188,7 @@ jobs:
 
 
   openblas_cmake:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     name: "OpenBLAS with CMake"
     steps:
@@ -216,7 +216,7 @@ jobs:
 
  
   netlib-debian:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     name: "Debian libblas/liblapack"
     steps:
@@ -245,7 +245,7 @@ jobs:
 
 
   netlib-split:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     container: opensuse/tumbleweed
     name: "OpenSUSE Netlib BLAS/LAPACK"
@@ -276,7 +276,7 @@ jobs:
 
 
   mkl:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     name: "MKL (LP64, ILP64, SDL)"
     steps:
@@ -339,7 +339,7 @@ jobs:
       run: spin test -- numpy/linalg
 
   blis:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     name: "BLIS"
     steps:
@@ -375,7 +375,7 @@ jobs:
       run: spin test -- numpy/linalg
 
   atlas:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
     runs-on: ubuntu-latest
     name: "ATLAS"
     steps:

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -53,9 +53,30 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   openblas32_stable_nightly:
-    # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -118,7 +139,10 @@ jobs:
 
 
   openblas_no_pkgconfig_fedora:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     container: fedora:39
     name: "OpenBLAS (Fedora, no pkg-config, LP64/ILP64)"
@@ -153,7 +177,10 @@ jobs:
 
 
   flexiblas_fedora:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     container: fedora:39
     name: "FlexiBLAS (LP64, ILP64 on Fedora)"
@@ -188,7 +215,10 @@ jobs:
 
 
   openblas_cmake:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     name: "OpenBLAS with CMake"
     steps:
@@ -216,7 +246,10 @@ jobs:
 
  
   netlib-debian:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     name: "Debian libblas/liblapack"
     steps:
@@ -245,7 +278,10 @@ jobs:
 
 
   netlib-split:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     container: opensuse/tumbleweed
     name: "OpenSUSE Netlib BLAS/LAPACK"
@@ -276,7 +312,10 @@ jobs:
 
 
   mkl:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     name: "MKL (LP64, ILP64, SDL)"
     steps:
@@ -339,7 +378,10 @@ jobs:
       run: spin test -- numpy/linalg
 
   blis:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     name: "BLIS"
     steps:
@@ -375,7 +417,10 @@ jobs:
       run: spin test -- numpy/linalg
 
   atlas:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[nixblas skip]') && !contains(github.event.head_commit.message, '[skip nixblas]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[nixblas skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip nixblas]')
     runs-on: ubuntu-latest
     name: "ATLAS"
     steps:

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   clang_sanitizers:
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[sanitizer skip]') && !contains(github.event.head_commit.message, '[skip sanitizer]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -37,7 +37,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   clang_sanitizers:

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -21,9 +21,30 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   clang_sanitizers:
-    # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[sanitizer skip]') && !contains(github.event.head_commit.message, '[skip sanitizer]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[sanitizer skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip sanitizer]')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -24,13 +24,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -20,7 +20,7 @@ jobs:
   musllinux_x86_64:
     runs-on: ubuntu-latest
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[musl skip]') && !contains(github.event.head_commit.message, '[skip musl]')"
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -17,10 +17,32 @@ permissions:
 
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   musllinux_x86_64:
     runs-on: ubuntu-latest
     # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[musl skip]') && !contains(github.event.head_commit.message, '[skip musl]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[musl skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip musl]')
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -33,7 +33,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   musllinux_x86_64:

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -20,13 +20,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message
@@ -38,7 +38,6 @@ jobs:
           echo github.ref ${{ github.ref }}
   musllinux_x86_64:
     runs-on: ubuntu-latest
-    # To enable this workflow on a fork, comment out:
     needs: get_commit_tags
     if: >-
       !contains(needs.get_commit_tags.outputs.message, '[musl skip]') &&

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -30,6 +30,7 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
@@ -47,7 +48,6 @@ jobs:
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   linux_qemu:
-    # To enable this workflow on a fork, comment out:
     needs: get_commit_tags
     if: >-
       !contains(needs.get_commit_tags.outputs.message, '[qemu skip]') &&

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -44,7 +44,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   linux_qemu:

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   linux_qemu:
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[qemu skip]') && !contains(github.event.head_commit.message, '[skip qemu]')"
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -27,9 +27,31 @@ permissions:
   contents: read
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   linux_qemu:
     # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[qemu skip]') && !contains(github.event.head_commit.message, '[skip qemu]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[qemu skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip qemu]')
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -53,7 +53,7 @@ permissions:
 jobs:
   baseline_only:
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[simd skip]') && !contains(github.event.head_commit.message, '[skip simd]')"
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=none"

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -51,9 +51,31 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   baseline_only:
     # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[simd skip]') && !contains(github.event.head_commit.message, '[skip simd]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[simd skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip simd]')
     runs-on: ubuntu-latest
     env:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-dispatch=none"

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -67,7 +67,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   baseline_only:

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -54,13 +54,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message
@@ -71,7 +71,6 @@ jobs:
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   baseline_only:
-    # To enable this workflow on a fork, comment out:
     needs: get_commit_tags
     if: >-
       !contains(needs.get_commit_tags.outputs.message, '[simd skip]') &&

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,10 +17,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   x86_conda:
     name: macOS x86-64 conda
-    # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[macos skip]') && !contains(github.event.head_commit.message, '[skip macos]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[macos skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip macos]')
     runs-on: macos-13
     strategy:
       fail-fast: false
@@ -104,7 +125,10 @@ jobs:
 
   accelerate:
     name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[macos skip]') && !contains(github.event.head_commit.message, '[skip macos]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[macos skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip macos]')
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,13 +20,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   x86_conda:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
   x86_conda:
     name: macOS x86-64 conda
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[macos skip]') && !contains(github.event.head_commit.message, '[skip macos]')"
     runs-on: macos-13
     strategy:
       fail-fast: false
@@ -104,7 +104,7 @@ jobs:
 
   accelerate:
     name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[macos skip]') && !contains(github.event.head_commit.message, '[skip macos]')"
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
       fail-fast: false

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -40,13 +40,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message
@@ -57,7 +57,6 @@ jobs:
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   mypy:
-    # To enable this workflow on a fork, comment out:
     needs: get_commit_tags
     if: >-
       !contains(needs.get_commit_tags.outputs.message, '[mypy skip]') &&

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -37,9 +37,31 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   mypy:
     # To enable this workflow on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[mypy skip]') && !contains(github.event.head_commit.message, '[skip mypy]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[mypy skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip mypy]')
     name: "MyPy"
     runs-on: ${{ matrix.os_python[0] }}
     strategy:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   mypy:
     # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[mypy skip]') && !contains(github.event.head_commit.message, '[skip mypy]')"
     name: "MyPy"
     runs-on: ${{ matrix.os_python[0] }}
     strategy:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -53,7 +53,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   mypy:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,7 +31,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   analysis:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,6 +14,26 @@ on:
 permissions: read-all
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,11 +14,32 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get_commit_tags:
+    name: Get commit tags
+    runs-on: ubuntu-latest
+    if: "github.repository == 'numpy/numpy'"
+    outputs:
+      message: ${{ steps.commit_message.outputs.message }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        # Gets the correct commit message for pull request
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get commit message
+        id: commit_message
+        run: |
+          set -xe
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
+          echo github.ref ${{ github.ref }}
   python64bit_openblas:
     name: x86-64, LP64 OpenBLAS
     runs-on: windows-2019
-    # To enable this job on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[wingha skip]') && !contains(github.event.head_commit.message, '[skip wingha]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[wingha skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip wingha]')
     strategy:
       fail-fast: false
       matrix:
@@ -84,8 +105,10 @@ jobs:
   msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS
     runs-on: windows-2019
-    # To enable this job on a fork, comment out:
-    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[wingha skip]') && !contains(github.event.head_commit.message, '[skip wingha]')"
+    needs: get_commit_tags
+    if: >-
+      !contains(needs.get_commit_tags.outputs.message, '[wingha skip]') &&
+      !contains(needs.get_commit_tags.outputs.message, '[skip wingha]')
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
         id: commit_message
         run: |
           set -xe
-          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs)
+          COMMIT_TAGS=$(git log --format=%B -n 1 | grep -o '\[[^]]*\]' | tr '\n' ' ' | xargs || true)
           echo "message=$COMMIT_TAGS" >> $GITHUB_OUTPUT
           echo github.ref ${{ github.ref }}
   python64bit_openblas:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     name: x86-64, LP64 OpenBLAS
     runs-on: windows-2019
     # To enable this job on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[wingha skip]') && !contains(github.event.head_commit.message, '[skip wingha]')"
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
     name: MSVC, 32-bit Python, no BLAS
     runs-on: windows-2019
     # To enable this job on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[wingha skip]') && !contains(github.event.head_commit.message, '[skip wingha]')"
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,13 +17,13 @@ jobs:
   get_commit_tags:
     name: Get commit tags
     runs-on: ubuntu-latest
+    # To enable this workflow on a fork, comment out:
     if: "github.repository == 'numpy/numpy'"
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
-        # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get commit message

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -249,7 +249,9 @@ for your changes. Here are the new tags you can use:
 * ``[skip wasm]``: skip Emscripten/Pyodide jobs
 * ``[skip codeql]``: skip CodeQL analysis jobs
 
-These tags do not need to be in the first line of the commit message and can appear anywhere in the body of the commit itself. Additionally, they can be used in any order, i.e. ``[skip mypy]`` is the same as ``[mypy skip]``
+These tags do not need to be in the first line of the commit message and can
+appear anywhere in the body of the commit itself. Additionally, they can be used
+in any order, i.e. ``[skip mypy]`` is the same as ``[mypy skip]``.
 
 Example Usage
 -------------

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -269,6 +269,26 @@ An example commit message to run only Windows F2PY tests and skip other jobs:
 
 Note: The ``[skip azp]`` tag can be anywhere in the commit message, but ``[skip cirrus]`` must be in the first or last line.
 
+Being CI Sensitive
+------------------
+
+Being mindful of CI doesn't have to mean keeping track of an ever increasing
+combinatorial set of tags. Instead, consider the following development workflow
+change to prevent hammering CI.
+
+- Make a fork
+  + Do **not** open a pull request (or a draft)
+- Comment out the special case handling for ``numpy/numpy`` which prevents CI running on forks
+  + For most CI workflows this is ``if: "github.repository == 'numpy/numpy'"``
+  + If that seems too complicated, delete all but the CI workflow which needs testing
+    - Make a single clean commit with this change
+  + Continue working on this branch
+- Finally, when everything is ready, make a new branch, and rebase, dropping the
+  single commit which removed / commented out ``numpy`` handling
+  + Open a pull request; profit with CI passing / fixes at minimal overhead
+
+Note that this is best suited to actions which do not require special
+authentication.
 
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -223,9 +223,52 @@ these fragments in each commit message of a PR:
 
 * ``[skip cirrus]``: skip Cirrus jobs
 
-  `CirrusCI <https://cirrus-ci.org/>`__ mostly triggers Linux aarch64 and MacOS Arm64 wheels
-  uploads.
-  `See the configuration file for these checks. <https://github.com/numpy/numpy/blob/main/.cirrus.star>`__
+  `CirrusCI <https://cirrus-ci.org/>`__ mostly triggers Linux aarch64 and MacOS
+  Arm64 wheels uploads. This is particularly expensive (see `gh-24280
+  <https://github.com/numpy/numpy/issues/24280>`__) and should be minimized.
+  `See the configuration file for these checks.
+  <https://github.com/numpy/numpy/blob/main/.cirrus.star>`__
+
+Additional CI Skip Tags
+~~~~~~~~~~~~~~~~~~~~~~~
+
+There are a range of additional tags that provide more fine-grained control over
+CI jobs. These tags allow are meant to skip specific jobs that are not needed
+for your changes. Here are the new tags you can use:
+
+* ``[skip circle]``: skip the CircleCI jobs (documentation and preview mostly)
+* ``[skip linux]``: skip Linux jobs, this is typically not a good idea unless another specific CI run is requested
+* ``[skip nixblas]``: skip BLAS NumPy jobs
+* ``[skip sanitizer]``: skip compiler sanitizer jobs (Linux)
+* ``[skip musl]``: skip musllinux_x86_64 jobs
+* ``[skip qemu]``: skip Linux QEMU jobs
+* ``[skip simd]``: skip SIMD optimization jobs
+* ``[skip macos]``: skip MacOS jobs
+* ``[skip mypy]``: skip ``mypy`` type checking jobs
+* ``[skip wingha]``: skip Windows GHA jobs
+* ``[skip wasm]``: skip Emscripten/Pyodide jobs
+* ``[skip codeql]``: skip CodeQL analysis jobs
+
+These tags do not need to be in the first line of the commit message and can appear anywhere in the body of the commit itself. Additionally, they can be used in any order, i.e. ``[skip mypy]`` is the same as ``[mypy skip]``
+
+Example Usage
+-------------
+
+An example commit message to run only Windows F2PY tests and skip other jobs:
+
+.. code-block:: text
+
+   CI: Configure F2PY GHA Windows [winci f2py]
+
+   [skip circle] [skip linux] [skip nixblas] [skip sanitizer] [skip musl]
+   [skip qemu] [skip simd] [skip macos] [skip mypy] [skip wingha] [wasm skip]
+   [codeql skip]
+
+   [skip azp]
+   [skip cirrus]
+
+Note: The ``[skip azp]`` tag can be anywhere in the commit message, but ``[skip cirrus]`` must be in the first or last line.
+
 
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -229,25 +229,25 @@ these fragments in each commit message of a PR:
   `See the configuration file for these checks.
   <https://github.com/numpy/numpy/blob/main/.cirrus.star>`__
 
-Additional CI Skip Tags
-~~~~~~~~~~~~~~~~~~~~~~~
+Additional CI Tags
+~~~~~~~~~~~~~~~~~~
 
 There are a range of additional tags that provide more fine-grained control over
-CI jobs. These tags allow are meant to skip specific jobs that are not needed
-for your changes. Here are the new tags you can use:
+CI jobs. These tags allow are meant to skip or include specific jobs that are
+not needed for your changes. Here are the new tags you can use:
 
-* ``[skip circle]``: skip the CircleCI jobs (documentation and preview mostly)
-* ``[skip linux]``: skip Linux jobs, this is typically not a good idea unless another specific CI run is requested
-* ``[skip nixblas]``: skip BLAS NumPy jobs
-* ``[skip sanitizer]``: skip compiler sanitizer jobs (Linux)
-* ``[skip musl]``: skip musllinux_x86_64 jobs
-* ``[skip qemu]``: skip Linux QEMU jobs
-* ``[skip simd]``: skip SIMD optimization jobs
-* ``[skip macos]``: skip MacOS jobs
-* ``[skip mypy]``: skip ``mypy`` type checking jobs
-* ``[skip wingha]``: skip Windows GHA jobs
-* ``[skip wasm]``: skip Emscripten/Pyodide jobs
-* ``[skip codeql]``: skip CodeQL analysis jobs
+* ``[skip/only circle]``: skip / run only the CircleCI jobs (documentation and preview mostly)
+* ``[skip/only linux]``: skip / run only Linux jobs, this is typically not a good idea unless another specific CI run is requested
+* ``[skip/only nixblas]``: skip / run only BLAS NumPy jobs
+* ``[skip/only sanitizer]``: skip / run only compiler sanitizer jobs (Linux)
+* ``[skip/only musl]``: skip / run only musllinux_x86_64 jobs
+* ``[skip/only qemu]``: skip / run only Linux QEMU jobs
+* ``[skip/only simd]``: skip / run only SIMD optimization jobs
+* ``[skip/only macos]``: skip / run only MacOS jobs
+* ``[skip/only mypy]``: skip / run only ``mypy`` type checking jobs
+* ``[skip/only wingha]``: skip / run only Windows GHA jobs
+* ``[skip/only wasm]``: skip / run only Emscripten/Pyodide jobs
+* ``[skip/only codeql]``: skip / run only CodeQL analysis jobs
 
 These tags do not need to be in the first line of the commit message and can
 appear anywhere in the body of the commit itself. Additionally, they can be used
@@ -260,7 +260,7 @@ An example commit message to run only Windows F2PY tests and skip other jobs:
 
 .. code-block:: text
 
-   CI: Configure F2PY GHA Windows [winci f2py]
+   CI: Configure F2PY GHA Windows [only winf2py]
 
    [skip circle] [skip linux] [skip nixblas] [skip sanitizer] [skip musl]
    [skip qemu] [skip simd] [skip macos] [skip mypy] [skip wingha] [wasm skip]
@@ -269,10 +269,23 @@ An example commit message to run only Windows F2PY tests and skip other jobs:
    [skip azp]
    [skip cirrus]
 
-Note: The ``[skip azp]`` tag can be anywhere in the commit message, but ``[skip cirrus]`` must be in the first or last line.
+Note: The ``[skip azp]`` tag can be anywhere in the commit message,
+but ``[skip cirrus]`` must be in the first or last line.
+
+Helper (compound) tags
+----------------------
+
+Since the tags can be a bit of a mouthful, there are some short-hand helpers,
+which expand to the above.
+
+* ``[skip gha]``: Skips everything on GithubActions except for ``[only ]`` directives
+* ``[skip except]``: Skips everything except for ``[only ]`` directives
+* ``[docs only]``: Skips everything but the documentation job
+* ``[skip exotic]``: ``[skip quemu] [skip simd] [skip macos] [skip wingha] [skip wasm] [skip musl] [skip circle] [skip azp] [ckip cirrus]``
+* ``[skip tools]``: Expands to ``[skip codeql] [skip mypy] [skip sanitizer]``
 
 Being CI Sensitive
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Being mindful of CI doesn't have to mean keeping track of an ever increasing
 combinatorial set of tags. Instead, consider the following development workflow
@@ -284,13 +297,13 @@ change to prevent hammering CI.
   + For most CI workflows this is ``if: "github.repository == 'numpy/numpy'"``
   + If that seems too complicated, delete all but the CI workflow which needs testing
     - Make a single clean commit with this change
-  + Continue working on this branch
+  + Continue working on this branch, open a pull request to another branch of your own repo
 - Finally, when everything is ready, make a new branch, and rebase, dropping the
   single commit which removed / commented out ``numpy`` handling
   + Open a pull request; profit with CI passing / fixes at minimal overhead
 
 Note that this is best suited to actions which do not require special
-authentication.
+authentication, so the ``dependency-review.yml`` should be the first to go.
 
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Spun out of #26708. Might maybe be helpful (post docs) with https://github.com/numpy/numpy/issues/24280.

Adds a bunch of tags which can be passed to conditionally disable what isn't needed:
  - `[skip circle]` 
  - `[skip linux]`
  - `[skip nixblas]` 
  - `[skip sanitizer]` 
  - `[skip musl]`
  - `[skip qemu]`
  - `[skip simd]`
  - `[skip macos]` 
  - `[skip mypy]`
  - `[skip wingha]`
  - `[wasm skip]`
  - `[codeql skip]`

Together with a per commit tag, like `[winci f2py]` (from #26708) these allow for a more fine-grained control over what is run and when. The tags above do not need to be in the first line of the commit, but can occur anywhere in the body of the commit itself. So an all but `[winci f2py]` commit would look like:

```bash
CI: Configure F2PY GHA Windows [winci f2py]

[skip circle] [skip linux] [skip nixblas] [skip sanitizer] [skip musl]
[skip qemu] [skip simd] [skip macos] [skip mypy] [skip wingha] [wasm skip]
[codeql skip]

[skip azp]
[skip cirrus]
```

Since `[skip azp]` can [be anywhere](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#skipping-ci-for-individual-pushes) in the commit message, but `[skip cirrus]` must be in the [first or last](https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution) line.