### PR TITLE
TYP: Mark stub-only classes as `@type_check_only`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -8,7 +8,6 @@ import datetime as dt
 import enum
 from abc import abstractmethod
 from types import EllipsisType, TracebackType, MappingProxyType, GenericAlias
-from contextlib import contextmanager
 from decimal import Decimal
 from fractions import Fraction
 from uuid import UUID
@@ -25,7 +24,6 @@ from numpy._typing import (
     _SupportsArray,
     _NestedSequence,
     _FiniteNestedSequence,
-    _SupportsArray,
     _ArrayLikeBool_co,
     _ArrayLikeUInt_co,
     _ArrayLikeInt_co,
@@ -207,6 +205,7 @@ from typing import (
     final,
     ClassVar,
     TypeAlias,
+    type_check_only,
 )
 
 # NOTE: `typing_extensions` is always available in `.pyi` stubs or when
@@ -744,6 +743,7 @@ _AnyStr_contra = TypeVar("_AnyStr_contra", LiteralString, builtins.str, bytes, c
 
 # Protocol for representing file-like-objects accepted
 # by `ndarray.tofile` and `fromfile`
+@type_check_only
 class _IOProtocol(Protocol):
     def flush(self) -> object: ...
     def fileno(self) -> int: ...
@@ -752,6 +752,7 @@ class _IOProtocol(Protocol):
 
 # NOTE: `seek`, `write` and `flush` are technically only required
 # for `readwrite`/`write` modes
+@type_check_only
 class _MemMapIOProtocol(Protocol):
     def flush(self) -> object: ...
     def fileno(self) -> SupportsIndex: ...
@@ -761,19 +762,14 @@ class _MemMapIOProtocol(Protocol):
     @property
     def read(self) -> object: ...
 
+@type_check_only
 class _SupportsWrite(Protocol[_AnyStr_contra]):
     def write(self, s: _AnyStr_contra, /) -> object: ...
-
-def __dir__() -> Sequence[str]: ...
 
 __version__: LiteralString
 __array_api_version__: LiteralString
 test: PytestTester
 
-# TODO: Move placeholders to their respective module once
-# their annotations are properly implemented
-#
-# Placeholders for classes
 
 def show_config() -> None: ...
 
@@ -1390,6 +1386,7 @@ _SortKind: TypeAlias = L[
 ]
 _SortSide: TypeAlias = L["left", "right"]
 
+@type_check_only
 class _ArrayOrScalarCommon:
     @property
     def T(self) -> Self: ...
@@ -1812,13 +1809,16 @@ else:
 
 _ArrayAPIVersion: TypeAlias = L["2021.12", "2022.12", "2023.12"]
 
+@type_check_only
 class _SupportsItem(Protocol[_T_co]):
     def item(self, args: Any, /) -> _T_co: ...
 
+@type_check_only
 class _SupportsReal(Protocol[_T_co]):
     @property
     def real(self) -> _T_co: ...
 
+@type_check_only
 class _SupportsImag(Protocol[_T_co]):
     @property
     def imag(self) -> _T_co: ...
@@ -3376,11 +3376,12 @@ class bool(generic):
 bool_: TypeAlias = bool
 
 _StringType = TypeVar("_StringType", bound=str | bytes)
-_ShapeType = TypeVar("_ShapeType", bound=Any)
+_ShapeType = TypeVar("_ShapeType", bound=_Shape)
 _ObjectType = TypeVar("_ObjectType", bound=object)
 
 # A sequence-like interface like `collections.abc.Sequence`, but without the
 # irrelevant methods.
+@type_check_only
 class _SimpleSequence(Protocol):
     def __len__(self, /) -> int: ...
     def __getitem__(self, index: int, /) -> Any: ...
@@ -3421,6 +3422,7 @@ class object_(generic):
 
 # The `datetime64` constructors requires an object with the three attributes below,
 # and thus supports datetime duck typing
+@type_check_only
 class _DatetimeScalar(Protocol):
     @property
     def day(self) -> int: ...
@@ -4727,6 +4729,7 @@ class matrix(ndarray[_Shape2DType_co, _DType_co]):
     def getH(self) -> matrix[_Shape2D, _DType_co]: ...
 
 
+@type_check_only
 class _SupportsDLPack(Protocol[_T_contra]):
     def __dlpack__(self, *, stream: None | _T_contra = ...) -> _PyCapsule: ...
 

--- a/numpy/_array_api_info.pyi
+++ b/numpy/_array_api_info.pyi
@@ -6,6 +6,7 @@ from typing import (
     TypeVar,
     final,
     overload,
+    type_check_only,
 )
 from typing_extensions import Never
 
@@ -63,38 +64,44 @@ _Permute3: TypeAlias = (
     | tuple[_T3, _T1, _T2] | tuple[_T3, _T2, _T1]
 )
 
+@type_check_only
 class _DTypesBool(TypedDict):
     bool: np.dtype[np.bool]
 
+@type_check_only
 class _DTypesInt(TypedDict):
     int8: np.dtype[np.int8]
     int16: np.dtype[np.int16]
     int32: np.dtype[np.int32]
     int64: np.dtype[np.int64]
 
+@type_check_only
 class _DTypesUInt(TypedDict):
     uint8: np.dtype[np.uint8]
     uint16: np.dtype[np.uint16]
     uint32: np.dtype[np.uint32]
     uint64: np.dtype[np.uint64]
 
-class _DTypesInteger(_DTypesInt, _DTypesUInt):
-    ...
+@type_check_only
+class _DTypesInteger(_DTypesInt, _DTypesUInt): ...
 
+@type_check_only
 class _DTypesFloat(TypedDict):
     float32: np.dtype[np.float32]
     float64: np.dtype[np.float64]
 
+@type_check_only
 class _DTypesComplex(TypedDict):
     complex64: np.dtype[np.complex64]
     complex128: np.dtype[np.complex128]
 
-class _DTypesNumber(_DTypesInteger, _DTypesFloat, _DTypesComplex):
-    ...
+@type_check_only
+class _DTypesNumber(_DTypesInteger, _DTypesFloat, _DTypesComplex): ...
 
-class _DTypes(_DTypesBool, _DTypesNumber):
-    ...
+@type_check_only
+class _DTypes(_DTypesBool, _DTypesNumber): ...
 
+@type_check_only
 class _DTypesUnion(TypedDict, total=False):
     bool: np.dtype[np.bool]
     int8: np.dtype[np.int8]
@@ -111,7 +118,6 @@ class _DTypesUnion(TypedDict, total=False):
     complex128: np.dtype[np.complex128]
 
 _EmptyDict: TypeAlias = dict[Never, Never]
-
 
 @final
 class __array_namespace_info__:

--- a/numpy/_core/_type_aliases.pyi
+++ b/numpy/_core/_type_aliases.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection
-from typing import Any, Final, Literal as L, TypeAlias, TypedDict
+from typing import Any, Final, Literal as L, TypeAlias, TypedDict, type_check_only
 
 import numpy as np
 
@@ -16,6 +16,7 @@ __all__ = (
 sctypeDict: Final[dict[str, type[np.generic]]]
 allTypes: Final[dict[str, type[np.generic]]]
 
+@type_check_only
 class _CNamesDict(TypedDict):
     BOOL: np.dtype[np.bool]
     HALF: np.dtype[np.half]
@@ -58,7 +59,7 @@ _AbstractTypeName: TypeAlias = L[
 ]
 _abstract_type_names: Final[set[_AbstractTypeName]]
 
-
+@type_check_only
 class _AliasesType(TypedDict):
     double: L["float64"]
     cdouble: L["complex128"]
@@ -71,6 +72,7 @@ class _AliasesType(TypedDict):
 
 _aliases: Final[_AliasesType]
 
+@type_check_only
 class _ExtraAliasesType(TypedDict):
     float: L["float64"]
     complex: L["complex128"]
@@ -83,6 +85,7 @@ class _ExtraAliasesType(TypedDict):
 
 _extra_aliases: Final[_ExtraAliasesType]
 
+@type_check_only
 class _SCTypes(TypedDict):
     int: Collection[type[np.signedinteger[Any]]]
     uint: Collection[type[np.unsignedinteger[Any]]]

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,17 +1,19 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict, type_check_only
 
 from numpy import _SupportsWrite
 
 _ErrKind: TypeAlias = Literal["ignore", "warn", "raise", "call", "print", "log"]
 _ErrFunc: TypeAlias = Callable[[str, int], Any]
 
+@type_check_only
 class _ErrDict(TypedDict):
     divide: _ErrKind
     over: _ErrKind
     under: _ErrKind
     invalid: _ErrKind
 
+@type_check_only
 class _ErrDictOptional(TypedDict, total=False):
     all: None | _ErrKind
     divide: None | _ErrKind

--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, TypedDict, SupportsIndex
+from typing import Any, Literal, TypeAlias, TypedDict, SupportsIndex, type_check_only
 
 # Using a private class is by no means ideal, but it is simply a consequence
 # of a `contextlib.context` returning an instance of aforementioned class
@@ -20,6 +20,7 @@ from numpy._typing import NDArray, _CharLike_co, _FloatLike_co
 
 _FloatMode: TypeAlias = Literal["fixed", "unique", "maxprec", "maxprec_equal"]
 
+@type_check_only
 class _FormatDict(TypedDict, total=False):
     bool: Callable[[np.bool], str]
     int: Callable[[integer[Any]], str]
@@ -38,6 +39,7 @@ class _FormatDict(TypedDict, total=False):
     complex_kind: Callable[[complexfloating[Any, Any]], str]
     str_kind: Callable[[_CharLike_co], str]
 
+@type_check_only
 class _FormatOptions(TypedDict):
     precision: int
     threshold: int

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -136,10 +136,12 @@ _RollKind: TypeAlias = L[  # `raise` is deliberately excluded
     "modifiedpreceding",
 ]
 
+@type_check_only
 class _SupportsLenAndGetItem(Protocol[_T_contra, _T_co]):
     def __len__(self) -> int: ...
     def __getitem__(self, key: _T_contra, /) -> _T_co: ...
 
+@type_check_only
 class _SupportsArray(Protocol[_ArrayType_co]):
     def __array__(self, /) -> _ArrayType_co: ...
 

--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -3,6 +3,7 @@ from typing import (
     Any,
     TypeVar,
     TypedDict,
+    type_check_only,
 )
 
 import numpy as np
@@ -43,6 +44,7 @@ from numpy._typing import DTypeLike
 _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
 
+@type_check_only
 class _TypeCodes(TypedDict):
     Character: L['c']
     Integer: L['bhilqnp']

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -8,7 +8,8 @@ from typing import (
     overload,
     Protocol,
     SupportsIndex,
-    Literal
+    Literal,
+    type_check_only
 )
 
 from numpy import (
@@ -38,6 +39,7 @@ _SCT = TypeVar("_SCT", bound=generic)
 
 _RecArray: TypeAlias = recarray[Any, dtype[_SCT]]
 
+@type_check_only
 class _SupportsReadInto(Protocol):
     def seek(self, offset: int, whence: int, /) -> object: ...
     def tell(self, /) -> int: ...

--- a/numpy/_typing/_callable.pyi
+++ b/numpy/_typing/_callable.pyi
@@ -18,6 +18,7 @@ from typing import (
     Any,
     NoReturn,
     Protocol,
+    type_check_only,
 )
 
 import numpy as np
@@ -62,6 +63,7 @@ _NumberType = TypeVar("_NumberType", bound=number[Any])
 _NumberType_co = TypeVar("_NumberType_co", covariant=True, bound=number[Any])
 _GenericType_co = TypeVar("_GenericType_co", covariant=True, bound=generic)
 
+@type_check_only
 class _BoolOp(Protocol[_GenericType_co]):
     @overload
     def __call__(self, other: _BoolLike_co, /) -> _GenericType_co: ...
@@ -74,6 +76,7 @@ class _BoolOp(Protocol[_GenericType_co]):
     @overload
     def __call__(self, other: _NumberType, /) -> _NumberType: ...
 
+@type_check_only
 class _BoolBitOp(Protocol[_GenericType_co]):
     @overload
     def __call__(self, other: _BoolLike_co, /) -> _GenericType_co: ...
@@ -82,6 +85,7 @@ class _BoolBitOp(Protocol[_GenericType_co]):
     @overload
     def __call__(self, other: _IntType, /) -> _IntType: ...
 
+@type_check_only
 class _BoolSub(Protocol):
     # Note that `other: bool` is absent here
     @overload
@@ -95,6 +99,7 @@ class _BoolSub(Protocol):
     @overload
     def __call__(self, other: _NumberType, /) -> _NumberType: ...
 
+@type_check_only
 class _BoolTrueDiv(Protocol):
     @overload
     def __call__(self, other: float | _IntLike_co, /) -> float64: ...
@@ -103,6 +108,7 @@ class _BoolTrueDiv(Protocol):
     @overload
     def __call__(self, other: _NumberType, /) -> _NumberType: ...
 
+@type_check_only
 class _BoolMod(Protocol):
     @overload
     def __call__(self, other: _BoolLike_co, /) -> int8: ...
@@ -115,6 +121,7 @@ class _BoolMod(Protocol):
     @overload
     def __call__(self, other: _FloatType, /) -> _FloatType: ...
 
+@type_check_only
 class _BoolDivMod(Protocol):
     @overload
     def __call__(self, other: _BoolLike_co, /) -> _2Tuple[int8]: ...
@@ -127,6 +134,7 @@ class _BoolDivMod(Protocol):
     @overload
     def __call__(self, other: _FloatType, /) -> _2Tuple[_FloatType]: ...
 
+@type_check_only
 class _TD64Div(Protocol[_NumberType_co]):
     @overload
     def __call__(self, other: timedelta64, /) -> _NumberType_co: ...
@@ -135,6 +143,7 @@ class _TD64Div(Protocol[_NumberType_co]):
     @overload
     def __call__(self, other: _FloatLike_co, /) -> timedelta64: ...
 
+@type_check_only
 class _IntTrueDiv(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> floating[_NBit1]: ...
@@ -151,6 +160,7 @@ class _IntTrueDiv(Protocol[_NBit1]):
         self, other: integer[_NBit2], /
     ) -> floating[_NBit1] | floating[_NBit2]: ...
 
+@type_check_only
 class _UnsignedIntOp(Protocol[_NBit1]):
     # NOTE: `uint64 + signedinteger -> float64`
     @overload
@@ -168,6 +178,7 @@ class _UnsignedIntOp(Protocol[_NBit1]):
         self, other: unsignedinteger[_NBit2], /
     ) -> unsignedinteger[_NBit1] | unsignedinteger[_NBit2]: ...
 
+@type_check_only
 class _UnsignedIntBitOp(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> unsignedinteger[_NBit1]: ...
@@ -180,6 +191,7 @@ class _UnsignedIntBitOp(Protocol[_NBit1]):
         self, other: unsignedinteger[_NBit2], /
     ) -> unsignedinteger[_NBit1] | unsignedinteger[_NBit2]: ...
 
+@type_check_only
 class _UnsignedIntMod(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> unsignedinteger[_NBit1]: ...
@@ -192,6 +204,7 @@ class _UnsignedIntMod(Protocol[_NBit1]):
         self, other: unsignedinteger[_NBit2], /
     ) -> unsignedinteger[_NBit1] | unsignedinteger[_NBit2]: ...
 
+@type_check_only
 class _UnsignedIntDivMod(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> _2Tuple[signedinteger[_NBit1]]: ...
@@ -204,6 +217,7 @@ class _UnsignedIntDivMod(Protocol[_NBit1]):
         self, other: unsignedinteger[_NBit2], /
     ) -> _2Tuple[unsignedinteger[_NBit1]] | _2Tuple[unsignedinteger[_NBit2]]: ...
 
+@type_check_only
 class _SignedIntOp(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> signedinteger[_NBit1]: ...
@@ -220,6 +234,7 @@ class _SignedIntOp(Protocol[_NBit1]):
         self, other: signedinteger[_NBit2], /
     ) -> signedinteger[_NBit1] | signedinteger[_NBit2]: ...
 
+@type_check_only
 class _SignedIntBitOp(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> signedinteger[_NBit1]: ...
@@ -230,6 +245,7 @@ class _SignedIntBitOp(Protocol[_NBit1]):
         self, other: signedinteger[_NBit2], /
     ) -> signedinteger[_NBit1] | signedinteger[_NBit2]: ...
 
+@type_check_only
 class _SignedIntMod(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> signedinteger[_NBit1]: ...
@@ -242,6 +258,7 @@ class _SignedIntMod(Protocol[_NBit1]):
         self, other: signedinteger[_NBit2], /
     ) -> signedinteger[_NBit1] | signedinteger[_NBit2]: ...
 
+@type_check_only
 class _SignedIntDivMod(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> _2Tuple[signedinteger[_NBit1]]: ...
@@ -254,6 +271,7 @@ class _SignedIntDivMod(Protocol[_NBit1]):
         self, other: signedinteger[_NBit2], /
     ) -> _2Tuple[signedinteger[_NBit1]] | _2Tuple[signedinteger[_NBit2]]: ...
 
+@type_check_only
 class _FloatOp(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> floating[_NBit1]: ...
@@ -270,6 +288,7 @@ class _FloatOp(Protocol[_NBit1]):
         self, other: integer[_NBit2] | floating[_NBit2], /
     ) -> floating[_NBit1] | floating[_NBit2]: ...
 
+@type_check_only
 class _FloatMod(Protocol[_NBit1]):
     @overload
     def __call__(self, other: bool, /) -> floating[_NBit1]: ...
@@ -298,26 +317,32 @@ class _FloatDivMod(Protocol[_NBit1]):
         self, other: integer[_NBit2] | floating[_NBit2], /
     ) -> _2Tuple[floating[_NBit1]] | _2Tuple[floating[_NBit2]]: ...
 
+@type_check_only
 class _NumberOp(Protocol):
     def __call__(self, other: _NumberLike_co, /) -> Any: ...
 
 @final
+@type_check_only
 class _SupportsLT(Protocol):
     def __lt__(self, other: Any, /) -> Any: ...
 
 @final
+@type_check_only
 class _SupportsLE(Protocol):
     def __le__(self, other: Any, /) -> Any: ...
 
 @final
+@type_check_only
 class _SupportsGT(Protocol):
     def __gt__(self, other: Any, /) -> Any: ...
 
 @final
+@type_check_only
 class _SupportsGE(Protocol):
     def __ge__(self, other: Any, /) -> Any: ...
 
 @final
+@type_check_only
 class _ComparisonOpLT(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> np.bool: ...
@@ -329,6 +354,7 @@ class _ComparisonOpLT(Protocol[_T1_contra, _T2_contra]):
     def __call__(self, other: _SupportsGT, /) -> np.bool: ...
 
 @final
+@type_check_only
 class _ComparisonOpLE(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> np.bool: ...
@@ -340,6 +366,7 @@ class _ComparisonOpLE(Protocol[_T1_contra, _T2_contra]):
     def __call__(self, other: _SupportsGE, /) -> np.bool: ...
 
 @final
+@type_check_only
 class _ComparisonOpGT(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> np.bool: ...
@@ -351,6 +378,7 @@ class _ComparisonOpGT(Protocol[_T1_contra, _T2_contra]):
     def __call__(self, other: _SupportsLT, /) -> np.bool: ...
 
 @final
+@type_check_only
 class _ComparisonOpGE(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> np.bool: ...

--- a/numpy/_typing/_ufunc.pyi
+++ b/numpy/_typing/_ufunc.pyi
@@ -18,7 +18,6 @@ from typing import (
     Literal,
     SupportsIndex,
     Protocol,
-    NoReturn,
     type_check_only,
 )
 from typing_extensions import LiteralString, Unpack
@@ -52,6 +51,7 @@ _ReturnType_co = TypeVar("_ReturnType_co", covariant=True)
 _ArrayType = TypeVar("_ArrayType", bound=np.ndarray[Any, Any])
 
 
+@type_check_only
 class _SupportsArrayUFunc(Protocol):
     def __array_ufunc__(
         self,
@@ -72,6 +72,7 @@ class _SupportsArrayUFunc(Protocol):
 # NOTE: If 2 output types are returned then `out` must be a
 # 2-tuple of arrays. Otherwise `None` or a plain array are also acceptable
 
+@type_check_only
 class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
@@ -140,7 +141,7 @@ class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
     def reduceat(self, *args, **kwargs) -> NoReturn: ...
     def outer(self, *args, **kwargs) -> NoReturn: ...
 
-
+@type_check_only
 class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
@@ -252,6 +253,7 @@ class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         signature: str | _3Tuple[None | str] = ...,
     ) -> NDArray[Any]: ...
 
+@type_check_only
 class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
@@ -319,6 +321,7 @@ class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
     def reduceat(self, *args, **kwargs) -> NoReturn: ...
     def outer(self, *args, **kwargs) -> NoReturn: ...
 
+@type_check_only
 class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
@@ -373,6 +376,7 @@ class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
     def reduceat(self, *args, **kwargs) -> NoReturn: ...
     def outer(self, *args, **kwargs) -> NoReturn: ...
 
+@type_check_only
 class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType, _Signature]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
@@ -460,7 +464,6 @@ class _PyFunc_Kwargs_Nargs4P(TypedDict, total=False):
     dtype: DTypeLike
     subok: bool
     signature: str | _4PTuple[DTypeLike]
-
 
 @type_check_only
 class _PyFunc_Nin1_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: ignore[misc]

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -1,14 +1,16 @@
 import os
 import subprocess
 from collections.abc import Iterable
-from typing import Literal as L, Any, overload, TypedDict
+from typing import Literal as L, Any, overload, TypedDict, type_check_only
 
 from numpy._pytesttester import PytestTester
 
+@type_check_only
 class _F2PyDictBase(TypedDict):
     csrc: list[str]
     h: list[str]
 
+@type_check_only
 class _F2PyDict(_F2PyDictBase, total=False):
     fsrc: list[str]
     ltx: list[str]

--- a/numpy/lib/_arraypad_impl.pyi
+++ b/numpy/lib/_arraypad_impl.pyi
@@ -5,6 +5,7 @@ from typing import (
     overload,
     TypeVar,
     Protocol,
+    type_check_only,
 )
 
 from numpy import generic
@@ -18,6 +19,7 @@ from numpy._typing import (
 
 _SCT = TypeVar("_SCT", bound=generic)
 
+@type_check_only
 class _ModeFunc(Protocol):
     def __call__(
         self,

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -10,7 +10,8 @@ from typing import (
     Protocol,
     SupportsIndex,
     SupportsInt,
-    TypeGuard
+    TypeGuard,
+    type_check_only
 )
 
 from numpy import (
@@ -61,11 +62,13 @@ _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 _2Tuple: TypeAlias = tuple[_T, _T]
 
+@type_check_only
 class _TrimZerosSequence(Protocol[_T_co]):
     def __len__(self) -> int: ...
     def __getitem__(self, key: slice, /) -> _T_co: ...
     def __iter__(self) -> Iterator[Any]: ...
 
+@type_check_only
 class _SupportsWriteFlush(Protocol):
     def write(self, s: str, /) -> object: ...
     def flush(self) -> object: ...

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -12,6 +12,7 @@ from typing import (
     IO,
     overload,
     Protocol,
+    type_check_only,
 )
 from typing_extensions import deprecated
 
@@ -46,16 +47,20 @@ _SCT = TypeVar("_SCT", bound=generic)
 _CharType_co = TypeVar("_CharType_co", str, bytes, covariant=True)
 _CharType_contra = TypeVar("_CharType_contra", str, bytes, contravariant=True)
 
+@type_check_only
 class _SupportsGetItem(Protocol[_T_contra, _T_co]):
     def __getitem__(self, key: _T_contra, /) -> _T_co: ...
 
+@type_check_only
 class _SupportsRead(Protocol[_CharType_co]):
     def read(self) -> _CharType_co: ...
 
+@type_check_only
 class _SupportsReadSeek(Protocol[_CharType_co]):
     def read(self, n: int, /) -> _CharType_co: ...
     def seek(self, offset: int, whence: int, /) -> object: ...
 
+@type_check_only
 class _SupportsWrite(Protocol[_CharType_contra]):
     def write(self, s: _CharType_contra, /) -> object: ...
 

--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -7,6 +7,7 @@ from typing import (
     Protocol,
     ParamSpec,
     Concatenate,
+    type_check_only,
 )
 
 import numpy as np
@@ -40,6 +41,7 @@ _P = ParamSpec("_P")
 _SCT = TypeVar("_SCT", bound=generic)
 
 # Signature of `__array_wrap__`
+@type_check_only
 class _ArrayWrap(Protocol):
     def __call__(
         self,
@@ -49,6 +51,7 @@ class _ArrayWrap(Protocol):
         /,
     ) -> Any: ...
 
+@type_check_only
 class _SupportsArrayWrap(Protocol):
     @property
     def __array_wrap__(self) -> _ArrayWrap: ...

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -5,6 +5,7 @@ from typing import (
     overload,
     TypeVar,
     Protocol,
+    type_check_only,
 )
 
 import numpy as np
@@ -35,10 +36,12 @@ _SCT = TypeVar("_SCT", bound=generic)
 _NBit1 = TypeVar("_NBit1", bound=NBitBase)
 _NBit2 = TypeVar("_NBit2", bound=NBitBase)
 
+@type_check_only
 class _SupportsReal(Protocol[_T_co]):
     @property
     def real(self) -> _T_co: ...
 
+@type_check_only
 class _SupportsImag(Protocol[_T_co]):
     @property
     def imag(self) -> _T_co: ...

--- a/numpy/lib/_utils_impl.pyi
+++ b/numpy/lib/_utils_impl.pyi
@@ -2,6 +2,7 @@ from typing import (
     Any,
     TypeVar,
     Protocol,
+    type_check_only,
 )
 
 from numpy._core.numerictypes import (
@@ -11,6 +12,7 @@ from numpy._core.numerictypes import (
 _T_contra = TypeVar("_T_contra", contravariant=True)
 
 # A file-like object opened in `w` mode
+@type_check_only
 class _SupportsWrite(Protocol[_T_contra]):
     def write(self, s: _T_contra, /) -> Any: ...
 

--- a/numpy/polynomial/_polytypes.pyi
+++ b/numpy/polynomial/_polytypes.pyi
@@ -7,8 +7,8 @@ from typing import (
     SupportsIndex,
     SupportsInt,
     TypeAlias,
-    final,
     overload,
+    type_check_only,
 )
 
 import numpy as np
@@ -38,6 +38,7 @@ _Self = TypeVar("_Self")
 _SCT = TypeVar("_SCT", bound=np.number[Any] | np.bool | np.object_)
 
 # compatible with e.g. int, float, complex, Decimal, Fraction, and ABCPolyBase
+@type_check_only
 class _SupportsCoefOps(Protocol[_T_contra]):
     def __eq__(self, x: object, /) -> bool: ...
     def __ne__(self, x: object, /) -> bool: ...
@@ -114,13 +115,14 @@ _ArrayLikeCoef_co: TypeAlias = (
 
 _Name_co = TypeVar("_Name_co", bound=LiteralString, covariant=True, default=LiteralString)
 
+@type_check_only
 class _Named(Protocol[_Name_co]):
     @property
     def __name__(self, /) -> _Name_co: ...
 
 _Line: TypeAlias = np.ndarray[tuple[Literal[1, 2]], np.dtype[_SCT]]
 
-@final
+@type_check_only
 class _FuncLine(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, off: _SCT, scl: _SCT) -> _Line[_SCT]: ...
@@ -143,7 +145,7 @@ class _FuncLine(_Named[_Name_co], Protocol[_Name_co]):
         scl: _SupportsCoefOps[Any],
     ) -> _Line[np.object_]: ...
 
-@final
+@type_check_only
 class _FuncFromRoots(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, roots: _SeriesLikeFloat_co) -> _FloatSeries: ...
@@ -152,7 +154,7 @@ class _FuncFromRoots(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, roots: _SeriesLikeCoef_co) -> _ObjectSeries: ...
 
-@final
+@type_check_only
 class _FuncBinOp(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -183,7 +185,7 @@ class _FuncBinOp(_Named[_Name_co], Protocol[_Name_co]):
         c2: _SeriesLikeCoef_co,
     ) -> _ObjectSeries: ...
 
-@final
+@type_check_only
 class _FuncUnOp(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, c: _SeriesLikeFloat_co) -> _FloatSeries: ...
@@ -192,7 +194,7 @@ class _FuncUnOp(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, c: _SeriesLikeCoef_co) -> _ObjectSeries: ...
 
-@final
+@type_check_only
 class _FuncPoly2Ortho(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, pol: _SeriesLikeFloat_co) -> _FloatSeries: ...
@@ -201,7 +203,7 @@ class _FuncPoly2Ortho(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, pol: _SeriesLikeCoef_co) -> _ObjectSeries: ...
 
-@final
+@type_check_only
 class _FuncPow(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -228,7 +230,7 @@ class _FuncPow(_Named[_Name_co], Protocol[_Name_co]):
         maxpower: None | _IntLike_co = ...,
     ) -> _ObjectSeries: ...
 
-@final
+@type_check_only
 class _FuncDer(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -258,7 +260,7 @@ class _FuncDer(_Named[_Name_co], Protocol[_Name_co]):
         axis: SupportsIndex = ...,
     ) -> _ObjectArray: ...
 
-@final
+@type_check_only
 class _FuncInteg(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -294,7 +296,7 @@ class _FuncInteg(_Named[_Name_co], Protocol[_Name_co]):
         axis: SupportsIndex = ...,
     ) -> _ObjectArray: ...
 
-@final
+@type_check_only
 class _FuncValFromRoots(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -345,7 +347,7 @@ class _FuncValFromRoots(_Named[_Name_co], Protocol[_Name_co]):
         tensor: bool = ...,
     ) -> _SupportsCoefOps[Any]: ...
 
-@final
+@type_check_only
 class _FuncVal(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -396,7 +398,7 @@ class _FuncVal(_Named[_Name_co], Protocol[_Name_co]):
         tensor: bool = ...,
     ) -> _SupportsCoefOps[Any]: ...
 
-@final
+@type_check_only
 class _FuncVal2D(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -447,7 +449,7 @@ class _FuncVal2D(_Named[_Name_co], Protocol[_Name_co]):
         c: _SeriesLikeCoef_co,
     ) -> _SupportsCoefOps[Any]: ...
 
-@final
+@type_check_only
 class _FuncVal3D(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -509,7 +511,7 @@ _AnyValF: TypeAlias = Callable[
     _CoefArray,
 ]
 
-@final
+@type_check_only
 class _FuncValND(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -560,7 +562,7 @@ class _FuncValND(_Named[_Name_co], Protocol[_Name_co]):
         *args: _ArrayLikeCoef_co,
     ) -> _ObjectArray: ...
 
-@final
+@type_check_only
 class _FuncVander(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -593,7 +595,7 @@ class _FuncVander(_Named[_Name_co], Protocol[_Name_co]):
 
 _AnyDegrees: TypeAlias = Sequence[SupportsIndex]
 
-@final
+@type_check_only
 class _FuncVander2D(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -628,7 +630,7 @@ class _FuncVander2D(_Named[_Name_co], Protocol[_Name_co]):
         deg: _AnyDegrees,
     ) -> _CoefArray: ...
 
-@final
+@type_check_only
 class _FuncVander3D(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -673,7 +675,7 @@ _AnyFuncVander: TypeAlias = Callable[
     _CoefArray,
 ]
 
-@final
+@type_check_only
 class _FuncVanderND(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -712,7 +714,7 @@ class _FuncVanderND(_Named[_Name_co], Protocol[_Name_co]):
 
 _FullFitResult: TypeAlias = Sequence[np.inexact[Any] | np.int32]
 
-@final
+@type_check_only
 class _FuncFit(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -819,7 +821,7 @@ class _FuncFit(_Named[_Name_co], Protocol[_Name_co]):
         w: None | _SeriesLikeFloat_co = ...,
     ) -> tuple[_ObjectArray, _FullFitResult]: ...
 
-@final
+@type_check_only
 class _FuncRoots(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -839,7 +841,7 @@ class _FuncRoots(_Named[_Name_co], Protocol[_Name_co]):
 
 _Companion: TypeAlias = np.ndarray[tuple[int, int], np.dtype[_SCT]]
 
-@final
+@type_check_only
 class _FuncCompanion(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -856,7 +858,7 @@ class _FuncCompanion(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, c: _SeriesLikeCoef_co) -> _Companion[np.object_]: ...
 
-@final
+@type_check_only
 class _FuncGauss(_Named[_Name_co], Protocol[_Name_co]):
     def __call__(
         self,
@@ -864,7 +866,7 @@ class _FuncGauss(_Named[_Name_co], Protocol[_Name_co]):
         deg: SupportsIndex,
     ) -> _Tuple2[_Series[np.float64]]: ...
 
-@final
+@type_check_only
 class _FuncWeight(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(
@@ -881,6 +883,6 @@ class _FuncWeight(_Named[_Name_co], Protocol[_Name_co]):
     @overload
     def __call__(self, /, c: _ArrayLikeCoef_co) -> _ObjectArray: ...
 
-@final
+@type_check_only
 class _FuncPts(_Named[_Name_co], Protocol[_Name_co]):
     def __call__(self, /, npts: _AnyInt) -> _Series[np.float64]: ...

--- a/numpy/random/_mt19937.pyi
+++ b/numpy/random/_mt19937.pyi
@@ -1,14 +1,16 @@
-from typing import TypedDict
+from typing import TypedDict, type_check_only
 
 from numpy import uint32
 from numpy.typing import NDArray
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 from numpy._typing import _ArrayLikeInt_co
 
+@type_check_only
 class _MT19937Internal(TypedDict):
     key: NDArray[uint32]
     pos: int
 
+@type_check_only
 class _MT19937State(TypedDict):
     bit_generator: str
     state: _MT19937Internal

--- a/numpy/random/_pcg64.pyi
+++ b/numpy/random/_pcg64.pyi
@@ -1,12 +1,14 @@
-from typing import TypedDict
+from typing import TypedDict, type_check_only
 
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 from numpy._typing import _ArrayLikeInt_co
 
+@type_check_only
 class _PCG64Internal(TypedDict):
     state: int
     inc: int
 
+@type_check_only
 class _PCG64State(TypedDict):
     bit_generator: str
     state: _PCG64Internal

--- a/numpy/random/_philox.pyi
+++ b/numpy/random/_philox.pyi
@@ -1,14 +1,16 @@
-from typing import TypedDict
+from typing import TypedDict, type_check_only
 
 from numpy import uint64
 from numpy.typing import NDArray
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 from numpy._typing import _ArrayLikeInt_co
 
+@type_check_only
 class _PhiloxInternal(TypedDict):
     counter: NDArray[uint64]
     key: NDArray[uint64]
 
+@type_check_only
 class _PhiloxState(TypedDict):
     bit_generator: str
     state: _PhiloxInternal

--- a/numpy/random/_sfc64.pyi
+++ b/numpy/random/_sfc64.pyi
@@ -1,12 +1,14 @@
-from typing import TypedDict
+from typing import TypedDict, type_check_only
 
 from numpy import uint64
 from numpy.random.bit_generator import BitGenerator, SeedSequence
 from numpy._typing import NDArray, _ArrayLikeInt_co
 
+@type_check_only
 class _SFC64Internal(TypedDict):
     state: NDArray[uint64]
 
+@type_check_only
 class _SFC64State(TypedDict):
     bit_generator: str
     state: _SFC64Internal

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -9,6 +9,7 @@ from typing import (
     TypeVar,
     overload,
     Literal,
+    type_check_only,
 )
 
 from numpy import dtype, uint32, uint64
@@ -36,12 +37,14 @@ _DTypeLikeUint64: TypeAlias = (
     | _UInt64Codes
 )
 
+@type_check_only
 class _SeedSeqState(TypedDict):
     entropy: None | int | Sequence[int]
     spawn_key: tuple[int, ...]
     pool_size: int
     n_children_spawned: int
 
+@type_check_only
 class _Interface(NamedTuple):
     state_address: Any
     state: Any


### PR DESCRIPTION
for info on `typing.type_check_only` see https://docs.python.org/3/library/typing.html#typing.type_check_only