### PR TITLE
TST: add timeouts for github actions tests and wheel builds.

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -30,8 +30,8 @@ runs:
       TERM: xterm-256color
     run: |
       echo "::group::Installing Test Dependencies"
-      pip install pytest pytest-xdist hypothesis typing_extensions setuptools
+      pip install pytest pytest-xdist pytest-timeout hypothesis typing_extensions setuptools
       echo "::endgroup::"
       echo "::group::Test NumPy"
-      spin test
+      spin test -- --durations=10 --timeout=600
       echo "::endgroup::"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         source venv/bin/activate
         cd tools
-        pytest --pyargs numpy -m "not slow"
+        pytest --timeout=600 --durations=10 --pyargs numpy -m "not slow"
 
   full:
     # Install as editable, then run the full test suite with code coverage
@@ -150,7 +150,7 @@ jobs:
         pip install -e . --no-build-isolation
     - name: Run full test suite
       run: |
-        pytest numpy --cov-report=html:build/coverage
+        pytest numpy --durations=10 --timeout=600 --cov-report=html:build/coverage
         # TODO: gcov
       env:
         PYTHONOPTIMIZE: 2

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions
+        pip install pytest hypothesis typing_extensions pytest-timeout
 
     - name: Build (LP64)
       run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true -Dallow-noblas=false
@@ -169,7 +169,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions
+        pip install pytest hypothesis typing_extensions pytest-timeout
 
     - name: Build
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
@@ -202,7 +202,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         sudo apt-get update
         sudo apt-get install libopenblas-dev cmake
         sudo apt-get remove pkg-config
@@ -239,7 +239,7 @@ jobs:
 
     - name: Test
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
@@ -270,7 +270,7 @@ jobs:
 
     - name: Test
       run: |
-        pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions
+        pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
@@ -290,7 +290,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         pip install mkl mkl-devel
 
     - name: Repair MKL pkg-config files and symlinks
@@ -353,7 +353,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         sudo apt-get update
         sudo apt-get install libblis-dev libopenblas-dev pkg-config
 
@@ -389,7 +389,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         sudo apt-get update
         sudo apt-get install libatlas-base-dev pkg-config
 

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -112,8 +112,8 @@ jobs:
       env:
         TERM: xterm-256color
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions
-        spin test -j auto
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        spin test -j auto -- --timeout=600 --durations=10
 
 
   openblas_no_pkgconfig_fedora:
@@ -140,7 +140,7 @@ jobs:
       run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
     - name: Build (ILP64)
       run: |
@@ -148,7 +148,7 @@ jobs:
         spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
 
   flexiblas_fedora:
@@ -175,7 +175,7 @@ jobs:
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
     - name: Build (ILP64)
       run: |
@@ -183,7 +183,7 @@ jobs:
         spin build -- -Ddisable-optimization=true -Duse-ilp64=true -Dallow-noblas=false
 
     - name: Test (ILP64)
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
 
   openblas_cmake:
@@ -211,7 +211,7 @@ jobs:
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -j auto -- numpy/linalg
+      run: spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
  
   netlib-debian:
@@ -240,7 +240,7 @@ jobs:
     - name: Test
       run: |
         pip install pytest pytest-xdist hypothesis typing_extensions
-        spin test -j auto -- numpy/linalg
+        spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
   netlib-split:
@@ -271,7 +271,7 @@ jobs:
     - name: Test
       run: |
         pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions
-        spin test -j auto -- numpy/linalg
+        spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
   mkl:
@@ -314,7 +314,7 @@ jobs:
         spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
     - name: Build with ILP64
       run: |
@@ -323,7 +323,7 @@ jobs:
         spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
     - name: Build without pkg-config (default options, SDL)
       run: |
@@ -335,7 +335,7 @@ jobs:
         spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
   blis:
     if: github.repository == 'numpy/numpy'
@@ -371,7 +371,7 @@ jobs:
       run: spin build -- -Dblas=blis -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test
-      run: spin test -- numpy/linalg
+      run: spin test -- numpy/linalg --timeout=600 --durations=10
 
   atlas:
     if: github.repository == 'numpy/numpy'

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         TERM: xterm-256color
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions
+        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         ASAN_OPTIONS=detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1:halt_on_error=1 \
         UBSAN_OPTIONS=halt_on_error=0 \
         LD_PRELOAD=$(clang --print-file-name=libclang_rt.asan-x86_64.so) \

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -55,4 +55,4 @@ jobs:
         ASAN_OPTIONS=detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1:halt_on_error=1 \
         UBSAN_OPTIONS=halt_on_error=0 \
         LD_PRELOAD=$(clang --print-file-name=libclang_rt.asan-x86_64.so) \
