### PR TITLE
DOC: Fix some out-of-data struct in c-api types-and-structures

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -74,6 +74,14 @@ and its sub-types).
     Clears the specified array flags. This function does no validation,
     and assumes that you know what you're doing.
 
+.. c:function:: void PyArray_HANDLER(PyArrayObject *arr)
+
+    .. versionadded:: 1.22
+
+    Returns a pointer to the memory handler of the array, which is
+    used for ``malloc``/``calloc``/``realloc``/``free`` per object.
+    Can return ``NULL`` for some cases.
+
 .. c:function:: void *PyArray_DATA(PyArrayObject *arr)
 
 .. c:function:: char *PyArray_BYTES(PyArrayObject *arr)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -80,8 +80,8 @@ and its sub-types).
 
     Returns a pointer to the memory handler of the array, which is used
     for memory allocation operations such as ``malloc`` , ``calloc`` ,
-    ``realloc`` , and ``free`` for each object. In some cases, it may return ``NULL`` .
-    For more details, refer to the :c:type:`PyDataMem_Handler`.
+    ``realloc`` , and ``free`` for each object. In some cases, it may return
+    ``NULL`` . For more details, refer to the :c:type:`PyDataMem_Handler`.
 
 .. c:function:: void *PyArray_DATA(PyArrayObject *arr)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -74,13 +74,14 @@ and its sub-types).
     Clears the specified array flags. This function does no validation,
     and assumes that you know what you're doing.
 
-.. c:function:: void PyArray_HANDLER(PyArrayObject *arr)
+.. c:function:: PyObject * PyArray_HANDLER(PyArrayObject *arr)
 
     .. versionadded:: 1.22
 
-    Returns a pointer to the memory handler of the array, which is
-    used for ``malloc``/``calloc``/``realloc``/``free`` per object.
-    Can return ``NULL`` for some cases.
+    Returns a pointer to the memory handler of the array, which is used
+    for memory allocation operations such as `malloc`, `calloc`, `realloc`,
+    and `free` for each object. In some cases, it may return `NULL`.
+    For more details, refer to the :c:type:`PyDataMem_Handler`.
 
 .. c:function:: void *PyArray_DATA(PyArrayObject *arr)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -79,8 +79,8 @@ and its sub-types).
     .. versionadded:: 1.22
 
     Returns a pointer to the memory handler of the array, which is used
-    for memory allocation operations such as `malloc`, `calloc`, `realloc`,
-    and `free` for each object. In some cases, it may return `NULL`.
+    for memory allocation operations such as ``malloc``, ``calloc``,
+    ``realloc``, and ``free`` for each object. In some cases, it may return ``NULL``.
     For more details, refer to the :c:type:`PyDataMem_Handler`.
 
 .. c:function:: void *PyArray_DATA(PyArrayObject *arr)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -74,13 +74,13 @@ and its sub-types).
     Clears the specified array flags. This function does no validation,
     and assumes that you know what you're doing.
 
-.. c:function:: PyObject * PyArray_HANDLER(PyArrayObject *arr)
+.. c:function:: PyObject *PyArray_HANDLER(PyArrayObject *arr)
 
     .. versionadded:: 1.22
 
     Returns a pointer to the memory handler of the array, which is used
-    for memory allocation operations such as ``malloc``, ``calloc``,
-    ``realloc``, and ``free`` for each object. In some cases, it may return ``NULL``.
+    for memory allocation operations such as ``malloc`` , ``calloc`` ,
+    ``realloc`` , and ``free`` for each object. In some cases, it may return ``NULL`` .
     For more details, refer to the :c:type:`PyDataMem_Handler`.
 
 .. c:function:: void *PyArray_DATA(PyArrayObject *arr)

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -423,7 +423,7 @@ to the front of the integer name.
 
 .. c:type:: npy_hash_t
 
-   An alias for ``Py_hash_t`` (a signed integer type used for hashing).
+   An alias for ``Py_hash_t`` (used for hashing).
    This type is utilized in NumPy to represent hash values for objects.
 
 

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -419,11 +419,11 @@ to the front of the integer name.
 
 .. c:type:: npy_uintp
 
-    The C ``size_t``/``Py_size_t``.
+   The C ``size_t``/``Py_size_t``.
 
 .. c:type:: npy_hash_t
 
-   The C ``Py_hash_t`` (a signed integer type used for hashing).
+   An alias for ``Py_hash_t`` (a signed integer type used for hashing).
    This type is utilized in NumPy to represent hash values for objects.
 
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -73,14 +73,23 @@ PyArray_Type and PyArrayObject
 
 .. c:type:: PyArrayObject_fields
 
-   The :c:type:`PyArrayObject_fields` C-structure contains all necessary
-   information for an array, used by ndarray instances and subclasses.
-   Direct access to its members should be avoided for compatibility. Instead,
-   interact with :c:type:`PyArrayObject` via provided functions and macros,
-   which offer a stable interface for array data and metadata. This structure
-   may be moved to a private header in the future, emphasizing the use of
-   macros for access.
+   An implementation detail for accessing the :c:data:`PyArrayObject` struct.
+   You should use :c:data:`PyArrayObject` to ensure code compatibility and stability.
 
