### PR TITLE
MAINT: Extend the default ruff exclude files

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-exclude = [
+extend-exclude = [
     "numpy/__config__.py",
     "numpy/distutils",
     "numpy/typing/_char_codes.py",


### PR DESCRIPTION
In ruff version 0.9.7, using `exclude` in the `ruff.toml` file has the effect of replacing the default ruff `exclude` list. Use `extend-exclude` instead.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
