### PR TITLE
CI: update test_moderately_small_alpha [wheel build]

### DIFF
--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1244,7 +1244,7 @@ class TestRandomDist:
     @pytest.mark.slow
     def test_dirichlet_moderately_small_alpha(self):
         # Use alpha.max() < 0.1 to trigger stick breaking code path
-        alpha = np.array([0.02, 0.04, 0.03])
+        alpha = np.array([0.02, 0.04])
         exact_mean = alpha / alpha.sum()
         random = Generator(MT19937(self.seed))
         sample = random.dirichlet(alpha, size=20000000)


### PR DESCRIPTION
The test_moderately_small_alpha dirichlet test fails for 32-bit Windows Python3.13t
wheel builds due to a memory error. Decrease the size of the test array by a bit.

Note that this test is only run for the mt19937 generator.

I don't know if this is a problem due to the free threading update, or a change
in the build infrastructure. Another solution would be to use try-except or a loop, but I
think decreasing the number of tested `alpha` is preferable -- if it works.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
