### PR TITLE
DOC: update to scipy-doctest 1.6.0 and fix tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -194,12 +194,13 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       run: |
         spin bench --quick
-    - name: Check docstests
-      shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
-      run: |
-        pip install scipy-doctest==1.5.1 hypothesis==6.104.1 matplotlib scipy pytz pandas
-        spin check-docs -v
-        spin check-tutorials -v
+    # These are run on CircleCI
+    # - name: Check docstests
+    #   shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
+    #   run: |
+    #     pip install scipy-doctest==1.6.0 hypothesis==6.104.1 matplotlib scipy pytz pandas
+    #     spin check-docs -v
+    #     spin check-tutorials -v
 
   sdist:
     needs: [smoke_test]

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2771,7 +2771,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('shape',
     >>> y.shape = (3, 6)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    ValueError: total size of new array must be unchanged
+    ValueError: cannot reshape array of size 24 into shape (3,6)
     >>> np.zeros((4,2))[::2].shape = (-1,)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
@@ -2854,31 +2854,32 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('strides',
     Examples
     --------
     >>> import numpy as np
-    >>> y = np.reshape(np.arange(2*3*4), (2,3,4))
+    >>> y = np.reshape(np.arange(2 * 3 * 4, dtype=np.int32), (2, 3, 4))
     >>> y
     array([[[ 0,  1,  2,  3],
             [ 4,  5,  6,  7],
             [ 8,  9, 10, 11]],
            [[12, 13, 14, 15],
             [16, 17, 18, 19],
-            [20, 21, 22, 23]]])
+            [20, 21, 22, 23]]], dtype=np.int32)
     >>> y.strides
     (48, 16, 4)
-    >>> y[1,1,1]
-    17
-    >>> offset=sum(y.strides * np.array((1,1,1)))
-    >>> offset/y.itemsize
-    17
+    >>> y[1, 1, 1]
+    np.int32(17)
+    >>> offset = sum(y.strides * np.array((1, 1, 1)))
+    >>> offset // y.itemsize
+    np.int64(17)
 
-    >>> x = np.reshape(np.arange(5*6*7*8), (5,6,7,8)).transpose(2,3,1,0)
+    >>> x = np.reshape(np.arange(5*6*7*8, dtype=np.int32), (5, 6, 7, 8))
+    >>> x = x.transpose(2, 3, 1, 0)
     >>> x.strides
     (32, 4, 224, 1344)
-    >>> i = np.array([3,5,2,2])
+    >>> i = np.array([3, 5, 2, 2], dtype=np.int32)
     >>> offset = sum(i * x.strides)
-    >>> x[3,5,2,2]
-    813
-    >>> offset / x.itemsize
-    813
+    >>> x[3, 5, 2, 2]
+    np.int32(813)
+    >>> offset // x.itemsize
+    np.int64(813)
 
     """))
 
@@ -4964,8 +4965,8 @@ add_newdoc('numpy._core', 'ufunc', ('identity',
     0
     >>> np.multiply.identity
     1
-    >>> np.power.identity
-    1
+    >>> print(np.power.identity)
+    None
     >>> print(np.exp.identity)
     None
     """))
@@ -5053,15 +5054,15 @@ add_newdoc('numpy._core', 'ufunc', ('ntypes',
     --------
     >>> import numpy as np
     >>> np.add.ntypes
-    18
+    22
     >>> np.multiply.ntypes
-    18
+    23
     >>> np.power.ntypes
-    17
+    21
     >>> np.exp.ntypes
-    7
+    10
     >>> np.remainder.ntypes
-    14
+    16
 
     """))
 
@@ -5080,26 +5081,16 @@ add_newdoc('numpy._core', 'ufunc', ('types',
     --------
     >>> import numpy as np
     >>> np.add.types
-    ['??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
-    'LL->L', 'qq->q', 'QQ->Q', 'ff->f', 'dd->d', 'gg->g', 'FF->F', 'DD->D',
-    'GG->G', 'OO->O']
-
-    >>> np.multiply.types
-    ['??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l',
-    'LL->L', 'qq->q', 'QQ->Q', 'ff->f', 'dd->d', 'gg->g', 'FF->F', 'DD->D',
-    'GG->G', 'OO->O']
+    ['??->?', 'bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', ...
 
     >>> np.power.types
-    ['bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l', 'LL->L',
-    'qq->q', 'QQ->Q', 'ff->f', 'dd->d', 'gg->g', 'FF->F', 'DD->D', 'GG->G',
-    'OO->O']
+    ['bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l', ...
 
     >>> np.exp.types
-    ['f->f', 'd->d', 'g->g', 'F->F', 'D->D', 'G->G', 'O->O']
+    ['e->e', 'f->f', 'd->d', 'f->f', 'd->d', 'g->g', 'F->F', 'D->D', 'G->G', 'O->O']
 
     >>> np.remainder.types
-    ['bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l', 'LL->L',
-    'qq->q', 'QQ->Q', 'ff->f', 'dd->d', 'gg->g', 'OO->O']
+    ['bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l', ...
 
     """))
 
