### PR TITLE
BUG: fix max_rows and chunked string/datetime reading in ``loadtxt``

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1055,7 +1055,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 next_arr = _load_from_filelike(
                     data, delimiter=delimiter, comment=comment, quote=quote,
                     imaginary_unit=imaginary_unit,
-                    usecols=usecols, skiplines=skiplines, max_rows=max_rows,
+                    usecols=usecols, skiplines=skiplines, max_rows=chunk_size,
                     converters=converters, dtype=dtype,
                     encoding=encoding, filelike=filelike,
                     byte_converters=byte_converters,

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1040,6 +1040,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
             # Due to chunking, certain error reports are less clear, currently.
             if filelike:
                 data = iter(data)  # cannot chunk when reading from file
+                filelike = False
 
             c_byte_converters = False
             if read_dtype_via_object_chunks == "S":

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1054,10 +1054,11 @@ def test_field_growing_cases():
         res = np.loadtxt(["," * i], delimiter=",", dtype=bytes)
         assert len(res) == i+1
 
-@pytest.mark.parametrize("nmax", (10000, 50000, 80000, 100000, 120000, 200000))
+@pytest.mark.parametrize("nmax", (10000, 50000, 55000, 60000))
 def test_maxrows_exceeding_chunksize(nmax):
-    # less, equal, greater, twice and more than _loadtxt_chunksize
-    file_length = 200000
+    # tries to read all of the file,
+    # or less, equal, greater than _loadtxt_chunksize
+    file_length = 60000
 
     # file-like path
     data = ["a 0.5 1"]*file_length

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -970,7 +970,7 @@ def test_parametric_unit_discovery(
     """Check that the correct unit (e.g. month, day, second) is discovered from
     the data when a user specifies a unitless datetime."""
     # Unit should be "D" (days) due to last entry
-    data = [generic_data] * 50000 + [long_datum]
+    data = [generic_data] * nrows + [long_datum]
     expected = np.array(data, dtype=expected_dtype)
 
     # file-like path

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1051,7 +1051,7 @@ def test_field_growing_cases():
     assert len(res) == 0
 
     for i in range(1, 1024):
-        res = np.loadtxt(["," * i], delimiter=",", dtype=bytes)
+        res = np.loadtxt(["," * i], delimiter=",", dtype=bytes, max_rows=10)
         assert len(res) == i+1
 
 @pytest.mark.parametrize("nmax", (10000, 50000, 55000, 60000))

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -987,7 +987,6 @@ def test_parametric_unit_discovery(
     os.close(fd)
     with open(fname, "w") as fh:
         fh.write("\n".join(data)+"\n")
-        fh.close()
     # loading the full file...
     a = np.loadtxt(fname, dtype=unitless_dtype)
     assert len(a) == len(expected)

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1043,3 +1043,13 @@ def test_field_growing_cases():
     for i in range(1, 1024):
         res = np.loadtxt(["," * i], delimiter=",", dtype=bytes)
         assert len(res) == i+1
+
+@pytest.mark.parametrize("nmax", (10000, 50000, 80000, 100000, 120000)) # less, equal, greater, twice and more than twice than _loadtxt_chunksize
+def test_maxrows_exceeding_chunksize(nmax):
+    file_length = 200000
+    data = ""
+    for i in range(file_length) :
+        data += "a 0.5 1\n"
+    txt = StringIO(data)
+    res = np.loadtxt(txt, dtype=str, delimiter=" ", max_rows=nmax)
+    assert len(res) == nmax


### PR DESCRIPTION
Within function _read(), called by loadtxt() method, large files are read in chunks of maximum _loadtxt_chunksize=50000 lines, by calling iteratively the function _load_from_filelike().
When max_rows exceeded _loadtxt_chunksize, the latter was still called with the option max_rows=max_rows, instead of max_rows=chunk_size, that cannot be greater than _loadtxt_chunksize. This caused the function to load chunks of max_rows lines while still thinking having loaded chunks of maximum _loadtxt_chunksize lines.
The option max_rows=max_rows at line 1058 has been changed with max_rows=chunk_size, and added a test function to check loadtxt() for different sizes in the file numpy/lib/tests/test_loadtxt.py.

Closes #26754.