### PR TITLE
CI: audit with zizmor

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -13,7 +13,7 @@ runs:
       pip install -r requirements/build_requirements.txt
       echo "::endgroup::"
       echo "::group::Building NumPy"
-      spin build --clean -- "${MESON_ARGS[@]}"
+      spin build --clean -- ${MESON_ARGS[@]}
       echo "::endgroup::"
 
   - name: Meson Log

--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -13,7 +13,7 @@ runs:
       pip install -r requirements/build_requirements.txt
       echo "::endgroup::"
       echo "::group::Building NumPy"
-      spin build --clean -- ${MESON_ARGS[@]}
+      spin build --clean -- "${MESON_ARGS[@]}"
       echo "::endgroup::"
 
   - name: Meson Log

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          persist-credentials: false
       - name: Install Cygwin
         uses: egor-tensin/setup-cygwin@d2c752bab416d4b0662591bd366fc2686297c82d # v4
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,5 +16,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          persist-credentials: false
 
       - uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969  # v2.22.0
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -44,8 +45,10 @@ jobs:
       run:
         python -m pip install -r requirements/linter_requirements.txt
     - name: Run linter on PR diff
+      env:
+        BASE_REF: ${{ github.base_ref }}
       run:
-        python tools/linter.py --branch origin/${{ github.base_ref }}
+        python tools/linter.py --branch origin/"$BASE_REF"
 
   smoke_test:
     # To enable this job on a fork, comment out:
@@ -61,6 +64,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:
         python-version: ${{ matrix.version }}
@@ -81,6 +85,7 @@ jobs:
       #with:
         #submodules: recursive
         #fetch-tags: true
+        #persist-credentials: false
     #- uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       #with:
         #python-version: 'pypy3.10-v7.3.17'
@@ -99,6 +104,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - name: Install debug Python
       run: |
         sudo apt-get update
@@ -128,6 +134,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -165,6 +172,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -202,6 +210,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -236,6 +245,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - name: Checkout array-api-tests
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -243,6 +253,7 @@ jobs:
         ref: '827edd804bcace9d64176b8115138d29ae3e8dec'  # Latest commit as of 2024-07-30
         submodules: 'true'
         path: 'array-api-tests'
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
@@ -272,6 +283,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -69,6 +69,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -130,6 +131,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Install dependencies
       run: |
@@ -165,6 +167,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Install dependencies
       run: |
@@ -195,6 +198,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -223,6 +227,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -259,6 +264,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Install PyPI dependencies
       run: |
@@ -283,6 +289,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -346,6 +353,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -382,6 +390,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'

--- a/.github/workflows/linux_compiler_sanitizers.yml
+++ b/.github/workflows/linux_compiler_sanitizers.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -104,6 +104,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -62,6 +62,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -79,6 +80,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -144,6 +146,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: "${{ matrix.BUILD_PROP[2] }}"
@@ -158,6 +161,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'
@@ -208,6 +212,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.11'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
+        persist-credentials: false
+      
 
     - name:  Prepare cache dirs and timestamps
       id:    prep-ccache
@@ -120,6 +123,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,8 +33,6 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-        persist-credentials: false
-      
 
     - name:  Prepare cache dirs and timestamps
       id:    prep-ccache

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -54,6 +54,8 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
+
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.os_python[1] }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -11,7 +11,7 @@ on:
     branches: ["main"]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,13 +52,16 @@ jobs:
         # Gets the correct commit message for pull request
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Get commit message
         id: commit_message
+        env:
+          HEAD: ${{ github.ref }}
         run: |
           set -xe
           COMMIT_MSG=$(git log --no-merges -1 --oneline)
           echo "message=$COMMIT_MSG" >> $GITHUB_OUTPUT
-          echo github.ref ${{ github.ref }}
+          echo github.ref "$HEAD"
 
   build_wheels:
     name: Build wheel ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
@@ -107,6 +110,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Setup MSVC (32-bit)
         if: ${{ matrix.buildplat[1] == 'win32' }}
@@ -228,6 +232,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
+          persist-credentials: false
       # Used to push the built wheels
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Setup Python
       uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
@@ -101,6 +102,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup Python (32-bit)
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/windows_arm64.yml
+++ b/.github/workflows/windows_arm64.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
+        persist-credentials: false
 
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
I recently discovered [zizmor](https://woodruffw.github.io/zizmor/), a tool to audit github workflows. It exposed some things we should change to make our workflows more secure. The main one, which is really not that important apparently is adding [persistant-credientials: false](https://github.com/actions/checkout/issues/485) to the checkout step. But once that was cleared, the real problems appeared: using un-escaped user-provided variables (like the branch name) to scripts.