### PR TITLE
BUG: f2py: better handle filtering of public/private subroutines

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -36,16 +36,15 @@ __all__ = [
     'isintent_nothide', 'isintent_out', 'isintent_overwrite', 'islogical',
     'islogicalfunction', 'islong_complex', 'islong_double',
     'islong_doublefunction', 'islong_long', 'islong_longfunction',
-    'ismodule', 'ismoduleroutine', 'isoptional', 'isprivate', 'isrequired',
-    'isroutine', 'isscalar', 'issigned_long_longarray', 'isstring',
-    'isstringarray', 'isstring_or_stringarray', 'isstringfunction',
-    'issubroutine', 'get_f2py_modulename',
-    'issubroutine_wrap', 'isthreadsafe', 'isunsigned', 'isunsigned_char',
-    'isunsigned_chararray', 'isunsigned_long_long',
-    'isunsigned_long_longarray', 'isunsigned_short',
-    'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess',
-    'replace', 'show', 'stripcomma', 'throw_error', 'isattr_value',
-    'getuseblocks', 'process_f2cmap_dict'
+    'ismodule', 'ismoduleroutine', 'isoptional', 'isprivate', 'isvariable',
+    'isrequired', 'isroutine', 'isscalar', 'issigned_long_longarray',
+    'isstring', 'isstringarray', 'isstring_or_stringarray', 'isstringfunction',
+    'issubroutine', 'get_f2py_modulename', 'issubroutine_wrap', 'isthreadsafe',
+    'isunsigned', 'isunsigned_char', 'isunsigned_chararray',
+    'isunsigned_long_long', 'isunsigned_long_longarray', 'isunsigned_short',
+    'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess', 'replace',
+    'show', 'stripcomma', 'throw_error', 'isattr_value', 'getuseblocks',
+    'process_f2cmap_dict'
 ]
 
 
@@ -517,6 +516,15 @@ isintent_dict = {isintent_in: 'INTENT_IN', isintent_inout: 'INTENT_INOUT',
 def isprivate(var):
     return 'attrspec' in var and 'private' in var['attrspec']
 
+
+def isvariable(var):
+    # heuristic to find public/private declarations of filtered subroutines
+    if len(var) == 1 and 'attrspec' in var and \
+            var['attrspec'][0] in ('public', 'private'):
+        is_var = False
+    else:
+        is_var = True
+    return is_var
 
 def hasinitvalue(var):
     return '=' in var

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -110,11 +110,16 @@ def buildhooks(pymod):
                 notvars.append(b['name'])
         for n in m['vars'].keys():
             var = m['vars'][n]
-            if (n not in notvars) and (not l_or(isintent_hide, isprivate)(var)):
+
+            if (n not in notvars and isvariable(var)) and (not l_or(isintent_hide, isprivate)(var)):
                 onlyvars.append(n)
                 mfargs.append(n)
         outmess('\t\tConstructing F90 module support for "%s"...\n' %
                 (m['name']))
+        if len(onlyvars) == 0 and len(notvars) == 1 and m['name'] in notvars:
+            outmess(f"\t\t\tSkipping {m['name']} since there are no public vars/func in this module...\n")
+            continue
+
         if m['name'] in usenames and not contains_functions_or_subroutines:
             outmess(f"\t\t\tSkipping {m['name']} since it is in 'use'...\n")
             continue

--- a/numpy/f2py/tests/src/modules/gh26920/two_mods_with_no_public_entities.f90
+++ b/numpy/f2py/tests/src/modules/gh26920/two_mods_with_no_public_entities.f90
@@ -1,0 +1,21 @@
+    module mod2
+        implicit none
+        private mod2_func1
+    contains
+
+        subroutine mod2_func1()
+            print*, "mod2_func1"
+        end subroutine mod2_func1
+
+    end module mod2
+
+    module mod1
+        implicit none
+        private :: mod1_func1
+    contains
+
+        subroutine mod1_func1()
+            print*, "mod1_func1"
+        end subroutine mod1_func1
+
+    end module mod1

--- a/numpy/f2py/tests/src/modules/gh26920/two_mods_with_one_public_routine.f90
+++ b/numpy/f2py/tests/src/modules/gh26920/two_mods_with_one_public_routine.f90
@@ -1,0 +1,21 @@
+    module mod2
+        implicit none
+        PUBLIC :: mod2_func1
+    contains
+
+        subroutine mod2_func1()
+            print*, "mod2_func1"
+        end subroutine mod2_func1
+
+    end module mod2
+
+    module mod1
+        implicit none
+        PUBLIC :: mod1_func1
+    contains
+
+        subroutine mod1_func1()
+            print*, "mod1_func1"
+        end subroutine mod1_func1
+
+    end module mod1

--- a/numpy/f2py/tests/test_modules.py
+++ b/numpy/f2py/tests/test_modules.py
@@ -6,6 +6,37 @@ from numpy.testing import IS_PYPY
 
 
 @pytest.mark.slow
+class TestModuleFilterPublicEntities(util.F2PyTest):
+    sources = [
+        util.getpath(
+            "tests", "src", "modules", "gh26920",
+            "two_mods_with_one_public_routine.f90"
+        )
+    ]
+    # we filter the only public function mod2
+    only = ["mod1_func1", ]
+
+    def test_gh26920(self):
+        # if it compiles and can be loaded, things are fine
+        pass
+
+
+@pytest.mark.slow
+class TestModuleWithoutPublicEntities(util.F2PyTest):
+    sources = [
+        util.getpath(
+            "tests", "src", "modules", "gh26920",
+            "two_mods_with_no_public_entities.f90"
+        )
+    ]
+    only = ["mod1_func1", ]
+
+    def test_gh26920(self):
+        # if it compiles and can be loaded, things are fine
+        pass
+
+
+@pytest.mark.slow
 class TestModuleDocString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "modules", "module_data_docstring.f90")]
 


### PR DESCRIPTION
Backport of #27049.

This should fix gh-26920 and add a corresponding test case.

I am unsure about some formalities and would appreciate some feedback:

* I am not sure if I put the test in the correct location
* Technically, this fixes another underlying bug: Handling of f90 modules that have no public variables or subroutines. I'm not sure if this warrants a separate test, but please let me know and I will reformat accordingly. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
