### PR TITLE
BUG:Fix bug 27269

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -30,6 +30,57 @@ and its sub-types).
 
     The number of dimensions in the array.
 
+.. c:function:: void *PyArray_DATA(PyArrayObject *arr)
+
+    The pointer to the first element of the array.
+
+.. c:function:: char *PyArray_BYTES(PyArrayObject *arr)
+
+    These two macros are similar and obtain the pointer to the
+    data-buffer for the array. The first macro can (and should be)
+    assigned to a particular pointer where the second is for generic
+    processing. If you have not guaranteed a contiguous and/or aligned
+    array then be sure you understand how to access the data in the
+    array to avoid memory and/or alignment problems.
+
+.. c:function:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
+
+    Returns a pointer to the dimensions/shape of the array. The
+    number of elements matches the number of dimensions
+    of the array. Can return ``NULL`` for 0-dimensional arrays.
+
+.. c:function:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
+
+    Returns a pointer to the strides of the array. The
+    number of elements matches the number of dimensions
+    of the array.
+
+.. c:function:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
+
+    Return the shape in the *n* :math:`^{\textrm{th}}` dimension.
+
+.. c:function:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
+
+    Return the stride in the *n* :math:`^{\textrm{th}}` dimension.
+
+.. c:function:: PyObject *PyArray_BASE(PyArrayObject* arr)
+
+    This returns the base object of the array. In most cases, this
+    means the object which owns the memory the array is pointing at.
+
+    If you are constructing an array using the C API, and specifying
+    your own memory, you should use the function :c:func:`PyArray_SetBaseObject`
+    to set the base to an object which owns the memory.
+
+    If the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag is set, it has a different
+    meaning, namely base is the array into which the current array will
+    be copied upon copy resolution. This overloading of the base property
+    for two functions is likely to change in a future version of NumPy.
+
+.. c:function:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
+
+    Returns a borrowed reference to the dtype property of the array.
+
 .. c:function:: int PyArray_FLAGS(PyArrayObject* arr)
 
     Returns an integer representing the :ref:`array-flags<array-flags>`.
@@ -37,6 +88,32 @@ and its sub-types).
 .. c:function:: int PyArray_TYPE(PyArrayObject* arr)
 
     Return the (builtin) typenumber for the elements of this array.
+
+.. c:function:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
+
+    A synonym for PyArray_DESCR, named to be consistent with the
+    'dtype' usage within Python.
+
+.. c:function:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
+
+    A synonym for :c:func:`PyArray_DIMS`, named to be consistent with the
+    `shape <numpy.ndarray.shape>` usage within Python.
+
+.. c:function:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
+
+    Enables the specified array flags. This function does no validation,
+    and assumes that you know what you're doing.
+
+.. c:function:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
+
+    Clears the specified array flags. This function does no validation,
+    and assumes that you know what you're doing.
+
+.. c:function:: int PyArray_HANDLER(PyArrayObject *arr)
+
+    .. versionadded:: 1.22
+
+    Returns the memory handler associated with the given array.
 
 .. c:function:: int PyArray_Pack(  \
         const PyArray_Descr *descr, void *item, const PyObject *value)
@@ -64,52 +141,6 @@ and its sub-types).
         handling arbitrary Python objects.  Setitem is for example not able
         to handle arbitrary casts between different dtypes.
 
-.. c:function:: void PyArray_ENABLEFLAGS(PyArrayObject* arr, int flags)
-
-    Enables the specified array flags. This function does no validation,
-    and assumes that you know what you're doing.
-
-.. c:function:: void PyArray_CLEARFLAGS(PyArrayObject* arr, int flags)
-
-    Clears the specified array flags. This function does no validation,
-    and assumes that you know what you're doing.
-
-.. c:function:: void *PyArray_DATA(PyArrayObject *arr)
-
-.. c:function:: char *PyArray_BYTES(PyArrayObject *arr)
-
-    These two macros are similar and obtain the pointer to the
-    data-buffer for the array. The first macro can (and should be)
-    assigned to a particular pointer where the second is for generic
-    processing. If you have not guaranteed a contiguous and/or aligned
-    array then be sure you understand how to access the data in the
-    array to avoid memory and/or alignment problems.
-
-.. c:function:: npy_intp *PyArray_DIMS(PyArrayObject *arr)
-
-    Returns a pointer to the dimensions/shape of the array. The
-    number of elements matches the number of dimensions
-    of the array. Can return ``NULL`` for 0-dimensional arrays.
-
-.. c:function:: npy_intp *PyArray_SHAPE(PyArrayObject *arr)
-
-    A synonym for :c:func:`PyArray_DIMS`, named to be consistent with the
-    `shape <numpy.ndarray.shape>` usage within Python.
-
-.. c:function:: npy_intp *PyArray_STRIDES(PyArrayObject* arr)
-
-    Returns a pointer to the strides of the array. The
-    number of elements matches the number of dimensions
-    of the array.
-
-.. c:function:: npy_intp PyArray_DIM(PyArrayObject* arr, int n)
-
-    Return the shape in the *n* :math:`^{\textrm{th}}` dimension.
-
-.. c:function:: npy_intp PyArray_STRIDE(PyArrayObject* arr, int n)
-
-    Return the stride in the *n* :math:`^{\textrm{th}}` dimension.
-
 .. c:function:: npy_intp PyArray_ITEMSIZE(PyArrayObject* arr)
 
     Return the itemsize for the elements of this array.
