### PR TITLE
TYP: Return the correct ``bool`` from ``issubdtype``

### DIFF
--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -177,12 +177,9 @@ class _TypeCodes(TypedDict):
     Datetime: L['Mm']
     All: L['?bhilqnpBHILQNPefdgFDGSUVOMm']
 
-def isdtype(
-    dtype: dtype[Any] | type[Any],
-    kind: DTypeLike | tuple[DTypeLike, ...],
-) -> builtins.bool: ...
+def isdtype(dtype: dtype[Any] | type[Any], kind: DTypeLike | tuple[DTypeLike, ...]) -> builtins.bool: ...
 
-def issubdtype(arg1: DTypeLike, arg2: DTypeLike) -> bool: ...
+def issubdtype(arg1: DTypeLike, arg2: DTypeLike) -> builtins.bool: ...
 
 typecodes: _TypeCodes
 ScalarType: tuple[


### PR DESCRIPTION
Backport of #28109.

This fixes a regression that was introduced in #27521, and is causing mypy to report an error in `polars`: https://github.com/pola-rs/polars/issues/20561 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
