### PR TITLE
TYP: Replace ``ellipsis`` with ``types.EllipsisType``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -7,7 +7,7 @@ import array as _array
 import datetime as dt
 import enum
 from abc import abstractmethod
-from types import TracebackType, MappingProxyType, GenericAlias
+from types import EllipsisType, TracebackType, MappingProxyType, GenericAlias
 from contextlib import contextmanager
 
 import numpy as np
@@ -1029,7 +1029,7 @@ class flatiter(Generic[_NdArraySubClass_co]):
     @overload
     def __getitem__(
         self,
-        key: _ArrayLikeInt | slice | ellipsis | tuple[_ArrayLikeInt | slice | ellipsis],
+        key: _ArrayLikeInt | slice | EllipsisType | tuple[_ArrayLikeInt | slice | EllipsisType],
     ) -> _NdArraySubClass_co: ...
     # TODO: `__setitem__` operates via `unsafe` casting rules, and can
     # thus accept any type accepted by the relevant underlying `np.generic`
@@ -1037,7 +1037,7 @@ class flatiter(Generic[_NdArraySubClass_co]):
     # This means that `value` must in reality be a supertype of `npt.ArrayLike`.
     def __setitem__(
         self,
-        key: _ArrayLikeInt | slice | ellipsis | tuple[_ArrayLikeInt | slice | ellipsis],
+        key: _ArrayLikeInt | slice | EllipsisType | tuple[_ArrayLikeInt | slice | EllipsisType],
         value: Any,
     ) -> None: ...
     @overload
@@ -1637,10 +1637,10 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType_co, _DType_co]):
     def __getitem__(self, key: (
         None
         | slice
-        | ellipsis
+        | EllipsisType
         | SupportsIndex
         | _ArrayLikeInt_co
-        | tuple[None | slice | ellipsis | _ArrayLikeInt_co | SupportsIndex, ...]
+        | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
     )) -> ndarray[Any, _DType_co]: ...
     @overload
     def __getitem__(self: NDArray[void], key: str) -> NDArray[Any]: ...
@@ -3954,10 +3954,10 @@ class matrix(ndarray[_Shape2DType_co, _DType_co]):
         key: (
             None
             | slice
-            | ellipsis
+            | EllipsisType
             | SupportsIndex
             | _ArrayLikeInt_co
-            | tuple[None | slice | ellipsis | _ArrayLikeInt_co | SupportsIndex, ...]
+            | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
         ),
         /,
     ) -> matrix[Any, _DType_co]: ...

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Sequence, Iterable
+from types import EllipsisType
 from typing import (
     Any,
     TypeVar,
@@ -97,19 +98,19 @@ class recarray(ndarray[_ShapeType_co, _DType_co]):
     def __getitem__(self: recarray[Any, dtype[void]], indx: (
         None
         | slice
-        | ellipsis
+        | EllipsisType
         | SupportsIndex
         | _ArrayLikeInt_co
-        | tuple[None | slice | ellipsis | _ArrayLikeInt_co | SupportsIndex, ...]
+        | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
     )) -> recarray[Any, _DType_co]: ...
     @overload
     def __getitem__(self, indx: (
         None
         | slice
-        | ellipsis
+        | EllipsisType
         | SupportsIndex
         | _ArrayLikeInt_co
-        | tuple[None | slice | ellipsis | _ArrayLikeInt_co | SupportsIndex, ...]
+        | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
     )) -> ndarray[Any, _DType_co]: ...
     @overload
     def __getitem__(self, indx: str) -> NDArray[Any]: ...

--- a/numpy/lib/_arrayterator_impl.pyi
+++ b/numpy/lib/_arrayterator_impl.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from types import EllipsisType
 from typing import (
     Any,
     TypeVar,
@@ -14,10 +15,10 @@ _DType = TypeVar("_DType", bound=dtype[Any])
 _ScalarType = TypeVar("_ScalarType", bound=generic)
 
 _Index = (
-    ellipsis
+    EllipsisType
     | int
     | slice
-    | tuple[ellipsis | int | slice, ...]
+    | tuple[EllipsisType | int | slice, ...]
 )
 
 __all__: list[str]

--- a/numpy/typing/tests/data/reveal/index_tricks.pyi
+++ b/numpy/typing/tests/data/reveal/index_tricks.pyi
@@ -1,4 +1,5 @@
 import sys
+from types import EllipsisType
 from typing import Any, Literal
 
 import numpy as np
@@ -63,11 +64,11 @@ assert_type(np.ogrid[1:1:2, None:10], tuple[npt.NDArray[Any], ...])
 
 assert_type(np.index_exp[0:1], tuple[slice])
 assert_type(np.index_exp[0:1, None:3], tuple[slice, slice])
-assert_type(np.index_exp[0, 0:1, ..., [0, 1, 3]], tuple[Literal[0], slice, ellipsis, list[int]])
+assert_type(np.index_exp[0, 0:1, ..., [0, 1, 3]], tuple[Literal[0], slice, EllipsisType, list[int]])
 
 assert_type(np.s_[0:1], slice)
 assert_type(np.s_[0:1, None:3], tuple[slice, slice])
-assert_type(np.s_[0, 0:1, ..., [0, 1, 3]], tuple[Literal[0], slice, ellipsis, list[int]])
+assert_type(np.s_[0, 0:1, ..., [0, 1, 3]], tuple[Literal[0], slice, EllipsisType, list[int]])
 
 assert_type(np.ix_(AR_LIKE_b), tuple[npt.NDArray[np.bool], ...])
 assert_type(np.ix_(AR_LIKE_i, AR_LIKE_f), tuple[npt.NDArray[np.float64], ...])


### PR DESCRIPTION
The ``builtin.ellipsis`` doesn't actually exist, but is a hack in typeshed that was used before ``types.EllipsisType`` was available: https://github.com/python/typeshed/issues/3556. So not all type-checkers recognize it; e.g. ``ruff`` marks it as an undefined name.

---

This changes it all ``ellipsis`` annotations to ``types.EllipsisType`` (available since Python 3.10).

---

For more info, see:

- https://github.com/python/typeshed/issues/3556
- https://bugs.python.org/issue41810
- https://github.com/python/cpython/issues/85976