### PR TITLE
BUG: Fix Linux QEMU CI workflow

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -44,22 +44,25 @@ jobs:
               # test_unary_spurious_fpexception is currently skipped
               # FIXME(@seiko2plus): Requires confirmation for the following issue:
               # The presence of an FP invalid exception caused by sqrt. Unsure if this is a qemu bug or not.
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_unary_spurious_fpexception"
-          ]
+              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_unary_spurious_fpexception",
+              "arm"
+            ]
           - [
               "ppc64le",
               "powerpc64le-linux-gnu",
               "ppc64le/ubuntu:22.04",
               "-Dallow-noblas=true",
               "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-          ]
+              "ppc64le"
+            ]
           - [
               "ppc64le - baseline(Power9)",
               "powerpc64le-linux-gnu",
               "ppc64le/ubuntu:22.04",
               "-Dallow-noblas=true -Dcpu-baseline=vsx3",
               "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-          ]
+              "ppc64le"
+            ]
           - [
               "s390x",
               "s390x-linux-gnu",
@@ -68,27 +71,31 @@ jobs:
               # Skipping TestRationalFunctions.test_gcd_overflow test
               # because of a possible qemu bug that appears to be related to int64 overflow in absolute operation.
               # TODO(@seiko2plus): Confirm the bug and provide a minimal reproducer, then report it to upstream.
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow"
-          ]
+              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
+              "s390x"
+            ]
           - [
               "s390x - baseline(Z13)",
               "s390x-linux-gnu",
               "s390x/ubuntu:22.04",
               "-Dallow-noblas=true -Dcpu-baseline=vx",
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow"
-          ]
+              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
+              "s390x"
+            ]
           - [
               "riscv64",
               "riscv64-linux-gnu",
               "riscv64/ubuntu:22.04",
               "-Dallow-noblas=true",
-              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc"
-          ]
+              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
+              "riscv64"
+            ]
     env:
       TOOLCHAIN_NAME: ${{ matrix.BUILD_PROP[1] }}
       DOCKER_CONTAINER: ${{ matrix.BUILD_PROP[2] }}
       MESON_OPTIONS: ${{ matrix.BUILD_PROP[3] }}
       RUNTIME_TEST_FILTER: ${{ matrix.BUILD_PROP[4] }}
+      ARCH: ${{ matrix.BUILD_PROP[5] }}
       TERM: xterm-256color
 
     name: "${{ matrix.BUILD_PROP[0] }}"
@@ -117,7 +124,8 @@ jobs:
     - name: Creates new container
       if: steps.container-cache.outputs.cache-hit != 'true'
       run: |
-        docker run --name the_container --interactive -v /:/host -v $(pwd):/numpy ${DOCKER_CONTAINER} /bin/bash -c "
+        docker run --platform=linux/${ARCH} --name the_container --interactive \
+          -v /:/host -v $(pwd):/numpy ${DOCKER_CONTAINER} /bin/bash -c "
           apt update &&
           apt install -y cmake git python3 python-is-python3 python3-dev python3-pip &&
           mkdir -p /lib64 && ln -s /host/lib64/ld-* /lib64/ &&
@@ -147,10 +155,11 @@ jobs:
 
     - name: Meson Build
       run: |
-        docker run --rm -e "TERM=xterm-256color" -v $(pwd):/numpy -v /:/host the_container \
-        /bin/script -e -q -c "/bin/bash --noprofile --norc -eo pipefail -c '
-          cd /numpy && spin build --clean -- ${MESON_OPTIONS}
-        '"
+        docker run --rm --platform=linux/${ARCH} -e "TERM=xterm-256color" \
+          -v $(pwd):/numpy -v /:/host the_container \
+          /bin/script -e -q -c "/bin/bash --noprofile --norc -eo pipefail -c '
+            cd /numpy && spin build --clean -- ${MESON_OPTIONS}
+          '"
 
     - name: Meson Log
       if: always()
@@ -158,9 +167,11 @@ jobs:
 
     - name: Run Tests
       run: |
-        docker run --rm -e "TERM=xterm-256color" -v $(pwd):/numpy -v /:/host the_container \
-        /bin/script -e -q -c "/bin/bash --noprofile --norc -eo pipefail -c '
-          export F90=/usr/bin/gfortran
-          cd /numpy && spin test -- -k \"${RUNTIME_TEST_FILTER}\"
-        '"
+        docker run --rm --platform=linux/${ARCH} -e "TERM=xterm-256color" \
+          -v $(pwd):/numpy -v /:/host the_container \
+          /bin/script -e -q -c "/bin/bash --noprofile --norc -eo pipefail -c '
+            export F90=/usr/bin/gfortran
+            cd /numpy && spin test -- -k \"${RUNTIME_TEST_FILTER}\"
+          '"
+
 


### PR DESCRIPTION
Fix https://github.com/numpy/numpy/issues/27601

Fix Linux QEMU CI workflow for cross-architecture builds

**Issue:**
- The Linux QEMU CI workflow was failing across multiple architectures (arm, ppc64le, s390x, riscv64) due to improper container setup and execution for cross-architecture builds as shown in figure.

![image](https://github.com/user-attachments/assets/395787b7-ed1d-48b9-a9ec-ef647ed86903)


**Solution:**
1. Added --platform flag to docker run commands to explicitly specify the target architecture.
2. Introduced a new ARCH variable in the matrix to simplify architecture specification.
3. Updated the docker run commands in the "Creates new container", "Meson Build", and "Run Tests" steps to use the --platform flag.

**Maintained:**
1. Retained the use of qemu-user-static for QEMU emulation setup, which is necessary for cross-architecture builds.
2. Kept the existing cache mechanism for docker containers to improve workflow efficiency.

**Outcome:**
- These changes ensure that the correct architecture is used throughout the workflow, allowing for successful cross compilation and testing across all target architectures.

cc @charris @andyfaff @seiko2plus @rgommers @r-devulap @Mousius 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
