### PR TITLE
CI: update circleci to python3.11.10, limit parallel builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             # get newer, pre-release versions of critical packages
             pip install --progress-bar=off --pre -r requirements/doc_requirements.txt
             # then install numpy HEAD, which will override the version installed above
-            spin build --with-scipy-openblas=64
+            spin build --with-scipy-openblas=64 -j 2
 
       - run:
           name: build devdocs w/ref warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/developer/images/image/cimg/python
-    - image: cimg/python:3.11.8
+    - image: cimg/python:3.12.7
   working_directory: ~/repo
 
 
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: build NumPy
           command: |
-            python3.11 -m venv venv
+            python3.12 -m venv venv
             . venv/bin/activate
             pip install --progress-bar=off -r requirements/test_requirements.txt \
                -r requirements/build_requirements.txt \
@@ -97,8 +97,8 @@ jobs:
             #  - validates ReST blocks (via validate_rst_syntax)
             #  - checks that all of a module's `__all__` is reflected in the
             #    module-level docstring autosummary
-            echo calling python tools/refguide_check.py -v
-            python tools/refguide_check.py -v
+            echo calling python3 tools/refguide_check.py -v
+            python3 tools/refguide_check.py -v
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: build NumPy
           command: |
-            python3.12 -m venv venv
+            python3.11 -m venv venv
             . venv/bin/activate
             pip install --progress-bar=off -r requirements/test_requirements.txt \
                -r requirements/build_requirements.txt \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/developer/images/image/cimg/python
-    - image: cimg/python:3.12.7
+    - image: cimg/python:3.11.10
   working_directory: ~/repo
 
 


### PR DESCRIPTION
Hopefully Fixes #27825 by updating the image, which uses ubuntu ~20.04.3 instead of 20.04.2~ 22.04.3 instead of 22.04.02