### PR TITLE
ENH: inline UTF-8 byte counter and make it branchless

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -55,19 +55,6 @@ find_previous_utf8_character(const unsigned char *c, size_t nchar)
     return c;
 }
 
-NPY_NO_EXPORT int
-num_bytes_for_utf8_character(const unsigned char *c) {
-    if (c[0] <= 0x7F) {
-        return 1;
-    }
-    else if (c[0] <= 0xDF) {
-        return 2;
-    }
-    else if (c[0] <= 0xEF) {
-        return 3;
-    }
-    return 4;
-}
 
 NPY_NO_EXPORT int
 num_utf8_bytes_for_codepoint(uint32_t code)

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
@@ -8,8 +8,16 @@ extern "C" {
 NPY_NO_EXPORT size_t
 utf8_char_to_ucs4_code(const unsigned char *c, Py_UCS4 *code);
 
-NPY_NO_EXPORT int
-num_bytes_for_utf8_character(const unsigned char *c);
+static inline int num_bytes_for_utf8_character(const unsigned char *c)
+{
+    // adapted from https://github.com/skeeto/branchless-utf8
+    // the first byte of a UTF-8 character encodes the length of the character
+    static const char LENGTHS_LUT[] = {
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
+    };
+    return LENGTHS_LUT[c[0] >> 3];
+}
 
 NPY_NO_EXPORT const unsigned char*
 find_previous_utf8_character(const unsigned char *c, size_t nchar);


### PR DESCRIPTION
Rewrites `num_bytes_for_utf8_character` to use a branchless algorithm and make it `static inline`.

This is not often the largest overhead but it can be in some pathological cases. For example, here's the timing for a case I constructed to test this. 

Before this change:

```
In [4]: arr = np.array(['🧇'*10000+'🧈🍁'], dtype="T")

In [5]: %timeit np.strings.find(arr, "🧈🍁")
124 μs ± 44 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

And after:

```
In [14]: arr = np.array(['🧇'*10000+'🧈🍁'], dtype="T")

In [15]: %timeit np.strings.find(arr, "🧈🍁")
90.8 μs ± 81.9 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```