### PR TITLE
TYP: Sane defaults for the  platform-specific ``NBitBase`` types.

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -2,94 +2,19 @@
 
 from __future__ import annotations
 
-from .._utils import set_module
-from typing import final
-
-
-@final  # Disallow the creation of arbitrary `NBitBase` subclasses
-@set_module("numpy.typing")
-class NBitBase:
-    """
-    A type representing `numpy.number` precision during static type checking.
-
-    Used exclusively for the purpose static type checking, `NBitBase`
-    represents the base of a hierarchical set of subclasses.
-    Each subsequent subclass is herein used for representing a lower level
-    of precision, *e.g.* ``64Bit > 32Bit > 16Bit``.
-
-    .. versionadded:: 1.20
-
-    Examples
-    --------
-    Below is a typical usage example: `NBitBase` is herein used for annotating
-    a function that takes a float and integer of arbitrary precision
-    as arguments and returns a new float of whichever precision is largest
-    (*e.g.* ``np.float16 + np.int64 -> np.float64``).
-
-    .. code-block:: python
-
-        >>> from __future__ import annotations
-        >>> from typing import TypeVar, TYPE_CHECKING
-        >>> import numpy as np
-        >>> import numpy.typing as npt
-
-        >>> T1 = TypeVar("T1", bound=npt.NBitBase)
-        >>> T2 = TypeVar("T2", bound=npt.NBitBase)
-
-        >>> def add(a: np.floating[T1], b: np.integer[T2]) -> np.floating[T1 | T2]:
-        ...     return a + b
-
-        >>> a = np.float16()
-        >>> b = np.int64()
-        >>> out = add(a, b)
-
-        >>> if TYPE_CHECKING:
-        ...     reveal_locals()
-        ...     # note: Revealed local types are:
-        ...     # note:     a: numpy.floating[numpy.typing._16Bit*]
-        ...     # note:     b: numpy.signedinteger[numpy.typing._64Bit*]
-        ...     # note:     out: numpy.floating[numpy.typing._64Bit*]
-
-    """
-
-    def __init_subclass__(cls) -> None:
-        allowed_names = {
-            "NBitBase", "_256Bit", "_128Bit", "_96Bit", "_80Bit",
-            "_64Bit", "_32Bit", "_16Bit", "_8Bit",
-        }
-        if cls.__name__ not in allowed_names:
-            raise TypeError('cannot inherit from final class "NBitBase"')
-        super().__init_subclass__()
-
-
-# Silence errors about subclassing a `@final`-decorated class
-class _256Bit(NBitBase):  # type: ignore[misc]
-    pass
-
-class _128Bit(_256Bit):  # type: ignore[misc]
-    pass
-
-class _96Bit(_128Bit):  # type: ignore[misc]
-    pass
-
-class _80Bit(_96Bit):  # type: ignore[misc]
-    pass
-
-class _64Bit(_80Bit):  # type: ignore[misc]
-    pass
-
-class _32Bit(_64Bit):  # type: ignore[misc]
-    pass
-
-class _16Bit(_32Bit):  # type: ignore[misc]
-    pass
-
-class _8Bit(_16Bit):  # type: ignore[misc]
-    pass
-
-
 from ._nested_sequence import (
     _NestedSequence as _NestedSequence,
+)
+from ._nbit_base import (
+    NBitBase as NBitBase,
+    _8Bit as _8Bit,
+    _16Bit as _16Bit,
+    _32Bit as _32Bit,
+    _64Bit as _64Bit,
+    _80Bit as _80Bit,
+    _96Bit as _96Bit,
+    _128Bit as _128Bit,
+    _256Bit as _256Bit,
 )
 from ._nbit import (
     _NBitByte as _NBitByte,

--- a/numpy/_typing/_nbit.py
+++ b/numpy/_typing/_nbit.py
@@ -1,17 +1,19 @@
 """A module with the precisions of platform-specific `~numpy.number`s."""
 
-from typing import Any
+from typing import TypeAlias
+from ._nbit_base import _8Bit, _16Bit, _32Bit, _64Bit, _96Bit, _128Bit
+
 
 # To-be replaced with a `npt.NBitBase` subclass by numpy's mypy plugin
-_NBitByte = Any
-_NBitShort = Any
-_NBitIntC = Any
-_NBitIntP = Any
-_NBitInt = Any
-_NBitLong = Any
-_NBitLongLong = Any
+_NBitByte: TypeAlias = _8Bit
+_NBitShort: TypeAlias = _16Bit
+_NBitIntC: TypeAlias = _32Bit
+_NBitIntP: TypeAlias = _32Bit | _64Bit
+_NBitInt: TypeAlias = _NBitIntP
+_NBitLong: TypeAlias = _32Bit | _64Bit
+_NBitLongLong: TypeAlias = _64Bit
 
-_NBitHalf = Any
-_NBitSingle = Any
-_NBitDouble = Any
-_NBitLongDouble = Any
+_NBitHalf: TypeAlias = _16Bit
+_NBitSingle: TypeAlias = _32Bit
+_NBitDouble: TypeAlias = _64Bit
+_NBitLongDouble: TypeAlias = _64Bit | _96Bit | _128Bit

--- a/numpy/_typing/_nbit_base.py
+++ b/numpy/_typing/_nbit_base.py
@@ -1,0 +1,100 @@
+"""A module with the precisions of generic `~numpy.number` types."""
+from .._utils import set_module
+from typing import final
+
+
+@final  # Disallow the creation of arbitrary `NBitBase` subclasses
+@set_module("numpy.typing")
+class NBitBase:
+    """
+    A type representing `numpy.number` precision during static type checking.
+
+    Used exclusively for the purpose static type checking, `NBitBase`
+    represents the base of a hierarchical set of subclasses.
+    Each subsequent subclass is herein used for representing a lower level
+    of precision, *e.g.* ``64Bit > 32Bit > 16Bit``.
+
+    .. versionadded:: 1.20
+
+    Examples
+    --------
+    Below is a typical usage example: `NBitBase` is herein used for annotating
+    a function that takes a float and integer of arbitrary precision
+    as arguments and returns a new float of whichever precision is largest
+    (*e.g.* ``np.float16 + np.int64 -> np.float64``).
+
+    .. code-block:: python
+
+        >>> from __future__ import annotations
+        >>> from typing import TypeVar, TYPE_CHECKING
+        >>> import numpy as np
+        >>> import numpy.typing as npt
+
+        >>> S = TypeVar("S", bound=npt.NBitBase)
+        >>> T = TypeVar("T", bound=npt.NBitBase)
+
+        >>> def add(a: np.floating[S], b: np.integer[T]) -> np.floating[S | T]:
+        ...     return a + b
+
+        >>> a = np.float16()
+        >>> b = np.int64()
+        >>> out = add(a, b)
+
+        >>> if TYPE_CHECKING:
+        ...     reveal_locals()
+        ...     # note: Revealed local types are:
+        ...     # note:     a: numpy.floating[numpy.typing._16Bit*]
+        ...     # note:     b: numpy.signedinteger[numpy.typing._64Bit*]
+        ...     # note:     out: numpy.floating[numpy.typing._64Bit*]
+
+    """
+
+    def __init_subclass__(cls) -> None:
+        allowed_names = {
+            "NBitBase", "_256Bit", "_128Bit", "_96Bit", "_80Bit",
+            "_64Bit", "_32Bit", "_16Bit", "_8Bit",
+        }
+        if cls.__name__ not in allowed_names:
+            raise TypeError('cannot inherit from final class "NBitBase"')
+        super().__init_subclass__()
+
+@final
+@set_module("numpy._typing")
+# Silence errors about subclassing a `@final`-decorated class
+class _256Bit(NBitBase):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _128Bit(_256Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _96Bit(_128Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _80Bit(_96Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _64Bit(_80Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _32Bit(_64Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _16Bit(_32Bit):  # type: ignore[misc]
+    pass
+
+@final
+@set_module("numpy._typing")
+class _8Bit(_16Bit):  # type: ignore[misc]
+    pass

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -69,9 +69,10 @@ def _get_precision_dict() -> dict[str, str]:
         ("_NBitLongDouble", np.longdouble),
     ]
     ret = {}
+    module = "numpy._typing"
     for name, typ in names:
         n: int = 8 * typ().dtype.itemsize
-        ret[f'numpy._typing._nbit.{name}'] = f"numpy._{n}Bit"
+        ret[f'{module}._nbit.{name}'] = f"{module}._nbit_base._{n}Bit"
     return ret
 
 
@@ -91,7 +92,6 @@ def _get_extended_precision_list() -> list[str]:
         "complex512",
     ]
     return [i for i in extended_names if hasattr(np, i)]
-
 
 def _get_c_intp_name() -> str:
     # Adapted from `np.core._internal._getintp_ctype`


### PR DESCRIPTION
This will help for those that don't use the mypy plugin.

The defaults match the ``numpy.dtypes`` stubs.

The new ``._typing._nbit_base`` module was needed to avoid a circular input.
