### PR TITLE
DOC: fix incorrect definitions 

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3537,7 +3537,7 @@ cdef class Generator:
 
         Notes
         -----
-        The probability density for the Hypergeometric distribution is
+        The probability mass function (PMF) for the Hypergeometric distribution is
 
         .. math:: P(x) = \\frac{\\binom{g}{x}\\binom{b}{n-x}}{\\binom{g+b}{n}},
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3282,7 +3282,7 @@ cdef class Generator:
 
         Notes
         -----
-        The Poisson distribution
+        The probability mass function (PMF) of Poisson distribution is
 
         .. math:: f(k; \\lambda)=\\frac{\\lambda^k e^{-\\lambda}}{k!}
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3372,7 +3372,7 @@ cdef class Generator:
 
         Notes
         -----
-        The probability density for the Zipf distribution is
+        The probability mass function (PMF) for the Zipf distribution is
 
         .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3656,7 +3656,7 @@ cdef class RandomState:
 
         Notes
         -----
-        The Poisson distribution
+        The probability mass function (PMF) of Poisson distribution is
 
         .. math:: f(k; \\lambda)=\\frac{\\lambda^k e^{-\\lambda}}{k!}
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3908,7 +3908,7 @@ cdef class RandomState:
 
         Notes
         -----
-        The probability density for the Hypergeometric distribution is
+        The probability mass function (PMF) for the Hypergeometric distribution is
 
         .. math:: P(x) = \\frac{\\binom{g}{x}\\binom{b}{n-x}}{\\binom{g+b}{n}},
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3744,7 +3744,7 @@ cdef class RandomState:
 
         Notes
         -----
-        The probability density for the Zipf distribution is
+        The probability mass function (PMF) for the Zipf distribution is
 
         .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
DOC: fix incorrect definitions 

Hypergeometric, Poisson and Zipf's distribution deal with discrete random variables, hence the distributions come under probability mass functions (PMF) and not probability density functions (PDF).
In the definition of Poisson function, it was not mentioned which probability function the distribution belonged to (it was unclear)