### PR TITLE
BUG: Fix new DTypes and new string promotion when signature is involved

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -47,6 +47,8 @@ npy_mark_tmp_array_if_pyscalar(
      * a custom DType registered, and then we should use that.
      * Further, `np.float64` is a double subclass, so must reject it.
      */
+    // TODO,NOTE: This function should be changed to do exact long checks
+    //            For NumPy 2.1!
     if (PyLong_Check(obj)
             && (PyArray_ISINTEGER(arr) || PyArray_ISOBJECT(arr))) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_INT;

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -992,7 +992,6 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
     }
 
     /* Pause warnings and always use "new" path */
-    int old_promotion_state = npy_promotion_state;
     npy_promotion_state = NPY_USE_WEAK_PROMOTION;
     PyObject *info = promote_and_get_info_and_ufuncimpl(ufunc,
             ops, signature, op_dtypes, legacy_promotion_is_possible);

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -974,7 +974,7 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         }
     }
 
-    int current_promotion_state = get_npy_promotion_state();
+    int current_promotion_state = npy_promotion_state;
 
     if (force_legacy_promotion && legacy_promotion_is_possible
             && current_promotion_state == NPY_USE_LEGACY_PROMOTION

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -996,7 +996,7 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
     npy_promotion_state = NPY_USE_WEAK_PROMOTION;
     PyObject *info = promote_and_get_info_and_ufuncimpl(ufunc,
             ops, signature, op_dtypes, legacy_promotion_is_possible);
-    set_npy_promotion_state(current_promotion_state);
+    npy_promotion_state = current_promotion_state;
 
     if (info == NULL) {
         goto handle_error;

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -46,6 +46,7 @@
 #include "numpy/npy_3kcompat.h"
 #include "common.h"
 
+#include "arrayobject.h"
 #include "dispatching.h"
 #include "dtypemeta.h"
 #include "npy_hashtable.h"
@@ -933,11 +934,11 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *op_dtypes[],
         npy_bool force_legacy_promotion,
-        npy_bool allow_legacy_promotion,
         npy_bool promoting_pyscalars,
         npy_bool ensure_reduce_compatible)
 {
     int nin = ufunc->nin, nargs = ufunc->nargs;
+    npy_bool allow_legacy_promotion = NPY_TRUE;
 
     /*
      * Get the actual DTypes we operate with by setting op_dtypes[i] from
@@ -962,10 +963,21 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
              */
             Py_CLEAR(op_dtypes[i]);
         }
+        /*
+         * If the op_dtype ends up being a non-legacy one, then we cannot use
+         * legacy promotion (unless this is a python scalar).
+         */
+        if (op_dtypes[i] != NULL && !NPY_DT_is_legacy(op_dtypes[i]) && (
+                signature[i] != NULL ||  // signature cannot be a pyscalar
+                !(PyArray_FLAGS(ops[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL))) {
+            allow_legacy_promotion = NPY_FALSE;
+        }
     }
 
-    if (force_legacy_promotion
-            && npy_promotion_state == NPY_USE_LEGACY_PROMOTION
+    int current_promotion_state = get_npy_promotion_state();
+
+    if (force_legacy_promotion && allow_legacy_promotion
+            && current_promotion_state == NPY_USE_LEGACY_PROMOTION
             && (ufunc->ntypes != 0 || ufunc->userloops != NULL)) {
         /*
          * We must use legacy promotion for value-based logic. Call the old
@@ -1029,7 +1041,7 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         Py_INCREF(signature[0]);
         return promote_and_get_ufuncimpl(ufunc,
                 ops, signature, op_dtypes,
-                force_legacy_promotion, allow_legacy_promotion,
+                force_legacy_promotion,
                 promoting_pyscalars, NPY_FALSE);
     }
 

--- a/numpy/_core/src/umath/dispatching.h
+++ b/numpy/_core/src/umath/dispatching.h
@@ -22,7 +22,6 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *op_dtypes[],
         npy_bool force_legacy_promotion,
-        npy_bool allow_legacy_promotion,
         npy_bool promote_pyscalars,
         npy_bool ensure_reduce_compatible);
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1028,9 +1028,9 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
                      PyArray_DTypeMeta *const signature[],
                      PyArray_DTypeMeta *new_op_dtypes[])
 {
-    if (op_dtypes[0] != &PyArray_StringDType &&
-            op_dtypes[1] != &PyArray_StringDType &&
-            op_dtypes[2] != &PyArray_StringDType) {
+    if ((op_dtypes[0] != &PyArray_StringDType &&
+         op_dtypes[1] != &PyArray_StringDType &&
+         op_dtypes[2] != &PyArray_StringDType)) {
         /*
          * This promoter was triggered with only unicode arguments, so use
          * unicode.  This can happen due to `dtype=` support which sets the
@@ -1041,9 +1041,9 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
         new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_UnicodeDType);
         return 0;
     }
-    if (signature[0] == &PyArray_UnicodeDType &&
-            signature[1] == &PyArray_UnicodeDType &&
-            signature[2] == &PyArray_UnicodeDType) {
+    if ((signature[0] == &PyArray_UnicodeDType &&
+         signature[1] == &PyArray_UnicodeDType &&
+         signature[2] == &PyArray_UnicodeDType)) {
         /* Unicode forced, but didn't override a string input: invalid */
         return -1;
     }

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1028,6 +1028,25 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
                      PyArray_DTypeMeta *const signature[],
                      PyArray_DTypeMeta *new_op_dtypes[])
 {
+    if (op_dtypes[0] != &PyArray_StringDType &&
+            op_dtypes[1] != &PyArray_StringDType &&
+            op_dtypes[2] != &PyArray_StringDType) {
+        /*
+         * This promoter was triggered with only unicode arguments, so use
+         * unicode.  This can happen due to `dtype=` support which sets the
+         * output DType/signature.
+         */
+        new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_UnicodeDType);
+        new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_UnicodeDType);
+        new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_UnicodeDType);
+        return 0;
+    }
+    if (signature[0] == &PyArray_UnicodeDType &&
+            signature[1] == &PyArray_UnicodeDType &&
+            signature[2] == &PyArray_UnicodeDType) {
+        /* Unicode forced, but didn't override a string input: invalid */
+        return -1;
+    }
     new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
     new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
