### PR TITLE
BUG: safer bincount casting

### DIFF
--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -151,8 +151,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
         if (PyArray_SIZE(tmp1) > 0) {
             /* The input is not empty, so convert it to NPY_INTP. */
             int flags = NPY_ARRAY_WRITEABLE | NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS;
-            if (PyArray_Check((PyObject *)tmp1) &&
-                PyArray_ISINTEGER((PyArrayObject *)tmp1)) {
+            if (PyArray_ISINTEGER(tmp1)) {
                 flags = flags | NPY_ARRAY_FORCECAST;
             }
             PyArray_Descr* local_dtype = PyArray_DescrFromType(NPY_INTP);

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -119,6 +119,7 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
     npy_intp *numbers, *ians, len, mx, mn, ans_size;
     npy_intp minlength = 0;
     npy_intp i;
+    int flags;
     double *weights , *dans;
 
     NPY_PREPARE_ARGPARSER;
@@ -177,12 +178,13 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
     }
 
     if (lst == NULL) {
-        PyArray_Descr* local_dtype = PyArray_DescrFromType(NPY_INTP);
-        list = PyArray_FromAny(list, local_dtype, 0, 0, NPY_ARRAY_FORCECAST, NULL);
-        if (list == NULL) {
-            goto fail;
+        flags = NPY_ARRAY_WRITEABLE | NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS;
+        if (PyArray_Size((PyObject *)list) &&
+            PyArray_ISINTEGER((PyArrayObject *)list)) {
+            flags = flags | NPY_ARRAY_FORCECAST;
         }
-        lst = (PyArrayObject *)PyArray_ContiguousFromAny(list, NPY_INTP, 1, 1);
+        PyArray_Descr* local_dtype = PyArray_DescrFromType(NPY_INTP);
+        lst = (PyArrayObject *)PyArray_FromAny(list, local_dtype, 1, 1, flags, NULL);
         if (lst == NULL) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -177,6 +177,11 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
     }
 
     if (lst == NULL) {
+        PyArray_Descr* local_dtype = PyArray_DescrFromType(NPY_INTP);
+        list = PyArray_FromAny(list, local_dtype, 0, 0, NPY_ARRAY_FORCECAST, NULL);
+        if (list == NULL) {
+            goto fail;
+        }
         lst = (PyArrayObject *)PyArray_ContiguousFromAny(list, NPY_INTP, 1, 1);
         if (lst == NULL) {
             goto fail;

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2959,6 +2959,13 @@ class TestBincount:
         with assert_raises(ValueError):
             np.bincount(vals)
 
+    @pytest.mark.parametrize("dt", np.typecodes["AllInteger"])
+    def test_gh_28354(self, dt):
+        a = np.array([0, 1, 1, 3, 2, 1, 7], dtype=dt)
+        actual = np.bincount(a)
+        expected = [1, 3, 1, 1, 0, 0, 0, 1]
+        assert_array_equal(actual, expected)
+
 
 class TestInterp:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2966,6 +2966,10 @@ class TestBincount:
         expected = [1, 3, 1, 1, 0, 0, 0, 1]
         assert_array_equal(actual, expected)
 
+    def test_contiguous_handling(self):
+        # check for absence of hard crash
+        np.bincount(np.arange(10000)[::2])
+
 
 class TestInterp:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2970,6 +2970,16 @@ class TestBincount:
         # check for absence of hard crash
         np.bincount(np.arange(10000)[::2])
 
+    def test_gh_28354_array_like(self):
+        class A:
+            def __array__(self):
+                return np.array([0, 1, 1, 3, 2, 1, 7], dtype=np.uint64)
+
+        a = A()
+        actual = np.bincount(a)
+        expected = [1, 3, 1, 1, 0, 0, 0, 1]
+        assert_array_equal(actual, expected)
+
 
 class TestInterp:
 


### PR DESCRIPTION
* Fixes #28354

* Allow some uint types to be cast a bit more gracefully for `np.bincount()`.
