### PR TITLE
TYP: Improved ``numpy.generic`` rich comparison operator type annotations.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -150,7 +150,10 @@ from numpy._typing._callable import (
     _FloatDivMod,
     _ComplexOp,
     _NumberOp,
-    _ComparisonOp,
+    _ComparisonOpLT,
+    _ComparisonOpLE,
+    _ComparisonOpGT,
+    _ComparisonOpGE,
 )
 
 # NOTE: Numpy's mypy plugin is used for removing the types unavailable
@@ -2795,10 +2798,10 @@ class number(generic, Generic[_NBit1]):  # type: ignore
     __rpow__: _NumberOp
     __truediv__: _NumberOp
     __rtruediv__: _NumberOp
-    __lt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __le__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __gt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __ge__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
+    __lt__: _ComparisonOpLT[_NumberLike_co, _ArrayLikeNumber_co]
+    __le__: _ComparisonOpLE[_NumberLike_co, _ArrayLikeNumber_co]
+    __gt__: _ComparisonOpGT[_NumberLike_co, _ArrayLikeNumber_co]
+    __ge__: _ComparisonOpGE[_NumberLike_co, _ArrayLikeNumber_co]
 
 class bool(generic):
     def __init__(self, value: object = ..., /) -> None: ...
@@ -2841,10 +2844,10 @@ class bool(generic):
     __rmod__: _BoolMod
     __divmod__: _BoolDivMod
     __rdivmod__: _BoolDivMod
-    __lt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __le__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __gt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
-    __ge__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
+    __lt__: _ComparisonOpLT[_NumberLike_co, _ArrayLikeNumber_co]
+    __le__: _ComparisonOpLE[_NumberLike_co, _ArrayLikeNumber_co]
+    __gt__: _ComparisonOpGT[_NumberLike_co, _ArrayLikeNumber_co]
+    __ge__: _ComparisonOpGE[_NumberLike_co, _ArrayLikeNumber_co]
 
 bool_: TypeAlias = bool
 
@@ -2897,10 +2900,10 @@ class datetime64(generic):
     @overload
     def __sub__(self, other: _TD64Like_co, /) -> datetime64: ...
     def __rsub__(self, other: datetime64, /) -> timedelta64: ...
-    __lt__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
-    __le__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
-    __gt__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
-    __ge__: _ComparisonOp[datetime64, _ArrayLikeDT64_co]
+    __lt__: _ComparisonOpLT[datetime64, _ArrayLikeDT64_co]
+    __le__: _ComparisonOpLE[datetime64, _ArrayLikeDT64_co]
+    __gt__: _ComparisonOpGT[datetime64, _ArrayLikeDT64_co]
+    __ge__: _ComparisonOpGE[datetime64, _ArrayLikeDT64_co]
 
 _IntValue: TypeAlias = SupportsInt | _CharLike_co | SupportsIndex
 _FloatValue: TypeAlias = None | _CharLike_co | SupportsFloat | SupportsIndex
@@ -3025,10 +3028,10 @@ class timedelta64(generic):
     def __rmod__(self, other: timedelta64, /) -> timedelta64: ...
     def __divmod__(self, other: timedelta64, /) -> tuple[int64, timedelta64]: ...
     def __rdivmod__(self, other: timedelta64, /) -> tuple[int64, timedelta64]: ...
-    __lt__: _ComparisonOp[_TD64Like_co, _ArrayLikeTD64_co]
-    __le__: _ComparisonOp[_TD64Like_co, _ArrayLikeTD64_co]
-    __gt__: _ComparisonOp[_TD64Like_co, _ArrayLikeTD64_co]
-    __ge__: _ComparisonOp[_TD64Like_co, _ArrayLikeTD64_co]
+    __lt__: _ComparisonOpLT[_TD64Like_co, _ArrayLikeTD64_co]
+    __le__: _ComparisonOpLE[_TD64Like_co, _ArrayLikeTD64_co]
+    __gt__: _ComparisonOpGT[_TD64Like_co, _ArrayLikeTD64_co]
+    __ge__: _ComparisonOpGE[_TD64Like_co, _ArrayLikeTD64_co]
 
 class unsignedinteger(integer[_NBit1]):
     # NOTE: `uint64 + signedinteger -> float64`

