### PR TITLE
DOC: fix spelling of "reality" in `_nanfunctions_impl.pyi`

### DIFF
--- a/numpy/lib/_nanfunctions_impl.pyi
+++ b/numpy/lib/_nanfunctions_impl.pyi
@@ -35,7 +35,7 @@ __all__ = [
     "nanquantile",
 ]
 
-# NOTE: In reaility these functions are not aliases but distinct functions
+# NOTE: In reality these functions are not aliases but distinct functions
 # with identical signatures.
 nanmin = amin
 nanmax = amax


### PR DESCRIPTION
Tiny PR which fixes the spelling of the word `reality` (was `reaility`) in `_nanfunctions_impl.pyi`.

[skip ci] - the PR only adjusts comment text in a type hint file

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->


