### PR TITLE
BUG: Fix a reference count leak in npy_find_descr_for_scalar.

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -476,7 +476,6 @@ npy_find_descr_for_scalar(
             /* If the DType doesn't know the scalar type, guess at default. */
             !NPY_DT_CALL_is_known_scalar_type(common, Py_TYPE(scalar))) {
         if (common->singleton != NULL) {
-            Py_INCREF(common->singleton);
             res = common->singleton;
             Py_INCREF(res);
         }


### PR DESCRIPTION
The reference count for common->singleton is incremented twice, when it should only be incremented once.

This leak was found when running Google's tests with NumPy 2.1.2, and appears to be a new leak as of NumPy 2.1, probably introduced in https://github.com/numpy/numpy/commit/1cb40445aaf63224b458601c1fff9a4e74b44eda.

In particular, this test:
https://github.com/protocolbuffers/protobuf/blob/6cb71402940c6645e49959dfc915f16f4d2e6c20/python/google/protobuf/internal/numpy/numpy_test.py runs in Py_DEBUG mode and verifies that the total reference count before and after various test cases is unchanged. The same test case has found other NumPy reference count leaks in the past and it may be sensible to add something similar to NumPy's own test suite.

@seberg 