### PR TITLE
MAINT: pass -v in cibw test command [wheel build]

### DIFF
--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -46,5 +46,5 @@ fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across
 # the available N CPU cores: 2 by default for Linux instances and 4 for macOS arm64
-python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto']))"
+python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-v', '-n=auto']))"
 python $PROJECT_DIR/tools/wheels/check_license.py


### PR DESCRIPTION
This makes the output more verbose but also makes it easier to track down rare hangs and crashes. c.f. https://github.com/numpy/numpy/issues/27872#issuecomment-2507483739