### PR TITLE
DOC: fix ctypes example

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -503,17 +503,17 @@ if ctypes is not None:
         --------
         Converting a simple dtype:
 
-        >>> dt = np.dtype('i4')
+        >>> dt = np.dtype('int8')
         >>> ctype = np.ctypeslib.as_ctypes_type(dt)
         >>> ctype
-        <class 'ctypes.c_int32'>
+        <class 'ctypes.c_byte'>
 
         Converting a structured dtype:
 
         >>> dt = np.dtype([('x', 'i4'), ('y', 'f4')])
         >>> ctype = np.ctypeslib.as_ctypes_type(dt)
         >>> ctype
-        <class 'ctypes.Structure'>
+        <class 'struct'>
 
         """
         return _ctype_from_dtype(_dtype(dtype))


### PR DESCRIPTION
I'm not sure if the problem with `c_int32` is because of an AI hallucination or because of cross-platform issues, so I switched it to `int8` which should be equivalent to `c_byte` on all platforms.

The `ctypes.Structure` that was there before was a hallucination I think?