### PR TITLE
MAINT: replace PyThread_type_lock with PyMutex on Python >= 3.13.0b3

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.c
+++ b/numpy/_core/src/common/npy_hashtable.c
@@ -30,37 +30,15 @@
 #endif
 
 #ifdef Py_GIL_DISABLED
-#if PY_VERSION_HEX < 0x30d00b3
-// TODO: replace with PyMutex when it is public
-#define LOCK_TABLE(tb)                                      \
-    if (!PyThread_acquire_lock(tb->mutex, NOWAIT_LOCK)) {   \
-        PyThread_acquire_lock(tb->mutex, WAIT_LOCK);        \
-    }
-#define UNLOCK_TABLE(tb) PyThread_release_lock(tb->mutex);
-#define INITIALIZE_LOCK(tb)                     \
-    tb->mutex = PyThread_allocate_lock();       \
-    if (tb->mutex == NULL) {                    \
-        PyErr_NoMemory();                       \
-        PyMem_Free(res);                        \
-        return NULL;                            \
-    }
-#define FREE_LOCK(tb)                           \
-    if (tb->mutex != NULL) {                    \
-        PyThread_free_lock(tb->mutex);          \
-    }
-#else
 #define LOCK_TABLE(tb) PyMutex_Lock(&tb->mutex)
 #define UNLOCK_TABLE(tb) PyMutex_Unlock(&tb->mutex)
 #define INITIALIZE_LOCK(tb) memset(&tb->mutex, 0, sizeof(PyMutex))
-#define FREE_LOCK(tb)
-#endif
 #else
 // the GIL serializes access to the table so no need
 // for locking if it is enabled
 #define LOCK_TABLE(tb)
 #define UNLOCK_TABLE(tb)
 #define INITIALIZE_LOCK(tb)
-#define FREE_LOCK(tb)
 #endif
 
 /*
@@ -150,7 +128,6 @@ NPY_NO_EXPORT void
 PyArrayIdentityHash_Dealloc(PyArrayIdentityHash *tb)
 {
     PyMem_Free(tb->buckets);
-    FREE_LOCK(tb);
     PyMem_Free(tb);
 }
 

--- a/numpy/_core/src/common/npy_hashtable.h
+++ b/numpy/_core/src/common/npy_hashtable.h
@@ -15,7 +15,7 @@ typedef struct {
     npy_intp nelem;  /* number of elements */
 #ifdef Py_GIL_DISABLED
 #if PY_VERSION_HEX < 0x30d00b3
-    PyThread_type_lock *mutex;
+#error "GIL-disabled builds require Python 3.13.0b3 or newer"
 #else
     PyMutex mutex;
 #endif

--- a/numpy/_core/src/common/npy_hashtable.h
+++ b/numpy/_core/src/common/npy_hashtable.h
@@ -14,7 +14,11 @@ typedef struct {
     npy_intp size;  /* current size */
     npy_intp nelem;  /* number of elements */
 #ifdef Py_GIL_DISABLED
+#if PY_VERSION_HEX < 0x30d00b3
     PyThread_type_lock *mutex;
+#else
+    PyMutex mutex;
+#endif
 #endif
 } PyArrayIdentityHash;
 
@@ -24,7 +28,7 @@ PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb,
         PyObject *const *key, PyObject *value, int replace);
 
 NPY_NO_EXPORT PyObject *
-PyArrayIdentityHash_GetItem(PyArrayIdentityHash const *tb, PyObject *const *key);
+PyArrayIdentityHash_GetItem(PyArrayIdentityHash *tb, PyObject *const *key);
 
 NPY_NO_EXPORT PyArrayIdentityHash *
 PyArrayIdentityHash_New(int key_len);

--- a/numpy/_core/src/common/npy_import.c
+++ b/numpy/_core/src/common/npy_import.c
@@ -10,10 +10,12 @@ NPY_VISIBILITY_HIDDEN npy_runtime_imports_struct npy_runtime_imports;
 
 NPY_NO_EXPORT int
 init_import_mutex(void) {
+#if PY_VERSION_HEX < 0x30d00b3
     npy_runtime_imports.import_mutex = PyThread_allocate_lock();
     if (npy_runtime_imports.import_mutex == NULL) {
         PyErr_NoMemory();
         return -1;
     }
+#endif
     return 0;
 }


### PR DESCRIPTION
[PyMutex is available in the public C API](https://docs.python.org/3.13/c-api/init.html#c.PyMutex) starting in 3.13.0b3 which our CI should be running.

My understanding is that PyMutex is faster than PyThread_type_lock in all cases and that it should be used whenever it's available instead of PyThread_type_lock.

There's one usage inside a `Py_GIL_DISABLED` block. We now fail to compile on 3.13.0b2 and older if we don't want to keep the `PyThread_type_lock` code.