### PR TITLE
BUG: Fix ``from_float_positional`` errors for huge pads

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1232,14 +1232,10 @@ def format_float_positional(x, precision=None, unique=True,
         Whether to show the sign for positive values.
     pad_left : non-negative integer, optional
         Pad the left side of the string with whitespace until at least that
-        many characters are to the left of the decimal point. Total length of 
-        string representation of the floating point value cannot exceed 16384, 
-        including pad_right, if any.
+        many characters are to the left of the decimal point.
     pad_right : non-negative integer, optional
         Pad the right side of the string with whitespace until at least that
-        many characters are to the right of the decimal point. Total length of 
-        string representation of the floating point value cannot exceed 16384, 
-        including pad_left, if any.
+        many characters are to the right of the decimal point.
     min_digits : non-negative integer or None, optional
         Minimum number of digits to print. Only has an effect if `unique=True`
         in which case additional digits past those necessary to uniquely
@@ -1251,6 +1247,12 @@ def format_float_positional(x, precision=None, unique=True,
     -------
     rep : string
         The string representation of the floating point value
+    
+    Raises
+    ------
+    RuntimeError
+        If the decimal string representation of the floating point scalar is longer
+        than 16384 characters
 
     See Also
     --------

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1247,12 +1247,6 @@ def format_float_positional(x, precision=None, unique=True,
     -------
     rep : string
         The string representation of the floating point value
-    
-    Raises
-    ------
-    RuntimeError
-        If the decimal string representation of the floating point scalar is longer
-        than 16384 characters
 
     See Also
     --------

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1232,10 +1232,14 @@ def format_float_positional(x, precision=None, unique=True,
         Whether to show the sign for positive values.
     pad_left : non-negative integer, optional
         Pad the left side of the string with whitespace until at least that
-        many characters are to the left of the decimal point.
+        many characters are to the left of the decimal point. Total length of 
+        string representation of the floating point value cannot exceed 16384, 
+        including pad_right, if any.
     pad_right : non-negative integer, optional
         Pad the right side of the string with whitespace until at least that
-        many characters are to the right of the decimal point.
+        many characters are to the right of the decimal point. Total length of 
+        string representation of the floating point value cannot exceed 16384, 
+        including pad_left, if any.
     min_digits : non-negative integer or None, optional
         Minimum number of digits to print. Only has an effect if `unique=True`
         in which case additional digits past those necessary to uniquely

--- a/numpy/_core/src/multiarray/dragon4.c
+++ b/numpy/_core/src/multiarray/dragon4.c
@@ -1669,7 +1669,7 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
 
             /* integer part too long for buffer, avoid overflow */
             if (count > maxPrintLen - pos) {
-                PyErr_SetString(PyExc_RuntimeError, "String buffer overflow");
+                PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
                 return -1;
             }
 
@@ -1777,7 +1777,7 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         
         /* too many trailing zeros required, avoid buffer overflow */
         if (count > maxPrintLen - pos) {
-            PyErr_SetString(PyExc_RuntimeError, "String buffer overflow");
+            PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
             return -1;
         }
         numFractionDigits += count;
@@ -1819,13 +1819,9 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
                 && pos < maxPrintLen) {
             buffer[pos++] = ' ';
         }
-        
-        /* 
-         * provided digits_rights is too large, 
-         * can't create the string required
-         */
+
         if (count > maxPrintLen - pos) {
-            PyErr_SetString(PyExc_RuntimeError, "String buffer overflow");
+            PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
             return -1;
         }
 
@@ -1837,10 +1833,9 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
     if (digits_left > numWholeDigits + has_sign) {
         npy_int32 shift = digits_left - (numWholeDigits + has_sign);
         npy_int32 count = pos;
-        
-        /* provided digits_left is too large, can't create the string required*/
-        if (count + shift > maxPrintLen) {
-            PyErr_SetString(PyExc_RuntimeError, "String buffer overflow");
+                
+        if (count > maxPrintLen - shift) {
+            PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
             return -1;
         }
 

--- a/numpy/_core/src/multiarray/dragon4.c
+++ b/numpy/_core/src/multiarray/dragon4.c
@@ -1614,9 +1614,6 @@ typedef struct Dragon4_Options {
  *    hasUnequalMargins - is the high margin twice as large as the low margin
  *
  * See Dragon4_Options for description of remaining arguments.
- *  
- * Required left or right padding may exceed the size of the string buffer.
- * Error codes for those conditions are defined below
  */
 
 static npy_int32
@@ -1667,7 +1664,6 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
             npy_int32 count = numWholeDigits - numDigits;
             pos += numDigits;
 
-            /* integer part too long for buffer, avoid overflow */
             if (count > maxPrintLen - pos) {
                 PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
                 return -1;
@@ -1775,7 +1771,6 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         
         npy_int32 count = desiredFractionalDigits - numFractionDigits;
         
-        /* too many trailing zeros required, avoid buffer overflow */
         if (count > maxPrintLen - pos) {
             PyErr_SetString(PyExc_RuntimeError, "Float formating result too large");
             return -1;

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -259,61 +259,93 @@ class TestRealScalars:
         assert_equal(fpos64('324', unique=False, precision=5,
                                    fractional=False), "324.00")
 
-    def test_dragon4_interface(self):
-        tps = [np.float16, np.float32, np.float64]
+    available_float_dtypes = [np.float16, np.float32, np.float64, np.float128]\
+        if hasattr(np, 'float128') else [np.float16, np.float32, np.float64]
+    
+    @pytest.mark.parametrize("tp", available_float_dtypes)
+    def test_dragon4_positional_interface(self, tp):
         # test is flaky for musllinux on np.float128
-        if hasattr(np, 'float128') and not IS_MUSL:
-            tps.append(np.float128)
-
+        if IS_MUSL and tp == np.float128:
+            pytest.skip("Skipping flaky test of float128 on musllinux")
+                
         fpos = np.format_float_positional
+        
+        # test padding
+        assert_equal(fpos(tp('1.0'), pad_left=4, pad_right=4), "   1.    ")
+        assert_equal(fpos(tp('-1.0'), pad_left=4, pad_right=4), "  -1.    ")
+        assert_equal(fpos(tp('-10.2'),
+                        pad_left=4, pad_right=4), " -10.2   ")
+        
+        # test fixed (non-unique) mode
+        assert_equal(fpos(tp('1.0'), unique=False, precision=4), "1.0000")
+
+    @pytest.mark.parametrize("tp", available_float_dtypes)
+    def test_dragon4_positional_interface_trim(self, tp):
+        # test is flaky for musllinux on np.float128
+        if IS_MUSL and tp == np.float128:
+            pytest.skip("Skipping flaky test of float128 on musllinux")
+                        
+        fpos = np.format_float_positional
+        # test trimming
+        # trim of 'k' or '.' only affects non-unique mode, since unique
+        # mode will not output trailing 0s.
+        assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='k'),
+                        "1.0000")
+
+        assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='.'),
+                        "1.")
+        assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='.'),
+                        "1.2" if tp != np.float16 else "1.2002")
+
+        assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='0'),
+                        "1.0")
+        assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='0'),
+                        "1.2" if tp != np.float16 else "1.2002")
+        assert_equal(fpos(tp('1.'), trim='0'), "1.0")
+
+        assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='-'),
+                        "1")
+        assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='-'),
+                        "1.2" if tp != np.float16 else "1.2002")
+        assert_equal(fpos(tp('1.'), trim='-'), "1")
+        assert_equal(fpos(tp('1.001'), precision=1, trim='-'), "1")
+                
+    @pytest.mark.parametrize("tp", available_float_dtypes)
+    @pytest.mark.parametrize("pad_val", [10**5, np.iinfo("int32").max])
+    def test_dragon4_positional_interface_overflow(self, tp, pad_val):
+        # test is flaky for musllinux on np.float128
+        if IS_MUSL and tp == np.float128:
+            pytest.skip("Skipping flaky test of float128 on musllinux")
+                
+        fpos = np.format_float_positional
+
+        #gh-28068            
+        with pytest.raises(RuntimeError, 
+                           match="Float formating result too large"):
+            fpos(tp('1.047'), unique=False, precision=pad_val)
+
+        with pytest.raises(RuntimeError, 
+                           match="Float formating result too large"):
+            fpos(tp('1.047'), precision=2, pad_left=pad_val)
+
+        with pytest.raises(RuntimeError, 
+                           match="Float formating result too large"):
+            fpos(tp('1.047'), precision=2, pad_right=pad_val)
+
+    @pytest.mark.parametrize("tp", available_float_dtypes)
+    def test_dragon4_scientific_interface(self, tp):
+        # test is flaky for musllinux on np.float128
+        if IS_MUSL and tp == np.float128:
+            pytest.skip("Skipping flaky test of float128 on musllinux")
+                        
         fsci = np.format_float_scientific
 
