### PR TITLE
CI: Upgrade ``array-api-tests``

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -253,7 +253,7 @@ jobs:
         PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
       run: |
         cd ${GITHUB_WORKSPACE}/array-api-tests
-        pytest array_api_tests -v -c pytest.ini --ci --max-examples=50 --derandomize --disable-deadline --xfails-file ${GITHUB_WORKSPACE}/tools/ci/array-api-xfails.txt
+        pytest array_api_tests -v -c pytest.ini --ci --max-examples=100 --derandomize --disable-deadline --xfails-file ${GITHUB_WORKSPACE}/tools/ci/array-api-xfails.txt
 
   custom_checks:
     needs: [smoke_test]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,7 +232,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: data-apis/array-api-tests
-        ref: '809a1984414cfc0bca68a823aeaeba7df3900d17'  # Latest commit as of 2024-06-26
+        ref: '827edd804bcace9d64176b8115138d29ae3e8dec'  # Latest commit as of 2024-07-30
         submodules: 'true'
         path: 'array-api-tests'
     - name: Set up Python
@@ -253,7 +253,7 @@ jobs:
         PYTHONWARNINGS: 'ignore::UserWarning::,ignore::DeprecationWarning::,ignore::RuntimeWarning::'
       run: |
         cd ${GITHUB_WORKSPACE}/array-api-tests
-        pytest array_api_tests -v -c pytest.ini --ci --max-examples=2 --derandomize --disable-deadline --skips-file ${GITHUB_WORKSPACE}/tools/ci/array-api-skips.txt
+        pytest array_api_tests -v -c pytest.ini --ci --max-examples=50 --derandomize --disable-deadline --xfails-file ${GITHUB_WORKSPACE}/tools/ci/array-api-xfails.txt
 
   custom_checks:
     needs: [smoke_test]

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2684,9 +2684,10 @@ def astype(x, dtype, /, *, copy=True, device=None):
     True
 
     """
-    if not isinstance(x, np.ndarray):
+    if not (isinstance(x, np.ndarray) or isscalar(x)):
         raise TypeError(
-            f"Input should be a NumPy array. It is a {type(x)} instead."
+            "Input should be a NumPy array or scalar. "
+            f"It is a {type(x)} instead."
         )
     if device is not None and device != "cpu":
         raise ValueError(

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4158,5 +4158,10 @@ class TestAsType:
             actual, np.astype(actual, actual.dtype, copy=False)
         )
 
+        actual = np.astype(np.int64(10), np.float64)
+        expected = np.float64(10)
+        assert_equal(actual, expected)
+        assert_equal(actual.dtype, expected.dtype)
+
         with pytest.raises(TypeError, match="Input should be a NumPy array"):
             np.astype(data, np.float64)

--- a/tools/ci/array-api-xfails.txt
+++ b/tools/ci/array-api-xfails.txt
@@ -18,3 +18,6 @@ array_api_tests/test_sorting_functions.py::test_sort
 # ufuncs signature on linux is always <Signature (*args, **kwargs)>
 # np.vecdot is the only ufunc with a keyword argument which causes a failure
 array_api_tests/test_signatures.py::test_func_signature[vecdot]
+
+# input is cast to min/max's dtype if they're different
+array_api_tests/test_operators_and_elementwise_functions.py::test_clip

--- a/tools/ci/array-api-xfails.txt
+++ b/tools/ci/array-api-xfails.txt
@@ -7,9 +7,13 @@ array_api_tests/test_signatures.py::test_func_signature[reshape]
 # 'min/max' args are present. 'a_min/a_max' are retained for backward compat.
 array_api_tests/test_signatures.py::test_func_signature[clip]
 
-# missing 'descending' keyword arguments
+# missing 'descending' keyword argument
 array_api_tests/test_signatures.py::test_func_signature[argsort]
 array_api_tests/test_signatures.py::test_func_signature[sort]
+
+# missing 'descending' keyword argument
+array_api_tests/test_sorting_functions.py::test_argsort
+array_api_tests/test_sorting_functions.py::test_sort
 
 # ufuncs signature on linux is always <Signature (*args, **kwargs)>
 # np.vecdot is the only ufunc with a keyword argument which causes a failure


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/27072 and increases `array-api-tests` suite `--max-examples` to 50.