### PR TITLE
BUG: Disable SVE VQSort

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -829,7 +829,7 @@ foreach gen_mtargets : [
     'highway_qsort.dispatch.h',
     'src/npysort/highway_qsort.dispatch.cpp',
     use_highway ? [
-      SVE, ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
+      ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
     ] : []
   ],
   [


### PR DESCRIPTION
This patch removes the SVE dispatch path for VQSort, due to it being broken with GCC 10.2.1 in the manylinux2014 image.

Compiling it outside of manylinux2014 with GCC 10.5.0 appears to work correctly.

I'm assuming this isn't being caught in CI due to there not being a SVE capable machine in the wheel builds?