### PR TITLE
DOC: Added additional guidance for compiling in Windows

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -162,7 +162,7 @@ your system.
     to ensure you have the Windows Universal C Runtime (the other components of
     Visual Studio are not needed when using Mingw-w64, and can be deselected if
     desired, to save disk space). The recommended version of the UCRT is
-    10.0.22621.0.
+    >= 10.0.22621.0.
 
     .. tab-set::
 
@@ -262,6 +262,12 @@ Building from source to use NumPy
       cd numpy
       git submodule update --init
       pip install . --no-build-isolation
+
+    .. warning::
+
+        On Windows, the AR, LD, and LDFLAGS environment variables may be set,
+        which will cause the pip install command to fail. These variables are only
+        needed for flang and can be safely unset prior to running pip install.
 
   .. tab-item:: Virtual env or system Python
     :sync: pip
@@ -372,11 +378,10 @@ interface is self-documenting, so please see ``spin --help`` and
 
 .. warning::
 
-    When building in Windows, `a bug in meson <https://github.com/mesonbuild/meson/issues/10022>`_ may cause the wrong build
-    tools to be selected, which manifests as a LNK1107 fatal error being
-    emitted by link.exe. To workaround, set environment variables CC_LD
-    and CXX_LD to lld-link.
-	
+    In an activated conda enviroment on Windows, the AR, LD, and LDFLAGS
+    environment variables may be set, which will cause the build to fail.
+    These variables are only needed for flang and can be safely unset
+    for build.
 
 .. _meson-editable-installs:
 

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -161,7 +161,8 @@ your system.
     This is needed even if you use the MinGW-w64 or Intel compilers, in order
     to ensure you have the Windows Universal C Runtime (the other components of
     Visual Studio are not needed when using Mingw-w64, and can be deselected if
-    desired, to save disk space).
+    desired, to save disk space). The recommended version of the UCRT is
+    10.0.22621.0.
 
     .. tab-set::
 
@@ -173,6 +174,12 @@ your system.
         C/C++ compilers available inside the shell you are using, you need to
         run a ``.bat`` file for the correct bitness and architecture (e.g., for
         64-bit Intel CPUs, use ``vcvars64.bat``).
+
+        If using a Conda environment while a version of Visual Studio 2019+ is
+        installed that includes the MSVC v142 package (VS 2019 C++ x86/x64
+        build tools), activating the conda environment should cause Visual
+        Studio to be found and the appropriate .bat file executed to set
+        these variables.
 
         For detailed guidance, see `Use the Microsoft C++ toolset from the command line
         <https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170>`__.
@@ -362,6 +369,14 @@ drop into IPython (``spin ipython``), or take other development steps
 like build the html documentation or running benchmarks. The ``spin``
 interface is self-documenting, so please see ``spin --help`` and
 ``spin <subcommand> --help`` for detailed guidance.
+
+.. warning::
+
+    When building in Windows, `a bug in meson <https://github.com/mesonbuild/meson/issues/10022>`_ may cause the wrong build
+    tools to be selected, which manifests as a LNK1107 fatal error being
+    emitted by link.exe. To workaround, set environment variables CC_LD
+    and CXX_LD to lld-link.
+	
 
 .. _meson-editable-installs:
 


### PR DESCRIPTION
Fixes #27747.

Building numpy on Windows has some pitfalls not explicitly mentioned in the existing documentation. I added some details that would have greatly reduced the timed needed to produce a working build if I had them. They are:

-Added a recommended UCRT version as the version I tried initially was missing stdalign.h
-Noted that MSVC environment variable setup gets handled by conda environment activation if the Visual Studio install includes the VS 2019 C++ x86/x64 build tools (MSVC v142).
-Provided advice on failed build with LNK1107 fatal error caused by a meson issue causing it to fail to select the appropriate build tools similar to the this reported issue:

https://github.com/mesonbuild/meson/issues/10022

It appears that the default build process on Windows creates .a files with llvm-ar and then tries to link them with link.exe, which does not recognize such files. Setting environment variables CC_LD and CXX_LD to lld-link seems to solve the problem. Reviewing np.show_config() for the Windows release build, it appears the linker is link.exe not lld-link, so if it there is an alternative fix that gets the build working with link.exe, I would appreciate any feedback on how it should be done.