### PR TITLE
TYP: Use ``Final`` and ``LiteralString`` for the constants in ``numpy.version``

### DIFF
--- a/numpy/version.pyi
+++ b/numpy/version.pyi
@@ -1,7 +1,24 @@
-version: str
-__version__: str
-full_version: str
+import sys
+from typing import Final, TypeAlias
 
-git_revision: str
-release: bool
-short_version: str
+if sys.version_info >= (3, 11):
+    from typing import LiteralString
+else:
+    LiteralString: TypeAlias = str
+
+__all__ = (
+    '__version__',
+    'full_version',
+    'git_revision',
+    'release',
+    'short_version',
+    'version',
+)
+
+version: Final[LiteralString]
+__version__: Final[LiteralString]
+full_version: Final[LiteralString]
+
+git_revision: Final[LiteralString]
+release: Final[bool]
+short_version: Final[LiteralString]


### PR DESCRIPTION
The ``numpy.version`` members are constants, and should be treated as such (overwriting them is possible, but a bad idea).

The use of [``typing.Final``](https://typing.readthedocs.io/en/latest/spec/qualifiers.html#uppercase-final) helps linters and type-checkers to recognize them as constants, even though their names aren't uppercase. These changes are backwards-compatible, unless the values are overwritten (but I can't imagine a usecase for this).

For ``python>=3.11`` the `str` annotations have been replaced with [``typing.LiteralString``](https://typing.readthedocs.io/en/latest/spec/literal.html#literalstring), which is fully backwards-compatible with ``str``. It will help typecheckers to identify  the version strings as pre-defined constant values.

In https://github.com/numpy/numpy/pull/26871 similar changes are made in the `numpy` namespace.