### PR TITLE
DOC: Fix documentation for np.dtype.kind to include 'T' for StringDType

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6096,9 +6096,6 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('kind',
     >>> dt = np.dtype([('field1', 'f8')])
     >>> dt.kind
     'V'
-    >>> dt = np.dtype('U10')  # Example for StringDType
-    >>> dt.kind
-    'T'
 
     """))
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6066,7 +6066,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('itemsize',
 
 add_newdoc('numpy._core.multiarray', 'dtype', ('kind',
     """
-    A character code (one of 'biufcmMOSUV') identifying the general kind of data.
+    A character code (one of 'biufcmMOSTUV') identifying the general kind of data.
 
     =  ======================
     b  boolean
@@ -6078,6 +6078,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('kind',
     M  datetime
     O  object
     S  (byte-)string
+    T  string (StringDType)
     U  Unicode
     V  void
     =  ======================
@@ -6095,6 +6096,9 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('kind',
     >>> dt = np.dtype([('field1', 'f8')])
     >>> dt.kind
     'V'
+    >>> dt = np.dtype('U10')  # Example for StringDType
+    >>> dt.kind
+    'T'
 
     """))
 


### PR DESCRIPTION
Fixes #27948 

This PR updates the NumPy documentation for the `np.dtype.kind` attribute to include 'T' for `StringDType`.

