### PR TITLE
MAINT: Keep applying ruff/pyupgrade rules (UP)

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -106,7 +106,7 @@ from ._dtype import _kind_name
 
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
-from builtins import bool, int, float, complex, object, str, bytes
+from builtins import bool, int, float, complex, object, str, bytes  # noqa: UP029
 
 
 # We use this later

--- a/numpy/lib/_array_utils_impl.pyi
+++ b/numpy/lib/_array_utils_impl.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable
 
 from numpy import generic
 from numpy.typing import NDArray
@@ -16,7 +16,7 @@ def normalize_axis_tuple(
     ndim: int = ..., 
     argname: None | str = ..., 
     allow_duplicate: None | bool = ...,
-) -> Tuple[int, int]: ...
+) -> tuple[int, int]: ...
 
 def normalize_axis_index(
     axis: int = ...,


### PR DESCRIPTION
Follow-up to #26882.

Apply additional rules in preparation for https://github.com/numpy/numpy/issues/24994.

I have left out these ruff/pyupgrade rules:
* [`UP015`](https://docs.astral.sh/ruff/rules/redundant-open-modes/): I suspect you prefer explicit over implicit open modes
* [`UP018`](https://docs.astral.sh/ruff/rules/native-literals/)
* [`UP027`](https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/): _This rule is deprecated and will be removed in a future release_ of ruff.
* [UP030](https://docs.astral.sh/ruff/rules/format-literals/), [UP031](https://docs.astral.sh/ruff/rules/printf-string-formatting/), [UP032](https://docs.astral.sh/ruff/rules/f-string/): they involve way too many string-related changes, as discussed in #23833.