### PR TITLE
TYP: annotate the missing deprecated ``row_stack`` function

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -574,6 +574,7 @@ from numpy.lib._polynomial_impl import (
 
 from numpy.lib._shape_base_impl import (
     column_stack,
+    row_stack,
     dstack,
     array_split,
     split,
@@ -730,10 +731,9 @@ __all__ = [  # noqa: RUF022
     "histogram2d", "mask_indices", "tril_indices", "tril_indices_from", "triu_indices",
     "triu_indices_from",
     # lib._shape_base_impl.__all__
-    # NOTE: `row_stack` is omitted because it is deprecated
     "column_stack", "dstack", "array_split", "split", "hsplit", "vsplit", "dsplit",
     "apply_over_axes", "expand_dims", "apply_along_axis", "kron", "tile",
-    "take_along_axis", "put_along_axis",
+    "take_along_axis", "put_along_axis", "row_stack",
     # lib._type_check_impl.__all__
     "iscomplexobj", "isrealobj", "imag", "iscomplex", "isreal", "nan_to_num", "real",
     "real_if_close", "typename", "mintypecode", "common_type",

--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -10,20 +10,13 @@ from typing import (
     type_check_only,
 )
 
+from typing_extensions import deprecated
+
 import numpy as np
-from numpy import (
-    generic,
-    integer,
-    ufunc,
-    unsignedinteger,
-    signedinteger,
-    floating,
-    complexfloating,
-    object_,
-)
-from numpy._core.shape_base import vstack as row_stack
+from numpy import _CastingKind, generic, integer, ufunc, unsignedinteger, signedinteger, floating, complexfloating, object_
 from numpy._typing import (
     ArrayLike,
+    DTypeLike,
     NDArray,
     _ShapeLike,
     _ArrayLike,
@@ -72,6 +65,8 @@ class _SupportsArrayWrap(Protocol):
     @property
     def __array_wrap__(self) -> _ArrayWrap: ...
 
+###
+
 def take_along_axis(
     arr: _SCT | NDArray[_SCT],
     indices: NDArray[integer[Any]],
@@ -119,6 +114,16 @@ def expand_dims(
     axis: _ShapeLike,
 ) -> NDArray[Any]: ...
 
+# Deprecated in NumPy 2.0, 2023-08-18
+@deprecated("`row_stack` alias is deprecated. Use `np.vstack` directly.")
+def row_stack(
+    tup: Sequence[ArrayLike],
+    *,
+    dtype: DTypeLike | None = None,
+    casting: _CastingKind = "same_kind",
+) -> NDArray[Any]: ...
+
+#
 @overload
 def column_stack(tup: Sequence[_ArrayLike[_SCT]]) -> NDArray[_SCT]: ...
 @overload

--- a/numpy/matlib.pyi
+++ b/numpy/matlib.pyi
@@ -394,7 +394,7 @@ from numpy import (
     roots,
     rot90,
     round,
-    # row_stack,
+    row_stack,
     s_,
     save,
     savetxt,


### PR DESCRIPTION
Ported from numpy/numtype#223

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
