### PR TITLE
DOC: fix documentation for Flag checking functions and macros

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1613,7 +1613,7 @@ For all of these macros *arr* must be an instance of a (subclass of)
     Evaluates true if the data area of *arr* consists of a single
     (C-style or Fortran-style) contiguous segment.
 
-.. c:function:: void PyArray_UpdateFlags(const PyArrayObject* arr, int flagmask)
+.. c:function:: void PyArray_UpdateFlags(PyArrayObject* arr, int flagmask)
 
     The :c:data:`NPY_ARRAY_C_CONTIGUOUS`, :c:data:`NPY_ARRAY_ALIGNED`, and
     :c:data:`NPY_ARRAY_F_CONTIGUOUS` array flags can be "calculated" from the

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1546,7 +1546,7 @@ Flag checking
 For all of these macros *arr* must be an instance of a (subclass of)
 :c:data:`PyArray_Type`.
 
-.. c:function:: int PyArray_CHKFLAGS(PyObject *arr, int flags)
+.. c:function:: int PyArray_CHKFLAGS(const PyArrayObject *arr, int flags)
 
     The first parameter, arr, must be an ndarray or subclass. The
     parameter, *flags*, should be an integer consisting of bitwise
@@ -1555,60 +1555,60 @@ For all of these macros *arr* must be an instance of a (subclass of)
     :c:data:`NPY_ARRAY_OWNDATA`, :c:data:`NPY_ARRAY_ALIGNED`,
     :c:data:`NPY_ARRAY_WRITEABLE`, :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`.
 
-.. c:function:: int PyArray_IS_C_CONTIGUOUS(PyObject *arr)
+.. c:function:: int PyArray_IS_C_CONTIGUOUS(PyArrayObject *arr)
 
     Evaluates true if *arr* is C-style contiguous.
 
-.. c:function:: int PyArray_IS_F_CONTIGUOUS(PyObject *arr)
+.. c:function:: int PyArray_IS_F_CONTIGUOUS(PyArrayObject *arr)
 
     Evaluates true if *arr* is Fortran-style contiguous.
 
-.. c:function:: int PyArray_ISFORTRAN(PyObject *arr)
+.. c:function:: int PyArray_ISFORTRAN(PyArrayObject *arr)
 
     Evaluates true if *arr* is Fortran-style contiguous and *not*
     C-style contiguous. :c:func:`PyArray_IS_F_CONTIGUOUS`
     is the correct way to test for Fortran-style contiguity.
 
-.. c:function:: int PyArray_ISWRITEABLE(PyObject *arr)
+.. c:function:: int PyArray_ISWRITEABLE(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* can be written to
 
-.. c:function:: int PyArray_ISALIGNED(PyObject *arr)
+.. c:function:: int PyArray_ISALIGNED(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is properly aligned on
     the machine.
 
-.. c:function:: int PyArray_ISBEHAVED(PyObject *arr)
+.. c:function:: int PyArray_ISBEHAVED(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is aligned and writeable
     and in machine byte-order according to its descriptor.
 
-.. c:function:: int PyArray_ISBEHAVED_RO(PyObject *arr)
+.. c:function:: int PyArray_ISBEHAVED_RO(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is aligned and in machine
     byte-order.
 
-.. c:function:: int PyArray_ISCARRAY(PyObject *arr)
+.. c:function:: int PyArray_ISCARRAY(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
     and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. c:function:: int PyArray_ISFARRAY(PyObject *arr)
+.. c:function:: int PyArray_ISFARRAY(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
     contiguous and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. c:function:: int PyArray_ISCARRAY_RO(PyObject *arr)
+.. c:function:: int PyArray_ISCARRAY_RO(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
     aligned, and in machine byte-order.
 
-.. c:function:: int PyArray_ISFARRAY_RO(PyObject *arr)
+.. c:function:: int PyArray_ISFARRAY_RO(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
     contiguous, aligned, and in machine byte-order **.**
 
-.. c:function:: int PyArray_ISONESEGMENT(PyObject *arr)
+.. c:function:: int PyArray_ISONESEGMENT(PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* consists of a single
     (C-style or Fortran-style) contiguous segment.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1555,65 +1555,65 @@ For all of these macros *arr* must be an instance of a (subclass of)
     :c:data:`NPY_ARRAY_OWNDATA`, :c:data:`NPY_ARRAY_ALIGNED`,
     :c:data:`NPY_ARRAY_WRITEABLE`, :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`.
 
