### PR TITLE
DOC: Remove reshape from appearing twice in toctree

### DIFF
--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -18,7 +18,6 @@ Changing array shape
 .. autosummary::
    :toctree: generated/
 
-
    reshape
    ravel
    ndarray.flat
@@ -119,6 +118,5 @@ Rearranging elements
    flip
    fliplr
    flipud
-   reshape
    roll
    rot90


### PR DESCRIPTION
Closes #27352 by removing reshape from one of the toctrees (it was cited twice).
