### PR TITLE
ENH: speedup evaluation of numpy.polynomial.legendre.legval.

### DIFF
--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -905,8 +905,8 @@ def legval(x, c, tensor=True):
         for i in range(3, len(c) + 1):
             tmp = c0
             nd = nd - 1
-            c0 = c[-i] - (c1*(nd - 1))/nd
-            c1 = tmp + (c1*x*(2*nd - 1))/nd
+            c0 = c[-i] - c1*((nd - 1)/nd)
+            c1 = tmp + c1*x*((2*nd - 1)/nd)
     return c0 + c1*x
 
 


### PR DESCRIPTION
Moving the parentheses combines two broadcasted scalar multiplies into one. 
This improves runtime by about 30% when evaluating on large grids.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
