### PR TITLE
TYP: Assume that ``typing_extensions`` is always available in the stubs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -184,7 +184,6 @@ from collections.abc import (
     Sequence,
 )
 from typing import (
-    TYPE_CHECKING,
     Literal as L,
     Any,
     Generator,
@@ -203,12 +202,12 @@ from typing import (
     TypeAlias,
 )
 
-if sys.version_info >= (3, 11):
-    from typing import LiteralString
-elif TYPE_CHECKING:
-    from typing_extensions import LiteralString
-else:
-    LiteralString: TypeAlias = str
+# NOTE: `typing_extensions` is always available in `.pyi` stubs or when
+# `TYPE_CHECKING` - even if not available at runtime.
+# This is because the `typeshed` stubs for the standard library include
+# `typing_extensions` stubs:
+# https://github.com/python/typeshed/blob/main/stdlib/typing_extensions.pyi
+from typing_extensions import LiteralString
 
 # Ensures that the stubs are picked up
 from numpy import (

--- a/numpy/_array_api_info.pyi
+++ b/numpy/_array_api_info.pyi
@@ -1,6 +1,4 @@
-import sys
 from typing import (
-    TYPE_CHECKING,
     ClassVar,
     Literal,
     TypeAlias,
@@ -9,17 +7,10 @@ from typing import (
     final,
     overload,
 )
+from typing_extensions import Never
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import Never
-elif TYPE_CHECKING:
-    from typing_extensions import Never
-else:
-    # `NoReturn` and `Never` are equivalent (but not equal) for type-checkers,
-    # but are used in different places by convention
-    from typing import NoReturn as Never
 
 _Device: TypeAlias = Literal["cpu"]
 _DeviceLike: TypeAlias = None | _Device

--- a/numpy/polynomial/_polybase.pyi
+++ b/numpy/polynomial/_polybase.pyi
@@ -1,10 +1,8 @@
 import abc
 import decimal
 import numbers
-import sys
 from collections.abc import Iterator, Mapping, Sequence
 from typing import (
-    TYPE_CHECKING,
     Any,
     ClassVar,
     Final,
@@ -44,12 +42,7 @@ from ._polytypes import (
     _ArrayLikeCoef_co,
 )
 
-if sys.version_info >= (3, 11):
-    from typing import LiteralString
-elif TYPE_CHECKING:
-    from typing_extensions import LiteralString
-else:
-    LiteralString: TypeAlias = str
+from typing_extensions import LiteralString
 
 
 __all__: Final[Sequence[str]] = ("ABCPolyBase",)

--- a/numpy/polynomial/_polytypes.pyi
+++ b/numpy/polynomial/_polytypes.pyi
@@ -1,7 +1,5 @@
-import sys
 from collections.abc import Callable, Sequence
 from typing import (
-    TYPE_CHECKING,
     Any,
     Literal,
     NoReturn,
@@ -31,12 +29,7 @@ from numpy._typing import (
     _NumberLike_co,
 )
 
-if sys.version_info >= (3, 11):
-    from typing import LiteralString
-elif TYPE_CHECKING:
-    from typing_extensions import LiteralString
-else:
-    LiteralString: TypeAlias = str
+from typing_extensions import LiteralString
 
 _T = TypeVar("_T")
 _T_contra = TypeVar("_T_contra", contravariant=True)

--- a/numpy/typing/tests/data/reveal/arithmetic.pyi
+++ b/numpy/typing/tests/data/reveal/arithmetic.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import _32Bit,_64Bit, _128Bit
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 # Can't directly import `np.float128` as it is not available on all platforms
 f16: np.floating[_128Bit]

--- a/numpy/typing/tests/data/reveal/array_api_info.pyi
+++ b/numpy/typing/tests/data/reveal/array_api_info.pyi
@@ -1,12 +1,8 @@
-import sys
 from typing import Literal
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import Never, assert_type
-else:
-    from typing_extensions import Never, assert_type
+from typing_extensions import Never, assert_type
 
 info = np.__array_namespace_info__()
 

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -6,10 +6,7 @@ from collections import deque
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 _SCT = TypeVar("_SCT", bound=np.generic, covariant=True)
 

--- a/numpy/typing/tests/data/reveal/arraypad.pyi
+++ b/numpy/typing/tests/data/reveal/arraypad.pyi
@@ -1,14 +1,10 @@
-import sys
 from collections.abc import Mapping
 from typing import Any, SupportsIndex
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 def mode_func(
     ar: npt.NDArray[np.number[Any]],

--- a/numpy/typing/tests/data/reveal/arrayprint.pyi
+++ b/numpy/typing/tests/data/reveal/arrayprint.pyi
@@ -1,4 +1,3 @@
-import sys
 import contextlib
 from collections.abc import Callable
 from typing import Any
@@ -7,10 +6,7 @@ import numpy as np
 import numpy.typing as npt
 from numpy._core.arrayprint import _FormatOptions
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR: npt.NDArray[np.int64]
 func_float: Callable[[np.floating[Any]], str]

--- a/numpy/typing/tests/data/reveal/arraysetops.pyi
+++ b/numpy/typing/tests/data/reveal/arraysetops.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 
 import numpy as np
@@ -7,10 +6,7 @@ from numpy.lib._arraysetops_impl import (
     UniqueAllResult, UniqueCountsResult, UniqueInverseResult
 )
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_b: npt.NDArray[np.bool]
 AR_i8: npt.NDArray[np.int64]

--- a/numpy/typing/tests/data/reveal/arrayterator.pyi
+++ b/numpy/typing/tests/data/reveal/arrayterator.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any
 from collections.abc import Generator
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_i8: npt.NDArray[np.int64]
 ar_iter = np.lib.Arrayterator(AR_i8)

--- a/numpy/typing/tests/data/reveal/bitwise_ops.pyi
+++ b/numpy/typing/tests/data/reveal/bitwise_ops.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import _64Bit, _32Bit
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 i8 = np.int64(1)
 u8 = np.uint64(1)

--- a/numpy/typing/tests/data/reveal/char.pyi
+++ b/numpy/typing/tests/data/reveal/char.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_U: npt.NDArray[np.str_]
 AR_S: npt.NDArray[np.bytes_]

--- a/numpy/typing/tests/data/reveal/chararray.pyi
+++ b/numpy/typing/tests/data/reveal/chararray.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_U: np.char.chararray[Any, np.dtype[np.str_]]
 AR_S: np.char.chararray[Any, np.dtype[np.bytes_]]

--- a/numpy/typing/tests/data/reveal/comparisons.pyi
+++ b/numpy/typing/tests/data/reveal/comparisons.pyi
@@ -1,4 +1,3 @@
-import sys
 import fractions
 import decimal
 from typing import Any
@@ -6,10 +5,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 c16 = np.complex128()
 f8 = np.float64()

--- a/numpy/typing/tests/data/reveal/constants.pyi
+++ b/numpy/typing/tests/data/reveal/constants.pyi
@@ -1,11 +1,6 @@
-import sys
-
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 assert_type(np.e, float)
 assert_type(np.euler_gamma, float)
@@ -16,4 +11,3 @@ assert_type(np.pi, float)
 assert_type(np.little_endian, bool)
 assert_type(np.True_, np.bool)
 assert_type(np.False_, np.bool)
-

--- a/numpy/typing/tests/data/reveal/ctypeslib.pyi
+++ b/numpy/typing/tests/data/reveal/ctypeslib.pyi
@@ -6,10 +6,7 @@ import numpy as np
 import numpy.typing as npt
 from numpy import ctypeslib
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_bool: npt.NDArray[np.bool]
 AR_ubyte: npt.NDArray[np.ubyte]

--- a/numpy/typing/tests/data/reveal/datasource.pyi
+++ b/numpy/typing/tests/data/reveal/datasource.pyi
@@ -1,13 +1,9 @@
-import sys
 from pathlib import Path
 from typing import IO, Any
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 path1: Path
 path2: str

--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -1,13 +1,9 @@
-import sys
 import ctypes as ct
 from typing import Any
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 dtype_U: np.dtype[np.str_]
 dtype_V: np.dtype[np.void]

--- a/numpy/typing/tests/data/reveal/einsumfunc.pyi
+++ b/numpy/typing/tests/data/reveal/einsumfunc.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_LIKE_b: list[bool]
 AR_LIKE_u: list[np.uint32]

--- a/numpy/typing/tests/data/reveal/emath.pyi
+++ b/numpy/typing/tests/data/reveal/emath.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_f8: npt.NDArray[np.float64]
 AR_c16: npt.NDArray[np.complex128]

--- a/numpy/typing/tests/data/reveal/false_positives.pyi
+++ b/numpy/typing/tests/data/reveal/false_positives.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_Any: npt.NDArray[Any]
 

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_f8: npt.NDArray[np.float64]
 AR_c16: npt.NDArray[np.complex128]

--- a/numpy/typing/tests/data/reveal/flatiter.pyi
+++ b/numpy/typing/tests/data/reveal/flatiter.pyi
@@ -1,13 +1,9 @@
-import sys
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 a: np.flatiter[npt.NDArray[np.str_]]
 a_1d: np.flatiter[np.ndarray[tuple[int], np.dtype[np.bytes_]]]

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -1,15 +1,11 @@
 """Tests for :mod:`_core.fromnumeric`."""
 
-import sys
 from typing import Any, NoReturn
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 class NDArraySubclass(npt.NDArray[np.complex128]):
     ...

--- a/numpy/typing/tests/data/reveal/getlimits.pyi
+++ b/numpy/typing/tests/data/reveal/getlimits.pyi
@@ -1,12 +1,8 @@
-import sys
 from typing import Any
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type, LiteralString
-else:
-    from typing_extensions import assert_type, LiteralString
+from typing_extensions import assert_type, LiteralString
 
 f: float
 f8: np.float64

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]

--- a/numpy/typing/tests/data/reveal/index_tricks.pyi
+++ b/numpy/typing/tests/data/reveal/index_tricks.pyi
@@ -1,14 +1,10 @@
-import sys
 from types import EllipsisType
 from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_LIKE_b: list[bool]
 AR_LIKE_i: list[int]

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -1,4 +1,3 @@
-import sys
 from fractions import Fraction
 from typing import Any
 from collections.abc import Callable
@@ -6,10 +5,7 @@ from collections.abc import Callable
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 vectorized_func: np.vectorize
 

--- a/numpy/typing/tests/data/reveal/lib_polynomial.pyi
+++ b/numpy/typing/tests/data/reveal/lib_polynomial.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any, NoReturn
 from collections.abc import Iterator
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_b: npt.NDArray[np.bool]
 AR_u4: npt.NDArray[np.uint32]

--- a/numpy/typing/tests/data/reveal/lib_utils.pyi
+++ b/numpy/typing/tests/data/reveal/lib_utils.pyi
@@ -1,14 +1,10 @@
-import sys
 from io import StringIO
 
 import numpy as np
 import numpy.typing as npt
 import numpy.lib.array_utils as array_utils
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR: npt.NDArray[np.float64]
 AR_DICT: dict[str, npt.NDArray[np.float64]]

--- a/numpy/typing/tests/data/reveal/lib_version.pyi
+++ b/numpy/typing/tests/data/reveal/lib_version.pyi
@@ -1,11 +1,6 @@
-import sys
-
 from numpy.lib import NumpyVersion
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 version = NumpyVersion("1.8.0")
 

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 
 import numpy as np
@@ -7,10 +6,7 @@ from numpy.linalg._linalg import (
     QRResult, EigResult, EighResult, SVDResult, SlogdetResult
 )
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]

--- a/numpy/typing/tests/data/reveal/matrix.pyi
+++ b/numpy/typing/tests/data/reveal/matrix.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 mat: np.matrix[Any, np.dtype[np.int64]]
 ar_f8: npt.NDArray[np.float64]

--- a/numpy/typing/tests/data/reveal/memmap.pyi
+++ b/numpy/typing/tests/data/reveal/memmap.pyi
@@ -1,12 +1,8 @@
-import sys
 from typing import Any
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 memmap_obj: np.memmap[Any, np.dtype[np.str_]]
 

--- a/numpy/typing/tests/data/reveal/mod.pyi
+++ b/numpy/typing/tests/data/reveal/mod.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import _32Bit, _64Bit
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 f8 = np.float64()
 i8 = np.int64()

--- a/numpy/typing/tests/data/reveal/modules.pyi
+++ b/numpy/typing/tests/data/reveal/modules.pyi
@@ -1,13 +1,9 @@
-import sys
 import types
 
 import numpy as np
 from numpy import f2py
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 assert_type(np, types.ModuleType)
 

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -1,14 +1,10 @@
-import sys
 import datetime as dt
 from typing import Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 _SCT = TypeVar("_SCT", bound=np.generic, covariant=True)
 

--- a/numpy/typing/tests/data/reveal/nbit_base_example.pyi
+++ b/numpy/typing/tests/data/reveal/nbit_base_example.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import TypeVar
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import _64Bit, _32Bit
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 T1 = TypeVar("T1", bound=npt.NBitBase)
 T2 = TypeVar("T2", bound=npt.NBitBase)

--- a/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 nd: npt.NDArray[np.int_]
 

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -6,7 +6,6 @@ function-based counterpart in `../from_numeric.py`.
 
 """
 
-import sys
 import operator
 import ctypes as ct
 from typing import Any, Literal
@@ -14,10 +13,7 @@ from typing import Any, Literal
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 class SubClass(npt.NDArray[np.object_]): ...
 

--- a/numpy/typing/tests/data/reveal/ndarray_shape_manipulation.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_shape_manipulation.pyi
@@ -1,13 +1,7 @@
-import sys
-from typing import Any
-
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 nd: npt.NDArray[np.int64]
 

--- a/numpy/typing/tests/data/reveal/nditer.pyi
+++ b/numpy/typing/tests/data/reveal/nditer.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 nditer_obj: np.nditer
 

--- a/numpy/typing/tests/data/reveal/nested_sequence.pyi
+++ b/numpy/typing/tests/data/reveal/nested_sequence.pyi
@@ -1,13 +1,9 @@
-import sys
 from collections.abc import Sequence
 from typing import Any
 
 from numpy._typing import _NestedSequence
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 a: Sequence[int]
 b: Sequence[Sequence[int]]

--- a/numpy/typing/tests/data/reveal/npyio.pyi
+++ b/numpy/typing/tests/data/reveal/npyio.pyi
@@ -1,5 +1,4 @@
 import re
-import sys
 import zipfile
 import pathlib
 from typing import IO, Any
@@ -9,10 +8,7 @@ import numpy.typing as npt
 import numpy as np
 from numpy.lib._npyio_impl import BagObj
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 str_path: str
 pathlib_path: pathlib.Path

--- a/numpy/typing/tests/data/reveal/numeric.pyi
+++ b/numpy/typing/tests/data/reveal/numeric.pyi
@@ -5,16 +5,12 @@ Does not include tests which fall under ``array_constructors``.
 
 """
 
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 class SubClass(npt.NDArray[np.int64]):
     ...

--- a/numpy/typing/tests/data/reveal/numerictypes.pyi
+++ b/numpy/typing/tests/data/reveal/numerictypes.pyi
@@ -1,12 +1,8 @@
-import sys
 from typing import Literal
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 assert_type(
     np.ScalarType,

--- a/numpy/typing/tests/data/reveal/polynomial_polybase.pyi
+++ b/numpy/typing/tests/data/reveal/polynomial_polybase.pyi
@@ -1,5 +1,4 @@
 from fractions import Fraction
-import sys
 from collections.abc import Sequence
 from decimal import Decimal
 from typing import Any, Literal as L, TypeAlias, TypeVar
@@ -8,10 +7,7 @@ import numpy as np
 import numpy.polynomial as npp
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import LiteralString, assert_type
-else:
-    from typing_extensions import LiteralString, assert_type
+from typing_extensions import assert_type, LiteralString
 
 _Ar_x: TypeAlias = npt.NDArray[np.inexact[Any] | np.object_]
 _Ar_f: TypeAlias = npt.NDArray[np.floating[Any]]

--- a/numpy/typing/tests/data/reveal/polynomial_polyutils.pyi
+++ b/numpy/typing/tests/data/reveal/polynomial_polyutils.pyi
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Sequence
 from decimal import Decimal
 from fractions import Fraction
@@ -9,10 +8,7 @@ import numpy.typing as npt
 import numpy.polynomial.polyutils as pu
 from numpy.polynomial._polytypes import _Tuple2
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 _ArrFloat1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.floating[Any]]]
 _ArrComplex1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.complexfloating[Any, Any]]]

--- a/numpy/typing/tests/data/reveal/polynomial_series.pyi
+++ b/numpy/typing/tests/data/reveal/polynomial_series.pyi
@@ -1,15 +1,11 @@
 from collections.abc import Sequence
-import sys
 from typing import Any, TypeAlias
 
 import numpy as np
 import numpy.polynomial as npp
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 _ArrFloat1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.floating[Any]]]
 _ArrFloat1D64: TypeAlias = np.ndarray[tuple[int], np.dtype[np.float64]]

