### PR TITLE
ENH: add matvec and vecmat gufuncs

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -16,12 +16,12 @@ ufuncs = ['abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
           'isinf', 'isnan', 'isnat', 'lcm', 'ldexp', 'left_shift', 'less',
           'less_equal', 'log', 'log10', 'log1p', 'log2', 'logaddexp',
           'logaddexp2', 'logical_and', 'logical_not', 'logical_or',
-          'logical_xor', 'matmul', 'maximum', 'minimum', 'mod', 'modf',
-          'multiply', 'negative', 'nextafter', 'not_equal', 'positive',
+          'logical_xor', 'matmul', 'matvec', 'maximum', 'minimum', 'mod',
+          'modf', 'multiply', 'negative', 'nextafter', 'not_equal', 'positive',
           'power', 'rad2deg', 'radians', 'reciprocal', 'remainder',
           'right_shift', 'rint', 'sign', 'signbit', 'sin',
           'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan', 'tanh',
-          'true_divide', 'trunc', 'vecdot']
+          'true_divide', 'trunc', 'vecdot', 'vecmat']
 arrayfuncdisp = ['real', 'round']
 
 for name in ufuncs:

--- a/doc/release/upcoming_changes/25675.new_feature.rst
+++ b/doc/release/upcoming_changes/25675.new_feature.rst
@@ -1,0 +1,20 @@
+New functions for matrix-vector and vector-matrix products
+----------------------------------------------------------
+
+Two new generalized ufuncs were defined:
+
+* `numpy.matvec` - matrix-vector product, treating the arguments as
+  stacks of matrices and column vectors, respectively.
+
+* `numpy.vecmat` - vector-matrix product, treating the arguments as
+  stacks of column vectors and matrices, respectively. For complex
+  vectors, the conjugate is taken.
+
+These add to the existing `numpy.matmul` as well as to `numpy.vecdot`,
+which was added in numpy 2.0.
+
+Note that `numpy.matmul` never takes a complex conjugate, also not
+when its left input is a vector, while both `numpy.vecdot` and
+`numpy.vecmat` do take the conjugate for complex vectors on the
+left-hand side (which are taken to be the ones that are transposed,
+following the physics convention).

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -62,6 +62,8 @@ Matrix and vector products
    outer
    matmul
    linalg.matmul (Array API compatible location)
+   matvec
+   vecmat
    tensordot
    linalg.tensordot (Array API compatible location)
    einsum

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -151,10 +151,10 @@ else:
         left_shift, less, less_equal, lexsort, linspace, little_endian, log,
         log10, log1p, log2, logaddexp, logaddexp2, logical_and, logical_not,
         logical_or, logical_xor, logspace, long, longdouble, longlong, matmul,
-        matrix_transpose, max, maximum, may_share_memory, mean, memmap, min,
-        min_scalar_type, minimum, mod, modf, moveaxis, multiply, nan, ndarray,
-        ndim, nditer, negative, nested_iters, newaxis, nextafter, nonzero,
-        not_equal, number, object_, ones, ones_like, outer, partition,
+        matvec, matrix_transpose, max, maximum, may_share_memory, mean, memmap,
+        min, min_scalar_type, minimum, mod, modf, moveaxis, multiply, nan,
+        ndarray, ndim, nditer, negative, nested_iters, newaxis, nextafter,
+        nonzero, not_equal, number, object_, ones, ones_like, outer, partition,
         permute_dims, pi, positive, pow, power, printoptions, prod,
         promote_types, ptp, put, putmask, rad2deg, radians, ravel, recarray,
         reciprocal, record, remainder, repeat, require, reshape, resize,
@@ -165,8 +165,8 @@ else:
         str_, subtract, sum, swapaxes, take, tan, tanh, tensordot,
         timedelta64, trace, transpose, true_divide, trunc, typecodes, ubyte,
         ufunc, uint, uint16, uint32, uint64, uint8, uintc, uintp, ulong,
-        ulonglong, unsignedinteger, unstack, ushort, var, vdot, vecdot, void,
-        vstack, where, zeros, zeros_like
+        ulonglong, unsignedinteger, unstack, ushort, var, vdot, vecdot,
+        vecmat, void, vstack, where, zeros, zeros_like
     )
 
     # NOTE: It's still under discussion whether these aliases

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4490,6 +4490,7 @@ logical_not: _UFunc_Nin1_Nout1[L['logical_not'], L[20], None]
 logical_or: _UFunc_Nin2_Nout1[L['logical_or'], L[20], L[False]]
 logical_xor: _UFunc_Nin2_Nout1[L['logical_xor'], L[19], L[False]]
 matmul: _GUFunc_Nin2_Nout1[L['matmul'], L[19], None, L["(n?,k),(k,m?)->(n?,m?)"]]
