### PR TITLE
TYP,BUG: Replace ``numpy._typing._UnknownType`` with ``typing.Never``

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -158,8 +158,10 @@ _ArrayLikeInt: TypeAlias = _DualArrayLike[
 # Used as the first overload, should only match NDArray[Any],
 # not any actual types.
 # https://github.com/numpy/numpy/pull/22193
-class _UnknownType:
-    ...
+if sys.version_info >= (3, 11):
+    from typing import Never as _UnknownType
+else:
+    from typing import NoReturn as _UnknownType
 
 
 _ArrayLikeUnknown: TypeAlias = _DualArrayLike[


### PR DESCRIPTION
This concerns the "fallback dtype" workaround in method overloads for pyright.

Previously, `_UnknownType` as type argument `numpy.dtype` was invalid, as it wasn't a subtype of `numpy.generic`. 
With `Never` (or equivalently, `NoReturn` on `python<3.11`), this isn't an issue (it is the "bottom type"), yet achieves the same goal.

For backwards compatabilty, `_UnknownType` still exists, but is an alias of `typing.Never`.

---

Fun fact: this reduced the amount of pylance (the `2024.6.104` pre-release version) errors in "basic" mode in `__init__.pyi` by 42 (!).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
