### PR TITLE
BUG: partially revert gh-28154

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1829,11 +1829,14 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
 {
     PyObject *obj;
     if (requires & NPY_ARRAY_NOTSWAPPED) {
-        if (!in_descr && PyArray_Check(op)) {
-            in_descr = PyArray_DESCR((PyArrayObject *)op);
-            Py_INCREF(in_descr);
+        if (!in_descr && PyArray_Check(op) &&
+                PyArray_ISBYTESWAPPED((PyArrayObject* )op)) {
+            in_descr = PyArray_DescrNew(PyArray_DESCR((PyArrayObject *)op));
+            if (in_descr == NULL) {
+                return NULL;
+            }
         }
-        if (in_descr) {
+        else if (in_descr && !PyArray_ISNBO(in_descr->byteorder)) {
             PyArray_DESCR_REPLACE_CANONICAL(in_descr);
         }
     }

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2653,3 +2653,9 @@ class TestRegression:
         inp = np.linspace(0, size, num=size, dtype=np.intc)
         out = np.sort(inp)
         assert_equal(inp, out)
+
+    def test_searchsorted_structured(self):
+        # gh-28190
+        x = np.array([(0, 1.)], dtype=[('time', '<i8'), ('value', '<f8')])
+        y = np.array((0, 0.), dtype=[('time', '<i8'), ('value', '<f8')])
+        x.searchsorted(y)


### PR DESCRIPTION
Fixes #28190.

Partially reverts gh-28154, in particular the changes to the no-descriptor, array operand, and is byteswapped codepaths that structured arrays are affected by.