### PR TITLE
MAINT: Avoid a redundant copy on `a[...] = b`

### DIFF
--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -249,7 +249,7 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      */
     ndim = PyArray_DiscoverDTypeAndShape(src_object,
             PyArray_NDIM(dest), dims, &cache,
-            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, 1, NULL);
+            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype, -1, NULL);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8576,6 +8576,12 @@ class TestArrayCreationCopyArgument:
         assert arr_random.true_passed
         assert second_copy is not copy_arr
 
+        arr_random = ArrayRandom()
+        arr = np.ones((size, size))
+        arr[...] = arr_random
+        assert not arr_random.true_passed
+        assert not np.shares_memory(arr, base_arr)
+
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test__array__reference_leak(self):
         class NotAnArray:


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/28070

In the example presented in #28070 there's an unnecessary copy made by calling `__array__` with `copy=True`:
```python
import numpy as np

class MyThing(object):
    def __array__(self, dtype=None, copy=None):
        print(f"MyThing.__array__(dtype={dtype}, copy={copy})")
        return np.ones((5, 5))

u = np.zeros((5, 5))
v = MyThing()

u[...] = v
```

I think we can switch from "always copy" to "copy if needed" for the input shape&dtype discovery in the `PyArray_CopyObject` function.
I want to stress that the `src` to `dest` copy is done anyway (AFAIU indexed assignment can't return a view) as `PyArray_CopyObject` calls `PyArray_AssignArray(dest, src, ...)` which iterates over elements and copies them to `dest`.