### PR TITLE
DOC: let docstring mention that unique_values is now unsorted

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -612,7 +612,11 @@ def unique_values(x):
 
     This function is an Array API compatible alternative to::
 
-        np.unique(x, equal_nan=False)
+        np.unique(x, equal_nan=False, sorted=False)
+
+    .. versionchanged:: 2.3
+       The algorithm was changed to a faster one that does not rely on
+       sorting, and hence the results are no longer implicitly sorted.
 
     Parameters
     ----------


### PR DESCRIPTION
This is a small follow-up to #26018, to add a note to `unique_values` to warn possible users that the results will not necessarily be sorted (since that change has let to failing tests downstream; see gh-28493)

Fixes #28493