### PR TITLE
BUG: `np.loadtxt` return F_CONTIGUOUS ndarray if row size is too big

### DIFF
--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -480,6 +480,12 @@ read_rows(stream *s,
         ((PyArrayObject_fields *)data_array)->dimensions[0] = row_count;
     }
 
+    /*
+     * If row_size is too big, F_CONTIGUOUS is always set
+     * as array was created for only one row of data.
+     * We just update the contiguous flags here.
+     */
+    PyArray_UpdateFlags(data_array, NPY_ARRAY_F_CONTIGUOUS);
     return data_array;
 
   error:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -266,6 +266,17 @@ class TestFlags:
         a = np.zeros(4, dtype=np.dtype([("a", "i4"), ("b", "i4")]))
         assert_(a.flags.aligned)
 
+    @pytest.mark.parametrize("row_size", [5, 1 << 16])
+    @pytest.mark.parametrize("row_count", [1, 5])
+    @pytest.mark.parametrize("ndmin", [0, 1, 2])
+    def test_xcontiguous_load_txt(self, row_size, row_count, ndmin):
+        s = io.StringIO('\n'.join(['1.0 ' * row_size] * row_count))
+        a = np.loadtxt(s, ndmin=ndmin)
+
+        assert a.flags.c_contiguous
+        x = [i for i in a.shape if i != 1]
+        assert a.flags.f_contiguous == (len(x) <= 1)
+
 
 class TestHash:
     # see #3793


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes #26900 