### PR TITLE
DOC: Fix sphinx markup in source/reference/random/extending.rst

### DIFF
--- a/doc/source/reference/random/extending.rst
+++ b/doc/source/reference/random/extending.rst
@@ -76,7 +76,7 @@ directly from the ``_generator`` shared object, using the `BitGenerator.cffi` in
 
 .. literalinclude:: ../../../../numpy/random/_examples/cffi/extending.py
     :language: python
-    :start-after: dlopen
+    :start-at: dlopen
 
 
 New BitGenerators


### PR DESCRIPTION
Change `:start-after: dlopen` to `:start-at: dlopen` so the line containing the call of `ffi.dlopen()` is included.

