### PR TITLE
ENH: Use ``PyObject_GetOptionalAttr``

### DIFF
--- a/doc/release/upcoming_changes/27119.performance.rst
+++ b/doc/release/upcoming_changes/27119.performance.rst
@@ -1,0 +1,4 @@
+* NumPy now uses fast-on-failure attribute lookups for protocols.
+  This can greatly reduce overheads of function calls or array creation
+  especially with custom Python objects.  The largest improvements
+  will be seen on Python 3.12 or newer.

--- a/numpy/_core/src/common/binop_override.h
+++ b/numpy/_core/src/common/binop_override.h
@@ -129,15 +129,15 @@ binop_should_defer(PyObject *self, PyObject *other, int inplace)
      * Classes with __array_ufunc__ are living in the future, and only need to
      * check whether __array_ufunc__ equals None.
      */
-    attr = PyArray_LookupSpecial(other, npy_interned_str.array_ufunc);
-    if (attr != NULL) {
+    if (PyArray_LookupSpecial(other, npy_interned_str.array_ufunc, &attr) < 0) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+    }
+    else if (attr != NULL) {
         defer = !inplace && (attr == Py_None);
         Py_DECREF(attr);
         return defer;
     }
-    else if (PyErr_Occurred()) {
-        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
-    }
+
     /*
      * Otherwise, we need to check for the legacy __array_priority__. But if
      * other.__class__ is a subtype of self.__class__, then it's already had

--- a/numpy/_core/src/common/get_attr_string.h
+++ b/numpy/_core/src/common/get_attr_string.h
@@ -2,7 +2,8 @@
 #define NUMPY_CORE_SRC_COMMON_GET_ATTR_STRING_H_
 
 #include <Python.h>
-#include "ufunc_object.h"
+#include "npy_pycompat.h"
+
 
 static inline npy_bool
 _is_basic_python_type(PyTypeObject *tp)
@@ -46,22 +47,19 @@ _is_basic_python_type(PyTypeObject *tp)
  *
  * In future, could be made more like _Py_LookupSpecial
  */
-static inline PyObject *
-PyArray_LookupSpecial(PyObject *obj, PyObject *name_unicode)
+static inline int
+PyArray_LookupSpecial(
+        PyObject *obj, PyObject *name_unicode, PyObject **res)
 {
     PyTypeObject *tp = Py_TYPE(obj);
 
     /* We do not need to check for special attributes on trivial types */
     if (_is_basic_python_type(tp)) {
-        return NULL;
-    }
-    PyObject *res = PyObject_GetAttr((PyObject *)tp, name_unicode);
-
-    if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
+        *res = NULL;
+        return 0;
     }
 
-    return res;
+    return PyObject_GetOptionalAttr((PyObject *)tp, name_unicode, res);
 }
 
 
@@ -73,23 +71,20 @@ PyArray_LookupSpecial(PyObject *obj, PyObject *name_unicode)
  *
  * Kept for backwards compatibility. In future, we should deprecate this.
  */
-static inline PyObject *
-PyArray_LookupSpecial_OnInstance(PyObject *obj, PyObject *name_unicode)
+static inline int
+PyArray_LookupSpecial_OnInstance(
+        PyObject *obj, PyObject *name_unicode, PyObject **res)
 {
     PyTypeObject *tp = Py_TYPE(obj);
 
     /* We do not need to check for special attributes on trivial types */
+    /* Note: This check should likely be reduced on Python 3.13+ */
     if (_is_basic_python_type(tp)) {
-        return NULL;
+        *res = NULL;
+        return 0;
     }
 
-    PyObject *res = PyObject_GetAttr(obj, name_unicode);
-
-    if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
-    }
-
-    return res;
+    return PyObject_GetOptionalAttr(obj, name_unicode, res);
 }
 
 #endif  /* NUMPY_CORE_SRC_COMMON_GET_ATTR_STRING_H_ */

--- a/numpy/_core/src/common/get_attr_string.h
+++ b/numpy/_core/src/common/get_attr_string.h
@@ -45,7 +45,7 @@ _is_basic_python_type(PyTypeObject *tp)
  * Assumes that the special method is a numpy-specific one, so does not look
  * at builtin types. It does check base ndarray and numpy scalar types.
  *
