### PR TITLE
ENH: update `__module__` in `numpy.random` module

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -5082,3 +5082,6 @@ def default_rng(seed=None):
     # Otherwise we need to instantiate a new BitGenerator and Generator as
     # normal.
     return Generator(PCG64(seed))
+
+
+default_rng.__module__ = "numpy.random"

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4956,3 +4956,14 @@ __all__ = [
     'zipf',
     'RandomState',
 ]
+
+seed.__module__ = "numpy.random"
+ranf.__module__ = "numpy.random"
+sample.__module__ = "numpy.random"
+get_bit_generator.__module__ = "numpy.random"
+set_bit_generator.__module__ = "numpy.random"
+
+for method_name in __all__[:-1]:
+    method = getattr(RandomState, method_name, None)
+    if method is not None:
+        method.__module__ = "numpy.random"

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -701,7 +701,7 @@ def test___module__attribute():
                 member_name not in [
                     "char", "core", "ctypeslib", "f2py", "ma", "lapack_lite",
                     "mrecords", "testing", "tests", "polynomial", "typing",
-                    "random",  # cython disallows overriding __module__
+                    "mtrand", "bit_generator",
                 ] and
                 member not in visited_modules  # not visited yet
             ):
@@ -725,6 +725,13 @@ def test___module__attribute():
                 if (
                     (member.__name__ == "recarray" and module.__name__ == "numpy") or
                     (member.__name__ == "record" and module.__name__ == "numpy.rec")
+                ):
+                    continue
+
+                # skip cdef classes
+                if member.__name__ in (
+                    "BitGenerator", "Generator", "MT19937", "PCG64", "PCG64DXSM",
+                    "Philox", "RandomState", "SFC64", "SeedSequence",
                 ):
                     continue
 


### PR DESCRIPTION
This is a follow-up PR after https://github.com/numpy/numpy/pull/27716. It updates `np.random` functions and methods' `__module__` to `numpy.random`.

The only items left with incorrect `__module__` are cdef classes, as Cython doesn't allows changing it.

List from here: https://github.com/pytorch/pytorch/issues/136559#issuecomment-2420637016