### PR TITLE
MAINT: distutils: remove obsolete search for `ecc` executable

### DIFF
--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -37,12 +37,7 @@ class IntelCCompiler(UnixCCompiler):
 
 class IntelItaniumCCompiler(IntelCCompiler):
     compiler_type = 'intele'
-
-    # On Itanium, the Intel Compiler used to be called ecc, let's search for
-    # it (now it's also icc, so ecc is last in the search).
-    for cc_exe in map(find_executable, ['icc', 'ecc']):
-        if cc_exe:
-            break
+    cc_exe = 'icc'
 
 
 class IntelEM64TCCompiler(UnixCCompiler):


### PR DESCRIPTION
This is a very old name for the `icc` executable. The problem that triggered this change is that the `find_executable` calls to determine if the name is `icc` or `ecc` was done at import time, and after an unrelated change in Meson (related to `icc` though) started printing `log.warn` output from within `find_executable` to report that the icc/ecc executables weren't found. That looked like:
```
  WARN: Could not locate executable icc
  WARN: Could not locate executable ecc
```
That in turn seemed to (but didn't actually) affect an import test (`test_api_importable` in `numpy/tests/test_public_api.py`).

Finally, the `ecc` name may simply be wrong, for example this is a compiler-like thing and the first hit when you search for `ecc` compiler: https://github.com/santerijps/ecc

Long story short: this removes some obsolete code which can yield potentially confusing stdout output.