### PR TITLE
BENCH: Missing ufunc in benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -21,7 +21,7 @@ ufuncs = ['abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
           'power', 'rad2deg', 'radians', 'reciprocal', 'remainder',
           'right_shift', 'rint', 'sign', 'signbit', 'sin',
           'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan', 'tanh',
-          'true_divide', 'trunc']
+          'true_divide', 'trunc', 'vecdot']
 arrayfuncdisp = ['real', 'round']
 
 for name in ufuncs:

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -24,13 +24,20 @@ ufuncs = ['abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
           'true_divide', 'trunc']
 arrayfuncdisp = ['real', 'round']
 
-missing_ufuncs = []
-for name in dir(np):
-    if isinstance(getattr(np, name, None), np.ufunc) and name not in ufuncs:
-        missing_ufuncs.append(name)
+for name in ufuncs:
+    f = getattr(np, name, None)
+    if not isinstance(f, np.ufunc):
+        raise ValueError(f"Bench target `np.{name}` is not a ufunc")
+
+all_ufuncs = (getattr(np, name, None) for name in dir(np))
+all_ufuncs = set(filter(lambda f: isinstance(f, np.ufunc), all_ufuncs))
+bench_ufuncs = set((getattr(np, name, None) for name in ufuncs))
+
+missing_ufuncs = all_ufuncs - bench_ufuncs
 if len(missing_ufuncs) > 0:
+    missing_ufunc_names = [f.__name__ for f in missing_ufuncs]
     raise NotImplementedError(
-        "Missing benchmarks for ufuncs %r" % missing_ufuncs)
+        "Missing benchmarks for ufuncs %r" % missing_ufunc_names)
 
 
 class ArrayFunctionDispatcher(Benchmark):

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -24,10 +24,13 @@ ufuncs = ['abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
           'true_divide', 'trunc']
 arrayfuncdisp = ['real', 'round']
 
-
+missing_ufuncs = []
 for name in dir(np):
     if isinstance(getattr(np, name, None), np.ufunc) and name not in ufuncs:
-        print("Missing ufunc %r" % (name,))
+        missing_ufuncs.append(name)
+if len(missing_ufuncs) > 0:
+    raise NotImplementedError(
+        "Missing benchmarks for ufuncs %r" % missing_ufuncs)
 
 
 class ArrayFunctionDispatcher(Benchmark):


### PR DESCRIPTION
This closes #26625. This PR makes missing ufunc benchmarks raise an exception. Furthermore, many of the missing benchmarks in the issue are aliases, so accounting for aliases the only missing benchmark is `np.vecdot`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
