### PR TITLE
MAINT: Update LICENSE Copyright to 2025

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2024, NumPy Developers.
+Copyright (c) 2005-2025, NumPy Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This PR updates the copyright year in the LICENSE file to reflect the new year (2025).

Wishing a productive year ahead for the NumPy development community and peace for the world! 😃