### PR TITLE
BUG: ``timedelta64.__[r]divmod__`` segfaults for incompatible units

### DIFF
--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -2228,19 +2228,17 @@ PyUFunc_DivmodTypeResolver(PyUFuncObject *ufunc,
         return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
                     type_tup, out_dtypes);
     }
-    if (type_num1 == NPY_TIMEDELTA) {
-        if (type_num2 == NPY_TIMEDELTA) {
-            out_dtypes[0] = PyArray_PromoteTypes(PyArray_DESCR(operands[0]),
-                                                PyArray_DESCR(operands[1]));
-            out_dtypes[1] = out_dtypes[0];
-            Py_INCREF(out_dtypes[1]);
-            out_dtypes[2] = PyArray_DescrFromType(NPY_LONGLONG);
-            out_dtypes[3] = out_dtypes[0];
-            Py_INCREF(out_dtypes[3]);
+    if (type_num1 == NPY_TIMEDELTA && type_num2 == NPY_TIMEDELTA) {
+        out_dtypes[0] = PyArray_PromoteTypes(PyArray_DESCR(operands[0]),
+                                            PyArray_DESCR(operands[1]));                             
+        if (!out_dtypes[0]) {
+            return -1;
         }
-        else {
-            return raise_binary_type_reso_error(ufunc, operands);
-        }
+        out_dtypes[1] = out_dtypes[0];
+        Py_INCREF(out_dtypes[1]);
+        out_dtypes[2] = PyArray_DescrFromType(NPY_LONGLONG);
+        out_dtypes[3] = out_dtypes[0];
+        Py_INCREF(out_dtypes[3]);
     }
     else {
         return raise_binary_type_reso_error(ufunc, operands);

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -2230,8 +2230,8 @@ PyUFunc_DivmodTypeResolver(PyUFuncObject *ufunc,
     }
     if (type_num1 == NPY_TIMEDELTA && type_num2 == NPY_TIMEDELTA) {
         out_dtypes[0] = PyArray_PromoteTypes(PyArray_DESCR(operands[0]),
-                                            PyArray_DESCR(operands[1]));                             
-        if (!out_dtypes[0]) {
+                                             PyArray_DESCR(operands[1]));                             
+        if (out_dtypes[0] == NULL) {
             return -1;
         }
         out_dtypes[1] = out_dtypes[0];

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1390,6 +1390,16 @@ class TestDateTime:
         expected = (op1 // op2, op1 % op2)
         assert_equal(divmod(op1, op2), expected)
 
+    @pytest.mark.parametrize("op1, op2", [
+        # Y and M are incompatible with all units except Y and M
+        (np.timedelta64(1, 'Y'),
+         np.timedelta64(1, 's')),
+        (np.timedelta64(1, 'D'),
+         np.timedelta64(1, 'M')),    
+        ])
+    def test_timedelta_divmod_typeerror(self, op1, op2):
+        assert_raises(TypeError, np.divmod, op1, op2)
+
     @pytest.mark.skipif(IS_WASM, reason="does not work in wasm")
     @pytest.mark.parametrize("op1, op2", [
         # reuse cases from floordiv

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1392,10 +1392,8 @@ class TestDateTime:
 
     @pytest.mark.parametrize("op1, op2", [
         # Y and M are incompatible with all units except Y and M
-        (np.timedelta64(1, 'Y'),
-         np.timedelta64(1, 's')),
-        (np.timedelta64(1, 'D'),
-         np.timedelta64(1, 'M')),    
+        (np.timedelta64(1, 'Y'), np.timedelta64(1, 's')),
+        (np.timedelta64(1, 'D'), np.timedelta64(1, 'M')),    
         ])
     def test_timedelta_divmod_typeerror(self, op1, op2):
         assert_raises(TypeError, np.divmod, op1, op2)


### PR DESCRIPTION
It is expected that timedelta64 Years and Months are incompatible with all units except themselves but method was giving segfault instead of TypeError exception. Updated PyUFunc_DivmodTypeResolver() to propogate the TypeError exception from PyArray_PromoteTypes(). See #27787.