+matvec: _GUFunc_Nin2_Nout1[L['matvec'], L[19], None, L["(m,n),(n)->(m)"]]
 maximum: _UFunc_Nin2_Nout1[L['maximum'], L[21], None]
 minimum: _UFunc_Nin2_Nout1[L['minimum'], L[21], None]
 mod: _UFunc_Nin2_Nout1[L['remainder'], L[16], None]
@@ -4519,6 +4520,7 @@ tanh: _UFunc_Nin1_Nout1[L['tanh'], L[8], None]
 true_divide: _UFunc_Nin2_Nout1[L['true_divide'], L[11], None]
 trunc: _UFunc_Nin1_Nout1[L['trunc'], L[7], None]
 vecdot: _GUFunc_Nin2_Nout1[L['vecdot'], L[19], None, L["(n),(n)->()"]]
+vecmat: _GUFunc_Nin2_Nout1[L['vecmat'], L[19], None, L["(n),(n,m)->(m)"]]
 
 abs = absolute
 acos = arccos

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1152,6 +1152,22 @@ defdict = {
           TD(O),
           signature='(n),(n)->()',
           ),
+'matvec':
+    Ufunc(2, 1, None,
+          docstrings.get('numpy._core.umath.matvec'),
+          "PyUFunc_SimpleUniformOperationTypeResolver",
+          TD(notimes_or_obj),
+          TD(O),
+          signature='(m,n),(n)->(m)',
+          ),
+'vecmat':
+    Ufunc(2, 1, None,
+          docstrings.get('numpy._core.umath.vecmat'),
+          "PyUFunc_SimpleUniformOperationTypeResolver",
+          TD(notimes_or_obj),
+          TD(O),
+          signature='(n),(n,m)->(m)',
+          ),
 'str_len':
     Ufunc(1, 1, Zero,
           docstrings.get('numpy._core.umath.str_len'),

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -44,7 +44,7 @@ def add_newdoc(place, name, doc):
 
     skip = (
         # gufuncs do not use the OUT_SCALAR replacement strings
-        'matmul', 'vecdot',
+        'matmul', 'vecdot', 'matvec', 'vecmat',
         # clip has 3 inputs, which is not handled by this
         'clip',
     )
@@ -2793,7 +2793,9 @@ add_newdoc('numpy._core.umath', 'matmul',
 
     See Also
     --------
-    vdot : Complex-conjugating dot product.
+    vecdot : Complex-conjugating dot product for stacks of vectors.
+    matvec : Matrix-vector product for stacks of matrices and vectors.
+    vecmat : Vector-matrix product for stacks of vectors and matrices.
     tensordot : Sum products over arbitrary axes.
     einsum : Einstein summation convention.
     dot : alternative matrix product with different broadcasting rules.
@@ -2808,10 +2810,10 @@ add_newdoc('numpy._core.umath', 'matmul',
       matrices residing in the last two indexes and broadcast accordingly.
     - If the first argument is 1-D, it is promoted to a matrix by
       prepending a 1 to its dimensions. After matrix multiplication
-      the prepended 1 is removed.
+      the prepended 1 is removed. (For stacks of vectors, use ``vecmat``.)
     - If the second argument is 1-D, it is promoted to a matrix by
       appending a 1 to its dimensions. After matrix multiplication
-      the appended 1 is removed.
+      the appended 1 is removed. (For stacks of vectors, use ``matvec``.)
 
     ``matmul`` differs from ``dot`` in two important ways:
 
@@ -2910,8 +2912,8 @@ add_newdoc('numpy._core.umath', 'vecdot',
         Input arrays, scalars not allowed.
     out : ndarray, optional
         A location into which the result is stored. If provided, it must have
-        a shape that the broadcasted shape of `x1` and `x2` with the last axis
-        removed. If not provided or None, a freshly-allocated array is used.
+        the broadcasted shape of `x1` and `x2` with the last axis removed.
+        If not provided or None, a freshly-allocated array is used.
     **kwargs
         For other keyword-only arguments, see the
         :ref:`ufunc docs <ufuncs.kwargs>`.
@@ -2933,6 +2935,9 @@ add_newdoc('numpy._core.umath', 'vecdot',
     See Also
     --------
     vdot : same but flattens arguments first
+    matmul : Matrix-matrix product.
+    vecmat : Vector-matrix product.
+    matvec : Matrix-vector product.
     einsum : Einstein summation convention.
 
     Examples
@@ -2947,6 +2952,135 @@ add_newdoc('numpy._core.umath', 'vecdot',
     array([ 3.,  8., 10.])
 
     .. versionadded:: 2.0.0
+    """)
+
+add_newdoc('numpy._core.umath', 'matvec',
+    """
+    Matrix-vector dot product of two arrays.
+
+    Given a matrix (or stack of matrices) :math:`\\mathbf{A}` in ``x1`` and
+    a vector (or stack of vectors) :math:`\\mathbf{v}` in ``x2``, the
+    matrix-vector product is defined as:
+
+    .. math::
+       \\mathbf{A} \\cdot \\mathbf{b} = \\sum_{j=0}^{n-1} A_{ij} v_j
+
+    where the sum is over the last dimensions in ``x1`` and ``x2``
+    (unless ``axes`` is specified).  (For a matrix-vector product with the
+    vector conjugated, use ``np.vecmat(x2, x1.mT)``.)
+
+    Parameters
+    ----------
+    x1, x2 : array_like
+        Input arrays, scalars not allowed.
+    out : ndarray, optional
+        A location into which the result is stored. If provided, it must have
+        the broadcasted shape of ``x1`` and ``x2`` with the summation axis
+        removed. If not provided or None, a freshly-allocated array is used.
+    **kwargs
+        For other keyword-only arguments, see the
+        :ref:`ufunc docs <ufuncs.kwargs>`.
+
+    Returns
+    -------
+    y : ndarray
+        The matrix-vector product of the inputs.
+
+    Raises
+    ------
+    ValueError
+        If the last dimensions of ``x1`` and ``x2`` are not the same size.
+
+        If a scalar value is passed in.
+
+    See Also
+    --------
+    vecdot : Vector-vector product.
+    vecmat : Vector-matrix product.
+    matmul : Matrix-matrix product.
+    einsum : Einstein summation convention.
+
+    Examples
+    --------
+    Rotate a set of vectors from Y to X along Z.
+
+    >>> a = np.array([[0., 1., 0.],
+    ...               [-1., 0., 0.],
+    ...               [0., 0., 1.]])
+    >>> v = np.array([[1., 0., 0.],
+    ...               [0., 1., 0.],
+    ...               [0., 0., 1.],
+    ...               [0., 6., 8.]])
+    >>> np.matvec(a, v)
+    array([[ 0., -1.,  0.],
+           [ 1.,  0.,  0.],
+           [ 0.,  0.,  1.],
+           [ 6.,  0.,  8.]])
+
+    .. versionadded:: 2.1.0
+    """)
+
+add_newdoc('numpy._core.umath', 'vecmat',
+    """
+    Vector-matrix dot product of two arrays.
+
+    Given a vector (or stack of vector) :math:`\\mathbf{v}` in ``x1`` and
+    a matrix (or stack of matrices) :math:`\\mathbf{A}` in ``x2``, the
+    vector-matrix product is defined as:
+
+    .. math::
+       \\mathbf{b} \\cdot \\mathbf{A} = \\sum_{i=0}^{n-1} \\overline{v_i}A_{ij}
+
+    where the sum is over the last dimension of ``x1`` and the one-but-last
+    dimensions in ``x2`` (unless `axes` is specified) and where
+    :math:`\\overline{v_i}` denotes the complex conjugate if :math:`v`
+    is complex and the identity otherwise. (For a non-conjugated vector-matrix
+    product, use ``np.matvec(x2.mT, x1)``.)
+
+    Parameters
+    ----------
+    x1, x2 : array_like
+        Input arrays, scalars not allowed.
+    out : ndarray, optional
+        A location into which the result is stored. If provided, it must have
+        the broadcasted shape of ``x1`` and ``x2`` with the summation axis
+        removed. If not provided or None, a freshly-allocated array is used.
+    **kwargs
+        For other keyword-only arguments, see the
+        :ref:`ufunc docs <ufuncs.kwargs>`.
+
+    Returns
+    -------
+    y : ndarray
+        The vector-matrix product of the inputs.
+
+    Raises
+    ------
+    ValueError
+        If the last dimensions of ``x1`` and the one-but-last dimension of
+        ``x2`` are not the same size.
+
+        If a scalar value is passed in.
+
+    See Also
+    --------
+    vecdot : Vector-vector product.
+    matvec : Matrix-vector product.
+    matmul : Matrix-matrix product.
+    einsum : Einstein summation convention.
+
+    Examples
+    --------
+    Project a vector along X and Y.
+
+    >>> v = np.array([0., 4., 2.])
+    >>> a = np.array([[1., 0., 0.],
+    ...               [0., 1., 0.],
+    ...               [0., 0., 0.]])
+    >>> np.vecmat(v, a)
+    array([ 0.,  4., 0.])
+
+    .. versionadded:: 2.1.0
     """)
 
 add_newdoc('numpy._core.umath', 'modf',

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -83,11 +83,11 @@ def _override___module__():
         'isfinite', 'isinf', 'isnan', 'isnat', 'lcm', 'ldexp', 'less',
         'less_equal', 'log', 'log10', 'log1p', 'log2', 'logaddexp',
         'logaddexp2', 'logical_and', 'logical_not', 'logical_or',
-        'logical_xor', 'matmul', 'maximum', 'minimum', 'remainder', 'modf',
-        'multiply', 'negative', 'nextafter', 'not_equal', 'positive', 'power',
-        'rad2deg', 'radians', 'reciprocal', 'rint', 'sign', 'signbit', 'sin',
-        'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan', 'tanh',
-        'trunc', 'vecdot',
+        'logical_xor', 'matmul', 'matvec', 'maximum', 'minimum', 'remainder',
+        'modf', 'multiply', 'negative', 'nextafter', 'not_equal', 'positive',
+        'power', 'rad2deg', 'radians', 'reciprocal', 'rint', 'sign', 'signbit',
+        'sin', 'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan', 'tanh',
+        'trunc', 'vecdot', 'vecmat',
     ]:
         ufunc = namespace_names[ufunc_name]
         ufunc.__module__ = "numpy"

--- a/numpy/_core/src/umath/matmul.c.src
+++ b/numpy/_core/src/umath/matmul.c.src
@@ -81,9 +81,9 @@ static const npy_cfloat oneF = 1.0f, zeroF = 0.0f;
  */
 NPY_NO_EXPORT void
 @name@_gemv(void *ip1, npy_intp is1_m, npy_intp is1_n,
-            void *ip2, npy_intp is2_n, npy_intp NPY_UNUSED(is2_p),
-            void *op, npy_intp op_m, npy_intp NPY_UNUSED(op_p),
-            npy_intp m, npy_intp n, npy_intp NPY_UNUSED(p))
+            void *ip2, npy_intp is2_n,
+            void *op, npy_intp op_m,
+            npy_intp m, npy_intp n)
 {
     /*
      * Vector matrix multiplication -- Level 2 BLAS
@@ -465,13 +465,12 @@ NPY_NO_EXPORT void
                                            op, os_m, os_p, dm, dn, dp);
             } else if (vector_matrix) {
                 /* vector @ matrix, switch ip1, ip2, p and m */
-                @TYPE@_gemv(ip2, is2_p, is2_n, ip1, is1_n, is1_m,
-                            op, os_p, os_m, dp, dn, dm);
+                @TYPE@_gemv(ip2, is2_p, is2_n, ip1, is1_n,
+                            op, os_p, dp, dn);
             } else if  (matrix_vector) {
                 /* matrix @ vector */
-                @TYPE@_gemv(ip1, is1_m, is1_n, ip2, is2_n, is2_p,
-
-                            op, os_m, os_p, dm, dn, dp);
+                @TYPE@_gemv(ip1, is1_m, is1_n, ip2, is2_n,
+                            op, os_m, dm, dn);
             } else {
                 /* column @ row, 2d output, no blas needed or non-blas-able input */
                 @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
@@ -652,6 +651,177 @@ NPY_NO_EXPORT void
             return;
         }
 #endif
+    }
+}
+/**end repeat**/
+
+#if defined(HAVE_CBLAS)
+/*
+ * Blas complex vector-matrix product via gemm (gemv cannot conjugate the vector).
+ */
+/**begin repeat
+ *
+ * #name = CFLOAT, CDOUBLE#
+ * #typ = npy_cfloat, npy_cdouble#
+ * #prefix = c, z#
+ * #step1 = &oneF, &oneD#
+ * #step0 = &zeroF, &zeroD#
+ */
+NPY_NO_EXPORT void
+@name@_vecmat_via_gemm(void *ip1, npy_intp is1_n,
+                       void *ip2, npy_intp is2_n, npy_intp is2_m,
+                       void *op, npy_intp os_m,
+                       npy_intp n, npy_intp m)
+{
+    enum CBLAS_ORDER order = CblasRowMajor;
+    enum CBLAS_TRANSPOSE trans1, trans2;
+    CBLAS_INT N, M, lda, ldb, ldc;
+    assert(n <= BLAS_MAXSIZE && m <= BLAS_MAXSIZE);
+    N = (CBLAS_INT)n;
+    M = (CBLAS_INT)m;
+
+    assert(os_m == sizeof(@typ@));
+    ldc = (CBLAS_INT)m;
+
+    assert(is_blasable2d(is1_n, sizeof(@typ@), n, 1, sizeof(@typ@)));
+    trans1 = CblasConjTrans;
+    lda = (CBLAS_INT)(is1_n / sizeof(@typ@));
+
+    if (is_blasable2d(is2_n, is2_m, n, m, sizeof(@typ@))) {
+        trans2 = CblasNoTrans;
+        ldb = (CBLAS_INT)(is2_n / sizeof(@typ@));
+    }
+    else {
+        assert(is_blasable2d(is2_m, is2_n, m, n, sizeof(@typ@)));
+        trans2 = CblasTrans;
+        ldb = (CBLAS_INT)(is2_m / sizeof(@typ@));
+    }
+    CBLAS_FUNC(cblas_@prefix@gemm)(
+        order, trans1, trans2, 1, M, N, @step1@, ip1, lda,
+        ip2, ldb, @step0@, op, ldc);
+}
+/**end repeat**/
+#endif
+
+/*
+ * matvec loops, using blas gemv if possible, and TYPE_dot implementations otherwise.
+ * signature is (m,n),(n)->(m)
+ */
+/**begin repeat
+ *  #TYPE = FLOAT, DOUBLE, LONGDOUBLE, HALF,
+ *          CFLOAT, CDOUBLE, CLONGDOUBLE,
+ *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
+ *          BYTE, SHORT, INT, LONG, LONGLONG,
+ *          BOOL, OBJECT#
+ *  #typ = npy_float,npy_double,npy_longdouble, npy_half,
+ *         npy_cfloat, npy_cdouble, npy_clongdouble,
+ *         npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,
+ *         npy_byte, npy_short, npy_int, npy_long, npy_longlong,
+ *         npy_bool, npy_object#
+ * #USEBLAS = 1, 1, 0, 0, 1, 1, 0*13#
+ * #CHECK_PYERR = 0*18, 1#
+ */
+NPY_NO_EXPORT void
+@TYPE@_matvec(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    npy_intp n_outer = dimensions[0];
+    npy_intp s0=steps[0], s1=steps[1], s2=steps[2];
+    npy_intp dm = dimensions[1], dn = dimensions[2];
+    npy_intp is1_m=steps[3], is1_n=steps[4], is2_n=steps[5], os_m=steps[6];
+#if @USEBLAS@ && defined(HAVE_CBLAS)
+    npy_bool too_big_for_blas = (dm > BLAS_MAXSIZE || dn > BLAS_MAXSIZE);
+    npy_bool i1_c_blasable = is_blasable2d(is1_m, is1_n, dm, dn, sizeof(@typ@));
+    npy_bool i1_f_blasable = is_blasable2d(is1_n, is1_m, dn, dm, sizeof(@typ@));
+    npy_bool i2_blasable = is_blasable2d(is2_n, sizeof(@typ@), dn, 1, sizeof(@typ@));
+    npy_bool blasable = ((i1_c_blasable || i1_f_blasable) && i2_blasable
+                         && !too_big_for_blas && dn > 1 && dm > 1);
+#endif
+    for (npy_intp i = 0; i < n_outer; i++,
+             args[0] += s0, args[1] += s1, args[2] += s2) {
+        char *ip1=args[0], *ip2=args[1], *op=args[2];
+#if @USEBLAS@ && defined(HAVE_CBLAS)
+        if (blasable) {
+            @TYPE@_gemv(ip1, is1_m, is1_n, ip2, is2_n, op, os_m, dm, dn);
+            continue;
+        }
+#endif
+        /*
+         * Dot the different matrix rows with the vector to get output elements.
+         * (no conjugation for complex, unlike vecdot and vecmat)
+         */
+        for (npy_intp j = 0; j < dm; j++, ip1 += is1_m, op += os_m) {
+            @TYPE@_dot(ip1, is1_n, ip2, is2_n, op, dn, NULL);
+#if @CHECK_PYERR@
+            if (PyErr_Occurred()) {
+                return;
+            }
+#endif
+        }
+    }
+}
+/**end repeat**/
+
+/*
+ * vecmat loops, using blas gemv for float and gemm for complex if possible,
+ * and TYPE_dot[c] implementations otherwise.
+ * Note that we cannot use gemv for complex, since we need to conjugate the vector.
+ * signature is (n),(n,m)->(m)
+ */
+/**begin repeat
+ *  #TYPE = FLOAT, DOUBLE, LONGDOUBLE, HALF,
+ *          CFLOAT, CDOUBLE, CLONGDOUBLE,
+ *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
+ *          BYTE, SHORT, INT, LONG, LONGLONG,
+ *          BOOL, OBJECT#
+ *  #typ = npy_float,npy_double,npy_longdouble, npy_half,
+ *         npy_cfloat, npy_cdouble, npy_clongdouble,
+ *         npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,
+ *         npy_byte, npy_short, npy_int, npy_long, npy_longlong,
+ *         npy_bool, npy_object#
+ * #USEBLAS = 1, 1, 0, 0, 1, 1, 0*13#
+ * #COMPLEX = 0*4, 1*3, 0*11, 1#
+ * #DOT = dot*4, dotc*3, dot*11, dotc#
+ * #CHECK_PYERR = 0*18, 1#
+ */
+NPY_NO_EXPORT void
+@TYPE@_vecmat(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    npy_intp n_outer = dimensions[0];
+    npy_intp s0=steps[0], s1=steps[1], s2=steps[2];
+    npy_intp dn = dimensions[1], dm = dimensions[2];
+    npy_intp is1_n=steps[3], is2_n=steps[4], is2_m=steps[5], os_m=steps[6];
+#if @USEBLAS@ && defined(HAVE_CBLAS)
+    npy_bool too_big_for_blas = (dm > BLAS_MAXSIZE || dn > BLAS_MAXSIZE);
+    npy_bool i1_blasable = is_blasable2d(is1_n, sizeof(@typ@), dn, 1, sizeof(@typ@));
+    npy_bool i2_c_blasable = is_blasable2d(is2_n, is2_m, dn, dm, sizeof(@typ@));
+    npy_bool i2_f_blasable = is_blasable2d(is2_m, is2_n, dm, dn, sizeof(@typ@));
+    npy_bool blasable = (i1_blasable && (i2_c_blasable || i2_f_blasable)
+                         && !too_big_for_blas && dn > 1 && dm > 1);
+#endif
+    for (npy_intp i = 0; i < n_outer; i++,
+             args[0] += s0, args[1] += s1, args[2] += s2) {
+        char *ip1=args[0], *ip2=args[1], *op=args[2];
+#if @USEBLAS@ && defined(HAVE_CBLAS)
+        if (blasable) {
+#if @COMPLEX@
+            /* For complex, use gemm so we can conjugate the vector */
+            @TYPE@_vecmat_via_gemm(ip1, is1_n, ip2, is2_n, is2_m, op, os_m, dn, dm);
+#else
+            /* For float, use gemv (hence flipped order) */
+            @TYPE@_gemv(ip2, is2_m, is2_n, ip1, is1_n, op, os_m, dm, dn);
+#endif
+            continue;
+        }
+#endif
+        /* Dot the vector with different matrix columns to get output elements. */
+        for (npy_intp j = 0; j < dm; j++, ip2 += is2_m, op += os_m) {
+            @TYPE@_@DOT@(ip1, is1_n, ip2, is2_n, op, dn, NULL);
+#if @CHECK_PYERR@
+            if (PyErr_Occurred()) {
+                return;
+            }
+#endif
+        }
     }
 }
 /**end repeat**/

--- a/numpy/_core/src/umath/matmul.h.src
+++ b/numpy/_core/src/umath/matmul.h.src
@@ -7,15 +7,10 @@
  **/
 NPY_NO_EXPORT void
 @TYPE@_matmul(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
-/**end repeat**/
-
-/**begin repeat
- *  #TYPE = FLOAT, DOUBLE, LONGDOUBLE, HALF,
- *          CFLOAT, CDOUBLE, CLONGDOUBLE,
- *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
- *          BYTE, SHORT, INT, LONG, LONGLONG,
- *          BOOL, OBJECT#
- */
 NPY_NO_EXPORT void
 @TYPE@_vecdot(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+NPY_NO_EXPORT void
+@TYPE@_matvec(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+NPY_NO_EXPORT void
+@TYPE@_vecmat(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 /**end repeat**/

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -824,19 +824,76 @@ class TestUfunc:
         actual3 = np.vecdot(arr1.astype("object"), arr2)
         assert_array_equal(actual3, expected.astype("object"))
 
-    def test_vecdot_complex(self):
+    def test_matvec(self):
+        arr1 = np.arange(6).reshape((2, 3))
+        arr2 = np.arange(3).reshape((1, 3))
+
+        actual = np.matvec(arr1, arr2)
+        expected = np.array([[5, 14]])
+
+        assert_array_equal(actual, expected)
+
+        actual2 = np.matvec(arr1.T, arr2.T, axes=[(-1, -2), -2, -1])
+        assert_array_equal(actual2, expected)
+
+        actual3 = np.matvec(arr1.astype("object"), arr2)
+        assert_array_equal(actual3, expected.astype("object"))
+
+    @pytest.mark.parametrize("vec", [
+        np.array([[1., 2., 3.], [4., 5., 6.]]),
+        np.array([[1., 2j, 3.], [4., 5., 6j]]),
+        np.array([[1., 2., 3.], [4., 5., 6.]], dtype=object),
+        np.array([[1., 2j, 3.], [4., 5., 6j]], dtype=object)])
+    @pytest.mark.parametrize("matrix", [
+        None,
+        np.array([[1.+1j, 0.5, -0.5j],
+                  [0.25, 2j, 0.],
+                  [4., 0., -1j]])])
+    def test_vecmatvec_identity(self, matrix, vec):
+        """Check that (x†A)x equals x†(Ax)."""
+        mat = matrix if matrix is not None else np.eye(3)
+        matvec = np.matvec(mat, vec)  # Ax
+        vecmat = np.vecmat(vec, mat)  # x†A
+        if matrix is None:
+            assert_array_equal(matvec, vec)
+            assert_array_equal(vecmat.conj(), vec)
+        assert_array_equal(matvec, (mat @ vec[..., np.newaxis]).squeeze(-1))
+        assert_array_equal(vecmat, (vec[..., np.newaxis].mT.conj()
+                                    @ mat).squeeze(-2))
+        expected = np.einsum('...i,ij,...j', vec.conj(), mat, vec)
+        vec_matvec = (vec.conj() * matvec).sum(-1)
+        vecmat_vec = (vecmat * vec).sum(-1)
+        assert_array_equal(vec_matvec, expected)
+        assert_array_equal(vecmat_vec, expected)
+
+    @pytest.mark.parametrize("ufunc, shape1, shape2, conj", [
+        (np.vecdot, (3,), (3,), True),
+        (np.vecmat, (3,), (3, 1), True),
+        (np.matvec, (1, 3), (3,), False),
+        (np.matmul, (1, 3), (3, 1), False),
+    ])
+    def test_vecdot_matvec_vecmat_complex(self, ufunc, shape1, shape2, conj):
         arr1 = np.array([1, 2j, 3])
         arr2 = np.array([1, 2, 3])
 
-        actual = np.vecdot(arr1, arr2)
-        expected = np.array([10-4j])
-        assert_array_equal(actual, expected)
+        actual1 = ufunc(arr1.reshape(shape1), arr2.reshape(shape2))
+        expected1 = np.array(((arr1.conj() if conj else arr1) * arr2).sum(),
+                             ndmin=min(len(shape1), len(shape2)))
+        assert_array_equal(actual1, expected1)
+        # This would fail for conj=True, since matmul omits the conjugate.
+        if not conj:
+            assert_array_equal(arr1.reshape(shape1) @ arr2.reshape(shape2),
+                               expected1)
 
-        actual2 = np.vecdot(arr2, arr1)
-        assert_array_equal(actual2, expected.conj())
+        actual2 = ufunc(arr2.reshape(shape1), arr1.reshape(shape2))
+        expected2 = np.array(((arr2.conj() if conj else arr2) * arr1).sum(),
+                             ndmin=min(len(shape1), len(shape2)))
+        assert_array_equal(actual2, expected2)
 
-        actual3 = np.vecdot(arr1.astype("object"), arr2.astype("object"))
-        assert_array_equal(actual3, expected.astype("object"))
+        actual3 = ufunc(arr1.reshape(shape1).astype("object"),
+                        arr2.reshape(shape2).astype("object"))
+        expected3 = expected1.astype(object)
+        assert_array_equal(actual3, expected3)
 
     def test_vecdot_subclass(self):
         class MySubclass(np.ndarray):
@@ -2757,9 +2814,9 @@ def test_ufunc_noncontiguous(ufunc):
             # bool, object, datetime are too irregular for this simple test
             continue
         inp, out = typ.split('->')
-        args_c = [np.empty(6, t) for t in inp]
-        # non contiguous (3 step)
-        args_n = [np.empty(18, t)[::3] for t in inp]
+        args_c = [np.empty((6, 6), t) for t in inp]
+        # non contiguous (2, 3 step on the two dimensions)
+        args_n = [np.empty((12, 18), t)[::2, ::3] for t in inp]
         # alignment != itemsize is possible.  So create an array with such
         # an odd step manually.
         args_o = []
@@ -2767,10 +2824,9 @@ def test_ufunc_noncontiguous(ufunc):
             orig_dt = np.dtype(t)
             off_dt = f"S{orig_dt.alignment}"  # offset by alignment
             dtype = np.dtype([("_", off_dt), ("t", orig_dt)], align=False)
-            args_o.append(np.empty(6, dtype=dtype)["t"])
-
+            args_o.append(np.empty((6, 6), dtype=dtype)["t"])
         for a in args_c + args_n + args_o:
-            a.flat = range(1,7)
+            a.flat = range(1, 37)
 
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("always")
@@ -2788,7 +2844,7 @@ def test_ufunc_noncontiguous(ufunc):
                 # since different algorithms (libm vs. intrinsics) can be used
                 # for different input strides
                 res_eps = np.finfo(dt).eps
-                tol = 2*res_eps
+                tol = 3*res_eps
                 assert_allclose(res_c, res_n, atol=tol, rtol=tol)
                 assert_allclose(res_c, res_o, atol=tol, rtol=tol)
             else:

--- a/numpy/_core/umath.py
+++ b/numpy/_core/umath.py
@@ -33,8 +33,8 @@ __all__ = [
     'heaviside', 'hypot', 'invert', 'isfinite', 'isinf', 'isnan', 'isnat',
     'lcm', 'ldexp', 'left_shift', 'less', 'less_equal', 'log', 'log10',
     'log1p', 'log2', 'logaddexp', 'logaddexp2', 'logical_and', 'logical_not',
-    'logical_or', 'logical_xor', 'maximum', 'minimum', 'mod', 'modf',
+    'logical_or', 'logical_xor', 'matvec', 'maximum', 'minimum', 'mod', 'modf',
     'multiply', 'negative', 'nextafter', 'not_equal', 'pi', 'positive',
     'power', 'rad2deg', 'radians', 'reciprocal', 'remainder', 'right_shift',
     'rint', 'sign', 'signbit', 'sin', 'sinh', 'spacing', 'sqrt', 'square',
-    'subtract', 'tan', 'tanh', 'true_divide', 'trunc']
+    'subtract', 'tan', 'tanh', 'true_divide', 'trunc', 'vecdot', 'vecmat']


### PR DESCRIPTION
Backport of #25675.

This PR adds new `matvec` and `vecmat` gufunc to calculate the matrix-vector and vector-matrix product, to add to plain matrix multiplication with `matmul` and the inner vector product with `vecdot`. 

Fixes #12348

Note that for complex numbers, `vecmat` is defined as `x†A`, i.e., the complex conjugate of the vector is taken. This seems to be the standard and is what we used for `vecdot` too (`x†x`). However, it is *not* what `matmul` does for vector-matrix or indeed vector-vector products. I think this is a bug in matmul, which I'm happy to fix here. But I'll post to the mailing list to get feedback.

Separately, with these functions available, in principle these could be used in `__matmul__` and the specializations in `np.matmul` removed. But that can be a separate PR (if it is wanted at all).

*Summary of [mailing list discussion](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/LX36TEAENIDSSFAKS6YLXXLWVOBABSEC/)*
- Behaviour of `np.matmul` for vector-matrix should not be adjusted. Some surprise that "matrix multiplcation" deals with vectors at all.
- Less obvious consensus on what `@` should do.
- Moderate support for having special `matvec` and `vecmat` functions.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
