### PR TITLE
DOC: Update link to Nix in Cross Compilation

### DIFF
--- a/doc/source/building/cross_compilation.rst
+++ b/doc/source/building/cross_compilation.rst
@@ -15,7 +15,7 @@ possible as well. Here are links to the NumPy "build recipes" on those
 distros:
 
 - `Void Linux <https://github.com/void-linux/void-packages/blob/master/srcpkgs/python3-numpy/template>`_
-- `Nix <https://github.com/nixos/nixpkgs/blob/master/pkgs/development/python-modules/numpy/default.nix>`_
+- `Nix <https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/numpy>`_
 - `Conda-forge <https://github.com/conda-forge/numpy-feedstock/blob/main/recipe/build.sh>`_
 
 See also `Meson's documentation on cross compilation


### PR DESCRIPTION
Update link to Nix in Cross Compilation.

Correct link:
https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/numpy

The `default.nix` file does not exist.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
