### PR TITLE
ENH: Use PyObject_GetAttrString in the datetime.c

### DIFF
--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2645,7 +2645,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         int seconds = 0, useconds = 0;
 
         /* Get the days */
-        res = PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp);
+        int res = PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp);
         if (res != 1) {
             return -1;
         }

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -29,6 +29,8 @@
 
 #include "dtype_transfer.h"
 #include "lowlevel_strided_loops.h"
+#include "npy_static_data.h"
+#include "npy_pycompat.h"
 
 #include <datetime.h>
 #include <time.h>
@@ -2064,8 +2066,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Get the year */
-    tmp = PyObject_GetAttrString(obj, "year");
-    if (tmp == NULL) {
+    int res = PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->year = PyLong_AsLong(tmp);
@@ -2076,8 +2078,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the month */
-    tmp = PyObject_GetAttrString(obj, "month");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.month, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->month = PyLong_AsLong(tmp);
@@ -2088,8 +2090,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the day */
-    tmp = PyObject_GetAttrString(obj, "day");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.day, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->day = PyLong_AsLong(tmp);
@@ -2122,8 +2124,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Get the hour */
-    tmp = PyObject_GetAttrString(obj, "hour");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.hour, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->hour = PyLong_AsLong(tmp);
@@ -2134,8 +2136,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the minute */
-    tmp = PyObject_GetAttrString(obj, "minute");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.minute, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->min = PyLong_AsLong(tmp);
@@ -2146,8 +2148,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the second */
-    tmp = PyObject_GetAttrString(obj, "second");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.second, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->sec = PyLong_AsLong(tmp);
@@ -2158,8 +2160,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the microsecond */
-    tmp = PyObject_GetAttrString(obj, "microsecond");
-    if (tmp == NULL) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.microsecond, &tmp);
+    if (res != 1) {
         return -1;
     }
     out->us = PyLong_AsLong(tmp);
@@ -2178,8 +2180,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
     /* Apply the time zone offset if it exists */
     if (apply_tzinfo && PyObject_HasAttrString(obj, "tzinfo")) {
-        tmp = PyObject_GetAttrString(obj, "tzinfo");
-        if (tmp == NULL) {
+        int res = PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp);
+        if (res != 1) {
             return -1;
         }
         if (tmp == Py_None) {
@@ -2641,8 +2643,8 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         int seconds = 0, useconds = 0;
 
         /* Get the days */
-        tmp = PyObject_GetAttrString(obj, "days");
-        if (tmp == NULL) {
+        res = PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp);
+        if (res != 1) {
             return -1;
         }
         days = PyLong_AsLongLong(tmp);
@@ -2653,8 +2655,8 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the seconds */
-        tmp = PyObject_GetAttrString(obj, "seconds");
-        if (tmp == NULL) {
+        res = PyObject_GetOptionalAttr(obj, npy_interned_str.seconds, &tmp);
+        if (res != 1) {
             return -1;
         }
         seconds = PyLong_AsLong(tmp);
@@ -2665,8 +2667,8 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the microseconds */
-        tmp = PyObject_GetAttrString(obj, "microseconds");
-        if (tmp == NULL) {
+        res = PyObject_GetOptionalAttr(obj, npy_interned_str.microseconds, &tmp);
+        if (res != 1) {
             return -1;
         }
         useconds = PyLong_AsLong(tmp);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2061,7 +2061,10 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
     /* Get the year */
     /* Checking if Exception will be raised it would be -1 else + value */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp) != 1) {
+    int res = PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp);
+    if (res == -1) {
+        return -1;
+    } else if (res == 0) {
         return 1;
     }
     out->year = PyLong_AsLong(tmp);
@@ -2072,7 +2075,10 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the month */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.month, &tmp) != 1) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.month, &tmp);
+    if (res == -1) {
+        return -1;
+    } else if (res == 0) {
         return 1;
     }
     out->month = PyLong_AsLong(tmp);
