### PR TITLE
BUG: Fix multiple modules in F2PY and COMMON handling

### DIFF
--- a/doc/release/upcoming_changes/27695.improvement.rst
+++ b/doc/release/upcoming_changes/27695.improvement.rst
@@ -1,0 +1,5 @@
+``f2py`` handles multiple modules and exposes variables again
+-------------------------------------------------------------
+A regression has been fixed which allows F2PY users to expose variables to
+Python in modules with only assignments, and also fixes situations where
+multiple modules are present within a single source file.

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -44,7 +44,7 @@ __all__ = [
     'isunsigned_long_long', 'isunsigned_long_longarray', 'isunsigned_short',
     'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess', 'replace',
     'show', 'stripcomma', 'throw_error', 'isattr_value', 'getuseblocks',
-    'process_f2cmap_dict'
+    'process_f2cmap_dict', 'containscommon'
 ]
 
 

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -97,9 +97,6 @@ def buildhooks(pymod):
 
     usenames = getuseblocks(pymod)
     for m in findf90modules(pymod):
-        contains_functions_or_subroutines = any(
-            item for item in m["body"] if item["block"] in ["function", "subroutine"]
-        )
         sargs, fargs, efargs, modobjs, notvars, onlyvars = [], [], [], [], [
             m['name']], []
         sargsp = []
@@ -120,8 +117,9 @@ def buildhooks(pymod):
             outmess(f"\t\t\tSkipping {m['name']} since there are no public vars/func in this module...\n")
             continue
 
-        if m['name'] in usenames and not contains_functions_or_subroutines:
-            outmess(f"\t\t\tSkipping {m['name']} since it is in 'use'...\n")
+        # gh-25186
+        if m['name'] in usenames and containscommon(m):
+            outmess(f"\t\t\tSkipping {m['name']} since it is in 'use' and contains a common block...\n")
             continue
         if onlyvars:
             outmess('\t\t  Variables: %s\n' % (' '.join(onlyvars)))

--- a/numpy/f2py/tests/src/regression/datonly.f90
+++ b/numpy/f2py/tests/src/regression/datonly.f90
@@ -1,0 +1,17 @@
+module datonly
+  implicit none
+  integer, parameter :: max_value = 100
+  real, dimension(:), allocatable :: data_array
+end module datonly
+
+module dat
+  implicit none
+  integer, parameter :: max_= 1009
+end module dat
+
+subroutine simple_subroutine(ain, aout)
+  use dat, only: max_
+  integer, intent(in) :: ain
+  integer, intent(out) :: aout
+  aout = ain + max_
+end subroutine simple_subroutine

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -24,6 +24,18 @@ class TestIntentInOut(util.F2PyTest):
         assert np.allclose(x, [3, 1, 2])
 
 
+class TestDataOnlyMultiModule(util.F2PyTest):
+    # Check that modules without subroutines work
+    sources = [util.getpath("tests", "src", "regression", "datonly.f90")]
+
+    @pytest.mark.slow
+    def test_mdat(self):
+        assert self.module.datonly.max_value == 100
+        assert self.module.dat.max_ == 1009
+        int_in = 5
+        assert self.module.simple_subroutine(5) == 1014
+
+
 class TestNegativeBounds(util.F2PyTest):
     # Check that negative bounds work correctly
     sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")]


### PR DESCRIPTION
Backport of #27695.

Closes #27622. The issue stemmed from #25186 which was patched in #25361, #26156, and #25337 but really the original change should have been scoped better.
Essentially:
- The common block issue was fixed by a broad change to the way F2PY handled modules, causing #27622 and #25361
- The right approach is to only skip if `common` blocks are present
This simplification (and additional test) ensures backwards compatibility.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
