### PR TITLE
BLD: treat SVML object files better to avoid compiler warnings

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1213,7 +1213,8 @@ py.extension_module('_multiarray_umath',
     src_numpy_api[1],  # __multiarray_api.h
     src_umath_doc_h,
     npy_math_internal_h,
-  ] + svml_objects,
+  ],
+  objects: svml_objects,
   c_args: c_args_common,
   cpp_args: cpp_args_common,
   include_directories: [


### PR DESCRIPTION
GCC and Clang didn't mind passing unused compile flags when building object files, but the OneAPI Intel compilers emit lots of warnings like:
```
[422/593] Compiling C object numpy/_core/_multiarray_umath.cpython-311-x86_64-linux-gnu.so.p/src_umath_svml_linux_avx512_svml_z0_asin_d_la.s.o
icx: warning: argument unused during compilation: '-fvisibility=hidden' [-Wunused-command-line-argument]
icx: warning: argument unused during compilation: '-fdiagnostics-color=always' [-Wunused-command-line-argument]
icx: warning: argument unused during compilation: '-fno-strict-aliasing' [-Wunused-command-line-argument]
icx: warning: argument unused during compilation: '-D NPY_HAVE_SSE2' [-Wunused-command-line-argument]
```
Those are fixed after this change. It also reduced the total number of build targets from 593 to 527 when building with SVML.