### PR TITLE
MAINT: declare that NumPy's C extensions support running without the GIL

### DIFF
--- a/numpy/_core/src/_simd/_simd.c
+++ b/numpy/_core/src/_simd/_simd.c
@@ -92,6 +92,12 @@ PyMODINIT_FUNC PyInit__simd(void)
         NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, ATTACH_MODULE, MAKE_MSVC_HAPPY)
         NPY__CPU_DISPATCH_BASELINE_CALL(ATTACH_BASELINE_MODULE, MAKE_MSVC_HAPPY)
     #endif
+
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 err:
     Py_DECREF(m);

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2411,6 +2411,12 @@ PyMODINIT_FUNC PyInit__multiarray_tests(void)
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot load _multiarray_tests module.");
     }
+
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5132,6 +5132,11 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 
  err:

--- a/numpy/_core/src/umath/_operand_flag_tests.c
+++ b/numpy/_core/src/umath/_operand_flag_tests.c
@@ -77,6 +77,11 @@ PyMODINIT_FUNC PyInit__operand_flag_tests(void)
     ((PyUFuncObject*)ufunc)->iter_flags = NPY_ITER_REDUCE_OK;
     PyModule_AddObject(m, "inplace_add", (PyObject*)ufunc);
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 
 fail:

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -1355,6 +1355,11 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     GCD_LCM_UFUNC(gcd,NPY_INT64,"greatest common denominator of two integers");
     GCD_LCM_UFUNC(lcm,NPY_INT64,"least common multiple of two integers");
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 
 fail:

--- a/numpy/_core/src/umath/_struct_ufunc_tests.c
+++ b/numpy/_core/src/umath/_struct_ufunc_tests.c
@@ -156,5 +156,11 @@ PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
 
     PyDict_SetItemString(d, "add_triplet", add_triplet);
     Py_DECREF(add_triplet);
+
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -829,5 +829,11 @@ PyMODINIT_FUNC PyInit__umath_tests(void) {
                         "cannot load _umath_tests module.");
         return NULL;
     }
+
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -236,6 +236,11 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 #initcommonhooks#
 #interface_usercode#
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
 #ifdef F2PY_REPORT_ATEXIT
     if (! PyErr_Occurred())
         on_exit(f2py_report_on_exit,(void*)\"#modulename#\");

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -236,11 +236,6 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 #initcommonhooks#
 #interface_usercode#
 
-#if Py_GIL_DISABLED
-    // signal this module supports running with the GIL disabled
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
-
 #ifdef F2PY_REPORT_ATEXIT
     if (! PyErr_Occurred())
         on_exit(f2py_report_on_exit,(void*)\"#modulename#\");

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -6,6 +6,8 @@ from numpy.f2py import crackfortran
 from numpy.testing import IS_WASM
 
 
+@pytest.mark.filterwarnings("ignore:.*The global interpreter lock \(GIL\) "
+                            "has been enabled.*:RuntimeWarning")
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
 class TestAbstractInterface(util.F2PyTest):

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -6,8 +6,8 @@ from numpy.f2py import crackfortran
 from numpy.testing import IS_WASM
 
 
-@pytest.mark.filterwarnings("ignore:.*The global interpreter lock \(GIL\) "
-                            "has been enabled.*:RuntimeWarning")
+@pytest.mark.filterwarnings(r"ignore:.*The global interpreter lock \(GIL\) "
+                            r"has been enabled.*:RuntimeWarning")
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
 class TestAbstractInterface(util.F2PyTest):

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,8 +11,8 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
-@pytest.mark.filterwarnings("ignore:.*The global interpreter lock \(GIL\) "
-                            "has been enabled.*:RuntimeWarning")
+@pytest.mark.filterwarnings(r"ignore:.*The global interpreter lock \(GIL\) "
+                            r"has been enabled.*:RuntimeWarning")
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,6 +11,8 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
+@pytest.mark.filterwarnings("ignore:.*The global interpreter lock \(GIL\) "
+                            "has been enabled.*:RuntimeWarning")
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 

--- a/numpy/fft/_pocketfft_umath.cpp
+++ b/numpy/fft/_pocketfft_umath.cpp
@@ -419,5 +419,10 @@ PyMODINIT_FUNC PyInit__pocketfft_umath(void)
         return NULL;
     }
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -409,5 +409,10 @@ PyMODINIT_FUNC PyInit_lapack_lite(void)
     PyDict_SetItemString(d, "_ilp64", Py_False);
 #endif
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -4699,5 +4699,10 @@ PyMODINIT_FUNC PyInit__umath_linalg(void)
     PyDict_SetItemString(d, "_ilp64", Py_False);
 #endif
 
+#if Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     return m;
 }


### PR DESCRIPTION
If I apply this PR and build NumPy using https://github.com/cython/cython/pull/6242 and the following diff:

<details>

```
diff --git a/numpy/random/_examples/cython/meson.build b/numpy/random/_examples/cython/meson.build
index 1ad754c536..e582847ec6 100644
--- a/numpy/random/_examples/cython/meson.build
+++ b/numpy/random/_examples/cython/meson.build
@@ -27,6 +27,7 @@ py3.extension_module(
     install: false,
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
+    cython_args: ['-Xfreethreading_compatible=True'],
 )
 py3.extension_module(
     'extending',
@@ -34,13 +35,15 @@ py3.extension_module(
     install: false,
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
+    cython_args: ['-Xfreethreading_compatible=True'],
 )
 py3.extension_module(
     'extending_cpp',
     'extending_distributions.pyx',
     install: false,
     override_options : ['cython_language=cpp'],
-    cython_args: ['--module-name', 'extending_cpp'],
+    cython_args: ['--module-name', 'extending_cpp',
+                  '-Xfreethreading_compatible=True'],
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
 )
diff --git a/numpy/random/meson.build b/numpy/random/meson.build
index 1c90fb5866..15772eec79 100644
--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -83,6 +83,7 @@ foreach gen: random_pyx_sources
     link_with: gen[3],
     install: true,
     subdir: 'numpy/random',
+    cython_args: ['-Xfreethreading_compatible=True'],
   )
 endforeach
 ```

</details>

Then I'm able to get the full numpy unit tests to pass with the GIL disabled without setting `PYTHON_GIL=0`.

I'm sending this in separate from the cython changes to ease review.

The one thing I'm not clear about is whether the f2py change needs to be a new configuration option for f2py. NumPy itself doesn't use f2py, I needed to make the changes to get the f2py tests to pass without raising a warning.