### PR TITLE
DOC, MAINT: Turn on version warning banner provided by PyData Sphinx Theme

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -266,6 +266,7 @@ html_theme_options = {
         "version_match": switcher_version,
         "json_url": "https://numpy.org/doc/_static/versions.json",
     },
+    "show_version_warning_banner": True,
 }
 
 html_title = "%s v%s Manual" % (project, version)


### PR DESCRIPTION
After https://github.com/numpy/doc/pull/25, this will show a warning banner for past (after 2.0) and unreleased dev versions of the docs.

See https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/announcements.html#version-warning-banners

The warning banner can be dismissed by the user.