### PR TITLE
CI: replace quansight-labs/setup-python with astral-sh/setup-uv

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -30,7 +30,8 @@ runs:
       TERM: xterm-256color
     run: |
       echo "::group::Installing Test Dependencies"
-      pip install pytest pytest-xdist pytest-timeout hypothesis typing_extensions setuptools
+      pip install pytest pytest-xdist pytest-timeout hypothesis typing_extensions
+      pip install -r requirements/setuptools_requirement.txt
       echo "::endgroup::"
       echo "::group::Test NumPy"
       spin test -- --durations=10 --timeout=600

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,3 +20,5 @@ jobs:
           persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        with:
+          allow-ghsas: GHSA-cx63-2mw6-8hw5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,9 +65,10 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-    - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
+    - uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca
       with:
         python-version: ${{ matrix.version }}
+        enable-cache: false
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       if: matrix.version == '3.13t'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,6 +69,8 @@ jobs:
       with:
         python-version: ${{ matrix.version }}
         enable-cache: false
+    - run:
+        uv pip install --python=${{ matrix.version }} pip
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       if: matrix.version == '3.13t'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
       - main
       - maintenance/**
 
+
 permissions:
    contents: read  # to fetch code (actions/checkout)
 
@@ -128,6 +129,9 @@ jobs:
         python-version: ${{ matrix.version }}
         enable-cache: false
 
+    - run:
+        uv pip install --python=${{ matrix.version }} pip
+
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       if: ${{ matrix.build_runner[0] == 'macos-13' }}
       with:
@@ -142,6 +146,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
+        pip install -r requirements/setuptools_requirement.txt
         pip install pytest pytest-xdist pytest-timeout hypothesis
 
     - name: Build against Accelerate (LP64)
@@ -152,7 +157,7 @@ jobs:
 
     - name: Build NumPy against Accelerate (ILP64)
       run: |
-        git clean -xdf
+        rm -r build build-install
         spin build -- -Duse-ilp64=true -Ddisable-optimization=true -Dallow-noblas=false
 
     - name: Test (fast tests)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -123,9 +123,10 @@ jobs:
         fetch-tags: true
         persist-credentials: false
 
-    - uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
+    - uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca
       with:
         python-version: ${{ matrix.version }}
+        enable-cache: false
 
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       if: ${{ matrix.build_runner[0] == 'macos-13' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,15 +35,21 @@ jobs:
         persist-credentials: false
 
     - name: Setup Python
-      uses: quansight-labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
+      uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca
       with:
         python-version: ${{ matrix.compiler-pyversion[1] }}
+        enable-cache: false
+
+    - name: Ensure pip is installed
+      run: |
+        python -m ensurepip
+        python -m pip install -U pip setuptools
 
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       if: matrix.compiler-pyversion[1] == '3.13t'
       run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+        python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install build dependencies from PyPI
       run: |
@@ -66,15 +72,15 @@ jobs:
     - name: Install NumPy (MSVC)
       if: matrix.compiler-pyversion[0] == 'MSVC'
       run: |
-        pip install -r requirements/ci_requirements.txt
-        spin build --with-scipy-openblas=32 -j2 -- --vsenv
+        python -m pip install -r requirements/ci_requirements.txt
+        python -m spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
       if: matrix.compiler-pyversion[0] == 'Clang-cl'
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        pip install -r requirements/ci_requirements.txt
-        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
+        python -m pip install -r requirements/ci_requirements.txt
+        python -m spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log
       shell: bash
@@ -89,7 +95,7 @@ jobs:
 
     - name: Run test suite
       run: |
-        spin test -- --timeout=600 --durations=10
+        python -m spin test -- --timeout=600 --durations=10
 
   msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,20 +40,18 @@ jobs:
         python-version: ${{ matrix.compiler-pyversion[1] }}
         enable-cache: false
 
-    - name: Ensure pip is installed
-      run: |
-        python -m ensurepip
-        python -m pip install -U pip setuptools
+    - run:
+        uv pip install --python=${{ matrix.version }} pip
 
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       if: matrix.compiler-pyversion[1] == '3.13t'
       run: |
-        python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install build dependencies from PyPI
       run: |
-        python -m pip install -r requirements/build_requirements.txt
+        pip install -r requirements/build_requirements.txt
 
     - name: Install pkg-config
       run: |
@@ -72,15 +70,15 @@ jobs:
     - name: Install NumPy (MSVC)
       if: matrix.compiler-pyversion[0] == 'MSVC'
       run: |
-        python -m pip install -r requirements/ci_requirements.txt
-        python -m spin build --with-scipy-openblas=32 -j2 -- --vsenv
+        pip install -r requirements/ci_requirements.txt
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv
 
     - name: Install NumPy (Clang-cl)
       if: matrix.compiler-pyversion[0] == 'Clang-cl'
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
-        python -m pip install -r requirements/ci_requirements.txt
-        python -m spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
+        pip install -r requirements/ci_requirements.txt
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log
       shell: bash
@@ -95,7 +93,7 @@ jobs:
 
     - name: Run test suite
       run: |
-        python -m spin test -- --timeout=600 --durations=10
+        spin test -- --timeout=600 --durations=10
 
   msvc_32bit_python_no_openblas:
     name: MSVC, 32-bit Python, no BLAS

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -2,11 +2,14 @@ import shutil
 import subprocess
 import sys
 import pytest
+import os
 
 from numpy.distutils import mingw32ccompiler
 
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='win32 only test')
+@pytest.mark.skipif(not os.path.exists(os.path.join(sys.prefix, 'libs')),
+                    reason="test requires mingw library layout")
 def test_build_import():
     '''Test the mingw32ccompiler.build_import_library, which builds a
     `python.a` from the MSVC `python.lib`

--- a/requirements/setuptools_requirement.txt
+++ b/requirements/setuptools_requirement.txt
@@ -1,0 +1,2 @@
+setuptools==65.5.1 ; python_version < '3.12'
+setuptools         ; python_version >= '3.12'


### PR DESCRIPTION
This PR replaces all uses of `quansight-labs/setup-python` (a fork my team at Quansight is reluctantly maintaining) with `setup-uv`.

`setup-uv` is an attempt to use `uv` to create a more-or-less drop-in replacement for `setup-python`.

This is a re-do of https://github.com/numpy/numpy/pull/27581, which tried to integrate setup-uv into the NumPy CI and ran into issues. Since then uv and setup-uv have seen a number of improvements, and as far as I can tell all the issues I ran into back in October have been fixed.

On Windows, the python scripts aren't in the PATH, so I updated everything to use the `python -m` convention. There was also one mingw-specific test that got triggered on Python 3.11 on CI due to the presence of `nm.exe` in the `PATH`. Since the test failed trying to write to a directory that doesn't exist (and presumably does on MinGW) - I made it so the test is skipped if the directory needed by the test doesn't exist. See [this CI run](https://github.com/ngoldbaum/numpy/actions/runs/12836725626/job/35798956006#step:13:946) on my fork for more detail.

ping @zanieb