### PR TITLE
TYP: fix missing `sys` import in numeric.pyi

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Callable, Sequence
 from typing import (
     Any,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
@@ -8,11 +7,8 @@ from typing import (
     SupportsAbs,
     SupportsIndex,
     NoReturn,
+    TypeGuard,
 )
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
 
 import numpy as np
 from numpy import (

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -12,7 +12,6 @@ from typing import (
 
 import numpy as np
 from numpy import (
-    ComplexWarning as ComplexWarning,
     generic,
     unsignedinteger,
     signedinteger,

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Sequence, Iterator, Callable, Iterable
 from typing import (
     Literal as L,
@@ -8,12 +7,8 @@ from typing import (
     Protocol,
     SupportsIndex,
     SupportsInt,
+    TypeGuard
 )
-
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
 
 from numpy import (
     vectorize as vectorize,

--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -1,11 +1,13 @@
-import sys
 from collections.abc import Callable, Sequence
-from typing import TypeVar, Any, overload, SupportsIndex, Protocol
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec, Concatenate
-else:
-    from typing_extensions import ParamSpec, Concatenate
+from typing import (
+    TypeVar,
+    Any,
+    overload,
+    SupportsIndex,
+    Protocol,
+    ParamSpec,
+    Concatenate,
+)
 
 import numpy as np
 from numpy import (

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -18,11 +18,8 @@ from typing import (
     TypeVar,
     Final,
     SupportsIndex,
+    ParamSpec
 )
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
 
 import numpy as np
 from numpy import number, object_, _FloatValue


### PR DESCRIPTION
Fixed missing `sys` import that's needed after 8de2ed5 for these lines to work:
https://github.com/numpy/numpy/blob/768724556fd9a60556fea5203b1489bb51c507a5/numpy/_core/numeric.pyi#L11-L14

Perhaps, ping @rgommers