### PR TITLE
TST: Add regression test for missing descr in array-interface

### DIFF
--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -762,6 +762,17 @@ class TestArrayLikes:
         with pytest.raises(error):
             np.array(BadSequence())
 
+    def test_array_interface_descr_optional(self):
+        # The descr should be optional regresion test for gh-27249
+        arr = np.ones(10, dtype="V10")
+        iface = arr.__array_interface__
+        iface.pop("descr")
+
+        class MyClass:
+            __array_interface__ = iface
+
+        assert_array_equal(np.asarray(MyClass), arr)
+
 
 class TestAsArray:
     """Test expected behaviors of ``asarray``."""


### PR DESCRIPTION
Backport of #27261.

This adds a simple regression test for the missing descr for gh-27249.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
