### PR TITLE
BUG: allclose does not warn for invalid value encountered in multiply or alternativly checks for validity of tolerances

### DIFF
--- a/doc/release/upcoming_changes/28205.improvement.rst
+++ b/doc/release/upcoming_changes/28205.improvement.rst
@@ -1,0 +1,6 @@
+Added warnings to `np.isclose`
+---------------------------------
+Added warning messages if at least one of atol or rtol are
+either `np.nan` or `np.inf` within `np.isclose`
+
+* Warnings follow the user's `np.seterr` settings

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2445,12 +2445,9 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
 
     with errstate(invalid='ignore'):
 
-        if np.any(np.isinf(atol)) or np.any(np.isinf(rtol)):
-            warnings.warn("At least one of rtol and atol are infinite", stacklevel=2)
-
-        if np.any(np.isnan(atol)) or np.any(np.isnan(rtol)):
-            warnings.warn("At least one of rtol and atol are not a number", stacklevel=2)
-        
+        if np.any(np.isinf(atol)) or np.any(np.isinf(rtol)) or np.any(np.isnan(atol)) or np.any(np.isnan(rtol)):
+            warnings.warn(f"One of rtol or atol is not valid, atol: {atol}, rtol: {rtol}", stacklevel=2)
+  
         result = (less_equal(abs(x - y), atol + rtol * abs(y))
                   & isfinite(y)
                   | (x == y))

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2454,8 +2454,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
             raise FloatingPointError(err_msg)
         elif err_s == "print":
             print(err_msg)
-        
-        
+              
     with errstate(invalid='ignore'):
   
         result = (less_equal(abs(x - y), atol + rtol * abs(y))

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2444,6 +2444,13 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         y = float(y)
 
     with errstate(invalid='ignore'):
+
+        if np.any(np.isinf(atol)) or np.any(np.isinf(rtol)):
+            warnings.warn("At least one of rtol and atol are infinite", stacklevel=2)
+
+        if np.any(np.isnan(atol)) or np.any(np.isnan(rtol)):
+            warnings.warn("At least one of rtol and atol are not a number", stacklevel=2)
+        
         result = (less_equal(abs(x - y), atol + rtol * abs(y))
                   & isfinite(y)
                   | (x == y))

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2443,10 +2443,20 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     elif isinstance(y, int):
         y = float(y)
 
+    # atol and rtol can be arrays
+    if not (np.all(np.isfinite(atol)) and np.all(np.isfinite(rtol))):
+        err_s = np.geterr()["invalid"]
+        err_msg = f"One of rtol or atol is not valid, atol: {atol}, rtol: {rtol}"
+
+        if err_s == "warn":
+            warnings.warn(err_msg, RuntimeWarning, stacklevel=2)
+        elif err_s == "raise":
+            raise FloatingPointError(err_msg)
+        elif err_s == "print":
+            print(err_msg)
+        
+        
     with errstate(invalid='ignore'):
-        # atol and rtol can be arrays
-        if not (np.all(np.isfinite(atol)) and np.all(np.isfinite(rtol))):
-            warnings.warn(f"One of rtol or atol is not valid, atol: {atol}, rtol: {rtol}", stacklevel=2)
   
         result = (less_equal(abs(x - y), atol + rtol * abs(y))
                   & isfinite(y)

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2444,8 +2444,8 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         y = float(y)
 
     with errstate(invalid='ignore'):
-
-        if np.any(np.isinf(atol)) or np.any(np.isinf(rtol)) or np.any(np.isnan(atol)) or np.any(np.isnan(rtol)):
+        # atol and rtol can be arrays
+        if not (np.all(np.isfinite(atol)) and np.all(np.isfinite(rtol))):
             warnings.warn(f"One of rtol or atol is not valid, atol: {atol}, rtol: {rtol}", stacklevel=2)
   
         result = (less_equal(abs(x - y), atol + rtol * abs(y))

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3177,6 +3177,57 @@ class TestIsclose:
         assert np.allclose(a, a, atol=0, equal_nan=True)
         assert np.allclose(a, a, atol=np.timedelta64(1, "ns"), equal_nan=True)
 
+    def test_tol_warnings(self):
+        a = np.array([1, 2, 3])
+        #Testing when rtol is infinite
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, rtol=np.inf)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+        #Testing when atol is infinite
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, atol=np.inf)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+        #Testing when both are infinite
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, atol=np.inf, rtol=np.inf)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+        #Testing when atol is nan
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, atol=np.nan)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+        #Testing when rtol is nan
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, rtol=np.nan)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+        #Testing when bath are nan
+        with warnings.catch_warnings(record=True) as w:
+
+            warnings.simplefilter("always")
+            b = np.isclose(a, a, atol=np.nan,)
+            assert(len(w) == 1)
+            assert(issubclass(w[-1].category, UserWarning))
+            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+
 
 class TestStdVar:
     def setup_method(self):

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3179,54 +3179,21 @@ class TestIsclose:
 
     def test_tol_warnings(self):
         a = np.array([1, 2, 3])
