### PR TITLE
MAINT: Correct NumPy 2.3 C-API versioning and version information

### DIFF
--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -77,5 +77,6 @@
 0x00000012 = 2b8f1f4da822491ff030b2b37dff07e3
 # Version 19 (NumPy 2.1.0) Only header additions
 # Version 19 (NumPy 2.2.0) No change
+0x00000013 = 2b8f1f4da822491ff030b2b37dff07e3
 # Version 19 (NumPy 2.3.0)
-0x00000013 = e56b74d32a934d085e7c3414cb9999b8,
+0x00000014 = e56b74d32a934d085e7c3414cb9999b8,

--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -83,7 +83,7 @@
 #define NPY_2_0_API_VERSION 0x00000012
 #define NPY_2_1_API_VERSION 0x00000013
 #define NPY_2_2_API_VERSION 0x00000013
-#define NPY_2_3_API_VERSION 0x00000013
+#define NPY_2_3_API_VERSION 0x00000014
 
 
 /*
@@ -172,6 +172,8 @@
     #define NPY_FEATURE_VERSION_STRING "2.0"
 #elif NPY_FEATURE_VERSION == NPY_2_1_API_VERSION
     #define NPY_FEATURE_VERSION_STRING "2.1"
+#elif NPY_FEATURE_VERSION == NPY_2_3_API_VERSION
+    #define NPY_FEATURE_VERSION_STRING "2.3"
 #else
     #error "Missing version string define for new NumPy version."
 #endif

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -48,7 +48,9 @@ C_ABI_VERSION = '0x02000000'
 # 0x00000011 - 1.25.x
 # 0x00000012 - 2.0.x
 # 0x00000013 - 2.1.x
-C_API_VERSION = '0x00000013'
+# 0x00000013 - 2.2.x
+# 0x00000014 - 2.3.x
+C_API_VERSION = '0x00000014'
 
 # Check whether we have a mismatch between the set C API VERSION and the
 # actual C API VERSION. Will raise a MismatchCAPIError if so.


### PR DESCRIPTION
This corrects the C-API version, there are a few places we need to update these days (and the 2.3 C-API line had not been added yet).