### PR TITLE
BLD: better fix for clang / ARM compiles

### DIFF
--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -1878,7 +1878,8 @@ get_fpu_mode(PyObject *NPY_UNUSED(self), PyObject *args)
         return PyLong_FromLongLong(result);
     }
 #elif (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) \
-  || (defined(_MSC_VER) && defined(__clang__) && !defined(__ARM_ARCH))
+  || (defined(_MSC_VER) && defined(__clang__) && \
+      (defined(_M_IX86) || defined(_M_AMD64)))
     {
         unsigned short cw = 0;
         __asm__("fstcw %w0" : "=m" (cw));


### PR DESCRIPTION
A more principled fix for the WoA build than https://github.com/numpy/numpy/pull/28235.

The `_M_IX86` and `_M_AMD64` macros defined for x86 and x64 builds respectively.

`_M_AMD64` defined for AMD and x86_64 installs.

See:
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