+.. c:type:: PyArrayObject
+
+   .. deprecated:: 1.7
+      Use ``NPY_AO`` for a shorter name.
+
+   Represents a NumPy array object in the C API, contains all of the required
+   information for an array.
+
+   To hide the implementation details, only the Python struct HEAD is exposed.
+   Direct access to the struct fields is deprecated;
+   instead, use the ``PyArray_*(*arr)`` functions (such as :c:func:`PyArray_NDIM`).
+
+   As of NumPy 1.20, the size of this struct is not considered part of the NumPy ABI
+   (see the note below).
 
    .. code-block:: c
 
@@ -94,9 +103,9 @@ PyArray_Type and PyArrayObject
           PyArray_Descr *descr;
           int flags;
           PyObject *weakreflist;
-          void *_buffer_info;
           PyObject *mem_handler;
-      } PyArrayObject_fields;
+          /* version dependent private members */
+      } PyArrayObject;
 
    :c:macro:`PyObject_HEAD`
        This is needed by all Python objects. It consists of (at least)
@@ -178,13 +187,6 @@ PyArray_Type and PyArrayObject
        This member allows array objects to have weak references (using the
        weakref module).
 
-   .. c:member:: void *_buffer_info
-
-   .. versionadded:: 1.20
-
-   Private buffer information, tagged for warning purposes. Direct
-   access is discouraged to ensure API stability.
-
    .. c:member:: PyObject *mem_handler
 
    .. versionadded:: 1.22
@@ -195,25 +197,8 @@ PyArray_Type and PyArrayObject
    instead of the standard `malloc`, `calloc`, `realloc`, and `free` functions.
 
    Accessed through the macro :c:data:`PyArray_HANDLER`.
-
-   .. note::
-
-      For setting or retrieving the current memory management policy,
-      see the `PyDataMem_SetHandler` and `PyDataMem_GetHandler` functions.
-
-.. c:type:: PyArrayObject
-
-   .. deprecated:: 1.7
-      Use ``NPY_AO`` for a shorter name.
-
-   Represents a NumPy array object in the C API.
-
-   To hide the implementation details, only the Python struct HEAD is exposed.
-   Direct access to the struct fields is deprecated;
-   instead, use the ``PyArray_*(*arr)`` functions (such as :c:func:`PyArray_NDIM`).
-
-   As of NumPy 1.20, the size of this struct is not considered part of the NumPy ABI
-   (see the note below).
+   For setting or retrieving the current memory management policy,
+   see the `PyDataMem_SetHandler` and `PyDataMem_GetHandler` functions.
 
    .. note::
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -73,19 +73,18 @@ PyArray_Type and PyArrayObject
 
 .. c:type:: PyArrayObject_fields
 
-   The :c:type:`PyArrayObject_fields` C-structure contains all of the
-   required information for an array. All instances of an ndarray (and
-   its subclasses) will have this structure. For future compatibility,
-   these structure members should normally be accessed using the provided
-   functions and macros. Direct access to the members of :c:type:`PyArrayObject_fields`
-   should be avoided. Instead, users should interact with :c:type:`PyArrayObject`,
-   which provides a stable interface for accessing array data and metadata.
-   This struct may be moved to a private header in a future release,
-   further emphasizing the importance of using the defined macros for access.
+   The :c:type:`PyArrayObject_fields` C-structure contains all necessary
+   information for an array, used by ndarray instances and subclasses.
+   Direct access to its members should be avoided for compatibility. Instead,
+   interact with :c:type:`PyArrayObject` via provided functions and macros,
+   which offer a stable interface for array data and metadata. This structure
+   may be moved to a private header in the future, emphasizing the use of
+   macros for access.
+
 
    .. code-block:: c
 
-      typedef struct PyArrayObject {
+      typedef struct{
           PyObject_HEAD
           char *data;
           int nd;
@@ -97,7 +96,7 @@ PyArray_Type and PyArrayObject
           PyObject *weakreflist;
           void *_buffer_info;
           PyObject *mem_handler;
-      } PyArrayObject;
+      } PyArrayObject_fields;
 
    :c:macro:`PyObject_HEAD`
        This is needed by all Python objects. It consists of (at least)

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -198,7 +198,7 @@ PyArray_Type and PyArrayObject
    enabling the use of user-defined memory allocation and deallocation routines
    instead of the standard `malloc`, `calloc`, `realloc`, and `free` functions.
 
-   Accessed through the macro :c:data:`PyArray_HANDLER`.
+   Accessed through :c:data:`PyArray_HANDLER`.
    For setting or retrieving the current memory management policy,
    see the `PyDataMem_SetHandler` and `PyDataMem_GetHandler` functions.
 


### PR DESCRIPTION
DOC: Update C-API docs

- Moved members from `PyArrayObject` to `PyArrayObject_fields`.
- Added documentation for `mem_handler` and `_buffer_info`.
- Reordered function sequence to match the code for consistency.
- Updated `PyArray_Descr` metadata field and added `npy_hash_t` documentation.
- Fixed discrepancies in `PyArray_ArrFuncs` and `PyUFuncObject`.

[skip azp] [skip actions] [skip cirrus]
