### PR TITLE
MAINT: Move user pointers out of axisdata and simplify iternext

### DIFF
--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -242,7 +242,6 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
         bufferdata = NIT_BUFFERDATA(iter);
         NBF_SIZE(bufferdata) = 0;
         memset(NBF_BUFFERS(bufferdata), 0, nop*NPY_SIZEOF_INTP);
-        memset(NBF_PTRS(bufferdata), 0, nop*NPY_SIZEOF_INTP);
         /* Ensure that the transferdata/auxdata is NULLed */
         memset(NBF_TRANSFERINFO(bufferdata), 0, nop * sizeof(NpyIter_TransferInfo));
     }
@@ -480,6 +479,11 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
                 return NULL;
             }
         }
+    }
+    else if (itflags&NPY_ITFLAG_EXLOOP)  {
+        /* make sure to update the user pointers (when buffering, it does this). */
+        assert(!(itflags & NPY_ITFLAG_HASINDEX));
+        memcpy(NIT_USERPTRS(iter), NIT_DATAPTRS(iter), nop * sizeof(void *));
     }
 
     NPY_IT_TIME_POINT(c_prepare_buffers);
@@ -1587,11 +1591,11 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
     axisdata = NIT_AXISDATA(iter);
     sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
 
+    memcpy(NIT_DATAPTRS(iter), op_dataptr, nop * sizeof(void *));
     if (ndim == 0) {
         /* Need to fill the first axisdata, even if the iterator is 0-d */
         NAD_SHAPE(axisdata) = 1;
         NAD_INDEX(axisdata) = 0;
-        memcpy(NAD_PTRS(axisdata), op_dataptr, NPY_SIZEOF_INTP*nop);
         memset(NAD_STRIDES(axisdata), 0, NPY_SIZEOF_INTP*nop);
     }
 
@@ -1602,7 +1606,6 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
 
         NAD_SHAPE(axisdata) = bshape;
         NAD_INDEX(axisdata) = 0;
-        memcpy(NAD_PTRS(axisdata), op_dataptr, NPY_SIZEOF_INTP*nop);
 
         for (iop = 0; iop < nop; ++iop) {
             op_cur = op[iop];
@@ -2424,13 +2427,7 @@ npyiter_replace_axisdata(
     /* Now the base data pointer is calculated, set it everywhere it's needed */
     NIT_RESETDATAPTR(iter)[iop] = op_dataptr;
     NIT_BASEOFFSETS(iter)[iop] = baseoffset;
-    axisdata = axisdata0;
-    /* Fill at least one axisdata, for the 0-d case */
-    NAD_PTRS(axisdata)[iop] = op_dataptr;
-    NIT_ADVANCE_AXISDATA(axisdata, 1);
-    for (idim = 1; idim < ndim; ++idim, NIT_ADVANCE_AXISDATA(axisdata, 1)) {
-        NAD_PTRS(axisdata)[iop] = op_dataptr;
-    }
+    NIT_DATAPTRS(iter)[iop] = op_dataptr;
 }
 
 /*
@@ -2451,15 +2448,15 @@ npyiter_compute_index_strides(NpyIter *iter, npy_uint32 flags)
     NpyIter_AxisData *axisdata;
     npy_intp sizeof_axisdata;
 
+    NIT_DATAPTRS(iter)[nop] = 0;
     /*
      * If there is only one element being iterated, we just have
-     * to touch the first AXISDATA because nothing will ever be
-     * incremented. This also initializes the data for the 0-d case.
+     * to touch the first set the "dataptr".
+     * This also initializes the data for the 0-d case.
      */
     if (NIT_ITERSIZE(iter) == 1) {
         if (itflags & NPY_ITFLAG_HASINDEX) {
             axisdata = NIT_AXISDATA(iter);
-            NAD_PTRS(axisdata)[nop] = 0;
         }
         return;
     }
@@ -2477,7 +2474,6 @@ npyiter_compute_index_strides(NpyIter *iter, npy_uint32 flags)
             else {
                 NAD_STRIDES(axisdata)[nop] = indexstride;
             }
-            NAD_PTRS(axisdata)[nop] = 0;
             indexstride *= shape;
         }
     }
