### PR TITLE
BUG: Don't use C99 construct in import_array

### DIFF
--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -65,6 +65,7 @@ _import_array(void)
 {
   int st;
   PyObject *numpy = PyImport_ImportModule("numpy._core._multiarray_umath");
+  PyObject *c_api;
   if (numpy == NULL && PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
     PyErr_Clear();
     numpy = PyImport_ImportModule("numpy.core._multiarray_umath");
@@ -74,7 +75,7 @@ _import_array(void)
       return -1;
   }
 
-  PyObject *c_api = PyObject_GetAttrString(numpy, "_ARRAY_API");
+  c_api = PyObject_GetAttrString(numpy, "_ARRAY_API");
   Py_DECREF(numpy);
   if (c_api == NULL) {
       return -1;

--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -38,6 +38,7 @@ static void **PyUFunc_API=NULL;
 static inline int
 _import_umath(void)
 {
+  PyObject *c_api;
   PyObject *numpy = PyImport_ImportModule("numpy._core._multiarray_umath");
   if (numpy == NULL && PyErr_ExceptionMatches(PyExc_ModuleNotFoundError)) {
     PyErr_Clear();
@@ -50,7 +51,7 @@ _import_umath(void)
       return -1;
   }
 
-  PyObject *c_api = PyObject_GetAttrString(numpy, "_UFUNC_API");
+  c_api = PyObject_GetAttrString(numpy, "_UFUNC_API");
   Py_DECREF(numpy);
   if (c_api == NULL) {
       PyErr_SetString(PyExc_AttributeError, "_UFUNC_API not found");


### PR DESCRIPTION
Encountered this because of gcc-14.
ISO C90 forbids mixed declarations and code

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
