### PR TITLE
DOC: Fix invalid URL in the index.rst file.

### DIFF
--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -5,8 +5,8 @@ Roadmap & NumPy enhancement proposals
 This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
-to the library—in various stages of discussion or completion (see `NEP
-0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__).
+to the library—in various stages of discussion or completion (see `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>
+`__).
 
 Roadmap
 -------

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -6,8 +6,8 @@ This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
 to the library—in various stages of discussion or completion (see `NEP 0
-<https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>
-`__).
+<https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__
+).
 
 Roadmap
 -------

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -6,7 +6,7 @@ This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
 to the library—in various stages of discussion or completion (see `NEP
-0 <nep-0000>`__).
+0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__).
 
 Roadmap
 -------

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -5,7 +5,8 @@ Roadmap & NumPy enhancement proposals
 This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
-to the library—in various stages of discussion or completion (see `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>
+to the library—in various stages of discussion or completion (see `NEP 0
+<https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>
 `__).
 
 Roadmap

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -5,9 +5,9 @@ Roadmap & NumPy enhancement proposals
 This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
-to the library—in various stages of discussion or completion (see `NEP 0
-<https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__
-).
+to the library—in various stages of discussion or completion.
+
+See `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__.
 
 Roadmap
 -------

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -6,8 +6,8 @@ This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
 to the library—in various stages of discussion or completion.
-
-See `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__.
+See `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__
+for more informations about NEPs.
 
 Roadmap
 -------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
The URL for "Nep 0" in https://github.com/numpy/numpy/blob/main/doc/neps/index.rst is invalid and should be changed to https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst.

Try to fix issue #27919 