### PR TITLE
BUG: Disable SVE VQSort

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -829,7 +829,7 @@ foreach gen_mtargets : [
     'highway_qsort.dispatch.h',
     'src/npysort/highway_qsort.dispatch.cpp',
     use_highway ? [
-      SVE, ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
+      ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
     ] : []
   ],
   [


### PR DESCRIPTION
Backport of #27438.

This patch removes the SVE dispatch path for VQSort, due to it being broken with GCC 10.2.1 in the manylinux2014 image.

Compiling it outside of manylinux2014 with GCC 10.5.0 appears to work correctly.

I'm assuming this isn't being caught in CI due to there not being a SVE capable machine in the wheel builds?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
