### PR TITLE
TST, MAINT: Loosen required test precision

### DIFF
--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -38,7 +38,7 @@ class TestFFT1D:
         # Test with explicitly given number of points, both for n
         # smaller and for n larger than the input size.
         maxlen = 16
-        atol = 4 * np.spacing(np.array(1., dtype=dtype))
+        atol = 5 * np.spacing(np.array(1., dtype=dtype))
         x = random(maxlen).astype(dtype) + 1j*random(maxlen).astype(dtype)
         xx = np.concatenate([x, np.zeros_like(x)])
         xr = random(maxlen).astype(dtype)


### PR DESCRIPTION
`TestFFT1D::test_identity_long_short[longdouble]` has been failing on musl linux, but not by much. This loosens the specified atol a hair to avoid that.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
