### PR TITLE
TYP: Replace ``typing.Union`` with ``|`` in ``numpy._typing``

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Collection, Callable, Sequence
-from typing import Any, Protocol, Union, TypeAlias, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypeVar, runtime_checkable
 
 import numpy as np
 from numpy import (
@@ -54,41 +54,41 @@ class _SupportsArrayFunc(Protocol):
 
 
 # TODO: Wait until mypy supports recursive objects in combination with typevars
-_FiniteNestedSequence: TypeAlias = Union[
-    _T,
-    Sequence[_T],
-    Sequence[Sequence[_T]],
-    Sequence[Sequence[Sequence[_T]]],
-    Sequence[Sequence[Sequence[Sequence[_T]]]],
-]
+_FiniteNestedSequence: TypeAlias = (
+    _T
+    | Sequence[_T]
+    | Sequence[Sequence[_T]]
+    | Sequence[Sequence[Sequence[_T]]]
+    | Sequence[Sequence[Sequence[Sequence[_T]]]]
+)
 
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
-_ArrayLike: TypeAlias = Union[
-    _SupportsArray[dtype[_ScalarType]],
-    _NestedSequence[_SupportsArray[dtype[_ScalarType]]],
-]
+_ArrayLike: TypeAlias = (
+    _SupportsArray[dtype[_ScalarType]]
+    | _NestedSequence[_SupportsArray[dtype[_ScalarType]]]
+)
 
 # A union representing array-like objects; consists of two typevars:
 # One representing types that can be parametrized w.r.t. `np.dtype`
 # and another one for the rest
-_DualArrayLike: TypeAlias = Union[
-    _SupportsArray[_DType],
-    _NestedSequence[_SupportsArray[_DType]],
-    _T,
-    _NestedSequence[_T],
-]
+_DualArrayLike: TypeAlias = (
+    _SupportsArray[_DType]
+    | _NestedSequence[_SupportsArray[_DType]]
+    | _T
+    | _NestedSequence[_T]
+)
 
 if sys.version_info >= (3, 12):
     from collections.abc import Buffer
 
     ArrayLike: TypeAlias = Buffer | _DualArrayLike[
         dtype[Any],
-        Union[bool, int, float, complex, str, bytes],
+        bool | int | float | complex | str | bytes,
     ]
 else:
     ArrayLike: TypeAlias = _DualArrayLike[
         dtype[Any],
-        Union[bool, int, float, complex, str, bytes],
+        bool | int | float | complex | str | bytes,
     ]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
@@ -98,47 +98,47 @@ _ArrayLikeBool_co: TypeAlias = _DualArrayLike[
     bool,
 ]
 _ArrayLikeUInt_co: TypeAlias = _DualArrayLike[
-    dtype[Union[np.bool, unsignedinteger[Any]]],
+    dtype[np.bool] | dtype[unsignedinteger[Any]],
     bool,
 ]
 _ArrayLikeInt_co: TypeAlias = _DualArrayLike[
-    dtype[Union[np.bool, integer[Any]]],
-    Union[bool, int],
+    dtype[np.bool] | dtype[integer[Any]],
+    bool | int,
 ]
 _ArrayLikeFloat_co: TypeAlias = _DualArrayLike[
-    dtype[Union[np.bool, integer[Any], floating[Any]]],
-    Union[bool, int, float],
+    dtype[np.bool] | dtype[integer[Any]] | dtype[floating[Any]],
+    bool | int | float,
 ]
 _ArrayLikeComplex_co: TypeAlias = _DualArrayLike[
-    dtype[Union[
-        np.bool,
-        integer[Any],
-        floating[Any],
-        complexfloating[Any, Any],
-    ]],
-    Union[bool, int, float, complex],
+    (
+        dtype[np.bool]
+        | dtype[integer[Any]]
+        | dtype[floating[Any]]
+        | dtype[complexfloating[Any, Any]]
+    ),
+    bool | int | float | complex,
 ]
 _ArrayLikeNumber_co: TypeAlias = _DualArrayLike[
-    dtype[Union[np.bool, number[Any]]],
-    Union[bool, int, float, complex],
+    dtype[np.bool] | dtype[number[Any]],
+    bool | int | float | complex,
 ]
 _ArrayLikeTD64_co: TypeAlias = _DualArrayLike[
-    dtype[Union[np.bool, integer[Any], timedelta64]],
-    Union[bool, int],
+    dtype[np.bool] | dtype[integer[Any]] | dtype[timedelta64],
+    bool | int,
 ]
-_ArrayLikeDT64_co: TypeAlias = Union[
-    _SupportsArray[dtype[datetime64]],
-    _NestedSequence[_SupportsArray[dtype[datetime64]]],
-]
-_ArrayLikeObject_co: TypeAlias = Union[
-    _SupportsArray[dtype[object_]],
-    _NestedSequence[_SupportsArray[dtype[object_]]],
-]
+_ArrayLikeDT64_co: TypeAlias = (
+    _SupportsArray[dtype[datetime64]]
+    | _NestedSequence[_SupportsArray[dtype[datetime64]]]
+)
+_ArrayLikeObject_co: TypeAlias = (
+    _SupportsArray[dtype[object_]]
+    | _NestedSequence[_SupportsArray[dtype[object_]]]
+)
 
-_ArrayLikeVoid_co: TypeAlias = Union[
-    _SupportsArray[dtype[void]],
-    _NestedSequence[_SupportsArray[dtype[void]]],
-]
+_ArrayLikeVoid_co: TypeAlias = (
+    _SupportsArray[dtype[void]]
+    | _NestedSequence[_SupportsArray[dtype[void]]]
+)
 _ArrayLikeStr_co: TypeAlias = _DualArrayLike[
     dtype[str_],
     str,
@@ -148,6 +148,7 @@ _ArrayLikeBytes_co: TypeAlias = _DualArrayLike[
     bytes,
 ]
 
+# NOTE: This includes `builtins.bool`, but not `numpy.bool`.
 _ArrayLikeInt: TypeAlias = _DualArrayLike[
     dtype[integer[Any]],
     int,

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -1,8 +1,6 @@
 from collections.abc import Sequence
 from typing import (
     Any,
-    Sequence,
-    Union,
     TypeAlias,
     TypeVar,
     Protocol,
@@ -88,164 +86,164 @@ class _SupportsDType(Protocol[_DType_co]):
 
 
 # A subset of `npt.DTypeLike` that can be parametrized w.r.t. `np.generic`
-_DTypeLike: TypeAlias = Union[
-    np.dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[np.dtype[_SCT]],
-]
+_DTypeLike: TypeAlias = (
+    np.dtype[_SCT]
+    | type[_SCT]
+    | _SupportsDType[np.dtype[_SCT]]
+)
 
 
 # Would create a dtype[np.void]
-_VoidDTypeLike: TypeAlias = Union[
+_VoidDTypeLike: TypeAlias = (
     # (flexible_dtype, itemsize)
-    tuple[_DTypeLikeNested, int],
+    tuple[_DTypeLikeNested, int]
     # (fixed_dtype, shape)
-    tuple[_DTypeLikeNested, _ShapeLike],
+    | tuple[_DTypeLikeNested, _ShapeLike]
     # [(field_name, field_dtype, field_shape), ...]
     #
     # The type here is quite broad because NumPy accepts quite a wide
     # range of inputs inside the list; see the tests for some
     # examples.
-    list[Any],
+    | list[Any]
     # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
     #  'itemsize': ...}
-    _DTypeDict,
+    | _DTypeDict
     # (base_dtype, new_dtype)
-    tuple[_DTypeLikeNested, _DTypeLikeNested],
-]
+    | tuple[_DTypeLikeNested, _DTypeLikeNested]
+)
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
-DTypeLike: TypeAlias = Union[
-    np.dtype[Any],
+DTypeLike: TypeAlias = (
+    np.dtype[Any]
     # default data type (float64)
-    None,
+    | None
     # array-scalar types and generic types
-    type[Any],  # NOTE: We're stuck with `type[Any]` due to object dtypes
+    | type[Any]  # NOTE: We're stuck with `type[Any]` due to object dtypes
     # anything with a dtype attribute
-    _SupportsDType[np.dtype[Any]],
+    | _SupportsDType[np.dtype[Any]]
     # character codes, type strings or comma-separated fields, e.g., 'float64'
-    str,
-    _VoidDTypeLike,
-]
+    | str
+    | _VoidDTypeLike
+)
 
 # NOTE: while it is possible to provide the dtype as a dict of
 # dtype-like objects (e.g. `{'field1': ..., 'field2': ..., ...}`),
 # this syntax is officially discourged and
-# therefore not included in the Union defining `DTypeLike`.
+# therefore not included in the type-union defining `DTypeLike`.
 #
 # See https://github.com/numpy/numpy/issues/16891 for more details.
 
 # Aliases for commonly used dtype-like objects.
 # Note that the precision of `np.number` subclasses is ignored herein.
-_DTypeLikeBool: TypeAlias = Union[
-    type[bool],
-    type[np.bool],
-    np.dtype[np.bool],
-    _SupportsDType[np.dtype[np.bool]],
-    _BoolCodes,
-]
-_DTypeLikeUInt: TypeAlias = Union[
-    type[np.unsignedinteger],
-    np.dtype[np.unsignedinteger],
-    _SupportsDType[np.dtype[np.unsignedinteger]],
-    _UInt8Codes,
-    _UInt16Codes,
-    _UInt32Codes,
-    _UInt64Codes,
-    _UByteCodes,
-    _UShortCodes,
-    _UIntCCodes,
-    _LongCodes,
-    _ULongLongCodes,
-    _UIntPCodes,
-    _UIntCodes,
-]
-_DTypeLikeInt: TypeAlias = Union[
-    type[int],
-    type[np.signedinteger],
-    np.dtype[np.signedinteger],
-    _SupportsDType[np.dtype[np.signedinteger]],
-    _Int8Codes,
-    _Int16Codes,
-    _Int32Codes,
-    _Int64Codes,
-    _ByteCodes,
-    _ShortCodes,
-    _IntCCodes,
-    _LongCodes,
-    _LongLongCodes,
-    _IntPCodes,
-    _IntCodes,
-]
-_DTypeLikeFloat: TypeAlias = Union[
-    type[float],
-    type[np.floating],
-    np.dtype[np.floating],
-    _SupportsDType[np.dtype[np.floating]],
-    _Float16Codes,
-    _Float32Codes,
-    _Float64Codes,
-    _HalfCodes,
-    _SingleCodes,
-    _DoubleCodes,
-    _LongDoubleCodes,
-]
-_DTypeLikeComplex: TypeAlias = Union[
-    type[complex],
-    type[np.complexfloating],
-    np.dtype[np.complexfloating],
-    _SupportsDType[np.dtype[np.complexfloating]],
-    _Complex64Codes,
-    _Complex128Codes,
-    _CSingleCodes,
-    _CDoubleCodes,
-    _CLongDoubleCodes,
-]
-_DTypeLikeDT64: TypeAlias = Union[
-    type[np.timedelta64],
-    np.dtype[np.timedelta64],
-    _SupportsDType[np.dtype[np.timedelta64]],
-    _TD64Codes,
-]
-_DTypeLikeTD64: TypeAlias = Union[
-    type[np.datetime64],
-    np.dtype[np.datetime64],
-    _SupportsDType[np.dtype[np.datetime64]],
-    _DT64Codes,
-]
-_DTypeLikeStr: TypeAlias = Union[
-    type[str],
-    type[np.str_],
-    np.dtype[np.str_],
-    _SupportsDType[np.dtype[np.str_]],
-    _StrCodes,
-]
-_DTypeLikeBytes: TypeAlias = Union[
-    type[bytes],
-    type[np.bytes_],
-    np.dtype[np.bytes_],
-    _SupportsDType[np.dtype[np.bytes_]],
-    _BytesCodes,
-]
-_DTypeLikeVoid: TypeAlias = Union[
-    type[np.void],
-    np.dtype[np.void],
-    _SupportsDType[np.dtype[np.void]],
-    _VoidCodes,
-    _VoidDTypeLike,
-]
-_DTypeLikeObject: TypeAlias = Union[
-    type,
-    np.dtype[np.object_],
-    _SupportsDType[np.dtype[np.object_]],
-    _ObjectCodes,
-]
+_DTypeLikeBool: TypeAlias = (
+    type[bool]
+    | type[np.bool]
+    | np.dtype[np.bool]
+    | _SupportsDType[np.dtype[np.bool]]
+    | _BoolCodes
+)
+_DTypeLikeUInt: TypeAlias = (
+    type[np.unsignedinteger]
+    | np.dtype[np.unsignedinteger]
+    | _SupportsDType[np.dtype[np.unsignedinteger]]
+    | _UInt8Codes
+    | _UInt16Codes
+    | _UInt32Codes
+    | _UInt64Codes
+    | _UByteCodes
+    | _UShortCodes
+    | _UIntCCodes
+    | _LongCodes
+    | _ULongLongCodes
+    | _UIntPCodes
+    | _UIntCodes
+)
+_DTypeLikeInt: TypeAlias = (
+    type[int]
+    | type[np.signedinteger]
+    | np.dtype[np.signedinteger]
+    | _SupportsDType[np.dtype[np.signedinteger]]
+    | _Int8Codes
+    | _Int16Codes
+    | _Int32Codes
+    | _Int64Codes
+    | _ByteCodes
+    | _ShortCodes
+    | _IntCCodes
+    | _LongCodes
+    | _LongLongCodes
+    | _IntPCodes
+    | _IntCodes
+)
+_DTypeLikeFloat: TypeAlias = (
+    type[float]
+    | type[np.floating]
+    | np.dtype[np.floating]
+    | _SupportsDType[np.dtype[np.floating]]
+    | _Float16Codes
+    | _Float32Codes
+    | _Float64Codes
+    | _HalfCodes
+    | _SingleCodes
+    | _DoubleCodes
+    | _LongDoubleCodes
+)
+_DTypeLikeComplex: TypeAlias = (
+    type[complex]
+    | type[np.complexfloating]
+    | np.dtype[np.complexfloating]
+    | _SupportsDType[np.dtype[np.complexfloating]]
+    | _Complex64Codes
+    | _Complex128Codes
+    | _CSingleCodes
+    | _CDoubleCodes
+    | _CLongDoubleCodes
+)
+_DTypeLikeDT64: TypeAlias = (
+    type[np.timedelta64]
+    | np.dtype[np.timedelta64]
+    | _SupportsDType[np.dtype[np.timedelta64]]
+    | _TD64Codes
+)
+_DTypeLikeTD64: TypeAlias = (
+    type[np.datetime64]
+    | np.dtype[np.datetime64]
+    | _SupportsDType[np.dtype[np.datetime64]]
+    | _DT64Codes
+)
+_DTypeLikeStr: TypeAlias = (
+    type[str]
+    | type[np.str_]
+    | np.dtype[np.str_]
+    | _SupportsDType[np.dtype[np.str_]]
+    | _StrCodes
+)
+_DTypeLikeBytes: TypeAlias = (
+    type[bytes]
+    | type[np.bytes_]
+    | np.dtype[np.bytes_]
+    | _SupportsDType[np.dtype[np.bytes_]]
+    | _BytesCodes
+)
+_DTypeLikeVoid: TypeAlias = (
+    type[np.void]
+    | np.dtype[np.void]
+    | _SupportsDType[np.dtype[np.void]]
+    | _VoidCodes
+    | _VoidDTypeLike
+)
+_DTypeLikeObject: TypeAlias = (
+    type
+    | np.dtype[np.object_]
+    | _SupportsDType[np.dtype[np.object_]]
+    | _ObjectCodes
+)
 
-_DTypeLikeComplex_co: TypeAlias = Union[
-    _DTypeLikeBool,
-    _DTypeLikeUInt,
-    _DTypeLikeInt,
-    _DTypeLikeFloat,
-    _DTypeLikeComplex,
-]
+_DTypeLikeComplex_co: TypeAlias = (
+    _DTypeLikeBool
+    | _DTypeLikeUInt
+    | _DTypeLikeInt
+    | _DTypeLikeFloat
+    | _DTypeLikeComplex
+)

--- a/numpy/_typing/_scalars.py
+++ b/numpy/_typing/_scalars.py
@@ -1,34 +1,27 @@
-from typing import Any, TypeAlias, Union
+from typing import Any, TypeAlias
 
 import numpy as np
 
 # NOTE: `_StrLike_co` and `_BytesLike_co` are pointless, as `np.str_` and
 # `np.bytes_` are already subclasses of their builtin counterpart
 
-_CharLike_co: TypeAlias = Union[str, bytes]
+_CharLike_co: TypeAlias = str | bytes
 
 # The 6 `<X>Like_co` type-aliases below represent all scalars that can be
 # coerced into `<X>` (with the casting rule `same_kind`)
-_BoolLike_co: TypeAlias = Union[bool, np.bool]
-_UIntLike_co: TypeAlias = Union[_BoolLike_co, np.unsignedinteger[Any]]
-_IntLike_co: TypeAlias = Union[_BoolLike_co, int, np.integer[Any]]
-_FloatLike_co: TypeAlias = Union[_IntLike_co, float, np.floating[Any]]
-_ComplexLike_co: TypeAlias = Union[
-    _FloatLike_co,
-    complex,
-    np.complexfloating[Any, Any],
-]
-_TD64Like_co: TypeAlias = Union[_IntLike_co, np.timedelta64]
+_BoolLike_co: TypeAlias = bool | np.bool
+_UIntLike_co: TypeAlias = np.unsignedinteger[Any] | _BoolLike_co
+_IntLike_co: TypeAlias = int | np.integer[Any] | _BoolLike_co
+_FloatLike_co: TypeAlias = float | np.floating[Any] | _IntLike_co
+_ComplexLike_co: TypeAlias = (
+    complex
+    | np.complexfloating[Any, Any]
+    | _FloatLike_co
+)
+_TD64Like_co: TypeAlias = np.timedelta64 | _IntLike_co
 
-_NumberLike_co: TypeAlias = Union[int, float, complex, np.number[Any], np.bool]
-_ScalarLike_co: TypeAlias = Union[
-    int,
-    float,
-    complex,
-    str,
-    bytes,
-    np.generic,
-]
+_NumberLike_co: TypeAlias = int | float | complex | np.number[Any] | np.bool
+_ScalarLike_co: TypeAlias = int | float | complex | str | bytes | np.generic
 
 # `_VoidLike_co` is technically not a scalar, but it's close enough
-_VoidLike_co: TypeAlias = Union[tuple[Any, ...], np.void]
+_VoidLike_co: TypeAlias = tuple[Any, ...] | np.void


### PR DESCRIPTION
Since Python 3.10 ``typing.Union[A, B]`` has been deprecated in favour of the ``A | B`` operator.
See https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional .

Note that the remaining ``typing.Union`` uses in ``numpy._array_api_info`` are already dealt with in  #26873.