--- a/numpy/typing/tests/data/reveal/random.pyi
+++ b/numpy/typing/tests/data/reveal/random.pyi
@@ -1,4 +1,3 @@
-import sys
 import threading
 from typing import Any
 from collections.abc import Sequence
@@ -12,10 +11,7 @@ from numpy.random._sfc64 import SFC64
 from numpy.random._philox import Philox
 from numpy.random.bit_generator import SeedSequence, SeedlessSeedSequence
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 def_rng = np.random.default_rng()
 seed_seq = np.random.SeedSequence()

--- a/numpy/typing/tests/data/reveal/rec.pyi
+++ b/numpy/typing/tests/data/reveal/rec.pyi
@@ -1,14 +1,10 @@
 import io
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_i8: npt.NDArray[np.int64]
 REC_AR_V: np.recarray[Any, np.dtype[np.record]]
@@ -74,7 +70,7 @@ assert_type(
 )
 
 assert_type(
-    np.rec.fromrecords((1, 1.5)), 
+    np.rec.fromrecords((1, 1.5)),
     np.recarray[Any, np.dtype[np.record]]
 )
 

--- a/numpy/typing/tests/data/reveal/scalars.pyi
+++ b/numpy/typing/tests/data/reveal/scalars.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 b: np.bool
 u8: np.uint64

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 i8: np.int64
 f8: np.float64

