### PR TITLE
DOC: Fix a copy-paste mistake in the cumulative_sum docstring.

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2817,7 +2817,7 @@ def cumulative_sum(x, /, *, axis=None, dtype=None, out=None,
         but the type will be cast if necessary. See :ref:`ufuncs-output-type`
         for more details.
     include_initial : bool, optional
-        Boolean indicating whether to include the initial value (ones) as
+        Boolean indicating whether to include the initial value (zeros) as
         the first value in the output. With ``include_initial=True``
         the shape of the output is different than the shape of the input.
         Default: ``False``.


### PR DESCRIPTION
Change '(ones)' to '(zeros)' in the description of `include_initial`. '(ones)' was probably left over from a copy-paste of the `cumulative_prod` docstring.

[skip actions] [skip azp] [skip cirrus]
