### PR TITLE
BUILD: update to OpenBLAS 0.3.28

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.27.44.5
+scipy-openblas32==0.3.28.0.1

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.28.0.1
+scipy-openblas32==0.3.28.0.2

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.27.44.5
-scipy-openblas64==0.3.27.44.5
+scipy-openblas32==0.3.28.0.1
+scipy-openblas64==0.3.28.0.1

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.28.0.1
-scipy-openblas64==0.3.28.0.1
+scipy-openblas32==0.3.28.0.2
+scipy-openblas64==0.3.28.0.2


### PR DESCRIPTION
Update to the newly released OpenBLAS 0.3.28. Note this uses the "shrunk" x86_64 and i686 OpenBLAS shared object with fewer kernels. The full shared object is available in the scipy-openblas 0.3.28.0.0 wheels.