### PR TITLE
TST: Refactor to consistently use CompilerChecker

### DIFF
--- a/doc/source/f2py/f2py-testing.rst
+++ b/doc/source/f2py/f2py-testing.rst
@@ -55,7 +55,7 @@ be able to access the fortran functions specified in source file by calling
 Each of the ``f2py`` tests should run without failure if no Fortran compilers
 are present on the host machine. To facilitate this, the ``CompilerChecker`` is
 used, essentially providing a ``meson`` dependent set of utilities namely
-``has_{c,f77,f90}_compiler()`` or ``has_fortran_compilers()``.
+``has_{c,f77,f90,fortran}_compiler()``.
 
 For the CLI tests in ``test_f2py2e``, flags which are expected to call ``meson``
 or otherwise depend on a compiler need to call ``compiler_check_f2pycli()``

--- a/doc/source/f2py/f2py-testing.rst
+++ b/doc/source/f2py/f2py-testing.rst
@@ -50,6 +50,17 @@ functions will be appended to ``self.module`` data member. Thus, the child class
 be able to access the fortran functions specified in source file by calling
 ``self.module.[fortran_function_name]``.
 
+.. versionadded:: v2.0.0b1
+
+Each of the ``f2py`` tests should run without failure if no Fortran compilers
+are present on the host machine. To facilitate this, the ``CompilerChecker`` is
+used, essentially providing a ``meson`` dependent set of utilities namely
+``has_{c,f77,f90}_compiler()`` or ``has_fortran_compilers()``.
+
+For the CLI tests in ``test_f2py2e``, flags which are expected to call ``meson``
+or otherwise depend on a compiler need to call ``compiler_check_f2pycli()``
+instead of ``f2pycli()``.
+
 Example
 ~~~~~~~
 

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -45,12 +45,15 @@ def check_language(lang, code_snippet=None):
                     f"{lang}_compiler.compiles({lang}_code,"
                     f" name: '{lang} feature check')\n"
                 )
-        runmeson = subprocess.run(
-            ["meson", "setup", "btmp"],
-            check=False,
-            cwd=tmpdir,
-            capture_output=True,
-        )
+        try:
+            runmeson = subprocess.run(
+                ["meson", "setup", "btmp"],
+                check=False,
+                cwd=tmpdir,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pytest.skip("meson not present, skipping compiler dependent test")
         return runmeson.returncode == 0
     finally:
         shutil.rmtree(tmpdir)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -27,6 +27,97 @@ from importlib import import_module
 from numpy.f2py._backends._meson import MesonBackend
 
 #
+# Check if compilers are available at all...
+#
+
+def check_language(lang, code_snippet=None):
+    tmpdir = tempfile.mkdtemp()
+    try:
+        meson_file = os.path.join(tmpdir, "meson.build")
+        with open(meson_file, "w") as f:
+            f.write("project('check_compilers')\n")
+            f.write(f"add_languages('{lang}')\n")
+            if code_snippet:
+                f.write(f"{lang}_compiler = meson.get_compiler('{lang}')\n")
+                f.write(f"{lang}_code = '''{code_snippet}'''\n")
+                f.write(
+                    f"_have_{lang}_feature ="
+                    f"{lang}_compiler.compiles({lang}_code,"
+                    f" name: '{lang} feature check')\n"
+                )
+        runmeson = subprocess.run(
+            ["meson", "setup", "btmp"],
+            check=False,
+            cwd=tmpdir,
+            capture_output=True,
+        )
+        return runmeson.returncode == 0
+    finally:
+        shutil.rmtree(tmpdir)
+    return False
+
+
+fortran77_code = '''
+C Example Fortran 77 code
+      PROGRAM HELLO
+      PRINT *, 'Hello, Fortran 77!'
+      END
+'''
+
+fortran90_code = '''
+! Example Fortran 90 code
+program hello90
+  type :: greeting
+    character(len=20) :: text
+  end type greeting
+
+  type(greeting) :: greet
+  greet%text = 'hello, fortran 90!'
+  print *, greet%text
+end program hello90
+'''
+
+# Dummy class for caching relevant checks
+class CompilerChecker:
+    def __init__(self):
+        self.compilers_checked = False
+        self.has_c = False
+        self.has_f77 = False
+        self.has_f90 = False
+
+    def check_compilers(self):
+        if (not self.compilers_checked) and (not sys.platform == "cygwin"):
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(check_language, "c"),
+                    executor.submit(check_language, "fortran", fortran77_code),
+                    executor.submit(check_language, "fortran", fortran90_code)
+                ]
+
+                self.has_c = futures[0].result()
+                self.has_f77 = futures[1].result()
+                self.has_f90 = futures[2].result()
+
+            self.compilers_checked = True
+
+if not IS_WASM:
+    checker = CompilerChecker()
+    checker.check_compilers()
+
+def has_c_compiler():
+    return checker.has_c
+
+def has_f77_compiler():
+    return checker.has_f77
+
+def has_f90_compiler():
+    return checker.has_f90
+
+def has_fortran_compiler():
+    return (checker.has_f90 and checker.has_f77)
+
+
+#
 # Maintaining a temporary module directory
 #
 
