### PR TITLE
CI: build Linux aarch64 wheels on GitHub Actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,8 +42,9 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    # To enable this job and subsequent jobs on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    # Only workflow_dispatch is enabled on forks.
+    # To enable this job and subsequent jobs on a fork for other events, comment out:
+    if: github.repository == 'numpy/numpy' || github.event_name == 'workflow_dispatch'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
@@ -197,7 +198,7 @@ jobs:
             anaconda-client
 
       - name: Upload wheels
-        if: success()
+        if: success() && github.repository == 'numpy/numpy'
         shell: bash -el {0}
         # see https://github.com/marketplace/actions/setup-miniconda for why
         # `-el {0}` is required.
@@ -276,7 +277,7 @@ jobs:
           python-version: "3.11"
 
       - name: Upload sdist
-        if: success()
+        if: success() && github.repository == 'numpy/numpy'
         shell: bash -el {0}
         env:
           NUMPY_STAGING_UPLOAD_TOKEN: ${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,6 +81,8 @@ jobs:
         buildplat:
           - [ubuntu-22.04, manylinux_x86_64, ""]
           - [ubuntu-22.04, musllinux_x86_64, ""]
+          - [ubuntu-22.04-arm, manylinux_aarch64, ""]
+          - [ubuntu-22.04-arm, musllinux_aarch64, ""]
           - [macos-13, macosx_x86_64, openblas]
 
           # targeting macos >= 14. Could probably build on macos-14, but it would be a cross-compile
@@ -88,13 +90,15 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        # TODO pypy: Add pp311 to this list when it comes out (pp310 removed)  
+        # TODO pypy: Add pp311 to this list when it comes out (pp310 removed)
         python: ["cp311", "cp312", "cp313", "cp313t"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
             python: "pp310"
           - buildplat: [ ubuntu-22.04, musllinux_x86_64, "" ]
+            python: "pp310"
+          - buildplat: [ ubuntu-22.04-arm, musllinux_aarch64, "" ]
             python: "pp310"
           - buildplat: [ macos-14, macosx_arm64, accelerate ]
             python: "pp310"
@@ -158,7 +162,7 @@ jobs:
             CIBW="RUNNER_OS=macOS"
             PKG_CONFIG_PATH="$PWD/.openblas"
             DYLD="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
-            echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"  
+            echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
           fi
 
       - name: Set up free-threaded build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
 # `tools/ci/cirrus_wheels.yml`.
 build-frontend = "build"
-skip = "cp36-* cp37-* cp-38* pp37-* *-manylinux_i686 *_ppc64le *_s390x *_universal2"
+skip = "*_i686 *_ppc64le *_s390x *_universal2"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"
@@ -153,6 +153,7 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.pyodide]
 config-settings = "build-dir=build setup-args=--cross-file=$PWD/tools/ci/emscripten/emscripten.meson.cross setup-args=-Dblas=none setup-args=-Dlapack=none"

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -1,51 +1,3 @@
-build_and_store_wheels: &BUILD_AND_STORE_WHEELS
-  install_cibuildwheel_script:
-    - python -m pip install cibuildwheel
-  cibuildwheel_script:
-    - cibuildwheel
-  wheels_artifacts:
-    path: "wheelhouse/*"
-
-######################################################################
-# Build linux_aarch64 natively
-######################################################################
-
-linux_aarch64_task:
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  env:
-    CIRRUS_CLONE_SUBMODULES: true
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder-arm64
-    architecture: arm64
-    platform: linux
-    cpu: 1
-    memory: 4G
-  matrix:
-    # build in a matrix because building and testing all four wheels in a
-    # single task takes longer than 60 mins (the default time limit for a
-    # cirrus-ci task).
-    - env:
-        CIBW_BUILD: cp311-*
-    - env:
-        CIBW_BUILD: cp312-*
-    - env:
-        CIBW_BUILD: cp313-*
-    - env:
-        CIBW_BUILD: cp313t-*
-        CIBW_FREE_THREADED_SUPPORT: 1
-        CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-
-  initial_setup_script: |
-    apt update
-    apt install -y python3-venv python-is-python3 gfortran libatlas-base-dev libgfortran5 eatmydata
-    git fetch origin
-    bash ./tools/wheels/cibw_before_build.sh ${PWD}
-    which python
-    echo $CIRRUS_CHANGE_MESSAGE
-  <<: *BUILD_AND_STORE_WHEELS
-
-
 ######################################################################
 # Build macosx_arm64 natively
 #
@@ -78,11 +30,11 @@ macosx_arm64_task:
     brew install micromamba gfortran
     micromamba shell init -s bash --root-prefix ~/micromamba
     source ~/.bash_profile
-    
+
     micromamba create -n numpydev
     micromamba activate numpydev
     micromamba install -y -c conda-forge python=3.11 2>/dev/null
-    
+
     # Use scipy-openblas wheels
     export INSTALL_OPENBLAS=true
     export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET='11.0' INSTALL_OPENBLAS=true RUNNER_OS=macOS PKG_CONFIG_PATH=$PWD/.openblas"


### PR DESCRIPTION
Now that Linux aarch64 runners are available on GHA, move the wheel builds from Cirrus CI to GHA.
This PR also allows to run the wheel builder workflow from forks using workflow_dispatch which might help a little when contributing to this workflow.

Other Linux aarch64 workflows are being worked on in #28263
