### PR TITLE
DOC: add sphinx-copybutton

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,6 +87,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
     'sphinx.ext.mathjax',
+    'sphinx_copybutton',
     'sphinx_design',
 ]
 
@@ -285,6 +286,7 @@ mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
 plot_html_show_formats = False
 plot_html_show_source_link = False
 
+copybutton_prompt_text = ">>> "
 # -----------------------------------------------------------------------------
 # LaTeX output
 # -----------------------------------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -286,7 +286,9 @@ mathjax_path = "scipy-mathjax/MathJax.js?config=scipy-mathjax"
 plot_html_show_formats = False
 plot_html_show_source_link = False
 
-copybutton_prompt_text = ">>> "
+# sphinx-copybutton configurations
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 # -----------------------------------------------------------------------------
 # LaTeX output
 # -----------------------------------------------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - mypy=1.10.0
   # For building docs
   - sphinx>=4.5.0
+  - sphinx-copybutton
   - sphinx-design
   - numpydoc=1.4.0
   - ipython

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -2,6 +2,7 @@
 sphinx==7.2.6
 numpydoc==1.4
 pydata-sphinx-theme>=0.15.2
+sphinx-copybutton
 sphinx-design
 scipy
 matplotlib


### PR DESCRIPTION
This PR adds the `sphinx-copybutton` to the docs.

![numpy_copybutton](https://github.com/user-attachments/assets/902d7bde-3410-477a-894a-d6b6e313a87e)

 - [x] fixes https://github.com/numpy/numpy/issues/26948
