### PR TITLE
BUG: avoid segfault on bad arguments in ndarray.__array_function__

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1120,7 +1120,14 @@ array_function(PyArrayObject *NPY_UNUSED(self), PyObject *c_args, PyObject *c_kw
             &func, &types, &args, &kwargs)) {
         return NULL;
     }
-
+    if (!PyTuple_CheckExact(args)) {
+        PyErr_SetString(PyExc_TypeError, "args must be a tuple.");
+        return NULL;
+    }
+    if (!PyDict_CheckExact(kwargs)) {
+        PyErr_SetString(PyExc_TypeError, "kwargs must be a dict.");
+        return NULL;
+    }
     types = PySequence_Fast(
         types,
         "types argument to ndarray.__array_function__ must be iterable");

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -203,6 +203,14 @@ class TestNDArrayArrayFunction:
             array.__array_function__(func=func, types=(np.ndarray,),
                                      args=(array,), kwargs={})
 
+    def test_wrong_arguments(self):
+        # Check our implementation guards against wrong arguments.
+        a = np.array([1, 2])
+        with pytest.raises(TypeError, match="args must be a tuple"):
+            a.__array_function__(np.reshape, (np.ndarray,), a, (2, 1))
+        with pytest.raises(TypeError, match="kwargs must be a dict"):
+            a.__array_function__(np.reshape, (np.ndarray,), (a,), (2, 1))
+
 
 class TestArrayFunctionDispatch:
 


### PR DESCRIPTION
While looking into fixing #27500, I found that one can quite easily cause a core dump:
```
a = np.arange(3)
a.__array_function__(np.reshape, (np.ndarray,), a, (3, 1))
Segmentation fault (core dumped)
```
This is because the arguments to `__array_function__` were not checked. 

Now they are!