### PR TITLE
MNT: Update dlpack docs and typing stubs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2563,7 +2563,15 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     @overload
     def __imatmul__(self: NDArray[object_], other: Any) -> NDArray[object_]: ...
 
-    def __dlpack__(self: NDArray[number[Any]], *, stream: None = ...) -> _PyCapsule: ...
+    def __dlpack__(
+        self: NDArray[number[Any]],
+        *,
+        stream: int | Any | None = ...,
+        max_version: tuple[int, int] | None = ...,
+        dl_device: tuple[int, L[0]] | None = ...,
+        copy: bool | None = ...,
+    ) -> _PyCapsule: ...
+
     def __dlpack_device__(self) -> tuple[int, L[0]]: ...
 
     def __array_namespace__(self, *, api_version: str | None = ...) -> Any: ...
@@ -3921,4 +3929,10 @@ _CharDType = TypeVar("_CharDType", dtype[str_], dtype[bytes_])
 class _SupportsDLPack(Protocol[_T_contra]):
     def __dlpack__(self, *, stream: None | _T_contra = ...) -> _PyCapsule: ...
 
-def from_dlpack(obj: _SupportsDLPack[None], /) -> NDArray[Any]: ...
+def from_dlpack(
+    obj: _SupportsDLPack[None],
+    /,
+    *,
+    device: L["cpu"] | None = ...,
+    copy: bool | None = ...,
+) -> NDArray[Any]: ...

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -937,7 +937,7 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         'K' (keep) preserve input order
         Defaults to 'K'.
     device : str, optional
-        The device on which to place the created array. Default: None.
+        The device on which to place the created array. Default: ``None``.
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.0.0
@@ -1031,7 +1031,7 @@ add_newdoc('numpy._core.multiarray', 'asanyarray',
         'K' (keep) preserve input order
         Defaults to 'C'.
     device : str, optional
-        The device on which to place the created array. Default: None.
+        The device on which to place the created array. Default: ``None``.
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.1.0
@@ -1235,7 +1235,7 @@ add_newdoc('numpy._core.multiarray', 'empty',
         (C-style) or column-major (Fortran-style) order in
         memory.
     device : str, optional
-        The device on which to place the created array. Default: None.
+        The device on which to place the created array. Default: ``None``.
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.0.0
@@ -1691,15 +1691,15 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
         A Python object that implements the ``__dlpack__`` and
         ``__dlpack_device__`` methods.
     device : device, optional
-        Device on which to place the created array. If device is ``None``
-        and ``x`` supports DLPack, the output array will be on the same
-        device as ``x``. Default: ``None``.
+        Device on which to place the created array. Default: ``None``.
+        For Array-API interoperability only, so must be ``"cpu"`` if passed.
     copy : bool, optional
         Boolean indicating whether or not to copy the input. If ``True``,
         the copy will be made. If ``False``, the function will never copy,
         and will raise ``BufferError`` in case a copy is deemed necessary.
         If ``None``, the function will reuse the existing memory buffer if
         possible and copy otherwise. Default: ``None``.
+
 
     Returns
     -------
@@ -1768,7 +1768,7 @@ add_newdoc('numpy._core.multiarray', 'arange',
         The type of the output array.  If `dtype` is not given, infer the data
         type from the other input arguments.
     device : str, optional
-        The device on which to place the created array. Default: None.
+        The device on which to place the created array. Default: ``None``.
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.0.0

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1698,6 +1698,8 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
         Boolean indicating whether or not to copy the input. If ``True``,
         the copy will be made. If ``False``, the function will never copy,
         and will raise ``BufferError`` in case a copy is deemed necessary.
+        Passing it requests a copy from the exporter who may or may not
+        implement the capability.
         If ``None``, the function will reuse the existing memory buffer if
         possible and copy otherwise. Default: ``None``.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1692,7 +1692,8 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
         ``__dlpack_device__`` methods.
     device : device, optional
         Device on which to place the created array. Default: ``None``.
-        For Array-API interoperability only, so must be ``"cpu"`` if passed.
+        Must be ``"cpu"`` if passed which may allow importing an array
+        that is not already CPU available.
     copy : bool, optional
         Boolean indicating whether or not to copy the input. If ``True``,
         the copy will be made. If ``False``, the function will never copy,

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1679,7 +1679,7 @@ add_newdoc('numpy._core.multiarray', 'frombuffer',
 
 add_newdoc('numpy._core.multiarray', 'from_dlpack',
     """
-    from_dlpack(x, /)
+    from_dlpack(x, /, *, device=None, copy=None)
 
     Create a NumPy array from an object implementing the ``__dlpack__``
     protocol. Generally, the returned NumPy array is a read-only view
@@ -1690,6 +1690,16 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
     x : object
         A Python object that implements the ``__dlpack__`` and
         ``__dlpack_device__`` methods.
+    device : device, optional
+        Device on which to place the created array. If device is ``None``
+        and ``x`` supports DLPack, the output array will be on the same
+        device as ``x``. Default: ``None``.
+    copy : bool, optional
+        Boolean indicating whether or not to copy the input. If ``True``,
+        the copy will be made. If ``False``, the function will never copy,
+        and will raise ``BufferError`` in case a copy is deemed necessary.
+        If ``None``, the function will reuse the existing memory buffer if
+        possible and copy otherwise. Default: ``None``.
 
     Returns
     -------
@@ -2380,14 +2390,20 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_struct__',
     """Array protocol: C-struct side."""))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack__',
-    """a.__dlpack__(*, stream=None)
+    """
+    a.__dlpack__(*, stream=None, max_version=None, dl_device=None, copy=None)
 
-    DLPack Protocol: Part of the Array API."""))
+    DLPack Protocol: Part of the Array API.
+
+    """))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack_device__',
-    """a.__dlpack_device__()
+    """
+    a.__dlpack_device__()
 
-    DLPack Protocol: Part of the Array API."""))
+    DLPack Protocol: Part of the Array API.
+
+    """))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('base',
     """


### PR DESCRIPTION
Hi @seberg,

This PR updates docs and typing stubs after https://github.com/numpy/numpy/pull/26501.