### PR TITLE
DOC: Update NEPs statuses

### DIFF
--- a/doc/neps/nep-0052-python-api-cleanup.rst
+++ b/doc/neps/nep-0052-python-api-cleanup.rst
@@ -8,7 +8,7 @@ NEP 52 — Python API cleanup for NumPy 2.0
 :Author: Stéfan van der Walt <stefanv@berkeley.edu>
 :Author: Nathan Goldbaum <ngoldbaum@quansight.com>
 :Author: Mateusz Sokół <msokol@quansight.com>
-:Status: Accepted
+:Status: Final
 :Type: Standards Track
 :Created: 2023-03-28
 :Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/QLMPFTWA67DXE3JCUQT2RIRLQ44INS4F/


### PR DESCRIPTION
Hi @rgommers @seberg,

Do we also want to update NEPs statuses?

As 2.0 has been released I think `NEP 52 — Python API cleanup for NumPy 2.0` should change its status to Final.

Do we want to update statuses for NEP 51 (currently Accepted, it has a resolution) and NEP 50 (currently Draft)?

There's also `NEP 53 — Evolving the NumPy C-API for NumPy 2.0` with a Draft status. 