### PR TITLE
BUG: Ensure that same-kind casting works for uints (mostly)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6175,7 +6175,7 @@ class MaskedArray(ndarray):
         >>> y.ptp(axis=1).view(np.uint8)
         masked_array(data=[126, 127, 128, 129],
                      mask=False,
-               fill_value=np.int64(999999),
+               fill_value=np.uint64(999999),
                     dtype=uint8)
         """
         if out is None:
@@ -7863,7 +7863,7 @@ def diff(a, /, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     >>> np.ma.diff(u8_arr)
     masked_array(data=[255],
                  mask=False,
-           fill_value=np.int64(999999),
+           fill_value=np.uint64(999999),
                 dtype=uint8)
     >>> u8_arr[1,...] - u8_arr[0,...]
     np.uint8(255)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -469,6 +469,16 @@ def _check_fill_value(fill_value, ndtype):
     ndtype = np.dtype(ndtype)
     if fill_value is None:
         fill_value = default_fill_value(ndtype)
+        # TODO: It seems better to always store a valid fill_value, the oddity
+        #       about is that `_fill_value = None` would behave even more
+        #       different then.
+        #       (e.g. this allows arr_uint8.astype(int64) to have the default
+        #       fill value again...)
+        # The one thing that changed in 2.0/2.1 around cast safety is that the
+        # default `int(99...)` is not a same-kind cast anymore, so if we
+        # have a uint, use the default uint.
+        if ndtype.kind == "u":
+            fill_value = np.uint(fill_value)
     elif ndtype.names is not None:
         if isinstance(fill_value, (ndarray, np.void)):
             try:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1351,7 +1351,7 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
-    @pytest.mark.parametrize("dtype","bBiIqQ")
+    @pytest.mark.parametrize("dtype", "bBiIqQ")
     @pytest.mark.parametrize("mask", [
         [False, False, False, True, True],  # masked min/max
         [False, False, False, True, False],  # masked max only

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1351,6 +1351,23 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
+    @pytest.mark.parametrize("dtype","bBiIqQ")
+    @pytest.mark.parametrize("mask", [
+        [False, False, False, True, True],  # masked min/max
+        [False, False, False, True, False],  # masked max only
+        [False, False, False, False, True],  # masked min only
+    ])
+    @pytest.mark.parametrize("axis", [None, -1])
+    def test_minmax_ints(self, dtype, mask, axis):
+        iinfo = np.iinfo(dtype)
+        # two dimensional to hit certain filling paths
+        a = np.array([[0, 10, -10, iinfo.min, iinfo.max]] * 2).astype(dtype)
+        mask = np.asarray([mask] * 2)
+
+        masked_a = masked_array(a, mask=mask)
+        assert_array_equal(masked_a.min(axis), a[~mask].min(axis))
+        assert_array_equal(masked_a.max(axis), a[~mask].max(axis))
+
     @pytest.mark.parametrize("time_type", ["M8[s]", "m8[s]"])
     def test_minmax_time_dtypes(self, time_type):
         def minmax_with_mask(arr, mask):
@@ -5755,3 +5772,15 @@ def test_deepcopy_0d_obj():
     deepcopy[...] = 17
     assert_equal(source, 0)
     assert_equal(deepcopy, 17)
+
+
+def test_uint_fill_value_and_filled():
+    # See also gh-27269
+    a = np.ma.MaskedArray([1, 1], [True, False], dtype="uint16")
+    # the fill value should likely not be 99999, but for now guarantee it:
+    assert a.fill_value == 999999
+    # However, it's type is uint:
+    assert a.fill_value.dtype.kind == "u"
+    # And this ensures things like filled work:
+    np.testing.assert_array_equal(
+        a.filled(), np.array([999999, 1]).astype("uint16"), strict=True)


### PR DESCRIPTION
This is the most minimal fix I could think off... If we have uints still use the out-of-bounds value, but make it uint.  This is because the code uses copyto with the default same-kind casting in places...

This doesn't remove all the other quirks, and surely, it is a behavior change in some awkward situations (since you got a uint, someone might mix the newly uint value with an integer and get float64 results, etc.)

But... it is by far the most minimal fix I could think of after a longer time.

A more thorough fix may be to just always store the exact dtype, but it would propagate differently e.g. when casting.  A start for this is currently in gh-27596.

Closes gh-27269, gh-27580

---

I am not convinced we should backport this or not.  It is the most minimal fix I could think of (besides adding unsafe casts everywhere and hoping for the best/that we found them all).  But it clearly has the potential to change behavior in some contexts...