### PR TITLE
TYP: fix typing errors in `_core.records`

### DIFF
--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -1,48 +1,24 @@
-from _typeshed import StrOrBytesPath
-from collections.abc import Sequence, Iterable
+# ruff: noqa: ANN401
+# pyright: reportSelfClsParameterName=false
+from collections.abc import Iterable, Sequence
 from types import EllipsisType
-from typing import (
-    Any,
-    TypeAlias,
-    TypeVar,
-    overload,
-    Protocol,
-    SupportsIndex,
-    Literal,
-    type_check_only
-)
+from typing import Any, Literal, Protocol, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
 
-from numpy import (
-    ndarray,
-    dtype,
-    generic,
-    void,
-    _ByteOrder,
-    _SupportsBuffer,
-    _OrderKACF,
-)
+from _typeshed import StrOrBytesPath
 
-from numpy._typing import (
-    ArrayLike,
-    DTypeLike,
-    NDArray,
-    _Shape,
-    _ShapeLike,
-    _ArrayLikeInt_co,
-    _ArrayLikeVoid_co,
-    _NestedSequence,
-)
+from numpy import _ByteOrder, _OrderKACF, _SupportsBuffer, dtype, generic, ndarray, void
+from numpy._typing import ArrayLike, DTypeLike, NDArray, _ArrayLikeVoid_co, _NestedSequence, _ShapeLike
 
 __all__ = [
-    "record",
-    "recarray",
-    "format_parser",
-    "fromarrays",
-    "fromrecords",
-    "fromstring",
-    "fromfile",
     "array",
     "find_duplicate",
+    "format_parser",
+    "fromarrays",
+    "fromfile",
+    "fromrecords",
+    "fromstring",
+    "recarray",
+    "record",
 ]
 
 _T = TypeVar("_T")
@@ -58,6 +34,9 @@ class _SupportsReadInto(Protocol):
     def tell(self, /) -> int: ...
     def readinto(self, buffer: memoryview, /) -> int: ...
 
+###
+
+# exported in `numpy.rec`
 class record(void):
     def __getattribute__(self, attr: str) -> Any: ...
     def __setattr__(self, attr: str, val: ArrayLike) -> None: ...
@@ -67,6 +46,7 @@ class record(void):
     @overload
     def __getitem__(self, key: list[str]) -> record: ...
 
+# exported in `numpy.rec`
 class recarray(ndarray[_ShapeT_co, _DType_co]):
     # NOTE: While not strictly mandatory, we're demanding here that arguments
     # for the `format_parser`- and `dtype`-based dtype constructors are
@@ -75,273 +55,252 @@ class recarray(ndarray[_ShapeT_co, _DType_co]):
     def __new__(
         subtype,
         shape: _ShapeLike,
-        dtype: None = ...,
-        buf: None | _SupportsBuffer = ...,
-        offset: SupportsIndex = ...,
-        strides: None | _ShapeLike = ...,
+        dtype: None = None,
+        buf: _SupportsBuffer | None = None,
+        offset: SupportsIndex = 0,
+        strides: _ShapeLike | None = None,
         *,
         formats: DTypeLike,
-        names: None | str | Sequence[str] = ...,
-        titles: None | str | Sequence[str] = ...,
-        byteorder: None | _ByteOrder = ...,
-        aligned: bool = ...,
-        order: _OrderKACF = ...,
+        names: str | Sequence[str] | None = None,
+        titles: str | Sequence[str] | None = None,
+        byteorder: _ByteOrder | None = None,
+        aligned: bool = False,
+        order: _OrderKACF = "C",
     ) -> recarray[Any, dtype[record]]: ...
     @overload
     def __new__(
         subtype,
         shape: _ShapeLike,
         dtype: DTypeLike,
-        buf: None | _SupportsBuffer = ...,
-        offset: SupportsIndex = ...,
-        strides: None | _ShapeLike = ...,
-        formats: None = ...,
-        names: None = ...,
-        titles: None = ...,
-        byteorder: None = ...,
-        aligned: Literal[False] = ...,
-        order: _OrderKACF = ...,
+        buf: _SupportsBuffer | None = None,
+        offset: SupportsIndex = 0,
+        strides: _ShapeLike | None = None,
+        formats: None = None,
+        names: None = None,
+        titles: None = None,
+        byteorder: None = None,
+        aligned: Literal[False] = False,
+        order: _OrderKACF = "C",
     ) -> recarray[Any, dtype[Any]]: ...
