### PR TITLE
BUG: fix race initializing legacy dtype casts

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -60,6 +60,8 @@ jobs:
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/ci_requirements.txt
         pip install -r requirements/test_requirements.txt
+        # xdist captures stdout/stderr, but we want the ASAN output
+        pip uninstall -y pytest-xdist
     - name: Build
       run:
         python -m spin build -j2 -- -Db_sanitize=address
@@ -111,6 +113,8 @@ jobs:
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/ci_requirements.txt
         pip install -r requirements/test_requirements.txt
+        # xdist captures stdout/stderr, but we want the TSAN output
+        pip uninstall -y pytest-xdist
     - name: Build
       run:
         python -m spin build -j2 -- -Db_sanitize=thread

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -63,46 +63,24 @@ static PyObject *
 PyArray_GetObjectToGenericCastingImpl(void);
 
 
-/**
- * Fetch the casting implementation from one DType to another.
- *
- * @param from The implementation to cast from
- * @param to The implementation to cast to
- *
- * @returns A castingimpl (PyArrayDTypeMethod *), None or NULL with an
- *          error set.
- */
-NPY_NO_EXPORT PyObject *
-PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
+static PyObject *
+create_casting_impl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 {
-    PyObject *res;
-    if (from == to) {
-        res = (PyObject *)NPY_DT_SLOTS(from)->within_dtype_castingimpl;
-    }
-    else {
-        res = PyDict_GetItemWithError(NPY_DT_SLOTS(from)->castingimpls, (PyObject *)to);
-    }
-    if (res != NULL || PyErr_Occurred()) {
-        Py_XINCREF(res);
-        return res;
-    }
     /*
-     * The following code looks up CastingImpl based on the fact that anything
+     * Look up CastingImpl based on the fact that anything
      * can be cast to and from objects or structured (void) dtypes.
-     *
-     * The last part adds casts dynamically based on legacy definition
      */
     if (from->type_num == NPY_OBJECT) {
-        res = PyArray_GetObjectToGenericCastingImpl();
+        return PyArray_GetObjectToGenericCastingImpl();
     }
     else if (to->type_num == NPY_OBJECT) {
-        res = PyArray_GetGenericToObjectCastingImpl();
+        return PyArray_GetGenericToObjectCastingImpl();
     }
     else if (from->type_num == NPY_VOID) {
-        res = PyArray_GetVoidToGenericCastingImpl();
+        return PyArray_GetVoidToGenericCastingImpl();
     }
     else if (to->type_num == NPY_VOID) {
-        res = PyArray_GetGenericToVoidCastingImpl();
+        return PyArray_GetGenericToVoidCastingImpl();
     }
     /*
      * Reject non-legacy dtypes. They need to use the new API to add casts and
@@ -125,43 +103,104 @@ PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
             PyArray_VectorUnaryFunc *castfunc = PyArray_GetCastFunc(
                     from->singleton, to->type_num);
             if (castfunc == NULL) {
-                PyErr_Clear();
-                /* Remember that this cast is not possible */
-                if (PyDict_SetItem(NPY_DT_SLOTS(from)->castingimpls,
-                            (PyObject *) to, Py_None) < 0) {
-                    return NULL;
-                }
-                Py_RETURN_NONE;
+                    PyErr_Clear();
+                    Py_RETURN_NONE;
             }
         }
-
-        /* PyArray_AddLegacyWrapping_CastingImpl find the correct casting level: */
-        /*
-         * TODO: Possibly move this to the cast registration time. But if we do
-         *       that, we have to also update the cast when the casting safety
-         *       is registered.
+        /* Create a cast using the state of the legacy casting setup defined
+         * during the setup of the DType.
+         *
+         * Ideally we would do this when we create the DType, but legacy user
+         * DTypes don't have a way to signal that a DType is done setting up
+         * casts. Without such a mechanism, the safest way to know that a
+         * DType is done setting up is to register the cast lazily the first
+         * time a user does the cast.
+         *
+         * We *could* register the casts when we create the wrapping
+         * DTypeMeta, but that means the internals of the legacy user DType
+         * system would need to update the state of the casting safety flags
+         * in the cast implementations stored on the DTypeMeta. That's an
+         * inversion of abstractions and would be tricky to do without
+         * creating circular dependencies inside NumPy.
          */
         if (PyArray_AddLegacyWrapping_CastingImpl(from, to, -1) < 0) {
             return NULL;
         }
