### PR TITLE
TYP: Fixed missing typing information of set_printoptions

### DIFF
--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -65,7 +65,7 @@ def set_printoptions(
     sign: Literal["-", "+", " "] | None = ...,
     floatmode: None | _FloatMode = ...,
     *,
-    legacy: Literal[False, "1.13", "1.21"] | None = ...,
+    legacy: Literal[False, "1.13", "1.21", "1.25", "2.1"] | None = ...,
     override_repr: None | Callable[[NDArray[Any]], str] = ...,
 ) -> None: ...
 def get_printoptions() -> _FormatOptions: ...


### PR DESCRIPTION
Added the "1.25" and "2.1" legacy options to `set_printoptions` typing information.
This is already documented and supported in the actual functions, just the type-stubs information was missing