### PR TITLE
BUG: add missing error handling in public_dtype_api.c

### DIFF
--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -71,7 +71,9 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
-    dtypemeta_initialize_struct_from_spec(DType, spec, 0);
+    if (dtypemeta_initialize_struct_from_spec(DType, spec, 0) < 0) {
+        return -1;
+    }
 
     if (NPY_DT_SLOTS(DType)->setitem == NULL
             || NPY_DT_SLOTS(DType)->getitem == NULL) {


### PR DESCRIPTION
@swayaminsync ran into some confusing behaviors working on a DType and I tracked it down to missing error handling here

Hard to write a test for this without defining an invalid DType.