### PR TITLE
BUG: remove numpy.f2py from excludedimports

### DIFF
--- a/numpy/_pyinstaller/hook-numpy.py
+++ b/numpy/_pyinstaller/hook-numpy.py
@@ -31,7 +31,6 @@ excludedimports = [
     "pytest",
     "f2py",
     "setuptools",
-    "numpy.f2py",
     "distutils",
     "numpy.distutils",
 ]


### PR DESCRIPTION
Backport of #26776.

We noticed that PyInstaller fails to correctly bundle our application when using SciPy 1.13.1 & NumPy 2.0.0

Scipy ends up trying to import `numpy.f2py`  when using optimize.root_scalar resulting in a runtime ModuleNotFoundError:

```
Traceback (most recent call last):
  File "numpy_min_reproducible\__init__.py", line 2, in <module>
  File "scipy\__init__.py", line 147, in __getattr__
  File "importlib\__init__.py", line 126, in import_module
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\optimize\__init__.py", line 413, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\optimize\_optimize.py", line 35, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\linalg\__init__.py", line 205, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\linalg\_basic.py", line 13, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\linalg\_decomp.py", line 26, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\_lib\_util.py", line 18, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\_lib\_array_api.py", line 17, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "scipy\_lib\array_api_compat\numpy\__init__.py", line 1, in <module>
  File "numpy\__init__.py", line 372, in __getattr__
ModuleNotFoundError: No module named 'numpy.f2py'
```

A minimal reproducible script would be the following:
```
from scipy import optimize
optimize.root_scalar(lambda x: x,x0=1)
```
Tested with these dependencies:

python = ">=3.10,<3.13"
numpy = "^2.0.0"
pyinstaller = "^6.8.0"
scipy = "^1.13.1"
