### PR TITLE
MAINT: Update FreeBSD version and fix test failure

### DIFF
--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -3517,7 +3517,9 @@ initialize_void_and_object_globals(void) {
     method->nin = 1;
     method->nout = 1;
     method->name = "object_to_any_cast";
-    method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
+    method->flags = (NPY_METH_SUPPORTS_UNALIGNED
+                     | NPY_METH_REQUIRES_PYAPI
+                     | NPY_METH_NO_FLOATINGPOINT_ERRORS);
     method->casting = NPY_UNSAFE_CASTING;
     method->resolve_descriptors = &object_to_any_resolve_descriptors;
     method->get_strided_loop = &object_to_any_get_loop;
@@ -3532,7 +3534,9 @@ initialize_void_and_object_globals(void) {
     method->nin = 1;
     method->nout = 1;
     method->name = "any_to_object_cast";
-    method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
+    method->flags = (NPY_METH_SUPPORTS_UNALIGNED
+                     | NPY_METH_REQUIRES_PYAPI
+                     | NPY_METH_NO_FLOATINGPOINT_ERRORS);
     method->casting = NPY_SAFE_CASTING;
     method->resolve_descriptors = &any_to_object_resolve_descriptors;
     method->get_strided_loop = &any_to_object_get_loop;

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -235,8 +235,8 @@ any_to_object_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-
-    *flags = NPY_METH_REQUIRES_PYAPI;  /* No need for floating point errors */
+    /* Python API doesn't use FPEs and this also attempts to hide spurious ones. */
+    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     *out_loop = _strided_to_strided_any_to_object;
     *out_transferdata = PyMem_Malloc(sizeof(_any_to_object_auxdata));
@@ -342,7 +342,8 @@ object_to_any_get_loop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    *flags = NPY_METH_REQUIRES_PYAPI;
+    /* Python API doesn't use FPEs and this also attempts to hide spurious ones. */
+    *flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     /* NOTE: auxdata is only really necessary to flag `move_references` */
     _object_to_any_auxdata *data = PyMem_Malloc(sizeof(*data));

--- a/tools/ci/cirrus_arm.yml
+++ b/tools/ci/cirrus_arm.yml
@@ -67,7 +67,7 @@ freebsd_test_task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   compute_engine_instance:
     image_project: freebsd-org-cloud-dev
-    image: family/freebsd-14-0
+    image: family/freebsd-14-2
     platform: freebsd
     cpu: 1
     memory: 4G


### PR DESCRIPTION
Backports of  #28328 and #28358.


#28328

 Change Freebsd image as per https://cirrus-ci.org/guide/FreeBSD/
 
 
<img width="374" alt="image" src="https://github.com/user-attachments/assets/9dce8ab3-9ec8-44d8-9058-95baa9f7fbe3" />


#28358

Since these go via Python (in some form) and Python doesn't use FPEs we can be sure that we don't need to check for FPEs.

Note that while it hides *almost always* spurious FPEs seen on some platforms, there could be certain chains or multiple cast situations where FPEs are checked for other reasons and the spurious FPE will show up.

So it "somewhat":

Closes gh-28351


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
