### PR TITLE
TYP: stub ``lib._datasource`` and fix ``lib._npyio_impl``

### DIFF
--- a/numpy/lib/_datasource.pyi
+++ b/numpy/lib/_datasource.pyi
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import IO, Any, TypeAlias
+
+from _typeshed import OpenBinaryMode, OpenTextMode
+
+_Mode: TypeAlias = OpenBinaryMode | OpenTextMode
+
+###
+
+# exported in numpy.lib.nppyio
+class DataSource:
+    def __init__(self, /, destpath: Path | str | None = ...) -> None: ...
+    def __del__(self, /) -> None: ...
+    def abspath(self, /, path: str) -> str: ...
+    def exists(self, /, path: str) -> bool: ...
+
+    # Whether the file-object is opened in string or bytes mode (by default)
+    # depends on the file-extension of `path`
+    def open(self, /, path: str, mode: _Mode = "r", encoding: str | None = None, newline: str | None = None) -> IO[Any]: ...
+
+class Repository(DataSource):
+    def __init__(self, /, baseurl: str, destpath: str | None = ...) -> None: ...
+    def listdir(self, /) -> list[str]: ...
+
+def open(
+    path: str,
+    mode: _Mode = "r",
+    destpath: str | None = ...,
+    encoding: str | None = None,
+    newline: str | None = None,
+) -> IO[Any]: ...

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -1,359 +1,285 @@
-import zipfile
 import types
-from _typeshed import StrOrBytesPath, StrPath, SupportsRead, SupportsWrite, SupportsKeysAndGetItem
+import zipfile
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
-from collections.abc import Collection, Mapping, Iterator, Sequence, Callable, Iterable
-from typing import (
-    Literal as L,
-    Any,
-    TypeVar,
-    Generic,
-    IO,
-    overload,
-    Protocol,
-    type_check_only,
-)
-from typing_extensions import deprecated
+from typing import IO, Any, ClassVar, Generic, Protocol, TypeAlias, overload, type_check_only
+from typing import Literal as L
 
-from numpy import (
-    recarray,
-    dtype,
-    generic,
-    float64,
-    void,
-    record,
-)
-from numpy.ma.mrecords import MaskedRecords
+from _typeshed import StrOrBytesPath, StrPath, SupportsKeysAndGetItem, SupportsRead, SupportsWrite
+from typing_extensions import Self, TypeVar, deprecated, override
+
+import numpy as np
 from numpy._core.multiarray import packbits, unpackbits
-from numpy._typing import (
-    ArrayLike,
-    DTypeLike,
-    NDArray,
-    _DTypeLike,
-    _SupportsArrayFunc,
-)
+from numpy._typing import ArrayLike, DTypeLike, NDArray, _DTypeLike, _SupportsArrayFunc
+from numpy.ma.mrecords import MaskedRecords
+
+from ._datasource import DataSource as DataSource
 
 __all__ = [
-    "savetxt",
-    "loadtxt",
+    "fromregex",
     "genfromtxt",
     "load",
+    "loadtxt",
+    "packbits",
     "save",
+    "savetxt",
     "savez",
     "savez_compressed",
-    "packbits",
     "unpackbits",
-    "fromregex",
 ]
 
-_T = TypeVar("_T")
-_T_contra = TypeVar("_T_contra", contravariant=True)
 _T_co = TypeVar("_T_co", covariant=True)
-_SCT = TypeVar("_SCT", bound=generic)
+_SCT = TypeVar("_SCT", bound=np.generic)
+_SCT_co = TypeVar("_SCT_co", bound=np.generic, default=Any, covariant=True)
+
+_FName: TypeAlias = StrPath | Iterable[str] | Iterable[bytes]
+_FNameRead: TypeAlias = StrPath | SupportsRead[str] | SupportsRead[bytes]
+_FNameWriteBytes: TypeAlias = StrPath | SupportsWrite[bytes]
+_FNameWrite: TypeAlias = _FNameWriteBytes | SupportsWrite[bytes]
 
 @type_check_only
 class _SupportsReadSeek(SupportsRead[_T_co], Protocol[_T_co]):
     def seek(self, offset: int, whence: int, /) -> object: ...
 
 class BagObj(Generic[_T_co]):
-    def __init__(self, obj: SupportsKeysAndGetItem[str, _T_co]) -> None: ...
-    def __getattribute__(self, key: str) -> _T_co: ...
+    def __init__(self, /, obj: SupportsKeysAndGetItem[str, _T_co]) -> None: ...
+    def __getattribute__(self, key: str, /) -> _T_co: ...
     def __dir__(self) -> list[str]: ...
 
