### PR TITLE
BUG: fix use-after-free error in npy_hashtable.cpp

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.cpp
+++ b/numpy/_core/src/common/npy_hashtable.cpp
@@ -126,10 +126,10 @@ NPY_NO_EXPORT void
 PyArrayIdentityHash_Dealloc(PyArrayIdentityHash *tb)
 {
     PyMem_Free(tb->buckets);
-    PyMem_Free(tb);
 #ifdef Py_GIL_DISABLED
     delete (std::shared_mutex *)tb->mutex;
 #endif
+    PyMem_Free(tb);
 }
 
 


### PR DESCRIPTION
Fixes #27953.

Those `Py_GIL_DISABLED` ifdefs clearly confused me.