### PR TITLE
DOC, MAINT: fix typos found by codespell

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ PAPER         ?=
 DOXYGEN       ?= doxygen
 # For merging a documentation archive into a git checkout of numpy/doc
 # Turn a tag like v1.18.0 into 1.18
-# Use sed -n -e 's/patttern/match/p' to return a blank value if no match
+# Use sed -n -e 's/pattern/match/p' to return a blank value if no match
 TAG ?= $(shell git describe --tag | sed -n -e's,v\([1-9]\.[0-9]*\)\.[0-9].*,\1,p')
 
 FILES=

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -990,7 +990,7 @@ in the array buffer as a short string.
 
 No matter where it is stored, once a string is initialized it is marked with the
 ``NPY_STRING_INITIALIZED`` flag. This lets us clearly distinguish between an
-unitialized empty string and a string that has been mutated into the empty
+uninitialized empty string and a string that has been mutated into the empty
 string.
 
 The size of the allocation is stored in the arena to allow reuse of the arena

--- a/doc/neps/nep-0056-array-api-main-namespace.rst
+++ b/doc/neps/nep-0056-array-api-main-namespace.rst
@@ -302,7 +302,7 @@ three types of behavior rather than two - ``copy=None`` means "copy if needed".
 an exception because they use* ``copy=False`` *explicitly in their copy but a
 copy was previously made anyway, they have to inspect their code and determine
 whether the intent of the code was the old or the new semantics (both seem
-rougly equally likely), and adapt the code as appropriate. We expect most cases
+roughly equally likely), and adapt the code as appropriate. We expect most cases
 to be* ``np.array(..., copy=False)``, *because until a few years ago that had
 lower overhead than* ``np.asarray(...)``. *This was solved though, and*
 ``np.asarray(...)`` *is idiomatic NumPy usage.*

--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -213,7 +213,7 @@ have been added for setting the real or imaginary part.
 The underlying type remains a struct under C++ (all of the above still remains
 valid).
 
-This has implications for Cython. It is recommened to always use the native
+This has implications for Cython. It is recommended to always use the native
 typedefs ``cfloat_t``, ``cdouble_t``, ``clongdouble_t`` rather than the NumPy
 types ``npy_cfloat``, etc, unless you have to interface with C code written
 using the NumPy types. You can still write cython code using the ``c.real`` and

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -18,7 +18,7 @@ upgraded to given NumPy's
 For usage guidelines for downstream libraries and end users who want to write
 code that will work with both NumPy and other array libraries, we refer to the
 documentation of the array API standard itself and to code and
