### PR TITLE
MAINT: PY_VERSION_HEX simplify

### DIFF
--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -570,9 +570,6 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     if (PyTypeNum_ISFLEXIBLE(type_num)) {
         if (type_num == NPY_STRING) {
             destptr = PyBytes_AS_STRING(obj);
-            #if PY_VERSION_HEX < 0x030b00b0
-                ((PyBytesObject *)obj)->ob_shash = -1;
-            #endif
             memcpy(destptr, data, itemsize);
             return obj;
         }


### PR DESCRIPTION
* We no longer support Python below `3.11`, so purge out a leftover `PY_VERSION_HEX` guard related to that.
