### PR TITLE
ENH: make check-{docs,tutorials} fail on dtype mismatch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,7 +181,8 @@ jobs:
     - name: Check docstests
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       run: |
-        pip install scipy-doctest hypothesis matplotlib scipy pytz pandas
+        pip install hypothesis matplotlib scipy pytz pandas
+        pip install git+https://github.com/scipy/scipy_doctest.git@strict-dtypes    # Temp
         spin check-docs -v
         spin check-tutorials -v
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,8 +181,7 @@ jobs:
     - name: Check docstests
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       run: |
-        pip install hypothesis matplotlib scipy pytz pandas
-        pip install git+https://github.com/scipy/scipy_doctest.git@strict-dtypes    # Temp
+        pip install scipy-doctest hypothesis matplotlib scipy pytz pandas
         spin check-docs -v
         spin check-tutorials -v
 

--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -535,7 +535,7 @@ Similarly to tuples, structured scalars can also be indexed with an integer::
 
  >>> scalar = np.array([(1, 2., 3.)], dtype='i, f, f')[0]
  >>> scalar[0]
- 1
+ np.int32(1)
  >>> scalar[1] = 4
 
 Thus, tuples might be thought of as the native Python equivalent to numpy's
@@ -595,7 +595,7 @@ removed::
 
     >>> dt = np.dtype("i1,V3,i4,V1")[["f0", "f2"]]
     >>> dt
-    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':9})
+    dtype({'names': ['f0', 'f2'], 'formats': ['i1', '<i4'], 'offsets': [0, 4], 'itemsize': 9})
     >>> np.result_type(dt)
     dtype([('f0', 'i1'), ('f2', '<i4')])
 
@@ -606,7 +606,8 @@ If a structured dtype is created with ``align=True`` ensuring that
 
     >>> dt = np.dtype("i1,V3,i4,V1", align=True)[["f0", "f2"]]
     >>> dt
-    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':12}, align=True)
+    dtype({'names': ['f0', 'f2'], 'formats': ['i1', '<i4'], 'offsets': [0, 4], 'itemsize': 12}, align=True)
+
     >>> np.result_type(dt)
     dtype([('f0', 'i1'), ('f2', '<i4')], align=True)
     >>> np.result_type(dt).isalignedstruct

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -314,7 +314,7 @@ but gives -1486618624 (incorrect) for a 32-bit integer.
     >>> np.power(100, 9, dtype=np.int64)
     1000000000000000000
     >>> np.power(100, 9, dtype=np.int32)
-    -1486618624
+    np.int32(-1486618624)
 
 The behaviour of NumPy and Python integer types differs significantly for
 integer overflows and may confuse users expecting NumPy integers to behave

--- a/doc/source/user/byteswapping.rst
+++ b/doc/source/user/byteswapping.rst
@@ -40,9 +40,9 @@ there are two integers, and that they are 16 bit and big-endian:
 >>> import numpy as np
 >>> big_end_arr = np.ndarray(shape=(2,),dtype='>i2', buffer=big_end_buffer)
 >>> big_end_arr[0]
-1
+np.int16(1)
 >>> big_end_arr[1]
-770
+np.int16(770)
 
 Note the array ``dtype`` above of ``>i2``.  The ``>`` means 'big-endian'
 (``<`` is little-endian) and ``i2`` means 'signed 2-byte integer'.  For
@@ -99,14 +99,14 @@ We make something where they don't match:
 
 >>> wrong_end_dtype_arr = np.ndarray(shape=(2,),dtype='<i2', buffer=big_end_buffer)
 >>> wrong_end_dtype_arr[0]
-256
+np.int16(256)
 
 The obvious fix for this situation is to change the dtype so it gives
 the correct endianness:
 
 >>> fixed_end_dtype_arr = wrong_end_dtype_arr.view(np.dtype('<i2').newbyteorder())
 >>> fixed_end_dtype_arr[0]
-1
+np.int16(1)
 
 Note the array has not changed in memory:
 
@@ -122,7 +122,7 @@ that needs a certain byte ordering.
 
 >>> fixed_end_mem_arr = wrong_end_dtype_arr.byteswap()
 >>> fixed_end_mem_arr[0]
-1
+np.int16(1)
 
 Now the array *has* changed in memory:
 
