### PR TITLE
MAINT: Add helper for static or heap allocated scratch space

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -12,6 +12,7 @@
 #include "npy_config.h"
 #include "alloc.h"
 #include "npy_static_data.h"
+#include "templ_common.h"
 #include "multiarraymodule.h"
 
 #include <assert.h>
@@ -565,4 +566,18 @@ get_handler_version(PyObject *NPY_UNUSED(self), PyObject *args)
     version = PyLong_FromLong(handler->version);
     Py_DECREF(mem_handler);
     return version;
+}
+
+
+/*
+ * Internal function to malloc, but add an overflow check similar to Calloc
+ */
+NPY_NO_EXPORT void *
+_Npy_MallocWithOverflowCheck(npy_intp size, npy_intp elsize)
+{
+    npy_intp total_size;
+    if (npy_mul_sizes_with_overflow(&total_size, size, elsize)) {
+        return NULL;
+    }
+    return PyMem_MALLOC(total_size);
 }

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -11,6 +11,7 @@
 #include "numpy/arrayscalars.h"
 
 
+#include "alloc.h"
 #include "common.h"
 #include "arrayobject.h"
 #include "ctors.h"
@@ -397,28 +398,21 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
         return -1;
     }
 
+    PyArray_Descr *descr = PyArray_DESCR(arr);
+
     /*
      * If we knew that the output array has at least one element, we would
      * not actually need a helping buffer, we always null it, just in case.
-     *
-     * (The longlong here should help with alignment.)
+     * Use `long double` to ensure that the heap allocation is aligned.
      */
-    npy_longlong value_buffer_stack[4] = {0};
-    char *value_buffer_heap = NULL;
-    char *value = (char *)value_buffer_stack;
-    PyArray_Descr *descr = PyArray_DESCR(arr);
-
-    if (PyDataType_ELSIZE(descr) > sizeof(value_buffer_stack)) {
-        /* We need a large temporary buffer... */
-        value_buffer_heap = PyMem_Calloc(1, PyDataType_ELSIZE(descr));
-        if (value_buffer_heap == NULL) {
-            PyErr_NoMemory();
-            return -1;
-        }
-        value = value_buffer_heap;
+    NPY_DEFINE_SMALL_WORKSPACE(value, long double, 2);
+    size_t n_max_align_t = (descr->elsize + sizeof(long double) - 1) / sizeof(long double);
+    if (npy_zero_init_workspace(value, n_max_align_t) < 0) {
+        return -1;
     }
+
     if (PyArray_Pack(descr, value, obj) < 0) {
-        PyMem_FREE(value_buffer_heap);
+        npy_free_small_workspace(value);
         return -1;
     }
 
@@ -429,12 +423,12 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
     int retcode = raw_array_assign_scalar(
             PyArray_NDIM(arr), PyArray_DIMS(arr), descr,
             PyArray_BYTES(arr), PyArray_STRIDES(arr),
-            descr, value);
+            descr, (void *)value);
 
     if (PyDataType_REFCHK(descr)) {
-        PyArray_ClearBuffer(descr, value, 0, 1, 1);
+        PyArray_ClearBuffer(descr, (void *)value, 0, 1, 1);
     }
-    PyMem_FREE(value_buffer_heap);
+    npy_free_small_workspace(value);
     return retcode;
 }
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -26,6 +26,7 @@
 #include "legacy_dtype_implementation.h"
 #include "stringdtype/dtype.h"
 
+#include "alloc.h"
 #include "abstractdtypes.h"
 #include "convert_datatype.h"
 #include "_datetime.h"
@@ -1550,24 +1551,13 @@ PyArray_ResultType(
         return NPY_DT_CALL_ensure_canonical(result);
     }
 
-    void **info_on_heap = NULL;
-    void *_info_on_stack[NPY_MAXARGS * 2];
-    PyArray_DTypeMeta **all_DTypes;
-    PyArray_Descr **all_descriptors;
+    NPY_DEFINE_SMALL_WORKSPACE(workspace, void *, 2 * 8);
+    if (npy_init_workspace(workspace, 2 * (narrs + ndtypes)) < 0) {
+        return NULL;
+    }
 
