### PR TITLE
BUG: ``sinc``: fix underflow for float16 

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3828,7 +3828,12 @@ def sinc(x):
     """
     x = np.asanyarray(x)
     x = pi * x
-    y = where(x, x, np.finfo(x.dtype).eps)
+    if x.dtype.kind == "f":  
+        eps = np.finfo(x.dtype).eps  
+    else:  
+        # Hope that 1e-20 is sufficient for objects...  
+        eps = 1e-20  
+    y = where(x, x, eps)
     return sin(y)/y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3827,7 +3827,7 @@ def sinc(x):
 
     """
     x = np.asanyarray(x)
-    x = x.astype(np.float64) if np.isdtype(x.dtype, 'integral') else x
+    x = x.astype(np.float64) if np.isdtype(x.dtype, ('bool', 'integral')) else x
     y = pi * where(x, x, np.finfo(x.dtype).smallest_normal)
     return sin(y)/y
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3827,7 +3827,8 @@ def sinc(x):
 
     """
     x = np.asanyarray(x)
-    y = pi * where(x == 0, 1.0e-20, x)
+    x = x.astype(np.float64) if np.isdtype(x.dtype, 'integral') else x
+    y = pi * where(x, x, np.finfo(x.dtype).smallest_normal)
     return sin(y)/y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3827,8 +3827,8 @@ def sinc(x):
 
     """
     x = np.asanyarray(x)
-    x = x.astype(np.float64) if np.isdtype(x.dtype, ('bool', 'integral')) else x
-    y = pi * where(x, x, np.finfo(x.dtype).smallest_normal)
+    x *= pi
+    y = where(x, x, np.finfo(x.dtype).eps)
     return sin(y)/y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3828,12 +3828,7 @@ def sinc(x):
     """
     x = np.asanyarray(x)
     x = pi * x
-    if x.dtype.kind == "f":  
-        eps = np.finfo(x.dtype).eps  
-    else:  
-        # Hope that 1e-20 is sufficient for objects...  
-        eps = 1e-20  
-    y = where(x, x, eps)
+    y = where(x, x, np.finfo(x.dtype).eps)
     return sin(y)/y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3828,7 +3828,9 @@ def sinc(x):
     """
     x = np.asanyarray(x)
     x = pi * x
-    y = where(x, x, np.finfo(x.dtype).eps)
+    # Hope that 1e-20 is sufficient for objects...
+    eps = np.finfo(x.dtype).eps if x.dtype.kind == "f" else 1e-20
+    y = where(x, x, eps)
     return sin(y)/y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3827,7 +3827,7 @@ def sinc(x):
 
     """
     x = np.asanyarray(x)
-    x *= pi
+    x = pi * x
     y = where(x, x, np.finfo(x.dtype).eps)
     return sin(y)/y
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2311,6 +2311,27 @@ class TestSinc:
         assert_array_equal(y1, y2)
         assert_array_equal(y1, y3)
 
+    @pytest.mark.parametrize('dtype', [np.uint8, np.int16, np.uint64])
+    def test_int_dtypes(self, dtype):
+        x = np.arange(4, dtype=dtype)
+        actual = sinc(x)
+        expected = sinc(x.astype(np.float64))
+        assert_allclose(actual, expected)
+        assert actual.dtype == np.float64
+
+    @pytest.mark.parametrize(
+            'dtype',
+            [np.float16, np.float32, np.complex64, np.complex128]
+    )
+    def test_float_dtypes(self, dtype):
+        x = np.arange(4, dtype=dtype)
+        assert sinc(x).dtype == x.dtype
+
+    def test_float16_underflow(self):
+        x = np.float16(0)
+        # before gh-27784, fill value for 0 in input would underflow float16,
+        # resulting in nan
+        assert_array_equal(sinc(x), np.asarray(1.0))
 
 class TestUnique:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2311,6 +2311,13 @@ class TestSinc:
         assert_array_equal(y1, y2)
         assert_array_equal(y1, y3)
 
+    def test_bool_dtypes(self, dtype):
+        x = (np.arange(4, dtype=np.uint8) % 2 == 1)
+        actual = sinc(x)
+        expected = sinc(x.astype(np.float64))
+        assert_allclose(actual, expected)
+        assert actual.dtype == np.float64
+
     @pytest.mark.parametrize('dtype', [np.uint8, np.int16, np.uint64])
     def test_int_dtypes(self, dtype):
         x = np.arange(4, dtype=dtype)
@@ -2318,7 +2325,6 @@ class TestSinc:
         expected = sinc(x.astype(np.float64))
         assert_allclose(actual, expected)
         assert actual.dtype == np.float64
-
     @pytest.mark.parametrize(
             'dtype',
             [np.float16, np.float32, np.complex64, np.complex128]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2311,7 +2311,7 @@ class TestSinc:
         assert_array_equal(y1, y2)
         assert_array_equal(y1, y3)
 
-    def test_bool_dtypes(self, dtype):
+    def test_bool_dtypes(self):
         x = (np.arange(4, dtype=np.uint8) % 2 == 1)
         actual = sinc(x)
         expected = sinc(x.astype(np.float64))

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2311,7 +2311,7 @@ class TestSinc:
         assert_array_equal(y1, y2)
         assert_array_equal(y1, y3)
 
-    def test_bool_dtypes(self):
+    def test_bool_dtype(self):
         x = (np.arange(4, dtype=np.uint8) % 2 == 1)
         actual = sinc(x)
         expected = sinc(x.astype(np.float64))
@@ -2328,10 +2328,14 @@ class TestSinc:
     
     @pytest.mark.parametrize(
             'dtype',
-            [np.float16, np.float32, np.complex64, np.complex128]
+            [np.float16, np.float32, np.longdouble, np.complex64, np.complex128]
     )
     def test_float_dtypes(self, dtype):
         x = np.arange(4, dtype=dtype)
+        assert sinc(x).dtype == x.dtype
+
+    def test_object_dtype(self):
+        x = np.arange(4, dtype=object)
         assert sinc(x).dtype == x.dtype
 
     def test_float16_underflow(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2325,6 +2325,7 @@ class TestSinc:
         expected = sinc(x.astype(np.float64))
         assert_allclose(actual, expected)
         assert actual.dtype == np.float64
+    
     @pytest.mark.parametrize(
             'dtype',
             [np.float16, np.float32, np.complex64, np.complex128]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2334,10 +2334,6 @@ class TestSinc:
         x = np.arange(4, dtype=dtype)
         assert sinc(x).dtype == x.dtype
 
-    def test_object_dtype(self):
-        x = np.arange(4, dtype=object)
-        assert sinc(x).dtype == x.dtype
-
     def test_float16_underflow(self):
         x = np.float16(0)
         # before gh-27784, fill value for 0 in input would underflow float16,


### PR DESCRIPTION
While reviewing https://github.com/data-apis/array-api-extra/pull/20, @jakirkham suggested these small improvements to the implementation of `sinc`.

If the change from `1.0e-20` to `np.finfo(x.dtype).smallest_normal` is classed as breaking, we can leave that out.