### PR TITLE
MAINT: 3.9/10 cleanups

### DIFF
--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -4,19 +4,6 @@
 #include "numpy/npy_3kcompat.h"
 #include "pythoncapi-compat/pythoncapi_compat.h"
 
-/*
- * In Python 3.10a7 (or b1), python started using the identity for the hash
- * when a value is NaN.  See https://bugs.python.org/issue43475
- */
-#if PY_VERSION_HEX > 0x030a00a6
 #define Npy_HashDouble _Py_HashDouble
-#else
-static inline Py_hash_t
-Npy_HashDouble(PyObject *NPY_UNUSED(identity), double val)
-{
-    return _Py_HashDouble(val);
-}
-#endif
-
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_ */

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2862,7 +2862,6 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         (PyCFunction) array_format,
         METH_VARARGS, NULL},
 
-    /* for typing; requires python >= 3.9 */
     {"__class_getitem__",
         (PyCFunction)array_class_getitem,
         METH_CLASS | METH_O, NULL},

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -3218,8 +3218,6 @@ def test_warn_noclose():
         assert len(sup.log) == 1
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 9) and sys.platform == "win32",
-                    reason="Errors with Python 3.9 on Windows")
 @pytest.mark.parametrize(["in_dtype", "buf_dtype"],
         [("i", "O"), ("O", "i"),  # most simple cases
          ("i,O", "O,O"),  # structured partially only copying O

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -2807,10 +2807,6 @@ class TestBitwiseUFuncs:
     def test_bitwise_count(self, input_dtype_obj, bitsize):
         input_dtype = input_dtype_obj.type
 
-        # bitwise_count is only in-built in 3.10+
-        if sys.version_info < (3, 10) and input_dtype == np.object_:
-            pytest.skip("Required Python >=3.10")
-
         for i in range(1, bitsize):
             num = 2**i - 1
             msg = f"bitwise_count for {num}"

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1923,8 +1923,7 @@ def test_xy_rename(assert_func):
         assert_func(1, y=1)
 
     type_message = '...got multiple values for argument'
-    # explicit linebreak to support Python 3.9
-    with pytest.warns(DeprecationWarning, match=dep_message), \
-          pytest.raises(TypeError, match=type_message):
+    with (pytest.warns(DeprecationWarning, match=dep_message),
+          pytest.raises(TypeError, match=type_message)):
         assert_func(1, x=1)
         assert_func(1, 2, y=2)


### PR DESCRIPTION
* Cleanup some shims related to the lower bound of Python now being `3.10`.

I was just doing this in SciPy, so many of the same `git grep ... ` applied. I did touch one C file to make sure it was't too easy...