### PR TITLE
BLD: pin setuptools to avoid breaking numpy.distutils

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - compilers
   - openblas
   - nomkl
-  - setuptools
+  - setuptools==65.5.1
   - ninja
   - pkg-config
   - meson-python


### PR DESCRIPTION
Maybe fixes #27428 by pinning setuptools in the conda requirements to an older version that supports numpy.distutils.