### PR TITLE
BUG: update check for highway compiler support

### DIFF
--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -10,9 +10,7 @@
 // dispatched sources.
 #if (HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD) ||                   \
     (HWY_ARCH_ARM_V7 && HWY_IS_DEBUG_BUILD) ||                      \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN) || \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG &&                      \
-    (HWY_IS_HWASAN || HWY_IS_MSAN || HWY_IS_TSAN || HWY_IS_ASAN))
+    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN)
 #define NPY_DISABLE_HIGHWAY_SORT
 #endif
 


### PR DESCRIPTION
Fixes #28087

I'm able to build numpy with TSAN after applying this change.