### PR TITLE
add a __dict__ to ufunc objects and use it to allow overriding __doc__

### DIFF
--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -76,5 +76,6 @@
 # Version 18 (NumPy 2.0.0)
 0x00000012 = 2b8f1f4da822491ff030b2b37dff07e3
 # Version 19 (NumPy 2.1.0) Only header additions
-# Version 19 (NumPy 2.2.0) No change
 0x00000013 = 2b8f1f4da822491ff030b2b37dff07e3
+# Version 20 (NumPy 2.2.0) Only header additions
+0x00000014 = 2b8f1f4da822491ff030b2b37dff07e3

--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -82,6 +82,7 @@
 #define NPY_1_25_API_VERSION 0x00000011
 #define NPY_2_0_API_VERSION 0x00000012
 #define NPY_2_1_API_VERSION 0x00000013
+#define NPY_2_2_API_VERSION 0x00000014
 
 
 /*
@@ -170,6 +171,8 @@
     #define NPY_FEATURE_VERSION_STRING "2.0"
 #elif NPY_FEATURE_VERSION == NPY_2_1_API_VERSION
     #define NPY_FEATURE_VERSION_STRING "2.1"
+#elif NPY_FEATURE_VERSION == NPY_2_2_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "2.2"
 #else
     #error "Missing version string define for new NumPy version."
 #endif

--- a/numpy/_core/include/numpy/ufuncobject.h
+++ b/numpy/_core/include/numpy/ufuncobject.h
@@ -230,6 +230,9 @@ typedef struct _tagPyUFuncObject {
          */
         PyUFunc_ProcessCoreDimsFunc *process_core_dims_func;
     #endif
+    #if NPY_FEATURE_VERSION >= NPY_2_2_API_VERSION
+        PyObject *dict;
+    #endif
 } PyUFuncObject;
 
 #include "arrayobject.h"

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -48,7 +48,8 @@ C_ABI_VERSION = '0x02000000'
 # 0x00000011 - 1.25.x
 # 0x00000012 - 2.0.x
 # 0x00000013 - 2.1.x
-C_API_VERSION = '0x00000013'
+# 0x00000014 - 2.2.x
+C_API_VERSION = '0x00000014'
 
 # Check whether we have a mismatch between the set C API VERSION and the
 # actual C API VERSION. Will raise a MismatchCAPIError if so.

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -63,6 +63,7 @@ intern_strings(void)
     INTERN_STRING(__dlpack__, "__dlpack__");
     INTERN_STRING(pyvals_name, "UFUNC_PYVALS_NAME");
     INTERN_STRING(legacy, "legacy");
+    INTERN_STRING(__doc__, "__doc__");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -38,6 +38,7 @@ typedef struct npy_interned_str_struct {
     PyObject *__dlpack__;
     PyObject *pyvals_name;
     PyObject *legacy;
+    PyObject *__doc__;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/src/umath/_struct_ufunc_tests.c
+++ b/numpy/_core/src/umath/_struct_ufunc_tests.c
@@ -134,7 +134,7 @@ PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
 
     add_triplet = PyUFunc_FromFuncAndData(NULL, NULL, NULL, 0, 2, 1,
                                     PyUFunc_None, "add_triplet",
-                                    "add_triplet_docstring", 0);
+                                    NULL, 0);
 
     dtype_dict = Py_BuildValue("[(s, s), (s, s), (s, s)]",
                                "f0", "u8", "f1", "u8", "f2", "u8");

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -9,6 +9,7 @@ from fractions import Fraction
 from functools import reduce
 from collections import namedtuple
 
+import numpy._core._struct_ufunc_tests as struct_ufunc
 import numpy._core.umath as ncu
 from numpy._core import _umath_tests as ncu_tests, sctypes
 import numpy as np
@@ -4015,6 +4016,21 @@ class TestSpecialMethods:
         # And the same with a valid call:
         res = a.__array_ufunc__(np.add, "__call__", a, a)
         assert_array_equal(res, a + a)
+
+    def test_ufunc_docstring(self):
+
+        struct_ufunc.add_triplet.__doc__ = "hello"
+
+        assert struct_ufunc.add_triplet.__doc__ == "hello"
+
+        msg = "attribute '__doc__' of 'numpy.ufunc' objects is not writable"
+        with pytest.raises(AttributeError, match=msg):
+            np.add.__doc__ = "hello"
+
+        # you can add a "__doc__" key to __dict__ but it doesn't do anything
+        orig_doc = np.add.__doc__
+        np.add.__dict__["__doc__"] = "hello"
+        assert np.add.__doc__ == orig_doc
 
 class TestChoose:
     def test_mixed(self):


### PR DESCRIPTION
Fixes #26233 

Marked as draft because I have a couple questions:

* Changing the C API isn't strictly necessary since there's a `void *reserved2` field I can re-use for this. Any reason not to?
* You can do this now:

```
In [1]: np.add.my_attribute = 7

In [2]: np.add.__dict__
Out[2]: {'my_attribute': 7}
```

Is that a thing we want? This adds a new way to monkeypatch numpy. People probably already do that in other pure python bits, but now they can do it with ufuncs too. I guess the consenting adults principle applies though and I'd be inclined to allow it.