@@ -5953,7 +5944,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('fields',
     >>> import numpy as np
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> print(dt.fields)
-    {'grades': (dtype(('float64',(2,))), 16), 'name': (dtype('|S16'), 0)}
+    {'name': (dtype('|S16'), 0), 'grades': (dtype(('float64',(2,))), 16)}
 
     """))
 
@@ -6131,13 +6122,12 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('metadata',
     >>> (arr + arr).dtype.metadata
     mappingproxy({'key': 'value'})
 
-    But if the arrays have different dtype metadata, the metadata may be
-    dropped:
+    If the arrays have different dtype metadata, the first one wins:
 
     >>> dt2 = np.dtype(float, metadata={"key2": "value2"})
     >>> arr2 = np.array([3, 2, 1], dtype=dt2)
-    >>> (arr + arr2).dtype.metadata is None
-    True  # The metadata field is cleared so None is returned
+    >>> print((arr + arr2).dtype.metadata)
+    {'key': 'value'}
     """))
 
 add_newdoc('numpy._core.multiarray', 'dtype', ('name',

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -685,9 +685,11 @@ class ABCPolyBase(abc.ABC):
 
         Create a polynomial object for ``1 + 7*x + 4*x**2``:
 
+        # set the print format to ascii for doctests
+        >>> np.polynomial.set_default_printstyle("ascii")
         >>> poly = np.polynomial.Polynomial([1, 7, 4])
         >>> print(poly)
-        1.0 + 7.0·x + 4.0·x²
+        1.0 + 7.0 x + 4.0 x**2
         >>> poly.degree()
         2
 
@@ -696,7 +698,7 @@ class ABCPolyBase(abc.ABC):
 
         >>> poly = np.polynomial.Polynomial([1, 7, 0])
         >>> print(poly)
-        1.0 + 7.0·x + 0.0·x²
+        1.0 + 7.0 x + 0.0 x**2
         >>> poly.degree()
         2
         >>> poly.trim().degree()

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -685,11 +685,10 @@ class ABCPolyBase(abc.ABC):
 
         Create a polynomial object for ``1 + 7*x + 4*x**2``:
 
-        # set the print format to ascii for doctests
-        >>> np.polynomial.set_default_printstyle("ascii")
+        >>> np.polynomial.set_default_printstyle("unicode")
         >>> poly = np.polynomial.Polynomial([1, 7, 4])
         >>> print(poly)
-        1.0 + 7.0 x + 4.0 x**2
+        1.0 + 7.0·x + 4.0·x²
         >>> poly.degree()
         2
 
@@ -698,7 +697,7 @@ class ABCPolyBase(abc.ABC):
 
         >>> poly = np.polynomial.Polynomial([1, 7, 0])
         >>> print(poly)
-        1.0 + 7.0 x + 0.0 x**2
+        1.0 + 7.0·x + 0.0·x²
         >>> poly.degree()
         2
         >>> poly.trim().degree()

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -18,4 +18,4 @@ towncrier
 toml
 
 # for doctests, also needs pytz which is in test_requirements
-scipy-doctest==1.5.1
+scipy-doctest==1.6.0


### PR DESCRIPTION
- update scipy-doctest to 1.6.0
- remove the check-docs from the linux benchmark CI run, if desired this should become a separate run
- fix failing doctests