### PR TITLE
BUG: Quantile closest_observation to round to nearest even order

### DIFF
--- a/doc/release/upcoming_changes/26656.improvement.rst
+++ b/doc/release/upcoming_changes/26656.improvement.rst
@@ -1,5 +1,5 @@
-`quantile` method ``closest_observation`` chooses nearest even order statistic
-------------------------------------------------------------------------------
+`np.quantile` with method ``closest_observation`` chooses nearest even order statistic
+--------------------------------------------------------------------------------------
 This changes the definition of nearest for border cases from the nearest odd
 order statistic to nearest even order statistic. The numpy implementation now
 matches other reference implementations.

--- a/doc/release/upcoming_changes/26656.improvement.rst
+++ b/doc/release/upcoming_changes/26656.improvement.rst
@@ -1,0 +1,5 @@
+`quantile` method ``closest_observation`` chooses nearest even order statistic
+------------------------------------------------------------------------------
+This changes the definition of nearest for border cases from the nearest odd
+order statistic to nearest even order statistic. The numpy implementation now
+matches other reference implementations.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -388,7 +388,7 @@ def iterable(y):
 
 def _weights_are_valid(weights, a, axis):
     """Validate weights array.
-    
+
     We assume, weights is not None.
     """
     wgt = np.asanyarray(weights)
@@ -448,7 +448,7 @@ def average(a, axis=None, weights=None, returned=False, *,
         The calculation is::
 
             avg = sum(a * weights) / sum(weights)
-        
+
         where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.
@@ -2049,7 +2049,7 @@ def disp(mesg, device=None, linefeed=True):
         "(deprecated in NumPy 2.0)",
         DeprecationWarning,
         stacklevel=2
-    )    
+    )
 
     if device is None:
         device = sys.stdout
@@ -3847,7 +3847,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         Axis or axes along which the medians are computed. The default,
         axis=None, will compute the median along a flattened version of
         the array.
-        
+
         .. versionadded:: 1.9.0
 
         If a sequence of axes, the array is first flattened along the
