### PR TITLE
DOC: Update link to Anaconda Eclipse/PyDev documentation

### DIFF
--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -78,7 +78,7 @@ Using Eclipse/PyDev with Anaconda Python (or environments)
 ----------------------------------------------------------
 
 Please see the
-`Anaconda Documentation <https://docs.anaconda.com/anaconda/user-guide/tasks/integration/eclipse-pydev/>`_
+`Anaconda Documentation <https://docs.anaconda.com/working-with-conda/ide-tutorials/eclipse-pydev/>`_
 on how to properly configure Eclipse/PyDev to use Anaconda Python with specific
 conda environments.
 


### PR DESCRIPTION
Update link to Anaconda Eclipse/PyDev documentation

Correct link:
https://docs.anaconda.com/working-with-conda/ide-tutorials/eclipse-pydev/

The old link does not work:
https://docs.anaconda.com/anaconda/ide-tutorials/eclipse-pydev/

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
