### PR TITLE
DEP: Finalize ``bool(empty_array)`` deprecation

### DIFF
--- a/doc/release/upcoming_changes/27160.expired.rst
+++ b/doc/release/upcoming_changes/27160.expired.rst
@@ -1,0 +1,2 @@
+* ``bool(np.array([]))`` and other empty arrays will now raise an error.
+  Use ``arr.size > 0`` instead to check whether an array has no elements.

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -467,11 +467,11 @@ Truth value of an array (:class:`bool() <bool>`):
 
    Truth-value testing of an array invokes
    :meth:`ndarray.__bool__`, which raises an error if the number of
-   elements in the array is larger than 1, because the truth value
+   elements in the array is not 1, because the truth value
    of such arrays is ambiguous. Use :meth:`.any() <ndarray.any>` and
    :meth:`.all() <ndarray.all>` instead to be clear about what is meant
-   in such cases. (If the number of elements is 0, the array evaluates
-   to ``False``.)
+   in such cases. (If you wish to check for whether an array is empty,
+   use for example ``.size > 0``.)
 
 
 Unary operations:

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -755,13 +755,10 @@ _array_nonzero(PyArrayObject *mp)
         return res;
     }
     else if (n == 0) {
-        /* 2017-09-25, 1.14 */
-        if (DEPRECATE("The truth value of an empty array is ambiguous. "
-                      "Returning False, but in future this will result in an error. "
-                      "Use `array.size > 0` to check that an array is not empty.") < 0) {
-            return -1;
-        }
-        return 0;
+        PyErr_SetString(PyExc_ValueError,
+                "The truth value of an empty array is ambiguous. "
+                "Use `array.size > 0` to check that an array is not empty.");
+        return -1;
     }
     else {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -199,19 +199,6 @@ class TestDatetimeEvent(_DeprecationTestCase):
             self.assert_deprecated(cls, args=(1, ('ms', 2, 1, 63)))
 
 
-class TestTruthTestingEmptyArrays(_DeprecationTestCase):
-    # 2017-09-25, 1.14.0
-    message = '.*truth value of an empty array is ambiguous.*'
-
-    def test_1d(self):
-        self.assert_deprecated(bool, args=(np.array([]),))
-
-    def test_2d(self):
-        self.assert_deprecated(bool, args=(np.zeros((1, 0)),))
-        self.assert_deprecated(bool, args=(np.zeros((0, 1)),))
-        self.assert_deprecated(bool, args=(np.zeros((0, 0)),))
-
-
 class TestBincount(_DeprecationTestCase):
     # 2017-06-01, 1.14.0
     def test_bincount_minlength(self):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8900,7 +8900,8 @@ class TestConversion:
         assert_equal(bool(np.array([False])), False)
         assert_equal(bool(np.array([True])), True)
         assert_equal(bool(np.array([[42]])), True)
-        assert_raises(ValueError, bool, np.array([1, 2]))
+
+    def test_to_bool_scalar_not_convertible(self):
 
         class NotConvertible:
             def __bool__(self):
@@ -8918,6 +8919,16 @@ class TestConversion:
 
         assert_raises(Error, bool, self_containing)  # previously stack overflow
         self_containing[0] = None  # resolve circular reference
+
+    def test_to_bool_scalar_size_errors(self):
+        with pytest.raises(ValueError, match=".*one element is ambiguous"):
+            bool(np.array([1, 2]))
+
+        with pytest.raises(ValueError, match=".*empty array is ambiguous"):
+            bool(np.empty((3, 0)))
+
+        with pytest.raises(ValueError, match=".*empty array is ambiguous"):
+            bool(np.empty((0,)))
 
     def test_to_int_scalar(self):
         # gh-9972 means that these aren't always the same


### PR DESCRIPTION
This deprecation has been around for many years, let's finalize it. This means that e.g. ``bool(np.array([]))`` fails.

Some discussion also in gh-9885 (but it also discusses single element non 0-D arrays).

Closes gh-6722

---

I'll assume downstream that tests against nightlies avoids deprecation warnings, so that 2.1rc timing shouldn't lead to confusion.