@@ -2494,7 +2490,6 @@ npyiter_compute_index_strides(NpyIter *iter, npy_uint32 flags)
             else {
                 NAD_STRIDES(axisdata)[nop] = indexstride;
             }
-            NAD_PTRS(axisdata)[nop] = 0;
             indexstride *= shape;
         }
     }
@@ -2563,12 +2558,12 @@ npyiter_flip_negative_strides(NpyIter *iter)
     int iop, nop = NIT_NOP(iter);
 
     npy_intp istrides, nstrides = NAD_NSTRIDES();
-    NpyIter_AxisData *axisdata, *axisdata0;
+    NpyIter_AxisData *axisdata;
     npy_intp *baseoffsets;
     npy_intp sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
     int any_flipped = 0;
 
-    axisdata0 = axisdata = NIT_AXISDATA(iter);
+    axisdata = NIT_AXISDATA(iter);
     baseoffsets = NIT_BASEOFFSETS(iter);
     for (idim = 0; idim < ndim; ++idim, NIT_ADVANCE_AXISDATA(axisdata, 1)) {
         npy_intp *strides = NAD_STRIDES(axisdata);
@@ -2619,13 +2614,7 @@ npyiter_flip_negative_strides(NpyIter *iter)
 
         for (istrides = 0; istrides < nstrides; ++istrides) {
             resetdataptr[istrides] += baseoffsets[istrides];
-        }
-        axisdata = axisdata0;
-        for (idim = 0; idim < ndim; ++idim, NIT_ADVANCE_AXISDATA(axisdata, 1)) {
-            char **ptrs = NAD_PTRS(axisdata);
-            for (istrides = 0; istrides < nstrides; ++istrides) {
-                ptrs[istrides] = resetdataptr[istrides];
-            }
+            NIT_DATAPTRS(iter)[istrides] = resetdataptr[istrides];
         }
         /*
          * Indicate that some of the perm entries are negative,

--- a/numpy/_core/src/multiarray/nditer_impl.h
+++ b/numpy/_core/src/multiarray/nditer_impl.h
@@ -182,9 +182,13 @@ typedef npy_int16 npyiter_opitflags;
         ((NPY_SIZEOF_PY_INTPTR_T)*(nop))
 #define NIT_OPITFLAGS_SIZEOF(itflags, ndim, nop) \
         (NPY_PTR_ALIGNED(sizeof(npyiter_opitflags) * nop))
+#define NIT_DATAPTRS_SIZEOF(itflags, ndim, nop) \
+        ((NPY_SIZEOF_PY_INTPTR_T)*(nop+1))
+#define NIT_USERPTRS_SIZEOF(itflags, ndim, nop) \
+        ((NPY_SIZEOF_PY_INTPTR_T)*(nop+1))
 #define NIT_BUFFERDATA_SIZEOF(itflags, ndim, nop) \
         ((itflags&NPY_ITFLAG_BUFFER) ? ( \
-            (NPY_SIZEOF_PY_INTPTR_T)*(8 + 5*nop) + sizeof(NpyIter_TransferInfo) * nop) : 0)
+            (NPY_SIZEOF_PY_INTPTR_T)*(8 + 4*nop) + sizeof(NpyIter_TransferInfo) * nop) : 0)
 
 /* Byte offsets of the iterator members starting from iter->iter_flexdata */
 #define NIT_PERM_OFFSET() \
@@ -207,9 +211,15 @@ typedef npy_int16 npyiter_opitflags;
 #define NIT_BUFFERDATA_OFFSET(itflags, ndim, nop) \
         (NIT_OPITFLAGS_OFFSET(itflags, ndim, nop) + \
          NIT_OPITFLAGS_SIZEOF(itflags, ndim, nop))
-#define NIT_AXISDATA_OFFSET(itflags, ndim, nop) \
+#define NIT_DATAPTRS_OFFSET(itflags, ndim, nop) + \
         (NIT_BUFFERDATA_OFFSET(itflags, ndim, nop) + \
          NIT_BUFFERDATA_SIZEOF(itflags, ndim, nop))
+#define NIT_USERPTRS_OFFSET(itflags, ndim, nop) + \
+        (NIT_DATAPTRS_OFFSET(itflags, ndim, nop) + \
+         NIT_DATAPTRS_SIZEOF(itflags, ndim, nop))
+#define NIT_AXISDATA_OFFSET(itflags, ndim, nop) \
+        (NIT_USERPTRS_OFFSET(itflags, ndim, nop) + \
+         NIT_USERPTRS_SIZEOF(itflags, ndim, nop))
 
 /* Internal-only ITERATOR DATA MEMBER ACCESS */
 #define NIT_ITFLAGS(iter) \
@@ -242,6 +252,10 @@ typedef npy_int16 npyiter_opitflags;
         iter->iter_flexdata + NIT_OPITFLAGS_OFFSET(itflags, ndim, nop)))
 #define NIT_BUFFERDATA(iter) ((NpyIter_BufferData *)( \
         iter->iter_flexdata + NIT_BUFFERDATA_OFFSET(itflags, ndim, nop)))
