### PR TITLE
BUILD: refactor circleci to use spin [skip actions][skip azp][skip cirrus]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,27 +54,20 @@ jobs:
           command: |
             python3.11 -m venv venv
             . venv/bin/activate
-            pip install --progress-bar=off -r requirements/test_requirements.txt
+            pip install --progress-bar=off -r requirements/test_requirements.txt \
+               -r requirements/build_requirements.txt \
+               -r requirements/ci_requirements.txt
             # get newer, pre-release versions of critical packages
             pip install --progress-bar=off --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r requirements/doc_requirements.txt
             # then install numpy HEAD, which will override the version installed above
-            pip install . --config-settings=setup-args="-Dallow-noblas=true"
-
-      - run:
-          name: create release notes
-          command: |
-            . venv/bin/activate
-            VERSION=$(pip show numpy | grep Version: | cut -d ' ' -f 2 | cut -c 1-5)
-            towncrier build --version $VERSION --yes
-            ./tools/ci/test_all_newsfragments_used.py
+            spin build --scipy-openblas=64
 
       - run:
           name: build devdocs w/ref warnings
           command: |
             . venv/bin/activate
-            cd doc
             # Don't use -q, show warning summary"
-            SPHINXOPTS="-W -n" make -e html
+            SPHINXOPTS="-W -n" spin docs
             if [[ $(find build/html -type f | wc -l) -lt 1000 ]]; then
                 echo "doc build failed: build/html is empty"
                 exit -1
@@ -95,10 +88,11 @@ jobs:
      #      destination: neps
 
       - run:
-          name: run refguide-check
+          name: check doctests
           command: |
             . venv/bin/activate
-            python tools/refguide_check.py -v
+            spin check-docs -v
+            spin check-tutorials -v
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             # get newer, pre-release versions of critical packages
             pip install --progress-bar=off --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -r requirements/doc_requirements.txt
             # then install numpy HEAD, which will override the version installed above
-            spin build --scipy-openblas=64
+            spin build --with-scipy-openblas=64
 
       - run:
           name: build devdocs w/ref warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ jobs:
             . venv/bin/activate
             # Don't use -q, show warning summary"
             SPHINXOPTS="-W -n" spin docs
-            if [[ $(find build/html -type f | wc -l) -lt 1000 ]]; then
-                echo "doc build failed: build/html is empty"
+            if [[ $(find doc/build/html -type f | wc -l) -lt 1000 ]]; then
+                echo "doc build failed: doc/build/html is empty"
                 exit -1
             fi
 
@@ -93,6 +93,11 @@ jobs:
             . venv/bin/activate
             spin check-docs -v
             spin check-tutorials -v
+            # Currently, this does two checks not done by check-docs:
+            #  - validates ReST blocks (via validate_rst_syntax)
+            #  - checks that all of a module's `__all__` is reflected in the
+            #    module-level docstring autosummary
+            python tools/refguide_check.py -v
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
             #  - validates ReST blocks (via validate_rst_syntax)
             #  - checks that all of a module's `__all__` is reflected in the
             #    module-level docstring autosummary
+            echo calling python tools/refguide_check.py -v
             python tools/refguide_check.py -v
 
       - persist_to_workspace:

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -369,14 +369,14 @@ def check_docs(ctx, pytest_args, n_jobs, verbose, *args, **kwargs):
 def check_tutorials(ctx, pytest_args, n_jobs, verbose, *args, **kwargs):
     """🔧 Run doctests of user-facing rst tutorials.
 
-    To test all tutorials in the numpy/doc/source/user/ directory, use
+    To test all tutorials in the numpy doc/source/user/ directory, use
 
       spin check-tutorials
 
     To run tests on a specific RST file:
 
      \b
-     spin check-tutorials numpy/doc/source/user/absolute-beginners.rst
+     spin check-tutorials doc/source/user/absolute-beginners.rst
 
     \b
     Note:
@@ -393,11 +393,11 @@ def check_tutorials(ctx, pytest_args, n_jobs, verbose, *args, **kwargs):
     #   - `spin check-tutorials path/to/rst`, and
     #   - `spin check-tutorials path/to/rst -- --durations=3`
     if (not pytest_args) or all(arg.startswith('-') for arg in pytest_args):
-        pytest_args = ('numpy/doc/source/user',) + pytest_args
+        pytest_args = ('doc/source/user',) + pytest_args
 
     # make all paths relative to the numpy source folder
     pytest_args = tuple(
-        str(curdir / '..' / '..' / arg) if not arg.startswith('-') else arg
+        str(curdir / '..' / arg) if not arg.startswith('-') else arg
         for arg in pytest_args
    )
 

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -16,3 +16,6 @@ pickleshare
 # needed to build release notes
 towncrier
 toml
+
+# for doctests, also needs pytz which is in test_requirements
+scipy-doctest


### PR DESCRIPTION
Use `spin` in circle CI. This is a small cleanup that came out of the triage discussion around doctesting, motivated by @ev-br. It also adds `scipy-doctest` to the doc building requirements, so developers can use `spin check-docs` to run the doctests via `scipy-doctest`.