### PR TITLE
TYP,BUG: Remove non-existant ``numpy.__git_version__`` in the stubs.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -629,7 +629,6 @@ class _SupportsWrite(Protocol[_AnyStr_contra]):
 __all__: list[str]
 __dir__: list[str]
 __version__: str
-__git_version__: str
 __array_api_version__: str
 test: PytestTester
 


### PR DESCRIPTION
Because

```pycon
>>> import numpy as np
>>> np.__git_version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/joren/.pyenv/versions/3.12.4/lib/python3.12/site-packages/numpy/__init__.py", line 410, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute '__git_version__'. Did you mean: '__version__'?
```