@@ -140,7 +140,7 @@ the previous operations:
 >>> swapped_end_arr = big_end_arr.byteswap()
 >>> swapped_end_arr = swapped_end_arr.view(swapped_end_arr.dtype.newbyteorder())
 >>> swapped_end_arr[0]
-1
+np.int16(1)
 >>> swapped_end_arr.tobytes() == big_end_buffer
 False
 
@@ -149,7 +149,7 @@ can be achieved with the ndarray astype method:
 
 >>> swapped_end_arr = big_end_arr.astype('<i2')
 >>> swapped_end_arr[0]
-1
+np.int16(1)
 >>> swapped_end_arr.tobytes() == big_end_buffer
 False
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -919,7 +919,7 @@ add_newdoc('numpy._core.multiarray', 'array',
 
     >>> x = np.array([(1,2),(3,4)],dtype=[('a','<i4'),('b','<i4')])
     >>> x['a']
-    array([1, 3])
+    array([1, 3], dtype=int32)
 
     Creating an array from sub-classes:
 
@@ -3350,7 +3350,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('byteswap',
     array([1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
            0, 0], dtype=uint8)
     >>> A.view(A.dtype.newbyteorder()).byteswap(inplace=True)
-    array([1, 2, 3])
+    array([1, 2, 3], dtype='>i8')
     >>> A.view(np.uint8)
     array([0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
            0, 3], dtype=uint8)
@@ -4459,7 +4459,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('tolist',
     >>> a = np.uint32([1, 2])
     >>> a_list = list(a)
     >>> a_list
-    [1, 2]
+    [np.uint32(1), np.uint32(2)]
     >>> type(a_list[0])
     <class 'numpy.uint32'>
     >>> a_tolist = a.tolist()

--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -77,7 +77,7 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     >>> import numpy as np
     >>> orig_settings = np.seterr(all='ignore')  # seterr to known value
     >>> np.int16(32000) * np.int16(3)
-    30464
+    np.int16(30464)
     >>> np.seterr(over='raise')
     {'divide': 'ignore', 'over': 'ignore', 'under': 'ignore', 'invalid': 'ignore'}
     >>> old_settings = np.seterr(all='warn', over='raise')
@@ -90,7 +90,7 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     >>> np.geterr()
     {'divide': 'print', 'over': 'print', 'under': 'print', 'invalid': 'print'}
     >>> np.int16(32000) * np.int16(3)
-    30464
+    np.int16(30464)
     >>> np.seterr(**orig_settings)  # restore original
     {'divide': 'print', 'over': 'print', 'under': 'print', 'invalid': 'print'}
 

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -703,7 +703,7 @@ add_newdoc('numpy._core.umath', 'bitwise_or',
     array([  6,   5, 255])
     >>> np.bitwise_or(np.array([2, 5, 255, 2147483647], dtype=np.int32),
     ...               np.array([4, 4, 4, 2147483647], dtype=np.int32))
-    array([         6,          5,        255, 2147483647])
+    array([         6,          5,        255, 2147483647], dtype=int32)
     >>> np.bitwise_or([True, True], [False, True])
     array([ True,  True])
 
@@ -1679,7 +1679,7 @@ add_newdoc('numpy._core.umath', 'invert',
 
     >>> x = np.invert(np.array(13, dtype=np.uint8))
     >>> x
-    242
+    np.uint8(242)
     >>> np.binary_repr(x, width=8)
     '11110010'
 
@@ -1687,7 +1687,7 @@ add_newdoc('numpy._core.umath', 'invert',
 
     >>> x = np.invert(np.array(13, dtype=np.uint16))
     >>> x
-    65522
+    np.uint16(65522)
     >>> np.binary_repr(x, width=16)
     '1111111111110010'
 
@@ -2683,7 +2683,7 @@ add_newdoc('numpy._core.umath', 'fmax',
     --------
     >>> import numpy as np
     >>> np.fmax([2, 3, 4], [1, 5, 2])
-    array([ 2.,  5.,  4.])
+    array([ 2,  5,  4])
 
     >>> np.fmax(np.eye(2), [0.5, 2])
     array([[ 1. ,  2. ],
@@ -4263,7 +4263,7 @@ add_newdoc('numpy._core.umath', 'frexp',
     array([ 0.   ,  0.5  ,  0.5  ,  0.75 ,  0.5  ,  0.625,  0.75 ,  0.875,
             0.5  ])
     >>> y2
-    array([0, 1, 2, 2, 3, 3, 3, 3, 4])
+    array([0, 1, 2, 2, 3, 3, 3, 3, 4], dtype=int32)
     >>> y1 * 2**y2
     array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.])
 
@@ -4411,7 +4411,7 @@ add_newdoc('numpy._core.umath', 'bitwise_count',
     --------
     >>> import numpy as np
     >>> np.bitwise_count(1023)
-    10
+    np.uint8(10)
     >>> a = np.array([2**i - 1 for i in range(16)])
     >>> np.bitwise_count(a)
     array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15],

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2452,7 +2452,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     >>> np.sum([0.5, 1.5])
     2.0
     >>> np.sum([0.5, 0.7, 0.2, 1.5], dtype=np.int32)
-    1
+    np.int32(1)
     >>> np.sum([[0, 1], [0, 5]])
     6
     >>> np.sum([[0, 1], [0, 5]], axis=0)
@@ -2465,7 +2465,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     If the accumulator is too small, overflow occurs:
 
     >>> np.ones(128, dtype=np.int8).sum(dtype=np.int8)
-    -128
+    np.int8(-128)
 
     You can also start the sum with a value other than zero:
 
@@ -3877,7 +3877,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     >>> a[0, :] = 1.0
     >>> a[1, :] = 0.1
     >>> np.mean(a)
-    0.54999924
+    np.float32(0.54999924)
 
     Computing the mean in float64 is more accurate:
 
@@ -4064,7 +4064,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     >>> a[0, :] = 1.0
     >>> a[1, :] = 0.1
     >>> np.std(a)
-    0.45000005
+    np.float32(0.45000005)
 
     Computing the standard deviation in float64 is more accurate:
 
@@ -4267,7 +4267,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
     >>> a[0, :] = 1.0
     >>> a[1, :] = 0.1
     >>> np.var(a)
-    0.20250003
+    np.float32(0.20250003)
 
     Computing the variance in float64 is more accurate:
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -211,6 +211,9 @@ if HAVE_SCPDT:
     dt_config.rndm_markers.add('#uninitialized')
     dt_config.rndm_markers.add('# uninitialized')
 
+    # make the checker pick on mismatched dtypes
+    dt_config.strict_check = True
+
     import doctest
     dt_config.optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1439,7 +1439,7 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     >>> np.diff(u8_arr)
     array([255], dtype=uint8)
     >>> u8_arr[1,...] - u8_arr[0,...]
-    255
+    np.uint8(255)
 
     If this is not desirable, then the array should be cast to a larger
     integer type first:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7808,7 +7808,7 @@ def diff(a, /, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
            fill_value=np.int64(999999),
                 dtype=uint8)
     >>> u8_arr[1,...] - u8_arr[0,...]
-    255
+    np.uint8(255)
 
     If this is not desirable, then the array should be cast to a larger
     integer type first:

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1468,7 +1468,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     array([-6.73496154e-17, -1.00000000e+00,  0.00000000e+00,  1.00000000e+00])
     >>> stats # note the minuscule SSR
     [array([8.79579319e-31]),
-     4,
+     np.int32(4),
      array([1.38446749, 1.32119158, 0.50443316, 0.28853036]),
      1.1324274851176597e-14]
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1138,7 +1138,7 @@ cdef class RandomState:
 
         >>> x = np.float32(5*0.99999999)
         >>> x
-        5.0
+        np.float32(5.0)
 
 
         Examples


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

closes https://github.com/numpy/numpy/issues/27263 

Make the `check-docs` check stricter and fail on dtype mismatch. Previously, it relied on however numpy defines equality, e.g.  `np.float64(3) == 3` hence the doctest below was passing:

```
>>> np.float64(3)
3
```

EDIT: <s>Making the checker stricter needs an a small update in `scipy-doctest`, https://github.com/scipy/scipy_doctest/pull/173, so this PR temporarily installs `scipy-doctest` from a branch, if only to flush the remaining ~100 failures.</s> scipy-doctest==1.4 is up on pypi, so use that. Locally need to do `pip install --upgrade scipy-doctest`