-class NpzFile(Mapping[str, NDArray[Any]]):
+class NpzFile(Mapping[str, NDArray[_SCT_co]]):
+    _MAX_REPR_ARRAY_COUNT: ClassVar[int] = 5
+
     zip: zipfile.ZipFile
-    fid: None | IO[str]
+    fid: IO[str] | None
     files: list[str]
     allow_pickle: bool
-    pickle_kwargs: None | Mapping[str, Any]
-    _MAX_REPR_ARRAY_COUNT: int
-    # Represent `f` as a mutable property so we can access the type of `self`
-    @property
-    def f(self: _T) -> BagObj[_T]: ...
-    @f.setter
-    def f(self: _T, value: BagObj[_T]) -> None: ...
+    pickle_kwargs: Mapping[str, Any] | None
+    f: BagObj[NpzFile[_SCT_co]]
+
+    #
     def __init__(
         self,
-        fid: IO[str],
-        own_fid: bool = ...,
-        allow_pickle: bool = ...,
-        pickle_kwargs: None | Mapping[str, Any] = ...,
-    ) -> None: ...
-    def __enter__(self: _T) -> _T: ...
-    def __exit__(
-        self,
-        exc_type: None | type[BaseException],
-        exc_value: None | BaseException,
-        traceback: None | types.TracebackType,
         /,
+        fid: IO[Any],
+        own_fid: bool = False,
+        allow_pickle: bool = False,
+        pickle_kwargs: Mapping[str, object] | None = None,
+        *,
+        max_header_size: int = 10_000,
     ) -> None: ...
-    def close(self) -> None: ...
     def __del__(self) -> None: ...
-    def __iter__(self) -> Iterator[str]: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, cls: type[BaseException] | None, e: BaseException | None, tb: types.TracebackType | None, /) -> None: ...
+    @override
     def __len__(self) -> int: ...
-    def __getitem__(self, key: str) -> NDArray[Any]: ...
-    def __contains__(self, key: str) -> bool: ...
-    def __repr__(self) -> str: ...
-
-class DataSource:
-    def __init__(self, destpath: StrPath | None = ...) -> None: ...
-    def __del__(self) -> None: ...
-    def abspath(self, path: str) -> str: ...
-    def exists(self, path: str) -> bool: ...
-
-    # Whether the file-object is opened in string or bytes mode (by default)
-    # depends on the file-extension of `path`
-    def open(
-        self,
-        path: str,
-        mode: str = ...,
-        encoding: None | str = ...,
-        newline: None | str = ...,
-    ) -> IO[Any]: ...
+    @override
+    def __iter__(self) -> Iterator[str]: ...
+    @override
+    def __getitem__(self, key: str, /) -> NDArray[_SCT_co]: ...
+    def close(self) -> None: ...
 
 # NOTE: Returns a `NpzFile` if file is a zip file;
 # returns an `ndarray`/`memmap` otherwise
 def load(
     file: StrOrBytesPath | _SupportsReadSeek[bytes],
-    mmap_mode: L["r+", "r", "w+", "c"] | None = ...,
-    allow_pickle: bool = ...,
-    fix_imports: bool = ...,
-    encoding: L["ASCII", "latin1", "bytes"] = ...,
+    mmap_mode: L["r+", "r", "w+", "c"] | None = None,
+    allow_pickle: bool = False,
+    fix_imports: bool = True,
+    encoding: L["ASCII", "latin1", "bytes"] = "ASCII",
+    *,
+    max_header_size: int = 10_000,
 ) -> Any: ...
 
 @overload
-def save(
-    file: StrPath | SupportsWrite[bytes],
-    arr: ArrayLike,
-    allow_pickle: bool = ...,
-) -> None: ...
+def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool = True) -> None: ...
 @overload
 @deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
-def save(
-    file: StrPath | SupportsWrite[bytes],
-    arr: ArrayLike,
-    allow_pickle: bool = ...,
-    *,
-    fix_imports: bool,
-) -> None: ...
+def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool, fix_imports: bool) -> None: ...
 @overload
 @deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
-def save(
-    file: StrPath | SupportsWrite[bytes],
-    arr: ArrayLike,
-    allow_pickle: bool,
-    fix_imports: bool,
-) -> None: ...
+def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool = True, *, fix_imports: bool) -> None: ...
 
-def savez(
-    file: StrPath | SupportsWrite[bytes],
-    *args: ArrayLike,
-    allow_pickle: bool = ...,
-    **kwds: ArrayLike,
-) -> None: ...
+#
+def savez(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
 
-def savez_compressed(
-    file: StrPath | SupportsWrite[bytes],
-    *args: ArrayLike,
-    allow_pickle: bool = ...,
-    **kwds: ArrayLike,
-) -> None: ...
+#
+def savez_compressed(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
 
 # File-like objects only have to implement `__iter__` and,
 # optionally, `encoding`
 @overload
 def loadtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    dtype: None = ...,
-    comments: None | str | Sequence[str] = ...,
-    delimiter: None | str = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] = ...,
-    skiprows: int = ...,
-    usecols: int | Sequence[int] | None = ...,
-    unpack: bool = ...,
-    ndmin: L[0, 1, 2] = ...,
-    encoding: None | str = ...,
-    max_rows: None | int = ...,
+    fname: _FName,
+    dtype: None = None,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1, 2] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
     *,
