### PR TITLE
MAINT: Drop Python 3.10 support.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,27 +71,28 @@ jobs:
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions
 
-  pypy:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-      with:
-        python-version: 'pypy3.10-v7.3.17'
-    - name: Setup using scipy-openblas
-      run: |
-        python -m pip install -r requirements/ci_requirements.txt
-        spin config-openblas --with-scipy-openblas=32
-    - uses: ./.github/meson_actions
+  # TODO pypy: uncomment when pypy3.11 becomes available    
+  #pypy:
+    #needs: [smoke_test]
+    #runs-on: ubuntu-latest
+    #if: github.event_name != 'push'
+    #steps:
+    #- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      #with:
+        #submodules: recursive
+        #fetch-tags: true
+    #- uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      #with:
+        #python-version: 'pypy3.10-v7.3.17'
+    #- name: Setup using scipy-openblas
+      #run: |
+        #python -m pip install -r requirements/ci_requirements.txt
+        #spin config-openblas --with-scipy-openblas=32
+    #- uses: ./.github/meson_actions
 
   debug:
     needs: [smoke_test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'push'
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install linter requirements
       run:
         python -m pip install -r requirements/linter_requirements.txt
@@ -55,7 +55,7 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
+        version: ["3.11", "3.12", "3.13", "3.13t"]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -129,7 +129,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install build and test dependencies from PyPI
       run: |
         pip install -r requirements/build_requirements.txt
@@ -164,7 +164,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install build and benchmarking dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -47,7 +47,7 @@ jobs:
         fi
         git submodule update --init
 
-        ln -s /usr/local/bin/python3.10 /usr/local/bin/python
+        ln -s /usr/local/bin/python3.11 /usr/local/bin/python
 
     - name: test-musllinux_x86_64
       env:

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -64,7 +64,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - uses: ./.github/meson_actions
       name: Build/Test
 
@@ -81,7 +81,7 @@ jobs:
         fetch-tags: true
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install GCC/8/9
       run: |
@@ -127,12 +127,12 @@ jobs:
           - [
             "without avx512",
             "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C,AVX2,FMA3",
-            "3.10"
+            "3.11"
           ]
           - [
             "without avx512/avx2/fma3",
             "-Dallow-noblas=true -Dcpu-dispatch=SSSE3,SSE41,POPCNT,SSE42,AVX,F16C",
-            "3.10"
+            "3.11"
           ]
 
     env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -113,7 +113,7 @@ jobs:
         build_runner:
           - [ macos-13, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
-        version: ["3.10", "3.13t"]
+        version: ["3.11", "3.13t"]
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -48,7 +48,7 @@ jobs:
         os_python:
           - [ubuntu-latest, '3.12']
           - [windows-latest, '3.11']
-          - [macos-latest, '3.10']
+          - [macos-latest, '3.11']
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,7 +85,7 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        python: ["cp310", "cp311", "cp312", "pp310", "cp313", "cp313t"]
+        python: ["cp311", "cp312", "pp310", "cp313", "cp313t"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
@@ -231,7 +231,7 @@ jobs:
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Build sdist on lowest supported Python
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build sdist
         run: |
           python -m pip install -U pip build
@@ -263,7 +263,7 @@ jobs:
           # Note that this step is *after* specific pythons have been used to
           # build and test
           auto-update-conda: true
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Upload sdist
         if: success()

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,7 +85,8 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        python: ["cp311", "cp312", "pp310", "cp313", "cp313t"]
+        # TODO pypy: Add pp311 to this list when it comes out (pp310 removed)  
+        python: ["cp311", "cp312", "cp313", "cp313t"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Python (32-bit)
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x86'
 
       - name: Setup MSVC (32-bit)

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 Building NumPy requires the following installed software:
 
-1) Python__ 3.10.x or newer.
+1) Python__ 3.11.x or newer.
 
    Please note that the Python development headers also need to be installed,
    e.g., on Debian/Ubuntu one needs to install both `python3` and

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,12 +89,13 @@ stages:
             TEST_MODE: full
             BITS: 64
             _USE_BLAS_ILP64: '1'
-          PyPy310-64bit-fast:
-            PYTHON_VERSION: 'pypy3.10'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: fast
-            BITS: 64
-            _USE_BLAS_ILP64: '1'
+# TODO pypy: uncomment when pypy3.11 comes out
+#          PyPy310-64bit-fast:
+#            PYTHON_VERSION: 'pypy3.10'
+#            PYTHON_ARCH: 'x64'
+#            TEST_MODE: fast
+#            BITS: 64
+#            _USE_BLAS_ILP64: '1'
 
     steps:
     - template: azure-steps-windows.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.10'
+        versionSpec: '3.11'
         addToPath: true
         architecture: 'x64'
     - script: >-
@@ -57,7 +57,7 @@ stages:
       displayName: 'Run Lint Checks'
       failOnStderr: true
 
-  - job: Linux_Python_310_32bit_full_with_asserts
+  - job: Linux_Python_311_32bit_full_with_asserts
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
@@ -78,13 +78,13 @@ stages:
     strategy:
       maxParallel: 3
       matrix:
-          Python310-64bit-fast:
-            PYTHON_VERSION: '3.10'
+          Python311-64bit-fast:
+            PYTHON_VERSION: '3.11'
             PYTHON_ARCH: 'x64'
             TEST_MODE: fast
             BITS: 64
-          Python311-64bit-full:
-            PYTHON_VERSION: '3.11'
+          Python312-64bit-full:
+            PYTHON_VERSION: '3.12'
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -17,9 +17,6 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
-// work around Python 3.10 and earlier issue, see
-// the commit message of 82fd2b8 for more details
-// also needed for the allocator mutex
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [{name = "Travis E. Oliphant et al."}]
 maintainers = [
     {name = "NumPy Developers", email="numpy-discussion@python.org"},
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.md"
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -26,7 +26,6 @@ classifiers = [
     'Programming Language :: C',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -42,10 +42,10 @@ linux_aarch64_test_task:
   prepare_env_script: |
     apt-get update
     apt-get install -y --no-install-recommends software-properties-common gcc g++ gfortran pkg-config ccache
-    apt-get install -y --no-install-recommends python3.10 python3.10-venv libopenblas-dev libatlas-base-dev liblapack-dev
+    apt-get install -y --no-install-recommends python3.11 python3.11-venv libopenblas-dev libatlas-base-dev liblapack-dev
 
-    # python3.10 -m ensurepip --default-pip --user
-    ln -s $(which python3.10) python
+    # python3.11 -m ensurepip --default-pip --user
+    ln -s $(which python3.11) python
 
     # put ccache and python on PATH
     export PATH=/usr/lib/ccache:$PWD:$PATH

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -26,8 +26,6 @@ linux_aarch64_task:
     # single task takes longer than 60 mins (the default time limit for a
     # cirrus-ci task).
     - env:
-        CIBW_BUILD: cp310-*
-    - env:
         CIBW_BUILD: cp311-*
     - env:
         CIBW_BUILD: cp312-*
@@ -65,9 +63,9 @@ macosx_arm64_task:
 
   matrix:
     - env:
-        CIBW_BUILD: cp310-* cp311-*
+        CIBW_BUILD: cp311-* cp312*
     - env:
-        CIBW_BUILD: cp312-* cp313-*
+        CIBW_BUILD: cp313-*
     - env:
         CIBW_BUILD: cp313t-*
         CIBW_FREE_THREADED_SUPPORT: 1

--- a/tools/ci/run_32_bit_linux_docker.sh
+++ b/tools/ci/run_32_bit_linux_docker.sh
@@ -2,7 +2,7 @@ set -xe
 
 git config --global --add safe.directory /numpy
 cd /numpy
-/opt/python/cp310-cp310/bin/python -mvenv venv
+/opt/python/cp311-cp311/bin/python -mvenv venv
 source venv/bin/activate
 pip install -r requirements/ci32_requirements.txt
 python3 -m pip install -r requirements/test_requirements.txt


### PR DESCRIPTION
Dropping support is in line with SPEC 0, NumPy 2.3 is due sometime in June 2025.

Closes #27861.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
