### PR TITLE
MAINT: MSVC does not support #warning directive

### DIFF
--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -128,7 +128,7 @@
 /* Sanity check the (requested) feature version */
 #if NPY_FEATURE_VERSION > NPY_API_VERSION
     #error "NPY_TARGET_VERSION higher than NumPy headers!"
-#elif NPY_FEATURE_VERSION < NPY_1_15_API_VERSION
+#elif NPY_FEATURE_VERSION < NPY_1_15_API_VERSION && !defined(_WIN32)
     /* No support for irrelevant old targets, no need for error, but warn. */
     #warning "Requested NumPy target lower than supported NumPy 1.15."
 #endif

--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -128,9 +128,16 @@
 /* Sanity check the (requested) feature version */
 #if NPY_FEATURE_VERSION > NPY_API_VERSION
     #error "NPY_TARGET_VERSION higher than NumPy headers!"
-#elif NPY_FEATURE_VERSION < NPY_1_15_API_VERSION && !defined(_WIN32)
+#elif NPY_FEATURE_VERSION < NPY_1_15_API_VERSION
     /* No support for irrelevant old targets, no need for error, but warn. */
-    #warning "Requested NumPy target lower than supported NumPy 1.15."
+    #ifndef _MSC_VER
+        #warning "Requested NumPy target lower than supported NumPy 1.15."
+    #else
+        #define _WARN___STR2__(x) #x
+        #define _WARN___STR1__(x) _WARN___STR2__(x)
+        #define _WARN___LOC__ __FILE__ "(" _WARN___STR1__(__LINE__) ") : Warning Msg: "
+        #pragma message(_WARN___LOC__"Requested NumPy target lower than supported NumPy 1.15.")
+    #endif
 #endif
 
 /*


### PR DESCRIPTION
Attempts to fix https://github.com/numpy/numpy/issues/27224.  I test `_WIN32` for consistency with another `#warning` directive in [npy_1_7_deprecated_api.h](https://github.com/numpy/numpy/blob/282c79ebc9b61ebc5f0755736ec953b8d954922c/numpy/_core/include/numpy/npy_1_7_deprecated_api.h#L10-L17).