### PR TITLE
ENH:  Ensure ``lib._format_impl.read_array`` handles file reading errors.

### DIFF
--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -872,6 +872,9 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
                     data = _read_bytes(fp, read_size, "array data")
                     array[i:i + read_count] = numpy.frombuffer(data, dtype=dtype,
                                                              count=read_count)
+        
+        if array.size != count:
+            raise IOError("Failed to read all data for array")
 
         if fortran_order:
             array.shape = shape[::-1]

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -874,7 +874,12 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
                                                              count=read_count)
         
         if array.size != count:
-            raise ValueError(f"Failed to read all data for array. Expected {shape} = {count} elements, read {array.size} elements.")
+            raise ValueError(
+                "Failed to read all data for array. "
+                f"Expected {shape} = {count} elements, "
+                f"could only read {array.size} elements. "
+                "(file seems not fully written?)"
+            )
 
         if fortran_order:
             array.shape = shape[::-1]

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -874,7 +874,7 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
                                                              count=read_count)
         
         if array.size != count:
-            raise IOError("Failed to read all data for array")
+            raise ValueError(f"Failed to read all data for array. Expected {shape} = {count} elements, read {array.size} elements.")
 
         if fortran_order:
             array.shape = shape[::-1]

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -283,7 +283,7 @@ from io import BytesIO
 import numpy as np
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises, assert_raises_regex,
-    assert_warns, IS_PYPY, IS_WASM, IS_64BIT
+    assert_warns, temppath, IS_PYPY, IS_WASM, IS_64BIT
     )
 from numpy.testing._private.utils import requires_memory
 from numpy.lib import format
@@ -428,6 +428,17 @@ def roundtrip_truncated(arr):
     arr2 = format.read_array(f2)
     return arr2
 
+def file_truncated(arr):
+    with temppath() as path:
+        with open(path, 'wb') as f:
+            format.write_array(f, arr)
+        #truncate the file by one byte
+        with open(path, 'rb+') as f:
+            f.seek(-1, os.SEEK_END)
+            f.truncate()
+        with open(path, 'rb') as f:
+            arr2 = format.read_array(f)
+        return arr2
 
 def assert_equal_(o1, o2):
     assert_(o1 == o2)
@@ -451,6 +462,10 @@ def test_roundtrip_truncated():
         if arr.dtype != object:
             assert_raises(ValueError, roundtrip_truncated, arr)
 
+def test_file_truncated():
+    for arr in basic_arrays:
+        if arr.dtype != object:
+            assert_raises(ValueError, file_truncated, arr)
 
 def test_long_str():
     # check items larger than internal buffer size, gh-4027

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -428,18 +428,6 @@ def roundtrip_truncated(arr):
     arr2 = format.read_array(f2)
     return arr2
 
-def file_truncated(arr):
-    with temppath() as path:
-        with open(path, 'wb') as f:
-            format.write_array(f, arr)
-        #truncate the file by one byte
-        with open(path, 'rb+') as f:
-            f.seek(-1, os.SEEK_END)
-            f.truncate()
-        with open(path, 'rb') as f:
-            arr2 = format.read_array(f)
-        return arr2
-
 def assert_equal_(o1, o2):
     assert_(o1 == o2)
 
@@ -462,10 +450,30 @@ def test_roundtrip_truncated():
         if arr.dtype != object:
             assert_raises(ValueError, roundtrip_truncated, arr)
 
-def test_file_truncated():
+def test_file_truncated(tmp_path):
+    path = tmp_path / "a.npy"
     for arr in basic_arrays:
         if arr.dtype != object:
-            assert_raises(ValueError, file_truncated, arr)
+            with open(path, 'wb') as f:
+                format.write_array(f, arr)
+            #truncate the file by one byte
+            with open(path, 'rb+') as f:
+                f.seek(-1, os.SEEK_END)
+                f.truncate()
+            with open(path, 'rb') as f:
+                with pytest.raises(
+                    ValueError, 
+                    match = (
+                        r"EOF: reading array header, "
+                        r"expected (\d+) bytes got (\d+)"
+                    ) if arr.size == 0 else (
+                        r"Failed to read all data for array\. "
+                        r"Expected \(.*?\) = (\d+) elements, "
+                        r"could only read (\d+) elements\. "
+                        r"\(file seems not fully written\?\)"
+                    )
+                ):
+                    _ = format.read_array(f)
 
 def test_long_str():
     # check items larger than internal buffer size, gh-4027

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -283,7 +283,7 @@ from io import BytesIO
 import numpy as np
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises, assert_raises_regex,
-    assert_warns, temppath, IS_PYPY, IS_WASM, IS_64BIT
+    assert_warns, IS_PYPY, IS_WASM, IS_64BIT
     )
 from numpy.testing._private.utils import requires_memory
 from numpy.lib import format


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

When a user uses `numpy.load(filename)` to read a `.npy` array file, and an error occurs during the reading operation (for example, if a 1024MiB file is missing the last 512MiB content), it will produce the following error:

```py
  File ".../numpy/lib/_format_impl.py", line 883, in read_array
    array.shape = shape
    ^^^^^^^^^^^
ValueError: cannot reshape array of size 65535984 into shape (128,1048576)
```

This error can be confusing to the user, as it does not indicate the actual cause of the problem.

This PR checks if the size of the array returned by numpy.fromfile in the read_array method matches the expected size. If it doesn't, it explicitly informs the user of the reason for the error:

```py
  File ".../numpy/lib/_format_impl.py", line 877, in read_array
    raise ValueError(f"Failed to read all data for array. Expected {shape} = {count} elements, read {array.size} elements.")
ValueError: Failed to read all data for array. Expected (128, 1048576) = 134217728 elements, read 67108848 elements.
```

