### PR TITLE
DOC: Add some missing examples for `np.strings` methods

### DIFF
--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -4482,6 +4482,17 @@ add_newdoc('numpy._core.umath', 'isalpha',
     --------
     str.isalpha
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array(['a', 'b', '0'])
+    >>> np.strings.isalpha(a)
+    array([ True,  True, False])
+
+    >>> a = np.array([['a', 'b', '0'], ['c', '1', '2']])
+    >>> np.strings.isalpha(a)
+    array([[ True,  True, False], [ True, False, False]])
+
     """)
 
 add_newdoc('numpy._core.umath', 'isdigit',

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -428,6 +428,17 @@ def startswith(a, prefix, start=0, end=None):
     --------
     str.startswith
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> s = np.array(['foo', 'bar'])
+    >>> s
+    array(['foo', 'bar'], dtype='<U3')
+    >>> np.strings.startswith(s, 'fo')
+    array([True,  False])
+    >>> np.strings.startswith(s, 'o', start=1, end=2)
+    array([True,  False])
+
     """
     end = end if end is not None else MAX
     return _startswith_ufunc(a, prefix, start, end)

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -277,6 +277,18 @@ def rfind(a, sub, start=0, end=None):
     --------
     str.rfind
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array(["Computer Science"])
+    >>> np.strings.rfind(a, "Science", start=0, end=None)
+    array([9])
+    >>> np.strings.rfind(a, "Science", start=0, end=8)
+    array([-1])
+    >>> b = np.array(["Computer Science", "Science"])
+    >>> np.strings.rfind(b, "Science", start=0, end=None)
+    array([9, 0])
+
     """
     end = end if end is not None else MAX
     return _rfind_ufunc(a, sub, start, end)

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -197,7 +197,19 @@ def mod(a, values):
     out : ndarray
         Output array of ``StringDType``, ``bytes_`` or ``str_`` dtype,
         depending on input types
-        
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array(["NumPy is a %s library"])
+    >>> np.strings.mod(a, values=["Python"])
+    array(['NumPy is a Python library'], dtype='<U25')
+
+    >>> a = np.array([b'%d bytes', b'%d bits'])
+    >>> values = np.array([8, 64])
+    >>> np.strings.mod(a, values)
+    array([b'8 bytes', b'64 bits'], dtype='|S7')
+
     """
     return _to_bytes_or_str_array(
         _vec_string(a, np.object_, '__mod__', (values,)), a)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This PR stems off from my findings in gh-26745, where I found some missing examples for a few functions under the `np.strings` module. I have added a few examples here, as noted below:

## Changes made

- Examples added in the docstring for `np.strings.isalpha()`
- Examples added in the docstring for `np.strings.mod()`
- Examples added in the docstring for `np.strings.rfind()`
- Examples added in the docstring for `np.strings.startswith()`