### PR TITLE
MAINT: update oldest supported GCC version from 8.4 to 9.3

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -85,27 +85,27 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install GCC/8/9
+    - name: Install GCC9/10
       run: |
         echo "deb http://archive.ubuntu.com/ubuntu focal main universe" | sudo tee /etc/apt/sources.list.d/focal.list
         sudo apt update
-        sudo apt install -y g++-8 g++-9
-
-    - name: Enable gcc-8
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
-
-    - uses: ./.github/meson_actions
-      name: Build/Test against gcc-8
+        sudo apt install -y g++-9 g++-10
 
     - name: Enable gcc-9
       run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 2
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 2
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1
 
     - uses: ./.github/meson_actions
       name: Build/Test against gcc-9
+
+    - name: Enable gcc-10
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 2
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 2
+
+    - uses: ./.github/meson_actions
+      name: Build/Test against gcc-10
 
   specialize:
     needs: [baseline_only]

--- a/doc/release/upcoming_changes/28101.change.rst
+++ b/doc/release/upcoming_changes/28101.change.rst
@@ -1,0 +1,6 @@
+The minimum supported GCC version is now 9.3.0
+----------------------------------------------
+The minimum supported version was updated from 8.4.0 to 9.3.0,
+primarily in order to reduce the chance of platform-specific bugs in old GCC
+versions from causing issues.
+

--- a/meson.build
+++ b/meson.build
@@ -24,8 +24,8 @@ cy = meson.get_compiler('cython')
 
 # Check compiler is recent enough (see the SciPy Toolchain Roadmap for details)
 if cc.get_id() == 'gcc'
-  if not cc.version().version_compare('>=8.4')
-    error('NumPy requires GCC >= 8.4')
+  if not cc.version().version_compare('>=9.3')
+    error('NumPy requires GCC >= 9.3')
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.20')


### PR DESCRIPTION
This hasn't been updated in quite a while, and 8.4 just ran into another SIMD-related bug in numpy#28030. Other considerations:

- GCC 9.3.0 will be >5 years old by the time we release NumPy 2.3.0
- All our own builds and relevant manylinux images use GCC >=10
- SciPy upgraded to >=9.1 a year ago and that was fine
- Ubuntu 20.04 LTS has GCC 9.3.0, there don't seem to be relevant distro versions which still require 8.x

xref https://scipy.github.io/devdocs/dev/toolchain.html#compilers and https://github.com/mayeut/pep600_compliance for relevant pages to track compiler and distro versions.