### PR TITLE
MAINT: Don't wrap ``#include <Python.h>`` with ``extern "C"``

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1,14 +1,14 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NDARRAYTYPES_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NDARRAYTYPES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "npy_common.h"
 #include "npy_endian.h"
 #include "npy_cpu.h"
 #include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define NPY_NO_EXPORT NPY_VISIBILITY_HIDDEN
 


### PR DESCRIPTION
Backport of #27986.

This extern block was recently moved, which exposed a latent bug in CPython (https://github.com/python/cpython/pull/127772), but it's probably not a good practice in general to wrap other code's headers with extern guards.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
