### PR TITLE
BUILD: use a shrunken version of scipy-openblas wheels [wheel build]

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.27.44.5
+scipy-openblas32==0.3.27.44.6

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.27.44.5
-scipy-openblas64==0.3.27.44.5
+scipy-openblas32==0.3.27.44.6
+scipy-openblas64==0.3.27.44.6


### PR DESCRIPTION
The 2.1.0rc1 wheels used a version of the scipy-openblas wheels that unfortunately were not shrunk.