### PR TITLE
BUG: Mismatched allocation domains in ``PyArray_FillWithScalar``

### DIFF
--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -408,9 +408,9 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     char *value = (char *)value_buffer_stack;
     PyArray_Descr *descr = PyArray_DESCR(arr);
 
-    if ((size_t)descr->elsize > sizeof(value_buffer_stack)) {
+    if (PyDataType_ELSIZE(descr) > sizeof(value_buffer_stack)) {
         /* We need a large temporary buffer... */
-        value_buffer_heap = PyObject_Calloc(1, descr->elsize);
+        value_buffer_heap = PyMem_Calloc(1, PyDataType_ELSIZE(descr));
         if (value_buffer_heap == NULL) {
             PyErr_NoMemory();
             return -1;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -425,6 +425,18 @@ class TestAttributes:
         with pytest.raises(ValueError, match=".*read-only"):
             a.fill(0)
 
+    def test_fill_subarrays(self):
+        # NOTE:
+        # This is also a regression test for a crash with PYTHONMALLOC=debug
+
+        dtype = np.dtype("2<i8, 2<i8, 2<i8")
+        data = ([1, 2], [3, 4], [5, 6])
+
+        arr = np.empty(1, dtype=dtype)
+        arr.fill(data)
+
+        assert_equal(arr, np.array(data, dtype=dtype))
+
 
 class TestArrayConstruction:
     def test_array(self):
@@ -3509,17 +3521,17 @@ class TestMethods:
         bad_array = [1, 2, 3]
         assert_raises(TypeError, np.put, bad_array, [0, 2], 5)
 
-        # when calling np.put, make sure an 
-        # IndexError is raised if the 
+        # when calling np.put, make sure an
+        # IndexError is raised if the
         # array is empty
         empty_array = np.asarray(list())
-        with pytest.raises(IndexError, 
+        with pytest.raises(IndexError,
                             match="cannot replace elements of an empty array"):
             np.put(empty_array, 1, 1, mode="wrap")
-        with pytest.raises(IndexError, 
+        with pytest.raises(IndexError,
                             match="cannot replace elements of an empty array"):
             np.put(empty_array, 1, 1, mode="clip")
-        
+
 
     def test_ravel(self):
         a = np.array([[0, 1], [2, 3]])


### PR DESCRIPTION
Backport of #26849.

`PyArray_FillWithScalar` allocates memory with `PyObject_Calloc` but releases it with `PyMem_FREE`.

When `PyArray_FillWithScalar` needs to heap-allocate a buffer, the deallocating function does not use the same domain as the allocating function.
Such API violations are detected when debug hooks are enabled.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