+#define NIT_DATAPTRS(iter) ((char **)( \
+        iter->iter_flexdata + NIT_DATAPTRS_OFFSET(itflags, ndim, nop)))
+#define NIT_USERPTRS(iter) ((char **)( \
+        iter->iter_flexdata + NIT_USERPTRS_OFFSET(itflags, ndim, nop)))
 #define NIT_AXISDATA(iter) ((NpyIter_AxisData *)( \
         iter->iter_flexdata + NIT_AXISDATA_OFFSET(itflags, ndim, nop)))
 
@@ -271,16 +285,14 @@ struct NpyIter_BufferData_tag {
 #define NBF_OUTERDIM(bufferdata) ((bufferdata)->outerdim)
 #define NBF_STRIDES(bufferdata) ( \
         &(bufferdata)->bd_flexdata + 0)
-#define NBF_PTRS(bufferdata) ((char **) \
-        (&(bufferdata)->bd_flexdata + 1*(nop)))
 #define NBF_REDUCE_OUTERSTRIDES(bufferdata) ( \
-        (&(bufferdata)->bd_flexdata + 2*(nop)))
+        (&(bufferdata)->bd_flexdata + 1*(nop)))
 #define NBF_REDUCE_OUTERPTRS(bufferdata) ((char **) \
-        (&(bufferdata)->bd_flexdata + 3*(nop)))
+        (&(bufferdata)->bd_flexdata + 2*(nop)))
 #define NBF_BUFFERS(bufferdata) ((char **) \
-        (&(bufferdata)->bd_flexdata + 4*(nop)))
+        (&(bufferdata)->bd_flexdata + 3*(nop)))
 #define NBF_TRANSFERINFO(bufferdata) ((NpyIter_TransferInfo *) \
-        (&(bufferdata)->bd_flexdata + 5*(nop)))
+        (&(bufferdata)->bd_flexdata + 4*(nop)))
 
 /* Internal-only AXISDATA MEMBER ACCESS. */
 struct NpyIter_AxisData_tag {
@@ -291,8 +303,6 @@ struct NpyIter_AxisData_tag {
 #define NAD_INDEX(axisdata) ((axisdata)->index)
 #define NAD_STRIDES(axisdata) ( \
         &(axisdata)->ad_flexdata + 0)
-#define NAD_PTRS(axisdata) ((char **) \
-        (&(axisdata)->ad_flexdata + 1*(nop+1)))
 
 #define NAD_NSTRIDES() \
         ((nop) + ((itflags&NPY_ITFLAG_HASINDEX) ? 1 : 0))
