### PR TITLE
TYP: Annotate type aliases without annotation

### DIFF
--- a/numpy/_core/_asarray.pyi
+++ b/numpy/_core/_asarray.pyi
@@ -1,19 +1,19 @@
 from collections.abc import Iterable
-from typing import Any, TypeVar, overload, Literal
+from typing import Any, TypeAlias, TypeVar, overload, Literal
 
 from numpy._typing import NDArray, DTypeLike, _SupportsArrayFunc
 
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-_Requirements = Literal[
+_Requirements: TypeAlias = Literal[
     "C", "C_CONTIGUOUS", "CONTIGUOUS",
     "F", "F_CONTIGUOUS", "FORTRAN",
     "A", "ALIGNED",
     "W", "WRITEABLE",
     "O", "OWNDATA"
 ]
-_E = Literal["E", "ENSUREARRAY"]
-_RequirementsWithE = _Requirements | _E
+_E: TypeAlias = Literal["E", "ENSUREARRAY"]
+_RequirementsWithE: TypeAlias = _Requirements | _E
 
 @overload
 def require(

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from numpy import _SupportsWrite
 
-_ErrKind = Literal["ignore", "warn", "raise", "call", "print", "log"]
-_ErrFunc = Callable[[str, int], Any]
+_ErrKind: TypeAlias = Literal["ignore", "warn", "raise", "call", "print", "log"]
+_ErrFunc: TypeAlias = Callable[[str, int], Any]
 
 class _ErrDict(TypedDict):
     divide: _ErrKind

--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict, SupportsIndex
+from typing import Any, Literal, TypeAlias, TypedDict, SupportsIndex
 
 # Using a private class is by no means ideal, but it is simply a consequence
 # of a `contextlib.context` returning an instance of aforementioned class
@@ -18,7 +18,7 @@ from numpy import (
 )
 from numpy._typing import NDArray, _CharLike_co, _FloatLike_co
 
-_FloatMode = Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+_FloatMode: TypeAlias = Literal["fixed", "unique", "maxprec", "maxprec_equal"]
 
 class _FormatDict(TypedDict, total=False):
     bool: Callable[[np.bool], str]

--- a/numpy/_core/einsumfunc.pyi
+++ b/numpy/_core/einsumfunc.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import TypeVar, Any, overload, Literal
+from typing import TypeAlias, TypeVar, Any, overload, Literal
 
 import numpy as np
 from numpy import number, _OrderKACF
@@ -25,9 +25,9 @@ _ArrayType = TypeVar(
     bound=NDArray[np.bool | number[Any]],
 )
 
-_OptimizeKind = None | bool | Literal["greedy", "optimal"] | Sequence[Any]
-_CastingSafe = Literal["no", "equiv", "safe", "same_kind"]
-_CastingUnsafe = Literal["unsafe"]
+_OptimizeKind: TypeAlias = bool | Literal["greedy", "optimal"] | Sequence[Any] | None
+_CastingSafe: TypeAlias = Literal["no", "equiv", "safe", "same_kind"]
+_CastingUnsafe: TypeAlias = Literal["unsafe"]
 
 __all__: list[str]
 

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -112,7 +112,7 @@ _1DArray: TypeAlias = ndarray[tuple[_SizeType], dtype[_SCT]]
 _Array: TypeAlias = ndarray[_ShapeType, dtype[_SCT]]
 
 # Valid time units
-_UnitKind = L[
+_UnitKind: TypeAlias = L[
     "Y",
     "M",
     "D",
@@ -126,7 +126,7 @@ _UnitKind = L[
     "fs",
     "as",
 ]
-_RollKind = L[  # `raise` is deliberately excluded
+_RollKind: TypeAlias = L[  # `raise` is deliberately excluded
     "nat",
     "forward",
     "following",
@@ -1164,7 +1164,7 @@ def compare_chararrays(
 
 def add_docstring(obj: Callable[..., Any], docstring: str, /) -> None: ...
 
-_GetItemKeys = L[
+_GetItemKeys: TypeAlias = L[
     "C", "CONTIGUOUS", "C_CONTIGUOUS",
     "F", "FORTRAN", "F_CONTIGUOUS",
     "W", "WRITEABLE",
@@ -1177,7 +1177,7 @@ _GetItemKeys = L[
     "FNC",
     "FORC",
 ]
-_SetItemKeys = L[
+_SetItemKeys: TypeAlias = L[
     "A", "ALIGNED",
     "W", "WRITEABLE",
     "X", "WRITEBACKIFCOPY",

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -2,6 +2,7 @@ from collections.abc import Callable, Sequence
 from typing import (
     Any,
     Final,
+    TypeAlias,
     overload,
     TypeVar,
     Literal as L,
@@ -61,7 +62,7 @@ _ArrayType = TypeVar("_ArrayType", bound=np.ndarray[Any, Any])
 _SizeType = TypeVar("_SizeType", bound=int)
 _ShapeType = TypeVar("_ShapeType", bound=tuple[int, ...])
 
-_CorrelateMode = L["valid", "same", "full"]
+_CorrelateMode: TypeAlias = L["valid", "same", "full"]
 
 __all__: list[str]
 

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -3,6 +3,7 @@ from collections.abc import Sequence, Iterable
 from types import EllipsisType
 from typing import (
     Any,
+    TypeAlias,
     TypeVar,
     overload,
     Protocol,
@@ -35,7 +36,7 @@ from numpy._typing import (
 
 _SCT = TypeVar("_SCT", bound=generic)
 
-_RecArray = recarray[Any, dtype[_SCT]]
+_RecArray: TypeAlias = recarray[Any, dtype[_SCT]]
 
 class _SupportsReadInto(Protocol):
     def seek(self, offset: int, whence: int, /) -> object: ...

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Sequence
 from typing import (
     Literal as L,
     Any,
+    TypeAlias,
     TypeVar,
     Generic,
     overload,
@@ -72,7 +73,7 @@ _DType = TypeVar("_DType", bound=dtype[Any])
 _DTypeOptional = TypeVar("_DTypeOptional", bound=None | dtype[Any])
 _SCT = TypeVar("_SCT", bound=generic)
 
-_FlagsKind = L[
+_FlagsKind: TypeAlias = L[
     'C_CONTIGUOUS', 'CONTIGUOUS', 'C',
     'F_CONTIGUOUS', 'FORTRAN', 'F',
     'ALIGNED', 'A',

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Sequence
-from typing import Literal as L
+from typing import Literal as L, TypeAlias
 
 from numpy import complex128, float64
 from numpy._typing import ArrayLike, NDArray, _ArrayLikeNumber_co
 
-_NormKind = L[None, "backward", "ortho", "forward"]
+_NormKind: TypeAlias = L[None, "backward", "ortho", "forward"]
 
 __all__: list[str]
 

--- a/numpy/lib/_arraypad_impl.pyi
+++ b/numpy/lib/_arraypad_impl.pyi
@@ -1,6 +1,7 @@
 from typing import (
     Literal as L,
     Any,
+    TypeAlias,
     overload,
     TypeVar,
     Protocol,
@@ -27,7 +28,7 @@ class _ModeFunc(Protocol):
         /,
     ) -> None: ...
 
-_ModeKind = L[
+_ModeKind: TypeAlias = L[
     "constant",
     "edge",
     "linear_ramp",

--- a/numpy/lib/_arrayterator_impl.pyi
+++ b/numpy/lib/_arrayterator_impl.pyi
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from types import EllipsisType
 from typing import (
     Any,
+    TypeAlias,
     TypeVar,
     overload,
 )
@@ -14,7 +15,7 @@ _Shape = TypeVar("_Shape", bound=_AnyShape)
 _DType = TypeVar("_DType", bound=dtype[Any])
 _ScalarType = TypeVar("_ScalarType", bound=generic)
 
-_Index = (
+_Index: TypeAlias = (
     EllipsisType
     | int
     | slice

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -4,6 +4,7 @@ from typing import (
     Literal as L,
     Any,
     ParamSpec,
+    TypeAlias,
     TypeVar,
     overload,
     Protocol,
@@ -58,7 +59,7 @@ _Pss = ParamSpec("_Pss")
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-_2Tuple = tuple[_T, _T]
+_2Tuple: TypeAlias = tuple[_T, _T]
 
 class _TrimZerosSequence(Protocol[_T_co]):
     def __len__(self) -> int: ...

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -3,6 +3,7 @@ from typing import (
     Literal as L,
     Any,
     SupportsIndex,
+    TypeAlias,
 )
 
 from numpy._typing import (
@@ -10,7 +11,7 @@ from numpy._typing import (
     ArrayLike,
 )
 
-_BinKind = L[
+_BinKind: TypeAlias = L[
     "stone",
     "auto",
     "doane",

--- a/numpy/lib/_polynomial_impl.pyi
+++ b/numpy/lib/_polynomial_impl.pyi
@@ -1,5 +1,6 @@
 from typing import (
     Literal as L,
+    TypeAlias,
     overload,
     Any,
     SupportsInt,
@@ -35,8 +36,8 @@ from numpy._typing import (
 
 _T = TypeVar("_T")
 
-_2Tup = tuple[_T, _T]
-_5Tup = tuple[
+_2Tup: TypeAlias = tuple[_T, _T]
+_5Tup: TypeAlias = tuple[
     _T,
     NDArray[float64],
     NDArray[int32],

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -43,7 +43,7 @@ _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
 
 # The returned arrays dtype must be compatible with `np.equal`
-_MaskFunc = Callable[
+_MaskFunc: TypeAlias = Callable[
     [NDArray[int_], _T],
     NDArray[number[Any] | np.bool | timedelta64 | datetime64 | object_],
 ]
@@ -178,19 +178,19 @@ _ArrayLike2D: TypeAlias = (
     | Sequence[_ArrayLike1D[_SCT]]
 )
 
-_ArrayLike1DInt_co = (
+_ArrayLike1DInt_co: TypeAlias = (
     _SupportsArray[np.dtype[_Int_co]]
     | Sequence[int | _Int_co]
 )
-_ArrayLike1DFloat_co = (
+_ArrayLike1DFloat_co: TypeAlias = (
     _SupportsArray[np.dtype[_Float_co]]
     | Sequence[float | int | _Float_co]
 )
-_ArrayLike2DFloat_co = (
+_ArrayLike2DFloat_co: TypeAlias = (
     _SupportsArray[np.dtype[_Float_co]]
     | Sequence[_ArrayLike1DFloat_co]
 )
-_ArrayLike1DNumber_co = (
+_ArrayLike1DNumber_co: TypeAlias = (
     _SupportsArray[np.dtype[_Number_co]]
     | Sequence[int | float | complex | _Number_co]
 )

--- a/numpy/polynomial/__init__.pyi
+++ b/numpy/polynomial/__init__.pyi
@@ -6,6 +6,7 @@ from .legendre import Legendre
 from .hermite import Hermite
 from .hermite_e import HermiteE
 from .laguerre import Laguerre
+from . import polynomial, chebyshev, legendre, hermite, hermite_e, laguerre
 
 __all__ = [
     "set_default_printstyle",

--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, overload, TypeVar, Literal
+from typing import Any, TypeAlias, overload, TypeVar, Literal
 
 import numpy as np
 from numpy import (
@@ -47,7 +47,7 @@ from numpy._typing import (
 
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-_DTypeLikeFloat32 = (
+_DTypeLikeFloat32: TypeAlias = (
     dtype[float32]
     | _SupportsDType[dtype[float32]]
     | type[float32]
@@ -55,7 +55,7 @@ _DTypeLikeFloat32 = (
     | _SingleCodes
 )
 
-_DTypeLikeFloat64 = (
+_DTypeLikeFloat64: TypeAlias = (
     dtype[float64]
     | _SupportsDType[dtype[float64]]
     | type[float]

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import (
     Any,
     NamedTuple,
+    TypeAlias,
     TypedDict,
     TypeVar,
     overload,
@@ -22,13 +23,13 @@ from numpy._typing import (
 
 _T = TypeVar("_T")
 
-_DTypeLikeUint32 = (
+_DTypeLikeUint32: TypeAlias = (
     dtype[uint32]
     | _SupportsDType[dtype[uint32]]
     | type[uint32]
     | _UInt32Codes
 )
-_DTypeLikeUint64 = (
+_DTypeLikeUint64: TypeAlias = (
     dtype[uint64]
     | _SupportsDType[dtype[uint64]]
     | type[uint64]

--- a/numpy/random/mtrand.pyi
+++ b/numpy/random/mtrand.pyi
@@ -5,7 +5,6 @@ from typing import Any, overload, Literal
 import numpy as np
 from numpy import (
     dtype,
-    float32,
     float64,
     int8,
     int16,
@@ -26,12 +25,7 @@ from numpy._typing import (
     NDArray,
     _ArrayLikeFloat_co,
     _ArrayLikeInt_co,
-    _DoubleCodes,
     _DTypeLikeBool,
-    _DTypeLikeInt,
-    _DTypeLikeUInt,
-    _Float32Codes,
-    _Float64Codes,
     _Int8Codes,
     _Int16Codes,
     _Int32Codes,
@@ -39,7 +33,6 @@ from numpy._typing import (
     _IntCodes,
     _LongCodes,
     _ShapeLike,
-    _SingleCodes,
     _SupportsDType,
     _UInt8Codes,
     _UInt16Codes,
@@ -49,22 +42,6 @@ from numpy._typing import (
     _ULongCodes,
 )
 
-_DTypeLikeFloat32 = (
-    dtype[float32]
-    | _SupportsDType[dtype[float32]]
-    | type[float32]
-    | _Float32Codes
-    | _SingleCodes
-)
-
-_DTypeLikeFloat64 = (
-    dtype[float64]
-    | _SupportsDType[dtype[float64]]
-    | type[float]
-    | type[float64]
-    | _Float64Codes
-    | _DoubleCodes
-)
 
 class RandomState:
     _bit_generator: BitGenerator

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -13,6 +13,7 @@ from typing import (
     AnyStr,
     ClassVar,
     NoReturn,
+    TypeAlias,
     overload,
     type_check_only,
     TypeVar,
@@ -44,7 +45,7 @@ _FT = TypeVar("_FT", bound=Callable[..., Any])
 
 # Must return a bool or an ndarray/generic type
 # that is supported by `np.logical_and.reduce`
-_ComparisonFunc = Callable[
+_ComparisonFunc: TypeAlias = Callable[
     [NDArray[Any], NDArray[Any]],
     (
         bool
@@ -59,7 +60,7 @@ __all__: list[str]
 class KnownFailureException(Exception): ...
 class IgnoreException(Exception): ...
 
-class clear_and_catch_warnings(warnings.catch_warnings):
+class clear_and_catch_warnings(warnings.catch_warnings[list[warnings.WarningMessage]]):
     class_modules: ClassVar[tuple[types.ModuleType, ...]]
     modules: set[types.ModuleType]
     @overload


### PR DESCRIPTION
This adds `typing.TypeAlias` to type aliases in the stubs that weren't covered in #26858

See also:
- https://docs.astral.sh/ruff/rules/type-alias-without-annotation/ 
- https://typing.readthedocs.io/en/latest/spec/aliases.html#typealias