### PR TITLE
REL: Prepare for the NumPy 2.2.0 release [wheel build]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,6 +10,7 @@
 !8bitmp3 <19637339+8bitmp3@users.noreply.github.com>
 !Algorithmist-Girl <36552319+Algorithmist-Girl@users.noreply.github.com>
 !DWesl <22566757+DWesl@users.noreply.github.com>
+!Dreamge <geetaakshata@gmail.com>
 !Endolith <endolith@gmail.com>
 !GalaxySnail <ylc991@163.com>
 !Illviljan <14371165+Illviljan@users.noreply.github.com>
@@ -20,6 +21,7 @@
 !Scian <65375075+hoony6134@users.noreply.github.com>
 !Searchingdays <pachatyabhaskar@gmail.com>
 !amagicmuffin <2014wcheng@gmail.com>
+!bersbersbers <12128514+bersbersbers@users.noreply.github.com>
 !code-review-doctor <contact+django-doctor-test@richardtier.co.uk>
 !cook-1229 <70235336+cook-1229@users.noreply.github.com>
 !dg3192 <113710955+dg3192@users.noreply.github.com>
@@ -29,6 +31,7 @@
 !fengluoqiuwu <fengluoqiuwu@gmail.com> <163119756+fengluoqiuwu@users.noreply.github.com>
 !h-vetinari <h.vetinari@gmx.com>
 !h6197627 <44726212+h6197627@users.noreply.github.com>
+!hutauf <mathemichi@gmx.de>
 !jbCodeHub <besselingcodehub@gmail.com>
 !juztamau5 <juztamau5@gmail.com>
 !legoffant <58195095+legoffant@users.noreply.github.com>
@@ -39,7 +42,9 @@
 !mcp292 <mcp292@nau.edu>
 !mgunyho <20118130+mgunyho@users.noreply.github.com>
 !msavinash <73682349+msavinash@users.noreply.github.com>
+!musvaage <musvaage@users.noreply.github.com>
 !mykykh <49101849+mykykh@users.noreply.github.com>
+!nullSoup <34267803+nullSoup@users.noreply.github.com>
 !ogidig5 <82846833+ogidig5@users.noreply.github.com>
 !partev <petrosyan@gmail.com>
 !pkubaj <pkubaj@FreeBSD.org>
@@ -642,6 +647,7 @@ Slava Gorloff <31761951+gorloffslava@users.noreply.github.com>
 Søren Rasmussen <soren.rasmussen@alexandra.dk> <47032123+sorenrasmussenai@users.noreply.github.com>
 Spencer Hill <spencerahill@gmail.com> <shill@atmos.ucla.edu>
 Srimukh Sripada <git@srimukh.com>
+Stan Ulbrych <89152624+StanFromIreland@users.noreply.github.com>
 Stefan Behnel <stefan_ml@behnel.de>
 Stefan van der Walt <stefanv@berkeley.edu> <sjvdwalt@gmail.com>
 Stefan van der Walt <stefanv@berkeley.edu> <stefan@sun.ac.za>

--- a/doc/changelog/2.2.0-changelog.rst
+++ b/doc/changelog/2.2.0-changelog.rst
@@ -1,4 +1,3 @@
-Generating change log for range v2.2.0.dev0^..HEAD
 
 Contributors
 ============
@@ -6,8 +5,14 @@ Contributors
 A total of 106 people contributed to this release.  People with a "+" by their
 names contributed a patch for the first time.
 
+* !Dreamge +
+* !bersbersbers +
 * !fengluoqiuwu +
 * !h-vetinari
+* !hutauf +
+* !musvaage +
+* !nullSoup +
+* Aarni Koskela +
 * Abhishek Kumar +
 * Abraham Medina +
 * Aditi Juneja +
@@ -18,7 +23,6 @@ names contributed a patch for the first time.
 * Amit Subhash Chejara +
 * Andrew Nelson
 * Anne Gunn
-* Aarni Koskela +
 * Austin Ran +
 * Ben Walsh
 * Benjamin A. Beasley +
@@ -31,7 +35,6 @@ names contributed a patch for the first time.
 * Clément Robert
 * Dane Reimers +
 * Dimitri Papadopoulos Orfanos
-* Dreamge +
 * Evgeni Burovski
 * GUAN MING
 * Habiba Hye +