@@ -2032,6 +2051,17 @@ init_stringdtype_ufuncs(PyObject *umath)
     };
 
     if (add_promoter(umath, "add", lall_strings_promoter_dtypes, 3,
+                     all_strings_promoter) < 0) {
+        return -1;
+    }
+
+    PyArray_DTypeMeta *out_strings_promoter_dtypes[] = {
+        &PyArray_UnicodeDType,
+        &PyArray_UnicodeDType,
+        &PyArray_StringDType,
+    };
+
+    if (add_promoter(umath, "add", out_strings_promoter_dtypes, 3,
                      all_strings_promoter) < 0) {
         return -1;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -5808,10 +5808,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             Py_INCREF(operand_DTypes[2]);
 
             if ((PyArray_NDIM(op1_array) == 0)
-                        != (PyArray_NDIM(op2_array) == 0)) {
-                    /* both are legacy and only one is 0-D: force legacy */
-                    force_legacy_promotion = should_use_min_scalar(2, tmp_operands, 0, NULL);
-                }
+                    != (PyArray_NDIM(op2_array) == 0)) {
+                /* both are legacy and only one is 0-D: force legacy */
+                force_legacy_promotion = should_use_min_scalar(2, tmp_operands, 0, NULL);
+            }
         }
         else {
             tmp_operands[1] = tmp_operands[0];

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -861,6 +861,15 @@ def test_add_promoter(string_list):
         np.add("a", "b", signature=("U", "U", StringDType))
 
 
+def test_add_no_legacy_promote_with_signature():
+    # Possibly misplaced, but useful to test with string DType.  We check that
+    # if there is clearly no loop found, a stray `dtype=` doesn't break things
+    # Regression test for the bad error in gh-26735
+    # (If legacy promotion is gone, this can be deleted...)
+    with pytest.raises(TypeError, match=".*did not contain a loop"):
+        np.add("3", 6, dtype=StringDType)
+
+
 def test_add_promoter_reduce():
     # Exact TypeError could change, but ensure StringDtype doesn't match
     with pytest.raises(TypeError, match="the resolved dtypes are not"):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -844,6 +844,22 @@ def test_add_promoter(string_list):
         assert_array_equal(op + arr, lresult)
         assert_array_equal(arr + op, rresult)
 
+    # The promoter should be able to handle things if users pass `dtype=`
+    res = np.add("hello", string_list, dtype=StringDType)
+    assert res.dtype == StringDType()
+
+    # The promoter should not kick in if users override the input,
+    # which means arr is cast, this fails because of the unknown length.
+    with pytest.raises(TypeError, match="cannot cast dtype"):
+        np.add(arr, "add", signature=("U", "U", None), casting="unsafe")
+
+    # But it must simply reject the following:
+    with pytest.raises(TypeError, match=".*did not contain a loop"):
+        np.add(arr, "add", signature=(None, "U", None))
+
+    with pytest.raises(TypeError, match=".*did not contain a loop"):
+        np.add("a", "b", signature=("U", "U", StringDType))
+
 
 def test_add_promoter_reduce():
     # Exact TypeError could change, but ensure StringDtype doesn't match


### PR DESCRIPTION
Backport of #26744.


Unfortunately, did a bit of cleanup to make this work, so this needs a bit of a careful look.

I.e. the first commit moves the "allow legacy promotion" logic to later, where the signature is more readily available. That shouldn't change anything else (the only reason it is used earlier is to decide if checking for "should use scalar" makes sense, but that code handles unknown dtypes just fine).

It then fixes the string add promoter to close the issue.

Closes https://github.com/numpy/numpy/issues/26735
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
