### PR TITLE
TYP: stub ``numpy._expired_attrs_2_0``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -442,6 +442,8 @@ from numpy._core.shape_base import (
     unstack,
 )
 
+from ._expired_attrs_2_0 import __expired_attributes__ as __expired_attributes__
+
 from numpy.lib import (
     scimath as emath,
 )
@@ -1181,7 +1183,6 @@ newaxis: Final[None] = None
 # not in __all__
 __NUMPY_SETUP__: Final[L[False]] = False
 __numpy_submodules__: Final[set[LiteralString]] = ...
-__expired_attributes__: Final[dict[LiteralString, LiteralString]]
 __former_attrs__: Final[_FormerAttrsDict] = ...
 __future_scalars__: Final[set[L["bytes", "str", "object"]]] = ...
 __array_api_version__: Final[L["2023.12"]] = "2023.12"

--- a/numpy/_expired_attrs_2_0.pyi
+++ b/numpy/_expired_attrs_2_0.pyi
@@ -1,0 +1,63 @@
+from typing import Final, TypedDict, final, type_check_only
+
+@final
+@type_check_only
+class _ExpiredAttributesType(TypedDict):
+    geterrobj: str
+    seterrobj: str
+    cast: str
+    source: str
+    lookfor: str
+    who: str
+    fastCopyAndTranspose: str
+    set_numeric_ops: str
+    NINF: str
+    PINF: str
+    NZERO: str
+    PZERO: str
+    add_newdoc: str
+    add_docstring: str
+    add_newdoc_ufunc: str
+    compat: str
+    safe_eval: str
+    float_: str
+    complex_: str
+    longfloat: str
+    singlecomplex: str
+    cfloat: str
+    longcomplex: str
+    clongfloat: str
+    string_: str
+    unicode_: str
+    Inf: str
+    Infinity: str
+    NaN: str
+    infty: str
+    issctype: str
+    maximum_sctype: str
+    obj2sctype: str
+    sctype2char: str
+    sctypes: str
+    issubsctype: str
+    set_string_function: str
+    asfarray: str
+    issubclass_: str
+    tracemalloc_domain: str
+    mat: str
+    recfromcsv: str
+    recfromtxt: str
+    deprecate: str
+    deprecate_with_doc: str
+    disp: str
+    find_common_type: str
+    round_: str
+    get_array_wrap: str
+    DataSource: str
+    nbytes: str
+    byte_bounds: str
+    compare_chararrays: str
+    format_parser: str
+    alltrue: str
+    sometrue: str
+
+__expired_attributes__: Final[_ExpiredAttributesType] = ...

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -281,6 +281,7 @@ python_sources = [
   '_pytesttester.py',
   '_pytesttester.pyi',
   '_expired_attrs_2_0.py',
+  '_expired_attrs_2_0.pyi',
   'conftest.py',
   'exceptions.py',
   'exceptions.pyi',


### PR DESCRIPTION
backport of https://github.com/numpy/numtype/pull/83