### PR TITLE
MAINT: add a 'tests' install tag to the `numpy._core._simd` extension module

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1278,6 +1278,7 @@ py.extension_module('_simd',
   link_with: [npymath_lib, _simd_mtargets.static_lib('_simd_mtargets')],
   install: true,
   subdir: 'numpy/_core',
+  install_tag: 'tests',
 )
 
 python_sources = [


### PR DESCRIPTION
This avoids installing `_simd.so` when the 'tests' install tag is omitted in order to strip the whole test suite.
This is a significant saving in binary size especially on x86-64 (see gh-25737, about 10% of the installed size).

Tested on macOS arm64 too, there `_simd.so` is 363 kb for a release build, or ~12% of the size of the main extension module (`_multiarray_umath.so`).
