### PR TITLE
Fix documentation for the chi-square distribution

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1676,7 +1676,7 @@ cdef class Generator:
         The variable obtained by summing the squares of `df` independent,
         standard normally distributed random variables:
 
-        .. math:: Q = \\sum_{i=0}^{\\mathtt{df}} X^2_i
+        .. math:: Q = \\sum_{i=1}^{\\mathtt{df}} X^2_i
 
         is chi-square distributed, denoted
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1969,7 +1969,7 @@ cdef class RandomState:
         The variable obtained by summing the squares of `df` independent,
         standard normally distributed random variables:
 
-        .. math:: Q = \\sum_{i=0}^{\\mathtt{df}} X^2_i
+        .. math:: Q = \\sum_{i=1}^{\\mathtt{df}} X^2_i
 
         is chi-square distributed, denoted
 


### PR DESCRIPTION
The chi-square distribution formula implies there are `df + 1` degrees of freedom, not the correct value `df`. 
