### PR TITLE
MAINT: Apply ruff/flake8-comprehensions rules (C4)

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -72,7 +72,7 @@ class Eindot(Benchmark):
 
 
 class Linalg(Benchmark):
-    params = sorted(set(TYPES1) - set(['float16']))
+    params = sorted(set(TYPES1) - {'float16'})
     param_names = ['dtype']
 
     def setup(self, typename):

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -31,7 +31,7 @@ for name in ufuncs:
 
 all_ufuncs = (getattr(np, name, None) for name in dir(np))
 all_ufuncs = set(filter(lambda f: isinstance(f, np.ufunc), all_ufuncs))
-bench_ufuncs = set(getattr(np, name, None) for name in ufuncs)
+bench_ufuncs = {getattr(np, name, None) for name in ufuncs}
 
 missing_ufuncs = all_ufuncs - bench_ufuncs
 if len(missing_ufuncs) > 0:

--- a/doc/preprocess.py
+++ b/doc/preprocess.py
@@ -29,7 +29,7 @@ def doxy_config(root_path):
     """
     confs = []
     dsrc_path = os.path.join(root_path, "doc", "source")
-    sub = dict(ROOT_DIR=root_path)
+    sub = {'ROOT_DIR': root_path}
     with open(os.path.join(dsrc_path, "doxyfile")) as fd:
         conf = DoxyTpl(fd.read())
         confs.append(conf.substitute(CUR_DIR=dsrc_path, **sub))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -592,7 +592,7 @@ class NumPyLexer(CLexer):
 # -----------------------------------------------------------------------------
 # Breathe & Doxygen
 # -----------------------------------------------------------------------------
-breathe_projects = dict(numpy=os.path.join("..", "build", "doxygen", "xml"))
+breathe_projects = {'numpy': os.path.join("..", "build", "doxygen", "xml")}
 breathe_default_project = "numpy"
 breathe_default_members = ("members", "undoc-members", "protected-members")
 

--- a/numpy/_build_utils/__init__.py
+++ b/numpy/_build_utils/__init__.py
@@ -5,9 +5,9 @@
 #
 #   config.add_extension('_name', sources=['source_fname'], **numpy_nodepr_api)
 #
-numpy_nodepr_api = dict(
-    define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_9_API_VERSION")]
-)
+numpy_nodepr_api = {
+    "define_macros": [("NPY_NO_DEPRECATED_API", "NPY_1_9_API_VERSION")]
+}
 
 
 def import_file(folder, module_name):

--- a/numpy/_build_utils/tempita/_tempita.py
+++ b/numpy/_build_utils/tempita/_tempita.py
@@ -883,7 +883,7 @@ def parse_for(tokens, name, context):
             position=pos,
             name=name,
         )
-    vars = tuple([v.strip() for v in first[: match.start()].split(",") if v.strip()])
+    vars = tuple(v.strip() for v in first[: match.start()].split(",") if v.strip())
     expr = first[match.end():]
     while 1:
         if not tokens:

--- a/numpy/_core/_dtype_ctypes.py
+++ b/numpy/_core/_dtype_ctypes.py
@@ -57,11 +57,11 @@ def _from_ctypes_structure(t):
             offsets.append(current_offset)
             current_offset += ctypes.sizeof(ftyp)
 
-        return np.dtype(dict(
-            formats=formats,
-            offsets=offsets,
-            names=names,
-            itemsize=ctypes.sizeof(t)))
+        return np.dtype({
+            "formats": formats,
+            "offsets": offsets,
+            "names": names,
+            "itemsize": ctypes.sizeof(t)})
     else:
         fields = []
         for fname, ftyp in t._fields_:
@@ -93,11 +93,11 @@ def _from_ctypes_union(t):
         formats.append(dtype_from_ctypes_type(ftyp))
         offsets.append(0)  # Union fields are offset to 0
 
-    return np.dtype(dict(
-        formats=formats,
-        offsets=offsets,
-        names=names,
-        itemsize=ctypes.sizeof(t)))
+    return np.dtype({
+        "formats": formats,
+        "offsets": offsets,
+        "names": names,
+        "itemsize": ctypes.sizeof(t)})
 
 
 def dtype_from_ctypes_type(t):

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -669,12 +669,12 @@ def _dtype_from_pep3118(spec):
     return dtype
 
 def __dtype_from_pep3118(stream, is_subdtype):
-    field_spec = dict(
-        names=[],
-        formats=[],
-        offsets=[],
-        itemsize=0
-    )
+    field_spec = {
+        'names': [],
+        'formats': [],
+        'offsets': [],
+        'itemsize': 0
+    }
     offset = 0
     common_alignment = 1
     is_padding = False
@@ -834,21 +834,21 @@ def _fix_names(field_spec):
 def _add_trailing_padding(value, padding):
     """Inject the specified number of padding bytes at the end of a dtype"""
     if value.fields is None:
-        field_spec = dict(
-            names=['f0'],
-            formats=[value],
-            offsets=[0],
-            itemsize=value.itemsize
-        )
+        field_spec = {
+            'names': ['f0'],
+            'formats': [value],
+            'offsets': [0],
+            'itemsize': value.itemsize
+        }
     else:
         fields = value.fields
         names = value.names
-        field_spec = dict(
-            names=names,
-            formats=[fields[name][0] for name in names],
-            offsets=[fields[name][1] for name in names],
-            itemsize=value.itemsize
-        )
+        field_spec = {
+            'names': names,
+            'formats': [fields[name][0] for name in names],
+            'offsets': [fields[name][1] for name in names],
+            'itemsize': value.itemsize
+        }
 
     field_spec['itemsize'] += padding
     return dtype(field_spec)

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -136,15 +136,15 @@ def check_td_order(tds):
         _check_order(signatures[prev_i], sign)
 
 
-_floatformat_map = dict(
-    e='npy_%sf',
-    f='npy_%sf',
-    d='npy_%s',
-    g='npy_%sl',
-    F='nc_%sf',
-    D='nc_%s',
-    G='nc_%sl'
-)
+_floatformat_map = {
+    "e": 'npy_%sf',
+    "f": 'npy_%sf',
+    "d": 'npy_%s',
+    "g": 'npy_%sl',
+    "F": 'nc_%sf',
+    "D": 'nc_%s',
+    "G": 'nc_%sl'
+}
 
 def build_func_data(types, f):
     func_data = [_floatformat_map.get(t, '%s') % (f,) for t in types]
@@ -1512,19 +1512,19 @@ def make_ufuncs(funcdict):
                 return -1;
             }}
         """)
-        args = dict(
-            name=name,
-            funcs=f"{name}_functions" if not uf.empty else "NULL",
-            data=f"{name}_data" if not uf.empty else "NULL",
-            signatures=f"{name}_signatures" if not uf.empty else "NULL",
-            nloops=len(uf.type_descriptions),
-            nin=uf.nin, nout=uf.nout,
-            has_identity='0' if uf.identity is None_ else '1',
-            identity='PyUFunc_IdentityValue',
-            identity_expr=uf.identity,
-            doc=uf.docstring,
-            sig=sig,
-        )
+        args = {
+            "name": name,
+            "funcs": f"{name}_functions" if not uf.empty else "NULL",
+            "data": f"{name}_data" if not uf.empty else "NULL",
+            "signatures": f"{name}_signatures" if not uf.empty else "NULL",
+            "nloops": len(uf.type_descriptions),
+            "nin": uf.nin, "nout": uf.nout,
+            "has_identity": '0' if uf.identity is None_ else '1',
+            "identity": 'PyUFunc_IdentityValue',
+            "identity_expr": uf.identity,
+            "doc": uf.docstring,
+            "sig": sig,
+        }
 
         # Only PyUFunc_None means don't reorder - we pass this using the old
         # argument

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -129,22 +129,22 @@ _convert_to_float = {
 # Parameters for creating MachAr / MachAr-like objects
 _title_fmt = 'numpy {} precision floating point number'
 _MACHAR_PARAMS = {
-    ntypes.double: dict(
-        itype = ntypes.int64,
-        fmt = '%24.16e',
-        title = _title_fmt.format('double')),
-    ntypes.single: dict(
-        itype = ntypes.int32,
-        fmt = '%15.7e',
-        title = _title_fmt.format('single')),
-    ntypes.longdouble: dict(
-        itype = ntypes.longlong,
-        fmt = '%s',
-        title = _title_fmt.format('long double')),
-    ntypes.half: dict(
-        itype = ntypes.int16,
-        fmt = '%12.5e',
-        title = _title_fmt.format('half'))}
+    ntypes.double: {
+        'itype': ntypes.int64,
+        'fmt': '%24.16e',
+        'title': _title_fmt.format('double')},
+    ntypes.single: {
+        'itype': ntypes.int32,
+        'fmt': '%15.7e',
+        'title': _title_fmt.format('single')},
+    ntypes.longdouble: {
+        'itype': ntypes.longlong,
+        'fmt': '%s',
+        'title': _title_fmt.format('long double')},
+    ntypes.half: {
+        'itype': ntypes.int16,
+        'fmt': '%12.5e',
+        'title': _title_fmt.format('half')}}
 
 # Key to identify the floating point type.  Key is result of
 #

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1432,7 +1432,7 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
         except TypeError:
             pass
     # Going via an iterator directly is slower than via list comprehension.
-    axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
+    axis = tuple(normalize_axis_index(ax, ndim, argname) for ax in axis)
     if not allow_duplicate and len(set(axis)) != len(axis):
         if argname:
             raise ValueError('repeated axis in `{}` argument'.format(argname))

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1268,7 +1268,7 @@ def roll(a, shift, axis=None):
         if broadcasted.ndim > 1:
             raise ValueError(
                 "'shift' and 'axis' should be scalars or 1D sequences")
-        shifts = {ax: 0 for ax in range(a.ndim)}
+        shifts = dict.fromkeys(range(a.ndim), 0)
         for sh, ax in broadcasted:
             shifts[ax] += int(sh)
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1830,7 +1830,7 @@ def indices(dimensions, dtype=int, sparse=False):
     N = len(dimensions)
     shape = (1,) * N
     if sparse:
-        res = tuple()
+        res = ()
     else:
         res = empty((N,) + dimensions, dtype=dtype)
     for i, dim in enumerate(dimensions):

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -74,14 +74,14 @@ def test_array_array():
     # test array interface
     a = np.array(100.0, dtype=np.float64)
     o = type("o", (object,),
-             dict(__array_interface__=a.__array_interface__))
+             {"__array_interface__": a.__array_interface__})
     assert_equal(np.array(o, dtype=np.float64), a)
 
     # test array_struct interface
     a = np.array([(1, 4.0, 'Hello'), (2, 6.0, 'World')],
                  dtype=[('f0', int), ('f1', float), ('f2', str)])
     o = type("o", (object,),
-             dict(__array_struct__=a.__array_struct__))
+             {"__array_struct__": a.__array_struct__})
     ## wasn't what I expected... is np.array(o) supposed to equal a ?
     ## instead we get a array([...], dtype=">V18")
     assert_equal(bytes(np.array(o).data), bytes(a.data))
@@ -90,7 +90,7 @@ def test_array_array():
     def custom__array__(self, dtype=None, copy=None):
         return np.array(100.0, dtype=dtype, copy=copy)
 
-    o = type("o", (object,), dict(__array__=custom__array__))()
+    o = type("o", (object,), {"__array__": custom__array__})()
     assert_equal(np.array(o, dtype=np.float64), np.array(100.0, np.float64))
 
     # test recursion

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -330,7 +330,7 @@ class TestArray2String:
             r"       b'\x1B\x5B\x33\x31\x6D\x52\x65\x64'], dtype='|V8')")
 
         assert_equal(eval(repr(a), vars(np)), a)
-        assert_equal(eval(repr(a[0]), dict(np=np)), a[0])
+        assert_equal(eval(repr(a[0]), {'np': np}), a[0])
 
     def test_edgeitems_kwarg(self):
         # previously the global print options would be taken over the kwarg

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -753,11 +753,11 @@ class TestCasting:
             # field cases (field to field is tested explicitly also):
             # Not considered viewable, because a negative offset would allow
             # may structured dtype to indirectly access invalid memory.
