### PR TITLE
TYP: fix incorrect import in ``ma/extras.pyi`` stub

### DIFF
--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -1,5 +1,6 @@
 from typing import Any
-from numpy.lib.index_tricks import AxisConcatenator
+
+from numpy.lib._index_tricks_impl import AxisConcatenator
 
 from numpy.ma.core import (
     dot as dot,

--- a/numpy/typing/tests/data/pass/ma.py
+++ b/numpy/typing/tests/data/pass/ma.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+import numpy as np
+import numpy.ma
+
+
+m : np.ma.MaskedArray[Any, np.dtype[np.float64]] = np.ma.masked_array([1.5, 2, 3], mask=[True, False, True])
+


### PR DESCRIPTION
The `numpy.ma` tests for type stubs are missing, so this kind of obvious error has a chance of creeping in. The import in the type stub now matches the one in the corresponding .py file again. The issue was reported in https://github.com/python/mypy/issues/17396#issuecomment-2179231214.

Also add the start of a very basic "pass" typing test for `numpy.ma`.