### PR TITLE
MAINT: simplify power fast path logic

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -586,6 +586,12 @@ class BinaryBench(Benchmark):
     def time_pow_half(self, dtype):
         np.power(self.a, 0.5)
 
+    def time_pow_2_op(self, dtype):
+        self.a ** 2
+
+    def time_pow_half_op(self, dtype):
+        self.a ** 0.5
+
     def time_atan2(self, dtype):
         np.arctan2(self.a, self.b)
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -337,7 +337,7 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 
     PyArrayObject *a1 = (PyArrayObject *)o1;
     if (PyArray_ISOBJECT(a1)) {
-        return -1;
+        return 1;
     }
 
     PyObject *fastop = NULL;
@@ -354,7 +354,7 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
             fastop = n_ops.square;
         }
         else {
-            return -1;
+            return 1;
         }
     }
     else if (PyFloat_CheckExact(o2)) {
@@ -367,11 +367,11 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
             fastop = n_ops.sqrt;
         }
         else {
-            return -1;
+            return 1;
         }
     }
     else {
-        return -1;
+        return 1;
     }
 
     if (inplace || can_elide_temp_unary(a1)) {

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -363,7 +363,7 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
     }
 
     PyArrayObject *a1 = (PyArrayObject *)o1;
-    if (PyArray_ISOBJECT(a1)) {
+    if (!(PyArray_ISFLOAT(a1) || PyArray_ISCOMPLEX(a1))) {
         return 1;
     }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -328,55 +328,6 @@ array_inplace_matrix_multiply(PyArrayObject *self, PyObject *other)
     return res;
 }
 
-static int
-fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
-{
-    PyObject *fastop = NULL;
-    if (PyLong_CheckExact(o2)) {
-        int overflow = 0;
-        long exp = PyLong_AsLongAndOverflow(o2, &overflow);
-        if (overflow != 0) {
-            return -1;
-        }
-
-        if (exp == -1) {
-            fastop = n_ops.reciprocal;
-        }
-        else if (exp == 2) {
-            fastop = n_ops.square;
-        }
-        else {
-            return 1;
-        }
-    }
-    else if (PyFloat_CheckExact(o2)) {
-        double exp = PyFloat_AsDouble(o2);
-        if (exp == 0.5) {
-            fastop = n_ops.sqrt;
-        }
-        else {
-            return 1;
-        }
-    }
-    else {
-        return 1;
-    }
-
-    PyArrayObject *a1 = (PyArrayObject *)o1;
-    if (PyArray_ISOBJECT(a1)) {
-        return 1;
-    }
-
-    if (inplace || can_elide_temp_unary(a1)) {
-        *result = PyArray_GenericInplaceUnaryFunction(a1, fastop);
-    }
-    else {
-        *result = PyArray_GenericUnaryFunction(a1, fastop);
-    }
-
-    return 0;
-}
-
 static PyObject *
 array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
 {
@@ -389,9 +340,7 @@ array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
     }
 
     BINOP_GIVE_UP_IF_NEEDED(a1, o2, nb_power, array_power);
-    if (fast_scalar_power(a1, o2, 0, &value) != 0) {
-        value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
-    }
+    value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
     return value;
 }
 
@@ -531,9 +480,7 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
 
     INPLACE_GIVE_UP_IF_NEEDED(
             a1, o2, nb_inplace_power, array_inplace_power);
-    if (fast_scalar_power((PyObject *) a1, o2, 1, &value) != 0) {
-        value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
-    }
+    value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
     return value;
 }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -342,9 +342,10 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 
     PyObject *fastop = NULL;
     if (PyLong_CheckExact(o2)) {
-        long exp = PyLong_AsLong(o2);
-        if (error_converting(exp)) {
-            PyErr_Clear();
+        int overflow = 0;
+        long exp = PyLong_AsLongAndOverflow(o2, &overflow);
+        if (overflow != 0) {
+            return -1;
         }
 
         if (exp == -1) {
@@ -359,10 +360,6 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
     }
     else if (PyFloat_CheckExact(o2)) {
         double exp = PyFloat_AsDouble(o2);
-        if (error_converting(exp)) {
-            PyErr_Clear();
-        }
-
         if (exp == 0.5) {
             fastop = n_ops.sqrt;
         }

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -328,6 +328,62 @@ array_inplace_matrix_multiply(PyArrayObject *self, PyObject *other)
     return res;
 }
 
+static int
+fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
+{
+    if (!PyArray_Check(o1)) {
+        return -1;
+    }
+
+    PyArrayObject *a1 = (PyArrayObject *)o1;
+    if (PyArray_ISOBJECT(a1)) {
+        return -1;
+    }
+
+    PyObject *fastop = NULL;
+    if (PyLong_CheckExact(o2)) {
+        long exp = PyLong_AsLong(o2);
+        if (error_converting(exp)) {
+            PyErr_Clear();
+        }
+
+        if (exp == -1) {
+            fastop = n_ops.reciprocal;
+        }
+        else if (exp == 2) {
+            fastop = n_ops.square;
+        }
+        else {
+            return -1;
+        }
+    }
+    else if (PyFloat_CheckExact(o2)) {
+        double exp = PyFloat_AsDouble(o2);
+        if (error_converting(exp)) {
+            PyErr_Clear();
+        }
+
+        if (exp == 0.5) {
+            fastop = n_ops.sqrt;
+        }
+        else {
+            return -1;
+        }
+    }
+    else {
+        return -1;
+    }
+
+    if (inplace || can_elide_temp_unary(a1)) {
+        *result = PyArray_GenericInplaceUnaryFunction(a1, fastop);
+    }
+    else {
+        *result = PyArray_GenericUnaryFunction(a1, fastop);
+    }
+
+    return 0;
+}
+
 static PyObject *
 array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
 {
@@ -340,7 +396,9 @@ array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
     }
 
     BINOP_GIVE_UP_IF_NEEDED(a1, o2, nb_power, array_power);
-    value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
+    if (fast_scalar_power(a1, o2, 0, &value) != 0) {
+        value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
+    }
     return value;
 }
 
@@ -480,7 +538,9 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
 
     INPLACE_GIVE_UP_IF_NEEDED(
             a1, o2, nb_inplace_power, array_inplace_power);
-    value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
+    if (fast_scalar_power((PyObject *) a1, o2, 1, &value) != 0) {
+        value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
+    }
     return value;
 }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -331,15 +331,6 @@ array_inplace_matrix_multiply(PyArrayObject *self, PyObject *other)
 static int
 fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 {
-    if (!PyArray_Check(o1)) {
-        return -1;
-    }
-
-    PyArrayObject *a1 = (PyArrayObject *)o1;
-    if (PyArray_ISOBJECT(a1)) {
-        return 1;
-    }
-
     PyObject *fastop = NULL;
     if (PyLong_CheckExact(o2)) {
         int overflow = 0;
@@ -368,6 +359,11 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
         }
     }
     else {
+        return 1;
+    }
+
+    PyArrayObject *a1 = (PyArrayObject *)o1;
+    if (PyArray_ISOBJECT(a1)) {
         return 1;
     }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -328,167 +328,6 @@ array_inplace_matrix_multiply(PyArrayObject *self, PyObject *other)
     return res;
 }
 
