### PR TITLE
DEV: changelog: make title processing more robust

### DIFF
--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -132,14 +132,47 @@ def main(token, revision_range):
     print("="*len(heading))
     print(pull_request_msg % len(pull_requests))
 
+    def backtick_repl(matchobj):
+        """repl to add an escaped space following a code block if needed"""
+        if matchobj.group(2) != ' ':
+            post = '\ ' + matchobj.group(2)
+        else:
+            post = matchobj.group(2)
+        return '``' + matchobj.group(1) + '``' + post
+
     for pull in pull_requests:
+        # sanitize whitespace
         title = re.sub(r"\s+", " ", pull.title.strip())
+
+        # substitute any single backtick not adjacent to a backtick
+        # for a double backtick
+        title = re.sub(
+            "(?P<pre>(?:^|(?<=[^`])))`(?P<post>(?=[^`]|$))",
+            "\g<pre>``\g<post>",
+            title
+        )
+        # add an escaped space if code block is not followed by a space
+        title = re.sub("``(.*?)``(.)", backtick_repl, title)
+
+        # sanitize asterisks
+        title = title.replace('*', '\\*')
+
         if len(title) > 60:
             remainder = re.sub(r"\s.*$", "...", title[60:])
             if len(remainder) > 20:
-                remainder = title[:80] + "..."
+                # just use the first 80 characters, with ellipses.
+                # note: this was previously bugged,
+                # assigning to `remainder` rather than `title`
+                title = title[:80] + "..."
             else:
+                # use the first 60 characters and the next word
                 title = title[:60] + remainder
+
+            if title.count('`') % 4 != 0:
+                # ellipses have cut in the middle of a code block,
+                # so finish the code block before the ellipses
+                title = title[:-3] + '``...'
+
         print(pull_msg.format(pull.number, pull.html_url, title))
 
 

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -135,7 +135,7 @@ def main(token, revision_range):
     def backtick_repl(matchobj):
         """repl to add an escaped space following a code block if needed"""
         if matchobj.group(2) != ' ':
-            post = '\ ' + matchobj.group(2)
+            post = r'\ ' + matchobj.group(2)
         else:
             post = matchobj.group(2)
         return '``' + matchobj.group(1) + '``' + post
@@ -148,7 +148,7 @@ def main(token, revision_range):
         # for a double backtick
         title = re.sub(
             "(?P<pre>(?:^|(?<=[^`])))`(?P<post>(?=[^`]|$))",
-            "\g<pre>``\g<post>",
+            r"\g<pre>``\g<post>",
             title
         )
         # add an escaped space if code block is not followed by a space


### PR DESCRIPTION
Hey @charris,

I made some adjustments to this script (which was copied into SciPy) over there a little while ago, to make the processing of titles more robust. In particular:

- a bug is fixed with the addition of ellipses for long remainders
- automatic handling of single backticks to double backticks is added (so you don't need to worry about editing titles which use single backticks :) )
- asterisks are also sanitised (I think that change pre-dated my work)
- code comments are added to make this more maintainable going forward

I haven't tested this, so it might be broken currently - would you be able to give it a test?