### PR TITLE
BUILD: fix missing include for std::ptrdiff_t for C++23 language mode

### DIFF
--- a/numpy/_core/src/umath/string_fastsearch.h
+++ b/numpy/_core/src/umath/string_fastsearch.h
@@ -9,6 +9,7 @@
 #include <wchar.h>
 
 #include <type_traits>
+#include <cstddef>
 
 #include <numpy/npy_common.h>
 


### PR DESCRIPTION
Backport of #27361.

This tiny PR fixes a failure happening when building numpy in C++23 language mode.

This issue is caused by the ongoing cleanup of C++ standard library from transitive includes, if they aren't explicitely allowed by the standard.

In particular, in [string_fastsearch.h](https://github.com/numpy/numpy/blob/9e43697124aa7b854f6515b189233286f6a305d7/numpy/_core/src/umath/string_fastsearch.h#L132) we rely on `std::ptrdiff_t` but don't explicitely include its header, `cstddef`, as prescribed bt the [standard](https://en.cppreference.com/w/cpp/types/ptrdiff_t).

Before C++23, this worked fine as some other headers we included transitvely included `cstddef`. 

Without this fix, both on Clang/LLVM and GCC upstreams the following error is observed:
`../numpy/_core/src/umath/string_fastsearch.h:132:5: error: no type named 'ptrdiff_t' in namespace 'std'; did you mean simply 'ptrdiff_t'?`

Please, find the attached logs with full details.
[log.txt](https://github.com/user-attachments/files/16927104/log.txt)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
