### PR TITLE
BUG: fix data race in `np.repeat`

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -922,16 +922,23 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
         }
     }
 
+    /* Fill in dimensions of new array */
+    npy_intp dims[NPY_MAXDIMS] = {0};
+
+    for (int i = 0; i < PyArray_NDIM(aop); i++) {
+        dims[i] = PyArray_DIMS(aop)[i];
+    }
+
+    dims[axis] = total;
+
     /* Construct new array */
-    PyArray_DIMS(aop)[axis] = total;
     Py_INCREF(PyArray_DESCR(aop));
     ret = (PyArrayObject *)PyArray_NewFromDescr(Py_TYPE(aop),
                                                 PyArray_DESCR(aop),
                                                 PyArray_NDIM(aop),
-                                                PyArray_DIMS(aop),
+                                                dims,
                                                 NULL, NULL, 0,
                                                 (PyObject *)aop);
-    PyArray_DIMS(aop)[axis] = n;
     if (ret == NULL) {
         goto fail;
     }

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -38,7 +38,7 @@ def test_parallel_ufunc_execution():
         b.wait()
         return a.sum()
 
-    run_threaded(f, NUM_THREADS, max_workers=NUM_THREADS, pass_barrier=True)
+    run_threaded(f, NUM_THREADS, pass_barrier=True)
 
 
 def test_temp_elision_thread_safety():
@@ -129,8 +129,7 @@ def test_parallel_reduction():
         b.wait()
         np.sum(x)
 
-    run_threaded(closure, NUM_THREADS, max_workers=NUM_THREADS,
-                 pass_barrier=True)
+    run_threaded(closure, NUM_THREADS, pass_barrier=True)
 
 
 def test_parallel_flat_iterator():

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -154,3 +154,14 @@ def test_parallel_flat_iterator():
             y.flat[x] = x
 
     run_threaded(closure, pass_barrier=True, prepare_args=prepare_args)
+
+
+def test_multithreaded_repeat():
+    x0 = np.arange(10)
+
+    def closure(b):
+        b.wait()
+        for _ in range(100):
+            x = np.repeat(x0, 2, axis=0)[::2]
+
+    run_threaded(closure, max_workers=10, pass_barrier=True)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2686,7 +2686,7 @@ _glibcver = _get_glibc_version()
 _glibc_older_than = lambda x: (_glibcver != '0.0' and _glibcver < x)
 
 
-def run_threaded(func, iters=8, pass_count=False, max_workers=8,
+def run_threaded(func, max_workers=8, pass_count=False,
                  pass_barrier=False, outer_iterations=1,
                  prepare_args=None):
     """Runs a function many times in parallel"""
@@ -2698,15 +2698,11 @@ def run_threaded(func, iters=8, pass_count=False, max_workers=8,
             else:
                 args = prepare_args()
             if pass_barrier:
-                if max_workers != iters:
-                    raise RuntimeError(
-                        "Must set max_workers equal to the number of "
-                        "iterations to avoid deadlocks.")
                 barrier = threading.Barrier(max_workers)
                 args.append(barrier)
             if pass_count:
-                futures = [tpe.submit(func, i, *args) for i in range(iters)]
+                futures = [tpe.submit(func, i, *args) for i in range(max_workers)]
             else:
-                futures = [tpe.submit(func, *args) for _ in range(iters)]
+                futures = [tpe.submit(func, *args) for _ in range(max_workers)]
             for f in futures:
                 f.result()


### PR DESCRIPTION
Fixes #28197.

The change to `run_threaded` is unrelated but needed for the way I wrote the test to avoid duplicating keyword arguments. My fault for introducing two keywords that do the same thing 🙃.