### PR TITLE
TYP: Annotate type aliases as ``typing.TypeAlias``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -195,6 +195,7 @@ from typing import (
     Final,
     final,
     ClassVar,
+    TypeAlias
 )
 
 # Ensures that the stubs are picked up
@@ -641,7 +642,7 @@ def show_config() -> None: ...
 
 _NdArraySubClass = TypeVar("_NdArraySubClass", bound=NDArray[Any])
 _DTypeScalar_co = TypeVar("_DTypeScalar_co", covariant=True, bound=generic)
-_ByteOrder = L["S", "<", ">", "=", "|", "L", "B", "N", "I", "little", "big", "native"]
+_ByteOrder: TypeAlias = L["S", "<", ">", "=", "|", "L", "B", "N", "I", "little", "big", "native"]
 
 @final
 class dtype(Generic[_DTypeScalar_co]):
@@ -894,7 +895,7 @@ class dtype(Generic[_DTypeScalar_co]):
     @property
     def type(self) -> type[_DTypeScalar_co]: ...
 
-_ArrayLikeInt = (
+_ArrayLikeInt: TypeAlias = (
     int
     | integer[Any]
     | Sequence[int | integer[Any]]
@@ -941,14 +942,14 @@ class flatiter(Generic[_NdArraySubClass]):
     @overload
     def __array__(self, dtype: _DType, /) -> ndarray[Any, _DType]: ...
 
-_OrderKACF = L[None, "K", "A", "C", "F"]
-_OrderACF = L[None, "A", "C", "F"]
-_OrderCF = L[None, "C", "F"]
+_OrderKACF: TypeAlias = L[None, "K", "A", "C", "F"]
+_OrderACF: TypeAlias = L[None, "A", "C", "F"]
+_OrderCF: TypeAlias = L[None, "C", "F"]
 
-_ModeKind = L["raise", "wrap", "clip"]
-_PartitionKind = L["introselect"]
-_SortKind = L["quicksort", "mergesort", "heapsort", "stable"]
-_SortSide = L["left", "right"]
+_ModeKind: TypeAlias = L["raise", "wrap", "clip"]
+_PartitionKind: TypeAlias = L["introselect"]
+_SortKind: TypeAlias = L["quicksort", "mergesort", "heapsort", "stable"]
+_SortSide: TypeAlias = L["left", "right"]
 
 _ArraySelf = TypeVar("_ArraySelf", bound=_ArrayOrScalarCommon)
 
@@ -1391,7 +1392,7 @@ _NumberType = TypeVar("_NumberType", bound=number[Any])
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer as _SupportsBuffer
 else:
-    _SupportsBuffer = (
+    _SupportsBuffer: TypeAlias = (
         bytes
         | bytearray
         | memoryview
@@ -1404,22 +1405,22 @@ else:
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
-_2Tuple = tuple[_T, _T]
-_CastingKind = L["no", "equiv", "safe", "same_kind", "unsafe"]
+_2Tuple: TypeAlias = tuple[_T, _T]
+_CastingKind: TypeAlias = L["no", "equiv", "safe", "same_kind", "unsafe"]
 
-_ArrayUInt_co = NDArray[np.bool | unsignedinteger[Any]]
-_ArrayInt_co = NDArray[np.bool | integer[Any]]
-_ArrayFloat_co = NDArray[np.bool | integer[Any] | floating[Any]]
-_ArrayComplex_co = NDArray[np.bool | integer[Any] | floating[Any] | complexfloating[Any, Any]]
-_ArrayNumber_co = NDArray[np.bool | number[Any]]
-_ArrayTD64_co = NDArray[np.bool | integer[Any] | timedelta64]
+_ArrayUInt_co: TypeAlias = NDArray[np.bool | unsignedinteger[Any]]
+_ArrayInt_co: TypeAlias = NDArray[np.bool | integer[Any]]
+_ArrayFloat_co: TypeAlias = NDArray[np.bool | integer[Any] | floating[Any]]
+_ArrayComplex_co: TypeAlias = NDArray[np.bool | integer[Any] | floating[Any] | complexfloating[Any, Any]]
+_ArrayNumber_co: TypeAlias = NDArray[np.bool | number[Any]]
+_ArrayTD64_co: TypeAlias = NDArray[np.bool | integer[Any] | timedelta64]
 
 # Introduce an alias for `dtype` to avoid naming conflicts.
-_dtype = dtype
+_dtype: TypeAlias = dtype
 
 # `builtins.PyCapsule` unfortunately lacks annotations as of the moment;
 # use `Any` as a stopgap measure
-_PyCapsule = Any
+_PyCapsule: TypeAlias = Any
 
 class _SupportsItem(Protocol[_T_co]):
     def item(self, args: Any, /) -> _T_co: ...
@@ -2837,7 +2838,7 @@ class bool(generic):
     __gt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
     __ge__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
 
-bool_ = bool
+bool_: TypeAlias = bool
 
 class object_(generic):
     def __init__(self, value: object = ..., /) -> None: ...
@@ -2893,9 +2894,9 @@ class datetime64(generic):
     __gt__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
     __ge__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
 
-_IntValue = SupportsInt | _CharLike_co | SupportsIndex
-_FloatValue = None | _CharLike_co | SupportsFloat | SupportsIndex
-_ComplexValue = (
+_IntValue: TypeAlias = SupportsInt | _CharLike_co | SupportsIndex
+_FloatValue: TypeAlias = None | _CharLike_co | SupportsFloat | SupportsIndex
+_ComplexValue: TypeAlias = (
     None
     | _CharLike_co
     | SupportsFloat
@@ -3049,18 +3050,18 @@ class unsignedinteger(integer[_NBit1]):
     __divmod__: _UnsignedIntDivMod[_NBit1]
     __rdivmod__: _UnsignedIntDivMod[_NBit1]
 
-uint8 = unsignedinteger[_8Bit]
-uint16 = unsignedinteger[_16Bit]
-uint32 = unsignedinteger[_32Bit]
-uint64 = unsignedinteger[_64Bit]
+uint8: TypeAlias = unsignedinteger[_8Bit]
+uint16: TypeAlias = unsignedinteger[_16Bit]
+uint32: TypeAlias = unsignedinteger[_32Bit]
+uint64: TypeAlias = unsignedinteger[_64Bit]
 
-ubyte = unsignedinteger[_NBitByte]
-ushort = unsignedinteger[_NBitShort]
-uintc = unsignedinteger[_NBitIntC]
-uintp = unsignedinteger[_NBitIntP]
-uint = uintp
-ulong = unsignedinteger[_NBitLong]
-ulonglong = unsignedinteger[_NBitLongLong]
+ubyte: TypeAlias = unsignedinteger[_NBitByte]
+ushort: TypeAlias = unsignedinteger[_NBitShort]
+uintc: TypeAlias = unsignedinteger[_NBitIntC]
+uintp: TypeAlias = unsignedinteger[_NBitIntP]
+uint: TypeAlias = uintp
+ulong: TypeAlias = unsignedinteger[_NBitLong]
+ulonglong: TypeAlias = unsignedinteger[_NBitLongLong]
 
 class inexact(number[_NBit1]):  # type: ignore
     def __getnewargs__(self: inexact[_64Bit]) -> tuple[float, ...]: ...
@@ -3106,14 +3107,14 @@ class floating(inexact[_NBit1]):
     __divmod__: _FloatDivMod[_NBit1]
     __rdivmod__: _FloatDivMod[_NBit1]
 
-float16 = floating[_16Bit]
-float32 = floating[_32Bit]
-float64 = floating[_64Bit]
+float16: TypeAlias = floating[_16Bit]
+float32: TypeAlias = floating[_32Bit]
+float64: TypeAlias = floating[_64Bit]
 
-half = floating[_NBitHalf]
-single = floating[_NBitSingle]
-double = floating[_NBitDouble]
-longdouble = floating[_NBitLongDouble]
+half: TypeAlias = floating[_NBitHalf]
+single: TypeAlias = floating[_NBitSingle]
+double: TypeAlias = floating[_NBitDouble]
+longdouble: TypeAlias = floating[_NBitLongDouble]
 
 # The main reason for `complexfloating` having two typevars is cosmetic.
 # It is used to clarify why `complex128`s precision is `_64Bit`, the latter
@@ -3144,12 +3145,12 @@ class complexfloating(inexact[_NBit1], Generic[_NBit1, _NBit2]):
     __pow__: _ComplexOp[_NBit1]
     __rpow__: _ComplexOp[_NBit1]
 
-complex64 = complexfloating[_32Bit, _32Bit]
-complex128 = complexfloating[_64Bit, _64Bit]
+complex64: TypeAlias = complexfloating[_32Bit, _32Bit]
+complex128: TypeAlias = complexfloating[_64Bit, _64Bit]
 
-csingle = complexfloating[_NBitSingle, _NBitSingle]
-cdouble = complexfloating[_NBitDouble, _NBitDouble]
-clongdouble = complexfloating[_NBitLongDouble, _NBitLongDouble]
+csingle: TypeAlias = complexfloating[_NBitSingle, _NBitSingle]
+cdouble: TypeAlias = complexfloating[_NBitDouble, _NBitDouble]
+clongdouble: TypeAlias = complexfloating[_NBitLongDouble, _NBitLongDouble]
 
 class flexible(generic): ...  # type: ignore
 
@@ -3528,7 +3529,7 @@ class iinfo(Generic[_IntType]):
     @overload
     def __new__(cls, dtype: str) -> iinfo[Any]: ...
 
-_NDIterFlagsKind = L[
+_NDIterFlagsKind: TypeAlias = L[
     "buffered",
     "c_index",
     "copy_if_overlap",
@@ -3544,7 +3545,7 @@ _NDIterFlagsKind = L[
     "zerosize_ok",
 ]
 
-_NDIterOpFlagsKind = L[
+_NDIterOpFlagsKind: TypeAlias = L[
     "aligned",
     "allocate",
     "arraymask",
@@ -3635,7 +3636,7 @@ class nditer:
     @property
     def value(self) -> tuple[NDArray[Any], ...]: ...
 
-_MemMapModeKind = L[
+_MemMapModeKind: TypeAlias = L[
     "readonly", "r",
     "copyonwrite", "c",
     "readwrite", "r+",

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Collection, Callable, Sequence
-from typing import Any, Protocol, Union, TypeVar, runtime_checkable
+from typing import Any, Protocol, Union, TypeAlias, TypeVar, runtime_checkable
 
 import numpy as np
 from numpy import (
@@ -29,7 +29,7 @@ _ScalarType_co = TypeVar("_ScalarType_co", bound=generic, covariant=True)
 _DType = TypeVar("_DType", bound=dtype[Any])
 _DType_co = TypeVar("_DType_co", covariant=True, bound=dtype[Any])
 
-NDArray = ndarray[Any, dtype[_ScalarType_co]]
+NDArray: TypeAlias = ndarray[Any, dtype[_ScalarType_co]]
 
 # The `_SupportsArray` protocol only cares about the default dtype
 # (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
@@ -54,7 +54,7 @@ class _SupportsArrayFunc(Protocol):
 
 
 # TODO: Wait until mypy supports recursive objects in combination with typevars
-_FiniteNestedSequence = Union[
+_FiniteNestedSequence: TypeAlias = Union[
     _T,
     Sequence[_T],
     Sequence[Sequence[_T]],
@@ -63,7 +63,7 @@ _FiniteNestedSequence = Union[
 ]
 
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
-_ArrayLike = Union[
+_ArrayLike: TypeAlias = Union[
     _SupportsArray[dtype[_ScalarType]],
     _NestedSequence[_SupportsArray[dtype[_ScalarType]]],
 ]
@@ -71,7 +71,7 @@ _ArrayLike = Union[
 # A union representing array-like objects; consists of two typevars:
 # One representing types that can be parametrized w.r.t. `np.dtype`
 # and another one for the rest
-_DualArrayLike = Union[
+_DualArrayLike: TypeAlias = Union[
     _SupportsArray[_DType],
     _NestedSequence[_SupportsArray[_DType]],
     _T,
@@ -81,35 +81,35 @@ _DualArrayLike = Union[
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 
-    ArrayLike = Buffer | _DualArrayLike[
+    ArrayLike: TypeAlias = Buffer | _DualArrayLike[
         dtype[Any],
         Union[bool, int, float, complex, str, bytes],
     ]
 else:
-    ArrayLike = _DualArrayLike[
+    ArrayLike: TypeAlias = _DualArrayLike[
         dtype[Any],
         Union[bool, int, float, complex, str, bytes],
     ]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`
-_ArrayLikeBool_co = _DualArrayLike[
+_ArrayLikeBool_co: TypeAlias = _DualArrayLike[
     dtype[np.bool],
     bool,
 ]
-_ArrayLikeUInt_co = _DualArrayLike[
+_ArrayLikeUInt_co: TypeAlias = _DualArrayLike[
     dtype[Union[np.bool, unsignedinteger[Any]]],
     bool,
 ]
-_ArrayLikeInt_co = _DualArrayLike[
+_ArrayLikeInt_co: TypeAlias = _DualArrayLike[
     dtype[Union[np.bool, integer[Any]]],
     Union[bool, int],
 ]
-_ArrayLikeFloat_co = _DualArrayLike[
+_ArrayLikeFloat_co: TypeAlias = _DualArrayLike[
     dtype[Union[np.bool, integer[Any], floating[Any]]],
     Union[bool, int, float],
 ]
-_ArrayLikeComplex_co = _DualArrayLike[
+_ArrayLikeComplex_co: TypeAlias = _DualArrayLike[
     dtype[Union[
         np.bool,
         integer[Any],
@@ -118,37 +118,37 @@ _ArrayLikeComplex_co = _DualArrayLike[
     ]],
     Union[bool, int, float, complex],
 ]
-_ArrayLikeNumber_co = _DualArrayLike[
+_ArrayLikeNumber_co: TypeAlias = _DualArrayLike[
     dtype[Union[np.bool, number[Any]]],
     Union[bool, int, float, complex],
 ]
-_ArrayLikeTD64_co = _DualArrayLike[
+_ArrayLikeTD64_co: TypeAlias = _DualArrayLike[
     dtype[Union[np.bool, integer[Any], timedelta64]],
     Union[bool, int],
 ]
-_ArrayLikeDT64_co = Union[
+_ArrayLikeDT64_co: TypeAlias = Union[
     _SupportsArray[dtype[datetime64]],
     _NestedSequence[_SupportsArray[dtype[datetime64]]],
 ]
-_ArrayLikeObject_co = Union[
+_ArrayLikeObject_co: TypeAlias = Union[
     _SupportsArray[dtype[object_]],
     _NestedSequence[_SupportsArray[dtype[object_]]],
 ]
 
-_ArrayLikeVoid_co = Union[
+_ArrayLikeVoid_co: TypeAlias = Union[
     _SupportsArray[dtype[void]],
     _NestedSequence[_SupportsArray[dtype[void]]],
 ]
-_ArrayLikeStr_co = _DualArrayLike[
+_ArrayLikeStr_co: TypeAlias = _DualArrayLike[
     dtype[str_],
     str,
 ]
-_ArrayLikeBytes_co = _DualArrayLike[
+_ArrayLikeBytes_co: TypeAlias = _DualArrayLike[
     dtype[bytes_],
     bytes,
 ]
 
-_ArrayLikeInt = _DualArrayLike[
+_ArrayLikeInt: TypeAlias = _DualArrayLike[
     dtype[integer[Any]],
     int,
 ]
@@ -161,7 +161,7 @@ class _UnknownType:
     ...
 
 
-_ArrayLikeUnknown = _DualArrayLike[
+_ArrayLikeUnknown: TypeAlias = _DualArrayLike[
     dtype[_UnknownType],
     _UnknownType,
 ]

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Sequence,
     Union,
+    TypeAlias,
     TypeVar,
     Protocol,
     TypedDict,
@@ -60,7 +61,7 @@ from ._char_codes import (
 _SCT = TypeVar("_SCT", bound=np.generic)
 _DType_co = TypeVar("_DType_co", covariant=True, bound=np.dtype[Any])
 
-_DTypeLikeNested = Any  # TODO: wait for support for recursive types
+_DTypeLikeNested: TypeAlias = Any  # TODO: wait for support for recursive types
 
 
 # Mandatory keys
@@ -87,7 +88,7 @@ class _SupportsDType(Protocol[_DType_co]):
 
 
 # A subset of `npt.DTypeLike` that can be parametrized w.r.t. `np.generic`
-_DTypeLike = Union[
+_DTypeLike: TypeAlias = Union[
     np.dtype[_SCT],
     type[_SCT],
     _SupportsDType[np.dtype[_SCT]],
@@ -95,7 +96,7 @@ _DTypeLike = Union[
 
 
 # Would create a dtype[np.void]
-_VoidDTypeLike = Union[
+_VoidDTypeLike: TypeAlias = Union[
     # (flexible_dtype, itemsize)
     tuple[_DTypeLikeNested, int],
     # (fixed_dtype, shape)
@@ -115,7 +116,7 @@ _VoidDTypeLike = Union[
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
-DTypeLike = Union[
+DTypeLike: TypeAlias = Union[
     np.dtype[Any],
     # default data type (float64)
     None,
@@ -137,14 +138,14 @@ DTypeLike = Union[
 
 # Aliases for commonly used dtype-like objects.
 # Note that the precision of `np.number` subclasses is ignored herein.
-_DTypeLikeBool = Union[
+_DTypeLikeBool: TypeAlias = Union[
     type[bool],
     type[np.bool],
     np.dtype[np.bool],
     _SupportsDType[np.dtype[np.bool]],
     _BoolCodes,
 ]
-_DTypeLikeUInt = Union[
+_DTypeLikeUInt: TypeAlias = Union[
     type[np.unsignedinteger],
     np.dtype[np.unsignedinteger],
     _SupportsDType[np.dtype[np.unsignedinteger]],
@@ -160,7 +161,7 @@ _DTypeLikeUInt = Union[
     _UIntPCodes,
     _UIntCodes,
 ]
-_DTypeLikeInt = Union[
+_DTypeLikeInt: TypeAlias = Union[
     type[int],
     type[np.signedinteger],
     np.dtype[np.signedinteger],
@@ -177,7 +178,7 @@ _DTypeLikeInt = Union[
     _IntPCodes,
     _IntCodes,
 ]
-_DTypeLikeFloat = Union[
+_DTypeLikeFloat: TypeAlias = Union[
     type[float],
     type[np.floating],
     np.dtype[np.floating],
@@ -190,7 +191,7 @@ _DTypeLikeFloat = Union[
     _DoubleCodes,
     _LongDoubleCodes,
 ]
-_DTypeLikeComplex = Union[
+_DTypeLikeComplex: TypeAlias = Union[
     type[complex],
     type[np.complexfloating],
     np.dtype[np.complexfloating],
@@ -201,47 +202,47 @@ _DTypeLikeComplex = Union[
     _CDoubleCodes,
     _CLongDoubleCodes,
 ]
-_DTypeLikeDT64 = Union[
+_DTypeLikeDT64: TypeAlias = Union[
     type[np.timedelta64],
     np.dtype[np.timedelta64],
     _SupportsDType[np.dtype[np.timedelta64]],
     _TD64Codes,
 ]
-_DTypeLikeTD64 = Union[
+_DTypeLikeTD64: TypeAlias = Union[
     type[np.datetime64],
     np.dtype[np.datetime64],
     _SupportsDType[np.dtype[np.datetime64]],
     _DT64Codes,
 ]
-_DTypeLikeStr = Union[
+_DTypeLikeStr: TypeAlias = Union[
     type[str],
     type[np.str_],
     np.dtype[np.str_],
     _SupportsDType[np.dtype[np.str_]],
     _StrCodes,
 ]
-_DTypeLikeBytes = Union[
+_DTypeLikeBytes: TypeAlias = Union[
     type[bytes],
     type[np.bytes_],
     np.dtype[np.bytes_],
     _SupportsDType[np.dtype[np.bytes_]],
     _BytesCodes,
 ]
-_DTypeLikeVoid = Union[
+_DTypeLikeVoid: TypeAlias = Union[
     type[np.void],
     np.dtype[np.void],
     _SupportsDType[np.dtype[np.void]],
     _VoidCodes,
     _VoidDTypeLike,
 ]
-_DTypeLikeObject = Union[
+_DTypeLikeObject: TypeAlias = Union[
     type,
     np.dtype[np.object_],
     _SupportsDType[np.dtype[np.object_]],
     _ObjectCodes,
 ]
 
-_DTypeLikeComplex_co = Union[
+_DTypeLikeComplex_co: TypeAlias = Union[
     _DTypeLikeBool,
     _DTypeLikeUInt,
     _DTypeLikeInt,

--- a/numpy/_typing/_scalars.py
+++ b/numpy/_typing/_scalars.py
@@ -1,23 +1,27 @@
-from typing import Union, Any
+from typing import Any, TypeAlias, Union
 
 import numpy as np
 
 # NOTE: `_StrLike_co` and `_BytesLike_co` are pointless, as `np.str_` and
 # `np.bytes_` are already subclasses of their builtin counterpart
 
-_CharLike_co = Union[str, bytes]
+_CharLike_co: TypeAlias = Union[str, bytes]
 
 # The 6 `<X>Like_co` type-aliases below represent all scalars that can be
 # coerced into `<X>` (with the casting rule `same_kind`)
-_BoolLike_co = Union[bool, np.bool]
-_UIntLike_co = Union[_BoolLike_co, np.unsignedinteger[Any]]
-_IntLike_co = Union[_BoolLike_co, int, np.integer[Any]]
-_FloatLike_co = Union[_IntLike_co, float, np.floating[Any]]
-_ComplexLike_co = Union[_FloatLike_co, complex, np.complexfloating[Any, Any]]
-_TD64Like_co = Union[_IntLike_co, np.timedelta64]
+_BoolLike_co: TypeAlias = Union[bool, np.bool]
+_UIntLike_co: TypeAlias = Union[_BoolLike_co, np.unsignedinteger[Any]]
+_IntLike_co: TypeAlias = Union[_BoolLike_co, int, np.integer[Any]]
+_FloatLike_co: TypeAlias = Union[_IntLike_co, float, np.floating[Any]]
+_ComplexLike_co: TypeAlias = Union[
+    _FloatLike_co,
+    complex,
+    np.complexfloating[Any, Any],
+]
+_TD64Like_co: TypeAlias = Union[_IntLike_co, np.timedelta64]
 
-_NumberLike_co = Union[int, float, complex, np.number[Any], np.bool]
-_ScalarLike_co = Union[
+_NumberLike_co: TypeAlias = Union[int, float, complex, np.number[Any], np.bool]
+_ScalarLike_co: TypeAlias = Union[
     int,
     float,
     complex,
@@ -27,4 +31,4 @@ _ScalarLike_co = Union[
 ]
 
 # `_VoidLike_co` is technically not a scalar, but it's close enough
-_VoidLike_co = Union[tuple[Any, ...], np.void]
+_VoidLike_co: TypeAlias = Union[tuple[Any, ...], np.void]

--- a/numpy/_typing/_shape.py
+++ b/numpy/_typing/_shape.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
-from typing import Union, SupportsIndex
+from typing import SupportsIndex, TypeAlias
 
-_Shape = tuple[int, ...]
+_Shape: TypeAlias = tuple[int, ...]
 
 # Anything that can be coerced to a shape tuple
-_ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
+_ShapeLike: TypeAlias = SupportsIndex | Sequence[SupportsIndex]

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from typing import (
     Literal as L,
     overload,
+    TypeAlias,
     TypeVar,
     Any,
     SupportsIndex,
@@ -45,8 +46,8 @@ _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 _SCT = TypeVar("_SCT", bound=generic, covariant=True)
 _SCT2 = TypeVar("_SCT2", bound=generic, covariant=True)
 
-_2Tuple = tuple[_T, _T]
-_ModeKind = L["reduced", "complete", "r", "raw"]
+_2Tuple: TypeAlias = tuple[_T, _T]
+_ModeKind: TypeAlias = L["reduced", "complete", "r", "raw"]
 
 __all__: list[str]
 


### PR DESCRIPTION
According to the [typing spec](https://typing.readthedocs.io/en/latest/spec/aliases.html#typealias):

> The explicit alias declaration syntax with `TypeAlias` clearly differentiates between the three possible kinds of assignments: typed global expressions, untyped global expressions, and type aliases. This avoids the existence of assignments that break type checking when an annotation is added, and avoids classifying the nature of the assignment based on the type of the value.