--- a/numpy/typing/tests/data/reveal/stride_tricks.pyi
+++ b/numpy/typing/tests/data/reveal/stride_tricks.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_f8: npt.NDArray[np.float64]
 AR_LIKE_f: list[float]

--- a/numpy/typing/tests/data/reveal/strings.pyi
+++ b/numpy/typing/tests/data/reveal/strings.pyi
@@ -1,12 +1,7 @@
-import sys
-
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_U: npt.NDArray[np.str_]
 AR_S: npt.NDArray[np.bytes_]

--- a/numpy/typing/tests/data/reveal/testing.pyi
+++ b/numpy/typing/tests/data/reveal/testing.pyi
@@ -11,10 +11,7 @@ from pathlib import Path
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_f8: npt.NDArray[np.float64]
 AR_i8: npt.NDArray[np.int64]

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 _SCT = TypeVar("_SCT", bound=np.generic)
 

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -1,14 +1,10 @@
-import sys
 from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import _16Bit, _32Bit, _64Bit, _128Bit
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 f8: np.float64
 f: float

--- a/numpy/typing/tests/data/reveal/ufunc_config.pyi
+++ b/numpy/typing/tests/data/reveal/ufunc_config.pyi
@@ -1,15 +1,11 @@
 """Typing tests for `_core._ufunc_config`."""
 
