### PR TITLE
BUG: Do not accidentally store dtype metadata in ``np.save``

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -271,6 +271,8 @@ def dtype_to_descr(dtype):
         warnings.warn("metadata on a dtype is not saved to an npy/npz. "
                       "Use another format (such as pickle) to store it.",
                       UserWarning, stacklevel=2)
+    dtype = new_dtype
+
     if dtype.names is not None:
         # This is a record array. The .descr is fine.  XXX: parts of the
         # record array with an empty name, like padding bytes, still get

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -43,7 +43,7 @@ def test_drop_metadata():
     assert dt_m.metadata is None
     assert dt_m['l1'].metadata is None
     assert dt_m['l1']['l2'].metadata is None
-    
+
     # alignment
     dt = np.dtype([('x', '<f8'), ('y', '<i4')],
                   align=True,


### PR DESCRIPTION
We had logic in place to drop (most) metadata, but the change had a small bug: During saving, we were still using the one with metadata...

Maybe doesn't quite close it, but big enough of an improvement for now, I think, so

Closes gh-14142
