### PR TITLE
ENH: AXV512 SIMD optimizations for float power fast paths

### DIFF
--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -249,13 +249,20 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
             npyv_loadable_stride_@sfx@(steps[0]) &&
             npyv_storable_stride_@sfx@(steps[2])
         ) {
-            npyv_@sfx@ srcv = npyv_load_till_@sfx@(src, dimensions[0], 0);
-            npyv_@sfx@ dstv = npyv_load_till_@sfx@(dst, dimensions[0], 0);
+            const npy_intp ssrc = steps[0] / sizeof(@type@);
+            const npy_intp sdst = steps[2] / sizeof(@type@);
 
-            if (*exp == -1.0) {
-                dstv = npyv_recip_@sfx@(srcv);
+            npyv_@sfx@ srcv;
+            npyv_@sfx@ dstv;
+
+            if (ssrc == 1) {
+                srcv = npyv_load_till_@sfx@(src, dimensions[0], 0);
+            } 
+            else {
+                srcv = npyv_loadn_till_@sfx@(src, ssrc, dimensions[0], 0);
             }
-            else if (*exp == 0.0) {
+
+            if (*exp == 0.0) {
                 dstv = npyv_setall_@sfx@(1.0);
             }
             else if (*exp == 0.5) {
@@ -272,7 +279,12 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
             }
             
             if (fastop_found) {
-                npyv_store_till_@sfx@(dst, dimensions[0], dstv);
+                if (sdst == 1) {
+                    npyv_store_till_@sfx@(dst, dimensions[0], dstv);
+                }
+                else {
+                    npyv_storen_till_@sfx@(dst, sdst, dimensions[0], dstv);
+                }
                 return;
             }
         }
@@ -282,10 +294,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
         const @type@ in2 = *(@type@ *)ip2;
         BINARY_LOOP_SLIDING {
             const @type@ in1 = *(@type@ *)ip1;
-            if (in2 == -1.0) {
-                *(@type@ *)op1 = 1.0 / in1;
-            }
-            else if (in2 == 0.0) {
+            if (in2 == 0.0) {
                 *(@type@ *)op1 = 1.0;
             }
             else if (in2 == 0.5) {

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -63,6 +63,52 @@ simd_@func@_@sfx@(const npyv_lanetype_@sfx@ *src, npy_intp ssrc,
  * #sfx = f32, f64#
  * #func_suffix = f16, 8_ha#
  */
+
+static inline int
+simd_fast_power_@sfx@(const npyv_lanetype_@sfx@ *src, npy_intp ssrc,
+                      const npyv_lanetype_@sfx@ *exp,
+                      npyv_lanetype_@sfx@ *dst, npy_intp sdst, npy_intp len)
+{
+    npyv_@sfx@ srcv;
+    npyv_@sfx@ dstv;
+
+    if (ssrc == 1) {
+        srcv = npyv_load_till_@sfx@(src, len, 0.0);
+    }
+    else {
+        srcv = npyv_loadn_till_@sfx@(src, ssrc, len, 0.0);
+    }
+    
+    if (*exp == 0.0) {
+        dstv = npyv_setall_@sfx@(1.0);
+    }
+    else if (*exp == 0.5) {
+        dstv = npyv_sqrt_@sfx@(srcv);
+    }
+    else if (*exp == 1.0) {
+        dstv = srcv;
+    }
+    else if (*exp == 2.0) {
+        dstv = npyv_square_@sfx@(srcv);
+    }
+    else {
+        return -1;
+    }
+
+    if (sdst == 1) {
+        npyv_store_till_@sfx@(dst, len, dstv);
+    }
+    else {
+        npyv_storen_till_@sfx@(dst, sdst, len, dstv);
+    }
+    return 0;
+}
+                       
+
+/**begin repeat
+ * #sfx = f32, f64#
+ * #func_suffix = f16, 8_ha#
+ */
 /**begin repeat1
  * #func = pow, atan2#
  */
@@ -236,59 +282,37 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
     int stride_zero = steps[1]==0;
-    if (stride_zero) {
-        int fastop_found = 1;
 
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX)
-        const @type@ *src = (@type@*)args[0];
-        const @type@ *exp = (@type@*)args[1];
-              @type@ *dst = (@type@*)args[2];
+#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+    const @type@ *src1 = (@type@*)args[0];
+    const @type@ *src2 = (@type@*)args[1];
+          @type@ *dst  = (@type@*)args[2];
 
-        if (!is_mem_overlap(src, steps[0], dst, steps[2], dimensions[0]) &&
-            !is_mem_overlap(exp, steps[1], dst, steps[2], dimensions[0]) &&
-            npyv_loadable_stride_@sfx@(steps[0]) &&
-            npyv_storable_stride_@sfx@(steps[2])
-        ) {
-            const npy_intp ssrc = steps[0] / sizeof(@type@);
-            const npy_intp sdst = steps[2] / sizeof(@type@);
+    const npy_intp len = dimensions[0];
 
-            npyv_@sfx@ srcv;
-            npyv_@sfx@ dstv;
+    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) &&
+        !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
+        npyv_loadable_stride_@sfx@(steps[0]) &&
+        npyv_loadable_stride_@sfx@(steps[1]) &&
+        npyv_storable_stride_@sfx@(steps[2])
+    ) {
+        const npy_intp ssrc1 = steps[0] / sizeof(@type@);
+        const npy_intp ssrc2 = steps[1] / sizeof(@type@);
+        const npy_intp sdst  = steps[2] / sizeof(@type@);
 
-            if (ssrc == 1) {
-                srcv = npyv_load_till_@sfx@(src, dimensions[0], 0);
-            } 
-            else {
-                srcv = npyv_loadn_till_@sfx@(src, ssrc, dimensions[0], 0);
-            }
-
-            if (*exp == 0.0) {
-                dstv = npyv_setall_@sfx@(1.0);
-            }
-            else if (*exp == 0.5) {
-                dstv = npyv_sqrt_@sfx@(srcv);
-            }
-            else if (*exp == 1.0) {
-                dstv = srcv;
-            }
-            else if (*exp == 2.0) {
-                dstv = npyv_square_@sfx@(srcv);
-            }
-            else {
-                fastop_found = 0;
-            }
-            
-            if (fastop_found) {
-                if (sdst == 1) {
-                    npyv_store_till_@sfx@(dst, dimensions[0], dstv);
-                }
-                else {
-                    npyv_storen_till_@sfx@(dst, sdst, dimensions[0], dstv);
-                }
+        if (stride_zero) {            
+            if (simd_fast_power_@sfx@(src1, ssrc1, src2, dst, sdst, len) == 0) {
                 return;
             }
         }
+
+        simd_@intrin@_@sfx@(src1, ssrc1, src2, ssrc2, dst, sdst, len);
+        return;
+    }
 #endif
+
+    if (stride_zero) {
+        int fastop_found = 1;
 
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
@@ -315,27 +339,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
             return;
         }
     }
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
-    const @type@ *src1 = (@type@*)args[0];
-    const @type@ *src2 = (@type@*)args[1];
-          @type@ *dst  = (@type@*)args[2];
 
-    const npy_intp len = dimensions[0];
-
-    if (!is_mem_overlap(src1, steps[0], dst, steps[2], len) &&
-        !is_mem_overlap(src2, steps[1], dst, steps[2], len) &&
-        npyv_loadable_stride_@sfx@(steps[0]) &&
-        npyv_loadable_stride_@sfx@(steps[1]) &&
-        npyv_storable_stride_@sfx@(steps[2])
-    ) {
-        const npy_intp ssrc1 = steps[0] / sizeof(@type@);
-        const npy_intp ssrc2 = steps[1] / sizeof(@type@);
-        const npy_intp sdst  = steps[2] / sizeof(@type@);
-
-        simd_@intrin@_@sfx@(src1, ssrc1, src2, ssrc2, dst, sdst, len);
-        return;
-    }
-#endif
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -237,9 +237,30 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 {
     int stride_zero = steps[1]==0;
     if (stride_zero) {
+        int fastop_found = 1;
+
+#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+        const @type@ *src = (@type@*)args[0];
+        const @type@ *exp = (@type@*)args[1];
+              @type@ *dst = (@type@*)args[2];
+
+        if (!is_mem_overlap(src, steps[0], dst, steps[2], dimensions[0]) &&
+            !is_mem_overlap(exp, steps[1], dst, steps[2], dimensions[0]) &&
+            npyv_loadable_stride_@sfx@(steps[0]) &&
+            npyv_storable_stride_@sfx@(steps[2])
+        ) {
+            const npy_intp ssrc = steps[0] / sizeof(@type@);
+            const npy_intp sdst = steps[2] / sizeof(@type@);
+
+            if (*exp == 2) {
+                simd_exp2_@sfx@(src, ssrc, dst, sdst, dimensions[0]);
+                return;
+            }
+        }
+#endif
+
         BINARY_DEFS
         const @type@ in2 = *(@type@ *)ip2;
-        int fastop_found = 1;
         BINARY_LOOP_SLIDING {
             const @type@ in1 = *(@type@ *)ip1;
             if (in2 == -1.0) {

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -239,7 +239,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     if (stride_zero) {
         int fastop_found = 1;
 
-#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX) && defined(NPY_CAN_LINK_SVML)
+#if NPY_SIMD && defined(NPY_HAVE_AVX512_SKX)
         const @type@ *src = (@type@*)args[0];
         const @type@ *exp = (@type@*)args[1];
               @type@ *dst = (@type@*)args[2];

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -249,11 +249,30 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
             npyv_loadable_stride_@sfx@(steps[0]) &&
             npyv_storable_stride_@sfx@(steps[2])
         ) {
-            const npy_intp ssrc = steps[0] / sizeof(@type@);
-            const npy_intp sdst = steps[2] / sizeof(@type@);
+            npyv_@sfx@ srcv = npyv_load_till_@sfx@(src, dimensions[0], 0);
+            npyv_@sfx@ dstv = npyv_load_till_@sfx@(dst, dimensions[0], 0);
 
-            if (*exp == 2) {
-                simd_exp2_@sfx@(src, ssrc, dst, sdst, dimensions[0]);
+            if (*exp == -1.0) {
+                dstv = npyv_recip_@sfx@(srcv);
+            }
+            else if (*exp == 0.0) {
+                dstv = npyv_setall_@sfx@(1.0);
+            }
+            else if (*exp == 0.5) {
+                dstv = npyv_sqrt_@sfx@(srcv);
+            }
+            else if (*exp == 1.0) {
+                dstv = srcv;
+            }
+            else if (*exp == 2.0) {
+                dstv = npyv_square_@sfx@(srcv);
+            }
+            else {
+                fastop_found = 0;
+            }
+            
+            if (fastop_found) {
+                npyv_store_till_@sfx@(dst, dimensions[0], dstv);
                 return;
             }
         }

--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -69,37 +69,40 @@ simd_fast_power_@sfx@(const npyv_lanetype_@sfx@ *src, npy_intp ssrc,
                       const npyv_lanetype_@sfx@ *exp,
                       npyv_lanetype_@sfx@ *dst, npy_intp sdst, npy_intp len)
 {
-    npyv_@sfx@ srcv;
-    npyv_@sfx@ dstv;
+    const int vstep = npyv_nlanes_@sfx@;
+    for (; len > 0; len -= vstep, src += ssrc*vstep, dst += sdst*vstep) {   
+        npyv_@sfx@ srcv;
+        npyv_@sfx@ dstv;
 
-    if (ssrc == 1) {
-        srcv = npyv_load_till_@sfx@(src, len, 0.0);
-    }
-    else {
-        srcv = npyv_loadn_till_@sfx@(src, ssrc, len, 0.0);
-    }
-    
-    if (*exp == 0.0) {
-        dstv = npyv_setall_@sfx@(1.0);
-    }
-    else if (*exp == 0.5) {
-        dstv = npyv_sqrt_@sfx@(srcv);
-    }
-    else if (*exp == 1.0) {
-        dstv = srcv;
-    }
-    else if (*exp == 2.0) {
-        dstv = npyv_square_@sfx@(srcv);
-    }
-    else {
-        return -1;
-    }
+        if (ssrc == 1) {
+            srcv = npyv_load_till_@sfx@(src, len, 0.0);
+        }
+        else {
+            srcv = npyv_loadn_till_@sfx@(src, ssrc, len, 0.0);
+        }
+        
+        if (*exp == 0.0) {
+            dstv = npyv_setall_@sfx@(1.0);
+        }
+        else if (*exp == 0.5) {
+            dstv = npyv_sqrt_@sfx@(srcv);
+        }
+        else if (*exp == 1.0) {
+            dstv = srcv;
+        }
+        else if (*exp == 2.0) {
+            dstv = npyv_square_@sfx@(srcv);
+        }
+        else {
+            return -1;
+        }
 
-    if (sdst == 1) {
-        npyv_store_till_@sfx@(dst, len, dstv);
-    }
-    else {
-        npyv_storen_till_@sfx@(dst, sdst, len, dstv);
+        if (sdst == 1) {
+            npyv_store_till_@sfx@(dst, len, dstv);
+        }
+        else {
+            npyv_storen_till_@sfx@(dst, sdst, len, dstv);
+        }
     }
     return 0;
 }

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1261,7 +1261,8 @@ class TestPower:
     def test_large_fast_power(self):
         # gh-28248
         for dt in [np.float32, np.float64]:
-            a = np.random.uniform(1, 4, 1000).astype(dt)
+            rng = np.random.default_rng(42)
+            a = rng.uniform(1, 4, 1000).astype(dt)
 
             result = np.power(a, 2)
             assert_array_equal(result, a * a)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1258,6 +1258,17 @@ class TestPower:
             result = np.power(a, 0.5)
             assert_array_max_ulp(result, expected, maxulp=1)
 
+    def test_large_fast_power(self):
+        # gh-28248
+        for dt in [np.float32, np.float64]:
+            a = np.random.uniform(1, 4, 1000).astype(dt)
+
+            result = np.power(a, 2)
+            assert_array_equal(result, a * a)
+
+            result = np.power(a, 0.5)
+            assert_array_equal(result, np.sqrt(a))
+
 
 class TestFloat_power:
     def test_type_conversion(self):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1268,7 +1268,7 @@ class TestPower:
             assert_array_equal(result, a * a)
 
             result = np.power(a, 0.5)
-            assert_array_max_ulp(result, np.sqrt(a), maxulp=1)
+            assert_array_max_ulp(result, np.sqrt(a), maxulp=2)
 
 
 class TestFloat_power:

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1267,7 +1267,7 @@ class TestPower:
             assert_array_equal(result, a * a)
 
             result = np.power(a, 0.5)
-            assert_array_equal(result, np.sqrt(a))
+            assert_array_max_ulp(result, np.sqrt(a), maxulp=1)
 
 
 class TestFloat_power:


### PR DESCRIPTION
Adds SIMD optimizations to float power fast paths (`np.power`) under AXV512.

This is shared somewhat as a start, since I wondered if this optimization is too granular and complicates things; though I think these are common enough to be valuable. It can be cleaned up further once we have optimizations for `np.reciprocal`,`np.square`, etc.

Thank you for reviewing!