-    if (narrs + ndtypes > NPY_MAXARGS) {
-        info_on_heap = PyMem_Malloc(2 * (narrs+ndtypes) * sizeof(PyObject *));
-        if (info_on_heap == NULL) {
-            PyErr_NoMemory();
-            return NULL;
-        }
-        all_DTypes = (PyArray_DTypeMeta **)info_on_heap;
-        all_descriptors = (PyArray_Descr **)(info_on_heap + narrs + ndtypes);
-    }
-    else {
-        all_DTypes = (PyArray_DTypeMeta **)_info_on_stack;
-        all_descriptors = (PyArray_Descr **)(_info_on_stack + narrs + ndtypes);
-    }
+    PyArray_DTypeMeta **all_DTypes = (PyArray_DTypeMeta **)workspace;
+    PyArray_Descr **all_descriptors = (PyArray_Descr **)(&all_DTypes[narrs+ndtypes]);
 
     /* Copy all dtypes into a single array defining non-value-based behaviour */
     for (npy_intp i=0; i < ndtypes; i++) {
@@ -1657,13 +1647,13 @@ PyArray_ResultType(
     }
 
     Py_DECREF(common_dtype);
-    PyMem_Free(info_on_heap);
+    npy_free_small_workspace(workspace);
     return result;
 
   error:
     Py_XDECREF(result);
     Py_XDECREF(common_dtype);
-    PyMem_Free(info_on_heap);
+    npy_free_small_workspace(workspace);
     return NULL;
 }
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -1551,8 +1551,8 @@ PyArray_ResultType(
         return NPY_DT_CALL_ensure_canonical(result);
     }
 
