### PR TITLE
MAINT: Clean up for PyUnicode_AsASCIIString

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -854,7 +854,7 @@ _try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj)
         return (PyArray_Descr *)Py_NotImplemented;
     }
     if (!PyDataType_ISLEGACY(type) || !PyDataType_ISLEGACY(conv)) {
-        /* 
+        /*
          * This specification should probably be never supported, but
          * certainly not for new-style DTypes.
          */
@@ -1972,7 +1972,7 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrNew(PyArray_Descr *base_descr)
 {
     if (!PyDataType_ISLEGACY(base_descr)) {
-        /* 
+        /*
          * The main use of this function is mutating strings, so probably
          * disallowing this is fine in practice.
          */
@@ -2972,18 +2972,19 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
     /* Parse endian */
     if (PyUnicode_Check(endian_obj) || PyBytes_Check(endian_obj)) {
         PyObject *tmp = NULL;
-        char *str;
+        const char *str;
         Py_ssize_t len;
 
-        if (PyUnicode_Check(endian_obj)) {
-            tmp = PyUnicode_AsASCIIString(endian_obj);
+        if (PyBytes_Check(endian_obj)) {
+            tmp = PyUnicode_FromEncodedObject(endian_obj, NULL, NULL);
             if (tmp == NULL) {
                 return NULL;
             }
             endian_obj = tmp;
         }
 
-        if (PyBytes_AsStringAndSize(endian_obj, &str, &len) < 0) {
+        str = PyUnicode_AsUTF8AndSize(endian_obj, &len);
+        if (str == NULL) {
             Py_XDECREF(tmp);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -127,10 +127,10 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
             return 0;
         }
 
-        if (PyUnicode_Check(f)) {
+        if (PyBytes_Check(f)) {
             /* accept unicode input */
             PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
+            f_str = PyUnicode_FromEncodedObject(f, NULL, NULL);
             if (f_str == NULL) {
                 Py_DECREF(f);
                 return 0;
@@ -138,8 +138,8 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
             Py_DECREF(f);
             f = f_str;
         }
-
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        str = PyUnicode_AsUTF8AndSize(f, &length);
+        if (str == NULL) {
             Py_DECREF(f);
             return 0;
         }
@@ -259,10 +259,10 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
             return 0;
         }
 
-        if (PyUnicode_Check(f)) {
+        if (PyBytes_Check(f)) {
             /* accept unicode input */
             PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
+            f_str = PyUnicode_FromEncodedObject(f, NULL, NULL);
             if (f_str == NULL) {
                 Py_DECREF(f);
                 return 0;
@@ -271,7 +271,8 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
             f = f_str;
         }
 
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        str = PyUnicode_AsUTF8AndSize(f, &length);
+        if ( str == NULL) {
             PyErr_Clear();
             Py_DECREF(f);
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -105,7 +105,7 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
     int iflags, nflags;
 
     PyObject *f;
-    char *str = NULL;
+    const char *str = NULL;
     Py_ssize_t length = 0;
     npy_uint32 flag;
 
@@ -251,7 +251,7 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
     *op_flags = 0;
     for (iflags = 0; iflags < nflags; ++iflags) {
         PyObject *f;
-        char *str = NULL;
+        const char *str = NULL;
         Py_ssize_t length = 0;
 
         f = PySequence_GetItem(op_flags_in, iflags);

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -711,7 +711,7 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",
             Py_INCREF(tmp);
         }
         else if (PyUnicode_Check(obj)) {
-            tmp = PyBytes_Check(obj);
+            tmp = PyUnicode_AsASCIIString(obj);
         }
         else {
             PyObject *tmp2;

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -711,13 +711,13 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",
             Py_INCREF(tmp);
         }
         else if (PyUnicode_Check(obj)) {
-            tmp = PyUnicode_AsASCIIString(obj);
+            tmp = PyUnicode_AsUTF8String(obj);
         }
         else {
             PyObject *tmp2;
             tmp2 = PyObject_Str(obj);
             if (tmp2) {
-                tmp = PyUnicode_FromEncodedObject(tmp2);
+                tmp = PyUnicode_AsUTF8String(tmp2);
                 Py_DECREF(tmp2);
             }
             else {

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -773,7 +773,10 @@ cfuncs['character_from_pyobj'] = """
 static int
 character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
     if (PyBytes_Check(obj)) {
-        PyObject* tmp = PyUnicode_FromEncodedObject(obj);
+        *v = PyBytes_AS_STRING(obj)[0];
+        return 1;
+    } else if (PyUnicode_Check(obj)) {
+        PyObject* tmp = PyUnicode_AsUTF8String(obj);
         if (tmp != NULL) {
             *v = PyBytes_AS_STRING(tmp)[0];
             Py_DECREF(tmp);

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -711,13 +711,13 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",
             Py_INCREF(tmp);
         }
         else if (PyUnicode_Check(obj)) {
-            tmp = PyUnicode_AsASCIIString(obj);
+            tmp = PyBytes_Check(obj);
         }
         else {
             PyObject *tmp2;
             tmp2 = PyObject_Str(obj);
             if (tmp2) {
-                tmp = PyUnicode_AsASCIIString(tmp2);
+                tmp = PyUnicode_FromEncodedObject(tmp2);
                 Py_DECREF(tmp2);
             }
             else {
@@ -776,8 +776,8 @@ character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
         /* empty bytes has trailing null, so dereferencing is always safe */
         *v = PyBytes_AS_STRING(obj)[0];
         return 1;
-    } else if (PyUnicode_Check(obj)) {
-        PyObject* tmp = PyUnicode_AsASCIIString(obj);
+    } else if (PyBytes_Check(obj)) {
+        PyObject* tmp = PyUnicode_FromEncodedObject(obj);
         if (tmp != NULL) {
             *v = PyBytes_AS_STRING(tmp)[0];
             Py_DECREF(tmp);

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -773,10 +773,6 @@ cfuncs['character_from_pyobj'] = """
 static int
 character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
     if (PyBytes_Check(obj)) {
-        /* empty bytes has trailing null, so dereferencing is always safe */
-        *v = PyBytes_AS_STRING(obj)[0];
-        return 1;
-    } else if (PyBytes_Check(obj)) {
         PyObject* tmp = PyUnicode_FromEncodedObject(obj);
         if (tmp != NULL) {
             *v = PyBytes_AS_STRING(tmp)[0];

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -773,6 +773,7 @@ cfuncs['character_from_pyobj'] = """
 static int
 character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
     if (PyBytes_Check(obj)) {
+        /* empty bytes has trailing null, so dereferencing is always safe */
         *v = PyBytes_AS_STRING(obj)[0];
         return 1;
     } else if (PyUnicode_Check(obj)) {


### PR DESCRIPTION
Issue Mentioned: https://github.com/numpy/numpy/issues/15317

we should be preferring UniCodeObject, so as suggested in some other commit, if we get any ByteCodeObject we should be converting it and using the UniCodeOject. 

It will also help us improve the error message, if we get any unique character as ByteCodeObject.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