@@ -2083,7 +2089,10 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the day */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.day, &tmp) != 1) {
+    res = PyObject_GetOptionalAttr(obj, npy_interned_str.day, &tmp);
+    if (res == -1) {
+        return -1;
+    } else if (res == 0) {
         return 1;
     }
     out->day = PyLong_AsLong(tmp);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2059,18 +2059,10 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     out->month = 1;
     out->day = 1;
 
-    /* Need at least year/month/day attributes */
-    if (!PyObject_HasAttrString(obj, "year") ||
-            !PyObject_HasAttrString(obj, "month") ||
-            !PyObject_HasAttrString(obj, "day")) {
-        return 1;
-    }
-
     /* Get the year */
     /* Checking if Exception will be raised it would be -1 else + value */
-    int res = PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp);
-    if (res != 1) {
-        return -1;
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp) != 1) {
+        return 1;
     }
     out->year = PyLong_AsLong(tmp);
     if (error_converting(out->year)) {
@@ -2080,9 +2072,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the month */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.month, &tmp);
-    if (res != 1) {
-        return -1;
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.month, &tmp) != 1) {
+        return 1;
     }
     out->month = PyLong_AsLong(tmp);
     if (error_converting(out->month)) {
@@ -2092,9 +2083,8 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the day */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.day, &tmp);
-    if (res != 1) {
-        return -1;
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.day, &tmp) != 1) {
+        return 1;
     }
     out->day = PyLong_AsLong(tmp);
     if (error_converting(out->day)) {
@@ -2126,8 +2116,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Get the hour */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.hour, &tmp);
-    if (res != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.hour, &tmp) != 1) {
         return -1;
     }
     out->hour = PyLong_AsLong(tmp);
@@ -2138,8 +2127,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the minute */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.minute, &tmp);
-    if (res != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.minute, &tmp) != 1) {
         return -1;
     }
     out->min = PyLong_AsLong(tmp);
@@ -2150,8 +2138,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the second */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.second, &tmp);
-    if (res != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.second, &tmp) != 1) {
         return -1;
     }
     out->sec = PyLong_AsLong(tmp);
@@ -2162,8 +2149,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the microsecond */
-    res = PyObject_GetOptionalAttr(obj, npy_interned_str.microsecond, &tmp);
-    if (res != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.microsecond, &tmp) != 1) {
         return -1;
     }
     out->us = PyLong_AsLong(tmp);
@@ -2182,8 +2168,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
     /* Apply the time zone offset if it exists */
     if (apply_tzinfo && PyObject_HasAttrString(obj, "tzinfo")) {
-        int res = PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp);
-        if (res != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp) != 1) {
             return -1;
         }
         if (tmp == Py_None) {
@@ -2645,8 +2630,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         int seconds = 0, useconds = 0;
 
         /* Get the days */
-        int res = PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp);
-        if (res != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp) != 1) {
             return -1;
         }
         days = PyLong_AsLongLong(tmp);
@@ -2657,8 +2641,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the seconds */
-        res = PyObject_GetOptionalAttr(obj, npy_interned_str.seconds, &tmp);
-        if (res != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.seconds, &tmp) != 1) {
             return -1;
         }
         seconds = PyLong_AsLong(tmp);
@@ -2669,8 +2652,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the microseconds */
-        res = PyObject_GetOptionalAttr(obj, npy_interned_str.microseconds, &tmp);
-        if (res != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.microseconds, &tmp) != 1) {
             return -1;
         }
         useconds = PyLong_AsLong(tmp);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -30,6 +30,7 @@
 #include "dtype_transfer.h"
 #include "lowlevel_strided_loops.h"
 #include "npy_static_data.h"
+/* Have to include for due to older version of PyObject_GetOptionalAttr*/
 #include "npy_pycompat.h"
 
 #include <datetime.h>
