### PR TITLE
MAINT: GitHub Actions: Replace deprecated macos-12 with macos-latest

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -48,7 +48,7 @@ jobs:
         os_python:
           - [ubuntu-latest, '3.12']
           - [windows-2019, '3.11']
-          - [macos-12, '3.10']
+          - [macos-latest, '3.10']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os_python:
           - [ubuntu-latest, '3.12']
-          - [windows-2019, '3.11']
+          - [windows-latest, '3.11']
           - [macos-latest, '3.10']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

> **macOS12 runner image**
We are beginning the deprecation process for the macOS 12 runner image, which allows us to balance our fleet capacity ahead of our upcoming [macOS 15 launch](https://github.com/github/roadmap/issues/986). This image will be fully retired by the December 3rd, 2024. We recommend updating workflows to use `macos-14`, `macos-13`, or `macos-latest`.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

* macos-12 and macos-13 are Intel
* macos-14 is M1 and the same as macos-latest (although macos-15 will become macos-latest in the near future)

It doesn't seem important which architecture is used for mypy here, so I put macos-latest to reduce future maintenance.
