### PR TITLE
TYP: Fix incompatible overrides in the ``numpy._typing._ufunc`` stubs

### DIFF
--- a/numpy/_typing/_ufunc.pyi
+++ b/numpy/_typing/_ufunc.pyi
@@ -17,6 +17,7 @@ from typing import (
     Protocol,
     NoReturn,
 )
+from typing_extensions import LiteralString
 
 from numpy import ufunc, _CastingKind, _OrderKACF
 from numpy.typing import NDArray
@@ -32,9 +33,9 @@ _3Tuple = tuple[_T, _T, _T]
 _4Tuple = tuple[_T, _T, _T, _T]
 
 _NTypes = TypeVar("_NTypes", bound=int, covariant=True)
-_IDType = TypeVar("_IDType", bound=Any, covariant=True)
-_NameType = TypeVar("_NameType", bound=str, covariant=True)
-_Signature = TypeVar("_Signature", bound=str, covariant=True)
+_IDType = TypeVar("_IDType", covariant=True)
+_NameType = TypeVar("_NameType", bound=LiteralString, covariant=True)
+_Signature = TypeVar("_Signature", bound=LiteralString, covariant=True)
 
 
 class _SupportsArrayUFunc(Protocol):


### PR DESCRIPTION
Backport of #27153.

This was introduced in https://github.com/numpy/numpy/pull/26871, which changed some ``numpy.ufunc`` properties from ``str`` to ``LiteralString``.

[skip cirrus] [skip azp]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
