### PR TITLE
BUG: Fix NPY_RAVEL_AXIS on backwards compatible NumPy 2 builds

### DIFF
--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -125,7 +125,7 @@ PyArray_ImportNumPyAPI(void)
     #define NPY_DEFAULT_INT  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_INTP : NPY_LONG)
     #define NPY_RAVEL_AXIS  \
-        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? -1 : 32)
+        (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? NPY_MIN_INT : 32)
     #define NPY_MAXARGS  \
         (PyArray_RUNTIME_VERSION >= NPY_2_0_API_VERSION ? 64 : 32)
 #endif

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -129,6 +129,10 @@ def get_default_integer():
         return cnp.dtype("intp")
     return None
 
+def get_ravel_axis():
+    return cnp.NPY_RAVEL_AXIS
+
+
 def conv_intp(cnp.intp_t val):
     return val
 

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -153,6 +153,13 @@ def test_default_int(install_temp):
 
     assert checks.get_default_integer() is np.dtype(int)
 
+
+def test_ravel_axis(install_temp):
+    import checks
+
+    assert checks.get_ravel_axis() == np.iinfo("intc").min
+
+
 def test_convert_datetime64_to_datetimestruct(install_temp):
     # GH#21199
     import checks


### PR DESCRIPTION
Backport of #27202.

The value was simply hardcoded to the wrong thing in the dynamic path...

Closes #27194.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
