### PR TITLE
MAINT: Apply assorted ruff/flake8-simplify rules (SIM)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -432,14 +432,11 @@ autosummary_generate = True
 # -----------------------------------------------------------------------------
 # Coverage checker
 # -----------------------------------------------------------------------------
-coverage_ignore_modules = r"""
-    """.split()
-coverage_ignore_functions = r"""
-    test($|_) (some|all)true bitwise_not cumproduct pkgload
-    generic\.
-    """.split()
-coverage_ignore_classes = r"""
-    """.split()
+coverage_ignore_modules = []
+coverage_ignore_functions = [
+	'test($|_)', '(some|all)true', 'bitwise_not', 'cumproduct', 'pkgload', 'generic\\.'
+]
+coverage_ignore_classes = []
 
 coverage_c_path = []
 coverage_c_regexes = {}

--- a/numpy/_core/tests/_natype.py
+++ b/numpy/_core/tests/_natype.py
@@ -14,10 +14,8 @@ def _create_binary_propagating_op(name, is_divmod=False):
     def method(self, other):
         if (
             other is pd_NA
-            or isinstance(other, (str, bytes))
-            or isinstance(other, (numbers.Number, np.bool))
-            or isinstance(other, np.ndarray)
-            and not other.shape
+            or isinstance(other, (str, bytes, numbers.Number, np.bool))
+            or isinstance(other, np.ndarray) and not other.shape
         ):
             # Need the other.shape clause to handle NumPy scalars,
             # since we do a setitem on `out` below, which

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1528,7 +1528,7 @@ class TestRegression:
 
     def test_ticket_1538(self):
         x = np.finfo(np.float32)
-        for name in 'eps epsneg max min resolution tiny'.split():
+        for name in ('eps', 'epsneg', 'max', 'min', 'resolution', 'tiny'):
             assert_equal(type(getattr(x, name)), np.float32,
                          err_msg=name)
 

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -877,19 +877,13 @@ def applyrules(rules, d, var={}):
                         for i in rules[k][k1]:
                             if isinstance(i, dict):
                                 res = applyrules({'supertext': i}, d, var)
-                                if 'supertext' in res:
-                                    i = res['supertext']
-                                else:
-                                    i = ''
+                                i = res.get('supertext', '')
                             ret[k].append(replace(i, d))
                     else:
                         i = rules[k][k1]
                         if isinstance(i, dict):
                             res = applyrules({'supertext': i}, d)
-                            if 'supertext' in res:
-                                i = res['supertext']
-                            else:
-                                i = ''
+                            i = res.get('supertext', '')
                         ret[k].append(replace(i, d))
         else:
             errmess('applyrules: ignoring rule %s.\n' % repr(rules[k]))

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1351,10 +1351,7 @@ def analyzeline(m, case, line):
         if m.group('after').strip().lower() == 'none':
             groupcache[groupcounter]['implicit'] = None
         elif m.group('after'):
-            if 'implicit' in groupcache[groupcounter]:
-                impl = groupcache[groupcounter]['implicit']
-            else:
-                impl = {}
+            impl = groupcache[groupcounter].get('implicit', {})
             if impl is None:
                 outmess(
                     'analyzeline: Overwriting earlier "implicit none" statement.\n')
@@ -3172,10 +3169,7 @@ def expr2name(a, block, args=[]):
         block['vars'][a] = at
     else:
         if a not in block['vars']:
