### PR TITLE
BUG: avoid segfault in np._core.multiarray.scalar

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2113,6 +2113,12 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                     "Cannot unpickle a scalar with object dtype.");
             return NULL;
         }
+        if (typecode->type_num == NPY_VSTRING) {
+            // TODO: if we ever add a StringDType scalar, this might need to change
+            PyErr_SetString(PyExc_TypeError,
+                            "Cannot unpickle a StringDType scalar");
+            return NULL;
+        }
         /* We store the full array to unpack it here: */
         if (!PyArray_CheckExact(obj)) {
             /* We pickle structured voids as arrays currently */

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1676,6 +1676,22 @@ class TestDTypeClasses:
         with pytest.raises(AttributeError):
             getattr(numpy.dtypes, name + "DType") is numpy.dtypes.Float16DType
 
+    def test_scalar_helper_all_dtypes(self):
+        for dtype in np.dtypes.__all__:
+            dt_class = getattr(np.dtypes, dtype)
+            dt = np.dtype(dt_class)
+            if dt.char not in 'OTVM':
+                assert np._core.multiarray.scalar(dt) == dt.type()
+            elif dt.char == 'V':
+                assert np._core.multiarray.scalar(dt) == dt.type(b'\x00')
+            elif dt.char == 'M':
+                # can't do anything with this without generating ValueError
+                # because 'M' has no units
+                _ = np._core.multiarray.scalar(dt)
+            else:
+                with pytest.raises(TypeError):
+                    np._core.multiarray.scalar(dt)
+
 
 class TestFromCTypes:
 


### PR DESCRIPTION
Fixes #28316

I decided it was simplest just to add a special-case for StringDType. While it would be pretty easy to find the "default" scalar for an arbitrary new-style dtype (just do `PyObject_CallNoArgs(NPY_DTYPE(descr)->scalar_type)`), because this function takes a second argument which might be anything, I thought it would be best to just raise an error and let future devs worry about pickle support for arbitrary new-style dtypes that don't work with the pickling code for legacy dtypes. There is of course always the escape hatch of defining a custom pickle implementation.