### PR TITLE
TYP,BUG: FIx ``numpy.ndenumerate`` annotations for ``object_`` sctype

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2856,6 +2856,7 @@ class bool(generic):
 
 bool_: TypeAlias = bool
 
+@final
 class object_(generic):
     def __init__(self, value: object = ..., /) -> None: ...
     @property
@@ -3452,8 +3453,20 @@ class ndenumerate(Generic[_ScalarType_co]):
     def __new__(cls, arr: float | _NestedSequence[float]) -> ndenumerate[float64]: ...
     @overload
     def __new__(cls, arr: complex | _NestedSequence[complex]) -> ndenumerate[complex128]: ...
+    @overload
+    def __new__(cls, arr: object) -> ndenumerate[object_]: ...
 
-    def __next__(self) -> tuple[_Shape, _ScalarType_co]: ...
+    # The first overload is a (semi-)workaround for a mypy bug (tested with v1.10 and v1.11)
+    @overload
+    def __next__(
+        self: ndenumerate[np.bool | datetime64 | timedelta64 | number[Any] | flexible],
+        /,
+    ) -> tuple[_Shape, _ScalarType_co]: ...
+    @overload
+    def __next__(self: ndenumerate[object_], /) -> tuple[_Shape, Any]: ...
+    @overload
+    def __next__(self, /) -> tuple[_Shape, _ScalarType_co]: ...
+
     def __iter__(self: _T) -> _T: ...
 
 class ndindex:

--- a/numpy/typing/tests/data/reveal/index_tricks.pyi
+++ b/numpy/typing/tests/data/reveal/index_tricks.pyi
@@ -13,24 +13,31 @@ AR_LIKE_b: list[bool]
 AR_LIKE_i: list[int]
 AR_LIKE_f: list[float]
 AR_LIKE_U: list[str]
+AR_LIKE_O: list[object]
 
 AR_i8: npt.NDArray[np.int64]
+AR_O: npt.NDArray[np.object_]
 
 assert_type(np.ndenumerate(AR_i8), np.ndenumerate[np.int64])
 assert_type(np.ndenumerate(AR_LIKE_f), np.ndenumerate[np.float64])
 assert_type(np.ndenumerate(AR_LIKE_U), np.ndenumerate[np.str_])
+assert_type(np.ndenumerate(AR_LIKE_O), np.ndenumerate[np.object_])
 
 assert_type(np.ndenumerate(AR_i8).iter, np.flatiter[npt.NDArray[np.int64]])
 assert_type(np.ndenumerate(AR_LIKE_f).iter, np.flatiter[npt.NDArray[np.float64]])
 assert_type(np.ndenumerate(AR_LIKE_U).iter, np.flatiter[npt.NDArray[np.str_]])
+assert_type(np.ndenumerate(AR_LIKE_O).iter, np.flatiter[npt.NDArray[np.object_]])
 
 assert_type(next(np.ndenumerate(AR_i8)), tuple[tuple[int, ...], np.int64])
 assert_type(next(np.ndenumerate(AR_LIKE_f)), tuple[tuple[int, ...], np.float64])
 assert_type(next(np.ndenumerate(AR_LIKE_U)), tuple[tuple[int, ...], np.str_])
+# this fails due to an unknown mypy bug
+# assert_type(next(np.ndenumerate(AR_LIKE_O)), tuple[tuple[int, ...], Any])
 
 assert_type(iter(np.ndenumerate(AR_i8)), np.ndenumerate[np.int64])
 assert_type(iter(np.ndenumerate(AR_LIKE_f)), np.ndenumerate[np.float64])
 assert_type(iter(np.ndenumerate(AR_LIKE_U)), np.ndenumerate[np.str_])
+assert_type(iter(np.ndenumerate(AR_LIKE_O)), np.ndenumerate[np.object_])
 
 assert_type(np.ndindex(1, 2, 3), np.ndindex)
 assert_type(np.ndindex((1, 2, 3)), np.ndindex)


### PR DESCRIPTION
This fixes two issues of ``ndenumerate[object_]`` in the stubs:

1. This fixes a false-negative issue when an arbitrary python object array-like was passed to the ``ndenumerate`` constructor, so that e.g. ``ndenumerate([None, None, None])`` now correctly returns a ``ndenumerate[object_]``.
2. Calling ``next`` on a ``ndenumerate[object_]`` should not have a ``object_`` type, which doesn't exist at runtime. This PR changes its ``__next__`` signature to returns ``typing.Any`` iff called from a ``ndenumerate[object_]`` instance. 

Because of an unknown mypy bug, related to overloaded ``__next__`` methods, fix 2 doesn't work there: Instead, mypy incorrectly infers the return type of ``next(_: ndenumerate[object_])`` as ``numpy.object_`` (i.e. the same as before).

So effectively this means that for mypy, only fix 1. applies.
I verified that fix 2. correctly works with Pyright / Pylance, and in theory it should also work for other type-checkers (i.e. those without the same bugs as mypy has).