### PR TITLE
BUG: Make np.nonzero threading safe

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Test
       run: |
         # These tests are slow, so only run tests in files that do "import threading" to make them count
-        TSAN_OPTIONS=allocator_may_return_null=1:halt_on_error=1 \
+        TSAN_OPTIONS="allocator_may_return_null=1:halt_on_error=1:suppressions=tools\ci\tsan_suppressions.txt" \
         python -m spin test \
         `find numpy -name "test*.py" | xargs grep -l "import threading" | tr '\n' ' '` \
         -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -120,6 +120,9 @@ jobs:
         python -m spin build -j2 -- -Db_sanitize=thread
     - name: Test
       run: |
+        # try to figure out root folder for source
+        echo $HOME
+        set
         # These tests are slow, so only run tests in files that do "import threading" to make them count
         TSAN_OPTIONS="allocator_may_return_null=1:suppressions=/Users/runner/work/numpy/numpy/tools/ci/tsan_suppressions.txt" \
         python -m spin test \

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Test
       run: |
         # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
-        ASAN_OPTIONS=detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1:halt_on_error=1 \
+        ASAN_OPTIONS=detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1 \
         python -m spin test -- -v -s --timeout=600 --durations=10
 
   clang_TSAN:
@@ -121,7 +121,7 @@ jobs:
     - name: Test
       run: |
         # These tests are slow, so only run tests in files that do "import threading" to make them count
-        TSAN_OPTIONS=allocator_may_return_null=1:halt_on_error=1 \
+        TSAN_OPTIONS=allocator_may_return_null=1 \
         python -m spin test \
         `find numpy -name "test*.py" | xargs grep -l "import threading" | tr '\n' ' '` \
         -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Test
       run: |
         # These tests are slow, so only run tests in files that do "import threading" to make them count
-        TSAN_OPTIONS="allocator_may_return_null=1:suppressions=tools\ci\tsan_suppressions.txt" \
+        TSAN_OPTIONS="allocator_may_return_null=1:suppressions=/Users/runner/work/numpy/numpy/tools/ci/tsan_suppressions.txt" \
         python -m spin test \
         `find numpy -name "test*.py" | xargs grep -l "import threading" | tr '\n' ' '` \
         -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -120,11 +120,8 @@ jobs:
         python -m spin build -j2 -- -Db_sanitize=thread
     - name: Test
       run: |
-        # try to figure out root folder for source
-        echo $HOME
-        set
         # These tests are slow, so only run tests in files that do "import threading" to make them count
-        TSAN_OPTIONS="allocator_may_return_null=1:suppressions=/Users/runner/work/numpy/numpy/tools/ci/tsan_suppressions.txt" \
+        TSAN_OPTIONS="allocator_may_return_null=1:suppressions=$GITHUB_WORKSPACE/tools/ci/tsan_suppressions.txt" \
         python -m spin test \
         `find numpy -name "test*.py" | xargs grep -l "import threading" | tr '\n' ' '` \
         -- -v -s --timeout=600 --durations=10

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2893,10 +2893,10 @@ PyArray_Nonzero(PyArrayObject *self)
              * the fast bool count is followed by this sparse path is faster
              * than combining the two loops, even for larger arrays
              */
