### PR TITLE
ENH: Add out option to np.convolve and np.correlate

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2672,7 +2672,7 @@ Array Functions
     See the :func:`~numpy.einsum` function for more details.
 
 .. c:function:: PyObject* PyArray_Correlate( \
-        PyObject* op1, PyObject* op2, int mode)
+        PyObject* op1, PyObject* op2, PyArrayObject* out, int mode)
 
     Compute the 1-d correlation of the 1-d arrays *op1* and *op2*
     . The correlation is computed at each output point by multiplying
@@ -2691,7 +2691,7 @@ Array Functions
     See PyArray_Correlate2 for the usual signal processing correlation.
 
 .. c:function:: PyObject* PyArray_Correlate2( \
-        PyObject* op1, PyObject* op2, int mode)
+        PyObject* op1, PyObject* op2, PyArrayObject* out, int mode)
 
     Updated version of PyArray_Correlate, which uses the usual definition of
     correlation for 1d arrays. The correlation is computed at each output point

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -685,12 +685,12 @@ def flatnonzero(a):
     return np.nonzero(np.ravel(a))[0]
 
 
-def _correlate_dispatcher(a, v, mode=None):
-    return (a, v)
+def _correlate_dispatcher(a, v, mode=None, out=None):
+    return (a, v, out)
 
 
 @array_function_dispatch(_correlate_dispatcher)
-def correlate(a, v, mode='valid'):
+def correlate(a, v, mode='valid', out=None):
     r"""
     Cross-correlation of two 1-dimensional sequences.
 
@@ -709,6 +709,8 @@ def correlate(a, v, mode='valid'):
     mode : {'valid', 'same', 'full'}, optional
         Refer to the `convolve` docstring.  Note that the default
         is 'valid', unlike `convolve`, which uses 'full'.
+    out : ndarray, optional
+        A location where the result is stored
 
     Returns
     -------
@@ -762,15 +764,15 @@ def correlate(a, v, mode='valid'):
     array([ 0.0+0.j ,  3.0+1.j ,  1.5+1.5j,  1.0+0.j ,  0.5+0.5j])
 
     """
-    return multiarray.correlate2(a, v, mode)
+    return multiarray.correlate2(a, v, out, mode)
 
 
-def _convolve_dispatcher(a, v, mode=None):
-    return (a, v)
+def _convolve_dispatcher(a, v, mode=None, out=None):
+    return (a, v, out)
 
 
 @array_function_dispatch(_convolve_dispatcher)
