### PR TITLE
BUG: Fix array flags propagation in boolean indexing

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1058,7 +1058,7 @@ array_boolean_subscript(PyArrayObject *self,
         ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
                 Py_TYPE(self), ret_dtype,
                 1, &size, PyArray_STRIDES(ret), PyArray_BYTES(ret),
-                PyArray_FLAGS(self), (PyObject *)self, (PyObject *)tmp);
+                PyArray_FLAGS(ret), (PyObject *)self, (PyObject *)tmp);
 
         Py_DECREF(tmp);
         if (ret == NULL) {

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -409,15 +409,19 @@ class TestIndexing:
         a[...] = memoryview(s)
         assert_array_equal(a, s)
 
-    def test_subclass_writeable(self):
+    @pytest.mark.parametrize("writeable", [True, False])
+    def test_subclass_writeable(self, writeable):
         d = np.rec.array([('NGC1001', 11), ('NGC1002', 1.), ('NGC1003', 1.)],
                          dtype=[('target', 'S20'), ('V_mag', '>f4')])
+        d.flags.writeable = writeable
+        # Advanced indexing results are always writeable:
         ind = np.array([False,  True,  True], dtype=bool)
-        assert_(d[ind].flags.writeable)
+        assert d[ind].flags.writeable
         ind = np.array([0, 1])
-        assert_(d[ind].flags.writeable)
-        assert_(d[...].flags.writeable)
-        assert_(d[0].flags.writeable)
+        assert d[ind].flags.writeable
+        # Views should be writeable if the original array is:
+        assert d[...].flags.writeable == writeable
+        assert d[0].flags.writeable == writeable
 
     def test_memory_order(self):
         # This is not necessary to preserve. Memory layouts for


### PR DESCRIPTION
Flags don't need to be propagated from the original array. Progating from the result array makes sense and is safe, but really... the only flag we normally need is writeable.
(However, this is a typical pattern right now.)

Expands the test to cover these cases.

Closes gh-27777