### PR TITLE
BUG: Fix simd loadable stride logic 

### DIFF
--- a/numpy/_core/src/common/simd/simd.h
+++ b/numpy/_core/src/common/simd/simd.h
@@ -1,5 +1,7 @@
 #ifndef _NPY_SIMD_H_
 #define _NPY_SIMD_H_
+
+#include <stdalign.h>  /* for alignof until C23 */
 /**
  * the NumPy C SIMD vectorization interface "NPYV" are types and functions intended
  * to simplify vectorization of code on different platforms, currently supports
@@ -150,28 +152,28 @@ typedef double     npyv_lanetype_f64;
 #ifndef NPY_SIMD_MAXSTORE_STRIDE64
     #define NPY_SIMD_MAXSTORE_STRIDE64 0
 #endif
-#define NPYV_IMPL_MAXSTRIDE(SFX, MAXLOAD, MAXSTORE)                          \
-    NPY_FINLINE int                                                          \
-    npyv_loadable_stride_##SFX(npy_intp stride)                              \
-    {                                                                        \
-        if (_Alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
-                stride % sizeof(npyv_lanetype_##SFX) != 0) {                 \
-            /* stride not a multiple of itemsize, cannot handle. */          \
-            return 0;                                                        \
-        }                                                                    \
-        stride = stride / sizeof(npyv_lanetype_##SFX);                       \
-        return MAXLOAD > 0 ? llabs(stride) <= MAXLOAD : 1;                   \
-    }                                                                        \
-    NPY_FINLINE int                                                          \
-    npyv_storable_stride_##SFX(npy_intp stride)                              \
-    {                                                                        \
-        if (_Alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
-                stride % sizeof(npyv_lanetype_##SFX) != 0) {                 \
-            /* stride not a multiple of itemsize, cannot handle. */          \
-            return 0;                                                        \
-        }                                                                    \
-        stride = stride / sizeof(npyv_lanetype_##SFX);                       \
-        return MAXSTORE > 0 ? llabs(stride) <= MAXSTORE : 1;                 \
+#define NPYV_IMPL_MAXSTRIDE(SFX, MAXLOAD, MAXSTORE)                         \
+    NPY_FINLINE int                                                         \
+    npyv_loadable_stride_##SFX(npy_intp stride)                             \
+    {                                                                       \
+        if (alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
+                stride % sizeof(npyv_lanetype_##SFX) != 0) {                \
+            /* stride not a multiple of itemsize, cannot handle. */         \
+            return 0;                                                       \
+        }                                                                   \
+        stride = stride / sizeof(npyv_lanetype_##SFX);                      \
+        return MAXLOAD > 0 ? llabs(stride) <= MAXLOAD : 1;                  \
+    }                                                                       \
+    NPY_FINLINE int                                                         \
+    npyv_storable_stride_##SFX(npy_intp stride)                             \
+    {                                                                       \
+        if (alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
+                stride % sizeof(npyv_lanetype_##SFX) != 0) {                \
+            /* stride not a multiple of itemsize, cannot handle. */         \
+            return 0;                                                       \
+        }                                                                   \
+        stride = stride / sizeof(npyv_lanetype_##SFX);                      \
+        return MAXSTORE > 0 ? llabs(stride) <= MAXSTORE : 1;                \
     }
 #if NPY_SIMD
     NPYV_IMPL_MAXSTRIDE(u32, NPY_SIMD_MAXLOAD_STRIDE32, NPY_SIMD_MAXSTORE_STRIDE32)

--- a/numpy/_core/src/common/simd/simd.h
+++ b/numpy/_core/src/common/simd/simd.h
@@ -123,10 +123,11 @@ typedef double     npyv_lanetype_f64;
  * acceptable limit of strides before using any of non-contiguous load/store intrinsics.
  *
  * For instance:
- *  npy_intp ld_stride = step[0] / sizeof(float);
- *  npy_intp st_stride = step[1] / sizeof(float);
  *
- *  if (npyv_loadable_stride_f32(ld_stride) && npyv_storable_stride_f32(st_stride)) {
+ *  if (npyv_loadable_stride_f32(steps[0]) && npyv_storable_stride_f32(steps[1])) {
+ *      // Strides are now guaranteed to be a multiple and compatible
+ *      npy_intp ld_stride = steps[0] / sizeof(float);
+ *      npy_intp st_stride = steps[1] / sizeof(float);
  *      for (;;)
  *          npyv_f32 a = npyv_loadn_f32(ld_pointer, ld_stride);
  *          // ...
@@ -134,7 +135,7 @@ typedef double     npyv_lanetype_f64;
  *  }
  *  else {
  *      for (;;)
- *          // C scalars
+ *          // C scalars, use byte steps/strides.
  *  }
  */
 #ifndef NPY_SIMD_MAXLOAD_STRIDE32
@@ -149,11 +150,29 @@ typedef double     npyv_lanetype_f64;
 #ifndef NPY_SIMD_MAXSTORE_STRIDE64
     #define NPY_SIMD_MAXSTORE_STRIDE64 0
 #endif
-#define NPYV_IMPL_MAXSTRIDE(SFX, MAXLOAD, MAXSTORE) \
-    NPY_FINLINE int npyv_loadable_stride_##SFX(npy_intp stride) \
-    { return MAXLOAD > 0 ? llabs(stride) <= MAXLOAD : 1; } \
-    NPY_FINLINE int npyv_storable_stride_##SFX(npy_intp stride) \
-    { return MAXSTORE > 0 ? llabs(stride) <= MAXSTORE : 1; }
+#define NPYV_IMPL_MAXSTRIDE(SFX, MAXLOAD, MAXSTORE)                          \
+    NPY_FINLINE int                                                          \
+    npyv_loadable_stride_##SFX(npy_intp stride)                              \
+    {                                                                        \
+        if (_Alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
+                stride % sizeof(npyv_lanetype_##SFX) != 0) {                 \
+            /* stride not a multiple of itemsize, cannot handle. */          \
+            return 0;                                                        \
+        }                                                                    \
+        stride = stride / sizeof(npyv_lanetype_##SFX);                       \
+        return MAXLOAD > 0 ? llabs(stride) <= MAXLOAD : 1;                   \
+    }                                                                        \
+    NPY_FINLINE int                                                          \
+    npyv_storable_stride_##SFX(npy_intp stride)                              \
+    {                                                                        \
+        if (_Alignof(npyv_lanetype_##SFX) != sizeof(npyv_lanetype_##SFX) &&  \
+                stride % sizeof(npyv_lanetype_##SFX) != 0) {                 \
+            /* stride not a multiple of itemsize, cannot handle. */          \
+            return 0;                                                        \
+        }                                                                    \
+        stride = stride / sizeof(npyv_lanetype_##SFX);                       \
+        return MAXSTORE > 0 ? llabs(stride) <= MAXSTORE : 1;                 \
+    }
 #if NPY_SIMD
     NPYV_IMPL_MAXSTRIDE(u32, NPY_SIMD_MAXLOAD_STRIDE32, NPY_SIMD_MAXSTORE_STRIDE32)
     NPYV_IMPL_MAXSTRIDE(s32, NPY_SIMD_MAXLOAD_STRIDE32, NPY_SIMD_MAXSTORE_STRIDE32)

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -346,14 +346,17 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             && __apple_build_version__ < 14030000
         goto loop_scalar;
     #endif  // end affected Apple clang.
+
     if (is_mem_overlap(b_src0, b_ssrc0, b_dst, b_sdst, len) ||
         is_mem_overlap(b_src1, b_ssrc1, b_dst, b_sdst, len) ||
-        b_sdst  % sizeof(@ftype@) != 0 || b_sdst == 0 ||
-        b_ssrc0 % sizeof(@ftype@) != 0 ||
-        b_ssrc1 % sizeof(@ftype@) != 0
+        !npyv_loadable_stride_@sfx@(b_ssrc0) ||
+        !npyv_loadable_stride_@sfx@(b_ssrc1) ||
+        !npyv_storable_stride_@sfx@(b_sdst)  ||
+        b_sdst == 0
     ) {
         goto loop_scalar;
     }
+
     const @ftype@ *src0 = (@ftype@*)b_src0;
     const @ftype@ *src1 = (@ftype@*)b_src1;
           @ftype@ *dst  = (@ftype@*)b_dst;
@@ -365,10 +368,6 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     const int vstep = npyv_nlanes_@sfx@;
     const int wstep = vstep * 2;
     const int hstep = vstep / 2;
-
-    const int loadable0 = npyv_loadable_stride_s64(ssrc0);
-    const int loadable1 = npyv_loadable_stride_s64(ssrc1);
-    const int storable = npyv_storable_stride_s64(sdst);
 
     // lots**lots of specializations, to squeeze out max performance
     // contig
@@ -414,7 +413,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             }
         }
         // non-contig
-        else if (loadable1 && storable) {
+        else {
             for (; len >= vstep; len -= vstep, src1 += ssrc1*vstep, dst += sdst*vstep) {
                 npyv_@sfx@ b0 = npyv_loadn2_@sfx@(src1, ssrc1);
                 npyv_@sfx@ b1 = npyv_loadn2_@sfx@(src1 + ssrc1*hstep, ssrc1);
@@ -432,9 +431,6 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_@sfx@ r = @vectorf@_@sfx@(a.val[0], b);
                 npyv_storen2_till_@sfx@(dst, sdst, len, r);
             }
-        }
-        else {
-            goto loop_scalar;
         }
     }
     // scalar 1
@@ -460,7 +456,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             }
         }
         // non-contig
-        else if (loadable0 && storable) {
+        else {
             for (; len >= vstep; len -= vstep, src0 += ssrc0*vstep, dst += sdst*vstep) {
                 npyv_@sfx@ a0 = npyv_loadn2_@sfx@(src0, ssrc0);
                 npyv_@sfx@ a1 = npyv_loadn2_@sfx@(src0 + ssrc0*hstep, ssrc0);
@@ -479,13 +475,10 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
                 npyv_storen2_till_@sfx@(dst, sdst, len, r);
             }
         }
-        else {
-            goto loop_scalar;
-        }
     }
     #if @is_mul@
     // non-contig
-    else if (loadable0 && loadable1 && storable) {
+    else {
         for (; len >= vstep; len -= vstep, src0 += ssrc0*vstep,
                             src1 += ssrc1*vstep, dst += sdst*vstep
         ) {
@@ -512,12 +505,16 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             npyv_storen2_till_@sfx@(dst, sdst, len, r);
         }
     }
-    #endif
+    #else  /* @is_mul@ */
     else {
+        // Only multiply is vectorized for the generic non-contig case.
         goto loop_scalar;
     }
+    #endif  /* @is_mul@ */
+
     npyv_cleanup();
     return;
+
 loop_scalar:
 #endif
     for (; len > 0; --len, b_src0 += b_ssrc0, b_src1 += b_ssrc1, b_dst += b_sdst) {
@@ -580,8 +577,8 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     npy_intp b_ssrc = steps[0], b_sdst = steps[1];
 #if @VECTOR@
     if (is_mem_overlap(b_src, b_ssrc, b_dst, b_sdst, len) ||
-        b_sdst % sizeof(@ftype@) != 0 ||
-        b_ssrc % sizeof(@ftype@) != 0
+        !npyv_loadable_stride_@sfx@(b_ssrc) ||
+        !npyv_storable_stride_@sfx@(b_sdst)
     ) {
         goto loop_scalar;
     }
@@ -609,7 +606,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             npyv_store2_till_@sfx@(dst, len, r);
         }
     }
-    else if (ssrc == 2 && npyv_storable_stride_s64(sdst)) {
+    else if (ssrc == 2) {
         for (; len >= vstep; len -= vstep, src += wstep, dst += sdst*vstep) {
             npyv_@sfx@ a0 = npyv_load_@sfx@(src);
             npyv_@sfx@ a1 = npyv_load_@sfx@(src + vstep);
@@ -624,7 +621,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             npyv_storen2_till_@sfx@(dst, sdst, len, r);
         }
     }
-    else if (sdst == 2 && npyv_loadable_stride_s64(ssrc)) {
+    else if (sdst == 2) {
         for (; len >= vstep; len -= vstep, src += ssrc*vstep, dst += wstep) {
             npyv_@sfx@ a0 = npyv_loadn2_@sfx@(src, ssrc);
             npyv_@sfx@ a1 = npyv_loadn2_@sfx@(src + ssrc*hstep, ssrc);

--- a/numpy/_core/src/umath/loops_exponent_log.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_exponent_log.dispatch.c.src
@@ -1315,16 +1315,16 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(DOUBLE_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
 #if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
-    const npy_double *src = (npy_double*)args[0];
-    npy_double *dst = (npy_double*)args[1];
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
     const npy_intp len = dimensions[0];
-    assert(steps[0] % lsize == 0 && steps[1] % lsize == 0);
-    if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
-            npyv_loadable_stride_f64(ssrc) &&
-            npyv_storable_stride_f64(sdst)) {
+
+    if (!is_mem_overlap(args[0], steps[0], args[1], steps[1], len) &&
+            npyv_loadable_stride_f64(steps[0]) &&
+            npyv_storable_stride_f64(steps[1])) {
+        const npy_double *src = (npy_double*)args[0];
+        npy_double *dst = (npy_double*)args[1];
+        const npy_intp ssrc = steps[0] / sizeof(src[0]);
+        const npy_intp sdst = steps[1] / sizeof(src[0]);
+
         simd_@func@_f64(src, ssrc, dst, sdst, len);
         return;
     }

--- a/numpy/_core/src/umath/loops_hyperbolic.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_hyperbolic.dispatch.c.src
@@ -610,9 +610,9 @@ simd_tanh_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst, npy_in
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
+#if @simd@
     npy_intp len = dimensions[0];
 
-#if @simd@
     if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
         !npyv_loadable_stride_@sfx@(steps[0]) ||
         !npyv_storable_stride_@sfx@(steps[1])

--- a/numpy/_core/src/umath/loops_hyperbolic.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_hyperbolic.dispatch.c.src
@@ -9,6 +9,8 @@
 #include "simd/simd.h"
 #include "loops_utils.h"
 #include "loops.h"
+// Provides the various *_LOOP macros
+#include "fast_loop_macros.h"
 
 #if NPY_SIMD_FMA3 // native support
 /*
@@ -608,32 +610,29 @@ simd_tanh_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst, npy_in
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
-    const @type@ *src = (@type@*)args[0];
-          @type@ *dst = (@type@*)args[1];
-
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
     npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
+
 #if @simd@
-    if (is_mem_overlap(src, steps[0], dst, steps[1], len) ||
-        !npyv_loadable_stride_@sfx@(ssrc) || !npyv_storable_stride_@sfx@(sdst)
+    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
+        !npyv_loadable_stride_@sfx@(steps[0]) ||
+        !npyv_storable_stride_@sfx@(steps[1])
     ) {
-        for (; len > 0; --len, src += ssrc, dst += sdst) {
-            simd_@func@_@sfx@(src, 1, dst, 1, 1);
+        UNARY_LOOP {
+            simd_@func@_@sfx@((@type@ *)ip1, 1, (@type@ *)op1, 1, 1);
         }
     } else {
-        simd_@func@_@sfx@(src, ssrc, dst, sdst, len);
+        npy_intp ssrc = steps[0] / sizeof(@type@);
+        npy_intp sdst = steps[1] / sizeof(@type@);
+        simd_@func@_@sfx@((@type@ *)args[0], ssrc, (@type@ *)args[1], sdst, len);
     }
     npyv_cleanup();
     #if @simd_req_clear@
         npy_clear_floatstatus_barrier((char*)dimensions);
     #endif
 #else
-    for (; len > 0; --len, src += ssrc, dst += sdst) {
-        const @type@ src0 = *src;
-        *dst = npy_@func@@ssfx@(src0);
+    UNARY_LOOP {
+        const @type@ in1 = *(@type@ *)ip1;
+        *(@type@ *)op1 = npy_@func@@ssfx@(in1);
     }
 #endif
 }

--- a/numpy/_core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_minmax.dispatch.c.src
@@ -352,9 +352,9 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
         }
     // unroll scalars faster than non-contiguous vector load/store on Arm
     #if !defined(NPY_HAVE_NEON) && @is_fp@
-        if (TO_SIMD_SFX(npyv_loadable_stride)(is1/sizeof(STYPE)) &&
-            TO_SIMD_SFX(npyv_loadable_stride)(is2/sizeof(STYPE)) &&
-            TO_SIMD_SFX(npyv_storable_stride)(os1/sizeof(STYPE))
+        if (TO_SIMD_SFX(npyv_loadable_stride)(is1) &&
+            TO_SIMD_SFX(npyv_loadable_stride)(is2) &&
+            TO_SIMD_SFX(npyv_storable_stride)(os1)
         ) {
             TO_SIMD_SFX(simd_binary_@intrin@)(
                 (STYPE*)ip1, is1/sizeof(STYPE),

--- a/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
@@ -214,21 +214,22 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(FLOAT_sin)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
 #if NPY_SIMD_FMA3
-    const npy_float *src = (npy_float*)args[0];
-          npy_float *dst = (npy_float*)args[1];
-
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
     npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
-    if (is_mem_overlap(src, steps[0], dst, steps[1], len) ||
-        !npyv_loadable_stride_f32(ssrc) || !npyv_storable_stride_f32(sdst)
+
+    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
+        !npyv_loadable_stride_f32(steps[0]) ||
+        !npyv_storable_stride_f32(steps[1])
     ) {
-        for (; len > 0; --len, src += ssrc, dst += sdst) {
-            simd_sincos_f32(src, 1, dst, 1, 1, SIMD_COMPUTE_SIN);
+        UNARY_LOOP {
+            simd_sincos_f32(
+                (npy_float *)ip1, 1, (npy_float *)op1, 1, 1, SIMD_COMPUTE_SIN);
         }
     } else {
+        const npy_float *src = (npy_float*)args[0];
+              npy_float *dst = (npy_float*)args[1];
+        const npy_intp ssrc = steps[0] / sizeof(npy_float);
+        const npy_intp sdst = steps[1] / sizeof(npy_float);
+
         simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_SIN);
     }
 #else
@@ -243,21 +244,22 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(FLOAT_cos)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
 #if NPY_SIMD_FMA3
-    const npy_float *src = (npy_float*)args[0];
-          npy_float *dst = (npy_float*)args[1];
-
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
     npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
-    if (is_mem_overlap(src, steps[0], dst, steps[1], len) ||
-        !npyv_loadable_stride_f32(ssrc) || !npyv_storable_stride_f32(sdst)
+
+    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
+        !npyv_loadable_stride_f32(steps[0]) ||
+        !npyv_storable_stride_f32(steps[1])
     ) {
-        for (; len > 0; --len, src += ssrc, dst += sdst) {
-            simd_sincos_f32(src, 1, dst, 1, 1, SIMD_COMPUTE_COS);
+        UNARY_LOOP {
+            simd_sincos_f32(
+                (npy_float *)ip1, 1, (npy_float *)op1, 1, 1, SIMD_COMPUTE_COS);
         }
     } else {
+        const npy_float *src = (npy_float*)args[0];
+              npy_float *dst = (npy_float*)args[1];
+        const npy_intp ssrc = steps[0] / sizeof(npy_float);
+        const npy_intp sdst = steps[1] / sizeof(npy_float);
+
         simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_COS);
     }
 #else

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -199,16 +199,16 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
 #if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
-    const @type@ *src = (@type@*)args[0];
-          @type@ *dst = (@type@*)args[1];
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
     const npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
+
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
-        npyv_loadable_stride_@sfx@(ssrc) &&
-        npyv_storable_stride_@sfx@(sdst)) {
+        npyv_loadable_stride_@sfx@(steps[0]) &&
+        npyv_storable_stride_@sfx@(steps[1]))
+    {
+        const @type@ *src = (@type@*)args[0];
+              @type@ *dst = (@type@*)args[1];
+        const npy_intp ssrc = steps[0] / sizeof(@type@);
+        const npy_intp sdst = steps[1] / sizeof(@type@);
         simd_@intrin@_@sfx@(src, ssrc, dst, sdst, len);
         return;
     }
@@ -251,15 +251,19 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     const @type@ *src1 = (@type@*)args[0];
     const @type@ *src2 = (@type@*)args[1];
           @type@ *dst  = (@type@*)args[2];
-    const int lsize = sizeof(src1[0]);
-    const npy_intp ssrc1 = steps[0] / lsize;
-    const npy_intp ssrc2 = steps[1] / lsize;
-    const npy_intp sdst  = steps[2] / lsize;
+
     const npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
-    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) && !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
-        npyv_loadable_stride_@sfx@(ssrc1) && npyv_loadable_stride_@sfx@(ssrc2) &&
-        npyv_storable_stride_@sfx@(sdst)) {
+
+    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) &&
+        !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
+        npyv_loadable_stride_@sfx@(steps[0]) &&
+        npyv_loadable_stride_@sfx@(steps[1]) &&
+        npyv_storable_stride_@sfx@(steps[2])
+    ) {
+        const npy_intp ssrc1 = steps[0] / sizeof(@type@);
+        const npy_intp ssrc2 = steps[1] / sizeof(@type@);
+        const npy_intp sdst  = steps[2] / sizeof(@type@);
+
         simd_@intrin@_@sfx@(src1, ssrc1, src2, ssrc2, dst, sdst, len);
         return;
     }
@@ -283,15 +287,19 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     const @type@ *src1 = (@type@*)args[0];
     const @type@ *src2 = (@type@*)args[1];
           @type@ *dst  = (@type@*)args[2];
-    const int lsize = sizeof(src1[0]);
-    const npy_intp ssrc1 = steps[0] / lsize;
-    const npy_intp ssrc2 = steps[1] / lsize;
-    const npy_intp sdst  = steps[2] / lsize;
+
     const npy_intp len = dimensions[0];
     assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
-    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) && !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
-        npyv_loadable_stride_@sfx@(ssrc1) && npyv_loadable_stride_@sfx@(ssrc2) &&
-        npyv_storable_stride_@sfx@(sdst)) {
+    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) &&
+        !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
+        npyv_loadable_stride_@sfx@(steps[0]) &&
+        npyv_loadable_stride_@sfx@(steps[1]) &&
+        npyv_storable_stride_@sfx@(steps[2])
+    ) {
+        const npy_intp ssrc1 = steps[0] / sizeof(@type@);
+        const npy_intp ssrc2 = steps[1] / sizeof(@type@);
+        const npy_intp sdst  = steps[2] / sizeof(@type@);
+
         simd_@intrin@_@sfx@(src1, ssrc1, src2, ssrc2, dst, sdst, len);
         return;
     }

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -160,13 +160,12 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(HALF_@func@)
 #if NPY_SIMD && defined(NPY_CAN_LINK_SVML)
     const npy_half *src = (npy_half*)args[0];
           npy_half *dst = (npy_half*)args[1];
-    const int lsize = sizeof(src[0]);
-    const npy_intp ssrc = steps[0] / lsize;
-    const npy_intp sdst = steps[1] / lsize;
+
     const npy_intp len = dimensions[0];
+
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
-        (ssrc == 1) &&
-        (sdst == 1)) {
+        (steps[0] == sizeof(npy_half)) &&
+        (steps[1] == sizeof(npy_half))) {
 #if defined(NPY_HAVE_AVX512_SPR)
         __svml_@intrin@s32(src, dst, len);
         return;
@@ -199,14 +198,15 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
 #if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+    const @type@ *src = (@type@*)args[0];
+          @type@ *dst = (@type@*)args[1];
+
     const npy_intp len = dimensions[0];
 
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
         npyv_loadable_stride_@sfx@(steps[0]) &&
         npyv_storable_stride_@sfx@(steps[1]))
     {
-        const @type@ *src = (@type@*)args[0];
-              @type@ *dst = (@type@*)args[1];
         const npy_intp ssrc = steps[0] / sizeof(@type@);
         const npy_intp sdst = steps[1] / sizeof(@type@);
         simd_@intrin@_@sfx@(src, ssrc, dst, sdst, len);
@@ -289,7 +289,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
           @type@ *dst  = (@type@*)args[2];
 
     const npy_intp len = dimensions[0];
-    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
+
     if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) &&
         !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
         npyv_loadable_stride_@sfx@(steps[0]) &&

--- a/numpy/_core/src/umath/loops_unary.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_unary.dispatch.c.src
@@ -298,12 +298,12 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             goto clear;
         }
     #if @supports_ncontig@
-        const npy_intp istride = istep / sizeof(STYPE);
-        const npy_intp ostride = ostep / sizeof(STYPE);
-        if (TO_SIMD_SFX(npyv_loadable_stride)(istride) &&
-            TO_SIMD_SFX(npyv_storable_stride)(ostride))
+        if (TO_SIMD_SFX(npyv_loadable_stride)(istep) &&
+            TO_SIMD_SFX(npyv_storable_stride)(ostep))
         {
-            if (istride == 1 && ostride != 1) {
+            const npy_intp istride = istep / sizeof(STYPE);
+            const npy_intp ostride = ostep / sizeof(STYPE);
+            if (istride == sizeof(STYPE) && ostride != 1) {
                 // contiguous input, non-contiguous output
                 TO_SIMD_SFX(simd_unary_cn_@intrin@)(
                     (STYPE*)ip, (STYPE*)op, ostride, len

--- a/numpy/_core/src/umath/loops_unary_complex.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_unary_complex.dispatch.c.src
@@ -88,14 +88,14 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_absolute)
 {
 #if @VECTOR@
     npy_intp len = dimensions[0];
-    npy_intp ssrc = steps[0] / sizeof(@ftype@);
-    npy_intp sdst = steps[1] / sizeof(@ftype@);
 
     if (!is_mem_overlap(args[0], steps[0], args[1], steps[1], len) &&
-        npyv_loadable_stride_@sfx@(ssrc) && npyv_storable_stride_@sfx@(sdst)
-        && steps[0] % sizeof(@ftype@) == 0
-        && steps[1] % sizeof(@ftype@) == 0
+        npyv_loadable_stride_@sfx@(steps[0]) &&
+        npyv_storable_stride_@sfx@(steps[1])
     ) {
+        npy_intp ssrc = steps[0] / sizeof(@ftype@);
+        npy_intp sdst = steps[1] / sizeof(@ftype@);
+
         const @ftype@ *src = (@ftype@*)args[0];
               @ftype@ *dst = (@ftype@*)args[1];
 

--- a/numpy/_core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_unary_fp.dispatch.c.src
@@ -212,15 +212,16 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     npy_intp len = dimensions[0];
 #if @VCHK@
     const int lsize = sizeof(npyv_lanetype_@sfx@);
-    assert(len <= 1 || (src_step % lsize == 0 && dst_step % lsize == 0));
+
     if (is_mem_overlap(src, src_step, dst, dst_step, len)) {
         goto no_unroll;
     }
-    const npy_intp ssrc = src_step / lsize;
-    const npy_intp sdst = dst_step / lsize;
-    if (!npyv_loadable_stride_@sfx@(ssrc) || !npyv_storable_stride_@sfx@(sdst)) {
+    if (!npyv_loadable_stride_@sfx@(src_step) || !npyv_storable_stride_@sfx@(dst_step)) {
         goto no_unroll;
     }
+
+    const npy_intp ssrc = src_step / lsize;
+    const npy_intp sdst = dst_step / lsize;
     if (ssrc == 1 && sdst == 1) {
         simd_@TYPE@_@kind@_CONTIG_CONTIG(src, 1, dst, 1, len);
     }

--- a/numpy/_core/src/umath/loops_unary_fp_le.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_unary_fp_le.dispatch.c.src
@@ -528,17 +528,14 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     const npy_intp istep = steps[0];
     const npy_intp ostep = steps[1];
     npy_intp len = dimensions[0];
-    const int ilsize = sizeof(npyv_lanetype_@sfx@);
-    const int olsize = sizeof(npy_bool);
-    const npy_intp istride = istep / ilsize;
-    const npy_intp ostride = ostep / olsize;
-    assert(len <= 1 || ostep % olsize == 0);
 
-    if ((istep % ilsize == 0) &&
-        !is_mem_overlap(ip, istep, op, ostep, len) &&
-        npyv_loadable_stride_@sfx@(istride) &&
-        npyv_storable_stride_@sfx@(ostride))
+    if (!is_mem_overlap(ip, istep, op, ostep, len) &&
+        npyv_loadable_stride_@sfx@(istep) &&
+        npyv_storable_stride_@sfx@(ostep))
     {
+        const npy_intp istride = istep / sizeof(npyv_lanetype_@sfx@);
+        const npy_intp ostride = ostep / sizeof(npy_bool);
+
         if (istride == 1 && ostride == 1) {
             simd_unary_@kind@_@TYPE@_CONTIG_CONTIG(ip, 1, op, 1, len);
         }

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2746,7 +2746,7 @@ def test_ufunc_noncontiguous(ufunc):
             orig_dt = np.dtype(t)
             off_dt = f"S{orig_dt.alignment}"  # offset by alignment
             dtype = np.dtype([("_", off_dt), ("t", orig_dt)], align=False)
-            args_o.append(np.empty(6, dtype="b")["t"])
+            args_o.append(np.empty(6, dtype=dtype)["t"])
 
         for a in args_c + args_n + args_o:
             a.flat = range(1,7)


### PR DESCRIPTION
It was never correct that strides are divisable by their itemsize and
*some* code even checked for it correctly, while others had asserts
in place that had no reason why they should be guaranteed to pass.

This moves the check into the `loadable_stride` macro.  The exp
implementation has it's own custom logic, that is probably OK.

I assume that compilers will optimize the duplicate division away,
if that may not be the case, the code should be optimized to avoid
it probably.
(although, I guess these are power of 2 divisions so they don't matter actually)

Closes gh-26775