### PR TITLE
CI: skip ninja installation in linux_qemu workflows

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -141,7 +141,8 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
-          python -m pip install -r /numpy/requirements/build_requirements.txt &&
+          grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
+          python -m pip install -r /tmp/build_requirements.txt &&
           python -m pip install pytest pytest-xdist hypothesis typing_extensions &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -141,6 +141,7 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
+          # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
           python -m pip install -r /tmp/build_requirements.txt &&
           python -m pip install pytest pytest-xdist hypothesis typing_extensions &&


### PR DESCRIPTION
The ninja used in the workflow is the one from the host.
Skipping ninja installation in the container allows to workaround issues that could arise when building it from source as is currently the case with riscv64.

xref: https://github.com/scikit-build/ninja-python-distributions/issues/226#issuecomment-2495844812
cc @mattip 