### PR TITLE
BUG: Fix out-of-bound minimum offset for in1d table method

### DIFF
--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -425,6 +425,22 @@ class TestSetOps:
         else:
             assert_array_equal(isin(ar1, ar2, kind=kind), expected)
 
+    @pytest.mark.parametrize("data", [
+        np.array([2**63, 2**63+1], dtype=np.uint64),
+        np.array([-2**62, -2**62-1], dtype=np.int64),
+    ])
+    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    def test_isin_mixed_huge_vals(self, kind, data):
+        """Test values outside intp range (negative ones if 32bit system)"""
+        query = data[1]
+        res = np.isin(data, query, kind=kind)
+        assert_array_equal(res, [False, True])
+        # Also check that nothing weird happens for values can't possibly
+        # in range.
+        data = data.astype(np.int32)  # clearly different values
+        res = np.isin(data, query, kind=kind)
+        assert_array_equal(res, [False, False])
+
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_isin_mixed_boolean(self, kind):
         """Test that isin works as expected for bool/int input."""


### PR DESCRIPTION
Backport of #26930.

We could always use ar2.dtype, but we want intp anyway, so that is nicer.  But if the minimum value doesn't fit intp, NumPy would complain (it may even guaranteed to work to force-cast, but...)

So just try to use intp, but if that doesn't work use ar2.dtype which must work, but means we'll have to cast once more (even if that cast is probably just a view in principle).

Closes gh-26922

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