-            if orig_a in block['vars']:
-                block['vars'][a] = block['vars'][orig_a]
-            else:
-                block['vars'][a] = {}
+            block['vars'][a] = block['vars'].get(orig_a, {})
         if 'externals' in block and orig_a in block['externals'] + block['interfaced']:
             block['vars'][a] = setattrspec(block['vars'][a], 'external')
     return a

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -15,7 +15,7 @@ from . import util
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 
-    @pytest.mark.parametrize("name", "t,t2".split(","))
+    @pytest.mark.parametrize("name", ["t", "t2"])
     @pytest.mark.slow
     def test_all(self, name):
         self.check_function(name)

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -250,7 +250,7 @@ def test_no_py312_distutils_fcompiler(capfd, hello_world_f90, monkeypatch):
         out, _ = capfd.readouterr()
         assert "--fcompiler cannot be used with meson" in out
     monkeypatch.setattr(
-        sys, "argv", "f2py --help-link".split()
+        sys, "argv", ["f2py", "--help-link"]
     )
     with util.switchdir(ipath.parent):
         f2pycli()
@@ -744,7 +744,7 @@ def test_version(capfd, monkeypatch):
 
     CLI :: -v
     """
-    monkeypatch.setattr(sys, "argv", 'f2py -v'.split())
+    monkeypatch.setattr(sys, "argv", ["f2py", "-v"])
     # TODO: f2py2e should not call sys.exit() after printing the version
     with pytest.raises(SystemExit):
         f2pycli()

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -36,11 +36,11 @@ class TestFReturnCharacter(TestReturnCharacter):
     ]
 
     @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
-    @pytest.mark.parametrize("name", "t0,t1,t5,s0,s1,s5,ss".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t1", "t5", "s0", "s1", "s5", "ss"])
     def test_all_f77(self, name):
         self.check_function(getattr(self.module, name), name)
 
     @pytest.mark.xfail(IS_S390X, reason="callback returns ' '")
-    @pytest.mark.parametrize("name", "t0,t1,t5,ts,s0,s1,s5,ss".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t1", "t5", "ts", "s0", "s1", "s5", "ss"])
     def test_all_f90(self, name):
         self.check_function(getattr(self.module.f90_return_char, name), name)

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -56,11 +56,11 @@ class TestFReturnComplex(TestReturnComplex):
         util.getpath("tests", "src", "return_complex", "foo90.f90"),
     ]
 
-    @pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t8", "t16", "td", "s0", "s8", "s16", "sd"])
     def test_all_f77(self, name):
         self.check_function(getattr(self.module, name), name)
 
-    @pytest.mark.parametrize("name", "t0,t8,t16,td,s0,s8,s16,sd".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t8", "t16", "td", "s0", "s8", "s16", "sd"])
     def test_all_f90(self, name):
         self.check_function(getattr(self.module.f90_return_complex, name),
                             name)

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -43,12 +43,12 @@ class TestFReturnInteger(TestReturnInteger):
     ]
 
     @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+                             ["t0", "t1", "t2", "t4", "t8", "s0", "s1", "s2", "s4", "s8"])
     def test_all_f77(self, name):
         self.check_function(getattr(self.module, name), name)
 
     @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+                             ["t0", "t1", "t2", "t4", "t8", "s0", "s1", "s2", "s4", "s8"])
     def test_all_f90(self, name):
         self.check_function(getattr(self.module.f90_return_integer, name),
                             name)

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -53,12 +53,12 @@ class TestFReturnLogical(TestReturnLogical):
     ]
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("name", "t0,t1,t2,t4,s0,s1,s2,s4".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t1", "t2", "t4", "s0", "s1", "s2", "s4"])
     def test_all_f77(self, name):
         self.check_function(getattr(self.module, name))
 
     @pytest.mark.slow
     @pytest.mark.parametrize("name",
-                             "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","))
+                             ["t0", "t1", "t2", "t4", "t8", "s0", "s1", "s2", "s4", "s8"])
     def test_all_f90(self, name):
         self.check_function(getattr(self.module.f90_return_logical, name))

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -88,7 +88,7 @@ end interface
 end python module c_ext_return_real
     """
 
-    @pytest.mark.parametrize("name", "t4,t8,s4,s8".split(","))
+    @pytest.mark.parametrize("name", ["t4", "t8", "s4", "s8"])
     def test_all(self, name):
         self.check_function(getattr(self.module, name), name)
 
