### PR TITLE
BUG: numpy.loadtxt reads only 50000 lines when skip_rows >= max_rows

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1085,7 +1085,7 @@ def _read(fname, *, delimiter=',', comment='#', quote='"',
                 # be adapted (in principle the concatenate could cast).
                 chunks.append(next_arr.astype(read_dtype_via_object_chunks))
 
-                skiprows = 0  # Only have to skip for first chunk
+                skiplines = 0  # Only have to skip for first chunk
                 if max_rows >= 0:
                     max_rows -= chunk_size
                 if len(next_arr) < chunk_size:

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1079,7 +1079,7 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
     # tries to read all of the file,
     # or less, equal, greater than _loadtxt_chunksize
     file_length = 400000
-    data = np.arange(1,file_length+1).astype(str) + np.array([" a 0.5 1"]*file_length)
+    data = np.arange(1, file_length + 1).astype(str) + np.array([" a 0.5 1"] * file_length)
 
     # file-like path
     txt = StringIO("\n".join(data))
@@ -1090,10 +1090,9 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
     assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))
 
     # file-obj path
-    fd, fname = mkstemp()
-    os.close(fd)
-    with open(fname, "w") as fh:
-        fh.write("\n".join(data))
+    tmp_file = tmpdir.join("test_data.txt")
+    tmp_file.write("\n".join(data))
+    fname = str(tmp_file)
     res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
     expected_length = min(100005, file_length - nskip)
     assert len(res) == expected_length

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1091,7 +1091,7 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(tmpdir, nskip):
     assert_array_equal(expected, res[:, 0])
 
     # file-obj path
-    tmp_file = tmpdir/"test_data.txt"
+    tmp_file = tmpdir / "test_data.txt"
     tmp_file.write(data)
     fname = str(tmp_file)
     res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1073,3 +1073,29 @@ def test_maxrows_exceeding_chunksize(nmax):
     res = np.loadtxt(fname, dtype=str, delimiter=" ", max_rows=nmax)
     os.remove(fname)
     assert len(res) == nmax
+
+@pytest.mark.parametrize("nskip", (0, 10000, 55000, 200000, 300000))
+def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
+    # tries to read all of the file,
+    # or less, equal, greater than _loadtxt_chunksize
+    file_length = 400000
+    data = np.arange(1,file_length+1).astype(str) + np.array([" a 0.5 1"]*file_length)
+
+    # file-like path
+    txt = StringIO("\n".join(data))
+    res = np.loadtxt(txt, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
+    expected_length = min(100005, file_length-nskip)
+    assert len(res) == expected_length
+    # are the right lines read in res?
+    assert np.all(np.equal(np.arange(nskip+1, nskip+1+expected_length).astype(str), res[:,0]))
+
+    # file-obj path
+    fd, fname = mkstemp()
+    os.close(fd)
+    with open(fname, "w") as fh:
+        fh.write("\n".join(data))
+    res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
+    expected_length = min(100005, file_length-nskip)
+    assert len(res) == expected_length
+    # are the right lines read in res?
+    assert np.all(np.equal(np.arange(nskip+1, nskip+1+expected_length).astype(str), res[:,0]))

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1084,10 +1084,10 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
     # file-like path
     txt = StringIO("\n".join(data))
     res = np.loadtxt(txt, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
-    expected_length = min(100005, file_length-nskip)
+    expected_length = min(100005, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
-    assert np.all(np.equal(np.arange(nskip+1, nskip+1+expected_length).astype(str), res[:,0]))
+    assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))
 
     # file-obj path
     fd, fname = mkstemp()
@@ -1095,7 +1095,7 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
     res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
-    expected_length = min(100005, file_length-nskip)
+    expected_length = min(100005, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
-    assert np.all(np.equal(np.arange(nskip+1, nskip+1+expected_length).astype(str), res[:,0]))
+    assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1074,17 +1074,17 @@ def test_maxrows_exceeding_chunksize(nmax):
     os.remove(fname)
     assert len(res) == nmax
 
-@pytest.mark.parametrize("nskip", (0, 10000, 55000, 200000, 300000))
-def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
+@pytest.mark.parametrize("nskip", (0, 10000, 50000, 100000))
+def test_skiprow_exceeding_maxrows_exceeding_chunksize(tmpdir, nskip):
     # tries to read all of the file,
     # or less, equal, greater than _loadtxt_chunksize
-    file_length = 400000
+    file_length = 110000
     data = np.arange(1, file_length + 1).astype(str) + np.array([" a 0.5 1"] * file_length)
 
     # file-like path
     txt = StringIO("\n".join(data))
-    res = np.loadtxt(txt, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
-    expected_length = min(100005, file_length - nskip)
+    res = np.loadtxt(txt, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)
+    expected_length = min(60000, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
     assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))
@@ -1093,8 +1093,8 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(nskip):
     tmp_file = tmpdir.join("test_data.txt")
     tmp_file.write("\n".join(data))
     fname = str(tmp_file)
-    res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=100005)
-    expected_length = min(100005, file_length - nskip)
+    res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)
+    expected_length = min(60000, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
     assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1094,7 +1094,7 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(tmpdir, nskip):
     tmp_file = tmpdir / "test_data.txt"
     tmp_file.write(data)
     fname = str(tmp_file)
-    res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)
+    res = np.loadtxt(fname, dtype='str', delimiter=" ", skiprows=nskip, max_rows=60000)
     assert len(res) == expected_length
     # are the right lines read in res?
     assert_array_equal(expected, res[:, 0])

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1083,7 +1083,7 @@ def test_skiprow_exceeding_maxrows_exceeding_chunksize(tmpdir, nskip):
 
     # file-like path
     txt = StringIO("\n".join(data))
