### PR TITLE
MAINT: Make qualname tests more specific and fix code where needed

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -231,7 +231,6 @@ def issctype(rep):
         return False
 
 
-@set_module('numpy')
 def obj2sctype(rep, default=None):
     """
     Return the scalar dtype or NumPy equivalent of Python type of an object.

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -400,7 +400,7 @@ PyMODINIT_FUNC PyInit_lapack_lite(void)
     }
     import_array();
     d = PyModule_GetDict(m);
-    LapackError = PyErr_NewException("lapack_lite.LapackError", NULL, NULL);
+    LapackError = PyErr_NewException("numpy.linalg.lapack_lite.LapackError", NULL, NULL);
     PyDict_SetItemString(d, "LapackError", LapackError);
 
 #ifdef HAVE_BLAS_ILP64

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1310,15 +1310,13 @@ hypot = _MaskedBinaryOperation(umath.hypot)
 
 # Domained binary ufuncs
 divide = _DomainedBinaryOperation(umath.divide, _DomainSafeDivide(), 0, 1)
-true_divide = _DomainedBinaryOperation(umath.true_divide,
-                                       _DomainSafeDivide(), 0, 1)
+true_divide = divide  # Since Python 3 just an alias for divide.
 floor_divide = _DomainedBinaryOperation(umath.floor_divide,
                                         _DomainSafeDivide(), 0, 1)
 remainder = _DomainedBinaryOperation(umath.remainder,
                                      _DomainSafeDivide(), 0, 1)
 fmod = _DomainedBinaryOperation(umath.fmod, _DomainSafeDivide(), 0, 1)
-mod = _DomainedBinaryOperation(umath.mod, _DomainSafeDivide(), 0, 1)
-
+mod = remainder
 
 ###############################################################################
 #                        Mask creation functions                              #
@@ -7144,7 +7142,7 @@ mean = _frommethod('mean')
 minimum = _extrema_operation(umath.minimum, less, minimum_fill_value)
 nonzero = _frommethod('nonzero')
 prod = _frommethod('prod')
-product = _frommethod('prod')
+product = _frommethod('product')
 ravel = _frommethod('ravel')
 repeat = _frommethod('repeat')
 shrink_mask = _frommethod('shrink_mask')

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -770,7 +770,7 @@ def _check_correct_qualname_and_module(obj) -> bool:
 
 def test___qualname___and___module___attribute():
     # NumPy messes with module and name/qualname attributes, but any object
-    # shuold be discoverable based on its module and qualname, so test that.
+    # should be discoverable based on its module and qualname, so test that.
     # We do this for anything with a name (ensuring qualname is also set).
     modules_queue = [np]
     visited_modules = {np}

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -759,9 +759,9 @@ def _check_correct_qualname_and_module(obj) -> bool:
     actual_obj = functools.reduce(getattr, qualname.split("."), module)
     return (
         actual_obj is obj or
-        # `obj` may be a bound method of `actual_obj`:
+        # `obj` may be a bound method/property of `actual_obj`:
         (
-            hasattr(actual_obj, "__get__") == hasattr(obj, "__self__") and
+            hasattr(actual_obj, "__get__") and hasattr(obj, "__self__") and
             actual_obj.__module__ == obj.__module__ and
             actual_obj.__qualname__ == qualname
         )
@@ -786,7 +786,8 @@ def test___qualname___and___module___attribute():
                 inspect.ismodule(member) and  # it's a module
                 "numpy" in member.__name__ and  # inside NumPy
                 not member_name.startswith("_") and  # not private
-                member_name not in ["tests"] and  # skip tests
+                member_name != "tests" and
+                member_name != "typing" and  # 2024-12: type names don't match
                 "numpy._core" not in member.__name__ and  # outside _core
                 member not in visited_modules  # not visited yet
             ):

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -749,7 +749,7 @@ def test___module___attribute():
         assert len(incorrect_entries) == 0, incorrect_entries
 
 
-def _check___qualname__(obj) -> bool:
+def _check_correct_qualname_and_module(obj) -> bool:
     qualname = obj.__qualname__
     name = obj.__name__
     module_name = obj.__module__
@@ -759,15 +759,19 @@ def _check___qualname__(obj) -> bool:
     actual_obj = functools.reduce(getattr, qualname.split("."), module)
     return (
         actual_obj is obj or
+        # `obj` may be a bound method of `actual_obj`:
         (
-            # for bound methods check qualname match
-            module_name.startswith("numpy.random") and
+            hasattr(actual_obj, "__get__") == hasattr(obj, "__self__") and
+            actual_obj.__module__ == obj.__module__ and
             actual_obj.__qualname__ == qualname
         )
     )
 
 
-def test___qualname___attribute():
+def test___qualname___and___module___attribute():
+    # NumPy messes with module and name/qualname attributes, but any object
+    # shuold be discoverable based on its module and qualname, so test that.
+    # We do this for anything with a name (ensuring qualname is also set).
     modules_queue = [np]
     visited_modules = {np}
     visited_functions = set()
@@ -782,10 +786,7 @@ def test___qualname___attribute():
                 inspect.ismodule(member) and  # it's a module
                 "numpy" in member.__name__ and  # inside NumPy
                 not member_name.startswith("_") and  # not private
-                member_name not in [
-                    "f2py", "ma", "tests", "testing", "typing",
-                    "bit_generator", "ctypeslib", "lapack_lite",
-                ] and  # skip modules
+                member_name not in ["tests"] and  # skip tests
                 "numpy._core" not in member.__name__ and  # outside _core
                 member not in visited_modules  # not visited yet
             ):
@@ -796,12 +797,13 @@ def test___qualname___attribute():
                 hasattr(member, "__name__") and
                 not member.__name__.startswith("_") and
                 not member_name.startswith("_") and
-                not _check___qualname__(member) and
+                not _check_correct_qualname_and_module(member) and
                 member not in visited_functions
             ):
                 incorrect_entries.append(
                     dict(
-                        actual=member.__qualname__, expected=member.__name__,
+                        found_at=f"{module.__name__}:{member_name}",
+                        advertises=f"{member.__module__}:{member.__qualname__}",
                     )
                 )
                 visited_functions.add(member)


### PR DESCRIPTION
This fixes the test to be more specific and more importantly not unnecessarily skip things.

It also fixes two qualname errors (yes they are in almost private things, but they should still be right).

Renamed the tests, since it is about qualname, but it is also about the fact that you should be able to find any object using the module and qualname.

Note, that the semi-private ufuncs inside `numpy._core` (skipped) would not pass this tests because they still lack a module and qualname. (e.g. `_clip`).