### PR TITLE
DOC: remove references to Python 2

### DIFF
--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -48,50 +48,6 @@ class TestRealScalars:
         check(1e15)
         check(1e16)
 
-    def test_py2_float_print(self):
-        # gh-10753
-        # In python2, the python float type implements an obsolete method
-        # tp_print, which overrides tp_repr and tp_str when using "print" to
-        # output to a "real file" (ie, not a StringIO). Make sure we don't
-        # inherit it.
-        x = np.double(0.1999999999999)
-        with TemporaryFile('r+t') as f:
-            print(x, file=f)
-            f.seek(0)
-            output = f.read()
-        assert_equal(output, str(x) + '\n')
-        # In python2 the value float('0.1999999999999') prints with reduced
-        # precision as '0.2', but we want numpy's np.double('0.1999999999999')
-        # to print the unique value, '0.1999999999999'.
-
-        # gh-11031
-        # Only in the python2 interactive shell and when stdout is a "real"
-        # file, the output of the last command is printed to stdout without
-        # Py_PRINT_RAW (unlike the print statement) so `>>> x` and `>>> print
-        # x` are potentially different. Make sure they are the same. The only
-        # way I found to get prompt-like output is using an actual prompt from
-        # the 'code' module. Again, must use tempfile to get a "real" file.
-
-        # dummy user-input which enters one line and then ctrl-Ds.
-        def userinput():
-            yield 'np.sqrt(2)'
-            raise EOFError
-        gen = userinput()
-        input_func = lambda prompt="": next(gen)
-
-        with TemporaryFile('r+t') as fo, TemporaryFile('r+t') as fe:
-            orig_stdout, orig_stderr = sys.stdout, sys.stderr
-            sys.stdout, sys.stderr = fo, fe
-
-            code.interact(local={'np': np}, readfunc=input_func, banner='')
-
-            sys.stdout, sys.stderr = orig_stdout, orig_stderr
-
-            fo.seek(0)
-            capture = fo.read().strip()
-
-        assert_equal(capture, repr(np.sqrt(2)))
-
     def test_dragon4(self):
         # these tests are adapted from Ryan Juckett's dragon4 implementation,
         # see dragon4.c for details.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1879,7 +1879,7 @@ class TestAssertNoGcCycles:
                 self.cycle = None
 
                 if ReferenceCycleInDel.make_cycle:
-                    # but create a new one so that the garbage collector has more
+                    # but create a new one so that the garbage collector (GC) has more
                     # work to do.
                     ReferenceCycleInDel()
 
@@ -1891,7 +1891,7 @@ class TestAssertNoGcCycles:
                     assert_no_gc_cycles(lambda: None)
             except AssertionError:
                 # the above test is only necessary if the GC actually tried to free
-                # our object anyway, which python 2.7 does not.
+                # our object anyway.
                 if w() is not None:
                     pytest.skip("GC does not call __del__ on cyclic objects")
                     raise


### PR DESCRIPTION
This change removes a documentation reference to python2, see https://github.com/numpy/numpy/issues/22635 for more context.
This PR removes 3 of ~10 references left in the codebase to python2.

- In `numpy/_core/tests/test_scalarprint.py`, I removed the test altogether since this applies only to Python 2
- In `numpy/testing/tests/test_utils.py`, I removed the reference to python 2.7


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