+            npy_intp * multi_index_end = multi_index + nonzero_count;
             if (((double)nonzero_count / count) <= 0.1) {
                 npy_intp subsize;
                 npy_intp j = 0;
-                npy_intp * multi_index_end = multi_index + nonzero_count;
                 while (multi_index < multi_index_end) {
                     npy_memchr(data + j * stride, 0, stride, count - j,
                                &subsize, 1);
@@ -2912,7 +2912,6 @@ PyArray_Nonzero(PyArrayObject *self)
              * stalls that are very expensive on most modern processors.
              */
             else {
-                npy_intp *multi_index_end = multi_index + nonzero_count;
                 npy_intp j = 0;
 
                 /* Manually unroll for GCC and maybe other compilers */

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2916,7 +2916,7 @@ PyArray_Nonzero(PyArrayObject *self)
                 npy_intp j = 0;
 
                 /* Manually unroll for GCC and maybe other compilers */
-                while (multi_index + 4 < multi_index_end) {
+                while (multi_index + 4 < multi_index_end && (j < count - 4) ) {
                     *multi_index = j;
                     multi_index += data[0] != 0;
                     *multi_index = j + 1;
@@ -2929,7 +2929,7 @@ PyArray_Nonzero(PyArrayObject *self)
                     j += 4;
                 }
 
-                while (multi_index < multi_index_end) {
+                while (multi_index < multi_index_end && (j < count) ) {
                     *multi_index = j;
                     multi_index += *data != 0;
                     data += stride;

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2896,7 +2896,8 @@ PyArray_Nonzero(PyArrayObject *self)
             if (((double)nonzero_count / count) <= 0.1) {
                 npy_intp subsize;
                 npy_intp j = 0;
-                while (1) {
+                npy_intp * multi_index_end = multi_index + nonzero_count;
+                while (multi_index < multi_index_end) {
                     npy_memchr(data + j * stride, 0, stride, count - j,
                                &subsize, 1);
                     j += subsize;

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -281,7 +281,6 @@ def test_nonzero_bool():
         x[::2] = np.random.randint(2)
         try:
             r = np.nonzero(x)
-            assert r[0].min() >= 0
         except RuntimeError as ex:
             assert 'number of non-zero array elements changed during function execution' in str(ex)            
 
@@ -296,7 +295,6 @@ def test_nonzero_int():
         x[::2] = np.random.randint(2)
         try:
             r = np.nonzero(x)
-            assert r[0].min() >= 0
         except RuntimeError as ex:
             assert 'number of non-zero array elements changed during function execution' in str(ex)            
 
@@ -311,7 +309,6 @@ def test_nonzero_float():
         x[::2] = np.random.randint(2)
         try:
             r = np.nonzero(x)
-            assert r[0].min() >= 0
         except RuntimeError as ex:
             assert 'number of non-zero array elements changed during function execution' in str(ex)            
 

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -272,45 +272,18 @@ def test_legacy_usertype_cast_init_thread_safety():
         # bug. Better to skip on some platforms than add a useless test.
         pytest.skip("Couldn't spawn enough threads to run the test")
 
-def test_nonzero_bool():
+@pytest.mark.parametrize("dtype", [bool, int, float])
+def test_nonzero_bool(dtype):
     # np.nonzero uses np.count_nonzero to determine the size of the output array
     # In a second pass the indices of the non-zero elements are determined, but they can have changed
-    x = np.random.randint(4, size=10_000).astype(bool)
+    x = np.random.randint(4, size=10_000).astype(dtype)
 
     def func(seed):
         x[::2] = np.random.randint(2)
         try:
-            r = np.nonzero(x)
+            _ = np.nonzero(x)
         except RuntimeError as ex:
             assert 'number of non-zero array elements changed during function execution' in str(ex)            
 
-    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
-
-def test_nonzero_int():
-    # np.nonzero uses np.count_nonzero to determine the size of the output array
-    # In a second pass the indices of the non-zero elements are determined, but they can have changed
-    x = np.random.randint(4, size=10_000).astype(int)
-
-    def func(seed):
-        x[::2] = np.random.randint(2)
-        try:
-            r = np.nonzero(x)
-        except RuntimeError as ex:
-            assert 'number of non-zero array elements changed during function execution' in str(ex)            
-
-    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
-
-def test_nonzero_float():
-    # np.nonzero uses np.count_nonzero to determine the size of the output array
-    # In a second pass the indices of the non-zero elements are determined, but they can have changed
-    x = np.random.randint(4, size=10_000).astype(float)
-
-    def func(seed):
-        x[::2] = np.random.randint(2)
-        try:
-            r = np.nonzero(x)
-        except RuntimeError as ex:
-            assert 'number of non-zero array elements changed during function execution' in str(ex)            
-
-    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=50)
 

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -272,20 +272,48 @@ def test_legacy_usertype_cast_init_thread_safety():
         # bug. Better to skip on some platforms than add a useless test.
         pytest.skip("Couldn't spawn enough threads to run the test")
 
-
-def test_nonzero():
+def test_nonzero_bool():
     # np.nonzero uses np.count_nonzero to determine the size of the output array
     # In a second pass the indices of the non-zero elements are determined, but they can have changed
-        
-    for dtype in [bool, int, float]:
-        x = np.random.randint(4, size=10_000).astype(dtype)
-    
-        def func(seed):
-            x[::2] = np.random.randint(2)
-            try:
-                r = np.nonzero(x)
-                assert r[0].min() >= 0
-            except RuntimeError as ex:
-                assert 'number of non-zero array elements changed during function execution' in str(ex)            
-   
-        run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
+    x = np.random.randint(4, size=10_000).astype(bool)
+
+    def func(seed):
+        x[::2] = np.random.randint(2)
+        try:
+            r = np.nonzero(x)
+            assert r[0].min() >= 0
+        except RuntimeError as ex:
+            assert 'number of non-zero array elements changed during function execution' in str(ex)            
+
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
+
+def test_nonzero_int():
+    # np.nonzero uses np.count_nonzero to determine the size of the output array
+    # In a second pass the indices of the non-zero elements are determined, but they can have changed
+    x = np.random.randint(4, size=10_000).astype(int)
+
+    def func(seed):
+        x[::2] = np.random.randint(2)
+        try:
+            r = np.nonzero(x)
+            assert r[0].min() >= 0
+        except RuntimeError as ex:
+            assert 'number of non-zero array elements changed during function execution' in str(ex)            
+
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
+
+def test_nonzero_float():
+    # np.nonzero uses np.count_nonzero to determine the size of the output array
+    # In a second pass the indices of the non-zero elements are determined, but they can have changed
+    x = np.random.randint(4, size=10_000).astype(float)
+
+    def func(seed):
+        x[::2] = np.random.randint(2)
+        try:
+            r = np.nonzero(x)
+            assert r[0].min() >= 0
+        except RuntimeError as ex:
+            assert 'number of non-zero array elements changed during function execution' in str(ex)            
+
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=10)
+

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -274,16 +274,21 @@ def test_legacy_usertype_cast_init_thread_safety():
 
 @pytest.mark.parametrize("dtype", [bool, int, float])
 def test_nonzero_bool(dtype):
+    # See: gh-28361
+    #
     # np.nonzero uses np.count_nonzero to determine the size of the output array
     # In a second pass the indices of the non-zero elements are determined, but they can have changed
+    #
+    # This test triggers a data race which is suppressed in the TSAN CI. The test is to ensure
+    # np.nonzero does not generate a segmentation fault
     x = np.random.randint(4, size=10_000).astype(dtype)
 
-    def func(seed):
+    def func():
         x[::2] = np.random.randint(2)
         try:
             _ = np.nonzero(x)
         except RuntimeError as ex:
             assert 'number of non-zero array elements changed during function execution' in str(ex)            
 
-    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=50)
+    run_threaded(func, max_workers=10, pass_count=False, outer_iterations=50)
 

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -278,7 +278,7 @@ def test_nonzero():
     # In a second pass the indices of the non-zero elements are determined, but they can have changed
         
     for dtype in [bool, int, float]:
-        x= np.random.randint(4, size=10_000).astype(dtype)
+        x = np.random.randint(4, size=10_000).astype(dtype)
     
         def func(seed):
             x[::2] = np.random.randint(2)

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -273,7 +273,7 @@ def test_legacy_usertype_cast_init_thread_safety():
         pytest.skip("Couldn't spawn enough threads to run the test")
 
 @pytest.mark.parametrize("dtype", [bool, int, float])
-def test_nonzero_bool(dtype):
+def test_nonzero(dtype):
     # See: gh-28361
     #
     # np.nonzero uses np.count_nonzero to determine the size of the output array
@@ -283,12 +283,15 @@ def test_nonzero_bool(dtype):
     # np.nonzero does not generate a segmentation fault
     x = np.random.randint(4, size=10_000).astype(dtype)
 
-    def func():
-        x[::2] = np.random.randint(2)
-        try:
-            _ = np.nonzero(x)
-        except RuntimeError as ex:
-            assert 'number of non-zero array elements changed during function execution' in str(ex)            
+    def func(index):
+        for _ in range(10):
+            if index == 0:
+                x[::2] = np.random.randint(2)
+            else:
+                try:
+                    _ = np.nonzero(x)
+                except RuntimeError as ex:
+                    assert 'number of non-zero array elements changed during function execution' in str(ex)
 
-    run_threaded(func, max_workers=10, pass_count=False, outer_iterations=50)
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=50)
 

--- a/tools/ci/tsan_suppressions.txt
+++ b/tools/ci/tsan_suppressions.txt
@@ -1,0 +1,9 @@
+# This file contains suppressions for the TSAN tool
+#
+# Reference: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+
+
+# These warnings trigger directly in a CPython function.
+
+# For np.nonzero, see gh-28361
+race:lowlevel_strided_loops.c.src

--- a/tools/ci/tsan_suppressions.txt
+++ b/tools/ci/tsan_suppressions.txt
@@ -2,11 +2,7 @@
 #
 # Reference: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
-
-# These warnings trigger directly in a CPython function.
-
 # For np.nonzero, see gh-28361
-#race:lowlevel_strided_loops.c.src
 race:PyArray_Nonzero
 race:count_nonzero_int
 race:count_nonzero_bool

--- a/tools/ci/tsan_suppressions.txt
+++ b/tools/ci/tsan_suppressions.txt
@@ -7,8 +7,9 @@
 
 # For np.nonzero, see gh-28361
 #race:lowlevel_strided_loops.c.src
+race:PyArray_Nonzero
 race:count_nonzero_int
 race:count_nonzero_bool
 race:count_nonzero_float
-
+race:DOUBLE_nonzero
 

--- a/tools/ci/tsan_suppressions.txt
+++ b/tools/ci/tsan_suppressions.txt
@@ -7,3 +7,8 @@
 
 # For np.nonzero, see gh-28361
 race:lowlevel_strided_loops.c.src
+race:count_nonzero_int
+race:count_nonzero_bool
+race:count_nonzero_float
+
+


### PR DESCRIPTION
We add a test for np.nonzero under multi-threading and make np.nonzero safe under the cpython free-threading build. We want to ensure concurrent invocations of the method on the same array do not corrupt the system. Correct results are not guaranteed:

* If the underlying data is changing, the non-zero indices are not well-defined
* If the underlying data is changing, we can get indices outside the size of the array due to a part of the return array not being initialized.

Also see https://github.com/numpy/numpy/pull/27519. An alternative approach would be to use locks to make the array read-only during the operation. 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
