### PR TITLE
BUG: f2py: fix issues with thread-local storage define

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -245,8 +245,8 @@ endforeach
 
 # variable attributes tested via "int %s a" % attribute
 optional_variable_attributes = [
-  ['thread_local', 'HAVE_THREAD_LOCAL'],
-  ['_Thread_local', 'HAVE__THREAD_LOCAL'],
+  ['thread_local', 'HAVE_THREAD_LOCAL'],    # C23
+  ['_Thread_local', 'HAVE__THREAD_LOCAL'],  # C11/C17
   ['__thread', 'HAVE__THREAD'],
   ['__declspec(thread)', 'HAVE___DECLSPEC_THREAD_']
 ]

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -553,7 +553,8 @@ cppmacros['OLDPYNUM'] = """
 # running a compile-time check (which we have no control over in generated
 # code used outside of NumPy) is hard. Therefore we support overriding this
 # via an external define - the f2py-using package can then use the same
-# compile-time checks as we use for `NPY_TLS` when building NumPy.
+# compile-time checks as we use for `NPY_TLS` when building NumPy (see
+# scipy#21860 for an example of that).
 #
 # __STDC_NO_THREADS__ should not be coupled to the availability of _Thread_local.
 # In case we get a bug report, guard it with __STDC_NO_THREADS__ after all.

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -552,7 +552,7 @@ cppmacros['OLDPYNUM'] = """
 # Defining the correct value to indicate thread-local storage in C without
 # running a compile-time check (which we have no control over in generated
 # code used outside of NumPy) is hard. Therefore we support overriding this
-# via an external define - the f2py-using package can them use the same
+# via an external define - the f2py-using package can then use the same
 # compile-time checks as we use for `NPY_TLS` when building NumPy.
 #
 # __STDC_NO_THREADS__ should not be coupled to the availability of _Thread_local.

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -548,24 +548,31 @@ cppmacros['OLDPYNUM'] = """
 #error You need to install NumPy version 0.13 or higher. See https://scipy.org/install.html
 #endif
 """
+
+# Defining the correct value to indicate thread-local storage in C without
+# running a compile-time check (which we have no control over in generated
+# code used outside of NumPy) is hard. Therefore we support overriding this
+# via an external define - the f2py-using package can them use the same
+# compile-time checks as we use for `NPY_TLS` when building NumPy.
+#
+# __STDC_NO_THREADS__ should not be coupled to the availability of _Thread_local.
+# In case we get a bug report, guard it with __STDC_NO_THREADS__ after all.
+#
+# `thread_local` has become a keyword in C23, but don't try to use that yet
+# (too new, doing so while C23 support is preliminary will likely cause more
+#  problems than it solves).
+#
+# Note: do not try to use `threads.h`, its availability is very low
+# *and* threads.h isn't actually used where `F2PY_THREAD_LOCAL_DECL` is
+# in the generated code. See gh-27718 for more details.
 cppmacros["F2PY_THREAD_LOCAL_DECL"] = """
 #ifndef F2PY_THREAD_LOCAL_DECL
 #if defined(_MSC_VER)
 #define F2PY_THREAD_LOCAL_DECL __declspec(thread)
 #elif defined(NPY_OS_MINGW)
 #define F2PY_THREAD_LOCAL_DECL __thread
-#elif defined(__STDC_VERSION__) \\
-      && (__STDC_VERSION__ >= 201112L) \\
-      && !defined(__STDC_NO_THREADS__) \\
-      && (!defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 12)) \\
-      && !defined(NPY_OS_OPENBSD) && !defined(NPY_OS_HAIKU)
-/* __STDC_NO_THREADS__ was first defined in a maintenance release of glibc 2.12,
-   see https://lists.gnu.org/archive/html/commit-hurd/2012-07/msg00180.html,
-   so `!defined(__STDC_NO_THREADS__)` may give false positive for the existence
-   of `threads.h` when using an older release of glibc 2.12
-   See gh-19437 for details on OpenBSD */
-#include <threads.h>
-#define F2PY_THREAD_LOCAL_DECL thread_local
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define F2PY_THREAD_LOCAL_DECL _Thread_local
 #elif defined(__GNUC__) \\
       && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4)))
 #define F2PY_THREAD_LOCAL_DECL __thread


### PR DESCRIPTION
This is a continuing source of issues, therefore we:
- stop using `threads.h` completely,
- better document what is happening, and
- ensure the f2py TLS define stays unchanged so users can override it at build time by passing the define as a compile flag.

Closes gh-27718

~Opening as Draft to get a confirmation about it working on macOS + GCC, and also to fix the SciPy side of the problem with the documented approach of overriding `F2PY_THREAD_LOCAL_DECL`.~ done

Let's not backport this PR I'd say, since there's a nonzero chance that it breaks again on some platform we don't test on. 