### PR TITLE
BUG: fixes for StringDType/unicode promoters

### DIFF
--- a/doc/release/upcoming_changes/27636.improvement.rst
+++ b/doc/release/upcoming_changes/27636.improvement.rst
@@ -1,0 +1,3 @@
+* Fixed a number of issues around promotion for string ufuncs with StringDType
+  arguments. Mixing StringDType and the fixed-width DTypes using the string
+  ufuncs should now generate much more uniform results.

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1598,6 +1598,20 @@ string_expandtabs_strided_loop(PyArrayMethod_Context *context,
     return -1;
 }
 
+static int
+string_center_ljust_rjust_promoter(
+        PyObject *NPY_UNUSED(ufunc),
+        PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
+        PyArray_DTypeMeta *new_op_dtypes[])
+{
+    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
+    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
+    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_StringDType);
+    return 0;
+}
+
 static NPY_CASTING
 center_ljust_rjust_resolve_descriptors(
         struct PyArrayMethodObject_tag *NPY_UNUSED(method),
@@ -2831,20 +2845,13 @@ init_stringdtype_ufuncs(PyObject *umath)
             return -1;
         }
 
-        PyArray_DTypeMeta *int_promoter_dtypes[] = {
-            &PyArray_StringDType,
-            &PyArray_IntAbstractDType,
-            &PyArray_StringDType,
-            &PyArray_StringDType,
-        };
-
-        if (add_promoter(umath, center_ljust_rjust_names[i],
-                         int_promoter_dtypes, 4,
-                         string_multiply_promoter) < 0) {
-            return -1;
-        }
-
-        PyArray_DTypeMeta *unicode_promoter_dtypes[2][4] = {
+        PyArray_DTypeMeta *promoter_dtypes[3][4] = {
+            {
+                &PyArray_StringDType,
+                &PyArray_IntAbstractDType,
+                &PyArray_StringDType,
+                &PyArray_StringDType,
+            },
             {
                 &PyArray_StringDType,
                 &PyArray_IntAbstractDType,
@@ -2859,10 +2866,10 @@ init_stringdtype_ufuncs(PyObject *umath)
             },
         };
 
-        for (int j=0; j<2; j++) {
+        for (int j=0; j<3; j++) {
             if (add_promoter(umath, center_ljust_rjust_names[i],
-                             unicode_promoter_dtypes[j], 4,
-                             string_multiply_promoter) < 0) {
+                             promoter_dtypes[j], 4,
+                             string_center_ljust_rjust_promoter) < 0) {
                 return -1;
             }
         }

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2595,10 +2595,17 @@ init_stringdtype_ufuncs(PyObject *umath)
         "find", "rfind", "index", "rindex", "count",
     };
 
-    PyArray_DTypeMeta *findlike_promoter_dtypes[] = {
-        &PyArray_StringDType, &PyArray_UnicodeDType,
-        &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-        &PyArray_DefaultIntDType,
+    PyArray_DTypeMeta *findlike_promoter_dtypes[2][5] = {
+        {
+            &PyArray_StringDType, &PyArray_UnicodeDType,
+            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
+            &PyArray_IntAbstractDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_StringDType,
+            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
+            &PyArray_IntAbstractDType,
+        },
     };
 
     find_like_function *findlike_functions[] = {
@@ -2618,11 +2625,12 @@ init_stringdtype_ufuncs(PyObject *umath)
             return -1;
         }
 
-
-        if (add_promoter(umath, findlike_names[i],
-                         findlike_promoter_dtypes,
-                         5, string_findlike_promoter) < 0) {
-            return -1;
+        for (int j=0; j<2; j++) {
+            if (add_promoter(umath, findlike_names[i],
+                             findlike_promoter_dtypes[j],
+                             5, string_findlike_promoter) < 0) {
+                return -1;
+            }
         }
     }
 
@@ -2636,10 +2644,17 @@ init_stringdtype_ufuncs(PyObject *umath)
         "startswith", "endswith",
     };
 
