### PR TITLE
WHL: bump (musl) linux image [wheel build]

### DIFF
--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -24,7 +24,7 @@ jobs:
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc
-      image: quay.io/pypa/musllinux_1_1_x86_64
+      image: quay.io/pypa/musllinux_1_2_x86_64
 
     steps:
     - name: setup

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,7 +90,7 @@ jobs:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
             python: "pp310"
-          - buildplat: [ ubuntu-20.04, musllinux_x86_64, "" ]
+          - buildplat: [ ubuntu-22.04, musllinux_x86_64, "" ]
             python: "pp310"
           - buildplat: [ macos-14, macosx_arm64, accelerate ]
             python: "pp310"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,8 +76,8 @@ jobs:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
-          - [ubuntu-20.04, manylinux_x86_64, ""]
-          - [ubuntu-20.04, musllinux_x86_64, ""]
+          - [ubuntu-22.04, manylinux_x86_64, ""]
+          - [ubuntu-22.04, musllinux_x86_64, ""]
           - [macos-13, macosx_x86_64, openblas]
 
           # targeting macos >= 14. Could probably build on macos-14, but it would be a cross-compile

--- a/doc/release/upcoming_changes/27088.change.rst
+++ b/doc/release/upcoming_changes/27088.change.rst
@@ -1,3 +1,2 @@
-PR `27088 <https://github.com/numpy/numpy/pull/27088>`_  contains changes to
-bump the musllinux image to 1_2 from 1_1. This is because the 1_1 image is
+Bump the musllinux CI image and wheels to 1_2 from 1_1. This is because 1_1 is
 `end of life <https://github.com/pypa/manylinux/issues/1629>`_.

--- a/doc/release/upcoming_changes/27088.change.rst
+++ b/doc/release/upcoming_changes/27088.change.rst
@@ -1,0 +1,3 @@
+PR `27088 <https://github.com/numpy/numpy/pull/27088>`_  contains changes to
+bump the musllinux image to 1_2 from 1_1. This is because the 1_1 image is
+`end of life <https://github.com/pypa/manylinux/issues/1629>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
-musllinux-x86_64-image = "musllinux_1_1"
+musllinux-x86_64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.linux.environment]
 # RUNNER_OS is a GitHub Actions specific env var; define it here so it works on Cirrus CI too


### PR DESCRIPTION
closes #27066.

- bumps the musllinux image from 1_1 to 1_2.
- bumps the ubuntu images used for wheel building from 20.04 to 22.04.