### PR TITLE
BUG: Rewrite complex log1p to improve precision.

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1153,6 +1153,7 @@ src_umath = umath_gen_headers + [
   src_file.process('src/umath/scalarmath.c.src'),
   'src/umath/ufunc_object.c',
   'src/umath/umathmodule.c',
+  src_file.process('src/umath/clog1p_wrappers.cpp.src'),
   'src/umath/special_integer_comparisons.cpp',
   'src/umath/string_ufuncs.cpp',
   'src/umath/stringdtype_ufuncs.cpp',

--- a/numpy/_core/src/umath/clog1p_wrappers.cpp.src
+++ b/numpy/_core/src/umath/clog1p_wrappers.cpp.src
@@ -1,0 +1,32 @@
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#include "numpy/npy_math.h"
+#include "numpy/ndarraytypes.h"
+#include <cmath>
+#include <complex>
+#include "log1p_complex.h"
+
+extern "C" {
+
+/**begin repeat
+ * #c_fp_type = float, double, long double#
+ * #np_cplx_type = npy_cfloat,npy_cdouble,npy_clongdouble#
+ * #c = f, , l#
+ */
+
+/*
+ * C wrapper for log1p_complex(z).  This function is to be used only
+ * when the input is close to the unit circle centered at -1+0j.
+ */
+NPY_NO_EXPORT void
+clog1p@c@(@np_cplx_type@ *x, @np_cplx_type@ *r)
+{
+    std::complex<@c_fp_type@> z{npy_creal@c@(*x), npy_cimag@c@(*x)};
+    auto w = log1p_complex::log1p_complex(z);
+    npy_csetreal@c@(r, w.real());
+    npy_csetimag@c@(r, w.imag());
+}
+
+/**end repeat**/
+
+}  // extern "C"

--- a/numpy/_core/src/umath/clog1p_wrappers.h
+++ b/numpy/_core/src/umath/clog1p_wrappers.h
@@ -1,0 +1,19 @@
+#ifndef CLOG1P_WRAPPERS_H
+#define CLOG1P_WRAPPERS_H
+
+// This header is to be included in umathmodule.c,
+// so it will be processed by a C compiler.
+//
+// This file assumes that the numpy header files have
+// already been included.
+
+NPY_NO_EXPORT void
+clog1pf(npy_cfloat *z, npy_cfloat *r);
+
+NPY_NO_EXPORT void
+clog1p(npy_cdouble *z, npy_cdouble *r);
+
+NPY_NO_EXPORT void
+clog1pl(npy_clongdouble *z, npy_clongdouble *r);
+
+#endif  // CLOG1P_WRAPPERS_H

--- a/numpy/_core/src/umath/funcs.inc.src
+++ b/numpy/_core/src/umath/funcs.inc.src
@@ -310,10 +310,31 @@ nc_log@c@(@ctype@ *x, @ctype@ *r)
 static void
 nc_log1p@c@(@ctype@ *x, @ctype@ *r)
 {
-    @ftype@ l = npy_hypot@c@(npy_creal@c@(*x) + 1,npy_cimag@c@(*x));
-    npy_csetimag@c@(r, npy_atan2@c@(npy_cimag@c@(*x), npy_creal@c@(*x) + 1));
-    npy_csetreal@c@(r, npy_log@c@(l));
-    return;
+    @ftype@ xr = npy_creal@c@(*x);
+    @ftype@ xi = npy_cimag@c@(*x);
+    @ctype@ xp1 = npy_cpack@c@(xr + 1, xi);
+    @ftype@ delta = 0.001;
+    /*
+     * Should we use the high precision calculation? First check if
+     * x is within a bounding box, and then check if x is close to the
+     * unit circle centered at -1+0j.  The bounding box is checked first
+     * to avoid overflow that might occur in npy_cabs@c@(xp1) when xr or
+     * xi is very close to the maximum value of @ftype@.
+     */
+    if (-2 - delta < xr && xr < delta && -1 - delta < xi && xi < 1 + delta) {
+        @ftype@ m = npy_cabs@c@(xp1);
+        if (1 - delta < m && m < 1 + delta) {
+            /* Use the high precision calculation in this region. */
+            clog1p@c@(x, r);
+            return;
+        }
+    }
+    /*
+     * Use clog(1 + x).
+     * This branch of the code will also be used if either
+     * xr or xi is nan.
+     */
+    nc_log@c@(&xp1, r);
 }
 
 static void

--- a/numpy/_core/src/umath/log1p_complex.h
+++ b/numpy/_core/src/umath/log1p_complex.h
@@ -1,0 +1,260 @@
+#ifndef LOG1P_COMPLEX_H
+#define LOG1P_COMPLEX_H
+
+#include <Python.h>
+#include "numpy/ndarraytypes.h"
+#include "numpy/npy_math.h"
+
+#include <cmath>
+#include <complex>
+#include <limits>
+
+// For memcpy
+#include <cstring>
+
+
+//
+// Trivial C++ wrappers for several npy_* functions.
+//
+
+#define CPP_WRAP1(name) \
+inline float name(const float x)                \
+{                                               \
+    return ::npy_ ## name ## f(x);              \
+}                                               \
+inline double name(const double x)              \
+{                                               \
+    return ::npy_ ## name(x);                   \
+}                                               \
+inline long double name(const long double x)    \
+{                                               \
+    return ::npy_ ## name ## l(x);              \
+}                                               \
+
+#define CPP_WRAP2(name) \
+inline float name(const float x,                \
+                  const float y)                \
+{                                               \
+    return ::npy_ ## name ## f(x, y);           \
+}                                               \
+inline double name(const double x,              \
+                   const double y)              \
+{                                               \
+    return ::npy_ ## name(x, y);                \
+}                                               \
+inline long double name(const long double x,    \
+                        const long double y)    \
+{                                               \
+    return ::npy_ ## name ## l(x, y);           \
+}                                               \
+
+
+namespace npy {
+
+CPP_WRAP1(fabs)
+CPP_WRAP1(log)
+CPP_WRAP1(log1p)
+CPP_WRAP2(atan2)
+CPP_WRAP2(hypot)
+
+}
+
+namespace log1p_complex
+{
+
+template<typename T>
+struct doubled_t {
+    T upper;
+    T lower;
+};
+
+//
+// There are three functions below where it is crucial that the
+// expressions are not optimized. E.g. `t - (t - x)` must not be
+// simplified by the compiler to just `x`. The NO_OPT macro defines
+// an attribute that should turn off optimization for the function.
+//
+// The inclusion of `gnu::target("fpmath=sse")` when __GNUC__ and
+// __i386 are defined also turns off the use of the floating-point
+// unit '387'.  It is important that when the type is, for example,
+// `double`, these functions compute their results with 64 bit
+// precision, and not with 80 bit extended precision.
+//
+
+#if defined(__clang__)
+#define NO_OPT [[clang::optnone]]
+#elif defined(__GNUC__)
+    #if defined(__i386)
+    #define NO_OPT [[gnu::optimize(0),gnu::target("fpmath=sse")]]
+    #else
+    #define NO_OPT [[gnu::optimize(0)]]
+    #endif
+#else
+#define NO_OPT
+#endif
+
+//
+// Dekker splitting.  See, for example, Theorem 1 of
+//
+//   Seppa Linnainmaa, Software for Double-Precision Floating-Point
+//   Computations, ACM Transactions on Mathematical Software, Vol 7, No 3,
+//   September 1981, pages 272-283.
+//
+// or Theorem 17 of
+//
+//   J. R. Shewchuk, Adaptive Precision Floating-Point Arithmetic and
+//   Fast Robust Geometric Predicates, CMU-CS-96-140R, from Discrete &
+//   Computational Geometry 18(3):305-363, October 1997.
+//
+template<typename T>
+NO_OPT inline void
+split(T x, doubled_t<T>& out)
+{
+    if (std::numeric_limits<T>::digits == 106) {
+        // Special case: IBM double-double format.  The value is already
+        // split in memory, so there is no need for any calculations.
+        std::memcpy(&out, &x, sizeof(out));
+    }
+    else {
+        constexpr int halfprec = (std::numeric_limits<T>::digits + 1)/2;
+        T t = ((1ull << halfprec) + 1)*x;
+        // The compiler must not be allowed to simplify this expression:
+        out.upper = t - (t - x);
+        out.lower = x - out.upper;
+    }
+}
+
+template<typename T>
+NO_OPT inline void
+two_sum_quick(T x, T y, doubled_t<T>& out)
+{
+    T r = x + y;
+    T e = y - (r - x);
+    out.upper = r;
+    out.lower = e;
+}
+
+template<typename T>
+NO_OPT inline void
+two_sum(T x, T y, doubled_t<T>& out)
+{
+    T s = x + y;
+    T v = s - x;
+    T e = (x - (s - v)) + (y - v);
+    out.upper = s;
+    out.lower = e;
+}
+
+template<typename T>
+inline void
+double_sum(const doubled_t<T>& x, const doubled_t<T>& y,
+           doubled_t<T>& out)
+{
+    two_sum<T>(x.upper, y.upper, out);
+    out.lower += x.lower + y.lower;
+    two_sum_quick<T>(out.upper, out.lower, out);
+}
+
+template<typename T>
+inline void
+square(T x, doubled_t<T>& out)
+{
+    doubled_t<T> xsplit;
+    out.upper = x*x;
+    split(x, xsplit);
+    out.lower = xsplit.lower*xsplit.lower
+                - ((out.upper - xsplit.upper*xsplit.upper)
+                   - 2*xsplit.lower*xsplit.upper);
+}
+
+//
+// As the name makes clear, this function computes x**2 + 2*x + y**2.
+// It uses doubled_t<T> for the intermediate calculations.
+// (That is, we give the floating point type T an upgrayedd, spelled with
+// two d's for a double dose of precision.)
+//
+// The function is used in log1p_complex() to avoid the loss of
+// precision that can occur in the expression when x**2 + y**2 ≈ -2*x.
+//
+template<typename T>
+inline T
+xsquared_plus_2x_plus_ysquared_dd(T x, T y)
+{
+    doubled_t<T> x2, y2, twox, sum1, sum2;
+
+    square<T>(x, x2);               // x2 = x**2
+    square<T>(y, y2);               // y2 = y**2
+    twox.upper = 2*x;               // twox = 2*x
+    twox.lower = 0.0;
+    double_sum<T>(x2, twox, sum1);  // sum1 = x**2 + 2*x
+    double_sum<T>(sum1, y2, sum2);  // sum2 = x**2 + 2*x + y**2
+    return sum2.upper;
+}
+
+//
+// For the float type, the intermediate calculation is done
+// with the double type.  We don't need to use doubled_t<float>.
+//
+inline float
+xsquared_plus_2x_plus_ysquared(float x, float y)
+{
+    double xd = x;
+    double yd = y;
+    return xd*(2.0 + xd) + yd*yd;
+}
+
+//
+// For double, we used doubled_t<double> if long double doesn't have
+// at least 106 bits of precision.
+//
+inline double
+xsquared_plus_2x_plus_ysquared(double x, double y)
+{
+    if (std::numeric_limits<long double>::digits >= 106) {
+        // Cast to long double for the calculation.
+        long double xd = x;
+        long double yd = y;
+        return xd*(2.0L + xd) + yd*yd;
+    }
+    else {
+        // Use doubled_t<double> for the calculation.
+        return xsquared_plus_2x_plus_ysquared_dd<double>(x, y);
+    }
+}
+
+//
+// For long double, we always use doubled_t<long double> for the
+// calculation.
+//
+inline long double
+xsquared_plus_2x_plus_ysquared(long double x, long double y)
+{
+    return xsquared_plus_2x_plus_ysquared_dd<long double>(x, y);
+}
+
+//
+// Implement log1p(z) for complex inputs that are near the unit circle
+// centered at -1+0j.
+//
+// The function assumes that neither component of z is nan.
+//
+template<typename T>
+inline std::complex<T>
+log1p_complex(std::complex<T> z)
+{
+    T x = z.real();
+    T y = z.imag();
+    // The input is close to the unit circle centered at -1+0j.
+    // Compute x**2 + 2*x + y**2 with higher precision than T.
+    // The calculation here is equivalent to log(hypot(x+1, y)),
+    // since
+    //    log(hypot(x+1, y)) = 0.5*log(x**2 + 2*x + 1 + y**2)
+    //                       = 0.5*log1p(x**2 + 2*x + y**2)
+    T t = xsquared_plus_2x_plus_ysquared(x, y);
+    T lnr = 0.5*npy::log1p(t);
+    return std::complex<T>(lnr, npy::atan2(y, x + static_cast<T>(1)));
+}
+
+} // namespace log1p_complex
+
+#endif

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -30,6 +30,7 @@
 #include "string_ufuncs.h"
 #include "stringdtype_ufuncs.h"
 #include "special_integer_comparisons.h"
+#include "clog1p_wrappers.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
 #include "ufunc_type_resolution.h"
 


### PR DESCRIPTION
Closes gh-22609

TL;DR: To implement `log1p(z)` for complex input `z = x + y*i`, use `log(1+z)` where that calculation doesn't lose precision. Otherwise, compute the real part of `log1p(z)` as `0.5*log1p(x**2 + 2*x + y**2)`, and use variables with doubled precision to avoid loss of precision in the expression `x**2 + 2*x + y**2`.

----- 

The formula for the complex logarithm of $z = x + iy$ is $\log z = \log |z| + i\arg z$, where $|z| = \left(x^2 + y^2\right)^{\frac{1}{2}}$, so for $\rm{log1p}(z)$ we have

$$
\begin{split}
    \textrm{log1p}(z) & = \log(1 + z) \\
                  & = \frac{1}{2}\log((x+1)^2 + y^2) + \textrm{atan2}(y, x)i \\
                  & = \log(\textrm{hypot}(x+1, y)) + \textrm{atan2}(y, x)i 
\end{split}
$$

I'll call this the naive formula.

The computation of $\textrm{atan2(y, x)}$ is stable, so we do not have to do anything special to compute it accurately.  The computation of the real part, $\frac{1}{2}\log((x+1)^2 + y^2)$, can lose precision in some regions of the complex plane.  The example from gh-22609 is `z = 1e-18 + 1e-18j`, where $\log(1+z)$ returns `1e-18j` but the correct value is `1e-18 + 1e-18j`. (Reference values are computed with mpmath.)  The reason for the incorrect result is clear from the expression $\log((x+1)^2 + y^2) = \log(1 + 2x + x^2 + y^2)$.  When $x$ and $y$ are sufficiently small, the terms $2x$, $x^2$ and $y^2$ are smaller than the machine $\varepsilon$, so the result is $\log(1) = 0$.  So clearly there is a problem with the naive formula when $x$ and $y$ are small.  We should use $\textrm{log1p}(2x + x^2 + y^2)$, but that expression turns out to still have a problem with precision loss.

Another example is `z = (-0.2892646601647662 + 0.7034589443707598j)`, where the correct value of `log1p(z)` is `-3.951471916126033e-07 + 0.7802529500871193j`, but the naive formula `log(1 + z)` (on a platform compiled with gcc 11.4.0) gives `-3.9514719157314957e-07+0.7802529500871193j`.  The relative error of the real part is about `1e-10`, and a similar relative error is observed in NumPy built on a Mac with Apple clang 14.0.3.  The $x$ and $y$ values are not particularly small, but there is still loss of precision.  Notice that the real part of the result is small; that occurs when $(x+1)^2 + y^2 = 1 + 2x + x^2 + y^2  \approx 1$.  The Taylor expansion of the real log function `log(u)` at u=1 is $(u - 1) - (u - 1)^2/2 + \ldots$, so it is not surprising that there can be precision issues near 1.  Moreover, for $1 + 2x + x^2 + y^2$ to be close to $1$, $2x + x^2 + y^2$ must be small.  And that implies that there must be cancellation between $2x$ and $x^2 + y^2$ (so the use of $\textrm{log1p}(2x + x^2 + y^2)$ doesn't eliminate the precision problem).  The region in the complex plane where this happens is near the unit circle centered at $z_0 = -1 + 0j$; that is, where $|z + 1| = 1$.

The severity of this loss of precision seems to depend on the details of the implementation of the complex log function in the standard library.  On my Linux system, where I used gcc 11.4.0 to build NumPy, there is loss of precision near unit circle centered at -1+0j only in the arc corresponding to x > -0.5.  On a Mac where I build NumPy with Apple clang version 14.0.3, there is loss of precision near the entire circle.  In this PR, the loss of precision is handled by implementing a higher precision version of the calculation that is only used in a region near that unit circle.

The high precision calculation is implemented in C++ in `log1p_complex.h`.  The essential idea is simple: compute the real part of the log with the formula $\textrm{log1p}(x^2 + 2x + y^2)$, and compute $x^2 + 2x + y^2$ with higher precision than provided by the input types. Single precision `float` is upgraded to `double`, and `double` is upgraded to `long double` *if* `long double` has at least 106 bits of precision.  Lower precision `double` types, and the `long double` type, are upgraded by using a doubled type (usually called double-double, but in the case of `long double`, the doubled type could be called *double-long double*).  Only the minimal set of functions needed to compute $x^2 + 2x + y^2$ with doubled variables is included.

The files `clog1p_wrappers.cpp.src` and `clog1p_wrappers.h` provide the shims for calling C++ code from C in `umathmodule.c`.  The functions `nc_log1p@c@(...)` in `funcs.inc.src` check whether the input is close enough to the unit circle centered at -1+0j to use the high precision calculation, otherwise they simply call `nc_log@c@(...)` with input `1+z`.

Tests are included for `np.complex64`, `np.complex128`, and the various flavors of platform-dependent `np.clongdouble`. 

Because the new code uses `log(1+z)` for points away from the circle, it benefits from whatever behavior is included in the standard library's implementation (or NumPy's implementation if the standard library's version is blocklisted).  In particular, this PR fixes an obscure bug in the main branch that occurs when the input $z = x + iy$ is so large that $\textrm{hypot}(x, y)$ is larger than the input type's maximum value.  For example, with the main development branch:

```
In [9]: m = 0.95*np.finfo(np.float64).max

In [10]: z = m + m*1j

In [11]: z
Out[11]: np.complex128(1.7078084781191998e+308+1.7078084781191998e+308j)

In [12]: np.log1p(z)
<ipython-input-12-b175d6a32d41>:1: RuntimeWarning: overflow encountered in log1p
  np.log1p(z)
Out[12]: np.complex128(inf+0.7853981633974483j)
```
We got an overflow and the real part of the result is `inf`.

With the change in this pull request, we get the correct result (at least on the platform where I ran this code):

```
In [2]: m = 0.95*np.finfo(np.float64).max

In [3]: z = m + m*1j

In [4]: z
Out[4]: np.complex128(1.7078084781191998e+308+1.7078084781191998e+308j)

In [5]: np.log1p(z)
Out[5]: np.complex128(710.0779931892764+0.7853981633974483j)
```

*Performance changes*

The new version is slower, but that is not because of the use of the doubled types. It uses the standard library with `log(1+z)` whenever the high precision calculation is not needed, and that function (at least on my Linux box) is slower than the implementation of complex `log1p` in main.  But the implementation in the main branch doesn't have any additional checks that might be in the standard library (see the "obscure bug" mentioned above).  

Here are timings for computing `log1p(z)` for samples taken from a normal distribution around 0+0j with standard deviation 2.  First, from the main branch:

```
np.__version__ = '2.1.0.dev0+git20240627.2f3da0d'
expression is "log1p(z)"
         n complex64 (ms)    complex128 (ms)   complex256 (ms)  
         5 0.000427          0.000456          0.000857         
        10 0.000512          0.000565          0.00136          
       100 0.002             0.00252           0.0108           
      1000 0.0172            0.022             0.106            
     10000 0.271             0.316             1.14             
    100000 2.85              3.27              11.9             
   1000000 28.6              32.8              120   
```

The timing for this pull request:

```
np.__version__ = '2.1.0.dev0+git20240626.c83a187'
expression is "log1p(z)"
         n complex64 (ms)    complex128 (ms)   complex256 (ms)  
         5 0.00058           0.000476          0.000858         
        10 0.000802          0.000621          0.00138          
       100 0.00524           0.00427           0.0135           
      1000 0.0492            0.0382            0.128            
     10000 0.624             0.475             1.38             
    100000 6.34              4.79              13.9             
   1000000 63.6              48                139   
```

The especially poor performance with `np.complex64` also occurs with `np.log(z)`, so it has nothing to do with this pull request, other than this change relying on `log(z)` for the "safe" case (see https://github.com/numpy/numpy/issues/26807).

The slowdown for `np.complex128` and `np.complex256` is the result of deferring to `log(1+z)` most of the time.  The performance of `log1p(z)` is basically the same as `log(1+z)`.
