### PR TITLE
TYP: allow ``None`` in operand sequence of nditer

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4746,7 +4746,7 @@ class iinfo(Generic[_IntegerT_co]):
 class nditer:
     def __new__(
         cls,
-        op: ArrayLike | Sequence[ArrayLike],
+        op: ArrayLike | Sequence[ArrayLike | None],
         flags: None | Sequence[_NDIterFlagsKind] = ...,
         op_flags: None | Sequence[Sequence[_NDIterFlagsOp]] = ...,
         op_dtypes: DTypeLike | Sequence[DTypeLike] = ...,

--- a/numpy/typing/tests/data/pass/nditer.py
+++ b/numpy/typing/tests/data/pass/nditer.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+arr = np.array([1])
+np.nditer([arr, None])


### PR DESCRIPTION
Backport of #28039.

Prevent type-hint errors when using `nditer` in an intended way (see https://numpy.org/doc/stable/reference/arrays.nditer.html#iterator-allocated-output-arrays).

Fix #28038
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
