### PR TITLE
DOC: Move linalg.outer from Decompositions to Matrix and vector products

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -60,6 +60,7 @@ Matrix and vector products
    linalg.vecdot
    inner
    outer
+   linalg.outer
    matmul
    linalg.matmul (Array API compatible location)
    matvec
@@ -71,7 +72,7 @@ Matrix and vector products
    linalg.matrix_power
    kron
    linalg.cross
-   linalg.outer
+   
 
 Decompositions
 --------------

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -71,14 +71,14 @@ Matrix and vector products
    linalg.matrix_power
    kron
    linalg.cross
+   linalg.outer
 
 Decompositions
 --------------
 .. autosummary::
    :toctree: generated/
 
-   linalg.cholesky
-   linalg.outer
+   linalg.cholesky   
    linalg.qr
    linalg.svd
    linalg.svdvals

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -78,7 +78,7 @@ Decompositions
 .. autosummary::
    :toctree: generated/
 
-   linalg.cholesky   
+   linalg.cholesky
    linalg.qr
    linalg.svd
    linalg.svdvals


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
fixes: #28061 
### Reorganize numpy.linalg.outer Documentation
<!-- **What does this PR implement or fix?** -->
This PR moves the documentation entry for `numpy.linalg.outer` from the "Decompositions" section to the "Matrix and Vector Products" section in the TOC tree.

<!-- **Why is this change necessary?** -->
The `outer` function is a matrix product, not a decomposition. Its placement under "Decompositions" may mislead users. By relocating it to the "Matrix and Vector Products" section, the documentation will be more intuitive and aligned with user expectations.