@@ -4355,12 +4355,14 @@ def quantile(a,
     The table above includes only the estimators from H&F that are continuous
     functions of probability `q` (estimators 4-9). NumPy also provides the
     three discontinuous estimators from H&F (estimators 1-3), where ``j`` is
-    defined as above and ``m`` and ``g`` are defined as follows.
+    defined as above, ``m`` is defined as follows, and ``g`` is a function
+    of the real-valued ``index = q*n + m - 1`` and ``j``.
 
-    1. ``inverted_cdf``: ``m = 0`` and ``g = int(q*n > 0)``
-    2. ``averaged_inverted_cdf``: ``m = 0`` and ``g = (1 + int(q*n > 0)) / 2``
+    1. ``inverted_cdf``: ``m = 0`` and ``g = int(index - j > 0)``
+    2. ``averaged_inverted_cdf``: ``m = 0`` and
+       ``g = (1 + int(index - j > 0)) / 2``
     3. ``closest_observation``: ``m = -1/2`` and
-       ``1 - int((g == 0) & (j%2 == 0))``
+       ``g = 1 - int((index == j) & (j%2 == 1))``
 
     For backward compatibility with previous versions of NumPy, `quantile`
     provides four additional discontinuous estimators. Like
@@ -4394,7 +4396,7 @@ def quantile(a,
 
     For weighted quantiles, the coverage conditions still hold. The
     empirical cumulative distribution is simply replaced by its weighted
-    version, i.e. 
+    version, i.e.
     :math:`P(Y \\leq t) = \\frac{1}{\\sum_i w_i} \\sum_i w_i 1_{x_i \\leq t}`.
     Only ``method="inverted_cdf"`` supports weights.
 
@@ -4608,7 +4610,9 @@ def _discret_interpolation_to_boundaries(index, gamma_condition_fun):
 
 
 def _closest_observation(n, quantiles):
-    gamma_fun = lambda gamma, index: (gamma == 0) & (np.floor(index) % 2 == 0)
+    # "choose the nearest even order statistic at g=0" (H&F (1996) pp. 362).
+    # Order is 1-based so for zero-based indexing round to nearest odd index.
+    gamma_fun = lambda gamma, index: (gamma == 0) & (np.floor(index) % 2 == 1)
     return _discret_interpolation_to_boundaries((n * quantiles) - 1 - 0.5,
                                                 gamma_fun)
 
@@ -4838,7 +4842,7 @@ def _quantile(
             return result
 
         r_shape = arr.shape[1:]
-        if quantiles.ndim > 0: 
+        if quantiles.ndim > 0:
             r_shape = quantiles.shape + r_shape
         if out is None:
             result = np.empty_like(arr, shape=r_shape)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -388,7 +388,7 @@ def iterable(y):
 
 def _weights_are_valid(weights, a, axis):
     """Validate weights array.
-
+    
     We assume, weights is not None.
     """
     wgt = np.asanyarray(weights)
@@ -448,7 +448,7 @@ def average(a, axis=None, weights=None, returned=False, *,
         The calculation is::
 
             avg = sum(a * weights) / sum(weights)
-
+        
         where the sum is over all included elements.
         The only constraint on the values of `weights` is that `sum(weights)`
         must not be 0.
@@ -2049,7 +2049,7 @@ def disp(mesg, device=None, linefeed=True):
         "(deprecated in NumPy 2.0)",
         DeprecationWarning,
         stacklevel=2
-    )
+    )    
 
     if device is None:
         device = sys.stdout
@@ -3847,7 +3847,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         Axis or axes along which the medians are computed. The default,
         axis=None, will compute the median along a flattened version of
         the array.
-
+        
         .. versionadded:: 1.9.0
 
         If a sequence of axes, the array is first flattened along the
@@ -4396,7 +4396,7 @@ def quantile(a,
 
     For weighted quantiles, the coverage conditions still hold. The
     empirical cumulative distribution is simply replaced by its weighted
-    version, i.e.
+    version, i.e. 
     :math:`P(Y \\leq t) = \\frac{1}{\\sum_i w_i} \\sum_i w_i 1_{x_i \\leq t}`.
     Only ``method="inverted_cdf"`` supports weights.
 
@@ -4842,7 +4842,7 @@ def _quantile(
             return result
 
         r_shape = arr.shape[1:]
-        if quantiles.ndim > 0:
+        if quantiles.ndim > 0: 
             r_shape = quantiles.shape + r_shape
         if out is None:
             result = np.empty_like(arr, shape=r_shape)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1904,7 +1904,7 @@ class TestVectorize:
 
     def test_datetime_conversion(self):
         otype = "datetime64[ns]"
-        arr = np.array(['2024-01-01', '2024-01-02', '2024-01-03'],
+        arr = np.array(['2024-01-01', '2024-01-02', '2024-01-03'], 
                        dtype='datetime64[ns]')
         assert_array_equal(np.vectorize(lambda x: x, signature="(i)->(j)",
                                         otypes=[otype])(arr), arr)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1904,7 +1904,7 @@ class TestVectorize:
 
     def test_datetime_conversion(self):
         otype = "datetime64[ns]"
-        arr = np.array(['2024-01-01', '2024-01-02', '2024-01-03'], 
+        arr = np.array(['2024-01-01', '2024-01-02', '2024-01-03'],
                        dtype='datetime64[ns]')
         assert_array_equal(np.vectorize(lambda x: x, signature="(i)->(j)",
                                         otypes=[otype])(arr), arr)
@@ -3997,6 +3997,20 @@ class TestQuantile:
         assert_equal(quantile, np.array(Fraction(0, 1)))
         quantile = np.quantile(arr, [Fraction(1, 2)], method='weibull')
         assert_equal(quantile, np.array(Fraction(1, 20)))
+
+    def test_closest_observation(self):
+        # Round ties to nearest even order statistic (see #26656)
+        m = 'closest_observation'
+        q = 0.5
+        arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        assert_equal(2, np.quantile(arr[0:3], q, method=m))
+        assert_equal(2, np.quantile(arr[0:4], q, method=m))
+        assert_equal(2, np.quantile(arr[0:5], q, method=m))
+        assert_equal(3, np.quantile(arr[0:6], q, method=m))
+        assert_equal(4, np.quantile(arr[0:7], q, method=m))
+        assert_equal(4, np.quantile(arr[0:8], q, method=m))
+        assert_equal(4, np.quantile(arr[0:9], q, method=m))
+        assert_equal(5, np.quantile(arr, q, method=m))
 
 
 class TestLerp:


### PR DESCRIPTION
Detection of an even order statistic (1-based) must check for an odd index due to use of 0-based indexing.

See #26656
