### PR TITLE
BUG: call PyType_Ready in f2py to avoid data races

### DIFF
--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -245,6 +245,11 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
     if (! PyErr_Occurred())
         on_exit(f2py_report_on_exit,(void*)\"#modulename#\");
 #endif
+
+    if (PyType_Ready(&PyFortran_Type) < 0) {
+        return NULL;
+    }
+
     return m;
 }
 #ifdef __cplusplus


### PR DESCRIPTION
Backport of #28133.

Fixes #28122 

Chesterton's fence: I have no idea if the lack of a `PyType_Ready` call was intentional. 

That said, it seems to be missing all the way back [in 2005](https://github.com/numpy/numpy/commit/4c1ae336a15e4f701848fac12a521ba67bf784d3) so it may be that f2py has always been implicitly relying on Python finalizing the type and that's been fine until now.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
