### PR TITLE
BUG: Fix repr for integer scalar subclasses

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -562,9 +562,9 @@ genint_type_repr(PyObject *self)
     int num = _typenum_fromtypeobj((PyObject *)Py_TYPE(self), 0);
 
     PyObject *repr;
-    if (num == 0) {
+    if (num == NPY_NOTYPE) {
         /* Not a builtin scalar (presumably), just use the name */
-        repr = PyUnicode_FromFormat("%S(%S)", Py_TYPE(self)->tp_name, value_string);
+        repr = PyUnicode_FromFormat("%s(%S)", Py_TYPE(self)->tp_name, value_string);
         Py_DECREF(value_string);
         return repr;
     }

--- a/numpy/_core/tests/test_scalarinherit.py
+++ b/numpy/_core/tests/test_scalarinherit.py
@@ -54,6 +54,13 @@ class TestInherit:
         with pytest.raises(TypeError):
             B1(1.0, 2.0)
 
+    def test_int_repr(self):
+        # Test that integer repr works correctly for subclasses (gh-27106)
+        class my_int16(np.int16):
+            pass
+    
+        s = repr(my_int16(3))
+        assert s == "my_int16(3)"
 
 class TestCharacter:
     def test_char_radd(self):


### PR DESCRIPTION
The subclass path was untested and thus not taken correctly.

Closes gh-27106