-.. c:function:: int PyArray_IS_C_CONTIGUOUS(PyArrayObject *arr)
+.. c:function:: int PyArray_IS_C_CONTIGUOUS(const PyArrayObject *arr)
 
     Evaluates true if *arr* is C-style contiguous.
 
-.. c:function:: int PyArray_IS_F_CONTIGUOUS(PyArrayObject *arr)
+.. c:function:: int PyArray_IS_F_CONTIGUOUS(const PyArrayObject *arr)
 
     Evaluates true if *arr* is Fortran-style contiguous.
 
-.. c:function:: int PyArray_ISFORTRAN(PyArrayObject *arr)
+.. c:function:: int PyArray_ISFORTRAN(const PyArrayObject *arr)
 
     Evaluates true if *arr* is Fortran-style contiguous and *not*
     C-style contiguous. :c:func:`PyArray_IS_F_CONTIGUOUS`
     is the correct way to test for Fortran-style contiguity.
 
-.. c:function:: int PyArray_ISWRITEABLE(PyArrayObject *arr)
+.. c:function:: int PyArray_ISWRITEABLE(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* can be written to
 
-.. c:function:: int PyArray_ISALIGNED(PyArrayObject *arr)
+.. c:function:: int PyArray_ISALIGNED(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is properly aligned on
     the machine.
 
-.. c:function:: int PyArray_ISBEHAVED(PyArrayObject *arr)
+.. c:function:: int PyArray_ISBEHAVED(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is aligned and writeable
     and in machine byte-order according to its descriptor.
 
-.. c:function:: int PyArray_ISBEHAVED_RO(PyArrayObject *arr)
+.. c:function:: int PyArray_ISBEHAVED_RO(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is aligned and in machine
     byte-order.
 
-.. c:function:: int PyArray_ISCARRAY(PyArrayObject *arr)
+.. c:function:: int PyArray_ISCARRAY(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
     and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. c:function:: int PyArray_ISFARRAY(PyArrayObject *arr)
+.. c:function:: int PyArray_ISFARRAY(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
     contiguous and :c:func:`PyArray_ISBEHAVED` (*arr*) is true.
 
-.. c:function:: int PyArray_ISCARRAY_RO(PyArrayObject *arr)
+.. c:function:: int PyArray_ISCARRAY_RO(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is C-style contiguous,
     aligned, and in machine byte-order.
 
-.. c:function:: int PyArray_ISFARRAY_RO(PyArrayObject *arr)
+.. c:function:: int PyArray_ISFARRAY_RO(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* is Fortran-style
     contiguous, aligned, and in machine byte-order **.**
 
-.. c:function:: int PyArray_ISONESEGMENT(PyArrayObject *arr)
+.. c:function:: int PyArray_ISONESEGMENT(const PyArrayObject *arr)
 
     Evaluates true if the data area of *arr* consists of a single
     (C-style or Fortran-style) contiguous segment.
 
-.. c:function:: void PyArray_UpdateFlags(PyArrayObject* arr, int flagmask)
+.. c:function:: void PyArray_UpdateFlags(const PyArrayObject* arr, int flagmask)
 
     The :c:data:`NPY_ARRAY_C_CONTIGUOUS`, :c:data:`NPY_ARRAY_ALIGNED`, and
     :c:data:`NPY_ARRAY_F_CONTIGUOUS` array flags can be "calculated" from the


### PR DESCRIPTION
fixes #28434: the array argument type should be `PyArrayObject *` instead of `PyObject *`


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
