### PR TITLE
DOC: update NEP 50 draft status to "Final"

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -4,7 +4,7 @@
 NEP 50 — Promotion rules for Python scalars
 ===========================================
 :Author: Sebastian Berg
-:Status: Draft
+:Status: Final
 :Type: Standards Track
 :Created: 2021-05-25
 


### PR DESCRIPTION
Hi all,

First time contributor here so feel free to leave any comments or suggestions. I welcome any and all feedback :)

Fixes: [#27016](https://github.com/numpy/numpy/issues/27016)

It looks like NEP 50 was added in Numpy 2.0.0 and it seems that the only relevant line I needed to update was to change the existing draft status of the NEP 50 doc to "Final" in order to move it to the "Finished NEPs" section.

I came to this conclusion by looking at /doc/neps/finished.rst.tmpl and noticing that it filters by status.