### PR TITLE
DOC: fix URL redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ https://doi.org/10.1038/s41586-020-2649-2)
 
 NumPy is the fundamental package for scientific computing with Python.
 
-- **Website:** https://www.numpy.org
+- **Website:** https://numpy.org
 - **Documentation:** https://numpy.org/doc
 - **Mailing list:** https://mail.python.org/mailman/listinfo/numpy-discussion
 - **Source code:** https://github.com/numpy/numpy
-- **Contributing:** https://www.numpy.org/devdocs/dev/index.html
+- **Contributing:** https://numpy.org/devdocs/dev/index.html
 - **Bug reports:** https://github.com/numpy/numpy/issues
 - **Report a security vulnerability:** https://tidelift.com/docs/security
 


### PR DESCRIPTION
fix URL redirects from www.numpy.org -> numpy.org