### PR TITLE
ENH: Extern memory management to Cython

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -257,23 +257,6 @@ cdef extern from "numpy/arrayobject.h":
         NPY_MAXDIMS  # 64 on NumPy 2.x and 32 on NumPy 1.x
         NPY_RAVEL_AXIS  # Used for functions like PyArray_Mean
 
-    # The memory handler functions require the NumPy 1.22 API
-    # and may require defining NPY_TARGET_VERSION
-    ctypedef struct PyDataMemAllocator:
-        void *ctx
-        void* (*malloc) (void *ctx, size_t size)
-        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
-        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
-        void (*free) (void *ctx, void *ptr, size_t size)
-
-    ctypedef struct PyDataMem_Handler:
-        char* name
-        npy_uint8 version
-        PyDataMemAllocator allocator
-
-    object PyDataMem_SetHandler(object handler)
-    object PyDataMem_GetHandler()
-
     ctypedef void (*PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,  void *)
 
     ctypedef struct PyArray_ArrayDescr:
@@ -773,6 +756,23 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_CheckAxis (ndarray, int *, int)
     npy_intp PyArray_OverflowMultiplyList (npy_intp *, int)
     int PyArray_SetBaseObject(ndarray, base) except -1 # NOTE: steals a reference to base! Use "set_array_base()" instead.
+
+    # The memory handler functions require the NumPy 1.22 API
+    # and may require defining NPY_TARGET_VERSION
+    ctypedef struct PyDataMemAllocator:
+        void *ctx
+        void* (*malloc) (void *ctx, size_t size)
+        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
+        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
+        void (*free) (void *ctx, void *ptr, size_t size)
+
+    ctypedef struct PyDataMem_Handler:
+        char* name
+        npy_uint8 version
+        PyDataMemAllocator allocator
+
+    object PyDataMem_SetHandler(object handler)
+    object PyDataMem_GetHandler()
 
     # additional datetime related functions are defined below
 

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -257,6 +257,23 @@ cdef extern from "numpy/arrayobject.h":
         NPY_MAXDIMS  # 64 on NumPy 2.x and 32 on NumPy 1.x
         NPY_RAVEL_AXIS  # Used for functions like PyArray_Mean
 
+    # The memory handler functions require the NumPy 1.22 API
+    # and may require defining NPY_TARGET_VERSION
+    ctypedef struct PyDataMemAllocator:
+        void *ctx
+        void* (*malloc) (void *ctx, size_t size)
+        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
+        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
+        void (*free) (void *ctx, void *ptr, size_t size)
+
+    ctypedef struct PyDataMem_Handler:
+        char* name
+        npy_uint8 version
+        PyDataMemAllocator allocator
+
+    object PyDataMem_SetHandler(object handler)
+    object PyDataMem_GetHandler()
+
     ctypedef void (*PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,  void *)
 
     ctypedef struct PyArray_ArrayDescr:

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -266,6 +266,23 @@ cdef extern from "numpy/arrayobject.h":
         NPY_MAXDIMS  # 64 on NumPy 2.x and 32 on NumPy 1.x
         NPY_RAVEL_AXIS  # Used for functions like PyArray_Mean
 
+    # The memory handler functions require the NumPy 1.22 API
+    # and may require defining NPY_TARGET_VERSION
+    ctypedef struct PyDataMemAllocator:
+        void *ctx
+        void* (*malloc) (void *ctx, size_t size)
+        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
+        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
+        void (*free) (void *ctx, void *ptr, size_t size)
+
+    ctypedef struct PyDataMem_Handler:
+        char* name
+        npy_uint8 version
+        PyDataMemAllocator allocator
+
+    object PyDataMem_SetHandler(object handler)
+    object PyDataMem_GetHandler()
+
     ctypedef void (*PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,  void *)
 
     ctypedef struct PyArray_ArrayDescr:

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -266,23 +266,6 @@ cdef extern from "numpy/arrayobject.h":
         NPY_MAXDIMS  # 64 on NumPy 2.x and 32 on NumPy 1.x
         NPY_RAVEL_AXIS  # Used for functions like PyArray_Mean
 
-    # The memory handler functions require the NumPy 1.22 API
-    # and may require defining NPY_TARGET_VERSION
-    ctypedef struct PyDataMemAllocator:
-        void *ctx
-        void* (*malloc) (void *ctx, size_t size)
-        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
-        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
-        void (*free) (void *ctx, void *ptr, size_t size)
-
-    ctypedef struct PyDataMem_Handler:
-        char* name
-        npy_uint8 version
-        PyDataMemAllocator allocator
-
-    object PyDataMem_SetHandler(object handler)
-    object PyDataMem_GetHandler()
-
     ctypedef void (*PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,  void *)
 
     ctypedef struct PyArray_ArrayDescr:
@@ -688,6 +671,23 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_CheckAxis (ndarray, int *, int)
     npy_intp PyArray_OverflowMultiplyList (npy_intp *, int)
     int PyArray_SetBaseObject(ndarray, base) except -1 # NOTE: steals a reference to base! Use "set_array_base()" instead.
+
+    # The memory handler functions require the NumPy 1.22 API
+    # and may require defining NPY_TARGET_VERSION
+    ctypedef struct PyDataMemAllocator:
+        void *ctx
+        void* (*malloc) (void *ctx, size_t size)
+        void* (*calloc) (void *ctx, size_t nelem, size_t elsize)
+        void* (*realloc) (void *ctx, void *ptr, size_t new_size)
+        void (*free) (void *ctx, void *ptr, size_t size)
+
+    ctypedef struct PyDataMem_Handler:
+        char* name
+        npy_uint8 version
+        PyDataMemAllocator allocator
+
+    object PyDataMem_SetHandler(object handler)
+    object PyDataMem_GetHandler()
 
     # additional datetime related functions are defined below
 


### PR DESCRIPTION
Add [NumPy's memory management functionality]( https://numpy.org/doc/stable/reference/c-api/data_memory.html ) to `numpy.pxd` so Cython users can leverage it.