### PR TITLE
DOC: Update 2.0 migration guide and release note

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -251,7 +251,9 @@ asfarray                Use ``np.asarray`` with a float dtype instead.
 byte_bounds             Now it's available under ``np.lib.array_utils.byte_bounds``
 cast                    Use ``np.asarray(arr, dtype=dtype)`` instead.
 cfloat                  Use ``np.complex128`` instead.
+charrarray              It's still available as ``np.char.chararray``.
 clongfloat              Use ``np.clongdouble`` instead.
+compare_chararrays      It's still available as ``np.char.compare_chararrays``.
 compat                  There's no replacement, as Python 2 is no longer supported.
 complex\_               Use ``np.complex128`` instead.
 cumproduct              Use ``np.cumprod`` instead.
@@ -266,6 +268,7 @@ find_common_type        Use ``numpy.promote_types`` or ``numpy.result_type`` ins
                         To achieve semantics for the ``scalar_types`` argument, 
                         use ``numpy.result_type`` and pass the Python values ``0``, 
                         ``0.0``, or ``0j``.
+format_parser           It's still available as ``np.rec.format_parser``.
 get_array_wrap
 float\_                 Use ``np.float64`` instead.
 geterrobj               Use the np.errstate context manager instead.

--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -209,7 +209,8 @@ NumPy 2.0 Python API removals
 
 * ``np.tracemalloc_domain`` is now only available from ``np.lib``.
 
-* ``np.recfromcsv`` and ``recfromtxt`` are now only available from ``np.lib.npyio``.
+* ``np.recfromcsv`` and ``np.recfromtxt`` were removed from the main namespace.
+  Use ``np.genfromtxt`` with comma delimiter instead.
 
 * ``np.issctype``, ``np.maximum_sctype``, ``np.obj2sctype``, ``np.sctype2char``,
   ``np.sctypes``, ``np.issubsctype`` were all removed from the


### PR DESCRIPTION
Hi!

This PR contains small 2.0 docs fixes (missing niche items in the migration guide, and an update to the 2.0 release note). It can be backported to 2.0.1. 