### PR TITLE
MAINT: Fix cirrus MacOs wheel builds [wheel build]

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -76,7 +76,7 @@ macosx_arm64_task:
 
   build_script: |
     brew install micromamba gfortran
-    micromamba shell init -s bash -p ~/micromamba
+    micromamba shell init -s bash --root-prefix ~/micromamba
     source ~/.bash_profile
     
     micromamba create -n numpydev


### PR DESCRIPTION
@andyfaff Ping. This started failing last week. See https://cirrus-ci.com/build/5843049672081408.

@ngoldbaum You didn't see this failure in #27899 because the added commits did not have [wheel build] in the title line.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
