### PR TITLE
TST, DOC: add doc and test for transpose axes with negative indices

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -653,11 +653,11 @@ def transpose(a, axes=None):
         Input array.
     axes : tuple or list of ints, optional
         If specified, it must be a tuple or list which contains a permutation
-        of [0, 1, ..., N-1] where N is the number of axes of `a`. Negative indices
-        can also be used to specify axes. The i-th axis of the returned array
-        will correspond to the axis numbered ``axes[i]`` of the input. If not
-        specified, defaults to ``range(a.ndim)[::-1]``, which reverses the order
-        of the axes.
+        of [0, 1, ..., N-1] where N is the number of axes of `a`. Negative 
+        indices can also be used to specify axes. The i-th axis of the returned 
+        array will correspond to the axis numbered ``axes[i]`` of the input. 
+        If not specified, defaults to ``range(a.ndim)[::-1]``, which reverses 
+        the order of the axes.
 
     Returns
     -------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -653,10 +653,11 @@ def transpose(a, axes=None):
         Input array.
     axes : tuple or list of ints, optional
         If specified, it must be a tuple or list which contains a permutation
-        of [0,1,...,N-1] where N is the number of axes of `a`. The `i`'th axis
-        of the returned array will correspond to the axis numbered ``axes[i]``
-        of the input. If not specified, defaults to ``range(a.ndim)[::-1]``,
-        which reverses the order of the axes.
+        of [0, 1, ..., N-1] where N is the number of axes of `a`. Negative indices
+        can also be used to specify axes. The i-th axis of the returned array
+        will correspond to the axis numbered ``axes[i]`` of the input. If not
+        specified, defaults to ``range(a.ndim)[::-1]``, which reverses the order
+        of the axes.
 
     Returns
     -------
@@ -698,6 +699,10 @@ def transpose(a, axes=None):
     >>> a = np.ones((2, 3, 4, 5))
     >>> np.transpose(a).shape
     (5, 4, 3, 2)
+
+    >>> a = np.arange(3*4*5).reshape((3, 4, 5))
+    >>> np.transpose(a, (-1, 0, -2)).shape
+    (5, 3, 4)
 
     """
     return _wrapfunc(a, 'transpose', axes)

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -343,6 +343,7 @@ class TestNonarrayArgs:
         arr = [[1, 2], [3, 4], [5, 6]]
         tgt = [[1, 3, 5], [2, 4, 6]]
         assert_equal(np.transpose(arr, (1, 0)), tgt)
+        assert_equal(np.transpose(arr, (-1, -2)), tgt)
         assert_equal(np.matrix_transpose(arr), tgt)
 
     def test_var(self):


### PR DESCRIPTION
## Description

This PR updates the documentation to clarify that negative indices are supported in the `axes` parameter of `np.transpose` and add test for it.

## Changes made

- Updated the docstring and  for `np.transpose` to explicitly mention support for negative indices

- Add test for `np.transpose`

Close #27024