- * In future, could be made more like _Py_LookupSpecial
+ * It may make sense to just replace this with `PyObject_GetOptionalAttr`.
  */
 static inline int
 PyArray_LookupSpecial(

--- a/numpy/_core/src/common/ufunc_override.c
+++ b/numpy/_core/src/common/ufunc_override.c
@@ -1,6 +1,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
+#include "numpy/ndarrayobject.h"
 #include "numpy/ndarraytypes.h"
 #include "npy_pycompat.h"
 #include "get_attr_string.h"
@@ -35,14 +36,12 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
      * Does the class define __array_ufunc__? (Note that LookupSpecial has fast
      * return for basic python types, so no need to worry about those here)
      */
-    cls_array_ufunc = PyArray_LookupSpecial(obj, npy_interned_str.array_ufunc);
-    if (cls_array_ufunc == NULL) {
-        if (PyErr_Occurred()) {
-            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
-        }
+    if (PyArray_LookupSpecial(
+            obj, npy_interned_str.array_ufunc, &cls_array_ufunc) < 0) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
         return NULL;
     }
-    /* Ignore if the same as ndarray.__array_ufunc__ */
+    /* Ignore if the same as ndarray.__array_ufunc__ (it may be NULL here) */
     if (cls_array_ufunc == npy_static_pydata.ndarray_array_ufunc) {
         Py_DECREF(cls_array_ufunc);
         return NULL;

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -4,6 +4,7 @@
 #include <Python.h>
 #include "structmember.h"
 
+#include "numpy/ndarrayobject.h"
 #include "numpy/ndarraytypes.h"
 #include "get_attr_string.h"
 #include "npy_import.h"
@@ -25,8 +26,9 @@ get_array_function(PyObject *obj)
         return npy_static_pydata.ndarray_array_function;
     }
 
-    PyObject *array_function = PyArray_LookupSpecial(obj, npy_interned_str.array_function);
-    if (array_function == NULL && PyErr_Occurred()) {
+    PyObject *array_function;
+    if (PyArray_LookupSpecial(
+            obj, npy_interned_str.array_function, &array_function) < 0) {
         PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 

--- a/numpy/_core/src/multiarray/arraywrap.c
+++ b/numpy/_core/src/multiarray/arraywrap.c
@@ -57,11 +57,12 @@ npy_find_array_wrap(
             }
         }
         else {
-            PyObject *new_wrap = PyArray_LookupSpecial_OnInstance(obj, npy_interned_str.array_wrap);
-            if (new_wrap == NULL) {
-                if (PyErr_Occurred()) {
-                    goto fail;
-                }
+            PyObject *new_wrap;
+            if (PyArray_LookupSpecial_OnInstance(
+                    obj, npy_interned_str.array_wrap, &new_wrap) < 0) {
+                goto fail;
+            }
+            else if (new_wrap == NULL) {
                 continue;
             }
             double curr_priority = PyArray_GetPriority(obj, 0);
@@ -159,14 +160,13 @@ npy_apply_wrap(
         }
         else {
             /* Replace passed wrap/wrap_type (borrowed refs) with new_wrap/type. */
-            new_wrap = PyArray_LookupSpecial_OnInstance(
-                    original_out, npy_interned_str.array_wrap);
-            if (new_wrap != NULL) {
+            if (PyArray_LookupSpecial_OnInstance(
+                    original_out, npy_interned_str.array_wrap, &new_wrap) < 0) {
+                return NULL;
+            }
+            else if (new_wrap != NULL) {
                 wrap = new_wrap;
                 wrap_type = (PyObject *)Py_TYPE(original_out);
-            }
-            else if (PyErr_Occurred()) {
-                return NULL;
             }
         }
     }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2036,13 +2036,12 @@ PyArray_FromStructInterface(PyObject *input)
     PyObject *attr;
     char endian = NPY_NATBYTE;
 
-    attr = PyArray_LookupSpecial_OnInstance(input, npy_interned_str.array_struct);
-    if (attr == NULL) {
-        if (PyErr_Occurred()) {
-            return NULL;
-        } else {
-            return Py_NotImplemented;
-        }
+    if (PyArray_LookupSpecial_OnInstance(
+            input, npy_interned_str.array_struct, &attr) < 0) {
+        return NULL;
+    }
+    else if (attr == NULL) {
+        return Py_NotImplemented;
     }
     if (!PyCapsule_CheckExact(attr)) {
         if (PyType_Check(input) && PyObject_HasAttrString(attr, "__get__")) {
@@ -2160,12 +2159,11 @@ PyArray_FromInterface(PyObject *origin)
     npy_intp dims[NPY_MAXDIMS], strides[NPY_MAXDIMS];
     int dataflags = NPY_ARRAY_BEHAVED;
 
-    iface = PyArray_LookupSpecial_OnInstance(origin, npy_interned_str.array_interface);
-
-    if (iface == NULL) {
-        if (PyErr_Occurred()) {
-            return NULL;
-        }
+    if (PyArray_LookupSpecial_OnInstance(
+            origin, npy_interned_str.array_interface, &iface) < 0) {
+        return NULL;
+    }
+    else if (iface == NULL) {
         return Py_NotImplemented;
     }
     if (!PyDict_Check(iface)) {
@@ -2515,11 +2513,11 @@ PyArray_FromArrayAttr_int(PyObject *op, PyArray_Descr *descr, int copy,
     PyObject *new;
     PyObject *array_meth;
 
-    array_meth = PyArray_LookupSpecial_OnInstance(op, npy_interned_str.array);
-    if (array_meth == NULL) {
-        if (PyErr_Occurred()) {
-            return NULL;
-        }
+    if (PyArray_LookupSpecial_OnInstance(
+                op, npy_interned_str.array, &array_meth) < 0) {
+        return NULL;
+    }
+    else if (array_meth == NULL) {
         return Py_NotImplemented;
     }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -157,12 +157,13 @@ PyArray_GetPriority(PyObject *obj, double default_)
         return NPY_SCALAR_PRIORITY;
     }
 
-    ret = PyArray_LookupSpecial_OnInstance(obj, npy_interned_str.array_priority);
-    if (ret == NULL) {
-        if (PyErr_Occurred()) {
-            /* TODO[gh-14801]: propagate crashes during attribute access? */
-            PyErr_Clear();
-        }
+    if (PyArray_LookupSpecial_OnInstance(
+            obj, npy_interned_str.array_priority, &ret) < 0) {
+        /* TODO[gh-14801]: propagate crashes during attribute access? */
+        PyErr_Clear();
+        return default_;
+    }
+    else if (ret == NULL) {
         return default_;
     }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -209,14 +209,14 @@ find_binary_operation_path(
      * our ufuncs without preventing recursion.
      * It may be nice to avoid double lookup in `BINOP_GIVE_UP_IF_NEEDED`.
      */
-    PyObject *attr = PyArray_LookupSpecial(other, npy_interned_str.array_ufunc);
-    if (attr != NULL) {
+    PyObject *attr;
+    if (PyArray_LookupSpecial(other, npy_interned_str.array_ufunc, &attr) < 0) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+    }
+    else if (attr != NULL) {
         Py_DECREF(attr);
         *other_op = Py_NewRef(other);
         return 0;
-    }
-    else if (PyErr_Occurred()) {
-        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
     /*


### PR DESCRIPTION
Now that `PyObject_GetOptionalAttr` is public in 3.13 and semi-public via the capi-backports... Let's use it!

This is a massive speed up for code paths that run into this.  For full throttle gains, you need 3.12, because only in 3.12 were type lookups improved (I didn't test it with it).

For example:
```
o = object()  # some object that doesn't have __array__, or the other dunders

%timeit np.asarray(o)
```
will go from 800+ns to <200ns on my setup.  Things like `np.result_type(dtype, dtype)` (dtypes hit slow lookups for `__array_function__`) should be at 2-3 times faster on Python 3.12 (untested as I didn't feel like bumping my Python version).


Just to give another example, a Python object that implements a no-op `__array__` (i.e. returning an already wrapped array) goes from 575ns to 175ns.


---

Draft, because I had to base it on gh-27117 to avoid the conflict.