### PR TITLE
BLD: use smaller scipy-openblas builds

### DIFF
--- a/doc/release/upcoming_changes/27147.performance.rst
+++ b/doc/release/upcoming_changes/27147.performance.rst
@@ -1,0 +1,8 @@
+* OpenBLAS on x86_64 and i686 is built with fewer kernels. Based on
+  benchmarking, there are 5 clusters of performance around these kernels:
+  ``PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX``.
+
+* OpenBLAS on windows is linked without quadmath, simplfying licensing
+
+* Due to a regression in OpenBLAS on windows, the performance improvements
+  when using multiple threads for OpenBLAS 0.3.26 were reverted.

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.27.44.4
+scipy-openblas32==0.3.27.44.5

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.27.44.4
-scipy-openblas64==0.3.27.44.4
+scipy-openblas32==0.3.27.44.5
+scipy-openblas64==0.3.27.44.5


### PR DESCRIPTION
Builds on #27140 to use the same OpenBLAS build but with fewer kernels. Based on the analysis in MacPython/openblas-libs#144 there are now 5 kernels based on cpu core labels `PRESCOTT NEHALEM SANDYBRIDGE HASWELL SKYLAKEX`. Needs a release note about the possible performance implications, and will also add a note about the windows changes in #27140.