### PR TITLE
np.setxor1d: always ravel inputs

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -740,6 +740,9 @@ def setxor1d(ar1, ar2, assume_unique=False):
     array([1, 4, 5, 7])
 
     """
+    ar1 = np.asarray(ar1).ravel()
+    ar2 = np.asarray(ar2).ravel()
+
     if not assume_unique:
         ar1 = unique(ar1)
         ar2 = unique(ar2)


### PR DESCRIPTION
This ensures that `np.setxor1d` works on N-dimensional inputs regardless of whether `assume_unique` is True.

Before this change:
```python
>>> import numpy as np

>>> np.setxor1d(1, [1, 2, 3])
array([2, 3])

>>> np.setxor1d(1, [1, 2, 3], assume_unique=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.12/site-packages/numpy/lib/_arraysetops_impl.py", line 716, in setxor1d
    aux = np.concatenate((ar1, ar2))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zero-dimensional arrays cannot be concatenated
```
After this change:
```python
>>> import numpy as np

>>> np.setxor1d(1, [1, 2, 3])
array([2, 3])

>>> np.setxor1d(1, [1, 2, 3], assume_unique=True)
array([2, 3])
```
Other set-like functions do this kind of processing already, for example `setdiff1d` here: https://github.com/numpy/numpy/blob/1d49c7f7ff527c696fc26ab2278ad51632a66660/numpy/lib/_arraysetops_impl.py#L1157-L1161