### PR TITLE
TYP: fix positional- and keyword-only params in ``astype``, ``cross`` and ``linalg``

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -699,8 +699,8 @@ def moveaxis(
 
 @overload
 def cross(
-    x1: _ArrayLikeUnknown,
-    x2: _ArrayLikeUnknown,
+    a: _ArrayLikeUnknown,
+    b: _ArrayLikeUnknown,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -708,8 +708,8 @@ def cross(
 ) -> NDArray[Any]: ...
 @overload
 def cross(
-    x1: _ArrayLikeBool_co,
-    x2: _ArrayLikeBool_co,
+    a: _ArrayLikeBool_co,
+    b: _ArrayLikeBool_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -717,8 +717,8 @@ def cross(
 ) -> NoReturn: ...
 @overload
 def cross(
-    x1: _ArrayLikeUInt_co,
-    x2: _ArrayLikeUInt_co,
+    a: _ArrayLikeUInt_co,
+    b: _ArrayLikeUInt_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -726,8 +726,8 @@ def cross(
 ) -> NDArray[unsignedinteger[Any]]: ...
 @overload
 def cross(
-    x1: _ArrayLikeInt_co,
-    x2: _ArrayLikeInt_co,
+    a: _ArrayLikeInt_co,
+    b: _ArrayLikeInt_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -735,8 +735,8 @@ def cross(
 ) -> NDArray[signedinteger[Any]]: ...
 @overload
 def cross(
-    x1: _ArrayLikeFloat_co,
-    x2: _ArrayLikeFloat_co,
+    a: _ArrayLikeFloat_co,
+    b: _ArrayLikeFloat_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -744,8 +744,8 @@ def cross(
 ) -> NDArray[floating[Any]]: ...
 @overload
 def cross(
-    x1: _ArrayLikeComplex_co,
-    x2: _ArrayLikeComplex_co,
+    a: _ArrayLikeComplex_co,
+    b: _ArrayLikeComplex_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
@@ -753,8 +753,8 @@ def cross(
 ) -> NDArray[complexfloating[Any, Any]]: ...
 @overload
 def cross(
-    x1: _ArrayLikeObject_co,
-    x2: _ArrayLikeObject_co,
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -874,6 +874,8 @@ def array_equiv(a1: ArrayLike, a2: ArrayLike) -> bool: ...
 def astype(
     x: ndarray[_ShapeType, dtype[Any]],
     dtype: _DTypeLike[_SCT],
+    /,
+    *,
     copy: bool = ...,
     device: None | L["cpu"] = ...,
 ) -> ndarray[_ShapeType, dtype[_SCT]]: ...
@@ -881,6 +883,8 @@ def astype(
 def astype(
     x: ndarray[_ShapeType, dtype[Any]],
     dtype: DTypeLike,
+    /,
+    *,
     copy: bool = ...,
     device: None | L["cpu"] = ...,
 ) -> ndarray[_ShapeType, dtype[Any]]: ...

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -175,11 +175,11 @@ def matrix_power(
 ) -> NDArray[Any]: ...
 
 @overload
-def cholesky(a: _ArrayLikeInt_co) -> NDArray[float64]: ...
+def cholesky(a: _ArrayLikeInt_co, /, *, upper: bool = False) -> NDArray[float64]: ...
 @overload
-def cholesky(a: _ArrayLikeFloat_co) -> NDArray[floating[Any]]: ...
+def cholesky(a: _ArrayLikeFloat_co, /, *, upper: bool = False) -> NDArray[floating[Any]]: ...
 @overload
-def cholesky(a: _ArrayLikeComplex_co) -> NDArray[complexfloating[Any, Any]]: ...
+def cholesky(a: _ArrayLikeComplex_co, /, *, upper: bool = False) -> NDArray[complexfloating[Any, Any]]: ...
 
 @overload
 def outer(x1: _ArrayLikeUnknown, x2: _ArrayLikeUnknown) -> NDArray[Any]: ...
@@ -372,12 +372,16 @@ def norm(
 @overload
 def matrix_norm(
     x: ArrayLike,
+    /,
+    *,
     ord: None | float | L["fro", "nuc"] = ...,
     keepdims: bool = ...,
 ) -> floating[Any]: ...
 @overload
 def matrix_norm(
     x: ArrayLike,
+    /,
+    *,
     ord: None | float | L["fro", "nuc"] = ...,
     keepdims: bool = ...,
 ) -> Any: ...
@@ -385,6 +389,8 @@ def matrix_norm(
 @overload
 def vector_norm(
     x: ArrayLike,
+    /,
+    *,
     axis: None = ...,
     ord: None | float = ...,
     keepdims: bool = ...,
@@ -392,6 +398,8 @@ def vector_norm(
 @overload
 def vector_norm(
     x: ArrayLike,
+    /,
+    *,
     axis: SupportsInt | SupportsIndex | tuple[int, ...] = ...,
     ord: None | float = ...,
     keepdims: bool = ...,
@@ -406,11 +414,15 @@ def multi_dot(
 
 def diagonal(
     x: ArrayLike,  # >= 2D array
+    /,
+    *,
     offset: SupportsIndex = ...,
 ) -> NDArray[Any]: ...
 
 def trace(
     x: ArrayLike,  # >= 2D array
+    /,
+    *,
     offset: SupportsIndex = ...,
     dtype: DTypeLike = ...,
 ) -> Any: ...
@@ -419,24 +431,32 @@ def trace(
 def cross(
     a: _ArrayLikeUInt_co,
     b: _ArrayLikeUInt_co,
+    /,
+    *,
     axis: int = ...,
 ) -> NDArray[unsignedinteger[Any]]: ...
 @overload
 def cross(
     a: _ArrayLikeInt_co,
     b: _ArrayLikeInt_co,
+    /,
+    *,
     axis: int = ...,
 ) -> NDArray[signedinteger[Any]]: ...
 @overload
 def cross(
     a: _ArrayLikeFloat_co,
     b: _ArrayLikeFloat_co,
+    /,
+    *,
     axis: int = ...,
 ) -> NDArray[floating[Any]]: ...
 @overload
 def cross(
     a: _ArrayLikeComplex_co,
     b: _ArrayLikeComplex_co,
+    /,
+    *,
     axis: int = ...,
 ) -> NDArray[complexfloating[Any, Any]]: ...
 

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -429,32 +429,32 @@ def trace(
 
 @overload
 def cross(
-    a: _ArrayLikeUInt_co,
-    b: _ArrayLikeUInt_co,
+    x1: _ArrayLikeUInt_co,
+    x2: _ArrayLikeUInt_co,
     /,
     *,
     axis: int = ...,
 ) -> NDArray[unsignedinteger[Any]]: ...
 @overload
 def cross(
-    a: _ArrayLikeInt_co,
-    b: _ArrayLikeInt_co,
+    x1: _ArrayLikeInt_co,
+    x2: _ArrayLikeInt_co,
     /,
     *,
     axis: int = ...,
 ) -> NDArray[signedinteger[Any]]: ...
 @overload
 def cross(
-    a: _ArrayLikeFloat_co,
-    b: _ArrayLikeFloat_co,
+    x1: _ArrayLikeFloat_co,
+    x2: _ArrayLikeFloat_co,
     /,
     *,
     axis: int = ...,
 ) -> NDArray[floating[Any]]: ...
 @overload
 def cross(
-    a: _ArrayLikeComplex_co,
-    b: _ArrayLikeComplex_co,
+    x1: _ArrayLikeComplex_co,
+    x2: _ArrayLikeComplex_co,
     /,
     *,
     axis: int = ...,


### PR DESCRIPTION
Example:
```python
import numpy as np
lst = np.eye(3)
# No typing issues but on runtime:
# TypeError: astype() got some positional-only arguments passed as keyword arguments: 'x, dtype'
np.astype(x=lst, dtype=np.float64)
```