### PR TITLE
MAINT: LoongArch: switch away from the __loongarch64 preprocessor macro

### DIFF
--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -109,7 +109,7 @@
     #elif __riscv_xlen == 32
 	#define NPY_CPU_RISCV32
     #endif
-#elif defined(__loongarch64)
+#elif defined(__loongarch_lp64)
     #define NPY_CPU_LOONGARCH64
 #elif defined(__EMSCRIPTEN__)
     /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -668,7 +668,7 @@ npy__cpu_init_features(void)
 
 /***************** LoongArch ******************/
 
-#elif defined(__loongarch64)
+#elif defined(__loongarch_lp64)
 
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
@@ -684,7 +684,6 @@ npy__cpu_init_features(void)
       return;
    }
 }
-
 
 /***************** ARM ******************/
 


### PR DESCRIPTION
According to the *Toolchain Conventions of the LoongArch Architecture* specification (v1.1) [1], the `__loongarch64` preprocessor macro is in fact a legacy symbol retained for compatibility; the reason being that the GPR width and the calling convention in use are orthogonal to each other, and in reality we care about the calling convention (e.g. ILP32 or LP64) more often than about the hardware capability -- think of ILP32 code on 64-bit hardware, in which case the GPR is wider than what a pointer actually can occupy, for example.

As for the two modified places, the header change is actually concerned with the calling convention, and the implementation change is actually correct regardless of bitness or calling convention. So, use `__loongarch_lp64` for the header, and just `__loongarch__` for the implementation.

[1]: https://github.com/loongson/la-toolchain-conventions/blob/releases/v1.1/LoongArch-toolchain-conventions-EN.adoc

cc @ErnstPeng -- this polishes up the preprocessor usage of #27856.