### PR TITLE
DOC: Add release snippets for iteration changes

### DIFF
--- a/doc/release/upcoming_changes/27883.c_api.rst
+++ b/doc/release/upcoming_changes/27883.c_api.rst
@@ -1,0 +1,3 @@
+* `NpyIter_GetTransferFlags` is now available to check if
+  the iterator itself needs the Python API or casts may
+  cause floating point warnings.

--- a/doc/release/upcoming_changes/27883.c_api.rst
+++ b/doc/release/upcoming_changes/27883.c_api.rst
@@ -1,3 +1,4 @@
 * `NpyIter_GetTransferFlags` is now available to check if
-  the iterator itself needs the Python API or casts may
-  cause floating point warnings.
+  the iterator needs the Python API or if casts may cause floating point
+  errors (FPE).  FPEs can for example be set when casting ``float64(1e300)``
+  to ``float32`` (overflow to infinity) or a NaN to an integer (invalid value).

--- a/doc/release/upcoming_changes/27883.change.rst
+++ b/doc/release/upcoming_changes/27883.change.rst
@@ -4,6 +4,7 @@ The main iterator used in math functions, for ``np.nditer`` and
 on the ``NpyIter`` in the C-API now behaves different for some
 buffered iterations.
 This means that:
+
 * The actual buffer size used will more often be smaller than
   the maximum buffer sized allowed
 * The "growinner" flag is now honored with buffered reqductions

--- a/doc/release/upcoming_changes/27883.change.rst
+++ b/doc/release/upcoming_changes/27883.change.rst
@@ -1,0 +1,17 @@
+Changes to the main iterator and potential numerical changes
+------------------------------------------------------------
+The main iterator used in math functions, for ``np.nditer`` and
+on the ``NpyIter`` in the C-API now behaves different for some
+buffered iterations.
+This means that:
+* The actual buffer size used will more often be smaller than
+  the maximum buffer sized allowed
+* The "growinner" flag is now honored with buffered reqductions
+  when no operand requires buffering.
+
+At least for ``np.sum()`` such changes in buffersize can change
+the precise numerical results.
+Users who use "growinner" for custom reductions could notice
+changes in precision (for example, in NumPy we removed it from
+``einsum`` to avoid most precision changes and improve precision
+for some 64bit floating point inputs).

--- a/doc/release/upcoming_changes/27883.change.rst
+++ b/doc/release/upcoming_changes/27883.change.rst
@@ -1,17 +1,16 @@
 Changes to the main iterator and potential numerical changes
 ------------------------------------------------------------
-The main iterator used in math functions, for ``np.nditer`` and
-on the ``NpyIter`` in the C-API now behaves different for some
-buffered iterations.
+The main iterator, used in math functions and via ``np.nditer`` from Python
+and ``NpyIter`` in C, now behaves differently for some buffered iterations.
 This means that:
 
-* The actual buffer size used will more often be smaller than
-  the maximum buffer sized allowed
-* The "growinner" flag is now honored with buffered reqductions
-  when no operand requires buffering.
+* The buffer size used will often be smaller than the maximum buffer sized
+  allowed by the ``buffersize`` parameter.
+* The "growinner" flag is now honored with buffered reductions when no operand
+  requires buffering.
 
-At least for ``np.sum()`` such changes in buffersize can change
-the precise numerical results.
+For ``np.sum()`` such changes in buffersize may slightly change numerical
+results of floating point operations.
 Users who use "growinner" for custom reductions could notice
 changes in precision (for example, in NumPy we removed it from
 ``einsum`` to avoid most precision changes and improve precision


### PR DESCRIPTION
Adds a snippet (maybe long?) for iteration order changes and a brief bullet point about the new public function.