### PR TITLE
DOC: Added links to CTypes and CFFI in Numba

### DIFF
--- a/doc/source/reference/random/extending.rst
+++ b/doc/source/reference/random/extending.rst
@@ -11,10 +11,13 @@ small set of required functions.
 
 Numba
 -----
-Numba can be used with either CTypes or CFFI.  The current iteration of the
+Numba can be used with either
+`CTypes <https://docs.python.org/3/library/ctypes.html>`_
+or `CFFI <https://cffi.readthedocs.io/en/stable/overview.html>`_.
+The current iteration of the
 `BitGenerator`\ s all export a small set of functions through both interfaces.
 
-This example shows how numba can be used to produce gaussian samples using
+This example shows how Numba can be used to produce Gaussian samples using
 a pure Python implementation which is then compiled.  The random numbers are
 provided by ``ctypes.next_double``.
 


### PR DESCRIPTION
Added links to CTypes and CFFI in Numba.
https://numpy.org/devdocs/reference/random/extending.html

CTypes: https://docs.python.org/3/library/ctypes.html

CFFI: https://cffi.readthedocs.io/en/stable/overview.html

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
