### PR TITLE
TYP,BUG: fix ``numpy.__dir__`` annotations

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -625,7 +625,8 @@ class _SupportsWrite(Protocol[_AnyStr_contra]):
     def write(self, s: _AnyStr_contra, /) -> object: ...
 
 __all__: list[str]
-__dir__: list[str]
+def __dir__() -> Sequence[str]: ...
+
 __version__: str
 __array_api_version__: str
 test: PytestTester


### PR DESCRIPTION
`numpy.__dir__` annotated as a `list[str]`, which is incorrect:

```pycon
>>> import numpy as np
>>> callable(np.__dir__)
True
```

This PR changes its annotation to `() -> Sequence[str]`. 
Since the mutability of the return value isn't relevant (and considered to be practice), a `collections.abc.Sequence` was used as return type, as opposed to a `list`. 

Although mostly irrelevant in this particular case, an additional benefit of using a `Sequence` in place of a `list` as (return) annotation, is that the type parameter of `Sequence` is *co*variant, whereas that of  `list` is *in*variant.