### PR TITLE
TST: extend np.lib.unwrap tests and doc, relates to #27631

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1717,7 +1717,8 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
 
      1. ``q[0] == p[0]``.
      2. :math:`\forall i`. ``(p[i] - q[i]) % period == 0``.
-     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` -> ``q[i] - q[i-1] == p[i] - p[i-1]``.
+     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` -> 
+      ``q[i] - q[i-1] == p[i] - p[i-1]``.
      4. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) >= discont`` ->
        a. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
        b. ``(p[i] - p[i-1]) % period == (period/2)`` ->

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1713,6 +1713,27 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     difference from their predecessor of more than ``max(discont, period/2)``
     to their `period`-complementary values.
 
+    Output `q` satisfies:
+
+     1. ``q[0] == p[0]``.
+
+     2. :math:`\forall i` ``(p[i] - q[i]) % period == 0``.
+
+     3. :math:`\forall i>0`
+      ``abs(p[i] - p[i-1]) < discont`` -> ``q[i] - q[i-1] == p[i] - p[i-1]``.
+
+     4. :math:`\forall i>0`
+
+      ``abs(p[i] - p[i-1]) >= discont`` ->
+
+       1. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
+       2. ``(p[i] - p[i-1]) % period == (period/2)`` ->
+        a. ``period > 0`` -> ``q[i] > q[i-1]`` iff ``p[i] > p[i-1]``.
+        b. ``period < 0`` -< ``q[i] < q[i-1]`` iff ``p[i] > p[i-1]``.
+
+     (things should be understood w.r.t. axis, and
+     comparisons are only approximately true in non-integral case)
+
     For the default case where `period` is :math:`2\pi` and `discont` is
     :math:`\pi`, this unwraps a radian phase `p` such that adjacent differences
     are never greater than :math:`\pi` by adding :math:`2k\pi` for some

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1717,13 +1717,12 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
 
      1. ``q[0] == p[0]``.
      2. :math:`\forall i`. ``(p[i] - q[i]) % period == 0``.
-     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` ->
-     ``q[i] - q[i-1] == p[i] - p[i-1]``.
+     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` -> ``q[i] - q[i-1] == p[i] - p[i-1]``.
      4. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) >= discont`` ->
-       1. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
-       2. ``(p[i] - p[i-1]) % period == (period/2)`` ->
-        a. ``period > 0`` -> ``q[i] > q[i-1]`` iff ``p[i] > p[i-1]``.
-        b. ``period < 0`` -< ``q[i] < q[i-1]`` iff ``p[i] > p[i-1]``.
+       a. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
+       b. ``(p[i] - p[i-1]) % period == (period/2)`` ->
+        1. ``period > 0`` -> ``q[i] > q[i-1]`` iff ``p[i] > p[i-1]``.
+        2. ``period < 0`` -< ``q[i] < q[i-1]`` iff ``p[i] > p[i-1]``.
 
     (everything should be understood w.r.t. axis, and
     comparisons are only approximately true in non-integral case)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1716,23 +1716,17 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     Output `q` satisfies:
 
      1. ``q[0] == p[0]``.
-
-     2. :math:`\forall i` ``(p[i] - q[i]) % period == 0``.
-
-     3. :math:`\forall i>0`
-      ``abs(p[i] - p[i-1]) < discont`` -> ``q[i] - q[i-1] == p[i] - p[i-1]``.
-
-     4. :math:`\forall i>0`
-
-      ``abs(p[i] - p[i-1]) >= discont`` ->
-
+     2. :math:`\forall i`. ``(p[i] - q[i]) % period == 0``.
+     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` ->
+     ``q[i] - q[i-1] == p[i] - p[i-1]``.
+     4. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) >= discont`` ->
        1. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
        2. ``(p[i] - p[i-1]) % period == (period/2)`` ->
         a. ``period > 0`` -> ``q[i] > q[i-1]`` iff ``p[i] > p[i-1]``.
         b. ``period < 0`` -< ``q[i] < q[i-1]`` iff ``p[i] > p[i-1]``.
 
-     (things should be understood w.r.t. axis, and
-     comparisons are only approximately true in non-integral case)
+    (everything should be understood w.r.t. axis, and
+    comparisons are only approximately true in non-integral case)
 
     For the default case where `period` is :math:`2\pi` and `discont` is
     :math:`\pi`, this unwraps a radian phase `p` such that adjacent differences

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1713,21 +1713,6 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     difference from their predecessor of more than ``max(discont, period/2)``
     to their `period`-complementary values.
 
-    Output `q` satisfies:
-
-     1. ``q[0] == p[0]``.
-     2. :math:`\forall i`. ``(p[i] - q[i]) % period == 0``.
-     3. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` -> 
-      ``q[i] - q[i-1] == p[i] - p[i-1]``.
-     4. :math:`\forall i>0`. ``abs(p[i] - p[i-1]) >= discont`` ->
-       a. ``abs(q[i] - q[i-1]) <= abs(period/2)``.
-       b. ``(p[i] - p[i-1]) % period == (period/2)`` ->
-        1. ``period > 0`` -> ``q[i] > q[i-1]`` iff ``p[i] > p[i-1]``.
-        2. ``period < 0`` -< ``q[i] < q[i-1]`` iff ``p[i] > p[i-1]``.
-
-    (everything should be understood w.r.t. axis, and
-    comparisons are only approximately true in non-integral case)
-
     For the default case where `period` is :math:`2\pi` and `discont` is
     :math:`\pi`, this unwraps a radian phase `p` such that adjacent differences
     are never greater than :math:`\pi` by adding :math:`2k\pi` for some