--- a/numpy/_typing/_callable.pyi
+++ b/numpy/_typing/_callable.pyi
@@ -11,7 +11,9 @@ See the `Mypy documentation`_ on protocols for more details.
 from __future__ import annotations
 
 from typing import (
+    TypeAlias,
     TypeVar,
+    final,
     overload,
     Any,
     NoReturn,
@@ -48,7 +50,8 @@ _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
 _T1_contra = TypeVar("_T1_contra", contravariant=True)
 _T2_contra = TypeVar("_T2_contra", contravariant=True)
-_2Tuple = tuple[_T1, _T1]
+
+_2Tuple: TypeAlias = tuple[_T1, _T1]
 
 _NBit1 = TypeVar("_NBit1", bound=NBitBase)
 _NBit2 = TypeVar("_NBit2", bound=NBitBase)
@@ -317,20 +320,62 @@ class _ComplexOp(Protocol[_NBit1]):
 class _NumberOp(Protocol):
     def __call__(self, other: _NumberLike_co, /) -> Any: ...
 
+@final
 class _SupportsLT(Protocol):
-    def __lt__(self, other: Any, /) -> object: ...
+    def __lt__(self, other: Any, /) -> Any: ...
 
+@final
+class _SupportsLE(Protocol):
+    def __le__(self, other: Any, /) -> Any: ...
+
+@final
 class _SupportsGT(Protocol):
-    def __gt__(self, other: Any, /) -> object: ...
+    def __gt__(self, other: Any, /) -> Any: ...
 
-class _ComparisonOp(Protocol[_T1_contra, _T2_contra]):
+@final
+class _SupportsGE(Protocol):
+    def __ge__(self, other: Any, /) -> Any: ...
+
+@final
+class _ComparisonOpLT(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> np.bool: ...
     @overload
     def __call__(self, other: _T2_contra, /) -> NDArray[np.bool]: ...
     @overload
-    def __call__(
-        self,
-        other: _SupportsLT | _SupportsGT | _NestedSequence[_SupportsLT | _SupportsGT],
-        /,
-    ) -> Any: ...
+    def __call__(self, other: _NestedSequence[_SupportsGT], /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _SupportsGT, /) -> np.bool: ...
+
+@final
+class _ComparisonOpLE(Protocol[_T1_contra, _T2_contra]):
+    @overload
+    def __call__(self, other: _T1_contra, /) -> np.bool: ...
+    @overload
+    def __call__(self, other: _T2_contra, /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _NestedSequence[_SupportsGE], /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _SupportsGE, /) -> np.bool: ...
+
+@final
+class _ComparisonOpGT(Protocol[_T1_contra, _T2_contra]):
+    @overload
+    def __call__(self, other: _T1_contra, /) -> np.bool: ...
+    @overload
+    def __call__(self, other: _T2_contra, /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _NestedSequence[_SupportsLT], /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _SupportsLT, /) -> np.bool: ...
+
+@final
+class _ComparisonOpGE(Protocol[_T1_contra, _T2_contra]):
+    @overload
+    def __call__(self, other: _T1_contra, /) -> np.bool: ...
+    @overload
+    def __call__(self, other: _T2_contra, /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _NestedSequence[_SupportsGT], /) -> NDArray[np.bool]: ...
+    @overload
+    def __call__(self, other: _SupportsGT, /) -> np.bool: ...

--- a/numpy/typing/tests/data/reveal/comparisons.pyi
+++ b/numpy/typing/tests/data/reveal/comparisons.pyi
@@ -38,10 +38,10 @@ SEQ = (0, 1, 2, 3, 4)
 
 # object-like comparisons
 
-assert_type(i8 > fractions.Fraction(1, 5), Any)
-assert_type(i8 > [fractions.Fraction(1, 5)], Any)
-assert_type(i8 > decimal.Decimal("1.5"), Any)
-assert_type(i8 > [decimal.Decimal("1.5")], Any)
+assert_type(i8 > fractions.Fraction(1, 5), np.bool)
+assert_type(i8 > [fractions.Fraction(1, 5)], npt.NDArray[np.bool])
+assert_type(i8 > decimal.Decimal("1.5"), np.bool)
+assert_type(i8 > [decimal.Decimal("1.5")], npt.NDArray[np.bool])
 
 # Time structures
 


### PR DESCRIPTION
This affects `numpy.generic` subtypes that implement `__lt__`, `__le__`, `__gt__`, or (but usually "and") `__ge__`.

Note that there are no commutativity issues here, because the numpy implementations of these comparison ops always return a `np.bool` scalar or array, regardless of the return type of the respective reflected comparison op of the "other" operand. 
And in the case that the `generic` subtype is on the right-hand side, type checkers will first consider the respective dunder method of the left-hand side.