### PR TITLE
ENH: Function for faster normal buffering increments

### DIFF
--- a/numpy/_core/src/multiarray/nditer_impl.h
+++ b/numpy/_core/src/multiarray/nditer_impl.h
@@ -372,6 +372,8 @@ npyiter_coalesce_axes(NpyIter *iter);
 NPY_NO_EXPORT int
 npyiter_allocate_buffers(NpyIter *iter, char **errmsg);
 NPY_NO_EXPORT void
+npyiter_incrementbuffer(NpyIter *iter);
+NPY_NO_EXPORT void
 npyiter_goto_iterindex(NpyIter *iter, npy_intp iterindex);
 NPY_NO_EXPORT int
 npyiter_copy_from_buffers(NpyIter *iter);

--- a/numpy/_core/src/multiarray/nditer_templ.c.src
+++ b/numpy/_core/src/multiarray/nditer_templ.c.src
@@ -257,7 +257,7 @@ npyiter_buffered_iternext(NpyIter *iter)
     }
     /* Increment to the next buffer */
     else {
-        npyiter_goto_iterindex(iter, NIT_ITERINDEX(iter));
+        npyiter_incrementbuffer(iter);
     }
 
     /* Prepare the next buffers and set iterend/size */


### PR DESCRIPTION
Addresses a task in #28018.

Adds a new function similar to `npyiter_goto_iterindex` for more quickly advancing the iterator in normal buffered iteration. It simplifies some logic and uses deltas until exhausted instead of re-setting each dimension from scratch.

I'm not sure if this adds complexity, so it is OK if another approach is needed or if we don't need or prioritize this right now. Thank you for reviewing!