### PR TITLE
Arm64 CI: Run debug and full builds CI on arm64 runners too

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,7 +100,10 @@ jobs:
 
   debug:
     needs: [smoke_test]
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
     if: github.event_name != 'push'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -131,7 +134,10 @@ jobs:
   full:
     # Install as editable, then run the full test suite with code coverage
     needs: [smoke_test]
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:


### PR DESCRIPTION
Following the [announcement](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) of the availability of Linux arm64 hosted runners, it would make sense to run CI on them too.

Other tests like Linux SIMD and BLAS tests can also be extended to run on these Arm instances in the future.
