### PR TITLE
TYP: improved ``numpy.frompyfunc`` type hints

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -79,6 +79,13 @@ from numpy._typing import (
     _FloatLike_co,
     _TD64Like_co,
 )
+from numpy._typing._ufunc import (
+    _2PTuple,
+    _PyFunc_Nin1_Nout1,
+    _PyFunc_Nin2_Nout1,
+    _PyFunc_Nin3P_Nout1,
+    _PyFunc_Nin1P_Nout2P,
+)
 
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
@@ -89,8 +96,12 @@ _ArrayType_co = TypeVar(
     bound=ndarray[Any, Any],
     covariant=True,
 )
-_SizeType = TypeVar("_SizeType", bound=int)
+_ReturnType = TypeVar("_ReturnType")
+_IDType = TypeVar("_IDType")
+_Nin = TypeVar("_Nin", bound=int)
+_Nout = TypeVar("_Nout", bound=int)
 
+_SizeType = TypeVar("_SizeType", bound=int)
 _1DArray: TypeAlias = ndarray[tuple[_SizeType], dtype[_SCT]]
 
 # Valid time units
@@ -682,12 +693,77 @@ def fromstring(
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[[Any], _ReturnType], /,
+    nin: L[1],
+    nout: L[1],
+    *,
+    identity: None = ...,
+) -> _PyFunc_Nin1_Nout1[_ReturnType, None]: ...
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[[Any], _ReturnType], /,
+    nin: L[1],
+    nout: L[1],
+    *,
+    identity: _IDType,
+) -> _PyFunc_Nin1_Nout1[_ReturnType, _IDType]: ...
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[[Any, Any], _ReturnType], /,
+    nin: L[2],
+    nout: L[1],
+    *,
+    identity: None = ...,
+) -> _PyFunc_Nin2_Nout1[_ReturnType, None]: ...
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[[Any, Any], _ReturnType], /,
+    nin: L[2],
+    nout: L[1],
+    *,
+    identity: _IDType,
+) -> _PyFunc_Nin2_Nout1[_ReturnType, _IDType]: ...
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[..., _ReturnType], /,
+    nin: _Nin,
+    nout: L[1],
+    *,
+    identity: None = ...,
+) -> _PyFunc_Nin3P_Nout1[_ReturnType, None, _Nin]: ...
+@overload
+def frompyfunc(  # type: ignore[overload-overlap]
+    func: Callable[..., _ReturnType], /,
+    nin: _Nin,
+    nout: L[1],
+    *,
+    identity: _IDType,
+) -> _PyFunc_Nin3P_Nout1[_ReturnType, _IDType, _Nin]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., _2PTuple[_ReturnType]], /,
+    nin: _Nin,
+    nout: _Nout,
+    *,
+    identity: None = ...,
+) -> _PyFunc_Nin1P_Nout2P[_ReturnType, None, _Nin, _Nout]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., _2PTuple[_ReturnType]], /,
+    nin: _Nin,
+    nout: _Nout,
+    *,
+    identity: _IDType,
+) -> _PyFunc_Nin1P_Nout2P[_ReturnType, _IDType, _Nin, _Nout]: ...
+@overload
 def frompyfunc(
     func: Callable[..., Any], /,
     nin: SupportsIndex,
     nout: SupportsIndex,
     *,
-    identity: Any = ...,
+    identity: None | object = ...,
 ) -> ufunc: ...
 
 @overload

--- a/numpy/_typing/_ufunc.pyi
+++ b/numpy/_typing/_ufunc.pyi
@@ -10,15 +10,20 @@ four private subclasses, one for each combination of
 from typing import (
     Any,
     Generic,
+    NoReturn,
+    TypedDict,
     overload,
+    TypeAlias,
     TypeVar,
     Literal,
     SupportsIndex,
     Protocol,
     NoReturn,
+    type_check_only,
 )
-from typing_extensions import LiteralString
+from typing_extensions import LiteralString, Unpack
 
+import numpy as np
 from numpy import ufunc, _CastingKind, _OrderKACF
 from numpy.typing import NDArray
 
@@ -28,14 +33,23 @@ from ._array_like import ArrayLike, _ArrayLikeBool_co, _ArrayLikeInt_co
 from ._dtype_like import DTypeLike
 
 _T = TypeVar("_T")
