### PR TITLE
TYP,BUG: Complete type stubs for ``numpy.dtypes``

### DIFF
--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import (
     Any,
     Final,
@@ -9,14 +8,9 @@ from typing import (
     TypeVar,
     final,
 )
+from typing_extensions import LiteralString
 
 import numpy as np
-
-if sys.version_info >= (3, 11):
-    from typing import LiteralString
-else:
-    LiteralString: TypeAlias = str
-
 
 __all__ = [
     'BoolDType',
@@ -54,17 +48,17 @@ __all__ = [
     'StringDType',
 ]
 
-_SelfType = TypeVar("_SelfType", bound=object)
-_SCT = TypeVar("_SCT", bound=np.generic, covariant=True)
-
 # Helper base classes (typing-only)
 
-class _BaseDType(Generic[_SCT], np.dtype[_SCT]):  # type: ignore[misc]
+_SelfT = TypeVar("_SelfT", bound=np.dtype[Any])
+_SCT_co = TypeVar("_SCT_co", bound=np.generic, covariant=True)
+
+class _SimpleDType(Generic[_SCT_co], np.dtype[_SCT_co]):  # type: ignore[misc]
     names: None  # pyright: ignore[reportIncompatibleVariableOverride]
-    def __new__(cls: type[_SelfType], /) -> _SelfType: ...
+    def __new__(cls: type[_SelfT], /) -> _SelfT: ...
     def __getitem__(self, key: Any, /) -> NoReturn: ...
     @property
-    def base(self) -> np.dtype[_SCT]: ...
+    def base(self) -> np.dtype[_SCT_co]: ...
     @property
     def fields(self) -> None: ...
     @property
@@ -72,38 +66,34 @@ class _BaseDType(Generic[_SCT], np.dtype[_SCT]):  # type: ignore[misc]
     @property
     def isnative(self) -> L[True]: ...
     @property
-    def metadata(self) -> None: ...
-    @property
     def ndim(self) -> L[0]: ...
     @property
     def shape(self) -> tuple[()]: ...
     @property
     def subdtype(self) -> None: ...
 
-class _BuiltinDType(Generic[_SCT], _BaseDType[_SCT]):
+class _LiteralDType(Generic[_SCT_co], _SimpleDType[_SCT_co]):
     @property
     def flags(self) -> L[0]: ...
     @property
     def hasobject(self) -> L[False]: ...
-    @property
-    def isbuiltin(self) -> L[1]: ...
 
 # Helper mixins (typing-only):
 
-_KindChar = TypeVar("_KindChar", bound=LiteralString, covariant=True)
-_TypeChar = TypeVar("_TypeChar", bound=LiteralString, covariant=True)
-_TypeNum = TypeVar("_TypeNum", bound=int, covariant=True)
+_KindT_co = TypeVar("_KindT_co", bound=LiteralString, covariant=True)
+_CharT_co = TypeVar("_CharT_co", bound=LiteralString, covariant=True)
+_NumT_co = TypeVar("_NumT_co", bound=int, covariant=True)
 
-class _TypeCodes(Generic[_KindChar, _TypeChar, _TypeNum]):
+class _TypeCodes(Generic[_KindT_co, _CharT_co, _NumT_co]):
     @final
     @property
-    def kind(self) -> _KindChar: ...
+    def kind(self) -> _KindT_co: ...
     @final
     @property
-    def char(self) -> _TypeChar: ...
+    def char(self) -> _CharT_co: ...
     @final
     @property
-    def num(self) -> _TypeNum: ...
+    def num(self) -> _NumT_co: ...
 
 class _NoOrder:
     @final
@@ -134,7 +124,7 @@ class _8Bit(_NoOrder, _NBit[L[1], L[1]]): ...
 class BoolDType(
     _TypeCodes[L["b"], L["?"], L[0]],
     _8Bit,
-    _BuiltinDType[np.bool],
+    _LiteralDType[np.bool],
 ):
     @property
     def name(self) -> L["bool"]: ...
@@ -147,7 +137,7 @@ class BoolDType(
 class Int8DType(
     _TypeCodes[L["i"], L["b"], L[1]],
     _8Bit,
-    _BuiltinDType[np.int8],
+    _LiteralDType[np.int8],
 ):
     @property
     def name(self) -> L["int8"]: ...
@@ -158,7 +148,7 @@ class Int8DType(
 class UInt8DType(
     _TypeCodes[L["u"], L["B"], L[2]],
     _8Bit,
-    _BuiltinDType[np.uint8],
+    _LiteralDType[np.uint8],
 ):
     @property
     def name(self) -> L["uint8"]: ...
@@ -170,7 +160,7 @@ class Int16DType(
     _TypeCodes[L["i"], L["h"], L[3]],
     _NativeOrder,
     _NBit[L[2], L[2]],
-    _BuiltinDType[np.int16],
+    _LiteralDType[np.int16],
 ):
     @property
     def name(self) -> L["int16"]: ...
@@ -182,7 +172,7 @@ class UInt16DType(
     _TypeCodes[L["u"], L["H"], L[4]],
     _NativeOrder,
     _NBit[L[2], L[2]],
-    _BuiltinDType[np.uint16],
+    _LiteralDType[np.uint16],
 ):
     @property
     def name(self) -> L["uint16"]: ...
@@ -194,7 +184,7 @@ class Int32DType(
     _TypeCodes[L["i"], L["i", "l"], L[5, 7]],
     _NativeOrder,
     _NBit[L[4], L[4]],
-    _BuiltinDType[np.int32],
+    _LiteralDType[np.int32],
 ):
     @property
     def name(self) -> L["int32"]: ...
@@ -206,7 +196,7 @@ class UInt32DType(
     _TypeCodes[L["u"], L["I", "L"], L[6, 8]],
     _NativeOrder,
     _NBit[L[4], L[4]],
-    _BuiltinDType[np.uint32],
+    _LiteralDType[np.uint32],
 ):
     @property
     def name(self) -> L["uint32"]: ...
@@ -218,7 +208,7 @@ class Int64DType(
     _TypeCodes[L["i"], L["l", "q"], L[7, 9]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BuiltinDType[np.int64],
+    _LiteralDType[np.int64],
 ):
     @property
     def name(self) -> L["int64"]: ...
@@ -230,7 +220,7 @@ class UInt64DType(
     _TypeCodes[L["u"], L["L", "Q"], L[8, 10]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BuiltinDType[np.uint64],
+    _LiteralDType[np.uint64],
 ):
     @property
     def name(self) -> L["uint64"]: ...
@@ -247,32 +237,32 @@ UShortDType: Final = UInt16DType
 class IntDType(
     _TypeCodes[L["i"], L["i"], L[5]],
     _NativeOrder,
-    _NBit[L[2, 4], L[2, 4]],
-    _BuiltinDType[np.intc],
+    _NBit[L[4], L[4]],
+    _LiteralDType[np.intc],
 ):
     @property
-    def name(self) -> L["int16", "int32"]: ...
+    def name(self) -> L["int32"]: ...
     @property
-    def str(self) -> L["<i2", ">i2", "<i4", ">i4"]: ...
+    def str(self) -> L["<i4", ">i4"]: ...
 
 @final
 class UIntDType(
     _TypeCodes[L["u"], L["I"], L[6]],
     _NativeOrder,
-    _NBit[L[2, 4], L[2, 4]],
-    _BuiltinDType[np.uintc],
+    _NBit[L[4], L[4]],
+    _LiteralDType[np.uintc],
 ):
     @property
-    def name(self) -> L["uint16", "uint32"]: ...
+    def name(self) -> L["uint32"]: ...
     @property
-    def str(self) -> L["<u2", ">u2", "<u4", ">u4"]: ...
+    def str(self) -> L["<u4", ">u4"]: ...
 
 @final
 class LongDType(
     _TypeCodes[L["i"], L["l"], L[7]],
     _NativeOrder,
     _NBit[L[4, 8], L[4, 8]],
-    _BuiltinDType[np.long],
+    _LiteralDType[np.long],
 ):
     @property
     def name(self) -> L["int32", "int64"]: ...
@@ -284,7 +274,7 @@ class ULongDType(
     _TypeCodes[L["u"], L["L"], L[8]],
     _NativeOrder,
     _NBit[L[4, 8], L[4, 8]],
-    _BuiltinDType[np.ulong],
+    _LiteralDType[np.ulong],
 ):
     @property
     def name(self) -> L["uint32", "uint64"]: ...
@@ -296,7 +286,7 @@ class LongLongDType(
     _TypeCodes[L["i"], L["q"], L[9]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BuiltinDType[np.longlong],
+    _LiteralDType[np.longlong],
 ):
     @property
     def name(self) -> L["int64"]: ...
@@ -308,7 +298,7 @@ class ULongLongDType(
     _TypeCodes[L["u"], L["Q"], L[10]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BuiltinDType[np.ulonglong],
+    _LiteralDType[np.ulonglong],
 ):
     @property
     def name(self) -> L["uint64"]: ...
@@ -322,7 +312,7 @@ class Float16DType(
     _TypeCodes[L["f"], L["e"], L[23]],
     _NativeOrder,
     _NBit[L[2], L[2]],
-    _BuiltinDType[np.float16],
+    _LiteralDType[np.float16],
 ):
     @property
     def name(self) -> L["float16"]: ...
@@ -334,7 +324,7 @@ class Float32DType(
     _TypeCodes[L["f"], L["f"], L[11]],
     _NativeOrder,
     _NBit[L[4], L[4]],
-    _BuiltinDType[np.float32],
+    _LiteralDType[np.float32],
 ):
     @property
     def name(self) -> L["float32"]: ...
@@ -346,7 +336,7 @@ class Float64DType(
     _TypeCodes[L["f"], L["d"], L[12]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BuiltinDType[np.float64],
+    _LiteralDType[np.float64],
 ):
     @property
     def name(self) -> L["float64"]: ...
@@ -358,7 +348,7 @@ class LongDoubleDType(
     _TypeCodes[L["f"], L["g"], L[13]],
     _NativeOrder,
     _NBit[L[8, 12, 16], L[8, 12, 16]],
-    _BuiltinDType[np.longdouble],
+    _LiteralDType[np.longdouble],
 ):
     @property
     def name(self) -> L["float64", "float96", "float128"]: ...
@@ -372,7 +362,7 @@ class Complex64DType(
     _TypeCodes[L["c"], L["F"], L[14]],
     _NativeOrder,
     _NBit[L[4], L[8]],
-    _BuiltinDType[np.complex64],
+    _LiteralDType[np.complex64],
 ):
     @property
     def name(self) -> L["complex64"]: ...
@@ -384,7 +374,7 @@ class Complex128DType(
     _TypeCodes[L["c"], L["D"], L[15]],
     _NativeOrder,
     _NBit[L[8], L[16]],
-    _BuiltinDType[np.complex128],
+    _LiteralDType[np.complex128],
 ):
     @property
     def name(self) -> L["complex128"]: ...
@@ -396,7 +386,7 @@ class CLongDoubleDType(
     _TypeCodes[L["c"], L["G"], L[16]],
     _NativeOrder,
     _NBit[L[8, 12, 16], L[16, 24, 32]],
-    _BuiltinDType[np.clongdouble],
+    _LiteralDType[np.clongdouble],
 ):
     @property
     def name(self) -> L["complex128", "complex192", "complex256"]: ...
@@ -410,14 +400,10 @@ class ObjectDType(
     _TypeCodes[L["O"], L["O"], L[17]],
     _NoOrder,
     _NBit[L[8], L[8]],
-    _BaseDType[np.object_],
+    _SimpleDType[np.object_],
 ):
     @property
-    def flags(self) -> L[63]: ...
-    @property
     def hasobject(self) -> L[True]: ...
-    @property
-    def isbuiltin(self) -> L[1]: ...
     @property
     def name(self) -> L["object"]: ...
     @property
@@ -431,15 +417,11 @@ class BytesDType(
     _TypeCodes[L["S"], L["S"], L[18]],
     _NoOrder,
     _NBit[L[1],_ItemSize_co],
-    _BaseDType[np.bytes_],
+    _SimpleDType[np.bytes_],
 ):
     def __new__(cls, size: _ItemSize_co, /) -> BytesDType[_ItemSize_co]: ...
     @property
-    def flags(self) -> L[0]: ...
-    @property
     def hasobject(self) -> L[False]: ...
-    @property
-    def isbuiltin(self) -> L[0]: ...
     @property
     def name(self) -> LiteralString: ...
     @property
@@ -451,15 +433,11 @@ class StrDType(
     _TypeCodes[L["U"], L["U"], L[19]],
     _NativeOrder,
     _NBit[L[4],_ItemSize_co],
-    _BaseDType[np.str_],
+    _SimpleDType[np.str_],
 ):
     def __new__(cls, size: _ItemSize_co, /) -> StrDType[_ItemSize_co]: ...
     @property
-    def flags(self) -> L[8]: ...
-    @property
     def hasobject(self) -> L[False]: ...
-    @property
-    def isbuiltin(self) -> L[0]: ...
     @property
     def name(self) -> LiteralString: ...
     @property
@@ -470,17 +448,23 @@ class VoidDType(
     Generic[_ItemSize_co],
     _TypeCodes[L["V"], L["V"], L[20]],
     _NoOrder,
-    _NBit[L[1],_ItemSize_co],
-    _BaseDType[np.void],
+    _NBit[L[1], _ItemSize_co],
+    np.dtype[np.void],  # type: ignore[misc]
 ):
     # NOTE: `VoidDType(...)` raises a `TypeError` at the moment
     def __new__(cls, length: _ItemSize_co, /) -> NoReturn: ...
     @property
-    def flags(self) -> L[0]: ...
+    def base(self: _SelfT) -> _SelfT: ...
     @property
-    def hasobject(self) -> L[False]: ...
+    def isalignedstruct(self) -> L[False]: ...
     @property
-    def isbuiltin(self) -> L[0]: ...
+    def isnative(self) -> L[True]: ...
+    @property
+    def ndim(self) -> L[0]: ...
+    @property
+    def shape(self) -> tuple[()]: ...
+    @property
+    def subdtype(self) -> None: ...
     @property
     def name(self) -> LiteralString: ...
     @property
@@ -488,32 +472,20 @@ class VoidDType(
 
 # Other:
 
-_DateTimeUnit_co = TypeVar(
-    "_DateTimeUnit_co",
-    bound=L[
-        "Y", "M", "W", "D",
-        "h", "m", "s", "ms", "us", "ns", "ps", "fs", "as",
-    ],
-    covariant=True,
-)
+_DateUnit: TypeAlias = L["Y", "M", "W", "D"]
+_TimeUnit: TypeAlias = L["h", "m", "s", "ms", "us", "ns", "ps", "fs", "as"]
+_DateTimeUnit: TypeAlias = _DateUnit | _TimeUnit
 
 @final
 class DateTime64DType(
-    Generic[_DateTimeUnit_co],
     _TypeCodes[L["M"], L["M"], L[21]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BaseDType[np.datetime64],
+    _LiteralDType[np.datetime64],
 ):
     # NOTE: `DateTime64DType(...)` raises a `TypeError` at the moment
     # TODO: Once implemented, don't forget the`unit: L["μs"]` overload.
-    def __new__(cls, unit: _DateTimeUnit_co, /) -> NoReturn: ...
-    @property
-    def flags(self) -> L[0]: ...
-    @property
-    def hasobject(self) -> L[False]: ...
-    @property
-    def isbuiltin(self) -> L[0]: ...
+    def __new__(cls, unit: _DateTimeUnit, /) -> NoReturn: ...
     @property
     def name(self) -> L[
         "datetime64",
@@ -551,21 +523,14 @@ class DateTime64DType(
 
 @final
 class TimeDelta64DType(
-    Generic[_DateTimeUnit_co],
     _TypeCodes[L["m"], L["m"], L[22]],
     _NativeOrder,
     _NBit[L[8], L[8]],
-    _BaseDType[np.timedelta64],
+    _LiteralDType[np.timedelta64],
 ):
     # NOTE: `TimeDelta64DType(...)` raises a `TypeError` at the moment
     # TODO: Once implemented, don't forget to overload on `unit: L["μs"]`.
-    def __new__(cls, unit: _DateTimeUnit_co, /) -> NoReturn: ...
-    @property
-    def flags(self) -> L[0]: ...
-    @property
-    def hasobject(self) -> L[False]: ...
-    @property
-    def isbuiltin(self) -> L[0]: ...
+    def __new__(cls, unit: _DateTimeUnit, /) -> NoReturn: ...
     @property
     def name(self) -> L[
         "timedelta64",
@@ -616,25 +581,19 @@ class StringDType(
     @property
     def fields(self) -> None: ...
     @property
-    def flags(self) -> L[107]: ...
-    @property
     def hasobject(self) -> L[True]: ...
     @property
     def isalignedstruct(self) -> L[False]: ...
     @property
-    def isbuiltin(self) -> L[0]: ...
-    @property
     def isnative(self) -> L[True]: ...
     @property
-    def metadata(self) -> None: ...
-    @property
-    def name(self) -> L["StringDType128"]: ...
+    def name(self) -> L["StringDType64", "StringDType128"]: ...
     @property
     def ndim(self) -> L[0]: ...
     @property
     def shape(self) -> tuple[()]: ...
     @property
-    def str(self) -> L["|T16"]: ...
+    def str(self) -> L["|T8", "|T16"]: ...
     @property
     def subdtype(self) -> None: ...
     @property

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -1,43 +1,641 @@
+import sys
+from typing import (
+    Any,
+    Final,
+    Generic,
+    Literal as L,
+    NoReturn,
+    TypeAlias,
+    TypeVar,
+    final,
+)
+
 import numpy as np
 
+if sys.version_info >= (3, 11):
+    from typing import LiteralString
+else:
+    LiteralString: TypeAlias = str
 
-__all__: list[str]
+
+__all__ = [
+    'BoolDType',
+    'Int8DType',
+    'ByteDType',
+    'UInt8DType',
+    'UByteDType',
+    'Int16DType',
+    'ShortDType',
+    'UInt16DType',
+    'UShortDType',
+    'Int32DType',
+    'IntDType',
+    'UInt32DType',
+    'UIntDType',
+    'Int64DType',
+    'LongDType',
+    'UInt64DType',
+    'ULongDType',
+    'LongLongDType',
+    'ULongLongDType',
+    'Float16DType',
+    'Float32DType',
+    'Float64DType',
+    'LongDoubleDType',
+    'Complex64DType',
+    'Complex128DType',
+    'CLongDoubleDType',
+    'ObjectDType',
+    'BytesDType',
+    'StrDType',
+    'VoidDType',
+    'DateTime64DType',
+    'TimeDelta64DType',
+    'StringDType',
+]
+
+_SelfType = TypeVar("_SelfType", bound=object)
+_SCT = TypeVar("_SCT", bound=np.generic, covariant=True)
+
+# Helper base classes (typing-only)
+
+class _BaseDType(Generic[_SCT], np.dtype[_SCT]):  # type: ignore[misc]
+    names: None  # pyright: ignore[reportIncompatibleVariableOverride]
+    def __new__(cls: type[_SelfType], /) -> _SelfType: ...
+    def __getitem__(self, key: Any, /) -> NoReturn: ...
+    @property
+    def base(self) -> np.dtype[_SCT]: ...
+    @property
+    def fields(self) -> None: ...
+    @property
+    def isalignedstruct(self) -> L[False]: ...
+    @property
+    def isnative(self) -> L[True]: ...
+    @property
+    def metadata(self) -> None: ...
+    @property
+    def ndim(self) -> L[0]: ...
+    @property
+    def shape(self) -> tuple[()]: ...
+    @property
+    def subdtype(self) -> None: ...
+
+class _BuiltinDType(Generic[_SCT], _BaseDType[_SCT]):
+    @property
+    def flags(self) -> L[0]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[1]: ...
+
+# Helper mixins (typing-only):
+
+_KindChar = TypeVar("_KindChar", bound=LiteralString, covariant=True)
+_TypeChar = TypeVar("_TypeChar", bound=LiteralString, covariant=True)
+_TypeNum = TypeVar("_TypeNum", bound=int, covariant=True)
+
+class _TypeCodes(Generic[_KindChar, _TypeChar, _TypeNum]):
+    @final
+    @property
+    def kind(self) -> _KindChar: ...
+    @final
+    @property
+    def char(self) -> _TypeChar: ...
+    @final
+    @property
+    def num(self) -> _TypeNum: ...
+
+class _NoOrder:
+    @final
+    @property
+    def byteorder(self) -> L["|"]: ...
+
+class _NativeOrder:
+    @final
+    @property
+    def byteorder(self) -> L["="]: ...
+
+_DataSize_co = TypeVar("_DataSize_co", bound=int, covariant=True)
+_ItemSize_co = TypeVar("_ItemSize_co", bound=int, covariant=True)
+
+class _NBit(Generic[_DataSize_co, _ItemSize_co]):
+    @final
+    @property
+    def alignment(self) -> _DataSize_co: ...
+    @final
+    @property
+    def itemsize(self) -> _ItemSize_co: ...
+
+class _8Bit(_NoOrder, _NBit[L[1], L[1]]): ...
 
 # Boolean:
-BoolDType = np.dtype[np.bool]
+
+@final
+class BoolDType(
+    _TypeCodes[L["b"], L["?"], L[0]],
+    _8Bit,
+    _BuiltinDType[np.bool],
+):
+    @property
+    def name(self) -> L["bool"]: ...
+    @property
+    def str(self) -> L["|b1"]: ...
+
 # Sized integers:
-Int8DType = np.dtype[np.int8]
-UInt8DType = np.dtype[np.uint8]
-Int16DType = np.dtype[np.int16]
-UInt16DType = np.dtype[np.uint16]
-Int32DType = np.dtype[np.int32]
-UInt32DType = np.dtype[np.uint32]
-Int64DType = np.dtype[np.int64]
-UInt64DType = np.dtype[np.uint64]
+
+@final
+class Int8DType(
+    _TypeCodes[L["i"], L["b"], L[1]],
+    _8Bit,
+    _BuiltinDType[np.int8],
+):
+    @property
+    def name(self) -> L["int8"]: ...
+    @property
+    def str(self) -> L["|i1"]: ...
+
+@final
+class UInt8DType(
+    _TypeCodes[L["u"], L["B"], L[2]],
+    _8Bit,
+    _BuiltinDType[np.uint8],
+):
+    @property
+    def name(self) -> L["uint8"]: ...
+    @property
+    def str(self) -> L["|u1"]: ...
+
+@final
+class Int16DType(
+    _TypeCodes[L["i"], L["h"], L[3]],
+    _NativeOrder,
+    _NBit[L[2], L[2]],
+    _BuiltinDType[np.int16],
+):
+    @property
+    def name(self) -> L["int16"]: ...
+    @property
+    def str(self) -> L["<i2", ">i2"]: ...
+
+@final
+class UInt16DType(
+    _TypeCodes[L["u"], L["H"], L[4]],
+    _NativeOrder,
+    _NBit[L[2], L[2]],
+    _BuiltinDType[np.uint16],
+):
+    @property
+    def name(self) -> L["uint16"]: ...
+    @property
+    def str(self) -> L["<u2", ">u2"]: ...
+
+@final
+class Int32DType(
+    _TypeCodes[L["i"], L["i", "l"], L[5, 7]],
+    _NativeOrder,
+    _NBit[L[4], L[4]],
+    _BuiltinDType[np.int32],
+):
+    @property
+    def name(self) -> L["int32"]: ...
+    @property
+    def str(self) -> L["<i4", ">i4"]: ...
+
+@final
+class UInt32DType(
+    _TypeCodes[L["u"], L["I", "L"], L[6, 8]],
+    _NativeOrder,
+    _NBit[L[4], L[4]],
+    _BuiltinDType[np.uint32],
+):
+    @property
+    def name(self) -> L["uint32"]: ...
+    @property
+    def str(self) -> L["<u4", ">u4"]: ...
+
+@final
+class Int64DType(
+    _TypeCodes[L["i"], L["l", "q"], L[7, 9]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BuiltinDType[np.int64],
+):
+    @property
+    def name(self) -> L["int64"]: ...
+    @property
+    def str(self) -> L["<i8", ">i8"]: ...
+
+@final
+class UInt64DType(
+    _TypeCodes[L["u"], L["L", "Q"], L[8, 10]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BuiltinDType[np.uint64],
+):
+    @property
+    def name(self) -> L["uint64"]: ...
+    @property
+    def str(self) -> L["<u8", ">u8"]: ...
+
 # Standard C-named version/alias:
-ByteDType = np.dtype[np.byte]
-UByteDType = np.dtype[np.ubyte]
-ShortDType = np.dtype[np.short]
-UShortDType = np.dtype[np.ushort]
-IntDType = np.dtype[np.intc]
-UIntDType = np.dtype[np.uintc]
-LongDType = np.dtype[np.long]
-ULongDType = np.dtype[np.ulong]
-LongLongDType = np.dtype[np.longlong]
-ULongLongDType = np.dtype[np.ulonglong]
-# Floats
-Float16DType = np.dtype[np.float16]
-Float32DType = np.dtype[np.float32]
-Float64DType = np.dtype[np.float64]
-LongDoubleDType = np.dtype[np.longdouble]
+ByteDType: Final = Int8DType
+UByteDType: Final = UInt8DType
+ShortDType: Final = Int16DType
+UShortDType: Final = UInt16DType
+
+@final
+class IntDType(
+    _TypeCodes[L["i"], L["i"], L[5]],
+    _NativeOrder,
+    _NBit[L[2, 4], L[2, 4]],
+    _BuiltinDType[np.intc],
+):
+    @property
+    def name(self) -> L["int16", "int32"]: ...
+    @property
+    def str(self) -> L["<i2", ">i2", "<i4", ">i4"]: ...
+
+@final
+class UIntDType(
+    _TypeCodes[L["u"], L["I"], L[6]],
+    _NativeOrder,
+    _NBit[L[2, 4], L[2, 4]],
+    _BuiltinDType[np.uintc],
+):
+    @property
+    def name(self) -> L["uint16", "uint32"]: ...
+    @property
+    def str(self) -> L["<u2", ">u2", "<u4", ">u4"]: ...
+
+@final
+class LongDType(
+    _TypeCodes[L["i"], L["l"], L[7]],
+    _NativeOrder,
+    _NBit[L[4, 8], L[4, 8]],
+    _BuiltinDType[np.long],
+):
+    @property
+    def name(self) -> L["int32", "int64"]: ...
+    @property
+    def str(self) -> L["<i4", ">i4", "<i8", ">i8"]: ...
+
+@final
+class ULongDType(
+    _TypeCodes[L["u"], L["L"], L[8]],
+    _NativeOrder,
+    _NBit[L[4, 8], L[4, 8]],
+    _BuiltinDType[np.ulong],
+):
+    @property
+    def name(self) -> L["uint32", "uint64"]: ...
+    @property
+    def str(self) -> L["<u4", ">u4", "<u8", ">u8"]: ...
+
+@final
+class LongLongDType(
+    _TypeCodes[L["i"], L["q"], L[9]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BuiltinDType[np.longlong],
+):
+    @property
+    def name(self) -> L["int64"]: ...
+    @property
+    def str(self) -> L["<i8", ">i8"]: ...
+
+@final
+class ULongLongDType(
+    _TypeCodes[L["u"], L["Q"], L[10]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BuiltinDType[np.ulonglong],
+):
+    @property
+    def name(self) -> L["uint64"]: ...
+    @property
+    def str(self) -> L["<u8", ">u8"]: ...
+
+# Floats:
+
+@final
+class Float16DType(
+    _TypeCodes[L["f"], L["e"], L[23]],
+    _NativeOrder,
+    _NBit[L[2], L[2]],
+    _BuiltinDType[np.float16],
+):
+    @property
+    def name(self) -> L["float16"]: ...
+    @property
+    def str(self) -> L["<f2", ">f2"]: ...
+
+@final
+class Float32DType(
+    _TypeCodes[L["f"], L["f"], L[11]],
+    _NativeOrder,
+    _NBit[L[4], L[4]],
+    _BuiltinDType[np.float32],
+):
+    @property
+    def name(self) -> L["float32"]: ...
+    @property
+    def str(self) -> L["<f4", ">f4"]: ...
+
+@final
+class Float64DType(
+    _TypeCodes[L["f"], L["d"], L[12]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BuiltinDType[np.float64],
+):
+    @property
+    def name(self) -> L["float64"]: ...
+    @property
+    def str(self) -> L["<f8", ">f8"]: ...
+
+@final
+class LongDoubleDType(
+    _TypeCodes[L["f"], L["g"], L[13]],
+    _NativeOrder,
+    _NBit[L[8, 12, 16], L[8, 12, 16]],
+    _BuiltinDType[np.longdouble],
+):
+    @property
+    def name(self) -> L["float64", "float96", "float128"]: ...
+    @property
+    def str(self) -> L["<f8", ">f8", "<f12", ">f12", "<f16", ">f16"]: ...
+
 # Complex:
-Complex64DType = np.dtype[np.complex64]
-Complex128DType = np.dtype[np.complex128]
-CLongDoubleDType = np.dtype[np.clongdouble]
-# Others:
-ObjectDType = np.dtype[np.object_]
-BytesDType = np.dtype[np.bytes_]
-StrDType = np.dtype[np.str_]
-VoidDType = np.dtype[np.void]
-DateTime64DType = np.dtype[np.datetime64]
-TimeDelta64DType = np.dtype[np.timedelta64]
+
+@final
+class Complex64DType(
+    _TypeCodes[L["c"], L["F"], L[14]],
+    _NativeOrder,
+    _NBit[L[4], L[8]],
+    _BuiltinDType[np.complex64],
+):
+    @property
+    def name(self) -> L["complex64"]: ...
+    @property
+    def str(self) -> L["<c8", ">c8"]: ...
+
+@final
+class Complex128DType(
+    _TypeCodes[L["c"], L["D"], L[15]],
+    _NativeOrder,
+    _NBit[L[8], L[16]],
+    _BuiltinDType[np.complex128],
+):
+    @property
+    def name(self) -> L["complex128"]: ...
+    @property
+    def str(self) -> L["<c16", ">c16"]: ...
+
+@final
+class CLongDoubleDType(
+    _TypeCodes[L["c"], L["G"], L[16]],
+    _NativeOrder,
+    _NBit[L[8, 12, 16], L[16, 24, 32]],
+    _BuiltinDType[np.clongdouble],
+):
+    @property
+    def name(self) -> L["complex128", "complex192", "complex256"]: ...
+    @property
+    def str(self) -> L["<c16", ">c16", "<c24", ">c24", "<c32", ">c32"]: ...
+
+# Python objects:
+
+@final
+class ObjectDType(
+    _TypeCodes[L["O"], L["O"], L[17]],
+    _NoOrder,
+    _NBit[L[8], L[8]],
+    _BaseDType[np.object_],
+):
+    @property
+    def flags(self) -> L[63]: ...
+    @property
+    def hasobject(self) -> L[True]: ...
+    @property
+    def isbuiltin(self) -> L[1]: ...
+    @property
+    def name(self) -> L["object"]: ...
+    @property
+    def str(self) -> L["|O"]: ...
+
+# Flexible:
+
+@final
+class BytesDType(
+    Generic[_ItemSize_co],
+    _TypeCodes[L["S"], L["S"], L[18]],
+    _NoOrder,
+    _NBit[L[1],_ItemSize_co],
+    _BaseDType[np.bytes_],
+):
+    def __new__(cls, size: _ItemSize_co, /) -> BytesDType[_ItemSize_co]: ...
+    @property
+    def flags(self) -> L[0]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def name(self) -> LiteralString: ...
+    @property
+    def str(self) -> LiteralString: ...
+
+@final
+class StrDType(
+    Generic[_ItemSize_co],
+    _TypeCodes[L["U"], L["U"], L[19]],
+    _NativeOrder,
+    _NBit[L[4],_ItemSize_co],
+    _BaseDType[np.str_],
+):
+    def __new__(cls, size: _ItemSize_co, /) -> StrDType[_ItemSize_co]: ...
+    @property
+    def flags(self) -> L[8]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def name(self) -> LiteralString: ...
+    @property
+    def str(self) -> LiteralString: ...
+
+@final
+class VoidDType(
+    Generic[_ItemSize_co],
+    _TypeCodes[L["V"], L["V"], L[20]],
+    _NoOrder,
+    _NBit[L[1],_ItemSize_co],
+    _BaseDType[np.void],
+):
+    # NOTE: `VoidDType(...)` raises a `TypeError` at the moment
+    def __new__(cls, length: _ItemSize_co, /) -> NoReturn: ...
+    @property
+    def flags(self) -> L[0]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def name(self) -> LiteralString: ...
+    @property
+    def str(self) -> LiteralString: ...
+
+# Other:
+
+_DateTimeUnit_co = TypeVar(
+    "_DateTimeUnit_co",
+    bound=L[
+        "Y", "M", "W", "D",
+        "h", "m", "s", "ms", "us", "ns", "ps", "fs", "as",
+    ],
+    covariant=True,
+)
+
+@final
+class DateTime64DType(
+    Generic[_DateTimeUnit_co],
+    _TypeCodes[L["M"], L["M"], L[21]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BaseDType[np.datetime64],
+):
+    # NOTE: `DateTime64DType(...)` raises a `TypeError` at the moment
+    # TODO: Once implemented, don't forget the`unit: L["μs"]` overload.
+    def __new__(cls, unit: _DateTimeUnit_co, /) -> NoReturn: ...
+    @property
+    def flags(self) -> L[0]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def name(self) -> L[
+        "datetime64",
+        "datetime64[Y]",
+        "datetime64[M]",
+        "datetime64[W]",
+        "datetime64[D]",
+        "datetime64[h]",
+        "datetime64[m]",
+        "datetime64[s]",
+        "datetime64[ms]",
+        "datetime64[us]",
+        "datetime64[ns]",
+        "datetime64[ps]",
+        "datetime64[fs]",
+        "datetime64[as]",
+    ]: ...
+    @property
+    def str(self) -> L[
+        "<M8", ">M8",
+        "<M8[Y]", ">M8[Y]",
+        "<M8[M]", ">M8[M]",
+        "<M8[W]", ">M8[W]",
+        "<M8[D]", ">M8[D]",
+        "<M8[h]", ">M8[h]",
+        "<M8[m]", ">M8[m]",
+        "<M8[s]", ">M8[s]",
+        "<M8[ms]", ">M8[ms]",
+        "<M8[us]", ">M8[us]",
+        "<M8[ns]", ">M8[ns]",
+        "<M8[ps]", ">M8[ps]",
+        "<M8[fs]", ">M8[fs]",
+        "<M8[as]", ">M8[as]",
+    ]: ...
+
+@final
+class TimeDelta64DType(
+    Generic[_DateTimeUnit_co],
+    _TypeCodes[L["m"], L["m"], L[22]],
+    _NativeOrder,
+    _NBit[L[8], L[8]],
+    _BaseDType[np.timedelta64],
+):
+    # NOTE: `TimeDelta64DType(...)` raises a `TypeError` at the moment
+    # TODO: Once implemented, don't forget to overload on `unit: L["μs"]`.
+    def __new__(cls, unit: _DateTimeUnit_co, /) -> NoReturn: ...
+    @property
+    def flags(self) -> L[0]: ...
+    @property
+    def hasobject(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def name(self) -> L[
+        "timedelta64",
+        "timedelta64[Y]",
+        "timedelta64[M]",
+        "timedelta64[W]",
+        "timedelta64[D]",
+        "timedelta64[h]",
+        "timedelta64[m]",
+        "timedelta64[s]",
+        "timedelta64[ms]",
+        "timedelta64[us]",
+        "timedelta64[ns]",
+        "timedelta64[ps]",
+        "timedelta64[fs]",
+        "timedelta64[as]",
+    ]: ...
+    @property
+    def str(self) -> L[
+        "<m8", ">m8",
+        "<m8[Y]", ">m8[Y]",
+        "<m8[M]", ">m8[M]",
+        "<m8[W]", ">m8[W]",
+        "<m8[D]", ">m8[D]",
+        "<m8[h]", ">m8[h]",
+        "<m8[m]", ">m8[m]",
+        "<m8[s]", ">m8[s]",
+        "<m8[ms]", ">m8[ms]",
+        "<m8[us]", ">m8[us]",
+        "<m8[ns]", ">m8[ns]",
+        "<m8[ps]", ">m8[ps]",
+        "<m8[fs]", ">m8[fs]",
+        "<m8[as]", ">m8[as]",
+    ]: ...
+
+@final
+class StringDType(
+    _TypeCodes[L["T"], L["T"], L[2056]],
+    _NativeOrder,
+    _NBit[L[8], L[16]],
+    # TODO: Replace the (invalid) `str` with the scalar type, once implemented
+    np.dtype[str],  # type: ignore[misc]
+):
+    def __new__(cls, /) -> StringDType: ...
+    def __getitem__(self, key: Any, /) -> NoReturn: ...
+    @property
+    def base(self) -> StringDType: ...
+    @property
+    def fields(self) -> None: ...
+    @property
+    def flags(self) -> L[107]: ...
+    @property
+    def hasobject(self) -> L[True]: ...
+    @property
+    def isalignedstruct(self) -> L[False]: ...
+    @property
+    def isbuiltin(self) -> L[0]: ...
+    @property
+    def isnative(self) -> L[True]: ...
+    @property
+    def metadata(self) -> None: ...
+    @property
+    def name(self) -> L["StringDType128"]: ...
+    @property
+    def ndim(self) -> L[0]: ...
+    @property
+    def shape(self) -> tuple[()]: ...
+    @property
+    def str(self) -> L["|T16"]: ...
+    @property
+    def subdtype(self) -> None: ...
+    @property
+    def type(self) -> type[str]: ...


### PR DESCRIPTION
The ``numpy.dtype`` *subtypes* in ``numpy.dtypes`` were annotated as type aliases of ``dtype``.
But since their constructor signatures are incompatible (the ones in ``numpy.dtypes`` accept either 0 or 1 positional-only arguments), so the ``numpy.dtypes`` stubs were incorrect.

This PR fixes this by adding specialized ``dtype`` subtypes in the ``numpy.dtypes`` stubs.

The previously missing type hints for ``StringDType`` were also added; fixing #26747 (for the most part, see the note), and superseding #26528.

> [!NOTE]
> The ``StringDType`` annotations aren't technically valid at the moment, since ``numpy.dtype[str]`` is invalid because ``str`` is not a subtype of ``np.generic``.
> But once its scalar-type is ready (I believe @ngoldbaum was working on this), this won't be a problem anymore.

---

*FYI, this concludes my numpy-typing PR-streak (for now), of 36 PR's in 18 days - I gotta get back to my day job**s**. But since my todo-list has grown more than it shrank, I have a feeling that a couple more will follow, albeit less frequently.*