### PR TITLE
TST: remove `-DNPY_NO_DEPRECATED_API=0`, now that cython>=3 is required

### DIFF
--- a/numpy/_core/include/numpy/npy_1_7_deprecated_api.h
+++ b/numpy/_core/include/numpy/npy_1_7_deprecated_api.h
@@ -5,20 +5,6 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_1_7_DEPRECATED_API_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_1_7_DEPRECATED_API_H_
 
-/* Emit a warning if the user did not specifically request the old API */
-#ifndef NPY_NO_DEPRECATED_API
-#if defined(_WIN32)
-#define _WARN___STR2__(x) #x
-#define _WARN___STR1__(x) _WARN___STR2__(x)
-#define _WARN___LOC__ __FILE__ "(" _WARN___STR1__(__LINE__) ") : Warning Msg: "
-#pragma message(_WARN___LOC__"Using deprecated NumPy API, disable it with " \
-                         "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION")
-#else
-#warning "Using deprecated NumPy API, disable it with " \
-         "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION"
-#endif
-#endif
-
 /*
  * This header exists to collect all dangerous/deprecated NumPy API
  * as of NumPy 1.7.

--- a/numpy/_core/tests/examples/cython/meson.build
+++ b/numpy/_core/tests/examples/cython/meson.build
@@ -34,7 +34,6 @@ py.extension_module(
     'checks.pyx',
     install: false,
     c_args: [
-      '-DNPY_NO_DEPRECATED_API=0',  # Cython still uses old NumPy C API
       # Require 1.25+ to test datetime additions
       '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
     ],

--- a/numpy/_core/tests/examples/cython/setup.py
+++ b/numpy/_core/tests/examples/cython/setup.py
@@ -12,7 +12,6 @@ from setuptools.extension import Extension
 import os
 
 macros = [
-    ("NPY_NO_DEPRECATED_API", 0),
     # Require 1.25+ to test datetime additions
     ("NPY_TARGET_VERSION", "NPY_2_0_API_VERSION"),
 ]

--- a/numpy/_core/tests/examples/limited_api/limited_api1.c
+++ b/numpy/_core/tests/examples/limited_api/limited_api1.c
@@ -1,4 +1,4 @@
-#define Py_LIMITED_API 0x03060000
+#define Py_LIMITED_API 0x03070000
 
 #include <Python.h>
 #include <numpy/arrayobject.h>

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -49,7 +49,6 @@ py.extension_module(
     'limited_api2.pyx',
     install: false,
     c_args: [
-      '-DNPY_NO_DEPRECATED_API=0',
       # Require 1.25+ to test datetime additions
       '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
       '-DCYTHON_LIMITED_API=1',

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -31,7 +31,7 @@ py.extension_module(
       '-DNPY_NO_DEPRECATED_API=NPY_1_21_API_VERSION',
     ],
     include_directories: [npy_include_path],
-    limited_api: '3.6',
+    limited_api: '3.7',
 )
 
 py.extension_module(
@@ -54,5 +54,5 @@ py.extension_module(
       '-DCYTHON_LIMITED_API=1',
     ],
     include_directories: [npy_include_path],
-    limited_api: '3.7',
+    limited_api: '3.9',
 )

--- a/numpy/_core/tests/examples/limited_api/setup.py
+++ b/numpy/_core/tests/examples/limited_api/setup.py
@@ -6,7 +6,7 @@ import numpy as np
 from setuptools import setup, Extension
 import os
 
-macros = [("Py_LIMITED_API", "0x03060000")]
+macros = [("Py_LIMITED_API", "0x03070000")]
 
 limited_api = Extension(
     "limited_api",

--- a/numpy/_core/tests/examples/limited_api/setup.py
+++ b/numpy/_core/tests/examples/limited_api/setup.py
@@ -6,7 +6,7 @@ import numpy as np
 from setuptools import setup, Extension
 import os
 
-macros = [("NPY_NO_DEPRECATED_API", 0), ("Py_LIMITED_API", "0x03060000")]
+macros = [("Py_LIMITED_API", "0x03060000")]
 
 limited_api = Extension(
     "limited_api",

--- a/numpy/random/meson.build
+++ b/numpy/random/meson.build
@@ -46,7 +46,6 @@ _bounded_integers_pyx = custom_target('_bounded_integer_pyx',
 
 c_args_random = [
   cflags_large_file_support,
-  '-DNPY_NO_DEPRECATED_API=0',  # Cython still uses old NumPy C API
 ]
 if host_machine.system() == 'cygwin'
   c_args_random += ['-Wl,--export-all-symbols']


### PR DESCRIPTION
While looking at #27314, I noticed some cruft that _might_ play a role. In particular, Cython 3+ does _not_ use the deprecated numpy API anymore, and https://github.com/numpy/numpy/commit/7ed8629885e6c479552b49237a6ec62adaffc5b4 bumped the minimum Cython version to 3, so remove it.

Also clean up the limited python API we're targeting to the lowest one supported by the respective numpy version.