### PR TITLE
[doc] Mention exceptions that can be raised by numpy.load upon corrup…

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -379,6 +379,11 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
     EOFError
         When calling ``np.load`` multiple times on the same file handle,
         if all data has already been read
+    tokenize.TokenError
+    zipfile.BadZipFile
+    IndentationError
+    ValueError
+        If the input file is corrupted.
 
     See Also
     --------


### PR DESCRIPTION
…ted files

While fuzzing numpy.load through https://github.com/google/oss-fuzz/pull/13001, I realized that some exceptions could be raised upon malformed .npy files but were not documented.

This patch documents those exceptions.