-        #Testing when rtol is infinite
-        with warnings.catch_warnings(record=True) as w:
+        b = np.array([np.inf, np.nan, 1])
 
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, rtol=np.inf)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
-        #Testing when atol is infinite
-        with warnings.catch_warnings(record=True) as w:
+        for i in b:
+            for j in b:
+                # Making sure that i and j are not both numbers, because that won't create a warning
+                if (i == 1) and (j == 1):
+                    continue
+                
+                with warnings.catch_warnings(record=True) as w:
 
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, atol=np.inf)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
-        #Testing when both are infinite
-        with warnings.catch_warnings(record=True) as w:
-
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, atol=np.inf, rtol=np.inf)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
-        #Testing when atol is nan
-        with warnings.catch_warnings(record=True) as w:
-
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, atol=np.nan)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
-        #Testing when rtol is nan
-        with warnings.catch_warnings(record=True) as w:
-
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, rtol=np.nan)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
-        #Testing when bath are nan
-        with warnings.catch_warnings(record=True) as w:
-
-            warnings.simplefilter("always")
-            b = np.isclose(a, a, atol=np.nan,)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
+                    warnings.simplefilter("always")
+                    c = np.isclose(a, a, atol=i, rtol=j)
+                    assert len(w) == 1
+                    assert issubclass(w[-1].category, UserWarning)
+                    assert f"One of rtol or atol is not valid, atol: {i}, rtol: {j}" in str(w[-1].message)
 
 
 class TestStdVar:

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3184,49 +3184,49 @@ class TestIsclose:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, rtol=np.inf)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
         #Testing when atol is infinite
         with warnings.catch_warnings(record=True) as w:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, atol=np.inf)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
         #Testing when both are infinite
         with warnings.catch_warnings(record=True) as w:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, atol=np.inf, rtol=np.inf)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are infinite" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are infinite" in str(w[-1].message)
         #Testing when atol is nan
         with warnings.catch_warnings(record=True) as w:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, atol=np.nan)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
         #Testing when rtol is nan
         with warnings.catch_warnings(record=True) as w:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, rtol=np.nan)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
         #Testing when bath are nan
         with warnings.catch_warnings(record=True) as w:
 
             warnings.simplefilter("always")
             b = np.isclose(a, a, atol=np.nan,)
-            assert(len(w) == 1)
-            assert(issubclass(w[-1].category, UserWarning))
-            assert("At least one of rtol and atol are not a number" in str(w[-1].message))
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "At least one of rtol and atol are not a number" in str(w[-1].message)
 
 
 class TestStdVar:

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3192,7 +3192,7 @@ class TestIsclose:
                     warnings.simplefilter("always")
                     c = np.isclose(a, a, atol=i, rtol=j)
                     assert len(w) == 1
-                    assert issubclass(w[-1].category, UserWarning)
+                    assert issubclass(w[-1].category, RuntimeWarning)
                     assert f"One of rtol or atol is not valid, atol: {i}, rtol: {j}" in str(w[-1].message)
 
 

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -976,7 +976,6 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 "disable comments."
             )
         comments = tuple(comment)
-        print("Test")
         comment = None
         if len(comments) == 0:
             comments = None  # No comments at all

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -976,6 +976,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 "disable comments."
             )
         comments = tuple(comment)
+        print("Test")
         comment = None
         if len(comments) == 0:
             comments = None  # No comments at all


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Added warning messages if atol or rtol are numpy.nan or numpy.inf within is close

Closes issue #28205 

