### PR TITLE
BUILD: satisfy gcc-13 pendantic errors

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -274,10 +274,8 @@ PyDataMem_RENEW(void *ptr, size_t size)
     void *result;
 
     assert(size != 0);
+    PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     result = realloc(ptr, size);
-    if (result != ptr) {
-        PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
-    }
     PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
     return result;
 }

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -1354,7 +1354,7 @@ static PyObject *
      */
     PyObject *ret;
     npy_float64 arg1, arg2, other_val;
-    @type@ other_val_conv;
+    @type@ other_val_conv = 0;
 
     int is_forward;
     if (Py_TYPE(a) == &Py@Name@ArrType_Type) {


### PR DESCRIPTION
Fixes #27548 pragmatically, without diving into whether the compiler is correct or not. The changes should be harmless.