### PR TITLE
DOC: Correct a typo in Intel License URL

### DIFF
--- a/doc/source/f2py/windows/intel.rst
+++ b/doc/source/f2py/windows/intel.rst
@@ -52,6 +52,6 @@ Powershell usage is a little less pleasant, and this configuration now works wit
 Note that the actual path to your local installation of `ifort` may vary, and the command above will need to be updated accordingly.
 
 .. _have been relaxed: https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-fortran-compiler-release-notes.html
-.. _disassembly of components and liability: https://software.sintel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+.. _disassembly of components and liability: https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html
 .. _Intel Fortran Compilers: https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-1
 .. _Classic Intel C/C++ Compiler: https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-undefined


### PR DESCRIPTION
DOC: Correct a typo in Intel License URL

Correct URL:
https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html

The old URL does not work:
https://software.sintel.com/content/www/us/en/develop/articles/end-user-license-agreement.html


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
