### PR TITLE
MAINT: add Python 3.13 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Software Development',


### PR DESCRIPTION
* NumPy already ships `3.13` binaries on PyPI so I think it is safe to add the `3.13` support metadata to `pyproject.toml`.

[ci skip]

I only noticed because I just did the same for SciPy at https://github.com/scipy/scipy/pull/21570