### PR TITLE
DOC: Add instructions to build NumPy on WoA

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -226,21 +226,21 @@ your system.
     In Windows on ARM64, the set of a compiler options that are available for
     building NumPy are limited. Compilers such as GCC and GFortran are not yet
     supported for Windows on ARM64. Currently, the NumPy build for Windows on ARM64
-    is supported with MSVC toolchain only. The use of a Fortran compiler is more
-    tricky than on other platforms, because MSVC does not support Fortran, and
+    is supported with MSVC and LLVM toolchains. The use of a Fortran compiler is
+    more tricky than on other platforms, because MSVC does not support Fortran, and
     gfortran and MSVC can't be used together. If you don't need to run the ``f2py``
     tests, simply using MSVC is easiest. Otherwise, you will need the following
     set of compilers:
 
-    1. MSVC + Flang-new (``flang-new``)
+    1. MSVC + flang (``cl``, ``flang``)
+    2. LLVM + flang (``clang-cl``, ``flang``)
 
     First, install Microsoft Visual Studio - the 2022 Community Edition will
-    work(see the `Visual Studio download site <https://visualstudio.microsoft.com/downloads/>`__).
-    In order to ensure you have the Windows Universal C Runtime (the other components
-    of Visual Studio can be deselected if desired, to save disk space). The
-    recommended version of the UCRT is >= 10.0.22621.0.
+    work (see the `Visual Studio download site <https://visualstudio.microsoft.com/downloads/>`__).
+    Ensure that you have installed necessary Visual Studio components for building NumPy 
+    on WoA from `here <https://gist.github.com/Mugundanmcw/c3bb93018d5da9311fb2b222f205ba19>`__.
 
-    To use flang-new fortran compiler for Windows on ARM64, install Latest LLVM
+    To use the flang compiler for Windows on ARM64, install Latest LLVM
     toolchain for WoA from `here <https://github.com/llvm/llvm-project/releases>`__.
 
     .. tab-set::
@@ -257,6 +257,14 @@ your system.
         For detailed guidance, see `Use the Microsoft C++ toolset from the command line
         <https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170>`__.
 
