### PR TITLE
TYP: improved ``numpy._array_api_info`` typing

### DIFF
--- a/numpy/_array_api_info.pyi
+++ b/numpy/_array_api_info.pyi
@@ -1,62 +1,213 @@
-from typing import TypedDict, Optional, Union, Tuple, List
-from numpy._typing import DtypeLike
+import sys
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Literal,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    final,
+    overload,
+)
 
-Capabilities = TypedDict(
-    "Capabilities",
+import numpy as np
+
+if sys.version_info >= (3, 11):
+    from typing import Never
+elif TYPE_CHECKING:
+    from typing_extensions import Never
+else:
+    # `NoReturn` and `Never` are equivalent (but not equal) for type-checkers,
+    # but are used in different places by convention
+    from typing import NoReturn as Never
+
+_Device: TypeAlias = Literal["cpu"]
+_DeviceLike: TypeAlias = None | _Device
+
+_Capabilities = TypedDict(
+    "_Capabilities",
     {
-        "boolean indexing": bool,
-        "data-dependent shapes": bool,
+        "boolean indexing": Literal[True],
+        "data-dependent shapes": Literal[True],
     },
 )
 
-DefaultDataTypes = TypedDict(
-    "DefaultDataTypes",
+_DefaultDTypes = TypedDict(
+    "_DefaultDTypes",
     {
-        "real floating": DtypeLike,
-        "complex floating": DtypeLike,
-        "integral": DtypeLike,
-        "indexing": DtypeLike,
+        "real floating": np.dtype[np.float64],
+        "complex floating": np.dtype[np.complex128],
+        "integral": np.dtype[np.intp],
+        "indexing": np.dtype[np.intp],
     },
 )
 
-DataTypes = TypedDict(
-    "DataTypes",
-    {
-        "bool": DtypeLike,
-        "float32": DtypeLike,
-        "float64": DtypeLike,
-        "complex64": DtypeLike,
-        "complex128": DtypeLike,
-        "int8": DtypeLike,
-        "int16": DtypeLike,
-        "int32": DtypeLike,
-        "int64": DtypeLike,
-        "uint8": DtypeLike,
-        "uint16": DtypeLike,
-        "uint32": DtypeLike,
-        "uint64": DtypeLike,
-    },
-    total=False,
+
+_KindBool: TypeAlias = Literal["bool"]
+_KindInt: TypeAlias = Literal["signed integer"]
+_KindUInt: TypeAlias = Literal["unsigned integer"]
+_KindInteger: TypeAlias = Literal["integral"]
+_KindFloat: TypeAlias = Literal["real floating"]
+_KindComplex: TypeAlias = Literal["complex floating"]
+_KindNumber: TypeAlias = Literal["numeric"]
+_Kind: TypeAlias = (
+    _KindBool
+    | _KindInt
+    | _KindUInt
+    | _KindInteger
+    | _KindFloat
+    | _KindComplex
+    | _KindNumber
 )
 
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+_T3 = TypeVar("_T3")
+_Permute1: TypeAlias = _T1 | tuple[_T1]
+_Permute2: TypeAlias = tuple[_T1, _T2] | tuple[_T2, _T1]
+_Permute3: TypeAlias = (
+    tuple[_T1, _T2, _T3] | tuple[_T1, _T3, _T2]
+    | tuple[_T2, _T1, _T3] | tuple[_T2, _T3, _T1]
+    | tuple[_T3, _T1, _T2] | tuple[_T3, _T2, _T1]
+)
+
+class _DTypesBool(TypedDict):
+    bool: np.dtype[np.bool]
+
+class _DTypesInt(TypedDict):
+    int8: np.dtype[np.int8]
+    int16: np.dtype[np.int16]
+    int32: np.dtype[np.int32]
+    int64: np.dtype[np.int64]
+
+class _DTypesUInt(TypedDict):
+    uint8: np.dtype[np.uint8]
+    uint16: np.dtype[np.uint16]
+    uint32: np.dtype[np.uint32]
+    uint64: np.dtype[np.uint64]
+
+class _DTypesInteger(_DTypesInt, _DTypesUInt):
+    ...
+
+class _DTypesFloat(TypedDict):
+    float32: np.dtype[np.float32]
+    float64: np.dtype[np.float64]
+
+class _DTypesComplex(TypedDict):
+    complex64: np.dtype[np.complex64]
+    complex128: np.dtype[np.complex128]
+
+class _DTypesNumber(_DTypesInteger, _DTypesFloat, _DTypesComplex):
+    ...
+
+class _DTypes(_DTypesBool, _DTypesNumber):
+    ...
+
+class _DTypesUnion(TypedDict, total=False):
+    bool: np.dtype[np.bool]
+    int8: np.dtype[np.int8]
+    int16: np.dtype[np.int16]
+    int32: np.dtype[np.int32]
+    int64: np.dtype[np.int64]
+    uint8: np.dtype[np.uint8]
+    uint16: np.dtype[np.uint16]
+    uint32: np.dtype[np.uint32]
+    uint64: np.dtype[np.uint64]
+    float32: np.dtype[np.float32]
+    float64: np.dtype[np.float64]
+    complex64: np.dtype[np.complex64]
+    complex128: np.dtype[np.complex128]
+
+_EmptyDict: TypeAlias = dict[Never, Never]
+
+
+@final
 class __array_namespace_info__:
-    __module__: str
+    __module__: ClassVar[Literal['numpy']]
 
-    def capabilities(self) -> Capabilities: ...
-
-    def default_device(self) -> str: ...
-
+    def capabilities(self) -> _Capabilities: ...
+    def default_device(self) -> _Device: ...
     def default_dtypes(
         self,
         *,
-        device: Optional[str] = None,
-    ) -> DefaultDataTypes: ...
+        device: _DeviceLike = ...,
+    ) -> _DefaultDTypes: ...
+    def devices(self) -> list[_Device]: ...
 
+    @overload
     def dtypes(
         self,
         *,
-        device: Optional[str] = None,
-        kind: Optional[Union[str, Tuple[str, ...]]] = None,
-    ) -> DataTypes: ...
-
-    def devices(self) -> List[str]: ...
+        device: _DeviceLike = ...,
+        kind: None = ...,
+    ) -> _DTypes: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: _Permute1[_KindBool],
+    ) -> _DTypesBool: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: _Permute1[_KindInt],
+    ) -> _DTypesInt: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: _Permute1[_KindUInt],
+    ) -> _DTypesUInt: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: _Permute1[_KindFloat],
+    ) -> _DTypesFloat: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: _Permute1[_KindComplex],
+    ) -> _DTypesComplex: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: (
+            _Permute1[_KindInteger]
+            | _Permute2[_KindInt, _KindUInt]
+        ),
+    ) -> _DTypesInteger: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: (
+            _Permute1[_KindNumber]
+            | _Permute3[_KindInteger, _KindFloat, _KindComplex]
+        ),
+    ) -> _DTypesNumber: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: tuple[()],
+    ) -> _EmptyDict: ...
+    @overload
+    def dtypes(
+        self,
+        *,
+        device: _DeviceLike = ...,
+        kind: tuple[_Kind, ...],
+    ) -> _DTypesUnion: ...