-def convolve(a, v, mode='full'):
+def convolve(a, v, mode='full', out=None):
     """
     Returns the discrete, linear convolution of two one-dimensional sequences.
 
@@ -804,6 +806,8 @@ def convolve(a, v, mode='full'):
           ``max(M, N) - min(M, N) + 1``.  The convolution product is only given
           for points where the signals overlap completely.  Values outside
           the signal boundary have no effect.
+    out : ndarray, optional
+        A location where the result is stored
 
     Returns
     -------
@@ -866,7 +870,7 @@ def convolve(a, v, mode='full'):
         raise ValueError('a cannot be empty')
     if len(v) == 0:
         raise ValueError('v cannot be empty')
-    return multiarray.correlate(a, v[::-1], mode)
+    return multiarray.correlate(a, v[::-1], out, mode)
 
 
 def _outer_dispatcher(a, b, out=None):

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1144,10 +1144,10 @@ fail:
  * inverted is set to 1 if computed correlate(ap2, ap1), 0 otherwise
  */
 static PyArrayObject*
-_pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
+_pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject *ret, int typenum,
                    int mode, int *inverted)
 {
-    PyArrayObject *ret;
+    PyArrayObject *tmp;
     npy_intp length;
     npy_intp i, n1, n2, n, n_left, n_right;
     npy_intp is1, is2, os;
@@ -1167,10 +1167,10 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
         return NULL;
     }
     if (n1 < n2) {
-        ret = ap1;
+        tmp = ap1;
         ap1 = ap2;
-        ap2 = ret;
-        ret = NULL;
+        ap2 = tmp;
+        tmp = NULL;
         i = n1;
         n1 = n2;
         n2 = i;
@@ -1204,9 +1204,24 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
      * Need to choose an output array that can hold a sum
      * -- use priority to determine which subtype.
      */
-    ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typenum, NULL);
-    if (ret == NULL) {
-        return NULL;
+    if (ret != NULL) {
+        if (PyArray_NDIM(ret) != 1) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Output array has wrong dimensionality");
+            return NULL;
+        }
+        if (PyArray_DIMS(ret)[0] != length) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Output array is the wrong shape");
+            return NULL;
+        }
+        Py_INCREF(ret);
+    }
+    else {
+        ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typenum, NULL);
+        if (ret == NULL) {
+            return NULL;
+        }
     }
     dot = PyDataType_GetArrFuncs(PyArray_DESCR(ret))->dotfunc;
     if (dot == NULL) {
@@ -1315,7 +1330,7 @@ _pyarray_revert(PyArrayObject *ret)
  * correlate(a2, a1), and conjugate the second argument for complex inputs
  */
 NPY_NO_EXPORT PyObject *
-PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
+PyArray_Correlate2(PyObject *op1, PyObject *op2, PyArrayObject *out, int mode)
 {
     PyArrayObject *ap1, *ap2, *ret = NULL;
     int typenum;
@@ -1356,7 +1371,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
         ap2 = cap2;
     }
 
-    ret = _pyarray_correlate(ap1, ap2, typenum, mode, &inverted);
+    ret = _pyarray_correlate(ap1, ap2, out, typenum, mode, &inverted);
     if (ret == NULL) {
         goto clean_ap2;
     }
@@ -1389,7 +1404,7 @@ clean_ap1:
  * Numeric.correlate(a1,a2,mode)
  */
 NPY_NO_EXPORT PyObject *
-PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
+PyArray_Correlate(PyObject *op1, PyObject *op2, PyArrayObject *out, int mode)
 {
     PyArrayObject *ap1, *ap2, *ret = NULL;
     int typenum;
@@ -1419,7 +1434,7 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
         goto fail;
     }
 
-    ret = _pyarray_correlate(ap1, ap2, typenum, mode, &unused);
+    ret = _pyarray_correlate(ap1, ap2, out, typenum, mode, &unused);
     if (ret == NULL) {
         goto fail;
     }
@@ -3023,17 +3038,28 @@ array_correlate(PyObject *NPY_UNUSED(dummy),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyObject *shape, *a0;
+    PyObject *out;
     int mode = 0;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("correlate", args, len_args, kwnames,
             "a", NULL, &a0,
             "v", NULL, &shape,
+            "|out", NULL, &out,
             "|mode", &PyArray_CorrelatemodeConverter, &mode,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
-    return PyArray_Correlate(a0, shape, mode);
+    if (out != NULL) {
+        if (out == Py_None) {
+            out = NULL;
+        }
+        else if (!PyArray_Check(out)) {
+            PyErr_SetString(PyExc_TypeError, "'out' must be an array");
+            return NULL;
+        }
+    }
+    return PyArray_Correlate(a0, shape, (PyArrayObject *)out, mode);
 }
 
 static PyObject*
@@ -3041,17 +3067,28 @@ array_correlate2(PyObject *NPY_UNUSED(dummy),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyObject *shape, *a0;
+    PyObject *out;
     int mode = 0;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("correlate2", args, len_args, kwnames,
             "a", NULL, &a0,
             "v", NULL, &shape,
+            "|out", NULL, &out,
             "|mode", &PyArray_CorrelatemodeConverter, &mode,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
-    return PyArray_Correlate2(a0, shape, mode);
+    if (out != NULL) {
+        if (out == Py_None) {
+            out = NULL;
+        }
+        else if (!PyArray_Check(out)) {
+            PyErr_SetString(PyExc_TypeError, "'out' must be an array");
+            return NULL;
+        }
+    }
+    return PyArray_Correlate2(a0, shape, (PyArrayObject *)out, mode);
 }
 
 static PyObject *

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3596,6 +3596,25 @@ class TestCorrelate:
         with assert_raises(TypeError):
             np.correlate(d, k, mode=None)
 
+    def test_out(self):
+        self._setup(float)
+        out = np.zeros(self.z1.shape)
+        res = np.correlate(self.x, self.y, 'full', out=out)
+        assert_equal(res, out)
+        assert_array_almost_equal(out, self.z1)
+        out = np.zeros(self.z2.shape)
+        res = np.correlate(self.y, self.x, 'full', out=out)
+        assert_equal(res, out)
+        assert_array_almost_equal(out, self.z2)
+        out = np.zeros(self.z1r.shape)
+        res = np.correlate(self.x[::-1], self.y, 'full', out=out)
+        assert_equal(res, out)
+        assert_array_almost_equal(out, self.z1r)
+        out = np.zeros(self.z2r.shape)
+        res = np.correlate(self.y, self.x[::-1], 'full', out=out)
+        assert_equal(res, out)
+        assert_array_almost_equal(out, self.z2r)
+
 
 class TestConvolve:
     def test_object(self):
@@ -3624,6 +3643,14 @@ class TestConvolve:
         # illegal arguments
         with assert_raises(TypeError):
             np.convolve(d, k, mode=None)
+
+    def test_out(self):
+        d = np.ones(100)
+        k = np.ones(3)
+        out = np.zeros(98)
+        res = np.convolve(d, k, mode='valid', out=out)
+        assert_equal(res, out)
+        assert_array_almost_equal(out, np.full(98, 3))
 
 
 class TestArgwhere:


### PR DESCRIPTION
Addresses #27744
Adding an optional 'out' parameter to np.convolve and np.correlate so as to avoid unnecessary memory allocation if desired.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
