### PR TITLE
DOC: Use internal/intersphinx links for neps.

### DIFF
--- a/doc/C_STYLE_GUIDE.rst
+++ b/doc/C_STYLE_GUIDE.rst
@@ -1,3 +1,3 @@
 
 The "NumPy C Style Guide" at this page has been superseded by
-"NEP 45 — C Style Guide" at https://numpy.org/neps/nep-0045-c_style_guide.html
+:external+nep:doc:`nep-0045-c_style_guide`

--- a/doc/neps/index.rst
+++ b/doc/neps/index.rst
@@ -6,8 +6,7 @@ This page provides an overview of development priorities for NumPy.
 Specifically, it contains a roadmap with a higher-level overview, as
 well as NumPy Enhancement Proposals (NEPs)—suggested changes
 to the library—in various stages of discussion or completion.
-See `NEP 0 <https://github.com/numpy/numpy/blob/main/doc/neps/nep-0000.rst>`__
-for more informations about NEPs.
+See :doc:`nep-0000` for more informations about NEPs.
 
 Roadmap
 -------

--- a/doc/neps/nep-0016-abstract-array.rst
+++ b/doc/neps/nep-0016-abstract-array.rst
@@ -13,8 +13,7 @@ NEP 16 — An abstract base class for identifying "duck arrays"
 .. note::
 
     This NEP has been withdrawn in favor of the protocol based approach
-    described in
-    `NEP 22 <nep-0022-ndarray-duck-typing-overview.html>`__
+    described in :doc:`nep-0022-ndarray-duck-typing-overview`
 
 Abstract
 --------

--- a/doc/neps/nep-0021-advanced-indexing.rst
+++ b/doc/neps/nep-0021-advanced-indexing.rst
@@ -659,5 +659,4 @@ References and footnotes
    with this work has waived all copyright and related or neighboring
    rights to this work. The CC0 license may be found at
    https://creativecommons.org/publicdomain/zero/1.0/
-.. [2] e.g., see NEP 18,
-   http://www.numpy.org/neps/nep-0018-array-function-protocol.html
+.. [2] e.g., see :doc:`nep-0018-array-function-protocol`

--- a/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
+++ b/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
@@ -256,8 +256,7 @@ It’s tempting to try to define cleaned up versions of ndarray methods
 with a more minimal interface to allow for easier implementation. For
 example, ``__array_reshape__`` could drop some of the strange
 arguments accepted by ``reshape`` and ``__array_basic_getitem__``
-could drop all the `strange edge cases
-<http://www.numpy.org/neps/nep-0021-advanced-indexing.html>`__ of
+could drop all the :doc:`strange edge cases <nep-0021-advanced-indexing>` of
 NumPy’s advanced indexing.
 
 But as discussed above, we don’t really know what APIs we need for

--- a/doc/neps/nep-0023-backwards-compatibility.rst
+++ b/doc/neps/nep-0023-backwards-compatibility.rst
@@ -224,8 +224,7 @@ Functionality with more strict deprecation policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - ``numpy.random`` has its own backwards compatibility policy with additional
-  requirements on top of the ones in this NEP, see
-  `NEP 19 <http://www.numpy.org/neps/nep-0019-rng-policy.html>`_.
+  requirements on top of the ones in this NEP, see :doc:`nep-0019-rng-policy`.
 - The file format of ``.npy`` and ``.npz`` files is strictly versioned
   independent of the NumPy version; existing format versions must remain
   backwards compatible even if a newer format version is introduced.

--- a/doc/source/reference/simd/index.rst
+++ b/doc/source/reference/simd/index.rst
@@ -32,12 +32,10 @@ The optimization process in NumPy is carried out in three layers:
 .. note::
 
    NumPy community had a deep discussion before implementing this work,
-   please check `NEP-38`_ for more clarification.
+   please check :external+neps:doc:`nep-0038-SIMD-optimizations` for more
+   clarification.
 
 .. toctree::
 
     build-options
     how-it-works
-
-.. _`NEP-38`: https://numpy.org/neps/nep-0038-SIMD-optimizations.html
-

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -69,8 +69,7 @@ class NDArrayOperatorsMixin:
 
     It is useful for writing classes that do not inherit from `numpy.ndarray`,
     but that should support arithmetic and numpy universal functions like
-    arrays as described in `A Mechanism for Overriding Ufuncs
-    <https://numpy.org/neps/nep-0013-ufunc-overrides.html>`_.
+    arrays as described in :external+neps:doc:`nep-0013-ufunc-overrides`.
 
     As an trivial example, consider this implementation of an ``ArrayLike``
     class that simply wraps a NumPy array and ensures that the result of any


### PR DESCRIPTION
Inspired by #27920 .

Replace external links to NEPs with explicit targets with the appropriate sphinx (or intersphinx) roles. A very minor tweak that should improve the robustness of links moving forward.

These are just the instances I found by grepping (ignoring e.g. release notes).