-/*
- * Determine if object is a scalar and if so, convert the object
- * to a double and place it in the out_exponent argument
- * and return the "scalar kind" as a result.   If the object is
- * not a scalar (or if there are other error conditions)
- * return NPY_NOSCALAR, and out_exponent is undefined.
- */
-static NPY_SCALARKIND
-is_scalar_with_conversion(PyObject *o2, double* out_exponent)
-{
-    PyObject *temp;
-    const int optimize_fpexps = 1;
-
-    if (PyLong_Check(o2)) {
-        long tmp = PyLong_AsLong(o2);
-        if (error_converting(tmp)) {
-            PyErr_Clear();
-            return NPY_NOSCALAR;
-        }
-        *out_exponent = (double)tmp;
-        return NPY_INTPOS_SCALAR;
-    }
-
-    if (optimize_fpexps && PyFloat_Check(o2)) {
-        *out_exponent = PyFloat_AsDouble(o2);
-        return NPY_FLOAT_SCALAR;
-    }
-
-    if (PyArray_Check(o2)) {
-        if ((PyArray_NDIM((PyArrayObject *)o2) == 0) &&
-                ((PyArray_ISINTEGER((PyArrayObject *)o2) ||
-                 (optimize_fpexps && PyArray_ISFLOAT((PyArrayObject *)o2))))) {
-            temp = Py_TYPE(o2)->tp_as_number->nb_float(o2);
-            if (temp == NULL) {
-                return NPY_NOSCALAR;
-            }
-            *out_exponent = PyFloat_AsDouble(o2);
-            Py_DECREF(temp);
-            if (PyArray_ISINTEGER((PyArrayObject *)o2)) {
-                return NPY_INTPOS_SCALAR;
-            }
-            else { /* ISFLOAT */
-                return NPY_FLOAT_SCALAR;
-            }
-        }
-    }
-    else if (PyArray_IsScalar(o2, Integer) ||
-                (optimize_fpexps && PyArray_IsScalar(o2, Floating))) {
-        temp = Py_TYPE(o2)->tp_as_number->nb_float(o2);
-        if (temp == NULL) {
-            return NPY_NOSCALAR;
-        }
-        *out_exponent = PyFloat_AsDouble(o2);
-        Py_DECREF(temp);
-
-        if (PyArray_IsScalar(o2, Integer)) {
-                return NPY_INTPOS_SCALAR;
-        }
-        else { /* IsScalar(o2, Floating) */
-            return NPY_FLOAT_SCALAR;
-        }
-    }
-    else if (PyIndex_Check(o2)) {
-        PyObject* value = PyNumber_Index(o2);
-        Py_ssize_t val;
-        if (value == NULL) {
-            if (PyErr_Occurred()) {
-                PyErr_Clear();
-            }
-            return NPY_NOSCALAR;
-        }
-        val = PyLong_AsSsize_t(value);
-        Py_DECREF(value);
-        if (error_converting(val)) {
-            PyErr_Clear();
-            return NPY_NOSCALAR;
-        }
-        *out_exponent = (double) val;
-        return NPY_INTPOS_SCALAR;
-    }
-    return NPY_NOSCALAR;
-}
-
-/*
- * optimize float array or complex array to a scalar power
- * returns 0 on success, -1 if no optimization is possible
- * the result is in value (can be NULL if an error occurred)
- */
-static int
-fast_scalar_power(PyObject *o1, PyObject *o2, int inplace,
-                  PyObject **value)
-{
-    double exponent;
-    NPY_SCALARKIND kind;   /* NPY_NOSCALAR is not scalar */
-
-    if (PyArray_Check(o1) &&
-            !PyArray_ISOBJECT((PyArrayObject *)o1) &&
-            ((kind=is_scalar_with_conversion(o2, &exponent))>0)) {
-        PyArrayObject *a1 = (PyArrayObject *)o1;
-        PyObject *fastop = NULL;
-        if (PyArray_ISFLOAT(a1) || PyArray_ISCOMPLEX(a1)) {
-            if (exponent == 1.0) {
-                fastop = n_ops.positive;
-            }
-            else if (exponent == -1.0) {
-                fastop = n_ops.reciprocal;
-            }
-            else if (exponent ==  0.0) {
-                fastop = n_ops._ones_like;
-            }
-            else if (exponent ==  0.5) {
-                fastop = n_ops.sqrt;
-            }
-            else if (exponent ==  2.0) {
-                fastop = n_ops.square;
-            }
-            else {
-                return -1;
-            }
-
-            if (inplace || can_elide_temp_unary(a1)) {
-                *value = PyArray_GenericInplaceUnaryFunction(a1, fastop);
-            }
-            else {
-                *value = PyArray_GenericUnaryFunction(a1, fastop);
-            }
-            return 0;
-        }
-        /* Because this is called with all arrays, we need to
-         *  change the output if the kind of the scalar is different
-         *  than that of the input and inplace is not on ---
-         *  (thus, the input should be up-cast)
-         */
-        else if (exponent == 2.0) {
-            fastop = n_ops.square;
-            if (inplace) {
-                *value = PyArray_GenericInplaceUnaryFunction(a1, fastop);
-            }
-            else {
-                /* We only special-case the FLOAT_SCALAR and integer types */
-                if (kind == NPY_FLOAT_SCALAR && PyArray_ISINTEGER(a1)) {
-                    PyArray_Descr *dtype = PyArray_DescrFromType(NPY_DOUBLE);
-                    a1 = (PyArrayObject *)PyArray_CastToType(a1, dtype,
-                            PyArray_ISFORTRAN(a1));
-                    if (a1 != NULL) {
-                        /* cast always creates a new array */
-                        *value = PyArray_GenericInplaceUnaryFunction(a1, fastop);
-                        Py_DECREF(a1);
-                    }
-                }
-                else {
-                    *value = PyArray_GenericUnaryFunction(a1, fastop);
-                }
-            }
-            return 0;
-        }
-    }
-    /* no fast operation found */
-    return -1;
-}
-
 static PyObject *
 array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
 {
@@ -501,9 +340,7 @@ array_power(PyObject *a1, PyObject *o2, PyObject *modulo)
     }
 
     BINOP_GIVE_UP_IF_NEEDED(a1, o2, nb_power, array_power);
