### PR TITLE
DOC: fix C API docs for `PyArray_Size`

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -121,7 +121,7 @@ and its sub-types).
 
     Returns the total size (in number of elements) of the array.
 
-.. c:function:: npy_intp PyArray_Size(PyArrayObject* obj)
+.. c:function:: npy_intp PyArray_Size(PyObject* obj)
 
     Returns 0 if *obj* is not a sub-class of ndarray. Otherwise,
     returns the total number of elements in the array. Safer version


### PR DESCRIPTION
* The actual C function signature is `PyArray_Size(PyObject *op)`, and the compiler will issue a warning if you follow the current C API docs that specify `PyArrayObject*`, so clean this up. I noticed this while working on gh-28355, but it was also mentioned as an aside 7 years ago in gh-10977.

[skip azp] [skip cirrus] [skip actions]