### PR TITLE
BUG,MAINT: Fix size bug in new alloc helper and use it in one more place

### DIFF
--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -61,7 +61,7 @@ static inline void
 _npy_init_workspace(
     void **buf, void *static_buf, size_t static_buf_size, size_t elsize, size_t size)
 {
-    if (NPY_LIKELY(size <= static_buf_size / elsize)) {
+    if (NPY_LIKELY(size <= static_buf_size)) {
         *buf = static_buf;
     }
     else {


### PR DESCRIPTION
I realized that the slow path seems to be hit too often, which is because I missed the division when changing the code.

There was also one more place that should have used this from the start because it already had a similar pattern, so using it there.

---

Nothing in the ~allocator~ iterator yet, because there is a use in the buffered inner-loop, and I have to think if that shouldn't move onto the iterator itself.