### PR TITLE
BLD: update cibuildwheel and build PyPy 3.11 wheels [wheel build]

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,25 +78,24 @@ jobs:
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions
 
-  # TODO pypy: uncomment when pypy3.11 becomes available    
-  #pypy:
-    #needs: [smoke_test]
-    #runs-on: ubuntu-latest
-    #if: github.event_name != 'push'
-    #steps:
-    #- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      #with:
-        #submodules: recursive
-        #fetch-tags: true
-        #persist-credentials: false
-    #- uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-      #with:
-        #python-version: 'pypy3.10-v7.3.17'
-    #- name: Setup using scipy-openblas
-      #run: |
-        #python -m pip install -r requirements/ci_requirements.txt
-        #spin config-openblas --with-scipy-openblas=32
-    #- uses: ./.github/meson_actions
+  pypy:
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push'
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: recursive
+        fetch-tags: true
+        persist-credentials: false
+    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      with:
+        python-version: 'pypy3.11-v7.3.19'
+    - name: Setup using scipy-openblas
+      run: |
+        python -m pip install -r requirements/ci_requirements.txt
+        spin config-openblas --with-scipy-openblas=32
+    - uses: ./.github/meson_actions
 
   debug:
     needs: [smoke_test]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,18 +91,16 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
-        # TODO pypy: Add pp311 to this list when it comes out (pp310 removed)
-        python: ["cp311", "cp312", "cp313", "cp313t"]
+        python: ["cp311", "cp312", "cp313", "cp313t", "pp311"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
-            python: "pp310"
+            python: "pp311"
+          # No PyPy on musllinux images
           - buildplat: [ ubuntu-22.04, musllinux_x86_64, "" ]
-            python: "pp310"
+            python: "pp311"
           - buildplat: [ ubuntu-22.04-arm, musllinux_aarch64, "" ]
-            python: "pp310"
-          - buildplat: [ macos-14, macosx_arm64, accelerate ]
-            python: "pp310"
+            python: "pp311"
           - buildplat: [ macos13, macosx_x86_64, openblas ]
             python: "cp313t"
 
@@ -173,10 +171,8 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969  # v2.22.0
+        uses: pypa/cibuildwheel@6cccd09a31908ffd175b012fb8bf4e1dbda3bc6c  # v2.23.0
         env:
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_FREE_THREADED_SUPPORT: True
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,12 +89,13 @@ stages:
             TEST_MODE: full
             BITS: 64
             _USE_BLAS_ILP64: '1'
-          PyPy311-64bit-fast:
-            PYTHON_VERSION: 'pypy3.11'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: fast
-            BITS: 64
-            _USE_BLAS_ILP64: '1'
+# TODO pypy: uncomment when pypy3.11 comes out
+#          PyPy311-64bit-fast:
+#            PYTHON_VERSION: 'pypy3.11'
+#            PYTHON_ARCH: 'x64'
+#            TEST_MODE: fast
+#            BITS: 64
+#            _USE_BLAS_ILP64: '1'
 
     steps:
     - template: azure-steps-windows.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,13 +89,12 @@ stages:
             TEST_MODE: full
             BITS: 64
             _USE_BLAS_ILP64: '1'
-# TODO pypy: uncomment when pypy3.11 comes out
-#          PyPy310-64bit-fast:
-#            PYTHON_VERSION: 'pypy3.10'
-#            PYTHON_ARCH: 'x64'
-#            TEST_MODE: fast
-#            BITS: 64
-#            _USE_BLAS_ILP64: '1'
+          PyPy311-64bit-fast:
+            PYTHON_VERSION: 'pypy3.11'
+            PYTHON_ARCH: 'x64'
+            TEST_MODE: fast
+            BITS: 64
+            _USE_BLAS_ILP64: '1'
 
     steps:
     - template: azure-steps-windows.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
+enable = ["cpython-freethreading", "pypy", "cpython-prerelease"]
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -20,7 +20,6 @@ macosx_arm64_task:
         CIBW_BUILD: cp313-*
     - env:
         CIBW_BUILD: cp313t-*
-        CIBW_FREE_THREADED_SUPPORT: 1
         CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
   env:
     PATH: /usr/local/lib:/usr/local/include:$PATH


### PR DESCRIPTION
Add PyPy back now that PyPy 3.11 is available.
