### PR TITLE
ENH: stack custom multiarray import exception with the original one

### DIFF
--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -46,7 +46,7 @@ Please carefully study the documentation linked above for further help.
 Original error was: %s
 """ % (sys.version_info[0], sys.version_info[1], sys.executable,
         __version__, exc)
-    raise ImportError(msg)
+    raise ImportError(msg) from exc
 finally:
     for envkey in env_added:
         del os.environ[envkey]


### PR DESCRIPTION
Before:

```py
Traceback (most recent call last):
  File "/home/anubis/git/numpy/numpy/_core/__init__.py", line 23, in <module>
    from . import multiarray
ImportError: cannot import name 'multiarray' from partially initialized module 'numpy._core' (most likely due to a circular import) (/home/anubis/git/numpy/numpy/_core/__init__.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/anubis/git/numpy/numpy/__init__.py", line 114, in <module>
    from numpy.__config__ import show as show_config
  File "/home/anubis/git/numpy/build/cp313td/numpy/__config__.py", line 4, in <module>
    from numpy._core._multiarray_umath import (
    ...<3 lines>...
    )
  File "/home/anubis/git/numpy/numpy/_core/__init__.py", line 49, in <module>
    raise ImportError(msg)
ImportError:

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python3.13 from "/home/anubis/.virtualenvs/numpy/bin/python"
  * The NumPy version is: "2.3.0.dev0+git20241126.4e8f724"

and make sure that they are the versions you expect.
Please carefully study the documentation linked above for further help.

Original error was: cannot import name 'multiarray' from partially initialized module 'numpy._core' (most likely due to a circular import) (/home/anubis/git/numpy/numpy/_core/__init__.py)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import numpy
  File "/home/anubis/git/numpy/numpy/__init__.py", line 119, in <module>
    raise ImportError(msg) from e
ImportError: Error importing numpy: you should not try to import numpy from
        its source directory; please exit the numpy source tree, and relaunch
        your python interpreter from there.
```

After:

```py
Traceback (most recent call last):
  File "/home/anubis/git/numpy/numpy/_core/__init__.py", line 23, in <module>
    from . import multiarray
ImportError: cannot import name 'multiarray' from partially initialized module 'numpy._core' (most likely due to a circular import) (/home/anubis/git/numpy/numpy/_core/__init__.py)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/anubis/git/numpy/numpy/__init__.py", line 114, in <module>
    from numpy.__config__ import show as show_config
  File "/home/anubis/git/numpy/build/cp313td/numpy/__config__.py", line 4, in <module>
    from numpy._core._multiarray_umath import (
    ...<3 lines>...
    )
  File "/home/anubis/git/numpy/numpy/_core/__init__.py", line 49, in <module>
    raise ImportError(msg) from exc
ImportError:

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python3.13 from "/home/anubis/.virtualenvs/numpy/bin/python"
  * The NumPy version is: "2.3.0.dev0+git20241126.4e8f724"

and make sure that they are the versions you expect.
Please carefully study the documentation linked above for further help.

Original error was: cannot import name 'multiarray' from partially initialized module 'numpy._core' (most likely due to a circular import) (/home/anubis/git/numpy/numpy/_core/__init__.py)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import numpy
  File "/home/anubis/git/numpy/numpy/__init__.py", line 119, in <module>
    raise ImportError(msg) from e
ImportError: Error importing numpy: you should not try to import numpy from
        its source directory; please exit the numpy source tree, and relaunch
        your python interpreter from there.

```