### PR TITLE
ENH: fix thread-unsafe C API usages

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2986,13 +2986,9 @@ array_einsum(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
     }
 
     /* Get the keyword arguments */
-    int error = 0;
     if (kwds != NULL) {
         PyObject *key, *value;
         Py_ssize_t pos = 0;
-#if Py_GIL_DISABLED
-        Py_BEGIN_CRITICAL_SECTION(kwds);
-#endif
         while (PyDict_Next(kwds, &pos, &key, &value)) {
             char *str = NULL;
 
@@ -3007,8 +3003,7 @@ array_einsum(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
             if (str == NULL) {
                 PyErr_Clear();
                 PyErr_SetString(PyExc_TypeError, "invalid keyword");
-                error = 1;
-                break;
+                goto finish;
             }
 
             if (strcmp(str,"out") == 0) {
@@ -3019,47 +3014,35 @@ array_einsum(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
                     PyErr_SetString(PyExc_TypeError,
                                 "keyword parameter out must be an "
                                 "array for einsum");
-                    error = 1;
-                    break;
+                    goto finish;
                 }
             }
             else if (strcmp(str,"order") == 0) {
                 if (!PyArray_OrderConverter(value, &order)) {
-                    error = 1;
-                    break;
+                    goto finish;
                 }
             }
             else if (strcmp(str,"casting") == 0) {
                 if (!PyArray_CastingConverter(value, &casting)) {
-                    error = 1;
-                    break;
+                    goto finish;
                 }
             }
             else if (strcmp(str,"dtype") == 0) {
                 if (!PyArray_DescrConverter2(value, &dtype)) {
-                    error = 1;
-                    break;
+                    goto finish;
                 }
             }
             else {
                 PyErr_Format(PyExc_TypeError,
                             "'%s' is an invalid keyword for einsum",
                             str);
-                error = 1;
-                break;
+                goto finish;
             }
         }
-#if Py_GIL_DISABLED
-        Py_END_CRITICAL_SECTION();
-#endif
-    }
-
-    if (error) {
-        goto finish;
     }
 
     ret = (PyObject *)PyArray_EinsteinSum(subscripts, nop, op, dtype,
-                                          order, casting, out);
+                                        order, casting, out);
 
     /* If no output was supplied, possibly convert to a scalar */
     if (ret != NULL && out == NULL) {

--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -58,6 +58,9 @@ create_conv_funcs(
 
     PyObject *key, *value;
     Py_ssize_t pos = 0;
+#if Py_GIL_DISABLED
+    Py_BEGIN_CRITICAL_SECTION(converters);
+#endif
     while (PyDict_Next(converters, &pos, &key, &value)) {
         Py_ssize_t column = PyNumber_AsSsize_t(key, PyExc_IndexError);
         if (column == -1 && PyErr_Occurred()) {
@@ -107,6 +110,9 @@ create_conv_funcs(
         Py_INCREF(value);
         conv_funcs[column] = value;
     }
+#if Py_GIL_DISABLED
+    Py_END_CRITICAL_SECTION();
+#endif
     return conv_funcs;
 
   error:


### PR DESCRIPTION
Ref #26159 

See also the CPython HOWTO on this topic: https://docs.python.org/3.13/howto/free-threading-extensions.html#freethreading-extensions-howto.

The remaining usages of `PyDict_GetItem` and `PyDict_Next` are all around the `fields` attribute of structured dtypes. I'm pretty sure that dictionary is effectively frozen after the DType is constructed, so I don't worry about those uses.

It's not straightforward to write tests for this, I'm just applying static refactorings in places where the refactoring shouldn't introduce new reference counting bugs.