### PR TITLE
MAINT: handle edge case in rfftfreq and fftfreq

### DIFF
--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -121,14 +121,13 @@ def ifftshift(x, axes=None):
 
     return roll(x, shift, axes)
 
-
 @set_module('numpy.fft')
 def fftfreq(n, d=1.0, device=None):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
     The returned float array `f` contains the frequency bin centers in cycles
-    per unit of the sample spacing (with zero at the start).  For instance, if
+    per unit of the sample spacing (with zero at the start). For instance, if
     the sample spacing is in seconds, then the frequency unit is cycles/second.
 
     Given a window length `n` and a sample spacing `d`::
@@ -139,7 +138,7 @@ def fftfreq(n, d=1.0, device=None):
     Parameters
     ----------
     n : int
-        Window length.
+        Window length. Must be a positive integer.
     d : scalar, optional
         Sample spacing (inverse of the sampling rate). Defaults to 1.
     device : str, optional
@@ -153,6 +152,11 @@ def fftfreq(n, d=1.0, device=None):
     f : ndarray
         Array of length `n` containing the sample frequencies.
 
+    Raises
+    ------
+    ValueError
+        If `n` is not a positive integer.
+
     Examples
     --------
     >>> import numpy as np
@@ -163,10 +167,9 @@ def fftfreq(n, d=1.0, device=None):
     >>> freq = np.fft.fftfreq(n, d=timestep)
     >>> freq
     array([ 0.  ,  1.25,  2.5 , ..., -3.75, -2.5 , -1.25])
-
     """
-    if not isinstance(n, integer_types):
-        raise ValueError("n should be an integer")
+    if not isinstance(n, integer_types) or n <= 0:
+        raise ValueError("n should be a positive integer")
     val = 1.0 / (n * d)
     results = empty(n, int, device=device)
     N = (n-1)//2 + 1
@@ -175,7 +178,6 @@ def fftfreq(n, d=1.0, device=None):
     p2 = arange(-(n//2), 0, dtype=int, device=device)
     results[N:] = p2
     return results * val
-
 
 @set_module('numpy.fft')
 def rfftfreq(n, d=1.0, device=None):
@@ -198,7 +200,7 @@ def rfftfreq(n, d=1.0, device=None):
     Parameters
     ----------
     n : int
-        Window length.
+        Window length. Must be a positive integer.
     d : scalar, optional
         Sample spacing (inverse of the sampling rate). Defaults to 1.
     device : str, optional
@@ -211,6 +213,11 @@ def rfftfreq(n, d=1.0, device=None):
     -------
     f : ndarray
         Array of length ``n//2 + 1`` containing the sample frequencies.
+
+    Raises
+    ------
+    ValueError
+        If `n` is not a positive integer.
 
     Examples
     --------
@@ -227,9 +234,10 @@ def rfftfreq(n, d=1.0, device=None):
     array([  0.,  10.,  20.,  30.,  40.,  50.])
 
     """
-    if not isinstance(n, integer_types):
-        raise ValueError("n should be an integer")
-    val = 1.0/(n*d)
-    N = n//2 + 1
+    if not isinstance(n, integer_types) or n <= 0:
+        raise ValueError("n should be a positive integer")
+    val = 1.0 / (n * d)
+    N = n // 2 + 1
     results = arange(0, N, dtype=int, device=device)
     return results * val
+

--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -167,10 +167,10 @@ def fftfreq(n, d=1.0, device=None):
     try:
         n = operator.index(n)
     except TypeError:
-        raise TypeError("n must be an integer")
+        raise ValueError("n must be an integer")
     
     if n <= 0:
-        raise TypeError("n should be a positive integer")
+        raise ValueError("n should be a positive integer")
     
     val = 1.0 / (n * d)
     results = empty(n, int, device=device)
@@ -235,10 +235,10 @@ def rfftfreq(n, d=1.0, device=None):
     try:
         n = operator.index(n)
     except TypeError:
-        raise TypeError("n must be an integer")
+        raise ValueError("n must be an integer")
     
     if n <= 0:
-        raise TypeError("n should be a positive integer")
+        raise ValueError("n should be a positive integer")
     
     val = 1.0 / (n * d)
     N = n // 2 + 1

