### PR TITLE
DOC: Add -avx512_spr to disable AVX512 in build options

### DIFF
--- a/doc/source/reference/simd/build-options.rst
+++ b/doc/source/reference/simd/build-options.rst
@@ -98,7 +98,7 @@ You may have some reservations about including of ``AVX512`` or
 any other CPU feature and you want to exclude from the dispatched features::
 
     python -m build --wheel -Csetup-args=-Dcpu-dispatch="max -avx512f -avx512cd \
-    -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl"
+    -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl -avx512_spr"
 
 .. _opt-supported-features:
 


### PR DESCRIPTION
I made the below changes represented by issue #27183. doc/source/reference/simd/build-options.rst now includes avx512_spr when disabling the build options.

On https://numpy.org/devdocs/reference/simd/build-options.html there are recommendations for turning off AVX512 support.

python -m build --wheel -Csetup-args=-Dcpu-dispatch="max -avx512f -avx512cd \
-avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl"
I saw the same list in the "CPU Optimization Options" output as 'requested' for dispatch, but all of them were still listed as "Enabled" in the next line.

Idea or request for content:

I had to add -avx512_spr to the list so that AVX512 was really disabled, i.e.

-Csetup-args=-Dcpu-dispatch="max -avx512f -avx512cd -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl -avx512_spr"
Then no AVX512 option was listed in "Enabled".
(I guess if any AVX512 is still allowed, it will turn on all of them?)