### PR TITLE
TST: fix 'spin test single_test' for future versions of spin

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -254,6 +254,9 @@ def test(ctx, pytest_args, markexpr, n_jobs, tests, verbose, *args, **kwargs):
         pytest_args = ('numpy',)
 
     if '-m' not in pytest_args:
+        if len(pytest_args) == 1 and not tests:
+            tests = pytest_args[0]
+            pytest_args = ()
         if markexpr != "full":
             pytest_args = ('-m', markexpr) + pytest_args
 


### PR DESCRIPTION
See @stefanv's comment over on the spin repo: https://github.com/scientific-python/spin/pull/211#issuecomment-2183352742

The default meson `spin test` has a special case for a single test argument and our logic to insert `-m "not slow"` into the testing command interferes with that case. That currently works with `spin`, but some changes to the `spin test` command that are coming will break that situation. The fix in this PR is to handle the single test command case ourselves explicitly.