### PR TITLE
BUG: Fix TestStringDiscovery float casting warning on FreeBSD

### DIFF
--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -179,7 +179,7 @@ class TestStringDiscovery:
         expected = np.dtype(f"S{length}")
         arr = np.array(obj, dtype="O")
         # On FreeBSD, expecting and verifying the RuntimeWarning for float-to-string cast
-        # See https://github.com/numpy/numpy/issues/28329
+        # See gh-28351
         if sys.platform.startswith("freebsd") and isinstance(obj, float):
             with pytest.warns(RuntimeWarning, match="invalid value encountered in cast") as w:
                 result = np.array([arr, arr], dtype="S")

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -170,6 +170,11 @@ class TestStringDiscovery:
         # The DType class is accepted by `.astype()`
         assert arr.astype(type(np.dtype("S"))).dtype == expected
 
+    # Suppress known RuntimeWarning that occurs specifically on FreeBSD when 
+    # casting float objects to string dtype in nested arrays. This warning does not 
+    # affect the actual string length determination being tested.
+    # See https://github.com/numpy/numpy/issues/28329
+    @pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")
     @pytest.mark.parametrize("obj",
             [object(), 1.2, 10**43, None, "string"],
             ids=["object", "1.2", "10**43", "None", "string"])
@@ -177,7 +182,8 @@ class TestStringDiscovery:
         length = len(str(obj))
         expected = np.dtype(f"S{length}")
         arr = np.array(obj, dtype="O")
-        assert np.array([arr, arr], dtype="S").dtype == expected
+        result = np.array([arr, arr], dtype="S").dtype
+        assert result == expected
 
     @pytest.mark.parametrize("arraylike", arraylikes())
     def test_unpack_first_level(self, arraylike):


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fixes #28329

The `test_nested_arrays_stringlength` test in `test_array_coercion.py` was failing on FreeBSD due to a platform-specific RuntimeWarning when casting float objects to string dtype. This PR modifies the test to properly handle and verify this warning.

Changes:
- Add FreeBSD-specific warning handling for float-to-string dtype conversion
- Only check for warning with float values, as other types don't trigger it
- Keep original test behavior for non-float types and non-FreeBSD platforms
- Add assertion to verify exactly one warning is raised, preventing multiple or unexpected warnings

cc: @ngoldbaum @rgommers @charris 