### PR TITLE
BUG: Avoid data race in PyArray_CheckFromAny_int

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1831,12 +1831,10 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
     if (requires & NPY_ARRAY_NOTSWAPPED) {
         if (!in_descr && PyArray_Check(op) &&
                 PyArray_ISBYTESWAPPED((PyArrayObject* )op)) {
-            in_descr = PyArray_DescrNew(PyArray_DESCR((PyArrayObject *)op));
-            if (in_descr == NULL) {
-                return NULL;
-            }
+            in_descr = PyArray_DESCR((PyArrayObject *)op);
+            Py_INCREF(in_descr);
         }
-        else if (in_descr && !PyArray_ISNBO(in_descr->byteorder)) {
+        if (in_descr) {
             PyArray_DESCR_REPLACE_CANONICAL(in_descr);
         }
     }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1837,10 +1837,7 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
             }
         }
         else if (in_descr && !PyArray_ISNBO(in_descr->byteorder)) {
-            PyArray_DESCR_REPLACE(in_descr);
-        }
-        if (in_descr && in_descr->byteorder != NPY_IGNORE) {
-            in_descr->byteorder = NPY_NATIVE;
+            PyArray_DESCR_REPLACE_CANONICAL(in_descr);
         }
     }
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1829,8 +1829,7 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
 {
     PyObject *obj;
     if (requires & NPY_ARRAY_NOTSWAPPED) {
-        if (!in_descr && PyArray_Check(op) &&
-                PyArray_ISBYTESWAPPED((PyArrayObject* )op)) {
+        if (!in_descr && PyArray_Check(op)) {
             in_descr = PyArray_DESCR((PyArrayObject *)op);
             Py_INCREF(in_descr);
         }

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -285,6 +285,11 @@ PyArray_SETITEM(PyArrayObject *arr, char *itemptr, PyObject *v)
             v, itemptr, arr);
 }
 
+// Like PyArray_DESCR_REPLACE, but calls ensure_canonical instead of DescrNew
+#define PyArray_DESCR_REPLACE_CANONICAL(descr) do { \
+                PyArray_Descr *_new_ = NPY_DT_CALL_ensure_canonical(descr); \
+                Py_XSETREF(descr, _new_);  \
+        } while(0)
 
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_DTYPEMETA_H_ */

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -134,6 +134,7 @@ def test_parallel_reduction():
 
 
 def test_parallel_flat_iterator():
+    # gh-28042
     x = np.arange(20).reshape(5, 4).T
 
     def closure(b):
@@ -142,3 +143,15 @@ def test_parallel_flat_iterator():
             list(x.flat)
 
     run_threaded(closure, outer_iterations=100, pass_barrier=True)
+
+    # gh-28143
+    def prepare_args():
+        return [np.arange(10)]
+
+    def closure(x, b):
+        b.wait()
+        for _ in range(100):
+            y = np.arange(10)
+            y.flat[x] = x
+
+    run_threaded(closure, pass_barrier=True, prepare_args=prepare_args)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2687,12 +2687,16 @@ _glibc_older_than = lambda x: (_glibcver != '0.0' and _glibcver < x)
 
 
 def run_threaded(func, iters=8, pass_count=False, max_workers=8,
-                 pass_barrier=False, outer_iterations=1):
+                 pass_barrier=False, outer_iterations=1,
+                 prepare_args=None):
     """Runs a function many times in parallel"""
     for _ in range(outer_iterations):
         with (concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
               as tpe):
-            args = []
+            if prepare_args is None:
+                args = []
+            else:
+                args = prepare_args()
             if pass_barrier:
                 if max_workers != iters:
                     raise RuntimeError(


### PR DESCRIPTION
Fixes #28143.

I verified the test triggers TSAN warnings on `main` and doesn't anymore with this applied.