### PR TITLE
ENH: Add locking to umath_linalg if no lapack is detected at build time

### DIFF
--- a/doc/release/upcoming_changes/26750.improvement.rst
+++ b/doc/release/upcoming_changes/26750.improvement.rst
@@ -1,8 +1,8 @@
-`lapack_lite` is thread safe
-----------------------------
+`lapack_lite` is now thread safe
+--------------------------------
 
-NumPy provides a minimal CPU-only version of LAPACK named ``lapack_lite`` that can
-be used if no BLAS/LAPACK system is detected at build time.
+NumPy provides a minimal low-performance version of LAPACK named ``lapack_lite``
+that can be used if no BLAS/LAPACK system is detected at build time.
 
 Until now, ``lapack_lite`` was not thread safe. Single-threaded use cases did
 not hit any issues, but running linear algebra operations in multiple threads

--- a/doc/release/upcoming_changes/26750.improvement.rst
+++ b/doc/release/upcoming_changes/26750.improvement.rst
@@ -1,0 +1,12 @@
+`lapack_lite` is thread safe
+----------------------------
+
+NumPy provides a minimal CPU-only version of LAPACK named ``lapack_lite`` that can
+be used if no BLAS/LAPACK system is detected at build time.
+
+Until now, ``lapack_lite`` was not thread safe. Single-threaded use cases did
+not hit any issues, but running linear algebra operations in multiple threads
+could lead to errors, incorrect results, or seg faults due to data races.
+
+We have added a global lock, serializing access to ``lapack_lite`` in multiple
+threads.

--- a/numpy/_core/config.h.in
+++ b/numpy/_core/config.h.in
@@ -108,6 +108,8 @@
 #mesondefine HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_LE
 #mesondefine HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_BE
 
+#mesondefine HAVE_EXTERNAL_LAPACK
+
 #ifndef __cplusplus
 /* #undef inline */
 #endif

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -508,7 +508,7 @@ cdata.set('NPY_VISIBILITY_HIDDEN', visibility_hidden)
 
 # if not set, we're using lapack_lite
 if have_lapack