-developer-focused documention in SciPy and scikit-learn.
+developer-focused documentation in SciPy and scikit-learn.
 
 Note that in order to use standard-complaint code with older NumPy versions
 (< 2.0), the `array-api-compat

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -823,7 +823,7 @@ cannot not be accessed directly.
 
 .. c:function:: PyArray_ArrayDescr *PyDataType_SUBARRAY(PyArray_Descr *descr)
 
-    Information about a subarray dtype eqivalent to the Python `np.dtype.base`
+    Information about a subarray dtype equivalent to the Python `np.dtype.base`
     and `np.dtype.shape`.
 
     If this is non- ``NULL``, then this data-type descriptor is a
@@ -3975,7 +3975,7 @@ the C-API is needed then some additional steps must be taken.
     behavior as NumPy 1.x.
 
     .. note::
-        Windows never had shared visbility although you can use this macro
+        Windows never had shared visibility although you can use this macro
         to achieve it.  We generally discourage sharing beyond shared boundary
         lines since importing the array API includes NumPy version checks.
 

--- a/doc/source/release/2.0.0-notes.rst
+++ b/doc/source/release/2.0.0-notes.rst
@@ -653,7 +653,7 @@ The ``metadata`` field is kept, but the macro version should also be preferred.
 
 Descriptor ``elsize`` and ``alignment`` access
 ----------------------------------------------
-Unless compiling only with NumPy 2 support, the ``elsize`` and ``aligment``
+Unless compiling only with NumPy 2 support, the ``elsize`` and ``alignment``
 fields must now be accessed via ``PyDataType_ELSIZE``,
 ``PyDataType_SET_ELSIZE``, and ``PyDataType_ALIGNMENT``.
 In cases where the descriptor is attached to an array, we advise

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1302,7 +1302,7 @@ typedef struct {
         PyArrayIterObject    *iters[64];
 #elif defined(__cplusplus)
         /*
-         * C++ doesn't stricly support flexible members and gives compilers
+         * C++ doesn't strictly support flexible members and gives compilers
          * warnings (pedantic only), so we lie.  We can't make it 64 because
          * then Cython is unhappy (larger struct at runtime is OK smaller not).
          */

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -53,7 +53,7 @@
 #if NPY_ABI_VERSION < 0x02000000
   /*
    * Define 2.0 feature version as it is needed below to decide whether we
-   * compile for both 1.x and 2.x (defining it gaurantees 1.x only).
+   * compile for both 1.x and 2.x (defining it guarantees 1.x only).
    */
   #define NPY_2_0_API_VERSION 0x00000012
   /*

--- a/numpy/_core/src/_simd/_simd_vector.inc
+++ b/numpy/_core/src/_simd/_simd_vector.inc
@@ -92,7 +92,7 @@ static PyTypeObject PySIMDVectorType = {
  * miss-align load variable of 256/512-bit vector from non-aligned
  * 256/512-bit stack pointer.
  *
- * check the following links for more clearification:
+ * check the following links for more clarification:
  * https://github.com/numpy/numpy/pull/18330#issuecomment-821539919
  * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001
  */

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1185,7 +1185,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
     }
 
     /*
-     * For a sequence we need to make a copy of the final aggreate anyway.
+     * For a sequence we need to make a copy of the final aggregate anyway.
      * There's no need to pass explicit `copy=True`, so we switch
      * to `copy=None` (copy if needed).
      */

--- a/numpy/_core/src/multiarray/common_dtype.c
+++ b/numpy/_core/src/multiarray/common_dtype.c
@@ -132,7 +132,7 @@ reduce_dtypes_to_most_knowledgeable(
         }
 
         if (res == (PyArray_DTypeMeta *)Py_NotImplemented) {
-            /* guess at other being more "knowledgable" */
+            /* guess at other being more "knowledgeable" */
             PyArray_DTypeMeta *tmp = dtypes[low];
             dtypes[low] = dtypes[high];
             dtypes[high] = tmp;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1403,7 +1403,7 @@ PyArray_DTypeMeta *_Void_dtype = NULL;
  * This function is exposed with an underscore "privately" because the
  * public version is a static inline function which only calls the function
  * on 2.x but directly accesses the `descr` struct on 1.x.
- * Once 1.x backwards compatibility is gone, it shoudl be exported without
+ * Once 1.x backwards compatibility is gone, it should be exported without
  * the underscore directly.
  * Internally, we define a private inline function `PyDataType_GetArrFuncs`
  * for convenience as we are allowed to access the `DType` slots directly.

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -23,7 +23,7 @@ typedef struct npy_thread_unsafe_state_struct {
      *          PyObject *value;
      *      }
      *
-     * so the initialization is thread-safe and the only possibile lock
+     * so the initialization is thread-safe and the only possible lock
      * contention happens before the cache is initialized, not on every single
      * read.
      */

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -293,7 +293,7 @@ get_loop(PyArrayMethod_Context *context,
 
 
 /*
- * Machinery to add the python integer to NumPy intger comparsisons as well
+ * Machinery to add the python integer to NumPy integer comparsisons as well
  * as a special promotion to special case Python int with Python int
  * comparisons.
  */

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -63,7 +63,7 @@ __all__ = [
     # _vec_string - Will probably not become ufuncs
     "mod", "decode", "encode", "translate",
 
-    # Removed from namespace until behavior has been crystalized
+    # Removed from namespace until behavior has been crystallized
     # "join", "split", "rsplit", "splitlines",
 ]
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1514,7 +1514,7 @@ class TestPromotion:
     @np._no_nep50_warning()
     def test_float_int_pyscalar_promote_rational(
             self, weak_promotion, other, expected):
-        # Note that rationals are a bit akward as they promote with float64
+        # Note that rationals are a bit awkward as they promote with float64
         # or default ints, but not float16 or uint8/int8 (which looks
         # inconsistent here).  The new promotion fixes this (partially?)
         if not weak_promotion and type(other) == float:

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -223,7 +223,7 @@ class TestGeomspace:
         assert_allclose(y, [-5, 3j])
 
     def test_complex_shortest_path(self):
-        # test the shortest logorithmic spiral is used, see gh-25644
+        # test the shortest logarithmic spiral is used, see gh-25644
         x = 1.2 + 3.4j
         y = np.exp(1j*(np.pi-.1)) * x
         z = np.geomspace(x, y, 5)

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -476,7 +476,7 @@ class TestIsDType:
             np.isdtype(np.int64, "int64")
 
     def test_sctypes_complete(self):
-        # issue 26439: int32/intc were masking eachother on 32-bit builds
+        # issue 26439: int32/intc were masking each other on 32-bit builds
         assert np.int32 in sctypes['int']
         assert np.intc in sctypes['int']
         assert np.int64 in sctypes['int']

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -2961,7 +2961,7 @@ class TestMinMax:
 
     def test_reduce_reorder(self):
         # gh 10370, 11029 Some compilers reorder the call to npy_getfloatstatus
-        # and put it before the call to an intrisic function that causes
+        # and put it before the call to an intrinsic function that causes
         # invalid status to be set. Also make sure warnings are not emitted
         for n in (2, 4, 8, 16, 32):
             for dt in (np.float32, np.float16, np.complex64):

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1420,7 +1420,7 @@ class Configuration:
         """Apply glob to paths and prepend local_path if needed.
 
         Applies glob.glob(...) to each path in the sequence (if needed) and
-        pre-pends the local_path if needed. Because this is called on all
+        prepends the local_path if needed. Because this is called on all
         source lists, this allows wildcard characters to be specified in lists
         of sources for extension modules and libraries and scripts and allows
         path-names be relative to the source directory.

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -675,7 +675,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
                 raise ValueError("the number of data points must exceed order "
                                  "to scale the covariance matrix")
             # note, this used to be: fac = resids / (len(x) - order - 2.0)
-            # it was deciced that the "- 2" (originally justified by "Bayesian
+            # it was decided that the "- 2" (originally justified by "Bayesian
             # uncertainty analysis") is not what the user expects
             # (see gh-11196 and gh-11197)
             fac = resids / (len(x) - order)

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3032,7 +3032,7 @@ def _multi_dot_three(A, B, C, out=None):
 
 def _multi_dot_matrix_chain_order(arrays, return_costs=False):
     """
-    Return a np.array that encodes the optimal order of mutiplications.
+    Return a np.array that encodes the optimal order of multiplications.
 
     The optimal order array is then used by `_multi_dot()` to do the
     multiplication.

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -1,5 +1,5 @@
 # This script is used by .github/workflows/wheels.yml to run the full test
-# suite, checks for lincense inclusion and that the openblas version is correct.
+# suite, checks for license inclusion and that the openblas version is correct.
 set -xe
 
 PROJECT_DIR="$1"


### PR DESCRIPTION
[skip cirrus] [skip azp]