### PR TITLE
MNT, CI: Use separate jobs for WASM wheel builds/uploads

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,11 +32,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read  # to fetch code (actions/checkout)
 
 jobs:
   build-wasm-emscripten:
+    permissions:
+      contents: read  # to fetch code (actions/checkout)
     name: Build NumPy distribution for Pyodide
     runs-on: ubuntu-22.04
     # To enable this workflow on a fork, comment out:
@@ -57,14 +57,27 @@ jobs:
         with:
           name: cp312-pyodide_wasm32
           path: ./wheelhouse/*.whl
+          if-no-files-found: error
 
-        # Push to https://anaconda.org/scientific-python-nightly-wheels/numpy
-        # WARNING: this job will overwrite any existing WASM wheels.
+  # Push to https://anaconda.org/scientific-python-nightly-wheels/numpy
+  # WARNING: this job will overwrite any existing WASM wheels.
+  upload-wheels:
+    name: Upload NumPy WASM wheels to Anaconda.org
+    runs-on: ubuntu-22.04
+    permissions: {}
+    needs: [build-wasm-emscripten]
+    if: >-
+      (github.repository == 'numpy/numpy') &&
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
+      (github.event_name == 'schedule')
+    steps:
+      - name: Download wheel artifact(s)
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          path: wheelhouse/
+          merge-multiple: true
+
       - name: Push to Anaconda PyPI index
-        if: >-
-          (github.repository == 'numpy/numpy') &&
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.push_wheels == 'true') ||
-          (github.event_name == 'schedule')
         uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc  # v0.5.0
         with:
           artifacts_path: wheelhouse/


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This is a small PR that separates out wheel builds and the wheel uploads for the `emscripten.yml` workflow into separate jobs, where the GHA actions `actions/upload-artifact` and `actions/download-artifact` are used to share artifacts between jobs.
- This is a slight restructure of the workflow and is intended so that a fresh runner is assigned to the job that is supposed to upload the wheel(s), in order to avoid actors of malicious intent from tampering with built binaries that are intended for distribution elsewhere (even though such a risk is low).
- Permission scopes for both build and upload jobs have been limited to the ones absolutely necessary according to the principle of least privilege.

## Additional context

While this job does not currently use trusted publishing nor requires elevated permissions, and does not use a GitHub environment either, this is in line with the recommendations of trusted publishing guidelines and other security recommendations for sharing artifacts via CI providers. For more information about this in the context of `pypa/gh-action-pypi-publish`, please read https://github.com/hynek/build-and-inspect-python-package/issues/105#issuecomment-2136262019. If we were to publish Pyodide/WASM wheels to PyPI _someday_, or were to provide attestations for them as a part of the official release artifacts at a different time when Pyodide completes its unvendoring of recipe builds, this PR would be useful. See also: https://scientific-python.org/specs/spec-0008/ (it does not make a mention of separating artifact builds and uploads, however – it probably should, though?).