### PR TITLE
TYP: Covariant ``numpy.ndenumerate`` type parameter

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -18,6 +18,7 @@ from numpy._typing import (
     # Arrays
     ArrayLike,
     NDArray,
+    _ArrayLike,
     _SupportsArray,
     _NestedSequence,
     _FiniteNestedSequence,
@@ -3422,8 +3423,12 @@ def _no_nep50_warning() -> Generator[None, None, None]: ...
 def _get_promotion_state() -> str: ...
 def _set_promotion_state(state: str, /) -> None: ...
 
-class ndenumerate(Generic[_ScalarType]):
-    iter: flatiter[NDArray[_ScalarType]]
+_ScalarType_co = TypeVar("_ScalarType_co", bound=generic, covariant=True)
+
+class ndenumerate(Generic[_ScalarType_co]):
+    @property
+    def iter(self) -> flatiter[NDArray[_ScalarType_co]]: ...
+
     @overload
     def __new__(
         cls, arr: _FiniteNestedSequence[_SupportsArray[dtype[_ScalarType]]],
@@ -3440,7 +3445,8 @@ class ndenumerate(Generic[_ScalarType]):
     def __new__(cls, arr: float | _NestedSequence[float]) -> ndenumerate[float64]: ...
     @overload
     def __new__(cls, arr: complex | _NestedSequence[complex]) -> ndenumerate[complex128]: ...
-    def __next__(self: ndenumerate[_ScalarType]) -> tuple[_Shape, _ScalarType]: ...
+
+    def __next__(self) -> tuple[_Shape, _ScalarType_co]: ...
     def __iter__(self: _T) -> _T: ...
 
 class ndindex:


### PR DESCRIPTION
Currently, the following code isn't accepted by typecheckers:

```python
from typing import Any
import numpy as np

def ndmax_int(
    obj: np.ndenumerate[np.integer[Any]],
) -> tuple[tuple[int, ...], np.integer[Any]]:
    return max(obj)

x: np.ndenumerate[np.int_] = np.ndenumerate(np.arange(42))
ndmax_int(x)  # error
```

Pyright reports this error as follows:

```
Argument of type "ndenumerate[int_]" cannot be assigned to parameter "obj" of type "ndenumerate[integer[Any]]" in function "ndmax_int"
  "ndenumerate[int_]" is incompatible with "ndenumerate[integer[Any]]"
    Type parameter "_ScalarType@ndenumerate" is invariant, but "int_" is not the same as "integer[Any]"
```

This PR fixes this, by making `_ScalarType@ndenumerate` covariant.