### PR TITLE
API,BUG: Fix copyto (and ufunc) handling of scalar cast safety

### DIFF
--- a/doc/release/upcoming_changes/27091.change.rst
+++ b/doc/release/upcoming_changes/27091.change.rst
@@ -1,0 +1,24 @@
+Cast-safety fixes in ``copyto`` and ``full``
+--------------------------------------------
+``copyto`` now uses NEP 50 correctly and applies this to its cast safety.
+Python integer to NumPy integer casts and Python float to NumPy float casts
+are now considered "safe" even if assignment may fail or precision may be lost.
+This means the following examples change slightly:
+
+* ``np.copyto(int8_arr, 1000)`` previously performed an unsafe/same-kind cast
+   of the Python integer.  It will now always raise, to achieve an unsafe cast
+   you must pass an array or NumPy scalar.
+* ``np.copyto(uint8_arr, 1000, casting="safe")`` will raise an OverflowError
+  rather than a TypeError due to same-kind casting.
+* ``np.copyto(float32_arr, 1e300, casting="safe")`` will overflow to ``inf``
+  (float32 cannot hold ``1e300``) rather raising a TypeError.
+
+Further, only the dtype is used when assigning NumPy scalars (or 0-d arrays),
+meaning that the following behaves differently:
+
+* ``np.copyto(float32_arr, np.float64(3.0), casting="safe")`` raises.
+* ``np.coptyo(int8_arr, np.int64(100), casting="safe")`` raises.
+  Previously, NumPy checked whether the 100 fits the ``int8_arr``.
+
+This aligns ``copyto``, ``full``, and ``full_like`` with the correct NumPy 2
+behavior.

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -1,6 +1,7 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_ABSTRACTDTYPES_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_ABSTRACTDTYPES_H_
 
+#include "numpy/ndarraytypes.h"
 #include "arrayobject.h"
 #include "dtypemeta.h"
 
@@ -67,6 +68,19 @@ npy_mark_tmp_array_if_pyscalar(
     }
     return 0;
 }
+
+
+NPY_NO_EXPORT int
+npy_update_operand_for_scalar(
+    PyArrayObject **operand, PyObject *scalar, PyArray_Descr *descr,
+    NPY_CASTING casting);
+
+
+NPY_NO_EXPORT PyArray_Descr *
+npy_find_descr_for_scalar(
+    PyObject *scalar, PyArray_Descr *original_descr,
+    PyArray_DTypeMeta *in_DT, PyArray_DTypeMeta *op_DT);
+
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/array_assign_scalar.c
+++ b/numpy/_core/src/multiarray/array_assign_scalar.c
@@ -243,8 +243,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
     }
 
     /* Check the casting rule */
