### PR TITLE
DOC: update ``np.unique`` docstring

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -216,17 +216,7 @@ def unique(ar, return_index=False, return_inverse=False,
     flattened subarrays are sorted in lexicographic order starting with the
     first element.
 
-    .. versionchanged: 1.21
-        If nan values are in the input array, a single nan is put
-        to the end of the sorted unique values.
-
-        Also for complex arrays all NaN values are considered equivalent
-        (no matter whether the NaN is in the real or imaginary part).
-        As the representant for the returned array the smallest one in the
-        lexicographical order is chosen - see np.sort for how the lexicographical
-        order is defined for complex arrays.
-
-    .. versionchanged: 2.0
+    .. versionchanged:: 2.0
         For multi-dimensional inputs, ``unique_inverse`` is reshaped
         such that the input can be reconstructed using
         ``np.take(unique, unique_inverse, axis=axis)``. The result is

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -180,7 +180,8 @@ def unique(ar, return_index=False, return_inverse=False,
         .. versionadded:: 1.13.0
 
     equal_nan : bool, optional
-        If True, collapses multiple NaN values in the return array into one.
+        If True, collapses multiple NaN values in the return array into one
+        and it is put to the end of the sorted unique values.      
 
         .. versionadded:: 1.24
 
@@ -215,6 +216,13 @@ def unique(ar, return_index=False, return_inverse=False,
     treated in the same way as any other 1-D array. The result is that the
     flattened subarrays are sorted in lexicographic order starting with the
     first element.
+
+    .. versionchanged:: 1.21
+        For complex arrays all NaN values are considered equivalent
+        (no matter whether the NaN is in the real or imaginary part).
+        As the representant for the returned array the smallest one in the
+        lexicographical order is chosen - see np.sort for how the lexicographical
+        order is defined for complex arrays.   
 
     .. versionchanged:: 2.0
         For multi-dimensional inputs, ``unique_inverse`` is reshaped

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -180,8 +180,7 @@ def unique(ar, return_index=False, return_inverse=False,
         .. versionadded:: 1.13.0
 
     equal_nan : bool, optional
-        If True, collapses multiple NaN values in the return array into one
-        and it is put to the end of the sorted unique values.      
+        If True, collapses multiple NaN values in the return array into one.
 
         .. versionadded:: 1.24
 
@@ -204,6 +203,7 @@ def unique(ar, return_index=False, return_inverse=False,
     See Also
     --------
     repeat : Repeat elements of an array.
+    sort : Return a sorted copy of an array.
 
     Notes
     -----
@@ -218,11 +218,12 @@ def unique(ar, return_index=False, return_inverse=False,
     first element.
 
     .. versionchanged:: 1.21
+        Like np.sort, NaN will sort to the end of the values.
         For complex arrays all NaN values are considered equivalent
         (no matter whether the NaN is in the real or imaginary part).
         As the representant for the returned array the smallest one in the
         lexicographical order is chosen - see np.sort for how the lexicographical
-        order is defined for complex arrays.   
+        order is defined for complex arrays.
 
     .. versionchanged:: 2.0
         For multi-dimensional inputs, ``unique_inverse`` is reshaped


### PR DESCRIPTION
There was a typo in doc string, `::` should be used instead of `:`  for updates related to a specific version otherwise it is not shown in the documentation.

In addition, I believe one of the notes should have been removed with the introduction of `equal_nan` keyword.