### PR TITLE
DOC: Removed outdated versionadded/changed directives in numpy random, ma, linalg and testing package

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -351,8 +351,6 @@ def solve(a, b):
     Notes
     -----
 
-    .. versionadded:: 1.8.0
-
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -527,8 +525,6 @@ def inv(a):
 
     Notes
     -----
-
-    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
@@ -789,8 +785,6 @@ def cholesky(a, /, *, upper=False):
 
     Notes
     -----
-
-    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
@@ -1176,8 +1170,6 @@ def eigvals(a):
     Notes
     -----
 
-    .. versionadded:: 1.8.0
-
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1280,8 +1272,6 @@ def eigvalsh(a, UPLO='L'):
 
     Notes
     -----
-
-    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
@@ -1390,8 +1380,6 @@ def eig(a):
 
     Notes
     -----
-
-    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
@@ -1552,8 +1540,6 @@ def eigh(a, UPLO='L'):
     Notes
     -----
 
-    .. versionadded:: 1.8.0
-
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
 
@@ -1686,8 +1672,6 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
         enabling a more efficient method for finding singular values.
         Defaults to False.
 
-        .. versionadded:: 1.17.0
-
     Returns
     -------
     When `compute_uv` is True, the result is a namedtuple with the following
@@ -1720,10 +1704,6 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
 
     Notes
     -----
-
-    .. versionchanged:: 1.8.0
-       Broadcasting rules apply, see the `numpy.linalg` documentation for
-       details.
 
     The decomposition is performed using LAPACK routine ``_gesdd``.
 
@@ -2043,9 +2023,6 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     Rank of the array is the number of singular values of the array that are
     greater than `tol`.
 
-    .. versionchanged:: 1.14
-       Can now operate on stacks of matrices
-
     Parameters
     ----------
     A : {(M,), (..., M, N)} array_like
@@ -2056,14 +2033,11 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
         ``eps`` is the epsilon value for datatype of ``S``, then `tol` is
         set to ``S.max() * max(M, N) * eps``.
 
-        .. versionchanged:: 1.14
-           Broadcasted against the stack of matrices
     hermitian : bool, optional
         If True, `A` is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.
         Defaults to False.
 
-        .. versionadded:: 1.14
     rtol : (...) array_like, float, optional
         Parameter for the relative tolerance component. Only ``tol`` or
         ``rtol`` can be set at a time. Defaults to ``max(M, N) * eps``.
@@ -2170,9 +2144,6 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
     singular-value decomposition (SVD) and including all
     *large* singular values.
 
-    .. versionchanged:: 1.14
-       Can now operate on stacks of matrices
-
     Parameters
     ----------
     a : (..., M, N) array_like
@@ -2187,7 +2158,6 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         enabling a more efficient method for finding singular values.
         Defaults to False.
 
-        .. versionadded:: 1.17.0
     rtol : (...) array_like of float, optional
         Same as `rcond`, but it's an Array API compatible parameter name.
         Only `rcond` or `rtol` can be set at a time. If none of them are
@@ -2321,12 +2291,8 @@ def slogdet(a):
     Notes
     -----
 
-    .. versionadded:: 1.8.0
-
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
-
-    .. versionadded:: 1.6.0
 
     The determinant is computed via LU factorization using the LAPACK
     routine ``z/dgetrf``.
@@ -2398,8 +2364,6 @@ def det(a):
 
     Notes
     -----
-
-    .. versionadded:: 1.8.0
 
     Broadcasting rules apply, see the `numpy.linalg` documentation for
     details.
@@ -2648,14 +2612,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
         is 1-D) or a matrix norm (when `x` is 2-D) is returned. The default
         is None.
 
-        .. versionadded:: 1.8.0
-
     keepdims : bool, optional
         If this is set to True, the axes which are normed over are left in the
         result as dimensions with size one.  With this option the result will
         broadcast correctly against the original `x`.
-
-        .. versionadded:: 1.10.0
 
     Returns
     -------
@@ -2923,8 +2883,6 @@ def multi_dot(arrays, *, out=None):
         for `dot(a, b)`. This is a performance feature. Therefore, if these
         conditions are not met, an exception is raised, instead of attempting
         to be flexible.
-
-        .. versionadded:: 1.19.0
 
     Returns
     -------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4627,8 +4627,6 @@ class MaskedArray(ndarray):
             the dimensions of the input array. `axis` may be negative, in
             which case it counts from the last to the first axis.
 
-            .. versionadded:: 1.10.0
-
             If this is a tuple of ints, the count is performed on multiple
             axes, instead of a single axis or all the axes as before.
         keepdims : bool, optional
@@ -5198,8 +5196,6 @@ class MaskedArray(ndarray):
         recommended that the optional arguments be treated as keyword only.
         At some point that may be mandatory.
 
-        .. versionadded:: 1.10.0
-
         Parameters
         ----------
         b : masked_array_like
@@ -5217,8 +5213,6 @@ class MaskedArray(ndarray):
             for the computation. Default is False.  Propagating the mask
             means that if a masked value appears in a row or column, the
             whole row or column is considered masked.
-
-            .. versionadded:: 1.10.2
 
         See Also
         --------
@@ -5911,7 +5905,6 @@ class MaskedArray(ndarray):
         axis : None or int or tuple of ints, optional
             Axis along which to operate.  By default, ``axis`` is None and the
             flattened input is used.
