### PR TITLE
TYP: Fix the annotations of ``ndarray.real`` and ``ndarray.imag`` 

### DIFF
--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -3,8 +3,7 @@ from typing import Literal as L, Any, overload, TypeVar
 
 import numpy as np
 from numpy import (
-    _SupportsImag,
-    _SupportsReal,
+    _HasRealAndImag,
     dtype,
     generic,
     floating,
@@ -50,12 +49,12 @@ def mintypecode(
 ) -> str: ...
 
 @overload
-def real(val: _SupportsReal[_T]) -> _T: ...
+def real(val: _HasRealAndImag[_T, Any]) -> _T: ...
 @overload
 def real(val: ArrayLike) -> NDArray[Any]: ...
 
 @overload
-def imag(val: _SupportsImag[_T]) -> _T: ...
+def imag(val: _HasRealAndImag[Any, _T]) -> _T: ...
 @overload
 def imag(val: ArrayLike) -> NDArray[Any]: ...
 

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -20,20 +20,18 @@ AR_c16: npt.NDArray[np.complex128]
 
 AR_LIKE_f: list[float]
 
-class RealObj:
+class ComplexObj:
     real: slice
-
-class ImagObj:
     imag: slice
 
 assert_type(np.mintypecode(["f8"], typeset="qfQF"), str)
 
-assert_type(np.real(RealObj()), slice)
+assert_type(np.real(ComplexObj()), slice)
 assert_type(np.real(AR_f8), npt.NDArray[np.float64])
 assert_type(np.real(AR_c16), npt.NDArray[np.float64])
 assert_type(np.real(AR_LIKE_f), npt.NDArray[Any])
 
-assert_type(np.imag(ImagObj()), slice)
+assert_type(np.imag(ComplexObj()), slice)
 assert_type(np.imag(AR_f8), npt.NDArray[np.float64])
 assert_type(np.imag(AR_c16), npt.NDArray[np.float64])
 assert_type(np.imag(AR_LIKE_f), npt.NDArray[Any])


### PR DESCRIPTION
This fixes the incorrect getter annotations of the ``ndarray.real`` and ``ndarray.imag`` properties using the same trick as in #27750.
For some reason this wasn't causing issues with mypy before, but pyright wasn't able to properly infer their return types.

---

I combined the (private & type-check-only) `_supportsReal` and `_supportsItem` because in practice, `real` and `imag` always go hand in hand. And if they don't; then it's probably not what want anyway.