### PR TITLE
MAINT: Move uint aligned check to actual transfer function setup

### DIFF
--- a/numpy/_core/src/multiarray/nditer_api.c
+++ b/numpy/_core/src/multiarray/nditer_api.c
@@ -1567,8 +1567,6 @@ NpyIter_DebugPrint(NpyIter *iter)
             printf("CAST ");
         if ((NIT_OPITFLAGS(iter)[iop])&NPY_OP_ITFLAG_BUFNEVER)
             printf("BUFNEVER ");
-        if ((NIT_OPITFLAGS(iter)[iop])&NPY_OP_ITFLAG_ALIGNED)
-            printf("ALIGNED ");
         if ((NIT_OPITFLAGS(iter)[iop])&NPY_OP_ITFLAG_REDUCE)
             printf("REDUCE ");
         if ((NIT_OPITFLAGS(iter)[iop])&NPY_OP_ITFLAG_VIRTUAL)

--- a/numpy/_core/src/multiarray/nditer_impl.h
+++ b/numpy/_core/src/multiarray/nditer_impl.h
@@ -121,8 +121,6 @@
 #define NPY_OP_ITFLAG_CAST         0x0004
 /* The operand never needs buffering */
 #define NPY_OP_ITFLAG_BUFNEVER     0x0008
-/* The operand is aligned */
-#define NPY_OP_ITFLAG_ALIGNED      0x0010
 /* The operand is being reduced */
 #define NPY_OP_ITFLAG_REDUCE       0x0020
 /* The operand is for temporary use, does not have a backing array */

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -3315,8 +3315,8 @@ def test_debug_print(capfd):
     | Operands:
     | Operand DTypes: dtype('int64') dtype('float64')
     | OpItFlags:
-    |   Flags[0]: READ CAST ALIGNED
-    |   Flags[1]: READ WRITE CAST ALIGNED REDUCE
+    |   Flags[0]: READ CAST
+    |   Flags[1]: READ WRITE CAST REDUCE
     |
     | BufferData:
     |   BufferSize: 50


### PR DESCRIPTION
The comment was already always incorrect, all newly allocated arrays are uint aligned.  But more importantly, we don't often need casting, so we should move this check to where the casts are required.

Since newly allocated arrays should not need casting or buffering we shouldn't check things unnecessarily.

(While before, we checked things unnecessarily all the time.)

Locally, I saw a flaky linalg warning, but I think it is the one we often saw (just surprised because I didn't see it in a long time).