### PR TITLE
MAIN: Update c,c++ line length to 88

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AllowShortEnumsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AlwaysBreakAfterReturnType: TopLevel
 BreakBeforeBraces: Stroustrup
-ColumnLimit: 79
+ColumnLimit: 88
 ContinuationIndentWidth: 8
 DerivePointerAlignment: false
 IndentWidth: 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 # https://numpy.org/neps/nep-0045-c_style_guide.html
 indent_size = 4
 indent_style = space
-max_line_length = 80
+max_line_length = 88
 trim_trailing_whitespace = true
 
 [*.{py,pyi,pxd}]


### PR DESCRIPTION
This makes the c/c++ line length the same as the modern Python defaults. Note that linux has dropped the hard 80 character limit, it is now only preferred. I don't know how to configure a linter for "preferred", so just make the hard limit 88.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
