### PR TITLE
TYP: improved ``numpy.array`` type hints for array-like input

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -82,7 +82,12 @@ from numpy._typing import (
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
-_ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
+_ArrayType = TypeVar("_ArrayType", bound=ndarray[Any, Any])
+_ArrayType_co = TypeVar(
+    "_ArrayType_co",
+    bound=ndarray[Any, Any],
+    covariant=True,
+)
 
 # Valid time units
 _UnitKind = L[
@@ -112,6 +117,9 @@ _RollKind = L[  # `raise` is deliberately excluded
 class _SupportsLenAndGetItem(Protocol[_T_contra, _T_co]):
     def __len__(self) -> int: ...
     def __getitem__(self, key: _T_contra, /) -> _T_co: ...
+
+class _SupportsArray(Protocol[_ArrayType_co]):
+    def __array__(self, /) -> _ArrayType_co: ...
 
 __all__: list[str]
 
@@ -185,6 +193,17 @@ def array(
     order: _OrderKACF = ...,
     subok: L[True],
     ndmin: int = ...,
+    like: None | _SupportsArrayFunc = ...,
+) -> _ArrayType: ...
+@overload
+def array(
+    object: _SupportsArray[_ArrayType],
+    dtype: None = ...,
+    *,
+    copy: None | bool | _CopyMode = ...,
+    order: _OrderKACF = ...,
+    subok: L[True],
+    ndmin: L[0] = ...,
     like: None | _SupportsArrayFunc = ...,
 ) -> _ArrayType: ...
 @overload

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -20,6 +20,7 @@ i8: np.int64
 A: npt.NDArray[np.float64]
 B: SubClass[np.float64]
 C: list[int]
+D: SubClass[np.float64 | np.int64]
 
 def func(i: int, j: int, **kwargs: Any) -> SubClass[np.float64]: ...
 
@@ -31,12 +32,16 @@ assert_type(np.empty_like(A, dtype='c16'), npt.NDArray[Any])
 
 assert_type(np.array(A), npt.NDArray[np.float64])
 assert_type(np.array(B), npt.NDArray[np.float64])
-assert_type(np.array(B, subok=True), SubClass[np.float64])
 assert_type(np.array([1, 1.0]), npt.NDArray[Any])
 assert_type(np.array(deque([1, 2, 3])), npt.NDArray[Any])
 assert_type(np.array(A, dtype=np.int64), npt.NDArray[np.int64])
 assert_type(np.array(A, dtype='c16'), npt.NDArray[Any])
 assert_type(np.array(A, like=A), npt.NDArray[np.float64])
+assert_type(np.array(A, subok=True), npt.NDArray[np.float64])
+assert_type(np.array(B, subok=True), SubClass[np.float64])
+assert_type(np.array(B, subok=True, ndmin=0), SubClass[np.float64])
+assert_type(np.array(B, subok=True, ndmin=1), SubClass[np.float64])
+assert_type(np.array(D), npt.NDArray[np.float64 | np.int64])
 
 assert_type(np.zeros([1, 5, 6]), npt.NDArray[np.float64])
 assert_type(np.zeros([1, 5, 6], dtype=np.int64), npt.NDArray[np.int64])


### PR DESCRIPTION
This partially fixes https://github.com/numpy/numpy/issues/25691 by adding an overload to ``numpy.array`` for array-likes input of numpy scalar types.


