### PR TITLE
TYP: preserve shape-type in ndarray.astype()

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2500,7 +2500,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DType_co]):
         casting: _CastingKind = ...,
         subok: builtins.bool = ...,
         copy: builtins.bool | _CopyMode = ...,
-    ) -> NDArray[_SCT]: ...
+    ) -> ndarray[_ShapeT_co, dtype[_SCT]]: ...
     @overload
     def astype(
         self,
@@ -2509,7 +2509,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DType_co]):
         casting: _CastingKind = ...,
         subok: builtins.bool = ...,
         copy: builtins.bool | _CopyMode = ...,
-    ) -> NDArray[Any]: ...
+    ) -> ndarray[_ShapeT_co, dtype[Any]]: ...
 
     @overload
     def view(self) -> Self: ...

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -872,15 +872,15 @@ def array_equiv(a1: ArrayLike, a2: ArrayLike) -> bool: ...
 
 @overload
 def astype(
-    x: NDArray[Any],
+    x: ndarray[_ShapeType, dtype[Any]],
     dtype: _DTypeLike[_SCT],
     copy: bool = ...,
     device: None | L["cpu"] = ...,
-) -> NDArray[_SCT]: ...
+) -> ndarray[_ShapeType, dtype[_SCT]]: ...
 @overload
 def astype(
-    x: NDArray[Any],
+    x: ndarray[_ShapeType, dtype[Any]],
     dtype: DTypeLike,
     copy: bool = ...,
     device: None | L["cpu"] = ...,
-) -> NDArray[Any]: ...
+) -> ndarray[_ShapeType, dtype[Any]]: ...

--- a/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
@@ -11,6 +11,7 @@ i4_2d: np.ndarray[tuple[int, int], np.dtype[np.int32]]
 f8_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float64]]
 cG_4d: np.ndarray[tuple[int, int, int, int], np.dtype[np.clongdouble]]
 i0_nd: npt.NDArray[np.int_]
+uncertain_dtype: np.int32 | np.float64 | np.str_
 
 # item
 assert_type(i0_nd.item(), int)
@@ -49,6 +50,13 @@ assert_type(i0_nd.astype(np.float64, "K", "unsafe", True), npt.NDArray[np.float6
 assert_type(i0_nd.astype(np.float64, "K", "unsafe", True, True), npt.NDArray[np.float64])
 
 assert_type(np.astype(i0_nd, np.float64), npt.NDArray[np.float64])
+
+assert_type(i4_2d.astype(np.uint16), np.ndarray[tuple[int, int], np.dtype[np.uint16]])
+assert_type(np.astype(i4_2d, np.uint16), np.ndarray[tuple[int, int], np.dtype[np.uint16]])
+assert_type(f8_3d.astype(np.int16), np.ndarray[tuple[int, int, int], np.dtype[np.int16]])
+assert_type(np.astype(f8_3d, np.int16), np.ndarray[tuple[int, int, int], np.dtype[np.int16]])
+assert_type(i4_2d.astype(uncertain_dtype), np.ndarray[tuple[int, int], np.dtype[np.generic[Any]]])
+assert_type(np.astype(i4_2d, uncertain_dtype), np.ndarray[tuple[int, int], np.dtype[Any]])
 
 # byteswap
 assert_type(i0_nd.byteswap(), npt.NDArray[np.int_])


### PR DESCRIPTION
Backport of #28169

This patch changes the return type in astype() from NDArray to ndarray so that shape information is preserved and adds tests for it.

Similar changes are added to np.astype() for consistency.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
