### PR TITLE
BUG: random: Fix edge case of Johnk's algorithm for the beta distribution.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -436,7 +436,7 @@ double random_beta(bitgen_t *bitgen_state, double a, double b) {
       XpY = X + Y;
       /* Reject if both U and V are 0.0, which is approx 1 in 10^106 */
       if ((XpY <= 1.0) && (U + V > 0.0)) {
-        if (XpY > 0) {
+        if ((X > 0) && (Y > 0)) {
           return X / XpY;
         } else {
           double logX = log(U) / a;


### PR DESCRIPTION
The first commit is the essential change (yeah, it is that simple).

The second commit refines the logarithm-based calculation of X/(X + Y) in Johnk's algorithm that is used when X = U**(1/a) or Y = V**(1/b) underflows to 0.  It uses `log1p` where appropriate instead of plain `log`.  This change is not essential.  Technically, there could be cases where it improves the precision of the calculation, but in fact, after trying lots of tests cases, I observed at most a 1 ULP improvement in the floating point results with this change.

The third commit adds a regression test that counts the number of occurrences of 0 in a sample from the beta distribution, and checks that it is reasonably close to the expected number of occurrences.  The acceptable bounds were not chosen with any sort of statistical rigor!  This test fails on the main branch, where `nzeros` is 133140 (much larger than the expected 77616.9...).

Closes gh-24475.