### PR TITLE
BUG: Fix warning "differs in levels of indirection" in npy_atomic.h with MSVC

### DIFF
--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -55,7 +55,7 @@ npy_atomic_load_ptr(const void *obj) {
 #if defined(_M_X64) || defined(_M_IX86)
     return (void *)*(volatile uint64_t *)obj;
 #elif defined(_M_ARM64)
-    return (void *)(uintptr_t)__ldar64((unsigned __int64 volatile *)obj);
+    return (void *)__ldar64((unsigned __int64 volatile *)obj);
 #endif
 #else
 #if defined(_M_X64) || defined(_M_IX86)

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -59,7 +59,7 @@ npy_atomic_load_ptr(const void *obj) {
 #endif
 #else
 #if defined(_M_X64) || defined(_M_IX86)
-    return (void *)(uintptr_t)*(volatile uint32_t *)obj;
+    return (void *)(volatile uint32_t *)obj;
 #elif defined(_M_ARM64)
     return (void *)(uintptr_t)__ldar32((unsigned __int32 volatile *)obj);
 #endif

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -37,7 +37,7 @@ npy_atomic_load_uint8(const npy_uint8 *obj) {
     return (npy_uint8)atomic_load((const _Atomic(uint8_t)*)obj);
 #elif defined(MSC_ATOMICS)
 #if defined(_M_X64) || defined(_M_IX86)
-    return (void *)(uintptr_t)*(volatile uint64_t *)obj;
+    return *(volatile npy_uint8 *)obj;
 #else // defined(_M_ARM64)
     return (npy_uint8)__ldar8((unsigned __int8 volatile *)obj);
 #endif
@@ -53,7 +53,7 @@ npy_atomic_load_ptr(const void *obj) {
 #elif defined(MSC_ATOMICS)
 #if SIZEOF_VOID_P == 8
 #if defined(_M_X64) || defined(_M_IX86)
-    return *(volatile uint64_t *)obj;
+    return (void *)(uintptr_t)*(volatile uint64_t *)obj;
 #elif defined(_M_ARM64)
     return (uint64_t)__ldar64((unsigned __int64 volatile *)obj);
 #endif

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -37,7 +37,7 @@ npy_atomic_load_uint8(const npy_uint8 *obj) {
     return (npy_uint8)atomic_load((const _Atomic(uint8_t)*)obj);
 #elif defined(MSC_ATOMICS)
 #if defined(_M_X64) || defined(_M_IX86)
-    return *(volatile npy_uint8 *)obj;
+    return (void *)(uintptr_t)*(volatile uint64_t *)obj;
 #else // defined(_M_ARM64)
     return (npy_uint8)__ldar8((unsigned __int8 volatile *)obj);
 #endif

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -53,7 +53,7 @@ npy_atomic_load_ptr(const void *obj) {
 #elif defined(MSC_ATOMICS)
 #if SIZEOF_VOID_P == 8
 #if defined(_M_X64) || defined(_M_IX86)
-    return (void *)(uintptr_t)*(volatile uint64_t *)obj;
+    return (void *)*(volatile uint64_t *)obj;
 #elif defined(_M_ARM64)
     return (void *)(uintptr_t)__ldar64((unsigned __int64 volatile *)obj);
 #endif

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -55,13 +55,13 @@ npy_atomic_load_ptr(const void *obj) {
 #if defined(_M_X64) || defined(_M_IX86)
     return (void *)(uintptr_t)*(volatile uint64_t *)obj;
 #elif defined(_M_ARM64)
-    return (uint64_t)__ldar64((unsigned __int64 volatile *)obj);
+    return (void *)(uintptr_t)__ldar64((unsigned __int64 volatile *)obj);
 #endif
 #else
 #if defined(_M_X64) || defined(_M_IX86)
-    return *(volatile uint32_t *)obj;
+    return (void *)(uintptr_t)*(volatile uint32_t *)obj;
 #elif defined(_M_ARM64)
-    return (uint32_t)__ldar32((unsigned __int32 volatile *)obj);
+    return (void *)(uintptr_t)__ldar32((unsigned __int32 volatile *)obj);
 #endif
 #endif
 #elif defined(GCC_ATOMICS)

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -59,7 +59,7 @@ npy_atomic_load_ptr(const void *obj) {
 #endif
 #else
 #if defined(_M_X64) || defined(_M_IX86)
-    return (void *)(volatile uint32_t *)obj;
+    return (void *)*(volatile uint32_t *)obj;
 #elif defined(_M_ARM64)
     return (void *)__ldar32((unsigned __int32 volatile *)obj);
 #endif

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -61,7 +61,7 @@ npy_atomic_load_ptr(const void *obj) {
 #if defined(_M_X64) || defined(_M_IX86)
     return (void *)(volatile uint32_t *)obj;
 #elif defined(_M_ARM64)
-    return (void *)(uintptr_t)__ldar32((unsigned __int32 volatile *)obj);
+    return (void *)__ldar32((unsigned __int32 volatile *)obj);
 #endif
 #endif
 #elif defined(GCC_ATOMICS)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->This pr is to fix #27547 

Fixed a warning in MSVC (C4047) that occurs due to a mismatch in levels of 
indirection between 'void *' and 'volatile uint64_t'. The issue arises in the 
MSC_ATOMICS section where a return statement in npy_atomic.h attempts to 
return a uint64_t value, but the function expects a void pointer.

The fix involves casting the uint64_t result back to a void pointer using 
(uintptr_t) to ensure compatibility and eliminate the warning.

Tested on MSVC 19.29 with numpy 2.1.2 to verify that the warning no longer 
appears during compilation.