### PR TITLE
MAINT: Use correct Python interpreter in tests

### DIFF
--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -46,7 +46,8 @@ def install_temp(tmpdir_factory):
     native_file = str(build_dir / 'interpreter-native-file.ini')
     with open(native_file, 'w') as f:
         f.write("[binaries]\n")
-        f.write(f"python = '{sys.executable}'")
+        f.write(f"python = '{sys.executable}'\n")
+        f.write(f"python3 = '{sys.executable}'")
 
     try:
         subprocess.check_call(["meson", "--version"])

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -40,6 +40,14 @@ def install_temp(tmpdir_factory):
     srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'limited_api')
     build_dir = tmpdir_factory.mktemp("limited_api") / "build"
     os.makedirs(build_dir, exist_ok=True)
+    # Ensure we use the correct Python interpreter even when `meson` is
+    # installed in a different Python environment (see gh-24956)
+    native_file = str(build_dir / 'interpreter-native-file.ini')
+    with open(native_file, 'w') as f:
+        f.write("[binaries]\n")
+        f.write(f"python = '{sys.executable}'\n")
+        f.write(f"python3 = '{sys.executable}'")
+
     try:
         subprocess.check_call(["meson", "--version"])
     except FileNotFoundError:
@@ -48,11 +56,13 @@ def install_temp(tmpdir_factory):
         subprocess.check_call(["meson", "setup",
                                "--werror",
                                "--buildtype=release",
-                               "--vsenv", str(srcdir)],
+                               "--vsenv", "--native-file", native_file,
+                               str(srcdir)],
                               cwd=build_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", "--werror", str(srcdir)],
+        subprocess.check_call(["meson", "setup", "--werror",
+                               "--native-file", native_file, str(srcdir)],
                               cwd=build_dir
                               )
     try:

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -63,14 +63,23 @@ def test_cython(tmp_path):
     build_dir = tmp_path / 'random' / '_examples' / 'cython'
     target_dir = build_dir / "build"
     os.makedirs(target_dir, exist_ok=True)
+    # Ensure we use the correct Python interpreter even when `meson` is
+    # installed in a different Python environment (see gh-24956)
+    native_file = str(build_dir / 'interpreter-native-file.ini')
+    with open(native_file, 'w') as f:
+        f.write("[binaries]\n")
+        f.write(f"python = '{sys.executable}'\n")
+        f.write(f"python3 = '{sys.executable}'")
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
                                "--buildtype=release",
-                               "--vsenv", str(build_dir)],
+                               "--vsenv", "--native-file", native_file,
+                               str(build_dir)],
                               cwd=target_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", str(build_dir)],
+        subprocess.check_call(["meson", "setup",
+                               "--native-file", native_file, str(build_dir)],
                               cwd=target_dir
                               )
     subprocess.check_call(["meson", "compile", "-vv"], cwd=target_dir)


### PR DESCRIPTION
This PR applies the fix for #24956 to additional test cases.

At least on Debian, meson started to pick "python3" as default Python
interpreter, so the native-file needs to have an additional override
key.
