### PR TITLE
DOC: only change tp_name on CPython

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,8 +52,12 @@ def replace_scalar_type_names():
     ]:
         typ = getattr(numpy, name)
         c_typ = PyTypeObject.from_address(id(typ))
-        c_typ.tp_name = _name_cache[typ] = b"numpy." + name.encode('utf8')
-
+        if sys.implementation.name == 'cpython':
+            c_typ.tp_name = _name_cache[typ] = b"numpy." + name.encode('utf8')
+        else:
+            # It is not guarenteed that the c_typ has this model on other
+            # implementations
+            _name_cache[typ] = b"numpy." + name.encode('utf8')
 
 replace_scalar_type_names()
 


### PR DESCRIPTION
PR #17331 added code to modify `tp_name` of scalars. Of course this is CPython specific, so add a condition. I am not sure the rename is even necessary: I built the documentation on both sides of the condition and compared the resulting generated RST (copied one build to `/tmp`, then compared with `diff -q -r /tmp/docs/source/ doc/source/`), and did not see any differences.

Closes #28479