### PR TITLE
TYP: Annotate ``numpy._core._type_aliases``.

### DIFF
--- a/numpy/_core/_type_aliases.pyi
+++ b/numpy/_core/_type_aliases.pyi
@@ -1,3 +1,93 @@
-from numpy import generic
+from collections.abc import Collection
+from typing import Any, Final, Literal as L, TypeAlias, TypedDict
 
-sctypeDict: dict[int | str, type[generic]]
+import numpy as np
+
+__all__ = (
+    "_abstract_type_names",
+    "_aliases",
+    "_extra_aliases",
+    "allTypes",
+    "c_names_dict",
+    "sctypeDict",
+    "sctypes",
+)
+
+sctypeDict: Final[dict[str, type[np.generic]]]
+allTypes: Final[dict[str, type[np.generic]]]
+
+class _CNamesDict(TypedDict):
+    BOOL: np.dtype[np.bool]
+    HALF: np.dtype[np.half]
+    FLOAT: np.dtype[np.single]
+    DOUBLE: np.dtype[np.double]
+    LONGDOUBLE: np.dtype[np.longdouble]
+    CFLOAT: np.dtype[np.csingle]
+    CDOUBLE: np.dtype[np.cdouble]
+    CLONGDOUBLE: np.dtype[np.clongdouble]
+    STRING: np.dtype[np.bytes_]
+    UNICODE: np.dtype[np.str_]
+    VOID: np.dtype[np.void]
+    OBJECT: np.dtype[np.object_]
+    DATETIME: np.dtype[np.datetime64]
+    TIMEDELTA: np.dtype[np.timedelta64]
+    BYTE: np.dtype[np.byte]
+    UBYTE: np.dtype[np.ubyte]
+    SHORT: np.dtype[np.short]
+    USHORT: np.dtype[np.ushort]
+    INT: np.dtype[np.intc]
+    UINT: np.dtype[np.uintc]
+    LONG: np.dtype[np.long]
+    ULONG: np.dtype[np.ulong]
+    LONGLONG: np.dtype[np.longlong]
+    ULONGLONG: np.dtype[np.ulonglong]
+
+c_names_dict: Final[_CNamesDict]
+
+_AbstractTypeName: TypeAlias = L[
+    "generic",
+    "flexible",
+    "character",
+    "number",
+    "integer",
+    "inexact",
+    "unsignedinteger",
+    "signedinteger",
+    "floating",
+    "complexfloating",
+]
+_abstract_type_names: Final[set[_AbstractTypeName]]
+
+
+class _AliasesType(TypedDict):
+    double: L["float64"]
+    cdouble: L["complex128"]
+    single: L["float32"]
+    csingle: L["complex64"]
+    half: L["float16"]
+    bool_: L["bool"]
+    int_: L["intp"]
+    uint: L["intp"]
+
+_aliases: Final[_AliasesType]
+
+class _ExtraAliasesType(TypedDict):
+    float: L["float64"]
+    complex: L["complex128"]
+    object: L["object_"]
+    bytes: L["bytes_"]
+    a: L["bytes_"]
+    int: L["int_"]
+    str: L["str_"]
+    unicode: L["str_"]
+
+_extra_aliases: Final[_ExtraAliasesType]
+
+class _SCTypes(TypedDict):
+    int: Collection[type[np.signedinteger[Any]]]
+    uint: Collection[type[np.unsignedinteger[Any]]]
+    float: Collection[type[np.floating[Any]]]
+    complex: Collection[type[np.complexfloating[Any, Any]]]
+    others: Collection[type[np.flexible | np.bool | np.object_]]
+
+sctypes: Final[_SCTypes]

--- a/numpy/typing/tests/data/reveal/numerictypes.pyi
+++ b/numpy/typing/tests/data/reveal/numerictypes.pyi
@@ -53,3 +53,5 @@ assert_type(np.bool_, type[np.bool])
 assert_type(np.typecodes["Character"], Literal["c"])
 assert_type(np.typecodes["Complex"], Literal["FDG"])
 assert_type(np.typecodes["All"], Literal["?bhilqnpBHILQNPefdgFDGSUVOMm"])
+
+assert_type(np.sctypeDict['uint8'], type[np.generic])


### PR DESCRIPTION
Almost all annotations in 
 ``numpy._core._type_aliases`` were missing.

The only previously existing annotation was for  ``.sctypeDict``, which this PR modified to be a ``Final`` , and to have a key type  of ``str`` (instead of ``int | str``).
And because it is exported as ``numpy.sctypeDict``, and therefore part of the public API, a (simple) type-test has been added for it.