### PR TITLE
TYP: Fix scalar constructors

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4134,6 +4134,9 @@ float32: TypeAlias = floating[_32Bit]
 
 # either a C `double`, `float`, or `longdouble`
 class float64(floating[_64Bit], float):  # type: ignore[misc]
+    def __new__(cls, x: _ConvertibleToFloat | None = ..., /) -> Self: ...
+
+    #
     @property
     def itemsize(self) -> L[8]: ...
     @property
@@ -4268,7 +4271,15 @@ longdouble: TypeAlias = floating[_NBitLongDouble]
 # describing the two 64 bit floats representing its real and imaginary component
 
 class complexfloating(inexact[_NBit1, complex], Generic[_NBit1, _NBit2]):
-    def __init__(self, value: _ConvertibleToComplex | None = ..., /) -> None: ...
+    @overload
+    def __init__(
+        self,
+        real: complex | SupportsComplex | SupportsFloat | SupportsIndex = ...,
+        imag: complex | SupportsFloat | SupportsIndex = ...,
+        /,
+    ) -> None: ...
+    @overload
+    def __init__(self, real: _ConvertibleToComplex | None = ..., /) -> None: ...
 
     @property
     def real(self) -> floating[_NBit1]: ...  # type: ignore[override]
@@ -4352,6 +4363,17 @@ class complexfloating(inexact[_NBit1, complex], Generic[_NBit1, _NBit2]):
 complex64: TypeAlias = complexfloating[_32Bit, _32Bit]
 
 class complex128(complexfloating[_64Bit, _64Bit], complex):  # type: ignore[misc]
+    @overload
+    def __new__(
+        cls,
+        real: complex | SupportsComplex | SupportsFloat | SupportsIndex = ...,
+        imag: complex | SupportsFloat | SupportsIndex = ...,
+        /,
+    ) -> Self: ...
+    @overload
+    def __new__(cls, real: _ConvertibleToComplex | None = ..., /) -> Self: ...
+
+    #
     @property
     def itemsize(self) -> L[16]: ...
     @property
@@ -4706,12 +4728,26 @@ class character(flexible[_CharacterItemT_co], Generic[_CharacterItemT_co]):
 
 class bytes_(character[bytes], bytes):
     @overload
-    def __init__(self, value: object = ..., /) -> None: ...
+    def __new__(cls, o: object = ..., /) -> Self: ...
     @overload
-    def __init__(self, value: str, /, encoding: str = ..., errors: str = ...) -> None: ...
+    def __new__(cls, s: str, /, encoding: str, errors: str = ...) -> Self: ...
+
+    #
+    @overload
+    def __init__(self, o: object = ..., /) -> None: ...
+    @overload
+    def __init__(self, s: str, /, encoding: str, errors: str = ...) -> None: ...
+
+    #
     def __bytes__(self, /) -> bytes: ...
 
 class str_(character[str], str):
+    @overload
+    def __new__(cls, value: object = ..., /) -> Self: ...
+    @overload
+    def __new__(cls, value: bytes, /, encoding: str = ..., errors: str = ...) -> Self: ...
+
+    #
     @overload
     def __init__(self, value: object = ..., /) -> None: ...
     @overload

--- a/numpy/typing/tests/data/fail/scalars.pyi
+++ b/numpy/typing/tests/data/fail/scalars.pyi
@@ -28,7 +28,6 @@ np.float32(3j)  # E: incompatible type
 np.float32([1.0, 0.0, 0.0])  # E: incompatible type
 np.complex64([])  # E: incompatible type
 
-np.complex64(1, 2)  # E: Too many arguments
 # TODO: protocols (can't check for non-existent protocols w/ __getattr__)
 
 np.datetime64(0)  # E: No overload variant
@@ -60,7 +59,7 @@ np.flexible(b"test")  # E: Cannot instantiate abstract class
 np.float64(value=0.0)  # E: Unexpected keyword argument
 np.int64(value=0)  # E: Unexpected keyword argument
 np.uint64(value=0)  # E: Unexpected keyword argument
-np.complex128(value=0.0j)  # E: Unexpected keyword argument
+np.complex128(value=0.0j)  # E: No overload variant
 np.str_(value='bob')  # E: No overload variant
 np.bytes_(value=b'test')  # E: No overload variant
 np.void(value=b'test')  # E: No overload variant


### PR DESCRIPTION
Backport of #28279.

backport of https://github.com/numpy/numtype/pull/28 and https://github.com/numpy/numtype/pull/78

---

This ensures correct behavior of the `float64`, `complex128`, `str_`, and `bytes_` constructors on pyright. This also fixes the `complexfloating` scalar types not accepting a second argument, which was causing `complex(1, 2)` to be rejected.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
