### PR TITLE
ENH, DOC: Improve foreign object interoperability

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -37,21 +37,6 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-def _get_method(obj, method):
-    # _get_method(object, name) -> callable
-    #
-    # Get a named method from an object.
-    # Raises:
-    # - AttributeError if method does not exist
-    # - TypeError if named attribute exists but is not callable
-
-    bound = getattr(obj, method)
-    if not callable(bound):
-        msg = f"Attribute '{method}' is not callable"
-        raise TypeError(msg)
-    return bound
-
-
 # functions that are now methods
 def _wrapit(obj, method, *args, **kwds):
     conv = _array_converter(obj)
@@ -65,21 +50,22 @@ def _wrapit(obj, method, *args, **kwds):
 
 def _wrapfunc(obj, method, *args, **kwds):
     bound = getattr(obj, method, NotImplemented)
-    if not callable(bound):
-        # attribute does not exists or is not callable
-        return _wrapit(obj, method, *args, **kwds)
 
-    try:
-        return bound(*args, **kwds)
-    except TypeError:
-        # A TypeError occurs if the object does have such a method in its
-        # class, but its signature is not identical to that of NumPy's. This
-        # situation has occurred in the case of a downstream library like
-        # 'pandas'.
-        #
-        # Call _wrapit from within the except clause to ensure a potential
-        # exception has a traceback chain.
-        return _wrapit(obj, method, *args, **kwds)
+    if callable(bound):
+        # dispatch to obj.method
+        try:
+            return bound(*args, **kwds)
+        except TypeError:
+            # A TypeError occurs if the object does have such a method in its
+            # class, but its signature is not identical to that of NumPy's. This
+            # situation has occurred in the case of a downstream library like
+            # 'pandas'.
+
+            # Should we raise a warning here?
+            pass
+
+    # fall back: no obj.method or error raised when calling obj.method(...)
+    return _wrapit(obj, method, *args, **kwds)
 
 
 def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
@@ -87,11 +73,8 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
                   if v is not np._NoValue}
 
     if type(obj) is not mu.ndarray:
-        try:
-            reduction = _get_method(obj, method)
-        except (AttributeError, TypeError):
-            pass
-        else:
+        reduction = getattr(obj, method, NotImplemented)
+        if callable(reduction):
             # This branch is needed for reductions like any which don't
             # support a dtype.
             if dtype is not None:
@@ -108,11 +91,8 @@ def _wrapreduction_any_all(obj, ufunc, method, axis, out, **kwargs):
                   if v is not np._NoValue}
 
     if type(obj) is not mu.ndarray:
-        try:
-            reduction = _get_method(obj, method)
-        except (AttributeError, TypeError):
-            pass
-        else:
+        reduction = getattr(obj, method, NotImplemented)
+        if callable(reduction):
             return reduction(axis=axis, out=out, **passkwargs)
 
     return ufunc.reduce(obj, axis, bool, out, **passkwargs)
@@ -578,13 +558,12 @@ def put(a, ind, v, mode='raise'):
     array([ 0,  1,  2,  3, -5])
 
     """
-    try:
-        put = _get_method(a, 'put')
-    except (AttributeError, TypeError) as e:
+    put = getattr(a, 'put', NotImplemented)
+    if not callable(put):
         msg = "argument 1 ({name}) does not have a 'put' method".format(
             name=type(a).__name__
             )
-        raise TypeError(msg) from e
+        raise TypeError(msg)
 
     return put(ind, v, mode=mode)
 
@@ -1696,9 +1675,8 @@ def squeeze(a, axis=None):
     1234
 
     """
-    try:
-        squeeze = _get_method(a, 'squeeze')
-    except (AttributeError, TypeError):
+    squeeze = getattr(a, 'squeeze', NotImplemented)
+    if not callable(squeeze):
         return _wrapit(a, 'squeeze', axis=axis)
     if axis is None:
         return squeeze()
@@ -3868,11 +3846,8 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     if where is not np._NoValue:
         kwargs['where'] = where
     if type(a) is not mu.ndarray:
-        try:
-            mean = _get_method(a, 'mean')
-        except (AttributeError, TypeError):
-            pass
-        else:
+        mean = getattr(a, 'mean', NotImplemented)
+        if callable(mean):
             return mean(axis=axis, dtype=dtype, out=out, **kwargs)
 
     return _methods._mean(a, axis=axis, dtype=dtype,
@@ -4072,11 +4047,8 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
             ddof = correction
 
     if type(a) is not mu.ndarray:
-        try:
-            std = _get_method(a, 'std')
-        except (AttributeError, TypeError):
-            pass
-        else:
+        std = getattr(a, 'std', NotImplemented)
+        if callable(std):
             return std(axis=axis, dtype=dtype, out=out, ddof=ddof, **kwargs)
 
     return _methods._std(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
@@ -4275,11 +4247,8 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
             ddof = correction
 
     if type(a) is not mu.ndarray:
-        try:
-            var = _get_method(a, 'var')
-        except (AttributeError, TypeError):
-            pass
-        else:
+        var = getattr(a, 'var', NotImplemented)
+        if callable(var):
             return var(axis=axis, dtype=dtype, out=out, ddof=ddof, **kwargs)
 
     return _methods._var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -64,9 +64,8 @@ def _wrapit(obj, method, *args, **kwds):
 
 
 def _wrapfunc(obj, method, *args, **kwds):
-    try:
-        bound = _get_method(obj, method)
-    except (AttributeError, TypeError):
+    bound = getattr(obj, method, NotImplemented)
+    if not callable(bound):
         # attribute does not exists or is not callable
         return _wrapit(obj, method, *args, **kwds)
 

--- a/numpy/_core/tests/test_fromnumeric_foreign_container.py
+++ b/numpy/_core/tests/test_fromnumeric_foreign_container.py
@@ -1,0 +1,94 @@
+import pytest
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from numpy.testing.overrides import allows_array_function_override
+
+
+class Container:
+    """container that implements basic __array__ protocol"""
+
+    def __init__(self, a):
+        self._a = np.asarray(a)
+
+    def __array__(self):
+        return self._a
+
+    def __array_wrap__(self, arr, context=None, return_scalar=False):
+        return self.__class__(arr)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._a})"
+
+
+class NonCallable(Container):
+    """container with attributes that clash with numpy methods"""
+
+    put = mean = std = var = None
+    sum = max = min = all = any = None
+    squeeze = None
+
+
+class Dummy:
+    """class with no __array__ interface"""
+
+    max = min = None
+    all = any = None
+
+
+class TestNonCallable:
+    """check that non callable attributes are not called by numpy functions"""
+
+    @pytest.fixture
+    def arr1D(self):
+        l = [1.0 / 7.0, 2.0 / 3.0, 3.0]
+        return NonCallable(l), np.array(l)
+
+    @pytest.fixture
+    def arr2D(self):
+        l = [[1.0 / 7.0, 2.0 / 3.0, 3.0]]
+        return NonCallable(l), np.array(l)
+
+    @pytest.fixture
+    def singleton(self):
+        return Dummy()
+
+    @pytest.mark.parametrize(
+        "fun",
+        [np.mean, np.std, np.var, np.sum, np.max, np.min, np.all, np.any],
+    )
+    def test_reductions(self, arr1D, fun):
+        # check _wrap_reduction and not wrapped functions 'mean', 'std', 'var'
+        assert allows_array_function_override(fun)
+        c, a = arr1D
+        res = fun(c, axis=0)
+        desired = fun(a, axis=0)
+        assert np.ndim(desired) == 0
+        assert res == desired
+
+    def test_put(self, arr1D):
+        c, _ = arr1D
+        with pytest.raises(
+            TypeError,
+            match=r"argument 1 \(NonCallable\) does not have a 'put' method",
+        ):
+            np.put(c, [0, 2], [-44, -55])
+
+    def test_squeeze(self, arr2D):
+        c, a = arr2D
+        res = np.squeeze(c)
+        desired = np.squeeze(a)
+        assert isinstance(res, NonCallable)
+        assert isinstance(desired, np.ndarray)
+        assert np.shape(res) == np.shape(desired)
+        assert_array_equal(res, desired)
+
+    @pytest.mark.parametrize("fun", [np.max, np.min])
+    def test_wrapped_singleton(self, singleton, fun):
+        res = fun(singleton)
+        assert res is singleton
+
+    @pytest.mark.parametrize("fun", [np.all, np.any])
+    def test_wrapped_singleton_any_all(self, singleton, fun):
+        res = fun(singleton)
+        assert res is np.True_


### PR DESCRIPTION
As discussed in GH-28024, the logic with which functions in `numpy/_core/fromnumeric.py` navigate methods in foreign objects is not clearly documented.

The major problem arises for object that *do not* implement the [`__array_function__`](https://numpy.org/devdocs/user/basics.interoperability.html#the-array-function-protocol)  protocol: the fact that say `np.mean(obj)` will call `obj.mean(axis=None, dtype=None, out=None)` even *before* trying `obj.__array__` is not documented.

In this PR:
- [x] add checks in numpy code to avoid calling non callable attributes
- [ ] add note in numpy docs to warn developers about order in which methods are tested if `__array_function__` not present
- [ ] gently nudge developers to adopt newer `__array_function__` protocol