### PR TITLE
MAINT: Fixup that spin can be installed via conda too now

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,7 @@ dependencies:
   - ninja
   - pkg-config
   - meson-python
-  - pip:
-      - spin==0.13
+  - spin==0.13
   - ccache
   # For testing
   - pytest


### PR DESCRIPTION
My bad, I should have looked through the PR first and not assumed it was _just_ waiting for spin to be on conda.
