### PR TITLE
DOC: document 'floatmode' and 'legacy' keys from np.get_printoptions' return dict

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -313,8 +313,10 @@ def get_printoptions():
         - suppress : bool
         - nanstr : str
         - infstr : str
-        - formatter : dict of callables
         - sign : str
+        - formatter : dict of callables
+        - floatmode : str
+        - legacy : str or False
 
         For a full description of these options, see `set_printoptions`.
 


### PR DESCRIPTION
I noticed these two options were documented for `np.set_printoptions` but were missing for `np.get_printoptions`. I also swapped `sign` and `formatter` to match the order they appear in `np.set_printoptions`' docstring.