### PR TITLE
TYP,BUG: Fix potentially unresolved typevar in ``median`` and ``percentile``

### DIFF
--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -462,8 +462,18 @@ def median(
 @overload
 def median(
     a: _ArrayLikeFloat_co | _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike,
+    out: _ArrayType,
+    /,
+    overwrite_input: bool = ...,
+    keepdims: bool = ...,
+) -> _ArrayType: ...
+@overload
+def median(
+    a: _ArrayLikeFloat_co | _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
     axis: None | _ShapeLike = ...,
-    out: _ArrayType = ...,
+    *,
+    out: _ArrayType,
     overwrite_input: bool = ...,
     keepdims: bool = ...,
 ) -> _ArrayType: ...
@@ -620,12 +630,25 @@ def percentile(
 def percentile(
     a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
     q: _ArrayLikeFloat_co,
-    axis: None | _ShapeLike = ...,
-    out: _ArrayType = ...,
+    axis: None | _ShapeLike,
+    out: _ArrayType,
+    /,
     overwrite_input: bool = ...,
     method: _MethodKind = ...,
     keepdims: bool = ...,
     *,
+    weights: None | _ArrayLikeFloat_co = ...,
+) -> _ArrayType: ...
+@overload
+def percentile(
+    a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    q: _ArrayLikeFloat_co,
+    axis: None | _ShapeLike = ...,
+    *,
+    out: _ArrayType,
+    overwrite_input: bool = ...,
+    method: _MethodKind = ...,
+    keepdims: bool = ...,
     weights: None | _ArrayLikeFloat_co = ...,
 ) -> _ArrayType: ...
 


### PR DESCRIPTION
This resolves the following Pyright error message in the ``numpy._function_base_impl`` stubs for ``median`` and ``percentile``.

```
Type variable "_ArrayType" may go unsolved if caller supplies no argument for parameter "out"
  Provide an overload that specifies the return type when the argument is not supplied
```

And even though I doubt that this is likely to cause problems in practice, it's better to solve error messages like these, than to e.g. suppress or ignore them.