### PR TITLE
BUG: fix PyArray_ImportNumPyAPI under -Werror=strict-prototypes

### DIFF
--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -74,7 +74,7 @@
 #ifdef import_array1
 
 static inline int
-PyArray_ImportNumPyAPI()
+PyArray_ImportNumPyAPI(void)
 {
     if (NPY_UNLIKELY(PyArray_API == NULL)) {
         import_array1(-1);


### PR DESCRIPTION
Backport of #26771.

Complete the prototype of `PyArray_ImportNumPyAPI()` by adding `void` to the argument list so that this header does not cause errors when the user is compiling with `-Werror=strict-prototypes`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
