### PR TITLE
CI: start building Windows free-threaded wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,10 +94,6 @@ jobs:
             python: "pp310"
           - buildplat: [ macos-14, macosx_arm64, accelerate ]
             python: "pp310"
-          - buildplat: [ windows-2019, win_amd64, "" ]
-            python: "cp313t"
-          - buildplat: [ windows-2019, win32, "" ]
-            python: "cp313t"
           - buildplat: [ macos13, macosx_x86_64, openblas ]
             python: "cp313t"
 
@@ -162,6 +158,7 @@ jobs:
 
       - name: Set up free-threaded build
         if: matrix.python == 'cp313t'
+        shell: bash -el {0}
         run: |
           echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Builds on top of gh-27550 to actually build the free-threaded wheels for Windows (both 64-bit and 32-bit). Should be back-portable for 2.1.3.

Closes gh-27527.

~(marked draft until gh-27550 is merged)~