### PR TITLE
BUG: Fix array_equal for numeric and non-numeric scalar types

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2503,17 +2503,17 @@ def array_equal(a1, a2, equal_nan=False):
     if a1.shape != a2.shape:
         return False
     if not equal_nan:
-        return builtins.bool((a1 == a2).all())
-    cannot_have_nan = (_dtype_cannot_hold_nan(a1.dtype)
-                       and _dtype_cannot_hold_nan(a2.dtype))
-    if cannot_have_nan:
-        if a1 is a2:
-            return True
-        return builtins.bool((a1 == a2).all())
+        return builtins.bool((asanyarray(a1 == a2)).all())
 
     if a1 is a2:
         # nan will compare equal so an array will compare equal to itself.
         return True
+
+    cannot_have_nan = (_dtype_cannot_hold_nan(a1.dtype)
+                       and _dtype_cannot_hold_nan(a2.dtype))
+    if cannot_have_nan:
+        return builtins.bool(asarray(a1 == a2).all())
+
     # Handling NaN values if equal_nan is True
     a1nan, a2nan = isnan(a1), isnan(a2)
     # NaN's occur at different locations
@@ -2572,7 +2572,7 @@ def array_equiv(a1, a2):
     except Exception:
         return False
 
-    return builtins.bool((a1 == a2).all())
+    return builtins.bool(asanyarray(a1 == a2).all())
 
 
 def _astype_dispatcher(x, dtype, /, *, copy=None):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2131,6 +2131,13 @@ class TestArrayComparisons:
         assert_(res is expected)
         assert_(type(res) is bool)
 
+    def test_array_equal_different_scalar_types(self):
+        # https://github.com/numpy/numpy/issues/27271
+        a = np.array("foo")
+        b = np.array(1)
+        assert not np.array_equal(a, b)
+        assert not np.array_equiv(a, b)
+
     def test_none_compares_elementwise(self):
         a = np.array([None, 1, None], dtype=object)
         assert_equal(a == None, [True, False, True])


### PR DESCRIPTION
Backport of #27275

Mitigates #27271. The underlying issue (an array comparison returning a python bool instead of a numpy bool) is not addressed.

The order of statements is slightly reordered, so that the if `a1 is a2:` check can be done before the calculation of `cannot_have_nan`

Closes gh-27271

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
