### PR TITLE
DOC: Add versionadded directive for axis argument in trim_zeros function

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1901,11 +1901,13 @@ def trim_zeros(filt, trim='fb', axis=None):
         to the side with the lowest index 0, and "back" referring to the highest
         index (or index -1).
     axis : int or sequence, optional
-        If None, `filt` is cropped such, that the smallest bounding box is
+        If None, `filt` is cropped such that the smallest bounding box is
         returned that still contains all values which are not zero.
         If an axis is specified, `filt` will be sliced in that dimension only
         on the sides specified by `trim`. The remaining area will be the
         smallest that still contains all values wich are not zero.
+
+        .. versionadded:: 2.2.0
 
     Returns
     -------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

The `axis` argument of the `trim_zeros` function was added in [version 2.2.0](https://github.com/numpy/numpy/blob/v2.2.0/numpy/lib/_function_base_impl.py#L1890) which makes it easier to trim zeros for N-dimensional arrays. But the `versionadded` directive is missing in the docstring.
