### PR TITLE
MAINT: Fix a few more typos

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -274,7 +274,7 @@ jobs:
         pip install vulture
     - name: Build and install NumPy
       run: |
-        # Install using the fastests way to build (no BLAS, no SIMD)
+        # Install using the fastest way to build (no BLAS, no SIMD)
         spin build -j2 -- -Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none
     - name: Check build-internal dependencies
       run: |

--- a/meson_cpu/main_config.h.in
+++ b/meson_cpu/main_config.h.in
@@ -11,7 +11,7 @@
  */
 #ifndef @P@_CPU_DISPATCHER_CONF_H_
 #define @P@_CPU_DISPATCHER_CONF_H_
-/// This definition is required to provide comptibility with NumPy distutils
+/// This definition is required to provide compatibility with NumPy distutils
 #define @P@_CPU_MESON_BUILD
 /**
  * @def @P@WITH_CPU_BASELINE
@@ -46,7 +46,7 @@
 /**
  * @def @P@WITH_CPU_BASELINE_CALL(EXEC_CB, ...)
  * Call each enabled baseline feature sorted by lowest interest
- * using preprocessor callback without testing whiher the
+ * using preprocessor callback without testing whether the
  * feature is supported by CPU or not.
  *
  * Required for logging purposes only, for example, generating

--- a/numpy/_core/src/common/simd/avx2/memory.h
+++ b/numpy/_core/src/common/simd/avx2/memory.h
@@ -705,7 +705,7 @@ NPYV_IMPL_AVX2_REST_PARTIAL_TYPES_PAIR(u64, s64)
 NPYV_IMPL_AVX2_REST_PARTIAL_TYPES_PAIR(f64, s64)
 
 /************************************************************
- *  de-interlave load / interleave contiguous store
+ *  de-interleave load / interleave contiguous store
  ************************************************************/
 // two channels
 #define NPYV_IMPL_AVX2_MEM_INTERLEAVE(SFX, ZSFX)                             \

--- a/numpy/_core/src/common/simd/avx512/memory.h
+++ b/numpy/_core/src/common/simd/avx512/memory.h
@@ -651,7 +651,7 @@ NPYV_IMPL_AVX512_REST_PARTIAL_TYPES_PAIR(u64, s64)
 NPYV_IMPL_AVX512_REST_PARTIAL_TYPES_PAIR(f64, s64)
 
 /************************************************************
- *  de-interlave load / interleave contiguous store
+ *  de-interleave load / interleave contiguous store
  ************************************************************/
 // two channels
 #define NPYV_IMPL_AVX512_MEM_INTERLEAVE(SFX, ZSFX)                           \

--- a/numpy/_core/src/common/simd/neon/memory.h
+++ b/numpy/_core/src/common/simd/neon/memory.h
@@ -584,7 +584,7 @@ NPYV_IMPL_NEON_REST_PARTIAL_TYPES_PAIR(f64, s64)
 #endif
 
 /************************************************************
- *  de-interlave load / interleave contiguous store
+ *  de-interleave load / interleave contiguous store
  ************************************************************/
 // two channels
 #define NPYV_IMPL_NEON_MEM_INTERLEAVE(SFX, T_PTR)                        \

--- a/numpy/_core/src/common/simd/sse/memory.h
+++ b/numpy/_core/src/common/simd/sse/memory.h
@@ -683,7 +683,7 @@ NPYV_IMPL_SSE_REST_PARTIAL_TYPES_PAIR(u64, s64)
 NPYV_IMPL_SSE_REST_PARTIAL_TYPES_PAIR(f64, s64)
 
 /************************************************************
- *  de-interlave load / interleave contiguous store
+ *  de-interleave load / interleave contiguous store
  ************************************************************/
 // two channels
 #define NPYV_IMPL_SSE_MEM_INTERLEAVE(SFX, ZSFX)                              \

