### PR TITLE
Show shape any time it cannot be inferred in repr

### DIFF
--- a/doc/release/upcoming_changes/27482.change.rst
+++ b/doc/release/upcoming_changes/27482.change.rst
@@ -1,0 +1,8 @@
+* The ``repr`` of arrays large enough to be summarized (i.e., where elements
+  are replaced with ``...``) now includes the ``shape`` of the array, similar
+  to what already was the case for arrays with zero size and non-obvious
+  shape. With this change, the shape is always given when it cannot be
+  inferred from the values.  Note that while written as ``shape=...``, this
+  argument cannot actually be passed in to the ``np.array`` constructor. If
+  you encounter problems, e.g., due to failing doctests, you can use the print
+  option ``legacy=2.1`` to get the old behaviour.

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -346,7 +346,13 @@ class TestArray2String:
         assert_equal(str(A), strA)
 
         reprA = 'array([   0,    1,    2, ...,  998,  999, 1000])'
-        assert_equal(repr(A), reprA)
+        try:
+            np.set_printoptions(legacy='2.1')
+            assert_equal(repr(A), reprA)
+        finally:
+            np.set_printoptions(legacy=False)
+
+        assert_equal(repr(A), reprA.replace(')', ', shape=(1001,))'))
 
     def test_summarize_2d(self):
         A = np.arange(1002).reshape(2, 501)
@@ -356,6 +362,23 @@ class TestArray2String:
 
         reprA = 'array([[   0,    1,    2, ...,  498,  499,  500],\n' \
                 '       [ 501,  502,  503, ...,  999, 1000, 1001]])'
+        try:
+            np.set_printoptions(legacy='2.1')
+            assert_equal(repr(A), reprA)
+        finally:
+            np.set_printoptions(legacy=False)
+
+        assert_equal(repr(A), reprA.replace(')', ', shape=(2, 501))'))
+
+    def test_summarize_2d_dtype(self):
+        A = np.arange(1002, dtype='i2').reshape(2, 501)
+        strA = '[[   0    1    2 ...  498  499  500]\n' \
+               ' [ 501  502  503 ...  999 1000 1001]]'
+        assert_equal(str(A), strA)
+
+        reprA = ('array([[   0,    1,    2, ...,  498,  499,  500],\n'
+                 '       [ 501,  502,  503, ...,  999, 1000, 1001]],\n'
+                 '      shape=(2, 501), dtype=int16)')
         assert_equal(repr(A), reprA)
 
     def test_summarize_structure(self):
@@ -1040,7 +1063,7 @@ class TestPrintOptions:
 
                    [[18, ..., 20],
                     ...,
-                    [24, ..., 26]]])""")
+                    [24, ..., 26]]], shape=(3, 3, 3))""")
         )
 
         b = np.zeros((3, 3, 1, 1))
@@ -1061,40 +1084,37 @@ class TestPrintOptions:
 
                     ...,
 
-                    [[0.]]]])""")
+                    [[0.]]]], shape=(3, 3, 1, 1))""")
         )
 
         # 1.13 had extra trailing spaces, and was missing newlines
-        np.set_printoptions(legacy='1.13')
-
-        assert_equal(
-            repr(a),
-            textwrap.dedent("""\
-            array([[[ 0, ...,  2],
-                    ..., 
-                    [ 6, ...,  8]],
-
-                   ..., 
-                   [[18, ..., 20],
-                    ..., 
-                    [24, ..., 26]]])""")
-        )
-
-        assert_equal(
-            repr(b),
-            textwrap.dedent("""\
-            array([[[[ 0.]],
-
-                    ..., 
-                    [[ 0.]]],
-
-
-                   ..., 
-                   [[[ 0.]],
-
-                    ..., 
-                    [[ 0.]]]])""")
-        )
+        try:
+            np.set_printoptions(legacy='1.13')
+            assert_equal(repr(a), (
+                "array([[[ 0, ...,  2],\n"
+                "        ..., \n"
+                "        [ 6, ...,  8]],\n"
+                "\n"
+                "       ..., \n"
+                "       [[18, ..., 20],\n"
+                "        ..., \n"
+                "        [24, ..., 26]]])")
+            )
+            assert_equal(repr(b), (
+                "array([[[[ 0.]],\n"
+                "\n"
+                "        ..., \n"
+                "        [[ 0.]]],\n"
+                "\n"
+                "\n"
+                "       ..., \n"
+                "       [[[ 0.]],\n"
+                "\n"
+                "        ..., \n"
+                "        [[ 0.]]]])")
+            )
+        finally:
+            np.set_printoptions(legacy=False)
 
     def test_edgeitems_structured(self):
         np.set_printoptions(edgeitems=1, threshold=1)


### PR DESCRIPTION
As noted in #27461, when an array is summarized, the `repr` no longer makes it clear what the shape is. This is a bit odd, since for the case of a zero-sized array, the shape is shown when it is not clear what it would be (i.e., when the size is zero but the shape multi-dimensional). Similarly, if the dtype is not obvious, it is shown. So, this PR also shows the shape when summaries are made:
```
In [2]: np.arange(1001)
Out[2]: array([   0,    1,    2, ...,  998,  999, 1000], shape=(1001,))
In [3]: np.arange(1001, dtype="i2")
Out[3]: 
array([   0,    1,    2, ...,  998,  999, 1000],
      shape=(1001,), dtype=int16)
```
One can get the old behaviour by using `legacy='2.1'` - I'm not sure this is really required; happy to remove it if desired.

Fixes #27461

p.s. The first commit reorganizes the routine to make it easier to add the shape, while the second has the actual enhancement and tests.