### PR TITLE
BUG: Fix building NumPy in FIPS mode

### DIFF
--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -159,7 +159,7 @@ class Function:
         return '%s%s %s(%s)' % (doccomment, self.return_type, self.name, argstr)
 
     def api_hash(self):
-        m = hashlib.md5()
+        m = hashlib.md5(usedforsecurity=False)
         m.update(remove_whitespace(self.return_type))
         m.update('\000')
         m.update(self.name)
@@ -532,7 +532,9 @@ def fullapi_hash(api_dicts):
             a.extend(name)
             a.extend(','.join(map(str, data)))
 
-    return hashlib.md5(''.join(a).encode('ascii')).hexdigest()
+    return hashlib.md5(
+        ''.join(a).encode('ascii'), usedforsecurity=False
+    ).hexdigest()
 
 # To parse strings like 'hex = checksum' where hex is e.g. 0x1234567F and
 # checksum a 128 bits md5 checksum (hex format as well)
@@ -554,7 +556,7 @@ def main():
     tagname = sys.argv[1]
     order_file = sys.argv[2]
     functions = get_api_functions(tagname, order_file)
-    m = hashlib.md5(tagname)
+    m = hashlib.md5(tagname, usedforsecurity=False)
     for func in functions:
         print(func)
         ah = func.api_hash()


### PR DESCRIPTION
Backport of #27104.

MD5 is an insecure cryptogrpahic hashing algorithm and is therefore blocked in FIPS mode. NumPy uses MD5 has digest algorithm without any security requirements. Use `usedforsecurity=False` flag to tell OpenSSL that the use of MD5 is okay in FIPS enforcing mode. I implemented the flag in Python 3.9 for exactly this purpose

Fixes: #27099

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
