### PR TITLE
Pin ninja build requirement

### DIFF
--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.13.1
 Cython>=3.0.6
-ninja
+ninja==1.11.1.1
 spin==0.13
 build


### PR DESCRIPTION
Since ninja 1.11.1.2, our builds fail with:
```
LookupError: https://files.pythonhosted.org/packages/b4/49/4f1a79f99f4c3eb5d22f943bba14832923bb44423254d5089d38a9f6da63/ninja-1.11.1.2.tar.gz (from https://pypi.org/simple/ninja/) (requires-python:>=3.7) is already being built: ninja>=1.8.2 from https://files.pythonhosted.org/packages/b4/49/4f1a79f99f4c3eb5d22f943bba14832923bb44423254d5089d38a9f6da63/ninja-1.11.1.2.tar.gz
```
See also:
https://github.com/scikit-build/ninja-python-distributions/issues/274

Therefore pin it until it is fixed.
