### PR TITLE
MAINT: skip slow_pypy tests on pypy

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,13 +1,15 @@
 import os
-import shutil
 import pathlib
 import importlib
+import shutil
 import subprocess
+import sys
 
 import click
 import spin
 from spin.cmds import meson
 
+IS_PYPY = (sys.implementation.name == 'pypy')
 
 # Check that the meson git submodule is present
 curdir = pathlib.Path(__file__).parent
@@ -127,12 +129,16 @@ def docs(*, parent_callback, **kwargs):
 jobs_param = next(p for p in docs.params if p.name == 'jobs')
 jobs_param.default = 1
 
+if IS_PYPY:
+    default = "not slow and not slow_pypy"
+else:
+    default = "not slow"
 
 @click.option(
     "-m",
     "markexpr",
     metavar='MARKEXPR',
-    default="not slow",
+    default=default,
     help="Run tests with the given markers"
 )
 @spin.util.extend_command(spin.cmds.meson.test)

--- a/doc/release/upcoming_changes/28436.change.rst
+++ b/doc/release/upcoming_changes/28436.change.rst
@@ -1,5 +1,10 @@
 Build manylinux_2_28 wheels
 ---------------------------
-Wheels for linux systems will use the ``manylinux_2_28`` tag, which means
+
+Wheels for linux systems will use the ``manylinux_2_28`` tag (instead of the ``manylinux2014`` tag), which means
 dropping support for redhat7/centos7, amazonlinux2, debian9, ubuntu18.04, and
-other pre-glibc2.28 operating system versions.
+other pre-glibc2.28 operating system versions, as per the `PEP 600 support
+table`_.
+
+.. _`PEP 600 support table`: https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#pep600-compliance-check
+


### PR DESCRIPTION
When running `spin test`, we wish to skip all tests marked `@slow` by default. But this did not include the ones marked `@slow_pypy`. This PR fixes the skips. Hopefully this speeds up CI. 

Also tweak the release note for #28436 to include the link to the PEP 600 compliance table.