### PR TITLE
DOC: Removing module name from by-topic docs

### DIFF
--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -1,8 +1,8 @@
 .. _numpy-distutils-refguide:
 
-**********************************
-Packaging (:mod:`numpy.distutils`)
-**********************************
+*********
+Packaging
+*********
 
 .. module:: numpy.distutils
 

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -4,8 +4,8 @@
 
 .. currentmodule:: numpy.random
 
-Random sampling (:mod:`numpy.random`)
-=====================================
+Random sampling
+===============
 
 .. _random-quick-start:
 

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -2,8 +2,8 @@
 
 .. module:: numpy.linalg
 
-Linear algebra (:mod:`numpy.linalg`)
-====================================
+Linear algebra
+==============
 
 The NumPy linear algebra functions rely on BLAS and LAPACK to provide efficient
 low level implementations of standard linear algebra algorithms. Those

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -1,8 +1,8 @@
 .. _routines.testing:
 .. module:: numpy.testing
 
-Test support (:mod:`numpy.testing`)
-===================================
+Test support
+============
 
 .. currentmodule:: numpy.testing
 

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -1,6 +1,6 @@
 """
-Exceptions and Warnings (:mod:`numpy.exceptions`)
-=================================================
+Exceptions and Warnings
+=======================
 
 General exceptions used by NumPy.  Note that some exceptions may be module
 specific, such as linear algebra errors.

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -1,6 +1,6 @@
 """
-Discrete Fourier Transform (:mod:`numpy.fft`)
-=============================================
+Discrete Fourier Transform
+==========================
 
 .. currentmodule:: numpy.fft
 

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -1,7 +1,8 @@
 """
-============================
-Typing (:mod:`numpy.typing`)
-============================
+Typing
+======
+
+.. currentmodule:: numpy.typing
 
 .. versionadded:: 1.20
 
@@ -20,8 +21,6 @@ Mypy plugin
 .. versionadded:: 1.21
 
 .. automodule:: numpy.typing.mypy_plugin
-
-.. currentmodule:: numpy.typing
 
 Differences from the runtime NumPy API
 --------------------------------------

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -1,8 +1,7 @@
 """
-Typing
-======
-
-.. currentmodule:: numpy.typing
+============================
+Typing (:mod:`numpy.typing`)
+============================
 
 .. versionadded:: 1.20
 
@@ -21,6 +20,8 @@ Mypy plugin
 .. versionadded:: 1.21
 
 .. automodule:: numpy.typing.mypy_plugin
+
+.. currentmodule:: numpy.typing
 
 Differences from the runtime NumPy API
 --------------------------------------


### PR DESCRIPTION
The high-level, conceptual API docs have a tiny inconsistency; most of the bullet points point to topics, but some point directly to labeled modules:

![Screenshot from 2024-09-01 21-35-34](https://github.com/user-attachments/assets/19d55868-9ced-4654-9557-50fea38642cd)

This PR is a simple, docs-only change to make the docs more consistent, as suggested by @rgommers [here](https://github.com/numpy/numpy/issues/26727#issuecomment-2174254377).

This is a very minor docs improvement, meant to close #26727 