### PR TITLE
DOC: Correct selected C docstrings to eliminate warnings

### DIFF
--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -268,7 +268,8 @@ typedef int (PyArrayMethod_TranslateGivenDescriptors)(int nin, int nout,
  *
  * The function must clean up on error.
  *
- * @param nargs Number of arguments
+ * @param nin Number of input arguments
+ * @param nout Number of output arguments
  * @param new_dtypes The DTypes of the output (usually probably not needed)
  * @param given_descrs Original given_descrs to the resolver, necessary to
  *        fetch any information related to the new dtypes from the original.

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -280,11 +280,11 @@ raise_missing_argument(const char *funcname,
  *
  * See macro version for an example pattern of how to use this function.
  *
- * @param funcname
- * @param cache
+ * @param funcname Function name
+ * @param cache a NULL initialized persistent storage for data
  * @param args Python passed args (METH_FASTCALL)
- * @param len_args
- * @param kwnames
+ * @param len_args Number of arguments (not flagged)
+ * @param kwnames Tuple as passed by METH_FASTCALL or NULL.
  * @param ... List of arguments (see macro version).
  *
  * @return Returns 0 on success and -1 on failure.

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -69,7 +69,7 @@ NPY_NO_EXPORT int init_argparse_mutex(void);
  * used in cunjunction with the macro defined in the same scope.
  * (No two `npy_parse_arguments` may share a single `NPY_PREPARE_ARGPARSER`.)
  *
- * @param funcname
+ * @param funcname Function name
  * @param args Python passed args (METH_FASTCALL)
  * @param len_args Number of arguments (not flagged)
  * @param kwnames Tuple as passed by METH_FASTCALL or NULL.

--- a/numpy/_core/src/common/npy_import.h
+++ b/numpy/_core/src/common/npy_import.h
@@ -81,7 +81,7 @@ npy_import(const char *module, const char *attr)
  *
  * @param module Absolute module name.
  * @param attr module attribute to cache.
- * @param cache Storage location for imported function.
+ * @param obj Storage location for imported function.
  */
 static inline int
 npy_cache_import_runtime(const char *module, const char *attr, PyObject **obj) {

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -660,8 +660,8 @@ npy_new_coercion_cache(
 /**
  * Unlink coercion cache item.
  *
- * @param current
- * @return next coercion cache object (or NULL)
+ * @param current This coercion cache object
+ * @return next Next coercion cache object (or NULL)
  */
 NPY_NO_EXPORT coercion_cache_obj *
 npy_unlink_coercion_cache(coercion_cache_obj *current)
@@ -905,7 +905,7 @@ find_descriptor_from_array(
  * it supports inspecting the elements when the array has object dtype
  * (and the given datatype describes a parametric DType class).
  *
- * @param arr
+ * @param arr The array object.
  * @param dtype NULL or a dtype class
  * @param descr A dtype instance, if the dtype is NULL the dtype class is
  *              found and e.g. "S0" is converted to denote only String.

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -123,15 +123,16 @@ is_contiguous(
  * true, i.e., for cast safety "no-cast". It will not recognize view as an
  * option for other casts (e.g., viewing '>i8' as '>i4' with an offset of 4).
  *
- * @param context
- * @param aligned
- * @param move_references UNUSED.
- * @param strides
- * @param descriptors
- * @param out_loop
- * @param out_transferdata
- * @param flags
- * @return 0 on success -1 on failure.
+ * @param context The arraymethod context
+ * @param aligned Flag indicating data is aligned (1) or not (0)
+ * param move_references UNUSED -- listed below but doxygen doesn't see as a parameter
+ * @param strides Array of step sizes for each dimension of the arrays involved
+ * @param out_loop Output pointer to the function that will perform the strided loop.
+ * @param out_transferdata Output pointer to auxiliary data (if any) 
+ *        needed by the out_loop function.
+ * @param flags Output pointer to additional flags (if any) 
+ *        needed by the out_loop function
+ * @returns 0 on success -1 on failure.
  */
 NPY_NO_EXPORT int
 npy_default_get_strided_loop(
@@ -169,7 +170,7 @@ npy_default_get_strided_loop(
 /**
  * Validate that the input is usable to create a new ArrayMethod.
  *
- * @param spec
+ * @param spec Array method specification to be validated
  * @return 0 on success -1 on error.
  */
 static int

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -188,9 +188,9 @@ _IsWriteable(PyArrayObject *ap)
 /**
  * Convert an array shape to a string such as "(1, 2)".
  *
- * @param Dimensionality of the shape
- * @param npy_intp pointer to shape array
- * @param String to append after the shape `(1, 2)%s`.
+ * @param n Dimensionality of the shape
+ * @param vals npy_intp pointer to shape array
+ * @param ending String to append after the shape `(1, 2)%s`.
  *
  * @return Python unicode string
  */
@@ -299,12 +299,11 @@ end:
 /**
  * unpack tuple of PyDataType_FIELDS(dtype) (descr, offset, title[not-needed])
  *
- * @param "value" should be the tuple.
+ * @param value should be the tuple.
+ * @param descr will be set to the field's dtype
+ * @param offset will be set to the field's offset
  *
- * @return "descr" will be set to the field's dtype
- * @return "offset" will be set to the field's offset
- *
- * returns -1 on failure, 0 on success.
+ * @return -1 on failure, 0 on success.
  */
 NPY_NO_EXPORT int
 _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset)

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -71,13 +71,6 @@ dot_alignment_error(PyArrayObject *a, int i, PyArrayObject *b, int j);
 
 /**
  * unpack tuple of PyDataType_FIELDS(dtype) (descr, offset, title[not-needed])
- *
- * @param "value" should be the tuple.
- *
- * @return "descr" will be set to the field's dtype
- * @return "offset" will be set to the field's offset
- *
- * returns -1 on failure, 0 on success.
  */
 NPY_NO_EXPORT int
 _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset);

--- a/numpy/_core/src/multiarray/common_dtype.c
+++ b/numpy/_core/src/multiarray/common_dtype.c
@@ -106,7 +106,7 @@ PyArray_CommonDType(PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2)
  * default_builtin_common_dtype
  *
  * @param length Number of DTypes
- * @param dtypes List of Dtypes to be reduced
+ * @param dtypes List of DTypes to be reduced
  */
 static PyArray_DTypeMeta *
 reduce_dtypes_to_most_knowledgeable(

--- a/numpy/_core/src/multiarray/common_dtype.c
+++ b/numpy/_core/src/multiarray/common_dtype.c
@@ -106,7 +106,7 @@ PyArray_CommonDType(PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2)
  * default_builtin_common_dtype
  *
  * @param length Number of DTypes
- * @param dtypes
+ * @param dtypes List of Dtypes to be reduced
  */
 static PyArray_DTypeMeta *
 reduce_dtypes_to_most_knowledgeable(

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1123,7 +1123,7 @@ PyArray_IntpFromPyIntConverter(PyObject *o, npy_intp *val)
  * @param  seq      A sequence created using `PySequence_Fast`.
  * @param  vals     Array used to store dimensions (must be large enough to
  *                      hold `maxvals` values).
- * @param  max_vals Maximum number of dimensions that can be written into `vals`.
+ * @param  maxvals  Maximum number of dimensions that can be written into `vals`.
  * @return          Number of dimensions or -1 if an error occurred.
  *
  * .. note::

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -65,8 +65,8 @@ PyArray_GetObjectToGenericCastingImpl(void);
 /**
  * Fetch the casting implementation from one DType to another.
  *
- * @params from
- * @params to
+ * @param from The implementation to cast from
+ * @param to The implementation to cast to
  *
  * @returns A castingimpl (PyArrayDTypeMethod *), None or NULL with an
  *          error set.
@@ -167,8 +167,8 @@ PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 /**
  * Fetch the (bound) casting implementation from one DType to another.
  *
- * @params from
- * @params to
+ * @params from source DType
+ * @params to destination DType
  *
  * @returns A bound casting implementation or None (or NULL for error).
  */
@@ -219,8 +219,8 @@ _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args)
  * extending cast-levels if necessary.
  * It is not valid for one of the arguments to be -1 to indicate an error.
  *
- * @param casting1
- * @param casting2
+ * @param casting1 First (left-hand) casting level to compare
+ * @param casting2 Second (right-hand) casting level to compare
  * @return The minimal casting error (can be -1).
  */
 NPY_NO_EXPORT NPY_CASTING
@@ -409,11 +409,12 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
  * implementations fully to have them available for doing the actual cast
  * later.
  *
- * @param from
+ * @param from The descriptor to cast from 
  * @param to The descriptor to cast to (may be NULL)
  * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
  *        is ignored).
- * @param[out] view_offset
+ * @param view_offset The byte offset, if any, between the original 
+ *        view/type and the view/type that would be cast to.
  * @return NPY_CASTING or -1 on error or if the cast is not possible.
  */
 NPY_NO_EXPORT NPY_CASTING
@@ -458,7 +459,7 @@ PyArray_GetCastInfo(
  * user would have to guess the string length.)
  *
  * @param casting the requested casting safety.
- * @param from
+ * @param from The descriptor to cast from
  * @param to The descriptor to cast to (may be NULL)
  * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
  *        is ignored).
@@ -793,11 +794,11 @@ npy_casting_to_string(NPY_CASTING casting)
 /**
  * Helper function to set a useful error when casting is not possible.
  *
- * @param src_dtype
- * @param dst_dtype
- * @param casting
- * @param scalar Whether this was a "scalar" cast (includes 0-D array with
- *               PyArray_CanCastArrayTo result).
+ * @param src_dtype The source descriptor to cast from
+ * @param dst_dtype The destination type trying to be cast to
+ * @param casting The casting rule that was violated
+ * @param scalar Boolean flag indicating if this was a "scalar" cast (includes 0-D 
+ *               array withPyArray_CanCastArrayTo result).
  */
 NPY_NO_EXPORT void
 npy_set_invalid_cast_error(
@@ -1662,7 +1663,7 @@ PyArray_ResultType(
  * I.e. the given DType could be a string, which then finds the correct
  * string length, given all `descrs`.
  *
- * @param ndescrs number of descriptors to cast and find the common instance.
+ * @param ndescr number of descriptors to cast and find the common instance.
  *        At least one must be passed in.
  * @param descrs The descriptors to work with.
  * @param DType The DType of the desired output descriptor.
@@ -1967,7 +1968,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
  * Private function to add a casting implementation by unwrapping a bound
  * array method.
  *
- * @param meth
+ * @param meth The array method to be unwrapped
  * @return 0 on success -1 on failure.
  */
 NPY_NO_EXPORT int
@@ -2019,7 +2020,7 @@ PyArray_AddCastingImplementation(PyBoundArrayMethodObject *meth)
 /**
  * Add a new casting implementation using a PyArrayMethod_Spec.
  *
- * @param spec
+ * @param spec The specification to use as a source
  * @param private If private, allow slots not publicly exposed.
  * @return 0 on success -1 on failure
  */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -413,8 +413,9 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
  * @param to The descriptor to cast to (may be NULL)
  * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
  *        is ignored).
- * @param view_offset The byte offset, if any, between the original 
- *        view/type and the view/type that would be cast to.
+ * @param view_offset If set, the cast can be described by a view with
+ *        this byte offset.  For example, casting "i8" to "i8,"
+ *        (the structured dtype) can be described with `*view_offset = 0`.
  * @return NPY_CASTING or -1 on error or if the cast is not possible.
  */
 NPY_NO_EXPORT NPY_CASTING
@@ -795,10 +796,9 @@ npy_casting_to_string(NPY_CASTING casting)
  * Helper function to set a useful error when casting is not possible.
  *
  * @param src_dtype The source descriptor to cast from
- * @param dst_dtype The destination type trying to be cast to
+ * @param dst_dtype The destination descriptor trying to cast to
  * @param casting The casting rule that was violated
- * @param scalar Boolean flag indicating if this was a "scalar" cast (includes 0-D 
- *               array withPyArray_CanCastArrayTo result).
+ * @param scalar Boolean flag indicating if this was a "scalar" cast.
  */
 NPY_NO_EXPORT void
 npy_set_invalid_cast_error(

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1416,7 +1416,7 @@ fail:
  * * an object with an __array__ function.
  *
  * @param op The object to convert to an array
- * @param requested_type a requested dtype instance, may be NULL; The result
+ * @param requested_dtype a requested dtype instance, may be NULL; The result
  *                       DType may be used, but is not enforced.
  * @param writeable whether the result must be writeable.
  * @param context Unused parameter, must be NULL (should be removed later).

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1410,7 +1410,7 @@ PyArray_DescrConverter2(PyObject *obj, PyArray_Descr **at)
  *       be removed.
  *
  * @param descr descriptor to be checked
- * @param DType pointer to the Dtype of the descriptor
+ * @param DType pointer to the DType of the descriptor
  * @return 1 if this is not a concrete dtype instance 0 otherwise
  */
 static int
@@ -1444,7 +1444,7 @@ descr_is_legacy_parametric_instance(PyArray_Descr *descr,
  *
  * @param dtype Input descriptor to be converted
  * @param out_descr Output descriptor
- * @param out_DType Dtype of the output descriptor
+ * @param out_DType DType of the output descriptor
  * @return 0 on success -1 on failure
  */
 NPY_NO_EXPORT int

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1409,7 +1409,8 @@ PyArray_DescrConverter2(PyObject *obj, PyArray_Descr **at)
  * TODO: This function should eventually receive a deprecation warning and
  *       be removed.
  *
- * @param descr
+ * @param descr descriptor to be checked
+ * @param DType pointer to the Dtype of the descriptor
  * @return 1 if this is not a concrete dtype instance 0 otherwise
  */
 static int
@@ -1441,9 +1442,9 @@ descr_is_legacy_parametric_instance(PyArray_Descr *descr,
  * both results can be NULL (if the input is).  But it always sets the DType
  * when a descriptor is set.
  *
- * @param dtype
- * @param out_descr
- * @param out_DType
+ * @param dtype Input descriptor to be converted
+ * @param out_descr Output descriptor
+ * @param out_DType Dtype of the output descriptor
  * @return 0 on success -1 on failure
  */
 NPY_NO_EXPORT int
@@ -1470,7 +1471,7 @@ PyArray_ExtractDTypeAndDescriptor(PyArray_Descr *dtype,
  * Converter function filling in an npy_dtype_info struct on success.
  *
  * @param obj representing a dtype instance (descriptor) or DType class.
- * @param[out] npy_dtype_info filled with the DType class and dtype/descriptor
+ * @param[out] dt_info npy_dtype_info filled with the DType class and dtype/descriptor
  *         instance.  The class is always set while the instance may be NULL.
  *         On error, both will be NULL.
  * @return 0 on failure and 1 on success (as a converter)
@@ -1522,7 +1523,7 @@ PyArray_DTypeOrDescrConverterRequired(PyObject *obj, npy_dtype_info *dt_info)
  * NULL anyway).
  *
  * @param obj None or obj representing a dtype instance (descr) or DType class.
- * @param[out] npy_dtype_info filled with the DType class and dtype/descriptor
+ * @param[out] dt_info filled with the DType class and dtype/descriptor
  *         instance.  If `obj` is None, is not modified.  Otherwise the class
  *         is always set while the instance may be NULL.
  *         On error, both will be NULL.

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -374,7 +374,7 @@ dtypemeta_initialize_struct_from_spec(
  * if the Py_TPFLAGS_HEAPTYPE flag is set (they are created from Python).
  * They are not for legacy DTypes or np.dtype itself.
  *
- * @param self
+ * @param dtype_class Pointer to the Python type object
  * @return nonzero if the object is garbage collected
  */
 static inline int

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -818,7 +818,7 @@ get_item_pointer(PyArrayObject *self, char **ptr,
  * @param view Resulting array (new reference)
  * @param indices parsed index information
  * @param index_num number of indices
- * @param ensure_array true if result should have type PArray, 
+ * @param ensure_array true if result should be a base class array, 
  *        false if result should inherit type from self
  *
  * @return 0 on success -1 on failure

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -263,13 +263,13 @@ unpack_indices(PyObject *index, PyObject **result, npy_intp result_n)
  *
  * Checks everything but the bounds.
  *
- * @param the array being indexed
- * @param the index object
- * @param index info struct being filled (size of NPY_MAXDIMS * 2 + 1)
- * @param number of indices found
- * @param dimension of the indexing result
- * @param dimension of the fancy/advanced indices part
- * @param whether to allow the boolean special case
+ * @param self the array being indexed
+ * @param index the index object
+ * @param indices index info struct being filled (size of NPY_MAXDIMS * 2 + 1)
+ * @param num number of indices found
+ * @param ndim dimension of the indexing result
+ * @param out_fancy_ndim dimension of the fancy/advanced indices part
+ * @param allow_boolean whether to allow the boolean special case
  *
  * @returns the index_type or -1 on failure and fills the number of indices.
  */
@@ -782,10 +782,10 @@ index_has_memory_overlap(PyArrayObject *self,
  * The caller must ensure that the index is a full integer
  * one.
  *
- * @param Array being indexed
- * @param result pointer
- * @param parsed index information
- * @param number of indices
+ * @param self Array being indexed
+ * @param ptr result pointer
+ * @param indices parsed index information
+ * @param index_num number of indices
  *
  * @return 0 on success -1 on failure
  */
@@ -814,11 +814,12 @@ get_item_pointer(PyArrayObject *self, char **ptr,
  * Ensure_array allows to fetch a safe subspace view for advanced
  * indexing.
  *
- * @param Array being indexed
- * @param resulting array (new reference)
- * @param parsed index information
- * @param number of indices
- * @param Whether result should inherit the type from self
+ * @param self Array being indexed
+ * @param view Resulting array (new reference)
+ * @param indices parsed index information
+ * @param index_num number of indices
+ * @param ensure_array true if result should have type PArray, 
+ *        false if result should inherit type from self
  *
  * @return 0 on success -1 on failure
  */
@@ -2412,10 +2413,10 @@ PyArray_MapIterNext(PyArrayMapIterObject *mit)
  *    * mit->dimensions: Broadcast dimension of the fancy indices and
  *          the subspace iteration dimension.
  *
- * @param MapIterObject
- * @param The parsed indices object
- * @param Number of indices
- * @param The array that is being iterated
+ * @param mit pointer to the MapIterObject
+ * @param indices The parsed indices object
+ * @param index_num Number of indices
+ * @param arr The array that is being iterated
  *
  * @return 0 on success -1 on failure (broadcasting or too many fancy indices)
  */

--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -154,8 +154,6 @@ create_conv_funcs(
  * @param out_descr The dtype used for allocating a new array.  This is not
  *        used if `data_array` is provided.  Note that the actual dtype of the
  *        returned array can differ for strings.
- * @param num_cols Pointer in which the actual (discovered) number of columns
- *        is returned.  This is only relevant if `homogeneous` is true.
  * @param homogeneous Whether the datatype of the array is not homogeneous,
  *        i.e. not structured.  In this case the number of columns has to be
  *        discovered an the returned array will be 2-dimensional rather than

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -618,8 +618,8 @@ legacy_userdtype_common_dtype_function(
  * used for legacy user-dtypes, but for example numeric to/from datetime
  * casts were only defined that way as well.
  *
- * @param from Source type
- * @param to Destination type
+ * @param from Source DType
+ * @param to Destination DType
  * @param casting If `NPY_NO_CASTING` will check the legacy registered cast,
  *        otherwise uses the provided cast.
  */

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -618,8 +618,8 @@ legacy_userdtype_common_dtype_function(
  * used for legacy user-dtypes, but for example numeric to/from datetime
  * casts were only defined that way as well.
  *
- * @param from
- * @param to
+ * @param from Source type
+ * @param to Destination type
  * @param casting If `NPY_NO_CASTING` will check the legacy registered cast,
  *        otherwise uses the provided cast.
  */

--- a/numpy/_core/src/umath/dispatching.c
+++ b/numpy/_core/src/umath/dispatching.c
@@ -213,7 +213,7 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
  *       both are `(f4, f4, f8)`.  The cache would need to store also which
  *       output was provided by `dtype=`/`signature=`.
  *
- * @param ufunc
+ * @param ufunc The universal function to be resolved
  * @param op_dtypes The DTypes that are either passed in (defined by an
  *        operand) or defined by the `signature` as also passed in as
  *        `fixed_DTypes`.

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4193,7 +4193,7 @@ resolve_descriptors(int nop,
  * None --- array-object passed in don't call PyArray_Return
  * method --- the __array_wrap__ method to call.
  *
- * @param ufunc
+ * @param ufunc The universal function to be wrapped
  * @param full_args Original inputs and outputs
  * @param subok Whether subclasses are allowed
  * @param result_arrays The ufunc result(s).  REFERENCES ARE STOLEN!


### PR DESCRIPTION
Addresses #27377, eliminating all C docstring warning messages.

This is a minimal set of changes, simply eliminating the observed warning messages, with no attempt to improve C docstring content overall, per advice of @mattip.

Reviewers, 
- Some changes were straightforward:
-- The name of the `@param` variable to be documented was missing. I inserted it.
-- The name of the `@param` variable was misspelled. I corrected it.
-- An `@param` line documented a variable that no longer existed or had been split into two. I made the obvious fix.
-- In one case, I removed a docstring from an .h file that simply duplicated the docstring in the corresponding .c file.
- The changes to pay more attention to are those where I had to supply missing Description text. For those, I simply took my best shot and used as few words as I could, figuring the less I wrote, the fewer things would be said incorrectly.

To verify the error messages were being eliminated, I used the same commands as were documented in the original issue but piped the sorted, unique warnings to a file which I diffed against the original list as I worked.
$ CC=clang CXX=clang++ CFLAGS=-Wdocumentation pip install --log PIP.log .
$ grep -- -Wdocumentation PIP.log | sed -E -e 's/^\S+\s+//' | sort -n | uniq > warnings.list

[skip actions] [skip azp] [skip cirrus]