### PR TITLE
DOC: Add a note that one should free the proto struct

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1240,6 +1240,11 @@ User-defined data types
         With these two changes, the code should compile and work on both 1.x
         and 2.x or later.
 
+        In the unlikely case that you are heap allocating the dtype struct you
+        should free it again on NumPy 2, since a copy is made.
+        The struct is not a valid Python object, so do not use ``Py_DECREF``
+        on it.
+
     Register a data-type as a new user-defined data type for
     arrays. The type must have most of its entries filled in. This is
     not always checked and errors can produce segfaults. In


### PR DESCRIPTION
Really, heap allocating should be very rare and I am not even sure it ever worked (in the error paths at least), but people should be able to work around it easily enough, so give a pointer.

Close gh-26763
