### PR TITLE
DOC: Fixed typos in development_advanced_debugging.rst

### DIFF
--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -10,7 +10,7 @@ day-to-day development.
 These are used more rarely, for example close to a new NumPy release,
 or when a large or particular complex change was made.
 
-Since not all of these tools are used on a regular bases and only available
+Since not all of these tools are used on a regular basis and only available
 on some systems, please expect differences, issues, or quirks;
 we will be happy to help if you get stuck and appreciate any improvements
 or suggestions to these workflows.
@@ -188,7 +188,7 @@ Use together with ``pytest``
 You can run the test suite with valgrind which may be sufficient
 when you are only interested in a few tests::
 
-    PYTHOMMALLOC=malloc valgrind python runtests.py \
+    PYTHONMALLOC=malloc valgrind python runtests.py \
      -t numpy/_core/tests/test_multiarray.py -- --continue-on-collection-errors
 
 Note the ``--continue-on-collection-errors``, which is currently necessary due to


### PR DESCRIPTION
Fixes #28012 

This PR fixes two typos in the development_advanced_debugging.rst file:

1. 'bases' is corrected to 'basis' 
2. 'PYTHOMMALLOC' is corrected to 'PYTHONMALLOC'