### PR TITLE
CI: add linux x86 32bit wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,8 @@ jobs:
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64, ""]
           - [ubuntu-20.04, musllinux_x86_64, ""]
+          - [ubuntu-20.04, manylinux_i686, ""]
+          - [ubuntu-20.04, musllinux_i686, ""]
           - [macos-13, macosx_x86_64, openblas]
 
           # targeting macos >= 14. Could probably build on macos-14, but it would be a cross-compile
@@ -91,6 +93,8 @@ jobs:
           - buildplat: [windows-2019, win32, ""]
             python: "pp310"
           - buildplat: [ ubuntu-20.04, musllinux_x86_64, "" ]
+            python: "pp310"
+          - buildplat: [ ubuntu-20.04, musllinux_i686, "" ]
             python: "pp310"
           - buildplat: [ macos-14, macosx_arm64, accelerate ]
             python: "pp310"


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Add the wheels for linux i686 (x86 32 bit) both for gnu libc and musl.