### PR TITLE
BUG: correct acceptable types for stack function call

### DIFF
--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -206,7 +206,7 @@ def atleast_3d(*arys):
 
 
 def _arrays_for_stack_dispatcher(arrays):
-    if not hasattr(arrays, "__getitem__"):
+    if not hasattr(arrays, "__iter__"):
         raise TypeError('arrays to stack must be passed as a "sequence" type '
                         'such as list or tuple.')
 


### PR DESCRIPTION
…s in numpy.core.shape_base.

Currently, an exception will be raised when any object is passed to numpy.stack, numpy.vstack, or numpy.hstack that does not include a __getitem__ method. However, the _arrays_for_stack_dispatcher immediately converts the inputted sequence to a tuple and disregards the initial sequence's type. Here, the tuple constructor requires an __iter__ method, not nececarily a __getitem__ method. Thus, any sequence that has an __iter__ method should be acceptable. Particularly, not all sequences have a __getitem__ method (e.g. queues). But those sequences should still be acceptable here.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
