### PR TITLE
BUG: fix reference counting bug in __array_interface__ implementation

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2233,7 +2233,8 @@ PyArray_FromInterface(PyObject *origin)
                 }
             }
         }
-        Py_DECREF(descr);
+        // descr doesn't have to be specified so this may be NULL
+        Py_XDECREF(descr);
     }
     Py_CLEAR(attr);
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2232,9 +2232,8 @@ PyArray_FromInterface(PyObject *origin)
                     Py_SETREF(dtype, new_dtype);
                 }
             }
+            Py_DECREF(descr);
         }
-        // descr doesn't have to be specified so this may be NULL
-        Py_XDECREF(descr);
     }
     Py_CLEAR(attr);
 


### PR DESCRIPTION
@seberg ran into this testing `cunumeric`: https://github.com/numpy/numpy/pull/26282/files#r1722321473.

Unfortunately there are no existing tests for this code path so we missed this breakage.

I tried writing an example that triggered this code path for a while this afternoon but was unable to.