### PR TITLE
DEP: lib: Deprecate acceptance of float (and more) in bincount.

### DIFF
--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -150,11 +150,10 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
         }
         if (PyArray_SIZE(tmp1) > 0) {
             /* The input is not empty, so convert it to NPY_INTP. */
-            PyArrayObject *tmp2 = (PyArrayObject *)PyArray_ContiguousFromAny(
-                                                    (PyObject *)tmp1,
-                                                    NPY_INTP, 1, 1);
+            lst = (PyArrayObject *)PyArray_ContiguousFromAny((PyObject *)tmp1,
+                                                             NPY_INTP, 1, 1);
             Py_DECREF(tmp1);
-            if (tmp2 == NULL) {
+            if (lst == NULL) {
                 /* Failed converting to NPY_INTP. */
                 if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                     PyErr_Clear();
@@ -169,10 +168,6 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
                     goto fail;
                 }
             }
-            else {
-                /* Cast to NPY_INTP succeeded, so no deprecation warning. */
-                Py_DECREF(tmp2);
-            }
         }
         else {
             /* Got an empty list. */
@@ -180,10 +175,11 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
         }
     }
 
-    /* Legacy conversion. This must be changed when the deprecation expires. */
-    lst = (PyArrayObject *)PyArray_ContiguousFromAny(list, NPY_INTP, 1, 1);
     if (lst == NULL) {
-        goto fail;
+        lst = (PyArrayObject *)PyArray_ContiguousFromAny(list, NPY_INTP, 1, 1);
+        if (lst == NULL) {
+            goto fail;
+        }
     }
     len = PyArray_SIZE(lst);
 

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -157,9 +157,10 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
                 /* Failed converting to NPY_INTP. */
                 if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                     PyErr_Clear();
+                    /* Deprecated 2024-08-02, NumPy 2.1 */
                     if (DEPRECATE("Non-integer input passed to bincount. In a "
                                   "future version of NumPy, this will be an "
-                                  "error.") < 0) {
+                                  "error. (Deprecated NumPy 2.1)") < 0) {
                         goto fail;
                     }
                 }

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -217,6 +217,11 @@ class TestBincount(_DeprecationTestCase):
     def test_bincount_minlength(self):
         self.assert_deprecated(lambda: np.bincount([1, 2, 3], minlength=None))
 
+    # 2024-07-29, 2.1.0
+    @pytest.mark.parametrize('badlist', [[0.5, 1.2, 1.5],
+                                         ['0', '1', '1']])
+    def test_bincount_bad_list(self, badlist):
+        self.assert_deprecated(lambda: np.bincount(badlist))
 
 
 class TestGeneratorSum(_DeprecationTestCase):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2848,6 +2848,11 @@ class TestBincount:
         y = np.bincount(x, minlength=5)
         assert_array_equal(y, np.zeros(5, dtype=int))
 
+    @pytest.mark.parametrize('minlength', [0, 3])
+    def test_empty_list(self, minlength):
+        assert_array_equal(np.bincount([], minlength=minlength),
+                           np.zeros(minlength, dtype=int))
+
     def test_with_incorrect_minlength(self):
         x = np.array([], dtype=int)
         assert_raises_regex(TypeError,


### PR DESCRIPTION
The first argument of bincount is expected to contain integers. As noted in gh-3138, it actually accepts floats, and casts them to integers with no warnings. (It also accepts other objects that can be cast to integers, so inputs such as ["1", Fraction(5, 3)] are accepted, with fractional parts silently dropped.)

This change deprecates that behavior.  Now a deprecation warning is generated if the input cannot be safely cast to integer.

For example,

```
In [1]: import numpy as np

In [2]: np.bincount([1.4, 1.5, 3.9, 5.1])
<ipython-input-2-6d924fc4fef0>:1: DeprecationWarning: Non-integer input passed to bincount. In a future version of NumPy, this will be an error.
  np.bincount([1.4, 1.5, 3.9, 5.1])
Out[2]: array([0, 2, 0, 1, 0, 1])
```

Closes gh-3138.