-    PyArray_DTypeMeta *startswith_endswith_promoter_dtypes[] = {
-        &PyArray_StringDType, &PyArray_UnicodeDType,
-        &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-        &PyArray_BoolDType,
+    PyArray_DTypeMeta *startswith_endswith_promoter_dtypes[2][5] = {
+        {
+            &PyArray_StringDType, &PyArray_UnicodeDType,
+            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
+            &PyArray_BoolDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_StringDType,
+            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
+            &PyArray_BoolDType,
+        },
     };
 
     static STARTPOSITION startswith_endswith_startposition[] = {
@@ -2656,11 +2671,12 @@ init_stringdtype_ufuncs(PyObject *umath)
             return -1;
         }
 
-
-        if (add_promoter(umath, startswith_endswith_names[i],
-                         startswith_endswith_promoter_dtypes,
-                         5, string_startswith_endswith_promoter) < 0) {
-            return -1;
+        for (int j=0; j<2; j++) {
+            if (add_promoter(umath, startswith_endswith_names[i],
+                             startswith_endswith_promoter_dtypes[j],
+                             5, string_startswith_endswith_promoter) < 0) {
+                return -1;
+            }
         }
     }
 
@@ -2732,24 +2748,38 @@ init_stringdtype_ufuncs(PyObject *umath)
         return -1;
     }
 