+        /* castingimpls is unconditionally filled by
+         * AddLegacyWrapping_CastingImpl, so this won't create a recursive
+         * critical section
+         */
         return PyArray_GetCastingImpl(from, to);
     }
+}
 
-    if (res == NULL) {
+static PyObject *
+ensure_castingimpl_exists(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
+{
+    int return_error = 0;
+    PyObject *res = NULL;
+
+    /* Need to create the cast. This might happen at runtime so we enter a
+       critical section to avoid races */
+
+    Py_BEGIN_CRITICAL_SECTION(NPY_DT_SLOTS(from)->castingimpls);
+
+    /* check if another thread filled it while this thread was blocked on
+       acquiring the critical section */
+    if (PyDict_GetItemRef(NPY_DT_SLOTS(from)->castingimpls, (PyObject *)to,
+                          &res) < 0) {
+        return_error = 1;
+    }
+
+    if (!return_error) {
+        res = create_casting_impl(from, to);
+        if (res == NULL) {
+            return_error = 1;
+        }
+    }
+    if (!return_error &&
+        PyDict_SetItem(NPY_DT_SLOTS(from)->castingimpls,
+                       (PyObject *)to, res) < 0) {
+        return_error = 1;
+    }
+    Py_END_CRITICAL_SECTION();
+    if (return_error) {
+        Py_XDECREF(res);
         return NULL;
     }
-    if (from == to) {
+    if (from == to && res == Py_None) {
         PyErr_Format(PyExc_RuntimeError,
                 "Internal NumPy error, within-DType cast missing for %S!", from);
-        Py_DECREF(res);
-        return NULL;
-    }
-    if (PyDict_SetItem(NPY_DT_SLOTS(from)->castingimpls,
-                (PyObject *)to, res) < 0) {
-        Py_DECREF(res);
         return NULL;
     }
     return res;
+}
+
+/**
+ * Fetch the casting implementation from one DType to another.
+ *
+ * @param from The implementation to cast from
+ * @param to The implementation to cast to
+ *
+ * @returns A castingimpl (PyArrayDTypeMethod *), None or NULL with an
+ *          error set.
+ */
+NPY_NO_EXPORT PyObject *
+PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
+{
+    PyObject *res;
+    if (from == to) {
+        res = Py_XNewRef((PyObject *)NPY_DT_SLOTS(from)->within_dtype_castingimpl);
+    }
+    else if (PyDict_GetItemRef(NPY_DT_SLOTS(from)->castingimpls,
+                               (PyObject *)to, &res) < 0) {
+        return NULL;
+    }
+    if (res != NULL) {
+        return res;
+    }
+
+    return ensure_castingimpl_exists(from, to);
 }
 
 
@@ -410,7 +449,7 @@ _get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
  * implementations fully to have them available for doing the actual cast
  * later.
  *
- * @param from The descriptor to cast from 
+ * @param from The descriptor to cast from
  * @param to The descriptor to cast to (may be NULL)
  * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
  *        is ignored).
@@ -2020,6 +2059,11 @@ PyArray_AddCastingImplementation(PyBoundArrayMethodObject *meth)
 
 /**
  * Add a new casting implementation using a PyArrayMethod_Spec.
+ *
+ * Using this function outside of module initialization without holding a
+ * critical section on the castingimpls dict may lead to a race to fill the
+ * dict. Use PyArray_GetGastingImpl to lazily register casts at runtime
+ * safely.
  *
  * @param spec The specification to use as a source
  * @param private If private, allow slots not publicly exposed.

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -151,17 +151,15 @@ ensure_castingimpl_exists(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
                           &res) < 0) {
         return_error = 1;
     }
-
-    if (res == NULL && !return_error) {
+    else if (res == NULL) {
         res = create_casting_impl(from, to);
         if (res == NULL) {
             return_error = 1;
         }
-    }
-    if (!return_error &&
-        PyDict_SetItem(NPY_DT_SLOTS(from)->castingimpls,
-                       (PyObject *)to, res) < 0) {
-        return_error = 1;
+        else if (PyDict_SetItem(NPY_DT_SLOTS(from)->castingimpls,
+                                (PyObject *)to, res) < 0) {
+            return_error = 1;
+        }
     }
     Py_END_CRITICAL_SECTION();
     if (return_error) {

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -188,9 +188,12 @@ ensure_castingimpl_exists(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 NPY_NO_EXPORT PyObject *
 PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 {
-    PyObject *res;
+    PyObject *res = NULL;
     if (from == to) {
-        res = Py_XNewRef((PyObject *)NPY_DT_SLOTS(from)->within_dtype_castingimpl);
+        if ((NPY_DT_SLOTS(from)->within_dtype_castingimpl) != NULL) {
+            res = Py_XNewRef(
+                    (PyObject *)NPY_DT_SLOTS(from)->within_dtype_castingimpl);
+        }
     }
     else if (PyDict_GetItemRef(NPY_DT_SLOTS(from)->castingimpls,
                                (PyObject *)to, &res) < 0) {

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -171,6 +171,7 @@ ensure_castingimpl_exists(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
     if (from == to && res == Py_None) {
         PyErr_Format(PyExc_RuntimeError,
                 "Internal NumPy error, within-DType cast missing for %S!", from);
+        Py_DECREF(res);
         return NULL;
     }
     return res;

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -103,8 +103,8 @@ create_casting_impl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
             PyArray_VectorUnaryFunc *castfunc = PyArray_GetCastFunc(
                     from->singleton, to->type_num);
             if (castfunc == NULL) {
-                    PyErr_Clear();
-                    Py_RETURN_NONE;
+                PyErr_Clear();
+                Py_RETURN_NONE;
             }
         }
         /* Create a cast using the state of the legacy casting setup defined

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -152,7 +152,7 @@ ensure_castingimpl_exists(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
         return_error = 1;
     }
 
-    if (!return_error) {
+    if (res == NULL && !return_error) {
         res = create_casting_impl(from, to);
         if (res == NULL) {
             return_error = 1;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1252,6 +1252,12 @@ dtypemeta_wrap_legacy_descriptor(
             return -1;
         }
     }
+    else {
+        // ensure the within dtype cast is populated for legacy user dtypes
+        if (PyArray_GetCastingImpl(dtype_class, dtype_class) == NULL) {
+            return -1;
+        }
+    }
 
     return 0;
 }

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -262,4 +262,4 @@ def test_legacy_usertype_cast_init_thread_safety():
         b.wait()
         np.full((10, 10), 1, _rational_tests.rational)
 
-    run_threaded(closure, 1000, pass_barrier=True)
+    run_threaded(closure, 250, pass_barrier=True)

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -7,6 +7,7 @@ import pytest
 
 from numpy.testing import IS_WASM
 from numpy.testing._private.utils import run_threaded
+from numpy._core import _rational_tests
 
 if IS_WASM:
     pytest.skip(allow_module_level=True, reason="no threading support in wasm")
@@ -254,3 +255,11 @@ def test_stringdtype_multithreaded_access_and_mutation(
 
         for f in futures:
             f.result()
+
+
+def test_legacy_usertype_cast_init_thread_safety():
+    def closure(b):
+        b.wait()
+        np.full((10, 10), 1, _rational_tests.rational)
+
+    run_threaded(closure, 1000, pass_barrier=True)

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -265,8 +265,9 @@ def test_legacy_usertype_cast_init_thread_safety():
     try:
         run_threaded(closure, 250, pass_barrier=True)
     except RuntimeError:
-        # couldn't spawn enough threads, so skip this test on this system
-        # for whatever reason the 32 bit linux runner will trigger
-        # this. I can trigger it on my Linux laptop with 500 threads but
-        # the runner is more resource-constrained
+        # The 32 bit linux runner will trigger this with 250 threads. I can
+        # trigger it on my Linux laptop with 500 threads but the CI runner is
+        # more resource-constrained.
+        # Reducing the number of threads means the test doesn't trigger the
+        # bug. Better to skip on some platforms than add a useless test.
         pytest.skip("Couldn't spawn enough threads to run the test")

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -262,4 +262,11 @@ def test_legacy_usertype_cast_init_thread_safety():
         b.wait()
         np.full((10, 10), 1, _rational_tests.rational)
 
-    run_threaded(closure, 250, pass_barrier=True)
+    try:
+        run_threaded(closure, 250, pass_barrier=True)
+    except RuntimeError:
+        # couldn't spawn enough threads, so skip this test on this system
+        # for whatever reason the 32 bit linux runner will trigger
+        # this. I can trigger it on my Linux laptop with 500 threads but
+        # the runner is more resource-constrained
+        pytest.skip("Couldn't spawn enough threads to run the test")

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2736,9 +2736,11 @@ def run_threaded(func, max_workers=8, pass_count=False,
                 if pass_barrier:
                     args.append(barrier)
                 if pass_count:
-                    futures = [tpe.submit(func, i, *args) for i in range(max_workers)]
+                    futures = [
+                        tpe.submit(func, i, *args) for i in range(max_workers)]
                 else:
-                    futures = [tpe.submit(func, *args) for _ in range(max_workers)]
+                    futures = [
+                        tpe.submit(func, *args) for _ in range(max_workers)]
                 for f in futures:
                     f.result()
         finally:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2724,8 +2724,8 @@ def run_threaded(func, max_workers=8, pass_count=False,
                  prepare_args=None):
     """Runs a function many times in parallel"""
     for _ in range(outer_iterations):
-        with (concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers) as tpe):
+        with (concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+              as tpe):
             if prepare_args is None:
                 args = []
             else:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2734,9 +2734,16 @@ def run_threaded(func, max_workers=8, pass_count=False,
                 barrier = threading.Barrier(max_workers)
                 args.append(barrier)
             if pass_count:
-                futures = [tpe.submit(func, i, *args) for i in range(max_workers)]
+                all_func_args = [(func, i, *args) for i in range(max_workers)]
             else:
-                futures = [tpe.submit(func, *args) for _ in range(max_workers)]
+                all_func_args = [(func, *args) for i in range(max_workers)]
+            try:
+                futures = [tpe.submit(*func_args) for func_args in
+                           all_func_args]
+            except BaseException:
+                if pass_barrier:
+                    barrier.abort()
+                raise
             for f in futures:
                 f.result()
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2738,13 +2738,11 @@ def run_threaded(func, max_workers=8, pass_count=False,
             else:
                 all_args = [(func, *args) for i in range(max_workers)]
             try:
-                n_submitted = 0
                 futures = []
                 for arg in all_args:
                     futures.append(tpe.submit(*arg))
-                    n_submitted += 1
             finally:
-                if n_submitted < max_workers and pass_barrier:
+                if len(futures) < max_workers and pass_barrier:
                     barrier.abort()
             for f in futures:
                 f.result()

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2733,18 +2733,19 @@ def run_threaded(func, max_workers=8, pass_count=False,
             if pass_barrier:
                 barrier = threading.Barrier(max_workers)
                 args.append(barrier)
+            if pass_count:
+                all_args = [(func, i, *args) for i in range(max_workers)]
+            else:
+                all_args = [(func, *args) for i in range(max_workers)]
             try:
-                if pass_count:
-                    futures = [tpe.submit(func, i, *args) for i in
-                               range(max_workers)]
-                else:
-                    futures = [tpe.submit(func, *args) for _ in
-                               range(max_workers)]
-            except RuntimeError:
-                # python raises RuntimeError when it can't spawn new threads
-                if pass_barrier:
+                n_submitted = 0
+                futures = []
+                for arg in all_args:
+                    futures.append(tpe.submit(*arg))
+                    n_submitted += 1
+            finally:
+                if n_submitted < max_workers and pass_barrier:
                     barrier.abort()
-                raise
             for f in futures:
                 f.result()
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2736,12 +2736,11 @@ def run_threaded(func, max_workers=8, pass_count=False,
                 if pass_barrier:
                     args.append(barrier)
                 if pass_count:
-                    all_args = [(func, i, *args) for i in range(max_workers)]
+                    futures = [tpe.submit(func, i, *args) for i in range(max_workers)]
                 else:
-                    all_args = [(func, *args) for _ in range(max_workers)]
-                futures = [tpe.submit(*func_args) for func_args in all_args]
-            for f in futures:
-                f.result()
+                    futures = [tpe.submit(func, *args) for _ in range(max_workers)]
+                for f in futures:
+                    f.result()
         finally:
             if pass_barrier:
                 barrier.abort()

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2724,28 +2724,29 @@ def run_threaded(func, max_workers=8, pass_count=False,
                  prepare_args=None):
     """Runs a function many times in parallel"""
     for _ in range(outer_iterations):
-        if pass_barrier:
-            barrier = threading.Barrier(max_workers)
-        try:
-            with (concurrent.futures.ThreadPoolExecutor(
-                    max_workers=max_workers) as tpe):
-                if prepare_args is None:
-                    args = []
-                else:
-                    args = prepare_args()
-                if pass_barrier:
-                    args.append(barrier)
-                if pass_count:
-                    futures = [
-                        tpe.submit(func, i, *args) for i in range(max_workers)]
-                else:
-                    futures = [
-                        tpe.submit(func, *args) for _ in range(max_workers)]
-                for f in futures:
-                    f.result()
-        finally:
+        with (concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers) as tpe):
+            if prepare_args is None:
+                args = []
+            else:
+                args = prepare_args()
             if pass_barrier:
-                barrier.abort()
+                barrier = threading.Barrier(max_workers)
+                args.append(barrier)
+            try:
+                if pass_count:
+                    futures = [tpe.submit(func, i, *args) for i in
+                               range(max_workers)]
+                else:
+                    futures = [tpe.submit(func, *args) for _ in
+                               range(max_workers)]
+            except RuntimeError:
+                # python raises RuntimeError when it can't spawn new threads
+                if pass_barrier:
+                    barrier.abort()
+                raise
+            for f in futures:
+                f.result()
 
 
 def get_stringdtype_dtype(na_object, coerce=True):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2724,28 +2724,27 @@ def run_threaded(func, max_workers=8, pass_count=False,
                  prepare_args=None):
     """Runs a function many times in parallel"""
     for _ in range(outer_iterations):
-        with (concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-              as tpe):
-            if prepare_args is None:
-                args = []
-            else:
-                args = prepare_args()
-            if pass_barrier:
-                barrier = threading.Barrier(max_workers)
-                args.append(barrier)
-            if pass_count:
-                all_func_args = [(func, i, *args) for i in range(max_workers)]
-            else:
-                all_func_args = [(func, *args) for i in range(max_workers)]
-            try:
-                futures = [tpe.submit(*func_args) for func_args in
-                           all_func_args]
-            except BaseException:
+        if pass_barrier:
+            barrier = threading.Barrier(max_workers)
+        try:
+            with (concurrent.futures.ThreadPoolExecutor(
+                    max_workers=max_workers) as tpe):
+                if prepare_args is None:
+                    args = []
+                else:
+                    args = prepare_args()
                 if pass_barrier:
-                    barrier.abort()
-                raise
+                    args.append(barrier)
+                if pass_count:
+                    all_args = [(func, i, *args) for i in range(max_workers)]
+                else:
+                    all_args = [(func, *args) for _ in range(max_workers)]
+                futures = [tpe.submit(*func_args) for func_args in all_args]
             for f in futures:
                 f.result()
+        finally:
+            if pass_barrier:
+                barrier.abort()
 
 
 def get_stringdtype_dtype(na_object, coerce=True):


### PR DESCRIPTION
Fixes #28048 

Locks `castingimpls` with a critical section when the `castingimpls` cache is empty before writing to the dict.

Because the critical section macros have braces, I refactored `PyArray_GetCastingImpl` into three functions that call each other. Only the "middle" function needs the critical section, so that reduces the pain of not being able to early return in a critical section a little bit.

I also added some comments because this took me quite a while to fully understand so future readers will hopefully be less confused.

Edit: there are also some unrelated fixes for the test infrastructure to avoid CI crashes and generate better debug output from CI jobs. Happy to do those separately if anyone requests.