### PR TITLE
ENH: add support in f2py to declare gil-disabled support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -310,16 +310,4 @@ jobs:
     - name: Install nightly Cython
       run: |
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-    # Set PYTHON_GIL=0 to force GIL off during tests and then manually verify
-    # importing numpy does not enable the GIL. When f2py grows the ability to
-    # declare GIL-disabled support we can just run the tests without the
-    # environment variable
     - uses: ./.github/meson_actions
-      env:
-        PYTHON_GIL: 0
-    - name: Verify import does not re-enable GIL
-      run: |
-        if [[ $(python -c "import numpy" 2>&1) == "*The global interpreter lock (GIL) has been enabled*" ]]; then
-            echo "Error: Importing NumPy re-enables the GIL in the free-threaded build"
-            exit 1
-        fi

--- a/doc/release/upcoming_changes/26981.new_feature.rst
+++ b/doc/release/upcoming_changes/26981.new_feature.rst
@@ -1,0 +1,9 @@
+``f2py`` can generate freethreading-compatible C extensions
+-----------------------------------------------------------
+
+Pass ``--freethreading-compatible`` to the f2py CLI tool to produce a C
+extension marked as compatible with the free threading CPython
+interpreter. Doing so prevents the interpreter from re-enabling the GIL at
+runtime when it imports the C extension. Note that ``f2py`` does not analyze
+fortran code for thread safety, so you must verify that the wrapped fortran
+code is thread safe before marking the extension as compatible.

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -86,12 +86,12 @@ Here ``<fortran files>`` may also contain signature files. Among other options
   ``--wrap-functions`` is default because it ensures maximum portability and
   compiler independence.
 
-``--[no-]requires-gil``
+``--[no-]freethreading-compatible``
   Create a module that declares it does or doesn't require the GIL. The default
-  is ``--requires-gil`` for backwards compatibility. Inspect the fortran
-  code you are wrapping for thread safety issues before passing
-  ``--no-requires-gil``, as ``f2py`` does not analyze fortran code for thread
-  safety issues.
+  is ``--no-freethreading-compatible`` for backwards compatibility. Inspect the
+  fortran code you are wrapping for thread safety issues before passing
+  ``--freethreading-compatible``, as ``f2py`` does not analyze fortran code for
+  thread safety issues.
 
 ``--include-paths "<path1>:<path2>..."``
   Search include files from given directories.

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -86,6 +86,13 @@ Here ``<fortran files>`` may also contain signature files. Among other options
   ``--wrap-functions`` is default because it ensures maximum portability and
   compiler independence.
 
