### PR TITLE
TST: fix issues with tests that use numpy.testing.extbuild

### DIFF
--- a/numpy/_core/tests/test_array_interface.py
+++ b/numpy/_core/tests/test_array_interface.py
@@ -9,8 +9,7 @@ def get_module(tmp_path):
     """ Some codes to generate data and manage temporary buffers use when
     sharing with numpy via the array interface protocol.
     """
-
-    if not sys.platform.startswith('linux'):
+    if sys.platform.startswith('cygwin'):
         pytest.skip('link fails on cygwin')
     if IS_WASM:
         pytest.skip("Can't build module inside Wasm")

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -12,11 +12,6 @@ from numpy.testing import extbuild, assert_warns, IS_WASM, IS_EDITABLE
 from numpy._core.multiarray import get_handler_name
 
 
-# FIXME: numpy.testing.extbuild uses `numpy.distutils`, so this won't work on
-# Python 3.12 and up. It's an internal test utility, so for now we just skip
-# these tests.
-
-
 @pytest.fixture
 def get_module(tmp_path):
     """ Add a memory policy that returns a false pointer 64 bytes into the
@@ -234,7 +229,6 @@ def get_module(tmp_path):
                                                more_init=more_init)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_set_policy(get_module):
 
     get_handler_name = np._core.multiarray.get_handler_name
@@ -267,7 +261,6 @@ def test_set_policy(get_module):
         get_module.set_wrong_capsule_name_data_policy()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_default_policy_singleton(get_module):
     get_handler_name = np._core.multiarray.get_handler_name
 
@@ -289,7 +282,6 @@ def test_default_policy_singleton(get_module):
     assert def_policy_1 is def_policy_2 is get_module.get_default_policy()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_policy_propagation(get_module):
     # The memory policy goes hand-in-hand with flags.owndata
 
@@ -348,7 +340,6 @@ async def async_test_context_locality(get_module):
     assert np._core.multiarray.get_handler_name() == orig_policy_name
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_context_locality(get_module):
     if (sys.implementation.name == 'pypy'
             and sys.pypy_version_info[:3] < (7, 3, 6)):
@@ -370,7 +361,6 @@ def concurrent_thread2(get_module, event):
     get_module.set_secret_data_policy()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_thread_locality(get_module):
     orig_policy_name = np._core.multiarray.get_handler_name()
 
@@ -389,7 +379,6 @@ def test_thread_locality(get_module):
     assert np._core.multiarray.get_handler_name() == orig_policy_name
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 @pytest.mark.skip(reason="too slow, see gh-23975")
 def test_new_policy(get_module):
     a = np.arange(10)
@@ -420,7 +409,6 @@ def test_new_policy(get_module):
     assert np._core.multiarray.get_handler_name(c) == orig_policy_name
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 @pytest.mark.xfail(sys.implementation.name == "pypy",
                    reason=("bad interaction between getenv and "
                            "os.environ inside pytest"))
@@ -454,7 +442,6 @@ def test_switch_owner(get_module, policy):
             np._core._multiarray_umath._set_numpy_warn_if_no_mem_policy(oldval)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="no numpy.distutils")
 def test_owner_is_base(get_module):
     a = get_module.get_array_with_base()
     with pytest.warns(UserWarning, match='warn_on_free'):

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -54,7 +54,11 @@ def build_and_import_extension(
     >>> assert mod.test_bytes(b'abc')
     """
     body = prologue + _make_methods(functions, modname)
-    init = """PyObject *mod = PyModule_Create(&moduledef);
+    init = """
+    PyObject *mod = PyModule_Create(&moduledef);
+    #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+    #endif
            """
     if not build_dir:
         build_dir = pathlib.Path('.')


### PR DESCRIPTION
@rgommers [noticed](https://github.com/numpy/numpy/pull/27043#issuecomment-2252778792) the GIL was being re-enabled during some of the wheel builds.

I didn't notice this because there was a test assuming !cygwin == linux, so my Mac never ran it.

While looking at this I also noticed a number of tests that are skipped on 3.12 and newer because `numpy.testing.extbuild` supposedly uses distutils. However, a meson code path was introduced in 0a140163369, and the skips are not actually needed.

I also added the necessary boilerplate to declare that test extensions support the free-threaded build. I haven't looked carefully at this code for thread safety issues, but it's only used in the tests and only in a single-threaded context, so I don't think it actually matters. I could also make sure the module gets imported in a subprocess, but just saying the extension supports free-threading is less surgery on the code in `extbuild.py`.