-import sys
 from typing import Any, Protocol
 from collections.abc import Callable
 
 import numpy as np
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 def func(a: str, b: int) -> None: ...
 

--- a/numpy/typing/tests/data/reveal/ufunclike.pyi
+++ b/numpy/typing/tests/data/reveal/ufunclike.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 AR_LIKE_b: list[bool]
 AR_LIKE_u: list[np.uint32]

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -1,13 +1,9 @@
-import sys
 from typing import Literal, Any, NoReturn
 
 import numpy as np
 import numpy.typing as npt
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 i8: np.int64
 f8: np.float64

--- a/numpy/typing/tests/data/reveal/warnings_and_errors.pyi
+++ b/numpy/typing/tests/data/reveal/warnings_and_errors.pyi
@@ -1,11 +1,6 @@
-import sys
-
 import numpy.exceptions as ex
 
-if sys.version_info >= (3, 11):
-    from typing import assert_type
-else:
-    from typing_extensions import assert_type
+from typing_extensions import assert_type
 
 assert_type(ex.ModuleDeprecationWarning(), ex.ModuleDeprecationWarning)
 assert_type(ex.VisibleDeprecationWarning(), ex.VisibleDeprecationWarning)

--- a/numpy/version.pyi
+++ b/numpy/version.pyi
@@ -1,10 +1,7 @@
 import sys
 from typing import Final, TypeAlias
 
