### PR TITLE
DEV: bump ``python`` to 3.12 in environment.yml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ name: numpy-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.11 #need to pin to avoid issues with builds
+  - python=3.12  # need to pin to avoid issues with builds
   - cython>=3.0
   - compilers
   - openblas


### PR DESCRIPTION
As discussed in https://github.com/numpy/numpy/pull/27550#issuecomment-2412201324. This avoid some issues with a flaky test, and it's anyway a useful bump.

Tested locally on macOS arm64, and on my fork for the macOS x86-64 CI job [here](https://github.com/rgommers/numpy/actions/runs/11341229516/job/31539111004). Both passed. No other CI jobs use `environment.yml`, so skipping CI here.