### PR TITLE
TYP,BUG: Remove ``numpy.cast`` and ``numpy.disp`` from the typing stubs.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -389,7 +389,6 @@ from numpy._core.numeric import (
 from numpy._core.numerictypes import (
     isdtype as isdtype,
     issubdtype as issubdtype,
-    cast as cast,
     ScalarType as ScalarType,
     typecodes as typecodes,
 )
@@ -439,7 +438,6 @@ from numpy.lib._function_base_impl import (
     angle as angle,
     unwrap as unwrap,
     sort_complex as sort_complex,
-    disp as disp,
     flip as flip,
     rot90 as rot90,
     extract as extract,

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -12,7 +12,6 @@ from typing import (
 
 from numpy import (
     vectorize as vectorize,
-    ufunc,
     generic,
     floating,
     complexfloating,
@@ -312,12 +311,6 @@ def extract(condition: ArrayLike, arr: _ArrayLike[_SCT]) -> NDArray[_SCT]: ...
 def extract(condition: ArrayLike, arr: ArrayLike) -> NDArray[Any]: ...
 
 def place(arr: NDArray[Any], mask: ArrayLike, vals: Any) -> None: ...
-
-def disp(
-    mesg: object,
-    device: None | _SupportsWriteFlush = ...,
-    linefeed: bool = ...,
-) -> None: ...
 
 @overload
 def cov(


### PR DESCRIPTION
Accessing `numpy.cast` or `numpy.disp` at runtime will raise an `AttributeError` since their removal in NumPy 2.0.
But this wasn't reflected in the typing stubs.
