### PR TITLE
ENH: Allow use of clip with Python integers to always succeed

### DIFF
--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -8,6 +8,7 @@ import pickle
 import warnings
 from contextlib import nullcontext
 
+import numpy as np
 from numpy._core import multiarray as mu
 from numpy._core import umath as um
 from numpy._core.multiarray import asanyarray
@@ -97,10 +98,18 @@ def _count_reduce_items(arr, axis, keepdims=False, where=True):
     return items
 
 def _clip(a, min=None, max=None, out=None, **kwargs):
+    if a.dtype.kind in "iu":
+        # If min/max is a Python integer, deal with out-of-bound values here.
+        # (This enforces NEP 50 rules as no value based promotion is done.)
+        if type(min) is int and min <= np.iinfo(a.dtype).min:
+            min = None
+        if type(max) is int and max >= np.iinfo(a.dtype).max:
+            max = None
+
     if min is None and max is None:
         # return identity
         return um.positive(a, out=out, **kwargs)
-    if min is None:
+    elif min is None:
         return um.minimum(a, max, out=out, **kwargs)
     elif max is None:
         return um.maximum(a, min, out=out, **kwargs)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5091,16 +5091,24 @@ class TestClip:
                 'uint', 1024, 10, 100, inplace=inplace)
 
     @pytest.mark.parametrize("inplace", [False, True])
-    def test_int_range_error(self, inplace):
-        # E.g. clipping uint with negative integers fails to promote
-        # (changed with NEP 50 and may be adaptable)
-        # Similar to last check in `test_basic`
+    def test_int_out_of_range(self, inplace):
+        # Simple check for out-of-bound integers, also testing the in-place
+        # path.
         x = (np.random.random(1000) * 255).astype("uint8")
-        with pytest.raises(OverflowError):
-            x.clip(-1, 10, out=x if inplace else None)
+        out = np.empty_like(x)
+        res = x.clip(-1, 300, out=out if inplace else None)
+        assert res is out or not inplace
+        assert (res == x).all()
 
-        with pytest.raises(OverflowError):
-            x.clip(0, 256, out=x if inplace else None)
+        res = x.clip(-1, 50, out=out if inplace else None)
+        assert res is out or not inplace
+        assert (res <= 50).all()
+        assert (res[x <= 50] == x[x <= 50]).all()
+
+        res = x.clip(100, 1000, out=out if inplace else None)
+        assert res is out or not inplace
+        assert (res >= 100).all()
+        assert (res[x >= 100] == x[x >= 100]).all()
 
     def test_record_array(self):
         rec = np.array([(-5, 2.0, 3.0), (5.0, 4.0, 3.0)],

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2880,6 +2880,24 @@ class TestClip:
         with assert_raises_regex(ValueError, msg):
             np.clip(arr, 2, 3, min=2)
 
+    @pytest.mark.parametrize("dtype,min,max", [
+        ("int32", -2**32-1, 2**32),
+        ("int32", -2**320, None),
+        ("int32", None, 2**300),
+        ("int32", -1000, 2**32),
+        ("int32", -2**32-1, 1000),
+        ("uint8", -1, 129),
+    ])
+    def test_out_of_bound_pyints(self, dtype, min, max):
+        a = np.arange(10000).astype(dtype)
+        # Check min only
+        c = np.clip(a, min=min, max=max)
+        assert not np.may_share_memory(a, c)
+        assert c.dtype == a.dtype
+        if min is not None:
+            assert (c >= min).all()
+        if max is not None:
+            assert (c <= max).all()
 
 class TestAllclose:
     rtol = 1e-5


### PR DESCRIPTION
This helps with NEP 50 behavior since the type is unchanged in that case, but the result is still clearly defined for clipping.

This part could be pushed into the loops, but is more tricky to do there.  It may make sense if it comes up as a problem with minimum/maximum.  However, I think the situation there is slightly less surprising.

(Does not preserve NEP 50 warnings/old behavior.)

Closes gh-26759