### PR TITLE
MAINT: Pin setuptools for testing [wheel build]

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,8 +1,7 @@
 Cython
 wheel==0.38.1
-#setuptools==65.5.1 ; python_version < '3.12'
-#setuptools         ; python_version >= '3.12'
-setuptools
+setuptools==65.5.1 ; python_version < '3.12'
+setuptools         ; python_version >= '3.12'
 hypothesis==6.104.1
 pytest==7.4.0
 pytz==2023.3.post1


### PR DESCRIPTION
The last three nightlies have failed to upload wheels for Python versions < 3.12 on Windows and Linux.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
