### PR TITLE
ENH: make np.dtype(scalar_type) return the default dtype instance

### DIFF
--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -247,13 +247,17 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
 }
 
 /*
- * Note: This function never fails, but will return `NULL` for unknown scalars
- *       and `None` for known array-likes (e.g. tuple, list, ndarray).
+ * Note: This function never fails, but will return `NULL` for unknown scalars or
+ *       known array-likes (e.g. tuple, list, ndarray).
  */
 NPY_NO_EXPORT PyObject *
 PyArray_DiscoverDTypeFromScalarType(PyTypeObject *pytype)
 {
-    return (PyObject *)npy_discover_dtype_from_pytype(pytype);
+    PyObject *DType = (PyObject *)npy_discover_dtype_from_pytype(pytype);
+    if (DType == NULL || DType == Py_None) {
+        return NULL;
+    }
+    return DType;
 }
 
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1557,14 +1557,6 @@ PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
     return NPY_DT_CALL_default_descr(DType);
 }
 
-NPY_NO_EXPORT PyArray_Descr *
-default_descr_from_scalar_type(PyTypeObject *typ) {
-    PyObject *DType = PyArray_DiscoverDTypeFromScalarType(typ);
-    if (DType == NULL || DType == Py_None) {
-        return NULL;
-    }
-    return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
-}
 
 /**
  * Get a dtype instance from a python type
@@ -1609,9 +1601,9 @@ _convert_from_type(PyObject *obj) {
         return PyArray_DescrFromType(NPY_OBJECT);
     }
     else {
-        PyArray_Descr *descr = default_descr_from_scalar_type(typ);
-        if (descr != NULL) {
-            return descr;
+        PyObject *DType = PyArray_DiscoverDTypeFromScalarType(typ);
+        if (DType != NULL) {
+            return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
         }
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
         if ((PyObject *)ret != Py_NotImplemented) {

--- a/numpy/_core/src/multiarray/descriptor.h
+++ b/numpy/_core/src/multiarray/descriptor.h
@@ -65,4 +65,7 @@ arraydescr_field_subset_view(_PyArray_LegacyDescr *self, PyObject *ind);
 
 extern NPY_NO_EXPORT char const *_datetime_strings[];
 
+NPY_NO_EXPORT PyArray_Descr *
+default_descr_from_scalar_type(PyTypeObject *typ);
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_DESCRIPTOR_H_ */

--- a/numpy/_core/src/multiarray/descriptor.h
+++ b/numpy/_core/src/multiarray/descriptor.h
@@ -65,7 +65,4 @@ arraydescr_field_subset_view(_PyArray_LegacyDescr *self, PyObject *ind);
 
 extern NPY_NO_EXPORT char const *_datetime_strings[];
 
-NPY_NO_EXPORT PyArray_Descr *
-default_descr_from_scalar_type(PyTypeObject *typ);
-
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_DESCRIPTOR_H_ */

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -390,7 +390,10 @@ PyArray_DescrFromTypeObject(PyObject *type)
         Py_INCREF(type);
         return (PyArray_Descr *)new;
     }
-    return _descr_from_subtype(type);
+
+    PyArray_Descr *default_descr = default_descr_from_scalar_type((PyTypeObject *)type);
+
+    return default_descr != NULL ? default_descr : _descr_from_subtype(type);
 }
 
 

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -391,9 +391,12 @@ PyArray_DescrFromTypeObject(PyObject *type)
         return (PyArray_Descr *)new;
     }
 
-    PyArray_Descr *default_descr = default_descr_from_scalar_type((PyTypeObject *)type);
+    PyObject *DType = PyArray_DiscoverDTypeFromScalarType((PyTypeObject *)type);
+    if (DType != NULL) {
+        return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
+    }
 
-    return default_descr != NULL ? default_descr : _descr_from_subtype(type);
+    return _descr_from_subtype(type);
 }
 
 


### PR DESCRIPTION
Fixes #27415, ping @hawkinsp.