+``--[no-]requires-gil``
+  Create a module that declares it does or doesn't require the GIL. The default
+  is ``--requires-gil`` for backwards compatibility. Inspect the fortran
+  code you are wrapping for thread safety issues before passing
+  ``--no-requires-gil``, as ``f2py`` does not analyze fortran code for thread
+  safety issues.
+
 ``--include-paths "<path1>:<path2>..."``
   Search include files from given directories.
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -87,15 +87,16 @@ def pytest_sessionstart(session):
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if NOGIL_BUILD and not gil_enabled_at_start and sys._is_gil_enabled():
-        terminalreporter.ensure_newline()
-        terminalreporter.section("GIL re-enabled", sep="=", red=True, bold=True)
-        terminalreporter.line("The GIL was re-enabled at runtime during the tests.")
-        terminalreporter.line("This can happen with no test failures if the RuntimeWarning")
-        terminalreporter.line("raised by Python when this happens is filtered by a test.")
-        terminalreporter.line("")
-        terminalreporter.line("Please ensure all new C modules declare support for running")
-        terminalreporter.line("without the GIL. Any new tests that intentionally imports code")
-        terminalreporter.line("that re-enables the GIL should do so in a subprocess.")
+        tr = terminalreporter
+        tr.ensure_newline()
+        tr.section("GIL re-enabled", sep="=", red=True, bold=True)
+        tr.line("The GIL was re-enabled at runtime during the tests.")
+        tr.line("This can happen with no test failures if the RuntimeWarning")
+        tr.line("raised by Python when this happens is filtered by a test.")
+        tr.line("")
+        tr.line("Please ensure all new C modules declare support for running")
+        tr.line("without the GIL. Any new tests that intentionally imports ")
+        tr.line("code that re-enables the GIL should do so in a subprocess.")
         pytest.exit("GIL re-enabled during tests", returncode=1)
 
 #FIXME when yield tests are gone.

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -2,6 +2,7 @@
 Pytest configuration and fixtures for the Numpy test suite.
 """
 import os
+import sys
 import tempfile
 from contextlib import contextmanager
 import warnings
@@ -11,6 +12,7 @@ import pytest
 import numpy
 
 from numpy._core._multiarray_tests import get_fpu_mode
+from numpy.testing._private.utils import NOGIL_BUILD
 
 try:
     from scipy_doctest.conftest import dt_config
@@ -72,11 +74,29 @@ def pytest_addoption(parser):
                            "automatically."))
 
 
+gil_enabled_at_start = True
+if NOGIL_BUILD:
+    gil_enabled_at_start = sys._is_gil_enabled()
+
+
 def pytest_sessionstart(session):
     available_mem = session.config.getoption('available_memory')
     if available_mem is not None:
         os.environ['NPY_AVAILABLE_MEM'] = available_mem
 
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if NOGIL_BUILD and not gil_enabled_at_start and sys._is_gil_enabled():
+        terminalreporter.ensure_newline()
+        terminalreporter.section("GIL re-enabled", sep="=", red=True, bold=True)
+        terminalreporter.line("The GIL was re-enabled at runtime during the tests.")
+        terminalreporter.line("This can happen with no test failures if the RuntimeWarning")
+        terminalreporter.line("raised by Python when this happens is filtered by a test.")
+        terminalreporter.line("")
+        terminalreporter.line("Please ensure all new C modules declare support for running")
+        terminalreporter.line("without the GIL. Any new tests that intentionally imports code")
+        terminalreporter.line("that re-enables the GIL should do so in a subprocess.")
+        pytest.exit("GIL re-enabled during tests", returncode=1)
 
 #FIXME when yield tests are gone.
 @pytest.hookimpl()

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -689,6 +689,8 @@ def modsign2map(m):
     else:
         ret['interface_usercode'] = ''
     ret['pymethoddef'] = getpymethoddef(m) or ''
+    if 'gil_used' in m:
+        ret['gil_used'] = m['gil_used']
     if 'coutput' in m:
         ret['coutput'] = m['coutput']
     if 'f2py_wrapper_output' in m:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -106,12 +106,13 @@ Options:
                    functions. --wrap-functions is default because it ensures
                    maximum portability/compiler independence.
 
-  --[no-]requires-gil    Create a module that declares it does or doesn't
-                   require the GIL. The default is --requires-gil for
-                   backward compatibility. Inspect the Fortran code you are
-                   wrapping for thread safety issues before passing
-                   --no-requires-gil, as ``f2py`` does not analyze fortran
-                   code for thread safety issues.
+  --[no-]freethreading-compatible    Create a module that declares it does or
+                   doesn't require the GIL. The default is
+                   --freethreading-compatible for backward
+                   compatibility. Inspect the Fortran code you are wrapping for
+                   thread safety issues before passing
+                   --no-freethreading-compatible, as f2py does not analyze
+                   fortran code for thread safety issues.
 
   --include-paths <path1>:<path2>:...   Search include files from the given
                    directories.
@@ -269,9 +270,9 @@ def scaninputline(inputline):
             cfuncs.userincludes[l[9:-1]] = '#include ' + l[8:]
         elif l == '--skip-empty-wrappers':
             emptygen = False
-        elif l == '--requires-gil':
+        elif l == '--no-freethreading-compatible':
             requires_gil = 1
-        elif l == '--no-requires-gil':
+        elif l == '--freethreading-compatible':
             requires_gil = 0
         elif l[0] == '-':
             errmess('Unknown option %s\n' % repr(l))
@@ -633,7 +634,7 @@ def run_compile():
         sysinfo_flags = [f[7:] for f in sysinfo_flags]
 
     _reg2 = re.compile(
-        r'--((no-|)(wrap-functions|lower|requires-gil)|debug-capi|quiet|skip-empty-wrappers)|-include')
+        r'--((no-|)(wrap-functions|lower|freethreading-compatible)|debug-capi|quiet|skip-empty-wrappers)|-include')
     f2py_flags = [_m for _m in sys.argv[1:] if _reg2.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in f2py_flags]
     f2py_flags2 = []

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -236,6 +236,11 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 #initcommonhooks#
 #interface_usercode#
 
+#if Py_GIL_DISABLED
+    // signal whether this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m , #gil_used#);
+#endif
+
 #ifdef F2PY_REPORT_ATEXIT
     if (! PyErr_Occurred())
         on_exit(f2py_report_on_exit,(void*)\"#modulename#\");

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -115,7 +115,7 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
                        PyArray_DESCR(arr)->type,
                        PyArray_TYPE(arr),
                        PyArray_ITEMSIZE(arr),
-                       PyDataType_ALIGNMENT(arr),
+                       PyDataType_ALIGNMENT(PyArray_DESCR(arr)),
                        PyArray_FLAGS(arr),
                        PyArray_ITEMSIZE(arr));
 }
@@ -214,13 +214,18 @@ PyMODINIT_FUNC PyInit_test_array_from_pyobj_ext(void) {
   ADDCONST("DEFAULT", NPY_ARRAY_DEFAULT);
   ADDCONST("UPDATE_ALL", NPY_ARRAY_UPDATE_ALL);
 
-#undef ADDCONST(
+#undef ADDCONST
 
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap");
 
 #ifdef F2PY_REPORT_ATEXIT
   on_exit(f2py_report_on_exit,(void*)"array_from_pyobj.wrap.call");
+#endif
+
+#if Py_GIL_DISABLED
+    // signal whether this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
   return m;

--- a/numpy/f2py/tests/test_abstract_interface.py
+++ b/numpy/f2py/tests/test_abstract_interface.py
@@ -6,8 +6,6 @@ from numpy.f2py import crackfortran
 from numpy.testing import IS_WASM
 
 
-@pytest.mark.filterwarnings(r"ignore:.*The global interpreter lock \(GIL\) "
-                            r"has been enabled.*:RuntimeWarning")
 @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
 @pytest.mark.slow
 class TestAbstractInterface(util.F2PyTest):

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -11,8 +11,6 @@ from numpy.testing import IS_PYPY
 from . import util
 
 
-@pytest.mark.filterwarnings(r"ignore:.*The global interpreter lock \(GIL\) "
-                            r"has been enabled.*:RuntimeWarning")
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -760,7 +760,7 @@ def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd = f"{sys.executable} -c \"import sys; print(sys._is_gil_enabled()); import blah; blah.hi();"
+        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
         if NOGIL_BUILD:
             cmd += "import sys; assert sys._is_gil_enabled() is True\""
         else:

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -751,16 +751,16 @@ def test_npdistop(hello_world_f90, monkeypatch):
 
 @pytest.mark.skipif(sys.version_info <= (3, 12),
                     reason='Python 3.12 or newer required')
-def test_requires_gil(hello_world_f90, monkeypatch):
+def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
     """
