### PR TITLE
DOC: Clarify obj parameter types in numpy.delete documentation

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5200,8 +5200,6 @@ def delete(arr, obj, axis=None):
         Input array.
     obj : slice, int, array-like of ints or bools
         Indicate indices of sub-arrays to remove along the specified axis.
-        Can be a single integer, a slice, an array of integers, a boolean array,
-        or any object that can be cast to an array of integers or booleans.
 
         .. versionchanged:: 1.19.0
             Boolean indices are now treated as a mask of elements to remove,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5380,7 +5380,7 @@ def insert(arr, obj, values, axis=None):
     ----------
     arr : array_like
         Input array.
-    obj : slice, int, array-like of ints or bools
+    obj : int, slice or sequence of ints
         Object that defines the index or indices before which `values` is
         inserted.
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5198,8 +5198,11 @@ def delete(arr, obj, axis=None):
     ----------
     arr : array_like
         Input array.
-    obj : slice, int or array of ints
-        Indicate indices of sub-arrays to remove along the specified axis.
+    obj : slice, int, array-like of ints or bools
+    Indices specifying which sub-arrays to remove along the specified axis.
+    Can be a single integer, a slice, an array of integers, a boolean array,
+    or any object that can be cast to an array of integers or booleans.
+
 
         .. versionchanged:: 1.19.0
             Boolean indices are now treated as a mask of elements to remove,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5380,7 +5380,7 @@ def insert(arr, obj, values, axis=None):
     ----------
     arr : array_like
         Input array.
-    obj : int, slice or sequence of ints
+    obj : slice, int, array-like of ints or bools
         Object that defines the index or indices before which `values` is
         inserted.
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5203,7 +5203,6 @@ def delete(arr, obj, axis=None):
     Can be a single integer, a slice, an array of integers, a boolean array,
     or any object that can be cast to an array of integers or booleans.
 
-
         .. versionchanged:: 1.19.0
             Boolean indices are now treated as a mask of elements to remove,
             rather than being cast to the integers 0 and 1.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5199,7 +5199,7 @@ def delete(arr, obj, axis=None):
     arr : array_like
         Input array.
     obj : slice, int, array-like of ints or bools
-        Indices specifying which sub-arrays to remove along the specified axis.
+        Indicate indices of sub-arrays to remove along the specified axis.
         Can be a single integer, a slice, an array of integers, a boolean array,
         or any object that can be cast to an array of integers or booleans.
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5199,9 +5199,9 @@ def delete(arr, obj, axis=None):
     arr : array_like
         Input array.
     obj : slice, int, array-like of ints or bools
-    Indices specifying which sub-arrays to remove along the specified axis.
-    Can be a single integer, a slice, an array of integers, a boolean array,
-    or any object that can be cast to an array of integers or booleans.
+        Indices specifying which sub-arrays to remove along the specified axis.
+        Can be a single integer, a slice, an array of integers, a boolean array,
+        or any object that can be cast to an array of integers or booleans.
 
         .. versionchanged:: 1.19.0
             Boolean indices are now treated as a mask of elements to remove,


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This pr is to fix #27459  

The current documentation for the 'obj' parameter in numpy.delete only mentions slices, ints, and arrays of ints, but in reality, the parameter supports a wider range of types, including boolean arrays and objects that can be converted to integer arrays, such as iterators, lists, etc. This is already reflected in the functionality of NumPy, but the documentation does not explicitly mention it. 

The type description of the obj parameter has been expanded to include support for array-like and boolean arrays, in order to better reflect the function's actual behavior. The clarity of the documentation has also been improved, explicitly stating that the obj parameter can be any object that can be converted to an integer array or boolean array.