### PR TITLE
TST: lib: Test average with object dtype and no weights.

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -476,10 +476,16 @@ class TestAverage:
         w /= w.sum()
         assert_almost_equal(a.mean(0), average(a, weights=w))
 
+    def test_object_no_weights(self):
+        a = np.array([decimal.Decimal(x) for x in range(10)])
+        m = average(a)
+        assert m == decimal.Decimal('4.5')
+
     def test_average_class_without_dtype(self):
         # see gh-21988
         a = np.array([Fraction(1, 5), Fraction(3, 5)])
         assert_equal(np.average(a), Fraction(2, 5))
+
 
 class TestSelect:
     choices = [np.array([1, 2, 3]),


### PR DESCRIPTION
This is a regression test for one of the problems reported in gh-8696.
