### PR TITLE
DOC: Fix migration note for ``alltrue`` and ``sometrue``

### DIFF
--- a/doc/source/numpy_2_0_migration_guide.rst
+++ b/doc/source/numpy_2_0_migration_guide.rst
@@ -246,7 +246,7 @@ removed member          migration guideline
 add_docstring           It's still available as ``np.lib.add_docstring``.
 add_newdoc              It's still available as ``np.lib.add_newdoc``.
 add_newdoc_ufunc        It's an internal function and doesn't have a replacement.
-alltrue                 Use ``all`` instead.
+alltrue                 Use ``np.all`` instead.
 asfarray                Use ``np.asarray`` with a float dtype instead.
 byte_bounds             Now it's available under ``np.lib.array_utils.byte_bounds``
 cast                    Use ``np.asarray(arr, dtype=dtype)`` instead.
@@ -307,7 +307,7 @@ set_string_function     Use ``np.set_printoptions`` instead with a formatter
                         for custom printing of NumPy objects.
 singlecomplex           Use ``np.complex64`` instead.
 string\_                Use ``np.bytes_`` instead.
-sometrue                Use ``any`` instead.
+sometrue                Use ``np.any`` instead.
 source                  Use ``inspect.getsource`` instead.
 tracemalloc_domain      It's now available from ``np.lib``.
 unicode\_               Use ``np.str_`` instead.

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -75,4 +75,6 @@ __expired_attributes__ = {
     "compare_chararrays": 
         "It's still available as `np.char.compare_chararrays`.",
     "format_parser": "It's still available as `np.rec.format_parser`.",
+    "alltrue": "Use `np.all` instead.",
+    "sometrue": "Use `np.any` instead.",
 }


### PR DESCRIPTION
Hi @ngoldbaum,

I think I made a mistake in https://github.com/numpy/numpy/pull/26517 as pointed out it in https://github.com/astral-sh/ruff/issues/12416.

`np.sometrue` and `np.alltrue` should be mapped to `np.any` and `np.all` instead of Python builtins `any`/`all`. (It could be also backported).
