### PR TITLE
MAINT: No need to check for check for FPEs in casts to/from object

### DIFF
--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -3507,7 +3507,9 @@ initialize_void_and_object_globals(void) {
     method->nin = 1;
     method->nout = 1;
     method->name = "object_to_any_cast";
-    method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
+    method->flags = (NPY_METH_SUPPORTS_UNALIGNED
+                     | NPY_METH_REQUIRES_PYAPI
+                     | NPY_METH_NO_FLOATINGPOINT_ERRORS);
     method->casting = NPY_UNSAFE_CASTING;
     method->resolve_descriptors = &object_to_any_resolve_descriptors;
     method->get_strided_loop = &object_to_any_get_loop;
@@ -3522,7 +3524,9 @@ initialize_void_and_object_globals(void) {
     method->nin = 1;
     method->nout = 1;
     method->name = "any_to_object_cast";
-    method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
+    method->flags = (NPY_METH_SUPPORTS_UNALIGNED
+                     | NPY_METH_REQUIRES_PYAPI
+                     | NPY_METH_NO_FLOATINGPOINT_ERRORS);
     method->casting = NPY_SAFE_CASTING;
     method->resolve_descriptors = &any_to_object_resolve_descriptors;
     method->get_strided_loop = &any_to_object_get_loop;

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -236,7 +236,7 @@ any_to_object_get_loop(
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
 
-    *flags = NPY_METH_REQUIRES_PYAPI;  /* No need for floating point errors */
+    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     *out_loop = _strided_to_strided_any_to_object;
     *out_transferdata = PyMem_Malloc(sizeof(_any_to_object_auxdata));
@@ -342,7 +342,7 @@ object_to_any_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    *flags = NPY_METH_REQUIRES_PYAPI;
+    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     /* NOTE: auxdata is only really necessary to flag `move_references` */
     _object_to_any_auxdata *data = PyMem_Malloc(sizeof(*data));

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -235,7 +235,7 @@ any_to_object_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-
+    /* Python API doesn't use FPEs and this also attempts to hide spurious ones. */
     *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     *out_loop = _strided_to_strided_any_to_object;
@@ -342,6 +342,7 @@ object_to_any_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
+    /* Python API doesn't use FPEs and this also attempts to hide spurious ones. */
     *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     /* NOTE: auxdata is only really necessary to flag `move_references` */


### PR DESCRIPTION
Since these go via Python (in some form) and Python doesn't use FPEs we can be sure that we don't need to check for FPEs.

Note that while it hides *almost always* spurious FPEs seen on some platforms, there could be certain chains or multiple cast situations where FPEs are checked for other reasons and the spurious FPE will show up.

So it "somewhat":

Closes gh-28351
