### PR TITLE
TYP: Replace ``typing.Optional[T]`` with ``T | None`` in the ``numpy.typing`` tests

### DIFF
--- a/numpy/typing/tests/data/pass/arithmetic.py
+++ b/numpy/typing/tests/data/pass/arithmetic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 import numpy as np
 import pytest
 
@@ -26,8 +26,8 @@ i = int(1)
 
 
 class Object:
-    def __array__(self, dtype: Optional[np.typing.DTypeLike] = None,
-                  copy: Optional[bool] = None) -> np.ndarray[Any, np.dtype[np.object_]]:
+    def __array__(self, dtype: np.typing.DTypeLike = None,
+                  copy: bool | None = None) -> np.ndarray[Any, np.dtype[np.object_]]:
         ret = np.empty((), dtype=object)
         ret[()] = self
         return ret

--- a/numpy/typing/tests/data/pass/ufunclike.py
+++ b/numpy/typing/tests/data/pass/ufunclike.py
@@ -13,7 +13,7 @@ class Object:
     def __ge__(self, value: object) -> bool:
         return True
 
-    def __array__(self, dtype: np.typing.DTypeLike = None,
+    def __array__(self, dtype: np.typing.DTypeLike | None = None,
                   copy: bool | None = None) -> np.ndarray[Any, np.dtype[np.object_]]:
         ret = np.empty((), dtype=object)
         ret[()] = self

--- a/numpy/typing/tests/data/pass/ufunclike.py
+++ b/numpy/typing/tests/data/pass/ufunclike.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Optional
+from typing import Any
 import numpy as np
 
 
@@ -13,8 +13,8 @@ class Object:
     def __ge__(self, value: object) -> bool:
         return True
 
-    def __array__(self, dtype: Optional[np.typing.DTypeLike] = None,
-                  copy: Optional[bool] = None) -> np.ndarray[Any, np.dtype[np.object_]]:
+    def __array__(self, dtype: np.typing.DTypeLike = None,
+                  copy: bool | None = None) -> np.ndarray[Any, np.dtype[np.object_]]:
         ret = np.empty((), dtype=object)
         ret[()] = self
         return ret


### PR DESCRIPTION
Since Python 3.10 ``typing.Optional[T]`` has been deprecated in favour of the ``T | None`` syntax.
See https://typing.readthedocs.io/en/latest/spec/historical.html#union-and-optional .

Note that the remaining ``typing.Optional`` uses in ``numpy._array_api_info`` are already dealt with in  #26873.