### PR TITLE
CI: Add Mac and update Linux free-threaded CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,15 +55,23 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
         fetch-tags: true
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
-      with:
-        python-version: ${{ matrix.version }}
+    - uses: astral-sh/setup-uv@v3
+    - run: |
+        uv python install ${{ matrix.version }}
+        uv venv --python ${{ matrix.version }}
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      if: ${{ matrix.version == '3.13t' }}
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions
 
   pypy:
@@ -291,23 +299,3 @@ jobs:
         rm -rf build-install
         ./vendored-meson/meson/meson.py install -C build --destdir ../build-install --tags=runtime,python-runtime,devel
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy') --no-tests
-
-  free-threaded:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-    # TODO: replace with setup-python when there is support
-    - uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
-      with:
-          python-version: '3.13-dev'
-          nogil: true
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-    - uses: ./.github/meson_actions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,23 +55,15 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
+        version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
         fetch-tags: true
-    - uses: astral-sh/setup-uv@v3
-    - run: |
-        uv python install ${{ matrix.version }}
-        uv venv --python ${{ matrix.version }}
-        . .venv/bin/activate
-        echo PATH=$PATH >> $GITHUB_ENV
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      if: ${{ matrix.version == '3.13t' }}
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      with:
+        python-version: ${{ matrix.version }}
     - uses: ./.github/meson_actions
 
   pypy:
@@ -299,3 +291,24 @@ jobs:
         rm -rf build-install
         ./vendored-meson/meson/meson.py install -C build --destdir ../build-install --tags=runtime,python-runtime,devel
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy') --no-tests
+
+  free-threaded:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push'
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+    - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d
+    - run: |
+        uv python install 3.13t
+        uv venv --python 3.13t
+        uv pip install pip
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+    - uses: ./.github/meson_actions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -293,6 +293,7 @@ jobs:
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy') --no-tests
 
   free-threaded:
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -165,10 +165,11 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d
     - run: |
         uv python install 3.13t
         uv venv --python 3.13t
+        uv pip install pip
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
     # TODO: remove cython nightly install when cython does a release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,6 +104,7 @@ jobs:
 
   accelerate:
     name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
+    # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
@@ -146,3 +147,37 @@ jobs:
 
     - name: Test (fast tests)
       run: spin test -j2
+
+  free-threaded:
+    name: MacOS Free-threaded - ${{ matrix.build_runner[1] }}
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
+    runs-on: ${{ matrix.build_runner[0] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_runner:
+          - [ macos-13, "macos_x86_64" ]
+          - [ macos-14, "macos_arm64" ]
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+    - uses: astral-sh/setup-uv@v3
+    - run: |
+        uv python install 3.13t
+        uv venv --python 3.13t
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+    - name: Install dependencies
+      run: |
+        pip install -r requirements/build_requirements.txt
+        pip install pytest pytest-xdist hypothesis
+    - name: Build and test
+      run: spin test

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -106,7 +106,10 @@ def compile_extension_module(
     dirname = builddir / name
     dirname.mkdir(exist_ok=True)
     cfile = _convert_str_to_file(source_string, dirname)
-    include_dirs = include_dirs + [sysconfig.get_config_var('INCLUDEPY'), sysconfig.get_path('include')]
+    include_dirs = include_dirs + [
+        sysconfig.get_config_var('INCLUDEPY'),
+        sysconfig.get_path('include')
+    ]
 
     return _c_compile(
         cfile, outputfilename=dirname / modname,

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -106,7 +106,7 @@ def compile_extension_module(
     dirname = builddir / name
     dirname.mkdir(exist_ok=True)
     cfile = _convert_str_to_file(source_string, dirname)
-    include_dirs = include_dirs + [sysconfig.get_config_var('INCLUDEPY')]
+    include_dirs = include_dirs + [sysconfig.get_config_var('INCLUDEPY'), sysconfig.get_path('include')]
 
     return _c_compile(
         cfile, outputfilename=dirname / modname,


### PR DESCRIPTION
This adds testing on MacOS for free-threaded Python and streamlines the linux tests.

In both cases I'm using [`setup-uv`](https://github.com/astral-sh/setup-uv) to get python. It turns out to be trivial to replace `setup-python` with it. The main advantage is it has native support for free-threaded Python.

Unfortunately I'm hitting some issues with spin on Windows (see https://github.com/scientific-python/spin/pull/241 for an upstream fix) when I install python with the setup-uv action, so I'm holding off on adding Windows CI for now.