### PR TITLE
DOC: Remove version notes

### DIFF
--- a/doc/source/reference/routines.polynomials.hermite_e.rst
+++ b/doc/source/reference/routines.polynomials.hermite_e.rst
@@ -1,5 +1,3 @@
-.. versionadded:: 1.6.0
-
 .. automodule:: numpy.polynomial.hermite_e
    :no-members:
    :no-inherited-members:

--- a/doc/source/reference/routines.polynomials.legendre.rst
+++ b/doc/source/reference/routines.polynomials.legendre.rst
@@ -1,5 +1,3 @@
-.. versionadded:: 1.6.0
-
 .. automodule:: numpy.polynomial.legendre
    :no-members:
    :no-inherited-members:

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -117,8 +117,6 @@ class AxisError(ValueError, IndexError):
     ``except ValueError`` and ``except IndexError`` statements continue
     to catch ``AxisError``.
 
-    .. versionadded:: 1.13
-
     Parameters
     ----------
     axis : int or str

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5641,13 +5641,6 @@ class MaskedArray(ndarray):
         axis : int, optional
             Axis along which to sort. If None, the default, the flattened array
             is used.
-
-            ..  versionchanged:: 1.13.0
-                Previously, the default was documented to be -1, but that was
-                in error. At some future date, the default will change to -1, as
-                originally intended.
-                Until then, the axis should be given explicitly when
-                ``arr.ndim > 1``, to avoid a FutureWarning.
         kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, optional
             The sorting algorithm used.
         order : list, optional


### PR DESCRIPTION
Closes #27239. A lot of work has been done already. This should address the last few occurrences.

The other `/routines.polynomials` files do not contain `versionadded::` notes, also the version is `1.6`. I think it is safe to remove it. We could discuss the removal of the following note in `ma/core.py`:
```
 ..  versionchanged:: 1.13.0
                Previously, the default was documented to be -1, but that was
                in error. At some future date, the default will change to -1, as
                originally intended.
                Until then, the axis should be given explicitly when
                ``arr.ndim > 1``, to avoid a FutureWarning.
```