### PR TITLE
MAINT: Add [[maybe_unused] to silence some warnings

### DIFF
--- a/numpy/_core/src/umath/loops_hyperbolic.dispatch.cpp.src
+++ b/numpy/_core/src/umath/loops_hyperbolic.dispatch.cpp.src
@@ -151,7 +151,7 @@ store_vector(vtype vec, type_t* dst, npy_intp sdst, npy_intp len){
 
 #if NPY_SIMD_F64
 
-HWY_ATTR NPY_FINLINE vec_f64 lut_16_f64(const double * lut, vec_u64 idx){
+[[maybe_unused]] HWY_ATTR NPY_FINLINE vec_f64 lut_16_f64(const double * lut, vec_u64 idx){
     if constexpr(hn::Lanes(f64) == 8){
         const vec_f64 lut0 = hn::Load(f64, lut);
         const vec_f64 lut1 = hn::Load(f64, lut + 8);
@@ -475,7 +475,7 @@ HWY_ATTR NPY_FINLINE hwy_f32x2 zip_f32(vec_f32 a, vec_f32 b){
     return res;
 }
 
-HWY_ATTR NPY_FINLINE vec_f32 lut_32_f32(const float * lut, vec_u32 idx){
+[[maybe_unused]] HWY_ATTR NPY_FINLINE vec_f32 lut_32_f32(const float * lut, vec_u32 idx){
     if constexpr(hn::Lanes(f32) == 16){
         const vec_f32 lut0 = hn::Load(f32, lut);
         const vec_f32 lut1 = hn::Load(f32, lut + 16);


### PR DESCRIPTION
This patch should close #27983 

It seems some compiler versions complain about the functions `lut_16_f64` and `lut_32_f32` as being unused, as they are only used in certain `if constexpr` branches. Since these functions are used, just in only one branch of a `if constexpr`, I simply marked them as `[[maybe_unused]]` to silence this warning.

@ngoldbaum, can you check if this silences the warning on your system?