-_2Tuple = tuple[_T, _T]
-_3Tuple = tuple[_T, _T, _T]
-_4Tuple = tuple[_T, _T, _T, _T]
+_2Tuple: TypeAlias = tuple[_T, _T]
+_3Tuple: TypeAlias = tuple[_T, _T, _T]
+_4Tuple: TypeAlias = tuple[_T, _T, _T, _T]
+
+_2PTuple: TypeAlias = tuple[_T, _T, Unpack[tuple[_T, ...]]]
+_3PTuple: TypeAlias = tuple[_T, _T, _T, Unpack[tuple[_T, ...]]]
+_4PTuple: TypeAlias = tuple[_T, _T, _T, _T, Unpack[tuple[_T, ...]]]
 
 _NTypes = TypeVar("_NTypes", bound=int, covariant=True)
 _IDType = TypeVar("_IDType", covariant=True)
 _NameType = TypeVar("_NameType", bound=LiteralString, covariant=True)
 _Signature = TypeVar("_Signature", bound=LiteralString, covariant=True)
+
+_NIn = TypeVar("_NIn", bound=int, covariant=True)
+_NOut = TypeVar("_NOut", bound=int, covariant=True)
+_ReturnType_co = TypeVar("_ReturnType_co", covariant=True)
+_ArrayType = TypeVar("_ArrayType", bound=np.ndarray[Any, Any])
 
 
 class _SupportsArrayUFunc(Protocol):
@@ -410,3 +424,444 @@ class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType, _Signature]
     def accumulate(self, *args, **kwargs) -> NoReturn: ...
     def reduceat(self, *args, **kwargs) -> NoReturn: ...
     def outer(self, *args, **kwargs) -> NoReturn: ...
