### PR TITLE
CI: use QEMU 9.2.2 for Linux Qemu tests

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -14,6 +14,7 @@ on:
     branches:
       - main
       - maintenance/**
+  workflow_dispatch:
 
 defaults:
   run:
@@ -28,8 +29,9 @@ permissions:
 
 jobs:
   linux_qemu:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+    # Only workflow_dispatch is enabled on forks.
+    # To enable this job and subsequent jobs on a fork for other events, comment out:
+    if: github.repository == 'numpy/numpy' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
@@ -107,7 +109,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers
       run: |
@@ -175,5 +177,4 @@ jobs:
             export F90=/usr/bin/gfortran
             cd /numpy && spin test -- -k \"${RUNTIME_TEST_FILTER}\"
           '"
-
 

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -109,6 +109,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
+       # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-       # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
+        # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
 
     - name: Install GCC cross-compilers


### PR DESCRIPTION
Backport of #28411.

Following a kernel update on GHA runners, QEMU tests are failing randomly.
Update the version of QEMU used in order to fix the random segfauls.

This PR also allows to run the wheel builder workflow from forks using workflow_dispatch which might help a little when contributing to this workflow.

xref https://github.com/tonistiigi/binfmt/issues/215

fix #28405

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
