### PR TITLE
CI: use QEMU 9.2.2 for Linux Qemu tests

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -14,6 +14,7 @@ on:
     branches:
       - main
       - maintenance/**
+  workflow_dispatch:
 
 defaults:
   run:
@@ -28,8 +29,9 @@ permissions:
 
 jobs:
   linux_qemu:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    # Only workflow_dispatch is enabled on forks.
+    # To enable this job and subsequent jobs on a fork for other events, comment out:
+    if: github.repository == 'numpy/numpy' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
@@ -108,7 +110,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers
       run: |
@@ -179,8 +181,9 @@ jobs:
 
 
   linux_loongarch64_qemu:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    # Only workflow_dispatch is enabled on forks.
+    # To enable this job and subsequent jobs on a fork for other events, comment out:
+    if: github.repository == 'numpy/numpy' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     continue-on-error: true
     strategy:

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -110,6 +110,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
+       # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-       # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
+        # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers


### PR DESCRIPTION
Following a kernel update on GHA runners, QEMU tests are failing randomly.
Update the version of QEMU used in order to fix the random segfauls.

This PR also allows to run the wheel builder workflow from forks using workflow_dispatch which might help a little when contributing to this workflow.

xref https://github.com/tonistiigi/binfmt/issues/215

fix #28405