### PR TITLE
BUG: add missing error handling in public_dtype_api.c

### DIFF
--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -71,7 +71,9 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
-    dtypemeta_initialize_struct_from_spec(DType, spec, 0);
+    if (dtypemeta_initialize_struct_from_spec(DType, spec, 0) < 0) {
+        return -1;
+    }
 
     if (NPY_DT_SLOTS(DType)->setitem == NULL
             || NPY_DT_SLOTS(DType)->getitem == NULL) {


### PR DESCRIPTION
Backport of #27098.

@swayaminsync ran into some confusing behaviors working on a DType and I tracked it down to missing error handling here

Hard to write a test for this without defining an invalid DType.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
