### PR TITLE
TYP:  Fix the incorrect ``bool`` return type of ``issubdtype``

### DIFF
--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -177,12 +177,9 @@ class _TypeCodes(TypedDict):
     Datetime: L['Mm']
     All: L['?bhilqnpBHILQNPefdgFDGSUVOMm']
 
-def isdtype(
-    dtype: dtype[Any] | type[Any],
-    kind: DTypeLike | tuple[DTypeLike, ...],
-) -> builtins.bool: ...
+def isdtype(dtype: dtype[Any] | type[Any], kind: DTypeLike | tuple[DTypeLike, ...]) -> builtins.bool: ...
 
-def issubdtype(arg1: DTypeLike, arg2: DTypeLike) -> bool: ...
+def issubdtype(arg1: DTypeLike, arg2: DTypeLike) -> builtins.bool: ...
 
 typecodes: _TypeCodes
 ScalarType: tuple[


### PR DESCRIPTION
This fixes a regression that was introduced in #27521, and is causing mypy to report an error in `polars`: https://github.com/pola-rs/polars/issues/20561 