### PR TITLE
DOC: Remove an invalid link in f2py-examples.rst

### DIFF
--- a/doc/source/f2py/f2py-examples.rst
+++ b/doc/source/f2py/f2py-examples.rst
@@ -241,7 +241,6 @@ Read more
 
 * `Wrapping C codes using f2py <https://scipy.github.io/old-wiki/pages/Cookbook/f2py_and_NumPy.html>`_
 * `F2py section on the SciPy Cookbook <https://scipy-cookbook.readthedocs.io/items/F2Py.html>`_
-* `F2py example: Interactive System for Ice sheet Simulation <http://websrv.cs.umt.edu/isis/index.php/F2py_example>`_
 * `"Interfacing With Other Languages" section on the SciPy Cookbook.
   <https://scipy-cookbook.readthedocs.io/items/idx_interfacing_with_other_languages.html>`_
 


### PR DESCRIPTION
Let's remove this invalid link in the Read More section of `f2py-examples.rst`:
http://websrv.cs.umt.edu/isis/index.php 

The only place I found the "F2py example: Interactive System for Ice sheet Simulation" is on an old wiki page for SciPy:
https://scipy.github.io/old-wiki/pages/Cookbook/F2Py.html


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
