### PR TITLE
BUG: Fix segfault in stringdtype lexsort

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2014,8 +2014,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                 }
                 rcode = argsort(its[j]->dataptr,
                         (npy_intp *)rit->dataptr, N, mps[j]);
-                if (rcode < 0 || (PyDataType_REFCHK(PyArray_DESCR(mps[j]))
-                            && PyErr_Occurred())) {
+                if (rcode < 0 || (object && PyErr_Occurred())) {
                     goto fail;
                 }
                 PyArray_ITER_NEXT(its[j]);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5374,6 +5374,13 @@ class TestLexsort:
             u, v = np.array(u, dtype='object'), np.array(v, dtype='object')
             assert_array_equal(idx, np.lexsort((u, v)))
 
+    def test_strings(self):  # gh-27984
+        for dtype in "TU":
+            surnames = np.array(['Hertz',    'Galilei', 'Hertz'], dtype=dtype)
+            first_names = np.array(['Heinrich', 'Galileo', 'Gustav'], dtype=dtype)
+            assert_array_equal(np.lexsort((first_names, surnames)), [1, 2, 0])
+
+
     def test_invalid_axis(self): # gh-7528
         x = np.linspace(0., 1., 42*3).reshape(42, 3)
         assert_raises(AxisError, np.lexsort, x, axis=2)


### PR DESCRIPTION
Fixes #27984 

The segfault was happening because REFCHK is not a sufficient condition anymore (if it ever was) to assume the GIL is held. The fix is to use the check that was already happening to see if the dtype has NEEDS_PYAPI set.

Also adds tests for both stringdtype argsort and string lexsort.