### PR TITLE
MAINT: Use VQSORT_COMPILER_COMPATIBLE to determine if we should use VQSort

### DIFF
--- a/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
@@ -1,6 +1,4 @@
 #include "highway_qsort.hpp"
-#define VQSORT_ONLY_STATIC 1
-#include "hwy/contrib/sort/vqsort-inl.h"
 
 #if VQSORT_ENABLED
 

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -1,18 +1,13 @@
 #ifndef NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 #define NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 
+#define VQSORT_ONLY_STATIC 1
 #include "hwy/highway.h"
+#include "hwy/contrib/sort/vqsort-inl.h"
 
 #include "common.hpp"
 
-// This replicates VQSORT_ENABLED from hwy/contrib/sort/shared-inl.h
-// without checking the scalar target as this is not built within the dynamic
-// dispatched sources.
-#if (HWY_COMPILER_MSVC && !HWY_IS_DEBUG_BUILD) ||                   \
-    (HWY_ARCH_ARM_V7 && HWY_IS_DEBUG_BUILD) ||                      \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_GCC_ACTUAL && HWY_IS_ASAN) || \
-    (HWY_ARCH_ARM_A64 && HWY_COMPILER_CLANG &&                      \
-    (HWY_IS_HWASAN || HWY_IS_MSAN || HWY_IS_TSAN || HWY_IS_ASAN))
+#if !VQSORT_COMPILER_COMPATIBLE
 #define NPY_DISABLE_HIGHWAY_SORT
 #endif
 

--- a/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort_16bit.dispatch.cpp
@@ -1,6 +1,4 @@
 #include "highway_qsort.hpp"
-#define VQSORT_ONLY_STATIC 1
-#include "hwy/contrib/sort/vqsort-inl.h"
 
 #include "quicksort.hpp"
 


### PR DESCRIPTION
Backport of #28202.

Previously we copied the compiler detection across from the Highway header, now we don't have to manually keep it up to date.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
