### PR TITLE
TYP: Type hints for ``numpy.__config__``

### DIFF
--- a/numpy/__config__.pyi
+++ b/numpy/__config__.pyi
@@ -1,0 +1,97 @@
+from enum import Enum
+from types import ModuleType
+from typing import Final, Literal as L, TypedDict, overload, type_check_only
+from typing_extensions import NotRequired
+
+_CompilerConfigDictValue = TypedDict(
+    "_CompilerConfigDictValue",
+    {
+        "name": str,
+        "linker": str,
+        "version": str,
+        "commands": str,
+        "args": str,
+        "linker args": str,
+    },
+)
+_CompilerConfigDict = TypedDict(
+    "_CompilerConfigDict",
+    {
+        "c": _CompilerConfigDictValue,
+        "cython": _CompilerConfigDictValue,
+        "c++": _CompilerConfigDictValue,
+    },
+)
+_MachineInformationDict = TypedDict(
+    "_MachineInformationDict",
+    {
+        "host":_MachineInformationDictValue,
+        "build": _MachineInformationDictValue,
+        "cross-compiled": NotRequired[L[True]],
+    },
+)
+
+@type_check_only
+class _MachineInformationDictValue(TypedDict):
+    cpu: str
+    family: str
+    endian: L["little", "big"]
+    system: str
+
+_BuildDependenciesDictValue = TypedDict(
+    "_BuildDependenciesDictValue",
+    {
+        "name": str,
+        "found": NotRequired[L[True]],
+        "version": str,
+        "include directory": str,
+        "lib directory": str,
+        "openblas configuration": str,
+        "pc file directory": str,
+    },
+)
+
+class _BuildDependenciesDict(TypedDict):
+    blas: _BuildDependenciesDictValue
+    lapack: _BuildDependenciesDictValue
+
+class _PythonInformationDict(TypedDict):
+    path: str
+    version: str
+
+_SIMDExtensionsDict = TypedDict(
+    "_SIMDExtensionsDict",
+    {
+        "baseline": list[str],
+        "found": list[str],
+        "not found": list[str],
+    },
+)
+
+_ConfigDict = TypedDict(
+    "_ConfigDict",
+    {
+        "Compilers": _CompilerConfigDict,
+        "Machine Information": _MachineInformationDict,
+        "Build Dependencies": _BuildDependenciesDict,
+        "Python Information": _PythonInformationDict,
+        "SIMD Extensions": _SIMDExtensionsDict,
+    },
+)
+
+###
+
+__all__ = ["show"]
+
+CONFIG: Final[_ConfigDict] = ...
+
+class DisplayModes(Enum):
+    stdout = "stdout"
+    dicts = "dicts"
+
+def _check_pyyaml() -> ModuleType: ...
+
+@overload
+def show(mode: L["stdout"] = "stdout") -> None: ...
+@overload
+def show(mode: L["dicts"]) -> _ConfigDict: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -12,6 +12,7 @@ from fractions import Fraction
 from uuid import UUID
 
 import numpy as np
+from numpy.__config__ import show as show_config
 from numpy._pytesttester import PytestTester
 from numpy._core._internal import _ctypes
 
@@ -4780,5 +4781,3 @@ def from_dlpack(
     device: L["cpu"] | None = None,
     copy: builtins.bool | None = None,
 ) -> NDArray[number[Any] | np.bool]: ...
-
-def show_config() -> None: ...

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -271,6 +271,7 @@ python_sources = [
   '__init__.pxd',
   '__init__.py',
   '__init__.pyi',
+  '__config__.pyi',
   '_array_api_info.py',
   '_array_api_info.pyi',
   '_configtool.py',


### PR DESCRIPTION
This also annotates the (previously missing) `mode` parameter of `numpy.show_config`.
