### PR TITLE
DOC: Clarify np.searchsorted documentation and add example for sorter

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1540,7 +1540,7 @@ def searchsorted(a, v, side='left', sorter=None):
     >>> a = np.array([40, 10, 20, 30])
     >>> sorter = np.argsort(a)
     >>> sorter
-    array([1, 2, 3, 0])  # Indices that would sort the array
+    array([1, 2, 3, 0])  # Indices that would sort the array 'a'
     >>> np.searchsorted(a, 25, sorter=sorter)
     2
     >>> a[sorter[np.searchsorted(a, 25, sorter=sorter)]]

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1535,6 +1535,16 @@ def searchsorted(a, v, side='left', sorter=None):
     >>> np.searchsorted([11,12,13,14,15], [-10, 20, 12, 13])
     array([0, 5, 1, 2])
 
+    When `sorter` is used, the returned indices refer to the sorted array of 'a' and not a itself:
+
+    >>> a = np.array([40, 10, 20, 30])
+    >>> sorter = np.argsort(a)
+    >>> sorter
+    array([1, 2, 3, 0])  # Indices that would sort the array
+    >>> np.searchsorted(a, 25, sorter=sorter)
+    2
+    >>> a[sorter[np.searchsorted(a, 25, sorter=sorter)]]
+    30  # The element at index 2 of the sorted array is 30.
     """
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1536,7 +1536,7 @@ def searchsorted(a, v, side='left', sorter=None):
     array([0, 5, 1, 2])
 
     When `sorter` is used, the returned indices refer to the sorted
-    array of 'a' and not 'a' itself:
+    array of `a` and not `a` itself:
 
     >>> a = np.array([40, 10, 20, 30])
     >>> sorter = np.argsort(a)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1542,9 +1542,10 @@ def searchsorted(a, v, side='left', sorter=None):
     >>> sorter = np.argsort(a)
     >>> sorter
     array([1, 2, 3, 0])  # Indices that would sort the array 'a'
-    >>> np.searchsorted(a, 25, sorter=sorter)
+    >>> result = np.searchsorted(a, 25, sorter=sorter)
+    >>> result 
     2
-    >>> a[sorter[np.searchsorted(a, 25, sorter=sorter)]]
+    >>> a[sorter[result]]
     30  # The element at index 2 of the sorted array is 30.
     """
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1535,7 +1535,8 @@ def searchsorted(a, v, side='left', sorter=None):
     >>> np.searchsorted([11,12,13,14,15], [-10, 20, 12, 13])
     array([0, 5, 1, 2])
 
-    When `sorter` is used, the returned indices refer to the sorted array of 'a' and not a itself:
+    When `sorter` is used, the returned indices refer to the sorted
+    array of 'a' and not 'a' itself:
 
     >>> a = np.array([40, 10, 20, 30])
     >>> sorter = np.argsort(a)


### PR DESCRIPTION
This PR clarifies that when sorter is used in np.searchsorted, the returned indices refer to the sorted array. An example demonstrating this has been added.

Closes #26409