### PR TITLE
BUG: Mirror VQSORT_ENABLED logic in Quicksort

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1204,6 +1204,7 @@ py.extension_module('_multiarray_umath',
     'src/multiarray',
     'src/npymath',
     'src/umath',
+    'src/highway'
   ],
   dependencies: [blas_dep],
   link_with: [npymath_lib, multiarray_umath_mtargets.static_lib('_multiarray_umath_mtargets')] + highway_lib,

--- a/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
@@ -2,6 +2,8 @@
 #define VQSORT_ONLY_STATIC 1
 #include "hwy/contrib/sort/vqsort-inl.h"
 
+#if VQSORT_ENABLED
+
 #define DISPATCH_VQSORT(TYPE) \
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(TYPE *arr, intptr_t size) \
 { \
@@ -18,3 +20,5 @@ namespace np { namespace highway { namespace qsort_simd {
     DISPATCH_VQSORT(float)
 
 } } } // np::highway::qsort_simd
+
+#endif // VQSORT_ENABLED

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -10,7 +10,9 @@
 // dispatched sources.
 #if (HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD) ||                   \
     (HWY_ARCH_ARM_V7 && HWY_IS_DEBUG_BUILD) ||                      \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN)
+    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN) || \
+    (HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG &&                      \
+    (HWY_IS_HWASAN || HWY_IS_MSAN || HWY_IS_TSAN || HWY_IS_ASAN))
 #define NPY_DISABLE_HIGHWAY_SORT
 #endif
 

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -1,8 +1,20 @@
 #ifndef NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 #define NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 
+#include "hwy/highway.h"
+
 #include "common.hpp"
 
+// This replicates VQSORT_ENABLED from hwy/contrib/sort/shared-inl.h
+// without checking the scalar target as this is not built within the dynamic
+// dispatched sources.
+#if (HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD) ||                   \
+    (HWY_ARCH_ARM_V7 && HWY_IS_DEBUG_BUILD) ||                      \
+    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN)
+#define NPY_DISABLE_HIGHWAY_SORT
+#endif
+
+#ifndef NPY_DISABLE_HIGHWAY_SORT
 namespace np { namespace highway { namespace qsort_simd {
 
 #ifndef NPY_DISABLE_OPTIMIZATION
@@ -21,3 +33,4 @@ NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp n
 } } } // np::highway::qsort_simd
 
 #endif // NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
+#endif // NPY_DISABLE_HIGHWAY_SORT

--- a/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
@@ -4,6 +4,8 @@
 
 #include "quicksort.hpp"
 
+#if VQSORT_ENABLED
+
 namespace np { namespace highway { namespace qsort_simd {
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, intptr_t size)
@@ -24,3 +26,5 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSort)(int16_t *arr, intptr_t size)
 }
 
 } } } // np::highway::qsort_simd
+
+#endif // VQSORT_ENABLED

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -80,7 +80,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
     using TF = typename np::meta::FixedWidth<T>::Type;
     void (*dispfunc)(TF*, intptr_t) = nullptr;
     if (sizeof(T) == sizeof(uint16_t)) {
-        #ifndef NPY_DISABLE_OPTIMIZATION
+        #if !defined(NPY_DISABLE_OPTIMIZATION) && !defined(NPY_DISABLE_HIGHWAY_SORT)
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort_16bit.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
@@ -91,7 +91,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
         #endif
     }
     else if (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
-        #ifndef NPY_DISABLE_OPTIMIZATION
+        #if !defined(NPY_DISABLE_OPTIMIZATION) && !defined(NPY_DISABLE_HIGHWAY_SORT)
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -80,22 +80,22 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
     using TF = typename np::meta::FixedWidth<T>::Type;
     void (*dispfunc)(TF*, intptr_t) = nullptr;
     if (sizeof(T) == sizeof(uint16_t)) {
-        #if !defined(NPY_DISABLE_OPTIMIZATION) && !defined(NPY_DISABLE_HIGHWAY_SORT)
+        #ifndef NPY_DISABLE_OPTIMIZATION
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort_16bit.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
-            #else
+            #elif !defined(NPY_DISABLE_HIGHWAY_SORT)
                 #include "highway_qsort_16bit.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSort, <TF>);
             #endif
         #endif
     }
     else if (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t)) {
-        #if !defined(NPY_DISABLE_OPTIMIZATION) && !defined(NPY_DISABLE_HIGHWAY_SORT)
+        #ifndef NPY_DISABLE_OPTIMIZATION
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
-            #else
+            #elif !defined(NPY_DISABLE_HIGHWAY_SORT)
                 #include "highway_qsort.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSort, <TF>);
             #endif


### PR DESCRIPTION
Backport of #27050.

This patch disables Highway VQSort if the same criteria is met as sort/shared-inl.h, to prevent it aborting at runtime.

I'm unsure whether this would look neater using Highway's dynamic dispatch.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
