### PR TITLE
MAINT: use OpenBLAS 0.3.29

### DIFF
--- a/.github/workflows/linux_musl.yml
+++ b/.github/workflows/linux_musl.yml
@@ -60,8 +60,6 @@ jobs:
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
         # use meson to build and test 
-        # the Duse-ilp64 is not needed with scipy-openblas wheels > 0.3.24.95.0
-        # spin build --with-scipy-openblas=64 -- -Duse-ilp64=true
         spin build --with-scipy-openblas=64
         spin test -j auto -- --timeout=600 --durations=10
 

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.13
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.28.0.2
+scipy-openblas32==0.3.29.0.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.28.0.2
-scipy-openblas64==0.3.28.0.2
+scipy-openblas32==0.3.29.0.0
+scipy-openblas64==0.3.29.0.0


### PR DESCRIPTION
OpenBLAS 0.3.29 was released Jan12. Let's use it for the next release.