### PR TITLE
BUG: Stub out ``get_build_msvc_version`` if ``distutils.msvccompiler`` cannot be imported 

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -24,7 +24,13 @@ from numpy.distutils import log
 
 import distutils.cygwinccompiler
 from distutils.unixccompiler import UnixCCompiler
-from distutils.msvccompiler import get_build_version as get_build_msvc_version
+
+try:
+    from distutils.msvccompiler import get_build_version as get_build_msvc_version
+except ImportError:
+    def get_build_msvc_version():
+        return None
+
 from distutils.errors import UnknownFileError
 from numpy.distutils.misc_util import (msvc_runtime_library,
                                        msvc_runtime_version,


### PR DESCRIPTION
Fixes #27405.