### PR TITLE
CI: Fix the github label for `TYP:` PR's and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/typing.yml
+++ b/.github/ISSUE_TEMPLATE/typing.yml
@@ -1,7 +1,7 @@
 name: Static Typing
 description: Report an issue with the NumPy typing hints.
 title: "TYP: <Please write a comprehensive title after the 'TYP: ' prefix>"
-labels: [Static typing]
+labels: [41 - Static typing]
 
 body:
 - type: markdown

--- a/.github/pr-prefix-labeler.yml
+++ b/.github/pr-prefix-labeler.yml
@@ -12,5 +12,5 @@
 "REV": "34 - Reversion"
 "STY": "03 - Maintenance"
 "TST": "05 - Testing"
-"TYP": "static typing"
+"TYP": "41 - Static typing"
 "WIP": "25 - WIP"


### PR DESCRIPTION
Backport of #28242.

The  `static typing` was renamed to `41 - Static typing`. This updates the PR prefix labeler config and typing issue template to use the new label.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
