### PR TITLE
MAINT: testing: specify python executable to use in extbuild

### DIFF
--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -220,7 +220,6 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                 include_directories: {include_dirs},
             )
         """))
-    # https://github.com/FFY00/meson-python/blob/2510cde44342f3167c44ea05d650c8a524a43879/mesonpy/__init__.py#L615-L618
     native_file_name = cfile.parent / ".mesonpy-native-file.ini"
     with open(native_file_name, "wt") as fid:
         fid.write(textwrap.dedent(f"""\
@@ -234,7 +233,6 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                               cwd=build_dir,
                               )
     else:
-        # https://github.com/FFY00/meson-python/blob/2510cde44342f3167c44ea05d650c8a524a43879/mesonpy/__init__.py#L665-L667
         subprocess.check_call(["meson", "setup", "--vsenv", "..", f'--native-file={os.fspath(native_file_name)}'],
                               cwd=build_dir
                               )

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -220,6 +220,13 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                 include_directories: {include_dirs},
             )
         """))
+    # https://github.com/FFY00/meson-python/blob/2510cde44342f3167c44ea05d650c8a524a43879/mesonpy/__init__.py#L615-L618
+    native_file_name = cfile.parent / ".mesonpy-native-file.ini"
+    with open(native_file_name, "wt") as fid:
+        fid.write(textwrap.dedent(f"""\
+            [binaries]
+            python = '{sys.executable}'
+        """))
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
                                "--buildtype=release",
@@ -227,7 +234,8 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                               cwd=build_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", "--vsenv", ".."],
+        # https://github.com/FFY00/meson-python/blob/2510cde44342f3167c44ea05d650c8a524a43879/mesonpy/__init__.py#L665-L667
+        subprocess.check_call(["meson", "setup", "--vsenv", "..", f'--native-file={os.fspath(native_file_name)}'],
                               cwd=build_dir
                               )
 


### PR DESCRIPTION
This would cause failures during testing distribution packages on Cygwin. The code is copied from meson-python, as advised in mesonbuild/meson-python#51 and amended in mesonbuild/meson-python#137.
Note the changed organization in many of the links.

I found the failure specifically in `numpy._core.tests.test_array_interface.py` on Cygwin, where the system meson has a python3.9 shebang, so the test failed when it couldn't find a 3.12 extension module.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
