### PR TITLE
DOC: Mention '1.25' legacy printing mode in ``set_printoptions``

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -220,6 +220,10 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         by not inserting spaces after commas that separate fields and after
         colons.
 
+        If set to ``'1.25'`` approximates printing of 1.25 which mainly means
+        that numeric scalars are printed without their type information, e.g.
+        as ``3.0`` rather than ``np.float64(3.0)``.
+
         If set to `False`, disables legacy mode.
 
         Unrecognized strings will be ignored with a warning for forward
@@ -227,6 +231,8 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
 
         .. versionadded:: 1.14.0
         .. versionchanged:: 1.22.0
+        .. versionchanged:: 2.0
+
     override_repr: callable, optional
         If set a passed function will be used for generating arrays' repr.
         Other options will be ignored.


### PR DESCRIPTION
Mention the new printing mode in ``set_printoptions`` and copy the doc also to the duplication in ``array2string``.

Closes gh-26731
