### PR TITLE
DOC: Mention '1.25' legacy printing mode in ``set_printoptions``

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -217,6 +217,10 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         by not inserting spaces after commas that separate fields and after
         colons.
 
+        If set to ``'1.25'`` approximates printing of 1.25 which mainly means
+        that numeric scalars are printed without their type information, e.g.
+        as ``3.0`` rather than ``np.float64(3.0)``.
+
         If set to `False`, disables legacy mode.
 
         Unrecognized strings will be ignored with a warning for forward
@@ -224,6 +228,7 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
 
         .. versionadded:: 1.14.0
         .. versionchanged:: 1.22.0
+        .. versionchanged:: 2.0
 
     See Also
     --------


### PR DESCRIPTION
Backport of #26742.

Mention the new printing mode in ``set_printoptions`` and copy the doc also to the duplication in ``array2string``.

Closes gh-26731

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
