### PR TITLE
DOC: more informative _excluded_ argument explanation in np.vectorize

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2339,7 +2339,8 @@ class vectorize:
     >>> vpolyval = np.vectorize(mypolyval, excluded={0, 'p'})
     >>> vpolyval(p=[1, 2, 3], x=[0, 1])
     array([3, 6])
-    Likewise exlusion with a positional variable:
+
+    Likewise exclusion with a positional input variable:
     >>> vpolyval([1, 2, 3], x=[0, 1])
     array([3, 6])
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2339,10 +2339,7 @@ class vectorize:
     >>> vpolyval = np.vectorize(mypolyval, excluded={0, 'p'})
     >>> vpolyval(p=[1, 2, 3], x=[0, 1])
     array([3, 6])
-
-    Positional arguments may also be excluded by specifying their position:
-
-    >>> vpolyval.excluded.add(0)
+    Likewise exlusion with a positional variable:
     >>> vpolyval([1, 2, 3], x=[0, 1])
     array([3, 6])
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2242,7 +2242,8 @@ class vectorize:
         ``pyfunc.__doc__``.
     excluded : set, optional
         Set of strings or integers representing the positional or keyword
-        arguments for which the function will not be vectorized.  These will be
+        arguments for which the function will not be vectorized (it is recommended
+        passing both positional and keyword identifiers). These will be
         passed directly to `pyfunc` unmodified.
 
         .. versionadded:: 1.7.0
@@ -2335,7 +2336,7 @@ class vectorize:
     ...     while _p:
     ...         res = res*x + _p.pop(0)
     ...     return res
-    >>> vpolyval = np.vectorize(mypolyval, excluded=['p'])
+    >>> vpolyval = np.vectorize(mypolyval, excluded={0, 'p'})
     >>> vpolyval(p=[1, 2, 3], x=[0, 1])
     array([3, 6])
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2242,8 +2242,7 @@ class vectorize:
         ``pyfunc.__doc__``.
     excluded : set, optional
         Set of strings or integers representing the positional or keyword
-        arguments for which the function will not be vectorized (it is recommended
-        passing both positional and keyword identifiers). These will be
+        arguments for which the function will not be vectorized. These will be
         passed directly to `pyfunc` unmodified.
 
         .. versionadded:: 1.7.0
@@ -2336,12 +2335,14 @@ class vectorize:
     ...     while _p:
     ...         res = res*x + _p.pop(0)
     ...     return res
-    >>> vpolyval = np.vectorize(mypolyval, excluded={0, 'p'})
-    >>> vpolyval(p=[1, 2, 3], x=[0, 1])
-    array([3, 6])
 
-    Likewise exclusion with a positional input variable:
+    Here, we exclude the zeroth argument from vectorization whether it is
+    passed by position or keyword.
+
+    >>> vpolyval = np.vectorize(mypolyval, excluded={0, 'p'})
     >>> vpolyval([1, 2, 3], x=[0, 1])
+    array([3, 6])
+    >>> vpolyval(p=[1, 2, 3], x=[0, 1])
     array([3, 6])
 
     The `signature` argument allows for vectorizing functions that act on


### PR DESCRIPTION
Current documentation of `exluded` argument (e.g. telling vectorize which input dimensions not to vectorize along) explains to pass the variable reference by position or name but does not advise to pass both, even though the decorated function would be more resilient to being called with a keyword and/or positional value for these non-vectorized variables.

In the documentation example:

```
    >>> def mypolyval(p, x):
    ...     _p = list(p)
    ...     res = _p.pop(0)
    ...     while _p:
    ...         res = res*x + _p.pop(0)
    ...     return res
    >>> vpolyval = np.vectorize(mypolyval, excluded=['p'])
    >>> vpolyval(p=[1, 2, 3], x=[0, 1])
    array([3, 6])
```

An error would happen if calling `vpolyval([1, 2, 3], x=[0, 1])`. The example adds `0` to the excluded member (decorator has cast `excluded` from list to set - which is not obvious until reading the code. After appending `vpolyval([1, 2, 3], x=[0, 1])` calls are working. Let's encourage practices in which the position and keywords are passed together to the decorator. I have experienced having to go through the underlying code to understand the need for it, an example passing a set of keyword and position for the same variable would have spared me some confusion and saved some time. 