### PR TITLE
ENH: Adding ``P.coeffs`` property

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -113,6 +113,22 @@ class ABCPolyBase(abc.ABC):
         return self._symbol
 
     @property
+    def coeffs(self):
+        """Polynomial coefficients for the natural variable.
+
+        Coefficients `coef` define the internal representation of the 
+        polynomial over its `window`, while coefficients `coeffs` describe 
+        the polynomial over its `domain` for the natural variable.
+
+        Returns
+        -------
+        coeffs : ndarray
+            Array of coefficients for the natural variable of the polynomial.
+
+        """
+        return self.convert().coef
+
+    @property
     @abc.abstractmethod
     def domain(self):
         pass
@@ -281,7 +297,7 @@ class ABCPolyBase(abc.ABC):
         Returns
         -------
         coef
-            The coefficients of`other` if it is a compatible instance,
+            The coefficients of `other` if it is a compatible instance,
             of ABCPolyBase, otherwise `other`.
 
         Raises

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -113,16 +113,18 @@ class ABCPolyBase(abc.ABC):
         return self._symbol
 
     @property
-    def coeffs(self):
-        """Polynomial coefficients for the natural variable.
+    def coef_natural(self):
+        """Coefficients of the polynomial for the natural variable.
 
-        Coefficients `coef` define the internal representation of the 
-        polynomial over its `window`, while coefficients `coeffs` describe 
-        the polynomial over its `domain` for the natural variable.
+        Coefficients `coef_natural` describe the polynomial over its `domain`
+        for the natural variable. 
+
+        Note: They are different from the coefficients `coef`, which define 
+        the internal representation of the polynomial over its `window`.
 
         Returns
         -------
-        coeffs : ndarray
+        coef_natural : ndarray
             Array of coefficients for the natural variable of the polynomial.
 
         """

--- a/numpy/polynomial/_polybase.pyi
+++ b/numpy/polynomial/_polybase.pyi
@@ -81,6 +81,9 @@ class ABCPolyBase(Generic[_NameCo], metaclass=abc.ABCMeta):
     @property
     def symbol(self, /) -> LiteralString: ...
 
+    @property
+    def coef_natural(self, /) -> _CoefSeries: ...
+
     def __init__(
         self,
         /,


### PR DESCRIPTION
Hello,
This is an enhancement adding a `coeffs` property to polynomials, as discussed in https://github.com/numpy/numpy/issues/26401.
The reason is that a lot of people get confused by `P.coef`, because this is not the coefficients they are looking for. This new property will offer them an easy access to `P.convert().coef`, i.e. what they are actually looking for, and explain the difference with `P.coef`.
Best regards,
Olivier
