### PR TITLE
Add RomuRandom to random module

### DIFF
--- a/numpy/random/_romurandom.pyi
+++ b/numpy/random/_romurandom.pyi
@@ -1,0 +1,111 @@
+from typing import TypedDict, type_check_only
+
+from numpy import uint32, uint64
+from numpy.typing import NDArray
+from numpy.random.bit_generator import BitGenerator, SeedSequence
+from numpy._typing import _ArrayLikeInt_co
+
+
+@type_check_only
+class _Romu64StateInternal(TypedDict):
+    key: NDArray[uint64]
+
+@type_check_only
+class _Romu64State(TypedDict):
+    bit_generator: str
+    state: _Romu64StateInternal
+
+@type_check_only
+class _Romu32StateInternal(TypedDict):
+    key: NDArray[uint32]
+
+@type_check_only
+class _Romu32State(TypedDict):
+    bit_generator: str
+    state: _Romu64StateInternal
+
+@type_check_only
+class Romu64(BitGenerator):
+    def __init__(self, seed: None | _ArrayLikeInt_co | SeedSequence = ...) -> None: ...
+    @property
+    def state(self) -> _Romu64State: ...
+    @state.setter
+    def state(self, value: _Romu64State) -> None: ...
+
+@type_check_only
+class Romu32(BitGenerator):
+    def __init__(self, seed: None | _ArrayLikeInt_co | SeedSequence = ...) -> None: ...
+    @property
+    def state(self) -> _Romu32State: ...
+    @state.setter
+    def state(self, value: _Romu32State) -> None: ...
+
+
+class RomuQuad(Romu64):
+    """
+    RomuQuad
+    --------
+
+    More robust than anyone could need, but uses more registers than RomuTrio.
+    Est. capacity >= 2^90 bytes. Register pressure = 8 (high). State size = 256 bits.
+    """
+
+
+
+class RomuTrio(Romu64):
+    """
+    RomuTrio
+    --------
+
+    Great for general purpose work, including huge jobs.
+    Est. capacity = 2^75 bytes. Register pressure = 6. State size = 192 bits.
+
+    """
+    
+
+
+class RomuDuo(Romu64):
+    """
+    RomuDuo
+    -------
+
+    Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.
+    Est. capacity = 2^61 bytes. Register pressure = 5. State size = 128 bits.
+    """
+    
+
+
+class RomuDuoJR(Romu64):
+    """
+
+    RomuDuoJR
+    ---------
+
+    The fastest generator using 64-bit arith., but not suited for huge jobs.
+    Est. capacity = 2^51 bytes. Register pressure = 4. State size = 128 bits.
+    """
+    
+
+
+class RomuQuad32(Romu32):
+    """
+    RomuQuad32
+    ----------
+
+    32-bit arithmetic: Good for general purpose use.
+    Est. capacity >= 2^62 bytes. Register pressure = 7. State size = 128 bits.
+    """
+
+
+class RomuTrio32(Romu32):
+    """
+    RomuTrio32
+    ----------
+
+    32-bit arithmetic: Good for general purpose use, except for huge jobs.
+    Est. capacity >= 2^53 bytes. Register pressure = 5. State size = 96 bits.
+    """
+
+    
+
+

--- a/numpy/random/_romurandom.pyx
+++ b/numpy/random/_romurandom.pyx
@@ -149,9 +149,16 @@ cdef uint64_t romutrio32_raw(void *st) noexcept nogil:
     return <uint64_t>romutrio32_next32(<romutrio32_state *> st)
 
 
-
+# TODO (Vizonex) Optimize when I have the time to.
 
 cdef class RomuQuad(BitGenerator):
+    """
+    RomuQuad
+    --------
+
+    More robust than anyone could need, but uses more registers than RomuTrio.
+    Est. capacity >= 2^90 bytes. Register pressure = 8 (high). State size = 256 bits.
+    """
 
     cdef romuquad_state rng_state
 
@@ -172,7 +179,7 @@ cdef class RomuQuad(BitGenerator):
     
     @property
     def state(self):
-        key = np.zeros(4, dtype=np.uint64)
+        cdef np.ndarray key = np.zeros(4, dtype=np.uint64)
         for i in range(4):
             key[i] = self.rng_state.state[i]
 
