### PR TITLE
DOC: add td64 example in `np.mean`

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3885,7 +3885,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     0.55000000074505806 # may vary
 
     Computing the mean in timedelta64 is available:
-    >>> b = np.array([np.timedelta64(1,'D'), np.timedelta64(3,'D')])
+    >>> b = np.array([1, 3], dtype="timedelta64[D]")
     >>> np.mean(b)
     2 days
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3885,6 +3885,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     0.55000000074505806 # may vary
 
     Computing the mean in timedelta64 is available:
+    
     >>> b = np.array([1, 3], dtype="timedelta64[D]")
     >>> np.mean(b)
     np.timedelta64(2,'D')

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3887,7 +3887,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     Computing the mean in timedelta64 is available:
     >>> b = np.array([1, 3], dtype="timedelta64[D]")
     >>> np.mean(b)
-    2 days
+    np.timedelta64(2,'D')
 
     Specifying a where argument:
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3884,6 +3884,11 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     >>> np.mean(a, dtype=np.float64)
     0.55000000074505806 # may vary
 
+    Computing the mean in timedelta64 is available:
+    >>> b = np.array([np.timedelta64(1,'D'), np.timedelta64(3,'D')])
+    >>> np.mean(b)
+    2 days
+
     Specifying a where argument:
 
     >>> a = np.array([[5, 9, 13], [14, 10, 12], [11, 15, 19]])


### PR DESCRIPTION
## Description

This PR add `timedelta64` example in `np.mean`

refer #27157

## Changes made

- add example below

  ```
  Computing the mean in timedelta64 is available:
  >>> b = np.array([np.timedelta64(1,'D'), np.timedelta64(3,'D')])
  >>> np.mean(b)
  2 days
  ```