### PR TITLE
BUG: fix f2py tests to work with v2 API

### DIFF
--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -115,7 +115,7 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
                        PyArray_DESCR(arr)->type,
                        PyArray_TYPE(arr),
                        PyArray_ITEMSIZE(arr),
-                       PyArray_DESCR(arr)->alignment,
+                       PyDataType_ALIGNMENT(arr),
                        PyArray_FLAGS(arr),
                        PyArray_ITEMSIZE(arr));
 }

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -332,7 +332,7 @@ def build_meson(source_files, module_name=None, **kwargs):
     # compiler stack is on the CI
     try:
         backend.compile()
-    except:
+    except subprocess.CalledProcessError:
         pytest.skip("Failed to compile module")
 
     # Import the compiled module


### PR DESCRIPTION
Backport of #26935.

Fixes #26917. I've also modernised/improved the code in the relevant test files.

CI was failing prior to a4bd4a899c9ac7530e00955e6dca4d575ded2a2d due to compiler errors in CI. Obviously not ideal reinstating this, but locally on my `macOS 14.5 arm64` all tests pass with `spin test -m full`.

This is a clear bug which CI unfortunately doesn't see because it just skips the f2py test if compilation fails (which it does here).

The error is slightly more precise now, but not precise enough to avoid that issue.