@@ -2066,6 +2067,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Get the year */
+    /* Checking if Exception will be raised it would be -1 else + value */
     int res = PyObject_GetOptionalAttr(obj, npy_interned_str.year, &tmp);
     if (res != 1) {
         return -1;

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2125,7 +2125,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Get the hour */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.hour, &tmp) != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.hour, &tmp) == -1) {
         return -1;
     }
     out->hour = PyLong_AsLong(tmp);
@@ -2136,7 +2136,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the minute */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.minute, &tmp) != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.minute, &tmp) == -1) {
         return -1;
     }
     out->min = PyLong_AsLong(tmp);
@@ -2147,7 +2147,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the second */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.second, &tmp) != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.second, &tmp) == -1) {
         return -1;
     }
     out->sec = PyLong_AsLong(tmp);
@@ -2158,7 +2158,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     Py_DECREF(tmp);
 
     /* Get the microsecond */
-    if (PyObject_GetOptionalAttr(obj, npy_interned_str.microsecond, &tmp) != 1) {
+    if (PyObject_GetOptionalAttr(obj, npy_interned_str.microsecond, &tmp) == -1) {
         return -1;
     }
     out->us = PyLong_AsLong(tmp);
@@ -2177,7 +2177,7 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
     /* Apply the time zone offset if it exists */
     if (apply_tzinfo && PyObject_HasAttrString(obj, "tzinfo")) {
-        if (PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp) != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp) == -1) {
             return -1;
         }
         if (tmp == Py_None) {
@@ -2639,7 +2639,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         int seconds = 0, useconds = 0;
 
         /* Get the days */
-        if (PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp) != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.days, &tmp) == -1) {
             return -1;
         }
         days = PyLong_AsLongLong(tmp);
@@ -2650,7 +2650,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the seconds */
-        if (PyObject_GetOptionalAttr(obj, npy_interned_str.seconds, &tmp) != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.seconds, &tmp) == -1) {
             return -1;
         }
         seconds = PyLong_AsLong(tmp);
@@ -2661,7 +2661,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(tmp);
 
         /* Get the microseconds */
-        if (PyObject_GetOptionalAttr(obj, npy_interned_str.microseconds, &tmp) != 1) {
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.microseconds, &tmp) == -1) {
             return -1;
         }
         useconds = PyLong_AsLong(tmp);

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -63,6 +63,19 @@ intern_strings(void)
     INTERN_STRING(__dlpack__, "__dlpack__");
     INTERN_STRING(pyvals_name, "UFUNC_PYVALS_NAME");
     INTERN_STRING(legacy, "legacy");
+    INTERN_STRING(year, "year");
+    INTERN_STRING(month, "month");
+    INTERN_STRING(day, "day");
+    INTERN_STRING(hour, "hour");
+    INTERN_STRING(minute, "minute");
+    INTERN_STRING(second, "second");
+    INTERN_STRING(microsecond, "microsecond");
+    INTERN_STRING(tzinfo, "tzinfo");
+    INTERN_STRING(days, "days");
+    INTERN_STRING(seconds, "seconds");
+    INTERN_STRING(microseconds, "microseconds");
+
+
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -74,8 +74,6 @@ intern_strings(void)
     INTERN_STRING(days, "days");
     INTERN_STRING(seconds, "seconds");
     INTERN_STRING(microseconds, "microseconds");
-
-
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -38,6 +38,17 @@ typedef struct npy_interned_str_struct {
     PyObject *__dlpack__;
     PyObject *pyvals_name;
     PyObject *legacy;
+    PyObject *year;
+    PyObject *month;
+    PyObject *day;
+    PyObject *hour;
+    PyObject *minute;
+    PyObject *second;
+    PyObject *microsecond;
+    PyObject *tzinfo;
+    PyObject *days;
+    PyObject *seconds;
+    PyObject *microseconds;
 } npy_interned_str_struct;
 
 /*


### PR DESCRIPTION
https://github.com/numpy/numpy/issues/27120

So we are using PyObject_GetAttrString, which will take some extra time while loading up the entries, so have fixed this for 1 file datetime.c,

Have tested this all the test cases are working fine post this changes so we are good.






<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
