### PR TITLE
ENH:Added power support to build Numpy wheels.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,6 +82,7 @@ jobs:
         buildplat:
           - [ubuntu-22.04, manylinux_x86_64, ""]
           - [ubuntu-22.04, musllinux_x86_64, ""]
+          - [ubuntu-22.04, manylinux_ppc64le, ""]
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
           - [macos-13, macosx_x86_64, openblas]
@@ -101,7 +102,11 @@ jobs:
             python: "pp311"
           - buildplat: [ ubuntu-22.04-arm, musllinux_aarch64, "" ]
             python: "pp311"
+          - buildplat: [ ubuntu-22.04, manylinux_ppc64le, "" ]
+            python: "pp311"
           - buildplat: [ macos13, macosx_x86_64, openblas ]
+            python: "cp313t"
+          - buildplat: [ ubuntu-22.04, manylinux_ppc64le, "" ] 
             python: "cp313t"
 
     env:
@@ -163,6 +168,17 @@ jobs:
             DYLD="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
             echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
           fi
+
+      - name: Set up qemu  for ppc64le
+        if: ${{ matrix.buildplat[1] == 'manylinux_ppc64le' }}
+        uses: docker/setup-qemu-action@v3
+        with:
+            platforms: ppc64le
+
+      - name: Set up environment for ppc64le
+        if: ${{ matrix.buildplat[1] == 'manylinux_ppc64le' }}
+        run: |
+          echo "CIBW_ARCHS="ppc64le"" >> "$GITHUB_ENV"
 
       - name: Set up free-threaded build
         if: matrix.python == 'cp313t'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml` and
 # `tools/ci/cirrus_wheels.yml`.
 build-frontend = "build"
-skip = "*_i686 *_ppc64le *_s390x *_universal2"
+skip = "*_i686 *_s390x *_universal2"
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 config-settings = "setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false build-dir=build"

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,6 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.29.0.0
-scipy-openblas64==0.3.29.0.0
+scipy-openblas32==0.3.29.0.0 ; platform_machine!="ppc64le"
+scipy-openblas64==0.3.29.0.0 ; platform_machine!="ppc64le"
+scipy-openblas32==0.3.27.63.1 ; platform_machine=="ppc64le"
+scipy-openblas64==0.3.27.63.1 ; platform_machine=="ppc64le"


### PR DESCRIPTION
**Description:**
Hello,
As discussed in [#28438](https://github.com/numpy/numpy/issues/28438) (EDIT: now closed in favor of [#22318](https://github.com/numpy/numpy/issues/22318), which has more discussion), we are adding support for building ppc64le wheels using **QEMU** and **cibuildwheel.**

**Why This Change?**
- Expands NumPy’s compatibility to IBM Power (ppc64le).
- Provides prebuilt wheels, avoiding the need for users to build from source.

**How It Works:**
- QEMU is used for emulation in CI since ppc64le isn’t natively supported.
- cibuildwheel is configured to build and test NumPy wheels for ppc64le.
- The test suite has been run successfully, confirming correctness.

**Changes Made:**
- Added QEMU setup  for ppc64le in CI workflow.
- Updated cibuildwheel configuration to include ppc64le.
- Verified successful builds and test results.
- Added changes related to ppc64le in ci_requirements.txt and pyproject.toml.

Please let us know your thoughts about this. Thank you.

