### PR TITLE
MAINT: increase max line length from 79 to 88, upgrade pycodestyle

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe>4.33.0
   # For linting
-  - pycodestyle=2.8.0
+  - pycodestyle=2.12.1
   - gitpython
   # Used in some tests
   - cffi

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -1,2 +1,2 @@
-pycodestyle==2.8.0
+pycodestyle==2.12.1
 GitPython>=3.1.30

--- a/tools/lint_diff.ini
+++ b/tools/lint_diff.ini
@@ -1,5 +1,5 @@
 [pycodestyle]
-max_line_length = 79
+max_line_length = 88
 statistics = True
 ignore = E121,E122,E123,E125,E126,E127,E128,E226,E241,E251,E265,E266,E302,E402,E704,E712,E721,E731,E741,W291,W293,W391,W503,W504
 exclude = numpy/__config__.py,numpy/typing/tests/data,.spin/cmds.py


### PR DESCRIPTION
In preparation for #24994.

Addresses https://github.com/numpy/numpy/issues/24994#issuecomment-2322129388.

There are of course pros and cons, and PEP 8 still recommends 79. However, lots of tools have increased max line length:
- [black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length) and ruff have bumped the limit to 88,
- the Linux script [`checkpatch.pl`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bdc48fa11e46) eventually bumped the limit from 80 to 100 characters.
    
 Also, the current codebase contains > 1800 lines wider than 79, against < 600 lines wider than 88:
```console
$ pycodestyle --exclude vendored-meson --exclude numpy/typing/tests/data --exclude numpy/typing/_char_codes.py --exclude numpy/__config__.py --exclude numpy/f2py --exclude numpy/distutils -qq --select=E501 --statistics .
1837    E501 line too long (117 > 79 characters)
$ 
$ pycodestyle --exclude vendored-meson --exclude numpy/typing/tests/data --exclude numpy/typing/_char_codes.py --exclude numpy/__config__.py --exclude numpy/f2py --exclude numpy/distutils -qq --select=E501 --max-line-length=88 --statistics .
594     E501 line too long (117 > 88 characters)
$ 
```

Also bump pycodestyle version.