### PR TITLE
BUG: Fix float128 FPE handling on ARM64 with Clang compiler

### DIFF
--- a/numpy/_core/src/npymath/npy_math_internal.h.src
+++ b/numpy/_core/src/npymath/npy_math_internal.h.src
@@ -514,6 +514,17 @@ NPY_INPLACE @type@
 npy_remainder@c@(@type@ a, @type@ b)
 {
     @type@ mod;
+#if defined(__aarch64__) && defined(__clang__)
+    /* Special handling for ARM64 with Clang to avoid FPE with float128 */
+     /*
+     * TODO: This is a workaround for a known Clang issue on ARM64 where float128
+     * operations trigger incorrect FPE behavior. This can be removed once fixed:
+     * https://github.com/llvm/llvm-project/issues/59924
+     */
+    if (NPY_UNLIKELY(sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
+        return npy_fmod@c@(a, b);  /* Let hardware handle NaN modulo */
+    }
+#endif
     if (NPY_UNLIKELY(!b)) {
         /*
          * in2 == 0 (and not NaN): normal fmod will give the correct
@@ -531,6 +542,17 @@ npy_remainder@c@(@type@ a, @type@ b)
 NPY_INPLACE @type@
 npy_floor_divide@c@(@type@ a, @type@ b) {
     @type@ div, mod;
+#if defined(__aarch64__) && defined(__clang__)
+    /* Special handling for ARM64 with Clang to avoid FPE with float128 */
+    /*
+     * TODO: This is a workaround for a known Clang issue on ARM64 where float128
+     * operations trigger incorrect FPE behavior. This can be removed once fixed:
+     * https://github.com/llvm/llvm-project/issues/59924
+     */
+    if (NPY_UNLIKELY(sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
+        return a / b;  /* Let hardware handle NaN division */
+    }
+#endif
     if (NPY_UNLIKELY(!b)) {
         /*
          * in2 == 0 (and not NaN): normal division will give the correct

--- a/numpy/_core/src/npymath/npy_math_internal.h.src
+++ b/numpy/_core/src/npymath/npy_math_internal.h.src
@@ -506,6 +506,14 @@ NPY_INPLACE @type@ npy_logaddexp2@c@(@type@ x, @type@ y)
     }
 }
 
+
+/* Define a macro for the ARM64 Clang specific condition */
+#if defined(__aarch64__) && defined(__clang__)
+    #define IS_ARM64_CLANG 1
+#else
+    #define IS_ARM64_CLANG 0
+#endif
+
 /*
  * Wrapper function for remainder edge cases
  * Internally calls npy_divmod*
@@ -514,56 +522,48 @@ NPY_INPLACE @type@
 npy_remainder@c@(@type@ a, @type@ b)
 {
     @type@ mod;
-#if defined(__aarch64__) && defined(__clang__)
-    /* Special handling for ARM64 with Clang to avoid FPE with float128 */
-     /*
-     * TODO: This is a workaround for a known Clang issue on ARM64 where float128
-     * operations trigger incorrect FPE behavior. This can be removed once fixed:
-     * https://github.com/llvm/llvm-project/issues/59924
-     */
-    if (NPY_UNLIKELY(sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
-        return npy_fmod@c@(a, b);  /* Let hardware handle NaN modulo */
-    }
-#endif
-    if (NPY_UNLIKELY(!b)) {
+    
+    if (NPY_UNLIKELY(!b) || 
+        NPY_UNLIKELY(IS_ARM64_CLANG && sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
         /*
-         * in2 == 0 (and not NaN): normal fmod will give the correct
-         * result (always NaN). `divmod` may set additional FPE for the
-         * division by zero creating an inf.
+         * Handle two cases:
+         * 1. in2 == 0 (and not NaN): normal fmod will give the correct
+         *    result (always NaN). `divmod` may set additional FPE for the
+         *    division by zero creating an inf.
+         * 2. ARM64 with Clang: Special handling to avoid FPE with float128
+         *    TODO: This is a workaround for a known Clang issue on ARM64 where 
+         *    float128 operations trigger incorrect FPE behavior. This can be 
+         *    removed once fixed:
+         *    https://github.com/llvm/llvm-project/issues/59924
          */
-        mod = npy_fmod@c@(a, b);
+        return npy_fmod@c@(a, b);
     }
-    else {
-        npy_divmod@c@(a, b, &mod);
-    }
+    
+    npy_divmod@c@(a, b, &mod);
     return mod;
 }
 
 NPY_INPLACE @type@
 npy_floor_divide@c@(@type@ a, @type@ b) {
     @type@ div, mod;
-#if defined(__aarch64__) && defined(__clang__)
-    /* Special handling for ARM64 with Clang to avoid FPE with float128 */
-    /*
-     * TODO: This is a workaround for a known Clang issue on ARM64 where float128
-     * operations trigger incorrect FPE behavior. This can be removed once fixed:
-     * https://github.com/llvm/llvm-project/issues/59924
-     */
-    if (NPY_UNLIKELY(sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
-        return a / b;  /* Let hardware handle NaN division */
-    }
-#endif
-    if (NPY_UNLIKELY(!b)) {
+    
+    if (NPY_UNLIKELY(!b) || 
+        NPY_UNLIKELY(IS_ARM64_CLANG && sizeof(@type@) == sizeof(long double) && (npy_isnan(a) || npy_isnan(b)))) {
         /*
-         * in2 == 0 (and not NaN): normal division will give the correct
-         * result (Inf or NaN). `divmod` may set additional FPE for the modulo
-         * evaluating to NaN.
+         * Handle two cases:
+         * 1. in2 == 0 (and not NaN): normal division will give the correct
+         *    result (Inf or NaN). `divmod` may set additional FPE for the modulo
+         *    evaluating to NaN.
+         * 2. ARM64 with Clang: Special handling to avoid FPE with float128
+         *    TODO: This is a workaround for a known Clang issue on ARM64 where 
+         *    float128 operations trigger incorrect FPE behavior. This can be 
+         *    removed once fixed:
+         *    https://github.com/llvm/llvm-project/issues/59924
          */
-        div = a / b;
+        return a / b;
     }
-    else {
-        div = npy_divmod@c@(a, b, &mod);
-    }
+    
+    div = npy_divmod@c@(a, b, &mod);
     return div;
 }
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1,5 +1,4 @@
 import platform
-import os
 import warnings
 import fnmatch
 import itertools
@@ -38,9 +37,6 @@ UFUNCS_BINARY = [
 UFUNCS_BINARY_ACC = [
     uf for uf in UFUNCS_BINARY if hasattr(uf, "accumulate") and uf.nout == 1
 ]
-
-def is_arm64_clang():
-    return (platform.machine() == 'aarch64' and os.environ.get('CC', '').find('clang') >= 0)
 
 def interesting_binop_operands(val1, val2, dtype):
     """
@@ -668,8 +664,6 @@ class TestDivision:
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     @pytest.mark.parametrize('dtype', np.typecodes['Float'])
     def test_floor_division_errors(self, dtype):
-        if is_arm64_clang() and dtype == 'g':
-            pytest.xfail("Fails on aarch64 with clang compiler and dtype='g' due to FloatingPointError")
         fnan = np.array(np.nan, dtype=dtype)
         fone = np.array(1.0, dtype=dtype)
         fzer = np.array(0.0, dtype=dtype)
@@ -818,8 +812,6 @@ class TestRemainder:
     @pytest.mark.parametrize('dtype', np.typecodes['Float'])
     @pytest.mark.parametrize('fn', [np.fmod, np.remainder])
     def test_float_remainder_errors(self, dtype, fn):
-        if is_arm64_clang() and dtype == 'g':
-            pytest.xfail("Fails on aarch64 with clang compiler and dtype='g' due to FloatingPointError")
         fzero = np.array(0.0, dtype=dtype)
         fone = np.array(1.0, dtype=dtype)
         finf = np.array(np.inf, dtype=dtype)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1,4 +1,5 @@
 import platform
+import os
 import warnings
 import fnmatch
 import itertools
@@ -37,6 +38,9 @@ UFUNCS_BINARY = [
 UFUNCS_BINARY_ACC = [
     uf for uf in UFUNCS_BINARY if hasattr(uf, "accumulate") and uf.nout == 1
 ]
+
+def is_arm64_clang():
+    return (platform.machine() == 'aarch64' and os.environ.get('CC', '').find('clang') >= 0)
 
 def interesting_binop_operands(val1, val2, dtype):
     """
@@ -664,6 +668,8 @@ class TestDivision:
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     @pytest.mark.parametrize('dtype', np.typecodes['Float'])
     def test_floor_division_errors(self, dtype):
+        if is_arm64_clang() and dtype == 'g':
+            pytest.xfail("Fails on aarch64 with clang compiler and dtype='g' due to FloatingPointError")
         fnan = np.array(np.nan, dtype=dtype)
         fone = np.array(1.0, dtype=dtype)
         fzer = np.array(0.0, dtype=dtype)
@@ -812,6 +818,8 @@ class TestRemainder:
     @pytest.mark.parametrize('dtype', np.typecodes['Float'])
     @pytest.mark.parametrize('fn', [np.fmod, np.remainder])
     def test_float_remainder_errors(self, dtype, fn):
+        if is_arm64_clang() and dtype == 'g':
+            pytest.xfail("Fails on aarch64 with clang compiler and dtype='g' due to FloatingPointError")
         fzero = np.array(0.0, dtype=dtype)
         fone = np.array(1.0, dtype=dtype)
         finf = np.array(np.inf, dtype=dtype)


### PR DESCRIPTION
Fixes: #26910 

Reference issue on LLVM related to this : https://github.com/llvm/llvm-project/issues/59924 

**Issue:** When build numpy from source with clang compiler on aarch64 machines, i got the following failure of `test_umath.py` :
```
==================================================================================== FAILURES ====================================================================================
___________________________________________________________________ TestDivision.test_floor_division_errors[g] ___________________________________________________________________

self = <test_umath.TestDivision object at 0xe4d31f7becd0>, dtype = 'g'

    @pytest.mark.skipif(hasattr(np.__config__, "blas_ssl2_info"),
            reason="gh-22982")
    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
    @pytest.mark.parametrize('dtype', np.typecodes['Float'])
    def test_floor_division_errors(self, dtype):
        fnan = np.array(np.nan, dtype=dtype)
        fone = np.array(1.0, dtype=dtype)
        fzer = np.array(0.0, dtype=dtype)
        finf = np.array(np.inf, dtype=dtype)
        # divide by zero error check
        with np.errstate(divide='raise', invalid='ignore'):
            assert_raises(FloatingPointError, np.floor_divide, fone, fzer)
        with np.errstate(divide='ignore', invalid='raise'):
            np.floor_divide(fone, fzer)
    
        # The following already contain a NaN and should not warn
        with np.errstate(all='raise'):
>           np.floor_divide(fnan, fone)
E           FloatingPointError: invalid value encountered in floor_divide

dtype      = 'g'
finf       = array(inf, dtype=float128)
fnan       = array(nan, dtype=float128)
fone       = array(1., dtype=float128)
fzer       = array(0., dtype=float128)
self       = <test_umath.TestDivision object at 0xe4d31f7becd0>

numpy/_core/tests/test_umath.py:679: FloatingPointError
_____________________________________________________________ TestRemainder.test_float_remainder_errors[remainder-g] _____________________________________________________________

self = <test_umath.TestRemainder object at 0xe4d3053aa210>, dtype = 'g', fn = <ufunc 'remainder'>

    @pytest.mark.skipif(hasattr(np.__config__, "blas_ssl2_info"),
            reason="gh-22982")
    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
    @pytest.mark.xfail(sys.platform.startswith("darwin"),
           reason="MacOS seems to not give the correct 'invalid' warning for "
                  "`fmod`.  Hopefully, others always do.")
    @pytest.mark.parametrize('dtype', np.typecodes['Float'])
    @pytest.mark.parametrize('fn', [np.fmod, np.remainder])
    def test_float_remainder_errors(self, dtype, fn):
        fzero = np.array(0.0, dtype=dtype)
        fone = np.array(1.0, dtype=dtype)
        finf = np.array(np.inf, dtype=dtype)
        fnan = np.array(np.nan, dtype=dtype)
    
        # The following already contain a NaN and should not warn.
        with np.errstate(all='raise'):
            with pytest.raises(FloatingPointError,
                    match="invalid value"):
                fn(fone, fzero)
            fn(fnan, fzero)
>           fn(fzero, fnan)
E           FloatingPointError: invalid value encountered in remainder

dtype      = 'g'
finf       = array(inf, dtype=float128)
fn         = <ufunc 'remainder'>
fnan       = array(nan, dtype=float128)
fone       = array(1., dtype=float128)
fzero      = array(0., dtype=float128)
self       = <test_umath.TestRemainder object at 0xe4d3053aa210>

numpy/_core/tests/test_umath.py:826: FloatingPointError
============================================================================ short test summary info =============================================================================
FAILED numpy/_core/tests/test_umath.py::TestDivision::test_floor_division_errors[g] - FloatingPointError: invalid value encountered in floor_divide
FAILED numpy/_core/tests/test_umath.py::TestRemainder::test_float_remainder_errors[remainder-g] - FloatingPointError: invalid value encountered in remainder
=================================================================== 2 failed, 4694 passed, 61 skipped in 8.68s ===================================================================
```

**Change Made:**

Fix floating-point exception (FPE) handling for float128 operations on ARM64 with Clang compiler. Previously, floor division and remainder operations with NaN values would incorrectly trigger floating-point exceptions on this platform.

The fix adds special handling in npy_math_internal.h.src for float128 NaN operations on ARM64 with Clang:
- Bypass additional FPE checks for NaN values
- Let hardware handle NaN division and modulo operations directly
- Only affects ARM64 + Clang + float128 combination

This resolves test failures in TestDivision.test_floor_division_errors and TestRemainder.test_float_remainder_errors when running with float128 on ARM64 platforms using the Clang compiler.
