### PR TITLE
Fix the multiple external links in the navbar of neps webpage and the version switcher text color in darkMode

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -94,11 +94,6 @@ html_theme_options = {
     "image_dark": "_static/numpylogo_dark.svg",
   },
   "github_url": "https://github.com/numpy/numpy",
-  "external_links": [
-      {"name": "Wishlist",
-       "url": "https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22",
-      },
-  ],
   "show_prev_next": False,
 }
 

--- a/doc/neps/content.rst
+++ b/doc/neps/content.rst
@@ -16,7 +16,7 @@ Roadmap
    Index <index>
    The Scope of NumPy <scope>
    Current roadmap <roadmap>
-   Wish list <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
+   Wishlist <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
 
 
 

--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -43,6 +43,9 @@ button.btn.version-switcher__button:hover {
   font-size: small;
 }
 
+html[data-theme=dark] button.btn.version-switcher__button{
+  color : white;
+}
 /* Main index page overview cards */
 
 .sd-card .sd-card-img-top {


### PR DESCRIPTION
**https://numpy.org/doc/stable/index.html Before:**
![Screenshot From 2025-01-22 12-59-48](https://github.com/user-attachments/assets/c7feb211-9048-4e36-a92f-84fd95870bc4)

**https://numpy.org/doc/stable/index.html After:**

**Navbar Before:**
![Screenshot From 2025-01-22 13-00-48](https://github.com/user-attachments/assets/6c6f35c7-2561-48a0-a890-054e998d4dd2)

**Navbar After:**
![Screenshot From 2025-01-22 13-00-20](https://github.com/user-attachments/assets/1203e9b1-214e-4429-8e43-f22c376d3ade)