### PR TITLE
BUG: Ensure output order follows input in numpy.fft

### DIFF
--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -34,7 +34,7 @@ import functools
 import warnings
 
 from numpy.lib.array_utils import normalize_axis_index
-from numpy._core import (asarray, empty, zeros, swapaxes, result_type,
+from numpy._core import (asarray, empty_like, result_type,
                          conjugate, take, sqrt, reciprocal)
 from . import _pocketfft_umath as pfu
 from numpy._core import overrides
@@ -85,8 +85,8 @@ def _raw_fft(a, n, axis, is_real, is_forward, norm, out=None):
             out_dtype = real_dtype
         else:  # Others, complex output.
             out_dtype = result_type(a.dtype, 1j)
-        out = empty(a.shape[:axis] + (n_out,) + a.shape[axis+1:],
-                    dtype=out_dtype)
+        out = empty_like(a, shape=a.shape[:axis] + (n_out,) + a.shape[axis+1:],
+                         dtype=out_dtype)
     elif ((shape := getattr(out, "shape", None)) is not None
           and (len(shape) != a.ndim or shape[axis] != n_out)):
         raise ValueError("output array has wrong shape.")

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -497,6 +497,16 @@ def test_fft_with_order(dtype, order, fft):
         raise ValueError()
 
 
+@pytest.mark.parametrize("order", ["F", "C"])
+@pytest.mark.parametrize("n", [None, 7, 12])
+def test_fft_output_order(order, n):
+    rng = np.random.RandomState(42)
+    x = rng.rand(10)
+    x = np.asarray(x, dtype=np.complex64, order=order)
+    res = np.fft.fft(x, n=n)
+    assert res.flags.c_contiguous == x.flags.c_contiguous
+    assert res.flags.f_contiguous == x.flags.f_contiguous
+
 @pytest.mark.skipif(IS_WASM, reason="Cannot start thread")
 class TestFFTThreadSafe:
     threads = 16


### PR DESCRIPTION
Backport of #26795.

closes #26777

Output after making the changes
```py
>>> import numpy
>>> a = numpy.ones((10,10), dtype=numpy.complex64, order="F")
>>> numpy.fft.fft(a).flags
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False

>>> a = numpy.ones((10,10), dtype=numpy.complex64, order="C")
>>> numpy.fft.fft(a).flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
