### PR TITLE
BUG: Fix handling of matrix class in np.unique.

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -343,6 +343,10 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     Find the unique elements of an array, ignoring shape.
     """
     ar = np.asanyarray(ar).flatten()
+    if len(ar.shape) != 1:
+        # np.matrix, and maybe some other array subclasses, insist on keeping
+        # two dimensions for all operations. Coerce to an ndarray in such cases.
+        ar = np.asarray(ar).flatten()
 
     optional_indices = return_index or return_inverse
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -998,3 +998,20 @@ class TestUnique:
             assert_array_equal(expected_values, result.values)
             assert_array_equal(expected_inverse, result.inverse_indices)
             assert_array_equal(arr, result.values[result.inverse_indices])
+
+    @pytest.mark.parametrize(
+        'data',
+        [[[1, 1, 1],
+          [1, 1, 1]],
+         [1, 3, 2],
+         1],
+    )
+    @pytest.mark.parametrize('transpose', [False, True])
+    @pytest.mark.parametrize('dtype', [np.int32, np.float64])
+    def test_unique_with_matrix(self, data, transpose, dtype):
+        mat = np.matrix(data).astype(dtype)
+        if transpose:
+            mat = mat.T
+        u = np.unique(mat)
+        expected = np.unique(np.asarray(mat))
+        assert_array_equal(u, expected, strict=True)


### PR DESCRIPTION
Closes gh-19405.

The fix is pretty much exactly what @rkern suggested in gh-19405.

If the removal of `matrix` is imminent and there is zero interest in any fixes related to the class, then we can close this PR without merging--and without complaints!