### PR TITLE
BUG: fix _shrink edge case in np.ma.mask_or

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1787,7 +1787,7 @@ def mask_or(m1, m2, copy=False, shrink=True):
         dtype = getattr(m1, 'dtype', MaskType)
         return make_mask(m1, copy=copy, shrink=shrink, dtype=dtype)
     if m1 is m2 and is_mask(m1):
-        return m1
+        return _shrink_mask(m1) if shrink else m1
     (dtype1, dtype2) = (getattr(m1, 'dtype', None), getattr(m2, 'dtype', None))
     if dtype1 != dtype2:
         raise ValueError("Incompatible dtypes '%s'<>'%s'" % (dtype1, dtype2))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4849,6 +4849,26 @@ class TestMaskedArrayFunctions:
         cntrl = np.array([(1, (1, 1)), (0, (1, 0))], dtype=dtype)
         assert_equal(mask_or(amask, bmask), cntrl)
 
+        a = np.array([False, False])
+        assert mask_or(a, a) is nomask  # gh-27360
+
+    def test_allequal(self):
+        x = array([1, 2, 3], mask=[0, 0, 0])
+        y = array([1, 2, 3], mask=[1, 0, 0])
+        z = array([[1, 2, 3], [4, 5, 6]], mask=[[0, 0, 0], [1, 1, 1]])
+
+        assert allequal(x, y)
+        assert not allequal(x, y, fill_value=False)
+        assert allequal(x, z)
+
+        # test allequal for the same input, with mask=nomask, this test is for
+        # the scenario raised in https://github.com/numpy/numpy/issues/27201
+        assert allequal(x, x)
+        assert allequal(x, x, fill_value=False)
+
+        assert allequal(y, y)
+        assert not allequal(y, y, fill_value=False)
+
     def test_flatten_mask(self):
         # Tests flatten mask
         # Standard dtype


### PR DESCRIPTION
Fix an edge case in numpy/ma/core.py::mask_or where a mask is returned unshrunk if the two inputs to the function are the same mask and `shrink=True` is passed to the `mask_or` function.

This also fixes an edge case in numpy/ma/core.py::allequal where calling the function on the same input (i.e. `allequal(x, x)`) where the input is an unmasked array (i.e. `mask=np.ma.nomask`) would return `False`. The fix involves updating the `np.ma.mask_or` function to call `_shrink_mask` on the mask returned in this case. See issue #27201.
