### PR TITLE
TYP: Optional ``numpy.number`` type parameters

### DIFF
--- a/doc/release/upcoming_changes/27736.new_feature.rst
+++ b/doc/release/upcoming_changes/27736.new_feature.rst
@@ -1,0 +1,3 @@
+* The "nbit" type parameter of ``np.number`` and its subtypes now defaults
+  to ``typing.Any``. This way, type-checkers will infer annotations such as
+  ``x: np.floating``  as ``x: np.floating[Any]``, even in strict mode.

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3060,8 +3060,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType_co, _DType_co]):
 # See https://github.com/numpy/numpy-stubs/pull/80 for more details.
 
 _ScalarType = TypeVar("_ScalarType", bound=generic)
-_NBit = TypeVar("_NBit", bound=NBitBase)
-_NBit1 = TypeVar("_NBit1", bound=NBitBase)
+_NBit = TypeVar("_NBit", bound=NBitBase, default=Any)
+_NBit1 = TypeVar("_NBit1", bound=NBitBase, default=Any)
 _NBit2 = TypeVar("_NBit2", bound=NBitBase, default=_NBit1)
 _NBit_fc = TypeVar("_NBit_fc", _NBitHalf, _NBitSingle, _NBitDouble, _NBitLongDouble)
 


### PR DESCRIPTION
The type parameters of `np.number` and its abstract subtypes now default to `Any`.
This means that typecheckers will now infer `np.floating` as `np.floating[Any]`, instead of rejecting it (when configured in strict mode).

This affects 

- `np.number`
- `np.integer`
- `np.signedinteger`
- `np.unsignedinteger`
- `np.inexact`
- `np.floating`
- `np.complexfloating` (by building upon #27420)

---

The reason for choosing `Any` as the default, instead of setting it to the upper bound (`numpy.typing.NBitBase`), is because these type parameters (`TypeVar`s) are invariant.
If they weren't invariant, then `x: int16 = int8(3)` would be a valid statement, which we probably don't want. So the invariance means that `x: number[NBitBase] = int8(3)` is rejected, but `x: number[Any] = int8(3)` is accepted. 

I usually tend to avoid using `Any`, but because those `_NBit` type-parameters aren't actually annotating anything, the `Any` won't affect anything "outside" of the `number` types, so it's no problem to use it here.