### PR TITLE
ENH: Implement np.strings.slice as a gufunc

### DIFF
--- a/doc/release/upcoming_changes/27789.new_function.rst
+++ b/doc/release/upcoming_changes/27789.new_function.rst
@@ -1,0 +1,4 @@
+* New function `numpy.strings.slice`
+  The new function `numpy.strings.slice` was added, which implements fast
+  native slicing of string arrays. It supports the full slicing API including
+  negative slice offsets and steps.

--- a/doc/source/reference/routines.strings.rst
+++ b/doc/source/reference/routines.strings.rst
@@ -46,6 +46,7 @@ String operations
    rjust
    rpartition
    rstrip
+   slice
    strip
    swapcase
    title

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1338,6 +1338,11 @@ defdict = {
           docstrings.get('numpy._core.umath._rpartition'),
           None,
           ),
+'_slice':
+    Ufunc(4, 1, None,
+          docstrings.get('numpy._core.umath._slice'),
+          None,
+          ),
 }
 
 def indent(st, spaces):

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -5451,3 +5451,40 @@ add_newdoc('numpy._core.umath', '_rpartition',
      array(['', '  ', 'Bba'], dtype=StringDType()))
 
     """)
+
+add_newdoc('numpy._core.umath', '_slice',
+    """
+    Slice the strings in `a` by slices specified by `start`, `stop`, `step`.
+    Like in the regular Python `slice` object, if only `start` is
+    specified then it is interpreted as the `stop`.
+
+    Parameters
+    ----------
+    a : array-like, with ``StringDType``, ``bytes_``, or ``str_`` dtype
+
+    start : the start of the slice, an integer or an array of integers
+            which can be broadcasted to`a`'s shape
+
+    stop : the end point of the slice, an integer or an array of integers
+           which can be broadcasted to`a`'s shape
+
+    step : the step for the slice, an integer or an array of integers
+           which can be broadcasted to`a`'s shape
+
+    Returns
+    -------
+    out : ndarray
+        Output array of str or unicode, depending on input type
+
+    Examples
+    --------
+    >>> import numpy as np
+
+    The ufunc is used most easily via ``np.strings.slice``,
+    which calls it under the hood::
+
+    >>> a = np.array(['hello', 'world'])
+    >>> np.strings.slice(a, 2)
+    array(['he', 'wo'], dtype='<U5')
+
+    """)

--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -1272,7 +1272,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
         fastest).  If order is 'A', then the returned array may
         be in any order (either C-, Fortran-contiguous, or even
         discontiguous).
-    
+
     Examples
     --------
 

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -1670,10 +1670,10 @@ def slice(a, start=None, stop=None, step=None, /):
     --------
     >>> import numpy as np
     >>> a = np.array(['hello', 'world'])
-    >>> np.char.slice(a, 2)
+    >>> np.strings.slice(a, 2)
     array(['he', 'wo'], dtype='<U5')
 
-    >>> np.char.slice(a, 1, 5, 2)
+    >>> np.strings.slice(a, 1, 5, 2)
     array(['el', 'ol'], dtype='<U5')
 
     One can specify different start/stop/step for different array entries:

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -46,6 +46,7 @@ from numpy._core.umath import (
     _partition_index,
     _rpartition,
     _rpartition_index,
+    _slice,
 )
 
 
@@ -68,7 +69,7 @@ __all__ = [
     "isupper", "istitle", "isdecimal", "isnumeric", "str_len", "find",
     "rfind", "index", "rindex", "count", "startswith", "endswith", "lstrip",
     "rstrip", "strip", "replace", "expandtabs", "center", "ljust", "rjust",
-    "zfill", "partition", "rpartition",
+    "zfill", "partition", "rpartition", "slice",
 
     # _vec_string - Will gradually become ufuncs as well
     "upper", "lower", "swapcase", "capitalize", "title",
@@ -1639,3 +1640,81 @@ def translate(a, table, deletechars=None):
             'translate',
             [table] + _clean_args(deletechars)
         )
+
+@set_module("numpy.strings")
+def slice(a, start=None, stop=None, step=None, /):
+    """
+    Slice the strings in `a` by slices specified by `start`, `stop`, `step`.
+    Like in the regular Python `slice` object, if only `start` is
+    specified then it is interpreted as the `stop`.
+
+    Parameters
+    ----------
+    a : array-like, with ``StringDType``, ``bytes_``, or ``str_`` dtype
+
+    start : the start of the slice, can be None, an integer or
+            an array of integers which can be broadcasted to`a`'s shape
+
+    stop : the end point of the slice, can be None, and integer or
+           an array of integers which can be broadcasted to`a`'s shape
+
+    step : the step for the slice, can be None, an integer or
+           an array of integers which can be broadcasted to`a`'s shape
+
+    Returns
+    -------
+    out : ndarray
+        Output array of str or unicode, depending on input type
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array(['hello', 'world'])
+    >>> np.char.slice(a, 2)
+    array(['he', 'wo'], dtype='<U5')
+
+    >>> np.char.slice(a, 1, 5, 2)
+    array(['el', 'ol'], dtype='<U5')
+
+    One can specify different start/stop/step for different array entries:
+
+    >>> np.strings.slice(a, np.array([1, 2]), np.array([4, 5]))
+    array(['ell', 'rld'], dtype='<U5')
+
+    Negative slices have the same meaning as in regular Python:
+
+    >>> b = np.array(['hello world', 'γεια σου κόσμε', '你好世界', '👋 🌍'],
+    ...              dtype=np.dtypes.StringDType())
+    >>> np.strings.slice(b, -2)
+    array(['hello wor', 'γεια σου κόσ', '你好', '👋'], dtype=StringDType())
+
+    >>> np.strings.slice(b, [3, -10, 2, -3], [-1, -2, -1, 3])
+    array(['lo worl', ' σου κόσ', '世', '👋 🌍'], dtype=StringDType())
+
+    >>> np.strings.slice(b, None, None, -1)
+    array(['dlrow olleh', 'εμσόκ υοσ αιεγ', '界世好你', '🌍 👋'],
+          dtype=StringDType())
+
+    """
+    # Just like in the construction of a regular slice object, if only start
+    # is speficied then start will become stop, see logic in slice_new.
+    if stop is None:
+        stop = start
+        start = None
+
+    # adjust start, stop, step to be integers, see logic in PySlice_Unpack
+    if step is None:
+        step = 1
+    step = np.asanyarray(step)
+    if not np.issubdtype(step.dtype, np.integer):
+        raise TypeError(f"unsupported type {step.dtype} for operand 'step'")
+    if np.any(step == 0):
+        raise ValueError("slice step cannot be zero")
+
+    if start is None:
+        start = np.where(step < 0, np.iinfo(np.intp).max, 0)
+
+    if stop is None:
+        stop = np.where(step < 0, np.iinfo(np.intp).min, np.iinfo(np.intp).max)
+
+    return _slice(a, start, stop, step)

--- a/numpy/_core/umath.py
+++ b/numpy/_core/umath.py
@@ -20,7 +20,7 @@ from ._multiarray_umath import (
     _replace, _strip_whitespace, _lstrip_whitespace, _rstrip_whitespace,
     _strip_chars, _lstrip_chars, _rstrip_chars, _expandtabs_length,
     _expandtabs, _center, _ljust, _rjust, _zfill, _partition, _partition_index,
-    _rpartition, _rpartition_index)
+    _rpartition, _rpartition_index, _slice)
 
 __all__ = [
     'absolute', 'add',


### PR DESCRIPTION
This commit adds a `np.strings.slice` function which vectorizes slicing of string arrays. For example
```
    >>> a = np.array(['hello', 'world'])
    >>> np.char.slice(a, 2)
    array(['he', 'wo'], dtype='<U5')
```

This supports fixed-length and variable-length string dtypes. It also supports broadcasting the start, stop, step args:
```
    >>> b = np.array(['hello world', 'γεια σου κόσμε', '你好世界', '👋 🌍️'], dtype=np.dtypes.StringDType())
    >>> np.strings.slice(b, [3, 0, 2, 1], -1)
    array(['lo worl', 'γεια σου κόσμ', '世', ' 🌍'], dtype=StringDType())
```

Closes #8579

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
