### PR TITLE
TST: Add tests for np.nonzero with different input types

### DIFF
--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1710,6 +1710,30 @@ class TestNonzero:
             assert_equal(np.nonzero(c)[0],
                          np.concatenate((np.arange(10 + i, 20 + i), [20 + i*2])))
 
+    def test_nonzero_dtypes(self):
+        rng = np.random.default_rng(seed = 10)
+        zero_indices = np.arange(50)
+        sample = ((2**33)*rng.normal(size=100))
+
+        # test for different dtypes
+        types = [bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64]
+        for dtype in types:
+            x = sample.astype(dtype)
+            rng.shuffle(zero_indices)
+            x[zero_indices] = 0
+            idxs = np.nonzero(x)[0]
+            assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
+
+        unsigned_types = [np.uint8, np.uint16, np.uint32, np.uint64]
+        sample = rng.integers(0, 255, size=100)
+        for dtype in unsigned_types:
+            x = sample.astype(dtype)
+            rng.shuffle(zero_indices)
+            x[zero_indices] = 0
+            idxs = np.nonzero(x)[0]
+            assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
+
+
     def test_return_type(self):
         class C(np.ndarray):
             pass

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1713,10 +1713,10 @@ class TestNonzero:
     def test_nonzero_dtypes(self):
         rng = np.random.default_rng(seed = 10)
         zero_indices = np.arange(50)
-        sample = ((2**33)*rng.normal(size=100))
 
         # test for different dtypes
         types = [bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64]
+        sample = ((2**33)*rng.normal(size=100))
         for dtype in types:
             x = sample.astype(dtype)
             rng.shuffle(zero_indices)

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1712,7 +1712,7 @@ class TestNonzero:
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
     def test_nonzero_float_dtypes(self, dtype):
-        rng = np.random.default_rng(seed = 10)
+        rng = np.random.default_rng(seed=10)
         x = ((2**33)*rng.normal(size=100)).astype(dtype)
         x[rng.choice(50, size=100)] = 0
         idxs = np.nonzero(x)[0]
@@ -1721,12 +1721,11 @@ class TestNonzero:
     @pytest.mark.parametrize('dtype', [bool, np.int8, np.int16, np.int32, np.int64,
                                        np.uint8, np.uint16, np.uint32, np.uint64])
     def test_nonzero_integer_dtypes(self, dtype):
-        rng = np.random.default_rng(seed = 10)
+        rng = np.random.default_rng(seed=10)
         x = rng.integers(0, 255, size=100).astype(dtype)
         x[rng.choice(50, size=100)] = 0
         idxs = np.nonzero(x)[0]
         assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
-
 
     def test_return_type(self):
         class C(np.ndarray):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1710,29 +1710,22 @@ class TestNonzero:
             assert_equal(np.nonzero(c)[0],
                          np.concatenate((np.arange(10 + i, 20 + i), [20 + i*2])))
 
-    def test_nonzero_dtypes(self):
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_nonzero_float_dtypes(self, dtype):
         rng = np.random.default_rng(seed = 10)
-        zero_indices = np.arange(50)
+        x = ((2**33)*rng.normal(size=100)).astype(dtype)
+        x[rng.choice(50, size=100)] = 0
+        idxs = np.nonzero(x)[0]
+        assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
 
-        # test for different dtypes
-        types = [bool, np.float32, np.float64]
-        sample = ((2**33)*rng.normal(size=100))
-        for dtype in types:
-            x = sample.astype(dtype)
-            rng.shuffle(zero_indices)
-            x[zero_indices] = 0
-            idxs = np.nonzero(x)[0]
-            assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
-
-        integer_types = [np.int8, np.int16, np.int32, np.int64,
-                         np.uint8, np.uint16, np.uint32, np.uint64]
-        sample = rng.integers(0, 255, size=100)
-        for dtype in integer_types:
-            x = sample.astype(dtype)
-            rng.shuffle(zero_indices)
-            x[zero_indices] = 0
-            idxs = np.nonzero(x)[0]
-            assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
+    @pytest.mark.parametrize('dtype', [bool, np.int8, np.int16, np.int32, np.int64,
+                                       np.uint8, np.uint16, np.uint32, np.uint64])
+    def test_nonzero_integer_dtypes(self, dtype):
+        rng = np.random.default_rng(seed = 10)
+        x = rng.integers(0, 255, size=100).astype(dtype)
+        x[rng.choice(50, size=100)] = 0
+        idxs = np.nonzero(x)[0]
+        assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
 
 
     def test_return_type(self):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1715,7 +1715,7 @@ class TestNonzero:
         zero_indices = np.arange(50)
 
         # test for different dtypes
-        types = [bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64]
+        types = [bool, np.float32, np.float64]
         sample = ((2**33)*rng.normal(size=100))
         for dtype in types:
             x = sample.astype(dtype)
@@ -1724,9 +1724,9 @@ class TestNonzero:
             idxs = np.nonzero(x)[0]
             assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
 
-        unsigned_types = [np.uint8, np.uint16, np.uint32, np.uint64]
+        integer_types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]
         sample = rng.integers(0, 255, size=100)
-        for dtype in unsigned_types:
+        for dtype in integer_types:
             x = sample.astype(dtype)
             rng.shuffle(zero_indices)
             x[zero_indices] = 0

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1724,7 +1724,8 @@ class TestNonzero:
             idxs = np.nonzero(x)[0]
             assert_equal(np.array_equal(np.where(x != 0)[0], idxs), True)
 
-        integer_types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64]
+        integer_types = [np.int8, np.int16, np.int32, np.int64,
+                         np.uint8, np.uint16, np.uint32, np.uint64]
         sample = rng.integers(0, 255, size=100)
         for dtype in integer_types:
             x = sample.astype(dtype)


### PR DESCRIPTION
Add tests for `np.nonzero` for different input types. PR based on work from @touqir14 in #18368.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
