### PR TITLE
BUG: Fix mismatch in definition and declaration for a couple functions (see #27719)

### DIFF
--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -416,7 +416,7 @@ NumPyOS_ascii_isupper(char c)
  * Same as tolower under C locale
  */
 NPY_NO_EXPORT int
-NumPyOS_ascii_tolower(int c)
+NumPyOS_ascii_tolower(char c)
 {
     if (c >= 'A' && c <= 'Z') {
         return c + ('a'-'A');

--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -416,7 +416,7 @@ NumPyOS_ascii_isupper(char c)
  * Same as tolower under C locale
  */
 NPY_NO_EXPORT int
-NumPyOS_ascii_tolower(char c)
+NumPyOS_ascii_tolower(int c)
 {
     if (c >= 'A' && c <= 'Z') {
         return c + ('a'-'A');

--- a/numpy/_core/src/common/numpyos.h
+++ b/numpy/_core/src/common/numpyos.h
@@ -51,7 +51,7 @@ NPY_NO_EXPORT int
 NumPyOS_ascii_isupper(char c);
 
 NPY_NO_EXPORT int
-NumPyOS_ascii_tolower(char c);
+NumPyOS_ascii_tolower(int c);
 
 /* Convert a string to an int in an arbitrary base */
 NPY_NO_EXPORT npy_longlong

--- a/numpy/_core/src/multiarray/compiled_base.h
+++ b/numpy/_core/src/multiarray/compiled_base.h
@@ -10,9 +10,9 @@ arr_bincount(PyObject *, PyObject *const *, Py_ssize_t, PyObject *);
 NPY_NO_EXPORT PyObject *
 arr__monotonicity(PyObject *, PyObject *, PyObject *kwds);
 NPY_NO_EXPORT PyObject *
-arr_interp(PyObject *, PyObject *const *, Py_ssize_t, PyObject *, PyObject *);
+arr_interp(PyObject *, PyObject *const *, Py_ssize_t, PyObject *);
 NPY_NO_EXPORT PyObject *
-arr_interp_complex(PyObject *, PyObject *const *, Py_ssize_t, PyObject *, PyObject *);
+arr_interp_complex(PyObject *, PyObject *const *, Py_ssize_t, PyObject *);
 NPY_NO_EXPORT PyObject *
 arr_ravel_multi_index(PyObject *, PyObject *, PyObject *);
 NPY_NO_EXPORT PyObject *


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Addresses #27719
```

- NumPyOS_ascii_tolower declaration conflicting its definition. The declaration says that the input parameter is a char while the definition says it is an `int.

- arr_interp declaration has one parameter more than the definition.

- arr_interp_complex declaration has one parameter more than the definition.

```