### PR TITLE
BUG: Fix #27256 and #27257

### DIFF
--- a/doc/release/upcoming_changes/26766.change.rst
+++ b/doc/release/upcoming_changes/26766.change.rst
@@ -1,0 +1,2 @@
+* `numpy.fix` now won't perform casting to a floating data-type for integer
+  and boolean data-type input arrays.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -795,7 +795,7 @@ add_newdoc('numpy._core.umath', 'ceil',
     Returns
     -------
     y : ndarray or scalar
-        The ceiling of each element in `x`, with `float` dtype.
+        The ceiling of each element in `x`.
         $OUT_SCALAR_1
 
     See Also

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -207,13 +207,13 @@ def take(a, indices, axis=None, out=None, mode='raise'):
     return _wrapfunc(a, 'take', indices, axis=axis, out=out, mode=mode)
 
 
-def _reshape_dispatcher(a, /, shape=None, *, newshape=None, order=None,
+def _reshape_dispatcher(a, /, shape=None, order=None, *, newshape=None,
                         copy=None):
     return (a,)
 
 
 @array_function_dispatch(_reshape_dispatcher)
-def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
+def reshape(a, /, shape=None, order='C', *, newshape=None, copy=None):
     """
     Gives a new shape to an array without changing its data.
 
@@ -226,10 +226,6 @@ def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
         an integer, then the result will be a 1-D array of that length.
         One shape dimension can be -1. In this case, the value is
         inferred from the length of the array and remaining dimensions.
-    newshape : int or tuple of ints
-        .. deprecated:: 2.1
-            Replaced by ``shape`` argument. Retained for backward
-            compatibility.
     order : {'C', 'F', 'A'}, optional
         Read the elements of ``a`` using this index order, and place the
         elements into the reshaped array using this index order. 'C'
@@ -243,6 +239,10 @@ def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
         'A' means to read / write the elements in Fortran-like index
         order if ``a`` is Fortran *contiguous* in memory, C-like order
         otherwise.
+    newshape : int or tuple of ints
+        .. deprecated:: 2.1
+            Replaced by ``shape`` argument. Retained for backward
+            compatibility.
     copy : bool, optional
         If ``True``, then the array data is copied. If ``None``, a copy will
         only be made if it's required by ``order``. For ``False`` it raises

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -92,15 +92,21 @@ def take(
 @overload
 def reshape(
     a: _ArrayLike[_SCT],
-    newshape: _ShapeLike,
+    /,
+    shape: _ShapeLike = ...,
     order: _OrderACF = ...,
+    *,
+    newshape: _ShapeLike = ...,
     copy: None | bool = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def reshape(
     a: ArrayLike,
-    newshape: _ShapeLike,
+    /,
+    shape: _ShapeLike = ...,
     order: _OrderACF = ...,
+    *,
+    newshape: _ShapeLike = ...,
     copy: None | bool = ...,
 ) -> NDArray[Any]: ...
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -184,6 +184,7 @@ class TestNonarrayArgs:
 
         assert_equal(np.reshape(arr, shape), expected)
         assert_equal(np.reshape(arr, shape, order="C"), expected)
+        assert_equal(np.reshape(arr, shape, "C"), expected)
         assert_equal(np.reshape(arr, shape=shape), expected)
         assert_equal(np.reshape(arr, shape=shape, order="C"), expected)
         with pytest.warns(DeprecationWarning):

--- a/numpy/lib/_ufunclike_impl.py
+++ b/numpy/lib/_ufunclike_impl.py
@@ -21,12 +21,12 @@ def fix(x, out=None):
     Round to nearest integer towards zero.
 
     Round an array of floats element-wise to nearest integer towards zero.
-    The rounded values are returned as floats.
+    The rounded values have the same data-type as the input.
 
     Parameters
     ----------
     x : array_like
-        An array of floats to be rounded
+        An array to be rounded
     out : ndarray, optional
         A location into which the result is stored. If provided, it must have
         a shape that the input broadcasts to. If not provided or None, a
@@ -35,12 +35,12 @@ def fix(x, out=None):
     Returns
     -------
     out : ndarray of floats
-        A float array with the same dimensions as the input.
-        If second argument is not supplied then a float array is returned
+        An array with the same dimensions and data-type as the input.
+        If second argument is not supplied then a new array is returned
         with the rounded values.
 
         If a second argument is supplied the result is stored there.
-        The return value `out` is then a reference to that array.
+        The return value ``out`` is then a reference to that array.
 
     See Also
     --------
@@ -53,7 +53,7 @@ def fix(x, out=None):
     >>> np.fix(3.14)
     3.0
     >>> np.fix(3)
-    3.0
+    3
     >>> np.fix([2.1, 2.9, -2.1, -2.9])
     array([ 2.,  2., -2., -2.])
 


### PR DESCRIPTION
Backport of #27262.

This PR addresses https://github.com/numpy/numpy/issues/27256 and https://github.com/numpy/numpy/issues/27257:

- Re-allow to pass `order` as a positional or keyword argument in `np.reshape`.
- Update `np.fix` docstring to include "no-casting to a floating data type" change.

To be backported to `2.1.x`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
