### PR TITLE
BUG: move reduction initialization to ufunc initialization

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -120,3 +120,17 @@ def test_printoptions_thread_safety():
 
     task1.start()
     task2.start()
+
+def test_parallel_reduction():
+    # gh-28041
+    NUM_THREADS = 50
+
+    b = threading.Barrier(NUM_THREADS)
+
+    x = np.arange(1000)
+
+    def closure():
+        b.wait()
+        np.sum(x)
+
+    run_threaded(closure, NUM_THREADS, max_workers=NUM_THREADS)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2684,9 +2684,9 @@ _glibcver = _get_glibc_version()
 _glibc_older_than = lambda x: (_glibcver != '0.0' and _glibcver < x)
 
 
-def run_threaded(func, iters, pass_count=False):
+def run_threaded(func, iters, pass_count=False, max_workers=8):
     """Runs a function many times in parallel"""
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as tpe:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as tpe:
         if pass_count:
             futures = [tpe.submit(func, i) for i in range(iters)]
         else:


### PR DESCRIPTION
Backport of #28123.

Fixes https://github.com/numpy/numpy/issues/28041.

Because the reduction initialization happens during ufunc initialization, this means that ufunc initialization now depends on the allocator context variables being initialized, so I moved those initialization steps up before ufunc initialization in the main `_multiarray_umath` module initialization function.

* BUG: move reduction initialization to ufunc initialization

* MAINT: refactor to call get_initial_from_ufunc during init

* TST: add test for multithreaded reductions

* MAINT: fix linter

* Apply suggestions from code review

* MAINT: simplify further

---------

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
