### PR TITLE
DOC: update np.shares_memory() docs

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -1350,7 +1350,7 @@ def shares_memory(a, b, max_work=None):
     .. warning::
 
        This function can be exponentially slow for some inputs, unless
-       `max_work` is set to a finite number or 0.
+       `max_work` is set to zero or a positive integer.
        If in doubt, use `numpy.may_share_memory` instead.
 
     Parameters
@@ -1362,12 +1362,13 @@ def shares_memory(a, b, max_work=None):
         of candidate solutions to consider). The following special
         values are recognized:
 
-        max_work=-1 (formerly MAY_SHARE_EXACT)
+        max_work=-1 (default)
             The problem is solved exactly. In this case, the function returns
             True only if there is an element shared between the arrays. Finding
             the exact solution may take extremely long in some cases.
-        max_work=0 (formerly MAY_SHARE_BOUNDS)
+        max_work=0
             Only the memory bounds of a and b are checked.
+            This is equivalent to using may_share_memory().
 
     Raises
     ------

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -1368,7 +1368,7 @@ def shares_memory(a, b, max_work=None):
             the exact solution may take extremely long in some cases.
         max_work=0
             Only the memory bounds of a and b are checked.
-            This is equivalent to using may_share_memory().
+            This is equivalent to using ``may_share_memory()``.
 
     Raises
     ------

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -1350,7 +1350,7 @@ def shares_memory(a, b, max_work=None):
     .. warning::
 
        This function can be exponentially slow for some inputs, unless
-       `max_work` is set to a finite number or ``MAY_SHARE_BOUNDS``.
+       `max_work` is set to a finite number or 0.
        If in doubt, use `numpy.may_share_memory` instead.
 
     Parameters
@@ -1362,11 +1362,11 @@ def shares_memory(a, b, max_work=None):
         of candidate solutions to consider). The following special
         values are recognized:
 
-        max_work=MAY_SHARE_EXACT  (default)
+        max_work=-1 (formerly MAY_SHARE_EXACT)
             The problem is solved exactly. In this case, the function returns
             True only if there is an element shared between the arrays. Finding
             the exact solution may take extremely long in some cases.
-        max_work=MAY_SHARE_BOUNDS
+        max_work=0 (formerly MAY_SHARE_BOUNDS)
             Only the memory bounds of a and b are checked.
 
     Raises


### PR DESCRIPTION
## Description

In NumPy 2.0, the `MAY_SHARE_EXACT` and `MAY_SHARE_BOUNDS` constants are no longer exposed as part of the public API. This PR updates the documentation for `np.shares_memory` functions to reflect this change.

## Changes made

1. Replaced `MAY_SHARE_EXACT` with its actual value `-1` in the documentation.
2. Replaced `MAY_SHARE_BOUNDS` with its actual value `0` in the documentation.
3. Updated the warning message to remove references to `MAY_SHARE_BOUNDS`.

These changes ensure that the documentation accurately reflects the current implementation and provides clear guidance for users on how to correctly use these functions in NumPy 2.0.

Close #27089