### PR TITLE
BUG: Fix ``PyArray_ZeroContiguousBuffer`` (resize) with struct dtypes

### DIFF
--- a/numpy/_core/src/multiarray/refcount.c
+++ b/numpy/_core/src/multiarray/refcount.c
@@ -83,14 +83,16 @@ PyArray_ZeroContiguousBuffer(
         if (get_fill_zero_loop(
                     NULL, descr, aligned, descr->elsize, &(zero_info.func),
                     &(zero_info.auxdata), &flags_unused) < 0) {
-            goto fail;
+            return -1;
         }
     }
     else {
+        assert(zero_info.func == NULL);
+    }
+    if (zero_info.func == NULL) {
         /* the multiply here should never overflow, since we already
            checked if the new array size doesn't overflow */
         memset(data, 0, size*stride);
-        NPY_traverse_info_xfree(&zero_info);
         return 0;
     }
 
@@ -98,10 +100,6 @@ PyArray_ZeroContiguousBuffer(
             NULL, descr, data, size, stride, zero_info.auxdata);
     NPY_traverse_info_xfree(&zero_info);
     return res;
-
-  fail:
-    NPY_traverse_info_xfree(&zero_info);
-    return -1;
 }
 
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9174,6 +9174,12 @@ if not IS_PYPY:
             d.resize(150)
             assert_(old < sys.getsizeof(d))
 
+        @pytest.mark.parametrize("dtype", ["u4,f4", "u4,O"])
+        def test_resize_structured(self, dtype):
+            a = np.array([(0, 0.0) for i in range(5)], dtype=dtype)
+            a.resize(1000)
+            assert_array_equal(a, np.zeros(1000, dtype=dtype))
+
         def test_error(self):
             d = np.ones(100)
             assert_raises(TypeError, d.__sizeof__, "a")


### PR DESCRIPTION
Backport of #27226.

We allow the structured dtype to return NULL for the zero fill function to indicate that a simple memset is sufficient.

Also simplifies error handling a bit.  The get_fill_zero_loop function must clean up on error and not return references if returns a `NULL` loop.

Closes #27225.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
