### PR TITLE
TYP: accept non-integer shapes in array constructor without a dtype

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -278,7 +278,7 @@ class _ConstructorEmpty(Protocol):
         self,
         /,
         shape: SupportsIndex,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None = ...,
         order: _OrderCF = ...,
         **kwargs: Unpack[_KwargsEmpty],
     ) -> _Array1D[Any]: ...
@@ -316,7 +316,7 @@ class _ConstructorEmpty(Protocol):
         self,
         /,
         shape: _AnyShapeType,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None = ...,
         order: _OrderCF = ...,
         **kwargs: Unpack[_KwargsEmpty],
     ) -> _Array[_AnyShapeType, Any]: ...
@@ -348,9 +348,10 @@ class _ConstructorEmpty(Protocol):
     ) -> NDArray[_SCT]: ...
     @overload
     def __call__(
-        self, /,
+        self,
+        /,
         shape: _ShapeLike,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None = ...,
         order: _OrderCF = ...,
         **kwargs: Unpack[_KwargsEmpty],
     ) -> NDArray[Any]: ...
@@ -419,16 +420,6 @@ def empty_like(
 ) -> NDArray[_SCT]: ...
 @overload
 def empty_like(
-    prototype: object,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: None | _ShapeLike = ...,
-    *,
-    device: None | L["cpu"] = ...,
-) -> NDArray[Any]: ...
-@overload
-def empty_like(
     prototype: Any,
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
@@ -440,7 +431,7 @@ def empty_like(
 @overload
 def empty_like(
     prototype: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
     shape: None | _ShapeLike = ...,
@@ -483,17 +474,6 @@ def array(
 ) -> NDArray[_SCT]: ...
 @overload
 def array(
-    object: object,
-    dtype: None = ...,
-    *,
-    copy: None | bool | _CopyMode = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    ndmin: int = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-@overload
-def array(
     object: Any,
     dtype: _DTypeLike[_SCT],
     *,
@@ -506,7 +486,7 @@ def array(
 @overload
 def array(
     object: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     *,
     copy: None | bool | _CopyMode = ...,
     order: _OrderKACF = ...,
@@ -555,15 +535,6 @@ def concatenate(  # type: ignore[misc]
     casting: None | _CastingKind = ...
 ) -> NDArray[_SCT]: ...
 @overload
-def concatenate(  # type: ignore[misc]
-    arrays: SupportsLenAndGetItem[ArrayLike],
-    /,
-    axis: None | SupportsIndex = ...,
-    out: None = ...,
-    *,
-    dtype: None = ...,
-    casting: None | _CastingKind = ...
-) -> NDArray[Any]: ...
 @overload
 def concatenate(  # type: ignore[misc]
     arrays: SupportsLenAndGetItem[ArrayLike],
@@ -581,7 +552,7 @@ def concatenate(  # type: ignore[misc]
     axis: None | SupportsIndex = ...,
     out: None = ...,
     *,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = None,
     casting: None | _CastingKind = ...
 ) -> NDArray[Any]: ...
 @overload
@@ -717,16 +688,6 @@ def asarray(
 ) -> NDArray[_SCT]: ...
 @overload
 def asarray(
-    a: object,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    copy: None | bool = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-@overload
-def asarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
@@ -738,7 +699,7 @@ def asarray(
 @overload
 def asarray(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     *,
     device: None | L["cpu"] = ...,
@@ -768,16 +729,6 @@ def asanyarray(
 ) -> NDArray[_SCT]: ...
 @overload
 def asanyarray(
-    a: object,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    *,
-    device: None | L["cpu"] = ...,
-    copy: None | bool = ...,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-@overload
-def asanyarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
@@ -789,7 +740,7 @@ def asanyarray(
 @overload
 def asanyarray(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     *,
     device: None | L["cpu"] = ...,
@@ -806,13 +757,6 @@ def ascontiguousarray(
 ) -> NDArray[_SCT]: ...
 @overload
 def ascontiguousarray(
-    a: object,
-    dtype: None = ...,
-    *,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-@overload
-def ascontiguousarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     *,
@@ -821,7 +765,7 @@ def ascontiguousarray(
 @overload
 def ascontiguousarray(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     *,
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
@@ -835,13 +779,6 @@ def asfortranarray(
 ) -> NDArray[_SCT]: ...
 @overload
 def asfortranarray(
-    a: object,
-    dtype: None = ...,
-    *,
-    like: None | _SupportsArrayFunc = ...,
-) -> NDArray[Any]: ...
-@overload
-def asfortranarray(
     a: Any,
     dtype: _DTypeLike[_SCT],
     *,
@@ -850,7 +787,7 @@ def asfortranarray(
 @overload
 def asfortranarray(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     *,
     like: None | _SupportsArrayFunc = ...,
 ) -> NDArray[Any]: ...
@@ -879,7 +816,7 @@ def fromstring(
 @overload
 def fromstring(
     string: str | bytes,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     count: SupportsIndex = ...,
     *,
     sep: str,
@@ -982,7 +919,7 @@ def fromfile(
 @overload
 def fromfile(
     file: StrOrBytesPath | _SupportsFileMethods,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     count: SupportsIndex = ...,
     sep: str = ...,
     offset: SupportsIndex = ...,
@@ -1028,7 +965,7 @@ def frombuffer(
 @overload
 def frombuffer(
     buffer: _SupportsBuffer,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     count: SupportsIndex = ...,
     offset: SupportsIndex = ...,
     *,
@@ -1121,7 +1058,7 @@ def arange(
 def arange(
     stop: Any, /,
     *,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     device: None | L["cpu"] = ...,
     like: None | _SupportsArrayFunc = ...,
 ) -> _Array1D[Any]: ...
@@ -1130,7 +1067,7 @@ def arange(
     start: Any,
     stop: Any,
     step: Any = ...,
-    dtype: DTypeLike = ...,
+    dtype: DTypeLike | None = ...,
     *,
     device: None | L["cpu"] = ...,
     like: None | _SupportsArrayFunc = ...,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -217,16 +217,6 @@ def zeros_like(
 ) -> NDArray[_SCT]: ...
 @overload
 def zeros_like(
-    a: object,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: None | _ShapeLike = ...,
-    *,
-    device: None | L["cpu"] = ...,
-) -> NDArray[Any]: ...
-@overload
-def zeros_like(
     a: Any,
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
@@ -238,7 +228,7 @@ def zeros_like(
 @overload
 def zeros_like(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
     shape: None | _ShapeLike = ...,
@@ -270,16 +260,6 @@ def ones_like(
 ) -> NDArray[_SCT]: ...
 @overload
 def ones_like(
-    a: object,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: None | _ShapeLike = ...,
-    *,
-    device: None | L["cpu"] = ...,
-) -> NDArray[Any]: ...
-@overload
-def ones_like(
     a: Any,
     dtype: _DTypeLike[_SCT],
     order: _OrderKACF = ...,
@@ -291,7 +271,7 @@ def ones_like(
 @overload
 def ones_like(
     a: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
     shape: None | _ShapeLike = ...,
@@ -424,17 +404,6 @@ def full_like(
 ) -> NDArray[_SCT]: ...
 @overload
 def full_like(
-    a: object,
-    fill_value: Any,
-    dtype: None = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: None | _ShapeLike = ...,
-    *,
-    device: None | L["cpu"] = ...,
-) -> NDArray[Any]: ...
-@overload
-def full_like(
     a: Any,
     fill_value: Any,
     dtype: _DTypeLike[_SCT],
@@ -448,7 +417,7 @@ def full_like(
 def full_like(
     a: Any,
     fill_value: Any,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
     shape: None | _ShapeLike = ...,
@@ -777,8 +746,15 @@ def indices(
 @overload
 def indices(
     dimensions: Sequence[int],
+    dtype: type[int],
+    sparse: L[True],
+) -> tuple[NDArray[int_], ...]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
     dtype: type[int] = ...,
-    sparse: L[True] = ...,
+    *,
+    sparse: L[True],
 ) -> tuple[NDArray[int_], ...]: ...
 @overload
 def indices(
@@ -795,7 +771,7 @@ def indices(
 @overload
 def indices(
     dimensions: Sequence[int],
-    dtype: DTypeLike,
+    dtype: DTypeLike = ...,
     sparse: L[False] = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -804,13 +780,20 @@ def indices(
     dtype: DTypeLike,
     sparse: L[True],
 ) -> tuple[NDArray[Any], ...]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
+    dtype: DTypeLike = ...,
+    *,
+    sparse: L[True],
+) -> tuple[NDArray[Any], ...]: ...
 
 def fromfunction(
     function: Callable[..., _T],
     shape: Sequence[int],
     *,
     dtype: DTypeLike = ...,
-    like: _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
     **kwargs: Any,
 ) -> _T: ...
 
@@ -823,7 +806,7 @@ def binary_repr(num: SupportsIndex, width: None | int = ...) -> str: ...
 def base_repr(
     number: SupportsAbs[float],
     base: float = ...,
-    padding: SupportsIndex = ...,
+    padding: SupportsIndex | None = ...,
 ) -> str: ...
 
 @overload
@@ -831,21 +814,21 @@ def identity(
     n: int,
     dtype: None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[float64]: ...
 @overload
 def identity(
     n: int,
     dtype: _DTypeLike[_SCT],
     *,
-    like: _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[_SCT]: ...
 @overload
 def identity(
     n: int,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None = ...,
     *,
-    like: _SupportsArrayFunc = ...,
+    like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[Any]: ...
 
 def allclose(

--- a/numpy/typing/tests/data/fail/multiarray.pyi
+++ b/numpy/typing/tests/data/fail/multiarray.pyi
@@ -34,7 +34,6 @@ np.unpackbits(AR_u1, bitorder=">")  # E: incompatible type
 np.shares_memory(1, 1, max_work=i8)  # E: incompatible type
 np.may_share_memory(1, 1, max_work=i8)  # E: incompatible type
 
-np.arange(M)  # E: No overload variant
 np.arange(stop=10)  # E: No overload variant
 
 np.datetime_data(int)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Literal as L, TypeVar
+from typing import Any, TypeVar
 from pathlib import Path
 from collections import deque
 
@@ -18,6 +18,8 @@ A: npt.NDArray[np.float64]
 B: SubClass[np.float64]
 C: list[int]
 D: SubClass[np.float64 | np.int64]
+
+mixed_shape: tuple[int, np.int64]
 
 def func(i: int, j: int, **kwargs: Any) -> SubClass[np.float64]: ...
 
@@ -43,10 +45,12 @@ assert_type(np.array(D), npt.NDArray[np.float64 | np.int64])
 assert_type(np.zeros([1, 5, 6]), npt.NDArray[np.float64])
 assert_type(np.zeros([1, 5, 6], dtype=np.int64), npt.NDArray[np.int64])
 assert_type(np.zeros([1, 5, 6], dtype='c16'), npt.NDArray[Any])
+assert_type(np.zeros(mixed_shape), npt.NDArray[np.float64])
 
 assert_type(np.empty([1, 5, 6]), npt.NDArray[np.float64])
 assert_type(np.empty([1, 5, 6], dtype=np.int64), npt.NDArray[np.int64])
 assert_type(np.empty([1, 5, 6], dtype='c16'), npt.NDArray[Any])
+assert_type(np.empty(mixed_shape), npt.NDArray[np.float64])
 
 assert_type(np.concatenate(A), npt.NDArray[np.float64])
 assert_type(np.concatenate([A, A]), npt.NDArray[Any])
@@ -182,6 +186,7 @@ assert_type(np.ones(_shape_1d, dtype=np.int64), np.ndarray[tuple[int], np.dtype[
 assert_type(np.ones(_shape_like), npt.NDArray[np.float64])
 assert_type(np.ones(_shape_like, dtype=np.dtypes.Int64DType()), np.ndarray[Any, np.dtypes.Int64DType])
 assert_type(np.ones(_shape_like, dtype=int), npt.NDArray[Any])
+assert_type(np.ones(mixed_shape), npt.NDArray[np.float64])
 
 assert_type(np.full(_size, i8), np.ndarray[tuple[int], np.dtype[np.int64]])
 assert_type(np.full(_shape_2d, i8), np.ndarray[tuple[int, int], np.dtype[np.int64]])


### PR DESCRIPTION
The mypy_primer output from https://github.com/numpy/numpy/pull/28497#issuecomment-2723454472 shows that calling `np.zeros` with `tuple[int, np.int64]` results in a typing error. This PR intended to address that.

But for some reason, I wasn't able to reproduce this error, and tese changes also did not  result in a mypy_primer diff 🤷🏻

Either way, even if these changes don't actually fix this specific problem, I can imagine that there are some theoretical edge-cases where *will* help, although those are probably rather unlikely use-cases. 

These changes are backwards compatible, and there are no other downsides that this would cause, as far as I can tell.