@@ -304,7 +314,7 @@ struct NpyIter_AxisData_tag {
         /* intp index */ \
         1 + \
         /* intp stride[nop+1] AND char* ptr[nop+1] */ \
-        2*((nop)+1) \
+        1*((nop)+1) \
         )*(size_t)NPY_SIZEOF_PY_INTPTR_T)
 
 /*

--- a/numpy/_core/src/multiarray/nditer_templ.c.src
+++ b/numpy/_core/src/multiarray/nditer_templ.c.src
@@ -36,10 +36,11 @@ static int
 npyiter_iternext_itflags@tag_itflags@_dims@tag_ndim@_iters@tag_nop@(
                                                       NpyIter *iter)
 {
-#if !(@const_itflags@&NPY_ITFLAG_EXLOOP) || (@const_ndim@ > 1)
     const npy_uint32 itflags = @const_itflags@;
-#  if @const_ndim@ >= NPY_MAXDIMS
-    int idim, ndim = NIT_NDIM(iter);
+#  if @const_ndim@ <= 2
+    int ndim = @const_ndim@;
+#  else
+    int ndim = NIT_NDIM(iter);
 #  endif
 #  if @const_nop@ < NPY_MAXDIMS
     const int nop = @const_nop@;
@@ -47,16 +48,8 @@ npyiter_iternext_itflags@tag_itflags@_dims@tag_ndim@_iters@tag_nop@(
     int nop = NIT_NOP(iter);
 #  endif
 
-    NpyIter_AxisData *axisdata0;
+    NpyIter_AxisData *axisdata;
     npy_intp istrides, nstrides = NAD_NSTRIDES();
-#endif
-#if @const_ndim@ > 1
-    NpyIter_AxisData *axisdata1;
-    npy_intp sizeof_axisdata;
-#endif
-#if @const_ndim@ > 2
-    NpyIter_AxisData *axisdata2;
-#endif
 
 #if (@const_itflags@&NPY_ITFLAG_RANGE)
     /* When ranged iteration is enabled, use the iterindex */
@@ -65,114 +58,60 @@ npyiter_iternext_itflags@tag_itflags@_dims@tag_ndim@_iters@tag_nop@(
     }
 #endif
 
-#if @const_ndim@ > 1
-    sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
-#endif
+    npy_intp sizeof_axisdata = NIT_AXISDATA_SIZEOF(itflags, ndim, nop);
+    char **ptrs = NIT_DATAPTRS(iter);
+    axisdata = NIT_AXISDATA(iter);
 
-#  if !(@const_itflags@&NPY_ITFLAG_EXLOOP) || (@const_ndim@ > 1)
-    axisdata0 = NIT_AXISDATA(iter);
+#  if @const_itflags@&NPY_ITFLAG_EXLOOP
+    /* If an external loop is used, the first dimension never changes. */
+    NIT_ADVANCE_AXISDATA(axisdata, 1);
+    ndim--;
 #  endif
-#  if !(@const_itflags@&NPY_ITFLAG_EXLOOP)
-    /* Increment index 0 */
-    NAD_INDEX(axisdata0)++;
-    /* Increment pointer 0 */
+
+    /*
+     * Unroll the first dimension.
+     */
+    NAD_INDEX(axisdata) += 1;
     for (istrides = 0; istrides < nstrides; ++istrides) {
-        NAD_PTRS(axisdata0)[istrides] += NAD_STRIDES(axisdata0)[istrides];
-    }
+        ptrs[istrides] += NAD_STRIDES(axisdata)[istrides];
+#  if (@const_itflags@&NPY_ITFLAG_EXLOOP)
+        NIT_USERPTRS(iter)[istrides] = ptrs[istrides];
 #  endif
-
-#if @const_ndim@ == 1
-
-#  if !(@const_itflags@&NPY_ITFLAG_EXLOOP)
-    /* Finished when the index equals the shape */
-    return NAD_INDEX(axisdata0) < NAD_SHAPE(axisdata0);
-#  else
-    return 0;
-#  endif
-
-#else
-
-#  if !(@const_itflags@&NPY_ITFLAG_EXLOOP)
-    if (NAD_INDEX(axisdata0) < NAD_SHAPE(axisdata0)) {
-        return 1;
-    }
-#  endif
-
-    axisdata1 = NIT_INDEX_AXISDATA(axisdata0, 1);
-    /* Increment index 1 */
-    NAD_INDEX(axisdata1)++;
-    /* Increment pointer 1 */
-    for (istrides = 0; istrides < nstrides; ++istrides) {
-        NAD_PTRS(axisdata1)[istrides] += NAD_STRIDES(axisdata1)[istrides];
     }
 