-    res = np.loadtxt(txt, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)
+    res = np.loadtxt(txt, dtype='str', delimiter=" ", skiprows=nskip, max_rows=60000)
     expected_length = min(60000, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -1074,27 +1074,27 @@ def test_maxrows_exceeding_chunksize(nmax):
     os.remove(fname)
     assert len(res) == nmax
 
-@pytest.mark.parametrize("nskip", (0, 10000, 50000, 100000))
+@pytest.mark.parametrize("nskip", (0, 10000, 12345, 50000, 67891, 100000))
 def test_skiprow_exceeding_maxrows_exceeding_chunksize(tmpdir, nskip):
-    # tries to read all of the file,
-    # or less, equal, greater than _loadtxt_chunksize
+    # tries to read a file in chunks by skipping a variable amount of lines,
+    # less, equal, greater than max_rows
     file_length = 110000
-    data = np.arange(1, file_length + 1).astype(str) + np.array([" a 0.5 1"] * file_length)
+    data = "\n".join(f"{i} a 0.5 1" for i in range(1, file_length + 1))
+    expected_length = min(60000, file_length - nskip)
+    expected = np.arange(nskip + 1, nskip + 1 + expected_length).astype(str)
 
     # file-like path
-    txt = StringIO("\n".join(data))
+    txt = StringIO(data)
     res = np.loadtxt(txt, dtype='str', delimiter=" ", skiprows=nskip, max_rows=60000)
-    expected_length = min(60000, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
-    assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))
+    assert_array_equal(expected, res[:, 0])
 
     # file-obj path
-    tmp_file = tmpdir.join("test_data.txt")
-    tmp_file.write("\n".join(data))
+    tmp_file = tmpdir/"test_data.txt"
+    tmp_file.write(data)
     fname = str(tmp_file)
     res = np.loadtxt(fname, dtype = 'str', delimiter=" ", skiprows=nskip, max_rows=60000)
-    expected_length = min(60000, file_length - nskip)
     assert len(res) == expected_length
     # are the right lines read in res?
-    assert np.all(np.equal(np.arange(nskip + 1, nskip + 1 + expected_length).astype(str), res[:, 0]))
+    assert_array_equal(expected, res[:, 0])


### PR DESCRIPTION
Fixed wrong behavior of loadtxt when reading files in chunks.

Misnamed variable (skiprows instead of skiplines) in function _read in numpy/lib/npyio_impl.py caused the function to skip lines at every chunk read.

Closes #28315 