### PR TITLE
TYP,BUG: Fix ``dtype`` type alias specialization issue in ``__init__.pyi``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1413,7 +1413,7 @@ _ArrayNumber_co: TypeAlias = NDArray[np.bool | number[Any]]
 _ArrayTD64_co: TypeAlias = NDArray[np.bool | integer[Any] | timedelta64]
 
 # Introduce an alias for `dtype` to avoid naming conflicts.
-_dtype: TypeAlias = dtype
+_dtype: TypeAlias = dtype[_ScalarType]
 
 if sys.version_info >= (3, 13):
     from types import CapsuleType as _PyCapsule


### PR DESCRIPTION
Currently, Pyright / Pylance reports an error for each of the 27 uses of the ``numpy._dtype``  type alias:

```
Type "dtype[Unknown]" is already specialized
```

The reason for this is that Pyright interprets ``_dtype: TypeAlias = dtype`` as ``_dtype: TypeAlias = dtype[Unknown]``, because it considers ``Unknown`` to be the "default default" for a ``typing.TypeVar`` (see [PEP 696](https://peps.python.org/pep-0696/)).

This was introduced in #26858