-            ("i", dict(names=["a"], formats=["i"], offsets=[2]), None),
-            (dict(names=["a"], formats=["i"], offsets=[2]), "i", 2),
+            ("i", {"names": ["a"], "formats": ["i"], "offsets": [2]}, None),
+            ({"names": ["a"], "formats": ["i"], "offsets": [2]}, "i", 2),
             # Currently considered not viewable, due to multiple fields
             # even though they overlap (maybe we should not allow that?)
-            ("i", dict(names=["a", "b"], formats=["i", "i"], offsets=[2, 2]),
+            ("i", {"names": ["a", "b"], "formats": ["i", "i"], "offsets": [2, 2]},
              None),
             # different number of fields can't work, should probably just fail
             # so it never reports "viewable":

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -26,7 +26,7 @@ def assert_features_equal(actual, desired, fname):
 
     try:
         import subprocess
-        auxv = subprocess.check_output(['/bin/true'], env=dict(LD_SHOW_AUXV="1"))
+        auxv = subprocess.check_output(['/bin/true'], env={"LD_SHOW_AUXV": "1"})
         auxv = auxv.decode()
     except Exception as err:
         auxv = str(err)
@@ -105,7 +105,7 @@ class AbstractTest:
         return values
 
     def load_flags_auxv(self):
-        auxv = subprocess.check_output(['/bin/true'], env=dict(LD_SHOW_AUXV="1"))
+        auxv = subprocess.check_output(['/bin/true'], env={"LD_SHOW_AUXV": "1"})
         for at in auxv.split(b'\n'):
             if not at.startswith(b"AT_HWCAP"):
                 continue
@@ -127,7 +127,7 @@ class TestEnvPrivation:
     env = os.environ.copy()
     _enable = os.environ.pop('NPY_ENABLE_CPU_FEATURES', None)
     _disable = os.environ.pop('NPY_DISABLE_CPU_FEATURES', None)
-    SUBPROCESS_ARGS = dict(cwd=cwd, capture_output=True, text=True, check=True)
+    SUBPROCESS_ARGS = {"cwd": cwd, "capture_output": True, "text": True, "check": True}
     unavailable_feats = [
         feat for feat in __cpu_dispatch__ if not __cpu_features__[feat]
     ]
@@ -346,27 +346,28 @@ class Test_X86_Features(AbstractTest):
         "AVX512VL", "AVX512BW", "AVX512DQ", "AVX512VNNI", "AVX512IFMA",
         "AVX512VBMI", "AVX512VBMI2", "AVX512BITALG", "AVX512FP16",
     ]
-    features_groups = dict(
-        AVX512_KNL = ["AVX512F", "AVX512CD", "AVX512ER", "AVX512PF"],
-        AVX512_KNM = ["AVX512F", "AVX512CD", "AVX512ER", "AVX512PF", "AVX5124FMAPS",
+    features_groups = {
+        "AVX512_KNL": ["AVX512F", "AVX512CD", "AVX512ER", "AVX512PF"],
+        "AVX512_KNM": ["AVX512F", "AVX512CD", "AVX512ER", "AVX512PF", "AVX5124FMAPS",
                       "AVX5124VNNIW", "AVX512VPOPCNTDQ"],
-        AVX512_SKX = ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL"],
-        AVX512_CLX = ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512VNNI"],
-        AVX512_CNL = ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512IFMA",
+        "AVX512_SKX": ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL"],
+        "AVX512_CLX": ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512VNNI"],
+        "AVX512_CNL": ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512IFMA",
                       "AVX512VBMI"],
-        AVX512_ICL = ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512IFMA",
+        "AVX512_ICL": ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ", "AVX512VL", "AVX512IFMA",
                       "AVX512VBMI", "AVX512VNNI", "AVX512VBMI2", "AVX512BITALG", "AVX512VPOPCNTDQ"],
-        AVX512_SPR = ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ",
+        "AVX512_SPR": ["AVX512F", "AVX512CD", "AVX512BW", "AVX512DQ",
                       "AVX512VL", "AVX512IFMA", "AVX512VBMI", "AVX512VNNI",
                       "AVX512VBMI2", "AVX512BITALG", "AVX512VPOPCNTDQ",
                       "AVX512FP16"],
-    )
-    features_map = dict(
-        SSE3="PNI", SSE41="SSE4_1", SSE42="SSE4_2", FMA3="FMA",
-        AVX512VNNI="AVX512_VNNI", AVX512BITALG="AVX512_BITALG", AVX512VBMI2="AVX512_VBMI2",
-        AVX5124FMAPS="AVX512_4FMAPS", AVX5124VNNIW="AVX512_4VNNIW", AVX512VPOPCNTDQ="AVX512_VPOPCNTDQ",
-        AVX512FP16="AVX512_FP16",
-    )
+    }
+    features_map = {
+        "SSE3": "PNI", "SSE41": "SSE4_1", "SSE42": "SSE4_2", "FMA3": "FMA",
+        "AVX512VNNI": "AVX512_VNNI", "AVX512BITALG": "AVX512_BITALG",
+        "AVX512VBMI2": "AVX512_VBMI2", "AVX5124FMAPS": "AVX512_4FMAPS",
+        "AVX5124VNNIW": "AVX512_4VNNIW", "AVX512VPOPCNTDQ": "AVX512_VPOPCNTDQ",
+        "AVX512FP16": "AVX512_FP16",
+    }
 
     def load_flags(self):
         self.load_flags_cpuinfo("flags")
@@ -376,7 +377,7 @@ is_power = re.match("^(powerpc|ppc)64", machine, re.IGNORECASE)
 @pytest.mark.skipif(not is_linux or not is_power, reason="Only for Linux and Power")
 class Test_POWER_Features(AbstractTest):
     features = ["VSX", "VSX2", "VSX3", "VSX4"]
-    features_map = dict(VSX2="ARCH_2_07", VSX3="ARCH_3_00", VSX4="ARCH_3_1")
+    features_map = {"VSX2": "ARCH_2_07", "VSX3": "ARCH_3_00", "VSX4": "ARCH_3_1"}
 
     def load_flags(self):
         self.load_flags_auxv()
@@ -398,10 +399,10 @@ class Test_ARM_Features(AbstractTest):
     features = [
         "SVE", "NEON", "ASIMD", "FPHP", "ASIMDHP", "ASIMDDP", "ASIMDFHM"
     ]
-    features_groups = dict(
-        NEON_FP16 = ["NEON", "HALF"],
-        NEON_VFPV4 = ["NEON", "VFPV4"],
-    )
+    features_groups = {
+        "NEON_FP16":  ["NEON", "HALF"],
+        "NEON_VFPV4": ["NEON", "VFPV4"],
+    }
 
     def load_flags(self):
         self.load_flags_cpuinfo("Features")
@@ -409,13 +410,13 @@ class Test_ARM_Features(AbstractTest):
         # in case of mounting virtual filesystem of aarch64 kernel
         is_rootfs_v8 = int('0' + next(iter(arch))) > 7 if arch else 0
         if re.match("^(aarch64|AARCH64)", machine) or is_rootfs_v8:
-            self.features_map = dict(
-                NEON="ASIMD", HALF="ASIMD", VFPV4="ASIMD"
-            )
+            self.features_map = {
+                "NEON": "ASIMD", "HALF": "ASIMD", "VFPV4": "ASIMD"
+            }
         else:
-            self.features_map = dict(
+            self.features_map = {
                 # ELF auxiliary vector and /proc/cpuinfo on Linux kernel(armv8 aarch32)
                 # doesn't provide information about ASIMD, so we assume that ASIMD is supported
                 # if the kernel reports any one of the following ARM8 features.
-                ASIMD=("AES", "SHA1", "SHA2", "PMULL", "CRC32")
-            )
+                "ASIMD": ("AES", "SHA1", "SHA2", "PMULL", "CRC32")
+            }

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -90,7 +90,7 @@ class _DeprecationTestCase:
 
         try:
             function(*args, **kwargs)
-        except (Exception if function_fails else tuple()):
+        except (Exception if function_fails else ()):
             pass
 
         # just in case, clear the registry
@@ -112,11 +112,11 @@ class _DeprecationTestCase:
                                     category=self.warning_cls)
             try:
                 function(*args, **kwargs)
-                if exceptions != tuple():
+                if exceptions != ():
                     raise AssertionError(
                             "No error raised during function call")
             except exceptions:
-                if exceptions == tuple():
+                if exceptions == ():
                     raise AssertionError(
                             "Error raised during function call")
 
@@ -129,7 +129,7 @@ class _DeprecationTestCase:
                         exceptions=tuple(), args=args, kwargs=kwargs)
         """
         self.assert_deprecated(function, num=0, ignore_others=True,
-                        exceptions=tuple(), args=args, kwargs=kwargs)
+                        exceptions=(), args=args, kwargs=kwargs)
 
 
 class _VisibleDeprecationTestCase(_DeprecationTestCase):
@@ -402,7 +402,7 @@ class FlatteningConcatenateUnsafeCast(_DeprecationTestCase):
     def test_deprecated(self):
         self.assert_deprecated(np.concatenate,
                 args=(([0.], [1.]),),
-                kwargs=dict(axis=None, out=np.empty(2, dtype=np.int64)))
+                kwargs={'axis': None, 'out': np.empty(2, dtype=np.int64)})
 
     def test_not_deprecated(self):
         self.assert_not_deprecated(np.concatenate,
@@ -644,7 +644,7 @@ class TestLibImports(_DeprecationTestCase):
         self.assert_deprecated(lambda: safe_eval("None"))
 
         data_gen = lambda: TextIO('A,B\n0,1\n2,3')
-        kwargs = dict(delimiter=",", missing_values="N/A", names=True)
+        kwargs = {'delimiter': ",", 'missing_values': "N/A", 'names': True}
         self.assert_deprecated(lambda: recfromcsv(data_gen()))
         self.assert_deprecated(lambda: recfromtxt(data_gen(), **kwargs))
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -281,7 +281,7 @@ class TestRecord:
         formats = ["f8"]
         titles = ["t1"]
         offsets = [0]
-        d = dict(names=names, formats=formats, titles=titles, offsets=offsets)
+        d = {"names": names, "formats": formats, "titles": titles, "offsets": offsets}
         refcounts = {k: sys.getrefcount(i) for k, i in d.items()}
         np.dtype(d)
         refcounts_new = {k: sys.getrefcount(i) for k, i in d.items()}
@@ -325,9 +325,9 @@ class TestRecord:
         the dtype constructor.
         """
         assert_raises(TypeError, np.dtype,
-                      dict(names={'A', 'B'}, formats=['f8', 'i4']))
+                      {"names": {'A', 'B'}, "formats": ['f8', 'i4']})
         assert_raises(TypeError, np.dtype,
-                      dict(names=['A', 'B'], formats={'f8', 'i4'}))
+                      {"names": ['A', 'B'], "formats": {'f8', 'i4'}})
 
     def test_aligned_size(self):
         # Check that structured dtypes get padded to an aligned size
@@ -652,7 +652,7 @@ class TestSubarray:
 
     def test_shape_equal(self):
         """Test some data types that are equal"""
-        assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
+        assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', ())))
         assert_dtype_equal(np.dtype('(1,)f8'), np.dtype(('f8', 1)))
         assert np.dtype(('f8', 1)).shape == (1,)
         assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
@@ -971,7 +971,7 @@ class TestMonsterType:
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
     def test_list_recursion(self):
-        l = list()
+        l = []
         l.append(('f', l))
         with pytest.raises(RecursionError):
             np.dtype(l)
@@ -986,7 +986,7 @@ class TestMonsterType:
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
     def test_dict_recursion(self):
-        d = dict(names=['self'], formats=[None], offsets=[0])
+        d = {"names": ['self'], "formats": [None], "offsets": [0]}
         d['formats'][0] = d
         with pytest.raises(RecursionError):
             np.dtype(d)
@@ -1732,12 +1732,12 @@ class TestFromCTypes:
                 ('a', ctypes.c_uint8),
                 ('b', ctypes.c_uint16),
             ]
-        expected = np.dtype(dict(
-            names=['a', 'b'],
-            formats=[np.uint8, np.uint16],
-            offsets=[0, 0],
-            itemsize=2
-        ))
+        expected = np.dtype({
+            "names": ['a', 'b'],
+            "formats": [np.uint8, np.uint16],
+            "offsets": [0, 0],
+            "itemsize": 2
+        })
         self.check(Union, expected)
 
     def test_union_with_struct_packed(self):
