### PR TITLE
TYP: Generic ``numpy.bool`` and statically typed boolean logic

### DIFF
--- a/numpy/typing/tests/data/reveal/bitwise_ops.pyi
+++ b/numpy/typing/tests/data/reveal/bitwise_ops.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal as L, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
@@ -6,19 +6,26 @@ from numpy._typing import _64Bit, _32Bit
 
 from typing_extensions import assert_type
 
-i8 = np.int64(1)
-u8 = np.uint64(1)
+FalseType: TypeAlias = L[False]
+TrueType: TypeAlias = L[True]
 
-i4 = np.int32(1)
-u4 = np.uint32(1)
+i4: np.int32
+i8: np.int64
 
-b_ = np.bool(1)
+u4: np.uint32
+u8: np.uint64
 
-b = bool(1)
-i = int(1)
+b_: np.bool[bool]
+b0_: np.bool[FalseType]
+b1_: np.bool[TrueType]
 
-AR = np.array([0, 1, 2], dtype=np.int32)
-AR.setflags(write=False)
+b: bool
+b0: FalseType
+b1: TrueType
+
+i: int
+
+AR: npt.NDArray[np.int32]
 
 
 assert_type(i8 << i8, np.int64)
@@ -119,13 +126,45 @@ assert_type(b_ & b, np.bool)
 
 assert_type(b_ << i, np.int_)
 assert_type(b_ >> i, np.int_)
-assert_type(b_ | i, np.int_)
-assert_type(b_ ^ i, np.int_)
-assert_type(b_ & i, np.int_)
+assert_type(b_ | i, np.bool | np.int_)
+assert_type(b_ ^ i, np.bool | np.int_)
+assert_type(b_ & i, np.bool | np.int_)
 
 assert_type(~i8, np.int64)
 assert_type(~i4, np.int32)
 assert_type(~u8, np.uint64)
 assert_type(~u4, np.uint32)
 assert_type(~b_, np.bool)
+assert_type(~b0_, np.bool[TrueType])
+assert_type(~b1_, np.bool[FalseType])
 assert_type(~AR, npt.NDArray[np.int32])
+
+assert_type(b_ | b0_, np.bool)
+assert_type(b0_ | b_, np.bool)
+assert_type(b_ | b1_, np.bool[TrueType])
+assert_type(b1_ | b_, np.bool[TrueType])
+
+assert_type(b_ ^ b0_, np.bool)
+assert_type(b0_ ^ b_, np.bool)
+assert_type(b_ ^ b1_, np.bool)
+assert_type(b1_ ^ b_, np.bool)
+
+assert_type(b_ & b0_, np.bool[FalseType])
+assert_type(b0_ & b_, np.bool[FalseType])
+assert_type(b_ & b1_, np.bool)
+assert_type(b1_ & b_, np.bool)
+
+assert_type(b0_ | b0_, np.bool[FalseType])
+assert_type(b0_ | b1_, np.bool[TrueType])
+assert_type(b1_ | b0_, np.bool[TrueType])
+assert_type(b1_ | b1_, np.bool[TrueType])
+
+assert_type(b0_ ^ b0_, np.bool[FalseType])
+assert_type(b0_ ^ b1_, np.bool[TrueType])
+assert_type(b1_ ^ b0_, np.bool[TrueType])
+assert_type(b1_ ^ b1_, np.bool[FalseType])
+
+assert_type(b0_ & b0_, np.bool[FalseType])
+assert_type(b0_ & b1_, np.bool[FalseType])
+assert_type(b1_ & b0_, np.bool[FalseType])
+assert_type(b1_ & b1_, np.bool[TrueType])

--- a/numpy/typing/tests/data/reveal/constants.pyi
+++ b/numpy/typing/tests/data/reveal/constants.pyi
@@ -1,6 +1,7 @@
-import numpy as np
-
+from typing import Literal
 from typing_extensions import assert_type
+
+import numpy as np
 
 assert_type(np.e, float)
 assert_type(np.euler_gamma, float)
@@ -9,5 +10,6 @@ assert_type(np.nan, float)
 assert_type(np.pi, float)
 
 assert_type(np.little_endian, bool)
-assert_type(np.True_, np.bool)
-assert_type(np.False_, np.bool)
+
+assert_type(np.True_, np.bool[Literal[True]])
+assert_type(np.False_, np.bool[Literal[False]])

--- a/numpy/typing/tests/data/reveal/numerictypes.pyi
+++ b/numpy/typing/tests/data/reveal/numerictypes.pyi
@@ -1,8 +1,8 @@
 from typing import Literal
+from typing_extensions import assert_type
 
 import numpy as np
 
-from typing_extensions import assert_type
 
 assert_type(
     np.ScalarType,
@@ -44,7 +44,7 @@ assert_type(np.ScalarType[0], type[int])
 assert_type(np.ScalarType[3], type[bool])
 assert_type(np.ScalarType[8], type[np.csingle])
 assert_type(np.ScalarType[10], type[np.clongdouble])
-assert_type(np.bool_, type[np.bool])
+assert_type(np.bool_(object()), np.bool)
 
 assert_type(np.typecodes["Character"], Literal["c"])
 assert_type(np.typecodes["Complex"], Literal["FDG"])

--- a/numpy/typing/tests/data/reveal/scalars.pyi
+++ b/numpy/typing/tests/data/reveal/scalars.pyi
@@ -52,7 +52,7 @@ assert_type(V[["field1", "field2"]], np.void)
 V[0] = 5
 
 # Aliases
-assert_type(np.bool_(), np.bool)
+assert_type(np.bool_(), np.bool[Literal[False]])
 assert_type(np.byte(), np.byte)
 assert_type(np.short(), np.short)
 assert_type(np.intc(), np.intc)


### PR DESCRIPTION
This adds an optional boolean type parameter to `numpy.bool`, so that:

```pyi
False_: np.bool[Literal[False]
True_: np.bool[Literal[True]]
```

The bitwise operators (`~`, `&`, `^`, `|`) of `np.bool` had their signatures extended to take the type parameter into account. Consequently, static type-checkers will now understand "simple"  statements like

![image](https://github.com/user-attachments/assets/d692fb5c-df84-4a50-8186-0c693d35a273)
