### PR TITLE
DOC: Remove ambiguity in docs for ndarray.byteswap()

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3310,7 +3310,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('byteswap',
     ``A.view(A.dtype.newbyteorder()).byteswap()`` produces an array with
     the same values but different representation in memory
 
-    >>> A = np.array([1, 2, 3])
+    >>> A = np.array([1, 2, 3],dtype=np.int64)
     >>> A.view(np.uint8)
     array([1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
            0, 0], dtype=uint8)


### PR DESCRIPTION
This fixes #27628. Thanks to @Shezeeblanka for pointing out the potential ambiguity in the documentation of numpy.ndarray.byteswap(). This commit explicitly mentions the datatype of the array A so that running the code snippet would yield reproducible results. 