### PR TITLE
CI: use free-threaded build for ASAN tests

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -53,10 +53,12 @@ jobs:
         echo CPPFLAGS="-I$LLVM_PREFIX/include" >> $GITHUB_ENV
     - name: Build Python with address sanitizer
       run: |
-        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.13
-        pyenv global 3.13
+        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.13t
+        pyenv global 3.13t
     - name: Install dependencies
       run: |
+        # TODO: remove when a released cython supports free-threaded python
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/ci_requirements.txt
         pip install -r requirements/test_requirements.txt


### PR DESCRIPTION
While working on #28390 today, I realized that ASAN can detect issues in the free-threaded build that are impossible to hit on the GIL-enabled build. In that PR the test I added showed failures under ASAN using free-threaded Python if I ran it against a version of NumPy from last week that was susceptible to memory corruption by running the test. On the GIL-enabled build, the GIL prevents the memory corruption.

For that reason, I think we can get more bang for our buck using a free-threaded interpreter to run the ASAN tests. I think the free-threaded build will catch almost all issues that the GIL-enabled build would catch as well as any problems that address sanitizer can check that are caused by race conditions. The only things we'd miss are from code in the `#else` block of an `#if Py_GIL_DISABLED` macro, and we don't really have any nontrivial code like that.

I also thought about using a build matrix with both the GIL-enabled and free-threaded interpreters but given what I said above, I think just one ASAN build is fine.