-    if (NAD_INDEX(axisdata1) < NAD_SHAPE(axisdata1)) {
-        /* Reset the 1st index to 0 */
-        NAD_INDEX(axisdata0) = 0;
-        /* Reset the 1st pointer to the value of the 2nd */
-        for (istrides = 0; istrides < nstrides; ++istrides) {
-            NAD_PTRS(axisdata0)[istrides] = NAD_PTRS(axisdata1)[istrides];
-        }
+    if (NAD_INDEX(axisdata) < NAD_SHAPE(axisdata)) {
         return 1;
     }
 
-# if @const_ndim@ == 2
-    return 0;
-# else
-
-    axisdata2 = NIT_INDEX_AXISDATA(axisdata1, 1);
-    /* Increment index 2 */
-    NAD_INDEX(axisdata2)++;
-    /* Increment pointer 2 */
-    for (istrides = 0; istrides < nstrides; ++istrides) {
-        NAD_PTRS(axisdata2)[istrides] += NAD_STRIDES(axisdata2)[istrides];
-    }
-
-    if (NAD_INDEX(axisdata2) < NAD_SHAPE(axisdata2)) {
-        /* Reset the 1st and 2nd indices to 0 */
-        NAD_INDEX(axisdata0) = 0;
-        NAD_INDEX(axisdata1) = 0;
-        /* Reset the 1st and 2nd pointers to the value of the 3rd */
+    /*
+     * Now continue (with resetting)
+     */
+    for (int idim = 1; idim < ndim; idim++) {
+        /* reset index and pointers on this dimension to 0 */
+        NAD_INDEX(axisdata) = 0;
         for (istrides = 0; istrides < nstrides; ++istrides) {
-            NAD_PTRS(axisdata0)[istrides] = NAD_PTRS(axisdata2)[istrides];
-            NAD_PTRS(axisdata1)[istrides] = NAD_PTRS(axisdata2)[istrides];
-        }
-        return 1;
-    }
-
-    for (idim = 3; idim < ndim; ++idim) {
-        NIT_ADVANCE_AXISDATA(axisdata2, 1);
-        /* Increment the index */
-        NAD_INDEX(axisdata2)++;
-        /* Increment the pointer */
-        for (istrides = 0; istrides < nstrides; ++istrides) {
-            NAD_PTRS(axisdata2)[istrides] += NAD_STRIDES(axisdata2)[istrides];
+            ptrs[istrides] -= NAD_SHAPE(axisdata) * NAD_STRIDES(axisdata)[istrides];
         }
 
+        /* And continue with the next dimension. */
+        NIT_ADVANCE_AXISDATA(axisdata, 1);
 
-        if (NAD_INDEX(axisdata2) < NAD_SHAPE(axisdata2)) {
-            /* Reset the indices and pointers of all previous axisdatas */
-            axisdata1 = axisdata2;
-            do {
-                NIT_ADVANCE_AXISDATA(axisdata1, -1);
-                /* Reset the index to 0 */
-                NAD_INDEX(axisdata1) = 0;
-                /* Reset the pointer to the updated value */
-                for (istrides = 0; istrides < nstrides; ++istrides) {
-                    NAD_PTRS(axisdata1)[istrides] =
-                                        NAD_PTRS(axisdata2)[istrides];
-                }
-            } while (axisdata1 != axisdata0);
+        /* Increment index and pointers */
+        NAD_INDEX(axisdata) += 1;
+        for (istrides = 0; istrides < nstrides; ++istrides) {
+            ptrs[istrides] += NAD_STRIDES(axisdata)[istrides];
+#  if (@const_itflags@&NPY_ITFLAG_EXLOOP)
+            NIT_USERPTRS(iter)[istrides] = ptrs[istrides];
+#  endif
+        }
 
+        if (NAD_INDEX(axisdata) < NAD_SHAPE(axisdata)) {
             return 1;
         }
     }
+    /* If the loop terminated, ran out of dimensions (end of array) */
 
     return 0;
-
-# endif /* ndim != 2 */
-
-#endif /* ndim != 1 */
 }
 
 /**end repeat2**/
@@ -202,12 +141,11 @@ npyiter_buffered_reduce_iternext_iters@tag_nop@(NpyIter *iter)
 
     int iop;
 
-    NpyIter_AxisData *axisdata;
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
     char **ptrs;
     char *prev_dataptrs[NPY_MAXARGS];
 
-    ptrs = NBF_PTRS(bufferdata);
+    ptrs = NIT_USERPTRS(iter);
 
     /*
      * If the iterator handles the inner loop, need to increment all
@@ -245,8 +183,7 @@ npyiter_buffered_reduce_iternext_iters@tag_nop@(NpyIter *iter)
     }
 
     /* Save the previously used data pointers */
-    axisdata = NIT_AXISDATA(iter);
-    memcpy(prev_dataptrs, NAD_PTRS(axisdata), NPY_SIZEOF_INTP*nop);
+    memcpy(prev_dataptrs, NIT_DATAPTRS(iter), NPY_SIZEOF_INTP*nop);
 
     /* Write back to the arrays */
     if (npyiter_copy_from_buffers(iter) < 0) {
@@ -297,7 +234,7 @@ npyiter_buffered_iternext(NpyIter *iter)
             char **ptrs;
 
             strides = NBF_STRIDES(bufferdata);
-            ptrs = NBF_PTRS(bufferdata);
+            ptrs = NIT_USERPTRS(iter);
             for (iop = 0; iop < nop; ++iop) {
                 ptrs[iop] += strides[iop];
             }

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -3384,6 +3384,8 @@ def test_debug_print(capfd):
     | DTypes: dtype('float64') dtype('int32')
     | InitDataPtrs:
     | BaseOffsets: 0 0
+    | Ptrs:
+    | User/buffer ptrs:
     | Operands:
     | Operand DTypes: dtype('int64') dtype('float64')
     | OpItFlags:
@@ -3399,7 +3401,6 @@ def test_debug_print(capfd):
     |   REDUCE OuterSize: 10
     |   REDUCE OuterDim: 1
     |   Strides: 8 4
-    |   Ptrs:
     |   REDUCE Outer Strides: 40 0
     |   REDUCE Outer Ptrs:
     |   ReadTransferFn:
@@ -3412,12 +3413,10 @@ def test_debug_print(capfd):
     |   Shape: 5
     |   Index: 0
     |   Strides: 16 8
-    |   Ptrs:
     | AxisData[1]:
     |   Shape: 10
     |   Index: 0
     |   Strides: 80 0
-    |   Ptrs:
     ------- END ITERATOR DUMP -------
     """.strip().splitlines()
 


### PR DESCRIPTION
This is just because I found the way things were iterated confusing and I think this is a lot less confusing and I can't imagine it's slower.

---

The pointers were always stored for each axis (pointing to the start of the whatever the index into the axis was). I found that confusing: One set of pointers is enough.

But some gufuncs relied on external loop giving a second set of pointers (buffers always do so ufuncs are fine).
So, merged the buffer pointers and the external loop into a new field.

I hope (but not sure) that compilers won't complain about loops that are never taken (didn't notice it locally, but...).

For speed testing, I tried to time with something like:
```
a = np.broadcast_to(np.zeros((2, 4))[:, ::2], (100000, 2, 2))

%timeit np.count_nonzero(a)
%timeit np.count_nonzero(a[..., 0])

%timeit np.nonzero(a)
%timeit np.nonzero(a[..., 0])
```
Especially the first (count nonzero).  That code uses the external loop path without buffering (i.e. what changed most). Locally, saw a small slowdown with nonzero, but on a different box and if anything I think a slight speedup for count-nonzero.

So, I doubt this makes a difference, of course an iteration only C test might see a tiny bit more of a difference.


EDIT: Actually, on my old laptop that has (without turbo-boosting) more stable benchmarks, it's better in all cases.  (of course architectures could behave slightly differently)