### PR TITLE
MAINT: Ensure correct handling for very large unicode strings

### DIFF
--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -62,7 +62,7 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_DTypeFromObjectStringDiscovery(
         PyObject *obj, PyArray_Descr *last_dtype, int string_type)
 {
-    int itemsize;
+    npy_intp itemsize;
 
     if (string_type == NPY_STRING) {
         PyObject *temp = PyObject_Str(obj);
@@ -75,6 +75,12 @@ PyArray_DTypeFromObjectStringDiscovery(
         if (itemsize < 0) {
             return NULL;
         }
+        if (itemsize > NPY_MAX_INT) {
+            /* We can allow this, but should audit code paths before we do. */
+            PyErr_SetString(PyExc_TypeError,
+                    "string too large to store inside array.");
+            return NULL;
+        }
     }
     else if (string_type == NPY_UNICODE) {
         PyObject *temp = PyObject_Str(obj);
@@ -84,6 +90,11 @@ PyArray_DTypeFromObjectStringDiscovery(
         itemsize = PyUnicode_GetLength(temp);
         Py_DECREF(temp);
         if (itemsize < 0) {
+            return NULL;
+        }
+        if (itemsize > NPY_MAX_INT / 4) {
+            PyErr_SetString(PyExc_TypeError,
+                    "string too large to store inside array.");
             return NULL;
         }
         itemsize *= 4;  /* convert UCS4 codepoints to bytes */

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -77,8 +77,8 @@ PyArray_DTypeFromObjectStringDiscovery(
         }
         if (itemsize > NPY_MAX_INT) {
             /* We can allow this, but should audit code paths before we do. */
-            PyErr_SetString(PyExc_TypeError,
-                    "string too large to store inside array.");
+            PyErr_Format(PyExc_TypeError,
+                    "string of length %zd is too large to store inside array.", itemsize);
             return NULL;
         }
     }
@@ -93,8 +93,8 @@ PyArray_DTypeFromObjectStringDiscovery(
             return NULL;
         }
         if (itemsize > NPY_MAX_INT / 4) {
-            PyErr_SetString(PyExc_TypeError,
-                    "string too large to store inside array.");
+            PyErr_Format(PyExc_TypeError,
+                    "string of length %zd is too large to store inside array.", itemsize);
             return NULL;
         }
         itemsize *= 4;  /* convert UCS4 codepoints to bytes */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2403,6 +2403,10 @@ cast_to_string_resolve_descriptors(
             return -1;
     }
     if (dtypes[1]->type_num == NPY_UNICODE) {
+        if (size > NPY_MAX_INT / 4) {
+            PyErr_SetString(PyExc_TypeError, "Result string too large.");
+            return -1;
+        }
         size *= 4;
     }
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2404,7 +2404,8 @@ cast_to_string_resolve_descriptors(
     }
     if (dtypes[1]->type_num == NPY_UNICODE) {
         if (size > NPY_MAX_INT / 4) {
-            PyErr_SetString(PyExc_TypeError, "Result string too large.");
+            PyErr_Format(PyExc_TypeError,
+                    "string of length %zd is too large to store inside array.", size);
             return -1;
         }
         size *= 4;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -494,12 +494,14 @@ string_discover_descr_from_pyobject(
         itemsize = PyUnicode_GetLength(obj);
     }
     if (itemsize != -1) {
-        if (cls->type_num == NPY_UNICODE) {
-            itemsize *= 4;
-        }
-        if (itemsize > NPY_MAX_INT) {
+        if (itemsize > NPY_MAX_INT || (
+                cls->type_num == NPY_UNICODE && itemsize > NPY_MAX_INT / 4)) {
             PyErr_SetString(PyExc_TypeError,
                     "string too large to store inside array.");
+            return NULL;
+        }
+        if (cls->type_num == NPY_UNICODE) {
+            itemsize *= 4;
         }
         PyArray_Descr *res = PyArray_DescrNewFromType(cls->type_num);
         if (res == NULL) {

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -643,9 +643,17 @@ string_addition_resolve_descriptors(
         PyArray_Descr *loop_descrs[3],
         npy_intp *NPY_UNUSED(view_offset))
 {
-    /* NOTE: elsize is large enough now, but too much code still uses ints */
-    if (given_descrs[0]->elsize + given_descrs[1]->elsize > NPY_MAX_INT) {
-        PyErr_SetString(PyExc_TypeError, "Result string too large.");
+    npy_intp result_itemsize = given_descrs[0]->elsize + given_descrs[1]->elsize;
+
+    /* NOTE: elsize can fit more than MAX_INT, but some code may still use ints */
+    if (result_itemsize > NPY_MAX_INT || result_itemsize < 0) {
+            npy_intp length = result_itemsize;
+            if (given_descrs[0]->type == NPY_UNICODE) {
+                length /= 4;
+            }
+            PyErr_Format(PyExc_TypeError,
+                    "addition result string of length %zd is too large to store inside array.",
+                    length);
         return _NPY_ERROR_OCCURRED_IN_CAST;
     }
 

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -141,7 +141,7 @@ def test_large_string_coercion_error(str_dt):
         large_string = "A" * (very_large + 1)
     except Exception:
         # We may not be able to create this Python string on 32bit.
-        return
+        pytest.skip("python failed to create huge string")
 
     class MyStr:
         def __str__(self):

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -5,7 +5,7 @@ import operator
 import numpy as np
 
 from numpy.testing import assert_array_equal, assert_raises, IS_PYPY
-
+from numpy.testing._private.utils import requires_memory
 
 COMPARISONS = [
     (operator.eq, np.equal, "=="),
@@ -107,6 +107,88 @@ def test_float_to_string_cast(str_dt, float_dt):
 
     res = arr.astype(str_dt)
     assert_array_equal(res, np.array(expected, dtype=str_dt))
+
+
+@pytest.mark.parametrize("str_dt", "US")
+@pytest.mark.parametrize("size", [-1, np.iinfo(np.intc).max])
+def test_string_size_dtype_errors(str_dt, size):
+    if size > 0:
+        size = size // np.dtype(f"{str_dt}1").itemsize + 1
+
+    with pytest.raises(ValueError):
+        np.dtype((str_dt, size))
+    with pytest.raises(TypeError):
+        np.dtype(f"{str_dt}{size}")
+
+
+@pytest.mark.parametrize("str_dt", "US")
+def test_string_size_dtype_large_repr(str_dt):
+    size = np.iinfo(np.intc).max // np.dtype(f"{str_dt}1").itemsize
+    size_str = str(size)
+
+    dtype = np.dtype((str_dt, size))
+    assert size_str in dtype.str
+    assert size_str in str(dtype)
+    assert size_str in repr(dtype)
+
+
+@pytest.mark.slow
+@requires_memory(2 * np.iinfo(np.intc).max)
+@pytest.mark.parametrize("str_dt", "US")
+def test_large_string_coercion_error(str_dt):
+    very_large = np.iinfo(np.intc).max // np.dtype(f"{str_dt}1").itemsize
+    try:
+        large_string = "A" * (very_large + 1)
+    except Exception:
+        # We may not be able to create this Python string on 32bit.
+        return
+
+    class MyStr:
+        def __str__(self):
+            return large_string
+
+    try:
+        # TypeError from NumPy, or OverflowError from 32bit Python.
+        with pytest.raises((TypeError, OverflowError)):
+            np.array([large_string], dtype=str_dt)
+
+        # Same as above, but input has to be converted to a string.
+        with pytest.raises((TypeError, OverflowError)):
+            np.array([MyStr()], dtype=str_dt)
+    except MemoryError:
+        # Catch memory errors, because `requires_memory` would do so.
+        raise AssertionError("Ops should raise before any large allocation.")
+
+@pytest.mark.slow
+@requires_memory(2 * np.iinfo(np.intc).max)
+@pytest.mark.parametrize("str_dt", "US")
+def test_large_string_addition_error(str_dt):
+    very_large = np.iinfo(np.intc).max // np.dtype(f"{str_dt}1").itemsize
+
+    a = np.array(["A" * very_large], dtype=str_dt)
+    b = np.array("B", dtype=str_dt)
+    try:
+        with pytest.raises(TypeError):
+            np.add(a, b)
+        with pytest.raises(TypeError):
+            np.add(a, a)
+    except MemoryError:
+        # Catch memory errors, because `requires_memory` would do so.
+        raise AssertionError("Ops should raise before any large allocation.")
+
+
+def test_large_string_cast():
+    very_large = np.iinfo(np.intc).max // 4
+    # Could be nice to test very large path, but it makes too many huge
+    # allocations right now (need non-legacy cast loops for this).
+    # a = np.array([], dtype=np.dtype(("S", very_large)))
+    # assert a.astype("U").dtype.itemsize == very_large * 4
+
+    a = np.array([], dtype=np.dtype(("S", very_large + 1)))
+    # It is not perfect but OK if this raises a MemoryError during setup
+    # (this happens due clunky code and/or buffer setup.)
+    with pytest.raises((TypeError, MemoryError)):
+        a.astype("U")
 
 
 @pytest.mark.parametrize("dt", ["S", "U", "T"])


### PR DESCRIPTION
Backport of #27875.

In the future, we can handle these strings (in parts we already can maybe), but for now have to stick to int length because more of the code needs cleanup to actually use it safely. (For user dtypes this is less of a problem, although corner cases probably exist.)

This adds necessary checks to avoid large unicode dtypes.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
