### PR TITLE
TYP: adopt ``typing.LiteralString`` and use more of ``typing.Literal``

### DIFF
--- a/numpy/typing/tests/data/reveal/getlimits.pyi
+++ b/numpy/typing/tests/data/reveal/getlimits.pyi
@@ -4,9 +4,9 @@ from typing import Any
 import numpy as np
 
 if sys.version_info >= (3, 11):
-    from typing import assert_type
+    from typing import assert_type, LiteralString
 else:
-    from typing_extensions import assert_type
+    from typing_extensions import assert_type, LiteralString
 
 f: float
 f8: np.float64
@@ -49,8 +49,8 @@ assert_type(np.iinfo(u4), np.iinfo[np.uint32])
 assert_type(np.iinfo('i2'), np.iinfo[Any])
 
 assert_type(iinfo_i8.dtype, np.dtype[np.int64])
-assert_type(iinfo_i8.kind, str)
+assert_type(iinfo_i8.kind, LiteralString)
 assert_type(iinfo_i8.bits, int)
-assert_type(iinfo_i8.key, str)
+assert_type(iinfo_i8.key, LiteralString)
 assert_type(iinfo_i8.min, int)
 assert_type(iinfo_i8.max, int)


### PR DESCRIPTION
Limited to the global `numpy` namespace.

See [typing spec](https://typing.readthedocs.io/en/latest/spec/literal.html#literalstring) or [PEP 675](https://peps.python.org/pep-0675/) for details on `typing.LiteralString`.

Because `typing.LiteralString` was introduced in Python 3.11, `LiteralString` is set to be an alias of `builtins.str` on `python<3.11`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
