### PR TITLE
MAINT: Use mask_store instead of store for compiler bug workaround

### DIFF
--- a/numpy/_core/src/umath/loops_exponent_log.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_exponent_log.dispatch.c.src
@@ -1074,10 +1074,14 @@ AVX512F_log_DOUBLE(npy_double * op,
             _mm512_mask_storeu_pd(op, load_mask, res);
         }
 
-        /* call glibc's log func when x around 1.0f */
+        /* call glibc's log func when x around 1.0f. */
         if (glibc_mask != 0) {
             double NPY_DECL_ALIGNED(64) ip_fback[8];
-            _mm512_store_pd(ip_fback, x_in);
+            /* Using a mask_store_pd instead of store_pd to prevent a fatal
+             * compiler optimization bug. See
+             * https://github.com/numpy/numpy/issues/27745#issuecomment-2498684564
+             * for details.*/
+            _mm512_mask_store_pd(ip_fback, avx512_get_full_load_mask_pd(), x_in);
 
             for (int ii = 0; ii < 8; ++ii, glibc_mask >>= 1) {
                 if (glibc_mask & 0x01) {


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/27745. 

GCC 12 and later versions incorrectly generate vextractf64x2 instruction (requires AVX512-DQ) when using -O3 with -mavx512f. The workaround in this commit prevents the optimization from taking place.

Bug demonstration: https://gcc.godbolt.org/z/xT6osP173

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
