### PR TITLE
ENH: ``default_rng`` coerces ``RandomState`` to ``Generator``

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -17,7 +17,7 @@ from numpy import (
     uint32,
     uint64,
 )
-from numpy.random import BitGenerator, SeedSequence
+from numpy.random import BitGenerator, SeedSequence, RandomState
 from numpy._typing import (
     ArrayLike,
     NDArray,
@@ -782,5 +782,5 @@ class Generator:
     def shuffle(self, x: ArrayLike, axis: int = ...) -> None: ...
 
 def default_rng(
-    seed: None | _ArrayLikeInt_co | SeedSequence | BitGenerator | Generator = ...
+    seed: None | _ArrayLikeInt_co | SeedSequence | BitGenerator | Generator | RandomState = ...
 ) -> Generator: ...

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -22,6 +22,7 @@ from ._bounded_integers cimport (_rand_bool, _rand_int32, _rand_int64,
          _rand_int16, _rand_int8, _rand_uint64, _rand_uint32, _rand_uint16,
          _rand_uint8, _gen_mask)
 from ._pcg64 import PCG64
+from ._mt19937 import MT19937
 from numpy.random cimport bitgen_t
 from ._common cimport (POISSON_LAM_MAX, CONS_POSITIVE, CONS_NONE,
             CONS_NON_NEGATIVE, CONS_BOUNDED_0_1, CONS_BOUNDED_GT_0_1,
@@ -4990,7 +4991,7 @@ def default_rng(seed=None):
 
     Parameters
     ----------
-    seed : {None, int, array_like[ints], SeedSequence, BitGenerator, Generator}, optional
+    seed : {None, int, array_like[ints], SeedSequence, BitGenerator, Generator, RandomState}, optional
         A seed to initialize the `BitGenerator`. If None, then fresh,
         unpredictable entropy will be pulled from the OS. If an ``int`` or
         ``array_like[ints]`` is passed, then all values must be non-negative and will be
@@ -4998,6 +4999,7 @@ def default_rng(seed=None):
         pass in a `SeedSequence` instance.
         Additionally, when passed a `BitGenerator`, it will be wrapped by
         `Generator`. If passed a `Generator`, it will be returned unaltered.
+        When passed a legacy `RandomState` instance it will be coerced to a `Generator`.
 
     Returns
     -------
@@ -5070,6 +5072,14 @@ def default_rng(seed=None):
     elif isinstance(seed, Generator):
         # Pass through a Generator.
         return seed
+    elif isinstance(seed, np.random.RandomState):
+        rs_state = seed.get_state(legacy=False)
+        klass = getattr(np.random, rs_state['bit_generator'])
+        bg = klass()
+        bg.state = rs_state
+        gen = np.random.Generator(bg)
+        return gen
+
     # Otherwise we need to instantiate a new BitGenerator and Generator as
     # normal.
     return Generator(PCG64(seed))

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -5073,11 +5073,7 @@ def default_rng(seed=None):
         # Pass through a Generator.
         return seed
     elif isinstance(seed, np.random.RandomState):
-        rs_state = seed.get_state(legacy=False)
-        klass = getattr(np.random, rs_state['bit_generator'])
-        bg = klass()
-        bg.state = rs_state
-        gen = np.random.Generator(bg)
+        gen = np.random.Generator(seed._bit_generator)
         return gen
 
     # Otherwise we need to instantiate a new BitGenerator and Generator as

--- a/numpy/random/tests/test_direct.py
+++ b/numpy/random/tests/test_direct.py
@@ -565,8 +565,7 @@ class TestDefaultRNG:
         rs = RandomState(1234)
         rg = default_rng(rs)
         assert isinstance(rg.bit_generator, MT19937)
-
-        assert_allclose(rg.random(), rs.rand())
+        assert rg.bit_generator is rs._bit_generator
 
         # RandomState with a non MT19937 bit generator
         _original = np.random.get_bit_generator()
@@ -574,7 +573,7 @@ class TestDefaultRNG:
         np.random.set_bit_generator(bg)
         rs = np.random.mtrand._rand
         rg = default_rng(rs)
-        assert_allclose(rg.random(), rs.rand())
+        assert rg.bit_generator is bg
 
         # vital to get global state back to original, otherwise
         # other tests start to fail.

--- a/numpy/random/tests/test_direct.py
+++ b/numpy/random/tests/test_direct.py
@@ -559,3 +559,23 @@ class TestDefaultRNG:
         rg2 = default_rng(rg)
         assert rg2 is rg
         assert rg2.bit_generator is bg
+
+    def test_coercion_RandomState_Generator(self):
+        # use default_rng to coerce RandomState to Generator
+        rs = RandomState(1234)
+        rg = default_rng(rs)
+        assert isinstance(rg.bit_generator, MT19937)
+
+        assert_allclose(rg.random(), rs.rand())
+
+        # RandomState with a non MT19937 bit generator
+        _original = np.random.get_bit_generator()
+        bg = PCG64(12342298)
+        np.random.set_bit_generator(bg)
+        rs = np.random.mtrand._rand
+        rg = default_rng(rs)
+        assert_allclose(rg.random(), rs.rand())
+
+        # vital to get global state back to original, otherwise
+        # other tests start to fail.
+        np.random.set_bit_generator(_original)


### PR DESCRIPTION
This PR proposes to allow `default_rng` to coerce `RandomState` to a `Generator`.

This is useful when downstream projects are doing a [SPEC7]( https://github.com/andyfaff/numpy/pull/new/random) transition from legacy `RandomState` to `Generator`.

One illustration is `RandomState` and `Generator` offer slightly different methods. e.g. `RandomState.randint`/`Generator.integers`, `RandomState.random_sample`/`Generator.random`, etc.

Codebases have therefore got to be written to cope with either class. If `default_rng` can do the normalisation then code only has to be written to deal with `Generator`.
The downstream libraries need to understand how a coerced object may be different.

e.g.
`RandomState.random_sample` and `Generator.random` (where the `Generator` was coerced from the same `RandomState` object) can give an identical stream of floats. However, the same can't be said for generating integers.