-    if (!can_cast_scalar_to(src_dtype, src_data,
-                            PyArray_DESCR(dst), casting)) {
+    if (!PyArray_CanCastTypeTo(src_dtype, PyArray_DESCR(dst), casting)) {
         npy_set_invalid_cast_error(
                 src_dtype, PyArray_DESCR(dst), casting, NPY_TRUE);
         return -1;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1957,14 +1957,14 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
     if (src == NULL) {
         goto fail;
     }
-    PyArray_DTypeMeta *dtype = NPY_DTYPE(PyArray_DESCR(src));
-    Py_INCREF(dtype);
-    if (npy_mark_tmp_array_if_pyscalar(src_obj, src, &dtype)) {
+    PyArray_DTypeMeta *DType = NPY_DTYPE(PyArray_DESCR(src));
+    Py_INCREF(DType);
+    if (npy_mark_tmp_array_if_pyscalar(src_obj, src, &DType)) {
         /* The user passed a Python scalar */
         PyArray_Descr *descr = npy_find_descr_for_scalar(
-                src_obj, PyArray_DESCR(src), dtype,
+                src_obj, PyArray_DESCR(src), DType,
                 NPY_DTYPE(PyArray_DESCR(dst)));
-        Py_DECREF(dtype);
+        Py_DECREF(DType);
         if (descr == NULL) {
             goto fail;
         }
@@ -1975,17 +1975,17 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         }
     }
     else {
-        Py_DECREF(dtype);
+        Py_DECREF(DType);
     }
 
     if (wheremask_in != NULL) {
         /* Get the boolean where mask */
-        PyArray_Descr *dtype = PyArray_DescrFromType(NPY_BOOL);
-        if (dtype == NULL) {
+        PyArray_Descr *descr = PyArray_DescrFromType(NPY_BOOL);
+        if (descr == NULL) {
             goto fail;
         }
         wheremask = (PyArrayObject *)PyArray_FromAny(wheremask_in,
-                                        dtype, 0, 0, 0, NULL);
+                                        descr, 0, 0, 0, NULL);
         if (wheremask == NULL) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5163,7 +5163,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
 
     // initialize static reference to a zero-like array
     npy_static_pydata.zero_pyint_like_arr = PyArray_ZEROS(
-            0, NULL, NPY_LONG, NPY_FALSE);
+            0, NULL, NPY_DEFAULT_INT, NPY_FALSE);
     if (npy_static_pydata.zero_pyint_like_arr == NULL) {
         goto err;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2356,7 +2356,7 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
     if (evil_ndim_mutating_hack) {
         ((PyArrayObject_fields *)out)->nd = 0;
     }
-    // TODO: Clean up multiple cleanup!
+
     if (ufuncimpl == NULL) {
         /* DTypes may currently get filled in fallbacks and XDECREF for error: */
         Py_XDECREF(operation_DTypes[0]);
@@ -2372,18 +2372,15 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      * casting safety could in principle be set to the default same-kind.
      * (although this should possibly happen through a deprecation)
      */
-    if (resolve_descriptors(3, ufunc, ufuncimpl,
-            ops, out_descrs, signature, operation_DTypes, NULL, casting) < 0) {
-        /* DTypes may currently get filled in fallbacks and XDECREF for error: */
-        Py_XDECREF(operation_DTypes[0]);
-        Py_XDECREF(operation_DTypes[1]);
-        Py_XDECREF(operation_DTypes[2]);
-        return NULL;
-    }
-    /* DTypes may currently get filled in fallbacks and XDECREF for error: */
+    int res = resolve_descriptors(3, ufunc, ufuncimpl,
+            ops, out_descrs, signature, operation_DTypes, NULL, casting);
+
     Py_XDECREF(operation_DTypes[0]);
     Py_XDECREF(operation_DTypes[1]);
     Py_XDECREF(operation_DTypes[2]);
+    if (res < 0) {
+        return NULL;
+    }
 
     /*
      * The first operand and output should be the same array, so they should

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -101,8 +101,8 @@ static int
 resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
-        PyArray_DTypeMeta *signature[], PyObject *inputs_tup,
-        NPY_CASTING casting);
+        PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
+        PyObject *inputs_tup, NPY_CASTING casting);
 
 
 /*UFUNC_API*/
@@ -2356,11 +2356,12 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
     if (evil_ndim_mutating_hack) {
         ((PyArrayObject_fields *)out)->nd = 0;
     }
-    /* DTypes may currently get filled in fallbacks and XDECREF for error: */
-    Py_XDECREF(operation_DTypes[0]);
-    Py_XDECREF(operation_DTypes[1]);
-    Py_XDECREF(operation_DTypes[2]);
+    // TODO: Clean up multiple cleanup!
     if (ufuncimpl == NULL) {
+        /* DTypes may currently get filled in fallbacks and XDECREF for error: */
+        Py_XDECREF(operation_DTypes[0]);
+        Py_XDECREF(operation_DTypes[1]);
+        Py_XDECREF(operation_DTypes[2]);
         return NULL;
     }
 
@@ -2372,9 +2373,17 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      * (although this should possibly happen through a deprecation)
      */
     if (resolve_descriptors(3, ufunc, ufuncimpl,
-            ops, out_descrs, signature, NULL, casting) < 0) {
+            ops, out_descrs, signature, operation_DTypes, NULL, casting) < 0) {
+        /* DTypes may currently get filled in fallbacks and XDECREF for error: */
+        Py_XDECREF(operation_DTypes[0]);
+        Py_XDECREF(operation_DTypes[1]);
+        Py_XDECREF(operation_DTypes[2]);
         return NULL;
     }
+    /* DTypes may currently get filled in fallbacks and XDECREF for error: */
+    Py_XDECREF(operation_DTypes[0]);
+    Py_XDECREF(operation_DTypes[1]);
+    Py_XDECREF(operation_DTypes[2]);
 
     /*
      * The first operand and output should be the same array, so they should
@@ -4023,12 +4032,12 @@ static int
 resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
-        PyArray_DTypeMeta *signature[], PyObject *inputs_tup,
-        NPY_CASTING casting)
+        PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
+        PyObject *inputs_tup, NPY_CASTING casting)
 {
     int retval = -1;
     NPY_CASTING safety;
-    PyArray_Descr *original_dtypes[NPY_MAXARGS];
+    PyArray_Descr *original_descrs[NPY_MAXARGS];
 
     NPY_UF_DBG_PRINT("Resolving the descriptors\n");
 
@@ -4043,12 +4052,12 @@ resolve_descriptors(int nop,
         PyObject *input_scalars[NPY_MAXARGS];
         for (int i = 0; i < nop; i++) {
             if (operands[i] == NULL) {
-                original_dtypes[i] = NULL;
+                original_descrs[i] = NULL;
             }
             else {
                 /* For abstract DTypes, we might want to change what this is */
-                original_dtypes[i] = PyArray_DTYPE(operands[i]);
-                Py_INCREF(original_dtypes[i]);
+                original_descrs[i] = PyArray_DTYPE(operands[i]);
+                Py_INCREF(original_descrs[i]);
             }
             /*
              * Check whether something is a scalar of the given type.
@@ -4067,27 +4076,71 @@ resolve_descriptors(int nop,
 
         npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
         safety = ufuncimpl->resolve_descriptors_with_scalars(
-            ufuncimpl, signature, original_dtypes, input_scalars,
+            ufuncimpl, signature, original_descrs, input_scalars,
             dtypes, &view_offset
         );
+
+        /* For scalars, replace the operand if needed (scalars can't be out) */
+        for (int i = 0; i < nin; i++) {
+            if ((PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL)) {
+                /* `resolve_descriptors_with_scalars` decides the descr */
+                if (npy_update_operand_for_scalar(
+                        &operands[i], input_scalars[i], dtypes[i],
+                        /* ignore cast safety for this op (resolvers job) */
+                        NPY_SAFE_CASTING) < 0) {
+                    goto finish;
+                }
+            }
+        }
         goto check_safety;
     }
 
     for (int i = 0; i < nop; ++i) {
         if (operands[i] == NULL) {
-            original_dtypes[i] = NULL;
+            original_descrs[i] = NULL;
+            continue;
         }
-        else {
-            /*
-             * The dtype may mismatch the signature, in which case we need
-             * to make it fit before calling the resolution.
-             */
-            PyArray_Descr *descr = PyArray_DTYPE(operands[i]);
-            original_dtypes[i] = PyArray_CastDescrToDType(descr, signature[i]);
-            if (original_dtypes[i] == NULL) {
+        PyArray_Descr *descr = PyArray_DTYPE(operands[i]);
+
+        /*
+         * If we are working with Python literals/scalars, deal with them.
+         * If needed, we create new array with the right descriptor.
+         */
+        if ((PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL)) {
+            PyObject *input;
+            if (inputs_tup == NULL) {
+                input = NULL;
+            }
+            else {
+                input = PyTuple_GET_ITEM(inputs_tup, i);
+            }
+
+            PyArray_Descr *new_descr = npy_find_descr_for_scalar(
+                    input, descr, original_DTypes[i], signature[i]);
+            if (new_descr == NULL) {
                 nop = i;  /* only this much is initialized */
                 goto finish;
             }
+            int res = npy_update_operand_for_scalar(
+                &operands[i], input, new_descr, casting);
+            Py_DECREF(new_descr);
+            if (res < 0) {
+                nop = i;  /* only this much is initialized */
+                goto finish;
+            }
+
+            /* Descriptor may have been modified along the way */
+            descr = PyArray_DESCR(operands[i]);
+        }
+
+        /*
+         * The dtype may mismatch the signature, in which case we need
+         * to make it fit before calling the resolution.
+         */
+        original_descrs[i] = PyArray_CastDescrToDType(descr, signature[i]);
+        if (original_descrs[i] == NULL) {
+            nop = i;  /* only this much is initialized */
+            goto finish;
         }
     }
 
@@ -4096,7 +4149,7 @@ resolve_descriptors(int nop,
         npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
 
         safety = ufuncimpl->resolve_descriptors(ufuncimpl,
-                signature, original_dtypes, dtypes, &view_offset);
+                signature, original_descrs, dtypes, &view_offset);
         goto check_safety;
     }
     else {
@@ -4124,7 +4177,7 @@ resolve_descriptors(int nop,
 
   finish:
     for (int i = 0; i < nop; i++) {
-        Py_XDECREF(original_dtypes[i]);
+        Py_XDECREF(original_descrs[i]);
     }
     return retval;
 }
@@ -4467,47 +4520,9 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
 
     /* Find the correct descriptors for the operation */
     if (resolve_descriptors(nop, ufunc, ufuncimpl,
-            operands, operation_descrs, signature, full_args.in, casting) < 0) {
+            operands, operation_descrs, signature, operand_DTypes,
+            full_args.in, casting) < 0) {
         goto fail;
-    }
-
-    if (promoting_pyscalars) {
-        /*
-         * Python integers need to be cast specially.  For other python
-         * scalars it does not hurt either.  It would be nice to never create
-         * the array in this case, but that is difficult until value-based
-         * promotion rules are gone.  (After that, we may get away with using
-         * dummy arrays rather than real arrays for the legacy resolvers.)
-         */
-        for (int i = 0; i < nin; i++) {
-            int orig_flags = PyArray_FLAGS(operands[i]);
-            if (!(orig_flags & NPY_ARRAY_WAS_PYTHON_LITERAL)) {
-                continue;
-            }
-            /*
-             * If descriptor matches, no need to convert, but integers may
-             * have been too large.
-             */
-            if (!(orig_flags & NPY_ARRAY_WAS_INT_AND_REPLACED)
-                    && PyArray_EquivTypes(
-                        PyArray_DESCR(operands[i]), operation_descrs[i])) {
-                continue;
-            }
-            /* Otherwise, replace the operand with a new array */
-            PyArray_Descr *descr = operation_descrs[i];
-            Py_INCREF(descr);
-            PyArrayObject *new = (PyArrayObject *)PyArray_NewFromDescr(
-                    &PyArray_Type, descr, 0, NULL, NULL, NULL, 0, NULL);
-            Py_SETREF(operands[i], new);
-            if (operands[i] == NULL) {
-                goto fail;
-            }
-
-            PyObject *value = PyTuple_GET_ITEM(full_args.in, i);
-            if (PyArray_SETITEM(new, PyArray_BYTES(operands[i]), value) < 0) {
-                goto fail;
-            }
-        }
     }
 
     /*
@@ -5827,7 +5842,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
         /* Find the correct operation_descrs for the operation */
         int resolve_result = resolve_descriptors(nop, ufunc, ufuncimpl,
-                tmp_operands, operation_descrs, signature, NULL, NPY_UNSAFE_CASTING);
+                tmp_operands, operation_descrs, signature, operand_DTypes, NULL, NPY_UNSAFE_CASTING);
         for (int i = 0; i < 3; i++) {
             Py_XDECREF(signature[i]);
             Py_XDECREF(operand_DTypes[i]);
@@ -6152,7 +6167,7 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
 
         /* Find the correct descriptors for the operation */
         if (resolve_descriptors(ufunc->nargs, ufunc, ufuncimpl,
-                dummy_arrays, operation_descrs, signature,
+                dummy_arrays, operation_descrs, signature, DTypes,
                 NULL, casting) < 0) {
             goto finish;
         }

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -428,7 +428,7 @@ def test_copyto_cast_safety():
     # As a special thing, object is equiv currently:
     np.copyto(np.arange(3, dtype=object), 3, casting="equiv")
 
-    # The following raises an overflow error/givs a warning but not
+    # The following raises an overflow error/gives a warning but not
     # type error (due to casting), though:
     with pytest.raises(OverflowError):
         np.copyto(np.arange(3), 2**80, casting="safe")

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -406,6 +406,37 @@ def test_copyto():
     # 'dst' must be an array
     assert_raises(TypeError, np.copyto, [1, 2, 3], [2, 3, 4])
 
+
+def test_copyto_cast_safety():
+    with pytest.raises(TypeError):
+        np.copyto(np.arange(3), 3., casting="safe")
+
+    # Can put integer and float scalars safely (and equiv):
+    np.copyto(np.arange(3), 3, casting="equiv")
+    np.copyto(np.arange(3.), 3., casting="equiv")
+    # And also with less precision safely:
+    np.copyto(np.arange(3, dtype="uint8"), 3, casting="safe")
+    np.copyto(np.arange(3., dtype="float32"), 3., casting="safe")
+
+    # But not equiv:
+    with pytest.raises(TypeError):
+        np.copyto(np.arange(3, dtype="uint8"), 3, casting="equiv")
+
+    with pytest.raises(TypeError):
+        np.copyto(np.arange(3., dtype="float32"), 3., casting="equiv")
+
+    # As a special thing, object is equiv currently:
+    np.copyto(np.arange(3, dtype=object), 3, casting="equiv")
+
+    # The following raises an overflow error/givs a warning but not
+    # type error (due to casting), though:
+    with pytest.raises(OverflowError):
+        np.copyto(np.arange(3), 2**80, casting="safe")
+
+    with pytest.warns(RuntimeWarning):
+        np.copyto(np.arange(3, dtype=np.float32), 2e300, casting="safe")
+
+
 def test_copyto_permut():
     # test explicit overflow case
     pad = 500

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3472,7 +3472,11 @@ class TestLikeFuncs:
     def test_filled_like(self):
         self.check_like_function(np.full_like, 0, True)
         self.check_like_function(np.full_like, 1, True)
-        self.check_like_function(np.full_like, 1000, True)
+        # Large integers may overflow, but using int64 is OK (casts)
+        # see also gh-27075
+        with pytest.raises(OverflowError):
+            np.full_like(np.ones(3, dtype=np.int8), 1000)
+        self.check_like_function(np.full_like, np.int64(1000), True)
         self.check_like_function(np.full_like, 123.456, True)
         # Inf to integer casts cause invalid-value errors: ignore them.
         with np.errstate(invalid="ignore"):

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -616,6 +616,31 @@ class TestUfunc:
         expected = call_ufunc(arr.astype(np.float64))  # upcast
         assert_array_equal(expected, res)
 
+    @pytest.mark.parametrize("ufunc", [np.add, np.equal])
+    def test_cast_safety_scalar(self, ufunc):
+        # We test add and equal, because equal has special scalar handling
+        # Note that the "equiv" casting behavior should maybe be considered
+        # a current implementation.
+        with pytest.raises(TypeError):
+            # The loop picked is integral, which is not safe
+            ufunc(3., 4., dtype=int, casting="safe")
+
+        with pytest.raises(TypeError):
+            # We accept python float as float64 but not float32 for equiv.
+            ufunc(3., 4., dtype="float32", casting="equiv")
+
+        # Special case for object and equal (note that equiv implies safe)
+        ufunc(3, 4, dtype=object, casting="equiv")
+        # Picks a double loop for both, first is equiv, second safe:
+        ufunc(np.array([3.]), 3., casting="equiv")
+        ufunc(np.array([3.]), 3, casting="safe")
+        ufunc(np.array([3]), 3, casting="equiv")
+
+    def test_cast_safety_scalar_special(self):
+        # We allow this (and it succeeds) via object, although the equiv
+        # part may not be important.
+        np.equal(np.array([3]), 2**300, casting="equiv")
+
     def test_true_divide(self):
         a = np.array(10)
         b = np.array(20)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -620,9 +620,9 @@ class TestUfunc:
     def test_cast_safety_scalar(self, ufunc):
         # We test add and equal, because equal has special scalar handling
         # Note that the "equiv" casting behavior should maybe be considered
-        # a current implementation.
+        # a current implementation detail.
         with pytest.raises(TypeError):
-            # The loop picked is integral, which is not safe
+            # this picks an integer loop, which is not safe
             ufunc(3., 4., dtype=int, casting="safe")
 
         with pytest.raises(TypeError):


### PR DESCRIPTION
This defines scalar cast safety to be "safe", "equiv", or "unsafe" (for Python int, float, complex).
Although, equiv is a bit of an odd one.  We define it by using the common DType with the desired one, and assuming that this cast is at least safe.  With that, we can create an appropriate array for the scalar (and the rest works fine).

This means that any python float can be safely cast to e.g. float32 and any Python integer to any NumPy integer even though the actual assignment may overflow (floats) or fail (integers). `can_cast` itself is not defined here.  It could be, but has the disadvantage that it won't error out on assignment later for integers.

Closes gh-26381, gh-27075

---

~Still needs release notes~, but ready for review.  Sorry it ended up as one big commit, but besides moving some helper out of ufunc.c looking at it per-file is just as well.