### PR TITLE
BLD: Do not set __STDC_VERSION__ to zero during build

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -681,7 +681,6 @@ c_args_common = [
 
 # Same as NPY_CXX_FLAGS (TODO: extend for what ccompiler_opt adds)
 cpp_args_common = c_args_common + [
-  '-D__STDC_VERSION__=0',  # for compatibility with C headers
 ]
 if cc.get_argument_syntax() != 'msvc'
   cpp_args_common += [

--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -9,7 +9,8 @@
 
 #include "numpy/npy_common.h"
 
-#if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+    && !defined(__STDC_NO_ATOMICS__)
 // TODO: support C++ atomics as well if this header is ever needed in C++
     #include <stdatomic.h>
     #include <stdint.h>


### PR DESCRIPTION
Backport of #27650.

The __STDC_VERSION__ set to zero prevents successful build on at least one platform - OpenIndiana.  In addiiton, zero is not a valid value for __STDC_VERSION__ and it is unclear why the setting was added.

Closes #25366.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
