### PR TITLE
MAINT: bump ``mypy`` to ``1.15.0``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.2.0  # needed for python < 3.10
-  - mypy=1.14.1
+  - mypy=1.15.0
   - orjson  # makes mypy faster
   # For building docs
   - sphinx>=4.5.0

--- a/numpy/typing/tests/data/mypy.ini
+++ b/numpy/typing/tests/data/mypy.ini
@@ -5,6 +5,4 @@ implicit_reexport = False
 pretty = True
 disallow_any_unimported = True
 disallow_any_generics = True
-; https://github.com/python/mypy/issues/15313
-disable_bytearray_promotion = true
-disable_memoryview_promotion = true
+strict_bytes = True

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -15,7 +15,7 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.14.1; platform_python_implementation != "PyPy"
+mypy==1.15.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.2.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
This mypy release includes several fixes for NumPy-related issues. It should also run quite a bit faster.

Release notes: https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-15

---

The removed `disable_bytearray_promotion` and `disable_memoryview_promotion` settings are replaced by the new (documented) `strict_bytes` setting, which results in the same behavior.