### PR TITLE
BUG: Fix array_equal for numeric and non-numeric scalar types

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2554,24 +2554,24 @@ def array_equal(a1, a2, equal_nan=False):
     if a1.shape != a2.shape:
         return False
     if not equal_nan:
-        return builtins.bool((a1 == a2).all())
-    cannot_have_nan = (_dtype_cannot_hold_nan(a1.dtype)
-                       and _dtype_cannot_hold_nan(a2.dtype))
-    if cannot_have_nan:
-        if a1 is a2:
-            return True
-        return builtins.bool((a1 == a2).all())
+        return builtins.bool((asarray(a1 == a2)).all())
 
     if a1 is a2:
         # nan will compare equal so an array will compare equal to itself.
         return True
+
+    cannot_have_nan = (_dtype_cannot_hold_nan(a1.dtype)
+                       and _dtype_cannot_hold_nan(a2.dtype))
+    if cannot_have_nan:
+        return builtins.bool(asarray(a1 == a2).all())
+
     # Handling NaN values if equal_nan is True
     a1nan, a2nan = isnan(a1), isnan(a2)
     # NaN's occur at different locations
     if not (a1nan == a2nan).all():
         return False
     # Shapes of a1, a2 and masks are guaranteed to be consistent by this point
-    return builtins.bool((a1[~a1nan] == a2[~a1nan]).all())
+    return builtins.bool(asarray(a1[~a1nan] == a2[~a1nan]).all())
 
 
 def _array_equiv_dispatcher(a1, a2):

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2624,7 +2624,7 @@ def array_equiv(a1, a2):
     except Exception:
         return False
 
-    return builtins.bool((a1 == a2).all())
+    return builtins.bool(asarray(a1 == a2).all())
 
 
 def _astype_dispatcher(x, dtype, /, *, copy=None, device=None):

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2554,7 +2554,7 @@ def array_equal(a1, a2, equal_nan=False):
     if a1.shape != a2.shape:
         return False
     if not equal_nan:
-        return builtins.bool((asarray(a1 == a2)).all())
+        return builtins.bool((asanyarray(a1 == a2)).all())
 
     if a1 is a2:
         # nan will compare equal so an array will compare equal to itself.

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2624,7 +2624,7 @@ def array_equiv(a1, a2):
     except Exception:
         return False
 
-    return builtins.bool(asarray(a1 == a2).all())
+    return builtins.bool(asanyarray(a1 == a2).all())
 
 
 def _astype_dispatcher(x, dtype, /, *, copy=None, device=None):

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2571,7 +2571,7 @@ def array_equal(a1, a2, equal_nan=False):
     if not (a1nan == a2nan).all():
         return False
     # Shapes of a1, a2 and masks are guaranteed to be consistent by this point
-    return builtins.bool(asarray(a1[~a1nan] == a2[~a1nan]).all())
+    return builtins.bool((a1[~a1nan] == a2[~a1nan]).all())
 
 
 def _array_equiv_dispatcher(a1, a2):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2192,6 +2192,13 @@ class TestArrayComparisons:
         assert_(res is expected)
         assert_(type(res) is bool)
 
+    def test_array_equal_different_scalar_types(self):
+        # https://github.com/numpy/numpy/issues/27271
+        a = np.array("foo")
+        b = np.array(1)
+        assert not np.array_equal(a, b)
+        assert not np.array_equiv(a, b)
+
     def test_none_compares_elementwise(self):
         a = np.array([None, 1, None], dtype=object)
         assert_equal(a == None, [True, False, True])


### PR DESCRIPTION
Mitigates [#27271](https://github.com/numpy/numpy/issues/27271). The underlying issue (an array comparison returning a python bool instead of a numpy bool) is not addressed.

The order of statements is slightly reordered, so that the `if a1 is a2:` check can be done before the calculation of `cannot_have_nan`


*EDIT,NOTE(seberg): Should be backported to both 2.0.2 and 2.1*

Closes gh-27271