-    quotechar: None | str = ...,
-    like: None | _SupportsArrayFunc = ...
-) -> NDArray[float64]: ...
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> NDArray[np.float64]: ...
 @overload
 def loadtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
+    fname: _FName,
     dtype: _DTypeLike[_SCT],
-    comments: None | str | Sequence[str] = ...,
-    delimiter: None | str = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] = ...,
-    skiprows: int = ...,
-    usecols: int | Sequence[int] | None = ...,
-    unpack: bool = ...,
-    ndmin: L[0, 1, 2] = ...,
-    encoding: None | str = ...,
-    max_rows: None | int = ...,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1, 2] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
     *,
-    quotechar: None | str = ...,
-    like: None | _SupportsArrayFunc = ...
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
 ) -> NDArray[_SCT]: ...
 @overload
 def loadtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
+    fname: _FName,
     dtype: DTypeLike,
-    comments: None | str | Sequence[str] = ...,
-    delimiter: None | str = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] = ...,
-    skiprows: int = ...,
-    usecols: int | Sequence[int] | None = ...,
-    unpack: bool = ...,
-    ndmin: L[0, 1, 2] = ...,
-    encoding: None | str = ...,
-    max_rows: None | int = ...,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1, 2] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
     *,
-    quotechar: None | str = ...,
-    like: None | _SupportsArrayFunc = ...
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
 ) -> NDArray[Any]: ...
 
 def savetxt(
-    fname: StrPath | SupportsWrite[str] | SupportsWrite[bytes],
+    fname: StrPath | _FNameWrite,
     X: ArrayLike,
-    fmt: str | Sequence[str] = ...,
-    delimiter: str = ...,
-    newline: str = ...,
-    header: str = ...,
-    footer: str = ...,
-    comments: str = ...,
-    encoding: None | str = ...,
+    fmt: str | Sequence[str] = "%.18e",
+    delimiter: str = " ",
+    newline: str = "\n",
+    header: str = "",
+    footer: str = "",
+    comments: str = "# ",
+    encoding: str | None = None,
 ) -> None: ...
 
 @overload
 def fromregex(
-    file: StrPath | SupportsRead[str] | SupportsRead[bytes],
+    file: _FNameRead,
     regexp: str | bytes | Pattern[Any],
     dtype: _DTypeLike[_SCT],
-    encoding: None | str = ...
+    encoding: str | None = None,
 ) -> NDArray[_SCT]: ...
 @overload
 def fromregex(
-    file: StrPath | SupportsRead[str] | SupportsRead[bytes],
+    file: _FNameRead,
     regexp: str | bytes | Pattern[Any],
     dtype: DTypeLike,
-    encoding: None | str = ...
+    encoding: str | None = None,
 ) -> NDArray[Any]: ...
 
 @overload
 def genfromtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    dtype: None = ...,
+    fname: _FName,
+    dtype: None = None,
     comments: str = ...,
-    delimiter: None | str | int | Iterable[int] = ...,
+    delimiter: str | int | Iterable[int] | None = ...,
     skip_header: int = ...,
     skip_footer: int = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] = ...,
+    converters: Mapping[int | str, Callable[[str], Any]] | None = ...,
     missing_values: Any = ...,
     filling_values: Any = ...,
-    usecols: None | Sequence[int] = ...,
+    usecols: Sequence[int] | None = ...,
     names: L[True] | str | Collection[str] | None = ...,
-    excludelist: None | Sequence[str] = ...,
+    excludelist: Sequence[str] | None = ...,
     deletechars: str = ...,
     replace_space: str = ...,
     autostrip: bool = ...,
-    case_sensitive: bool | L['upper', 'lower'] = ...,
+    case_sensitive: bool | L["upper", "lower"] = ...,
     defaultfmt: str = ...,
-    unpack: None | bool = ...,
+    unpack: bool | None = ...,
     usemask: bool = ...,
     loose: bool = ...,
     invalid_raise: bool = ...,
-    max_rows: None | int = ...,
+    max_rows: int | None = ...,
     encoding: str = ...,
     *,
     ndmin: L[0, 1, 2] = ...,
-    like: None | _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[Any]: ...
 @overload
 def genfromtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
