### PR TITLE
BUG: fix importing numpy in Python's optimized mode (#27868)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,6 +152,8 @@ jobs:
       run: |
         pytest numpy --cov-report=html:build/coverage
         # TODO: gcov
+      env:
+        PYTHONOPTIMIZE: 2
 
   benchmark:
     needs: [smoke_test]

--- a/numpy/_core/overrides.py
+++ b/numpy/_core/overrides.py
@@ -19,7 +19,7 @@ array_function_like_doc = (
         compatible with that passed in via this argument."""
 )
 
-def get_array_function_like_doc(public_api, docstring_template=None):
+def get_array_function_like_doc(public_api, docstring_template=""):
     ARRAY_FUNCTIONS.add(public_api)
     docstring = public_api.__doc__ or docstring_template
     return docstring.replace("${ARRAY_FUNCTION_LIKE}", array_function_like_doc)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2796,8 +2796,10 @@ def test_load_multiple_arrays_until_eof():
     np.save(f, 1)
     np.save(f, 2)
     f.seek(0)
-    assert np.load(f) == 1
-    assert np.load(f) == 2
+    out1 = np.load(f)
+    assert out1 == 1
+    out2 = np.load(f)
+    assert out2 == 2
     with pytest.raises(EOFError):
         np.load(f)
 


### PR DESCRIPTION
Backport of #27868.

* TST: add PYTHONOPTIMIZE=2 to full CI (linux)

* BUG: fix importing numpy in Python's optimized mode

* TST: fix a test for compatibility with PYTHONOPTIMIZE

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
