### PR TITLE
TYP: fix missing sys import in numeric.pyi

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Callable, Sequence
 from typing import (
     Any,


### PR DESCRIPTION
Motivated by #26788, but we cannot employ that fix directly as NumPy 2.0.x still supports Python 3.9.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
