### PR TITLE
BUG,ENH: Fix internal ``__array_wrap__`` for direct calls

### DIFF
--- a/doc/release/upcoming_changes/27807.change.rst
+++ b/doc/release/upcoming_changes/27807.change.rst
@@ -1,0 +1,4 @@
+* Calling ``__array_wrap__`` directly on NumPy arrays or scalars
+  now does the right thing when ``return_scalar`` is passed
+  (Added in NumPy 2).  It is further safe now to call the scalar
+  ``__array_wrap__`` on a non-scalar result.

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -25,6 +25,7 @@
 #include "numpyos.h"
 #include "can_cast_table.h"
 #include "common.h"
+#include "conversion_utils.h"
 #include "flagsobject.h"
 #include "scalartypes.h"
 #include "_datetime.h"
@@ -2035,29 +2036,33 @@ gentype_getarray(PyObject *scalar, PyObject *args)
     return ret;
 }
 
-static char doc_sc_wraparray[] = "sc.__array_wrap__(obj) return scalar from array";
+static char doc_sc_wraparray[] = "Array wrap to implementation for scalar types";
 
+/*
+ * Array wrap for scalars, returning a scalar again preferentially.
+ * (note that NumPy itself may well never call this itself).
+ */
 static PyObject *
 gentype_wraparray(PyObject *NPY_UNUSED(scalar), PyObject *args)
 {
-    PyObject *obj;
     PyArrayObject *arr;
+    PyObject *context_ignored = NULL;
+    /* return_scalar should be passed, but it was a scalar so prefer scalar */
+    int return_scalar = 1;
 
-    if (PyTuple_Size(args) < 1) {
-        PyErr_SetString(PyExc_TypeError,
-                "only accepts 1 argument.");
+    if (!PyArg_ParseTuple(args, "O!|OO&:__array_wrap__",
+                &PyArray_Type, &arr, &context_ignored,
+                &PyArray_OptionalBoolConverter, &return_scalar)) {
         return NULL;
     }
-    obj = PyTuple_GET_ITEM(args, 0);
-    if (!PyArray_Check(obj)) {
-        PyErr_SetString(PyExc_TypeError,
-                "can only be called with ndarray object");
-        return NULL;
-    }
-    arr = (PyArrayObject *)obj;
 
-    return PyArray_Scalar(PyArray_DATA(arr),
-                    PyArray_DESCR(arr), (PyObject *)arr);
+    Py_INCREF(arr);
+    if (!return_scalar) {
+        return (PyObject *)arr;
+    }
+    else {
+        return PyArray_Return(arr);
+    }
 }
 
 /*

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2036,22 +2036,22 @@ gentype_getarray(PyObject *scalar, PyObject *args)
     return ret;
 }
 
-static char doc_sc_wraparray[] = "Array wrap to implementation for scalar types";
+static char doc_sc_wraparray[] = "__array_wrap__ implementation for scalar types";
 
 /*
- * Array wrap for scalars, returning a scalar again preferentially.
+ * __array_wrap__ for scalars, returning a scalar if possible.
  * (note that NumPy itself may well never call this itself).
  */
 static PyObject *
 gentype_wraparray(PyObject *NPY_UNUSED(scalar), PyObject *args)
 {
     PyArrayObject *arr;
-    PyObject *context_ignored = NULL;
-    /* return_scalar should be passed, but it was a scalar so prefer scalar */
+    PyObject *UNUSED = NULL;  /* for the context argument */
+    /* return_scalar should be passed, but we're scalar, so return scalar by default */
     int return_scalar = 1;
 
     if (!PyArg_ParseTuple(args, "O!|OO&:__array_wrap__",
-                &PyArray_Type, &arr, &context_ignored,
+                &PyArray_Type, &arr, &UNUSED,
                 &PyArray_OptionalBoolConverter, &return_scalar)) {
         return NULL;
     }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9807,7 +9807,7 @@ def test_equal_subclass_no_override(op, dt1, dt2):
 
         def __array_wrap__(self, new, context=None, return_scalar=False):
             type(self).called_wrap += 1
-            return super().__array_wrap__(new)
+            return super().__array_wrap__(new, context, return_scalar)
 
     numpy_arr = np.zeros(5, dtype=dt1)
     my_arr = np.zeros(5, dtype=dt2).view(MyArr)

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -223,3 +223,24 @@ class TestDevice:
     @pytest.mark.parametrize("scalar", scalars)
     def test___array_namespace__(self, scalar):
         assert scalar.__array_namespace__() is np
+
+
+@pytest.mark.parametrize("scalar", [np.bool(True), np.int8(1), np.float64(1)])
+def test_array_wrap(scalar):
+    # Test scalars array wrap as long as it exists.  NumPy itself should
+    # probably not use it, so it may not be necessary to keep it around.
+
+    arr0d = np.array(3, dtype=np.int8)
+    # Third argument not passed, None, or True "decays" to scalar.
+    # (I don't think NumPy would pass `None`, but it seems clear to support)
+    assert type(scalar.__array_wrap__(arr0d)) is np.int8
+    assert type(scalar.__array_wrap__(arr0d, None, None)) is np.int8
+    assert type(scalar.__array_wrap__(arr0d, None, True)) is np.int8
+
+    # Otherwise, result should be the input
+    assert scalar.__array_wrap__(arr0d, None, False) is arr0d
+
+    # An old bug.  A non 0-d array cannot be converted to scalar:
+    arr1d = np.array([3], dtype=np.int8)
+    assert scalar.__array_wrap__(arr1d) is arr1d
+    assert scalar.__array_wrap__(arr1d, None, True) is arr1d


### PR DESCRIPTION
Since adding `return_scalar` as am argument, the array-wrap implementations were slightly wrong when that argument was actually passed and the function called directly.

NumPy itself rarely (or never) did so for our builtin types now so that was not a problem within NumPy.

Further, the scalar version was completely broken, converting to scalar even when such a conversion was impossible.

As explained in the code.  For array subclasses we NEVER want to convert to scalar by default.  The subclass must make that choice explicitly.
(There are plenty of tests for this behavior.)

Closes gh-27783