### PR TITLE
BUG: avoid side-effect of 'include complex.h'

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -379,6 +379,12 @@ typedef struct
 
 #include <complex.h>
 
+// Downstream libraries like sympy would like to use I
+// see https://github.com/numpy/numpy/issues/26787
+#ifdef I
+#undef I
+#endif
+
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 typedef _Dcomplex npy_cdouble;
 typedef _Fcomplex npy_cfloat;


### PR DESCRIPTION
Fixes #26787 

I confirmed the example in the issue fails before, passes after this fix.