### PR TITLE
BUG: Add object cast to avoid warning with limited API

### DIFF
--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -449,7 +449,7 @@ typedef PyArray_DTypeMeta *(PyArrayDTypeMeta_CommonDType)(
 
 static inline PyArray_DTypeMeta *
 NPY_DT_NewRef(PyArray_DTypeMeta *o) {
-    Py_INCREF(o);
+    Py_INCREF((PyObject *)o);
     return o;
 }
 

--- a/numpy/_core/tests/examples/limited_api/limited_api_latest.c
+++ b/numpy/_core/tests/examples/limited_api/limited_api_latest.c
@@ -1,0 +1,19 @@
+#if Py_LIMITED_API != PY_VERSION_HEX & 0xffff0000
+    # error "Py_LIMITED_API not defined to Python major+minor version"
+#endif
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+#include <numpy/ufuncobject.h>
+
+static PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "limited_api_latest"
+};
+
+PyMODINIT_FUNC PyInit_limited_api_latest(void)
+{
+    import_array();
+    import_umath();
+    return PyModule_Create(&moduledef);
+}

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -35,6 +35,16 @@ py.extension_module(
 )
 
 py.extension_module(
+    'limited_api_latest',
+    'limited_api_latest.c',
+    c_args: [
+      '-DNPY_NO_DEPRECATED_API=NPY_1_21_API_VERSION',
+    ],
+    include_directories: [npy_include_path],
+    limited_api: py.language_version(),
+)
+
+py.extension_module(
     'limited_api2',
     'limited_api2.pyx',
     install: false,

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -40,16 +40,18 @@ def install_temp(tmpdir_factory):
         pytest.skip("No usable 'meson' found")
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
+                               "--werror",
                                "--buildtype=release",
                                "--vsenv", str(srcdir)],
                               cwd=build_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", str(srcdir)],
+        subprocess.check_call(["meson", "setup", "--werror", str(srcdir)],
                               cwd=build_dir
                               )
     try:
-        subprocess.check_call(["meson", "compile", "-vv"], cwd=build_dir)
+        subprocess.check_call(
+            ["meson", "compile", "-vv"], cwd=build_dir)
     except subprocess.CalledProcessError as p:
         print(f"{p.stdout=}")
         print(f"{p.stderr=}")
@@ -73,5 +75,6 @@ def test_limited_api(install_temp):
     and building a cython extension with the limited API
     """
 
-    import limited_api1
-    import limited_api2
+    import limited_api1  # Earliest (3.6)
+    import limited_api_latest  # Latest version (current Python)
+    import limited_api2  # cython


### PR DESCRIPTION
Backport of #26985.

To be honest, I think we should just delete this from the public API. But I thought I'll start with this, since at least in principle that isn't a bug-release thing to backport.

I am not sure setting warnings to errors is wise (at least for Cython and MSVC).  OTOH, the Cython module currently truly does nothing except include the headers (it doesn't even use the NumPy `.pyd` yet).

Closes gh-26756

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