-    def __array_finalize__(self, obj: object) -> None: ...
-    def __getattribute__(self, attr: str) -> Any: ...
-    def __setattr__(self, attr: str, val: ArrayLike) -> None: ...
+    def __array_finalize__(self, /, obj: object) -> None: ...
+    def __getattribute__(self, attr: str, /) -> Any: ...
+    def __setattr__(self, attr: str, val: ArrayLike, /) -> None: ...
     @overload
-    def __getitem__(self, indx: (
-        SupportsIndex
-        | _ArrayLikeInt_co
-        | tuple[SupportsIndex | _ArrayLikeInt_co, ...]
-    )) -> Any: ...
+    def field(self, /, attr: int | str, val: None = None) -> Any: ...
     @overload
-    def __getitem__(self: recarray[Any, dtype[void]], indx: (
-        None
-        | slice
-        | EllipsisType
-        | SupportsIndex
-        | _ArrayLikeInt_co
-        | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
-    )) -> recarray[_Shape, _DType_co]: ...
-    @overload
-    def __getitem__(self, indx: (
-        None
-        | slice
-        | EllipsisType
-        | SupportsIndex
-        | _ArrayLikeInt_co
-        | tuple[None | slice | EllipsisType | _ArrayLikeInt_co | SupportsIndex, ...]
-    )) -> ndarray[_Shape, _DType_co]: ...
-    @overload
-    def __getitem__(self, indx: str) -> NDArray[Any]: ...
-    @overload
-    def __getitem__(self, indx: list[str]) -> recarray[_ShapeT_co, dtype[record]]: ...
-    @overload
-    def field(self, attr: int | str, val: None = ...) -> Any: ...
-    @overload
-    def field(self, attr: int | str, val: ArrayLike) -> None: ...
+    def field(self, /, attr: int | str, val: ArrayLike) -> None: ...
 
+# exported in `numpy.rec`
 class format_parser:
     dtype: dtype[void]
     def __init__(
         self,
+        /,
         formats: DTypeLike,
-        names: None | str | Sequence[str],
-        titles: None | str | Sequence[str],
-        aligned: bool = ...,
-        byteorder: None | _ByteOrder = ...,
+        names: str | Sequence[str] | None,
+        titles: str | Sequence[str] | None,
+        aligned: bool = False,
+        byteorder: _ByteOrder | None = None,
     ) -> None: ...
 
+# exported in `numpy.rec`
 @overload
 def fromarrays(
     arrayList: Iterable[ArrayLike],
-    dtype: DTypeLike = ...,
-    shape: None | _ShapeLike = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
+    dtype: DTypeLike | None = None,
+    shape: _ShapeLike | None = None,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
 ) -> _RecArray[Any]: ...
 @overload
 def fromarrays(
     arrayList: Iterable[ArrayLike],
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
     *,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
 ) -> _RecArray[record]: ...
 
 @overload
 def fromrecords(
-    recList: _ArrayLikeVoid_co | tuple[Any, ...] | _NestedSequence[tuple[Any, ...]],
-    dtype: DTypeLike = ...,
-    shape: None | _ShapeLike = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
+    recList: _ArrayLikeVoid_co | tuple[object, ...] | _NestedSequence[tuple[object, ...]],
+    dtype: DTypeLike | None = None,
+    shape: _ShapeLike | None = None,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
 ) -> _RecArray[record]: ...
 @overload
 def fromrecords(
-    recList: _ArrayLikeVoid_co | tuple[Any, ...] | _NestedSequence[tuple[Any, ...]],
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
+    recList: _ArrayLikeVoid_co | tuple[object, ...] | _NestedSequence[tuple[object, ...]],
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
     *,
-    formats: DTypeLike = ...,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
+    formats: DTypeLike,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
 ) -> _RecArray[record]: ...
 