-        python -m spin test -- -v -s
+        python -m spin test -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -63,7 +63,7 @@ jobs:
         # the Duse-ilp64 is not needed with scipy-openblas wheels > 0.3.24.95.0
         # spin build --with-scipy-openblas=64 -- -Duse-ilp64=true
         spin build --with-scipy-openblas=64
-        spin test -j auto
+        spin test -j auto -- --timeout=600 --durations=10
 
     - name: Meson Log
       shell: bash

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -173,7 +173,7 @@ jobs:
           -v $(pwd):/numpy -v /:/host the_container \
           /bin/script -e -q -c "/bin/bash --noprofile --norc -eo pipefail -c '
             export F90=/usr/bin/gfortran
-            cd /numpy && spin test -- -k \"${RUNTIME_TEST_FILTER}\"
+            cd /numpy && spin test -- --timeout=600 --durations=10 -k \"${RUNTIME_TEST_FILTER}\"
           '"
 
 

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -144,7 +144,7 @@ jobs:
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
           python -m pip install -r /tmp/build_requirements.txt &&
-          python -m pip install pytest pytest-xdist hypothesis typing_extensions &&
+          python -m pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -139,13 +139,13 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis
+        pip install pytest pytest-xdist pytest-timeout hypothesis
 
     - name: Build against Accelerate (LP64)
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test (linalg only)
-      run: spin test -j2 -- numpy/linalg
+      run: spin test -j2 -- numpy/linalg --timeout=600 --durations=10
 
     - name: Build NumPy against Accelerate (ILP64)
       run: |
@@ -153,4 +153,4 @@ jobs:
         spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test (fast tests)
-      run: spin test -j2
+      run: spin test -j2 -- --timeout=600 --durations=10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Run test suite
       run: |
-        spin test
+        spin test -- --timeout=600 --durations=10
 
   msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS
@@ -124,4 +124,4 @@ jobs:
       - name: Run test suite (fast)
         run: |
           cd tools
-          python -m pytest --pyargs numpy -m "not slow" -n2
+          python -m pytest --pyargs numpy -m "not slow" -n2 --timeout=600 --durations=10

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -21,7 +21,7 @@ from numpy.linalg._linalg import _multi_dot_matrix_chain_order
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal,
     assert_almost_equal, assert_allclose, suppress_warnings,
-    assert_raises_regex, HAS_LAPACK64, IS_WASM
+    assert_raises_regex, HAS_LAPACK64, IS_WASM, NOGIL_BUILD,
     )
 try:
     import numpy.linalg.lapack_lite
@@ -1944,9 +1944,13 @@ def test_generalized_raise_multiloop():
 
     assert_raises(np.linalg.LinAlgError, np.linalg.inv, x)
 
+
 @pytest.mark.skipif(
     threading.active_count() > 1,
     reason="skipping test that uses fork because there are multiple threads")
+@pytest.mark.skipif(
+    NOGIL_BUILD,
+    reason="Cannot safely use fork in tests on the free-threaded build")
 def test_xerbla_override():
     # Check that our xerbla has been successfully linked in. If it is not,
     # the default xerbla routine is called, which prints a message to stdout

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -9,6 +9,7 @@ pytest-cov==4.1.0
 meson
 ninja; sys_platform != "emscripten"
 pytest-xdist
+pytest-timeout
 # for numpy.random.test.test_extending
 cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -46,5 +46,8 @@ fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across
 # the available N CPU cores: 2 by default for Linux instances and 4 for macOS arm64
-python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto']))"
+# Also set a 30 minute timeout in case of test hangs and on success, print the
+# durations for the 10 slowests tests to help with debugging slow or hanging
+# tests
+python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto', '--timeout=1800', '--durations=10']))"
 python $PROJECT_DIR/tools/wheels/check_license.py


### PR DESCRIPTION
This is an attempt to track down the hang reported in #27872.

`pytest-timeout` sets a per-test timeout that also prints a C stack trace if it kills a timed out test runner. It looks like a few years ago there were issues using pytest-timeout and pytest-xdist together, but they seem to have been fixed.

I added it to `test-requirements.txt` since it's a pure-python dependency and should be harmless even if it's not needed. I can also just `pip install` it in the wheel testing script if that would be preferred.

I'm passing `--durations` and `--timeout` for all the wheel builds because it seems useful to me to always have this information and to always timeout if a single test takes longer than 30 minutes. I can also just do it for the free-threaded build if reviewers would prefer only doing it there.