-    PyArray_DTypeMeta *replace_promoter_pyint_dtypes[] = {
-        &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_UnicodeDType,
-        &PyArray_IntAbstractDType, &PyArray_StringDType,
+    PyArray_DTypeMeta *replace_promoter_unicode_dtypes[6][5] = {
+        {
+            &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_UnicodeDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_StringDType, &PyArray_UnicodeDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_UnicodeDType, &PyArray_StringDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_StringDType, &PyArray_StringDType, &PyArray_UnicodeDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_StringDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_StringDType, &PyArray_StringDType,
+            &PyArray_IntAbstractDType, &PyArray_StringDType,
+        },
     };
 
-    if (add_promoter(umath, "_replace", replace_promoter_pyint_dtypes, 5,
-                     string_replace_promoter) < 0) {
-        return -1;
-    }
-
-    PyArray_DTypeMeta *replace_promoter_int64_dtypes[] = {
-        &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_UnicodeDType,
-        &PyArray_Int64DType, &PyArray_StringDType,
-    };
-
-    if (add_promoter(umath, "_replace", replace_promoter_int64_dtypes, 5,
-                     string_replace_promoter) < 0) {
-        return -1;
+    for (int j=0; j<6; j++) {
+        if (add_promoter(umath, "_replace", replace_promoter_unicode_dtypes[j], 5,
+                         string_replace_promoter) < 0) {
+            return -1;
+        }
     }
 
     PyArray_DTypeMeta *expandtabs_dtypes[] = {
@@ -2767,9 +2797,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *expandtabs_promoter_dtypes[] = {
-        &PyArray_StringDType,
-        (PyArray_DTypeMeta *)Py_None,
-        &PyArray_StringDType
+            &PyArray_StringDType,
+            &PyArray_IntAbstractDType,
+            &PyArray_StringDType
     };
 
     if (add_promoter(umath, "_expandtabs", expandtabs_promoter_dtypes,
@@ -2803,7 +2833,7 @@ init_stringdtype_ufuncs(PyObject *umath)
 
         PyArray_DTypeMeta *int_promoter_dtypes[] = {
             &PyArray_StringDType,
-            (PyArray_DTypeMeta *)Py_None,
+            &PyArray_IntAbstractDType,
             &PyArray_StringDType,
             &PyArray_StringDType,
         };
@@ -2814,17 +2844,27 @@ init_stringdtype_ufuncs(PyObject *umath)
             return -1;
         }
 
-        PyArray_DTypeMeta *unicode_promoter_dtypes[] = {
-            &PyArray_StringDType,
-            (PyArray_DTypeMeta *)Py_None,
-            &PyArray_UnicodeDType,
-            &PyArray_StringDType,
+        PyArray_DTypeMeta *unicode_promoter_dtypes[2][4] = {
+            {
+                &PyArray_StringDType,
+                &PyArray_IntAbstractDType,
+                &PyArray_UnicodeDType,
+                &PyArray_StringDType,
+            },
+            {
+                &PyArray_UnicodeDType,
+                &PyArray_IntAbstractDType,
+                &PyArray_StringDType,
+                &PyArray_StringDType,
+            },
         };
 
-        if (add_promoter(umath, center_ljust_rjust_names[i],
-                         unicode_promoter_dtypes, 4,
-                         string_multiply_promoter) < 0) {
-            return -1;
+        for (int j=0; j<2; j++) {
+            if (add_promoter(umath, center_ljust_rjust_names[i],
+                             unicode_promoter_dtypes[j], 4,
+                             string_multiply_promoter) < 0) {
+                return -1;
+            }
         }
     }
 
@@ -2840,13 +2880,13 @@ init_stringdtype_ufuncs(PyObject *umath)
         return -1;
     }
 
-    PyArray_DTypeMeta *int_promoter_dtypes[] = {
+    PyArray_DTypeMeta *zfill_promoter_dtypes[] = {
             &PyArray_StringDType,
-            (PyArray_DTypeMeta *)Py_None,
+            &PyArray_IntAbstractDType,
             &PyArray_StringDType,
     };
 
-    if (add_promoter(umath, "_zfill", int_promoter_dtypes, 3,
+    if (add_promoter(umath, "_zfill", zfill_promoter_dtypes, 3,
                      string_multiply_promoter) < 0) {
         return -1;
     }

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -669,20 +669,29 @@ def center(a, width, fillchar=' '):
     array(['a1b2', '1b2a', 'b2a1', '2a1b'], dtype='<U4')
 
     """
+    width = np.asanyarray(width)
+    if not np.issubdtype(width.dtype, np.integer):
+        raise TypeError(f"unsupported type {width.dtype} for operand 'width'")
+
     a = np.asanyarray(a)
-    fillchar = np.asanyarray(fillchar, dtype=a.dtype)
+    fillchar = np.asanyarray(fillchar)
+
+    try_out_dt = np.result_type(a, fillchar)
+    if try_out_dt.char == "T":
+        a = a.astype(try_out_dt, copy=False)
+        fillchar = fillchar.astype(try_out_dt, copy=False)
+        out = None
+    else:
+        fillchar = fillchar.astype(a.dtype, copy=False)
+        width = np.maximum(str_len(a), width)
+        out_dtype = f"{a.dtype.char}{width.max()}"
+        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+        out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
 
-    if a.dtype.char == "T":
-        return _center(a, width, fillchar)
-
-    width = np.maximum(str_len(a), width)
-    out_dtype = f"{a.dtype.char}{width.max()}"
-    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-    out = np.empty_like(a, shape=shape, dtype=out_dtype)
     return _center(a, width, fillchar, out=out)
 
 
@@ -726,20 +735,29 @@ def ljust(a, width, fillchar=' '):
     array(['aAaAaA   ', '  aA     ', 'abBABba  '], dtype='<U9')
 
     """
+    width = np.asanyarray(width)
+    if not np.issubdtype(width.dtype, np.integer):
+        raise TypeError(f"unsupported type {width.dtype} for operand 'width'")
+
     a = np.asanyarray(a)
-    fillchar = np.asanyarray(fillchar, dtype=a.dtype)
+    fillchar = np.asanyarray(fillchar)
+
+    try_out_dt = np.result_type(a, fillchar)
+    if try_out_dt.char == "T":
+        a = a.astype(try_out_dt, copy=False)
+        fillchar = fillchar.astype(try_out_dt, copy=False)
+        out = None
+    else:
+        fillchar = fillchar.astype(a.dtype, copy=False)
+        width = np.maximum(str_len(a), width)
+        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+        out_dtype = f"{a.dtype.char}{width.max()}"
+        out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
 
-    if a.dtype.char == "T":
-        return _ljust(a, width, fillchar)
-
-    width = np.maximum(str_len(a), width)
-    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-    out_dtype = f"{a.dtype.char}{width.max()}"
-    out = np.empty_like(a, shape=shape, dtype=out_dtype)
     return _ljust(a, width, fillchar, out=out)
 
 
@@ -783,20 +801,29 @@ def rjust(a, width, fillchar=' '):
     array(['   aAaAaA', '     aA  ', '  abBABba'], dtype='<U9')
 
     """
+    width = np.asanyarray(width)
+    if not np.issubdtype(width.dtype, np.integer):
+        raise TypeError(f"unsupported type {width.dtype} for operand 'width'")
+
     a = np.asanyarray(a)
-    fillchar = np.asanyarray(fillchar, dtype=a.dtype)
+    fillchar = np.asanyarray(fillchar)
+
+    try_out_dt = np.result_type(a, fillchar)
+    if try_out_dt.char == "T":
+        a = a.astype(try_out_dt, copy=False)
+        fillchar = fillchar.astype(try_out_dt, copy=False)
+        out = None
+    else:
+        fillchar = fillchar.astype(a.dtype, copy=False)
+        width = np.maximum(str_len(a), width)
+        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+        out_dtype = f"{a.dtype.char}{width.max()}"
+        out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
 
-    if a.dtype.char == "T":
-        return _rjust(a, width, fillchar)
-
-    width = np.maximum(str_len(a), width)
-    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-    out_dtype = f"{a.dtype.char}{width.max()}"
-    out = np.empty_like(a, shape=shape, dtype=out_dtype)
     return _rjust(a, width, fillchar, out=out)
 
 
@@ -830,6 +857,10 @@ def zfill(a, width):
     array(['001', '-01', '+01'], dtype='<U3')
 
     """
+    width = np.asanyarray(width)
+    if not np.issubdtype(width.dtype, np.integer):
+        raise TypeError(f"unsupported type {width.dtype} for operand 'width'")
+
     a = np.asanyarray(a)
 
     if a.dtype.char == "T":
@@ -1205,22 +1236,33 @@ def replace(a, old, new, count=-1):
     array(['The dwash was fresh', 'Thwas was it'], dtype='<U19')
 
     """
-    arr = np.asanyarray(a)
-    a_dt = arr.dtype
-    old = np.asanyarray(old, dtype=getattr(old, 'dtype', a_dt))
-    new = np.asanyarray(new, dtype=getattr(new, 'dtype', a_dt))
     count = np.asanyarray(count)
+    if not np.issubdtype(count.dtype, np.integer):
+        raise TypeError(f"unsupported type {count.dtype} for operand 'count'")
 
-    if arr.dtype.char == "T":
-        return _replace(arr, old, new, count)
+    arr = np.asanyarray(a)
+    old_dtype = getattr(old, 'dtype', None)
+    old = np.asanyarray(old)
+    new_dtype = getattr(new, 'dtype', None)
+    new = np.asanyarray(new)
 
-    max_int64 = np.iinfo(np.int64).max
-    counts = _count_ufunc(arr, old, 0, max_int64)
-    counts = np.where(count < 0, counts, np.minimum(counts, count))
-
-    buffersizes = str_len(arr) + counts * (str_len(new) - str_len(old))
-    out_dtype = f"{arr.dtype.char}{buffersizes.max()}"
-    out = np.empty_like(arr, shape=buffersizes.shape, dtype=out_dtype)
+    try_out_dt = np.result_type(arr, old, new)
+    if try_out_dt.char == "T":
+        arr = a.astype(try_out_dt, copy=False)
+        old = old.astype(try_out_dt, copy=False)
+        new = new.astype(try_out_dt, copy=False)
+        counts = count
+        out = None
+    else:
+        a_dt = arr.dtype
+        old = old.astype(old_dtype if old_dtype else a_dt, copy=False)
+        new = new.astype(new_dtype if new_dtype else a_dt, copy=False)
+        max_int64 = np.iinfo(np.int64).max
+        counts = _count_ufunc(arr, old, 0, max_int64)
+        counts = np.where(count < 0, counts, np.minimum(counts, count))
+        buffersizes = str_len(arr) + counts * (str_len(new) - str_len(old))
+        out_dtype = f"{arr.dtype.char}{buffersizes.max()}"
+        out = np.empty_like(arr, shape=buffersizes.shape, dtype=out_dtype)
     return _replace(arr, old, new, counts, out=out)
 
 
@@ -1421,11 +1463,15 @@ def partition(a, sep):
 
     """
     a = np.asanyarray(a)
-    # TODO switch to copy=False when issues around views are fixed
-    sep = np.array(sep, dtype=a.dtype, copy=True, subok=True)
-    if a.dtype.char == "T":
+    sep = np.asanyarray(sep)
+
+    try_out_dt = np.result_type(a, sep)
+    if try_out_dt.char == "T":
+        a = a.astype(try_out_dt, copy=False)
+        sep = sep.astype(try_out_dt, copy=False)
         return _partition(a, sep)
 
+    sep = sep.astype(a.dtype, copy=False)
     pos = _find_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)
@@ -1487,11 +1533,15 @@ def rpartition(a, sep):
 
     """
     a = np.asanyarray(a)
-    # TODO switch to copy=False when issues around views are fixed
-    sep = np.array(sep, dtype=a.dtype, copy=True, subok=True)
-    if a.dtype.char == "T":
+    sep = np.asanyarray(sep)
+
+    try_out_dt = np.result_type(a, sep)
+    if try_out_dt.char == "T":
+        a = a.astype(try_out_dt, copy=False)
+        sep = sep.astype(try_out_dt, copy=False)
         return _rpartition(a, sep)
 
+    sep = sep.astype(a.dtype, copy=False)
     pos = _rfind_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -670,27 +670,25 @@ def center(a, width, fillchar=' '):
 
     """
     width = np.asanyarray(width)
+
     if not np.issubdtype(width.dtype, np.integer):
         raise TypeError(f"unsupported type {width.dtype} for operand 'width'")
 
     a = np.asanyarray(a)
     fillchar = np.asanyarray(fillchar)
 
-    try_out_dt = np.result_type(a, fillchar)
-    if try_out_dt.char == "T":
-        a = a.astype(try_out_dt, copy=False)
-        fillchar = fillchar.astype(try_out_dt, copy=False)
-        out = None
-    else:
-        fillchar = fillchar.astype(a.dtype, copy=False)
-        width = np.maximum(str_len(a), width)
-        out_dtype = f"{a.dtype.char}{width.max()}"
-        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-        out = np.empty_like(a, shape=shape, dtype=out_dtype)
-
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
+
+    if np.result_type(a, fillchar).char == "T":
+        return _center(a, width, fillchar)
+
+    fillchar = fillchar.astype(a.dtype, copy=False)
+    width = np.maximum(str_len(a), width)
+    out_dtype = f"{a.dtype.char}{width.max()}"
+    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+    out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     return _center(a, width, fillchar, out=out)
 
@@ -742,21 +740,18 @@ def ljust(a, width, fillchar=' '):
     a = np.asanyarray(a)
     fillchar = np.asanyarray(fillchar)
 
-    try_out_dt = np.result_type(a, fillchar)
-    if try_out_dt.char == "T":
-        a = a.astype(try_out_dt, copy=False)
-        fillchar = fillchar.astype(try_out_dt, copy=False)
-        out = None
-    else:
-        fillchar = fillchar.astype(a.dtype, copy=False)
-        width = np.maximum(str_len(a), width)
-        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-        out_dtype = f"{a.dtype.char}{width.max()}"
-        out = np.empty_like(a, shape=shape, dtype=out_dtype)
-
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
+
+    if np.result_type(a, fillchar).char == "T":
+        return _ljust(a, width, fillchar)
+
+    fillchar = fillchar.astype(a.dtype, copy=False)
+    width = np.maximum(str_len(a), width)
+    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+    out_dtype = f"{a.dtype.char}{width.max()}"
+    out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     return _ljust(a, width, fillchar, out=out)
 
@@ -808,21 +803,18 @@ def rjust(a, width, fillchar=' '):
     a = np.asanyarray(a)
     fillchar = np.asanyarray(fillchar)
 
-    try_out_dt = np.result_type(a, fillchar)
-    if try_out_dt.char == "T":
-        a = a.astype(try_out_dt, copy=False)
-        fillchar = fillchar.astype(try_out_dt, copy=False)
-        out = None
-    else:
-        fillchar = fillchar.astype(a.dtype, copy=False)
-        width = np.maximum(str_len(a), width)
-        shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
-        out_dtype = f"{a.dtype.char}{width.max()}"
-        out = np.empty_like(a, shape=shape, dtype=out_dtype)
-
     if np.any(str_len(fillchar) != 1):
         raise TypeError(
             "The fill character must be exactly one character long")
+
+    if np.result_type(a, fillchar).char == "T":
+        return _rjust(a, width, fillchar)
+
+    fillchar = fillchar.astype(a.dtype, copy=False)
+    width = np.maximum(str_len(a), width)
+    shape = np.broadcast_shapes(a.shape, width.shape, fillchar.shape)
+    out_dtype = f"{a.dtype.char}{width.max()}"
+    out = np.empty_like(a, shape=shape, dtype=out_dtype)
 
     return _rjust(a, width, fillchar, out=out)
 
@@ -1246,23 +1238,19 @@ def replace(a, old, new, count=-1):
     new_dtype = getattr(new, 'dtype', None)
     new = np.asanyarray(new)
 
-    try_out_dt = np.result_type(arr, old, new)
-    if try_out_dt.char == "T":
-        arr = a.astype(try_out_dt, copy=False)
-        old = old.astype(try_out_dt, copy=False)
-        new = new.astype(try_out_dt, copy=False)
-        counts = count
-        out = None
-    else:
-        a_dt = arr.dtype
-        old = old.astype(old_dtype if old_dtype else a_dt, copy=False)
-        new = new.astype(new_dtype if new_dtype else a_dt, copy=False)
-        max_int64 = np.iinfo(np.int64).max
-        counts = _count_ufunc(arr, old, 0, max_int64)
-        counts = np.where(count < 0, counts, np.minimum(counts, count))
-        buffersizes = str_len(arr) + counts * (str_len(new) - str_len(old))
-        out_dtype = f"{arr.dtype.char}{buffersizes.max()}"
-        out = np.empty_like(arr, shape=buffersizes.shape, dtype=out_dtype)
+    if np.result_type(arr, old, new).char == "T":
+        return _replace(arr, old, new, count)
+
+    a_dt = arr.dtype
+    old = old.astype(old_dtype if old_dtype else a_dt, copy=False)
+    new = new.astype(new_dtype if new_dtype else a_dt, copy=False)
+    max_int64 = np.iinfo(np.int64).max
+    counts = _count_ufunc(arr, old, 0, max_int64)
+    counts = np.where(count < 0, counts, np.minimum(counts, count))
+    buffersizes = str_len(arr) + counts * (str_len(new) - str_len(old))
+    out_dtype = f"{arr.dtype.char}{buffersizes.max()}"
+    out = np.empty_like(arr, shape=buffersizes.shape, dtype=out_dtype)
+
     return _replace(arr, old, new, counts, out=out)
 
 
@@ -1465,10 +1453,7 @@ def partition(a, sep):
     a = np.asanyarray(a)
     sep = np.asanyarray(sep)
 
-    try_out_dt = np.result_type(a, sep)
-    if try_out_dt.char == "T":
-        a = a.astype(try_out_dt, copy=False)
-        sep = sep.astype(try_out_dt, copy=False)
+    if np.result_type(a, sep).char == "T":
         return _partition(a, sep)
 
     sep = sep.astype(a.dtype, copy=False)
@@ -1535,10 +1520,7 @@ def rpartition(a, sep):
     a = np.asanyarray(a)
     sep = np.asanyarray(sep)
 
-    try_out_dt = np.result_type(a, sep)
-    if try_out_dt.char == "T":
-        a = a.astype(try_out_dt, copy=False)
-        sep = sep.astype(try_out_dt, copy=False)
+    if np.result_type(a, sep).char == "T":
         return _rpartition(a, sep)
 
     sep = sep.astype(a.dtype, copy=False)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -996,6 +996,56 @@ def test_ufunc_multiply(dtype, string_list, other, other_dtype, use_out):
             other * arr
 
 
+def test_findlike_promoters():
+    r = "Wally"
+    l = "Where's Wally?"
+    s = np.int32(3)
+    e = np.int8(13)
+    for dtypes in [("T", "U"), ("U", "T")]:
+        for function, answer in [
+            (np.strings.index, 8),
+            (np.strings.endswith, True),
+        ]:
+            assert answer == function(
+                np.array(l, dtype=dtypes[0]), np.array(r, dtype=dtypes[1]), s, e
+            )
+
+
+def test_strip_promoter():
+    arg = "Hello!!!!"
+    strip_char = "!"
+    answer = "Hello"
+    for dtypes in [("T", "U"), ("U", "T")]:
+        assert answer == np.strings.strip(
+            np.array(arg, dtype=dtypes[0]), np.array(strip_char, dtype=dtypes[1])
+        )
+
+
+def test_replace_promoter():
+    arg = ["Hello, planet!", "planet, Hello!"]
+    old = "planet"
+    new = "world"
+    answer = ["Hello, world!", "world, Hello!"]
+    for dtypes in itertools.product("TU", repeat=3):
+        if dtypes == ("U", "U", "U"):
+            continue
+        answer_arr = np.strings.replace(
+            np.array(arg, dtype=dtypes[0]),
+            np.array(old, dtype=dtypes[1]),
+            np.array(new, dtype=dtypes[2]),
+        )
+        assert_array_equal(answer_arr, answer)
+
+
+def test_center_promoter():
+    arg = "Hello, planet!"
+    fillchar = "/"
+    for dtypes in [("T", "U"), ("U", "T")]:
+        assert "/Hello, planet!/" == np.strings.center(
+            np.array(arg, dtype=dtypes[0]), 16, np.array(fillchar, dtype=dtypes[1])
+        )
+
+
 DATETIME_INPUT = [
     np.datetime64("1923-04-14T12:43:12"),
     np.datetime64("1994-06-21T14:43:15"),

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1012,13 +1012,16 @@ def test_findlike_promoters():
 
 
 def test_strip_promoter():
-    arg = "Hello!!!!"
+    arg = ["Hello!!!!", "Hello??!!"]
     strip_char = "!"
-    answer = "Hello"
+    answer = ["Hello", "Hello??"]
     for dtypes in [("T", "U"), ("U", "T")]:
-        assert answer == np.strings.strip(
-            np.array(arg, dtype=dtypes[0]), np.array(strip_char, dtype=dtypes[1])
+        result = np.strings.strip(
+            np.array(arg, dtype=dtypes[0]),
+            np.array(strip_char, dtype=dtypes[1])
         )
+        assert_array_equal(result, answer)
+        assert result.dtype.char == "T"
 
 
 def test_replace_promoter():
@@ -1035,15 +1038,18 @@ def test_replace_promoter():
             np.array(new, dtype=dtypes[2]),
         )
         assert_array_equal(answer_arr, answer)
+        assert answer_arr.dtype.char == "T"
 
 
 def test_center_promoter():
-    arg = "Hello, planet!"
+    arg = ["Hello", "planet!"]
     fillchar = "/"
     for dtypes in [("T", "U"), ("U", "T")]:
-        assert "/Hello, planet!/" == np.strings.center(
-            np.array(arg, dtype=dtypes[0]), 16, np.array(fillchar, dtype=dtypes[1])
+        answer = np.strings.center(
+            np.array(arg, dtype=dtypes[0]), 9, np.array(fillchar, dtype=dtypes[1])
         )
+        assert_array_equal(answer, ["//Hello//", "/planet!/"])
+        assert answer.dtype.char == "T"
 
 
 DATETIME_INPUT = [


### PR DESCRIPTION
Backport of #27636.

Fixes https://github.com/numpy/numpy/issues/27493. Fixes #27637.

There are a number of missing cases for mixed unicode/string operations that this adds promoters for. Also adds tests for these cases.

Additionally replaces uses of `Py_None` as an abstract promoter target with `PyArray_IntAbstractDType`, which makes the promoters fire less offten in unintended cases and is closer to the intention in the code.

Also fixes issues with the python wrappers for the string ufuncs incorrectly selecting the fixed-width string branches for some signatures by relying on `np.result_type` to check for `StringDType` inputs.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
