### PR TITLE
MAINT: mark scipy-openblas nightly tests as allowed to fail

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -111,7 +111,7 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
-
+      continue-on-error: true
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions
         spin test -j auto

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -111,6 +111,8 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
+      # TODO: remove when scipy-openblas nightly tests aren't failing anymore.
+      # xref gh-26824
       continue-on-error: true
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions


### PR DESCRIPTION
Once #26989 is merged, my understanding is that this will make our CI green once again.

I could also individually xfail the tests that are failing if we'd prefer that. I'm just not sure how to detect the nightly openblas wheel at runtime in the test to only xfail it in that case.

xref https://github.com/numpy/numpy/issues/26824#issuecomment-2213979707