### PR TITLE
DOC: Correct version-added for mean arg for nanvar and nanstd

### DIFF
--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1761,7 +1761,7 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
         The axis for the calculation of the mean should be the same as used in
         the call to this var function.
 
-        .. versionadded:: 1.26.0
+        .. versionadded:: 2.0.0
 
     correction : {int, float}, optional
         Array API compatible name for the ``ddof`` parameter. Only one of them
@@ -1958,7 +1958,7 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
         The axis for the calculation of the mean should be the same as used in
         the call to this std function.
 
-        .. versionadded:: 1.26.0
+        .. versionadded:: 2.0.0
 
     correction : {int, float}, optional
         Array API compatible name for the ``ddof`` parameter. Only one of them


### PR DESCRIPTION
[The commit that added](https://github.com/numpy/numpy/commit/ab2178b47c0ee834180c318db196976623710691) the `mean=...` argument to `nanvar()` and `nanstd()` only actually landed in the 2.x series, not 1.26.0.

Refs https://github.com/numpy/numpy/pull/24126.

See https://stackoverflow.com/q/79222329/51685 for discussion.
