### PR TITLE
BLD: cp311- macosx_arm64 wheels [wheel build]

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -65,7 +65,7 @@ macosx_arm64_task:
 
   matrix:
     - env:
-        CIBW_BUILD: cp310-* cp311
+        CIBW_BUILD: cp310-* cp311-*
     - env:
         CIBW_BUILD: cp312-* cp313-*
     - env:


### PR DESCRIPTION
I think this closes #27283. The `numpy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl` is missing from PyPI. I'm not sure if you need to do a backport on this.

@charris.