### PR TITLE
BUG: Fix extra decref of PyArray_UInt8DType.

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -177,7 +177,6 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
         /* This is a back-compat fallback to usually do the right thing... */
         PyArray_DTypeMeta *uint8_dt = &PyArray_UInt8DType;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, uint8_dt);
-        Py_DECREF(uint8_dt);
         if (res == NULL) {
             PyErr_Clear();
         }


### PR DESCRIPTION
We didn't take a reference to this type, so we shouldn't be freeing one. This appears to have been missed by PR #25329.

This was found to cause segfaults when running Google-internal tests under NumPy 2.1.

@ngoldbaum 