### PR TITLE
BUG: Never negate strides in reductions (for now)

### DIFF
--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -218,10 +218,13 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
             NPY_ITER_ZEROSIZE_OK |
             NPY_ITER_REFS_OK |
             NPY_ITER_DELAY_BUFALLOC |
+            /*
+             * stride negation (if reorderable) could currently misalign the
+             * first-visit and initial value copy logic.
+             */
+            NPY_ITER_DONT_NEGATE_STRIDES |
             NPY_ITER_COPY_IF_OVERLAP;
-    if (!(context->method->flags & NPY_METH_IS_REORDERABLE)) {
-        it_flags |= NPY_ITER_DONT_NEGATE_STRIDES;
-    }
+
     op_flags[0] = NPY_ITER_READWRITE |
                   NPY_ITER_ALIGNED |
                   NPY_ITER_ALLOCATE |


### PR DESCRIPTION
Straight forward fix (and trying to consolidate tests...

The annoying part is that stride-reordering only kicks in when `out=` is passed.

Closes gh-27820

----

Notes on strides reordering (negation):

That is partially understandable, because a new array cannot have negative strides (`free(arr.data)` needs to work) and maybe we don't want to drag around negative strides indefinitely
(if we did, maybe `arr.dealloc()` should deal with it.)

It also makes the whole mechanism a bit a confusing, right now...
* For reduction axes it clearly doesn't matter if we allocate or not.
* It is rare that an allocator doesn't allocate any array... so the whole mechanism seems currently rather useless...