-    CLI :: --requires-gil
+    CLI :: --no-freethreading-compatible
     """
     ipath = Path(hello_world_f90)
-    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --requires-gil'.split())
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --no-freethreading-compatible'.split())
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
+        cmd = f"{sys.executable} -c \"import sys; print(sys._is_gil_enabled()); import blah; blah.hi();"
         if NOGIL_BUILD:
             cmd += "import sys; assert sys._is_gil_enabled() is True\""
         else:
@@ -776,12 +776,12 @@ def test_requires_gil(hello_world_f90, monkeypatch):
 
 @pytest.mark.skipif(sys.version_info <= (3, 12),
                     reason='Python 3.12 or newer required')
-def test_no_requires_gil(hello_world_f90, monkeypatch):
+def test_freethreading_compatible(hello_world_f90, monkeypatch):
     """
-    CLI :: --no-requires-gil
+    CLI :: --freethreading_compatible
     """
     ipath = Path(hello_world_f90)
-    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --no-requires-gil'.split())
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --freethreading-compatible'.split())
 
     with util.switchdir(ipath.parent):
         f2pycli()

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -749,6 +749,8 @@ def test_npdistop(hello_world_f90, monkeypatch):
         assert rout.stdout == eout
 
 
+@pytest.mark.skipif(sys.version_info <= (3, 12),
+                    reason='Python 3.12 or newer required')
 def test_requires_gil(hello_world_f90, monkeypatch):
     """
     CLI :: --requires-gil
