### PR TITLE
TYP,TST: Bump ``mypy`` from ``1.11.1`` to ``1.13.0``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,8 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.11.1
+  - mypy=1.13.0
+  - orjson  # makes mypy faster
   # For building docs
   - sphinx>=4.5.0
   - sphinx-copybutton

--- a/numpy/typing/tests/data/fail/testing.pyi
+++ b/numpy/typing/tests/data/fail/testing.pyi
@@ -23,6 +23,6 @@ np.testing.assert_array_max_ulp(AR_U, AR_U)  # E: incompatible type
 np.testing.assert_warns(warning_class=RuntimeWarning, func=func)  # E: No overload variant
 np.testing.assert_no_warnings(func=func)  # E: No overload variant
 np.testing.assert_no_warnings(func, None)  # E: Too many arguments
-np.testing.assert_no_warnings(func, test=None)  # E: Unexpected keyword argument
+np.testing.assert_no_warnings(func, test=None)  # E: No overload variant
 
 np.testing.assert_no_gc_cycles(func=func)  # E: No overload variant

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -14,7 +14,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.11.1; platform_python_implementation != "PyPy"
+mypy[faster-cache]==1.13.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
By additionally installing `orjson` (e.g. through the `mypy[faster-cache]` extra), `mypy 1.13` should be 5-20% faster than mypy `1.12.1`.

relevant release notes:

- `1.12.0`: https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-12
- `1.12.1`: https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-12-1
- `1.13.0`: https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-13
