### PR TITLE
DOC: Fix typo

### DIFF
--- a/doc/source/f2py/windows/index.rst
+++ b/doc/source/f2py/windows/index.rst
@@ -9,7 +9,7 @@ F2PY and Windows
    F2PY support for Windows is not always at par with Linux support
 
 .. note::
-   `ScPy's documentation`_ has some information on system-level dependencies
+   `SciPy's documentation`_ has some information on system-level dependencies
    which are well tested for Fortran as well.
 
 Broadly speaking, there are two issues working with F2PY on Windows:
@@ -217,4 +217,4 @@ path using a hash. This needs to be added to the ``PATH`` variable.
 .. _are outdated: https://github.com/conda-forge/conda-forge.github.io/issues/1044
 .. _now deprecated: https://github.com/numpy/numpy/pull/20875
 .. _LLVM Flang: https://releases.llvm.org/11.0.0/tools/flang/docs/ReleaseNotes.html
-.. _ScPy's documentation: http://scipy.github.io/devdocs/building/index.html#system-level-dependencies
+.. _SciPy's documentation: http://scipy.github.io/devdocs/building/index.html#system-level-dependencies


### PR DESCRIPTION
"ScPy" <- "SciPy"