### PR TITLE
DOC: repositioned bitwise_count under bit-wise operations

### DIFF
--- a/doc/source/reference/routines.bitwise.rst
+++ b/doc/source/reference/routines.bitwise.rst
@@ -17,6 +17,7 @@ Elementwise bit operations
    bitwise_left_shift
    right_shift
    bitwise_right_shift
+   bitwise_count   
 
 Bit packing
 -----------

--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -193,4 +193,3 @@ Miscellaneous
 
    interp
 
-   bitwise_count


### PR DESCRIPTION
Fixes #28440 : Placed `bitwise_count` under `bit-wise operations` for better navigation

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
