### PR TITLE
BLD: Compile fix for clang-cl on WoA

### DIFF
--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -1877,7 +1877,8 @@ get_fpu_mode(PyObject *NPY_UNUSED(self), PyObject *args)
         result = _controlfp(0, 0);
         return PyLong_FromLongLong(result);
     }
-#elif (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) || (defined(_MSC_VER) && defined(__clang__))
+#elif (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) \
+  || (defined(_MSC_VER) && defined(__clang__) && !defined(__ARM_ARCH))
     {
         unsigned short cw = 0;
         __asm__("fstcw %w0" : "=m" (cw));


### PR DESCRIPTION
Backport of #28235.

Do not try and use x86 FPU instruction on ARM. See : #28106

This is a partial fix for WoA compiles.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