@@ -183,11 +190,13 @@ cdef class RomuQuad(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuQuad' or len(value) != 2:
                 raise ValueError('state is not a RomuQuad state')
-            value = {'bit_generator': 'RomuQuad', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuQuad', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
+
         bitgen = value.get('bit_generator', '')
+        
         if bitgen != self.__class__.__name__:
             raise ValueError('state must be for a {0} '
                              'PRNG'.format(self.__class__.__name__))
@@ -200,6 +209,14 @@ cdef class RomuQuad(BitGenerator):
 
 
 cdef class RomuTrio(BitGenerator):
+    """
+    RomuTrio
+    --------
+
+    Great for general purpose work, including huge jobs.
+    Est. capacity = 2^75 bytes. Register pressure = 6. State size = 192 bits.
+
+    """
 
     cdef romutrio_state rng_state
 
@@ -231,7 +248,7 @@ cdef class RomuTrio(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuTrio' or len(value) != 2:
                 raise ValueError('state is not a RomuTrio state')
-            value = {'bit_generator': 'RomuTrio', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuTrio', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
@@ -246,7 +263,14 @@ cdef class RomuTrio(BitGenerator):
 
 
 cdef class RomuDuo(BitGenerator):
+    """
+    RomuDuo
+    -------
 
+    Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.
+    Est. capacity = 2^61 bytes. Register pressure = 5. State size = 128 bits.
+    """
+    
     cdef romuduo_state rng_state
 
     def __init__(self, seed=None) -> None:
@@ -266,7 +290,7 @@ cdef class RomuDuo(BitGenerator):
 
     @property
     def state(self):
-        key = np.zeros(2, dtype=np.uint64)
+        cdef np.ndarray key = np.zeros(2, dtype=np.uint64)
         for i in range(2):
             key[i] = self.rng_state.state[i]
 
@@ -277,7 +301,7 @@ cdef class RomuDuo(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuDuo' or len(value) != 2:
                 raise ValueError('state is not a RomuDuo state')
-            value = {'bit_generator': 'RomuDuo', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuDuo', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
@@ -292,7 +316,14 @@ cdef class RomuDuo(BitGenerator):
 
 
 cdef class RomuDuoJR(BitGenerator):
+    """
 
+    RomuDuoJR
+    ---------
+
+    The fastest generator using 64-bit arith., but not suited for huge jobs.
+    Est. capacity = 2^51 bytes. Register pressure = 4. State size = 128 bits.
+    """
     cdef romuduojr_state rng_state
 
     def __init__(self, seed=None) -> None:
@@ -312,7 +343,7 @@ cdef class RomuDuoJR(BitGenerator):
 
     @property
     def state(self):
-        key = np.zeros(2, dtype=np.uint64)
+        cdef np.ndarray key = np.zeros(2, dtype=np.uint64)
         for i in range(2):
             key[i] = self.rng_state.state[i]
 
@@ -323,7 +354,7 @@ cdef class RomuDuoJR(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuDuoJR' or len(value) != 2:
                 raise ValueError('state is not a RomuDuoJR state')
-            value = {'bit_generator': 'RomuDuoJR', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuDuoJR', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
@@ -338,6 +369,13 @@ cdef class RomuDuoJR(BitGenerator):
 
 
 cdef class RomuQuad32(BitGenerator):
+    """
+    RomuQuad32
+    ----------
+
+    32-bit arithmetic: Good for general purpose use.
+    Est. capacity >= 2^62 bytes. Register pressure = 7. State size = 128 bits.
+    """
 
     cdef romuquad32_state rng_state
 
@@ -372,7 +410,7 @@ cdef class RomuQuad32(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuQuad32' or len(value) != 2:
                 raise ValueError('state is not a RomuQuad32 state')
-            value = {'bit_generator': 'RomuQuad32', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuQuad32', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
@@ -388,6 +426,13 @@ cdef class RomuQuad32(BitGenerator):
 
 
 cdef class RomuTrio32(BitGenerator):
+    """
+    RomuTrio32
+    ----------
+
+    32-bit arithmetic: Good for general purpose use, except for huge jobs.
+    Est. capacity >= 2^53 bytes. Register pressure = 5. State size = 96 bits.
+    """
 
     cdef romutrio32_state rng_state
 
@@ -408,7 +453,7 @@ cdef class RomuTrio32(BitGenerator):
 
     @property
     def state(self):
-        key = np.zeros(3, dtype=np.uint32)
+        cdef np.ndarray key = np.zeros(3, dtype=np.uint32)
         for i in range(3):
             key[i] = self.rng_state.state[i]
         
@@ -419,7 +464,7 @@ cdef class RomuTrio32(BitGenerator):
         if isinstance(value, tuple):
             if value[0] != 'RomuTrio32' or len(value) != 2:
                 raise ValueError('state is not a RomuTrio32 state')
-            value = {'bit_generator': 'RomuTrio32', 'state': {'key': value}}
+            value = {'bit_generator': 'RomuTrio32', 'state': {'key': value[1]}}
 
         if not isinstance(value, dict):
             raise TypeError('state must be a dict')
@@ -431,3 +476,5 @@ cdef class RomuTrio32(BitGenerator):
         
         for i in range(4):
             self.rng_state.key[i] = key[i]
+
+

--- a/numpy/random/_romurandom.pyx
+++ b/numpy/random/_romurandom.pyx
@@ -1,0 +1,433 @@
+#cython: binding=True
+
+import numpy as np
+cimport numpy as np
+from libc.stdint cimport uint32_t, uint64_t
+from numpy.random cimport BitGenerator, SeedSequence
+from numpy.random._common cimport uint64_to_double, wrap_int
+
+np.import_array()
+
+
+from libc.stdint cimport uint32_t as uint32_t
+from libc.stdint cimport uint64_t as uint64_t
+
+cdef extern from "src/RomuRandom/RomuRandom.h" nogil:      
+    struct s_romuquad_state:
+        uint64_t[4] state
+        int has_uint32
+        uint32_t uinteger
+    
+    ctypedef s_romuquad_state romuquad_state 
+    
+    uint64_t romuquad_next(uint64_t*)        
+    uint64_t romuquad_next64(romuquad_state*)
+    uint32_t romuquad_next32(romuquad_state*)
+    
+    struct s_romutrio_state:
+        uint64_t[3] state
+        int has_uint32
+        uint32_t uinteger
+    
+    ctypedef s_romutrio_state romutrio_state 
+    
+    uint64_t romutrio_next(uint64_t*)        
+    uint64_t romutrio_next64(romutrio_state*)
+    uint32_t romutrio_next32(romutrio_state*)
+    
+    struct s_romuduo_state:
+        uint64_t[2] state
+        int has_uint32
+        uint32_t uinteger
+    
+    ctypedef s_romuduo_state romuduo_state   
+    
+    uint64_t romuduo_next(uint64_t*)
+    uint64_t romuduo_next64(romuduo_state*)
+    uint32_t romuduo_next32(romuduo_state*)
+
+    struct s_romuduojr_state:
+        uint64_t[2] state
+        int has_uint32
+        uint32_t uinteger
+
+    ctypedef s_romuduojr_state romuduojr_state
+    
+    uint64_t romuduojr_next(uint64_t*)
+    uint64_t romuduojr_next64(romuduojr_state*)
+    uint32_t romuduojr_next32(romuduojr_state*)
+
+    struct s_romuquad32_state:
+        uint32_t[4] state
+    
+    ctypedef s_romuquad32_state romuquad32_state
+    
+    uint32_t romuquad32_next(uint32_t*)
+    uint64_t romuquad32_next64(romuquad32_state*)
+    uint32_t romuquad32_next32(romuquad32_state*)
+
+    struct s_romutrio32_state:
+        uint32_t[3] state
+  
+    ctypedef s_romutrio32_state romutrio32_state
+    
+    uint32_t romutrio32_next(uint32_t*)
+    uint64_t romutrio32_next64(romutrio32_state*)
+    uint32_t romutrio32_next32(romutrio32_state*)
+
+
+cdef uint64_t romuquad_uint64(void* st) noexcept nogil:
+    return romuquad_next64(<romuquad_state *>st)
+
+cdef uint32_t romuquad_uint32(void *st) noexcept nogil:
+    return romuquad_next32(<romuquad_state *> st)
+
+cdef double romuquad_double(void* st) noexcept nogil:
+    return uint64_to_double(romuquad_next64(<romuquad_state *>st))
+
+cdef uint64_t romuquad_raw(void *st) noexcept nogil:
+    return <uint64_t>romuquad_next32(<romuquad_state *> st)
+
+cdef uint64_t romutrio_uint64(void* st) noexcept nogil:
+    return romutrio_next64(<romutrio_state *>st)
+
+cdef uint32_t romutrio_uint32(void *st) noexcept nogil:
+    return romutrio_next32(<romutrio_state *> st)
+
+cdef double romutrio_double(void* st) noexcept nogil:
+    return uint64_to_double(romutrio_next64(<romutrio_state *>st))
+
+cdef uint64_t romutrio_raw(void *st) noexcept nogil:
+    return <uint64_t>romutrio_next32(<romutrio_state *> st)
+
+cdef uint64_t romuduo_uint64(void* st) noexcept nogil:
+    return romuduo_next64(<romuduo_state *>st)
+
+cdef uint32_t romuduo_uint32(void *st) noexcept nogil:
+    return romuduo_next32(<romuduo_state *> st)
+
+cdef double romuduo_double(void* st) noexcept nogil:
+    return uint64_to_double(romuduo_next64(<romuduo_state *>st))
+
+cdef uint64_t romuduo_raw(void *st) noexcept nogil:
+    return <uint64_t>romuduo_next32(<romuduo_state *> st)
+
+cdef uint64_t romuduojr_uint64(void* st) noexcept nogil:
+    return romuduojr_next64(<romuduojr_state *>st)
+
+cdef uint32_t romuduojr_uint32(void *st) noexcept nogil:
+    return romuduojr_next32(<romuduojr_state *> st)
+
+cdef double romuduojr_double(void* st) noexcept nogil:
+    return uint64_to_double(romuduojr_next64(<romuduojr_state *>st))
+
+cdef uint64_t romuduojr_raw(void *st) noexcept nogil:
+    return <uint64_t>romuduojr_next32(<romuduojr_state *> st)
+
+cdef uint64_t romuquad32_uint64(void* st) noexcept nogil:
+    return romuquad32_next64(<romuquad32_state *>st)
+
+cdef uint32_t romuquad32_uint32(void *st) noexcept nogil:
+    return romuquad32_next32(<romuquad32_state *> st)
+
+cdef double romuquad32_double(void* st) noexcept nogil:
+    return uint64_to_double(romuquad32_next64(<romuquad32_state *>st))
+
+cdef uint64_t romuquad32_raw(void *st) noexcept nogil:
+    return <uint64_t>romuquad32_next32(<romuquad32_state *> st)
+
+cdef uint64_t romutrio32_uint64(void* st) noexcept nogil:
+    return romutrio32_next64(<romutrio32_state *>st)
+
+cdef uint32_t romutrio32_uint32(void *st) noexcept nogil:
+    return romutrio32_next32(<romutrio32_state *> st)
+
+cdef double romutrio32_double(void* st) noexcept nogil:
+    return uint64_to_double(romutrio32_next64(<romutrio32_state *>st))
+
+cdef uint64_t romutrio32_raw(void *st) noexcept nogil:
+    return <uint64_t>romutrio32_next32(<romutrio32_state *> st)
+
+
+
+
+cdef class RomuQuad(BitGenerator):
+
+    cdef romuquad_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+        
+        val = self._seed_seq.generate_state(4, np.uint64)
+        
+        for i in range(4):
+            self.rng_state.state[i] = val
+        
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romuquad_uint32      
+        self._bitgen.next_uint64 = &romuquad_uint64      
+        self._bitgen.next_double = &romuquad_double      
+        self._bitgen.next_raw = &romuquad_raw
+    
+    @property
+    def state(self):
+        key = np.zeros(4, dtype=np.uint64)
+        for i in range(4):
+            key[i] = self.rng_state.state[i]
+
+        return {'bit_generator': self.__class__.__name__, 'state':{'key':key}}
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuQuad' or len(value) != 2:
+                raise ValueError('state is not a RomuQuad state')
+            value = {'bit_generator': 'RomuQuad', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(4):
+            self.rng_state.key[i] = key[i]
+
+
+
+
+cdef class RomuTrio(BitGenerator):
+
+    cdef romutrio_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+
+        val = self._seed_seq.generate_state(3, np.uint64)
+
+        for i in range(3):
+            self.rng_state.state[i] = val
+
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romutrio_uint32
+        self._bitgen.next_uint64 = &romutrio_uint64
+        self._bitgen.next_double = &romutrio_double
+        self._bitgen.next_raw = &romutrio_raw
+
+    @property
+    def state(self):
+        key = np.zeros(3, dtype=np.uint64)
+        for i in range(3):
+            key[i] = self.rng_state.state[i]
+
+        return {'bit_generator': self.__class__.__name__, 'state':{'key':key}}
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuTrio' or len(value) != 2:
+                raise ValueError('state is not a RomuTrio state')
+            value = {'bit_generator': 'RomuTrio', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(3):
+            self.rng_state.key[i] = key[i]
+
+
+cdef class RomuDuo(BitGenerator):
+
+    cdef romuduo_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+
+        val = self._seed_seq.generate_state(2, np.uint64)
+
+        for i in range(2):
+            self.rng_state.state[i] = val
+
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romuduo_uint32
+        self._bitgen.next_uint64 = &romuduo_uint64
+        self._bitgen.next_double = &romuduo_double
+        self._bitgen.next_raw = &romuduo_raw
+
+    @property
+    def state(self):
+        key = np.zeros(2, dtype=np.uint64)
+        for i in range(2):
+            key[i] = self.rng_state.state[i]
+
+        return {'bit_generator': self.__class__.__name__, 'state':{'key':key}}
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuDuo' or len(value) != 2:
+                raise ValueError('state is not a RomuDuo state')
+            value = {'bit_generator': 'RomuDuo', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(2):
+            self.rng_state.key[i] = key[i]
+
+
+cdef class RomuDuoJR(BitGenerator):
+
+    cdef romuduojr_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+
+        val = self._seed_seq.generate_state(2, np.uint64)
+
+        for i in range(2):
+            self.rng_state.state[i] = val
+
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romuduojr_uint32
+        self._bitgen.next_uint64 = &romuduojr_uint64
+        self._bitgen.next_double = &romuduojr_double
+        self._bitgen.next_raw = &romuduojr_raw
+
+    @property
+    def state(self):
+        key = np.zeros(2, dtype=np.uint64)
+        for i in range(2):
+            key[i] = self.rng_state.state[i]
+
+        return {'bit_generator': self.__class__.__name__, 'state':{'key':key}}
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuDuoJR' or len(value) != 2:
+                raise ValueError('state is not a RomuDuoJR state')
+            value = {'bit_generator': 'RomuDuoJR', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(4):
+            self.rng_state.key[i] = key[i]
+
+
+cdef class RomuQuad32(BitGenerator):
+
+    cdef romuquad32_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+
+        val = self._seed_seq.generate_state(4, np.uint32)
+
+        for i in range(4):
+            self.rng_state.state[i] = val
+
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romuquad32_uint32
+        self._bitgen.next_uint64 = &romuquad32_uint64
+        self._bitgen.next_double = &romuquad32_double
+        self._bitgen.next_raw = &romuquad32_raw
+
+    @property
+    def state(self):
+        cdef np.ndarray key = np.zeros(4, dtype=np.uint32)
+        for i in range(4):
+            key[i] = self.rng_state.state[i]
+
+        return {
+            'bit_generator': self.__class__.__name__, 
+            'state': {'key':key}
+        }
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuQuad32' or len(value) != 2:
+                raise ValueError('state is not a RomuQuad32 state')
+            value = {'bit_generator': 'RomuQuad32', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(4):
+            self.rng_state.key[i] = key[i]
+
+
+cdef class RomuTrio32(BitGenerator):
+
+    cdef romutrio32_state rng_state
+
+    def __init__(self, seed=None) -> None:
+        BitGenerator.__init__(self, seed)
+
+        val = self._seed_seq.generate_state(3, np.uint32)
+
+        for i in range(3):
+            self.rng_state.state[i] = val
+
+
+        self._bitgen.state = &self.rng_state
+        self._bitgen.next_uint32 = &romutrio32_uint32
+        self._bitgen.next_uint64 = &romutrio32_uint64
+        self._bitgen.next_double = &romutrio32_double
+        self._bitgen.next_raw = &romutrio32_raw
+
+    @property
+    def state(self):
+        key = np.zeros(3, dtype=np.uint32)
+        for i in range(3):
+            key[i] = self.rng_state.state[i]
+        
+        return {'bit_generator': self.__class__.__name__, 'state':{'key':key}}
+    
+    @state.setter
+    def state(self, value):
+        if isinstance(value, tuple):
+            if value[0] != 'RomuTrio32' or len(value) != 2:
+                raise ValueError('state is not a RomuTrio32 state')
+            value = {'bit_generator': 'RomuTrio32', 'state': {'key': value}}
+
+        if not isinstance(value, dict):
+            raise TypeError('state must be a dict')
+        bitgen = value.get('bit_generator', '')
+        if bitgen != self.__class__.__name__:
+            raise ValueError('state must be for a {0} '
+                             'PRNG'.format(self.__class__.__name__))
+        key = value['state']['key']
+        
+        for i in range(4):
+            self.rng_state.key[i] = key[i]

--- a/numpy/random/src/RomuRandom/RomuRandom.c
+++ b/numpy/random/src/RomuRandom/RomuRandom.c
@@ -1,0 +1,213 @@
+
+// Romu Random states made into arrays for numpy
+
+// Romu Pseudorandom Number Generators
+//
+// Copyright 2020 Mark A. Overton
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ------------------------------------------------------------------------------------------------
+//
+// Website: romu-random.org
+// Paper:   http://arxiv.org/abs/2002.11331
+
+#include <stdint.h>
+#include "romu_random_array.h"
+
+/* === 64 BIT RNG Generators === */
+
+//===== RomuQuad ==================================================================================
+//
+// More robust than anyone could need, but uses more registers than RomuTrio.
+// Est. capacity >= 2^90 bytes. Register pressure = 8 (high). State size = 256 bits.
+
+
+static inline uint64_t romuquad_next(uint64_t* state){
+    uint64_t wp = state[0], xp = state[1], yp = state[2], zp = state[3];
+    state[0] = 15241094284759029579u * zp; // a-mult
+    state[1] = zp + ROTL(wp,52);           // b-rotl, c-add
+    state[2] = yp - xp;                    // d-sub
+    state[3] = yp + wp;                    // e-add
+    state[3] = ROTL(state[3], 19);            // f-rotl
+    return xp;
+}
+
+static inline uint64_t romuquad_next64(romuquad_state* state){
+    return romuquad_next(state->state);
+}
+
+static inline uint32_t romuquad_next32(romuquad_state* state){
+    uint64_t next;
+    if (state->has_uint32) {
+      state->has_uint32 = 0;
+      return state->uinteger;
+    }
+    next = romuquad_next64(state);
+    state->has_uint32 = 1;
+    state->uinteger = (uint32_t)(next >> 32);
+    return (uint32_t)(next & 0xffffffff);
+}   
+
+
+
+//===== RomuTrio ==================================================================================
+//
+// Great for general purpose work, including huge jobs.
+// Est. capacity = 2^75 bytes. Register pressure = 6. State size = 192 bits.
+
+
+
+uint64_t romutrio_next(uint64_t* state) {
+   uint64_t xp = state[0] , yp = state[1], zp = state[2];
+   state[0] = 15241094284759029579u * zp;
+   state[1] = yp - xp;  state[1] = ROTL(state[1], 12);
+   state[2] = zp - yp;  state[2] = ROTL(state[2], 44);
+   return xp;
+}
+
+
+static inline uint64_t romutrio_next64(romuquad_state* state){
+    return romutrio_next(state->state);
+}
+
+static inline uint32_t romutrio_next32(romuquad_state* state){
+    uint64_t next;
+    if (state->has_uint32) {
+      state->has_uint32 = 0;
+      return state->uinteger;
+    }
+    next = romutrio_next64(state);
+    state->has_uint32 = 1;
+    state->uinteger = (uint32_t)(next >> 32);
+    return (uint32_t)(next & 0xffffffff);
+}  
+
+
+//===== RomuDuo ==================================================================================
+//
+// Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.
+// Est. capacity = 2^61 bytes. Register pressure = 5. State size = 128 bits.
+
+
+
+uint64_t romuduo_next (uint64_t *state) {
+   uint64_t xp = state[0];
+   state[0] = 15241094284759029579u * state[1];
+   state[1] = ROTL(state[1],36) + ROTL(state[1], 15) - xp;
+   return xp;
+}
+
+static inline uint64_t romuduo_next64(romuduo_state* state){
+    return romuduo_next(state->state);
+}
+
+static inline uint32_t romuduo_next32(romuduo_state* state){
+    uint64_t next;
+    if (state->has_uint32) {
+      state->has_uint32 = 0;
+      return state->uinteger;
+    }
+    next = romuquad_next64(state);
+    state->has_uint32 = 1;
+    state->uinteger = (uint32_t)(next >> 32);
+    return (uint32_t)(next & 0xffffffff);
+}   
+
+//===== RomuDuoJr ================================================================================
+//
+// The fastest generator using 64-bit arith., but not suited for huge jobs.
+// Est. capacity = 2^51 bytes. Register pressure = 4. State size = 128 bits.
+
+// typedef struct s_romuduojr_state{
+//     uint64_t state[2];
+//     int has_uint32;
+//     uint32_t uinteger;
+// } romuduojr_state;
+
+
+uint64_t romuduojr_next (uint64_t *state) {
+   uint64_t xp = state[0];
+   state[0] = 15241094284759029579u * state[1];
+   state[1] = state[0] - xp;  state[1] = ROTL(state[1], 27);
+   return xp;
+}
+
+static inline uint64_t romuduojr_next64(romuduojr_state* state){
+    return romuduojr_next(state->state);
+}
+
+static inline uint32_t romuduojr_next32(romuduo_state* state){
+    uint64_t next;
+    if (state->has_uint32) {
+      state->has_uint32 = 0;
+      return state->uinteger;
+    }
+    next = romuduojr_next64(state);
+    state->has_uint32 = 1;
+    state->uinteger = (uint32_t)(next >> 32);
+    return (uint32_t)(next & 0xffffffff);
+}   
+
+
+/* === 32 Bit RNG GENERATORS === */
+
+
+//===== RomuQuad32 ================================================================================
+//
+// 32-bit arithmetic: Good for general purpose use.
+// Est. capacity >= 2^62 bytes. Register pressure = 7. State size = 128 bits.
+
+
+typedef struct s_romuquad32_state{
+    uint32_t state[4];
+} romuquad32_state;
+
+uint32_t romuquad32_next(uint32_t *state) {
+    uint32_t wp = state[0], xp = state[1], yp = state[2], zp = state[3];
+    state[0] = 3323815723u * zp;  // a-mult
+    state[1] = zp + ROTL(wp,26);  // b-rotl, c-add
+    state[2] = yp - xp;           // d-sub
+    state[3] = yp + wp;           // e-add
+    state[3] = ROTL(state[3],9);    // f-rotl
+    return xp;
+}
+
+static inline uint64_t romuquad32_next64(romuquad32_state *state) { 
+    return (uint64_t)romuquad32_next(state) << 32 | romuquad32_next(state); 
+}
+
+static inline uint32_t romuquad32_next32(romuquad32_state * state) { 
+    return romuquad32_next(state->state); 
+}
+
+//===== RomuTrio32 ===============================================================================
+//
+// 32-bit arithmetic: Good for general purpose use, except for huge jobs.
+// Est. capacity >= 2^53 bytes. Register pressure = 5. State size = 96 bits.
+
+
+uint32_t romutrio32_next (uint32_t *state) {
+    uint32_t xp = state[0], yp = state[1], zp = state[2];
+    state[0] = 3323815723u * zp;
+    state[1] = yp - xp; state[1] = ROTL(state[1],6);
+    state[2] = zp - yp; state[2] = ROTL(state[2],22);
+    return xp;
+ }
+
+static inline uint64_t romutrio32_next64(romutrio32_state *state) { 
+    return (uint64_t)romutrio32_next(state) << 32 | romutrio32_next(state); 
+} 
+static inline uint32_t romutrio32_next32(romutrio32_state * state) { 
+    return romutrio32_next(state->state); 
+}

--- a/numpy/random/src/RomuRandom/RomuRandom.h
+++ b/numpy/random/src/RomuRandom/RomuRandom.h
@@ -1,0 +1,98 @@
+
+// Romu Random states were rewritten into arrays for use with numpy
+
+// Romu Pseudorandom Number Generators
+//
+// Copyright 2020 Mark A. Overton
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ------------------------------------------------------------------------------------------------
+//
+// Website: romu-random.org
+// Paper:   http://arxiv.org/abs/2002.11331
+
+
+#ifndef __ROMURANDOM_H__
+#define __ROMURANDOM_H__
+
+#include <stdint.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif /*__cplusplus */
+
+
+typedef struct s_romuquad_state{
+    uint64_t state[4];
+    int has_uint32;
+    uint32_t uinteger;
+} romuquad_state;
+
+static inline uint64_t romuquad_next(uint64_t* state);
+static inline uint64_t romuquad_next64(romuquad_state * state);
+static inline uint32_t romuquad_next32(romuquad_state * state);
+
+typedef struct s_romutrio_state{
+    uint64_t state[3];
+    int has_uint32;
+    uint32_t uinteger;
+} romutrio_state;
+
+static inline uint64_t romutrio_next(uint64_t* state);
+static inline uint64_t romutrio_next64(romutrio_state * state);
+static inline uint32_t romutrio_next32(romutrio_state * state);
+
+typedef struct s_romuduo_state{
+    uint64_t state[2];
+    int has_uint32;
+    uint32_t uinteger;
+} romuduo_state;
+
+static inline uint64_t romuduo_next(uint64_t* state);
+static inline uint64_t romuduo_next64(romuduo_state * state);
+static inline uint32_t romuduo_next32(romuduo_state * state);
+
+typedef struct s_romuduojr_state{
+    uint64_t state[2];
+    int has_uint32;
+    uint32_t uinteger;
+} romuduojr_state;
+
+static inline uint64_t romuduojr_next(uint64_t* state);
+static inline uint64_t romuduojr_next64(romuduojr_state * state);
+static inline uint32_t romuduojr_next32(romuduojr_state * state);
+
+
+typedef struct s_romuquad32_state{
+    uint32_t state[4];
+} romuquad32_state;
+
+static inline uint32_t romuquad32_next(uint32_t* state);
+static inline uint64_t romuquad32_next64(romuquad32_state * state);
+static inline uint32_t romuquad32_next32(romuquad32_state * state);
+
+typedef struct s_romutrio32_state{
+    uint32_t state[3];
+} romutrio32_state;
+
+static inline uint32_t romutrio32_next(uint32_t* state);
+static inline uint64_t romutrio32_next64(romutrio32_state * state);
+static inline uint32_t romutrio32_next32(romutrio32_state * state);
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus */
+
+#endif /* __ROMURANDOM_H__ */


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
I am still in progress of implementing the Romu-Random  RNG Algorythm but for the most part the C Backend I have written for the purpose of use with numpy is complete. I do have some trouble using a commandline so know that this Pull Request might turn out to be slow. Other than that I hope for people to guide me in the right direction with getting this RNG Generator added.
RomuRandom is one of the best random libraries in C that I have ever used and it felt disappointing to not see this in this library so I took it upon myself to add it in to the best of my abilities. The License is friendly and the original code can be obtained from their [website](https://romu-random.org/). I will need to however send an email to the host provider since the website's ssl-certificate died 3 years ago. 

Anyways I am glad that I was able to once again put my ideas to good use and hope this new addition to numpy is useful to any other programmers would like to use it.
 