-    if (fast_scalar_power(a1, o2, 0, &value) != 0) {
-        value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
-    }
+    value = PyArray_GenericBinaryFunction(a1, o2, n_ops.power);
     return value;
 }
 
@@ -643,9 +480,7 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
 
     INPLACE_GIVE_UP_IF_NEEDED(
             a1, o2, nb_inplace_power, array_inplace_power);
-    if (fast_scalar_power((PyObject *)a1, o2, 1, &value) != 0) {
-        value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
-    }
+    value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
     return value;
 }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -532,7 +532,7 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
     INPLACE_GIVE_UP_IF_NEEDED(
             a1, o2, nb_inplace_power, array_inplace_power);
 
-    if (fast_scalar_power(a1, o2, 1, &value) != 0) {
+    if (fast_scalar_power((PyObject *) a1, o2, 1, &value) != 0) {
         value = PyArray_GenericInplaceBinaryFunction(a1, o2, n_ops.power);
     }
     return value;

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -489,10 +489,7 @@ _@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int firs
 static inline @type@
 _@TYPE@_power_fast_path_helper(@type@ in1, @type@ in2, @type@ *op1) {
     // Fast path for power calculation
-    if (in1 == 1) {
-        *op1 = 1;
-    }
-    else if (in2 == 0 && in1 != 0) {
+    if (in2 == 0 || in1 == 1) {
         *op1 = 1;
     }
     else if (in2 == 1) {
@@ -527,17 +524,11 @@ NPY_NO_EXPORT void
         int first_bit = in2 & 1;
         @type@ in2start = in2 >> 1;
 
-        if (in2 == 0 || in2 == 1 || in2 == 2) {
-            BINARY_LOOP_SLIDING {
-                @type@ in1 = *(@type@ *)ip1;
-                if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-                    *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
-                }
-            }
-        }
-        else {
-            BINARY_LOOP_SLIDING {
-                @type@ in1 = *(@type@ *)ip1;
+        int fastop_exists = 1;
+        BINARY_LOOP_SLIDING {
+            @type@ in1 = *(@type@ *)ip1;
+            if (fastop_exists && _@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
+                fastop_exists = 0;
                 *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
             }
         }

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -489,13 +489,6 @@ _@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int firs
 static inline @type@
 _@TYPE@_power_fast_path_helper(@type@ in1, @type@ in2, @type@ *op1) {
     // Fast path for power calculation
-    #if @SIGNED@
-        if (in2 < 0) {
-            npy_gil_error(PyExc_ValueError,
-                            "Integers to negative integer powers are not allowed.");
-            return 0;
-        }
-    #endif
     if (in1 == 1) {
         *op1 = 1;
     }
@@ -523,12 +516,28 @@ NPY_NO_EXPORT void
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
 
+#if @SIGNED@
+        if (in2 < 0) {
+            npy_gil_error(PyExc_ValueError,
+                            "Integers to negative integer powers are not allowed.");
+            return;
+        }
+#endif
+
         int first_bit = in2 & 1;
         @type@ in2start = in2 >> 1;
 
-        BINARY_LOOP_SLIDING {
-            @type@ in1 = *(@type@ *)ip1;
-            if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
+        if (in2 == 0 || in2 == 1 || in2 == 2) {
+            BINARY_LOOP {
+                @type@ in1 = *(@type@ *)ip1;
+                if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
+                    *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
+                }
+            }
+        }
+        else {
+            BINARY_LOOP_SLIDING {
+                @type@ in1 = *(@type@ *)ip1;
                 *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
             }
         }
@@ -537,6 +546,14 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;
+
+#if @SIGNED@
+        if (in2 < 0) {
+            npy_gil_error(PyExc_ValueError,
+                            "Integers to negative integer powers are not allowed.");
+            return;
+        }
+#endif
 
         if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
             int first_bit = in2 & 1;

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -525,15 +525,25 @@ NPY_NO_EXPORT void
         if (in2 == 0) {
             *((@type@ *)op1) = 1;
             continue;
+        } 
+        else if (in2 == 1)
+        {
+            *((@type@ *)op1) = *(@type@ *)ip1;
         }
-        if (in1 == 1) {
+        else if (in2 == 2)
+        {
+            *((@type@ *)op1) = *(@type@ *)ip1 * *(@type@ *)ip1;
+        }
+        else if (in1 == 1) {
             *((@type@ *)op1) = 1;
             continue;
         }
-
-        int first_bit = in2 & 1;
-        in2 >>= 1;
-        *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);
+        else
+        {
+            int first_bit = in2 & 1;
+            in2 >>= 1;
+            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);
+        }
     }
 }
 /**end repeat**/

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -493,7 +493,7 @@ _@TYPE@_power_fast_path_helper(@type@ in1, @type@ in2, @type@ *op1) {
         if (in2 < 0) {
             npy_gil_error(PyExc_ValueError,
                             "Integers to negative integer powers are not allowed.");
-            return;
+            return 0;
         }
     #endif
     if (in1 == 1) {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -530,7 +530,9 @@ NPY_NO_EXPORT void
         if (in2 == 0 || in2 == 1 || in2 == 2) {
             BINARY_LOOP_SLIDING {
                 @type@ in1 = *(@type@ *)ip1;
-                _@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1)
+                if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
+                    *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
+                }
             }
         }
         else {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -528,11 +528,9 @@ NPY_NO_EXPORT void
         @type@ in2start = in2 >> 1;
 
         if (in2 == 0 || in2 == 1 || in2 == 2) {
-            BINARY_LOOP {
+            BINARY_LOOP_SLIDING {
                 @type@ in1 = *(@type@ *)ip1;
-                if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-                    *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
-                }
+                _@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1)
             }
         }
         else {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -524,11 +524,14 @@ NPY_NO_EXPORT void
         int first_bit = in2 & 1;
         @type@ in2start = in2 >> 1;
 
-        int fastop_exists = 1;
+        int fastop_exists = (in2 == 0) || (in2 == 1) || (in2 == 2);
+        
         BINARY_LOOP_SLIDING {
             @type@ in1 = *(@type@ *)ip1;
-            if (fastop_exists && _@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-                fastop_exists = 0;
+            if (fastop_exists) {
+                _@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1);
+            }
+            else {
                 *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
             }
         }

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -523,14 +523,13 @@ NPY_NO_EXPORT void
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
 
-        @type@ in2_working = in2;
-        int first_bit = in2_working & 1;
-        in2_working >>= 1;
+        int first_bit = in2 & 1;
+        @type@ in2start = in2 >> 1;
 
         BINARY_LOOP_SLIDING {
             @type@ in1 = *(@type@ *)ip1;
             if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-                *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2_working, first_bit);
+                *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
             }
         }
         return;
@@ -538,12 +537,11 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;
-        @type@ in2_working = in2;
 
         if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-            int first_bit = in2_working & 1;
-            in2_working >>= 1;
-            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2_working, first_bit);
+            int first_bit = in2 & 1;
+            in2 >>= 1;
+            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);
         }
     }
 }

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -522,22 +522,15 @@ NPY_NO_EXPORT void
         // stride for second argument is 0
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
-        #if @SIGNED@
-            if (in2 < 0) {
-                npy_gil_error(PyExc_ValueError,
-                              "Integers to negative integer powers are not allowed.");
-                return;
-            }
-        #endif
 