--- a/numpy/_core/src/common/simd/vec/memory.h
+++ b/numpy/_core/src/common/simd/vec/memory.h
@@ -623,7 +623,7 @@ NPYV_IMPL_VEC_REST_PARTIAL_TYPES_PAIR(u64, s64)
 NPYV_IMPL_VEC_REST_PARTIAL_TYPES_PAIR(f64, s64)
 
 /************************************************************
- *  de-interlave load / interleave contiguous store
+ *  de-interleave load / interleave contiguous store
  ************************************************************/
 // two channels
 #define NPYV_IMPL_VEC_MEM_INTERLEAVE(SFX)                                \

--- a/numpy/_core/tests/test_half.py
+++ b/numpy/_core/tests/test_half.py
@@ -22,7 +22,7 @@ class TestHalf:
         self.all_f16 = np.arange(0x10000, dtype=uint16)
         self.all_f16.dtype = float16
 
-        # NaN value can cause an invalid FP exception if HW is been used
+        # NaN value can cause an invalid FP exception if HW is being used
         with np.errstate(invalid='ignore'):
             self.all_f32 = np.array(self.all_f16, dtype=float32)
             self.all_f64 = np.array(self.all_f16, dtype=float64)
@@ -49,7 +49,7 @@ class TestHalf:
         # Convert from float32 back to float16
         with np.errstate(invalid='ignore'):
             b = np.array(self.all_f32, dtype=float16)
-        # avoid testing NaNs due to differ bits wither Q/SNaNs
+        # avoid testing NaNs due to differing bit patterns in Q/S NaNs
         b_nn = b == b
         assert_equal(self.all_f16[b_nn].view(dtype=uint16),
                      b[b_nn].view(dtype=uint16))
@@ -119,8 +119,8 @@ class TestHalf:
         # Convert back to float16 and its bit pattern:
         res_patterns = f16s_float.astype(np.float16).view(np.uint16)
 
-        # The above calculations tries the original values, or the exact
-        # mid points between the float16 values. It then further offsets them
+        # The above calculation tries the original values, or the exact
+        # midpoints between the float16 values. It then further offsets them
         # by as little as possible. If no offset occurs, "round to even"
         # logic will be necessary, an arbitrarily small offset should cause
         # normal up/down rounding always.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -62,7 +62,7 @@ __all__ = [
 # get_virtual_index : Callable
 #   The function used to compute the virtual_index.
 # fix_gamma : Callable
-#   A function used for discret methods to force the index to a specific value.
+#   A function used for discrete methods to force the index to a specific value.
 _QuantileMethods = dict(
     # --- HYNDMAN and FAN METHODS
     # Discrete methods
@@ -4633,7 +4633,7 @@ def _get_gamma_mask(shape, default_value, conditioned_value, where):
     return out
 
 
-def _discret_interpolation_to_boundaries(index, gamma_condition_fun):
+def _discrete_interpolation_to_boundaries(index, gamma_condition_fun):
     previous = np.floor(index)
     next = previous + 1
     gamma = index - previous
@@ -4651,14 +4651,14 @@ def _closest_observation(n, quantiles):
     # "choose the nearest even order statistic at g=0" (H&F (1996) pp. 362).
     # Order is 1-based so for zero-based indexing round to nearest odd index.
     gamma_fun = lambda gamma, index: (gamma == 0) & (np.floor(index) % 2 == 1)
-    return _discret_interpolation_to_boundaries((n * quantiles) - 1 - 0.5,
-                                                gamma_fun)
+    return _discrete_interpolation_to_boundaries((n * quantiles) - 1 - 0.5,
+                                                 gamma_fun)
 
 
 def _inverted_cdf(n, quantiles):
     gamma_fun = lambda gamma, _: (gamma == 0)
-    return _discret_interpolation_to_boundaries((n * quantiles) - 1,
-                                                gamma_fun)
+    return _discrete_interpolation_to_boundaries((n * quantiles) - 1,
+                                                 gamma_fun)
 
 
 def _quantile_ureduce_func(


### PR DESCRIPTION
Additional typos not fixed in #27376.

I am not sure how to fix this comment:
```
$ grep -n wither numpy/numpy/_core/tests/test_half.py 
52:        # avoid testing NaNs due to differ bits wither Q/SNaNs
$ 
```
Perhaps:
```
        # avoid testing NaNs due to differing bits in Q/S NaNs
```