@@ -772,6 +774,8 @@ def test_requires_gil(hello_world_f90, monkeypatch):
         assert rout.returncode == 0
 
 
+@pytest.mark.skipif(sys.version_info <= (3, 12),
+                    reason='Python 3.12 or newer required')
 def test_no_requires_gil(hello_world_f90, monkeypatch):
     """
     CLI :: --no-requires-gil

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -7,6 +7,7 @@ import pytest
 
 from . import util
 from numpy.f2py.f2py2e import main as f2pycli
+from numpy.testing._private.utils import NOGIL_BUILD
 
 #########################
 # CLI utils and classes #
@@ -573,7 +574,7 @@ def test_debugcapi_bld(hello_world_f90, monkeypatch):
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd_run = shlex.split("python3 -c \"import blah; blah.hi()\"")
+        cmd_run = shlex.split(f"{sys.executable} -c \"import blah; blah.hi()\"")
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         eerr = textwrap.dedent("""\
@@ -742,15 +743,59 @@ def test_npdistop(hello_world_f90, monkeypatch):
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd_run = shlex.split("python -c \"import blah; blah.hi()\"")
+        cmd_run = shlex.split(f"{sys.executable} -c \"import blah; blah.hi()\"")
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         assert rout.stdout == eout
 
 
+def test_requires_gil(hello_world_f90, monkeypatch):
+    """
+    CLI :: --requires-gil
+    """
+    ipath = Path(hello_world_f90)
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --requires-gil'.split())
+
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
+        if NOGIL_BUILD:
+            cmd += "import sys; assert sys._is_gil_enabled() is True\""
+        else:
+            cmd += "\""
+        cmd_run = shlex.split(cmd)
+        rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
+        eout = ' Hello World\n'
+        assert rout.stdout == eout
+        if NOGIL_BUILD:
+            assert "The global interpreter lock (GIL) has been enabled to load module 'blah'" in rout.stderr
+        assert rout.returncode == 0
+
+
+def test_no_requires_gil(hello_world_f90, monkeypatch):
+    """
+    CLI :: --no-requires-gil
+    """
+    ipath = Path(hello_world_f90)
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --no-requires-gil'.split())
+
+    with util.switchdir(ipath.parent):
+        f2pycli()
+        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
+        if NOGIL_BUILD:
+            cmd += "import sys; assert sys._is_gil_enabled() is False\""
+        else:
+            cmd += "\""
+        cmd_run = shlex.split(cmd)
+        rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
+        eout = ' Hello World\n'
+        assert rout.stdout == eout
+        assert rout.stderr == ""
+        assert rout.returncode == 0
+
+
 # Numpy distutils flags
 # TODO: These should be tested separately
