### PR TITLE
ENH: fixes for warnings on free-threaded wheel builds

### DIFF
--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -352,18 +352,11 @@ def test_thread_local_promotion_state():
         np._set_promotion_state("legacy")
         b.wait()
         assert np._get_promotion_state() == "legacy"
-        # turn warnings into errors, this should not warn with
-        # legacy promotion state
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            np.float16(1) + 131008
 
     def weak_warn():
         np._set_promotion_state("weak")
         b.wait()
         assert np._get_promotion_state() == "weak"
-        with pytest.raises(RuntimeWarning):
-            np.float16(1) + 131008
 
     task1 = threading.Thread(target=legacy_no_warn)
     task2 = threading.Thread(target=weak_warn)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import itertools
+import threading
 import traceback
 import textwrap
 import subprocess
@@ -1943,7 +1944,9 @@ def test_generalized_raise_multiloop():
 
     assert_raises(np.linalg.LinAlgError, np.linalg.inv, x)
 
-
+@pytest.mark.skipif(
+    threading.active_count() > 1,
+    reason="skipping test that uses fork because there are multiple threads")
 def test_xerbla_override():
     # Check that our xerbla has been successfully linked in. If it is not,
     # the default xerbla routine is called, which prints a message to stdout

--- a/numpy/random/_examples/cython/meson.build
+++ b/numpy/random/_examples/cython/meson.build
@@ -12,7 +12,7 @@ if not cy.version().version_compare('>=3.0.6')
 endif
 
 base_cython_args = []
-if cy.version().version_compare('>=3.1.0a0')
+if cy.version().version_compare('>=3.1.0')
   base_cython_args += ['-Xfreethreading_compatible=True']
 endif
 


### PR DESCRIPTION
See #27063, although this doesn't fix the crash reported there.

For the first issue, meson's compiler version comparison doesn't check the alpha/beta version, so including it is incorrect.

The skipped xerbla test is because the test explicitly uses `os.fork()`, which generates a `DeprecationWarning` if there are active threads ([see this CI log](https://github.com/numpy/numpy/actions/runs/10123674205/job/27997191826)):

```
    /private/var/folders/hn/5bx1f4_d4ds5vhwhkxc7vdcr0000gn/T/cibw-run-e0nrh73s/cp313t-macosx_arm64/venv-test-arm64/lib/python3.13/site-packages/numpy/linalg/tests/test_linalg.py:1955: DeprecationWarning: This process (pid=7969) is multi-threaded, use of fork() may lead to deadlocks in the child.
      pid = os.fork()
```

And the deleted code in the nep50 promotions tests is because the code assumes you can use `warnings.catch_warnings()` in a multi-threaded program, but [the docs](https://docs.python.org/3.14/library/warnings.html#temporarily-suppressing-warnings) explicitly say it's not thread-safe. This intermittently triggers warnings on CI and deleting the buggy test code gets rid of them. Merely checking the value of the promotion state like the test already does is sufficient.