### PR TITLE
ENH: Disable name suggestions on some AttributeErrors

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -371,7 +371,7 @@ else:
             return char
         elif attr == "array_api":
             raise AttributeError("`numpy.array_api` is not available from "
-                                 "numpy 2.0 onwards")
+                                 "numpy 2.0 onwards", name=None)
         elif attr == "core":
             import numpy.core as core
             return core
@@ -384,7 +384,7 @@ else:
                 return distutils
             else:
                 raise AttributeError("`numpy.distutils` is not available from "
-                                     "Python 3.12 onwards")
+                                     "Python 3.12 onwards", name=None)
 
         if attr in __future_scalars__:
             # And future warnings for those that will change, but also give
@@ -394,12 +394,13 @@ else:
                 "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
 
         if attr in __former_attrs__:
-            raise AttributeError(__former_attrs__[attr])
+            raise AttributeError(__former_attrs__[attr], name=None)
         
         if attr in __expired_attributes__:
             raise AttributeError(
                 f"`np.{attr}` was removed in the NumPy 2.0 release. "
-                f"{__expired_attributes__[attr]}"
+                f"{__expired_attributes__[attr]}",
+                name=None
             )
 
         if attr == "chararray":

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -67,7 +67,8 @@ def __getattr__(attr):
         raise AttributeError(
             "numpy.lib.emath was an alias for emath module that was removed "
             "in NumPy 2.0. Replace usages of numpy.lib.emath with "
-            "numpy.emath."
+            "numpy.emath.", 
+            name=None
         )
     elif attr in (
         "histograms", "type_check", "nanfunctions", "function_base",
@@ -77,12 +78,14 @@ def __getattr__(attr):
         raise AttributeError(
             f"numpy.lib.{attr} is now private. If you are using a public "
             "function, it should be available in the main numpy namespace, "
-            "otherwise check the NumPy 2.0 migration guide."
+            "otherwise check the NumPy 2.0 migration guide.", 
+            name=None
         )
     elif attr == "arrayterator":
         raise AttributeError(
             "numpy.lib.arrayterator submodule is now private. To access "
-            "Arrayterator class use numpy.lib.Arrayterator."
+            "Arrayterator class use numpy.lib.Arrayterator.", 
+            name=None
         )
     else:
         raise AttributeError("module {!r} has no attribute "


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Since [Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#attributeerrors), python returns name suggestions on AttributesErrors and NameErrors ("Did you mean ..."). But for some errors (e.g. deprecation) it can be unnecessary repetition, or even misleading.

Before:
```python
>>> import numpy
>>> numpy.float_
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/arnaud-ma/.pyenv/versions/3.12.4/lib/python3.12/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```

With this PR: 
```python
>>> import numpy
>>> numpy.float_
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/arnaud-ma/.pyenv/versions/3.12.4/lib/python3.12/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```

This is done by setting the `name` argument to `None`. According to the [python doc](https://docs.python.org/3/library/exceptions.html#NameError): 
> The name attribute can be set using a keyword-only argument to the constructor. When set it represent the name of the variable that was attempted to be accessed.
