### PR TITLE
DOC: Clarify use of standard deviation in mtrand.pyx

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1258,7 +1258,7 @@ cdef class Generator:
         >>> rng = np.random.default_rng()
         >>> s = rng.normal(mu, sigma, 1000)
 
-        Verify the mean and the variance:
+        Verify the mean and the standard deviation:
 
         >>> abs(mu - np.mean(s))
         0.0  # may vary

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1547,7 +1547,7 @@ cdef class RandomState:
         >>> mu, sigma = 0, 0.1 # mean and standard deviation
         >>> s = np.random.normal(mu, sigma, 1000)
 
-        Verify the mean and the variance:
+        Verify the mean and the standard deviation:
 
         >>> abs(mu - np.mean(s))
         0.0  # may vary


### PR DESCRIPTION
Previous texts mistakenly referred to the value as variance. Updated them to correctly reflect that standard deviation is being used. Removes confusion.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
