### PR TITLE
BUG,TYP: Allow subscripting ``iinfo`` and ``finfo`` generic types at runtime, or omit the type params

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -205,7 +205,6 @@ from typing import (
     SupportsComplex,
     SupportsFloat,
     SupportsInt,
-    TypeVar,
     Protocol,
     SupportsIndex,
     Final,
@@ -219,7 +218,7 @@ from typing import (
 # This is because the `typeshed` stubs for the standard library include
 # `typing_extensions` stubs:
 # https://github.com/python/typeshed/blob/main/stdlib/typing_extensions.pyi
-from typing_extensions import LiteralString, Self
+from typing_extensions import LiteralString, Self, TypeVar
 
 from numpy import (
     core,
@@ -4131,7 +4130,7 @@ class busdaycalendar:
     def holidays(self) -> NDArray[datetime64]: ...
 
 
-_FloatType_co = TypeVar('_FloatType_co', bound=floating[Any], covariant=True)
+_FloatType_co = TypeVar('_FloatType_co', bound=floating[Any], covariant=True, default=floating[NBitBase])
 
 class finfo(Generic[_FloatType_co]):
     dtype: Final[dtype[_FloatType_co]]
@@ -4167,7 +4166,7 @@ class finfo(Generic[_FloatType_co]):
         cls, dtype: str
     ) -> finfo[floating[Any]]: ...
 
-_IntType_co = TypeVar("_IntType_co", bound=integer[Any], covariant=True)
+_IntType_co = TypeVar("_IntType_co", bound=integer[Any], covariant=True, default=integer[NBitBase])
 
 class iinfo(Generic[_IntType_co]):
     dtype: Final[dtype[_IntType_co]]

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -3,6 +3,7 @@
 """
 __all__ = ['finfo', 'iinfo']
 
+import types
 import warnings
 
 from .._utils import set_module
@@ -487,6 +488,8 @@ class finfo:
 
     _finfo_cache = {}
 
+    __class_getitem__ = classmethod(types.GenericAlias)
+
     def __new__(cls, dtype):
         try:
             obj = cls._finfo_cache.get(dtype)  # most common path
@@ -688,6 +691,8 @@ class iinfo:
 
     _min_vals = {}
     _max_vals = {}
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __init__(self, int_type):
         try:

--- a/numpy/_core/tests/test_getlimits.py
+++ b/numpy/_core/tests/test_getlimits.py
@@ -1,6 +1,7 @@
 """ Test functions for limits module.
 
 """
+import types
 import warnings
 import numpy as np
 import pytest
@@ -192,3 +193,11 @@ def test_plausible_finfo():
         assert_(info.nmant > 1)
         assert_(info.minexp < -1)
         assert_(info.maxexp > 1)
+
+
+class TestRuntimeSubscriptable:
+    def test_finfo_generic(self):
+        assert isinstance(np.finfo[np.float64], types.GenericAlias)
+
+    def test_iinfo_generic(self):
+        assert isinstance(np.iinfo[np.int_], types.GenericAlias)


### PR DESCRIPTION
This fixes #27341 in two ways:

- Added `__class_getitem__` classmethods to `numpy.(f|i)info`, so that, at runtime,  `np.info[Any]` won't raise a `TypeError` anymore.
- Added [PEP 696](https://peps.python.org/pep-0696/) defaults to the `typing.TypeVar` type-parameters of `numpy.(f|i)info`. Type checkers will now effectively interpret a "bare" `iinfo` as `iinfo[integer[NBitBase]]`, and `finfo` as `finfo[floating[NBitBase]]`. See #27132 for an explanation on how this is possible on Python <3.12.