@@ -201,95 +292,6 @@ def build_code(source_code,
                             only=only,
                             module_name=module_name)
 
-
-#
-# Check if compilers are available at all...
-#
-
-def check_language(lang, code_snippet=None):
-    tmpdir = tempfile.mkdtemp()
-    try:
-        meson_file = os.path.join(tmpdir, "meson.build")
-        with open(meson_file, "w") as f:
-            f.write("project('check_compilers')\n")
-            f.write(f"add_languages('{lang}')\n")
-            if code_snippet:
-                f.write(f"{lang}_compiler = meson.get_compiler('{lang}')\n")
-                f.write(f"{lang}_code = '''{code_snippet}'''\n")
-                f.write(
-                    f"_have_{lang}_feature ="
-                    f"{lang}_compiler.compiles({lang}_code,"
-                    f" name: '{lang} feature check')\n"
-                )
-        runmeson = subprocess.run(
-            ["meson", "setup", "btmp"],
-            check=False,
-            cwd=tmpdir,
-            capture_output=True,
-        )
-        return runmeson.returncode == 0
-    finally:
-        shutil.rmtree(tmpdir)
-    return False
-
-fortran77_code = '''
-C Example Fortran 77 code
-      PROGRAM HELLO
-      PRINT *, 'Hello, Fortran 77!'
-      END
-'''
-
-fortran90_code = '''
-! Example Fortran 90 code
-program hello90
-  type :: greeting
-    character(len=20) :: text
-  end type greeting
-
-  type(greeting) :: greet
-  greet%text = 'hello, fortran 90!'
-  print *, greet%text
-end program hello90
-'''
-
-# Dummy class for caching relevant checks
-class CompilerChecker:
-    def __init__(self):
-        self.compilers_checked = False
-        self.has_c = False
-        self.has_f77 = False
-        self.has_f90 = False
-
-    def check_compilers(self):
-        if (not self.compilers_checked) and (not sys.platform == "cygwin"):
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                futures = [
-                    executor.submit(check_language, "c"),
-                    executor.submit(check_language, "fortran", fortran77_code),
-                    executor.submit(check_language, "fortran", fortran90_code)
-                ]
-
-                self.has_c = futures[0].result()
-                self.has_f77 = futures[1].result()
-                self.has_f90 = futures[2].result()
-
-            self.compilers_checked = True
-
-if not IS_WASM:
-    checker = CompilerChecker()
-    checker.check_compilers()
-
-def has_c_compiler():
-    return checker.has_c
-
-def has_f77_compiler():
-    return checker.has_f77
-
-def has_f90_compiler():
-    return checker.has_f90
-
-def has_fortran_compiler():
-    return (checker.has_f90 and checker.has_f77)
 
 #
 # Building with meson

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -31,6 +31,8 @@ from numpy.f2py._backends._meson import MesonBackend
 #
 
 def check_language(lang, code_snippet=None):
+    if sys.platform == "win32":
+        pytest.skip("No Fortran tests on Windows (Issue #25134)", allow_module_level=True)
     tmpdir = tempfile.mkdtemp()
     try:
         meson_file = os.path.join(tmpdir, "meson.build")
@@ -53,7 +55,7 @@ def check_language(lang, code_snippet=None):
                 capture_output=True,
             )
         except subprocess.CalledProcessError:
-            pytest.skip("meson not present, skipping compiler dependent test")
+            pytest.skip("meson not present, skipping compiler dependent test", allow_module_level=True)
         return runmeson.returncode == 0
     finally:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
Closes #27045, by using the `CompilerChecker` object to make sure tests which would need a compiler are skipped correctly. 

**TODO**

- [x] Documentation addition detailing the no-compiler and `CompilerChecker` bits in `f2py-testing.rst`.

**Implementation note**
- `CompilerChecker` basically runs `meson`, so if there are environments where the tests may be run without `meson` being installed at all then this needs to be reworked.
  - ~~Like all the failing Windows builds~~ In these scenarios the compiled tests can be skipped anyway.
- Soft reverts [17f529a](https://github.com/numpy/numpy/commit/17f529a2682660b563fb87acebbf5413c382fc0b)