### PR TITLE
TYP: overload ``numpy.frompyfunc`` for specific ``nin``/``nout``

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -77,12 +77,19 @@ from numpy._typing import (
     _IntLike_co,
     _FloatLike_co,
     _TD64Like_co,
+
+    # Ufuncs
+    _UFunc_Nin1_Nout1,
+    _UFunc_Nin2_Nout1,
+    _UFunc_Nin1_Nout2,
+    _UFunc_Nin2_Nout2,
 )
 
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
+_IdentityType = TypeVar("_IdentityType", bound=object)
 
 # Valid time units
 _UnitKind = L[
@@ -659,12 +666,53 @@ def fromstring(
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
+@overload
+def frompyfunc(
+    func: Callable[..., Any], /,
+    nin: L[1],
+    nout: L[1],
+    *,
+    identity: None = ...,
+) -> _UFunc_Nin1_Nout1[Any, L[1], None]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., Any], /,
+    nin: L[2],
+    nout: L[1],
+    *,
+    identity: _IdentityType,
+) -> _UFunc_Nin2_Nout1[Any, L[1], _IdentityType]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., Any], /,
+    nin: L[2],
+    nout: L[1],
+    *,
+    identity: None = ...,
+) -> _UFunc_Nin2_Nout1[Any, L[1], None]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., tuple[Any, Any]], /,
+    nin: L[1],
+    nout: L[2],
+    *,
+    identity: None = ...,
+) -> _UFunc_Nin1_Nout2[Any, L[1], None]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., tuple[Any, Any]], /,
+    nin: L[2],
+    nout: L[2],
+    *,
+    identity: None = ...,
+) -> _UFunc_Nin2_Nout2[Any, L[1], None]: ...
+@overload
 def frompyfunc(
     func: Callable[..., Any], /,
     nin: SupportsIndex,
     nout: SupportsIndex,
     *,
-    identity: Any = ...,
+    identity: None | object = ...,
 ) -> ufunc: ...
 
 @overload

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -1,6 +1,6 @@
 import sys
 import datetime as dt
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -37,7 +37,11 @@ date_scalar: dt.date
 date_seq: list[dt.date]
 timedelta_seq: list[dt.timedelta]
 
-def func(a: int) -> bool: ...
+def func11(a: int) -> bool: ...
+def func21(a: int, b: int) -> int: ...
+def func12(a: int) -> tuple[float, bool]: ...
+def func22(a: int, b: float) -> tuple[complex, bool]: ...
+def func42(a: int, b: float, c: bytes, d: str) -> tuple[complex, bool]: ...
 
 assert_type(next(b_f8), tuple[Any, ...])
 assert_type(b_f8.reset(), None)
@@ -106,7 +110,42 @@ assert_type(np.may_share_memory(AR_f8, AR_f8, max_work=1), bool)
 assert_type(np.promote_types(np.int32, np.int64), np.dtype[Any])
 assert_type(np.promote_types("f4", float), np.dtype[Any])
 
-assert_type(np.frompyfunc(func, 1, 1, identity=None), np.ufunc)
+assert_type(np.frompyfunc(func11, 1, 1).nin, Literal[1])
+assert_type(np.frompyfunc(func11, 1, 1).nout, Literal[1])
+assert_type(np.frompyfunc(func11, 1, 1).nargs, Literal[2])
+assert_type(np.frompyfunc(func11, 1, 1).ntypes, Literal[1])
+assert_type(np.frompyfunc(func11, 1, 1).identity, None)
+assert_type(np.frompyfunc(func11, 1, 1).signature, None)
+
+assert_type(np.frompyfunc(func21, 2, 1).nin, Literal[2])
+assert_type(np.frompyfunc(func21, 2, 1).nout, Literal[1])
+assert_type(np.frompyfunc(func21, 2, 1).nargs, Literal[3])
+assert_type(np.frompyfunc(func21, 2, 1).ntypes, Literal[1])
+assert_type(np.frompyfunc(func21, 2, 1).identity, None)
+assert_type(np.frompyfunc(func21, 2, 1).signature, None)
+
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).nin, Literal[2])
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).nout, Literal[1])
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).nargs, Literal[3])
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).ntypes, Literal[1])
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).identity, int)
+assert_type(np.frompyfunc(func21, 2, 1, identity=0).signature, None)
+
+assert_type(np.frompyfunc(func12, 1, 2).nin, Literal[1])
+assert_type(np.frompyfunc(func12, 1, 2).nout, Literal[2])
+assert_type(np.frompyfunc(func12, 1, 2).nargs, Literal[3])
+assert_type(np.frompyfunc(func12, 1, 2).ntypes, Literal[1])
+assert_type(np.frompyfunc(func12, 1, 2).identity, None)
+assert_type(np.frompyfunc(func12, 1, 2).signature, None)
+
+assert_type(np.frompyfunc(func12, 2, 2).nin, Literal[2])
+assert_type(np.frompyfunc(func12, 2, 2).nout, Literal[2])
+assert_type(np.frompyfunc(func12, 2, 2).nargs, Literal[4])
+assert_type(np.frompyfunc(func12, 2, 2).ntypes, Literal[1])
+assert_type(np.frompyfunc(func12, 2, 2).identity, None)
+assert_type(np.frompyfunc(func12, 2, 2).signature, None)
+
+assert_type(np.frompyfunc(func42, 4, 2), np.ufunc)
 
 assert_type(np.datetime_data("m8[D]"), tuple[str, int])
 assert_type(np.datetime_data(np.datetime64), tuple[str, int])


### PR DESCRIPTION
Added 4 overloads for each of the `numpy._typing._ufunc._UFunc_Nin*_Nout*`,types, plus 1 other for `nin=2` and `nout=1` with specified identity`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