@@ -1755,12 +1755,12 @@ class TestFromCTypes:
                 ('c', ctypes.c_uint32),
                 ('d', Struct),
             ]
-        expected = np.dtype(dict(
-            names=['a', 'b', 'c', 'd'],
-            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
-            offsets=[0, 0, 0, 0],
-            itemsize=ctypes.sizeof(Union)
-        ))
+        expected = np.dtype({
+            "names": ['a', 'b', 'c', 'd'],
+            "formats": ['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            "offsets": [0, 0, 0, 0],
+            "itemsize": ctypes.sizeof(Union)
+        })
         self.check(Union, expected)
 
     def test_union_packed(self):
@@ -1779,12 +1779,12 @@ class TestFromCTypes:
                 ('c', ctypes.c_uint32),
                 ('d', Struct),
             ]
-        expected = np.dtype(dict(
-            names=['a', 'b', 'c', 'd'],
-            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
-            offsets=[0, 0, 0, 0],
-            itemsize=ctypes.sizeof(Union)
-        ))
+        expected = np.dtype({
+            "names": ['a', 'b', 'c', 'd'],
+            "formats": ['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            "offsets": [0, 0, 0, 0],
+            "itemsize": ctypes.sizeof(Union)
+        })
         self.check(Union, expected)
 
     def test_packed_structure(self):
@@ -1812,11 +1812,11 @@ class TestFromCTypes:
                 ('f', ctypes.c_uint32),
                 ('g', ctypes.c_uint8)
                 ]
-        expected = np.dtype(dict(
-            formats=[np.uint8, np.uint16, np.uint8, np.uint16, np.uint32, np.uint32, np.uint8],
-            offsets=[0, 2, 4, 6, 8, 12, 16],
-            names=['a', 'b', 'c', 'd', 'e', 'f', 'g'],
-            itemsize=18))
+        expected = np.dtype({
+            "formats": [np.uint8, np.uint16, np.uint8, np.uint16, np.uint32, np.uint32, np.uint8],
+            "offsets": [0, 2, 4, 6, 8, 12, 16],
+            "names": ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+            "itemsize": 18})
         self.check(PackedStructure, expected)
 
     def test_big_endian_structure_packed(self):

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -15,7 +15,7 @@ class TestTake:
         modes = ['raise', 'wrap', 'clip']
         indices = [-1, 4]
         index_arrays = [np.empty(0, dtype=np.intp),
-                        np.empty(tuple(), dtype=np.intp),
+                        np.empty((), dtype=np.intp),
                         np.empty((1, 1), dtype=np.intp)]
         real_indices = {'raise': {-1: 1, 4: IndexError},
                         'wrap': {-1: 1, 4: 0},

--- a/numpy/_core/tests/test_mem_overlap.py
+++ b/numpy/_core/tests/test_mem_overlap.py
@@ -72,8 +72,8 @@ def test_overlapping_assignments():
     inds = _indices(ndims)
 
     for ind in inds:
-        srcidx = tuple([a[0] for a in ind])
-        dstidx = tuple([a[1] for a in ind])
+        srcidx = tuple(a[0] for a in ind)
+        dstidx = tuple(a[1] for a in ind)
 
         _check_assignment(srcidx, dstidx)
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1534,7 +1534,7 @@ class TestStructured:
         assert_equal(xx, [[b'', b''], [b'', b'']])
         # check for no uninitialized memory due to viewing S0 array
         assert_equal(xx[:].dtype, xx.dtype)
-        assert_array_equal(eval(repr(xx), dict(np=np, array=np.array)), xx)
+        assert_array_equal(eval(repr(xx), {"np": np, "array": np.array}), xx)
 
         b = io.BytesIO()
         np.save(b, xx)
@@ -1653,9 +1653,9 @@ class TestStructured:
         assert_equal(np.concatenate([a, a]).dtype, np.dtype([('x', 'i4')]))
 
     @pytest.mark.parametrize("dtype_dict", [
-            dict(names=["a", "b"], formats=["i4", "f"], itemsize=100),
-            dict(names=["a", "b"], formats=["i4", "f"],
-                 offsets=[0, 12])])
+            {"names": ["a", "b"], "formats": ["i4", "f"], "itemsize": 100},
+            {"names": ["a", "b"], "formats": ["i4", "f"],
+                 "offsets": [0, 12]}])
     @pytest.mark.parametrize("align", [True, False])
     def test_structured_promotion_packs(self, dtype_dict, align):
         # Structured dtypes are packed when promoted (we consider the packed
@@ -3538,7 +3538,7 @@ class TestMethods:
         # when calling np.put, make sure an
         # IndexError is raised if the
         # array is empty
-        empty_array = np.asarray(list())
+        empty_array = np.asarray([])
         with pytest.raises(IndexError,
                             match="cannot replace elements of an empty array"):
             np.put(empty_array, 1, 1, mode="wrap")
@@ -7900,7 +7900,7 @@ class TestPEP3118Dtype:
         def aligned(n):
             return align * (1 + (n - 1) // align)
 
-        base = dict(formats=['i'], names=['f0'])
+        base = {"formats": ['i'], "names": ['f0']}
 
         self._check('ix',    dict(itemsize=aligned(size + 1), **base))
         self._check('ixx',   dict(itemsize=aligned(size + 2), **base))
@@ -7947,12 +7947,12 @@ class TestPEP3118Dtype:
         def aligned(n):
             return (align * (1 + (n - 1) // align))
 
-        self._check('(3)T{ix}', (dict(
-            names=['f0'],
-            formats=['i'],
-            offsets=[0],
-            itemsize=aligned(size + 1)
-        ), (3,)))
+        self._check('(3)T{ix}', ({
+            "names": ['f0'],
+            "formats": ['i'],
+            "offsets": [0],
+            "itemsize": aligned(size + 1)
+        }, (3,)))
 
     def test_char_vs_string(self):
         dt = np.dtype('c')
@@ -8294,12 +8294,12 @@ class TestNewBufferProtocol:
             assert_(strides[-1] == 8)
 
     def test_out_of_order_fields(self):
-        dt = np.dtype(dict(
-            formats=['<i4', '<i4'],
-            names=['one', 'two'],
-            offsets=[4, 0],
-            itemsize=8
-        ))
+        dt = np.dtype({
+            "formats": ['<i4', '<i4'],
+            "names": ['one', 'two'],
+            "offsets": [4, 0],
+            "itemsize": 8
+        })
 
         # overlapping fields cannot be represented by PEP3118
         arr = np.empty(1, dt)
@@ -9412,12 +9412,12 @@ class TestCTypes:
         np.array([['one', 'two'], ['three', 'four']]),
         np.array((1, 2), dtype='i4,i4'),
         np.zeros((2,), dtype=
-            np.dtype(dict(
-                formats=['<i4', '<i4'],
-                names=['a', 'b'],
-                offsets=[0, 2],
-                itemsize=6
-            ))
+            np.dtype({
+                "formats": ['<i4', '<i4'],
+                "names": ['a', 'b'],
+                "offsets": [0, 2],
+                "itemsize": 6
+            })
         ),
         np.array([None], dtype=object),
         np.array([]),

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8179,7 +8179,7 @@ class TestNewBufferProtocol:
         assert_equal(y.ndim, 1)
         assert_equal(y.suboffsets, ())
 
-        sz = sum([np.dtype(b).itemsize for a, b in dt])
+        sz = sum(np.dtype(b).itemsize for a, b in dt)
         if np.dtype('l').itemsize == 4:
             assert_equal(y.format, 'T{b:a:=h:b:i:c:l:d:q:dx:B:e:@H:f:=I:g:L:h:Q:hx:f:i:d:j:^g:k:=Zf:ix:Zd:jx:^Zg:kx:4s:l:=4w:m:3x:n:?:o:@e:p:}')
         else:

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1707,7 +1707,7 @@ def test_iter_remove_multi_index_inner_loop():
     # Removing the inner loop means there's just one iteration
     i.reset()
     assert_equal(i.itersize, 24)
-    assert_equal(i[0].shape, tuple())
+    assert_equal(i[0].shape, ())
     i.enable_external_loop()
     assert_equal(i.itersize, 24)
     assert_equal(i[0].shape, (24,))

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -926,10 +926,10 @@ class TestSeterr:
     def test_default(self):
         err = np.geterr()
         assert_equal(err,
-                     dict(divide='warn',
-                          invalid='warn',
-                          over='warn',
-                          under='ignore')
+                     {'divide': 'warn',
+                          'invalid': 'warn',
+                          'over': 'warn',
+                          'under': 'ignore'}
                      )
 
     def test_set(self):

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -133,7 +133,7 @@ class TestGetImplementingArgs:
         assert_equal(_get_implementing_args([a, c, b]), [c, b, a])
 
     def test_too_many_duck_arrays(self):
-        namespace = dict(__array_function__=_return_not_implemented)
+        namespace = {'__array_function__': _return_not_implemented}
         types = [type('A' + str(i), (object,), namespace) for i in range(65)]
         relevant_args = [t() for t in types]
 

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2470,9 +2470,9 @@ class TestRegression:
 
     def test__array_interface__descr(self):
         # gh-17068
-        dt = np.dtype(dict(names=['a', 'b'],
-                           offsets=[0, 0],
-                           formats=[np.int64, np.int64]))
+        dt = np.dtype({'names': ['a', 'b'],
+                           'offsets': [0, 0],
+                           'formats': [np.int64, np.int64]})
         descr = np.array((1, 1), dtype=dt).__array_interface__['descr']
         assert descr == [('', '|V8')]  # instead of [(b'', '|V8')]
 

--- a/numpy/_core/tests/test_scalarbuffer.py
+++ b/numpy/_core/tests/test_scalarbuffer.py
@@ -55,8 +55,8 @@ class TestScalarPEP3118:
     @pytest.mark.parametrize('scalar, code', scalars_and_codes, ids=codes_only)
     def test_scalar_code_and_properties(self, scalar, code):
         x = scalar()
-        expected = dict(strides=(), itemsize=x.dtype.itemsize, ndim=0,
-                        shape=(), format=code, readonly=True)
+        expected = {'strides': (), 'itemsize': x.dtype.itemsize, 'ndim': 0,
+                        'shape': (), 'format': code, 'readonly': True}
 
         mv_x = memoryview(x)
         assert self._as_dict(mv_x) == expected
@@ -93,8 +93,8 @@ class TestScalarPEP3118:
             get_buffer_info(x, ["WRITABLE"])
 
     def _as_dict(self, m):
-        return dict(strides=m.strides, shape=m.shape, itemsize=m.itemsize,
-                    ndim=m.ndim, format=m.format, readonly=m.readonly)
+        return {'strides': m.strides, 'shape': m.shape, 'itemsize': m.itemsize,
+                    'ndim': m.ndim, 'format': m.format, 'readonly': m.readonly}
 
     def test_datetime_memoryview(self):
         # gh-11656
@@ -102,8 +102,8 @@ class TestScalarPEP3118:
 
         dt1 = np.datetime64('2016-01-01')
         dt2 = np.datetime64('2017-01-01')
-        expected = dict(strides=(1,), itemsize=1, ndim=1, shape=(8,),
-                        format='B', readonly=True)
+        expected = {'strides': (1,), 'itemsize': 1, 'ndim': 1, 'shape': (8,),
+                        'format': 'B', 'readonly': True}
         v = memoryview(dt1)
         assert self._as_dict(v) == expected
 
@@ -128,8 +128,8 @@ class TestScalarPEP3118:
         s = np.str_(s)  # only our subclass implements the buffer protocol
 
         # all the same, characters always encode as ucs4
-        expected = dict(strides=(), itemsize=8, ndim=0, shape=(), format='2w',
-                        readonly=True)
+        expected = {'strides': (), 'itemsize': 8, 'ndim': 0, 'shape': (), 'format': '2w',
+                        'readonly': True}
 
         v = memoryview(s)
         assert self._as_dict(v) == expected

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -315,7 +315,7 @@ class TestModulus:
         dividend = nlst + [0] + plst
         divisor = nlst + plst
         arg = list(itertools.product(dividend, divisor))
-        tgt = list(divmod(*t) for t in arg)
+        tgt = [divmod(*t) for t in arg]
 
         a, b = np.array(arg, dtype=int).T
         # convert exact integer results from Python to float so that

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -455,7 +455,7 @@ class TestComplexDivision:
             for t in [np.complex64, np.complex128]:
                 # tupled (numerator, denominator, expected)
                 # for testing as expected == numerator/denominator
-                data = list()
+                data = []
 
                 # trigger branch: real(fabs(denom)) > imag(fabs(denom))
                 # followed by else condition as neither are == 0

--- a/numpy/_core/tests/test_simd.py
+++ b/numpy/_core/tests/test_simd.py
@@ -185,7 +185,7 @@ class _SIMD_BOOL(_Test_Utility):
         assert data_xnor == vxnor
 
     def test_tobits(self):
-        data2bits = lambda data: sum([int(x != 0) << i for i, x in enumerate(data, 0)])
+        data2bits = lambda data: sum(int(x != 0) << i for i, x in enumerate(data, 0))
         for data in (self._data(), self._data(reverse=True)):
             vdata = self._load_b(data)
             data_bits = data2bits(data)

--- a/numpy/_core/tests/test_simd.py
+++ b/numpy/_core/tests/test_simd.py
@@ -1314,7 +1314,7 @@ for target_name, npyv in targets.items():
         pretty_name = pretty_name[0]
 
     skip = ""
-    skip_sfx = dict()
+    skip_sfx = {}
     if not npyv:
         skip = f"target '{pretty_name}' isn't supported by current machine"
     elif not npyv.simd:
@@ -1331,7 +1331,7 @@ for target_name, npyv in targets.items():
         for sfx in sfxes:
             skip_m = skip_sfx.get(sfx, skip)
             inhr = (cls,)
-            attr = dict(npyv=targets[target_name], sfx=sfx, target_name=target_name)
+            attr = {"npyv": targets[target_name], "sfx": sfx, "target_name": target_name}
             tcls = type(f"Test{cls.__name__}_{simd_width}_{target_name}_{sfx}", inhr, attr)
             if skip_m:
                 pytest.mark.skip(reason=skip_m)(tcls)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -271,7 +271,7 @@ class TestStringLikeCasts:
     def test_void_casts(self, dtype, strings):
         sarr = np.array(strings, dtype=dtype)
         utf8_bytes = [s.encode("utf-8") for s in strings]
-        void_dtype = f"V{max([len(s) for s in utf8_bytes])}"
+        void_dtype = f"V{max(len(s) for s in utf8_bytes)}"
         varr = np.array(utf8_bytes, dtype=void_dtype)
         assert_array_equal(varr, sarr.astype(void_dtype))
         assert_array_equal(varr.astype(dtype), sarr)
@@ -280,7 +280,7 @@ class TestStringLikeCasts:
         sarr = np.array(strings, dtype=dtype)
         try:
             utf8_bytes = [s.encode("ascii") for s in strings]
-            bytes_dtype = f"S{max([len(s) for s in utf8_bytes])}"
+            bytes_dtype = f"S{max(len(s) for s in utf8_bytes)}"
             barr = np.array(utf8_bytes, dtype=bytes_dtype)
             assert_array_equal(barr, sarr.astype(bytes_dtype))
             assert_array_equal(barr.astype(dtype), sarr)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -487,8 +487,8 @@ class TestUfunc:
         np.add(3, 4, signature=(float_dtype, float_dtype, None))
 
     @pytest.mark.parametrize("get_kwarg", [
-            lambda dt: dict(dtype=dt),
-            lambda dt: dict(signature=(dt, None, None))])
+            lambda dt: {"dtype": dt},
+            lambda dt: {"signature": (dt, None, None)}])
     def test_signature_dtype_instances_allowed(self, get_kwarg):
         # We allow certain dtype instances when there is a clear singleton
         # and the given one is equivalent; mainly for backcompat.
@@ -502,8 +502,8 @@ class TestUfunc:
         assert np.add(td, td, **get_kwarg("m8")).dtype == "m8[s]"
 
     @pytest.mark.parametrize("get_kwarg", [
-            param(lambda x: dict(dtype=x), id="dtype"),
-            param(lambda x: dict(signature=(x, None, None)), id="signature")])
+            param(lambda x: {"dtype": x}, id="dtype"),
+            param(lambda x: {"signature": (x, None, None)}, id="signature")])
     def test_signature_dtype_instances_allowed(self, get_kwarg):
         msg = "The `dtype` and `signature` arguments to ufuncs"
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -740,7 +740,7 @@ class TestRemainder:
         dividend = nlst + [0] + plst
         divisor = nlst + plst
         arg = list(itertools.product(dividend, divisor))
