### PR TITLE
ENH: Add cython wrappers for NpyString API

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -117,6 +117,7 @@ cdef extern from "numpy/arrayobject.h":
         NPY_OBJECT
         NPY_STRING
         NPY_UNICODE
+        NPY_VSTRING
         NPY_VOID
         NPY_DATETIME
         NPY_TIMEDELTA
@@ -1240,3 +1241,35 @@ cdef extern from "numpy/arrayobject.h":
     void NpyIter_GetInnerFixedStrideArray(NpyIter* it, npy_intp* outstrides) nogil
     npy_bool NpyIter_IterationNeedsAPI(NpyIter* it) nogil
     void NpyIter_DebugPrint(NpyIter* it)
+
+# NpyString API
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef struct npy_string_allocator:
+        pass
+
+    ctypedef struct npy_packed_static_string:
+        pass
+
+    ctypedef struct npy_static_string:
+        size_t size
+        const char *buf
+
+    ctypedef struct PyArray_StringDTypeObject:
+        PyArray_Descr base
+        PyObject *na_object
+        char coerce
+        char has_nan_na
+        char has_string_na
+        char array_owned
+        npy_static_string default_string
+        npy_static_string na_name
+        npy_string_allocator *allocator
+
+cdef extern from "numpy/arrayobject.h":
+    npy_string_allocator *NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
+    void NpyString_acquire_allocators(size_t n_descriptors, PyArray_Descr *const descrs[], npy_string_allocator *allocators[])
+    void NpyString_release_allocator(npy_string_allocator *allocator)
+    void NpyString_release_allocators(size_t length, npy_string_allocator *allocators[])
+    int NpyString_load(npy_string_allocator *allocator, const npy_packed_static_string *packed_string, npy_static_string *unpacked_string)
+    int NpyString_pack_null(npy_string_allocator *allocator, npy_packed_static_string *packed_string)
+    int NpyString_pack(npy_string_allocator *allocator, npy_packed_static_string *packed_string, const char *buf, size_t size)

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -126,6 +126,7 @@ cdef extern from "numpy/arrayobject.h":
         NPY_OBJECT
         NPY_STRING
         NPY_UNICODE
+        NPY_VSTRING
         NPY_VOID
         NPY_DATETIME
         NPY_TIMEDELTA

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -1156,3 +1156,35 @@ cdef extern from "numpy/arrayobject.h":
     void NpyIter_GetInnerFixedStrideArray(NpyIter* it, npy_intp* outstrides) nogil
     npy_bool NpyIter_IterationNeedsAPI(NpyIter* it) nogil
     void NpyIter_DebugPrint(NpyIter* it)
+
+# NpyString API
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef struct npy_string_allocator:
+        pass
+
+    ctypedef struct npy_packed_static_string:
+        pass
+
+    ctypedef struct npy_static_string:
+        size_t size
+        const char *buf
+
+    ctypedef struct PyArray_StringDTypeObject:
+        PyArray_Descr base
+        PyObject *na_object
+        char coerce
+        char has_nan_na
+        char has_string_na
+        char array_owned
+        npy_static_string default_string
+        npy_static_string na_name
+        npy_string_allocator *allocator
+
+cdef extern from "numpy/arrayobject.h":
+    npy_string_allocator *NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
+    void NpyString_acquire_allocators(size_t n_descriptors, PyArray_Descr *const descrs[], npy_string_allocator *allocators[])
+    void NpyString_release_allocator(npy_string_allocator *allocator)
+    void NpyString_release_allocators(size_t length, npy_string_allocator *allocators[])
+    int NpyString_load(npy_string_allocator *allocator, const npy_packed_static_string *packed_string, npy_static_string *unpacked_string)
+    int NpyString_pack_null(npy_string_allocator *allocator, npy_packed_static_string *packed_string)
+    int NpyString_pack(npy_string_allocator *allocator, npy_packed_static_string *packed_string, const char *buf, size_t size)

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -277,13 +277,12 @@ def npystring_pack(arr):
     )
 
     # copy string->packed_string, the pointer to the underlying array buffer
-    if cnp.NpyString_pack(
+    ret = cnp.NpyString_pack(
         allocator, <cnp.npy_packed_static_string *>cnp.PyArray_DATA(arr), string, size,
-    ) == -1:
-        return -1
+    )
 
     cnp.NpyString_release_allocator(allocator)
-    return 0
+    return ret
 
 
 def npystring_load(arr):
@@ -356,4 +355,4 @@ def npystring_allocators_other_types(arr1, arr2):
             break
 
     cnp.NpyString_release_allocators(2, allocators)
-    return 0
+    return ret

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -295,3 +295,34 @@ def test_complex(install_temp):
     arr = np.array([0, 10+10j], dtype="F")
     inc2_cfloat_struct(arr)
     assert arr[1] == (12 + 12j)
+
+
+def test_npystring_pack(install_temp):
+    """Check that the cython API can write to a vstring array."""
+    import checks
+
+    arr = np.array(['a', 'b', 'c'], dtype='T')
+    assert checks.npystring_pack(arr) == 0
+
+    # checks.npystring_pack writes to the beginning of the array
+    assert arr[0] == "Hello world"
+
+def test_npystring_load(install_temp):
+    """Check that the cython API can load strings from a vstring array."""
+    import checks
+
+    arr = np.array(['abcd', 'b', 'c'], dtype='T')
+    result = checks.npystring_load(arr)
+    assert result == 'abcd'
+
+
+def test_npystring_multiple_allocators(install_temp):
+    """Check that the cython API can acquire/release multiple vstring allocators."""
+    import checks
+
+    arr1 = np.array(['abcd', 'b', 'c'], dtype='T')
+    arr2 = np.array(['a', 'b', 'c'], dtype='T')
+
+    assert checks.npystring_pack_multiple(arr1, arr2) == 0
+    assert arr1[0] == "Hello world"
+    assert arr2[0] == "test this"

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -320,9 +320,21 @@ def test_npystring_multiple_allocators(install_temp):
     """Check that the cython API can acquire/release multiple vstring allocators."""
     import checks
 
-    arr1 = np.array(['abcd', 'b', 'c'], dtype='T')
-    arr2 = np.array(['a', 'b', 'c'], dtype='T')
+    dt = np.dtypes.StringDType(na_object=None)
+    arr1 = np.array(['abcd', 'b', 'c'], dtype=dt)
+    arr2 = np.array(['a', 'b', 'c'], dtype=dt)
 
     assert checks.npystring_pack_multiple(arr1, arr2) == 0
     assert arr1[0] == "Hello world"
+    assert arr1[-1] is None
     assert arr2[0] == "test this"
+
+
+def test_npystring_allocators_other_dtype(install_temp):
+    """Check that allocators for non-StringDType arrays is NULL."""
+    import checks
+
+    arr1 = np.array([1, 2, 3], dtype='i')
+    arr2 = np.array([4, 5, 6], dtype='i')
+
+    assert checks.npystring_allocators_other_types(arr1, arr2) == 0


### PR DESCRIPTION
## Summary

This PR adds cython wrappers for the NpyString API, checking off [one of the items on the remaining NpyString API todo list](https://github.com/numpy/numpy/issues/25693).

## Changes

- Exposed the NpyString API to cython. Opaque types in the C-API are kept opaque here.
- Added tests of the cython wrappers for packing strings into an vstring array and loading them from a vstring array, and for acquiring/releasing multiple allocators at a single time.

cc @ngoldbaum - can you take a look?
