### PR TITLE
TYP: Shape-typed array constructors: ``numpy.{empty,zeros,ones,full}``

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -1,5 +1,4 @@
 # TODO: Sort out any and all missing functions in this namespace
-import builtins
 import os
 import datetime as dt
 from collections.abc import Sequence, Callable, Iterable
@@ -8,16 +7,20 @@ from typing import (
     Any,
     TypeAlias,
     overload,
+    TypeAlias,
     TypeVar,
+    TypedDict,
     SupportsIndex,
     final,
     Final,
     Protocol,
     ClassVar,
+    type_check_only,
 )
+from typing_extensions import Unpack
 
 import numpy as np
-from numpy import (
+from numpy import (  # type: ignore[attr-defined]
     # Re-exports
     busdaycalendar as busdaycalendar,
     broadcast as broadcast,
@@ -57,6 +60,7 @@ from numpy._typing import (
     # DTypes
     DTypeLike,
     _DTypeLike,
+    _SupportsDType,
 
     # Arrays
     NDArray,
@@ -90,6 +94,7 @@ from numpy._typing._ufunc import (
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
+_DType = TypeVar("_DType", bound=np.dtype[Any])
 _ArrayType = TypeVar("_ArrayType", bound=ndarray[Any, Any])
 _ArrayType_co = TypeVar(
     "_ArrayType_co",
@@ -102,7 +107,9 @@ _Nin = TypeVar("_Nin", bound=int)
 _Nout = TypeVar("_Nout", bound=int)
 
 _SizeType = TypeVar("_SizeType", bound=int)
+_ShapeType = TypeVar("_ShapeType", bound=tuple[int, ...])
 _1DArray: TypeAlias = ndarray[tuple[_SizeType], dtype[_SCT]]
+_Array: TypeAlias = ndarray[_ShapeType, dtype[_SCT]]
 
 # Valid time units
 _UnitKind = L[
@@ -136,6 +143,119 @@ class _SupportsLenAndGetItem(Protocol[_T_contra, _T_co]):
 class _SupportsArray(Protocol[_ArrayType_co]):
     def __array__(self, /) -> _ArrayType_co: ...
 
+@type_check_only
+class _KwargsEmptyLike(TypedDict, total=False):
+    device: None | L["cpu"]
+
+@type_check_only
+class _KwargsEmpty(_KwargsEmptyLike, total=False):
+    like: None | _SupportsArrayFunc
+
+@type_check_only
+class _ConstructorEmpty(Protocol):
+    # 1-D shape
+    @overload
+    def __call__(
+        self, /,
+        shape: _SizeType,
+        dtype: None = ...,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[tuple[_SizeType], float64]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _SizeType,
+        dtype: _DType | _SupportsDType[_DType],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> ndarray[tuple[_SizeType], _DType]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _SizeType,
+        dtype: type[_SCT],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[tuple[_SizeType], _SCT]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _SizeType,
+        dtype: DTypeLike,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[tuple[_SizeType], Any]: ...
+
+    # known shape
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeType,
+        dtype: None = ...,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[_ShapeType, float64]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeType,
+        dtype: _DType | _SupportsDType[_DType],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> ndarray[_ShapeType, _DType]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeType,
+        dtype: type[_SCT],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[_ShapeType, _SCT]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeType,
+        dtype: DTypeLike,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> _Array[_ShapeType, Any]: ...
+
+    # unknown shape
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeLike,
+        dtype: None = ...,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> NDArray[float64]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeLike,
+        dtype: _DType | _SupportsDType[_DType],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> ndarray[Any, _DType]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeLike,
+        dtype: type[_SCT],
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> NDArray[_SCT]: ...
+    @overload
+    def __call__(
+        self, /,
+        shape: _ShapeLike,
+        dtype: DTypeLike,
+        order: _OrderCF = ...,
+        **kwargs: Unpack[_KwargsEmpty],
+    ) -> NDArray[Any]: ...
+
+
 __all__: list[str]
 
 ALLOW_THREADS: Final[int]  # 0 or 1 (system-specific)
@@ -147,6 +267,9 @@ MAXDIMS: L[32]
 MAY_SHARE_BOUNDS: L[0]
 MAY_SHARE_EXACT: L[-1]
 tracemalloc_domain: L[389047]
+
+zeros: Final[_ConstructorEmpty]
+empty: Final[_ConstructorEmpty]
 
 @overload
 def empty_like(
@@ -263,62 +386,6 @@ def array(
     order: _OrderKACF = ...,
     subok: bool = ...,
     ndmin: int = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-
-@overload
-def zeros(
-    shape: _ShapeLike,
-    dtype: None = ...,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[float64]: ...
-@overload
-def zeros(
-    shape: _ShapeLike,
-    dtype: _DTypeLike[_SCT],
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[_SCT]: ...
-@overload
-def zeros(
-    shape: _ShapeLike,
-    dtype: DTypeLike,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-
-@overload
-def empty(
-    shape: _ShapeLike,
-    dtype: None = ...,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[float64]: ...
-@overload
-def empty(
-    shape: _ShapeLike,
-    dtype: _DTypeLike[_SCT],
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[_SCT]: ...
-@overload
-def empty(
-    shape: _ShapeLike,
-    dtype: DTypeLike,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
 

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
+    Final,
     overload,
     TypeVar,
     Literal as L,
@@ -9,6 +10,7 @@ from typing import (
     NoReturn,
     TypeGuard,
 )
+from typing_extensions import Unpack
 
 import numpy as np
 from numpy import (
@@ -30,6 +32,7 @@ from numpy._typing import (
     ArrayLike,
     NDArray,
     DTypeLike,
+    _SupportsDType,
     _ShapeLike,
     _DTypeLike,
     _ArrayLike,
@@ -45,9 +48,18 @@ from numpy._typing import (
     _ArrayLikeUnknown,
 )
 
+from .multiarray import (
+    _Array,
+    _ConstructorEmpty,
+    _KwargsEmpty,
+)
+
 _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
-_ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
+_DType = TypeVar("_DType", bound=np.dtype[Any])
+_ArrayType = TypeVar("_ArrayType", bound=np.ndarray[Any, Any])
+_SizeType = TypeVar("_SizeType", bound=int)
+_ShapeType = TypeVar("_ShapeType", bound=tuple[int, ...])
 
 _CorrelateMode = L["valid", "same", "full"]
 
@@ -104,33 +116,7 @@ def zeros_like(
     device: None | L["cpu"] = ...,
 ) -> NDArray[Any]: ...
 
-@overload
-def ones(
-    shape: _ShapeLike,
-    dtype: None = ...,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
-) -> NDArray[float64]: ...
-@overload
-def ones(
-    shape: _ShapeLike,
-    dtype: _DTypeLike[_SCT],
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
-) -> NDArray[_SCT]: ...
-@overload
-def ones(
-    shape: _ShapeLike,
-    dtype: DTypeLike,
-    order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
+ones: Final[_ConstructorEmpty]
 
 @overload
 def ones_like(
@@ -183,35 +169,105 @@ def ones_like(
     device: None | L["cpu"] = ...,
 ) -> NDArray[Any]: ...
 
+# TODO: Add overloads for bool, int, float, complex, str, bytes, and memoryview
+# 1-D shape
 @overload
 def full(
-    shape: _ShapeLike,
-    fill_value: Any,
+    shape: _SizeType,
+    fill_value: _SCT,
     dtype: None = ...,
     order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[tuple[_SizeType], _SCT]: ...
+@overload
+def full(
+    shape: _SizeType,
+    fill_value: Any,
+    dtype: _DType | _SupportsDType,
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> np.ndarray[tuple[_SizeType], _DType]: ...
+@overload
+def full(
+    shape: _SizeType,
+    fill_value: Any,
+    dtype: type[_SCT],
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[tuple[_SizeType], _SCT]: ...
+@overload
+def full(
+    shape: _SizeType,
+    fill_value: Any,
+    dtype: None | DTypeLike = ...,
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[tuple[_SizeType], Any]: ...
+# known shape
+@overload
+def full(
+    shape: _ShapeType,
+    fill_value: _SCT,
+    dtype: None = ...,
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[_ShapeType, _SCT]: ...
+@overload
+def full(
+    shape: _ShapeType,
+    fill_value: Any,
+    dtype: _DType | _SupportsDType[_DType],
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> np.ndarray[_ShapeType, _DType]: ...
+@overload
+def full(
+    shape: _ShapeType,
+    fill_value: Any,
+    dtype: type[_SCT],
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[_ShapeType, _SCT]: ...
+@overload
+def full(
+    shape: _ShapeType,
+    fill_value: Any,
+    dtype: None | DTypeLike = ...,
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> _Array[_ShapeType, Any]: ...
+# unknown shape
 @overload
 def full(
     shape: _ShapeLike,
-    fill_value: Any,
-    dtype: _DTypeLike[_SCT],
+    fill_value: _SCT,
+    dtype: None = ...,
     order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
+    **kwargs: Unpack[_KwargsEmpty],
 ) -> NDArray[_SCT]: ...
 @overload
 def full(
     shape: _ShapeLike,
     fill_value: Any,
-    dtype: DTypeLike,
+    dtype: _DType | _SupportsDType[_DType],
     order: _OrderCF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    like: _SupportsArrayFunc = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> np.ndarray[Any, _DType]: ...
+@overload
+def full(
+    shape: _ShapeLike,
+    fill_value: Any,
+    dtype: type[_SCT],
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
+) -> NDArray[_SCT]: ...
+@overload
+def full(
+    shape: _ShapeLike,
+    fill_value: Any,
+    dtype: None | DTypeLike = ...,
+    order: _OrderCF = ...,
+    **kwargs: Unpack[_KwargsEmpty],
 ) -> NDArray[Any]: ...
 
 @overload

--- a/numpy/typing/tests/data/pass/literal.py
+++ b/numpy/typing/tests/data/pass/literal.py
@@ -25,15 +25,15 @@ order_list: list[tuple[frozenset[str | None], Callable[..., Any]]] = [
     (KACF, AR.flatten),
     (KACF, AR.ravel),
     (KACF, partial(np.array, 1)),
-    (CF, partial(np.zeros, 1)),
-    (CF, partial(np.ones, 1)),
-    (CF, partial(np.empty, 1)),
+    # NOTE: __call__ is needed due to mypy 1.11 bugs (#17620, #17631)
+    (CF, partial(np.zeros.__call__, 1)),
+    (CF, partial(np.ones.__call__, 1)),
+    (CF, partial(np.empty.__call__, 1)),
     (CF, partial(np.full, 1, 1)),
     (KACF, partial(np.zeros_like, AR)),
     (KACF, partial(np.ones_like, AR)),
     (KACF, partial(np.empty_like, AR)),
     (KACF, partial(np.full_like, AR, 1)),
-    # __call__ is needed due to mypy 1.11 bugs (#17620, #17631)
     (KACF, partial(np.add.__call__, 1, 1)),  # i.e. np.ufunc.__call__
     (ACF, partial(np.reshape, AR, 1)),
     (KACF, partial(np.ravel, AR)),

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -167,15 +167,30 @@ assert_type(np.full_like(A, i8, dtype=int), npt.NDArray[Any])
 assert_type(np.full_like(B, i8), SubClass[np.float64])
 assert_type(np.full_like(B, i8, dtype=np.int64), npt.NDArray[np.int64])
 
-assert_type(np.ones(1), npt.NDArray[np.float64])
-assert_type(np.ones([1, 1, 1]), npt.NDArray[np.float64])
-assert_type(np.ones(5, dtype=np.int64), npt.NDArray[np.int64])
-assert_type(np.ones(5, dtype=int), npt.NDArray[Any])
+_size: int
+_shape_0d: tuple[()]
+_shape_1d: tuple[int]
+_shape_2d: tuple[int, int]
+_shape_nd: tuple[int, ...]
+_shape_like: list[int]
 
-assert_type(np.full(1, i8), npt.NDArray[Any])
-assert_type(np.full([1, 1, 1], i8), npt.NDArray[Any])
-assert_type(np.full(1, i8, dtype=np.float64), npt.NDArray[np.float64])
-assert_type(np.full(1, i8, dtype=float), npt.NDArray[Any])
+assert_type(np.ones(_shape_0d), np.ndarray[tuple[()], np.dtype[np.float64]])
+assert_type(np.ones(_size), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.ones(_shape_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.ones(_shape_nd), np.ndarray[tuple[int, ...], np.dtype[np.float64]])
+assert_type(np.ones(_shape_1d, dtype=np.int64), np.ndarray[tuple[int], np.dtype[np.int64]])
+assert_type(np.ones(_shape_like), npt.NDArray[np.float64])
+assert_type(np.ones(_shape_like, dtype=np.dtypes.Int64DType()), np.ndarray[Any, np.dtypes.Int64DType])
+assert_type(np.ones(_shape_like, dtype=int), npt.NDArray[Any])
+
+assert_type(np.full(_size, i8), np.ndarray[tuple[int], np.dtype[np.int64]])
+assert_type(np.full(_shape_2d, i8), np.ndarray[tuple[int, int], np.dtype[np.int64]])
+assert_type(np.full(_shape_like, i8), npt.NDArray[np.int64])
+assert_type(np.full(_shape_like, 42), npt.NDArray[Any])
+assert_type(np.full(_size, i8, dtype=np.float64), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.full(_size, i8, dtype=float), np.ndarray[tuple[int], np.dtype[Any]])
+assert_type(np.full(_shape_like, 42, dtype=float), npt.NDArray[Any])
+assert_type(np.full(_shape_0d, i8, dtype=object), np.ndarray[tuple[()], np.dtype[Any]])
 
 assert_type(np.indices([1, 2, 3]), npt.NDArray[np.int_])
 assert_type(np.indices([1, 2, 3], sparse=True), tuple[npt.NDArray[np.int_], ...])


### PR DESCRIPTION
Added overloads to the (direct) array constructor functions in the stubs. These "bind" the type of the passed ``shape`` argument to the shape-type parameter of the ``numpy.ndarray``. Note that this is only possible when the shape is passed as ``shape: int`` or ``shape: tuple[int, int]``, since e.g. the ``list`` type contains no information about its length (i.e. the number of dimensions).

This affects the type-signatures of:

- ``numpy.empty`` (``numpy._core.multiarray.empty``)
- ``numpy.zeros`` (``numpy._core.multiarray.zeros``)
- ``numpy.ones`` (``numpy._core.numeric.ones``)
- ``numpy.full`` (``numpy._core.numeric.full``)

---

**implementation notes**:

- For the sake of "DRY", I reduced some duplicated keyword-only parameters with ``typing.TypedDict`` and ``typing_extensions.Unpack``, as defined in [PEP 692](https://peps.python.org/pep-0692/).
- Because ``empty``, ``zeros`` and ``ones`` have an identical signature (from a typing perspective), and each one has 12 overloads, I refactored them using a [callable protocol](https://typing.readthedocs.io/en/latest/reference/protocols.html#callback-protocols), and decorated it with [``@typing.type_check_only``](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#stub-only-objects).
- It's ok to use ``typing_extensions`` in the stubs, see https://github.com/numpy/numpy/pull/27132 .

---

This should be backwards-compatible, because the ``ndarray`` shape-type parameter is covariant, see https://github.com/numpy/numpy/pull/26081.