### PR TITLE
MAINT: update default NPY_FEATURE_VERSION after dropping py39

### DIFF
--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -121,8 +121,8 @@
     /* user provided a target version, use it */
     #define NPY_FEATURE_VERSION NPY_TARGET_VERSION
 #else
-    /* Use the default (increase when dropping Python 3.9 support) */
-    #define NPY_FEATURE_VERSION NPY_1_19_API_VERSION
+    /* Use the default (increase when dropping Python 3.10 support) */
+    #define NPY_FEATURE_VERSION NPY_1_21_API_VERSION
 #endif
 
 /* Sanity check the (requested) feature version */


### PR DESCRIPTION
Fixes #27186

