### PR TITLE
MAINT: Drop useless shebang

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 This file defines a set of system_info classes for getting
 information about various resources (libraries, library directories,

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Fortran to Python Interface Generator.
 
 Copyright 1999 -- 2011 Pearu Peterson all rights reserved.

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 C declarations, CPP macros, and C functions for f2py2e.
 Only required declarations/macros/functions will be used.

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 crackfortran --- read fortran (77,90) code and extract declaration information.
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 
 f2py2e - Fortran to Python C/API generator. 2nd Edition.

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 
 Rules for building C/API module with f2py2e.

--- a/numpy/random/_examples/cython/extending.pyx
+++ b/numpy/random/_examples/cython/extending.pyx
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #cython: language_level=3
 
 from libc.stdint cimport uint32_t

--- a/numpy/random/_examples/cython/extending_distributions.pyx
+++ b/numpy/random/_examples/cython/extending_distributions.pyx
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #cython: language_level=3
 """
 This file shows how the to use a BitGenerator to create a distribution.

--- a/numpy/random/c_distributions.pxd
+++ b/numpy/random/c_distributions.pxd
@@ -1,4 +1,3 @@
-#!python
 #cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3
 from numpy cimport npy_intp
 


### PR DESCRIPTION
The shebang in these files suggests they are directly executable, but they are not for various reasons (see below).  In addition, six out of nine files modified here does not have the executable permission set.  For three that does (`numpy/f2py/crackfortran.py`, `numpy/f2py/f2py2e.py`, `numpy/f2py/rules.py`) the permission is removed in this PR.

Here are reasons why the shebang in these files is wrong:
```
$ MKLROOT=/tmp numpy/distutils/system_info.py > /dev/null
/data/builds/numpy/numpy/distutils/system_info.py:192: DeprecationWarning:

  `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
  of the deprecation of `distutils` itself. It will be removed for
  Python >= 3.12. For older Python versions it will remain present.
  It is recommended to use `setuptools < 60.0` for those Python versions.
  For more details, see:
    https://numpy.org/devdocs/reference/distutils_status_migration.html


  from numpy.distutils import log
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/distutils/system_info.py", line 3268, in <module>
    show_all()
  File "/data/builds/numpy/numpy/distutils/system_info.py", line 3259, in show_all
    conf = c()
  File "/data/builds/numpy/numpy/distutils/system_info.py", line 1297, in __init__
    from .cpuinfo import cpu
ImportError: attempted relative import with no known parent package
$ numpy/f2py/__init__.py
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/f2py/__init__.py", line 19, in <module>
    from . import f2py2e
ImportError: attempted relative import with no known parent package
$ numpy/f2py/cfuncs.py
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/f2py/cfuncs.py", line 16, in <module>
    from . import __version__
ImportError: attempted relative import with no known parent package
$ numpy/f2py/crackfortran.py
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/f2py/crackfortran.py", line 154, in <module>
    from . import __version__
ImportError: attempted relative import with no known parent package
$ numpy/f2py/f2py2e.py
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/f2py/f2py2e.py", line 20, in <module>
    from . import crackfortran
ImportError: attempted relative import with no known parent package
$ numpy/f2py/rules.py
Traceback (most recent call last):
  File "/data/builds/numpy/numpy/f2py/rules.py", line 57, in <module>
    from . import __version__
ImportError: attempted relative import with no known parent package
$ numpy/random/_examples/cython/extending.pyx
  File "/data/builds/numpy/numpy/random/_examples/cython/extending.pyx", line 4
    from libc.stdint cimport uint32_t
                     ^
SyntaxError: invalid syntax
$ numpy/random/_examples/cython/extending_distributions.pyx
  File "/data/builds/numpy/numpy/random/_examples/cython/extending_distributions.pyx", line 7
    cimport numpy as np
            ^
SyntaxError: invalid syntax
$ numpy/random/c_distributions.pxd
bash: numpy/random/c_distributions.pxd: cannot execute: required file not found
$
```