-if sys.version_info >= (3, 11):
-    from typing import LiteralString
-else:
-    LiteralString: TypeAlias = str
+from typing_extensions import LiteralString
 
 __all__ = (
     '__version__',


### PR DESCRIPTION
Recently I found out that [`typing_extensions`](https://github.com/python/typing_extensions) is always available in `.pyi` stubs (and when `typing.TYPE_CHECKING`) -- even if it's not available at runtime.
This is because the [`typeshed`](https://github.com/python/typeshed/tree/main) stubs for the standard library includes the [`typing_extensions.pyi`](https://github.com/python/typeshed/blob/main/stdlib/typing_extensions.pyi) stubs, so that type-checkers consider it a standard library (even though it might not exist at runtime).

This allows for most of the conditional-import code in `*.pyi` to be simplified, and is what I've done in this PR.
Apart from it being cleaner, more DRY, more readable, and easier to maintain, it makes the type stubs less incorrect, since `if` statements are a runtime thing, not a typing thing. 
But even though type-checkers usually understood it in this particular case, it was bad practice to do so, and should be avoid if possible; hence this PR.

---

But the real great thing about this, is that we apparently are able to use all of those other cool new features from `typing_extensions` that aren't available in `typing` on Python 3.10.

The first example of this that comes to mind is [PEP 696](https://peps.python.org/pep-0696/); which we could use so that `complexfloating[N]` is an alias for `complexfloating[N, N]`.
It would also allow us to reduce the amount of overloads in case of parameters like `spam: T = ...` from 2 or 3 (in case it accepts both a positional or a keyword argument) to 1.