### PR TITLE
MAINT: speed up slow test under TSAN

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -281,7 +281,7 @@ def test_nonzero(dtype):
     #
     # This test triggers a data race which is suppressed in the TSAN CI. The test is to ensure
     # np.nonzero does not generate a segmentation fault
-    x = np.random.randint(4, size=10_000).astype(dtype)
+    x = np.random.randint(4, size=100).astype(dtype)
 
     def func(index):
         for _ in range(10):
@@ -293,5 +293,4 @@ def test_nonzero(dtype):
                 except RuntimeError as ex:
                     assert 'number of non-zero array elements changed during function execution' in str(ex)
 
-    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=50)
-
+    run_threaded(func, max_workers=10, pass_count=True, outer_iterations=5)


### PR DESCRIPTION
As currently written this test is very slow (longer than a minute) when I run a debug build of NumPy under TSAN. This is annoying when I'm testing thread safety related changes using TSAN.

I found that ASAN triggers heap-overflow errors on `main` as of last week if I add the test as I have it in this PR, so I think making the test less computationally intensive is fine and still tests what we want to test.

ping @eendebakpt