### PR TITLE
DEV: Add ``.editorconfig`` rules for Python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,21 @@ indent_size = 4
 indent_style = space
 max_line_length = 80
 trim_trailing_whitespace = true
+
+[*.{py,pyi,pxd}]
+# https://peps.python.org/pep-0008/
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+# Keep in sync with `tools/lint_diff.ini` and `tools/linter.py`
+# https://pycodestyle.pycqa.org/en/latest/intro.html#configuration
+max_line_length = 88
+
+[*.pyi]
+# https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#style-guide
+max_line_length = 130


### PR DESCRIPTION
This should help prevent CI failures due to linter errors, and (eventually) lead to smaller diff sizes (e.g. due to trailing whitespace).

- ``*.{py,pyi,pxd}``: [PEP 8](https://peps.python.org/pep-0008/)-compatible rules for minimal diffs and platform-agnostic encoding.
- ``*.py``: Max line length of 79, which matches the pydocstyle linter config.
- ``*.pyi``: Max line length of 130: https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#style-guide

See https://editorconfig.org/ for details and a list of IDE plugins.