### PR TITLE
TST: Refactor to consistently use CompilerChecker 

### DIFF
--- a/doc/source/f2py/f2py-testing.rst
+++ b/doc/source/f2py/f2py-testing.rst
@@ -55,7 +55,7 @@ be able to access the fortran functions specified in source file by calling
 Each of the ``f2py`` tests should run without failure if no Fortran compilers
 are present on the host machine. To facilitate this, the ``CompilerChecker`` is
 used, essentially providing a ``meson`` dependent set of utilities namely
-``has_{c,f77,f90}_compiler()`` or ``has_fortran_compilers()``.
+``has_{c,f77,f90,fortran}_compiler()``.
 
 For the CLI tests in ``test_f2py2e``, flags which are expected to call ``meson``
 or otherwise depend on a compiler need to call ``compiler_check_f2pycli()``

--- a/doc/source/f2py/f2py-testing.rst
+++ b/doc/source/f2py/f2py-testing.rst
@@ -50,6 +50,17 @@ functions will be appended to ``self.module`` data member. Thus, the child class
 be able to access the fortran functions specified in source file by calling
 ``self.module.[fortran_function_name]``.
 
+.. versionadded:: v2.0.0b1
+
+Each of the ``f2py`` tests should run without failure if no Fortran compilers
+are present on the host machine. To facilitate this, the ``CompilerChecker`` is
+used, essentially providing a ``meson`` dependent set of utilities namely
+``has_{c,f77,f90}_compiler()`` or ``has_fortran_compilers()``.
+
+For the CLI tests in ``test_f2py2e``, flags which are expected to call ``meson``
+or otherwise depend on a compiler need to call ``compiler_check_f2pycli()``
+instead of ``f2pycli()``.
+
 Example
 ~~~~~~~
 

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -701,9 +701,9 @@ def getcallprotoargument(rout, cb_map={}):
             else:
                 if not isattr_value(var):
                     ctype = ctype + '*'
-            if ((isstring(var)
+            if (isstring(var)
                  or isarrayofstrings(var)  # obsolete?
-                 or isstringarray(var))):
+                 or isstringarray(var)):
                 arg_types2.append('size_t')
         arg_types.append(ctype)
 

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -689,6 +689,8 @@ def modsign2map(m):
     else:
         ret['interface_usercode'] = ''
     ret['pymethoddef'] = getpymethoddef(m) or ''
+    if 'gil_used' in m:
+        ret['gil_used'] = m['gil_used']
     if 'coutput' in m:
         ret['coutput'] = m['coutput']
     if 'f2py_wrapper_output' in m:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -806,7 +806,7 @@ def crackline(line, reset=0):
             raise Exception('crackline: groupcounter(=%s) is nonpositive. '
                             'Check the blocks.'
                             % (groupcounter))
