### PR TITLE
TYP: Fix default return dtype of ``numpy.random.Generator.integers`` with specified ``endpoint``

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -214,6 +214,8 @@ class Generator:
         low: int,
         high: None | int = ...,
         size: None = ...,
+        *,
+        endpoint: bool = ...,
     ) -> int: ...
     @overload
     def integers(  # type: ignore[misc]
@@ -338,6 +340,8 @@ class Generator:
         low: _ArrayLikeInt_co,
         high: None | _ArrayLikeInt_co = ...,
         size: None | _ShapeLike = ...,
+        *,
+        endpoint: bool = ...
     ) -> NDArray[int64]: ...
     @overload
     def integers(  # type: ignore[misc]


### PR DESCRIPTION
fixes #27388

reproducing `.pyi` example:

```python
import numpy as np

rng: np.random.Generator
reveal_type(rng.integers(1, 6, endpoint=True, size=(10, 6)))
```

before:

```
[mypy] Revealed type is "numpy.ndarray[Any, numpy.dtype[numpy.bool]]"
[pylance] Type of "rng.integers(1, 6, endpoint=True, size=(10, 6))" is "ndarray[Any, dtype[bool]]"
```

after:

```
[mypy] Revealed type is "numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[numpy.signedinteger[numpy._typing._nbit_base._64Bit]]]"
[pylance] Type of "rng.integers(1, 6, endpoint=True, size=(10, 6))" is "ndarray[tuple[int, ...], dtype[signedinteger[_64Bit]]]"
```