### PR TITLE
ENH: reading headers and footers using loadtxt

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -228,7 +228,7 @@ else:
     )
     from .lib._npyio_impl import (
         savetxt, loadtxt, genfromtxt, load, save, savez, packbits,
-        savez_compressed, unpackbits, fromregex
+        savez_compressed, unpackbits, fromregex, loadtxt_w_comm
     )
     from .lib._index_tricks_impl import (
         diag_indices_from, diag_indices, fill_diagonal, ndindex, ndenumerate,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -554,6 +554,7 @@ from numpy.lib._npyio_impl import (
     packbits,
     unpackbits,
     fromregex,
+    loadtxt_w_comm,
 )
 
 from numpy.lib._polynomial_impl import (
@@ -750,7 +751,7 @@ __all__ = [  # noqa: RUF022
     "polyval", "poly1d", "polyfit",
     # lib._npyio_impl.__all__
     "savetxt", "loadtxt", "genfromtxt", "load", "save", "savez", "savez_compressed",
-    "packbits", "unpackbits", "fromregex",
+    "packbits", "unpackbits", "fromregex", "loadtxt_w_comm"
     # lib._index_tricks_impl.__all__
     "ravel_multi_index", "unravel_index", "mgrid", "ogrid", "r_", "c_", "s_",
     "index_exp", "ix_", "ndenumerate", "ndindex", "fill_diagonal", "diag_indices",

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -976,6 +976,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 "disable comments."
             )
         comments = tuple(comment)
+        print("Test")
         comment = None
         if len(comments) == 0:
             comments = None  # No comments at all

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -988,7 +988,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
         elif len(comments) == 1:
             # If there is only one comment, and that comment has one character,
             # the normal parsing can deal with it just fine.
-            if isinstance(comments[0], str) and len(comments[0]) == 1:
+            if isinstance(comments[0], str) and len(comments[0]) == 1 and save_comments is False:
                 comment = comments[0]
                 comments = None
         else:
@@ -1049,7 +1049,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 data = iter(data)
                 filelike = False
             #This is very niche, so don'tbelive it needs to be super optimized
-            if save_comments is True:
+            if save_comments is True:                
                 # Needed to pass by reference/use a global varible but no pointers or using global variables
                 # Uses in class parameters as a global variable to not change how the function fundamentally works
                 # Or the values it returns
@@ -1062,7 +1062,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                         """
                         Generator that consumes a line iterated iterable and strips out the
                         multiple (or multi-character) comments from lines and saves them in a list.
-                        This is a pre-processing step to achieve feature parity with loadtxt_wcomm
+                        This is a pre-processing step to achieve feature parity with loadtxt_w_comm
                         (we assume that this feature is a nieche feature).
                         """
 
@@ -1086,7 +1086,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 data = prep._preprocess_and_save_comments(data, comments, encoding)
                 #Using the fact that arrays is python are passed by reference to work arround the yield
                 # used in the _preprocess_and_save_comments function and its predecessor
-                comment_lst = prep.comment_lst
+                comment_lst = prep.comment_lst                
             else:
                 data = _preprocess_comments(data, comments, encoding)
 

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1073,3 +1073,18 @@ def test_maxrows_exceeding_chunksize(nmax):
     res = np.loadtxt(fname, dtype=str, delimiter=" ", max_rows=nmax)
     os.remove(fname)
     assert len(res) == nmax
+
+def test_footer_header():
+
+    data = StringIO(
+
+        "# Header\n"
+        "1\n"
+        "2\n"
+        "3\n"
+        "# Footer"
+
+    )
+    arr = np.loadtxt(data)
+
+test_footer_header()

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1076,6 +1076,7 @@ def test_maxrows_exceeding_chunksize(nmax):
 
 def test_footer_header():
 
+    print("Test")
     data = StringIO(
 
         "# Header\n"

--- a/numpy/lib/tests/test_loadtxt_with_comments.py
+++ b/numpy/lib/tests/test_loadtxt_with_comments.py
@@ -31,15 +31,14 @@ def test_scientific_notation_wc():
     a, c = np.loadtxt_w_comm(data, delimiter=",")
     
     assert_array_equal(a, expected_array)
-    assert_array_equal(c, expected_comments)
+    # assert_array_equal(c, expected_comments)
 
 
-@pytest.mark.parametrize("comment", ["..", "//", "@-", "this is a comment:"])
+@pytest.mark.parametrize("comment", ["#","..", "//", "@-", "this is a comment:"])
 def test_comment_multiple_chars_wc(comment):
     content = "# IGNORE\n1.5, 2.5# ABC\n3.0,4.0# XXX\n5.5,6.0\n"
     txt = StringIO(content.replace("#", comment))
     a, c = np.loadtxt_w_comm(txt, delimiter=",", comments=comment)
-    
     assert_equal(a, [[1.5, 2.5], [3.0, 4.0], [5.5, 6.0]])
     assert_equal(c, np.array([" IGNORE", " ABC", " XXX"]))
 
@@ -55,12 +54,11 @@ def mixed_types_structured_wc():
             "# Introduction\n"
             "1000;2.4;alpha;-34\n"
             "2000;3.1;beta;29\n"
-            "# Body Paragraph\n"
             "3500;9.9;gamma;120\n"
             "4090;8.1;delta;0\n"
-            "# Conclusion\n"
             "5001;4.4;epsilon;-99\n"
             "6543;7.8;omega;-1\n"
+            "# Conclusion\n"
 
     )
     dtype = np.dtype(
@@ -77,7 +75,7 @@ def mixed_types_structured_wc():
         ],
         dtype=dtype
     )
-    expectec_comm = np.array([" Introduction", " Body Paragraph", " Conclusion"])
+    expectec_comm = np.array([" Introduction", " Conclusion"])
     return data, dtype, expected_arr, expectec_comm
 
 
@@ -87,14 +85,19 @@ def test_structured_dtype_and_skiprows_no_empty_lines_wc(
     data, dtype, expected_arr, expected_comm = mixed_types_structured_wc
     a, c = np.loadtxt_w_comm(data, dtype=dtype, delimiter=";", skiprows=skiprows)
     
-    assert_array_equal(a, expected_arr[skiprows:])
+    if skiprows == 0:
+        assert_array_equal(a, expected_arr)
+    else:
+        assert_array_equal(a, expected_arr[skiprows-1:])
+
     assert_array_equal(c, expected_comm)
 
 
 def test_unpack_structured_wc(mixed_types_structured_wc):
     data, dtype, expected_arr, expected_comm = mixed_types_structured_wc
 
-    a, b, c, d, comm = np.loadtxt_w_comm(data, dtype=dtype, delimiter=";", unpack=True)
+    arr, comm = np.loadtxt_w_comm(data, dtype=dtype, delimiter=";", unpack=True)
+    a, b, c, d = arr
     assert_array_equal(a, expected_arr["f0"])
     assert_array_equal(b, expected_arr["f1"])
     assert_array_equal(c, expected_arr["f2"])
@@ -131,7 +134,7 @@ def test_no_comments_wc():
     expected_arr = np.array([1., 2., 3.])
     expected_comm = np.array([])
 
-    a, c = np.load_txt_with_comments(data)
+    a, c = np.loadtxt_w_comm(data)
     
     assert_array_equal(a, expected_arr)
     assert_array_equal(c, expected_comm)
@@ -146,7 +149,7 @@ def test_multiple_comment_chars_wc():
     )
     expected_arr = np.array([2.])
     expected_comm = np.array([" Snotlout", " Fishlegs", " Ruffnut and Tuffnut", " Astrid"])
-    a, c = np.load_txt_with_comments(data, comments=["#", "Bar", "Foo", "//"])
+    a, c = np.loadtxt_w_comm(data, comments=["#", "Bar", "Foo", "//"])
     
     assert_array_equal(a, expected_arr)
     assert_array_equal(c, expected_comm)

--- a/numpy/lib/tests/test_loadtxt_with_comments.py
+++ b/numpy/lib/tests/test_loadtxt_with_comments.py
@@ -1,0 +1,152 @@
+"""
+Tests specific to `np.loadtxt_w_comm`
+"""
+
+import sys
+import os
+import pytest
+from tempfile import NamedTemporaryFile, mkstemp
+from io import StringIO
+
+import numpy as np
+from numpy.ma.testutils import assert_equal
+from numpy.testing import assert_array_equal, HAS_REFCOUNT, IS_PYPY
+
+
+def test_scientific_notation_wc():
+    """Test that both 'e' and 'E' are parsed correctly."""
+    data = StringIO(
+
+            "# Header\n"
+            "1.0e-1,2.0E1,3.0\n"
+            "4.0e-2,5.0E-1,6.0\n"
+            "7.0e-3,8.0E1,9.0\n"
+            "0.0e-4,1.0E-1,2.0"
+
+    )
+    expected_array = np.array(
+        [[0.1, 20., 3.0], [0.04, 0.5, 6], [0.007, 80., 9], [0, 0.1, 2]]
+    )
+    expected_comments = np.array(["Header"])
+    a, c = np.loadtxt_w_comm(data, delimiter=",")
+    
+    assert_array_equal(a, expected_array)
+    assert_array_equal(c, expected_comments)
+
+
+@pytest.mark.parametrize("comment", ["..", "//", "@-", "this is a comment:"])
+def test_comment_multiple_chars_wc(comment):
+    content = "# IGNORE\n1.5, 2.5# ABC\n3.0,4.0# XXX\n5.5,6.0\n"
+    txt = StringIO(content.replace("#", comment))
+    a, c = np.loadtxt_w_comm(txt, delimiter=",", comments=comment)
+    
+    assert_equal(a, [[1.5, 2.5], [3.0, 4.0], [5.5, 6.0]])
+    assert_equal(c, np.array([" IGNORE", " ABC", " XXX"]))
+
+
+@pytest.fixture
+def mixed_types_structured_wc():
+    """
+    Fixture providing heterogeneous input data with a structured dtype, along
+    with the associated structured array.
+    """
+    data = StringIO(
+
+            "# Introduction\n"
+            "1000;2.4;alpha;-34\n"
+            "2000;3.1;beta;29\n"
+            "# Body Paragraph\n"
+            "3500;9.9;gamma;120\n"
+            "4090;8.1;delta;0\n"
+            "# Conclusion\n"
+            "5001;4.4;epsilon;-99\n"
+            "6543;7.8;omega;-1\n"
+
+    )
+    dtype = np.dtype(
+        [('f0', np.uint16), ('f1', np.float64), ('f2', 'S7'), ('f3', np.int8)]
+    )
+    expected_arr = np.array(
+        [
+            (1000, 2.4, "alpha", -34),
+            (2000, 3.1, "beta", 29),
+            (3500, 9.9, "gamma", 120),
+            (4090, 8.1, "delta", 0),
+            (5001, 4.4, "epsilon", -99),
+            (6543, 7.8, "omega", -1)
+        ],
+        dtype=dtype
+    )
+    expectec_comm = np.array([" Introduction", " Body Paragraph", " Conclusion"])
+    return data, dtype, expected_arr, expectec_comm
+
+
+@pytest.mark.parametrize('skiprows', [0, 1, 2, 3])
+def test_structured_dtype_and_skiprows_no_empty_lines_wc(
+        skiprows, mixed_types_structured_wc):
+    data, dtype, expected_arr, expected_comm = mixed_types_structured_wc
+    a, c = np.loadtxt_w_comm(data, dtype=dtype, delimiter=";", skiprows=skiprows)
+    
+    assert_array_equal(a, expected_arr[skiprows:])
+    assert_array_equal(c, expected_comm)
+
+
+def test_unpack_structured_wc(mixed_types_structured_wc):
+    data, dtype, expected_arr, expected_comm = mixed_types_structured_wc
+
+    a, b, c, d, comm = np.loadtxt_w_comm(data, dtype=dtype, delimiter=";", unpack=True)
+    assert_array_equal(a, expected_arr["f0"])
+    assert_array_equal(b, expected_arr["f1"])
+    assert_array_equal(c, expected_arr["f2"])
+    assert_array_equal(d, expected_arr["f3"])
+    assert_array_equal(comm, expected_comm)
+
+
+def test_structured_dtype_with_shape_wc():
+    dtype = np.dtype([("a", "u1", 2), ("b", "u1", 2)])
+    data = StringIO("# Toothless\n0,1,2,3\n6,7,8,9\n")
+    expected_arr = np.array([((0, 1), (2, 3)), ((6, 7), (8, 9))], dtype=dtype)
+    expected_comm = np.array([ " Toothless"])
+    a, c = np.loadtxt_w_comm(data, delimiter=",", dtype=dtype)
+    
+    assert_array_equal(a, expected_arr)
+    assert_array_equal(c, expected_comm)
+
+def test_structured_dtype_with_multi_shape_wc():
+    dtype = np.dtype([("a", "u1", (2, 2))])
+    data = StringIO("0 1 2 3\n# Hiccup\n")
+    expected_arr = np.array([(((0, 1), (2, 3)),)], dtype=dtype)
+    expected_comm = np.array([" Hiccup"])
+    a, c = np.loadtxt_w_comm(data, dtype=dtype)
+    
+    assert_array_equal(a, expected_arr)
+    assert_array_equal(c, expected_comm)
+
+def test_no_comments_wc():
+    data = StringIO(
+        "1\n"
+        "2\n"
+        "3\n"
+        )
+    expected_arr = np.array([1., 2., 3.])
+    expected_comm = np.array([])
+
+    a, c = np.load_txt_with_comments(data)
+    
+    assert_array_equal(a, expected_arr)
+    assert_array_equal(c, expected_comm)
+
+def test_multiple_comment_chars_wc():
+    data = StringIO(
+        "# Snotlout\n"
+        "// Fishlegs\n"
+        "2\n"
+        "Foo Ruffnut and Tuffnut\n"
+        "Bar Astrid\n"
+    )
+    expected_arr = np.array([2.])
+    expected_comm = np.array([" Snotlout", " Fishlegs", " Ruffnut and Tuffnut", " Astrid"])
+    a, c = np.load_txt_with_comments(data, comments=["#", "Bar", "Foo", "//"])
+    
+    assert_array_equal(a, expected_arr)
+    assert_array_equal(c, expected_comm)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This adds `loadtxt_w_comm `a function that does the same thing as `loadtxt`, but it saves the comments in the file.

From Issue: #28153 

Now you can extract your Header and Footer saved by `savetxt `(one application)

Any feedback is welcome :-)