+    fname: _FName,
     dtype: _DTypeLike[_SCT],
     comments: str = ...,
-    delimiter: None | str | int | Iterable[int] = ...,
+    delimiter: str | int | Iterable[int] | None = ...,
     skip_header: int = ...,
     skip_footer: int = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] = ...,
+    converters: Mapping[int | str, Callable[[str], Any]] | None = ...,
     missing_values: Any = ...,
     filling_values: Any = ...,
-    usecols: None | Sequence[int] = ...,
+    usecols: Sequence[int] | None = ...,
     names: L[True] | str | Collection[str] | None = ...,
-    excludelist: None | Sequence[str] = ...,
+    excludelist: Sequence[str] | None = ...,
     deletechars: str = ...,
     replace_space: str = ...,
     autostrip: bool = ...,
-    case_sensitive: bool | L['upper', 'lower'] = ...,
+    case_sensitive: bool | L["upper", "lower"] = ...,
     defaultfmt: str = ...,
-    unpack: None | bool = ...,
+    unpack: bool | None = ...,
     usemask: bool = ...,
     loose: bool = ...,
     invalid_raise: bool = ...,
-    max_rows: None | int = ...,
+    max_rows: int | None = ...,
     encoding: str = ...,
     *,
     ndmin: L[0, 1, 2] = ...,
-    like: None | _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def genfromtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
+    fname: _FName,
     dtype: DTypeLike,
     comments: str = ...,
-    delimiter: None | str | int | Iterable[int] = ...,
+    delimiter: str | int | Iterable[int] | None = ...,
     skip_header: int = ...,
     skip_footer: int = ...,
-    converters: None | Mapping[int | str, Callable[[str], Any]] = ...,
+    converters: Mapping[int | str, Callable[[str], Any]] | None = ...,
     missing_values: Any = ...,
     filling_values: Any = ...,
-    usecols: None | Sequence[int] = ...,
+    usecols: Sequence[int] | None = ...,
     names: L[True] | str | Collection[str] | None = ...,
-    excludelist: None | Sequence[str] = ...,
+    excludelist: Sequence[str] | None = ...,
     deletechars: str = ...,
     replace_space: str = ...,
     autostrip: bool = ...,
-    case_sensitive: bool | L['upper', 'lower'] = ...,
+    case_sensitive: bool | L["upper", "lower"] = ...,
     defaultfmt: str = ...,
-    unpack: None | bool = ...,
+    unpack: bool | None = ...,
     usemask: bool = ...,
     loose: bool = ...,
     invalid_raise: bool = ...,
-    max_rows: None | int = ...,
+    max_rows: int | None = ...,
     encoding: str = ...,
     *,
     ndmin: L[0, 1, 2] = ...,
-    like: None | _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[Any]: ...
 
 @overload
-def recfromtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    *,
-    usemask: L[False] = ...,
-    **kwargs: Any,
-) -> recarray[Any, dtype[record]]: ...
+def recfromtxt(fname: _FName, *, usemask: L[False] = False, **kwargs: object) -> np.recarray[Any, np.dtype[np.record]]: ...
 @overload
-def recfromtxt(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    *,
-    usemask: L[True],
-    **kwargs: Any,
-) -> MaskedRecords[Any, dtype[void]]: ...
+def recfromtxt(fname: _FName, *, usemask: L[True], **kwargs: object) -> MaskedRecords[Any, np.dtype[np.void]]: ...
 
 @overload
-def recfromcsv(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    *,
-    usemask: L[False] = ...,
-    **kwargs: Any,
-) -> recarray[Any, dtype[record]]: ...
+def recfromcsv(fname: _FName, *, usemask: L[False] = False, **kwargs: object) -> np.recarray[Any, np.dtype[np.record]]: ...
 @overload
-def recfromcsv(
-    fname: StrPath | Iterable[str] | Iterable[bytes],
-    *,
-    usemask: L[True],
-    **kwargs: Any,
-) -> MaskedRecords[Any, dtype[void]]: ...
+def recfromcsv(fname: _FName, *, usemask: L[True], **kwargs: object) -> MaskedRecords[Any, np.dtype[np.void]]: ...

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -1,4 +1,5 @@
 from numpy.lib._npyio_impl import (
     DataSource as DataSource,
     NpzFile as NpzFile,
+    __doc__ as __doc__,
 )


### PR DESCRIPTION
backport of https://github.com/numpy/numtype/pull/85

---

changes in `lib._npyio` :

- add missing `max_header_size` kwarg to `load`
- pos-only `NpzFile` dunder method params 
- ~annotate the possibility for the `NpzFile.{zip,f}`  attrs to become `None`~
- add explicit parameter defaults
- reduce code duplication using `TypeAlias`
- conform to the official [style guide](https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#style-guide) for stubs