### PR TITLE
BUG: Include Python-including headers first

### DIFF
--- a/numpy/_core/src/common/common.hpp
+++ b/numpy/_core/src/common/common.hpp
@@ -5,8 +5,8 @@
  * they are gathered to make it easy for us and for the future need to support PCH.
  */
 #include "npdef.hpp"
-#include "utils.hpp"
 #include "npstd.hpp"
+#include "utils.hpp"
 #include "half.hpp"
 #include "meta.hpp"
 #include "float_status.hpp"

--- a/numpy/_core/src/common/npstd.hpp
+++ b/numpy/_core/src/common/npstd.hpp
@@ -1,6 +1,8 @@
 #ifndef NUMPY_CORE_SRC_COMMON_NPSTD_HPP
 #define NUMPY_CORE_SRC_COMMON_NPSTD_HPP
 
+#include <numpy/npy_common.h>
+
 #include <cstddef>
 #include <cstring>
 #include <cctype>
@@ -13,8 +15,6 @@
 #include <cmath>
 #include <complex>
 #include <type_traits>
-
-#include <numpy/npy_common.h>
 
 #include "npy_config.h"
 

--- a/numpy/_core/src/common/npy_hashtable.cpp
+++ b/numpy/_core/src/common/npy_hashtable.cpp
@@ -12,11 +12,12 @@
  * case is likely desired.
  */
 
+#include "npy_hashtable.h"
+
 #include <mutex>
 #include <shared_mutex>
 
 #include "templ_common.h"
-#include "npy_hashtable.h"
 #include <new>
 
 

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -38,12 +38,12 @@
 #define _MULTIARRAYMODULE
 #define _UMATHMODULE
 
-#include <mutex>
-#include <shared_mutex>
-
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <convert_datatype.h>
+
+#include <mutex>
+#include <shared_mutex>
 
 #include "numpy/ndarraytypes.h"
 #include "numpy/npy_3kcompat.h"

--- a/numpy/_core/src/umath/fast_loop_macros.h
+++ b/numpy/_core/src/umath/fast_loop_macros.h
@@ -10,9 +10,9 @@
 #ifndef _NPY_UMATH_FAST_LOOP_MACROS_H_
 #define _NPY_UMATH_FAST_LOOP_MACROS_H_
 
-#include <assert.h>
-
 #include "simd/simd.h"
+
+#include <assert.h>
 
 /*
  * largest simd vector size in bytes numpy supports

--- a/numpy/fft/_pocketfft_umath.cpp
+++ b/numpy/fft/_pocketfft_umath.cpp
@@ -12,8 +12,8 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #define PY_SSIZE_T_CLEAN
-#include <assert.h>
 #include <Python.h>
+#include <assert.h>
 
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"


### PR DESCRIPTION
Found while trying to get NumPy to compile on the Cygwin test release of Python 3.12

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
