### PR TITLE
TYP: add td64 overload for ``np.average``

### DIFF
--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -108,6 +108,14 @@ def average(
 ) -> complexfloating[Any, Any]: ...
 @overload
 def average(
+    a: _ArrayLikeTD64_co,
+    axis: None = ...,
+    weights: None | Any = ...,
+    returned: L[False] = ...,
+    keepdims: L[False] = ...,
+) -> timedelta64: ...
+@overload
+def average(
     a: _ArrayLikeObject_co,
     axis: None = ...,
     weights: None | Any = ...,
@@ -130,6 +138,14 @@ def average(
     returned: L[True] = ...,
     keepdims: L[False] = ...,
 ) -> _2Tuple[complexfloating[Any, Any]]: ...
+@overload
+def average(
+    a: _ArrayLikeTD64_co,
+    axis: None = ...,
+    weights: None | Any= ...,
+    returned: L[True] = ...,
+    keepdims: L[False] = ...,
+) -> _2Tuple[Any]: ...
 @overload
 def average(
     a: _ArrayLikeObject_co,

--- a/numpy/typing/tests/data/fail/lib_function_base.pyi
+++ b/numpy/typing/tests/data/fail/lib_function_base.pyi
@@ -11,7 +11,7 @@ AR_O: npt.NDArray[np.object_]
 
 def func(a: int) -> None: ...
 
-np.average(AR_m)  # E: incompatible type
+np.average(AR_M)  # E: incompatible type
 np.select(1, [AR_f8])  # E: incompatible type
 np.angle(AR_m)  # E: incompatible type
 np.unwrap(AR_m)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -62,6 +62,8 @@ assert_type(np.average(AR_f8, weights=AR_c16, returned=True), tuple[np.complexfl
 assert_type(np.average(AR_O, returned=True), tuple[Any, Any])
 assert_type(np.average(AR_f8, axis=0), Any)
 assert_type(np.average(AR_f8, axis=0, returned=True), tuple[Any, Any])
+assert_type(np.average(AR_m), np.timedelta64)
+assert_type(np.average(AR_m, returned=True), tuple[Any, Any])
 
 assert_type(np.asarray_chkfinite(AR_f8), npt.NDArray[np.float64])
 assert_type(np.asarray_chkfinite(AR_LIKE_f8), npt.NDArray[Any])


### PR DESCRIPTION
## Description

This PR updates the `td64` type overload for `mean` and add type test for `td64` and `dt64`.

refer to #27204 

## Changes made

- Updates the `td64` type overload

- Add type test for `np.average`