### PR TITLE
BUG: fix data race in a more minimal way on stable branch

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1829,12 +1829,18 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
 {
     PyObject *obj;
     if (requires & NPY_ARRAY_NOTSWAPPED) {
-        if (!in_descr && PyArray_Check(op)) {
-            in_descr = PyArray_DESCR((PyArrayObject *)op);
-            Py_INCREF(in_descr);
+        if (!in_descr && PyArray_Check(op) &&
+                PyArray_ISBYTESWAPPED((PyArrayObject* )op)) {
+            in_descr = PyArray_DescrNew(PyArray_DESCR((PyArrayObject *)op));
+            if (in_descr == NULL) {
+                return NULL;
+            }
         }
-        if (in_descr) {
-            PyArray_DESCR_REPLACE_CANONICAL(in_descr);
+        else if (in_descr && !PyArray_ISNBO(in_descr->byteorder)) {
+            PyArray_DESCR_REPLACE(in_descr);
+        }
+        if (in_descr && in_descr->byteorder != NPY_IGNORE && in_descr->byteorder != NPY_NATIVE) {
+            in_descr->byteorder = NPY_NATIVE;
         }
     }
 


### PR DESCRIPTION
Fixes #28190 by mostly reverting the backport.