### PR TITLE
DOC: Note that allow-pickle is not safe also in error

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -483,8 +483,10 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         else:
             # Try a pickle
             if not allow_pickle:
-                raise ValueError("Cannot load file containing pickled data "
-                                 "when allow_pickle=False")
+                raise ValueError(
+                    "This file contains pickled (object) data. If you trust "
+                    "the file you can load it unsafely using the "
+                    "`allow_pickle=` keyword argument or `pickle.load()`.")
             try:
                 return pickle.load(fid, **pickle_kwargs)
             except Exception as e:


### PR DESCRIPTION
This is the one thing that makes sense to me: nobody reads the documentation, so it may make sense to point out unsafe here.

(Although, the message already said turn off `allow_pickle=False` in a sense.  So it wasn't like the can quite copy paste the suggestion.)

---

No strong opinion, but if it seems like an improvement to others we can put it in.