@@ -130,29 +161,6 @@ and its sub-types).
 .. c:function:: npy_intp PyArray_NBYTES(PyArrayObject* arr)
 
     Returns the total number of bytes consumed by the array.
-
-.. c:function:: PyObject *PyArray_BASE(PyArrayObject* arr)
-
-    This returns the base object of the array. In most cases, this
-    means the object which owns the memory the array is pointing at.
-
-    If you are constructing an array using the C API, and specifying
-    your own memory, you should use the function :c:func:`PyArray_SetBaseObject`
-    to set the base to an object which owns the memory.
-
-    If the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag is set, it has a different
-    meaning, namely base is the array into which the current array will
-    be copied upon copy resolution. This overloading of the base property
-    for two functions is likely to change in a future version of NumPy.
-
-.. c:function:: PyArray_Descr *PyArray_DESCR(PyArrayObject* arr)
-
-    Returns a borrowed reference to the dtype property of the array.
-
-.. c:function:: PyArray_Descr *PyArray_DTYPE(PyArrayObject* arr)
-
-    A synonym for PyArray_DESCR, named to be consistent with the
-    'dtype' usage within Python.
 
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -421,6 +421,11 @@ to the front of the integer name.
 
     The C ``size_t``/``Py_size_t``.
 
+.. c:type:: npy_hash_t
+
+   The C ``Py_hash_t`` (a signed integer type used for hashing).
+   This type is utilized in NumPy to represent hash values for objects.
+
 
 (Complex) Floating point
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -205,7 +205,7 @@ PyArray_Type and PyArrayObject
 .. c:type:: PyArrayObject
 
    .. deprecated:: 1.7
-      Use :c:type:`NPY_AO` for a shorter name.
+      Use ``NPY_AO`` for a shorter name.
 
    Represents a NumPy array object in the C API.
 
@@ -563,7 +563,7 @@ PyArray_ArrFuncs
 
         An array of function pointers to cast from the current type to
         most of the other builtin types. The types
-        :c:type:`NPY_DATETIME`, :c:type:`NPY_TIMEDELTA`, and :c:type:`HALF`
+        :c:type:`NPY_DATETIME`, :c:type:`NPY_TIMEDELTA`, and :c:type:`NPY_HALF`
         go into the castdict even though they are built-in. Each function
         casts a contiguous, aligned, and notswapped buffer pointed at by
         *from* to a contiguous, aligned, and notswapped buffer pointed

--- a/my_test_.py
+++ b/my_test_.py
@@ -1,0 +1,2 @@
+import numpy as np
+assert np.ma.MaskedArray([1,1,1], [True, False, True], dtype='uint64').filled().dtype == np.dtype("uint64")

--- a/my_test_.py
+++ b/my_test_.py
@@ -1,2 +1,0 @@
-import numpy as np
-assert np.ma.MaskedArray([1,1,1], [True, False, True], dtype='uint64').filled().dtype == np.dtype("uint64")

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3914,6 +3914,7 @@ class MaskedArray(ndarray):
         else:
             result = self._data.copy('K')
             try:
+                fill_value = _check_fill_value(fill_value,result.dtype)
                 np.copyto(result, fill_value, where=m)
             except (TypeError, AttributeError):
                 fill_value = narray(fill_value, dtype=object)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -759,6 +759,17 @@ class TestMaskedArray:
         atest[idx] = btest[idx]
         assert_equal(atest, [20])
 
+    def test_filled_with_basic_dtype(self):
+        # Function may change dtype of array with
+        # some basic type, see issue 27269
+        # https://github.com/numpy/numpy/issues/27269
+        types = [np.int8,np.uint8,np.complex64]
+
+        # Test is the filled array has the same type
+        for type in types:
+            a = np.arange(1,7).reshape(2,3).astype(type)
+            assert masked_where(a<=3,a).filled().dtype == type
+
     def test_filled_with_object_dtype(self):
         a = np.ma.masked_all(1, dtype='O')
         assert_equal(a.filled('x')[0], 'x')


### PR DESCRIPTION
fix bug 27269, by adding a force type casting before calling `copyto`.
partially addresses #27269 