### PR TITLE
DOC: Update np.unique_all example to demonstrate namedtuple output

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -414,8 +414,12 @@ def unique_all(x):
     """
     Find the unique elements of an array, and counts, inverse, and indices.
 
-    This function is an Array API compatible alternative to `np.unique`, but
-    returns a namedtuple for easier access to each output.
+    This function is an Array API compatible alternative to::
+
+        np.unique(x, return_index=True, return_inverse=True,
+                  return_counts=True, equal_nan=False)
+
+    but returns a namedtuple for easier access to each output.
 
     Parameters
     ----------
@@ -426,6 +430,7 @@ def unique_all(x):
     -------
     out : namedtuple
         The result containing:
+
         * values - The unique elements of an input array.
         * indices - The first occurring indices for each unique element.
         * inverse_indices - The indices from the set of unique elements
@@ -438,10 +443,17 @@ def unique_all(x):
 
     Examples
     --------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_all(x)
-    UniqueAllResult(values=array([1, 2]), indices=array([0, 2]),
-                    inverse_indices=array([0, 0, 1]), counts=array([2, 1]))
+    >>> import numpy as np
+    >>> x = [1, 1, 2]
+    >>> uniq = np.unique_all(x)
+    >>> uniq.values
+    array([1, 2])
+    >>> uniq.indices
+    array([0, 2])
+    >>> uniq.inverse_indices
+    array([0, 0, 1])
+    >>> uniq.counts
+    array([2, 1])
     """
     result = unique(
         x,
@@ -462,7 +474,10 @@ def unique_counts(x):
     """
     Find the unique elements and counts of an input array `x`.
 
-    This function is an Array API compatible alternative to `np.unique`,
+    This function is an Array API compatible alternative to::
+
+        np.unique(x, return_counts=True, equal_nan=False)
+
     but returns a namedtuple for easier access to each output.
 
     Parameters
@@ -474,6 +489,7 @@ def unique_counts(x):
     -------
     out : namedtuple
         The result containing:
+
         * values - The unique elements of an input array.
         * counts - The corresponding counts for each unique element.
 
@@ -483,9 +499,13 @@ def unique_counts(x):
 
     Examples
     --------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_counts(x)
-    UniqueCountsResult(values=array([1, 2]), counts=array([2, 1]))
+    >>> import numpy as np
+    >>> x = [1, 1, 2]
+    >>> uniq = np.unique_counts(x)
+    >>> uniq.values
+    array([1, 2])
+    >>> uniq.counts
+    array([2, 1])
     """
     result = unique(
         x,
@@ -496,7 +516,6 @@ def unique_counts(x):
     )
     return UniqueCountsResult(*result)
 
-
 def _unique_inverse_dispatcher(x, /):
     return (x,)
 
@@ -506,7 +525,10 @@ def unique_inverse(x):
     """
     Find the unique elements of `x` and indices to reconstruct `x`.
 
-    This function is an Array API compatible alternative to `np.unique`,
+    This function is an Array API compatible alternative to::
+
+        np.unique(x, return_inverse=True, equal_nan=False)
+
     but returns a namedtuple for easier access to each output.
 
     Parameters
@@ -518,6 +540,7 @@ def unique_inverse(x):
     -------
     out : namedtuple
         The result containing:
+
         * values - The unique elements of an input array.
         * inverse_indices - The indices from the set of unique elements
           that reconstruct `x`.
@@ -528,9 +551,13 @@ def unique_inverse(x):
 
     Examples
     --------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_inverse(x)
-    UniqueInverseResult(values=array([1, 2]), inverse_indices=array([0, 0, 1]))
+    >>> import numpy as np
+    >>> x = [1, 1, 2]
+    >>> uniq = np.unique_inverse(x)
+    >>> uniq.values
+    array([1, 2])
+    >>> uniq.inverse_indices
+    array([0, 0, 1])
     """
     result = unique(
         x,
@@ -551,8 +578,9 @@ def unique_values(x):
     """
     Returns the unique elements of an input array `x`.
 
-    This function is an Array API compatible alternative to `np.unique`,
-    but returns only the unique values.
+    This function is an Array API compatible alternative to::
+
+        np.unique(x, equal_nan=False)
 
     Parameters
     ----------
@@ -570,7 +598,8 @@ def unique_values(x):
 
     Examples
     --------
-    >>> x = np.array([1, 1, 2])
+    >>> import numpy as np
+    >>> x = [1, 1, 2]
     >>> np.unique_values(x)
     array([1, 2])
     """

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -464,11 +464,14 @@ def unique_counts(x):
     """
     Find the unique elements and counts of an input array `x`.
 
-    This function is an Array API compatible alternative to:
+    This function is an Array API compatible alternative to `np.unique`,
+    but returns a namedtuple for easier access to each output.
 
+    Example
+    -------
     >>> x = np.array([1, 1, 2])
-    >>> np.unique(x, return_counts=True, equal_nan=False)
-    (array([1, 2]), array([2, 1]))
+    >>> np.unique_counts(x)
+    UniqueCountsResult(values=array([1, 2]), counts=array([2, 1]))
 
     Parameters
     ----------
@@ -486,12 +489,6 @@ def unique_counts(x):
     See Also
     --------
     unique : Find the unique elements of an array.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.unique_counts([1, 1, 2])
-    UniqueCountsResult(values=array([1, 2]), counts=array([2, 1]))
 
     """
     result = unique(

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -516,6 +516,7 @@ def unique_counts(x):
     )
     return UniqueCountsResult(*result)
 
+
 def _unique_inverse_dispatcher(x, /):
     return (x,)
 
@@ -599,9 +600,9 @@ def unique_values(x):
     Examples
     --------
     >>> import numpy as np
-    >>> x = [1, 1, 2]
-    >>> np.unique_values(x)
+    >>> np.unique_values([1, 1, 2])
     array([1, 2])
+
     """
     return unique(
         x,
@@ -610,7 +611,6 @@ def unique_values(x):
         return_counts=False,
         equal_nan=False
     )
-
 
 
 def _intersect1d_dispatcher(

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -557,10 +557,13 @@ def unique_values(x):
     """
     Returns the unique elements of an input array `x`.
 
-    This function is Array API compatible alternative to:
+    This function is an Array API compatible alternative to `np.unique`,
+    but returns only the unique values.
 
+    Example
+    -------
     >>> x = np.array([1, 1, 2])
-    >>> np.unique(x, equal_nan=False)
+    >>> np.unique_values(x)
     array([1, 2])
 
     Parameters
@@ -577,12 +580,6 @@ def unique_values(x):
     --------
     unique : Find the unique elements of an array.
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.unique_values([1, 1, 2])
-    array([1, 2])
-
     """
     return unique(
         x,
@@ -591,6 +588,7 @@ def unique_values(x):
         return_counts=False,
         equal_nan=False
     )
+
 
 
 def _intersect1d_dispatcher(

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -412,17 +412,10 @@ def _unique_all_dispatcher(x, /):
 @array_function_dispatch(_unique_all_dispatcher)
 def unique_all(x):
     """
-    Find the unique elements of an array, and counts, inverse and indices.
+    Find the unique elements of an array, and counts, inverse, and indices.
 
     This function is an Array API compatible alternative to `np.unique`, but
     returns a namedtuple for easier access to each output.
-
-    Example
-    -------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_all(x)
-    UniqueAllResult(values=array([1, 2]), indices=array([0, 2]), 
-                    inverse_indices=array([0, 0, 1]), counts=array([2, 1]))
 
     Parameters
     ----------
@@ -433,7 +426,6 @@ def unique_all(x):
     -------
     out : namedtuple
         The result containing:
-
         * values - The unique elements of an input array.
         * indices - The first occurring indices for each unique element.
         * inverse_indices - The indices from the set of unique elements
@@ -444,6 +436,12 @@ def unique_all(x):
     --------
     unique : Find the unique elements of an array.
 
+    Examples
+    --------
+    >>> x = np.array([1, 1, 2])
+    >>> np.unique_all(x)
+    UniqueAllResult(values=array([1, 2]), indices=array([0, 2]),
+                    inverse_indices=array([0, 0, 1]), counts=array([2, 1]))
     """
     result = unique(
         x,
@@ -467,12 +465,6 @@ def unique_counts(x):
     This function is an Array API compatible alternative to `np.unique`,
     but returns a namedtuple for easier access to each output.
 
-    Example
-    -------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_counts(x)
-    UniqueCountsResult(values=array([1, 2]), counts=array([2, 1]))
-
     Parameters
     ----------
     x : array_like
@@ -482,7 +474,6 @@ def unique_counts(x):
     -------
     out : namedtuple
         The result containing:
-
         * values - The unique elements of an input array.
         * counts - The corresponding counts for each unique element.
 
@@ -490,6 +481,11 @@ def unique_counts(x):
     --------
     unique : Find the unique elements of an array.
 
+    Examples
+    --------
+    >>> x = np.array([1, 1, 2])
+    >>> np.unique_counts(x)
+    UniqueCountsResult(values=array([1, 2]), counts=array([2, 1]))
     """
     result = unique(
         x,
@@ -513,12 +509,6 @@ def unique_inverse(x):
     This function is an Array API compatible alternative to `np.unique`,
     but returns a namedtuple for easier access to each output.
 
-    Example
-    -------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_inverse(x)
-    UniqueInverseResult(values=array([1, 2]), inverse_indices=array([0, 0, 1]))
-
     Parameters
     ----------
     x : array_like
@@ -528,7 +518,6 @@ def unique_inverse(x):
     -------
     out : namedtuple
         The result containing:
-
         * values - The unique elements of an input array.
         * inverse_indices - The indices from the set of unique elements
           that reconstruct `x`.
@@ -537,6 +526,11 @@ def unique_inverse(x):
     --------
     unique : Find the unique elements of an array.
 
+    Examples
+    --------
+    >>> x = np.array([1, 1, 2])
+    >>> np.unique_inverse(x)
+    UniqueInverseResult(values=array([1, 2]), inverse_indices=array([0, 0, 1]))
     """
     result = unique(
         x,
@@ -560,12 +554,6 @@ def unique_values(x):
     This function is an Array API compatible alternative to `np.unique`,
     but returns only the unique values.
 
-    Example
-    -------
-    >>> x = np.array([1, 1, 2])
-    >>> np.unique_values(x)
-    array([1, 2])
-
     Parameters
     ----------
     x : array_like
@@ -580,6 +568,11 @@ def unique_values(x):
     --------
     unique : Find the unique elements of an array.
 
+    Examples
+    --------
+    >>> x = np.array([1, 1, 2])
+    >>> np.unique_values(x)
+    array([1, 2])
     """
     return unique(
         x,

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -510,11 +510,14 @@ def unique_inverse(x):
     """
     Find the unique elements of `x` and indices to reconstruct `x`.
 
-    This function is Array API compatible alternative to:
+    This function is an Array API compatible alternative to `np.unique`,
+    but returns a namedtuple for easier access to each output.
 
+    Example
+    -------
     >>> x = np.array([1, 1, 2])
-    >>> np.unique(x, return_inverse=True, equal_nan=False)
-    (array([1, 2]), array([0, 0, 1]))
+    >>> np.unique_inverse(x)
+    UniqueInverseResult(values=array([1, 2]), inverse_indices=array([0, 0, 1]))
 
     Parameters
     ----------
@@ -533,12 +536,6 @@ def unique_inverse(x):
     See Also
     --------
     unique : Find the unique elements of an array.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.unique_inverse([1, 1, 2])
-    UniqueInverseResult(values=array([1, 2]), inverse_indices=array([0, 0, 1]))
 
     """
     result = unique(

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -414,12 +414,15 @@ def unique_all(x):
     """
     Find the unique elements of an array, and counts, inverse and indices.
 
-    This function is an Array API compatible alternative to:
+    This function is an Array API compatible alternative to `np.unique`, but
+    returns a namedtuple for easier access to each output.
 
+    Example
+    -------
     >>> x = np.array([1, 1, 2])
-    >>> np.unique(x, return_index=True, return_inverse=True,
-    ...           return_counts=True, equal_nan=False)
-    (array([1, 2]), array([0, 2]), array([0, 0, 1]), array([2, 1]))
+    >>> np.unique_all(x)
+    UniqueAllResult(values=array([1, 2]), indices=array([0, 2]), 
+                    inverse_indices=array([0, 0, 1]), counts=array([2, 1]))
 
     Parameters
     ----------
@@ -440,15 +443,6 @@ def unique_all(x):
     See Also
     --------
     unique : Find the unique elements of an array.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.unique_all([1, 1, 2])
-    UniqueAllResult(values=array([1, 2]),
-                    indices=array([0, 2]),
-                    inverse_indices=array([0, 0, 1]),
-                    counts=array([2, 1]))
 
     """
     result = unique(


### PR DESCRIPTION
DOC: **update** `np.unique_all` example to show **namedtuple** output

Replaced `np.unique` example with `np.unique_all` to demonstrate the 
namedtuple result format. Clarified output fields: `values`, `indices`, 
`inverse_indices`, and `counts`. This change enhances documentation clarity 
by showing the actual output of `np.unique_all`.

DOC: **update** `np.unique_counts` example to show **namedtuple** output

Replaced `np.unique` example with `np.unique_counts` to demonstrate the 
namedtuple result format. Clarified output fields: `values` and `counts`. 
This change enhances documentation clarity by showing the actual 
output of `np.unique_counts`.

DOC: **update** `np.unique_inverse` example to show **namedtuple** output

Replaced `np.unique` example with `np.unique_inverse` to demonstrate the 
namedtuple result format. Clarified output fields: `values` and 
`inverse_indices`. This change enhances documentation clarity by showing 
the actual output of np.unique_inverse.


DOC: **update** `np.unique_values` example to demonstrate the correct function

Replaced `np.unique` example with `np.unique_values` to show the correct 
output of the function, returning only the unique elements of the input 
array. This change clarifies the intended behavior of np.unique_values.


Closes #27214.
