### PR TITLE
BUG: cfuncs.py: fix crash when sys.stderr is not available

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 
 from . import __version__
 from . import cfuncs
+from .cfuncs import errmess
 
 __all__ = [
     'applyrules', 'debugcapi', 'dictappend', 'errmess', 'gentitle',
@@ -51,7 +52,6 @@ __all__ = [
 f2py_version = __version__.version
 
 
-errmess = sys.stderr.write
 show = pprint.pprint
 
 options = {}

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -16,7 +16,16 @@ import copy
 from . import __version__
 
 f2py_version = __version__.version
-errmess = sys.stderr.write
+
+
+def errmess(s: str) -> None:
+    """
+    Write an error message to stderr.
+
+    This indirection is needed because sys.stderr might not always be available (see #26862).
+    """
+    if sys.stderr is not None:
+        sys.stderr.write(s)
 
 ##################### Definitions ##################
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -28,11 +28,12 @@ from . import cfuncs
 from . import f90mod_rules
 from . import __version__
 from . import capi_maps
+from .cfuncs import errmess
 from numpy.f2py._backends import f2py_build_generator
 
 f2py_version = __version__.version
 numpy_version = __version__.version
-errmess = sys.stderr.write
+
 # outmess=sys.stdout.write
 show = pprint.pprint
 outmess = auxfuncs.outmess


### PR DESCRIPTION
Backport of #27013.

In some environments (for example frozen executables created with PyInstaller for GUI applications) `sys.stderr` and `sys.stdout` might be `None`.

The import-time access to `sys.stderr.write` in some `f2py` modules was causing such applications to crash during startup.

Fix #26862

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
