### PR TITLE
BUG: Allow fitting of degree zero polynomials with Polynomial.fit

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -1041,6 +1041,9 @@ class ABCPolyBase(abc.ABC):
         """
         if domain is None:
             domain = pu.getdomain(x)
+            if domain[0] == domain[1]:
+                domain[0] -= 1
+                domain[1] += 1   
         elif type(domain) is list and len(domain) == 0:
             domain = cls.domain
 

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -5,11 +5,12 @@ from functools import reduce
 from fractions import Fraction
 import numpy as np
 import numpy.polynomial.polynomial as poly
+import numpy.polynomial.polyutils as pu
 import pickle
 from copy import deepcopy
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
-    assert_array_equal, assert_raises_regex)
+    assert_array_equal, assert_raises_regex, assert_warns)
 
 
 def trim(x):
@@ -627,6 +628,14 @@ class TestMisc:
 
     def test_polyline_zero(self):
         assert_equal(poly.polyline(3, 0), [3])
+
+    def test_fit_degenerate_domain(self):
+        p = poly.Polynomial.fit([1], [2], deg=0)
+        assert_equal(p.coef, [2.])
+        p = poly.Polynomial.fit([1, 1], [2, 2.1], deg=0)
+        assert_almost_equal(p.coef, [2.05])
+        with assert_warns(pu.RankWarning):
+            p = poly.Polynomial.fit([1, 1], [2, 2.1], deg=1)
 
     def test_result_type(self):
         w = np.array([-1, 1], dtype=np.float32)


### PR DESCRIPTION
Backport of #25984.

For degenerate domains in Polynomial.fit (which occurs when all independent datapoints are equal) we expand the domain. This allows fitting of degree zero polynomials.

Fixes #25982

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