-        for tp in tps:
-            # test padding
-            assert_equal(fpos(tp('1.0'), pad_left=4, pad_right=4), "   1.    ")
-            assert_equal(fpos(tp('-1.0'), pad_left=4, pad_right=4), "  -1.    ")
-            assert_equal(fpos(tp('-10.2'),
-                         pad_left=4, pad_right=4), " -10.2   ")
-            
-            # test exp_digits
-            assert_equal(fsci(tp('1.23e1'), exp_digits=5), "1.23e+00001")
+        # test exp_digits
+        assert_equal(fsci(tp('1.23e1'), exp_digits=5), "1.23e+00001")
 
-            # test fixed (non-unique) mode
-            assert_equal(fpos(tp('1.0'), unique=False, precision=4), "1.0000")
-            assert_equal(fsci(tp('1.0'), unique=False, precision=4),
-                         "1.0000e+00")
-
-            # test trimming
-            # trim of 'k' or '.' only affects non-unique mode, since unique
-            # mode will not output trailing 0s.
-            assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='k'),
-                         "1.0000")
-
-            assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='.'),
-                         "1.")
-            assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='.'),
-                         "1.2" if tp != np.float16 else "1.2002")
-
-            assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='0'),
-                         "1.0")
-            assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='0'),
-                         "1.2" if tp != np.float16 else "1.2002")
-            assert_equal(fpos(tp('1.'), trim='0'), "1.0")
-
-            assert_equal(fpos(tp('1.'), unique=False, precision=4, trim='-'),
-                         "1")
-            assert_equal(fpos(tp('1.2'), unique=False, precision=4, trim='-'),
-                         "1.2" if tp != np.float16 else "1.2002")
-            assert_equal(fpos(tp('1.'), trim='-'), "1")
-            assert_equal(fpos(tp('1.001'), precision=1, trim='-'), "1")
-            
-            #gh-28068            
-            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
-                                tp('1.047'), unique=False, precision=int(1e5))
-            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
-                                tp('1.047'), precision=2, pad_left=int(1e5))
-            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
-                                tp('1.047'), precision=2, pad_right=int(1e5))
+        # test fixed (non-unique) mode
+        assert_equal(fsci(tp('1.0'), unique=False, precision=4),
+                        "1.0000e+00")
 
     @pytest.mark.skipif(not platform.machine().startswith("ppc64"),
                         reason="only applies to ppc float128 values")

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -8,8 +8,8 @@ import sys
 
 from tempfile import TemporaryFile
 import numpy as np
