### PR TITLE
DOC, CI: Pin pillow version

### DIFF
--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -15,3 +15,6 @@ pickleshare
 # needed to build release notes
 towncrier
 toml
+
+# TODO: https://github.com/numpy/numpy/issues/26820
+pillow==10.3.0


### PR DESCRIPTION
Temporarily fixes: https://github.com/numpy/numpy/issues/26820

Latest pillow release `10.4.0` causes an error in `conf.py` by importing `numpy._core._add_newdocs_scalars` preemptively.

Here's a detailed explanation of what is going on: https://github.com/numpy/numpy/issues/26820#issuecomment-2202997271