@@ -1764,6 +1749,18 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     If the discontinuity in `p` is smaller than ``period/2``,
     but larger than `discont`, no unwrapping is done because taking
     the complement would only make the discontinuity larger.
+
+    Output `q` satisfies:
+
+    * ``q[0] == p[0]``.
+    * :math:`\forall i`. ``(p[i] - q[i]) % period == 0``.
+    * :math:`\forall i>0`. ``abs(p[i] - p[i-1]) < discont`` ->
+      ``q[i] - q[i-1] == p[i] - p[i-1]``.
+    * :math:`\forall i>0`. ``abs(p[i] - p[i-1]) >= discont`` ->
+        * ``abs(q[i] - q[i-1]) <= abs(period/2)``.
+        * ``(p[i] - p[i-1]) % period == (period/2)`` ->
+            * ``period > 0`` -> ``diff(q)`` and ``diff(p)`` have the same sign.
+            * ``period < 0`` -> ``diff(q)`` and ``diff(p)`` have opposite signs.
 
     Examples
     --------

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2209,7 +2209,7 @@ class TestUnwrap:
             ), where=relevant_inds))
 
     @pytest.mark.xfail(
-        reason="np.lib.unwrap doesn't handle big_int arrays well")
+        reason="gh-27686: np.unwrap returns incorrect values for bigints")
     @pytest.mark.parametrize("big_int_array, period, discont, axis", (
         ("big_int_array", 4, 7, 1),
     ), indirect=("big_int_array", ))

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2120,7 +2120,9 @@ def TestUnwrapInexact():
 
         assert_allclose(arr[slices], out_arr[slices], atol=tol)
         assert_allclose(
-            np.mod(arr - out_arr + half_period, period), half_period, atol=tol)
+            np.mod(arr - out_arr + half_period, period),
+            half_period, atol=tol
+        )
         assert_(np.all(implies(
             np.abs(np.diff(arr, axis=axis)) < discont - tol,
             np.isclose(
@@ -2172,38 +2174,49 @@ class TestUnwrap:
         assert_array_equal(sm_discont, [0, 75, 150, 225, 300, 430])
         assert sm_discont.dtype == wrap_uneven.dtype
 
-    def test_unwrap_int_array(self, TestUnwrapExact, TestUnwrapInexact, seed=1337):
+    def test_unwrap_int_array(self,
+                    TestUnwrapExact, TestUnwrapInexact, seed=1337):
         randState = np.random.RandomState(seed=seed)
         arr = randState.randint(-32, 32, 1 << 20).reshape(16, -1, 16)
         # check normal functionality
         period, discont, axis = 4, 3, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapExact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check axis works
         period, discont, axis = 4, 3, 0
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapExact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check discont None
         period, discont, axis = 4, None, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapExact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check negative period
         period, discont, axis = -4, 3, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapExact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check non-integer period with integer array
         period, discont, axis = 2 * np.pi, 3, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
 
     @pytest.mark.xfail(
@@ -2213,33 +2226,43 @@ class TestUnwrap:
         arr = randState.uniform(-1e9, 1e9, 1 << 20).reshape(16, -1, 16)
         # check normal functionality
         period, discont, axis = 2 * np.pi, 1e7, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check discont None
         period, discont, axis = 2 * np.pi, None, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check negative period
         period, discont, axis = -2 * np.pi, 1e7, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check normal with rational period
         period, discont, axis = 0.5, 1e7, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
         # check normal with negative rational period
         period, discont, axis = -0.5, 1e7, 1
-        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        result = np.unwrap(
+            arr, period=period, discont=discont, axis=axis
+        )
         TestUnwrapInexact(
-            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+            arr, result, period=period, discont=discont, axis=axis
         )
 
 @pytest.mark.parametrize(

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2118,17 +2118,17 @@ def TestUnwrapInexact():
         slices[axis] = slice(0, 1)
         slices = tuple(slices)
 
-        assert_allclose(arr[slices], out_arr[slices])
+        assert_allclose(arr[slices], out_arr[slices], atol=tol)
         assert_allclose(
-            np.mod(arr - out_arr + half_period, period), half_period)
+            np.mod(arr - out_arr + half_period, period), half_period, atol=tol)
         assert_(np.all(implies(
-            np.abs(np.diff(arr, axis=axis)) < discont,
+            np.abs(np.diff(arr, axis=axis)) < discont - tol,
             np.isclose(
                 np.diff(out_arr, axis=axis),
                 np.diff(arr, axis=axis))
         )))
         assert_(np.all(implies(
-            np.abs(np.diff(arr, axis=axis)) >= discont - tol,
+            np.abs(np.diff(arr, axis=axis)) >= discont + tol,
             np.abs(np.diff(out_arr, axis=axis)) <= abs(half_period) + tol
         )))
         relevant_inds = \

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2172,6 +2172,40 @@ class TestUnwrap:
         assert_array_equal(sm_discont, [0, 75, 150, 225, 300, 430])
         assert sm_discont.dtype == wrap_uneven.dtype
 
+    def test_unwrap_int_array(self, TestUnwrapExact, TestUnwrapInexact, seed=1337):
+        randState = np.random.RandomState(seed=seed)
+        arr = randState.randint(-1<<5, 1<<5, 1<<20).reshape(16, -1, 16)
+        # check normal functionality
+        period, discont, axis = 4, 3, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapExact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check axis works
+        period, discont, axis = 4, 3, 0
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapExact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check discont None
+        period, discont, axis = 4, None, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapExact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check negative period
+        period, discont, axis = -4, 3, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapExact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check non-integer period with integer array
+        period, discont, axis = 2 * np.pi, 3, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+
 
 @pytest.mark.parametrize(
     "dtype", "O" + np.typecodes["AllInteger"] + np.typecodes["Float"]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2206,6 +2206,41 @@ class TestUnwrap:
             arr, unwrapped_arr, period=period, discont=discont, axis=axis
         )
 
+    @pytest.mark.xfail(
+        reason="gh-27609: np.lib.unwrap accumulates rounding errors")
+    def test_unwrap_float_array(self, TestUnwrapInexact, seed=1337):
+        randState = np.random.RandomState(seed=seed)
+        arr = randState.uniform(-1e9, 1e9, 1<<20).reshape(16, -1, 16)
+        # check normal functionality
+        period, discont, axis = 2 * np.pi, 1e7, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check discont None
+        period, discont, axis = 2 * np.pi, None, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check negative period
+        period, discont, axis = -2 * np.pi, 1e7, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check normal with rational period
+        period, discont, axis = 0.5, 1e7, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
+        # check normal with negative rational period
+        period, discont, axis = -0.5, 1e7, 1
+        unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
+        TestUnwrapInexact(
+            arr, unwrapped_arr, period=period, discont=discont, axis=axis
+        )
 
 @pytest.mark.parametrize(
     "dtype", "O" + np.typecodes["AllInteger"] + np.typecodes["Float"]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2174,7 +2174,7 @@ class TestUnwrap:
 
     def test_unwrap_int_array(self, TestUnwrapExact, TestUnwrapInexact, seed=1337):
         randState = np.random.RandomState(seed=seed)
-        arr = randState.randint(-1<<5, 1<<5, 1<<20).reshape(16, -1, 16)
+        arr = randState.randint(-32, 32, 1 << 20).reshape(16, -1, 16)
         # check normal functionality
         period, discont, axis = 4, 3, 1
         unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)
@@ -2210,7 +2210,7 @@ class TestUnwrap:
         reason="gh-27609: np.lib.unwrap accumulates rounding errors")
     def test_unwrap_float_array(self, TestUnwrapInexact, seed=1337):
         randState = np.random.RandomState(seed=seed)
-        arr = randState.uniform(-1e9, 1e9, 1<<20).reshape(16, -1, 16)
+        arr = randState.uniform(-1e9, 1e9, 1 << 20).reshape(16, -1, 16)
         # check normal functionality
         period, discont, axis = 2 * np.pi, 1e7, 1
         unwrapped_arr = np.unwrap(arr, period=period, discont=discont, axis=axis)


### PR DESCRIPTION
TST: extend np.lib.unwrap tests and doc, relates to #27631

Following #27631 added tests for np.lib.unwrap.
Also extended doc to make the boundary conditions fully formalized.

New tests include:
1. Basic functionality test - discont, negative period, axis
2. Different variations of unwrap for int arrays
3. Different variations of unwrap for float arrays
**xfailed due to #27609** 

Tests #27609 

