### PR TITLE
BUG: apply critical sections around populating the dispatch cache

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.h
+++ b/numpy/_core/src/common/npy_hashtable.h
@@ -13,13 +13,6 @@ typedef struct {
     PyObject **buckets;
     npy_intp size;  /* current size */
     npy_intp nelem;  /* number of elements */
-#ifdef Py_GIL_DISABLED
-#if PY_VERSION_HEX < 0x30d00b3
-#error "GIL-disabled builds require Python 3.13.0b3 or newer"
-#else
-    PyMutex mutex;
-#endif
-#endif
 } PyArrayIdentityHash;
 
 

--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -6,6 +6,7 @@
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
 #include "numpy/npy_3kcompat.h"
+#include "npy_pycompat.h"
 #include "alloc.h"
 
 #include <string.h>
@@ -59,9 +60,7 @@ create_conv_funcs(
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     int error = 0;
-#if Py_GIL_DISABLED
     Py_BEGIN_CRITICAL_SECTION(converters);
-#endif
     while (PyDict_Next(converters, &pos, &key, &value)) {
         Py_ssize_t column = PyNumber_AsSsize_t(key, PyExc_IndexError);
         if (column == -1 && PyErr_Occurred()) {
@@ -114,9 +113,7 @@ create_conv_funcs(
         Py_INCREF(value);
         conv_funcs[column] = value;
     }
-#if Py_GIL_DISABLED
     Py_END_CRITICAL_SECTION();
-#endif
 
     if (error) {
         goto error;

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -976,6 +976,10 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         }
     }
 
+    int error_res = 0;
+    PyObject *all_dtypes;
+    PyArrayMethodObject *method;
+    Py_BEGIN_CRITICAL_SECTION((PyObject *)ufunc);
     int current_promotion_state = get_npy_promotion_state();
 
     if (force_legacy_promotion && legacy_promotion_is_possible
@@ -989,41 +993,50 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         int cacheable = 1;  /* unused, as we modify the original `op_dtypes` */
         if (legacy_promote_using_legacy_type_resolver(ufunc,
                 ops, signature, op_dtypes, &cacheable, NPY_FALSE) < 0) {
-            goto handle_error;
+            error_res = -1;
         }
     }
 
-    /* Pause warnings and always use "new" path */
-    set_npy_promotion_state(NPY_USE_WEAK_PROMOTION);
-    PyObject *info = promote_and_get_info_and_ufuncimpl(ufunc,
-            ops, signature, op_dtypes, legacy_promotion_is_possible);
-    set_npy_promotion_state(current_promotion_state);
+    PyObject *info = NULL;
+    if (error_res == 0) {
+        /* Pause warnings and always use "new" path */
+        set_npy_promotion_state(NPY_USE_WEAK_PROMOTION);
+        info = promote_and_get_info_and_ufuncimpl(ufunc,
+                ops, signature, op_dtypes, legacy_promotion_is_possible);
+        set_npy_promotion_state(current_promotion_state);
 
-    if (info == NULL) {
+        if (info == NULL) {
+            error_res = -1;
+        }
+    }
+
+    if (error_res == 0) {
+        method = (PyArrayMethodObject *)PyTuple_GET_ITEM(info, 1);
+        all_dtypes = PyTuple_GET_ITEM(info, 0);
+
+        /* If necessary, check if the old result would have been different */
+        if (NPY_UNLIKELY(current_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN)
+                && (force_legacy_promotion || promoting_pyscalars)
+                && npy_give_promotion_warnings()) {
+            PyArray_DTypeMeta *check_dtypes[NPY_MAXARGS];
+            for (int i = 0; i < nargs; i++) {
+                check_dtypes[i] = (PyArray_DTypeMeta *)PyTuple_GET_ITEM(
+                        all_dtypes, i);
+            }
+            /* Before calling to the legacy promotion, pretend that is the state: */
+            set_npy_promotion_state(NPY_USE_LEGACY_PROMOTION);
+            int res = legacy_promote_using_legacy_type_resolver(ufunc,
+                    ops, signature, check_dtypes, NULL, NPY_TRUE);
+            /* Reset the promotion state: */
+            set_npy_promotion_state(NPY_USE_WEAK_PROMOTION_AND_WARN);
+            if (res < 0) {
+                error_res = 0;
+            }
+        }
+    }
+    Py_END_CRITICAL_SECTION();
+    if (error_res < 0) {
         goto handle_error;
-    }
-
-    PyArrayMethodObject *method = (PyArrayMethodObject *)PyTuple_GET_ITEM(info, 1);
-    PyObject *all_dtypes = PyTuple_GET_ITEM(info, 0);
-
-    /* If necessary, check if the old result would have been different */
-    if (NPY_UNLIKELY(current_promotion_state == NPY_USE_WEAK_PROMOTION_AND_WARN)
-            && (force_legacy_promotion || promoting_pyscalars)
-            && npy_give_promotion_warnings()) {
-        PyArray_DTypeMeta *check_dtypes[NPY_MAXARGS];
-        for (int i = 0; i < nargs; i++) {
-            check_dtypes[i] = (PyArray_DTypeMeta *)PyTuple_GET_ITEM(
-                    all_dtypes, i);
-        }
-        /* Before calling to the legacy promotion, pretend that is the state: */
-        set_npy_promotion_state(NPY_USE_LEGACY_PROMOTION);
-        int res = legacy_promote_using_legacy_type_resolver(ufunc,
-                ops, signature, check_dtypes, NULL, NPY_TRUE);
-        /* Reset the promotion state: */
-        set_npy_promotion_state(NPY_USE_WEAK_PROMOTION_AND_WARN);
-        if (res < 0) {
-            goto handle_error;
-        }
     }
 
     /*


### PR DESCRIPTION
Backport of #27392.

Fixes #27386.

This moves the locking to a higher conceptual level in the code. Now we lock the entire ufunc object whenever we go into `promote_and_get_info_and_ufuncimpl`.

In my testing I'm not able to reproduce the duplicate identity cache entry error @jakevdp saw in the `ml_dtypes` CI locally after making this change. Unfortunately it's a multithreaded issue and inherently flaky, so I can't be 100% positive this fixes it.

Also side benefit of being a lot simpler!

Updating `pythoncapi-compat` lets us use the critical section macros without putting them inside `Py_GIL_DISABLED` macros. They're just open and close brace on the GIL-enabled build.

One question for @seberg or maybe @mhvk: is dtype promotion ever re-entrant? I don't think so but I'd like to double-check because I think it might be problematic if we ever recursively created critical sections here.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