-        tgt = list(divmod(*t) for t in arg)
+        tgt = [divmod(*t) for t in arg]
 
         a, b = np.array(arg, dtype=int).T
         # convert exact integer results from Python to float so that

--- a/numpy/_core/tests/test_unicode.py
+++ b/numpy/_core/tests/test_unicode.py
@@ -7,7 +7,7 @@ def buffer_length(arr):
         if not arr:
             charmax = 0
         else:
-            charmax = max([ord(c) for c in arr])
+            charmax = max(ord(c) for c in arr)
         if charmax < 256:
             size = 1
         elif charmax < 65536:

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -204,12 +204,12 @@ if HAVE_SCPDT:
     dt_config.check_namespace['StringDType'] = numpy.dtypes.StringDType
 
     # temporary skips
-    dt_config.skiplist = set([
+    dt_config.skiplist = {
         'numpy.savez',    # unclosed file
         'numpy.matlib.savez',
         'numpy.__array_namespace_info__',
         'numpy.matlib.__array_namespace_info__',
-    ])
+    }
 
     # xfail problematic tutorials
     dt_config.pytest_extra_xfail = {

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -416,11 +416,11 @@ if ctypes is not None:
                 _fields_.append(('', ctypes.c_char * dtype.itemsize))
 
             # we inserted manual padding, so always `_pack_`
-            return type('union', (ctypes.Union,), dict(
-                _fields_=_fields_,
-                _pack_=1,
-                __module__=None,
-            ))
+            return type('union', (ctypes.Union,), {
+                '_fields_': _fields_,
+                '_pack_': 1,
+                '__module__': None,
+            })
         else:
             last_offset = 0
             _fields_ = []
@@ -439,11 +439,11 @@ if ctypes is not None:
                 _fields_.append(('', ctypes.c_char * padding))
 
             # we inserted manual padding, so always `_pack_`
-            return type('struct', (ctypes.Structure,), dict(
-                _fields_=_fields_,
-                _pack_=1,
-                __module__=None,
-            ))
+            return type('struct', (ctypes.Structure,), {
+                '_fields_': _fields_,
+                '_pack_': 1,
+                '__module__': None,
+            })
 
     def _ctype_from_dtype(dtype):
         if dtype.fields is not None:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1039,7 +1039,7 @@ def analyzeline(m, case, line):
             block = 'abstract interface'
         if block == 'type':
             name, attrs, _ = _resolvetypedefpattern(m.group('after'))
-            groupcache[groupcounter]['vars'][name] = dict(attrspec = attrs)
+            groupcache[groupcounter]['vars'][name] = {'attrspec': attrs}
             args = []
             result = None
         else:
@@ -3619,7 +3619,7 @@ def traverse(obj, visit, parents=[], result=None, *args, **kwargs):
             if new_index is not None:
                 new_result.append(new_item)
     elif isinstance(obj, dict):
-        new_result = dict()
+        new_result = {}
         for key, value in obj.items():
             new_key, new_value = traverse((key, value), visit,
                                           parents=parents + [parent],

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2624,7 +2624,7 @@ def analyzevars(block):
         del vars['']
         if 'attrspec' in block['vars']['']:
             gen = block['vars']['']['attrspec']
-            for n in set(vars) | set(b['name'] for b in block['body']):
+            for n in set(vars) | {b['name'] for b in block['body']}:
                 for k in ['public', 'private']:
                     if k in gen:
                         vars[n] = setattrspec(vars.get(n, {}), k)
@@ -2793,9 +2793,9 @@ def analyzevars(block):
                                     # solve_v function here.
                                     solve_v = None
                                     all_symbols = set(dsize.symbols())
-                                v_deps = set(
+                                v_deps = {
                                     s.data for s in all_symbols
-                                    if s.data in vars)
+                                    if s.data in vars}
                                 solver_and_deps[v] = solve_v, list(v_deps)
                         # Note that dsize may contain symbols that are
                         # not defined in block['vars']. Here we assume

--- a/numpy/f2py/func2subr.py
+++ b/numpy/f2py/func2subr.py
@@ -85,7 +85,7 @@ def createfuncwrapper(rout, signature=0):
         for i, d in enumerate(v.get('dimension', [])):
             if d == ':':
                 dn = 'f2py_%s_d%s' % (a, i)
-                dv = dict(typespec='integer', intent=['hide'])
+                dv = {'typespec': 'integer', 'intent': ['hide']}
                 dv['='] = 'shape(%s, %s)' % (a, i)
                 extra_args.append(dn)
                 vars[dn] = dv
@@ -209,7 +209,7 @@ def createsubrwrapper(rout, signature=0):
         for i, d in enumerate(v.get('dimension', [])):
             if d == ':':
                 dn = 'f2py_%s_d%s' % (a, i)
-                dv = dict(typespec='integer', intent=['hide'])
+                dv = {'typespec': 'integer', 'intent': ['hide']}
                 dv['='] = 'shape(%s, %s)' % (a, i)
                 extra_args.append(dn)
                 vars[dn] = dv

--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -570,7 +570,7 @@ class Expr:
         # TODO: implement a method for deciding when __call__ should
         # return an INDEXING expression.
         return as_apply(self, *map(as_expr, args),
-                        **dict((k, as_expr(v)) for k, v in kwargs.items()))
+                        **{k: as_expr(v) for k, v in kwargs.items()})
 
     def __getitem__(self, index):
         # Provided to support C indexing operations that .pyf files
@@ -636,8 +636,8 @@ class Expr:
             if isinstance(target, Expr):
                 target = target.substitute(symbols_map)
             args = tuple(a.substitute(symbols_map) for a in args)
-            kwargs = dict((k, v.substitute(symbols_map))
-                          for k, v in kwargs.items())
+            kwargs = {k: v.substitute(symbols_map)
+                          for k, v in kwargs.items()}
             return normalize(Expr(self.op, (target, args, kwargs)))
         if self.op is Op.INDEXING:
             func = self.data[0]
@@ -693,8 +693,8 @@ class Expr:
                     if isinstance(obj, Expr) else obj)
             operands = tuple(operand.traverse(visit, *args, **kwargs)
                              for operand in self.data[1])
-            kwoperands = dict((k, v.traverse(visit, *args, **kwargs))
-                              for k, v in self.data[2].items())
+            kwoperands = {k: v.traverse(visit, *args, **kwargs)
+                              for k, v in self.data[2].items()}
             return normalize(Expr(self.op, (func, operands, kwoperands)))
         elif self.op is Op.INDEXING:
             obj = self.data[0]
@@ -1011,7 +1011,7 @@ def as_apply(func, *args, **kwargs):
     """
     return Expr(Op.APPLY,
                 (func, tuple(map(as_expr, args)),
-                 dict((k, as_expr(v)) for k, v in kwargs.items())))
+                 {k: as_expr(v) for k, v in kwargs.items()}))
 
 
 def as_ternary(cond, expr1, expr2):
@@ -1494,8 +1494,8 @@ class _FromStringWorker:
             if not isinstance(args, tuple):
                 args = args,
             if paren == 'ROUND':
-                kwargs = dict((a.left, a.right) for a in args
-                              if isinstance(a, _Pair))
+                kwargs = {a.left: a.right for a in args
+                              if isinstance(a, _Pair)}
                 args = tuple(a for a in args if not isinstance(a, _Pair))
                 # Warning: this could also be Fortran indexing operation..
                 return as_apply(target, *args, **kwargs)

--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -1262,8 +1262,8 @@ def unreplace_parenthesis(s, d):
     """
     for k, v in d.items():
         p = _get_parenthesis_kind(k)