+
+@type_check_only
+class _PyFunc_Kwargs_Nargs2(TypedDict, total=False):
+    where: None | _ArrayLikeBool_co
+    casting: _CastingKind
+    order: _OrderKACF
+    dtype: DTypeLike
+    subok: bool
+    signature: str | tuple[DTypeLike, DTypeLike]
+
+@type_check_only
+class _PyFunc_Kwargs_Nargs3(TypedDict, total=False):
+    where: None | _ArrayLikeBool_co
+    casting: _CastingKind
+    order: _OrderKACF
+    dtype: DTypeLike
+    subok: bool
+    signature: str | tuple[DTypeLike, DTypeLike, DTypeLike]
+
+@type_check_only
+class _PyFunc_Kwargs_Nargs3P(TypedDict, total=False):
+    where: None | _ArrayLikeBool_co
+    casting: _CastingKind
+    order: _OrderKACF
+    dtype: DTypeLike
+    subok: bool
+    signature: str | _3PTuple[DTypeLike]
+
+@type_check_only
+class _PyFunc_Kwargs_Nargs4P(TypedDict, total=False):
+    where: None | _ArrayLikeBool_co
+    casting: _CastingKind
+    order: _OrderKACF
+    dtype: DTypeLike
+    subok: bool
+    signature: str | _4PTuple[DTypeLike]
+
+
+@type_check_only
+class _PyFunc_Nin1_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: ignore[misc]
+    @property
+    def identity(self) -> _IDType: ...
+    @property
+    def nin(self) -> Literal[1]: ...
+    @property
+    def nout(self) -> Literal[1]: ...
+    @property
+    def nargs(self) -> Literal[2]: ...
+    @property
+    def ntypes(self) -> Literal[1]: ...
+    @property
+    def signature(self) -> None: ...
+
+    @overload
+    def __call__(
+        self,
+        x1: _ScalarLike_co,
+        /,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
+    ) -> _ReturnType_co: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        /,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
+    ) -> _ReturnType_co | NDArray[np.object_]: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        /,
+        out: _ArrayType | tuple[_ArrayType],
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
+    ) -> _ArrayType: ...
+    @overload
+    def __call__(
+        self,
+        x1: _SupportsArrayUFunc,
+        /,
+        out: None | NDArray[Any] | tuple[NDArray[Any]] = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
+    ) -> Any: ...
+
+    def at(self, a: _SupportsArrayUFunc, ixs: _ArrayLikeInt_co, /) -> None: ...
+    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+
+@type_check_only
+class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: ignore[misc]
+    @property
+    def identity(self) -> _IDType: ...
+    @property
+    def nin(self) -> Literal[2]: ...
+    @property
+    def nout(self) -> Literal[1]: ...
+    @property
+    def nargs(self) -> Literal[3]: ...
+    @property
+    def ntypes(self) -> Literal[1]: ...
+    @property
+    def signature(self) -> None: ...
+
+    @overload
+    def __call__(
+        self,
+        x1: _ScalarLike_co,
+        x2: _ScalarLike_co,
+        /,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ReturnType_co: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        x2: ArrayLike,
+        /,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ReturnType_co | NDArray[np.object_]: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        x2: ArrayLike,
+        /,
+        out: _ArrayType | tuple[_ArrayType],
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ArrayType: ...
+    @overload
+    def __call__(
+        self,
+        x1: _SupportsArrayUFunc,
+        x2: _SupportsArrayUFunc | ArrayLike,
+        /,
+        out: None | NDArray[Any] | tuple[NDArray[Any]] = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> Any: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        x2: _SupportsArrayUFunc,
+        /,
+        out: None | NDArray[Any] | tuple[NDArray[Any]] = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> Any: ...
+
+    def at(self, a: _SupportsArrayUFunc, ixs: _ArrayLikeInt_co, b: ArrayLike, /) -> None: ...
+
+    @overload
+    def reduce(
+        self,
+        array: ArrayLike,
+        axis: None | _ShapeLike,
+        dtype: DTypeLike,
+        out: _ArrayType,
+        /,
+        keepdims: bool = ...,
+        initial: _ScalarLike_co = ...,
+        where: _ArrayLikeBool_co = ...,
+    ) -> _ArrayType: ...
+    @overload
+    def reduce(
+        self,
+        /,
+        array: ArrayLike,
+        axis: None | _ShapeLike = ...,
+        dtype: DTypeLike = ...,
+        *,
+        out: _ArrayType | tuple[_ArrayType],
+        keepdims: bool = ...,
+        initial: _ScalarLike_co = ...,
+        where: _ArrayLikeBool_co = ...,
+    ) -> _ArrayType: ...
+    @overload
+    def reduce(
+        self,
+        /,
+        array: ArrayLike,
+        axis: None | _ShapeLike = ...,
+        dtype: DTypeLike = ...,
+        out: None = ...,
+        *,
+        keepdims: Literal[True],
+        initial: _ScalarLike_co = ...,
+        where: _ArrayLikeBool_co = ...,
+    ) -> NDArray[np.object_]: ...
+    @overload
+    def reduce(
+        self,
+        /,
+        array: ArrayLike,
+        axis: None | _ShapeLike = ...,
+        dtype: DTypeLike = ...,
+        out: None = ...,
+        keepdims: bool = ...,
+        initial: _ScalarLike_co = ...,
+        where: _ArrayLikeBool_co = ...,
+    ) -> _ReturnType_co | NDArray[np.object_]: ...
+
+    @overload
+    def reduceat(
+        self,
+        array: ArrayLike,
+        indices: _ArrayLikeInt_co,
+        axis: SupportsIndex,
+        dtype: DTypeLike,
+        out: _ArrayType,
+        /,
+    ) -> _ArrayType: ...
+    @overload
+    def reduceat(
+        self,
+        /,
+        array: ArrayLike,
+        indices: _ArrayLikeInt_co,
+        axis: SupportsIndex = ...,
+        dtype: DTypeLike = ...,
+        *,
+        out: _ArrayType | tuple[_ArrayType],
+    ) -> _ArrayType: ...
+    @overload
+    def reduceat(
+        self,
+        /,
+        array: ArrayLike,
+        indices: _ArrayLikeInt_co,
+        axis: SupportsIndex = ...,
+        dtype: DTypeLike = ...,
+        out: None = ...,
+    ) -> NDArray[np.object_]: ...
+    @overload
+    def reduceat(
+        self,
+        /,
+        array: _SupportsArrayUFunc,
+        indices: _ArrayLikeInt_co,
+        axis: SupportsIndex = ...,
+        dtype: DTypeLike = ...,
+        out: None | NDArray[Any] | tuple[NDArray[Any]] = ...,
+    ) -> Any: ...
+
+    @overload
+    def accumulate(
+        self,
+        array: ArrayLike,
+        axis: SupportsIndex,
+        dtype: DTypeLike,
+        out: _ArrayType,
+        /,
+    ) -> _ArrayType: ...
+    @overload
+    def accumulate(
+        self,
+        array: ArrayLike,
+        axis: SupportsIndex = ...,
+        dtype: DTypeLike = ...,
+        *,
+        out: _ArrayType | tuple[_ArrayType],
+    ) -> _ArrayType: ...
+    @overload
+    def accumulate(
+        self,
+        /,
+        array: ArrayLike,
+        axis: SupportsIndex = ...,
+        dtype: DTypeLike = ...,
+        out: None = ...,
+    ) -> NDArray[np.object_]: ...
+
+    @overload
+    def outer(
+        self,
+        A: _ScalarLike_co,
+        B: _ScalarLike_co,
+        /, *,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ReturnType_co: ...
+    @overload
+    def outer(
+        self,
+        A: ArrayLike,
+        B: ArrayLike,
+        /, *,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ReturnType_co | NDArray[np.object_]: ...
+    @overload
+    def outer(
+        self,
+        A: ArrayLike,
+        B: ArrayLike,
+        /, *,
+        out: _ArrayType,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> _ArrayType: ...
+    @overload
+    def outer(
+        self,
+        A: _SupportsArrayUFunc,
+        B: _SupportsArrayUFunc | ArrayLike,
+        /, *,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> Any: ...
+    @overload
+    def outer(
+        self,
+        A: _ScalarLike_co,
+        B: _SupportsArrayUFunc | ArrayLike,
+        /, *,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
+    ) -> Any: ...
+
+@type_check_only
+class _PyFunc_Nin3P_Nout1(ufunc, Generic[_ReturnType_co, _IDType, _NIn]):  # type: ignore[misc]
+    @property
+    def identity(self) -> _IDType: ...
+    @property
+    def nin(self) -> _NIn: ...
+    @property
+    def nout(self) -> Literal[1]: ...
+    @property
+    def ntypes(self) -> Literal[1]: ...
+    @property
+    def signature(self) -> None: ...
+
+    @overload
+    def __call__(
+        self,
+        x1: _ScalarLike_co,
+        x2: _ScalarLike_co,
+        x3: _ScalarLike_co,
+        /,
+        *xs: _ScalarLike_co,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs4P],
+    ) -> _ReturnType_co: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        x2: ArrayLike,
+        x3: ArrayLike,
+        /,
+        *xs: ArrayLike,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs4P],
+    ) -> _ReturnType_co | NDArray[np.object_]: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        x2: ArrayLike,
+        x3: ArrayLike,
+        /,
+        *xs: ArrayLike,
+        out: _ArrayType | tuple[_ArrayType],
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs4P],
+    ) -> _ArrayType: ...
+    @overload
+    def __call__(
+        self,
+        x1: _SupportsArrayUFunc | ArrayLike,
+        x2: _SupportsArrayUFunc | ArrayLike,
+        x3: _SupportsArrayUFunc | ArrayLike,
+        /,
+        *xs: _SupportsArrayUFunc | ArrayLike,
+        out: None | NDArray[Any] | tuple[NDArray[Any]] = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs4P],
+    ) -> Any: ...
+
+    def at(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+
+@type_check_only
+class _PyFunc_Nin1P_Nout2P(ufunc, Generic[_ReturnType_co, _IDType, _NIn, _NOut]):  # type: ignore[misc]
+    @property
+    def identity(self) -> _IDType: ...
+    @property
+    def nin(self) -> _NIn: ...
+    @property
+    def nout(self) -> _NOut: ...
+    @property
+    def ntypes(self) -> Literal[1]: ...
+    @property
+    def signature(self) -> None: ...
+
+    @overload
+    def __call__(
+        self,
+        x1: _ScalarLike_co,
+        /,
+        *xs: _ScalarLike_co,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3P],
+    ) -> _2PTuple[_ReturnType_co]: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        /,
+        *xs: ArrayLike,
+        out: None = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3P],
+    ) -> _2PTuple[_ReturnType_co | NDArray[np.object_]]: ...
+    @overload
+    def __call__(
+        self,
+        x1: ArrayLike,
+        /,
+        *xs: ArrayLike,
+        out: _2PTuple[_ArrayType],
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3P],
+    ) -> _2PTuple[_ArrayType]: ...
+    @overload
+    def __call__(
+        self,
+        x1: _SupportsArrayUFunc | ArrayLike,
+        /,
+        *xs: _SupportsArrayUFunc | ArrayLike,
+        out: None | _2PTuple[NDArray[Any]] = ...,
+        **kwargs: Unpack[_PyFunc_Kwargs_Nargs3P],
+    ) -> Any: ...
+
+    def at(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -1,10 +1,10 @@
 import datetime as dt
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
-from typing_extensions import assert_type
+from typing_extensions import Unpack, assert_type
 
 _SCT = TypeVar("_SCT", bound=np.generic, covariant=True)
 
@@ -33,7 +33,15 @@ date_scalar: dt.date
 date_seq: list[dt.date]
 timedelta_seq: list[dt.timedelta]
 
-def func(a: int) -> bool: ...
+n1: Literal[1]
+n2: Literal[2]
+n3: Literal[3]
+
+f8: np.float64
+
+def func11(a: int) -> bool: ...
+def func21(a: int, b: int) -> int: ...
+def func12(a: int) -> tuple[complex, bool]: ...
 
 assert_type(next(b_f8), tuple[Any, ...])
 assert_type(b_f8.reset(), None)
@@ -102,7 +110,56 @@ assert_type(np.may_share_memory(AR_f8, AR_f8, max_work=1), bool)
 assert_type(np.promote_types(np.int32, np.int64), np.dtype[Any])
 assert_type(np.promote_types("f4", float), np.dtype[Any])
 
-assert_type(np.frompyfunc(func, 1, 1, identity=None), np.ufunc)
+assert_type(np.frompyfunc(func11, n1, n1).nin, Literal[1])
+assert_type(np.frompyfunc(func11, n1, n1).nout, Literal[1])
+assert_type(np.frompyfunc(func11, n1, n1).nargs, Literal[2])
+assert_type(np.frompyfunc(func11, n1, n1).ntypes, Literal[1])
+assert_type(np.frompyfunc(func11, n1, n1).identity, None)
+assert_type(np.frompyfunc(func11, n1, n1).signature, None)
+assert_type(np.frompyfunc(func11, n1, n1)(f8), bool)
+assert_type(np.frompyfunc(func11, n1, n1)(AR_f8), bool | npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func11, n1, n1).at(AR_f8, AR_i8), None)
+
+assert_type(np.frompyfunc(func21, n2, n1).nin, Literal[2])
+assert_type(np.frompyfunc(func21, n2, n1).nout, Literal[1])
+assert_type(np.frompyfunc(func21, n2, n1).nargs, Literal[3])
+assert_type(np.frompyfunc(func21, n2, n1).ntypes, Literal[1])
+assert_type(np.frompyfunc(func21, n2, n1).identity, None)
+assert_type(np.frompyfunc(func21, n2, n1).signature, None)
+assert_type(np.frompyfunc(func21, n2, n1)(f8, f8), int)
+assert_type(np.frompyfunc(func21, n2, n1)(AR_f8, f8), int | npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func21, n2, n1)(f8, AR_f8), int | npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func21, n2, n1).reduce(AR_f8, axis=0), int | npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func21, n2, n1).accumulate(AR_f8), npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func21, n2, n1).reduceat(AR_f8, AR_i8), npt.NDArray[np.object_])
+assert_type(np.frompyfunc(func21, n2, n1).outer(f8, f8), int)
+assert_type(np.frompyfunc(func21, n2, n1).outer(AR_f8, f8), int | npt.NDArray[np.object_])
+
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).nin, Literal[2])
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).nout, Literal[1])
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).nargs, Literal[3])
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).ntypes, Literal[1])
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).identity, int)
+assert_type(np.frompyfunc(func21, n2, n1, identity=0).signature, None)
+
+assert_type(np.frompyfunc(func12, n1, n2).nin, Literal[1])
+assert_type(np.frompyfunc(func12, n1, n2).nout, Literal[2])
+assert_type(np.frompyfunc(func12, n1, n2).nargs, int)
+assert_type(np.frompyfunc(func12, n1, n2).ntypes, Literal[1])
+assert_type(np.frompyfunc(func12, n1, n2).identity, None)
+assert_type(np.frompyfunc(func12, n1, n2).signature, None)
+assert_type(
+    np.frompyfunc(func12, n2, n2)(f8, f8),
+    tuple[complex, complex, Unpack[tuple[complex, ...]]],
+)
+assert_type(
+    np.frompyfunc(func12, n2, n2)(AR_f8, f8),
+    tuple[
+        complex | npt.NDArray[np.object_],
+        complex | npt.NDArray[np.object_],
+        Unpack[tuple[complex | npt.NDArray[np.object_], ...]],
+    ],
+)
 
 assert_type(np.datetime_data("m8[D]"), tuple[str, int])
 assert_type(np.datetime_data(np.datetime64), tuple[str, int])


### PR DESCRIPTION
Changed the `frompyfunc` signature and added overloads. It now returns a specialized `ufunc` type for integer `nin` and `nout`, that e.g. reflects the `object_` scalar return type.

Related to #26847

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
