### PR TITLE
BUG: index overlap copy

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1797,6 +1797,7 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
     PyArray_Descr *descr = PyArray_DESCR(self);
     PyArrayObject *view = NULL;
     PyArrayObject *tmp_arr = NULL;
+    PyObject *copy, *deepcopy;
     npy_index_info indices[NPY_MAXDIMS * 2 + 1];
 
     PyArrayMapIterObject *mit = NULL;
@@ -1968,6 +1969,22 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
 
     if (tmp_arr && solve_may_share_memory(self, tmp_arr, 1) != 0) {
         Py_SETREF(tmp_arr, (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER));
+    }
+    if (index_has_memory_overlap(self, index_type, indices, index_num, (PyObject *)tmp_arr) == 1) {
+        copy = PyImport_ImportModule("copy");
+        if (copy == NULL) {
+            goto fail;
+        }
+        deepcopy = PyObject_GetAttrString(copy, "deepcopy");
+        if (deepcopy == NULL) {
+            Py_DECREF(copy);
+            goto fail;
+        }
+        Py_DECREF(copy);
+        PyObject *args = PyTuple_Pack(1, indices->object);
+        Py_SETREF(indices->object, PyObject_CallObject(deepcopy, args));
+        Py_DECREF(deepcopy);
+        Py_DECREF(args);
     }
 
     /*

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1797,7 +1797,6 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
     PyArray_Descr *descr = PyArray_DESCR(self);
     PyArrayObject *view = NULL;
     PyArrayObject *tmp_arr = NULL;
-    PyObject *copy, *deepcopy;
     npy_index_info indices[NPY_MAXDIMS * 2 + 1];
 
     PyArrayMapIterObject *mit = NULL;
@@ -1971,20 +1970,7 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
         Py_SETREF(tmp_arr, (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER));
     }
     if (index_has_memory_overlap(self, index_type, indices, index_num, (PyObject *)tmp_arr) == 1) {
-        copy = PyImport_ImportModule("copy");
-        if (copy == NULL) {
-            goto fail;
-        }
-        deepcopy = PyObject_GetAttrString(copy, "deepcopy");
-        if (deepcopy == NULL) {
-            Py_DECREF(copy);
-            goto fail;
-        }
-        Py_DECREF(copy);
-        PyObject *args = PyTuple_Pack(1, indices->object);
-        Py_SETREF(indices->object, PyObject_CallObject(deepcopy, args));
-        Py_DECREF(deepcopy);
-        Py_DECREF(args);
+        Py_SETREF(indices->object, PyArray_NewCopy((PyArrayObject *)indices->object, NPY_KEEPORDER));
     }
 
     /*

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1969,8 +1969,14 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
     if (tmp_arr && solve_may_share_memory(self, tmp_arr, 1) != 0) {
         Py_SETREF(tmp_arr, (PyArrayObject *)PyArray_NewCopy(tmp_arr, NPY_ANYORDER));
     }
-    if (index_has_memory_overlap(self, index_type, indices, index_num, (PyObject *)tmp_arr) == 1) {
-        Py_SETREF(indices->object, PyArray_NewCopy((PyArrayObject *)indices->object, NPY_KEEPORDER));
+    for (i = 0; i < index_num; ++i) {
+        if (indices[i].object != NULL && PyArray_Check(indices[i].object) &&
+            solve_may_share_memory(self, (PyArrayObject *)indices[i].object, 1) != 0) {
+                Py_SETREF(indices[i].object, PyArray_Copy((PyArrayObject*)indices[i].object));
+                if (indices[i].object == NULL) {
+                    goto fail;
+                }
+        }
     }
 
     /*

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -155,6 +155,12 @@ class TestIndexing:
         actual_vals = arr[10:]
         assert_equal(actual_vals, expected_vals)
 
+    def test_gh_26844(self):
+        expected = [0, 1, 3, 3, 3]
+        a = np.arange(5)
+        a[2:][a[:-2]] = 3
+        assert_equal(a, expected)
+
     def test_ellipsis_index(self):
         a = np.array([[1, 2, 3],
                       [4, 5, 6],

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -161,6 +161,14 @@ class TestIndexing:
         a[2:][a[:-2]] = 3
         assert_equal(a, expected)
 
+    def test_gh_26844_segfault(self):
+        # check for absence of segfault for:
+        # https://github.com/numpy/numpy/pull/26958/files#r1854589178
+        a = np.arange(5)
+        expected = [0, 1, 3, 3, 3]
+        a[2:][None, a[:-2]] = 3
+        assert_equal(a, expected)
+
     def test_ellipsis_index(self):
         a = np.array([[1, 2, 3],
                       [4, 5, 6],


### PR DESCRIPTION
* Fixes #26844

* Perform a defensive copy of array indices when the indices themselves may have memory overlap with `self`.

It does feel a bit complicated, though the tests passed locally. I was hoping to avoid usage of both `solve_may_share_memory` and `index_has_memory_overlap` in succession, since the latter contains the former, but then I think I'd need to perform both defensive copies. I wonder if it might be useful for `index_has_memory_overlap` to have a different return code for index vs. "other" overlap so that the defensive copy might be performed selectively to the type of overlap. I'm guessing my ref counting is probably missing some stuff too.