### PR TITLE
ENH: fix wasm32 runtime type error in numpy._core

### DIFF
--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1256,22 +1256,22 @@ dtypemeta_wrap_legacy_descriptor(
 
 
 static PyObject *
-dtypemeta_get_abstract(PyArray_DTypeMeta *self) {
+dtypemeta_get_abstract(PyArray_DTypeMeta *self, void *NPY_UNUSED(ignored)) {
     return PyBool_FromLong(NPY_DT_is_abstract(self));
 }
 
 static PyObject *
-dtypemeta_get_legacy(PyArray_DTypeMeta *self) {
+dtypemeta_get_legacy(PyArray_DTypeMeta *self, void *NPY_UNUSED(ignored)) {
     return PyBool_FromLong(NPY_DT_is_legacy(self));
 }
 
 static PyObject *
-dtypemeta_get_parametric(PyArray_DTypeMeta *self) {
+dtypemeta_get_parametric(PyArray_DTypeMeta *self, void *NPY_UNUSED(ignored)) {
     return PyBool_FromLong(NPY_DT_is_parametric(self));
 }
 
 static PyObject *
-dtypemeta_get_is_numeric(PyArray_DTypeMeta *self) {
+dtypemeta_get_is_numeric(PyArray_DTypeMeta *self, void *NPY_UNUSED(ignored)) {
     return PyBool_FromLong(NPY_DT_is_numeric(self));
 }
 


### PR DESCRIPTION
Backport of #27663.

As per [python spec](https://docs.python.org/3/c-api/structures.html#c.getter) getters accept two arguments, second being closure context.
In [descriptor.c](https://github.com/numpy/numpy/blob/70fde29fdd4d8fcc6098df7ef8a34c84844e347f/numpy/_core/src/multiarray/descriptor.c#L2311C51-L2311C78) numpy follows it, while in patched file it did not.

Why is it important? I was compiling for wasm32-wasip1 (I know that it is not supported), and expression `str(np.dtype("float32"))` gives runtime error due to incompatible function pointer type (omitting an argument), because it boils down to calling `._legacy` getter. After this patch the snippet works. This issue is (probably) not observable in emscripten due to [`ifdef`](https://github.com/python/cpython/blob/b2eaa75b176e07730215d76d8dce4d63fb493391/Include/internal/pycore_emscripten_trampoline.h#L59) in the place that handles getters in cpython

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
