### PR TITLE
CI: Set up free-threaded CI using quansight-labs/setup-python

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,15 +55,20 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
         fetch-tags: true
-    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+    - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:
         python-version: ${{ matrix.version }}
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      if: matrix.version == '3.13t'
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions
 
   pypy:
@@ -291,23 +296,3 @@ jobs:
         rm -rf build-install
         ./vendored-meson/meson/meson.py install -C build --destdir ../build-install --tags=runtime,python-runtime,devel
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy') --no-tests
-
-  free-threaded:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-    # TODO: replace with setup-python when there is support
-    - uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
-      with:
-          python-version: '3.13-dev'
-          nogil: true
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-    - uses: ./.github/meson_actions

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -103,7 +103,8 @@ jobs:
 
 
   accelerate:
-    name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }}
+    name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }} - ${{ matrix.version }}
+    # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     runs-on: ${{ matrix.build_runner[0] }}
     strategy:
@@ -112,6 +113,7 @@ jobs:
         build_runner:
           - [ macos-13, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
+        version: ["3.10", "3.13t"]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -119,14 +121,20 @@ jobs:
         submodules: recursive
         fetch-tags: true
 
-    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+    - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.version }}
 
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       if: ${{ matrix.build_runner[0] == 'macos-13' }}
       with:
         xcode-version: '14.3'
+
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      if: matrix.version == '3.13t'
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: macOS tests (meson)
+name: macOS tests
 
 on:
   pull_request:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -103,7 +103,7 @@ jobs:
 
 
   accelerate:
-    name: Accelerate (LP64, ILP64) - ${{ matrix.build_runner[1] }} - ${{ matrix.version }}
+    name: Accelerate - ${{ matrix.build_runner[1] }} - ${{ matrix.version }}
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     runs-on: ${{ matrix.build_runner[0] }}


### PR DESCRIPTION
We've forked `actions/setup-python` to enable installing free-threaded python on more platforms. See https://github.com/Quansight-Labs/free-threaded-compatibility/issues/107 for context.

This makes the MacOS and Linux tests use the forked version of `setup-python` to enable integrating the free-threaded tests with the rest of the CI configuration.

This creates two new CI jobs that run against every PR for MacOS free-threaded using builds on intel and ARM CPUs. The linux CI job isn't new, but now it's integrated better with the smoke tests. I also took the opportunity to drop `3.13-dev` from the build matrix.

Updating Windows CI is blocked on a `spin` release, see https://github.com/scientific-python/spin/pull/241.

Supersedes https://github.com/numpy/numpy/pull/27581.