### PR TITLE
MAINT: Don't wrap ``#include <Python.h>`` with ``extern "C"``

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1,14 +1,14 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NDARRAYTYPES_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NDARRAYTYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "npy_common.h"
 #include "npy_endian.h"
 #include "npy_cpu.h"
 #include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define NPY_NO_EXPORT NPY_VISIBILITY_HIDDEN
 


### PR DESCRIPTION
This exposed a small latent bug in CPython
(https://github.com/python/cpython/pull/127772), but it's probably not a good practice in general to wrap other code's headers with extern guards.
