### PR TITLE
BUG: Fix repeat for strings and accumulate API logic

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -785,21 +785,21 @@ static NPY_GCC_OPT_3 inline int
 npy_fastrepeat_impl(
     npy_intp n_outer, npy_intp n, npy_intp nel, npy_intp chunk,
     npy_bool broadcast, npy_intp* counts, char* new_data, char* old_data,
-    npy_intp elsize, NPY_cast_info cast_info, int needs_refcounting)
+    npy_intp elsize, NPY_cast_info *cast_info, int needs_custom_copy)
 {
     npy_intp i, j, k;
     for (i = 0; i < n_outer; i++) {
         for (j = 0; j < n; j++) {
             npy_intp tmp = broadcast ? counts[0] : counts[j];
             for (k = 0; k < tmp; k++) {
-                if (!needs_refcounting) {
+                if (!needs_custom_copy) {
                     memcpy(new_data, old_data, chunk);
                 }
                 else {
                     char *data[2] = {old_data, new_data};
                     npy_intp strides[2] = {elsize, elsize};
-                    if (cast_info.func(&cast_info.context, data, &nel,
-                                       strides, cast_info.auxdata) < 0) {
+                    if (cast_info->func(&cast_info->context, data, &nel,
+                                       strides, cast_info->auxdata) < 0) {
                         return -1;
                     }
                 }
@@ -811,48 +811,53 @@ npy_fastrepeat_impl(
     return 0;
 }
 
+
+/*
+ * Helper to allow the compiler to specialize for all direct element copy
+ * cases (e.g. all numerical dtypes).
+ */
 static NPY_GCC_OPT_3 int
 npy_fastrepeat(
     npy_intp n_outer, npy_intp n, npy_intp nel, npy_intp chunk,
     npy_bool broadcast, npy_intp* counts, char* new_data, char* old_data,
-    npy_intp elsize, NPY_cast_info cast_info, int needs_refcounting)
+    npy_intp elsize, NPY_cast_info *cast_info, int needs_custom_copy)
 {
-    if (!needs_refcounting) {
+    if (!needs_custom_copy) {
         if (chunk == 1) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
         if (chunk == 2) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
         if (chunk == 4) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
         if (chunk == 8) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
         if (chunk == 16) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
         if (chunk == 32) {
             return npy_fastrepeat_impl(
                 n_outer, n, nel, chunk, broadcast, counts, new_data, old_data,
-                elsize, cast_info, needs_refcounting);
+                elsize, cast_info, needs_custom_copy);
         }
     }
 
     return npy_fastrepeat_impl(
         n_outer, n, nel, chunk, broadcast, counts, new_data, old_data, elsize,
-        cast_info, needs_refcounting);
+        cast_info, needs_custom_copy);
 }
 
 
@@ -872,7 +877,6 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
     char *new_data, *old_data;
     NPY_cast_info cast_info;
     NPY_ARRAYMETHOD_FLAGS flags;
-    int needs_refcounting;
 
     repeats = (PyArrayObject *)PyArray_ContiguousFromAny(op, NPY_INTP, 0, 1);
     if (repeats == NULL) {
@@ -897,7 +901,6 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
     aop = (PyArrayObject *)ap;
     n = PyArray_DIM(aop, axis);
     NPY_cast_info_init(&cast_info);
-    needs_refcounting = PyDataType_REFCHK(PyArray_DESCR(aop));
 
     if (!broadcast && PyArray_SIZE(repeats) != n) {
         PyErr_Format(PyExc_ValueError,
@@ -947,16 +950,18 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
         n_outer *= PyArray_DIMS(aop)[i];
     }
 
-    if (needs_refcounting) {
+    int needs_custom_copy = 0;
+    if (PyDataType_REFCHK(PyArray_DESCR(ret))) {
+        needs_custom_copy = 1;
         if (PyArray_GetDTypeTransferFunction(
-                1, elsize, elsize, PyArray_DESCR(aop), PyArray_DESCR(aop), 0,
+                1, elsize, elsize, PyArray_DESCR(aop), PyArray_DESCR(ret), 0,
                 &cast_info, &flags) < 0) {
             goto fail;
         }
     }
 
     if (npy_fastrepeat(n_outer, n, nel, chunk, broadcast, counts, new_data,
-                       old_data, elsize, cast_info, needs_refcounting) < 0) {
+                       old_data, elsize, &cast_info, needs_custom_copy) < 0) {
         goto fail;
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2916,8 +2916,6 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
             NPY_UF_DBG_PRINT1("iterator loop count %d\n", (int)count);
 
-            needs_api = PyDataType_REFCHK(descrs[0]);
-
             if (!needs_api) {
                 NPY_BEGIN_THREADS_THRESHOLDED(count);
             }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1574,6 +1574,17 @@ def test_unset_na_coercion():
             arr == op
 
 
+def test_repeat(string_array):
+    res = string_array.repeat(1000)
+    # Create an empty array with expanded dimension, and fill it.  Then,
+    # reshape it to the expected result.
+    expected = np.empty_like(string_array, shape=string_array.shape + (1000,))
+    expected[...] = string_array[:, np.newaxis]
+    expected = expected.reshape(-1)
+
+    assert_array_equal(res, expected, strict=True)
+
+
 class TestImplementation:
     """Check that strings are stored in the arena when possible.
 


### PR DESCRIPTION
Backport of gh-27773 but not including fixes to allow strings in accumulation.

This fixes threethings:
1. `needs_api` was wrongly overwritten, this was just a line not deleted earlier.
2. `repeat` was just broken with string dtype... I guess there was no actual test.
3. `repeat` internals passed on `cast_info` not by reference. I guess that isn't a bug, but it's weird.