### PR TITLE
MAINT: add freethreading_compatible directive to cython build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -309,7 +309,7 @@ jobs:
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       run: |
-        pip install git+https://github.com/cython/cython
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     # Set PYTHON_GIL=0 to force GIL off during tests and then manually verify
     # importing numpy does not enable the GIL. When f2py grows the ability to
     # declare GIL-disabled support we can just run the tests without the

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -311,5 +311,3 @@ jobs:
       run: |
         pip install git+https://github.com/cython/cython
     - uses: ./.github/meson_actions
-      env:
-        PYTHON_GIL: 0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -311,3 +311,6 @@ jobs:
       run: |
         pip install git+https://github.com/cython/cython
     - uses: ./.github/meson_actions
+      env:
+        # needed until f2py grows a config flag for GIL-disabled support
+        PYTHON_GIL: 0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -310,7 +310,16 @@ jobs:
     - name: Install nightly Cython
       run: |
         pip install git+https://github.com/cython/cython
+    # Set PYTHON_GIL=0 to force GIL off during tests and then manually verify
+    # importing numpy does not enable the GIL. When f2py grows the ability to
+    # declare GIL-disabled support we can just run the tests without the
+    # environment variable
     - uses: ./.github/meson_actions
       env:
-        # needed until f2py grows a config flag for GIL-disabled support
         PYTHON_GIL: 0
+    - name: Verify import does not re-enable GIL
+      run: |
+        if [[ $(python -c "import numpy" 2>&1) == "*The global interpreter lock (GIL) has been enabled*" ]]; then
+            echo "Error: Importing NumPy re-enables the GIL in the free-threaded build"
+            exit 1
+        fi

--- a/numpy/_core/tests/examples/cython/meson.build
+++ b/numpy/_core/tests/examples/cython/meson.build
@@ -10,6 +10,11 @@ if not cy.version().version_compare('>=3.0.6')
   error('tests requires Cython >= 3.0.6')
 endif
 
+cython_args = []
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 npy_include_path = run_command(py, [
     '-c',
     'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
@@ -34,4 +39,5 @@ py.extension_module(
       '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
     ],
     include_directories: [npy_include_path],
+    cython_args: cython_args,
 )

--- a/numpy/_core/tests/examples/cython/setup.py
+++ b/numpy/_core/tests/examples/cython/setup.py
@@ -3,7 +3,9 @@ Provide python-space access to the functions exposed in numpy/__init__.pxd
 for testing.
 """
 
+import Cython
 import numpy as np
+from numpy._utils import _pep440
 from distutils.core import setup
 from Cython.Build import cythonize
 from setuptools.extension import Extension
@@ -24,6 +26,12 @@ checks = Extension(
 
 extensions = [checks]
 
+compiler_directives = {}
+if _pep440.parse(Cython.__version__) >= _pep440.parse("3.1.0a0"):
+    compiler_directives['freethreading_compatible'] = True
+
 setup(
-    ext_modules=cythonize(extensions)
+    ext_modules=cythonize(
+        extensions,
+        compiler_directives=compiler_directives)
 )

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -369,7 +369,7 @@ install_subdir('tests', install_dir: np_dir, install_tag: 'tests')
 compilers = {
   'C': cc,
   'CPP': cpp,
-  'CYTHON': meson.get_compiler('cython')
+  'CYTHON': cy,
 }
 
 machines = {

--- a/numpy/random/_examples/cython/meson.build
+++ b/numpy/random/_examples/cython/meson.build
@@ -11,6 +11,11 @@ if not cy.version().version_compare('>=3.0.6')
   error('tests requires Cython >= 3.0.6')
 endif
 
+base_cython_args = []
+if cy.version().version_compare('>=3.1.0a0')
+  base_cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 _numpy_abs = run_command(py3, ['-c',
                'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include() + "../../.."))'],
                          check: true).stdout().strip()
@@ -27,6 +32,7 @@ py3.extension_module(
     install: false,
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
+    cython_args: base_cython_args,
 )
 py3.extension_module(
     'extending',
@@ -34,13 +40,14 @@ py3.extension_module(
     install: false,
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
+    cython_args: base_cython_args,
 )
 py3.extension_module(
     'extending_cpp',
     'extending_distributions.pyx',
     install: false,
     override_options : ['cython_language=cpp'],
-    cython_args: ['--module-name', 'extending_cpp'],
+    cython_args: base_cython_args + ['--module-name', 'extending_cpp'],
     include_directories: [npy_include_path],
     dependencies: [npyrandom_lib, npymath_lib],
 )

--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -52,6 +52,11 @@ if host_machine.system() == 'cygwin'
   c_args_random += ['-Wl,--export-all-symbols']
 endif
 
+cython_args = []
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 # name, sources, extra c_args, extra static libs to link
 random_pyx_sources = [
   ['_bounded_integers', _bounded_integers_pyx, [], [npyrandom_lib, npymath_lib]],
@@ -83,6 +88,7 @@ foreach gen: random_pyx_sources
     link_with: gen[3],
     install: true,
     subdir: 'numpy/random',
+    cython_args: cython_args,
   )
 endforeach
 

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -34,10 +34,6 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # with a released version of cython
     python -m pip uninstall -y cython
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-    # TODO: delete when importing numpy no longer enables the GIL
-    # setting to zero ensures the GIL is disabled while running the
-    # tests under free-threaded python
-    export PYTHON_GIL=0
 fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -34,6 +34,20 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # with a released version of cython
     python -m pip uninstall -y cython
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+
+    # Manually check that importing NumPy does not re-enable the GIL.
+    # Afterwards, force the GIL to always be disabled so it does not get
+    # re-enabled during the tests.
+    #
+    # TODO: delete when f2py grows the ability to define extensions that declare
+    # they can run without the gil or when we can work around the fact the f2py
+    # tests import modules that don't declare gil-disabled support.
+    if [[ $(python -c "import numpy" 2>&1) == "*The global interpreter lock (GIL) has been enabled*" ]]; then
+        echo "Error: Importing NumPy re-enables the GIL in the free-threaded build"
+        exit 1
+    fi
+
+    export PYTHON_GIL=0
 fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across


### PR DESCRIPTION
This updates the cython build configuration in numpy's tests and in `numpy.random` to add `freethreading_compatible=True` compiler directives.

With this PR, numpy no longer re-enables the GIL in the free-threaded build! :rocket:

```
Python 3.13.0b3 experimental free-threading build (main, Jul  2 2024, 14:08:18) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>>
```

`numpy.random` should be thread safe, all low-level access to the RNG state is guarded by a `threading.lock` in the cython code. There may be other data races I missed but IMO it's better to add these flags now to ease downstream build configuration rather than worry about theoretical thread safety issues.

The `setup.py` script used in the cython examples tests is dead code. I updated it and manually verified it still builds the extension, but maybe we should just delete it? The test itself does a `pytest.skip` if it can't find meson.