### PR TITLE
BUG : avoid maximum fill value of datetime and timedelta return `NaT` in masked array

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -193,7 +193,7 @@ for sctype in ntypes.sctypeDict.values():
 
     if scalar_dtype.kind in "Mm":
         info = np.iinfo(np.int64)
-        min_val, max_val = info.min, info.max
+        min_val, max_val = info.min + 1, info.max
     elif np.issubdtype(scalar_dtype, np.integer):
         info = np.iinfo(sctype)
         min_val, max_val = info.min, info.max
@@ -5979,7 +5979,7 @@ class MaskedArray(ndarray):
                 result = masked
             return result
         # Explicit output
-        result = self.filled(fill_value).min(axis=axis, out=out, **kwargs)
+        self.filled(fill_value).min(axis=axis, out=out, **kwargs)
         if isinstance(out, MaskedArray):
             outmask = getmask(out)
             if outmask is nomask:
@@ -6084,7 +6084,7 @@ class MaskedArray(ndarray):
                 result = masked
             return result
         # Explicit output
-        result = self.filled(fill_value).max(axis=axis, out=out, **kwargs)
+        self.filled(fill_value).max(axis=axis, out=out, **kwargs)
         if isinstance(out, MaskedArray):
             outmask = getmask(out)
             if outmask is nomask:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1368,7 +1368,7 @@ class TestMaskedArrayArithmetic:
         m = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0]
 
         for x in x_test:
-            minmax_with_mask(x,m)
+            minmax_with_mask(x, m)
 
     def test_addsumprod(self):
         # Tests add, sum, product.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1351,16 +1351,24 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
-    @pytest.mark.parametrize("time_type", [np.datetime64("NaT", 's'),
-                                          np.timedelta64("NaT", 's')])
+    @pytest.mark.parametrize("time_type", ["M8[s]", "m8[s]"])
     def test_minmax_time_dtypes(self, time_type):
-        # Additional tests on max/min for time dtypes
-        x = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype= time_type)
-        m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0]
-        xm = masked_array(x, mask= m1)
+        def minmax_with_mask(arr, mask):
+            masked_arr = masked_array(arr, mask=mask)
+            expected_min = arr[~np.array(mask, dtype=bool)].min()
+            expected_max = arr[~np.array(mask, dtype=bool)].max()
 
-        assert_equal(np.int64(xm.min()), -10)
-        assert_equal(np.int64(xm.max()), 5)
+            assert_equal(np.int64(masked_arr.min()), np.int64(expected_min))
+            assert_equal(np.int64(masked_arr.max()), np.int64(expected_max))
+        # Additional tests on max/min for time dtypes
+        x1 = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
+        x2 = np.array(['NaT', 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
+        x3 = np.array(['NaT', 'NaT', -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
+        x_test = [x1, x2, x3]
+        m = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0]
+
+        for x in x_test:
+            minmax_with_mask(x,m)
 
     def test_addsumprod(self):
         # Tests add, sum, product.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1358,10 +1358,11 @@ class TestMaskedArrayArithmetic:
             expected_min = arr[~np.array(mask, dtype=bool)].min()
             expected_max = arr[~np.array(mask, dtype=bool)].max()
 
-            assert_equal(np.int64(masked_arr.min()), np.int64(expected_min))
-            assert_equal(np.int64(masked_arr.max()), np.int64(expected_max))
+            assert_array_equal(masked_arr.min(), expected_min, strict=True)
+            assert_array_equal(masked_arr.max(), expected_max, strict=True)
+
         # Additional tests on max/min for time dtypes
-        x1 = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
+        x1 = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, -2**63+1], dtype=time_type)
         x2 = np.array(['NaT', 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
         x3 = np.array(['NaT', 'NaT', -2, 4, 5, -10, 10, 1, 2, 3], dtype=time_type)
         x_test = [x1, x2, x3]

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1351,6 +1351,17 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
+    @pytest.mark.parametrize("time_type",[np.datetime64("NaT", 's'),
+                                         np.timedelta64("NaT", 's')])
+    def test_minmax_time_dtypes(self, time_type):
+        # Additional tests on max/min for time dtypes
+        x = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype= time_type)
+        m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0]
+        xm = masked_array(x, mask= m1)
+
+        assert_equal(np.int64(xm.min()), -10)
+        assert_equal(np.int64(xm.max()), 5)
+
     def test_addsumprod(self):
         # Tests add, sum, product.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1351,8 +1351,8 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
-    @pytest.mark.parametrize("time_type",[np.datetime64("NaT", 's'),
-                                         np.timedelta64("NaT", 's')])
+    @pytest.mark.parametrize("time_type", [np.datetime64("NaT", 's'),
+                                          np.timedelta64("NaT", 's')])
     def test_minmax_time_dtypes(self, time_type):
         # Additional tests on max/min for time dtypes
         x = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, 3], dtype= time_type)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1358,8 +1358,8 @@ class TestMaskedArrayArithmetic:
             expected_min = arr[~np.array(mask, dtype=bool)].min()
             expected_max = arr[~np.array(mask, dtype=bool)].max()
 
-            assert_array_equal(masked_arr.min(), expected_min, strict=True)
-            assert_array_equal(masked_arr.max(), expected_max, strict=True)
+            assert_array_equal(masked_arr.min(), expected_min)
+            assert_array_equal(masked_arr.max(), expected_max)
 
         # Additional tests on max/min for time dtypes
         x1 = np.array([1, 1, -2, 4, 5, -10, 10, 1, 2, -2**63+1], dtype=time_type)


### PR DESCRIPTION
Avoid maximum fill value of datetime and timedelta return `NaT` in masked array, which could cause to some errors as comparing.
It is set to `min(np.int64)+1`.

fixes #18240 