### PR TITLE
BUG: Handle --f77flags and --f90flags for meson [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Setup macOS
         if: matrix.buildplat[0] == 'macos-13' || matrix.buildplat[0] == 'macos-14'
         run: |
+          # Needed due to https://github.com/actions/runner-images/issues/3371
+          # Supported versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+          echo "FC=gfortran-13" >> "$GITHUB_ENV"
+          echo "F77=gfortran-13" >> "$GITHUB_ENV"
+          echo "F90=gfortran-13" >> "$GITHUB_ENV"
           if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
             # macosx_arm64 and macosx_x86_64 with accelerate
             # only target Sonoma onwards

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -51,4 +51,5 @@ ${dep_list}
 ${lib_list}
 ${lib_dir_list}
                      ],
+${fortran_args}
                      install : true)

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -635,10 +635,14 @@ def run_compile():
         r'--((f(90)?compiler(-exec|)|compiler)=|help-compiler)')
     flib_flags = [_m for _m in sys.argv[1:] if _reg3.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in flib_flags]
-    _reg4 = re.compile(
-        r'--((f(77|90)(flags|exec)|opt|arch)=|(debug|noopt|noarch|help-fcompiler))')
-    fc_flags = [_m for _m in sys.argv[1:] if _reg4.match(_m)]
-    sys.argv = [_m for _m in sys.argv if _m not in fc_flags]
+    # TODO: Once distutils is dropped completely, i.e. min_ver >= 3.12, unify into --fflags
+    reg_f77_f90_flags = re.compile(r'--f(77|90)flags=')
+    reg_distutils_flags = re.compile(r'--((f(77|90)exec|opt|arch)=|(debug|noopt|noarch|help-fcompiler))')
+    fc_flags = [_m for _m in sys.argv[1:] if reg_f77_f90_flags.match(_m)]
+    distutils_flags = [_m for _m in sys.argv[1:] if reg_distutils_flags.match(_m)]
+    if not (MESON_ONLY_VER or backend_key == 'meson'):
+        fc_flags.extend(distutils_flags)
+    sys.argv = [_m for _m in sys.argv if _m not in (fc_flags + distutils_flags)]
 
     del_list = []
     for s in flib_flags:

--- a/numpy/f2py/tests/src/regression/f77fixedform.f95
+++ b/numpy/f2py/tests/src/regression/f77fixedform.f95
@@ -1,0 +1,5 @@
+C This is an invalid file, but it does compile with -ffixed-form
+      subroutine mwe(
+     & x)
+          real x
+      end subroutine mwe

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -121,7 +121,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
         dst_sources.append(dst)
 
         base, ext = os.path.splitext(dst)
-        if ext in (".f90", ".f", ".c", ".pyf"):
+        if ext in (".f90", ".f95", ".f", ".c", ".pyf"):
             f2py_sources.append(dst)
 
     assert f2py_sources


### PR DESCRIPTION
Backport of #26703, #26706, and #26812.

Closes #25784. Background and notes:
- Although the CLI was passing `fc_flags` to the Meson backend they weren't being used
- The behavior currently is to (redundantly) collect the unique set of flags passed via either `--f77flags` or `--f90flags`
  - They all map to `fortran_args` for the `meson.build` (`distutils` used to have separate handling for the two cases)
  - Eventually these should be merged into a single `--fflags` argument (basically since they're now redundant post-distutils)
    - This is likely only when we have 3.12 as the lowest supported version, since `distutils` will need to have both CLI options
- The test is specially crafted to get an error without `-ffixed-form` but is otherwise junk
  - Adding a continuation character at the end of the line as well will both get `f2py` and `gfortran` to compile without `-ffixed-form`
  - Or putting the same code in a `.f` file, thereby signalling to F2PY that this is a Fortran 77 file

It does make sense to handle `fortran_args` this way though, since it is more robust than setting `FFLAGS` (which anyway won't work due to a `meson` bug, https://github.com/mesonbuild/meson/pull/13327).

Squashed commit of the following:

commit bbc198b48b79417f210bd38de6c60ab98d18857d
Author: Rohit Goswami <rog32@hi.is>
Date:   Fri Jun 28 19:43:41 2024 +0200

    CI,MAINT: Bump gfortran version [wheel build]

    Co-authored-by: ngoldbaum <ngoldbaum@users.noreply.github.com>

commit fffa296b7a611de1ab25f85619e92e6d6c5185a4
Author: Rohit Goswami <rog32@hi.is>
Date:   Fri Jun 28 14:54:50 2024 +0200

    CI,TST: Fix meson tests needing gfortran [wheel build]

commit 807e898e80e544e720512f9feccc9c897cd55f08
Author: Rohit Goswami <rog32@hi.is>
Date:   Sun Jun 16 09:40:06 2024 +0000

    TST: Skip an f2py module test on Windows

commit cbcb6c2c4340f5bbca46e2c6d8474bbed7d90664
Author: Rohit Goswami <rog32@hi.is>
Date:   Sun Jun 16 04:06:16 2024 +0000

    MAINT: Be more robust wrt f2py flags

commit 09e3eb004b0e076271817384a92d489b3b0cc0eb
Author: Rohit Goswami <rog32@hi.is>
Date:   Sun Jun 16 03:44:17 2024 +0000

    TST: Add one for passing arguments to f2py

    Co-authored-by: warrickball <warrickball@users.noreply.github.com>

commit 04d53b44b75537fc5b411cf9e54c2f169198419f
Author: Rohit Goswami <rog32@hi.is>
Date:   Sun Jun 16 00:14:54 2024 +0000

    BUG: Use fortran args from f2py in meson

commit 6f736b0cbe977ba9270c45f7cc22b7ae8ce06ed2
Author: Rohit Goswami <rog32@hi.is>
Date:   Sat Jun 15 23:36:55 2024 +0000

    MAINT,BUG: Correctly skip distutils options

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
