### PR TITLE
TYP: Add missing type arguments

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -183,7 +183,7 @@ def full(
 def full(
     shape: _SizeType,
     fill_value: Any,
-    dtype: _DType | _SupportsDType,
+    dtype: _DType | _SupportsDType[_DType],
     order: _OrderCF = ...,
     **kwargs: Unpack[_KwargsEmpty],
 ) -> np.ndarray[tuple[_SizeType], _DType]: ...

--- a/numpy/_typing/_callable.pyi
+++ b/numpy/_typing/_callable.pyi
@@ -56,10 +56,10 @@ _2Tuple: TypeAlias = tuple[_T1, _T1]
 _NBit1 = TypeVar("_NBit1", bound=NBitBase)
 _NBit2 = TypeVar("_NBit2", bound=NBitBase)
 
-_IntType = TypeVar("_IntType", bound=integer)
-_FloatType = TypeVar("_FloatType", bound=floating)
-_NumberType = TypeVar("_NumberType", bound=number)
-_NumberType_co = TypeVar("_NumberType_co", covariant=True, bound=number)
+_IntType = TypeVar("_IntType", bound=integer[Any])
+_FloatType = TypeVar("_FloatType", bound=floating[Any])
+_NumberType = TypeVar("_NumberType", bound=number[Any])
+_NumberType_co = TypeVar("_NumberType_co", covariant=True, bound=number[Any])
 _GenericType_co = TypeVar("_GenericType_co", covariant=True, bound=generic)
 
 class _BoolOp(Protocol[_GenericType_co]):

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -144,9 +144,9 @@ _DTypeLikeBool: TypeAlias = (
     | _BoolCodes
 )
 _DTypeLikeUInt: TypeAlias = (
-    type[np.unsignedinteger]
-    | np.dtype[np.unsignedinteger]
-    | _SupportsDType[np.dtype[np.unsignedinteger]]
+    type[np.unsignedinteger[Any]]
+    | np.dtype[np.unsignedinteger[Any]]
+    | _SupportsDType[np.dtype[np.unsignedinteger[Any]]]
     | _UInt8Codes
     | _UInt16Codes
     | _UInt32Codes
@@ -161,9 +161,9 @@ _DTypeLikeUInt: TypeAlias = (
 )
 _DTypeLikeInt: TypeAlias = (
     type[int]
-    | type[np.signedinteger]
-    | np.dtype[np.signedinteger]
-    | _SupportsDType[np.dtype[np.signedinteger]]
+    | type[np.signedinteger[Any]]
+    | np.dtype[np.signedinteger[Any]]
+    | _SupportsDType[np.dtype[np.signedinteger[Any]]]
     | _Int8Codes
     | _Int16Codes
     | _Int32Codes
@@ -178,9 +178,9 @@ _DTypeLikeInt: TypeAlias = (
 )
 _DTypeLikeFloat: TypeAlias = (
     type[float]
-    | type[np.floating]
-    | np.dtype[np.floating]
-    | _SupportsDType[np.dtype[np.floating]]
+    | type[np.floating[Any]]
+    | np.dtype[np.floating[Any]]
+    | _SupportsDType[np.dtype[np.floating[Any]]]
     | _Float16Codes
     | _Float32Codes
     | _Float64Codes
@@ -191,9 +191,9 @@ _DTypeLikeFloat: TypeAlias = (
 )
 _DTypeLikeComplex: TypeAlias = (
     type[complex]
-    | type[np.complexfloating]
-    | np.dtype[np.complexfloating]
-    | _SupportsDType[np.dtype[np.complexfloating]]
+    | type[np.complexfloating[Any]]
+    | np.dtype[np.complexfloating[Any]]
+    | _SupportsDType[np.dtype[np.complexfloating[Any]]]
     | _Complex64Codes
     | _Complex128Codes
     | _CSingleCodes

--- a/numpy/polynomial/_polybase.pyi
+++ b/numpy/polynomial/_polybase.pyi
@@ -11,7 +11,6 @@ from typing import (
     SupportsIndex,
     TypeAlias,
     TypeGuard,
-    TypeVar,
     overload,
 )
 
@@ -42,15 +41,15 @@ from ._polytypes import (
     _ArrayLikeCoef_co,
 )
 
-from typing_extensions import LiteralString
+from typing_extensions import LiteralString, TypeVar
 
 
 __all__: Final[Sequence[str]] = ("ABCPolyBase",)
 
 
-_NameCo = TypeVar("_NameCo", bound=None | LiteralString, covariant=True)
+_NameCo = TypeVar("_NameCo", bound=LiteralString | None, covariant=True, default=LiteralString | None)
 _Self = TypeVar("_Self")
-_Other = TypeVar("_Other", bound=ABCPolyBase[Any])
+_Other = TypeVar("_Other", bound=ABCPolyBase)
 
 _AnyOther: TypeAlias = ABCPolyBase | _CoefLike_co | _SeriesLikeCoef_co
 _Hundred: TypeAlias = Literal[100]

--- a/numpy/polynomial/_polytypes.pyi
+++ b/numpy/polynomial/_polytypes.pyi
@@ -7,7 +7,6 @@ from typing import (
     SupportsIndex,
     SupportsInt,
     TypeAlias,
-    TypeVar,
     final,
     overload,
 )
@@ -30,7 +29,7 @@ from numpy._typing import (
     _NumberLike_co,
 )
 
-from typing_extensions import LiteralString
+from typing_extensions import LiteralString, TypeVar
 
 
 _T = TypeVar("_T")
@@ -113,7 +112,7 @@ _ArrayLikeCoef_co: TypeAlias = (
     | _ArrayLikeCoefObject_co
 )
 
-_Name_co = TypeVar("_Name_co", bound=LiteralString, covariant=True)
+_Name_co = TypeVar("_Name_co", bound=LiteralString, covariant=True, default=LiteralString)
 
 class _Named(Protocol[_Name_co]):
     @property


### PR DESCRIPTION
Generic types with missing type arguments are reported by pyright/pylance as `reportMissingTypeArgument` errors (enabled by default in strict mode). If ignored, pyright would infer them as `Unknown` types, which often indirectly leads to other reported errors.

This fixes these errors by either adding a `default` to the relevant `TypeVar`, or by directly passing the missing type arguments.