-            .. versionadded:: 1.7.0
             If this is a tuple of ints, the minimum is selected over multiple
             axes, instead of a single axis or all the axes as before.
         out : array_like, optional
@@ -6010,7 +6003,6 @@ class MaskedArray(ndarray):
         axis : None or int or tuple of ints, optional
             Axis along which to operate.  By default, ``axis`` is None and the
             flattened input is used.
-            .. versionadded:: 1.7.0
             If this is a tuple of ints, the maximum is selected over multiple
             axes, instead of a single axis or all the axes as before.
         out : array_like, optional
@@ -6352,8 +6344,6 @@ class MaskedArray(ndarray):
         Return the array data as a string containing the raw bytes in the array.
 
         The array is filled with a fill value before the string conversion.
-
-        .. versionadded:: 1.9.0
 
         Parameters
         ----------
@@ -8163,8 +8153,6 @@ def dot(a, b, strict=False, out=None):
         conditions are not met, an exception is raised, instead of attempting
         to be flexible.
 
-        .. versionadded:: 1.10.2
-
     See Also
     --------
     numpy.dot : Equivalent function for ndarrays.
@@ -8857,8 +8845,6 @@ zeros_like = _convert2ma(
 
 def append(a, b, axis=None):
     """Append values to the end of an array.
-
-    .. versionadded:: 1.9.0
 
     Parameters
     ----------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -742,8 +742,6 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the input array.
 
-        .. versionadded:: 1.10.0
-
     Returns
     -------
     median : ndarray
@@ -1439,8 +1437,6 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
 
     Notes
     -----
-    .. versionadded:: 1.4.0
-
     Examples
     --------
     >>> import numpy as np
@@ -1490,8 +1486,6 @@ def isin(element, test_elements, assume_unique=False, invert=False):
 
     Notes
     -----
-    .. versionadded:: 1.13.0
-
     Examples
     --------
     >>> import numpy as np
@@ -1665,8 +1659,6 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
         If not ``None`` normalization is by ``(N - ddof)``, where ``N`` is
         the number of observations; this overrides the value implied by
         ``bias``. The default value is ``None``.
-
-        .. versionadded:: 1.5
 
     Raises
     ------
@@ -2056,9 +2048,6 @@ def flatnotmasked_contiguous(a):
     slice_list : list
         A sorted sequence of `slice` objects (start index, end index).
 
-        .. versionchanged:: 1.15.0
-            Now returns an empty list instead of None for a fully masked array
-
     See Also
     --------
     flatnotmasked_edges, notmasked_contiguous, notmasked_edges
@@ -2225,8 +2214,6 @@ def clump_unmasked(a):
 
     Notes
     -----
-    .. versionadded:: 1.4.0
-
     See Also
     --------
     flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges
@@ -2265,8 +2252,6 @@ def clump_masked(a):
 
     Notes
     -----
-    .. versionadded:: 1.4.0
-
     See Also
     --------
     flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1579,9 +1579,6 @@ cdef class Generator:
         ----------
         dfnum : float or array_like of floats
             Numerator degrees of freedom, must be > 0.
-
-            .. versionchanged:: 1.14.0
-               Earlier NumPy versions required dfnum > 1.
         dfden : float or array_like of floats
             Denominator degrees of freedom, must be > 0.
         nonc : float or array_like of floats
@@ -1736,9 +1733,6 @@ cdef class Generator:
         ----------
         df : float or array_like of floats
             Degrees of freedom, must be > 0.
-
-            .. versionchanged:: 1.10.0
-               Earlier NumPy versions required dfnum > 1.
         nonc : float or array_like of floats
             Non-centrality, must be non-negative.
         size : int or tuple of ints, optional
@@ -3759,8 +3753,6 @@ cdef class Generator:
             the slowest method. The method `eigh` uses eigen decomposition to
             compute A and is faster than svd but slower than cholesky.
 
-            .. versionadded:: 1.18.0
-
         Returns
         -------
         out : ndarray
@@ -4304,8 +4296,6 @@ cdef class Generator:
         can be significantly faster than the "marginals" method.  If
         performance of the algorithm is important, test the two methods
         with typical inputs to decide which works best.
-
-        .. versionadded:: 1.18.0
 
         Examples
         --------

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1589,8 +1589,6 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
     that ``allclose`` has different default values). It compares the difference
     between `actual` and `desired` to ``atol + rtol * abs(desired)``.
 
-    .. versionadded:: 1.5.0
-
     Parameters
     ----------
     actual : array_like
@@ -1918,8 +1916,6 @@ def assert_warns(warning_class, *args, **kwargs):
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
 
-    .. versionadded:: 1.4.0
-
     Parameters
     ----------
     warning_class : class
@@ -1984,8 +1980,6 @@ def assert_no_warnings(*args, **kwargs):
             do_something()
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
-
-    .. versionadded:: 1.7.0
 
     Parameters
     ----------
@@ -2525,8 +2519,6 @@ def assert_no_gc_cycles(*args, **kwargs):
 
         with assert_no_gc_cycles():
             do_something()
-
-    .. versionadded:: 1.15.0
 
     Parameters
     ----------


### PR DESCRIPTION
DOC: Removed outdated versionadded/changed directives in,

1. numpy/random/_generator.pyx
2. numpy/ma/core.py
3. numpy/ma/extras.py
4. numpy/linalg/_linalg.py
5. numpy/testing/_private/utils.py

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
