### PR TITLE
CI: add windows free-threaded CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,8 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: ["MSVC", "Clang-cl"]
-        version: ["3.11", "3.13t"]
+        compiler-pyversion:
+          - ["MSVC", "3.11"]
+          - ["Clang-cl", "3.13t"]
+
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -34,11 +36,11 @@ jobs:
     - name: Setup Python
       uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:
-        python-version: ${{ matrix.version }}
+        python-version: ${{ matrix.compiler-pyversion[1] }}
 
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
-      if: matrix.version == '3.13t'
+      if: matrix.compiler-pyversion[1] == '3.13t'
       run: |
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
@@ -50,10 +52,10 @@ jobs:
       run: |
         choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
         echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
-        
+
 
     - name: Install Clang-cl
-      if: matrix.compiler == 'Clang-cl'
+      if: matrix.compiler-pyversion[0] == 'Clang-cl'
       run: |
         # llvm is preinstalled, but leave
         # this here in case we need to pin the
@@ -61,13 +63,13 @@ jobs:
         #choco install llvm -y
 
     - name: Install NumPy (MSVC)
-      if: matrix.compiler == 'MSVC'
+      if: matrix.compiler-pyversion[0] == 'MSVC'
       run: |
         pip install -r requirements/ci_requirements.txt
         spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
-      if: matrix.compiler == 'Clang-cl'
+      if: matrix.compiler-pyversion[0] == 'Clang-cl'
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
         pip install -r requirements/ci_requirements.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ["MSVC", "Clang-cl"]
+        version: ["3.11", "3.13t"]
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -31,9 +32,15 @@ jobs:
         fetch-tags: true
 
     - name: Setup Python
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.version }}
+
+    # TODO: remove cython nightly install when cython does a release
+    - name: Install nightly Cython
+      if: matrix.version == '3.13t'
+      run: |
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install build dependencies from PyPI
       run: |

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -168,7 +168,6 @@ def _make_methods(functions, modname):
 def _make_source(name, init, body):
     """ Combines the code fragments into source code ready to be compiled
     """
-    # python.h doesn't set Py_GIL_DISABLED on the windows free-threade build
     code = """
     #include <Python.h>
 
@@ -229,7 +228,7 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                               cwd=build_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", ".."],
+        subprocess.check_call(["meson", "setup", "--vsenv", ".."],
                               cwd=build_dir
                               )
 

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -195,7 +195,9 @@ def _c_compile(cfile, outputfilename, include_dirs, libraries,
     if sys.platform == 'win32':
         compile_extra = ["/we4013"]
         link_extra = [f"-L{sysconfig.get_config_var('LIBDIR')}"]
-        link_extra.append(f"-l{sysconfig.get_config_var('LDLIBRARY')}".strip(".dll"))
+        library_name = sysconfig.get_config_var('LDLIBRARY')
+        if library_name:
+            link_extra.append(f"-l{library_name}".strip(".dll"))
         link_extra.append('/DEBUG')  # generate .pdb file
     elif sys.platform.startswith('linux'):
         compile_extra = [

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -53,7 +53,7 @@ def build_and_import_extension(
     >>> assert not mod.test_bytes('abc')
     >>> assert mod.test_bytes(b'abc')
     """
-    if include_dirs == None:
+    if include_dirs is None:
         include_dirs = []
     body = prologue + _make_methods(functions, modname)
     init = """


### PR DESCRIPTION
This enables CI for the free-threaded build on Windows. The CI config follows what I did for Linux and MacOS. 

It adds two new CI jobs to our Github Actions config.

This also fixes a number of issues with the `extbuild` helper for testing C extensions, both on the free-threaded build and in general.

While I was here, I fixed some questionable software engineering choices like using mutables as the default value for keyword arguments and an unnecessary try/except I found annoying for debugging.

It also fixes the way libpython is linked against on the free-threaded build. Meson's `link_args` can use unix-style `-L/path -lname_of_library` syntax on all platforms, so I used it here even if it looks weird in Windows-specific configuration.

Also fixes issues caused by `python.h` not setting `Py_GIL_DISABLED` on Windows, so we need to do that ourselves.