### PR TITLE
BUG: apply critical sections around populating the dispatch cache

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.h
+++ b/numpy/_core/src/common/npy_hashtable.h
@@ -13,13 +13,6 @@ typedef struct {
     PyObject **buckets;
     npy_intp size;  /* current size */
     npy_intp nelem;  /* number of elements */
-#ifdef Py_GIL_DISABLED
-#if PY_VERSION_HEX < 0x30d00b3
-#error "GIL-disabled builds require Python 3.13.0b3 or newer"
-#else
-    PyMutex mutex;
-#endif
-#endif
 } PyArrayIdentityHash;
 
 

--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -6,6 +6,7 @@
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
 #include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 #include "alloc.h"
 
 #include <string.h>
@@ -59,9 +60,7 @@ create_conv_funcs(
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     int error = 0;
-#if Py_GIL_DISABLED
     Py_BEGIN_CRITICAL_SECTION(converters);
-#endif
     while (PyDict_Next(converters, &pos, &key, &value)) {
         Py_ssize_t column = PyNumber_AsSsize_t(key, PyExc_IndexError);
         if (column == -1 && PyErr_Occurred()) {
@@ -114,9 +113,7 @@ create_conv_funcs(
         Py_INCREF(value);
         conv_funcs[column] = value;
     }
-#if Py_GIL_DISABLED
     Py_END_CRITICAL_SECTION();
-#endif
 
     if (error) {
         goto error;

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -976,8 +976,11 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         }
     }
 
-    PyObject *info = promote_and_get_info_and_ufuncimpl(ufunc,
+    PyObject *info;
+    Py_BEGIN_CRITICAL_SECTION((PyObject *)ufunc);
+    info = promote_and_get_info_and_ufuncimpl(ufunc,
             ops, signature, op_dtypes, legacy_promotion_is_possible);
+    Py_END_CRITICAL_SECTION();
 
     if (info == NULL) {
         goto handle_error;


### PR DESCRIPTION
Fixes #27386.

This moves the locking to a higher conceptual level in the code. Now we lock the entire ufunc object whenever we go into `promote_and_get_info_and_ufuncimpl`.

In my testing I'm not able to reproduce the duplicate identity cache entry error @jakevdp saw in the `ml_dtypes` CI locally after making this change. Unfortunately it's a multithreaded issue and inherently flaky, so I can't be 100% positive this fixes it.

Also side benefit of being a lot simpler!

Updating `pythoncapi-compat` lets us use the critical section macros without putting them inside `Py_GIL_DISABLED` macros. They're just open and close brace on the GIL-enabled build.

One question for @seberg or maybe @mhvk: is dtype promotion ever re-entrant? I don't think so but I'd like to double-check because I think it might be problematic if we ever recursively created critical sections here.