-  cdata.set10('HAVE_EXTERNAL_LAPACK', have_blas)
+  cdata.set10('HAVE_EXTERNAL_LAPACK', have_lapack)
 endif
 
 config_h = configure_file(

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -506,6 +506,10 @@ if cc.has_function_attribute('visibility:hidden') and host_machine.system() != '
 endif
 cdata.set('NPY_VISIBILITY_HIDDEN', visibility_hidden)
 
+# if not set, we're using lapack_lite
+if have_lapack
+  cdata.set10('HAVE_EXTERNAL_LAPACK', have_blas)
+endif
 
 config_h = configure_file(
   input: 'config.h.in',

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -71,3 +71,16 @@ def test_temp_elision_thread_safety():
             (alarge + blarge) - 2
 
     run_threaded(func, 100, pass_count=True)
+
+
+def test_eigvalsh_thread_safety():
+    # if lapack isn't thread safe this will randomly segfault or error
+    # see gh-24512
+    rng = np.random.RandomState(873699172)
+    matrices = (
+        rng.random((5, 10, 10, 3, 3)),
+        rng.random((5, 10, 10, 3, 3)),
+    )
+
+    run_threaded(lambda i: np.linalg.eigvalsh(matrices[i]), 2,
+                 pass_count=True)

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -27,6 +27,9 @@
 
 static const char* umath_linalg_version_string = "0.1.5";
 
+// global lock to serialize calls into lapack_lite
+static PyThread_type_lock lapack_lite_lock;
+
 /*
  ****************************************************************************
  *                        Debugging support                                 *
@@ -400,6 +403,13 @@ FNAME(zgemm)(char *transa, char *transb,
 #define LAPACK(FUNC)                            \
     FNAME(FUNC)
 
+#ifdef HAVE_EXTERNAL_LAPACK
+    #define LOCK_LAPACK_LITE
+    #define UNLOCK_LAPACK_LITE
+#else
+    #define LOCK_LAPACK_LITE PyThread_acquire_lock(lapack_lite_lock, WAIT_LOCK)
+    #define UNLOCK_LAPACK_LITE PyThread_release_lock(lapack_lite_lock)
+#endif
 
 /*
  *****************************************************************************
@@ -1110,7 +1120,9 @@ using ftyp = fortran_type_t<typ>;
     fortran_int lda = fortran_int_max(m, 1);
     int i;
     /* note: done in place */
+    LOCK_LAPACK_LITE;
     getrf(&m, &m, (ftyp*)src, &lda, pivots, &info);
+    UNLOCK_LAPACK_LITE;
 
     if (info == 0) {
         int change_sign = 0;
@@ -1262,22 +1274,26 @@ static inline fortran_int
 call_evd(EIGH_PARAMS_t<npy_float> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(ssyevd)(&params->JOBZ, &params->UPLO, &params->N,
                           params->A, &params->LDA, params->W,
                           params->WORK, &params->LWORK,
                           params->IWORK, &params->LIWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 static inline fortran_int
 call_evd(EIGH_PARAMS_t<npy_double> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dsyevd)(&params->JOBZ, &params->UPLO, &params->N,
                           params->A, &params->LDA, params->W,
                           params->WORK, &params->LWORK,
                           params->IWORK, &params->LIWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1364,12 +1380,14 @@ static inline fortran_int
 call_evd(EIGH_PARAMS_t<npy_cfloat> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(cheevd)(&params->JOBZ, &params->UPLO, &params->N,
                           (fortran_type_t<npy_cfloat>*)params->A, &params->LDA, params->W,
                           (fortran_type_t<npy_cfloat>*)params->WORK, &params->LWORK,
                           params->RWORK, &params->LRWORK,
                           params->IWORK, &params->LIWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1377,12 +1395,14 @@ static inline fortran_int
 call_evd(EIGH_PARAMS_t<npy_cdouble> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zheevd)(&params->JOBZ, &params->UPLO, &params->N,
                           (fortran_type_t<npy_cdouble>*)params->A, &params->LDA, params->W,
                           (fortran_type_t<npy_cdouble>*)params->WORK, &params->LWORK,
                           params->RWORK, &params->LRWORK,
                           params->IWORK, &params->LIWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1616,11 +1636,13 @@ static inline fortran_int
 call_gesv(GESV_PARAMS_t<fortran_real> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(sgesv)(&params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->IPIV,
                           params->B, &params->LDB,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1628,11 +1650,13 @@ static inline fortran_int
 call_gesv(GESV_PARAMS_t<fortran_doublereal> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dgesv)(&params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->IPIV,
                           params->B, &params->LDB,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1640,11 +1664,13 @@ static inline fortran_int
 call_gesv(GESV_PARAMS_t<fortran_complex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(cgesv)(&params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->IPIV,
                           params->B, &params->LDB,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1652,11 +1678,13 @@ static inline fortran_int
 call_gesv(GESV_PARAMS_t<fortran_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zgesv)(&params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->IPIV,
                           params->B, &params->LDB,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1870,9 +1898,11 @@ static inline fortran_int
 call_potrf(POTR_PARAMS_t<fortran_real> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(spotrf)(&params->UPLO,
                           &params->N, params->A, &params->LDA,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1880,9 +1910,11 @@ static inline fortran_int
 call_potrf(POTR_PARAMS_t<fortran_doublereal> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dpotrf)(&params->UPLO,
                           &params->N, params->A, &params->LDA,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1890,9 +1922,11 @@ static inline fortran_int
 call_potrf(POTR_PARAMS_t<fortran_complex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(cpotrf)(&params->UPLO,
                           &params->N, params->A, &params->LDA,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -1900,9 +1934,11 @@ static inline fortran_int
 call_potrf(POTR_PARAMS_t<fortran_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zpotrf)(&params->UPLO,
                           &params->N, params->A, &params->LDA,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -2073,6 +2109,7 @@ static inline fortran_int
 call_geev(GEEV_PARAMS_t<float>* params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(sgeev)(&params->JOBVL, &params->JOBVR,
                           &params->N, params->A, &params->LDA,
                           params->WR, params->WI,
@@ -2080,6 +2117,7 @@ call_geev(GEEV_PARAMS_t<float>* params)
                           params->VRR, &params->LDVR,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -2087,6 +2125,7 @@ static inline fortran_int
 call_geev(GEEV_PARAMS_t<double>* params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dgeev)(&params->JOBVL, &params->JOBVR,
                           &params->N, params->A, &params->LDA,
                           params->WR, params->WI,
@@ -2094,6 +2133,7 @@ call_geev(GEEV_PARAMS_t<double>* params)
                           params->VRR, &params->LDVR,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -2285,6 +2325,7 @@ call_geev(GEEV_PARAMS_t<fortran_complex>* params)
 {
     fortran_int rv;
 
+    LOCK_LAPACK_LITE;
     LAPACK(cgeev)(&params->JOBVL, &params->JOBVR,
                           &params->N, params->A, &params->LDA,
                           params->W,
@@ -2293,6 +2334,7 @@ call_geev(GEEV_PARAMS_t<fortran_complex>* params)
                           params->WORK, &params->LWORK,
                           params->WR, /* actually RWORK */
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 #endif
@@ -2302,6 +2344,7 @@ call_geev(GEEV_PARAMS_t<fortran_doublecomplex>* params)
 {
     fortran_int rv;
 
+    LOCK_LAPACK_LITE;
     LAPACK(zgeev)(&params->JOBVL, &params->JOBVR,
                           &params->N, params->A, &params->LDA,
                           params->W,
@@ -2310,6 +2353,7 @@ call_geev(GEEV_PARAMS_t<fortran_doublecomplex>* params)
                           params->WORK, &params->LWORK,
                           params->WR, /* actually RWORK */
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -2632,6 +2676,7 @@ static inline fortran_int
 call_gesdd(GESDD_PARAMS_t<fortran_real> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(sgesdd)(&params->JOBZ, &params->M, &params->N,
                           params->A, &params->LDA,
                           params->S,
@@ -2640,12 +2685,14 @@ call_gesdd(GESDD_PARAMS_t<fortran_real> *params)
                           params->WORK, &params->LWORK,
                           (fortran_int*)params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 static inline fortran_int
 call_gesdd(GESDD_PARAMS_t<fortran_doublereal> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dgesdd)(&params->JOBZ, &params->M, &params->N,
                           params->A, &params->LDA,
                           params->S,
@@ -2654,6 +2701,7 @@ call_gesdd(GESDD_PARAMS_t<fortran_doublereal> *params)
                           params->WORK, &params->LWORK,
                           (fortran_int*)params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -2760,6 +2808,7 @@ static inline fortran_int
 call_gesdd(GESDD_PARAMS_t<fortran_complex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(cgesdd)(&params->JOBZ, &params->M, &params->N,
                           params->A, &params->LDA,
                           params->S,
@@ -2769,12 +2818,14 @@ call_gesdd(GESDD_PARAMS_t<fortran_complex> *params)
                           params->RWORK,
                           params->IWORK,
                           &rv);
+    LOCK_LAPACK_LITE;
     return rv;
 }
 static inline fortran_int
 call_gesdd(GESDD_PARAMS_t<fortran_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zgesdd)(&params->JOBZ, &params->M, &params->N,
                           params->A, &params->LDA,
                           params->S,
@@ -2784,6 +2835,7 @@ call_gesdd(GESDD_PARAMS_t<fortran_doublecomplex> *params)
                           params->RWORK,
                           params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3074,22 +3126,26 @@ static inline fortran_int
 call_geqrf(GEQRF_PARAMS_t<double> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dgeqrf)(&params->M, &params->N,
                           params->A, &params->LDA,
                           params->TAU,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 static inline fortran_int
 call_geqrf(GEQRF_PARAMS_t<f2c_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zgeqrf)(&params->M, &params->N,
                           params->A, &params->LDA,
                           params->TAU,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3316,22 +3372,26 @@ static inline fortran_int
 call_gqr(GQR_PARAMS_t<double> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dorgqr)(&params->M, &params->MC, &params->MN,
                           params->Q, &params->LDA,
                           params->TAU,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 static inline fortran_int
 call_gqr(GQR_PARAMS_t<f2c_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zungqr)(&params->M, &params->MC, &params->MN,
                           params->Q, &params->LDA,
                           params->TAU,
                           params->WORK, &params->LWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3712,6 +3772,7 @@ static inline fortran_int
 call_gelsd(GELSD_PARAMS_t<fortran_real> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(sgelsd)(&params->M, &params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->B, &params->LDB,
@@ -3720,6 +3781,7 @@ call_gelsd(GELSD_PARAMS_t<fortran_real> *params)
                           params->WORK, &params->LWORK,
                           params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3728,6 +3790,7 @@ static inline fortran_int
 call_gelsd(GELSD_PARAMS_t<fortran_doublereal> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(dgelsd)(&params->M, &params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->B, &params->LDB,
@@ -3736,6 +3799,7 @@ call_gelsd(GELSD_PARAMS_t<fortran_doublereal> *params)
                           params->WORK, &params->LWORK,
                           params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3839,6 +3903,7 @@ static inline fortran_int
 call_gelsd(GELSD_PARAMS_t<fortran_complex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(cgelsd)(&params->M, &params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->B, &params->LDB,
@@ -3847,6 +3912,7 @@ call_gelsd(GELSD_PARAMS_t<fortran_complex> *params)
                           params->WORK, &params->LWORK,
                           params->RWORK, (fortran_int*)params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -3854,6 +3920,7 @@ static inline fortran_int
 call_gelsd(GELSD_PARAMS_t<fortran_doublecomplex> *params)
 {
     fortran_int rv;
+    LOCK_LAPACK_LITE;
     LAPACK(zgelsd)(&params->M, &params->N, &params->NRHS,
                           params->A, &params->LDA,
                           params->B, &params->LDB,
@@ -3862,6 +3929,7 @@ call_gelsd(GELSD_PARAMS_t<fortran_doublecomplex> *params)
                           params->WORK, &params->LWORK,
                           params->RWORK, (fortran_int*)params->IWORK,
                           &rv);
+    UNLOCK_LAPACK_LITE;
     return rv;
 }
 
@@ -4567,7 +4635,7 @@ addUfuncs(PyObject *dictionary) {
 
 
 /* -------------------------------------------------------------------------- */
-                  /* Module initialization stuff  */
+                  /* Module initialization and state  */
 
 static PyMethodDef UMath_LinAlgMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
@@ -4616,6 +4684,12 @@ PyMODINIT_FUNC PyInit__umath_linalg(void)
 
     /* Load the ufunc operators into the module's namespace */
     if (addUfuncs(d) < 0) {
+        return NULL;
+    }
+
+    lapack_lite_lock = PyThread_allocate_lock();
+    if (lapack_lite_lock == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
 


### PR DESCRIPTION
Closes #22509

This is a re-do of #26687 following the suggestion in https://github.com/numpy/numpy/pull/26687#issuecomment-2167777366.

This adds locking macros around all the calls into the low-level LAPACK code in umath_linalg.cpp. The macros are either no-ops or calls to lock or unlock a global mutex declared statically in the `_umath_linalg` module and initialized during that modules' initialization. The mutex is only used if we do not detect a LAPACK during the build, indicating that lapack_lite is being used.

The test I added randomly fails or segfaults on `main` if you force numpy to build using lapack_lite.

Happy to add more extensive thread safety testing if there's a desire for it.

I think I got all the low-level calls but please let me know if you think I missed something.