### PR TITLE
DOC: Add a release fragment for gh-14622

### DIFF
--- a/doc/release/upcoming_changes/14622.improvement.rst
+++ b/doc/release/upcoming_changes/14622.improvement.rst
@@ -1,0 +1,4 @@
+* The ``datetime64`` and ``timedelta64`` hashes now
+  correctly match the Pythons builtin ``datetime`` and
+  ``timedelta`` ones.  The hashes now evaluated equal
+  even for equal values with different time units.


### PR DESCRIPTION
This just adds a release bullet, seemed probably good to mention the change in hashing.

(See gh-14622)

---

Realized this fix deserves a release note, ping @walshb.