--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -2,6 +2,7 @@
 Discrete Fourier Transforms - _helper.py
 
 """
+import operator
 from numpy._core import integer, empty, arange, asarray, roll
 from numpy._core.overrides import array_function_dispatch, set_module
 
@@ -152,11 +153,6 @@ def fftfreq(n, d=1.0, device=None):
     f : ndarray
         Array of length `n` containing the sample frequencies.
 
-    Raises
-    ------
-    ValueError
-        If `n` is not a positive integer.
-
     Examples
     --------
     >>> import numpy as np
@@ -168,15 +164,22 @@ def fftfreq(n, d=1.0, device=None):
     >>> freq
     array([ 0.  ,  1.25,  2.5 , ..., -3.75, -2.5 , -1.25])
     """
-    if not isinstance(n, integer_types) or n <= 0:
-        raise ValueError("n should be a positive integer")
+    try:
+        n = operator.index(n)
+    except TypeError:
+        raise TypeError("n must be an integer")
+    
+    if n <= 0:
+        raise TypeError("n should be a positive integer")
+    
     val = 1.0 / (n * d)
     results = empty(n, int, device=device)
-    N = (n-1)//2 + 1
+    N = (n - 1) // 2 + 1
     p1 = arange(0, N, dtype=int, device=device)
     results[:N] = p1
-    p2 = arange(-(n//2), 0, dtype=int, device=device)
+    p2 = arange(-(n // 2), 0, dtype=int, device=device)
     results[N:] = p2
+
     return results * val
 
 @set_module('numpy.fft')
@@ -214,11 +217,6 @@ def rfftfreq(n, d=1.0, device=None):
     f : ndarray
         Array of length ``n//2 + 1`` containing the sample frequencies.
 
-    Raises
-    ------
-    ValueError
-        If `n` is not a positive integer.
-
     Examples
     --------
     >>> import numpy as np
@@ -234,10 +232,17 @@ def rfftfreq(n, d=1.0, device=None):
     array([  0.,  10.,  20.,  30.,  40.,  50.])
 
     """
-    if not isinstance(n, integer_types) or n <= 0:
-        raise ValueError("n should be a positive integer")
+    try:
+        n = operator.index(n)
+    except TypeError:
+        raise TypeError("n must be an integer")
+    
+    if n <= 0:
+        raise TypeError("n should be a positive integer")
+    
     val = 1.0 / (n * d)
     N = n // 2 + 1
     results = arange(0, N, dtype=int, device=device)
+    
     return results * val
 

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -4,7 +4,7 @@ Copied from fftpack.helper by Pearu Peterson, October 2005
 
 """
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_raises
 from numpy import fft, pi
 
 
@@ -142,6 +142,14 @@ class TestFFTFreq:
         x = [0, 1, 2, 3, 4, -5, -4, -3, -2, -1]
         assert_array_almost_equal(10*fft.fftfreq(10), x)
         assert_array_almost_equal(10*pi*fft.fftfreq(10, pi), x)
+    
+    def test_invalid_n(self):
+        with assert_raises(TypeError):
+            fft.rfftfreq("invalid")
+        with assert_raises(TypeError):
+            fft.rfftfreq(-5)
+        with assert_raises(TypeError):
+            fft.rfftfreq(0)
 
 
 class TestRFFTFreq:
@@ -153,6 +161,14 @@ class TestRFFTFreq:
         x = [0, 1, 2, 3, 4, 5]
         assert_array_almost_equal(10*fft.rfftfreq(10), x)
         assert_array_almost_equal(10*pi*fft.rfftfreq(10, pi), x)
+
+    def test_invalid_n(self):
+        with assert_raises(TypeError):
+            fft.rfftfreq("invalid")
+        with assert_raises(TypeError):
+            fft.rfftfreq(-5)
+        with assert_raises(TypeError):
+            fft.rfftfreq(0)
 
 
 class TestIRFFTN:

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -144,11 +144,11 @@ class TestFFTFreq:
         assert_array_almost_equal(10*pi*fft.fftfreq(10, pi), x)
     
     def test_invalid_n(self):
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq("invalid")
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq(-5)
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq(0)
 
 
@@ -163,11 +163,11 @@ class TestRFFTFreq:
         assert_array_almost_equal(10*pi*fft.rfftfreq(10, pi), x)
 
     def test_invalid_n(self):
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq("invalid")
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq(-5)
-        with assert_raises(TypeError):
+        with assert_raises(ValueError):
             fft.rfftfreq(0)
 
 


### PR DESCRIPTION
 If n = 0, it would imply that there are no data points to work with, and hence no frequency bins to return. This would make the function's output meaningless.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
