### PR TITLE
BUG: Fix f2py directives and --lower casing

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -26,7 +26,7 @@ __all__ = [
     'hasexternals', 'hasinitvalue', 'hasnote', 'hasresultnote',
     'isallocatable', 'isarray', 'isarrayofstrings',
     'ischaracter', 'ischaracterarray', 'ischaracter_or_characterarray',
-    'iscomplex',
+    'iscomplex', 'iscstyledirective',
     'iscomplexarray', 'iscomplexfunction', 'iscomplexfunction_warn',
     'isdouble', 'isdummyroutine', 'isexternal', 'isfunction',
     'isfunction_wrap', 'isint1', 'isint1array', 'isinteger', 'isintent_aux',
@@ -421,6 +421,11 @@ def getdimension(var):
 
 def isrequired(var):
     return not isoptional(var) and isintent_nothide(var)
+
+
+def iscstyledirective(f2py_line):
+    directives = {"callstatement", "callprotoargument", "pymethoddef"}
+    return any(directive in f2py_line.lower() for directive in directives)
 
 
 def isintent_in(var):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -510,11 +510,9 @@ def readfortrancode(ffile, dowithline=show, istop=1):
                 origfinalline = ''
             else:
                 if localdolowercase:
-                    # lines with intent() should be lowered otherwise
-                    # TestString::test_char fails due to mixed case
-                    # f2py directives without intent() should be left untouched
-                    # gh-2547, gh-27697, gh-26681
-                    finalline = ll.lower() if "intent" in ll.lower() or not is_f2py_directive else ll
+                    # only skip lowering for C style constructs
+                    # gh-2547, gh-27697, gh-26681, gh-28014
+                    finalline = ll.lower() if not (is_f2py_directive and iscstyledirective(ll)) else ll
                 else:
                     finalline = ll
                 origfinalline = ll

--- a/numpy/f2py/tests/src/regression/lower_f2py_fortran.f90
+++ b/numpy/f2py/tests/src/regression/lower_f2py_fortran.f90
@@ -1,0 +1,5 @@
+subroutine inquire_next(IU)
+   IMPLICIT NONE
+   integer :: IU
+   !f2py intent(in) IU
+end subroutine

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -122,6 +122,15 @@ class TestF90Contiuation(util.F2PyTest):
         assert(res[0] == 8)
         assert(res[1] == 15)
 
+class TestLowerF2PYDirectives(util.F2PyTest):
+    # Check variables are cased correctly
+    sources = [util.getpath("tests", "src", "regression", "lower_f2py_fortran.f90")]
+
+    @pytest.mark.slow
+    def test_gh28014(self):
+        self.module.inquire_next(3)
+        assert True
+
 @pytest.mark.slow
 def test_gh26623():
     # Including libraries with . should not generate an incorrect meson.build


### PR DESCRIPTION
Backport of #28056

Closes #28014 which snuck in over in #27728. Essentially, only the added `f2py` directives which take C-exprs [noted here](https://numpy.org/doc/stable/f2py/signature-file.html#f2py-statements) need to be skipped for the lowering logic (since C is case sensitive).
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