-
 
 def test_npd_fcompiler():
     """

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -130,9 +130,9 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     if module_name is None:
         module_name = get_temp_module_name()
     gil_options = []
-    if '--requires-gil' not in options and '--no-requires-gil' not in options:
+    if '--freethreading-compatible' not in options and '--no-freethreading-compatible' not in options:
         # default to disabling the GIL if unset in options
-        gil_options = ['--no-requires-gil']
+        gil_options = ['--freethreading-compatible']
     f2py_opts = ["-c", "-m", module_name] + options + gil_options + f2py_sources
     f2py_opts += ["--backend", "meson"]
     if skip:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -129,7 +129,11 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     # Prepare options
     if module_name is None:
         module_name = get_temp_module_name()
-    f2py_opts = ["-c", "-m", module_name] + options + f2py_sources
+    gil_options = []
+    if '--requires-gil' not in options and '--no-requires-gil' not in options:
+        # default to disabling the GIL if unset in options
+        gil_options = ['--no-requires-gil']
+    f2py_opts = ["-c", "-m", module_name] + options + gil_options + f2py_sources
     f2py_opts += ["--backend", "meson"]
     if skip:
         f2py_opts += ["skip:"] + skip

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -36,18 +36,12 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     # Manually check that importing NumPy does not re-enable the GIL.
-    # Afterwards, force the GIL to always be disabled so it does not get
-    # re-enabled during the tests.
-    #
-    # TODO: delete when f2py grows the ability to define extensions that declare
-    # they can run without the gil or when we can work around the fact the f2py
-    # tests import modules that don't declare gil-disabled support.
+    # In principle the tests should catch this but it seems harmless to leave it
+    # here as a final sanity check before uploading broken wheels
     if [[ $(python -c "import numpy" 2>&1) == "*The global interpreter lock (GIL) has been enabled*" ]]; then
         echo "Error: Importing NumPy re-enables the GIL in the free-threaded build"
         exit 1
     fi
-
-    export PYTHON_GIL=0
 fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across


### PR DESCRIPTION
This adds two new flags to the f2py CLI: `--[no-]requires-gil`, defaulting to `--requires-gil`. This allows f2py to generate modules that declare they support running without the GIL. I added tests and docs and can expand on those if anyone has suggestions.

As far as the thread safety of the f2py wrapper code, I did an audit on the lapack wrappers in f2py and some test wrappers I generated based on the f2py tests. I didn't see any thread safety issues there. There is also already special handling to make sure callbacks are thread safe. See [this gist](https://gist.github.com/rgommers/7c722bfd79c48753900d86668884faf6) where Ralf and I were looking at this.

This also adds some support in NumPy's tests to make sure the GIL never gets re-enabled during the tests. Happy to split off the testing changes from the f2py changes if they are controversial.

It uses `pytest.exit()` and when it fails it looks like this:

<details>

```
± spin test -m full numpy/f2py/tests/test_abstract_interface.py
Invoking `build` prior to running tests:
$ /Users/goldbaum/.pyenv/versions/3.13.0b3t/bin/python vendored-meson/meson/meson.py compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /Users/goldbaum/.pyenv/versions/3.13.0b3t/bin/ninja -C /Users/goldbaum/Documents/numpy/build
ninja: Entering directory `/Users/goldbaum/Documents/numpy/build'
[1/1] Generating numpy/generate-version with a custom command
Saving version to numpy/version.py
$ /Users/goldbaum/.pyenv/versions/3.13.0b3t/bin/python vendored-meson/meson/meson.py install --only-changed -C build --destdir ../build-install
$ export PYTHONPATH="/Users/goldbaum/Documents/numpy/build-install/usr/lib/python3.13/site-packages"
$ export PYTHONPATH="/Users/goldbaum/Documents/numpy/build-install/usr/lib/python3.13/site-packages"
$ /Users/goldbaum/.pyenv/versions/3.13.0b3t/bin/python -P -c 'import numpy'
$ cd /Users/goldbaum/Documents/numpy/build-install/usr/lib/python3.13/site-packages
$ /Users/goldbaum/.pyenv/versions/3.13.0b3t/bin/python -P -m pytest --import-mode=importlib --pyargs numpy/f2py/tests/test_abstract_interface.py
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.13.0b3, pytest-8.2.2, pluggy-1.5.0
rootdir: /Users/goldbaum/Documents/numpy
configfile: pytest.ini
plugins: repeat-0.9.3, hypothesis-6.104.2
collected 2 items

numpy/f2py/tests/test_abstract_interface.py ..                                                                                              [100%]

================================================================= GIL re-enabled ==================================================================
The GIL was re-enabled at runtime during the tests.
This can happen with no test failures if the RuntimeWarning
raised by Python when this happens is filtered by a test.

Please ensure all new C modules declare support for running
without the GIL. Any new tests that intentionally imports code
that re-enables the GIL should do so in a subprocess.
Exit: GIL re-enabled during tests
```

</details>

In that example I forced the failure by updating to the `main` branch and applied the `conftest.py` changes from this PR.

So, no regular final pytest output about how many tests passed, failed, xpassed, etc, just a message saying `Exit: GIL re-enabled during tests`. Unfortunately I don't see a nicer way to fail the whole test suite after the tests are finished running using the pytest API, but maybe someone knows a better way?