### PR TITLE
BUG: Fix crackfortran parsing error when a division occurs within a common block

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1494,7 +1494,7 @@ def analyzeline(m, case, line):
         f = 0
         bn = ''
         ol = ''
-        nslash = 0 # For counting common block instances.
+        nslash = 0  # For counting common block instances.
         for c in line:
             if c == '/' and nslash < 2:
                 f = f + 1

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1492,7 +1492,7 @@ def analyzeline(m, case, line):
             line = '//' + line
 
         cl = []
-        [_,bn,ol] = re.split('/', line,2)
+        [_,bn,ol] = re.split('/', line, 2)
         bn = bn.strip()
         if not bn:
             bn = '_BLNK_'

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1494,12 +1494,12 @@ def analyzeline(m, case, line):
         f = 0
         bn = ''
         ol = ''
-        
-        # Find the /<common block name>/ and split the string at
-        # that location. 
-        split_line = re.split(r'\s*/[A-Za-z_]*[A-Za-z0-9_]*/', line)
-
-        for c in split_line[-1]:
+        nslash = 0 # For counting common block instances.
+        for c in line:
+            if c == '/' and nslash < 2:
+                f = f + 1
+                nslash = nslash + 1
+                continue
             if f >= 3:
                 bn = bn.strip()
                 if not bn:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1492,7 +1492,7 @@ def analyzeline(m, case, line):
             line = '//' + line
 
         cl = []
-        [_, bn, ol] = re.split('/', line, 2)
+        [_, bn, ol] = re.split('/', line, maxsplit=2)
         bn = bn.strip()
         if not bn:
             bn = '_BLNK_'

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1490,28 +1490,9 @@ def analyzeline(m, case, line):
         line = m.group('after').strip()
         if not line[0] == '/':
             line = '//' + line
+
         cl = []
-        f = 0
-        bn = ''
-        ol = ''
-        nslash = 0  # For counting common block instances.
-        for c in line:
-            if c == '/' and nslash < 2:
-                f = f + 1
-                nslash = nslash + 1
-                continue
-            if f >= 3:
-                bn = bn.strip()
-                if not bn:
-                    bn = '_BLNK_'
-                cl.append([bn, ol])
-                f = f - 2
-                bn = ''
-                ol = ''
-            if f % 2:
-                bn = bn + c
-            else:
-                ol = ol + c
+        [_,bn,ol] = re.split('/', line,2)
         bn = bn.strip()
         if not bn:
             bn = '_BLNK_'

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1492,7 +1492,7 @@ def analyzeline(m, case, line):
             line = '//' + line
 
         cl = []
-        [_,bn,ol] = re.split('/', line, 2)
+        [_, bn, ol] = re.split('/', line, 2)
         bn = bn.strip()
         if not bn:
             bn = '_BLNK_'

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1494,9 +1494,11 @@ def analyzeline(m, case, line):
         f = 0
         bn = ''
         ol = ''
+        nslash = 0
         for c in line:
-            if c == '/':
+            if c == '/' and nslash < 2:
                 f = f + 1
+                nslash = nslash + 1
                 continue
             if f >= 3:
                 bn = bn.strip()

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1494,12 +1494,12 @@ def analyzeline(m, case, line):
         f = 0
         bn = ''
         ol = ''
-        nslash = 0
-        for c in line:
-            if c == '/' and nslash < 2:
-                f = f + 1
-                nslash = nslash + 1
-                continue
+        
+        # Find the /<common block name>/ and split the string at
+        # that location. 
+        split_line = re.split(r'\s*/[A-Za-z_]*[A-Za-z0-9_]*/', line)
+
+        for c in split_line[-1]:
             if f >= 3:
                 bn = bn.strip()
                 if not bn:

--- a/numpy/f2py/tests/src/crackfortran/common_with_division.f
+++ b/numpy/f2py/tests/src/crackfortran/common_with_division.f
@@ -3,13 +3,13 @@
       integer lmu,lb,lub,lpmin
       parameter (lmu=1)
       parameter (lb=20)
-c     crackpython fails to parse this  
+c     crackfortran fails to parse this  
       parameter (lub=(lb-1)*lmu+1)
-c     crackpython can successfully parse this though
+c     crackfortran can successfully parse this though
 c     parameter (lub=lb*lmu-lmu+1)
       parameter (lpmin=1)
 
-c     crackpython fails to parse this correctly 
+c     crackfortran fails to parse this correctly 
       common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
       return
       end

--- a/numpy/f2py/tests/src/crackfortran/common_with_division.f
+++ b/numpy/f2py/tests/src/crackfortran/common_with_division.f
@@ -1,0 +1,15 @@
+      subroutine test
+      implicit none
+      integer lmu,lb,lub,lpmin
+      parameter (lmu=1)
+      parameter (lb=20)
+c     crackpython fails to parse this  
+      parameter (lub=(lb-1)*lmu+1)
+c     crackpython can successfully parse this though
+c     parameter (lub=lb*lmu-lmu+1)
+      parameter (lpmin=1)
+
+c     crackpython fails to parse this correctly 
+      common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
+      return
+      end

--- a/numpy/f2py/tests/src/crackfortran/common_with_division.f
+++ b/numpy/f2py/tests/src/crackfortran/common_with_division.f
@@ -1,15 +1,17 @@
-      subroutine test
-      implicit none
+      subroutine common_with_division
       integer lmu,lb,lub,lpmin
       parameter (lmu=1)
       parameter (lb=20)
 c     crackfortran fails to parse this  
-      parameter (lub=(lb-1)*lmu+1)
+c     parameter (lub=(lb-1)*lmu+1)
 c     crackfortran can successfully parse this though
-c     parameter (lub=lb*lmu-lmu+1)
-      parameter (lpmin=1)
+      parameter (lub=lb*lmu-lmu+1)
+      parameter (lpmin=2)
 
 c     crackfortran fails to parse this correctly 
-      common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
+c     common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
+      
+      common /mortmp/ ctmp(lub/lpmin+1)
+      
       return
       end

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -114,12 +114,17 @@ class TestExternal(util.F2PyTest):
 
 class TestCrackFortran(util.F2PyTest):
     # gh-2848: commented lines between parameters in subroutine parameter lists
-    sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90")]
+    sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90"),
+               util.getpath("tests", "src", "crackfortran", "common_with_division.f")
+              ]
 
     def test_gh2848(self):
         r = self.module.gh2848(1, 2)
         assert r == (1, 2)
 
+    def test_common_with_division(self):
+        # Currently crackfortran fails to correctly parse "common_with_division.f"
+        pass
 
 class TestMarkinnerspaces:
     # gh-14118: markinnerspaces does not handle multiple quotations

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -123,8 +123,7 @@ class TestCrackFortran(util.F2PyTest):
         assert r == (1, 2)
 
     def test_common_with_division(self):
-        # Currently crackfortran fails to correctly parse "common_with_division.f"
-        pass
+        assert len(self.module.mortmp.ctmp) == 11
 
 class TestMarkinnerspaces:
     # gh-14118: markinnerspaces does not handle multiple quotations


### PR DESCRIPTION
The `analyzeline` function currently passes over all `/` characters, presumably assuming they only indicate the name of the common block. However, this means division operations after the common block name are also passed over. 
For instance 
``      common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
``
fails to parse correctly.

This pull request attempts to rectify this by counting the number of slashes encountered in the line and only passing over the first two.