-        left = dict(ROUND='(', SQUARE='[', CURLY='{', ROUNDDIV='(/')[p]
-        right = dict(ROUND=')', SQUARE=']', CURLY='}', ROUNDDIV='/)')[p]
+        left = {'ROUND': '(', 'SQUARE': '[', 'CURLY': '{', 'ROUNDDIV': '(/'}[p]
+        right = {'ROUND': ')', 'SQUARE': ']', 'CURLY': '}', 'ROUNDDIV': '/)'}[p]
         s = s.replace(k, left + v + right)
     return s
 

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -15,7 +15,7 @@ class TestCharacterString(util.F2PyTest):
     code = ''
     for length in length_list:
         fsuffix = length
-        clength = dict(star='(*)').get(length, length)
+        clength = {'star': '(*)'}.get(length, length)
 
         code += textwrap.dedent(f"""
 
@@ -538,13 +538,13 @@ class TestMiscCharacter(util.F2PyTest):
         f = getattr(self.module, self.fprefix + '_gh4519')
 
         for x, expected in [
-                ('a', dict(shape=(), dtype=np.dtype('S1'))),
-                ('text', dict(shape=(), dtype=np.dtype('S4'))),
+                ('a', {'shape': (), 'dtype': np.dtype('S1')}),
+                ('text', {'shape': (), 'dtype': np.dtype('S4')}),
                 (np.array(['1', '2', '3'], dtype='S1'),
-                 dict(shape=(3,), dtype=np.dtype('S1'))),
+                 {'shape': (3,), 'dtype': np.dtype('S1')}),
                 (['1', '2', '34'],
-                 dict(shape=(3,), dtype=np.dtype('S2'))),
-                (['', ''], dict(shape=(2,), dtype=np.dtype('S1')))]:
+                 {'shape': (3,), 'dtype': np.dtype('S2')}),
+                (['', ''], {'shape': (2,), 'dtype': np.dtype('S1')})]:
             r = f(x)
             for k, v in expected.items():
                 assert_equal(getattr(r, k), v)

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -259,7 +259,7 @@ class TestEval(util.F2PyTest):
 
         assert eval_scalar('123', {}) == '123'
         assert eval_scalar('12 + 3', {}) == '15'
-        assert eval_scalar('a + b', dict(a=1, b=2)) == '3'
+        assert eval_scalar('a + b', {"a": 1, "b": 2}) == '3'
         assert eval_scalar('"123"', {}) == "'123'"
 
 
@@ -356,9 +356,9 @@ class TestParamEval:
     # issue gh-11612, array parameter parsing
     def test_param_eval_nested(self):
         v = '(/3.14, 4./)'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
+        g_params = {"kind": crackfortran._kind_func,
+                "selected_int_kind": crackfortran._selected_int_kind_func,
+                "selected_real_kind": crackfortran._selected_real_kind_func}
         params = {'dp': 8, 'intparamarray': {1: 3, 2: 5},
                   'nested': {1: 1, 2: 2, 3: 3}}
         dimspec = '(2)'
@@ -367,9 +367,9 @@ class TestParamEval:
 
     def test_param_eval_nonstandard_range(self):
         v = '(/ 6, 3, 1 /)'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
+        g_params = {"kind": crackfortran._kind_func,
+                "selected_int_kind": crackfortran._selected_int_kind_func,
+                "selected_real_kind": crackfortran._selected_real_kind_func}
         params = {}
         dimspec = '(-1:1)'
         ret = crackfortran.param_eval(v, g_params, params, dimspec=dimspec)
@@ -377,9 +377,9 @@ class TestParamEval:
 
     def test_param_eval_empty_range(self):
         v = '6'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
+        g_params = {"kind": crackfortran._kind_func,
+                "selected_int_kind": crackfortran._selected_int_kind_func,
+                "selected_real_kind": crackfortran._selected_real_kind_func}
         params = {}
         dimspec = ''
         pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,
@@ -387,18 +387,18 @@ class TestParamEval:
 
     def test_param_eval_non_array_param(self):
         v = '3.14_dp'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
+        g_params = {"kind": crackfortran._kind_func,
+                "selected_int_kind": crackfortran._selected_int_kind_func,
+                "selected_real_kind": crackfortran._selected_real_kind_func}
         params = {}
         ret = crackfortran.param_eval(v, g_params, params, dimspec=None)
         assert ret == '3.14_dp'
 
     def test_param_eval_too_many_dims(self):
         v = 'reshape((/ (i, i=1, 250) /), (/5, 10, 5/))'
-        g_params = dict(kind=crackfortran._kind_func,
-                selected_int_kind=crackfortran._selected_int_kind_func,
-                selected_real_kind=crackfortran._selected_real_kind_func)
+        g_params = {"kind": crackfortran._kind_func,
+                "selected_int_kind": crackfortran._selected_int_kind_func,
+                "selected_real_kind": crackfortran._selected_real_kind_func}
         params = {}
         dimspec = '(0:4, 3:12, 5)'
         pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -63,87 +63,87 @@ __all__ = [
 #   The function used to compute the virtual_index.
 # fix_gamma : Callable
 #   A function used for discrete methods to force the index to a specific value.
-_QuantileMethods = dict(
+_QuantileMethods = {
     # --- HYNDMAN and FAN METHODS
     # Discrete methods
-    inverted_cdf=dict(
-        get_virtual_index=lambda n, quantiles: _inverted_cdf(n, quantiles),
-        fix_gamma=None,  # should never be called
-    ),
-    averaged_inverted_cdf=dict(
-        get_virtual_index=lambda n, quantiles: (n * quantiles) - 1,
-        fix_gamma=lambda gamma, _: _get_gamma_mask(
+    'inverted_cdf': {
+        'get_virtual_index': lambda n, quantiles: _inverted_cdf(n, quantiles),
+        'fix_gamma': None,  # should never be called
+    },
+    'averaged_inverted_cdf': {
+        'get_virtual_index': lambda n, quantiles: (n * quantiles) - 1,
+        'fix_gamma': lambda gamma, _: _get_gamma_mask(
             shape=gamma.shape,
             default_value=1.,
             conditioned_value=0.5,
             where=gamma == 0),
-    ),
-    closest_observation=dict(
-        get_virtual_index=lambda n, quantiles: _closest_observation(n,
+    },
+    'closest_observation': {
+        'get_virtual_index': lambda n, quantiles: _closest_observation(n,
                                                                     quantiles),
-        fix_gamma=None,  # should never be called
-    ),
+        'fix_gamma': None,  # should never be called
+    },
     # Continuous methods
-    interpolated_inverted_cdf=dict(
-        get_virtual_index=lambda n, quantiles:
+    'interpolated_inverted_cdf': {
+        'get_virtual_index': lambda n, quantiles:
         _compute_virtual_index(n, quantiles, 0, 1),
-        fix_gamma=lambda gamma, _: gamma,
-    ),
-    hazen=dict(
-        get_virtual_index=lambda n, quantiles:
+        'fix_gamma': lambda gamma, _: gamma,
+    },
+    'hazen': {
+        'get_virtual_index': lambda n, quantiles:
         _compute_virtual_index(n, quantiles, 0.5, 0.5),
-        fix_gamma=lambda gamma, _: gamma,
-    ),
-    weibull=dict(
-        get_virtual_index=lambda n, quantiles:
+        'fix_gamma': lambda gamma, _: gamma,
+    },
+    'weibull': {
+        'get_virtual_index': lambda n, quantiles:
         _compute_virtual_index(n, quantiles, 0, 0),
-        fix_gamma=lambda gamma, _: gamma,
-    ),
+        'fix_gamma': lambda gamma, _: gamma,
+    },
     # Default method.
     # To avoid some rounding issues, `(n-1) * quantiles` is preferred to
     # `_compute_virtual_index(n, quantiles, 1, 1)`.
     # They are mathematically equivalent.
-    linear=dict(
-        get_virtual_index=lambda n, quantiles: (n - 1) * quantiles,
-        fix_gamma=lambda gamma, _: gamma,
-    ),
-    median_unbiased=dict(
-        get_virtual_index=lambda n, quantiles:
+    'linear': {
+        'get_virtual_index': lambda n, quantiles: (n - 1) * quantiles,
+        'fix_gamma': lambda gamma, _: gamma,
+    },
+    'median_unbiased': {
+        'get_virtual_index': lambda n, quantiles:
         _compute_virtual_index(n, quantiles, 1 / 3.0, 1 / 3.0),
-        fix_gamma=lambda gamma, _: gamma,
-    ),
-    normal_unbiased=dict(
-        get_virtual_index=lambda n, quantiles:
+        'fix_gamma': lambda gamma, _: gamma,
+    },
+    'normal_unbiased': {
+        'get_virtual_index': lambda n, quantiles:
         _compute_virtual_index(n, quantiles, 3 / 8.0, 3 / 8.0),
-        fix_gamma=lambda gamma, _: gamma,
-    ),
+        'fix_gamma': lambda gamma, _: gamma,
+    },
     # --- OTHER METHODS
-    lower=dict(
-        get_virtual_index=lambda n, quantiles: np.floor(
+    'lower': {
+        'get_virtual_index': lambda n, quantiles: np.floor(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=None,  # should never be called, index dtype is int
-    ),
-    higher=dict(
-        get_virtual_index=lambda n, quantiles: np.ceil(
+        'fix_gamma': None,  # should never be called, index dtype is int
+    },
+    'higher': {
+        'get_virtual_index': lambda n, quantiles: np.ceil(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=None,  # should never be called, index dtype is int
-    ),
-    midpoint=dict(
-        get_virtual_index=lambda n, quantiles: 0.5 * (
+        'fix_gamma': None,  # should never be called, index dtype is int
+    },
+    'midpoint': {
+        'get_virtual_index': lambda n, quantiles: 0.5 * (
                 np.floor((n - 1) * quantiles)
                 + np.ceil((n - 1) * quantiles)),
-        fix_gamma=lambda gamma, index: _get_gamma_mask(
+        'fix_gamma': lambda gamma, index: _get_gamma_mask(
             shape=gamma.shape,
             default_value=0.5,
             conditioned_value=0.,
             where=index % 1 == 0),
-    ),
-    nearest=dict(
-        get_virtual_index=lambda n, quantiles: np.around(
+    },
+    'nearest': {
+        'get_virtual_index': lambda n, quantiles: np.around(
             (n - 1) * quantiles).astype(np.intp),
-        fix_gamma=None,
+        'fix_gamma': None,
         # should never be called, index dtype is int
-    ))
+    }}
 
 
 def _rot90_dispatcher(m, k=None, axes=None):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2606,8 +2606,8 @@ class vectorize:
             if ufunc.nout == 1:
                 res = asanyarray(outputs, dtype=otypes[0])
             else:
-                res = tuple([asanyarray(x, dtype=t)
-                             for x, t in zip(outputs, otypes)])
+                res = tuple(asanyarray(x, dtype=t)
+                             for x, t in zip(outputs, otypes))
         return res
 
     def _vectorize_call_with_signature(self, func, args):

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -354,7 +354,7 @@ class NameValidator:
         replace_space = self.replace_space
         # Initializes some variables ...
         validatednames = []
-        seen = dict()
+        seen = {}
         nbempty = 0
 
         for item in names:
@@ -869,7 +869,7 @@ def easy_dtype(ndtype, names=None, defaultfmt="f%i", **validationargs):
         elif isinstance(names, str):
             names = names.split(",")
         names = validate(names, nbfields=nbfields, defaultfmt=defaultfmt)
-        ndtype = np.dtype(dict(formats=ndtype, names=names))
+        ndtype = np.dtype({"formats": ndtype, "names": names})
     else:
         # Explicit names
         if names is not None:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -2284,9 +2284,9 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             # Store the values
             append_to_rows(tuple(values))
             if usemask:
-                append_to_masks(tuple([v.strip() in m
+                append_to_masks(tuple(v.strip() in m
                                        for (v, m) in zip(values,
-                                                         missing_values)]))
+                                                         missing_values)))
             if len(rows) == max_rows:
                 break
 

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -441,7 +441,7 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         # result can similarly silently corrupt numerical data.
         raise ValueError("encoding must be 'ASCII', 'latin1', or 'bytes'")
 
-    pickle_kwargs = dict(encoding=encoding, fix_imports=fix_imports)
+    pickle_kwargs = {'encoding': encoding, 'fix_imports': fix_imports}
 
     with contextlib.ExitStack() as stack:
         if hasattr(file, 'read'):
@@ -579,7 +579,7 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
     with file_ctx as fid:
         arr = np.asanyarray(arr)
         format.write_array(fid, arr, allow_pickle=allow_pickle,
-                           pickle_kwargs=dict(fix_imports=fix_imports))
+                           pickle_kwargs={'fix_imports': fix_imports})
 
 
 def _savez_dispatcher(file, *args, allow_pickle=True, **kwds):

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -69,7 +69,7 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
     """
     typecodes = ((isinstance(t, str) and t) or asarray(t).dtype.char
                  for t in typechars)
-    intersection = set(t for t in typecodes if t in typeset)
+    intersection = {t for t in typecodes if t in typeset}
     if not intersection:
         return default
     if 'F' in intersection and 'd' in intersection:

--- a/numpy/lib/_utils_impl.py
+++ b/numpy/lib/_utils_impl.py
@@ -754,9 +754,9 @@ def drop_metadata(dtype, /):
         if not found_metadata:
             return dtype
 
-        structure = dict(
-            names=names, formats=formats, offsets=offsets, titles=titles,
-            itemsize=dtype.itemsize)
+        structure = {
+            'names': names, 'formats': formats, 'offsets': offsets, 'titles': titles,
+            'itemsize': dtype.itemsize}
 
         # NOTE: Could pass (dtype.type, structure) to preserve record dtypes...
         return np.dtype(structure, align=dtype.isalignedstruct)

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -930,11 +930,11 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
         if dtype.hasobject:
             msg = "Array can't be memory-mapped: Python objects in dtype."
             raise ValueError(msg)
-        d = dict(
-            descr=dtype_to_descr(dtype),
-            fortran_order=fortran_order,
-            shape=shape,
-        )
+        d = {
+            "descr": dtype_to_descr(dtype),
+            "fortran_order": fortran_order,
+            "shape": shape,
+        }
         # If we got here, then it should be safe to create the file.
         with open(os.fspath(filename), mode + 'b') as fp:
             _write_array_header(fp, d, version)

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1656,7 +1656,7 @@ def join_by(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
             current[-r2spc:] = selected[r2cmn:]
     # Sort and finalize the output
     output.sort(order=key)
-    kwargs = dict(usemask=usemask, asrecarray=asrecarray)
+    kwargs = {'usemask': usemask, 'asrecarray': asrecarray}
     return _fix_output(_fix_defaults(output, defaults), **kwargs)
 
 
@@ -1677,8 +1677,8 @@ def rec_join(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
     --------
     join_by : equivalent function
     """
-    kwargs = dict(jointype=jointype, r1postfix=r1postfix, r2postfix=r2postfix,
-                  defaults=defaults, usemask=False, asrecarray=True)
+    kwargs = {'jointype': jointype, 'r1postfix': r1postfix, 'r2postfix': r2postfix,
+                  'defaults': defaults, 'usemask': False, 'asrecarray': True}
     return join_by(key, r1, r2, **kwargs)
 
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1611,7 +1611,7 @@ def join_by(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
     for fname, fdtype in _get_fieldspec(r2.dtype):
         # Have we seen the current name already ?
         # we need to rebuild this list every time
-        names = list(name for name, dtype in ndtype)
+        names = [name for name, dtype in ndtype]
         try:
             nameidx = names.index(fname)
         except ValueError:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -837,7 +837,7 @@ def test_bad_magic_args():
 
 def test_large_header():
     s = BytesIO()
-    d = {'shape': tuple(), 'fortran_order': False, 'descr': '<i8'}
+    d = {'shape': (), 'fortran_order': False, 'descr': '<i8'}
     format.write_array_header_1_0(s, d)
 
     s = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1395,7 +1395,7 @@ class TestFromTxt(LoadTxtBase):
     def test_skiprows(self):
         # Test row skipping
         control = np.array([1, 2, 3, 5], int)
-        kwargs = dict(dtype=int, delimiter=',')
+        kwargs = {"dtype": int, "delimiter": ','}
         #
         data = TextIO('comment\n1,2,3,5\n')
         test = np.genfromtxt(data, skip_header=1, **kwargs)
@@ -1410,7 +1410,7 @@ class TestFromTxt(LoadTxtBase):
         data.append("A, B, C")
         data.extend(["%i,%3.1f,%03s" % (i, i, i) for i in range(51)])
         data[-1] = "99,99"
-        kwargs = dict(delimiter=",", names=True, skip_header=5, skip_footer=10)
+        kwargs = {"delimiter": ",", "names": True, "skip_header": 5, "skip_footer": 10}
         test = np.genfromtxt(TextIO("\n".join(data)), **kwargs)
         ctrl = np.array([("%f" % i, "%f" % i, "%f" % i) for i in range(41)],
                         dtype=[(_, float) for _ in "ABC"])
@@ -1629,9 +1629,9 @@ M   33  21.99
         s = TextIO("D01N01,10/1/2003 ,1 %,R 75,400,600\r\n"
                    "L24U05,12/5/2003, 2 %,1,300, 150.5\r\n"
                    "D02N03,10/10/2004,R 1,,7,145.55")
-        kwargs = dict(
-            converters={2: strip_per, 3: strip_rand}, delimiter=",",
-            dtype=None, encoding="bytes")
+        kwargs = {
+            "converters": {2: strip_per, 3: strip_rand}, "delimiter": ",",
+            "dtype": None, "encoding": "bytes"}
         assert_raises(ConverterError, np.genfromtxt, s, **kwargs)
 
     def test_tricky_converter_bug1666(self):
@@ -1806,7 +1806,7 @@ M   33  21.99
         # Test usecols with named columns
         ctrl = np.array([(1, 3), (4, 6)], dtype=[('a', float), ('c', float)])
         data = "1 2 3\n4 5 6"
-        kwargs = dict(names="a, b, c")
+        kwargs = {"names": "a, b, c"}
         test = np.genfromtxt(TextIO(data), usecols=(0, -1), **kwargs)
         assert_equal(test, ctrl)
         test = np.genfromtxt(TextIO(data),
@@ -1844,7 +1844,7 @@ M   33  21.99
 
     def test_withmissing(self):
         data = TextIO('A,B\n0,1\n2,N/A')
-        kwargs = dict(delimiter=",", missing_values="N/A", names=True)
+        kwargs = {"delimiter": ",", "missing_values": "N/A", "names": True}
         test = np.genfromtxt(data, dtype=None, usemask=True, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
@@ -1862,7 +1862,7 @@ M   33  21.99
 
     def test_user_missing_values(self):
         data = "A, B, C\n0, 0., 0j\n1, N/A, 1j\n-9, 2.2, N/A\n3, -99, 3j"
-        basekwargs = dict(dtype=None, delimiter=",", names=True,)
+        basekwargs = {"dtype": None, "delimiter": ",", "names": True}
         mdtype = [('A', int), ('B', float), ('C', complex)]
         #
         test = np.genfromtxt(TextIO(data), missing_values="N/A",
@@ -1896,11 +1896,11 @@ M   33  21.99
         # Test with missing and filling values
         ctrl = np.array([(0, 3), (4, -999)], dtype=[('a', int), ('b', int)])
         data = "N/A, 2, 3\n4, ,???"
-        kwargs = dict(delimiter=",",
-                      dtype=int,
-                      names="a,b,c",
-                      missing_values={0: "N/A", 'b': " ", 2: "???"},
-                      filling_values={0: 0, 'b': 0, 2: -999})
+        kwargs = {"delimiter": ",",
+                      "dtype": int,
+                      "names": "a,b,c",
+                      "missing_values": {0: "N/A", 'b': " ", 2: "???"},
+                      "filling_values": {0: 0, 'b': 0, 2: -999}}
         test = np.genfromtxt(TextIO(data), **kwargs)
         ctrl = np.array([(0, 2, 3), (4, 0, -999)],
                         dtype=[(_, int) for _ in "abc"])
@@ -1956,7 +1956,7 @@ M   33  21.99
         data.insert(0, "a, b, c, d, e")
         mdata = TextIO("\n".join(data))
 
-        kwargs = dict(delimiter=",", dtype=None, names=True)
+        kwargs = {"delimiter": ",", "dtype": None, "names": True}
 
         def f():
             return np.genfromtxt(mdata, invalid_raise=False, **kwargs)
@@ -1976,8 +1976,8 @@ M   33  21.99
         data.insert(0, "a, b, c, d, e")
         mdata = TextIO("\n".join(data))
 
-        kwargs = dict(delimiter=",", dtype=None, names=True,
-                      invalid_raise=False)
+        kwargs = {"delimiter": ",", "dtype": None, "names": True,
+                      "invalid_raise": False}
 
         def f():
             return np.genfromtxt(mdata, usecols=(0, 4), **kwargs)
@@ -1998,8 +1998,8 @@ M   33  21.99
         mdata = TextIO("\n".join(data))
 
         converters = {4: lambda x: "(%s)" % x.decode()}
-        kwargs = dict(delimiter=",", converters=converters,
-                      dtype=[(_, int) for _ in 'abcde'], encoding="bytes")
+        kwargs = {"delimiter": ",", "converters": converters,
+                      "dtype": [(_, int) for _ in 'abcde'], "encoding": "bytes"}
         assert_raises(ValueError, np.genfromtxt, mdata, **kwargs)
 
     def test_default_field_format(self):
@@ -2049,7 +2049,7 @@ M   33  21.99
     def test_autostrip(self):
         # Test autostrip
         data = "01/01/2003  , 1.3,   abcde"
-        kwargs = dict(delimiter=",", dtype=None, encoding="bytes")
+        kwargs = {"delimiter": ",", "dtype": None, "encoding": "bytes"}
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', VisibleDeprecationWarning)
             mtest = np.genfromtxt(TextIO(data), **kwargs)
@@ -2116,7 +2116,7 @@ M   33  21.99
     def test_incomplete_names(self):
         # Test w/ incomplete names
         data = "A,,C\n0,1,2\n3,4,5"
-        kwargs = dict(delimiter=",", names=True)
+        kwargs = {"delimiter": ",", "names": True}
         # w/ dtype=None
         ctrl = np.array([(0, 1, 2), (3, 4, 5)],
                         dtype=[(_, int) for _ in ('A', 'f0', 'C')])
@@ -2158,13 +2158,13 @@ M   33  21.99
     def test_fixed_width_names(self):
         # Test fix-width w/ names
         data = "    A    B   C\n    0    1 2.3\n   45   67   9."
-        kwargs = dict(delimiter=(5, 5, 4), names=True, dtype=None)
+        kwargs = {"delimiter": (5, 5, 4), "names": True, "dtype": None}
         ctrl = np.array([(0, 1, 2.3), (45, 67, 9.)],
                         dtype=[('A', int), ('B', int), ('C', float)])
         test = np.genfromtxt(TextIO(data), **kwargs)
         assert_equal(test, ctrl)
         #
-        kwargs = dict(delimiter=5, names=True, dtype=None)
+        kwargs = {"delimiter": 5, "names": True, "dtype": None}
         ctrl = np.array([(0, 1, 2.3), (45, 67, 9.)],
                         dtype=[('A', int), ('B', int), ('C', float)])
         test = np.genfromtxt(TextIO(data), **kwargs)
@@ -2173,7 +2173,7 @@ M   33  21.99
     def test_filling_values(self):
         # Test missing values
         data = b"1, 2, 3\n1, , 5\n0, 6, \n"
-        kwargs = dict(delimiter=",", dtype=None, filling_values=-999)
+        kwargs = {"delimiter": ",", "dtype": None, "filling_values": -999}
         ctrl = np.array([[1, 2, 3], [1, -999, 5], [0, 6, -999]], dtype=int)
         test = np.genfromtxt(TextIO(data), **kwargs)
         assert_equal(test, ctrl)
@@ -2307,7 +2307,7 @@ M   33  21.99
     def test_recfromtxt(self):
         #
         data = TextIO('A,B\n0,1\n2,3')
-        kwargs = dict(delimiter=",", missing_values="N/A", names=True)
+        kwargs = {"delimiter": ",", "missing_values": "N/A", "names": True}
         test = recfromtxt(data, **kwargs)
         control = np.array([(0, 1), (2, 3)],
                            dtype=[('A', int), ('B', int)])
@@ -2327,8 +2327,8 @@ M   33  21.99
     def test_recfromcsv(self):
         #
         data = TextIO('A,B\n0,1\n2,3')
-        kwargs = dict(missing_values="N/A", names=True, case_sensitive=True,
-                      encoding="bytes")
+        kwargs = {"missing_values": "N/A", "names": True, "case_sensitive": True,
+                      "encoding": "bytes"}
         test = recfromcsv(data, dtype=None, **kwargs)
         control = np.array([(0, 1), (2, 3)],
                            dtype=[('A', int), ('B', int)])
@@ -2632,7 +2632,7 @@ class TestPathUsage:
             with open(path, 'w') as f:
                 f.write('A,B\n0,1\n2,3')
 
-            kwargs = dict(delimiter=",", missing_values="N/A", names=True)
+            kwargs = {"delimiter": ",", "missing_values": "N/A", "names": True}
             test = recfromtxt(path, **kwargs)
             control = np.array([(0, 1), (2, 3)],
                                dtype=[('A', int), ('B', int)])
@@ -2647,9 +2647,9 @@ class TestPathUsage:
             with open(path, 'w') as f:
                 f.write('A,B\n0,1\n2,3')
 
-            kwargs = dict(
-                missing_values="N/A", names=True, case_sensitive=True
-            )
+            kwargs = {
+                "missing_values": "N/A", "names": True, "case_sensitive": True
+            }
             test = recfromcsv(path, dtype=None, **kwargs)
             control = np.array([(0, 1), (2, 3)],
                                dtype=[('A', int), ('B', int)])

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1115,8 +1115,8 @@ class TestNanFunctions_Percentile:
                 "weights": np.ones_like(nan_mat), "method": "inverted_cdf"
             }
         else:
-            w_args = dict()
-            nan_w_args = dict()
+            w_args = {}
+            nan_w_args = {}
         tgt = np.percentile(mat, 42, axis=1, **w_args)
         res = np.nanpercentile(nan_mat, 42, axis=1, out=resout, **nan_w_args)
         assert_almost_equal(res, resout)
@@ -1309,7 +1309,7 @@ class TestNanFunctions_Quantile:
         if weighted:
             w_args = {"weights": np.ones_like(ar), "method": "inverted_cdf"}
         else:
-            w_args = dict()
+            w_args = {}
 
         assert_equal(np.nanquantile(ar, q=0.5, **w_args),
                      np.nanpercentile(ar, q=50, **w_args))

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -1027,7 +1027,7 @@ class TestAppendFieldsObj:
 
     def setup_method(self):
         from datetime import date
-        self.data = dict(obj=date(2000, 1, 1))
+        self.data = {'obj': date(2000, 1, 1)}
 
     def test_append_to_objects(self):
         "Test append_fields when the base array contains objects"

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -35,9 +35,9 @@ class TestTakeAlongAxis:
         a = rand(3, 4, 5)
 
         funcs = [
-            (np.sort, np.argsort, dict()),
-            (_add_keepdims(np.min), _add_keepdims(np.argmin), dict()),
-            (_add_keepdims(np.max), _add_keepdims(np.argmax), dict()),
+            (np.sort, np.argsort, {}),
+            (_add_keepdims(np.min), _add_keepdims(np.argmin), {}),
+            (_add_keepdims(np.max), _add_keepdims(np.argmax), {}),
             #(np.partition, np.argpartition, dict(kth=2)),
         ]
 

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -290,12 +290,12 @@ class TestHistogram2d:
         r = histogram2d(xy, s_d)
         assert_(r == ((ShouldDispatch,), (xy, s_d), {}))
         r = histogram2d(xy, xy, bins=s_d)
-        assert_(r, ((ShouldDispatch,), (xy, xy), dict(bins=s_d)))
+        assert_(r, ((ShouldDispatch,), (xy, xy), {'bins': s_d}))
         r = histogram2d(xy, xy, bins=[s_d, 5])
-        assert_(r, ((ShouldDispatch,), (xy, xy), dict(bins=[s_d, 5])))
+        assert_(r, ((ShouldDispatch,), (xy, xy), {'bins': [s_d, 5]}))
         assert_raises(Exception, histogram2d, xy, xy, bins=[s_d])
         r = histogram2d(xy, xy, weights=s_d)
-        assert_(r, ((ShouldDispatch,), (xy, xy), dict(weights=s_d)))
+        assert_(r, ((ShouldDispatch,), (xy, xy), {'weights': s_d}))
 
     @pytest.mark.parametrize(("x_len", "y_len"), [(10, 11), (20, 19)])
     def test_bad_length(self, x_len, y_len):

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -272,8 +272,8 @@ def replaceDlamch(source):
     """Replace dlamch_ calls with appropriate macros"""
     def repl(m):
         s = m.group(1)
-        return dict(E='EPSILON', P='PRECISION', S='SAFEMINIMUM',
-                    B='BASE')[s[0]]
+        return {'E': 'EPSILON', 'P': 'PRECISION', 'S': 'SAFEMINIMUM',
+                    'B': 'BASE'}[s[0]]
     source = re.sub(r'dlamch_\("(.*?)"\)', repl, source)
     source = re.sub(r'^\s+extern.*? dlamch_.*?;$(?m)', '', source)
     return source

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -292,7 +292,7 @@ def create_name_header(output_dir):
     extern_re = re.compile(r'^extern [a-z]+ ([a-z0-9_]+)\(.*$')
 
     # BLAS/LAPACK symbols
-    symbols = set(['xerbla'])
+    symbols = {'xerbla'}
     for fn in os.listdir(output_dir):
         fn = os.path.join(output_dir, fn)
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -298,7 +298,7 @@ def _stride_comb_iter(x):
 
     for repeats in itertools.product(*tuple(stride_set)):
         new_shape = [abs(a * b) for a, b in zip(x.shape, repeats)]
-        slices = tuple([slice(None, None, repeat) for repeat in repeats])
+        slices = tuple(slice(None, None, repeat) for repeat in repeats)
 
         # new array with different strides, but same data
         xi = np.empty(new_shape, dtype=x.dtype)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4142,7 +4142,7 @@ class MaskedArray(ndarray):
             prefix = ''  # absorbed into the first indent
         else:
             # each key on its own line, indented by two spaces
-            indents = {k: ' ' * min_indent for k in keys}
+            indents = dict.fromkeys(keys, ' ' * min_indent)
             prefix = prefix + '\n'  # first key on the next line
 
         # format the field values

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2503,15 +2503,15 @@ def _recursive_printoption(result, mask, printopt):
 
 
 # For better or worse, these end in a newline
-_legacy_print_templates = dict(
-    long_std=textwrap.dedent("""\
+_legacy_print_templates = {
+    'long_std': textwrap.dedent("""\
         masked_%(name)s(data =
          %(data)s,
         %(nlen)s        mask =
          %(mask)s,
         %(nlen)s  fill_value = %(fill)s)
         """),
-    long_flx=textwrap.dedent("""\
+    'long_flx': textwrap.dedent("""\
         masked_%(name)s(data =
          %(data)s,
         %(nlen)s        mask =
@@ -2519,18 +2519,18 @@ _legacy_print_templates = dict(
         %(nlen)s  fill_value = %(fill)s,
         %(nlen)s       dtype = %(dtype)s)
         """),
-    short_std=textwrap.dedent("""\
+    'short_std': textwrap.dedent("""\
         masked_%(name)s(data = %(data)s,
         %(nlen)s        mask = %(mask)s,
         %(nlen)s  fill_value = %(fill)s)
         """),
-    short_flx=textwrap.dedent("""\
+    'short_flx': textwrap.dedent("""\
         masked_%(name)s(data = %(data)s,
         %(nlen)s        mask = %(mask)s,
         %(nlen)s  fill_value = %(fill)s,
         %(nlen)s       dtype = %(dtype)s)
         """)
-)
+}
 
 ###############################################################################
 #                          MaskedArray class                                  #
@@ -3034,13 +3034,13 @@ class MaskedArray(ndarray):
         _optinfo.update(getattr(obj, '_basedict', {}))
         if not isinstance(obj, MaskedArray):
             _optinfo.update(getattr(obj, '__dict__', {}))
-        _dict = dict(_fill_value=getattr(obj, '_fill_value', None),
-                     _hardmask=getattr(obj, '_hardmask', False),
-                     _sharedmask=getattr(obj, '_sharedmask', False),
-                     _isfield=getattr(obj, '_isfield', False),
-                     _baseclass=getattr(obj, '_baseclass', _baseclass),
-                     _optinfo=_optinfo,
-                     _basedict=_optinfo)
+        _dict = {'_fill_value': getattr(obj, '_fill_value', None),
+                     '_hardmask': getattr(obj, '_hardmask', False),
+                     '_sharedmask': getattr(obj, '_sharedmask', False),
+                     '_isfield': getattr(obj, '_isfield', False),
+                     '_baseclass': getattr(obj, '_baseclass', _baseclass),
+                     '_optinfo': _optinfo,
+                     '_basedict': _optinfo}
         self.__dict__.update(_dict)
         self.__dict__.update(_optinfo)
         return
@@ -4098,14 +4098,14 @@ class MaskedArray(ndarray):
         # 2016-11-19: Demoted to legacy format
         if np._core.arrayprint._get_legacy_print_mode() <= 113:
             is_long = self.ndim > 1
-            parameters = dict(
-                name=name,
-                nlen=" " * len(name),
-                data=str(self),
-                mask=str(self._mask),
-                fill=str(self.fill_value),
-                dtype=str(self.dtype)
-            )
+            parameters = {
+                'name': name,
+                'nlen': " " * len(name),
+                'data': str(self),
+                'mask': str(self._mask),
+                'fill': str(self.fill_value),
+                'dtype': str(self.dtype)
+            }
             is_structured = bool(self.dtype.names)
             key = '{}_{}'.format(
                 'long' if is_long else 'short',
@@ -7009,9 +7009,9 @@ class _extrema_operation(_MaskedUFunc):
             axis = None
 
         if axis is not np._NoValue:
-            kwargs = dict(axis=axis)
+            kwargs = {'axis': axis}
         else:
-            kwargs = dict()
+            kwargs = {}
 
         if m is nomask:
             t = self.f.reduce(target, **kwargs)
@@ -8861,19 +8861,19 @@ class _convert2ma:
 
 arange = _convert2ma(
     'arange',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='arange : ndarray',
     np_ma_ret='arange : MaskedArray',
 )
 clip = _convert2ma(
     'clip',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='clipped_array : ndarray',
     np_ma_ret='clipped_array : MaskedArray',
 )
 empty = _convert2ma(
     'empty',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='out : ndarray',
     np_ma_ret='out : MaskedArray',
 )
@@ -8894,19 +8894,19 @@ fromfunction = _convert2ma(
 )
 identity = _convert2ma(
     'identity',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='out : ndarray',
     np_ma_ret='out : MaskedArray',
 )
 indices = _convert2ma(
     'indices',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='grid : one ndarray or tuple of ndarrays',
     np_ma_ret='grid : one MaskedArray or tuple of MaskedArrays',
 )
 ones = _convert2ma(
     'ones',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='out : ndarray',
     np_ma_ret='out : MaskedArray',
 )
@@ -8917,13 +8917,13 @@ ones_like = _convert2ma(
 )
 squeeze = _convert2ma(
     'squeeze',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='squeezed : ndarray',
     np_ma_ret='squeezed : MaskedArray',
 )
 zeros = _convert2ma(
     'zeros',
-    params=dict(fill_value=None, hardmask=False),
+    params={'fill_value': None, 'hardmask': False},
     np_ret='out : ndarray',
     np_ma_ret='out : MaskedArray',
 )

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -306,8 +306,8 @@ class _fromnxfunction_seq(_fromnxfunction):
     """
     def __call__(self, x, *args, **params):
         func = getattr(np, self.__name__)
-        _d = func(tuple([np.asarray(a) for a in x]), *args, **params)
-        _m = func(tuple([getmaskarray(a) for a in x]), *args, **params)
+        _d = func(tuple(np.asarray(a) for a in x), *args, **params)
+        _m = func(tuple(getmaskarray(a) for a in x), *args, **params)
         return masked_array(_d, mask=_m)
 
 
@@ -2030,8 +2030,8 @@ def notmasked_edges(a, axis=None):
         return flatnotmasked_edges(a)
     m = getmaskarray(a)
     idx = array(np.indices(a.shape), mask=np.asarray([m] * a.ndim))
-    return [tuple([idx[i].min(axis).compressed() for i in range(a.ndim)]),
-            tuple([idx[i].max(axis).compressed() for i in range(a.ndim)]), ]
+    return [tuple(idx[i].min(axis).compressed() for i in range(a.ndim)),
+            tuple(idx[i].max(axis).compressed() for i in range(a.ndim)), ]
 
 
 def flatnotmasked_contiguous(a):

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -343,7 +343,7 @@ class MaskedRecords(ma.MaskedArray):
 
         """
         _names = self.dtype.names
-        fmt = "%%%is : %%s" % (max([len(n) for n in _names]) + 4,)
+        fmt = "%%%is : %%s" % (max(len(n) for n in _names) + 4,)
         reprstr = [fmt % (f, getattr(self, f)) for f in self.dtype.names]
         reprstr.insert(0, 'masked_records(')
         reprstr.extend([fmt % ('    fill_value', self.fill_value),

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3593,12 +3593,12 @@ class TestMaskedArrayMethods:
     def test_argsort_matches_sort(self):
         x = array([1, 4, 2, 3], mask=[0, 1, 0, 0], dtype=np.uint8)
 
-        for kwargs in [dict(),
-                       dict(endwith=True),
-                       dict(endwith=False),
-                       dict(fill_value=2),
-                       dict(fill_value=2, endwith=True),
-                       dict(fill_value=2, endwith=False)]:
+        for kwargs in [{},
+                       {"endwith": True},
+                       {"endwith": False},
+                       {"fill_value": 2},
+                       {"fill_value": 2, "endwith": True},
+                       {"fill_value": 2, "endwith": False}]:
             sortedx = sort(x, **kwargs)
             argsortedx = x[argsort(x, **kwargs)]
             assert_equal(sortedx._data, argsortedx._data)
@@ -5039,7 +5039,7 @@ class TestMaskedFields:
         mdtype = [('a', bool), ('b', bool), ('c', bool)]
         mask = [0, 1, 0, 0, 1]
         base = array(list(zip(ilist, flist, slist)), mask=mask, dtype=ddtype)
-        self.data = dict(base=base, mask=mask, ddtype=ddtype, mdtype=mdtype)
+        self.data = {"base": base, "mask": mask, "ddtype": ddtype, "mdtype": mdtype}
 
     def test_set_records_masks(self):
         base = self.data['base']

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -178,7 +178,7 @@ class matrix(N.ndarray):
         if (ndim == 2):
             return
         if (ndim > 2):
-            newshape = tuple([x for x in self.shape if x > 1])
+            newshape = tuple(x for x in self.shape if x > 1)
             ndim = len(newshape)
             if ndim == 2:
                 self.shape = newshape

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -323,7 +323,7 @@ def test_truediv(Poly):
         s = stype(5, 0)
         assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)
-    for s in [tuple(), list(), dict(), bool(), np.array([1])]:
+    for s in [(), [], {}, bool(), np.array([1])]:
         assert_raises(TypeError, op.truediv, p2, s)
         assert_raises(TypeError, op.truediv, s, p2)
     for ptype in classes:

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -867,7 +867,7 @@ class TestRandomDist:
         assert_(random.choice(arr, replace=True) is a)
 
         # Check 0-d array
-        s = tuple()
+        s = ()
         assert_(not np.isscalar(random.choice(2, s, replace=True)))
         assert_(not np.isscalar(random.choice(2, s, replace=False)))
         assert_(not np.isscalar(random.choice(2, s, replace=True, p=p)))
@@ -2450,7 +2450,7 @@ class TestBroadcast:
         random = Generator(MT19937(self.seed))
         pvals = np.array([1 / 4] * 4)
         actual = random.multinomial(n, pvals)
-        n_shape = tuple() if isinstance(n, int) else n.shape
+        n_shape = () if isinstance(n, int) else n.shape
         expected_shape = n_shape + (4,)
         assert actual.shape == expected_shape
         pvals = np.vstack([pvals, pvals])

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -436,7 +436,7 @@ class TestRandomDist:
         assert_(np.random.choice(arr, replace=True) is a)
 
         # Check 0-d array
-        s = tuple()
+        s = ()
         assert_(not np.isscalar(np.random.choice(2, s, replace=True)))
         assert_(not np.isscalar(np.random.choice(2, s, replace=False)))
         assert_(not np.isscalar(np.random.choice(2, s, replace=True, p=p)))

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -629,7 +629,7 @@ class TestRandomDist:
         assert_(random.choice(arr, replace=True) is a)
 
         # Check 0-d array
-        s = tuple()
+        s = ()
         assert_(not np.isscalar(random.choice(2, s, replace=True)))
         assert_(not np.isscalar(random.choice(2, s, replace=False)))
         assert_(not np.isscalar(random.choice(2, s, replace=True, p=p)))

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -161,7 +161,7 @@ def _make_methods(functions, modname):
         -1,             /* m_size */
         methods,        /* m_methods */
     };
-    """ % dict(methods='\n'.join(methods_table), modname=modname)
+    """ % {'methods': '\n'.join(methods_table), 'modname': modname}
     return body
 
 
@@ -177,9 +177,9 @@ def _make_source(name, init, body):
     PyInit_%(name)s(void) {
     %(init)s
     }
-    """ % dict(
-        name=name, init=init, body=body,
-    )
+    """ % {
+        'name': name, 'init': init, 'body': body,
+    }
     return code
 
 

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -150,12 +150,12 @@ class TestNdpointerCFunc:
     @pytest.mark.parametrize(
         'dt', [
             float,
-            np.dtype(dict(
-                formats=['<i4', '<i4'],
-                names=['a', 'b'],
-                offsets=[0, 2],
-                itemsize=6
-            ))
+            np.dtype({
+                'formats': ['<i4', '<i4'],
+                'names': ['a', 'b'],
+                'offsets': [0, 2],
+                'itemsize': 6
+            })
         ], ids=[
             'float',
             'overlapping-fields'
@@ -337,11 +337,11 @@ class TestAsCtypesType:
         ])
 
     def test_union(self):
-        dt = np.dtype(dict(
-            names=['a', 'b'],
-            offsets=[0, 0],
-            formats=[np.uint16, np.uint32]
-        ))
+        dt = np.dtype({
+            'names': ['a', 'b'],
+            'offsets': [0, 0],
+            'formats': [np.uint16, np.uint32]
+        })
 
         ct = np.ctypeslib.as_ctypes_type(dt)
         assert_(issubclass(ct, ctypes.Union))
@@ -352,12 +352,12 @@ class TestAsCtypesType:
         ])
 
     def test_padded_union(self):
-        dt = np.dtype(dict(
-            names=['a', 'b'],
-            offsets=[0, 0],
-            formats=[np.uint16, np.uint32],
-            itemsize=5,
-        ))
+        dt = np.dtype({
+            'names': ['a', 'b'],
+            'offsets': [0, 0],
+            'formats': [np.uint16, np.uint32],
+            'itemsize': 5,
+        })
 
         ct = np.ctypeslib.as_ctypes_type(dt)
         assert_(issubclass(ct, ctypes.Union))
@@ -369,9 +369,9 @@ class TestAsCtypesType:
         ])
 
     def test_overlapping(self):
-        dt = np.dtype(dict(
-            names=['a', 'b'],
-            offsets=[0, 2],
-            formats=[np.uint32, np.uint32]
-        ))
+        dt = np.dtype({
+            'names': ['a', 'b'],
+            'offsets': [0, 2],
+            'formats': [np.uint32, np.uint32]
+        })
         assert_raises(NotImplementedError, np.ctypeslib.as_ctypes_type, dt)

--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -42,7 +42,7 @@ def test_short_version():
 
 
 def test_version_module():
-    contents = set([s for s in dir(np.version) if not s.startswith('_')])
+    contents = {s for s in dir(np.version) if not s.startswith('_')}
     expected = set([
         'full_version',
         'git_revision',

--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -43,12 +43,12 @@ def test_short_version():
 
 def test_version_module():
     contents = {s for s in dir(np.version) if not s.startswith('_')}
-    expected = set([
+    expected = {
         'full_version',
         'git_revision',
         'release',
         'short_version',
         'version',
-    ])
+    }
 
     assert contents == expected

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -582,7 +582,7 @@ def test_functions_single_location():
     visited_functions: Set[Callable[..., Any]] = set()
     # Functions often have `__name__` overridden, therefore we need
     # to keep track of locations where functions have been found.
-    functions_original_paths: Dict[Callable[..., Any], str] = dict()
+    functions_original_paths: Dict[Callable[..., Any], str] = {}
 
     # Here we aggregate functions with more than one location.
     # It must be empty for the test to pass.
@@ -736,11 +736,11 @@ def test___module___attribute():
                     continue
 
                 incorrect_entries.append(
-                    dict(
-                        Func=member.__name__,
-                        actual=member.__module__,
-                        expected=module.__name__,
-                    )
+                    {
+                        "Func": member.__name__,
+                        "actual": member.__module__,
+                        "expected": module.__name__,
+                    }
                 )
                 visited_functions.add(member)
 
@@ -801,10 +801,10 @@ def test___qualname___and___module___attribute():
                 member not in visited_functions
             ):
                 incorrect_entries.append(
-                    dict(
-                        found_at=f"{module.__name__}:{member_name}",
-                        advertises=f"{member.__module__}:{member.__qualname__}",
-                    )
+                    {
+                        "found_at": f"{module.__name__}:{member_name}",
+                        "advertises": f"{member.__module__}:{member.__qualname__}",
+                    }
                 )
                 visited_functions.add(member)
 

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -11,7 +11,7 @@ from xml.sax.saxutils import quoteattr, escape
 
 try:
     import pygments
-    if tuple([int(x) for x in pygments.__version__.split('.')]) < (0, 11):
+    if tuple(int(x) for x in pygments.__version__.split('.')) < (0, 11):
         raise ImportError
     from pygments import highlight
     from pygments.lexers import CLexer

--- a/tools/check_installed_files.py
+++ b/tools/check_installed_files.py
@@ -120,5 +120,5 @@ if __name__ == '__main__':
             if values['tag'] not in all_tags:
                 all_tags.add(values['tag'])
 
-    if all_tags != set(['runtime', 'python-runtime', 'devel', 'tests']):
+    if all_tags != {'runtime', 'python-runtime', 'devel', 'tests'}:
         raise AssertionError(f"Found unexpected install tag: {all_tags}")

--- a/tools/check_installed_files.py
+++ b/tools/check_installed_files.py
@@ -76,7 +76,7 @@ def main(install_dir, tests_check):
 
 
 def get_files(dir_to_check, kind='test'):
-    files = dict()
+    files = {}
     patterns = {
         'test': f'{dir_to_check}/**/test_*.py',
         'stub': f'{dir_to_check}/**/*.pyi',

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -406,12 +406,12 @@ def validate_rst_syntax(text, name, dots=True):
             output_dot('E')
         return False, "ERROR: %s: no documentation" % (name,)
 
-    ok_unknown_items = set([
+    ok_unknown_items = {
         'mod', 'doc', 'currentmodule', 'autosummary', 'data', 'attr',
         'obj', 'versionadded', 'versionchanged', 'module', 'class',
         'ref', 'func', 'toctree', 'moduleauthor', 'term', 'c:member',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'
-    ])
+    }
 
     # Run through docutils
     error_stream = io.StringIO()

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -423,16 +423,16 @@ def validate_rst_syntax(text, name, dots=True):
 
     docutils.core.publish_doctree(
         text, token,
-        settings_overrides = dict(halt_level=5,
-                                  traceback=True,
-                                  default_reference_context='title-reference',
-                                  default_role='emphasis',
-                                  link_base='',
-                                  resolve_name=resolve,
-                                  stylesheet_path='',
-                                  raw_enabled=0,
-                                  file_insertion_enabled=0,
-                                  warning_stream=error_stream))
+        settings_overrides = {'halt_level': 5,
+                                  'traceback': True,
+                                  'default_reference_context': 'title-reference',
+                                  'default_role': 'emphasis',
+                                  'link_base': '',
+                                  'resolve_name': resolve,
+                                  'stylesheet_path': '',
+                                  'raw_enabled': 0,
+                                  'file_insertion_enabled': 0,
+                                  'warning_stream': error_stream})
 
     # Print errors, disregarding unimportant ones
     error_msg = error_stream.getvalue()


### PR DESCRIPTION
Merging #27300 first will help with residual linter errors.