-        int first_bit = in2 & 1;
-        @type@ in2start = in2 >> 1;
+        @type@ in2_working = in2;
+        int first_bit = in2_working & 1;
+        in2_working >>= 1;
 
         BINARY_LOOP_SLIDING {
             @type@ in1 = *(@type@ *)ip1;
-
-            if (_@TYPE@_power_fast_path_helper(in1, in2start, (@type@ *)op1) != 0) {
-                *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
+            if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
+                *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2_working, first_bit);
             }
         }
         return;
@@ -545,11 +538,12 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;
+        @type@ in2_working = in2;
 
         if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
-            int first_bit = in2 & 1;
-            in2 >>= 1;
-            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);
+            int first_bit = in2_working & 1;
+            in2_working >>= 1;
+            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2_working, first_bit);
         }
     }
 }

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -499,7 +499,7 @@ _@TYPE@_power_fast_path_helper(@type@ in1, @type@ in2, @type@ *op1) {
     if (in1 == 1) {
         *op1 = 1;
     }
-    else if (in2 == 0 & in1 != 0) {
+    else if (in2 == 0 && in1 != 0) {
         *op1 = 1;
     }
     else if (in2 == 1) {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -524,19 +524,17 @@ NPY_NO_EXPORT void
 #endif
         if (in2 == 0) {
             *((@type@ *)op1) = 1;
-            continue;
         } 
         else if (in2 == 1)
         {
-            *((@type@ *)op1) = *(@type@ *)ip1;
+            *((@type@ *)op1) = in1;
         }
         else if (in2 == 2)
         {
-            *((@type@ *)op1) = *(@type@ *)ip1 * *(@type@ *)ip1;
+            *((@type@ *)op1) = in1 * in1;
         }
         else if (in1 == 1) {
             *((@type@ *)op1) = 1;
-            continue;
         }
         else
         {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -486,6 +486,35 @@ _@TYPE@_squared_exponentiation_helper(@type@ base, @type@ exponent_two, int firs
    return out;
 }
 
+static inline @type@
+_@TYPE@_power_fast_path_helper(@type@ in1, @type@ in2, @type@ *op1) {
+    // Fast path for power calculation
+    #if @SIGNED@
+        if (in2 < 0) {
+            npy_gil_error(PyExc_ValueError,
+                            "Integers to negative integer powers are not allowed.");
+            return;
+        }
+    #endif
+    if (in1 == 1) {
+        *op1 = 1;
+    }
+    else if (in2 == 0 & in1 != 0) {
+        *op1 = 1;
+    }
+    else if (in2 == 1) {
+        *op1 = in1;
+    }
+    else if (in2 == 2) {
+        *op1 = in1 * in1;
+    }
+    else {
+        return 1;
+    }
+    return 0;
+}
+
+
 NPY_NO_EXPORT void
 @TYPE@_power(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
@@ -507,7 +536,9 @@ NPY_NO_EXPORT void
         BINARY_LOOP_SLIDING {
             @type@ in1 = *(@type@ *)ip1;
 
-            *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
+            if (_@TYPE@_power_fast_path_helper(in1, in2start, (@type@ *)op1) != 0) {
+                *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2start, first_bit);
+            }
         }
         return;
     }
@@ -515,29 +546,7 @@ NPY_NO_EXPORT void
         @type@ in1 = *(@type@ *)ip1;
         @type@ in2 = *(@type@ *)ip2;
 
-#if @SIGNED@
-        if (in2 < 0) {
-            npy_gil_error(PyExc_ValueError,
-                          "Integers to negative integer powers are not allowed.");
-            return;
-        }
-#endif
-        if (in2 == 0) {
-            *((@type@ *)op1) = 1;
-        } 
-        else if (in2 == 1)
-        {
-            *((@type@ *)op1) = in1;
-        }
-        else if (in2 == 2)
-        {
-            *((@type@ *)op1) = in1 * in1;
-        }
-        else if (in1 == 1) {
-            *((@type@ *)op1) = 1;
-        }
-        else
-        {
+        if (_@TYPE@_power_fast_path_helper(in1, in2, (@type@ *)op1) != 0) {
             int first_bit = in2 & 1;
             in2 >>= 1;
             *((@type@ *) op1) = _@TYPE@_squared_exponentiation_helper(in1, in2, first_bit);

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -239,31 +239,30 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     if (stride_zero) {
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
-        if (in2 == 0.0) {
-            BINARY_LOOP_SLIDING {
+        int fastop_found = 1;
+        BINARY_LOOP_SLIDING {
+            const @type@ in1 = *(@type@ *)ip1;
+            if (in2 == -1.0) {
+                *(@type@ *)op1 = 1.0 / in1;
+            }
+            else if (in2 == 0.0) {
                 *(@type@ *)op1 = 1.0;
             }
-            return;
-        }
-        else if (in2 == 0.5) {
-            BINARY_LOOP_SLIDING {
-                const @type@ in1 = *(@type@ *)ip1;
-                *(@type@ *)op1 = sqrt(in1);
+            else if (in2 == 0.5) {
+                *(@type@ *)op1 = @sqrt@(in1);
             }
-            return;
-        }
-        else if (in2 == 1.0) {
-            BINARY_LOOP_SLIDING {
-                const @type@ in1 = *(@type@ *)ip1;
+            else if (in2 == 1.0) {
                 *(@type@ *)op1 = in1;
             }
-            return;
-        }
-        else if (in2 == 2.0) {
-            BINARY_LOOP_SLIDING {
-                const @type@ in1 = *(@type@ *)ip1;
+            else if (in2 == 2.0) {
                 *(@type@ *)op1 = in1 * in1;
             }
+            else {
+                fastop_found = 0;
+                break;
+            }
+        }
+        if (fastop_found) {
             return;
         }
     }

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -239,7 +239,27 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     if (stride_zero) {
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
-        if (in2 == 2.0) {
+        if (in2 == 0.0) {
+            BINARY_LOOP_SLIDING {
+                *(@type@ *)op1 = 1.0;
+            }
+            return;
+        }
+        else if (in2 == 0.5) {
+            BINARY_LOOP_SLIDING {
+                const @type@ in1 = *(@type@ *)ip1;
+                *(@type@ *)op1 = sqrt(in1);
+            }
+            return;
+        }
+        else if (in2 == 1.0) {
+            BINARY_LOOP_SLIDING {
+                const @type@ in1 = *(@type@ *)ip1;
+                *(@type@ *)op1 = in1;
+            }
+            return;
+        }
+        else if (in2 == 2.0) {
             BINARY_LOOP_SLIDING {
                 const @type@ in1 = *(@type@ *)ip1;
                 *(@type@ *)op1 = in1 * in1;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4123,27 +4123,6 @@ class TestBinop:
         assert_equal(A[0], 30)
         assert_(isinstance(A, OutClass))
 
-    def test_pow_override_with_errors(self):
-        # regression test for gh-9112
-        class PowerOnly(np.ndarray):
-            def __array_ufunc__(self, ufunc, method, *inputs, **kw):
-                if ufunc is not np.power:
-                    raise NotImplementedError
-                return "POWER!"
-        # explicit cast to float, to ensure the fast power path is taken.
-        a = np.array(5., dtype=np.float64).view(PowerOnly)
-        assert_equal(a ** 2.5, "POWER!")
-        with assert_raises(NotImplementedError):
-            a ** 0.5
-        with assert_raises(NotImplementedError):
-            a ** 0
-        with assert_raises(NotImplementedError):
-            a ** 1
-        with assert_raises(NotImplementedError):
-            a ** -1
-        with assert_raises(NotImplementedError):
-            a ** 2
-
     def test_pow_array_object_dtype(self):
         # test pow on arrays of object dtype
         class SomeClass:

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -6,8 +6,12 @@ import pytest
 import numpy as np
 from numpy import linalg, arange, float64, array, dot, transpose
 from numpy.testing import (
-    assert_, assert_raises, assert_equal, assert_array_equal,
-    assert_array_almost_equal, assert_array_less
+    assert_,
+    assert_raises,
+    assert_equal,
+    assert_array_equal,
+    assert_array_almost_equal,
+    assert_array_less,
 )
 
 
@@ -15,19 +19,23 @@ class TestRegression:
 
     def test_eig_build(self):
         # Ticket #652
-        rva = array([1.03221168e+02 + 0.j,
-                     -1.91843603e+01 + 0.j,
-                     -6.04004526e-01 + 15.84422474j,
-                     -6.04004526e-01 - 15.84422474j,
-                     -1.13692929e+01 + 0.j,
-                     -6.57612485e-01 + 10.41755503j,
-                     -6.57612485e-01 - 10.41755503j,
-                     1.82126812e+01 + 0.j,
-                     1.06011014e+01 + 0.j,
-                     7.80732773e+00 + 0.j,
-                     -7.65390898e-01 + 0.j,
-                     1.51971555e-15 + 0.j,
-                     -1.51308713e-15 + 0.j])
+        rva = array(
+            [
+                1.03221168e02 + 0.0j,
+                -1.91843603e01 + 0.0j,
+                -6.04004526e-01 + 15.84422474j,
+                -6.04004526e-01 - 15.84422474j,
+                -1.13692929e01 + 0.0j,
+                -6.57612485e-01 + 10.41755503j,
+                -6.57612485e-01 - 10.41755503j,
+                1.82126812e01 + 0.0j,
+                1.06011014e01 + 0.0j,
+                7.80732773e00 + 0.0j,
+                -7.65390898e-01 + 0.0j,
+                1.51971555e-15 + 0.0j,
+                -1.51308713e-15 + 0.0j,
+            ]
+        )
         a = arange(13 * 13, dtype=float64)
         a.shape = (13, 13)
         a = a % 17
@@ -40,16 +48,20 @@ class TestRegression:
         # Ticket 662.
         rvals = [68.60568999, 89.57756725, 106.67185574]
 
-        cov = array([[77.70273908,   3.51489954,  15.64602427],
-                     [3.51489954,  88.97013878,  -1.07431931],
-                     [15.64602427,  -1.07431931,  98.18223512]])
+        cov = array(
+            [
+                [77.70273908, 3.51489954, 15.64602427],
+                [3.51489954, 88.97013878, -1.07431931],
+                [15.64602427, -1.07431931, 98.18223512],
+            ]
+        )
 
         vals, vecs = linalg.eigh(cov)
         assert_array_almost_equal(vals, rvals)
 
     def test_svd_build(self):
         # Ticket 627.
-        a = array([[0., 1.], [1., 1.], [2., 1.], [3., 1.]])
+        a = array([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [3.0, 1.0]])
         m, n = a.shape
         u, s, vh = linalg.svd(a)
 
@@ -60,13 +72,12 @@ class TestRegression:
     def test_norm_vector_badarg(self):
         # Regression for #786: Frobenius norm for vectors raises
         # ValueError.
-        assert_raises(ValueError, linalg.norm, array([1., 2., 3.]), 'fro')
+        assert_raises(ValueError, linalg.norm, array([1.0, 2.0, 3.0]), "fro")
 
     def test_lapack_endian(self):
         # For bug #1482
-        a = array([[5.7998084,  -2.1825367],
-                   [-2.1825367,   9.85910595]], dtype='>f8')
-        b = array(a, dtype='<f8')
+        a = array([[5.7998084, -2.1825367], [-2.1825367, 9.85910595]], dtype=">f8")
+        b = array(a, dtype="<f8")
 
         ap = linalg.cholesky(a)
         bp = linalg.cholesky(b)
@@ -97,42 +108,42 @@ class TestRegression:
 
         norm = linalg.norm(testvector)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype('float64'))
+        assert_(norm.dtype == np.dtype("float64"))
 
         norm = linalg.norm(testvector, ord=1)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype != np.dtype('float64'))
+        assert_(norm.dtype != np.dtype("float64"))
 
         norm = linalg.norm(testvector, ord=2)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype('float64'))
+        assert_(norm.dtype == np.dtype("float64"))
 
-        for ord in ['fro', 'nuc', np.inf, -np.inf, 0, -1, -2]:
-            pytest.raises(
-                (ValueError, ZeroDivisionError, RuntimeWarning),
-                linalg.norm,
-                testvector,
-                ord=ord,
-            )
+        assert_raises(ValueError, linalg.norm, testvector, ord='fro')
+        assert_raises(ValueError, linalg.norm, testvector, ord='nuc')
+        assert_raises(ValueError, linalg.norm, testvector, ord=np.inf)
+        assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
+        assert_raises(ValueError, linalg.norm, testvector, ord=0)
+        assert_raises(ValueError, linalg.norm, testvector, ord=-1)
 
-        testmatrix = np.array([[np.array([0, 1]), 0, 0],
-                               [0,                0, 0]], dtype=object)
+        testmatrix = np.array([[np.array([0, 1]), 0, 0], [0, 0, 0]], dtype=object)
 
         norm = linalg.norm(testmatrix)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype('float64'))
+        assert_(norm.dtype == np.dtype("float64"))
 
-        norm = linalg.norm(testmatrix, ord='fro')
+        norm = linalg.norm(testmatrix, ord="fro")
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype('float64'))
+        assert_(norm.dtype == np.dtype("float64"))
 
-        for ord in ['nuc', np.inf, -np.inf, 0, 1, -1, 2, -2, 3]:
-            pytest.raises(
-                (ValueError, TypeError, ZeroDivisionError, RuntimeWarning),
-                linalg.norm,
-                testmatrix,
-                ord=ord,
-            )
+        assert_raises(TypeError, linalg.norm, testmatrix, ord='nuc')
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=np.inf)
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=-np.inf)
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=0)
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=1)
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=-1)
+        assert_raises(TypeError, linalg.norm, testmatrix, ord=2)
+        assert_raises(TypeError, linalg.norm, testmatrix, ord=-2)
+        assert_raises(ValueError, linalg.norm, testmatrix, ord=3)
 
     def test_lstsq_complex_larger_rhs(self):
         # gh-9891
@@ -164,12 +175,14 @@ class TestRegression:
         # Test whether matrix multiplication involving a large matrix always
         # gives the same (correct) answer
         x = np.arange(500000, dtype=np.float64)
-        src = np.vstack((x, -10*x)).T
+        src = np.vstack((x, -10 * x)).T
         matrix = np.array([[0, 1], [1, 0]])
-        expected = np.vstack((-10*x, x)).T  # src @ matrix
+        expected = np.vstack((-10 * x, x)).T  # src @ matrix
         for i in range(200):
             result = src @ matrix
             mismatches = (~np.isclose(result, expected)).sum()
             if mismatches != 0:
-                assert False, ("unexpected result from matmul, "
-                    "probably due to OpenBLAS threading issues")
+                assert False, (
+                    "unexpected result from matmul, "
+                    "probably due to OpenBLAS threading issues"
+                )

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -112,7 +112,7 @@ class TestRegression:
         assert_raises(ValueError, linalg.norm, testvector, ord=np.inf)
         assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
         assert_raises(ValueError, linalg.norm, testvector, ord=0)
-        assert_raises(ValueError, linalg.norm, testvector, ord=-1)
+        assert_raises(RuntimeWarning, linalg.norm, testvector, ord=-1)
         assert_raises(ValueError, linalg.norm, testvector, ord=-2)
 
         testmatrix = np.array([[np.array([0, 1]), 0, 0],

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -6,12 +6,8 @@ import pytest
 import numpy as np
 from numpy import linalg, arange, float64, array, dot, transpose
 from numpy.testing import (
-    assert_,
-    assert_raises,
-    assert_equal,
-    assert_array_equal,
-    assert_array_almost_equal,
-    assert_array_less,
+    assert_, assert_raises, assert_equal, assert_array_equal,
+    assert_array_almost_equal, assert_array_less
 )
 
 
@@ -19,23 +15,19 @@ class TestRegression:
 
     def test_eig_build(self):
         # Ticket #652
-        rva = array(
-            [
-                1.03221168e02 + 0.0j,
-                -1.91843603e01 + 0.0j,
-                -6.04004526e-01 + 15.84422474j,
-                -6.04004526e-01 - 15.84422474j,
-                -1.13692929e01 + 0.0j,
-                -6.57612485e-01 + 10.41755503j,
-                -6.57612485e-01 - 10.41755503j,
-                1.82126812e01 + 0.0j,
-                1.06011014e01 + 0.0j,
-                7.80732773e00 + 0.0j,
-                -7.65390898e-01 + 0.0j,
-                1.51971555e-15 + 0.0j,
-                -1.51308713e-15 + 0.0j,
-            ]
-        )
+        rva = array([1.03221168e+02 + 0.j,
+                     -1.91843603e+01 + 0.j,
+                     -6.04004526e-01 + 15.84422474j,
+                     -6.04004526e-01 - 15.84422474j,
+                     -1.13692929e+01 + 0.j,
+                     -6.57612485e-01 + 10.41755503j,
+                     -6.57612485e-01 - 10.41755503j,
+                     1.82126812e+01 + 0.j,
+                     1.06011014e+01 + 0.j,
+                     7.80732773e+00 + 0.j,
+                     -7.65390898e-01 + 0.j,
+                     1.51971555e-15 + 0.j,
+                     -1.51308713e-15 + 0.j])
         a = arange(13 * 13, dtype=float64)
         a.shape = (13, 13)
         a = a % 17
@@ -48,20 +40,16 @@ class TestRegression:
         # Ticket 662.
         rvals = [68.60568999, 89.57756725, 106.67185574]
 
-        cov = array(
-            [
-                [77.70273908, 3.51489954, 15.64602427],
-                [3.51489954, 88.97013878, -1.07431931],
-                [15.64602427, -1.07431931, 98.18223512],
-            ]
-        )
+        cov = array([[77.70273908,   3.51489954,  15.64602427],
+                     [3.51489954,  88.97013878,  -1.07431931],
+                     [15.64602427,  -1.07431931,  98.18223512]])
 
         vals, vecs = linalg.eigh(cov)
         assert_array_almost_equal(vals, rvals)
 
     def test_svd_build(self):
         # Ticket 627.
-        a = array([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [3.0, 1.0]])
+        a = array([[0., 1.], [1., 1.], [2., 1.], [3., 1.]])
         m, n = a.shape
         u, s, vh = linalg.svd(a)
 
@@ -72,12 +60,13 @@ class TestRegression:
     def test_norm_vector_badarg(self):
         # Regression for #786: Frobenius norm for vectors raises
         # ValueError.
-        assert_raises(ValueError, linalg.norm, array([1.0, 2.0, 3.0]), "fro")
+        assert_raises(ValueError, linalg.norm, array([1., 2., 3.]), 'fro')
 
     def test_lapack_endian(self):
         # For bug #1482
-        a = array([[5.7998084, -2.1825367], [-2.1825367, 9.85910595]], dtype=">f8")
-        b = array(a, dtype="<f8")
+        a = array([[5.7998084,  -2.1825367],
+                   [-2.1825367,   9.85910595]], dtype='>f8')
+        b = array(a, dtype='<f8')
 
         ap = linalg.cholesky(a)
         bp = linalg.cholesky(b)
@@ -108,15 +97,15 @@ class TestRegression:
 
         norm = linalg.norm(testvector)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype("float64"))
+        assert_(norm.dtype == np.dtype('float64'))
 
         norm = linalg.norm(testvector, ord=1)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype != np.dtype("float64"))
+        assert_(norm.dtype != np.dtype('float64'))
 
         norm = linalg.norm(testvector, ord=2)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype("float64"))
+        assert_(norm.dtype == np.dtype('float64'))
 
         assert_raises(ValueError, linalg.norm, testvector, ord='fro')
         assert_raises(ValueError, linalg.norm, testvector, ord='nuc')
@@ -124,16 +113,18 @@ class TestRegression:
         assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
         assert_raises(ValueError, linalg.norm, testvector, ord=0)
         assert_raises(ValueError, linalg.norm, testvector, ord=-1)
+        assert_raises(ValueError, linalg.norm, testvector, ord=-2)
 
-        testmatrix = np.array([[np.array([0, 1]), 0, 0], [0, 0, 0]], dtype=object)
+        testmatrix = np.array([[np.array([0, 1]), 0, 0],
+                               [0,                0, 0]], dtype=object)
 
         norm = linalg.norm(testmatrix)
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype("float64"))
+        assert_(norm.dtype == np.dtype('float64'))
 
-        norm = linalg.norm(testmatrix, ord="fro")
+        norm = linalg.norm(testmatrix, ord='fro')
         assert_array_equal(norm, [0, 1])
-        assert_(norm.dtype == np.dtype("float64"))
+        assert_(norm.dtype == np.dtype('float64'))
 
         assert_raises(TypeError, linalg.norm, testmatrix, ord='nuc')
         assert_raises(ValueError, linalg.norm, testmatrix, ord=np.inf)
@@ -175,14 +166,12 @@ class TestRegression:
         # Test whether matrix multiplication involving a large matrix always
         # gives the same (correct) answer
         x = np.arange(500000, dtype=np.float64)
-        src = np.vstack((x, -10 * x)).T
+        src = np.vstack((x, -10*x)).T
         matrix = np.array([[0, 1], [1, 0]])
-        expected = np.vstack((-10 * x, x)).T  # src @ matrix
+        expected = np.vstack((-10*x, x)).T  # src @ matrix
         for i in range(200):
             result = src @ matrix
             mismatches = (~np.isclose(result, expected)).sum()
             if mismatches != 0:
-                assert False, (
-                    "unexpected result from matmul, "
-                    "probably due to OpenBLAS threading issues"
-                )
+                assert False, ("unexpected result from matmul, "
+                    "probably due to OpenBLAS threading issues")

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -107,13 +107,13 @@ class TestRegression:
         assert_array_equal(norm, [0, 1])
         assert_(norm.dtype == np.dtype('float64'))
 
-        assert_raises(ValueError, linalg.norm, testvector, ord='fro')
-        assert_raises(ValueError, linalg.norm, testvector, ord='nuc')
-        assert_raises(ValueError, linalg.norm, testvector, ord=np.inf)
-        assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
-        assert_raises(ValueError, linalg.norm, testvector, ord=0)
-        assert_raises(RuntimeWarning, linalg.norm, testvector, ord=-1)
-        assert_raises(ValueError, linalg.norm, testvector, ord=-2)
+        for ord in ['fro', 'nuc', np.inf, -np.inf, 0, -1, -2]:
+            pytest.raises(
+                (ValueError, ZeroDivisionError, RuntimeWarning),
+                linalg.norm,
+                testvector,
+                ord=ord,
+            )
 
         testmatrix = np.array([[np.array([0, 1]), 0, 0],
                                [0,                0, 0]], dtype=object)
@@ -126,15 +126,13 @@ class TestRegression:
         assert_array_equal(norm, [0, 1])
         assert_(norm.dtype == np.dtype('float64'))
 
-        assert_raises(TypeError, linalg.norm, testmatrix, ord='nuc')
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=np.inf)
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=-np.inf)
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=0)
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=1)
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=-1)
-        assert_raises(TypeError, linalg.norm, testmatrix, ord=2)
-        assert_raises(TypeError, linalg.norm, testmatrix, ord=-2)
-        assert_raises(ValueError, linalg.norm, testmatrix, ord=3)
+        for ord in ['nuc', np.inf, -np.inf, 0, 1, -1, 2, -2, 3]:
+            pytest.raises(
+                (ValueError, TypeError, ZeroDivisionError, RuntimeWarning),
+                linalg.norm,
+                testmatrix,
+                ord=ord,
+            )
 
     def test_lstsq_complex_larger_rhs(self):
         # gh-9891


### PR DESCRIPTION
This is an initial draft to resolve https://github.com/numpy/numpy/issues/27082.

I have removed the fast paths from array_power and am planning to implement them in the individual UFunc templates which seem to be few. This prevents the need for scalar extraction and reduces divergence from the UFunc. Currently, I have only implemented for integer loops, but would appreciate feedback before I proceed.

I hope I understood the issue correctly. Thank you!