### PR TITLE
DEP: testing: disable deprecated use of keywords x/y

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -892,7 +892,6 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         raise ValueError(msg)
 
 
-@_rename_parameter(['x', 'y'], ['actual', 'desired'], dep_version='2.0.0')
 def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
                        strict=False):
     """
@@ -1022,7 +1021,6 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
                          strict=strict)
 
 
-@_rename_parameter(['x', 'y'], ['actual', 'desired'], dep_version='2.0.0')
 def assert_array_almost_equal(actual, desired, decimal=6, err_msg='',
                               verbose=True):
     """
@@ -1378,10 +1376,10 @@ def check_support_sve(__cache=[]):
     """
     gh-22982
     """
-    
+
     if __cache:
         return __cache[0]
-    
+
     import subprocess
     cmd = 'lscpu'
     try:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1899,31 +1899,3 @@ class TestAssertNoGcCycles:
         finally:
             # make sure that we stop creating reference cycles
             ReferenceCycleInDel.make_cycle = False
-
-
-@pytest.mark.parametrize('assert_func', [assert_array_equal,
-                                         assert_array_almost_equal])
-def test_xy_rename(assert_func):
-    # Test that keywords `x` and `y` have been renamed to `actual` and
-    # `desired`, respectively. These tests and use of `_rename_parameter`
-    # decorator can be removed before the release of NumPy 2.2.0.
-    assert_func(1, 1)
-    assert_func(actual=1, desired=1)
-
-    assert_message = "Arrays are not..."
-    with pytest.raises(AssertionError, match=assert_message):
-        assert_func(1, 2)
-    with pytest.raises(AssertionError, match=assert_message):
-        assert_func(actual=1, desired=2)
-
-    dep_message = 'Use of keyword argument...'
-    with pytest.warns(DeprecationWarning, match=dep_message):
-        assert_func(x=1, desired=1)
-    with pytest.warns(DeprecationWarning, match=dep_message):
-        assert_func(1, y=1)
-
-    type_message = '...got multiple values for argument'
-    with (pytest.warns(DeprecationWarning, match=dep_message),
-          pytest.raises(TypeError, match=type_message)):
-        assert_func(1, x=1)
-        assert_func(1, 2, y=2)


### PR DESCRIPTION
gh-24978 deprecated the use of keywords `x` and `y` in `numpy.testing.assert_array_equal` and `numpy.testing.assert_array_almost_equal`. 

This PR removes the decorator that warned about the deprecation and allowed continued use of `x` and `y`; after the PR, only `actual` and `desired` are accepted.