### PR TITLE
DOC: fix broken reference in arrays.classes.rst

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -288,7 +288,7 @@ NumPy provides several hooks that classes can customize:
 
    .. note::
       It is hoped to eventually deprecate this method in favour of
-      func:`__array_ufunc__` for ufuncs (and :func:`__array_function__`
+      :func:`__array_ufunc__` for ufuncs (and :func:`__array_function__`
       for a few other functions like :func:`numpy.squeeze`).
 
 .. py:attribute:: class.__array_priority__


### PR DESCRIPTION
Fixes a typo in array.classes.rst where a `:func:` was missing the leading `:`.

[skip ci]
