### PR TITLE
DOC: Make numpy.fft a clickable link to module

### DIFF
--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -5,7 +5,7 @@ Discrete Fourier Transform
 .. currentmodule:: numpy.fft
 
 The SciPy module `scipy.fft` is a more comprehensive superset
-of ``numpy.fft``, which includes only a basic set of routines.
+of `numpy.fft`, which includes only a basic set of routines.
 
 Standard FFTs
 -------------


### PR DESCRIPTION
Make numpy.fft a clickable link to module.

https://numpy.org/devdocs/reference/routines.fft.html

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
