### PR TITLE
BUG: fix building numpy on musl s390x

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -632,11 +632,12 @@ npy__cpu_init_features(void)
 
 #include <sys/auxv.h>
 
-#ifndef HWCAP_S390_VX
-    #define HWCAP_S390_VX 2048
+/* kernel HWCAP names, available in musl, not available in glibc<2.33: https://sourceware.org/bugzilla/show_bug.cgi?id=25971 */
+#ifndef HWCAP_S390_VXRS
+    #define HWCAP_S390_VXRS 2048
 #endif
-#ifndef HWCAP_S390_VXE
-    #define HWCAP_S390_VXE 8192
+#ifndef HWCAP_S390_VXRS_EXT
+    #define HWCAP_S390_VXRS_EXT 8192
 #endif
 #ifndef HWCAP_S390_VXRS_EXT2
     #define HWCAP_S390_VXRS_EXT2 32768
@@ -648,7 +649,7 @@ npy__cpu_init_features(void)
     memset(npy__cpu_have, 0, sizeof(npy__cpu_have[0]) * NPY_CPU_FEATURE_MAX);
 
     unsigned int hwcap = getauxval(AT_HWCAP);
-    if ((hwcap & HWCAP_S390_VX) == 0) {
+    if ((hwcap & HWCAP_S390_VXRS) == 0) {
         return;
     }
 
@@ -659,7 +660,7 @@ npy__cpu_init_features(void)
        return;
     }
 
-    npy__cpu_have[NPY_CPU_FEATURE_VXE] = (hwcap & HWCAP_S390_VXE) != 0;
+    npy__cpu_have[NPY_CPU_FEATURE_VXE] = (hwcap & HWCAP_S390_VXRS_EXT) != 0;
 
     npy__cpu_have[NPY_CPU_FEATURE_VX]  = 1;
 }

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -631,10 +631,13 @@ npy__cpu_init_features(void)
 #elif defined(__s390x__)
 
 #include <sys/auxv.h>
+
+#ifndef HWCAP_S390_VX
+    #define HWCAP_S390_VX 2048
+#endif
 #ifndef HWCAP_S390_VXE
     #define HWCAP_S390_VXE 8192
 #endif
-
 #ifndef HWCAP_S390_VXRS_EXT2
     #define HWCAP_S390_VXRS_EXT2 32768
 #endif


### PR DESCRIPTION
`HWCAP_S390_VX` is not defined on musl libc. Define the macro when not already defined.

xref https://gitlab.alpinelinux.org/alpine/aports/-/blob/v3.21.0/community/py3-numpy/s390x-hwcap.patch?ref_type=tags

fix #27932

The second commit can be removed or kept pending review. It uses the kernel HWCAP names for s390 which are defined in musl libc and recent glibc versions (>= 2.33):
```
find /usr -name '*.h' -exec grep -H HWCAP_S390_VX {} \;

glibc 2.17
/usr/include/bits/hwcap.h:#define HWCAP_S390_VX           2048
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXD          4096
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXE          8192

glibc 2.34
/usr/include/bits/hwcap.h:#define HWCAP_S390_VX           2048
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS         HWCAP_S390_VX
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXD          4096
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_BCD     HWCAP_S390_VXD
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXE          8192
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_EXT     HWCAP_S390_VXE
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_EXT2    32768
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_PDE     65536
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_PDE2    524288

musl 1.2
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS		2048
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_BCD	4096
/usr/include/bits/hwcap.h:#define HWCAP_S390_VXRS_EXT	8192
```