### PR TITLE
BUG: Fix f2py directives and `--lower` casing

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -26,7 +26,7 @@ __all__ = [
     'hasexternals', 'hasinitvalue', 'hasnote', 'hasresultnote',
     'isallocatable', 'isarray', 'isarrayofstrings',
     'ischaracter', 'ischaracterarray', 'ischaracter_or_characterarray',
-    'iscomplex',
+    'iscomplex', 'iscstyledirective',
     'iscomplexarray', 'iscomplexfunction', 'iscomplexfunction_warn',
     'isdouble', 'isdummyroutine', 'isexternal', 'isfunction',
     'isfunction_wrap', 'isint1', 'isint1array', 'isinteger', 'isintent_aux',
@@ -421,6 +421,11 @@ def getdimension(var):
 
 def isrequired(var):
     return not isoptional(var) and isintent_nothide(var)
+
+
+def iscstyledirective(f2py_line):
+    directives = {"callstatement", "callprotoargument", "pymethoddef"}
+    return any(directive in f2py_line.lower() for directive in directives)
 
 
 def isintent_in(var):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -511,11 +511,9 @@ def readfortrancode(ffile, dowithline=show, istop=1):
                 origfinalline = ''
             else:
                 if localdolowercase:
-                    # lines with intent() should be lowered otherwise
-                    # TestString::test_char fails due to mixed case
-                    # f2py directives without intent() should be left untouched
-                    # gh-2547, gh-27697, gh-26681
-                    finalline = ll.lower() if "intent" in ll.lower() or not is_f2py_directive else ll
+                    # only skip lowering for C style constructs
+                    # gh-2547, gh-27697, gh-26681, gh-28014
+                    finalline = ll.lower() if not (is_f2py_directive and iscstyledirective(ll)) else ll
                 else:
                     finalline = ll
                 origfinalline = ll

--- a/numpy/f2py/tests/src/regression/lower_f2py_fortran.f90
+++ b/numpy/f2py/tests/src/regression/lower_f2py_fortran.f90
@@ -1,0 +1,5 @@
+subroutine inquire_next(IU)
+   IMPLICIT NONE
+   integer :: IU
+   !f2py intent(in) IU
+end subroutine

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -124,6 +124,15 @@ class TestF90Contiuation(util.F2PyTest):
         assert res[0] == 8
         assert res[1] == 15
 
+class TestLowerF2PYDirectives(util.F2PyTest):
+    # Check variables are cased correctly
+    sources = [util.getpath("tests", "src", "regression", "lower_f2py_fortran.f90")]
+
+    @pytest.mark.slow
+    def test_gh28014(self):
+        self.module.inquire_next(3)
+        assert True
+
 @pytest.mark.slow
 def test_gh26623():
     # Including libraries with . should not generate an incorrect meson.build


### PR DESCRIPTION
Closes #28014 which snuck in over in #27728. Essentially, only the added `f2py` directives which take C-exprs [noted here](https://numpy.org/doc/stable/f2py/signature-file.html#f2py-statements) need to be skipped for the lowering logic (since C is case sensitive).