--- a/numpy/typing/tests/data/reveal/array_api_info.pyi
+++ b/numpy/typing/tests/data/reveal/array_api_info.pyi
@@ -1,18 +1,76 @@
 import sys
-from typing import List
+from typing import Literal
 
 import numpy as np
 
 if sys.version_info >= (3, 11):
-    from typing import assert_type
+    from typing import Never, assert_type
 else:
-    from typing_extensions import assert_type
+    from typing_extensions import Never, assert_type
 
-array_namespace_info = np.__array_namespace_info__()
+info = np.__array_namespace_info__()
 
-assert_type(array_namespace_info.__module__, str)
-assert_type(array_namespace_info.capabilities(), np._array_api_info.Capabilities)
-assert_type(array_namespace_info.default_device(), str)
-assert_type(array_namespace_info.default_dtypes(), np._array_api_info.DefaultDataTypes)
-assert_type(array_namespace_info.dtypes(), np._array_api_info.DataTypes)
-assert_type(array_namespace_info.devices(), List[str])
+assert_type(info.__module__, Literal["numpy"])
+
+assert_type(info.default_device(), Literal["cpu"])
+assert_type(info.devices()[0], Literal["cpu"])
+assert_type(info.devices()[-1], Literal["cpu"])
+
+assert_type(info.capabilities()["boolean indexing"], Literal[True])
+assert_type(info.capabilities()["data-dependent shapes"], Literal[True])
+
+assert_type(info.default_dtypes()["real floating"], np.dtype[np.float64])
+assert_type(info.default_dtypes()["complex floating"], np.dtype[np.complex128])
+assert_type(info.default_dtypes()["integral"], np.dtype[np.int_])
+assert_type(info.default_dtypes()["indexing"], np.dtype[np.intp])
+
+assert_type(info.dtypes()["bool"], np.dtype[np.bool])
+assert_type(info.dtypes()["int8"], np.dtype[np.int8])
+assert_type(info.dtypes()["uint8"], np.dtype[np.uint8])
+assert_type(info.dtypes()["float32"], np.dtype[np.float32])
+assert_type(info.dtypes()["complex64"], np.dtype[np.complex64])
+
+assert_type(info.dtypes(kind="bool")["bool"], np.dtype[np.bool])
+assert_type(info.dtypes(kind="signed integer")["int64"], np.dtype[np.int64])
+assert_type(info.dtypes(kind="unsigned integer")["uint64"], np.dtype[np.uint64])
+assert_type(info.dtypes(kind="integral")["int32"], np.dtype[np.int32])
+assert_type(info.dtypes(kind="integral")["uint32"], np.dtype[np.uint32])
+assert_type(info.dtypes(kind="real floating")["float64"], np.dtype[np.float64])
+assert_type(info.dtypes(kind="complex floating")["complex128"], np.dtype[np.complex128])
+assert_type(info.dtypes(kind="numeric")["int16"], np.dtype[np.int16])
+assert_type(info.dtypes(kind="numeric")["uint16"], np.dtype[np.uint16])
+assert_type(info.dtypes(kind="numeric")["float64"], np.dtype[np.float64])
+assert_type(info.dtypes(kind="numeric")["complex128"], np.dtype[np.complex128])
+
+assert_type(info.dtypes(kind=()), dict[Never, Never])
+
+assert_type(info.dtypes(kind=("bool",))["bool"], np.dtype[np.bool])
+assert_type(info.dtypes(kind=("signed integer",))["int64"], np.dtype[np.int64])
+assert_type(info.dtypes(kind=("integral",))["uint32"], np.dtype[np.uint32])
+assert_type(info.dtypes(kind=("complex floating",))["complex128"], np.dtype[np.complex128])
+assert_type(info.dtypes(kind=("numeric",))["float64"], np.dtype[np.float64])
+
+assert_type(
+    info.dtypes(kind=("signed integer", "unsigned integer"))["int8"],
+    np.dtype[np.int8],
+)
+assert_type(
+    info.dtypes(kind=("signed integer", "unsigned integer"))["uint8"],
+    np.dtype[np.uint8],
+)
+assert_type(
+    info.dtypes(kind=("integral", "real floating", "complex floating"))["int16"],
+    np.dtype[np.int16],
+)
+assert_type(
+    info.dtypes(kind=("integral", "real floating", "complex floating"))["uint16"],
+    np.dtype[np.uint16],
+)
+assert_type(
+    info.dtypes(kind=("integral", "real floating", "complex floating"))["float32"],
+    np.dtype[np.float32],
+)
+assert_type(
+    info.dtypes(kind=("integral", "real floating", "complex floating"))["complex64"],
+    np.dtype[np.complex64],
+)


### PR DESCRIPTION
Added detailed literal types, typed dicts, overloads, and more to the `numpy._array_api_info` stubs.

Additionally, the related type-tests are more thorough, and depend less on implementation details.

The `typing.TypedDict` types in `numpy._array_api_info` have been prefixed with a `_`. They only exist within the stubs, so aren't accessible at runtime.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
