### PR TITLE
TYP: allow ``None`` in operand sequence of nditer

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4740,7 +4740,7 @@ class iinfo(Generic[_IntegerT_co]):
 class nditer:
     def __new__(
         cls,
-        op: ArrayLike | Sequence[ArrayLike],
+        op: ArrayLike | Sequence[ArrayLike | None],
         flags: None | Sequence[_NDIterFlagsKind] = ...,
         op_flags: None | Sequence[Sequence[_NDIterFlagsOp]] = ...,
         op_dtypes: DTypeLike | Sequence[DTypeLike] = ...,

--- a/numpy/typing/tests/data/pass/nditer.py
+++ b/numpy/typing/tests/data/pass/nditer.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+arr = np.array([1])
+np.nditer([arr, None])


### PR DESCRIPTION
Prevent type-hint errors when using `nditer` in an intended way (see https://numpy.org/doc/stable/reference/arrays.nditer.html#iterator-allocated-output-arrays).

Fix #28038