### PR TITLE
MAINT: Improved error message for `PyArray_CopyInitialReduceValues`

### DIFF
--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -98,8 +98,8 @@ PyArray_CopyInitialReduceValues(
         if (axis_flags[idim]) {
             if (NPY_UNLIKELY(shape_orig[idim] == 0)) {
                 PyErr_Format(PyExc_ValueError,
-                        "zero-size array to reduction operation %s "
-                        "which has no identity", funcname);
+                        "attempt to apply a reduction operation (\"%s\") "
+                        "with no identity to a zero-sized array", funcname);
                 return -1;
             }
             if (keepdims) {


### PR DESCRIPTION
When a reduction operation is applied to a zero-sized array, the resultant value can only be meaningful if the given reduction operation has a natural identity value. The error value returned in the case when it doesn't was worded confusingly to the point of being unhelpful; this change improves the wording.
