### PR TITLE
ENH: Re-enable VXE from build targets for sin/cos 

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -953,6 +953,7 @@ foreach gen_mtargets : [
       AVX512_SKX, [AVX2, FMA3],
       VSX4, VSX3, VSX2,
       NEON_VFPV4,
+      VXE2, VXE,
     ]
   ],
   [


### PR DESCRIPTION
As discussed in the optimization meeting, @seiko2plus wanted to split VSX and VXE into two separate PR's. 

For clarification, SIMD optimizations for sine and cosine functions on both ppc64 and z/Architecture (IBM Z) were disabled by #25781 to bypass CI tests. This PR aims to re-enable optimizations for z/Architecture after addressing the following runtime errors, while #27627 re-enabled ppc64 optimizations.
```Bash

numpy/_core/tests/test_umath_accuracy.py:84: AssertionError
=========================== short test summary info ============================
FAILED numpy/_core/tests/test_umath.py::TestSpecialFloats::test_sincos_values[f] - AssertionError: 
FAILED numpy/_core/tests/test_umath.py::TestSpecialFloats::test_sincos_errors[inf-f-sin] - AssertionError: FloatingPointError not raised by sin
FAILED numpy/_core/tests/test_umath.py::TestSpecialFloats::test_sincos_errors[inf-f-cos] - AssertionError: FloatingPointError not raised by cos
FAILED numpy/_core/tests/test_umath.py::TestSpecialFloats::test_sincos_errors[-inf-f-sin] - AssertionError: FloatingPointError not raised by sin
FAILED numpy/_core/tests/test_umath.py::TestSpecialFloats::test_sincos_errors[-inf-f-cos] - AssertionError: FloatingPointError not raised by cos
FAILED numpy/_core/tests/test_umath.py::TestAVXFloat32Transcendental::test_sincos_float32 - AssertionError: Arrays are not almost equal up to 2 ULP (max difference is ...
FAILED numpy/_core/tests/test_umath.py::TestAVXFloat32Transcendental::test_strided_float32 - AssertionError: Arrays are not equal to 2 ULP (max is 1.05785e+09)
FAILED numpy/_core/tests/test_umath_accuracy.py::TestAccuracy::test_validate_fp16_transcendentals[cos] - AssertionError: Arrays are not almost equal up to 1 ULP (max difference is ...
FAILED numpy/_core/tests/test_umath_accuracy.py::TestAccuracy::test_validate_fp16_transcendentals[sin] - AssertionError: Arrays are not almost equal up to 1 ULP (max difference is ...
= 9 failed, 22213 passed, 1559 skipped, 26186 deselected, 7 xfailed, 2 xpassed in 555.12s (0:09:15) =
````


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
