### PR TITLE
BUG: fix use-after-free error in npy_hashtable.cpp (#27955)

### DIFF
--- a/numpy/_core/src/common/npy_hashtable.cpp
+++ b/numpy/_core/src/common/npy_hashtable.cpp
@@ -126,10 +126,10 @@ NPY_NO_EXPORT void
 PyArrayIdentityHash_Dealloc(PyArrayIdentityHash *tb)
 {
     PyMem_Free(tb->buckets);
-    PyMem_Free(tb);
 #ifdef Py_GIL_DISABLED
     delete (std::shared_mutex *)tb->mutex;
 #endif
+    PyMem_Free(tb);
 }
 
 


### PR DESCRIPTION
Backport of #27955.

Fixes https://github.com/numpy/numpy/issues/27953.

Those Py_GIL_DISABLED ifdefs clearly confused me.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
