### PR TITLE
BUG: Raise if histogram cannot create finite bin sizes

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -450,6 +450,10 @@ def _get_bin_edges(a, bins, range, weights):
         bin_edges = np.linspace(
             first_edge, last_edge, n_equal_bins + 1,
             endpoint=True, dtype=bin_type)
+        if np.any(bin_edges[:-1] >= bin_edges[1:]):
+            raise ValueError(
+                f'Too many bins for data range. Cannot create {n_equal_bins} '
+                f'finite-sized bins.')
         return bin_edges, (first_edge, last_edge, n_equal_bins)
     else:
         return bin_edges, None

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -270,7 +270,7 @@ class TestHistogram:
             histogram, [np.array(0.4) for i in range(10)] + [np.inf])
 
         # these should not crash
-        np.histogram([np.array(0.5) for i in range(10)] + [.500000000000001])
+        np.histogram([np.array(0.5) for i in range(10)] + [.500000000000002])
         np.histogram([np.array(0.5) for i in range(10)] + [.5])
 
     def test_some_nan_values(self):
@@ -394,6 +394,11 @@ class TestHistogram:
         hist, e = histogram(arr, bins='auto', range=(0, 1))
         edges = histogram_bin_edges(arr, bins='auto', range=(0, 1))
         assert_array_equal(edges, e)
+
+    def test_small_value_range(self):
+        arr = np.array([1, 1 + 2e-16] * 10)
+        with pytest.raises(ValueError, match="Too many bins for data range"):
+            histogram(arr, bins=10)
 
     # @requires_memory(free_bytes=1e10)
     # @pytest.mark.slow


### PR DESCRIPTION
When many bins are requested in a small value region, it may not be possible to create enough distinct bin edges due to limited numeric precision. Up to now, `histogram` then returned identical subsequent bin edges, which would mean a bin width of 0. These bins could also have counts associated with them.

Instead of returning such unlogical bin distributions, this PR raises a value error if the calculated bins do not all have a finite size.

Closes #27142.