-    NPY_DEFINE_SMALL_WORKSPACE(workspace, void *, 2 * 8);
-    if (npy_init_workspace(workspace, 2 * (narrs + ndtypes)) < 0) {
+    NPY_ALLOC_WORKSPACE(workspace, void *, 2 * 8, 2 * (narrs + ndtypes));
+    if (workspace == NULL) {
         return NULL;
     }
 
@@ -1647,13 +1647,13 @@ PyArray_ResultType(
     }
 
     Py_DECREF(common_dtype);
-    npy_free_small_workspace(workspace);
+    npy_free_workspace(workspace);
     return result;
 
   error:
     Py_XDECREF(result);
     Py_XDECREF(common_dtype);
-    npy_free_small_workspace(workspace);
+    npy_free_workspace(workspace);
     return NULL;
 }
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -74,36 +74,28 @@ npy_forward_method(
         PyObject *callable, PyObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
-    PyObject *args_buffer[NPY_MAXARGS];
-    /* Practically guaranteed NPY_MAXARGS is enough. */
-    PyObject **new_args = args_buffer;
-
     /*
      * `PY_VECTORCALL_ARGUMENTS_OFFSET` seems never set, probably `args[-1]`
      * is always `self` but do not rely on it unless Python documents that.
      */
     npy_intp len_kwargs = kwnames != NULL ? PyTuple_GET_SIZE(kwnames) : 0;
-    size_t original_arg_size = (len_args + len_kwargs) * sizeof(PyObject *);
+    npy_intp total_nargs = (len_args + len_kwargs);
 
-    if (NPY_UNLIKELY(len_args + len_kwargs > NPY_MAXARGS)) {
-        new_args = (PyObject **)PyMem_MALLOC(original_arg_size + sizeof(PyObject *));
-        if (new_args == NULL) {
-            /*
-             * If this fails Python uses `PY_VECTORCALL_ARGUMENTS_OFFSET` and
-             * we should probably add a fast-path for that (hopefully almost)
-             * always taken.
-             */
-            return PyErr_NoMemory();
-        }
+    NPY_DEFINE_SMALL_WORKSPACE(new_args, PyObject *, 14);
+    if (npy_init_workspace(new_args, total_nargs + 1) < 0) {
+        /*
+         * If this fails Python uses `PY_VECTORCALL_ARGUMENTS_OFFSET` and
+         * we should probably add a fast-path for that (hopefully almost)
+         * always taken.
+         */
+        return NULL;
     }
 
     new_args[0] = self;
-    memcpy(&new_args[1], args, original_arg_size);
+    memcpy(&new_args[1], args, total_nargs * sizeof(PyObject *));
     PyObject *res = PyObject_Vectorcall(callable, new_args, len_args+1, kwnames);
 
-    if (NPY_UNLIKELY(len_args + len_kwargs > NPY_MAXARGS)) {
-        PyMem_FREE(new_args);
-    }
+    npy_free_small_workspace(new_args);
     return res;
 }
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -81,11 +81,11 @@ npy_forward_method(
     npy_intp len_kwargs = kwnames != NULL ? PyTuple_GET_SIZE(kwnames) : 0;
     npy_intp total_nargs = (len_args + len_kwargs);
 
-    NPY_DEFINE_SMALL_WORKSPACE(new_args, PyObject *, 14);
-    if (npy_init_workspace(new_args, total_nargs + 1) < 0) {
+    NPY_ALLOC_WORKSPACE(new_args, PyObject *, 14, total_nargs + 1);
+    if (new_args == NULL) {
         /*
-         * If this fails Python uses `PY_VECTORCALL_ARGUMENTS_OFFSET` and
-         * we should probably add a fast-path for that (hopefully almost)
+         * This may fail if Python starts passing `PY_VECTORCALL_ARGUMENTS_OFFSET`
+         * and we should probably add a fast-path for that (hopefully almost)
          * always taken.
          */
         return NULL;
@@ -95,7 +95,7 @@ npy_forward_method(
     memcpy(&new_args[1], args, total_nargs * sizeof(PyObject *));
     PyObject *res = PyObject_Vectorcall(callable, new_args, len_args+1, kwnames);
 
-    npy_free_small_workspace(new_args);
+    npy_free_workspace(new_args);
     return res;
 }
 

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -14,6 +14,7 @@
 /* Allow this .c file to include nditer_impl.h */
 #define NPY_ITERATOR_IMPLEMENTATION_CODE
 
+#include "alloc.h"
 #include "nditer_impl.h"
 #include "arrayobject.h"
 #include "array_coercion.h"
@@ -2425,9 +2426,14 @@ npyiter_get_common_dtype(int nop, PyArrayObject **op,
 {
     int iop;
     npy_intp narrs = 0, ndtypes = 0;
-    PyArrayObject *arrs[NPY_MAXARGS];
-    PyArray_Descr *dtypes[NPY_MAXARGS];
     PyArray_Descr *ret;
+    NPY_DEFINE_SMALL_WORKSPACE(arrs_and_dtypes, void *, 2 * 4);
+    if (npy_init_workspace(arrs_and_dtypes, 2 * nop) < 0) {
+        return NULL;
+    }
+
+    PyArrayObject **arrs = (PyArrayObject **)arrs_and_dtypes;
+    PyArray_Descr **dtypes = (PyArray_Descr **)arrs_and_dtypes + nop;
 
     NPY_IT_DBG_PRINT("Iterator: Getting a common data type from operands\n");
 
@@ -2470,6 +2476,7 @@ npyiter_get_common_dtype(int nop, PyArrayObject **op,
         ret = PyArray_ResultType(narrs, arrs, ndtypes, dtypes);
     }
 
+    npy_free_small_workspace(arrs_and_dtypes);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -2427,8 +2427,8 @@ npyiter_get_common_dtype(int nop, PyArrayObject **op,
     int iop;
     npy_intp narrs = 0, ndtypes = 0;
     PyArray_Descr *ret;
-    NPY_DEFINE_SMALL_WORKSPACE(arrs_and_dtypes, void *, 2 * 4);
-    if (npy_init_workspace(arrs_and_dtypes, 2 * nop) < 0) {
+    NPY_ALLOC_WORKSPACE(arrs_and_dtypes, void *, 2 * 4, 2 * nop);
+    if (arrs_and_dtypes == NULL) {
         return NULL;
     }
 
@@ -2476,7 +2476,7 @@ npyiter_get_common_dtype(int nop, PyArrayObject **op,
         ret = PyArray_ResultType(narrs, arrs, ndtypes, dtypes);
     }
 
-    npy_free_small_workspace(arrs_and_dtypes);
+    npy_free_workspace(arrs_and_dtypes);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/textreading/conversions.c
+++ b/numpy/_core/src/multiarray/textreading/conversions.c
@@ -66,8 +66,8 @@ double_from_ucs4(
 
     size_t str_len = end - str + 1;
     /* We convert to ASCII for the Python parser, use stack if small: */
-    NPY_DEFINE_SMALL_WORKSPACE(ascii, char, 128);
-    if (npy_init_workspace(ascii, str_len) < 0) {
+    NPY_ALLOC_WORKSPACE(ascii, char, 128, str_len);
+    if (ascii == NULL) {
         return -1;
     }
 
@@ -87,7 +87,7 @@ double_from_ucs4(
     /* Rewind `end` to the first UCS4 character not parsed: */
     end = end - (c - end_parsed);
 
-    npy_free_small_workspace(ascii);
+    npy_free_workspace(ascii);
 
     if (*result == -1. && PyErr_Occurred()) {
         return -1;

--- a/numpy/_core/src/multiarray/textreading/conversions.c
+++ b/numpy/_core/src/multiarray/textreading/conversions.c
@@ -13,6 +13,7 @@
 #include "conversions.h"
 #include "str_to_int.h"
 
+#include "alloc.h"
 #include "array_coercion.h"
 
 
@@ -63,20 +64,13 @@ double_from_ucs4(
         return -1;  /* empty or only whitespace: not a floating point number */
     }
 
-    /* We convert to ASCII for the Python parser, use stack if small: */
-    char stack_buf[128];
-    char *heap_buf = NULL;
-    char *ascii = stack_buf;
-
     size_t str_len = end - str + 1;
-    if (str_len > 128) {
-        heap_buf = PyMem_MALLOC(str_len);
-        if (heap_buf == NULL) {
-            PyErr_NoMemory();
-            return -1;
-        }
-        ascii = heap_buf;
+    /* We convert to ASCII for the Python parser, use stack if small: */
+    NPY_DEFINE_SMALL_WORKSPACE(ascii, char, 128);
+    if (npy_init_workspace(ascii, str_len) < 0) {
+        return -1;
     }
+
     char *c = ascii;
     for (; str < end; str++, c++) {
         if (NPY_UNLIKELY(*str >= 128)) {
@@ -93,7 +87,7 @@ double_from_ucs4(
     /* Rewind `end` to the first UCS4 character not parsed: */
     end = end - (c - end_parsed);
 
-    PyMem_FREE(heap_buf);
+    npy_free_small_workspace(ascii);
 
     if (*result == -1. && PyErr_Occurred()) {
         return -1;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4306,10 +4306,12 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
      * Scratch space for operands, dtypes, etc.  Note that operands and
      * operation_descrs may hold an entry for the wheremask.
      */
-    NPY_DEFINE_SMALL_WORKSPACE(scratch_objs, void *, UFUNC_STACK_NARGS * 4 + 2);
-    if (npy_zero_init_workspace(scratch_objs, nop * 4 + 2) < 0) {
+    NPY_ALLOC_WORKSPACE(scratch_objs, void *, UFUNC_STACK_NARGS * 4 + 2, nop * 4 + 2);
+    if (scratch_objs == NULL) {
         return NULL;
     }
+    memset(scratch_objs, 0, sizeof(void *) * (nop * 4 + 2));
+    
     PyArray_DTypeMeta **signature = (PyArray_DTypeMeta **)scratch_objs;
     PyArrayObject **operands = (PyArrayObject **)(signature + nop);
     PyArray_DTypeMeta **operand_DTypes = (PyArray_DTypeMeta **)(operands + nop + 1);
@@ -4566,7 +4568,7 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
 
-    npy_free_small_workspace(scratch_objs);
+    npy_free_workspace(scratch_objs);
     return result;
 
 fail:
@@ -4579,7 +4581,7 @@ fail:
         Py_XDECREF(operand_DTypes[i]);
         Py_XDECREF(operation_descrs[i]);
     }
-    npy_free_small_workspace(scratch_objs);
+    npy_free_workspace(scratch_objs);
     return NULL;
 }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -51,6 +51,7 @@
 #include "npy_import.h"
 #include "extobj.h"
 
+#include "alloc.h"
 #include "arrayobject.h"
 #include "arraywrap.h"
 #include "common.h"
@@ -127,6 +128,9 @@ PyUFunc_clearfperr()
     npy_clear_floatstatus_barrier(&param);
 }
 
+
+/* This many operands we optimize for on the stack. */
+#define UFUNC_STACK_NARGS 5
 
 #define NPY_UFUNC_DEFAULT_INPUT_FLAGS \
     NPY_ITER_READONLY | \
@@ -4295,18 +4299,21 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     int nin = ufunc->nin, nout = ufunc->nout, nop = ufunc->nargs;
 
     /* All following variables are cleared in the `fail` error path */
-    ufunc_full_args full_args;
+    ufunc_full_args full_args = {NULL, NULL};
     PyArrayObject *wheremask = NULL;
 
-    PyArray_DTypeMeta *signature[NPY_MAXARGS];
-    PyArrayObject *operands[NPY_MAXARGS];
-    PyArray_DTypeMeta *operand_DTypes[NPY_MAXARGS];
-    PyArray_Descr *operation_descrs[NPY_MAXARGS];
-    /* Initialize all arrays (we usually only need a small part) */
-    memset(signature, 0, nop * sizeof(*signature));
-    memset(operands, 0, nop * sizeof(*operands));
-    memset(operand_DTypes, 0, nop * sizeof(*operation_descrs));
-    memset(operation_descrs, 0, nop * sizeof(*operation_descrs));
+    /*
+     * Scratch space for operands, dtypes, etc.  Note that operands and
+     * operation_descrs may hold an entry for the wheremask.
+     */
+    NPY_DEFINE_SMALL_WORKSPACE(scratch_objs, void *, UFUNC_STACK_NARGS * 4 + 2);
+    if (npy_zero_init_workspace(scratch_objs, nop * 4 + 2) < 0) {
+        return NULL;
+    }
+    PyArray_DTypeMeta **signature = (PyArray_DTypeMeta **)scratch_objs;
+    PyArrayObject **operands = (PyArrayObject **)(signature + nop);
+    PyArray_DTypeMeta **operand_DTypes = (PyArray_DTypeMeta **)(operands + nop + 1);
+    PyArray_Descr **operation_descrs = (PyArray_Descr **)(operand_DTypes + nop);
 
     /*
      * Note that the input (and possibly output) arguments are passed in as
@@ -4322,13 +4329,13 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
                 "%s() takes from %d to %d positional arguments but "
                 "%zd were given",
                 ufunc_get_name_cstr(ufunc) , nin, nop, len_args);
-        return NULL;
+        goto fail;
     }
 
     /* Fetch input arguments. */
     full_args.in = PyArray_TupleFromItems(ufunc->nin, args, 0);
     if (full_args.in == NULL) {
-        return NULL;
+        goto fail;
     }
 
     /*
@@ -4559,6 +4566,7 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
 
+    npy_free_small_workspace(scratch_objs);
     return result;
 
 fail:
@@ -4571,6 +4579,7 @@ fail:
         Py_XDECREF(operand_DTypes[i]);
         Py_XDECREF(operation_descrs[i]);
     }
+    npy_free_small_workspace(scratch_objs);
     return NULL;
 }
 


### PR DESCRIPTION
This simplifies usage in a few places, although it requires fixing error cleanup paths sometimes.

Based on an old start, I also had one using `alloca()`.
EDIT: `alloca` doesn't require the DEFINE helper, otherwise not sure it changes much.  But I wasn't sure if `alloca` has its own problems or not.

The ufunc change is useful, mainly because right now it memsets way too much space.

I am not wed to this thought.  One could also just use a cached small allocation which may get close enough speed wise. Although I am not sure how that would pan out with the nogil effort.

---

I don't care about this, I am not even sure it is nice.  But I would like to make some progress on getting rid of `NPY_MAXARGS` usages.

(I think there may be just one remaining in the iterator, but it is in a weird reduction path, that I really think should be moved around and simplified...)