### PR TITLE
BUG: handle possible error for PyTraceMallocTrack

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4099,8 +4099,8 @@ Memory management
 
 .. c:function:: char* PyDataMem_RENEW(void * ptr, size_t newbytes)
 
-    Macros to allocate, free, and reallocate memory. These macros are used
-    internally to create arrays.
+    Functions to allocate, free, and reallocate memory. These are used
+    internally to manage array data memory unless overridden.
 
 .. c:function:: npy_intp*  PyDimMem_NEW(int nd)
 

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -238,7 +238,11 @@ PyDataMem_NEW(size_t size)
 
     assert(size != 0);
     result = malloc(size);
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    if (ret == -1) {
+        free(result);
+        return NULL;
+    }
     return result;
 }
 
@@ -251,7 +255,11 @@ PyDataMem_NEW_ZEROED(size_t nmemb, size_t size)
     void *result;
 
     result = calloc(nmemb, size);
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, nmemb * size);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, nmemb * size);
+    if (ret == -1) {
+        free(result);
+        return NULL;
+    }
     return result;
 }
 
@@ -276,7 +284,11 @@ PyDataMem_RENEW(void *ptr, size_t size)
     assert(size != 0);
     PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     result = realloc(ptr, size);
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    if (ret == -1) {
+        free(result);
+        return NULL;
+    }
     return result;
 }
 
@@ -360,7 +372,11 @@ PyDataMem_UserNEW(size_t size, PyObject *mem_handler)
     }
     assert(size != 0);
     result = handler->allocator.malloc(handler->allocator.ctx, size);
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    if (ret == -1) {
+        handler->allocator.free(handler->allocator.ctx, result, size);
+        return NULL;
+    }
     return result;
 }
 
@@ -374,7 +390,11 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler)
         return NULL;
     }
     result = handler->allocator.calloc(handler->allocator.ctx, nmemb, size);
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, nmemb * size);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, nmemb * size);
+    if (ret == -1) {
+        handler->allocator.free(handler->allocator.ctx, result, size);
+        return NULL;
+    }
     return result;
 }
 
@@ -404,11 +424,13 @@ PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler)
     }
 
     assert(size != 0);
+    int ret = PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
     result = handler->allocator.realloc(handler->allocator.ctx, ptr, size);
-    if (result != ptr) {
-        PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
+    int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    if (ret == -1) {
+        handler->allocator.free(handler->allocator.ctx, result, size);
+        return NULL;
     }
-    PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
     return result;
 }
 

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -424,7 +424,7 @@ PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler)
     }
 
     assert(size != 0);
-    int ret = PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
+    PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     result = handler->allocator.realloc(handler->allocator.ctx, ptr, size);
     int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
     if (ret == -1) {


### PR DESCRIPTION
Backport of #27567.

Follow up to #27566 where @charris noted the PyTraceMalloc_Track call can fail with -1 if there is no memory to allocate tracking information. There was also a missing `Untrack` call in the memory handler `realloc` routine.

I touched up the documentation around the API functions `PyDataMem_*` which still called them macros, but they are now functions.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
