### PR TITLE
BUG: Silencing errors of filled_value's casting in array_finalize in MaskedArray

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -10,7 +10,6 @@
 // this file are shared by the _simd, _umath_tests, and
 // _multiarray_umath modules
 
-
 // Hold all CPU features boolean values
 static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -10,6 +10,7 @@
 // this file are shared by the _simd, _umath_tests, and
 // _multiarray_umath modules
 
+
 // Hold all CPU features boolean values
 static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3124,7 +3124,10 @@ class MaskedArray(ndarray):
 
         # Finalize the fill_value
         if self._fill_value is not None:
-            self._fill_value = _check_fill_value(self._fill_value, self.dtype)
+            try:
+                self._fill_value = _check_fill_value(self._fill_value, self.dtype)
+            except TypeError:
+                self._fill_value = _check_fill_value(None, self.dtype)
         elif self.dtype.names is not None:
             # Finalize the default fill_value for structured arrays
             self._fill_value = _check_fill_value(None, self.dtype)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -498,6 +498,29 @@ def _check_fill_value(fill_value, ndtype):
                 raise TypeError(err_msg % (fill_value, ndtype)) from e
     return np.array(fill_value)
 
+def _force_fill_value_cast(fill_value, ndtype, fallback=None):
+    """
+    Wraps `_check_fill_value` to cast the given `fill_value` into the specified dtype.
+
+    If the `fill_value` cannot be cast into the given dtype, it returns the provided
+    fallback value. The result is always a 0-dimensional array if the casting is
+    successful.
+
+    Parameters:
+    fill_value: The value to be cast.
+    ndtype: The target data type for casting.
+    fallback: The value to return if casting fails
+              (default is None, which will return default value).
+
+    Returns:
+    A 0-dimensional array if casting is successful; otherwise, the fallback value.
+    """
+    try:
+        result = _check_fill_value(fill_value, ndtype)
+    except Exception:
+        result = fallback
+    return result
+
 
 def set_fill_value(a, fill_value):
     """
@@ -3124,10 +3147,8 @@ class MaskedArray(ndarray):
 
         # Finalize the fill_value
         if self._fill_value is not None:
-            try:
-                self._fill_value = _check_fill_value(self._fill_value, self.dtype)
-            except TypeError:
-                self._fill_value = _check_fill_value(None, self.dtype)
+            self._fill_value = _force_fill_value_cast(self._fill_value,
+                                                      self.dtype)
         elif self.dtype.names is not None:
             # Finalize the default fill_value for structured arrays
             self._fill_value = _check_fill_value(None, self.dtype)
@@ -4254,11 +4275,7 @@ class MaskedArray(ndarray):
         # Cast fill value to np.bool if needed. If it cannot be cast, the
         # default boolean fill value is used.
         if check._fill_value is not None:
-            try:
-                fill = _check_fill_value(check._fill_value, np.bool)
-            except (TypeError, ValueError):
-                fill = _check_fill_value(None, np.bool)
-            check._fill_value = fill
+            check._fill_value = _force_fill_value_cast(check._fill_value, np.bool)
 
         return check
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2523,15 +2523,14 @@ class TestUfuncs:
         f = np.vectorize(lambda c: ord(c) if c else -1, otypes=[int])
 
         a = np.ma.masked_all(1, str)
-        x = a.fill_value # Assign default fill_value
+        x = a.fill_value  # Assign default fill_value
         assert_equal(f(a), np.ma.masked_all(1, np.int64))
 
         a = np.ma.masked_array([""], True)
-        x = a.fill_value # Assign default fill_value
+        x = a.fill_value  # Assign default fill_value
         assert_equal(f(a), np.ma.masked_all(1, np.int64))
         a = np.ma.masked_array([""], True, fill_value="?")
         assert_equal(f(a), np.ma.masked_all(1, np.int64))
-
 
     def test_treatment_of_NotImplemented(self):
         # Check that NotImplemented is returned at appropriate places

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2517,6 +2517,22 @@ class TestUfuncs:
         assert_equal(test.mask, control.mask)
         assert_(not isinstance(test.mask, MaskedArray))
 
+    def test_vectorize_with_type_casting(self):
+        # TypeError may be raised with return dtype different to input dtype.
+        # See issue 27165
+        f = np.vectorize(lambda c: ord(c) if c else -1, otypes=[int])
+
+        a = np.ma.masked_all(1, str)
+        x = a.fill_value # Assign default fill_value
+        assert_equal(f(a), np.ma.masked_all(1, np.int64))
+
+        a = np.ma.masked_array([""], True)
+        x = a.fill_value # Assign default fill_value
+        assert_equal(f(a), np.ma.masked_all(1, np.int64))
+        a = np.ma.masked_array([""], True, fill_value="?")
+        assert_equal(f(a), np.ma.masked_all(1, np.int64))
+
+
     def test_treatment_of_NotImplemented(self):
         # Check that NotImplemented is returned at appropriate places
 


### PR DESCRIPTION
Silencing errors related to the casting of `fill_value` in `__array_finalize__` of `MaskedArray`, and using a default value if the original `fill_value` cannot be cast even with the method `_check_fill_value`.

While this approach may introduce some level of risk, it is reasonable to assume that if users set the `fill_value` themselves, they are aware that it may lead to undefined behavior with specific type casting. It is unfortunate that the casting of `masked_array` types is hindered simply because we assigned `fill_value` with the default value indirectly. This not only causes issues with methods that use `dtype=` directly, but also impedes any calls to `ufunc` that return a dtype different from the original dtype (since calls to the `ufunc` won't be applied to the stored `fill_value`), exacerbating the situation.

I believe this is the most effective way to address these issues, rather than designing a new ufunc for `masked_array` or marking whether the value was set by the user or not.
fixes #27165