### PR TITLE
DOC: fix several doctests in dtype method docstrings

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2514,13 +2514,15 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dtype',
 
     Examples
     --------
+    >>> import numpy as np
+    >>> x = np.arange(4).reshape((2, 2))
     >>> x
     array([[0, 1],
            [2, 3]])
     >>> x.dtype
-    dtype('int32')
-    >>> type(x.dtype)
-    <type 'numpy.dtype'>
+    dtype('int32')   # may vary (OS, bitness)
+    >>> isinstance(x.dtype, np.dtype)
+    True
 
     """))
 
@@ -6255,11 +6257,11 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('subdtype',
     Examples
     --------
     >>> import numpy as np
-    >>> x = numpy.dtype('8f')
+    >>> x = np.dtype('8f')
     >>> x.subdtype
     (dtype('float32'), (8,))
 
-    >>> x =  numpy.dtype('i2')
+    >>> x =  np.dtype('i2')
     >>> x.subdtype
     >>>
 
@@ -6277,11 +6279,11 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('base',
     Examples
     --------
     >>> import numpy as np
-    >>> x = numpy.dtype('8f')
+    >>> x = np.dtype('8f')
     >>> x.base
     dtype('float32')
 
-    >>> x =  numpy.dtype('i2')
+    >>> x =  np.dtype('i2')
     >>> x.base
     dtype('int16')
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2520,7 +2520,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dtype',
     array([[0, 1],
            [2, 3]])
     >>> x.dtype
-    dtype('int32')   # may vary (OS, bitness)
+    dtype('int64')   # may vary (OS, bitness)
     >>> isinstance(x.dtype, np.dtype)
     True
 


### PR DESCRIPTION
fix several small issues in docstrings of `np.dtype` methods, smoked out in https://github.com/numpy/numpy/issues/28002

flagged by https://github.com/scipy/scipy_doctest/pull/180

This only fixes "obvious" ones, there are several others:

```
______________________ [doctest] numpy.dtypes.StringDType.fields ______________________
EXAMPLE LOCATION UNKNOWN, not showing all tests of that example
??? >>> print(dt.fields)
Expected:
    {'grades': (dtype(('float64',(2,))), 16), 'name': (dtype('|S16'), 0)}
Got:
    {'name': (dtype('<U16'), 0), 'grades': (dtype(('<f8', (2,))), 64)}

None:None: DocTestFailure
_____________________ [doctest] numpy.dtypes.StringDType.metadata _____________________
EXAMPLE LOCATION UNKNOWN, not showing all tests of that example
??? >>> (arr + arr2).dtype.metadata is None
Expected:
    True  # The metadata field is cleared so None is returned
Got:
    False

```