### PR TITLE
CI: Re-enable nightly OpenBLAS test runs

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -111,9 +111,6 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
-      # TODO: remove when scipy-openblas nightly tests aren't failing anymore.
-      # xref gh-26824
-      continue-on-error: true
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions
         spin test -j auto


### PR DESCRIPTION
These were skipped due to failing, but they are passing again now.

Closes gh-26824
