### PR TITLE
BUG: Allow empty memmaps in most situations

### DIFF
--- a/doc/release/upcoming_changes/27723.improvement.rst
+++ b/doc/release/upcoming_changes/27723.improvement.rst
@@ -1,0 +1,4 @@
+* Improved support for empty `memmap`. Previously an empty `memmap` would fail
+  unless a non-zero ``offset`` was set. Now a zero-size `memmap` is supported
+  even if ``offset=0``. To achieve this, if a `memmap` is mapped to an empty
+  file that file is padded with a single byte.

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -276,6 +276,8 @@ class memmap(ndarray):
 
             start = offset - offset % mmap.ALLOCATIONGRANULARITY
             bytes -= start
+            # bytes == 0 is problematic as in mmap length=0 maps the full file.
+            # See PR gh-27723 for a more detailed explanation.
             if bytes == 0 and start > 0:
                 bytes += mmap.ALLOCATIONGRANULARITY
                 start -= mmap.ALLOCATIONGRANULARITY

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -276,6 +276,9 @@ class memmap(ndarray):
 
             start = offset - offset % mmap.ALLOCATIONGRANULARITY
             bytes -= start
+            if bytes == 0 and start > 0:
+                bytes += mmap.ALLOCATIONGRANULARITY
+                start -= mmap.ALLOCATIONGRANULARITY
             array_offset = offset - start
             mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
 

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -262,10 +262,14 @@ class memmap(ndarray):
 
             bytes = int(offset + size*_dbytes)
 
-            if mode in ('w+', 'r+') and flen < bytes:
-                fid.seek(bytes - 1, 0)
-                fid.write(b'\0')
-                fid.flush()
+            if mode in ('w+', 'r+'):
+                # gh-27723
+                # if bytes == 0, we write out 1 byte to allow empty memmap.
+                bytes = max(bytes, 1)
+                if flen < bytes:
+                    fid.seek(bytes - 1, 0)
+                    fid.write(b'\0')
+                    fid.flush()
 
             if mode == 'c':
                 acc = mmap.ACCESS_COPY

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -218,7 +218,7 @@ class TestMemmap:
 
         # gh-27723
         # empty memmap works with mode in ('w+','r+')
-        memmap(self.tmpfp, shape=(0,4), mode='w+')
+        memmap(self.tmpfp, shape=(0, 4), mode='w+')
 
         self.tmpfp.write(b'\0')
         # ok now the file is not empty

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -214,7 +214,7 @@ class TestMemmap:
     def test_empty_array(self):
         # gh-12653
         with pytest.raises(ValueError, match='empty file'):
-            memmap(self.tmpfp, shape=(0,4), mode='r')
+            memmap(self.tmpfp, shape=(0, 4), mode='r')
 
         # gh-27723
         # empty memmap works with mode in ('w+','r+')

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -222,7 +222,7 @@ class TestMemmap:
 
         self.tmpfp.write(b'\0')
         # ok now the file is not empty
-        memmap(self.tmpfp, shape=(0,4), mode='w+')
+        memmap(self.tmpfp, shape=(0, 4), mode='w+')
 
     def test_shape_type(self):
         memmap(self.tmpfp, shape=3, mode='w+')

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -199,6 +199,12 @@ class TestMemmap:
         fp = memmap(self.tmpfp, shape=size, mode='w+', offset=offset)
         assert_(fp.offset == offset)
 
+    def test_empty_array_with_offset_multiple_of_allocation_granularity(self):
+        self.tmpfp.write(b'a'*mmap.ALLOCATIONGRANULARITY)
+        size = 0
+        offset = mmap.ALLOCATIONGRANULARITY
+        fp = memmap(self.tmpfp, shape=size, mode='w+', offset=offset)
+
     def test_no_shape(self):
         self.tmpfp.write(b'a'*16)
         mm = memmap(self.tmpfp, dtype='float64')

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -204,6 +204,7 @@ class TestMemmap:
         size = 0
         offset = mmap.ALLOCATIONGRANULARITY
         fp = memmap(self.tmpfp, shape=size, mode='w+', offset=offset)
+        assert_equal(fp.offset, offset)
 
     def test_no_shape(self):
         self.tmpfp.write(b'a'*16)

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -214,10 +214,13 @@ class TestMemmap:
     def test_empty_array(self):
         # gh-12653
         with pytest.raises(ValueError, match='empty file'):
-            memmap(self.tmpfp, shape=(0,4), mode='w+')
+            memmap(self.tmpfp, shape=(0,4), mode='r')
+
+        # gh-27723
+        # empty memmap works with mode in ('w+','r+')
+        memmap(self.tmpfp, shape=(0,4), mode='w+')
 
         self.tmpfp.write(b'\0')
-
         # ok now the file is not empty
         memmap(self.tmpfp, shape=(0,4), mode='w+')
 

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -220,7 +220,6 @@ class TestMemmap:
         # empty memmap works with mode in ('w+','r+')
         memmap(self.tmpfp, shape=(0, 4), mode='w+')
 
-        self.tmpfp.write(b'\0')
         # ok now the file is not empty
         memmap(self.tmpfp, shape=(0, 4), mode='w+')
 


### PR DESCRIPTION
- Fixes #27722
- Added a test case to confirm the fix.