### PR TITLE
Update documentation for floating-point precision and determinant calculations

### DIFF
--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -348,7 +348,8 @@ range of possible values.
 
     >>> import numpy as np
     >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
-    >>> print(np.linalg.det(a))  # Expected: 0
+    >>> print(np.linalg.det(a))  # # Result is close to 0 due to floating-point precision
+    -3.1974423109204565e-14
     
 
     One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is a known behavior of floating-point operations in numerical         
@@ -356,8 +357,8 @@ range of possible values.
 
     To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
 
-    >>> if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
-    >>>     print("The determinant is effectively zero.")
+    >>> np.isclose(np.linalg.det(a), 0)  # Check for closeness to 0
+    True
 
     This method allows you to account for the small inaccuracies that can occur in floating-point calculations.
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -342,12 +342,13 @@ range of possible values.
     >>> np.power(100, 100, dtype=np.float64)
     1e+200
 
-.. note::
+Floating point precision
+========================
 
-    Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point
-    arithmetic, which can introduce small inaccuracies due to the way computers 
-    represent decimal numbers. For instance, when computing the determinant of the 
-    following matrix:
+Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point
+arithmetic, which can introduce small inaccuracies due to the way computers 
+represent decimal numbers. For instance, when computing the determinant of the 
+following matrix:
 
     >>> import numpy as np
     >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
@@ -355,19 +356,19 @@ range of possible values.
     -3.1974423109204565e-14
     
 
-    One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
-    a known behavior of floating-point operations in numerical libraries.
+One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
+a known behavior of floating-point operations in numerical libraries.
 
-    To handle such cases, it's advisable to set a threshold for comparison when checking
-    if a determinant is effectively zero. For example:
+To handle such cases, it's advisable to set a threshold for comparison when checking
+if a determinant is effectively zero. For example:
 
     >>> np.isclose(np.linalg.det(a), 0)  # Check for closeness to 0
     True
 
-    This method allows you to account for the small inaccuracies that can occur in 
-    floating-point calculations.
+This method allows you to account for the small inaccuracies that can occur in 
+floating-point calculations.
 
-    For information about precision in calculations, see `Floating-Point Arithmetic <https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html>`_.
+For information about precision in calculations, see `Floating-Point Arithmetic <https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html>`_.
 
 
 Extended precision

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -357,7 +357,7 @@ following matrix:
     
 
 One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
-a known behavior of floating-point operations in numerical libraries.
+a behavior common to all frameworks that use floating point arithmetic.
 
 To handle such cases, it's advisable to set a threshold for comparison when checking
 if a determinant is effectively zero. For example:

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -342,7 +342,7 @@ range of possible values.
     >>> np.power(100, 100, dtype=np.float64)
     1e+200
 
-.. note:::
+.. note::
 
     Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way       computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -346,17 +346,18 @@ range of possible values.
 
     Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way          computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
 
-    >>>import numpy as np
-    >>>a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
-    >>>print(np.linalg.det(a))  # Expected: 0
+    >>> import numpy as np
+    >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
+    >>> print(np.linalg.det(a))  # Expected: 0
     
 
-    One may receive a result like `-3.1974423109204565e-14` instead of `0`. This is a known behavior of floating-point operations in numerical libraries.
+    One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is a known behavior of floating-point operations in numerical         
+    libraries.
 
     To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
 
-    >>>if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
-    >>>    print("The determinant is effectively zero.")
+    >>> if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
+    >>>     print("The determinant is effectively zero.")
 
     This method allows you to account for the small inaccuracies that can occur in floating-point calculations.
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -344,23 +344,19 @@ range of possible values.
 
 .. note::
 
-    Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way         computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
+    Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way          computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
 
-    ```
-    import numpy as np
-
-    a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
-    print(np.linalg.det(a))  # Expected: 0
-    ```
+    >>>import numpy as np
+    >>>a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
+    >>>print(np.linalg.det(a))  # Expected: 0
+    
 
     One may receive a result like `-3.1974423109204565e-14` instead of `0`. This is a known behavior of floating-point operations in numerical libraries.
 
     To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
 
-    ```
-    if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
-        print("The determinant is effectively zero.")
-    ```
+    >>>if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
+    >>>    print("The determinant is effectively zero.")
 
     This method allows you to account for the small inaccuracies that can occur in floating-point calculations.
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -364,7 +364,7 @@ which provides information about the matrix's sensitivity to numerical errors.
 For example:
 
     >>> np.linalg.cond(a)  # Compute condition number to assess matrix stability
-    inf
+    inf  
 
 A high condition number indicates that the matrix is close to singular, meaning 
 small changes or inaccuracies in floating-point arithmetic can lead to large errors.

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -342,9 +342,9 @@ range of possible values.
     >>> np.power(100, 100, dtype=np.float64)
     1e+200
 
-.. note::
+.. note:::
 
-    Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way          computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
+    Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way       computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
 
     >>> import numpy as np
     >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -367,7 +367,7 @@ range of possible values.
     This method allows you to account for the small inaccuracies that can occur in 
     floating-point calculations.
 
-    For information about precision in calculations, see [Floating-Point Arithmetic](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html).
+    For information about precision in calculations, see `Floating-Point Arithmetic <https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html>`_.
 
 
 Extended precision

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -359,14 +359,15 @@ following matrix:
 One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
 a behavior common to all frameworks that use floating point arithmetic.
 
-To handle such cases, it's advisable to set a threshold for comparison when checking
-if a determinant is effectively zero. For example:
+To handle such cases, it's advisable to use the condition number of the matrix, 
+which provides information about the matrix's sensitivity to numerical errors. 
+For example:
 
