### PR TITLE
DOC: Mention that c is reassigned but still points to a (quickstart)

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -881,7 +881,7 @@ creates a new array object that looks at the same data.
     >>> c.flags.owndata
     False
     >>>
-    >>> c = c.reshape((2, 6))  # a's shape doesn't change
+    >>> c = c.reshape((2, 6))  # a's shape doesn't change, reassigned c is still a view of a
     >>> a.shape
     (3, 4)
     >>> c[0, 4] = 1234         # a's data changes

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -929,6 +929,8 @@ a small fraction of ``a``, a deep copy should be made when constructing ``b`` wi
 If ``b = a[:100]`` is used instead, ``a`` is referenced by ``b`` and will persist in memory
 even if ``del a`` is executed.
 
+See also :ref:`basics.copies-and-views`.
+
 Functions and methods overview
 ------------------------------
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
### Issue with current documentation:

### Issue Description
In the "Copies and Views" section of the NumPy Quickstart guide, the following line could be clearer:

```python
c = c.reshape((2, 6))  # a's shape doesn't change
```

While it correctly states that `a`’s shape doesn’t change, it doesn’t explicitly mention that reshape returns a new array and that `c` is reassigned to this new array. This might be confusing for some users.

### Idea or request for content:

A more precise comment might be:

```python
c = c.reshape((2, 6))  # a's shape doesn't change, reassigned c is still a view of a
```

This makes it clear that `c` is reassigned to the reshaped view of a, while `a` remains unaffected.

Fixes #27321 