### PR TITLE
DOC: Change documentation copyright strings to use a dynamic end year

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -16,6 +16,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+from datetime import datetime
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -48,7 +49,8 @@ master_doc = 'content'
 
 # General information about the project.
 project = 'NumPy Enhancement Proposals'
-copyright = '2017-2018, NumPy Developers'
+year = datetime.now().year
+copyright = f'2017-{year}, NumPy Developers'
 author = 'NumPy Developers'
 title = 'NumPy Enhancement Proposals Documentation'
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,6 +4,7 @@ import sys
 import importlib
 from docutils import nodes
 from docutils.parsers.rst import Directive
+from datetime import datetime
 
 # Minimum version, enforced by sphinx
 needs_sphinx = '4.3'
@@ -107,7 +108,8 @@ source_suffix = '.rst'
 
 # General substitutions.
 project = 'NumPy'
-copyright = '2008-2024, NumPy Developers'
+year = datetime.now().year
+copyright = f'2008-{year}, NumPy Developers'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
This pull request addresses #26834 by changing the web page copyright strings for documentation and NEPs to have a dynamic end year which will always reflect the current year.

[skip actions] [skip azp] [skip cirrus]
