### PR TITLE
DOC: remove hack to override _add_newdocs_scalars (#26826)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,10 +41,6 @@ def replace_scalar_type_names():
         ('tp_name', ctypes.c_char_p),
     ]
 
-    # prevent numpy attaching docstrings to the scalar types
-    assert 'numpy._core._add_newdocs_scalars' not in sys.modules
-    sys.modules['numpy._core._add_newdocs_scalars'] = object()
-
     import numpy
 
     # change the __name__ of the scalar types
@@ -58,9 +54,6 @@ def replace_scalar_type_names():
         c_typ = PyTypeObject.from_address(id(typ))
         c_typ.tp_name = _name_cache[typ] = b"numpy." + name.encode('utf8')
 
-    # now generate the docstrings as usual
-    del sys.modules['numpy._core._add_newdocs_scalars']
-    import numpy._core._add_newdocs_scalars
 
 replace_scalar_type_names()
 


### PR DESCRIPTION
Backport of #26826.

Fixes #26820, replaces #26825 

Something has changed in the way autoclasses adds all the members. The function `replace_scalar_type_names` is still needed, but locally removing `_add_newdocs_scalars` is not. If I totally remove `replace_scalar_type_names`, documentation is built with full class methods for `float16`, but not so if the function is in place.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
