### PR TITLE
CI,TST: Fix meson tests needing gfortran [wheel build]

### DIFF
--- a/.github/workflows/free-threaded-wheels.yml
+++ b/.github/workflows/free-threaded-wheels.yml
@@ -118,6 +118,11 @@ jobs:
       - name: Setup macOS
         if: matrix.buildplat[0] == 'macos-13' || matrix.buildplat[0] == 'macos-14'
         run: |
+          # Needed due to https://github.com/actions/runner-images/issues/3371
+          # Supported versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+          echo "FC=gfortran-13" >> "$GITHUB_ENV"
+          echo "F77=gfortran-13" >> "$GITHUB_ENV"
+          echo "F90=gfortran-13" >> "$GITHUB_ENV"
           if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
             # macosx_arm64 and macosx_x86_64 with accelerate
             # only target Sonoma onwards

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -131,9 +131,10 @@ jobs:
         if: matrix.buildplat[0] == 'macos-13' || matrix.buildplat[0] == 'macos-14'
         run: |
           # Needed due to https://github.com/actions/runner-images/issues/3371
-          echo "FC=gfortran-10" >> "$GITHUB_ENV"
-          echo "F77=gfortran-10" >> "$GITHUB_ENV"
-          echo "F90=gfortran-10" >> "$GITHUB_ENV"
+          # Supported versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+          echo "FC=gfortran-13" >> "$GITHUB_ENV"
+          echo "F77=gfortran-13" >> "$GITHUB_ENV"
+          echo "F90=gfortran-13" >> "$GITHUB_ENV"
           if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
             # macosx_arm64 and macosx_x86_64 with accelerate
             # only target Sonoma onwards

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,6 +130,10 @@ jobs:
       - name: Setup macOS
         if: matrix.buildplat[0] == 'macos-13' || matrix.buildplat[0] == 'macos-14'
         run: |
+          # Needed due to https://github.com/actions/runner-images/issues/3371
+          echo "FC=gfortran-10" >> "$GITHUB_ENV"
+          echo "F77=gfortran-10" >> "$GITHUB_ENV"
+          echo "F90=gfortran-10" >> "$GITHUB_ENV"
           if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
             # macosx_arm64 and macosx_x86_64 with accelerate
             # only target Sonoma onwards


### PR DESCRIPTION
Should close #26810. The root cause is postfixing of `gfortran` on `macos` discussed in https://github.com/actions/runner-images/issues/3371 