### PR TITLE
BUG: Fix building NumPy in FIPS mode

### DIFF
--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -160,7 +160,7 @@ class Function:
         return '%s%s %s(%s)' % (doccomment, self.return_type, self.name, argstr)
 
     def api_hash(self):
-        m = hashlib.md5()
+        m = hashlib.md5(usedforsecurity=False)
         m.update(remove_whitespace(self.return_type))
         m.update('\000')
         m.update(self.name)
@@ -533,7 +533,9 @@ def fullapi_hash(api_dicts):
             a.extend(name)
             a.extend(','.join(map(str, data)))
 
-    return hashlib.md5(''.join(a).encode('ascii')).hexdigest()
+    return hashlib.md5(
+        ''.join(a).encode('ascii'), usedforsecurity=False
+    ).hexdigest()
 
 # To parse strings like 'hex = checksum' where hex is e.g. 0x1234567F and
 # checksum a 128 bits md5 checksum (hex format as well)
@@ -555,7 +557,7 @@ def main():
     tagname = sys.argv[1]
     order_file = sys.argv[2]
     functions = get_api_functions(tagname, order_file)
-    m = hashlib.md5(tagname)
+    m = hashlib.md5(tagname, usedforsecurity=False)
     for func in functions:
         print(func)
         ah = func.api_hash()


### PR DESCRIPTION
MD5 is an insecure cryptogrpahic hashing algorithm and is therefore blocked in FIPS mode. NumPy uses MD5 has digest algorithm without any security requirements. Use `usedforsecurity=False` flag to tell OpenSSL that the use of MD5 is okay in FIPS enforcing mode. I implemented the flag in Python 3.9 for exactly this purpose

Fixes: #27099