### PR TITLE
TYP,BUG: Type annotations for ``numpy.trapezoid``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -462,6 +462,7 @@ from numpy.lib._function_base_impl import (
     append as append,
     interp as interp,
     quantile as quantile,
+    trapezoid as trapezoid,
 )
 
 from numpy.lib._histograms_impl import (

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -638,7 +638,7 @@ quantile = percentile
 
 _SCT_fm = TypeVar(
     "_SCT_fm",
-    bound=floating[Any] | complexfloating[ANy, Any] | timedelta64,
+    bound=floating[Any] | complexfloating[Any, Any] | timedelta64,
 )
 
 class _SupportsRMulFloat(Protocol[_T_co]):

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -13,6 +13,7 @@ from typing import (
 from numpy import (
     vectorize as vectorize,
     generic,
+    integer,
     floating,
     complexfloating,
     intp,
@@ -21,6 +22,7 @@ from numpy import (
     timedelta64,
     datetime64,
     object_,
+    bool as bool_,
     _OrderKACF,
 )
 
@@ -632,6 +634,68 @@ def percentile(
 # NOTE: Not an alias, but they do have identical signatures
 # (that we can reuse)
 quantile = percentile
+
+
+_SCT_fm = TypeVar(
+    "_SCT_fm",
+    bound=floating[Any] | complexfloating[ANy, Any] | timedelta64,
+)
+
+class _SupportsRMulFloat(Protocol[_T_co]):
+    def __rmul__(self, other: float, /) -> _T_co: ...
+
+@overload
+def trapezoid(  # type: ignore[overload-overlap]
+    y: Sequence[_FloatLike_co],
+    x: Sequence[_FloatLike_co] | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> float64: ...
+@overload
+def trapezoid(
+    y: Sequence[_ComplexLike_co],
+    x: Sequence[_ComplexLike_co] | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> complex128: ...
+@overload
+def trapezoid(
+    y: _ArrayLike[bool_ | integer[Any]],
+    x: _ArrayLike[bool_ | integer[Any]] | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> float64 | NDArray[float64]: ...
+@overload
+def trapezoid(  # type: ignore[overload-overlap]
+    y: _ArrayLikeObject_co,
+    x: _ArrayLikeFloat_co | _ArrayLikeObject_co | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> float | NDArray[object_]: ...
+@overload
+def trapezoid(
+    y: _ArrayLike[_SCT_fm],
+    x: _ArrayLike[_SCT_fm] | _ArrayLikeInt_co | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> _SCT_fm | NDArray[_SCT_fm]: ...
+@overload
+def trapezoid(
+    y: Sequence[_SupportsRMulFloat[_T]],
+    x: Sequence[_SupportsRMulFloat[_T] | _T] | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> _T: ...
+@overload
+def trapezoid(
+    y: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    x: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co | None = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> (
+    floating[Any] | complexfloating[Any, Any] | timedelta64
+    | NDArray[floating[Any] | complexfloating[Any, Any] | timedelta64 | object_]
+): ...
 
 def meshgrid(
     *xi: ArrayLike,

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -1,4 +1,5 @@
 import sys
+from fractions import Fraction
 from typing import Any
 from collections.abc import Callable
 
@@ -14,6 +15,8 @@ vectorized_func: np.vectorize
 
 f8: np.float64
 AR_LIKE_f8: list[float]
+AR_LIKE_c16: list[complex]
+AR_LIKE_O: list[Fraction]
 
 AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]
@@ -158,6 +161,21 @@ assert_type(np.quantile(AR_O, [0.5]), npt.NDArray[np.object_])
 assert_type(np.quantile(AR_f8, [0.5], keepdims=True), Any)
 assert_type(np.quantile(AR_f8, [0.5], axis=[1]), Any)
 assert_type(np.quantile(AR_f8, [0.5], out=AR_c16), npt.NDArray[np.complex128])
+
+assert_type(np.trapezoid(AR_LIKE_f8), np.float64)
+assert_type(np.trapezoid(AR_LIKE_f8, AR_LIKE_f8), np.float64)
+assert_type(np.trapezoid(AR_LIKE_c16), np.complex128)
+assert_type(np.trapezoid(AR_LIKE_c16, AR_LIKE_f8), np.complex128)
+assert_type(np.trapezoid(AR_LIKE_f8, AR_LIKE_c16), np.complex128)
+assert_type(np.trapezoid(AR_LIKE_O), float)
+assert_type(np.trapezoid(AR_LIKE_O, AR_LIKE_f8), float)
+assert_type(np.trapezoid(AR_f8), np.float64 | npt.NDArray[np.float64])
+assert_type(np.trapezoid(AR_f8, AR_f8), np.float64 | npt.NDArray[np.float64])
+assert_type(np.trapezoid(AR_c16), np.complex128 | npt.NDArray[np.complex128])
+assert_type(np.trapezoid(AR_c16, AR_c16), np.complex128 | npt.NDArray[np.complex128])
+assert_type(np.trapezoid(AR_m), np.timedelta64 | npt.NDArray[np.timedelta64])
+assert_type(np.trapezoid(AR_O), float | npt.NDArray[np.object_])
+assert_type(np.trapezoid(AR_O, AR_LIKE_f8), float | npt.NDArray[np.object_])
 
 assert_type(np.meshgrid(AR_f8, AR_i8, copy=False), tuple[npt.NDArray[Any], ...])
 assert_type(np.meshgrid(AR_f8, AR_i8, AR_c16, indexing="ij"), tuple[npt.NDArray[Any], ...])


### PR DESCRIPTION
This adds the missing type annotations for ``numpy.trapezoid``, so that e.g.

```python
import numpy as np
s = np.trapezoid([1, 2, 3])
```

doesn't cause any type-checker errors anymore.