+# exported in `numpy.rec`
 @overload
 def fromstring(
     datastring: _SupportsBuffer,
     dtype: DTypeLike,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
 ) -> _RecArray[record]: ...
 @overload
 def fromstring(
     datastring: _SupportsBuffer,
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
     *,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
 ) -> _RecArray[record]: ...
 
+# exported in `numpy.rec`
 @overload
 def fromfile(
     fd: StrOrBytesPath | _SupportsReadInto,
     dtype: DTypeLike,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
 ) -> _RecArray[Any]: ...
 @overload
 def fromfile(
     fd: StrOrBytesPath | _SupportsReadInto,
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
     *,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
 ) -> _RecArray[record]: ...
 
+# exported in `numpy.rec`
 @overload
 def array(
     obj: _SCT | NDArray[_SCT],
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
-    copy: bool = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
+    copy: bool = True,
 ) -> _RecArray[_SCT]: ...
 @overload
 def array(
     obj: ArrayLike,
     dtype: DTypeLike,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
-    copy: bool = ...,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
+    copy: bool = True,
 ) -> _RecArray[Any]: ...
 @overload
 def array(
     obj: ArrayLike,
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
     *,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
-    copy: bool = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
+    copy: bool = True,
 ) -> _RecArray[record]: ...
 @overload
 def array(
     obj: None,
     dtype: DTypeLike,
     shape: _ShapeLike,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
-    copy: bool = ...,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
+    copy: bool = True,
 ) -> _RecArray[Any]: ...
 @overload
 def array(
     obj: None,
-    dtype: None = ...,
+    dtype: None = None,
     *,
     shape: _ShapeLike,
-    offset: int = ...,
+    offset: int = 0,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
-    copy: bool = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
+    copy: bool = True,
 ) -> _RecArray[record]: ...
 @overload
 def array(
     obj: _SupportsReadInto,
     dtype: DTypeLike,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
-    formats: None = ...,
-    names: None = ...,
-    titles: None = ...,
-    aligned: bool = ...,
-    byteorder: None = ...,
-    copy: bool = ...,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
+    formats: None = None,
+    names: None = None,
+    titles: None = None,
+    aligned: bool = False,
+    byteorder: None = None,
+    copy: bool = True,
 ) -> _RecArray[Any]: ...
 @overload
 def array(
     obj: _SupportsReadInto,
-    dtype: None = ...,
-    shape: None | _ShapeLike = ...,
-    offset: int = ...,
+    dtype: None = None,
+    shape: _ShapeLike | None = None,
+    offset: int = 0,
     *,
     formats: DTypeLike,
-    names: None | str | Sequence[str] = ...,
-    titles: None | str | Sequence[str] = ...,
-    aligned: bool = ...,
-    byteorder: None | _ByteOrder = ...,
-    copy: bool = ...,
+    names: str | Sequence[str] | None = None,
+    titles: str | Sequence[str] | None = None,
+    aligned: bool = False,
+    byteorder: _ByteOrder | None = None,
+    copy: bool = True,
 ) -> _RecArray[record]: ...
 
+# exported in `numpy.rec`
 def find_duplicate(list: Iterable[_T]) -> list[_T]: ...

--- a/numpy/typing/tests/data/reveal/rec.pyi
+++ b/numpy/typing/tests/data/reveal/rec.pyi
@@ -7,7 +7,7 @@ import numpy.typing as npt
 from typing_extensions import assert_type
 
 AR_i8: npt.NDArray[np.int64]
-REC_AR_V: np.recarray[Any, np.dtype[np.record]]
+REC_AR_V: np.recarray[tuple[int, ...], np.dtype[np.record]]
 AR_LIST: list[npt.NDArray[np.int64]]
 
 record: np.record


### PR DESCRIPTION
Backport of numpy/numtype#116
Towards #28428

---

In this case "fix typing errors" should be read as "ignore unavoidable typing errors". This also fixes all ruff errors, and ensures compatibility with the (official) [stubs style guide](https://typing.python.org/en/latest/guides/writing_stubs.html#style-guide)

---

I'm not attached to the *backport-candidate* label, so in case someone objects, feel free to remove it.