### PR TITLE
MAINT: use an atomic load/store and a mutex to initialize the argparse and runtime import caches

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1041,6 +1041,7 @@ src_multiarray_umath_common = [
   'src/common/mem_overlap.c',
   'src/common/npy_argparse.c',
   'src/common/npy_hashtable.c',
+  'src/common/npy_import.c',
   'src/common/npy_longdouble.c',
   'src/common/ucsnarrow.c',
   'src/common/ufunc_override.c',

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -7,11 +7,22 @@
 #include "numpy/ndarraytypes.h"
 #include "numpy/npy_2_compat.h"
 #include "npy_argparse.h"
-
+#include "npy_atomic.h"
 #include "npy_import.h"
 
 #include "arrayfunction_override.h"
 
+static PyThread_type_lock argparse_mutex;
+
+NPY_NO_EXPORT int
+init_argparse_mutex(void) {
+    argparse_mutex = PyThread_allocate_lock();
+    if (argparse_mutex == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    return 0;
+}
 
 /**
  * Small wrapper converting to array just like CPython does.
@@ -274,14 +285,22 @@ _npy_parse_arguments(const char *funcname,
         /* ... is NULL, NULL, NULL terminated: name, converter, value */
         ...)
 {
-    if (NPY_UNLIKELY(cache->npositional == -1)) {
-        va_list va;
-        va_start(va, kwnames);
-
-        int res = initialize_keywords(funcname, cache, va);
-        va_end(va);
-        if (res < 0) {
-            return -1;
+    if (NPY_UNLIKELY(!cache->initialized)) {
+        // only do a possibly slow atomic load if the cache isn't already initialized
+        if (!npy_atomic_load_uint8(&cache->initialized)) {
+            PyThread_acquire_lock(argparse_mutex, WAIT_LOCK);
+            if (!cache->initialized) {
+                va_list va;
+                va_start(va, kwnames);
+                int res = initialize_keywords(funcname, cache, va);
+                va_end(va);
+                if (res < 0) {
+                    PyThread_release_lock(argparse_mutex);
+                    return -1;
+                }
+                cache->initialized = 1;
+            }
+            PyThread_release_lock(argparse_mutex);
         }
     }
 

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -38,7 +38,7 @@ NPY_NO_EXPORT int init_argparse_mutex(void);
  * The sole purpose of this macro is to hide the argument parsing cache.
  * Since this cache must be static, this also removes a source of error.
  */
-#define NPY_PREPARE_ARGPARSER static _NpyArgParserCache __argparse_cache = {-1}
+#define NPY_PREPARE_ARGPARSER static _NpyArgParserCache __argparse_cache;
 
 /**
  * Macro to help with argument parsing.

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -20,7 +20,6 @@
 NPY_NO_EXPORT int
 PyArray_PythonPyIntFromInt(PyObject *obj, int *value);
 
-
 #define _NPY_MAX_KWARGS 15
 
 typedef struct {
@@ -28,10 +27,12 @@ typedef struct {
     int nargs;
     int npositional_only;
     int nrequired;
+    npy_uint8 initialized;
     /* Null terminated list of keyword argument name strings */
     PyObject *kw_strings[_NPY_MAX_KWARGS+1];
 } _NpyArgParserCache;
 
+NPY_NO_EXPORT int init_argparse_mutex(void);
 
 /*
  * The sole purpose of this macro is to hide the argument parsing cache.

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -1,0 +1,42 @@
+/*
+ * Provides wrappers around C11 standard library atomics and MSVC intrinsics
+ * to provide basic atomic load and store functionality. This is based on
+ * code in CPython's pyatomic.h, pyatomic_std.h, and pyatomic_msc.h
+ */
+
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_ATOMIC_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_ATOMIC_H_
+
+#include "numpy/npy_common.h"
+
+#if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+// TODO: support C++ atomics as well if this header is ever needed in C++
+    #include <stdatomic.h>
+    #include <stdint.h>
+    #define STDC_ATOMICS
+#elif _MSC_VER
+    #include <intrin.h>
+    #define MSC_ATOMICS
+#else
+    #error "no support for missing C11 atomics except with MSVC"
+#endif
+
+
+static inline npy_uint8 npy_atomic_load_uint8(const npy_uint8 *obj) {
+#ifdef STDC_ATOMICS
+    return (npy_uint8)atomic_load((const _Atomic(uint8_t)*)obj);
+#elif defined(MSC_ATOMICS)
+#if defined(_M_X64) || defined(_M_IX86)
+    return *(volatile npy_uint8 *)obj;
+#elif defined(_M_ARM64)
+    return (npy_uint8)__ldar8((unsigned __int8 volatile *)obj);
+#else
+#error "Unsupported MSVC build configuration, neither x86 or ARM"
+#endif
+#endif
+}
+
+#undef MSC_ATOMICS
+#undef STDC_ATOMICS
+
+#endif // NUMPY_CORE_SRC_COMMON_NPY_NPY_ATOMIC_H_

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -17,7 +17,7 @@
 #elif _MSC_VER
     #include <intrin.h>
     #define MSC_ATOMICS
-    #if !defined(_M_X64) || !defined(_M_IX86) || !defined(_M_ARM64)
+    #if !defined(_M_X64) && !defined(_M_IX86) && !defined(_M_ARM64)
         #error "Unsupported MSVC build configuration, neither x86 or ARM"
     #endif
 #elif defined(__GNUC__) && (__GNUC__ > 4)

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -17,8 +17,14 @@
 #elif _MSC_VER
     #include <intrin.h>
     #define MSC_ATOMICS
+#elif defined(__GNUC__) && (__GNUC__ > 4)
+    #define GCC_ATOMICS
+#elif defined(__clang__)
+    #if __has_builtin(__atomic_load)
+        #define GCC_ATOMICS
+    #endif
 #else
-    #error "no support for missing C11 atomics except with MSVC"
+    #error "no supported atomic implementation for this platform/compiler"
 #endif
 
 
@@ -33,10 +39,13 @@ static inline npy_uint8 npy_atomic_load_uint8(const npy_uint8 *obj) {
 #else
 #error "Unsupported MSVC build configuration, neither x86 or ARM"
 #endif
+#elif defined(GCC_ATOMICS)
+    return __atomic_load_n(obj, __ATOMIC_SEQ_CST);
 #endif
 }
 
 #undef MSC_ATOMICS
 #undef STDC_ATOMICS
+#undef GCC_ATOMICS
 
 #endif // NUMPY_CORE_SRC_COMMON_NPY_NPY_ATOMIC_H_

--- a/numpy/_core/src/common/npy_ctypes.h
+++ b/numpy/_core/src/common/npy_ctypes.h
@@ -21,14 +21,14 @@ npy_ctypes_check(PyTypeObject *obj)
     PyObject *ret_obj;
     int ret;
 
-    npy_cache_import("numpy._core._internal", "npy_ctypes_check",
-                     &npy_thread_unsafe_state.npy_ctypes_check);
-    if (npy_thread_unsafe_state.npy_ctypes_check == NULL) {
+    if (npy_cache_import_runtime(
+                "numpy._core._internal", "npy_ctypes_check",
+                &npy_runtime_imports.npy_ctypes_check) == -1) {
         goto fail;
     }
 
-    ret_obj = PyObject_CallFunctionObjArgs(npy_thread_unsafe_state.npy_ctypes_check,
-                                           (PyObject *)obj, NULL);
+    ret_obj = PyObject_CallFunctionObjArgs(
+            npy_runtime_imports.npy_ctypes_check.obj, (PyObject *)obj, NULL);
     if (ret_obj == NULL) {
         goto fail;
     }

--- a/numpy/_core/src/common/npy_ctypes.h
+++ b/numpy/_core/src/common/npy_ctypes.h
@@ -21,6 +21,7 @@ npy_ctypes_check(PyTypeObject *obj)
     PyObject *ret_obj;
     int ret;
 
+
     if (npy_cache_import_runtime(
                 "numpy._core._internal", "npy_ctypes_check",
                 &npy_runtime_imports.npy_ctypes_check) == -1) {
@@ -28,7 +29,7 @@ npy_ctypes_check(PyTypeObject *obj)
     }
 
     ret_obj = PyObject_CallFunctionObjArgs(
-            npy_runtime_imports.npy_ctypes_check.obj, (PyObject *)obj, NULL);
+            npy_runtime_imports.npy_ctypes_check, (PyObject *)obj, NULL);
     if (ret_obj == NULL) {
         goto fail;
     }

--- a/numpy/_core/src/common/npy_import.c
+++ b/numpy/_core/src/common/npy_import.c
@@ -1,0 +1,19 @@
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+
+#include "numpy/ndarraytypes.h"
+#include "npy_import.h"
+#include "npy_atomic.h"
+
+
+NPY_VISIBILITY_HIDDEN npy_runtime_imports_struct npy_runtime_imports;
+
+NPY_NO_EXPORT int
+init_import_mutex(void) {
+    npy_runtime_imports.import_mutex = PyThread_allocate_lock();
+    if (npy_runtime_imports.import_mutex == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    return 0;
+}

--- a/numpy/_core/src/common/npy_import.h
+++ b/numpy/_core/src/common/npy_import.h
@@ -3,7 +3,80 @@
 
 #include <Python.h>
 
-/*! \brief Fetch and cache Python function.
+#include "numpy/npy_common.h"
+#include "npy_atomic.h"
+
+/*
+ * Holds a cached PyObject where the cache is initialized via a
+ * runtime import. The cache is only filled once.
+ */
+
+typedef struct npy_runtime_import {
+    npy_uint8 initialized;
+    PyObject *obj;
+} npy_runtime_import;
+
+/*
+ * Cached references to objects obtained via an import. All of these are
+ * can be initialized at any time by npy_cache_import_runtime.
+ */
+typedef struct npy_runtime_imports_struct {
+    PyThread_type_lock import_mutex;
+    npy_runtime_import _add_dtype_helper;
+    npy_runtime_import _all;
+    npy_runtime_import _amax;
+    npy_runtime_import _amin;
+    npy_runtime_import _any;
+    npy_runtime_import array_function_errmsg_formatter;
+    npy_runtime_import array_ufunc_errmsg_formatter;
+    npy_runtime_import _clip;
+    npy_runtime_import _commastring;
+    npy_runtime_import _convert_to_stringdtype_kwargs;
+    npy_runtime_import _default_array_repr;
+    npy_runtime_import _default_array_str;
+    npy_runtime_import _dump;
+    npy_runtime_import _dumps;
+    npy_runtime_import _getfield_is_safe;
+    npy_runtime_import internal_gcd_func;
+    npy_runtime_import _mean;
+    npy_runtime_import NO_NEP50_WARNING;
+    npy_runtime_import npy_ctypes_check;
+    npy_runtime_import numpy_matrix;
+    npy_runtime_import _prod;
+    npy_runtime_import _promote_fields;
+    npy_runtime_import _std;
+    npy_runtime_import _sum;
+    npy_runtime_import _ufunc_doc_signature_formatter;
+    npy_runtime_import _var;
+    npy_runtime_import _view_is_safe;
+    npy_runtime_import _void_scalar_to_string;
+} npy_runtime_imports_struct;
+
+NPY_VISIBILITY_HIDDEN extern npy_runtime_imports_struct npy_runtime_imports;
+
+/*! \brief Import a Python object.
+
+ * This function imports the Python function specified by
+ * \a module and \a function, increments its reference count, and returns
+ * the result. On error, returns NULL.
+ *
+ * @param module Absolute module name.
+ * @param attr module attribute to cache.
+ */
+static inline PyObject*
+npy_import(const char *module, const char *attr)
+{
+    PyObject *ret = NULL;
+    PyObject *mod = PyImport_ImportModule(module);
+
+    if (mod != NULL) {
+        ret = PyObject_GetAttrString(mod, attr);
+        Py_DECREF(mod);
+    }
+    return ret;
+}
+
+/*! \brief Fetch and cache Python object at runtime.
  *
  * Import a Python function and cache it for use. The function checks if
  * cache is NULL, and if not NULL imports the Python function specified by
@@ -16,17 +89,28 @@
  * @param attr module attribute to cache.
  * @param cache Storage location for imported function.
  */
-static inline void
-npy_cache_import(const char *module, const char *attr, PyObject **cache)
-{
-    if (NPY_UNLIKELY(*cache == NULL)) {
-        PyObject *mod = PyImport_ImportModule(module);
-
-        if (mod != NULL) {
-            *cache = PyObject_GetAttrString(mod, attr);
-            Py_DECREF(mod);
+static inline int
+npy_cache_import_runtime(const char *module, const char *attr, npy_runtime_import *cache) {
+    if (cache->initialized) {
+        return 0;
+    }
+    else {
+        if (!npy_atomic_load_uint8(&cache->initialized)) {
+            PyThread_acquire_lock(npy_runtime_imports.import_mutex, WAIT_LOCK);
+            if (!cache->initialized) {
+                cache->obj = npy_import(module, attr);
+                cache->initialized = 1;
+            }
+            PyThread_release_lock(npy_runtime_imports.import_mutex);
         }
     }
+    if (cache->obj == NULL) {
+        return -1;
+    }
+    return 0;    
 }
+
+NPY_NO_EXPORT int
+init_import_mutex(void);
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_IMPORT_H_ */

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2432,6 +2432,9 @@ PyMODINIT_FUNC PyInit__multiarray_tests(void)
         return m;
     }
     import_array();
+    if (init_argparse_mutex() < 0) {
+        return NULL;
+    }
     if (PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot load _multiarray_tests module.");

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -42,6 +42,28 @@ argparse_example_function(PyObject *NPY_UNUSED(mod),
     Py_RETURN_NONE;
 }
 
+/*
+ *  Tests that argparse cache creation is thread-safe. *must* be called only
+ *  by the python-level test_thread_safe_argparse_cache function, otherwise
+ *  the cache might be created before the test to make sure cache creation is
+ *  thread-safe runs
+ */
+static PyObject *
+threaded_argparse_example_function(PyObject *NPY_UNUSED(mod),
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    NPY_PREPARE_ARGPARSER;
+    int arg1;
+    PyObject *arg2;
+    if (npy_parse_arguments("thread_func", args, len_args, kwnames,
+            "$arg1", &PyArray_PythonPyIntFromInt, &arg1,
+            "$arg2", NULL, &arg2,
+            NULL, NULL, NULL) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
 /* test PyArray_IsPythonScalar, before including private py3 compat header */
 static PyObject *
 IsPythonScalar(PyObject * dummy, PyObject *args)
@@ -2204,6 +2226,9 @@ run_scalar_intp_from_sequence(PyObject *NPY_UNUSED(self), PyObject *obj)
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"argparse_example_function",
          (PyCFunction)argparse_example_function,
+         METH_KEYWORDS | METH_FASTCALL, NULL},
+    {"threaded_argparse_example_function",
+         (PyCFunction)threaded_argparse_example_function,
          METH_KEYWORDS | METH_FASTCALL, NULL},
     {"IsPythonScalar",
         IsPythonScalar,

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -237,7 +237,7 @@ set_no_matching_types_error(PyObject *public_api, PyObject *types)
             "array_function_errmsg_formatter",
             &npy_runtime_imports.array_function_errmsg_formatter) == 0) {
         PyObject *errmsg = PyObject_CallFunctionObjArgs(
-                npy_runtime_imports.array_function_errmsg_formatter.obj,
+                npy_runtime_imports.array_function_errmsg_formatter,
                 public_api, types, NULL);
         if (errmsg != NULL) {
             PyErr_SetObject(PyExc_TypeError, errmsg);

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -232,12 +232,12 @@ static void
 set_no_matching_types_error(PyObject *public_api, PyObject *types)
 {
     /* No acceptable override found, raise TypeError. */
-    npy_cache_import("numpy._core._internal",
-                     "array_function_errmsg_formatter",
-                     &npy_thread_unsafe_state.array_function_errmsg_formatter);
-    if (npy_thread_unsafe_state.array_function_errmsg_formatter != NULL) {
+    if (npy_cache_import_runtime(
+            "numpy._core._internal",
+            "array_function_errmsg_formatter",
+            &npy_runtime_imports.array_function_errmsg_formatter) == 0) {
         PyObject *errmsg = PyObject_CallFunctionObjArgs(
-                npy_thread_unsafe_state.array_function_errmsg_formatter,
+                npy_runtime_imports.array_function_errmsg_formatter.obj,
                 public_api, types, NULL);
         if (errmsg != NULL) {
             PyErr_SetObject(PyExc_TypeError, errmsg);

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -90,7 +90,7 @@ npy_give_promotion_warnings(void)
         return 1;
     }
 
-    if (PyContextVar_Get(npy_runtime_imports.NO_NEP50_WARNING.obj,
+    if (PyContextVar_Get(npy_runtime_imports.NO_NEP50_WARNING,
                          Py_False, &val) < 0) {
         /* Errors should not really happen, but if it does assume we warn. */
         PyErr_WriteUnraisable(NULL);

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -83,15 +83,14 @@ npy_give_promotion_warnings(void)
 {
     PyObject *val;
 
-    npy_cache_import(
+    if (npy_cache_import_runtime(
             "numpy._core._ufunc_config", "NO_NEP50_WARNING",
-            &npy_thread_unsafe_state.NO_NEP50_WARNING);
-    if (npy_thread_unsafe_state.NO_NEP50_WARNING == NULL) {
+            &npy_runtime_imports.NO_NEP50_WARNING) == -1) {
         PyErr_WriteUnraisable(NULL);
         return 1;
     }
 
-    if (PyContextVar_Get(npy_thread_unsafe_state.NO_NEP50_WARNING,
+    if (PyContextVar_Get(npy_runtime_imports.NO_NEP50_WARNING.obj,
                          Py_False, &val) < 0) {
         /* Errors should not really happen, but if it does assume we warn. */
         PyErr_WriteUnraisable(NULL);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -731,7 +731,7 @@ _convert_from_commastring(PyObject *obj, int align)
             &npy_runtime_imports._commastring) == -1) {
         return NULL;
     }
-    parsed = PyObject_CallOneArg(npy_runtime_imports._commastring.obj, obj);
+    parsed = PyObject_CallOneArg(npy_runtime_imports._commastring, obj);
     if (parsed == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -726,12 +726,12 @@ _convert_from_commastring(PyObject *obj, int align)
     PyObject *parsed;
     PyArray_Descr *res;
     assert(PyUnicode_Check(obj));
-    npy_cache_import("numpy._core._internal", "_commastring",
-                     &npy_thread_unsafe_state._commastring);
-    if (npy_thread_unsafe_state._commastring == NULL) {
+    if (npy_cache_import_runtime(
+            "numpy._core._internal", "_commastring",
+            &npy_runtime_imports._commastring) == -1) {
         return NULL;
     }
-    parsed = PyObject_CallOneArg(npy_thread_unsafe_state._commastring, obj);
+    parsed = PyObject_CallOneArg(npy_runtime_imports._commastring.obj, obj);
     if (parsed == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -772,7 +772,7 @@ void_common_instance(_PyArray_LegacyDescr *descr1, _PyArray_LegacyDescr *descr2)
             return NULL;
         }
         PyObject *result = PyObject_CallFunctionObjArgs(
-                npy_runtime_imports._promote_fields.obj,
+                npy_runtime_imports._promote_fields,
                 descr1, descr2, NULL);
         if (result == NULL) {
             return NULL;
@@ -1246,7 +1246,7 @@ dtypemeta_wrap_legacy_descriptor(
         }
 
         if (PyObject_CallFunction(
-                npy_runtime_imports._add_dtype_helper.obj,
+                npy_runtime_imports._add_dtype_helper,
                 "Os", (PyObject *)dtype_class, alias) == NULL) {
             return -1;
         }

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -766,13 +766,13 @@ void_common_instance(_PyArray_LegacyDescr *descr1, _PyArray_LegacyDescr *descr2)
 
     if (descr1->names != NULL && descr2->names != NULL) {
         /* If both have fields promoting individual fields may be possible */
-        npy_cache_import("numpy._core._internal", "_promote_fields",
-                         &npy_thread_unsafe_state._promote_fields);
-        if (npy_thread_unsafe_state._promote_fields == NULL) {
+        if (npy_cache_import_runtime(
+                    "numpy._core._internal", "_promote_fields",
+                    &npy_runtime_imports._promote_fields) == -1) {
             return NULL;
         }
         PyObject *result = PyObject_CallFunctionObjArgs(
-                npy_thread_unsafe_state._promote_fields,
+                npy_runtime_imports._promote_fields.obj,
                 descr1, descr2, NULL);
         if (result == NULL) {
             return NULL;
@@ -1240,14 +1240,13 @@ dtypemeta_wrap_legacy_descriptor(
 
     /* And it to the types submodule if it is a builtin dtype */
     if (!PyTypeNum_ISUSERDEF(descr->type_num)) {
-        npy_cache_import("numpy.dtypes", "_add_dtype_helper",
-                         &npy_thread_unsafe_state._add_dtype_helper);
-        if (npy_thread_unsafe_state._add_dtype_helper == NULL) {
+        if (npy_cache_import_runtime("numpy.dtypes", "_add_dtype_helper",
+                                     &npy_runtime_imports._add_dtype_helper) == -1) {
             return -1;
         }
 
         if (PyObject_CallFunction(
-                npy_thread_unsafe_state._add_dtype_helper,
+                npy_runtime_imports._add_dtype_helper.obj,
                 "Os", (PyObject *)dtype_class, alias) == NULL) {
             return -1;
         }

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -388,13 +388,13 @@ array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
     if (_may_have_objects(PyArray_DESCR(self)) || _may_have_objects(newtype)) {
         PyObject *safe;
 
-        npy_cache_import("numpy._core._internal", "_view_is_safe",
-                         &npy_thread_unsafe_state._view_is_safe);
-        if (npy_thread_unsafe_state._view_is_safe == NULL) {
+        if (npy_cache_import_runtime(
+                "numpy._core._internal", "_view_is_safe",
+                &npy_runtime_imports._view_is_safe) == -1) {
             goto fail;
         }
 
-        safe = PyObject_CallFunction(npy_thread_unsafe_state._view_is_safe,
+        safe = PyObject_CallFunction(npy_runtime_imports._view_is_safe.obj,
                                      "OO", PyArray_DESCR(self), newtype);
         if (safe == NULL) {
             goto fail;

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -394,7 +394,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
             goto fail;
         }
 
-        safe = PyObject_CallFunction(npy_runtime_imports._view_is_safe.obj,
+        safe = PyObject_CallFunction(npy_runtime_imports._view_is_safe,
                                      "OO", PyArray_DESCR(self), newtype);
         if (safe == NULL) {
             goto fail;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -113,13 +113,11 @@ npy_forward_method(
  * be correct.
  */
 #define NPY_FORWARD_NDARRAY_METHOD(name)                                \
-    npy_cache_import(                                                   \
-            "numpy._core._methods", #name,                              \
-            &npy_thread_unsafe_state.name);                         \
-    if (npy_thread_unsafe_state.name == NULL) {                     \
+    if (npy_cache_import_runtime("numpy._core._methods", #name,         \
+                                 &npy_runtime_imports.name) == -1) {    \
         return NULL;                                                    \
     }                                                                   \
-    return npy_forward_method(npy_thread_unsafe_state.name,         \
+    return npy_forward_method(npy_runtime_imports.name.obj,             \
                               (PyObject *)self, args, len_args, kwnames)
 
 
@@ -406,15 +404,15 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
 
     /* check that we are not reinterpreting memory containing Objects. */
     if (_may_have_objects(PyArray_DESCR(self)) || _may_have_objects(typed)) {
-        npy_cache_import("numpy._core._internal", "_getfield_is_safe",
-                         &npy_thread_unsafe_state._getfield_is_safe);
-        if (npy_thread_unsafe_state._getfield_is_safe == NULL) {
+        if (npy_cache_import_runtime(
+                    "numpy._core._internal", "_getfield_is_safe",
+                    &npy_runtime_imports._getfield_is_safe) == -1) {
             Py_DECREF(typed);
             return NULL;
         }
 
         /* only returns True or raises */
-        safe = PyObject_CallFunction(npy_thread_unsafe_state._getfield_is_safe,
+        safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe.obj,
                                      "OOi", PyArray_DESCR(self),
                                      typed, offset);
         if (safe == NULL) {
@@ -2248,18 +2246,19 @@ NPY_NO_EXPORT int
 PyArray_Dump(PyObject *self, PyObject *file, int protocol)
 {
     PyObject *ret;
-    npy_cache_import("numpy._core._methods", "_dump",
-                     &npy_thread_unsafe_state._dump);
-    if (npy_thread_unsafe_state._dump == NULL) {
+    if (npy_cache_import_runtime(
+                "numpy._core._methods", "_dump",
+                &npy_runtime_imports._dump) == -1) {
         return -1;
     }
+
     if (protocol < 0) {
         ret = PyObject_CallFunction(
-                npy_thread_unsafe_state._dump, "OO", self, file);
+                npy_runtime_imports._dump.obj, "OO", self, file);
     }
     else {
         ret = PyObject_CallFunction(
-                npy_thread_unsafe_state._dump, "OOi", self, file, protocol);
+                npy_runtime_imports._dump.obj, "OOi", self, file, protocol);
     }
     if (ret == NULL) {
         return -1;
@@ -2272,17 +2271,16 @@ PyArray_Dump(PyObject *self, PyObject *file, int protocol)
 NPY_NO_EXPORT PyObject *
 PyArray_Dumps(PyObject *self, int protocol)
 {
-    npy_cache_import("numpy._core._methods", "_dumps",
-                     &npy_thread_unsafe_state._dumps);
-    if (npy_thread_unsafe_state._dumps == NULL) {
+    if (npy_cache_import_runtime("numpy._core._methods", "_dumps",
+                                 &npy_runtime_imports._dumps) == -1) {
         return NULL;
     }
     if (protocol < 0) {
-        return PyObject_CallFunction(npy_thread_unsafe_state._dumps, "O", self);
+        return PyObject_CallFunction(npy_runtime_imports._dumps.obj, "O", self);
     }
     else {
         return PyObject_CallFunction(
-                npy_thread_unsafe_state._dumps, "Oi", self, protocol);
+                npy_runtime_imports._dumps.obj, "Oi", self, protocol);
     }
 }
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -117,7 +117,7 @@ npy_forward_method(
                                  &npy_runtime_imports.name) == -1) {    \
         return NULL;                                                    \
     }                                                                   \
-    return npy_forward_method(npy_runtime_imports.name.obj,             \
+    return npy_forward_method(npy_runtime_imports.name,                 \
                               (PyObject *)self, args, len_args, kwnames)
 
 
@@ -412,7 +412,7 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
         }
 
         /* only returns True or raises */
-        safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe.obj,
+        safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe,
                                      "OOi", PyArray_DESCR(self),
                                      typed, offset);
         if (safe == NULL) {
@@ -2254,11 +2254,11 @@ PyArray_Dump(PyObject *self, PyObject *file, int protocol)
 
     if (protocol < 0) {
         ret = PyObject_CallFunction(
-                npy_runtime_imports._dump.obj, "OO", self, file);
+                npy_runtime_imports._dump, "OO", self, file);
     }
     else {
         ret = PyObject_CallFunction(
-                npy_runtime_imports._dump.obj, "OOi", self, file, protocol);
+                npy_runtime_imports._dump, "OOi", self, file, protocol);
     }
     if (ret == NULL) {
         return -1;
@@ -2276,11 +2276,11 @@ PyArray_Dumps(PyObject *self, int protocol)
         return NULL;
     }
     if (protocol < 0) {
-        return PyObject_CallFunction(npy_runtime_imports._dumps.obj, "O", self);
+        return PyObject_CallFunction(npy_runtime_imports._dumps, "O", self);
     }
     else {
         return PyObject_CallFunction(
-                npy_runtime_imports._dumps.obj, "Oi", self, protocol);
+                npy_runtime_imports._dumps, "Oi", self, protocol);
     }
 }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4842,6 +4842,10 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
+    if (init_import_mutex() < 0) {
+        goto err;
+    }
+
     if (init_extobj() < 0) {
         goto err;
     }
@@ -5067,14 +5071,15 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
      * init_string_dtype() but that needs to happen after
      * the legacy dtypemeta classes are available.
      */
-    npy_cache_import("numpy.dtypes", "_add_dtype_helper",
-                     &npy_thread_unsafe_state._add_dtype_helper);
-    if (npy_thread_unsafe_state._add_dtype_helper == NULL) {
+    
+    if (npy_cache_import_runtime(
+            "numpy.dtypes", "_add_dtype_helper",
+            &npy_runtime_imports._add_dtype_helper) == -1) {
         goto err;
     }
 
     if (PyObject_CallFunction(
-            npy_thread_unsafe_state._add_dtype_helper,
+            npy_runtime_imports._add_dtype_helper.obj,
             "Os", (PyObject *)&PyArray_StringDType, NULL) == NULL) {
         goto err;
     }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5079,7 +5079,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     }
 
     if (PyObject_CallFunction(
-            npy_runtime_imports._add_dtype_helper.obj,
+            npy_runtime_imports._add_dtype_helper,
             "Os", (PyObject *)&PyArray_StringDType, NULL) == NULL) {
         goto err;
     }

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -66,7 +66,7 @@ intern_strings(void)
 
 #define IMPORT_GLOBAL(base_path, name, object)  \
     assert(object == NULL);                     \
-    npy_cache_import(base_path, name, &object); \
+    object = npy_import(base_path, name);       \
     if (object == NULL) {                       \
         return -1;                              \
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -608,15 +608,14 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
 
 static PyObject *
 _void_scalar_to_string(PyObject *obj, int repr) {
-    npy_cache_import("numpy._core.arrayprint",
-                     "_void_scalar_to_string",
-                     &npy_thread_unsafe_state._void_scalar_to_string);
-    if (npy_thread_unsafe_state._void_scalar_to_string == NULL) {
+    if (npy_cache_import_runtime(
+                "numpy._core.arrayprint", "_void_scalar_to_string",
+                &npy_runtime_imports._void_scalar_to_string) == -1) {
         return NULL;
     }
     PyObject *is_repr = repr ? Py_True : Py_False;
     return PyObject_CallFunctionObjArgs(
-            npy_thread_unsafe_state._void_scalar_to_string, obj, is_repr, NULL);
+            npy_runtime_imports._void_scalar_to_string.obj, obj, is_repr, NULL);
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -615,7 +615,7 @@ _void_scalar_to_string(PyObject *obj, int repr) {
     }
     PyObject *is_repr = repr ? Py_True : Py_False;
     return PyObject_CallFunctionObjArgs(
-            npy_runtime_imports._void_scalar_to_string.obj, obj, is_repr, NULL);
+            npy_runtime_imports._void_scalar_to_string, obj, is_repr, NULL);
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/strfuncs.c
+++ b/numpy/_core/src/multiarray/strfuncs.c
@@ -38,15 +38,14 @@ array_repr(PyArrayObject *self)
      * We need to do a delayed import here as initialization on module load
      * leads to circular import problems.
      */
-    npy_cache_import("numpy._core.arrayprint", "_default_array_repr",
-                     &npy_thread_unsafe_state._default_array_repr);
-    if (npy_thread_unsafe_state._default_array_repr == NULL) {
+    if (npy_cache_import_runtime("numpy._core.arrayprint", "_default_array_repr",
+                                 &npy_runtime_imports._default_array_repr) == -1) {
         npy_PyErr_SetStringChained(PyExc_RuntimeError,
                 "Unable to configure default ndarray.__repr__");
         return NULL;
     }
     return PyObject_CallFunctionObjArgs(
-            npy_thread_unsafe_state._default_array_repr, self, NULL);
+            npy_runtime_imports._default_array_repr.obj, self, NULL);
 }
 
 
@@ -57,15 +56,15 @@ array_str(PyArrayObject *self)
      * We need to do a delayed import here as initialization on module load leads
      * to circular import problems.
      */
-    npy_cache_import("numpy._core.arrayprint", "_default_array_str",
-                     &npy_thread_unsafe_state._default_array_str);
-    if (npy_thread_unsafe_state._default_array_str == NULL) {
+    if (npy_cache_import_runtime(
+                "numpy._core.arrayprint", "_default_array_str",
+                &npy_runtime_imports._default_array_str) == -1) {
         npy_PyErr_SetStringChained(PyExc_RuntimeError,
                 "Unable to configure default ndarray.__str__");
         return NULL;
     }
     return PyObject_CallFunctionObjArgs(
-            npy_thread_unsafe_state._default_array_str, self, NULL);
+            npy_runtime_imports._default_array_str.obj, self, NULL);
 }
 
 

--- a/numpy/_core/src/multiarray/strfuncs.c
+++ b/numpy/_core/src/multiarray/strfuncs.c
@@ -45,7 +45,7 @@ array_repr(PyArrayObject *self)
         return NULL;
     }
     return PyObject_CallFunctionObjArgs(
-            npy_runtime_imports._default_array_repr.obj, self, NULL);
+            npy_runtime_imports._default_array_repr, self, NULL);
 }
 
 
@@ -64,7 +64,7 @@ array_str(PyArrayObject *self)
         return NULL;
     }
     return PyObject_CallFunctionObjArgs(
-            npy_runtime_imports._default_array_str.obj, self, NULL);
+            npy_runtime_imports._default_array_str, self, NULL);
 }
 
 

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -715,21 +715,20 @@ stringdtype_repr(PyArray_StringDTypeObject *self)
 static PyObject *
 stringdtype__reduce__(PyArray_StringDTypeObject *self, PyObject *NPY_UNUSED(args))
 {
-    npy_cache_import("numpy._core._internal", "_convert_to_stringdtype_kwargs",
-                     &npy_thread_unsafe_state._convert_to_stringdtype_kwargs);
-
-    if (npy_thread_unsafe_state._convert_to_stringdtype_kwargs == NULL) {
+    if (npy_cache_import_runtime(
+                "numpy._core._internal", "_convert_to_stringdtype_kwargs",
+                &npy_runtime_imports._convert_to_stringdtype_kwargs) == -1) {
         return NULL;
     }
 
     if (self->na_object != NULL) {
         return Py_BuildValue(
-                "O(iO)", npy_thread_unsafe_state._convert_to_stringdtype_kwargs,
+                "O(iO)", npy_runtime_imports._convert_to_stringdtype_kwargs.obj,
                 self->coerce, self->na_object);
     }
 
     return Py_BuildValue(
-            "O(i)", npy_thread_unsafe_state._convert_to_stringdtype_kwargs,
+            "O(i)", npy_runtime_imports._convert_to_stringdtype_kwargs.obj,
             self->coerce);
 }
 

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -723,12 +723,12 @@ stringdtype__reduce__(PyArray_StringDTypeObject *self, PyObject *NPY_UNUSED(args
 
     if (self->na_object != NULL) {
         return Py_BuildValue(
-                "O(iO)", npy_runtime_imports._convert_to_stringdtype_kwargs.obj,
+                "O(iO)", npy_runtime_imports._convert_to_stringdtype_kwargs,
                 self->coerce, self->na_object);
     }
 
     return Py_BuildValue(
-            "O(i)", npy_runtime_imports._convert_to_stringdtype_kwargs.obj,
+            "O(i)", npy_runtime_imports._convert_to_stringdtype_kwargs,
             self->coerce);
 }
 

--- a/numpy/_core/src/umath/funcs.inc.src
+++ b/numpy/_core/src/umath/funcs.inc.src
@@ -196,7 +196,7 @@ npy_ObjectGCD(PyObject *i1, PyObject *i2)
                                      &npy_runtime_imports.internal_gcd_func) == -1) {
             return NULL;
         }
-        gcd = PyObject_CallFunction(npy_runtime_imports.internal_gcd_func.obj,
+        gcd = PyObject_CallFunction(npy_runtime_imports.internal_gcd_func,
                                     "OO", i1, i2);
         if (gcd == NULL) {
             return NULL;

--- a/numpy/_core/src/umath/funcs.inc.src
+++ b/numpy/_core/src/umath/funcs.inc.src
@@ -192,12 +192,11 @@ npy_ObjectGCD(PyObject *i1, PyObject *i2)
 
     /* otherwise, use our internal one, written in python */
     {
-        npy_cache_import("numpy._core._internal", "_gcd",
-                         &npy_thread_unsafe_state.internal_gcd_func);
-        if (npy_thread_unsafe_state.internal_gcd_func == NULL) {
+        if (npy_cache_import_runtime("numpy._core._internal", "_gcd",
+                                     &npy_runtime_imports.internal_gcd_func) == -1) {
             return NULL;
         }
-        gcd = PyObject_CallFunction(npy_thread_unsafe_state.internal_gcd_func,
+        gcd = PyObject_CallFunction(npy_runtime_imports.internal_gcd_func.obj,
                                     "OO", i1, i2);
         if (gcd == NULL) {
             return NULL;

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -376,7 +376,7 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
                 goto fail;
             }
             errmsg = PyObject_Call(
-                    npy_runtime_imports.array_ufunc_errmsg_formatter.obj,
+                    npy_runtime_imports.array_ufunc_errmsg_formatter,
                     override_args, normal_kwds);
             if (errmsg != NULL) {
                 PyErr_SetObject(PyExc_TypeError, errmsg);

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -369,13 +369,14 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
             /* All tuple items must be set before use */
             Py_INCREF(Py_None);
             PyTuple_SET_ITEM(override_args, 0, Py_None);
-            npy_cache_import(
+            if (npy_cache_import_runtime(
                     "numpy._core._internal",
                     "array_ufunc_errmsg_formatter",
-                    &npy_thread_unsafe_state.array_ufunc_errmsg_formatter);
-            assert(npy_thread_unsafe_state.array_ufunc_errmsg_formatter != NULL);
+                    &npy_runtime_imports.array_ufunc_errmsg_formatter) == -1) {
+                goto fail;
+            }
             errmsg = PyObject_Call(
-                    npy_thread_unsafe_state.array_ufunc_errmsg_formatter,
+                    npy_runtime_imports.array_ufunc_errmsg_formatter.obj,
                     override_args, normal_kwds);
             if (errmsg != NULL) {
                 PyErr_SetObject(PyExc_TypeError, errmsg);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -5228,7 +5228,8 @@ prepare_input_arguments_for_outer(PyObject *args, PyUFuncObject *ufunc)
 {
     PyArrayObject *ap1 = NULL;
     PyObject *tmp;
-    npy_cache_import("numpy", "matrix", &npy_thread_unsafe_state.numpy_matrix);
+    npy_cache_import_runtime("numpy", "matrix",
+                             &npy_runtime_imports.numpy_matrix);
 
     const char *matrix_deprecation_msg = (
             "%s.outer() was passed a numpy matrix as %s argument. "
@@ -5239,7 +5240,7 @@ prepare_input_arguments_for_outer(PyObject *args, PyUFuncObject *ufunc)
 
     tmp = PyTuple_GET_ITEM(args, 0);
 
-    if (PyObject_IsInstance(tmp, npy_thread_unsafe_state.numpy_matrix)) {
+    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix.obj)) {
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "first") < 0) {
@@ -5256,7 +5257,7 @@ prepare_input_arguments_for_outer(PyObject *args, PyUFuncObject *ufunc)
 
     PyArrayObject *ap2 = NULL;
     tmp = PyTuple_GET_ITEM(args, 1);
-    if (PyObject_IsInstance(tmp, npy_thread_unsafe_state.numpy_matrix)) {
+    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix.obj)) {
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "second") < 0) {
@@ -6401,12 +6402,9 @@ ufunc_get_doc(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     PyObject *doc;
 
-    npy_cache_import(
-        "numpy._core._internal",
-        "_ufunc_doc_signature_formatter",
-        &npy_thread_unsafe_state._ufunc_doc_signature_formatter);
-
-    if (npy_thread_unsafe_state._ufunc_doc_signature_formatter == NULL) {
+    if (npy_cache_import_runtime(
+            "numpy._core._internal", "_ufunc_doc_signature_formatter",
+            &npy_runtime_imports._ufunc_doc_signature_formatter) == -1) {
         return NULL;
     }
 
@@ -6415,8 +6413,9 @@ ufunc_get_doc(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
      * introspection on name and nin + nout to automate the first part
      * of it the doc string shouldn't need the calling convention
      */
-    doc = PyObject_CallFunctionObjArgs(npy_thread_unsafe_state._ufunc_doc_signature_formatter,
-                                       (PyObject *)ufunc, NULL);
+    doc = PyObject_CallFunctionObjArgs(
+            npy_runtime_imports._ufunc_doc_signature_formatter.obj,
+            (PyObject *)ufunc, NULL);
     if (doc == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -5240,7 +5240,7 @@ prepare_input_arguments_for_outer(PyObject *args, PyUFuncObject *ufunc)
 
     tmp = PyTuple_GET_ITEM(args, 0);
 
-    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix.obj)) {
+    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix)) {
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "first") < 0) {
@@ -5257,7 +5257,7 @@ prepare_input_arguments_for_outer(PyObject *args, PyUFuncObject *ufunc)
 
     PyArrayObject *ap2 = NULL;
     tmp = PyTuple_GET_ITEM(args, 1);
-    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix.obj)) {
+    if (PyObject_IsInstance(tmp, npy_runtime_imports.numpy_matrix)) {
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "second") < 0) {
@@ -6414,7 +6414,7 @@ ufunc_get_doc(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
      * of it the doc string shouldn't need the calling convention
      */
     doc = PyObject_CallFunctionObjArgs(
-            npy_runtime_imports._ufunc_doc_signature_formatter.obj,
+            npy_runtime_imports._ufunc_doc_signature_formatter,
             (PyObject *)ufunc, NULL);
     if (doc == NULL) {
         return NULL;

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -35,10 +35,9 @@
 #include "npy_config.h"
 
 #include "numpy/npy_common.h"
-#include "npy_import.h"
-
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
+#include "npy_import.h"
 #include "ufunc_type_resolution.h"
 #include "ufunc_object.h"
 #include "common.h"

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -22,6 +22,7 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_3kcompat.h"
 #include "npy_pycompat.h"
+#include "npy_argparse.h"
 #include "abstract.h"
 
 #include "numpy/npy_math.h"
@@ -318,6 +319,10 @@ int initumath(PyObject *m)
     }
 
     if (init_special_int_comparisons(d) < 0) {
+        return -1;
+    }
+
+    if (init_argparse_mutex() < 0) {
         return -1;
     }
 

--- a/numpy/_core/tests/test_argparse.py
+++ b/numpy/_core/tests/test_argparse.py
@@ -11,10 +11,29 @@ match exactly, and could be adjusted):
         return None
 """
 
+import threading
+
 import pytest
 
 import numpy as np
-from numpy._core._multiarray_tests import argparse_example_function as func
+from numpy._core._multiarray_tests import (
+    argparse_example_function as func,
+    threaded_argparse_example_function as thread_func,
+)
+from numpy.testing import IS_WASM
+
+
+@pytest.mark.skipif(IS_WASM, reason="wasm doesn't have support for threads")
+def test_thread_safe_argparse_cache():
+    b = threading.Barrier(8)
+
+    def call_thread_func():
+        b.wait()
+        thread_func(arg1=3, arg2=None)
+
+    tasks = [threading.Thread(target=call_thread_func) for _ in range(8)]
+    [t.start() for t in tasks]
+    [t.join() for t in tasks]
 
 
 def test_invalid_integers():

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -214,6 +214,51 @@ else
   lapack_dep = declare_dependency(dependencies: [lapack, blas_dep])
 endif
 
+# Determine whether it is necessary to link libatomic. This could be the
+# case on 32-bit platforms when atomic operations are used on 64-bit
+# types or on RISC-V using 8-bit atomics, so we explicitly check for
+# both 64 bit and 8 bit operations.  The check is adapted from SciPy,
+# who copied it from Mesa.
+null_dep = dependency('', required : false)
+atomic_dep = null_dep
+code_non_lockfree = '''
+  #include <stdint.h>
+  int main() {
+   struct {
+     uint64_t *u64v;
+     uint8_t *u8v;
+   } x;
+   x.u8v = 0;
+   x.u64v = 0;
+   uint64_t res1 = __atomic_load_n(x.u64v, __ATOMIC_ACQUIRE) &
+          __atomic_add_fetch(x.u64v, (uint64_t)1, __ATOMIC_ACQ_REL);
+   uint8_t res2 = __atomic_load_n(x.u8v, __ATOMIC_ACQUIRE) &
+          __atomic_add_fetch(x.u8v, (uint8_t)1, __ATOMIC_ACQ_REL);
+   return 0;
+  }
+'''
+if cc.get_id() != 'msvc'
+  if not cc.links(
+      code_non_lockfree,
+      name : 'Check atomic builtins without -latomic'
+    )
+    atomic_dep = cc.find_library('atomic', required: false)
+    if atomic_dep.found()
+      # We're not sure that with `-latomic` things will work for all compilers,
+      # so verify and only keep libatomic as a dependency if this works. It is
+      # possible the build will fail later otherwise - unclear under what
+      # circumstances (compilers, runtimes, etc.) exactly and this may need to
+      # be extended when support is added for new CPUs
+      if not cc.links(
+          code_non_lockfree,
+          dependencies: atomic_dep,
+          name : 'Check atomic builtins with -latomic'
+        )
+        atomic_dep = null_dep
+      endif
+    endif
+  endif
+endif
 
 # Copy the main __init__.py|pxd files to the build dir (needed for Cython)
 __init__py = fs.copyfile('__init__.py')

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -214,28 +214,28 @@ else
   lapack_dep = declare_dependency(dependencies: [lapack, blas_dep])
 endif
 
-# Determine whether it is necessary to link libatomic. This could be the
-# case on 32-bit platforms when atomic operations are used on 64-bit
-# types or on RISC-V using 8-bit atomics, so we explicitly check for
-# both 64 bit and 8 bit operations.  The check is adapted from SciPy,
-# who copied it from Mesa.
+# Determine whether it is necessary to link libatomic with gcc. This
+# could be the case on 32-bit platforms when atomic operations are used
+# on 64-bit types or on RISC-V using 8-bit atomics, so we explicitly
+# check for both 64 bit and 8 bit operations.  The check is adapted from
+# SciPy, who copied it from Mesa.
 null_dep = dependency('', required : false)
 atomic_dep = null_dep
 code_non_lockfree = '''
   #include <stdint.h>
   int main() {
    struct {
-     uint64_t *u64v;
-     uint8_t *u8v;
+     void *p;
+     uint8_t u8v;
    } x;
+   x.p = NULL;
    x.u8v = 0;
-   x.u64v = 0;
-   uint64_t res1 = __atomic_load_n(x.u64v, __ATOMIC_ACQUIRE) &
-          __atomic_add_fetch(x.u64v, (uint64_t)1, __ATOMIC_ACQ_REL);
-   uint8_t res2 = __atomic_load_n(x.u8v, __ATOMIC_ACQUIRE) &
-          __atomic_add_fetch(x.u8v, (uint8_t)1, __ATOMIC_ACQ_REL);
+   uint8_t res = __atomic_load_n(x.u8v, __ATOMIC_SEQ_CST);
+   __atomic_store_n(x.u8v, 1, ATOMIC_SEQ_CST);
+   void *p = __atomic_load_n(x.p, __ATOMIC_SEQ_CST);
+   __atomic_store_n((void **)x.p, NULL, __ATOMIC_SEQ_CST)
    return 0;
-  }
+   }
 '''
 if cc.get_id() != 'msvc'
   if not cc.links(


### PR DESCRIPTION
This is a re-do of #26430.

It adds locking to the argparse cache and the cached runtime imports, making both thread safe.

Both caches leverage a new `npy_atomic.h` header that wraps C11 atomics and MSVC intrinsics to implement a uint8 atomic load. I think this is sufficient to work on all supported platforms but we'll see what CI says.

First, we do a regular load to see if the cache is initialized. If it is, we read from the cache and go on our way. If it isn't, we do an atomic load to serialize access and then immediately acquire a lock. Whichever thread wins the race to acquire the lock fills in the cache and the other threads wait until the lock is released, acquire the lock, see the cache is filled, and continue. Since the lock is only used before the cache is filled in, a global lock is OK I think.

I could probably refactor both uses to make use of an abstract single-initialization API that takes a function pointer, but given that there are only two usages I don't think the extra abstraction and needing to make all the cache initialization functions have the same function signature is worth the effort.