### PR TITLE
DOC: clarify np.gradient varargs requirement for axis parameter

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -999,7 +999,7 @@ def gradient(f, *varargs, axis=None, edge_order=1):
            the corresponding dimension
         4. Any combination of N scalars/arrays with the meaning of 2. and 3.
 
-        If `axis` is given, the number of varargs must equal the number of axes.
+        If `axis` is given, the number of varargs must equal the number of axes specified in the axis parameter.
         Default: 1. (see Examples below).
 
     edge_order : {1, 2}, optional


### PR DESCRIPTION
This PR fixes #27995 the documentation for numpy.gradient's varargs parameter when used with the axis parameter.


The current documentation states:
> If axis is given, the number of varargs must equal the number of axes.

This is ambiguous as it's unclear whether it refers to the total number of array axes or the number of axes specified in the axis parameter. The actual behavior requires matching the number of axes specified in the axis parameter, as shown in this example:

```python
# This works - 2 varargs (.1, .2) for 2 axes (0,1)
np.gradient(np.random.random((5, 6, 7)), .1, .2, axis=(0,1))

# This fails even though array is 3D
np.gradient(np.random.random((5, 6, 7)), .1, .2, .3, axis=(0,1))