### PR TITLE
BUG: use proper input and output descriptor in array_assign_subscript cast setup

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1996,9 +1996,9 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
             npy_intp itemsize = PyArray_ITEMSIZE(self);
             int is_aligned = IsUintAligned(self) && IsUintAligned(tmp_arr);
 
-            if (PyArray_GetDTypeTransferFunction(is_aligned,
-                    itemsize, itemsize,
-                    PyArray_DESCR(self), PyArray_DESCR(self),
+            if (PyArray_GetDTypeTransferFunction(
+                        is_aligned, itemsize, itemsize,
+                        PyArray_DESCR(tmp_arr), PyArray_DESCR(self),
                     0, &cast_info, &transfer_flags) != NPY_SUCCEED) {
                 goto fail;
             }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -495,6 +495,14 @@ def test_fancy_indexing(string_list):
     sarr = np.array(string_list, dtype="T")
     assert_array_equal(sarr, sarr[np.arange(sarr.shape[0])])
 
+    # see gh-27003
+    for ind in [[0, 1], ...]:
+        a = np.array(['a'*16, 'b'*16], dtype="T")
+        b = np.array(['d'*16, 'e'*16], dtype="T")
+        a[ind] = b
+        assert_array_equal(a, b)
+        assert a[0] == 'd'*16
+
 
 def test_creation_functions():
     assert_array_equal(np.zeros(3, dtype="T"), ["", "", ""])


### PR DESCRIPTION
Fixes #27003.

Probably going to be a long tail of these.