### PR TITLE
MAINT: fix typo in normal distribution functions docstrings

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1553,7 +1553,7 @@ cdef class RandomState:
         0.0  # may vary
 
         >>> abs(sigma - np.std(s, ddof=1))
-        0.1  # may vary
+        0.0  # may vary
 
         Display the histogram of the samples, along with
         the probability density function:


### PR DESCRIPTION
This commit replaces an incorrect expected result in the docstring of the numpy.random.normal() and numpy.random.RandomState.normal() versions of the normal distribution function by the correct value; namely, the standard deviation of the normal distribution should be (closely equal to) the sigma input parameter.

Note that this typo was partially fixed in commit f2faf84, but only for the random.Generator.normal() version of the function.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
