### PR TITLE
ENH: Add ``__slots__`` to private (sub-)classes in ``numpy.lib._index_tricks_impl``

### DIFF
--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -140,6 +140,7 @@ class nd_grid:
     Users should use these pre-defined instances instead of using `nd_grid`
     directly.
     """
+    __slots__ = ('sparse',)
 
     def __init__(self, sparse=False):
         self.sparse = sparse
@@ -261,6 +262,7 @@ class MGridClass(nd_grid):
     (3, 4, 5, 6)
 
     """
+    __slots__ = ()
 
     def __init__(self):
         super().__init__(sparse=False)
@@ -312,6 +314,7 @@ class OGridClass(nd_grid):
      array([[0, 1, 2, 3, 4]]))
 
     """
+    __slots__ = ()
 
     def __init__(self):
         super().__init__(sparse=True)
@@ -326,6 +329,8 @@ class AxisConcatenator:
 
     For detailed documentation on usage, see `r_`.
     """
+    __slots__ = ('axis', 'matrix', 'trans1d', 'ndmin')
+
     # allow ma.mr_ to override this
     concatenate = staticmethod(_nx.concatenate)
     makemat = staticmethod(matrixlib.matrix)
@@ -539,6 +544,7 @@ class RClass(AxisConcatenator):
     matrix([[1, 2, 3, 4, 5, 6]])
 
     """
+    __slots__ = ()
 
     def __init__(self):
         AxisConcatenator.__init__(self, 0)
@@ -571,6 +577,7 @@ class CClass(AxisConcatenator):
     array([[1, 2, 3, ..., 4, 5, 6]])
 
     """
+    __slots__ = ()
 
     def __init__(self):
         AxisConcatenator.__init__(self, -1, ndmin=2, trans1d=0)
@@ -771,6 +778,7 @@ class IndexExpression:
     array([2, 4])
 
     """
+    __slots__ = ('maketuple',)
 
     def __init__(self, maketuple):
         self.maketuple = maketuple
@@ -1023,7 +1031,7 @@ def diag_indices_from(arr):
 
     Examples
     --------
-    
+
     Create a 4 by 4 array.
 
     >>> a = np.arange(16).reshape(4, 4)
@@ -1032,7 +1040,7 @@ def diag_indices_from(arr):
            [ 4,  5,  6,  7],
            [ 8,  9, 10, 11],
            [12, 13, 14, 15]])
-    
+
     Get the indices of the diagonal elements.
 
     >>> di = np.diag_indices_from(a)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1014,7 +1014,7 @@ def compress_rows(a):
     ...                                                   [0, 0, 0]])
     >>> np.ma.compress_rows(a)
     array([[6, 7, 8]])
-    
+
     """
     a = asarray(a)
     if a.ndim != 2:
@@ -1387,7 +1387,7 @@ def setxor1d(ar1, ar2, assume_unique=False):
     >>> ar2 = np.ma.array([2, 3, 5, 7, 5])
     >>> np.ma.setxor1d(ar1, ar2)
     masked_array(data=[1, 4, 5, 7],
-                 mask=False,    
+                 mask=False,
            fill_value=999999)
 
     """
@@ -1569,8 +1569,8 @@ def _covhelper(x, y=None, rowvar=True, allow_masked=True):
         tup = (None, slice(None))
     #
     if y is None:
-        # Check if we can guarantee that the integers in the (N - ddof) 
-        # normalisation can be accurately represented with single-precision 
+        # Check if we can guarantee that the integers in the (N - ddof)
+        # normalisation can be accurately represented with single-precision
         # before computing the dot product.
         if x.shape[0] > 2 ** 24 or x.shape[1] > 2 ** 24:
             xnm_dtype = np.float64
@@ -1591,8 +1591,8 @@ def _covhelper(x, y=None, rowvar=True, allow_masked=True):
                     x._sharedmask = False
                     y._sharedmask = False
         x = ma.concatenate((x, y), axis)
-        # Check if we can guarantee that the integers in the (N - ddof) 
-        # normalisation can be accurately represented with single-precision 
+        # Check if we can guarantee that the integers in the (N - ddof)
+        # normalisation can be accurately represented with single-precision
         # before computing the dot product.
         if x.shape[0] > 2 ** 24 or x.shape[1] > 2 ** 24:
             xnm_dtype = np.float64
@@ -1673,7 +1673,7 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
           [ True,  True,  True,  True]],
     fill_value=1e+20,
     dtype=float64)
-    
+
     """
     # Check inputs
     if ddof is not None and ddof != int(ddof):
@@ -1791,6 +1791,8 @@ class MAxisConcatenator(AxisConcatenator):
     mr_class
 
     """
+    __slots__ = ()
+
     concatenate = staticmethod(concatenate)
 
     @classmethod
@@ -1828,6 +1830,8 @@ class mr_class(MAxisConcatenator):
            fill_value=999999)
 
     """
+    __slots__ = ()
+
     def __init__(self):
         MAxisConcatenator.__init__(self, 0)
 


### PR DESCRIPTION
This adds ``__slots__`` to the (private) classes in ``numpy.lib._index_tricks_impl`` and their subclasses, improving the performance of:

- ``numpy.mgrid``
- ``numpy.ogrid``
- ``numpy.r_``
- ``numpy.c_``
- ``numpy.index_exp``
- ``numpy.s_``
- ``numpy.ma.mr_``

> [!NOTE]
> I initially wanted to add ``__slots__`` to ``ndenumerate`` and ``ndindex`` as well, but decided not to, as there's a (small) chance that it will be backwards compatible.: 
> Because they are part of the public API, and not marked as ``@final``, it's possible that > they're used as base-class for user-defined types. And while that, on its own, is not a problem here, it could become one if such a user-defined type has more than one base class.
> 
> But if this isn't a problem, I'd be happy to add ``__slots__`` to these classes, too :)