### PR TITLE
TYP: Modernized ``numpy.dtypes`` annotations

### DIFF
--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -8,7 +8,7 @@ from typing import (
     TypeVar,
     final,
 )
-from typing_extensions import LiteralString
+from typing_extensions import LiteralString, Self
 
 import numpy as np
 
@@ -50,12 +50,11 @@ __all__ = [
 
 # Helper base classes (typing-only)
 
-_SelfT = TypeVar("_SelfT", bound=np.dtype[Any])
 _SCT_co = TypeVar("_SCT_co", bound=np.generic, covariant=True)
 
 class _SimpleDType(Generic[_SCT_co], np.dtype[_SCT_co]):  # type: ignore[misc]
     names: None  # pyright: ignore[reportIncompatibleVariableOverride]
-    def __new__(cls: type[_SelfT], /) -> _SelfT: ...
+    def __new__(cls, /) -> Self: ...
     def __getitem__(self, key: Any, /) -> NoReturn: ...
     @property
     def base(self) -> np.dtype[_SCT_co]: ...
@@ -454,7 +453,7 @@ class VoidDType(
     # NOTE: `VoidDType(...)` raises a `TypeError` at the moment
     def __new__(cls, length: _ItemSize_co, /) -> NoReturn: ...
     @property
-    def base(self: _SelfT) -> _SelfT: ...
+    def base(self) -> Self: ...
     @property
     def isalignedstruct(self) -> L[False]: ...
     @property

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -71,7 +71,7 @@ class _SimpleDType(Generic[_SCT_co], np.dtype[_SCT_co]):  # type: ignore[misc]
     @property
     def subdtype(self) -> None: ...
 
-class _LiteralDType(Generic[_SCT_co], _SimpleDType[_SCT_co]):
+class _LiteralDType(Generic[_SCT_co], _SimpleDType[_SCT_co]):  # type: ignore[misc]
     @property
     def flags(self) -> L[0]: ...
     @property
@@ -120,7 +120,7 @@ class _8Bit(_NoOrder, _NBit[L[1], L[1]]): ...
 # Boolean:
 
 @final
-class BoolDType(
+class BoolDType(  # type: ignore[misc]
     _TypeCodes[L["b"], L["?"], L[0]],
     _8Bit,
     _LiteralDType[np.bool],
@@ -133,7 +133,7 @@ class BoolDType(
 # Sized integers:
 
 @final
-class Int8DType(
+class Int8DType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["b"], L[1]],
     _8Bit,
     _LiteralDType[np.int8],
@@ -144,7 +144,7 @@ class Int8DType(
     def str(self) -> L["|i1"]: ...
 
 @final
-class UInt8DType(
+class UInt8DType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["B"], L[2]],
     _8Bit,
     _LiteralDType[np.uint8],
@@ -155,7 +155,7 @@ class UInt8DType(
     def str(self) -> L["|u1"]: ...
 
 @final
-class Int16DType(
+class Int16DType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["h"], L[3]],
     _NativeOrder,
     _NBit[L[2], L[2]],
@@ -167,7 +167,7 @@ class Int16DType(
     def str(self) -> L["<i2", ">i2"]: ...
 
 @final
-class UInt16DType(
+class UInt16DType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["H"], L[4]],
     _NativeOrder,
     _NBit[L[2], L[2]],
@@ -179,7 +179,7 @@ class UInt16DType(
     def str(self) -> L["<u2", ">u2"]: ...
 
 @final
-class Int32DType(
+class Int32DType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["i", "l"], L[5, 7]],
     _NativeOrder,
     _NBit[L[4], L[4]],
@@ -191,7 +191,7 @@ class Int32DType(
     def str(self) -> L["<i4", ">i4"]: ...
 
 @final
-class UInt32DType(
+class UInt32DType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["I", "L"], L[6, 8]],
     _NativeOrder,
     _NBit[L[4], L[4]],
@@ -203,7 +203,7 @@ class UInt32DType(
     def str(self) -> L["<u4", ">u4"]: ...
 
 @final
-class Int64DType(
+class Int64DType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["l", "q"], L[7, 9]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -215,7 +215,7 @@ class Int64DType(
     def str(self) -> L["<i8", ">i8"]: ...
 
 @final
-class UInt64DType(
+class UInt64DType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["L", "Q"], L[8, 10]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -233,7 +233,7 @@ ShortDType: Final = Int16DType
 UShortDType: Final = UInt16DType
 
 @final
-class IntDType(
+class IntDType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["i"], L[5]],
     _NativeOrder,
     _NBit[L[4], L[4]],
@@ -245,7 +245,7 @@ class IntDType(
     def str(self) -> L["<i4", ">i4"]: ...
 
 @final
-class UIntDType(
+class UIntDType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["I"], L[6]],
     _NativeOrder,
     _NBit[L[4], L[4]],
@@ -257,7 +257,7 @@ class UIntDType(
     def str(self) -> L["<u4", ">u4"]: ...
 
 @final
-class LongDType(
+class LongDType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["l"], L[7]],
     _NativeOrder,
     _NBit[L[4, 8], L[4, 8]],
@@ -269,7 +269,7 @@ class LongDType(
     def str(self) -> L["<i4", ">i4", "<i8", ">i8"]: ...
 
 @final
-class ULongDType(
+class ULongDType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["L"], L[8]],
     _NativeOrder,
     _NBit[L[4, 8], L[4, 8]],
@@ -281,7 +281,7 @@ class ULongDType(
     def str(self) -> L["<u4", ">u4", "<u8", ">u8"]: ...
 
 @final
-class LongLongDType(
+class LongLongDType(  # type: ignore[misc]
     _TypeCodes[L["i"], L["q"], L[9]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -293,7 +293,7 @@ class LongLongDType(
     def str(self) -> L["<i8", ">i8"]: ...
 
 @final
-class ULongLongDType(
+class ULongLongDType(  # type: ignore[misc]
     _TypeCodes[L["u"], L["Q"], L[10]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -307,7 +307,7 @@ class ULongLongDType(
 # Floats:
 
 @final
-class Float16DType(
+class Float16DType(  # type: ignore[misc]
     _TypeCodes[L["f"], L["e"], L[23]],
     _NativeOrder,
     _NBit[L[2], L[2]],
@@ -319,7 +319,7 @@ class Float16DType(
     def str(self) -> L["<f2", ">f2"]: ...
 
 @final
-class Float32DType(
+class Float32DType(  # type: ignore[misc]
     _TypeCodes[L["f"], L["f"], L[11]],
     _NativeOrder,
     _NBit[L[4], L[4]],
@@ -331,7 +331,7 @@ class Float32DType(
     def str(self) -> L["<f4", ">f4"]: ...
 
 @final
-class Float64DType(
+class Float64DType(  # type: ignore[misc]
     _TypeCodes[L["f"], L["d"], L[12]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -343,7 +343,7 @@ class Float64DType(
     def str(self) -> L["<f8", ">f8"]: ...
 
 @final
-class LongDoubleDType(
+class LongDoubleDType(  # type: ignore[misc]
     _TypeCodes[L["f"], L["g"], L[13]],
     _NativeOrder,
     _NBit[L[8, 12, 16], L[8, 12, 16]],
@@ -357,7 +357,7 @@ class LongDoubleDType(
 # Complex:
 
 @final
-class Complex64DType(
+class Complex64DType(  # type: ignore[misc]
     _TypeCodes[L["c"], L["F"], L[14]],
     _NativeOrder,
     _NBit[L[4], L[8]],
@@ -369,7 +369,7 @@ class Complex64DType(
     def str(self) -> L["<c8", ">c8"]: ...
 
 @final
-class Complex128DType(
+class Complex128DType(  # type: ignore[misc]
     _TypeCodes[L["c"], L["D"], L[15]],
     _NativeOrder,
     _NBit[L[8], L[16]],
@@ -381,7 +381,7 @@ class Complex128DType(
     def str(self) -> L["<c16", ">c16"]: ...
 
 @final
-class CLongDoubleDType(
+class CLongDoubleDType(  # type: ignore[misc]
     _TypeCodes[L["c"], L["G"], L[16]],
     _NativeOrder,
     _NBit[L[8, 12, 16], L[16, 24, 32]],
@@ -395,7 +395,7 @@ class CLongDoubleDType(
 # Python objects:
 
 @final
-class ObjectDType(
+class ObjectDType(  # type: ignore[misc]
     _TypeCodes[L["O"], L["O"], L[17]],
     _NoOrder,
     _NBit[L[8], L[8]],
@@ -411,7 +411,7 @@ class ObjectDType(
 # Flexible:
 
 @final
-class BytesDType(
+class BytesDType(  # type: ignore[misc]
     Generic[_ItemSize_co],
     _TypeCodes[L["S"], L["S"], L[18]],
     _NoOrder,
@@ -427,7 +427,7 @@ class BytesDType(
     def str(self) -> LiteralString: ...
 
 @final
-class StrDType(
+class StrDType(  # type: ignore[misc]
     Generic[_ItemSize_co],
     _TypeCodes[L["U"], L["U"], L[19]],
     _NativeOrder,
@@ -443,12 +443,12 @@ class StrDType(
     def str(self) -> LiteralString: ...
 
 @final
-class VoidDType(
+class VoidDType(  # type: ignore[misc]
     Generic[_ItemSize_co],
     _TypeCodes[L["V"], L["V"], L[20]],
     _NoOrder,
     _NBit[L[1], _ItemSize_co],
-    np.dtype[np.void],  # type: ignore[misc]
+    np.dtype[np.void],
 ):
     # NOTE: `VoidDType(...)` raises a `TypeError` at the moment
     def __new__(cls, length: _ItemSize_co, /) -> NoReturn: ...
@@ -476,7 +476,7 @@ _TimeUnit: TypeAlias = L["h", "m", "s", "ms", "us", "ns", "ps", "fs", "as"]
 _DateTimeUnit: TypeAlias = _DateUnit | _TimeUnit
 
 @final
-class DateTime64DType(
+class DateTime64DType(  # type: ignore[misc]
     _TypeCodes[L["M"], L["M"], L[21]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -521,7 +521,7 @@ class DateTime64DType(
     ]: ...
 
 @final
-class TimeDelta64DType(
+class TimeDelta64DType(  # type: ignore[misc]
     _TypeCodes[L["m"], L["m"], L[22]],
     _NativeOrder,
     _NBit[L[8], L[8]],
@@ -566,12 +566,12 @@ class TimeDelta64DType(
     ]: ...
 
 @final
-class StringDType(
+class StringDType(  # type: ignore[misc]
     _TypeCodes[L["T"], L["T"], L[2056]],
     _NativeOrder,
     _NBit[L[8], L[16]],
     # TODO: Replace the (invalid) `str` with the scalar type, once implemented
-    np.dtype[str],  # type: ignore[misc]
+    np.dtype[str],  # type: ignore[type-var]
 ):
     def __new__(cls, /) -> StringDType: ...
     def __getitem__(self, key: Any, /) -> NoReturn: ...
@@ -596,4 +596,4 @@ class StringDType(
     @property
     def subdtype(self) -> None: ...
     @property
-    def type(self) -> type[str]: ...
+    def type(self) -> type[str]: ...  # type: ignore[valid-type]

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -5,11 +5,10 @@ from typing import (
     Literal as L,
     NoReturn,
     TypeAlias,
-    TypeVar,
     final,
     type_check_only,
 )
-from typing_extensions import LiteralString, Self
+from typing_extensions import LiteralString, Self, TypeVar
 
 import numpy as np
 
@@ -111,7 +110,7 @@ class _NativeOrder:
     def byteorder(self) -> L["="]: ...
 
 _DataSize_co = TypeVar("_DataSize_co", bound=int, covariant=True)
-_ItemSize_co = TypeVar("_ItemSize_co", bound=int, covariant=True)
+_ItemSize_co = TypeVar("_ItemSize_co", bound=int, covariant=True, default=int)
 
 @type_check_only
 class _NBit(Generic[_DataSize_co, _ItemSize_co]):

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -7,6 +7,7 @@ from typing import (
     TypeAlias,
     TypeVar,
     final,
+    type_check_only,
 )
 from typing_extensions import LiteralString, Self
 
@@ -52,6 +53,7 @@ __all__ = [
 
 _SCT_co = TypeVar("_SCT_co", bound=np.generic, covariant=True)
 
+@type_check_only
 class _SimpleDType(Generic[_SCT_co], np.dtype[_SCT_co]):  # type: ignore[misc]
     names: None  # pyright: ignore[reportIncompatibleVariableOverride]
     def __new__(cls, /) -> Self: ...
@@ -71,6 +73,7 @@ class _SimpleDType(Generic[_SCT_co], np.dtype[_SCT_co]):  # type: ignore[misc]
     @property
     def subdtype(self) -> None: ...
 
+@type_check_only
 class _LiteralDType(Generic[_SCT_co], _SimpleDType[_SCT_co]):  # type: ignore[misc]
     @property
     def flags(self) -> L[0]: ...
@@ -83,6 +86,7 @@ _KindT_co = TypeVar("_KindT_co", bound=LiteralString, covariant=True)
 _CharT_co = TypeVar("_CharT_co", bound=LiteralString, covariant=True)
 _NumT_co = TypeVar("_NumT_co", bound=int, covariant=True)
 
+@type_check_only
 class _TypeCodes(Generic[_KindT_co, _CharT_co, _NumT_co]):
     @final
     @property
@@ -94,11 +98,13 @@ class _TypeCodes(Generic[_KindT_co, _CharT_co, _NumT_co]):
     @property
     def num(self) -> _NumT_co: ...
 
+@type_check_only
 class _NoOrder:
     @final
     @property
     def byteorder(self) -> L["|"]: ...
 
+@type_check_only
 class _NativeOrder:
     @final
     @property
@@ -107,6 +113,7 @@ class _NativeOrder:
 _DataSize_co = TypeVar("_DataSize_co", bound=int, covariant=True)
 _ItemSize_co = TypeVar("_ItemSize_co", bound=int, covariant=True)
 
+@type_check_only
 class _NBit(Generic[_DataSize_co, _ItemSize_co]):
     @final
     @property
@@ -115,6 +122,7 @@ class _NBit(Generic[_DataSize_co, _ItemSize_co]):
     @property
     def itemsize(self) -> _ItemSize_co: ...
 
+@type_check_only
 class _8Bit(_NoOrder, _NBit[L[1], L[1]]): ...
 
 # Boolean:


### PR DESCRIPTION
This improves the type-hints of ``numpy.dtypes`` for users and static-type checkers, in a backwards-compatible manner:

- Use [``Self``](https://typing.readthedocs.io/en/latest/reference/generics.html#automatic-self-types-using-typing-self) for self types
- Ignored some (unavoidable) mypy errors (related to ``numpy.dtype`` being ``@final``, and ``StringDType`` not having a scalar type)
- Mark stub-only private helper classes with [``@type_check_only``](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#stub-only-objects)
- Allow omitting the "itemsize" type-argument in ``(Bytes|Str|Void)DType`` by using [type parameter defaults](https://typing.readthedocs.io/en/latest/spec/generics.html#type-parameter-defaults)

See #27132 for details on the use of ``typing_extensions`` in ``.pyi`` stubs