### PR TITLE
ENH: Fix np.insert to handle boolean arrays as masks

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5385,7 +5385,7 @@ def insert(arr, obj, values, axis=None):
         inserted.
 
         .. versionchanged:: 2.1.2
-            Boolean indices are now treated as a mask of elements to remove,
+            Boolean indices are now treated as a mask of elements to insert,
             rather than being cast to the integers 0 and 1.
 
         Support for multiple insertions when `obj` is a single scalar or a

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5380,11 +5380,13 @@ def insert(arr, obj, values, axis=None):
     ----------
     arr : array_like
         Input array.
-    obj : int, slice or sequence of ints
+    obj : slice, int, array-like of ints or bools
         Object that defines the index or indices before which `values` is
         inserted.
 
-        .. versionadded:: 1.8.0
+        .. versionchanged:: 2.1.2
+            Boolean indices are now treated as a mask of elements to remove,
+            rather than being cast to the integers 0 and 1.
 
         Support for multiple insertions when `obj` is a single scalar or a
         sequence with one element (similar to calling insert multiple
@@ -5491,18 +5493,10 @@ def insert(arr, obj, values, axis=None):
         # need to copy obj, because indices will be changed in-place
         indices = np.array(obj)
         if indices.dtype == bool:
-            # See also delete
-            # 2012-10-11, NumPy 1.8
-            warnings.warn(
-                "in the future insert will treat boolean arrays and "
-                "array-likes as a boolean index instead of casting it to "
-                "integer", FutureWarning, stacklevel=2)
-            indices = indices.astype(intp)
-            # Code after warning period:
-            #if obj.ndim != 1:
-            #    raise ValueError('boolean array argument obj to insert '
-            #                     'must be one dimensional')
-            #indices = np.flatnonzero(obj)
+            if obj.ndim != 1:
+                raise ValueError('boolean array argument obj to insert '
+                                'must be one dimensional')
+            indices = np.flatnonzero(obj)
         elif indices.ndim > 1:
             raise ValueError(
                 "index array argument obj to insert must be one dimensional "

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -557,13 +557,9 @@ class TestInsert:
         b = np.array([0, 1], dtype=np.float64)
         assert_equal(insert(b, 0, b[0]), [0., 0., 1.])
         assert_equal(insert(b, [], []), b)
-        # Bools will be treated differently in the future:
-        # assert_equal(insert(a, np.array([True]*4), 9), [9, 1, 9, 2, 9, 3, 9])
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', FutureWarning)
-            assert_equal(
-                insert(a, np.array([True] * 4), 9), [1, 9, 9, 9, 9, 2, 3])
-            assert_(w[0].category is FutureWarning)
+        assert_equal(insert(a, np.array([True]*4), 9), [9, 1, 9, 2, 9, 3, 9])
+        assert_equal(insert(a, np.array([True, False, True, False]), 9),
+                     [9, 1, 2, 9, 3])
 
     def test_multidim(self):
         a = [[1, 1, 1]]


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR addresses the issue where np.insert would raise a FutureWarning when using boolean arrays as obj and implicitly cast them to integers. The following changes have been made:

Added support for boolean arrays as masks:

Boolean arrays (1D) are now treated as masks, where True values indicate the positions before which the values should be inserted.
The previous behavior of casting boolean arrays to integers has been removed, aligning the behavior with other NumPy functions like np.delete.
Error handling:

If a multi-dimensional boolean array is passed, a ValueError is raised, ensuring that only 1D boolean arrays are allowed for the obj parameter.
Updated the obj parameter documentation:

The documentation has been updated to reflect the support for boolean arrays, describing their use as masks for insertion points.And like np.delete I add a versionchanged.