### PR TITLE
MAINT: Update `spin lint` command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -320,36 +320,20 @@ def _run_asv(cmd):
 
 @click.command()
 @click.option(
-    "-b", "--branch",
-    metavar='branch',
-    default="main",
-)
-@click.option(
-    '--uncommitted',
+    '--fix',
     is_flag=True,
     default=False,
     required=False,
 )
 @click.pass_context
-def lint(ctx, branch, uncommitted):
-    """🔦 Run lint checks on diffs.
-    Provide target branch name or `uncommitted` to check changes before committing:
+def lint(ctx, fix):
+    """🔦 Run lint checks with Ruff
 
     \b
-    Examples:
+    To run automatic fixes use:
 
     \b
-    For lint checks of your development branch with `main` or a custom branch:
-
-    \b
-    $ spin lint # defaults to main
-    $ spin lint --branch custom_branch
-
-    \b
-    To check just the uncommitted changes before committing
-
-    \b
-    $ spin lint --uncommitted
+    $ spin lint --fix
     """
     try:
         linter = _get_numpy_tools(pathlib.Path('linter.py'))
@@ -358,7 +342,7 @@ def lint(ctx, branch, uncommitted):
             f"{e.msg}. Install using requirements/linter_requirements.txt"
         )
 
-    linter.DiffLinter(branch).run_lint(uncommitted)
+    linter.DiffLinter().run_lint(fix)
 
 @click.command()
 @click.option(

--- a/tools/linter.py
+++ b/tools/linter.py
@@ -2,41 +2,45 @@ import os
 import sys
 import subprocess
 from argparse import ArgumentParser
-from git import Repo, exc
+
 
 CWD = os.path.abspath(os.path.dirname(__file__))
 
 
 class DiffLinter:
-    def __init__(self):
-        self.repository_root = os.path.realpath(os.path.join(CWD, '..'))
+    def __init__(self) -> None:
+        self.repository_root = os.path.realpath(os.path.join(CWD, ".."))
 
-    def run_ruff(self):
+    def run_ruff(self, fix: bool) -> tuple[int, str]:
         """
-            Original Author: Josh Wilson (@person142)
-            Source:
-              https://github.com/scipy/scipy/blob/main/tools/lint_diff.py
-            Unlike pycodestyle, ruff by itself is not capable of limiting
-            its output to the given diff.
+        Original Author: Josh Wilson (@person142)
+        Source:
+            https://github.com/scipy/scipy/blob/main/tools/lint_diff.py
+        Unlike pycodestyle, ruff by itself is not capable of limiting
+        its output to the given diff.
         """
+        command = ["ruff", "check"]
+        if fix:
+            command.append("--fix")
+
         res = subprocess.run(
-            ['ruff', 'check', '--statistics'],
+            command,
             stdout=subprocess.PIPE,
             cwd=self.repository_root,
-            encoding='utf-8',
+            encoding="utf-8",
         )
         return res.returncode, res.stdout
 
-    def run_lint(self):
-        retcode, errors = self.run_ruff()
+    def run_lint(self, fix: bool) -> None:
+        retcode, errors = self.run_ruff(fix)
 
         errors and print(errors)
 
         sys.exit(retcode)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = ArgumentParser()
     args = parser.parse_args()
 
-    DiffLinter().run_lint()
+    DiffLinter().run_lint(fix=False)


### PR DESCRIPTION
Hi @charris @DimitriPapadopoulos,

I think the `spin lint` command got broken in https://github.com/numpy/numpy/pull/27300.

Here's an update to this command, it can be run with `spin lint` to run checks, or `spin lint --fix` to also solve all fixable issues.
I additionally removed `--statistics` option from the Ruff command so that the linter shows where issues are, and add support for `--fix` so a user can fix them automatically with `spin`. 