@@ -95,7 +98,7 @@ names contributed a patch for the first time.
 * Slava Gorloff +
 * Slobodan Miletic +
 * Soutrik Bandyopadhyay +
-* Stan U. +
+* Stan Ulbrych +
 * Stefan van der Walt
 * Tim Hoffmann
 * Timo Röhling
@@ -106,17 +109,13 @@ names contributed a patch for the first time.
 * Warren Weckesser
 * Xiao Yuan +
 * Yashasvi Misra
-* bersbersbers +
 * bilderbuchi +
 * dependabot[bot]
-* hutauf +
-* musvaage +
-* nullSoup +
 
 Pull requests merged
 ====================
 
-A total of 307 pull requests were merged for this release.
+A total of 317 pull requests were merged for this release.
 
 * `#14622 <https://github.com/numpy/numpy/pull/14622>`__: BUG: fix datetime64/timedelta64 hash and match Python
 * `#15181 <https://github.com/numpy/numpy/pull/15181>`__: ENH: Add nd-support to trim_zeros
@@ -425,4 +424,14 @@ A total of 307 pull requests were merged for this release.
 * `#27845 <https://github.com/numpy/numpy/pull/27845>`__: BUG: Never negate strides in reductions (for now)
 * `#27846 <https://github.com/numpy/numpy/pull/27846>`__: ENH: add matvec and vecmat gufuncs
 * `#27852 <https://github.com/numpy/numpy/pull/27852>`__: DOC: Correct versionadded for vecmat and matvec.
+* `#27853 <https://github.com/numpy/numpy/pull/27853>`__: REL: Prepare for the NumPy 2.2.0rc1 release [wheel build]
+* `#27874 <https://github.com/numpy/numpy/pull/27874>`__: BUG: fix importing numpy in Python's optimized mode (#27868)
+* `#27895 <https://github.com/numpy/numpy/pull/27895>`__: DOC: Fix double import in docs (#27878)
+* `#27904 <https://github.com/numpy/numpy/pull/27904>`__: MAINT: Ensure correct handling for very large unicode strings
+* `#27906 <https://github.com/numpy/numpy/pull/27906>`__: MAINT: Use mask_store instead of store for compiler workaround
+* `#27908 <https://github.com/numpy/numpy/pull/27908>`__: MAINT: Update highway from main.
+* `#27911 <https://github.com/numpy/numpy/pull/27911>`__: ENH: update __module__ in numpy.random module
+* `#27912 <https://github.com/numpy/numpy/pull/27912>`__: ENH: Refactor ``__qualname__`` across API
+* `#27913 <https://github.com/numpy/numpy/pull/27913>`__: PERF: improve multithreaded ufunc scaling
+* `#27916 <https://github.com/numpy/numpy/pull/27916>`__: MAINT: Bump actions/cache from 4.1.2 to 4.2.0
 

--- a/doc/release/upcoming_changes/27896.performance.rst
+++ b/doc/release/upcoming_changes/27896.performance.rst
@@ -1,2 +1,0 @@
-* Improved multithreaded scaling on the free-threaded build when many threads
-  simultaneously call the same ufunc operations.

--- a/doc/source/release/2.2.0-notes.rst
+++ b/doc/source/release/2.2.0-notes.rst
@@ -125,6 +125,11 @@ multiple modules are present within a single source file.
 Performance improvements and changes
 ====================================
 
+* Improved multithreaded scaling on the free-threaded build when many threads
+  simultaneously call the same ufunc operations.
+
+  (`gh-27896 <https://github.com/numpy/numpy/pull/27896>`__)
+
 * NumPy now uses fast-on-failure attribute lookups for protocols.  This can
   greatly reduce overheads of function calls or array creation especially with
   custom Python objects.  The largest improvements will be seen on Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "numpy"
-version = "2.2.0rc1"
+version = "2.2.0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 license = {file = "LICENSE.txt"}
 

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -78,7 +78,7 @@ macosx_arm64_task:
 
   build_script: |
     brew install micromamba gfortran
-    micromamba shell init -s bash -p ~/micromamba
+    micromamba shell init -s bash --root-prefix ~/micromamba
     source ~/.bash_profile
     
     micromamba create -n numpydev


### PR DESCRIPTION
- Update .mailmap
- Update pyproject.toml
- Update 2.2.0-changelog.rst
- Update 2.2.0-notes.rst
- Remove fragment

Also fixes the cirrus MacOs wheel builds. See #27930.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
