### PR TITLE
TYP: Fixed & improved type-hinting for ``any`` and ``all``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1449,62 +1449,6 @@ class _ArrayOrScalarCommon:
     # an `np.bool` is returned when `keepdims=True` and `self` is a 0d array
 
     @overload
-    def all(
-        self,
-        axis: None = ...,
-        out: None = ...,
-        keepdims: L[False] = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> np.bool: ...
-    @overload
-    def all(
-        self,
-        axis: None | _ShapeLike = ...,
-        out: None = ...,
-        keepdims: builtins.bool = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> Any: ...
-    @overload
-    def all(
-        self,
-        axis: None | _ShapeLike = ...,
-        out: _NdArraySubClass = ...,
-        keepdims: builtins.bool = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> _NdArraySubClass: ...
-
-    @overload
-    def any(
-        self,
-        axis: None = ...,
-        out: None = ...,
-        keepdims: L[False] = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> np.bool: ...
-    @overload
-    def any(
-        self,
-        axis: None | _ShapeLike = ...,
-        out: None = ...,
-        keepdims: builtins.bool = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> Any: ...
-    @overload
-    def any(
-        self,
-        axis: None | _ShapeLike = ...,
-        out: _NdArraySubClass = ...,
-        keepdims: builtins.bool = ...,
-        *,
-        where: _ArrayLikeBool_co = ...,
-    ) -> _NdArraySubClass: ...
-
-    @overload
     def argmax(
         self,
         axis: None = ...,
@@ -2026,6 +1970,80 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType_co, _DType_co]):
     def transpose(self, axes: None | _ShapeLike, /) -> Self: ...
     @overload
     def transpose(self, *axes: SupportsIndex) -> Self: ...
+
+    @overload
+    def all(
+        self,
+        axis: None = None,
+        out: None = None,
+        keepdims: L[False, 0] = False,
+        *,
+        where: _ArrayLikeBool_co = True
+    ) -> np.bool: ...
+    @overload
+    def all(
+        self,
+        axis: None | int | tuple[int, ...] = None,
+        out: None = None,
+        keepdims: SupportsIndex = False,
+        *,
+        where: _ArrayLikeBool_co = True,
+    ) -> np.bool | NDArray[np.bool]: ...
+    @overload
+    def all(
+        self,
+        axis: None | int | tuple[int, ...],
+        out: _NdArraySubClass,
+        keepdims: SupportsIndex = False,
+        *,
+        where: _ArrayLikeBool_co = True,
+    ) -> _NdArraySubClass: ...
+    @overload
+    def all(
+        self,
+        axis: None | int | tuple[int, ...] = None,
+        *,
+        out: _NdArraySubClass,
+        keepdims: SupportsIndex = False,
+        where: _ArrayLikeBool_co = True,
+    ) -> _NdArraySubClass: ...
+
+    @overload
+    def any(
+        self,
+        axis: None = None,
+        out: None = None,
+        keepdims: L[False, 0] = False,
+        *,
+        where: _ArrayLikeBool_co = True
+    ) -> np.bool: ...
+    @overload
+    def any(
+        self,
+        axis: None | int | tuple[int, ...] = None,
+        out: None = None,
+        keepdims: SupportsIndex = False,
+        *,
+        where: _ArrayLikeBool_co = True,
+    ) -> np.bool | NDArray[np.bool]: ...
+    @overload
+    def any(
+        self,
+        axis: None | int | tuple[int, ...],
+        out: _NdArraySubClass,
+        keepdims: SupportsIndex = False,
+        *,
+        where: _ArrayLikeBool_co = True,
+    ) -> _NdArraySubClass: ...
+    @overload
+    def any(
+        self,
+        axis: None | int | tuple[int, ...] = None,
+        *,
+        out: _NdArraySubClass,
+        keepdims: SupportsIndex = False,
+        where: _ArrayLikeBool_co = True,
+    ) -> _NdArraySubClass: ...
 
     def argpartition(
         self,
@@ -3212,6 +3230,69 @@ class generic(_ArrayOrScalarCommon):
 
     def squeeze(self, axis: None | L[0] | tuple[()] = ...) -> Self: ...
     def transpose(self, axes: None | tuple[()] = ..., /) -> Self: ...
+
+    @overload
+    def all(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None = None,
+        out: None = None,
+        keepdims: SupportsIndex = False,
+        *,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True
+    ) -> np.bool: ...
+    @overload
+    def all(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None,
+        out: ndarray[tuple[()], dtype[_SCT]],
+        keepdims: SupportsIndex = False,
+        *,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True,
+    ) -> _SCT: ...
+    @overload
+    def all(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None = None,
+        *,
+        out: ndarray[tuple[()], dtype[_SCT]],
+        keepdims: SupportsIndex = False,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True,
+    ) -> _SCT: ...
+
+    @overload
+    def any(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None = None,
+        out: None = None,
+        keepdims: SupportsIndex = False,
+        *,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True
+    ) -> np.bool: ...
+    @overload
+    def any(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None,
+        out: ndarray[tuple[()], dtype[_SCT]],
+        keepdims: SupportsIndex = False,
+        *,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True,
+    ) -> _SCT: ...
+    @overload
+    def any(
+        self,
+        /,
+        axis: L[0, -1] | tuple[()] | None = None,
+        *,
+        out: ndarray[tuple[()], dtype[_SCT]],
+        keepdims: SupportsIndex = False,
+        where: builtins.bool | np.bool | ndarray[tuple[()], dtype[np.bool]] = True,
+    ) -> _SCT: ...
+
     # Keep `dtype` at the bottom to avoid name conflicts with `np.dtype`
     @property
     def dtype(self) -> _dtype[Self]: ...

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -575,57 +575,75 @@ def sum(
 @overload
 def all(
     a: ArrayLike,
-    axis: None = ...,
-    out: None = ...,
-    keepdims: Literal[False] = ...,
+    axis: None = None,
+    out: None = None,
+    keepdims: Literal[False, 0] = False,
     *,
-    where: _ArrayLikeBool_co = ...,
+    where: _ArrayLikeBool_co = True,
 ) -> np.bool: ...
 @overload
 def all(
     a: ArrayLike,
-    axis: None | _ShapeLike = ...,
-    out: None = ...,
-    keepdims: bool = ...,
+    axis: None | int | tuple[int, ...] = None,
+    out: None = None,
+    keepdims: SupportsIndex = False,
     *,
-    where: _ArrayLikeBool_co = ...,
-) -> Any: ...
+    where: _ArrayLikeBool_co = True,
+) -> np.bool | NDArray[np.bool]: ...
 @overload
 def all(
     a: ArrayLike,
-    axis: None | _ShapeLike = ...,
-    out: _ArrayType = ...,
-    keepdims: bool = ...,
+    axis: None | int | tuple[int, ...],
+    out: _ArrayType,
+    keepdims: SupportsIndex = False,
     *,
-    where: _ArrayLikeBool_co = ...,
+    where: _ArrayLikeBool_co = True,
+) -> _ArrayType: ...
+@overload
+def all(
+    a: ArrayLike,
+    axis: None | int | tuple[int, ...] = None,
+    *,
+    out: _ArrayType,
+    keepdims: SupportsIndex = False,
+    where: _ArrayLikeBool_co = True,
 ) -> _ArrayType: ...
 
 @overload
 def any(
     a: ArrayLike,
-    axis: None = ...,
-    out: None = ...,
-    keepdims: Literal[False] = ...,
+    axis: None = None,
+    out: None = None,
+    keepdims: Literal[False, 0] = False,
     *,
-    where: _ArrayLikeBool_co = ...,
+    where: _ArrayLikeBool_co = True,
 ) -> np.bool: ...
 @overload
 def any(
     a: ArrayLike,
-    axis: None | _ShapeLike = ...,
-    out: None = ...,
-    keepdims: bool = ...,
+    axis: None | int | tuple[int, ...] = None,
+    out: None = None,
+    keepdims: SupportsIndex = False,
     *,
-    where: _ArrayLikeBool_co = ...,
-) -> Any: ...
+    where: _ArrayLikeBool_co = True,
+) -> np.bool | NDArray[np.bool]: ...
 @overload
 def any(
     a: ArrayLike,
-    axis: None | _ShapeLike = ...,
-    out: _ArrayType = ...,
-    keepdims: bool = ...,
+    axis: None | int | tuple[int, ...],
+    out: _ArrayType,
+    keepdims: SupportsIndex = False,
     *,
-    where: _ArrayLikeBool_co = ...,
+    where: _ArrayLikeBool_co = True,
+) -> _ArrayType: ...
+@overload
+def any(
+    a: ArrayLike,
+    axis: None | int | tuple[int, ...] = None,
+    *,
+    out: _ArrayType,
+    keepdims: SupportsIndex = False,
+    where: _ArrayLikeBool_co = True,
 ) -> _ArrayType: ...
 
 @overload

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -44,14 +44,14 @@ assert_type(ctypes_obj.strides_as(ct.c_ubyte), ct.Array[ct.c_ubyte])
 
 assert_type(f8.all(), np.bool)
 assert_type(AR_f8.all(), np.bool)
-assert_type(AR_f8.all(axis=0), Any)
-assert_type(AR_f8.all(keepdims=True), Any)
+assert_type(AR_f8.all(axis=0), np.bool | npt.NDArray[np.bool])
+assert_type(AR_f8.all(keepdims=True), np.bool | npt.NDArray[np.bool])
 assert_type(AR_f8.all(out=B), SubClass)
 
 assert_type(f8.any(), np.bool)
 assert_type(AR_f8.any(), np.bool)
-assert_type(AR_f8.any(axis=0), Any)
-assert_type(AR_f8.any(keepdims=True), Any)
+assert_type(AR_f8.any(axis=0), np.bool | npt.NDArray[np.bool])
+assert_type(AR_f8.any(keepdims=True), np.bool | npt.NDArray[np.bool])
 assert_type(AR_f8.any(out=B), SubClass)
 
 assert_type(f8.argmax(), np.intp)


### PR DESCRIPTION
This affects ``numpy.{any,all}``, ``numpy.ndarray.{any,all}``, and ``numpy.generic.{any,all}``.

Apart from the more accurate parameter- and return types, this also fixes several cases of ``reportInvalidTypeVarUse`` pyright errors, with messages like:

```
Type variable "_ArrayType" may go unsolved if caller supplies no argument for parameter "out"
  Provide an overload that specifies the return type when the argument is not supplied
```

Currently, there are quite a few other functions and methods that have this issue. 
But in order to avoid this PR from getting too big, I thought I'd start with these two, so that they might serve as an example for how to fix the others.

And as suggested by the [typing docs](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#functions-and-methods), the `...` parameter defaults with their literal defaults.