### PR TITLE
DOC: Change selected hardlinks to NEPs to intersphinx mappings

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -327,7 +327,6 @@ typically packaged as ``python-dbg``) is highly recommended.
 .. _Waf: https://code.google.com/p/waf/
 .. _`match test names using python operators`: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests
 .. _`Python Style Guide`: https://www.python.org/dev/peps/pep-0008/
-.. :ref:`NEP45`
 
 Understanding the code & getting started
 ----------------------------------------

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -205,7 +205,7 @@ since the linter runs as part of the CI pipeline.
 For more details on Style Guidelines:
 
 - `Python Style Guide`_
-- `C Style Guide`_
+- :ref:`NEP45`
 
 Rebuilding & cleaning the workspace
 -----------------------------------
@@ -327,7 +327,7 @@ typically packaged as ``python-dbg``) is highly recommended.
 .. _Waf: https://code.google.com/p/waf/
 .. _`match test names using python operators`: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests
 .. _`Python Style Guide`: https://www.python.org/dev/peps/pep-0008/
-.. _`C Style Guide`: https://numpy.org/neps/nep-0045-c_style_guide.html
+.. :ref:`NEP45`
 
 Understanding the code & getting started
 ----------------------------------------

--- a/doc/source/dev/howto-docs.rst
+++ b/doc/source/dev/howto-docs.rst
@@ -79,7 +79,7 @@ ideas and feedback. If you want to alert us to a gap,
 
 If you're looking for subjects, our formal roadmap for documentation is a
 *NumPy Enhancement Proposal (NEP)*,
-`NEP 44 - Restructuring the NumPy Documentation <https://www.numpy.org/neps/nep-0044-restructuring-numpy-docs>`__.
+:ref:`NEP44`.
 It identifies areas where our docs need help and lists several
 additions we'd like to see, including :ref:`Jupyter notebooks <numpy_tutorials>`.
 

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -231,7 +231,7 @@ private.
 Please see the tables below for guidance on migration.  For most changes this
 means replacing it with a backwards compatible alternative. 
 
-Please refer to `NEP 52 <https://numpy.org/neps/nep-0052-python-api-cleanup.html>`_ for more details.
+Please refer to :ref:`NEP52` for more details.
 
 Main namespace
 --------------

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -13,7 +13,7 @@ NumPy aims to implement support for the
 `2023.12 version <https://data-apis.org/array-api/2023.12/index.html>`__
 and future versions of the standard - assuming that those future versions can be
 upgraded to given NumPy's
-`backwards compatibility policy <https://numpy.org/neps/nep-0023-backwards-compatibility.html>`__.
+:ref:`backwards compatibility policy <NEP23>`.
 
 For usage guidelines for downstream libraries and end users who want to write
 code that will work with both NumPy and other array libraries, we refer to the
@@ -33,8 +33,8 @@ rather than anything NumPy-specific, the `array-api-strict
     standard, via a separate ``numpy.array_api`` submodule. This module was
     marked as experimental (it emitted a warning on import) and removed in
     NumPy 2.0 because full support was included in the main namespace.
-    `NEP 47 <https://numpy.org/neps/nep-0047-array-api-standard.html>`__ and
-    `NEP 56 <https://numpy.org/neps/nep-0056-array-api-main-namespace.html>`__
+    :ref:`NEP 47 <NEP47>` and
+    :ref:`NEP 56 <NEP56>`
     describe the motivation and scope for implementing the array API standard
     in NumPy.
 
@@ -57,7 +57,7 @@ an entry point.
 .. rubric:: Footnotes
 
 .. [1] With a few very minor exceptions, as documented in
-   `NEP 56 <https://numpy.org/neps/nep-0056-array-api-main-namespace.html>`__.
+   :ref:`NEP 56 <NEP56>`.
    The ``sum``, ``prod`` and ``trace`` behavior adheres to the 2023.12 version
    instead, as do function signatures; the only known incompatibility that may
    remain is that the standard forbids unsafe casts for in-place operators

--- a/doc/source/reference/c-api/strings.rst
+++ b/doc/source/reference/c-api/strings.rst
@@ -6,7 +6,7 @@ NpyString API
 .. versionadded:: 2.0
 
 This API allows access to the UTF-8 string data stored in NumPy StringDType
-arrays. See `NEP-55 <https://numpy.org/neps/nep-0055-string_dtype.html>`_ for
+arrays. See :ref:`NEP-55 <NEP55>` for
 more in-depth details into the design of StringDType.
 
 Examples


### PR DESCRIPTION
This commit changes links to NEPs from explicit https urls to intersphinx :ref:s. Selected files are 'actual doc files' (my phrase), not release notes, change logs, or the NEPs themselves.

These changes are a first installment towards addressing #26707. 

I plan on making the same sort of changes to the NEP files themselves, where most of the hardlinks are found. But I'd like to get this first PR through review and acceptance first as I'm new to the development workflow.

[skip actions] [skip azp] [skip cirrus]

