### PR TITLE
DOC:  Remove reference to python2

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -681,8 +681,9 @@ class TestAssignment:
 
     def test_cast_to_string(self):
         # cast to str should do "str(scalar)", not "str(scalar.item())"
-        # Example: In python2, str(float) is truncated, so we want to avoid
-        # str(np.float64(...).item()) as this would incorrectly truncate.
+        # When converting a float to a string via array assignment, we
+        # want to ensure that the conversion uses str(scalar) to preserve
+        # the expected precision.
         a = np.zeros(1, dtype='S20')
         a[:] = np.array(['1.12345678901234567890'], dtype='f8')
         assert_equal(a[0], b"1.1234567890123457")


### PR DESCRIPTION
This change removes a documentation reference to python2, see #22635 for more context.
This PR removes 1 of ~10 references left in the codebase to python2.

I removed the reference to python2 since the example does not apply to python3. Instead I just added some additional context for the test.
 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
