### PR TITLE
MAINT, DOC: Add sphinx extension to allow svg images in PDF docs build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,6 +88,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinx.ext.imgconverter',
 ]
 
 skippable_extensions = [


### PR DESCRIPTION
Adds a sphinx extension to allow building the PDF version of the docs with SVG images.

The actual PDF build will be done separately.