### PR TITLE
BUG：``np.sqrt`` return no_masked array 

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -10,7 +10,6 @@
 // this file are shared by the _simd, _umath_tests, and
 // _multiarray_umath modules
 
-
 // Hold all CPU features boolean values
 static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -10,6 +10,7 @@
 // this file are shared by the _simd, _umath_tests, and
 // _multiarray_umath modules
 
+
 // Hold all CPU features boolean values
 static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3141,9 +3141,9 @@ class MaskedArray(ndarray):
         else:
             result = obj.view(type(self))
             result._update_from(self)
+            result._mask = self._mask.copy()
 
         if context is not None:
-            result._mask = result._mask.copy()
             func, args, out_i = context
             # args sometimes contains outputs (gh-10459), which we don't want
             input_args = args[:func.nin]
@@ -3182,8 +3182,6 @@ class MaskedArray(ndarray):
             else:
                 result._mask = m
                 result._sharedmask = False
-        else:
-            result._mask = self._mask.copy()
         return result
 
     def view(self, dtype=None, type=None, fill_value=None):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -28,7 +28,6 @@ import textwrap
 import re
 from functools import reduce
 from typing import Dict
-
 import numpy as np
 import numpy._core.umath as umath
 import numpy._core.numerictypes as ntypes
@@ -868,7 +867,7 @@ class _DomainTan:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less(umath.absolute(umath.cos(x)), self.eps)
+            return umath.less(umath.absolute(umath.cos(x)), self.eps).astype(np.bool)
 
 
 class _DomainSafeDivide:
@@ -905,7 +904,7 @@ class _DomainGreater:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less_equal(x, self.critical_value)
+            return umath.less_equal(x, self.critical_value).astype(np.bool)
 
 
 class _DomainGreaterEqual:
@@ -921,7 +920,7 @@ class _DomainGreaterEqual:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less(x, self.critical_value)
+            return umath.less(x, self.critical_value).astype(np.bool)
 
 
 class _MaskedUFunc:
@@ -3167,7 +3166,7 @@ class MaskedArray(ndarray):
                         # Domain not recognized, use fill_value instead
                         fill_value = self.fill_value
 
-                    np.copyto(result, fill_value, where=d)
+                    np.copyto(result,fill_value,where=d)
 
                     # Update the mask
                     if m is nomask:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3182,7 +3182,8 @@ class MaskedArray(ndarray):
             else:
                 result._mask = m
                 result._sharedmask = False
-
+        else:
+            result._mask = self._mask.copy()
         return result
 
     def view(self, dtype=None, type=None, fill_value=None):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -848,8 +848,8 @@ class _DomainCheckInterval:
         # nans at masked positions cause RuntimeWarnings, even though
         # they are masked. To avoid this we suppress warnings.
         with np.errstate(invalid='ignore'):
-            return umath.logical_or(umath.greater(x, self.b),
-                                    umath.less(x, self.a))
+            return np.logical_or(np.greater(x, self.b),
+                                    np.less(x, self.a))
 
 
 class _DomainTan:
@@ -867,7 +867,7 @@ class _DomainTan:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less(umath.absolute(umath.cos(x)), self.eps).astype(np.bool)
+            return np.less(umath.absolute(umath.cos(x)), self.eps)
 
 
 class _DomainSafeDivide:
@@ -904,7 +904,7 @@ class _DomainGreater:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less_equal(x, self.critical_value).astype(np.bool)
+            return np.less_equal(x, self.critical_value)
 
 
 class _DomainGreaterEqual:
@@ -920,7 +920,7 @@ class _DomainGreaterEqual:
     def __call__(self, x):
         "Executes the call behavior."
         with np.errstate(invalid='ignore'):
-            return umath.less(x, self.critical_value).astype(np.bool)
+            return np.less(x, self.critical_value)
 
 
 class _MaskedUFunc:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3166,7 +3166,7 @@ class MaskedArray(ndarray):
                         # Domain not recognized, use fill_value instead
                         fill_value = self.fill_value
 
-                    np.copyto(result,fill_value,where=d)
+                    np.copyto(result, fill_value, where=d)
 
                     # Update the mask
                     if m is nomask:


### PR DESCRIPTION
Add mask copy to `__array_wrap__` if context is `None`.

I believe this is the correct approach, but I'm not entirely confident. The method `__array_wrap__` lacks both a proper explanation in the [documentation](https://numpy.org/devdocs/reference/generated/numpy.ma.MaskedArray.__array_wrap__.html#numpy.ma.MaskedArray.__array_wrap__) and in the code itself, which greatly impedes understanding and thorough testing.

```python
    def __array_wrap__(self, obj, context=None, return_scalar=False):
        """
        Special hook for ufuncs.

        Wraps the numpy array and sets the mask according to context.

        """
```

That said, the bug has been fixed with this PR, and all tests have passed on my computer. However, to be honest, I remain concerned about this method since many other methods call it. It could potentially lead to issues if not handled carefully.

Fixes #25635