-    >>> np.isclose(np.linalg.det(a), 0)  # Check for closeness to 0
-    True
+    >>> np.linalg.cond(a)  # Compute condition number to assess matrix stability
+    inf
 
-This method allows you to account for the small inaccuracies that can occur in 
-floating-point calculations.
+A high condition number indicates that the matrix is close to singular, meaning 
+small changes or inaccuracies in floating-point arithmetic can lead to large errors.
 
 For information about precision in calculations, see `Floating-Point Arithmetic <https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html>`_.
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -346,7 +346,7 @@ range of possible values.
 
     Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way         computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
 
-    ```python
+    ```
     import numpy as np
 
     a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
@@ -357,7 +357,7 @@ range of possible values.
 
     To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
 
-    ```python
+    ```
     if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
         print("The determinant is effectively zero.")
     ```

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -347,27 +347,21 @@ Floating point precision
 
 Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point
 arithmetic, which can introduce small inaccuracies due to the way computers 
-represent decimal numbers. For instance, when computing the determinant of the 
-following matrix:
+represent decimal numbers. For instance, when performing basic arithmetic operations 
+involving floating-point numbers:
 
-    >>> import numpy as np
-    >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
-    >>> print(np.linalg.det(a)) # Result is close to 0 due to floating-point precision
-    -3.1974423109204565e-14
-    
+    >>> 0.3 - 0.2 - 0.1  # This does not equal 0 due to floating-point precision
+    -2.7755575615628914e-17
 
-One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
-a behavior common to all frameworks that use floating point arithmetic.
+To handle such cases, it's advisable to use functions like `np.isclose` to compare 
+values, rather than checking for exact equality:
 
-To handle such cases, it's advisable to use the condition number of the matrix, 
-which provides information about the matrix's sensitivity to numerical errors. 
-For example:
+    >>> np.isclose(0.3 - 0.2 - 0.1, 0, rtol=1e-05)  # Check for closeness to 0
+    True
 
-    >>> np.linalg.cond(a)  # Compute condition number to assess matrix stability
-    inf  
-
-A high condition number indicates that the matrix is close to singular, meaning 
-small changes or inaccuracies in floating-point arithmetic can lead to large errors.
+In this example, `np.isclose` accounts for the minor inaccuracies that occur in 
+floating-point calculations by applying a relative tolerance, ensuring that results
+within a small threshold are considered close.
 
 For information about precision in calculations, see `Floating-Point Arithmetic <https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html>`_.
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -342,6 +342,28 @@ range of possible values.
     >>> np.power(100, 100, dtype=np.float64)
     1e+200
 
+.. note::
+
+    Many functions in NumPy, especially those in `np.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way         computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
+
+    ```python
+    import numpy as np
+
+    a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
+    print(np.linalg.det(a))  # Expected: 0
+    ```
+
+    One may receive a result like `-3.1974423109204565e-14` instead of `0`. This is a known behavior of floating-point operations in numerical libraries.
+
+    To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
+
+    ```python
+    if np.isclose(det, 0, atol=1e-10):  # Absolute tolerance
+        print("The determinant is effectively zero.")
+    ```
+
+    This method allows you to account for the small inaccuracies that can occur in floating-point calculations.
+
 Extended precision
 ==================
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -344,23 +344,31 @@ range of possible values.
 
 .. note::
 
-    Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point arithmetic, which can introduce small inaccuracies due to the way       computers represent decimal numbers. For instance, when computing the determinant of the following matrix:
+    Many functions in NumPy, especially those in `numpy.linalg`, involve floating-point
+    arithmetic, which can introduce small inaccuracies due to the way computers 
+    represent decimal numbers. For instance, when computing the determinant of the 
+    following matrix:
 
     >>> import numpy as np
     >>> a = np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]])
-    >>> print(np.linalg.det(a))  # # Result is close to 0 due to floating-point precision
+    >>> print(np.linalg.det(a)) # Result is close to 0 due to floating-point precision
     -3.1974423109204565e-14
     
 
-    One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is a known behavior of floating-point operations in numerical         
-    libraries.
+    One may receive a result like ``-3.1974423109204565e-14`` instead of ``0``. This is
+    a known behavior of floating-point operations in numerical libraries.
 
-    To handle such cases, it's advisable to set a threshold for comparison when checking if a determinant is effectively zero. For example:
+    To handle such cases, it's advisable to set a threshold for comparison when checking
+    if a determinant is effectively zero. For example:
 
     >>> np.isclose(np.linalg.det(a), 0)  # Check for closeness to 0
     True
 
-    This method allows you to account for the small inaccuracies that can occur in floating-point calculations.
+    This method allows you to account for the small inaccuracies that can occur in 
+    floating-point calculations.
+
+    For information about precision in calculations, see [Floating-Point Arithmetic](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html).
+
 
 Extended precision
 ==================


### PR DESCRIPTION
This pull request updates the documentation related to floating-point precision in NumPy, specifically addressing the issue of incorrect determinant calculations for certain matrices.

- Added a note on how the determinant of the matrix np.array([[5, 5, 6], [7, 7, 5], [4, 4, 8]]) is expected to be zero, highlighting the observed precision issues.

- Included a code example demonstrating how to compute the determinant and check if it is close to zero using np.isclose().

- Ensured consistency in formatting and improved clarity throughout the documentation.

This change aims to provide users with a better understanding of floating-point arithmetic in NumPy and how to handle potential precision errors.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
