### PR TITLE
TYP: Deprecate calling ``numpy.save`` with ``fix_imports`` (PEP 702)

### DIFF
--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -13,6 +13,7 @@ from typing import (
     overload,
     Protocol,
 )
+from typing_extensions import deprecated
 
 from numpy import (
     ndarray,
@@ -129,11 +130,29 @@ def load(
     encoding: L["ASCII", "latin1", "bytes"] = ...,
 ) -> Any: ...
 
+@overload
 def save(
     file: str | os.PathLike[str] | _SupportsWrite[bytes],
     arr: ArrayLike,
     allow_pickle: bool = ...,
-    fix_imports: bool = ...,
+) -> None: ...
+@overload
+@deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
+def save(
+    file: str | os.PathLike[str] | _SupportsWrite[bytes],
+    arr: ArrayLike,
+    allow_pickle: bool = ...,
+    *,
+    fix_imports: bool,
+) -> None: ...
+@overload
+@deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
+def save(
+    file: str | os.PathLike[str] | _SupportsWrite[bytes],
+    arr: ArrayLike,
+    allow_pickle: bool,
+    fix_imports: bool,
+    /,
 ) -> None: ...
 
 def savez(

--- a/numpy/typing/tests/data/fail/npyio.pyi
+++ b/numpy/typing/tests/data/fail/npyio.pyi
@@ -12,7 +12,9 @@ AR_i8: npt.NDArray[np.int64]
 
 np.load(str_file)  # E: incompatible type
 
-np.save(bytes_path, AR_i8)  # E: incompatible type
+np.save(bytes_path, AR_i8)  # E: No overload variant
+# https://github.com/python/mypy/issues/16111
+# np.save(str_path, AR_i8, fix_imports=True)  # W: deprecated
 
 np.savez(bytes_path, AR_i8)  # E: incompatible type
 


### PR DESCRIPTION
IDE's such as VSCode (+Pylance) will provide a helpful message when attempting to pass ``fix_imports`` to ``numpy.save``:
![image](https://github.com/user-attachments/assets/6c338292-5a8c-4377-979a-3a6c56b414ba)

But mypy currently doesn't support [PEP 702](https://peps.python.org/pep-0702/): https://github.com/python/mypy/issues/16111. 

---

Fun coincidence: the PR number contains only the digits `7`, `0`, and `2` 🙃 