+      .. tab-item:: LLVM
+
+        Similar to MSVC, LLVM does not put the compilers on the system path.
+        To set system path for LLVM compilers, users may need to use ``set``
+        command to put compilers on the system path. To check compiler's path
+        for LLVM's clang-cl, try invoking LLVM's clang-cl compiler in the shell you use
+        (``clang-cl --version``).
+
     .. note::
 
         Compilers should be on the system path (i.e., the ``PATH`` environment
@@ -265,7 +273,7 @@ your system.
         will be found automatically if and only if there are no other compilers
         on the ``PATH``. You can use any shell (e.g., Powershell, ``cmd`` or
         Git Bash) to invoke a build. To check that this is the case, try
-        invoking a Fortran compiler in the shell you use (e.g., ``flang-new
+        invoking a Fortran compiler in the shell you use (e.g., ``flang
         --version``).
 
     .. warning::
@@ -428,7 +436,7 @@ virtual environments:
           Building NumPy with BLAS and LAPACK functions requires OpenBLAS
           library at Runtime. In Windows on ARM64, this can be done by setting
           up pkg-config for OpenBLAS dependency. The build steps for OpenBLAS
-          for Windows on ARM64 can be found `here <https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md#windows-on-arm>`__.
+          for Windows on ARM64 can be found `here <http://www.openmathlib.org/OpenBLAS/docs/install/#windows-on-arm>`__.
 
 
     Then install the Python-level dependencies from PyPI with::

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -220,6 +220,60 @@ your system.
         try again. The Fortran compiler should be installed as described in
         this section.
 
+  .. tab-item:: Windows on ARM64
+    :sync: Windows on ARM64
+
+    In Windows on ARM64, the set of a compiler options that are available for
+    building NumPy are limited. Compilers such as GCC and GFortran are not yet
+    supported for Windows on ARM64. Currently, the NumPy build for Windows on ARM64
+    is supported with MSVC toolchain only. The use of a Fortran compiler is more
+    tricky than on other platforms, because MSVC does not support Fortran, and
+    gfortran and MSVC can't be used together. If you don't need to run the ``f2py``
+    tests, simply using MSVC is easiest. Otherwise, you will need the following
+    set of compilers:
+
+    1. MSVC + Flang-new (``flang-new``)
+
+    First, install Microsoft Visual Studio - the 2022 Community Edition will
+    work(see the `Visual Studio download site <https://visualstudio.microsoft.com/downloads/>`__).
+    In order to ensure you have the Windows Universal C Runtime (the other components
+    of Visual Studio can be deselected if desired, to save disk space). The
+    recommended version of the UCRT is >= 10.0.22621.0.
+
+    To use flang-new fortran compiler for Windows on ARM64, install Latest LLVM
+    toolchain for WoA from `here <https://github.com/llvm/llvm-project/releases>`__.
+
+    .. tab-set::
+
+      .. tab-item:: MSVC
+
+        The MSVC installer does not put the compilers on the system path, and
+        the install location may change. To query the install location, MSVC
+        comes with a ``vswhere.exe`` command-line utility. And to make the
+        C/C++ compilers available inside the shell you are using, you need to
+        run a ``.bat`` file for the correct bitness and architecture (e.g., for
+        ARM64-based CPUs, use ``vcvarsarm64.bat``).
+
+        For detailed guidance, see `Use the Microsoft C++ toolset from the command line
+        <https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170>`__.
+
+    .. note::
+
+        Compilers should be on the system path (i.e., the ``PATH`` environment
+        variable should contain the directory in which the compiler executables
+        can be found) in order to be found, with the exception of MSVC which
+        will be found automatically if and only if there are no other compilers
+        on the ``PATH``. You can use any shell (e.g., Powershell, ``cmd`` or
+        Git Bash) to invoke a build. To check that this is the case, try
+        invoking a Fortran compiler in the shell you use (e.g., ``flang-new
+        --version``).
+
+    .. warning::
+
+        Currently, Conda environment is not yet supported officially on `Windows
+        on ARM64 <https://github.com/conda-forge/conda-forge.github.io/issues/1940>`__.
+        The present approach uses virtualenv for building NumPy from source on
+        Windows on ARM64.
 
 Building NumPy from source
 --------------------------
@@ -302,7 +356,7 @@ Then you want to do the following:
 1. Create a dedicated development environment (virtual environment or conda
    environment),
 2. Install all needed dependencies (*build*, and also *test*, *doc* and
-   *optional* dependencies), 
+   *optional* dependencies),
 3. Build NumPy with the ``spin`` developer interface.
 
 Step (3) is always the same, steps (1) and (2) are different between conda and
@@ -361,9 +415,25 @@ virtual environments:
           python -m venv venv
           .\venv\Scripts\activate
 
+      .. tab-item:: Windows on ARM64
+        :sync: Windows on ARM64
+
+        ::
+
+          python -m venv venv
+          .\venv\Scripts\activate
+
+        .. note::
+
+          Building NumPy with BLAS and LAPACK functions requires OpenBLAS
+          library at Runtime. In Windows on ARM64, this can be done by setting
+          up pkg-config for OpenBLAS dependency. The build steps for OpenBLAS
+          for Windows on ARM64 can be found `here <https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md#windows-on-arm>`__.
+
+
     Then install the Python-level dependencies from PyPI with::
 
-       python -m pip install -r requirements/all_requirements.txt
+       python -m pip install -r requirements/build_requirements.txt
 
 To build NumPy in an activated development environment, run::
 


### PR DESCRIPTION
This pull request introduces documentation to guide users for building NumPy from source on Windows on Arm64(WoA).
1. Add intructions to build NumPy on WoA:
- This commit updates the source file index.rst to include comprehensive steps for building NumPy on WoA in [documentation](https://numpy.org/doc/stable/building/index.html)
- The current build setup successfully compiles NumPy on WoA using the MSVC compiler along with flang-new.
- The updated documentation includes a reference for linking and compiling OpenBLAS on WoA for NumPy.