@@ -99,10 +99,10 @@ class TestFReturnReal(TestReturnReal):
         util.getpath("tests", "src", "return_real", "foo90.f90"),
     ]
 
-    @pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t4", "t8", "td", "s0", "s4", "s8", "sd"])
     def test_all_f77(self, name):
         self.check_function(getattr(self.module, name), name)
 
-    @pytest.mark.parametrize("name", "t0,t4,t8,td,s0,s4,s8,sd".split(","))
+    @pytest.mark.parametrize("name", ["t0", "t4", "t8", "td", "s0", "s4", "s8", "sd"])
     def test_all_f90(self, name):
         self.check_function(getattr(self.module.f90_return_real, name), name)

--- a/numpy/f2py/use_rules.py
+++ b/numpy/f2py/use_rules.py
@@ -69,10 +69,7 @@ def buildusevars(m, r):
                     '\t\t\tNo definition for variable "%s=>%s". Skipping.\n' % (v, r['map'][v]))
     else:
         for v in m['vars'].keys():
-            if v in revmap:
-                varsmap[v] = revmap[v]
-            else:
-                varsmap[v] = v
+            varsmap[v] = revmap.get(v, v)
     for v in varsmap.keys():
         ret = dictappend(ret, buildusevar(v, varsmap[v], m['vars'], m['name']))
     return ret

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -848,7 +848,7 @@ def pad(array, pad_width, mode='constant', **kwargs):
 
     elif mode in stat_functions:
         func = stat_functions[mode]
-        length = kwargs.get("stat_length", None)
+        length = kwargs.get("stat_length")
         length = _as_pairs(length, padded.ndim, as_index=True)
         for axis, width_pair, length_pair in zip(axes, pad_width, length):
             roi = _view_roi(padded, original_area_slice, axis)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3860,8 +3860,8 @@ def _ureduce(a, func, keepdims=False, **kwargs):
 
     """
     a = np.asanyarray(a)
-    axis = kwargs.get('axis', None)
-    out = kwargs.get('out', None)
+    axis = kwargs.get('axis')
+    out = kwargs.get('out')
 
     if keepdims is np._NoValue:
         keepdims = False

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -296,10 +296,7 @@ class TestMatrixReturn:
                 # reset contents of a
                 a.astype('f8')
                 a.fill(1.0)
-                if attrib in methodargs:
-                    args = methodargs[attrib]
-                else:
-                    args = ()
+                args = methodargs.get(attrib, ())
                 b = f(*args)
                 assert_(type(b) is matrix, "%s" % attrib)
         assert_(type(a.real) is matrix)

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -199,12 +199,10 @@ class ABCPolyBase(abc.ABC):
             True if the coefficients are the same, False otherwise.
 
         """
-        if len(self.coef) != len(other.coef):
-            return False
-        elif not np.all(self.coef == other.coef):
-            return False
-        else:
-            return True
+        return (
+			len(self.coef) == len(other.coef)
+			and np.all(self.coef == other.coef)
+		)
 
     def has_samedomain(self, other):
         """Check if domains match.

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -271,19 +271,12 @@ if sys.version_info < (3, 12):
 
 def is_unexpected(name):
     """Check if this needs to be considered."""
-    if '._' in name or '.tests' in name or '.setup' in name:
-        return False
-
-    if name in PUBLIC_MODULES:
-        return False
-
-    if name in PUBLIC_ALIASED_MODULES:
-        return False
-
-    if name in PRIVATE_BUT_PRESENT_MODULES:
-        return False
-
-    return True
+    return (
+        '._' not in name and '.tests' not in name and '.setup' not in name
+		and name not in PUBLIC_MODULES
+		and name not in PUBLIC_ALIASED_MODULES
+		and name not in PRIVATE_BUT_PRESENT_MODULES
+	)
 
 
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
Merging #27300 first will help with residual linter errors.