### PR TITLE
DOC: Fix some out-of-data struct in c-api types-and-structures

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -30,6 +30,57 @@ and its sub-types).
 
     The number of dimensions in the array.
 
+.. c:function:: void *PyArray_DATA(PyArrayObject *arr)
+
+    The pointer to the first element of the array.
+
+.. c:function:: char *PyArray_BYTES(PyArrayObject *arr)
+
+    These two macros are similar and obtain the pointer to the
+    data-buffer for the array. The first macro can (and should be)
+    assigned to a particular pointer where the second is for generic
+    processing. If you have not guaranteed a contiguous and/or aligned
+    array then be sure you understand how to access the data in the
+    array to avoid memory and/or alignment problems.
+
+.. c:function:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
+
+    Returns a pointer to the dimensions/shape of the array. The
+    number of elements matches the number of dimensions
+    of the array. Can return ``NULL`` for 0-dimensional arrays.
+
+.. c:function:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
+
+    Returns a pointer to the strides of the array. The
+    number of elements matches the number of dimensions
+    of the array.
+
+.. c:function:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
+
+    Return the shape in the *n* :math:`^{\textrm{th}}` dimension.
+
+.. c:function:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
+
+    Return the stride in the *n* :math:`^{\textrm{th}}` dimension.
+
+.. c:function:: PyObject *PyArray_BASE(PyArrayObject* arr)
+
+    This returns the base object of the array. In most cases, this
+    means the object which owns the memory the array is pointing at.
+
+    If you are constructing an array using the C API, and specifying
+    your own memory, you should use the function :c:func:`PyArray_SetBaseObject`
+    to set the base to an object which owns the memory.
+
+    If the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag is set, it has a different
+    meaning, namely base is the array into which the current array will
+    be copied upon copy resolution. This overloading of the base property
+    for two functions is likely to change in a future version of NumPy.
+
+.. c:function:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
+
+    Returns a borrowed reference to the dtype property of the array.
+
 .. c:function:: int PyArray_FLAGS(PyArrayObject* arr)
 
     Returns an integer representing the :ref:`array-flags<array-flags>`.
@@ -37,6 +88,32 @@ and its sub-types).
 .. c:function:: int PyArray_TYPE(PyArrayObject* arr)
 
     Return the (builtin) typenumber for the elements of this array.
+
+.. c:function:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
+
+    A synonym for PyArray_DESCR, named to be consistent with the
+    'dtype' usage within Python.
+
+.. c:function:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
+
+    A synonym for :c:func:`PyArray_DIMS`, named to be consistent with the
+    `shape <numpy.ndarray.shape>` usage within Python.
+
+.. c:function:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
+
+    Enables the specified array flags. This function does no validation,
+    and assumes that you know what you're doing.
+
+.. c:function:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
+
+    Clears the specified array flags. This function does no validation,
+    and assumes that you know what you're doing.
+
+.. c:function:: int PyArray_HANDLER(PyArrayObject *arr)
+
+    .. versionadded:: 1.22
+
+    Returns the memory handler associated with the given array.
 
 .. c:function:: int PyArray_Pack(  \
         const PyArray_Descr *descr, void *item, const PyObject *value)
@@ -64,52 +141,6 @@ and its sub-types).
         handling arbitrary Python objects.  Setitem is for example not able
         to handle arbitrary casts between different dtypes.
 
-.. c:function:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
-
-    Enables the specified array flags. This function does no validation,
-    and assumes that you know what you're doing.
-
-.. c:function:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
-
-    Clears the specified array flags. This function does no validation,
-    and assumes that you know what you're doing.
-
-.. c:function:: void *PyArray_DATA(PyArrayObject *arr)
-
-.. c:function:: char *PyArray_BYTES(PyArrayObject *arr)
-
-    These two macros are similar and obtain the pointer to the
-    data-buffer for the array. The first macro can (and should be)
-    assigned to a particular pointer where the second is for generic
-    processing. If you have not guaranteed a contiguous and/or aligned
-    array then be sure you understand how to access the data in the
-    array to avoid memory and/or alignment problems.
-
-.. c:function:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
-
-    Returns a pointer to the dimensions/shape of the array. The
-    number of elements matches the number of dimensions
-    of the array. Can return ``NULL`` for 0-dimensional arrays.
-
-.. c:function:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
-
-    A synonym for :c:func:`PyArray_DIMS`, named to be consistent with the
-    `shape <numpy.ndarray.shape>` usage within Python.
-
-.. c:function:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
-
-    Returns a pointer to the strides of the array. The
-    number of elements matches the number of dimensions
-    of the array.
-
-.. c:function:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
-
-    Return the shape in the *n* :math:`^{\textrm{th}}` dimension.
-
-.. c:function:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
-
-    Return the stride in the *n* :math:`^{\textrm{th}}` dimension.
-
 .. c:function:: npy_intp PyArray_ITEMSIZE(PyArrayObject* arr)
 
     Return the itemsize for the elements of this array.
@@ -130,29 +161,6 @@ and its sub-types).
 .. c:function:: npy_intp PyArray_NBYTES(PyArrayObject* arr)
 
     Returns the total number of bytes consumed by the array.
-
-.. c:function:: PyObject *PyArray_BASE(PyArrayObject* arr)
-
-    This returns the base object of the array. In most cases, this
-    means the object which owns the memory the array is pointing at.
-
-    If you are constructing an array using the C API, and specifying
-    your own memory, you should use the function :c:func:`PyArray_SetBaseObject`
-    to set the base to an object which owns the memory.
-
-    If the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag is set, it has a different
-    meaning, namely base is the array into which the current array will
-    be copied upon copy resolution. This overloading of the base property
-    for two functions is likely to change in a future version of NumPy.
-
-.. c:function:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
-
-    Returns a borrowed reference to the dtype property of the array.
-
-.. c:function:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
-
-    A synonym for PyArray_DESCR, named to be consistent with the
-    'dtype' usage within Python.
 
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -421,6 +421,11 @@ to the front of the integer name.
 
     The C ``size_t``/``Py_size_t``.
 
+.. c:type:: npy_hash_t
+
+   The C ``Py_hash_t`` (a signed integer type used for hashing).
+   This type is utilized in NumPy to represent hash values for objects.
+
 
 (Complex) Floating point
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
DOC: Rewrite some out-of-data struct in [this page](https://numpy.org/devdocs/reference/c-api/types-and-structures.html)
#### Description:

This Pull Request updates and improves the C-API documentation to better reflect the current code and implementation. Key changes include restructuring and adding missing documentation, as well as correcting discrepancies between the documentation and the actual code. Specifically, the following changes were made:

## 1. Modifications to `PyArrayObject` and `PyArrayObject_fields`:
 - Moved the members of `PyArrayObject` to `PyArrayObject_fields` to align with the current structure in the code.
 - Added documentation for the new members: `mem_handler` and `_buffer_info`.

## 2. Added `PyArray_HANDLER`:
 - Documented the `PyArray_HANDLER` macro in [this page](https://numpy.org/devdocs/reference/c-api/array.html).
 - Reordered the function listings to match the order in the code.

## 3. Changes to PyArray_Descr:
 - Replaced `NpyAuxData *c_metadata;` with `PyObject *metadata;` to reflect the current definition.
 - Moved the documentation for `npy_hash_t` to [this page](https://numpy.org/devdocs/reference/c-api/dtype.html#un-signed-integer) for better clarity.

## 4. Adjustments to `PyArray_ArrFuncs` and `PyUFuncObject`:
 - Updated the member descriptions in both `PyArray_ArrFuncs` and `PyUFuncObject` to match the current code structure.