### PR TITLE
BUG: move reduction initialization to ufunc initialization

### DIFF
--- a/numpy/_core/src/umath/legacy_array_method.c
+++ b/numpy/_core/src/umath/legacy_array_method.c
@@ -429,14 +429,6 @@ PyArray_NewLegacyWrappingArrayMethod(PyUFuncObject *ufunc,
     // set cached initial value for numeric reductions to avoid creating
     // a python int in every reduction
     if (PyTypeNum_ISNUMBER(bound_res->dtypes[0]->type_num)) {
-        char *initial =
-                PyMem_Calloc(1, bound_res->dtypes[0]->singleton->elsize);
-
-        if (initial == NULL) {
-            PyErr_NoMemory();
-            return NULL;
-        }
-
         PyArray_Descr **descrs = PyMem_Calloc(ufunc->nin + ufunc->nout,
                                               sizeof(PyArray_Descr *));
 
@@ -459,7 +451,7 @@ PyArray_NewLegacyWrappingArrayMethod(PyUFuncObject *ufunc,
                 descrs,
         };
 
-        int ret = get_initial_from_ufunc(&context, 0, initial);
+        int ret = get_initial_from_ufunc(&context, 0, context.method->legacy_initial);
 
         if (ret < 0) {
             PyMem_Free(initial);
@@ -467,14 +459,11 @@ PyArray_NewLegacyWrappingArrayMethod(PyUFuncObject *ufunc,
             return NULL;
         }
 
-        // only use the initial value if it's valid
+        // only use the cached initial value if it's valid
         if (ret > 0) {
-            memcpy(context.method->legacy_initial, initial,
-                   context.descriptors[0]->elsize);
             context.method->get_reduction_initial = &copy_cached_initial;
         }
 
-        PyMem_Free(initial);
         PyMem_Free(descrs);
     }
 

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -120,3 +120,16 @@ def test_printoptions_thread_safety():
 
     task1.start()
     task2.start()
+
+def test_parallel_reduction():
+    # gh-28041
+    NUM_THREADS = 50
+
+    b = threading.Barrier(NUM_THREADS)
+
+    x = np.arange(1000)
+    def closure():
+        b.wait()
+        np.sum(x)
+
+    run_threaded(closure, NUM_THREADS, max_workers=NUM_THREADS)

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -128,6 +128,7 @@ def test_parallel_reduction():
     b = threading.Barrier(NUM_THREADS)
 
     x = np.arange(1000)
+
     def closure():
         b.wait()
         np.sum(x)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2685,9 +2685,9 @@ _glibcver = _get_glibc_version()
 _glibc_older_than = lambda x: (_glibcver != '0.0' and _glibcver < x)
 
 
-def run_threaded(func, iters, pass_count=False):
+def run_threaded(func, iters, pass_count=False, max_workers=8):
     """Runs a function many times in parallel"""
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as tpe:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as tpe:
         if pass_count:
             futures = [tpe.submit(func, i) for i in range(iters)]
         else:


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/28041.

Because the reduction initialization happens during ufunc initialization, this means that ufunc initialization now depends on the allocator context variables being initialized, so I moved those initialization steps up before ufunc initialization in the main `_multiarray_umath` module initialization function.