-from numpy.testing import assert_, assert_equal, assert_raises
-from numpy.testing import assert_raises_regex, IS_MUSL
+from numpy.testing import (
+    assert_, assert_equal, assert_raises, assert_raises_regex, IS_MUSL)
 
 class TestRealScalars:
     def test_str(self):

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -306,9 +306,14 @@ class TestRealScalars:
                          "1.2" if tp != np.float16 else "1.2002")
             assert_equal(fpos(tp('1.'), trim='-'), "1")
             assert_equal(fpos(tp('1.001'), precision=1, trim='-'), "1")
-                        
-            assert_raises_regex(ValueError, "Left padding exceeds buffer size of 16384", fpos, tp('1.047'), precision=2, pad_left=int(1e5))            
-            assert_raises_regex(ValueError, "Right padding exceeds buffer size of 16384", fpos, tp('1.047'), precision=2, pad_right=int(1e5))
+            
+            #gh-28068            
+            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
+                                tp('1.047'), unique=False, precision=int(1e5))
+            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
+                                tp('1.047'), precision=2, pad_left=int(1e5))
+            assert_raises_regex(RuntimeError, "String buffer overflow", fpos, 
+                                tp('1.047'), precision=2, pad_right=int(1e5))
 
     @pytest.mark.skipif(not platform.machine().startswith("ppc64"),
                         reason="only applies to ppc float128 values")

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -8,7 +8,8 @@ import sys
 
 from tempfile import TemporaryFile
 import numpy as np
-from numpy.testing import assert_, assert_equal, assert_raises, IS_MUSL
+from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_raises_regex, IS_MUSL
 
 class TestRealScalars:
     def test_str(self):
@@ -273,7 +274,7 @@ class TestRealScalars:
             assert_equal(fpos(tp('-1.0'), pad_left=4, pad_right=4), "  -1.    ")
             assert_equal(fpos(tp('-10.2'),
                          pad_left=4, pad_right=4), " -10.2   ")
-
+            
             # test exp_digits
             assert_equal(fsci(tp('1.23e1'), exp_digits=5), "1.23e+00001")
 
@@ -305,6 +306,9 @@ class TestRealScalars:
                          "1.2" if tp != np.float16 else "1.2002")
             assert_equal(fpos(tp('1.'), trim='-'), "1")
             assert_equal(fpos(tp('1.001'), precision=1, trim='-'), "1")
+                        
+            assert_raises_regex(ValueError, "Left padding exceeds buffer size of 16384", fpos, tp('1.047'), precision=2, pad_left=int(1e5))            
+            assert_raises_regex(ValueError, "Right padding exceeds buffer size of 16384", fpos, tp('1.047'), precision=2, pad_right=int(1e5))
 
     @pytest.mark.skipif(not platform.machine().startswith("ppc64"),
                         reason="only applies to ppc float128 values")


### PR DESCRIPTION
This PR adds graceful error handling for `np.format_float_positional ` when provided `pad_left` or `pad_right` arguments are too large, leading to an overflow of the string buffer.  

In such cases, a `ValueError` exception is raised. 
Added tests and updated the doc to describe limits on `pad_left` and `pad_right`

fixes #28068 
