### PR TITLE
DOC: Add clarifications np.argpartition

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -925,9 +925,9 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     is unstable, and hence the returned indices are not guaranteed
     to be the earliest/latest occurrence of the element.
 
-    The sort order of ``np.nan`` is bigger than ``np.inf``.
-
-    See `partition` for notes on the different selection algorithms.
+    `argpartition` works for real/complex inputs with nan values,
+    see `partition` for notes on the enhanced sort order and
+    different selection algorithms.
 
     Examples
     --------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -823,6 +823,8 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     the real parts except when they are equal, in which case the order
     is determined by the imaginary parts.
 
+    The sort order of ``np.nan`` is bigger than ``np.inf``.
+
     Examples
     --------
     >>> a = np.array([7, 1, 7, 7, 1, 5, 7, 2, 3, 2, 6, 2, 3, 0])
@@ -923,7 +925,7 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     is unstable, and hence the returned indices are not guaranteed
     to be the earliest/latest occurrence of the element.
 
-    The treatment of ``np.nan`` in the input array is undefined.
+    The sort order of ``np.nan`` is bigger than ``np.inf``.
 
     See `partition` for notes on the different selection algorithms.
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -918,6 +918,13 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
 
     Notes
     -----
+    The returned indices are not guaranteed to be sorted according to
+    the values. Furthermore, the default selection algorithm ``introselect``
+    is unstable, and hence the returned indices are not guaranteed
+    to be the earliest/latest occurrence of the element.
+
+    The treatment of ``np.nan`` in the input array is undefined.
+
     See `partition` for notes on the different selection algorithms.
 
     Examples

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10211,6 +10211,16 @@ def test_partition_fp(N, dtype):
     assert_arr_partitioned(np.sort(arr)[k], k,
             arr[np.argpartition(arr, k, kind='introselect')])
 
+    # Check that `np.inf < np.nan`
+    # This follows np.sort
+    arr[0] = np.nan
+    arr[1] = np.inf
+    o1 = np.partition(arr, -2, kind='introselect')
+    o2 = arr[np.argpartition(arr, -2, kind='introselect')]
+    for out in [o1,o2]:
+        assert_(np.isnan(out[-1]))
+        assert_equal(out[-2], np.inf)
+
 def test_cannot_assign_data():
     a = np.arange(10)
     b = np.linspace(0, 1, 10)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10217,7 +10217,7 @@ def test_partition_fp(N, dtype):
     arr[1] = np.inf
     o1 = np.partition(arr, -2, kind='introselect')
     o2 = arr[np.argpartition(arr, -2, kind='introselect')]
-    for out in [o1,o2]:
+    for out in [o1, o2]:
         assert_(np.isnan(out[-1]))
         assert_equal(out[-2], np.inf)
 


### PR DESCRIPTION
Linking the PR for `np.top_k` #26666, since it is helpful for the docs for `np.top_k` to specify explicitly the treatment of `np.nan` and the stability of the returned indices, and the behaviour of `np.top_k` relies on the implementation of `np.argpartition`, I suggest adding similar clarifications to `np.argpartition` docs.

With regards to the treatment of `np.nan`, currently `np.argpartition` does not explicitly handle `np.nan` and by the nature of its implementation, `np.nan` is treated like `np.inf`. This seems like something that can change in the future so I wrote that the treatment of `np.nan` is undefined. If this is not desirable, perhaps one can consider adding a `np.nanargpartition` and `np.nanpartition` variant.

Making this change also allows `np.top_k` to justly say that it follows `np.argpartition`'s specifications.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
