### PR TITLE
TYP: Fixed & improved type hints for ``numpy.histogram2d``

### DIFF
--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -2,6 +2,7 @@ import builtins
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
+    TypeAlias,
     overload,
     TypeVar,
     Literal as L,
@@ -16,6 +17,7 @@ from numpy import (
     int_,
     intp,
     float64,
+    complex128,
     signedinteger,
     floating,
     complexfloating,
@@ -29,6 +31,7 @@ from numpy._typing import (
     ArrayLike,
     _ArrayLike,
     NDArray,
+    _SupportsArray,
     _SupportsArrayFunc,
     _ArrayLikeInt_co,
     _ArrayLikeFloat_co,
@@ -164,44 +167,220 @@ def vander(
     increasing: bool = ...,
 ) -> NDArray[object_]: ...
 
+
+_Int_co: TypeAlias = np.integer[Any] | np.bool
+_Float_co: TypeAlias = np.floating[Any] | _Int_co
+_Number_co: TypeAlias = np.number[Any] | np.bool
+
+_ArrayLike1D: TypeAlias = _SupportsArray[np.dtype[_SCT]] | Sequence[_SCT]
+_ArrayLike2D: TypeAlias = (
+    _SupportsArray[np.dtype[_SCT]]
+    | Sequence[_ArrayLike1D[_SCT]]
+)
+
+_ArrayLike1DInt_co = (
+    _SupportsArray[np.dtype[_Int_co]]
+    | Sequence[int | _Int_co]
+)
+_ArrayLike1DFloat_co = (
+    _SupportsArray[np.dtype[_Float_co]]
+    | Sequence[float | int | _Float_co]
+)
+_ArrayLike2DFloat_co = (
+    _SupportsArray[np.dtype[_Float_co]]
+    | Sequence[_ArrayLike1DFloat_co]
+)
+_ArrayLike1DNumber_co = (
+    _SupportsArray[np.dtype[_Number_co]]
+    | Sequence[int | float | complex | _Number_co]
+)
+
+_SCT_complex = TypeVar("_SCT_complex", bound=np.complexfloating[Any, Any])
+_SCT_inexact = TypeVar("_SCT_inexact", bound=np.inexact[Any])
+_SCT_number_co = TypeVar("_SCT_number_co", bound=_Number_co)
+
 @overload
-def histogram2d(  # type: ignore[misc]
-    x: _ArrayLikeFloat_co,
-    y: _ArrayLikeFloat_co,
+def histogram2d(
+    x: _ArrayLike1D[_SCT_complex],
+    y: _ArrayLike1D[_SCT_complex | _Float_co],
     bins: int | Sequence[int] = ...,
-    range: None | _ArrayLikeFloat_co = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
     density: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
-    NDArray[floating[Any]],
-    NDArray[floating[Any]],
+    NDArray[_SCT_complex],
+    NDArray[_SCT_complex],
 ]: ...
 @overload
 def histogram2d(
-    x: _ArrayLikeComplex_co,
-    y: _ArrayLikeComplex_co,
+    x: _ArrayLike1D[_SCT_complex | _Float_co],
+    y: _ArrayLike1D[_SCT_complex],
     bins: int | Sequence[int] = ...,
-    range: None | _ArrayLikeFloat_co = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
     density: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
-    NDArray[complexfloating[Any, Any]],
-    NDArray[complexfloating[Any, Any]],
+    NDArray[_SCT_complex],
+    NDArray[_SCT_complex],
 ]: ...
-@overload  # TODO: Sort out `bins`
+@overload
 def histogram2d(
-    x: _ArrayLikeComplex_co,
-    y: _ArrayLikeComplex_co,
-    bins: Sequence[_ArrayLikeInt_co],
-    range: None | _ArrayLikeFloat_co = ...,
+    x: _ArrayLike1D[_SCT_inexact],
+    y: _ArrayLike1D[_SCT_inexact | _Int_co],
+    bins: int | Sequence[int] = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
     density: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
-    NDArray[Any],
-    NDArray[Any],
+    NDArray[_SCT_inexact],
+    NDArray[_SCT_inexact],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1D[_SCT_inexact | _Int_co],
+    y: _ArrayLike1D[_SCT_inexact],
+    bins: int | Sequence[int] = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[_SCT_inexact],
+    NDArray[_SCT_inexact],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DInt_co | Sequence[float | int],
+    y: _ArrayLike1DInt_co | Sequence[float | int],
+    bins: int | Sequence[int] = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[float64],
+    NDArray[float64],
+]: ...
+@overload
+def histogram2d(
+    x: Sequence[complex | float | int],
+    y: Sequence[complex | float | int],
+    bins: int | Sequence[int] = ...,
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[complex128 | float64],
+    NDArray[complex128 | float64],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DNumber_co,
+    y: _ArrayLike1DNumber_co,
+    bins: _ArrayLike1D[_SCT_number_co] | Sequence[_ArrayLike1D[_SCT_number_co]],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[_SCT_number_co],
+    NDArray[_SCT_number_co],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1D[_SCT_inexact],
+    y: _ArrayLike1D[_SCT_inexact],
+    bins: Sequence[_ArrayLike1D[_SCT_number_co] | int],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[_SCT_number_co | _SCT_inexact],
+    NDArray[_SCT_number_co | _SCT_inexact],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DInt_co | Sequence[float | int],
+    y: _ArrayLike1DInt_co | Sequence[float | int],
+    bins: Sequence[_ArrayLike1D[_SCT_number_co] | int],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[_SCT_number_co | float64],
+    NDArray[_SCT_number_co | float64],
+]: ...
+@overload
+def histogram2d(
+    x: Sequence[complex | float | int],
+    y: Sequence[complex | float | int],
+    bins: Sequence[_ArrayLike1D[_SCT_number_co] | int],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[_SCT_number_co | complex128 | float64],
+    NDArray[_SCT_number_co | complex128 | float64] ,
+]: ...
+
+@overload
+def histogram2d(
+    x: _ArrayLike1DNumber_co,
+    y: _ArrayLike1DNumber_co,
+    bins: Sequence[Sequence[bool]],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[np.bool],
+    NDArray[np.bool],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DNumber_co,
+    y: _ArrayLike1DNumber_co,
+    bins: Sequence[Sequence[int | bool]],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[np.int_ | np.bool],
+    NDArray[np.int_ | np.bool],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DNumber_co,
+    y: _ArrayLike1DNumber_co,
+    bins: Sequence[Sequence[float | int | bool]],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[np.float64 | np.int_ | np.bool],
+    NDArray[np.float64 | np.int_ | np.bool],
+]: ...
+@overload
+def histogram2d(
+    x: _ArrayLike1DNumber_co,
+    y: _ArrayLike1DNumber_co,
+    bins: Sequence[Sequence[complex | float | int | bool]],
+    range: None | _ArrayLike2DFloat_co = ...,
+    density: None | bool = ...,
+    weights: None | _ArrayLike1DFloat_co = ...,
+) -> tuple[
+    NDArray[float64],
+    NDArray[np.complex128 | np.float64 | np.int_ | np.bool],
+    NDArray[np.complex128 | np.float64 | np.int_ | np.bool],
 ]: ...
 
 # NOTE: we're assuming/demanding here the `mask_func` returns

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -28,6 +28,7 @@ AR_c: npt.NDArray[np.complex128]
 AR_O: npt.NDArray[np.object_]
 
 AR_LIKE_b: list[bool]
+AR_LIKE_c: list[complex]
 
 assert_type(np.fliplr(AR_b), npt.NDArray[np.bool])
 assert_type(np.fliplr(AR_LIKE_b), npt.NDArray[Any])
@@ -63,27 +64,83 @@ assert_type(np.vander(AR_c), npt.NDArray[np.complexfloating[Any, Any]])
 assert_type(np.vander(AR_O), npt.NDArray[np.object_])
 
 assert_type(
-    np.histogram2d(AR_i, AR_b),
+    np.histogram2d(AR_LIKE_c, AR_LIKE_c),
     tuple[
         npt.NDArray[np.float64],
-        npt.NDArray[np.floating[Any]],
-        npt.NDArray[np.floating[Any]],
+        npt.NDArray[np.complex128 | np.float64],
+        npt.NDArray[np.complex128 | np.float64],
     ],
 )
 assert_type(
-    np.histogram2d(AR_f, AR_f),
+    np.histogram2d(AR_i, AR_b),
     tuple[
         npt.NDArray[np.float64],
-        npt.NDArray[np.floating[Any]],
-        npt.NDArray[np.floating[Any]],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_f, AR_i),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_i, AR_f),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
     ],
 )
 assert_type(
     np.histogram2d(AR_f, AR_c, weights=AR_LIKE_b),
     tuple[
         npt.NDArray[np.float64],
-        npt.NDArray[np.complexfloating[Any, Any]],
-        npt.NDArray[np.complexfloating[Any, Any]],
+        npt.NDArray[np.complex128],
+        npt.NDArray[np.complex128],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_f, AR_c, bins=8),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.complex128],
+        npt.NDArray[np.complex128],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_c, AR_f, bins=(8, 5)),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.complex128],
+        npt.NDArray[np.complex128],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_c, AR_i, bins=AR_u),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.uint64],
+        npt.NDArray[np.uint64],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_c, AR_c, bins=(AR_u, AR_u)),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.uint64],
+        npt.NDArray[np.uint64],
+    ],
+)
+assert_type(
+    np.histogram2d(AR_c, AR_c, bins=(AR_b, 8)),
+    tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.bool | np.complex128],
+        npt.NDArray[np.bool | np.complex128],
     ],
 )
 


### PR DESCRIPTION
Backport of #27100.

This fixes https://github.com/numpy/numpy/issues/27092, as well as the overlapping overloads with incompatible return types (see https://github.com/numpy/numpy/issues/27032) in ``numpy.histogram2d``.

[skip cirrus] [skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