-        m1 = beginpattern[0].match((line))
+        m1 = beginpattern[0].match(line)
         if (m1) and (not m1.group('this') == groupname[groupcounter]):
             raise Exception('crackline: End group %s does not match with '
                             'previous Begin group %s\n\t%s' %
@@ -2539,7 +2539,7 @@ def get_parameters(vars, global_params={}):
                 outmess(f'get_parameters[TODO]: '
                         f'implement evaluation of complex expression {v}\n')
 
-            dimspec = ([s.lstrip('dimension').strip()
+            dimspec = ([s.removeprefix('dimension').strip()
                         for s in vars[n]['attrspec']
                        if s.startswith('dimension')] or [None])[0]
 
@@ -2735,8 +2735,8 @@ def analyzevars(block):
                         d = param_parse(d, params)
                     except (ValueError, IndexError, KeyError):
                         outmess(
-                            ('analyzevars: could not parse dimension for '
-                            f'variable {d!r}\n')
+                            'analyzevars: could not parse dimension for '
+                            f'variable {d!r}\n'
                         )
 
                     dim_char = ':' if d == ':' else '*'
@@ -2816,9 +2816,9 @@ def analyzevars(block):
                                         compute_deps(v1, deps)
                             all_deps = set()
                             compute_deps(v, all_deps)
-                            if ((v in n_deps
+                            if (v in n_deps
                                  or '=' in vars[v]
-                                 or 'depend' in vars[v])):
+                                 or 'depend' in vars[v]):
                                 # Skip a variable that
                                 # - n depends on
                                 # - has user-defined initialization expression

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -107,6 +107,14 @@ Options:
                    functions. --wrap-functions is default because it ensures
                    maximum portability/compiler independence.
 
+  --[no-]freethreading-compatible    Create a module that declares it does or
+                   doesn't require the GIL. The default is
+                   --freethreading-compatible for backward
+                   compatibility. Inspect the Fortran code you are wrapping for
+                   thread safety issues before passing
+                   --no-freethreading-compatible, as f2py does not analyze
+                   fortran code for thread safety issues.
+
   --include-paths <path1>:<path2>:...   Search include files from the given
                    directories.
 
@@ -200,7 +208,7 @@ def scaninputline(inputline):
     dorestdoc = 0
     wrapfuncs = 1
     buildpath = '.'
-    include_paths, inputline = get_includes(inputline)
+    include_paths, freethreading_compatible, inputline = get_newer_options(inputline)
     signsfile, modulename = None, None
     options = {'buildpath': buildpath,
                'coutput': None,
@@ -328,6 +336,7 @@ def scaninputline(inputline):
     options['wrapfuncs'] = wrapfuncs
     options['buildpath'] = buildpath
     options['include_paths'] = include_paths
+    options['requires_gil'] = not freethreading_compatible
     options.setdefault('f2cmap_file', None)
     return files, options
 
@@ -365,6 +374,11 @@ def callcrackfortran(files, options):
     else:
         for mod in postlist:
             mod["f2py_wrapper_output"] = options["f2py_wrapper_output"]
+    for mod in postlist:
+        if options["requires_gil"]:
+            mod['gil_used'] = 'Py_MOD_GIL_USED'
+        else:
+            mod['gil_used'] = 'Py_MOD_GIL_NOT_USED'
     return postlist
 
 
@@ -535,21 +549,22 @@ class CombineIncludePaths(argparse.Action):
             include_paths_set.add(values)
         setattr(namespace, 'include_paths', list(include_paths_set))
 
-def include_parser():
+def f2py_parser():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("-I", dest="include_paths", action=CombineIncludePaths)
     parser.add_argument("--include-paths", dest="include_paths", action=CombineIncludePaths)
     parser.add_argument("--include_paths", dest="include_paths", action=CombineIncludePaths)
+    parser.add_argument("--freethreading-compatible", dest="ftcompat", action=argparse.BooleanOptionalAction)
     return parser
 
-def get_includes(iline):
+def get_newer_options(iline):
     iline = (' '.join(iline)).split()
-    parser = include_parser()
+    parser = f2py_parser()
     args, remain = parser.parse_known_args(iline)
     ipaths = args.include_paths
     if args.include_paths is None:
         ipaths = []
-    return ipaths, remain
+    return ipaths, args.ftcompat, remain
 
 def make_f2py_compile_parser():
     parser = argparse.ArgumentParser(add_help=False)
@@ -616,7 +631,7 @@ def run_compile():
         sysinfo_flags = [f[7:] for f in sysinfo_flags]
 
     _reg2 = re.compile(
-        r'--((no-|)(wrap-functions|lower)|debug-capi|quiet|skip-empty-wrappers)|-include')
+        r'--((no-|)(wrap-functions|lower|freethreading-compatible)|debug-capi|quiet|skip-empty-wrappers)|-include')
     f2py_flags = [_m for _m in sys.argv[1:] if _reg2.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in f2py_flags]
     f2py_flags2 = []
@@ -718,7 +733,7 @@ def run_compile():
             run_main(f" {' '.join(f2py_flags)} {' '.join(pyf_files)}".split())
 
     # Order matters here, includes are needed for run_main above
-    include_dirs, sources = get_includes(sources)
+    include_dirs, _, sources = get_newer_options(sources)
     # Now use the builder
     builder = build_backend(
         modulename,

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -236,6 +236,11 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 #initcommonhooks#
 #interface_usercode#
 
+#if Py_GIL_DISABLED
+    // signal whether this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m , #gil_used#);
+#endif
+
 #ifdef F2PY_REPORT_ATEXIT
     if (! PyErr_Occurred())
         on_exit(f2py_report_on_exit,(void*)\"#modulename#\");

--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -1084,9 +1084,9 @@ def as_factors(obj):
                 if coeff == 1:
                     return Expr(Op.FACTORS, {term: 1})
                 return Expr(Op.FACTORS, {term: 1, Expr.number(coeff): 1})
-        if ((obj.op is Op.APPLY
+        if (obj.op is Op.APPLY
              and obj.data[0] is ArithOp.DIV
-             and not obj.data[2])):
+             and not obj.data[2]):
             return Expr(Op.FACTORS, {obj.data[1][0]: 1, obj.data[1][1]: -1})
         return Expr(Op.FACTORS, {obj: 1})
     raise OpError(f'cannot convert {type(obj)} to terms Expr')

--- a/numpy/f2py/tests/__init__.py
+++ b/numpy/f2py/tests/__init__.py
@@ -1,8 +1,15 @@
-from numpy.testing import IS_WASM
+from numpy.testing import IS_WASM, IS_EDITABLE
 import pytest
 
 if IS_WASM:
     pytest.skip(
         "WASM/Pyodide does not use or support Fortran",
+        allow_module_level=True
+    )
+
+
+if IS_EDITABLE:
+    pytest.skip(
+        "Editable install doesn't support tests with a compile step",
         allow_module_level=True
     )

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -115,7 +115,7 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
                        PyArray_DESCR(arr)->type,
                        PyArray_TYPE(arr),
                        PyArray_ITEMSIZE(arr),
-                       PyDataType_ALIGNMENT(arr),
+                       PyDataType_ALIGNMENT(PyArray_DESCR(arr)),
                        PyArray_FLAGS(arr),
                        PyArray_ITEMSIZE(arr));
 }
@@ -214,13 +214,18 @@ PyMODINIT_FUNC PyInit_test_array_from_pyobj_ext(void) {
   ADDCONST("DEFAULT", NPY_ARRAY_DEFAULT);
   ADDCONST("UPDATE_ALL", NPY_ARRAY_UPDATE_ALL);
 
-#undef ADDCONST(
+#undef ADDCONST
 
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap");
 
 #ifdef F2PY_REPORT_ATEXIT
   on_exit(f2py_report_on_exit,(void*)"array_from_pyobj.wrap.call");
+#endif
+
+#if Py_GIL_DISABLED
+    // signal whether this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
   return m;

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -90,10 +90,7 @@ class Intent:
         return "Intent(%r)" % (self.intent_list)
 
     def is_intent(self, *names):
-        for name in names:
-            if name not in self.intent_list:
-                return False
-        return True
+        return all(name in self.intent_list for name in names)
 
     def is_intent_exact(self, *names):
         return len(self.intent_list) == len(names) and self.is_intent(*names)

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -66,7 +66,7 @@ class TestPublicPrivate:
         pyf = crackfortran.crack2fortran(mod)
         assert 'bar' not in pyf
 
-class TestModuleProcedure():
+class TestModuleProcedure:
     def test_moduleOperators(self, tmp_path):
         fpath = util.getpath("tests", "src", "crackfortran", "operators.f90")
         mod = crackfortran.crackfortran([str(fpath)])
@@ -347,14 +347,14 @@ class TestFortranGroupCounters(util.F2PyTest):
             assert False, f"'crackfortran.crackfortran' raised an exception {exc}"
 
 
-class TestF77CommonBlockReader():
+class TestF77CommonBlockReader:
     def test_gh22648(self, tmp_path):
         fpath = util.getpath("tests", "src", "crackfortran", "gh22648.pyf")
         with contextlib.redirect_stdout(io.StringIO()) as stdout_f2py:
             mod = crackfortran.crackfortran([str(fpath)])
         assert "Mismatch" not in stdout_f2py.getvalue()
 
-class TestParamEval():
+class TestParamEval:
     # issue gh-11612, array parameter parsing
     def test_param_eval_nested(self):
         v = '(/3.14, 4./)'

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -7,6 +7,7 @@ import pytest
 
 from . import util
 from numpy.f2py.f2py2e import main as f2pycli
+from numpy.testing._private.utils import NOGIL_BUILD
 
 #######################
 # F2PY Test utilities #
@@ -587,7 +588,7 @@ def test_debugcapi_bld(hello_world_f90, monkeypatch):
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd_run = shlex.split("python3 -c \"import blah; blah.hi()\"")
+        cmd_run = shlex.split(f"{sys.executable} -c \"import blah; blah.hi()\"")
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         eerr = textwrap.dedent("""\
@@ -756,14 +757,14 @@ def test_npdistop(hello_world_f90, monkeypatch):
 
     with util.switchdir(ipath.parent):
         f2pycli()
-        cmd_run = shlex.split("python -c \"import blah; blah.hi()\"")
+        cmd_run = shlex.split(f"{sys.executable} -c \"import blah; blah.hi()\"")
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         assert rout.stdout == eout
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 12),
-                    reason='Python 3.12 or newer required')
+@pytest.mark.skipif((platform.system() != 'Linux') or sys.version_info <= (3, 12),
+                    reason='Compiler and Python 3.12 or newer required')
 def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
     """
     CLI :: --no-freethreading-compatible
@@ -787,8 +788,8 @@ def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
         assert rout.returncode == 0
 
 
-@pytest.mark.skipif(sys.version_info <= (3, 12),
-                    reason='Python 3.12 or newer required')
+@pytest.mark.skipif((platform.system() != 'Linux') or sys.version_info <= (3, 12),
+                    reason='Compiler and Python 3.12 or newer required')
 def test_freethreading_compatible(hello_world_f90, monkeypatch):
     """
     CLI :: --freethreading_compatible
@@ -813,7 +814,6 @@ def test_freethreading_compatible(hello_world_f90, monkeypatch):
 
 # Numpy distutils flags
 # TODO: These should be tested separately
-
 
 def test_npd_fcompiler():
     """

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -8,6 +8,18 @@ import pytest
 from . import util
 from numpy.f2py.f2py2e import main as f2pycli
 
+#######################
+# F2PY Test utilities #
+######################
+
+# Tests for CLI commands which call meson will fail if no compilers are present, these are to be skipped
+
+def compiler_check_f2pycli():
+    if not util.has_fortran_compiler():
+        pytest.skip("CLI command needs a Fortran compiler")
+    else:
+        f2pycli()
+
 #########################
 # CLI utils and classes #
 #########################
@@ -49,9 +61,9 @@ def get_io_paths(fname_inp, mname="untitled"):
     )
 
 
-##############
-# CLI Fixtures and Tests #
-#############
+################
+# CLI Fixtures #
+################
 
 
 @pytest.fixture(scope="session")
@@ -109,6 +121,9 @@ def f2cmap_f90(tmpdir_factory):
     fmap.write_text(f2cmap, encoding="ascii")
     return fn
 
+#########
+# Tests #
+#########
 
 def test_gh22819_cli(capfd, gh22819_cli, monkeypatch):
     """Check that module names are handled correctly
@@ -198,8 +213,7 @@ def test_gen_pyf_no_overwrite(capfd, hello_world_f90, monkeypatch):
             assert "Use --overwrite-signature to overwrite" in err
 
 
-@pytest.mark.skipif((platform.system() != 'Linux') or (sys.version_info <= (3, 12)),
-                    reason='Compiler and 3.12 required')
+@pytest.mark.skipif(sys.version_info <= (3, 12), reason="Python 3.12 required")
 def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
     """Check that modules are named correctly
 
@@ -208,7 +222,7 @@ def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
     ipath = Path(hello_world_f90)
     monkeypatch.setattr(sys, "argv", f"f2py --backend meson -c {ipath}".split())
     with util.switchdir(ipath.parent):
-        f2pycli()
+        compiler_check_f2pycli()
         out, _ = capfd.readouterr()
         assert "untitledmodule.c" in out
 
@@ -225,7 +239,7 @@ def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
         sys, "argv", f"f2py {ipath} -c --fcompiler=gfortran -m {MNAME}".split()
     )
     with util.switchdir(ipath.parent):
-        f2pycli()
+        compiler_check_f2pycli()
         out, _ = capfd.readouterr()
         assert "--fcompiler cannot be used with meson" in out
     monkeypatch.setattr(
@@ -746,6 +760,55 @@ def test_npdistop(hello_world_f90, monkeypatch):
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         assert rout.stdout == eout
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 12),
+                    reason='Python 3.12 or newer required')
+def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
+    """
+    CLI :: --no-freethreading-compatible
+    """
+    ipath = Path(hello_world_f90)
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --no-freethreading-compatible'.split())
+
+    with util.switchdir(ipath.parent):
+        compiler_check_f2pycli()
+        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
+        if NOGIL_BUILD:
+            cmd += "import sys; assert sys._is_gil_enabled() is True\""
+        else:
+            cmd += "\""
+        cmd_run = shlex.split(cmd)
+        rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
+        eout = ' Hello World\n'
+        assert rout.stdout == eout
+        if NOGIL_BUILD:
+            assert "The global interpreter lock (GIL) has been enabled to load module 'blah'" in rout.stderr
+        assert rout.returncode == 0
+
+
+@pytest.mark.skipif(sys.version_info <= (3, 12),
+                    reason='Python 3.12 or newer required')
+def test_freethreading_compatible(hello_world_f90, monkeypatch):
+    """
+    CLI :: --freethreading_compatible
+    """
+    ipath = Path(hello_world_f90)
+    monkeypatch.setattr(sys, "argv", f'f2py -m blah {ipath} -c --freethreading-compatible'.split())
+
+    with util.switchdir(ipath.parent):
+        compiler_check_f2pycli()
+        cmd = f"{sys.executable} -c \"import blah; blah.hi();"
+        if NOGIL_BUILD:
+            cmd += "import sys; assert sys._is_gil_enabled() is False\""
+        else:
+            cmd += "\""
+        cmd_run = shlex.split(cmd)
+        rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
+        eout = ' Hello World\n'
+        assert rout.stdout == eout
+        assert rout.stderr == ""
+        assert rout.returncode == 0
 
 
 # Numpy distutils flags

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -228,7 +228,11 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     # Prepare options
     if module_name is None:
         module_name = get_temp_module_name()
-    f2py_opts = ["-c", "-m", module_name] + options + f2py_sources
+    gil_options = []
+    if '--freethreading-compatible' not in options and '--no-freethreading-compatible' not in options:
+        # default to disabling the GIL if unset in options
+        gil_options = ['--freethreading-compatible']
+    f2py_opts = ["-c", "-m", module_name] + options + gil_options + f2py_sources
     f2py_opts += ["--backend", "meson"]
     if skip:
         f2py_opts += ["skip:"] + skip

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -45,12 +45,15 @@ def check_language(lang, code_snippet=None):
                     f"{lang}_compiler.compiles({lang}_code,"
                     f" name: '{lang} feature check')\n"
                 )
-        runmeson = subprocess.run(
-            ["meson", "setup", "btmp"],
-            check=False,
-            cwd=tmpdir,
-            capture_output=True,
-        )
+        try:
+            runmeson = subprocess.run(
+                ["meson", "setup", "btmp"],
+                check=False,
+                cwd=tmpdir,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pytest.skip("meson not present, skipping compiler dependent test")
         return runmeson.returncode == 0
     finally:
         shutil.rmtree(tmpdir)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -31,6 +31,8 @@ from numpy.f2py._backends._meson import MesonBackend
 #
 
 def check_language(lang, code_snippet=None):
+    if sys.platform == "win32":
+        pytest.skip("No Fortran tests on Windows (Issue #25134)", allow_module_level=True)
     tmpdir = tempfile.mkdtemp()
     try:
         meson_file = os.path.join(tmpdir, "meson.build")
@@ -53,7 +55,7 @@ def check_language(lang, code_snippet=None):
                 capture_output=True,
             )
         except subprocess.CalledProcessError:
-            pytest.skip("meson not present, skipping compiler dependent test")
+            pytest.skip("meson not present, skipping compiler dependent test", allow_module_level=True)
         return runmeson.returncode == 0
     finally:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
Backport of #27051.

Closes #27045, by using the `CompilerChecker` object to make sure tests which would need a compiler are skipped correctly. 

**TODO**

- [x] Documentation addition detailing the no-compiler and `CompilerChecker` bits in `f2py-testing.rst`.

**Implementation note**
- `CompilerChecker` basically runs `meson`, so if there are environments where the tests may be run without `meson` being installed at all then this needs to be reworked.
  - ~~Like all the failing Windows builds~~ In these scenarios the compiled tests can be skipped anyway.
- Soft reverts [17f529a](https://github.com/numpy/numpy/commit/17f529a2682660b563fb87acebbf5413c382fc0b)


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
