### PR TITLE
TYP: Allow returning non-array-likes from the ``apply_along_axis`` function

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -95,7 +95,7 @@ def apply_along_axis(
 ) -> NDArray[_SCT]: ...
 @overload
 def apply_along_axis(
-    func1d: Callable[Concatenate[NDArray[Any], _P], ArrayLike],
+    func1d: Callable[Concatenate[NDArray[Any], _P], Any],
     axis: SupportsIndex,
     arr: ArrayLike,
     *args: _P.args,


### PR DESCRIPTION
fixes #27660