### PR TITLE
BUG: Fix missing error return in copyto

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1950,6 +1950,7 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         PyErr_Format(PyExc_TypeError,
             "copyto() argument 1 must be a numpy.ndarray, not %s",
             Py_TYPE(dst_obj)->tp_name);
+        goto fail;
     }
     PyArrayObject *dst = (PyArrayObject *)dst_obj;
 


### PR DESCRIPTION
Could also just return NULL, but right now the earlier one also uses goto fail, so stick with it.

Found in the fast-path PR, it seems there are so many `PyErr_Occurred()` checks, that this didn't really register before.

