### PR TITLE
ENH: Check for floating point exceptions in dot

### DIFF
--- a/doc/release/upcoming_changes/28442.improvement.rst
+++ b/doc/release/upcoming_changes/28442.improvement.rst
@@ -1,0 +1,1 @@
+* ``np.dot`` now reports floating point exceptions.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3345,6 +3345,20 @@ class TestMethods:
         a.dot(b=b, out=c)
         assert_equal(c, np.dot(a, b))
 
+    @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
+    def test_dot_errstate(self):
+        a = np.array([1, 1])
+        b = np.array([-np.inf, np.inf])
+
+        with np.errstate(invalid='raise'):
+            with pytest.raises(FloatingPointError,
+                    match="invalid value encountered in dot"):
+                np.dot(a, b)
+
+            with pytest.raises(FloatingPointError,
+                    match="invalid value encountered in dot"):
+                np.dot(a[np.newaxis, np.newaxis, ...], b[np.newaxis, ..., np.newaxis])
+
     def test_dot_type_mismatch(self):
         c = 1.
         A = np.array((1, 1), dtype='i,i')

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3347,17 +3347,26 @@ class TestMethods:
 
     @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
     def test_dot_errstate(self):
-        a = np.array([1, 1])
+        a = np.array([1., 1.])
         b = np.array([-np.inf, np.inf])
 
         with np.errstate(invalid='raise'):
+            # there are two paths, depending on the number of dimensions - test
+            # them both
             with pytest.raises(FloatingPointError,
                     match="invalid value encountered in dot"):
                 np.dot(a, b)
 
+            # test that fp exceptions are properly cleared
+            np.dot(a, a)
+
             with pytest.raises(FloatingPointError,
                     match="invalid value encountered in dot"):
-                np.dot(a[np.newaxis, np.newaxis, ...], b[np.newaxis, ..., np.newaxis])
+                np.dot(a[np.newaxis, np.newaxis, ...],
+                       b[np.newaxis, ..., np.newaxis])
+
+            np.dot(a[np.newaxis, np.newaxis, ...],
+                   a[np.newaxis, ..., np.newaxis])
 
     def test_dot_type_mismatch(self):
         c = 1.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3345,7 +3345,7 @@ class TestMethods:
         a.dot(b=b, out=c)
         assert_equal(c, np.dot(a, b))
 
-    @pytest.mark.parametrize("dtype", [np.float16, np.float64, np.float128])
+    @pytest.mark.parametrize("dtype", [np.half, np.double, np.longdouble])
     @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
     def test_dot_errstate(self, dtype):
         a = np.array([1, 1], dtype=dtype)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3345,10 +3345,11 @@ class TestMethods:
         a.dot(b=b, out=c)
         assert_equal(c, np.dot(a, b))
 
+    @pytest.mark.parametrize("dtype", [np.float16, np.float64, np.float128])
     @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
-    def test_dot_errstate(self):
-        a = np.array([1., 1.])
-        b = np.array([-np.inf, np.inf])
+    def test_dot_errstate(self, dtype):
+        a = np.array([1, 1], dtype=dtype)
+        b = np.array([-np.inf, np.inf], dtype=dtype)
 
         with np.errstate(invalid='raise'):
             # there are two paths, depending on the number of dimensions - test


### PR DESCRIPTION
Currently dot does not check for floating point exceptions, while similar functions (such as multiply and matmul) do.  Add these checks for consistency.

Note that certain types of floating point exceptions are still not caught:
- Multiplications of 0 with nan or inf are ignored (see #27902)
- Integer overflows are ignored.  These aren't true floating point exceptions, but the behavior is inconsistent with scalar multiply, i.e.
```
>>> np.int16(32000) * np.int16(3)
<python-input-7>:1: RuntimeWarning: overflow encountered in scalar multiply
  np.int16(32000) * np.int16(3)
np.int16(30464)
>>> np.dot(np.int16(32000), np.int16(3))
np.int16(30464)
```

Fixes #14925
