### PR TITLE
DOC: Change the scientific page link in NumPy/MATLAB

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -813,7 +813,7 @@ Another somewhat outdated MATLAB/NumPy cross-reference can be found at
 http://mathesaurus.sf.net/
 
 An extensive list of tools for scientific work with Python can be
-found in the `topical software page <https://scipy.org/topical-software.html>`__.
+found in the `topical software page <https://projects.scipy.org/topical-software.html>`__.
 
 See
 `List of Python software: scripting


### PR DESCRIPTION
In the `numpy-for-matlab-users.rst`, the topical software page has moved.

New link: https://projects.scipy.org/topical-software.html

Old link does not work.
https://scipy.org/topical-software.html

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
