### PR TITLE
CI, TST: Bump to cibuildwheel 2.23 (Pyodide 0.27.0) for WASM builds; skip Pyston tests for WASM too

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969  # v2.22.0
+      - uses: pypa/cibuildwheel@6cccd09a31908ffd175b012fb8bf4e1dbda3bc6c  # 2.23.0
         env:
           CIBW_PLATFORM: pyodide
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -13,7 +13,7 @@ from numpy._core._rational_tests import rational
 from numpy._core._multiarray_tests import create_custom_field_dtype
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT,
-    IS_PYSTON)
+    IS_PYSTON, IS_WASM)
 from itertools import permutations
 import random
 
@@ -970,6 +970,7 @@ class TestMonsterType:
         assert_dtype_equal(c, d)
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_list_recursion(self):
         l = []
         l.append(('f', l))
@@ -977,6 +978,7 @@ class TestMonsterType:
             np.dtype(l)
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_tuple_recursion(self):
         d = np.int32
         for i in range(100000):
@@ -985,6 +987,7 @@ class TestMonsterType:
             np.dtype(d)
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_dict_recursion(self):
         d = {"names": ['self'], "formats": [None], "offsets": [0]}
         d['formats'][0] = d
@@ -1568,6 +1571,7 @@ class TestFromDTypeAttribute:
         assert np.dtype(dt()) == np.float64
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_recursion(self):
         class dt:
             pass
@@ -1592,6 +1596,7 @@ class TestFromDTypeAttribute:
         np.dtype(dt(1))
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_void_subtype_recursion(self):
         class vdt(np.void):
             pass

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8916,6 +8916,8 @@ class TestConversion:
         assert_raises(NotImplementedError, bool, np.array([NotConvertible()]))
         if IS_PYSTON:
             pytest.skip("Pyston disables recursion checking")
+        if IS_WASM:
+            pytest.skip("Pyodide/WASM has limited stack size")
 
         self_containing = np.array([None])
         self_containing[0] = self_containing

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1772,6 +1772,7 @@ class TestRegression:
         assert_(b.flags.c_contiguous)
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_object_array_self_reference(self):
         # Object arrays with references to themselves can cause problems
         a = np.array(0, dtype=object)
@@ -1781,6 +1782,7 @@ class TestRegression:
         a[()] = None
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
     def test_object_array_circular_reference(self):
         # Test the same for a circular reference.
         a = np.array(0, dtype=object)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

## Description

This pull request is related to gh-28463; cibuildwheel's 2.23 release introduced Pyodide 0.27.0, which causes "maximum call stack size exceeded" errors with the WASM/Pyodide tests. This PR bumps cibuildwheel from version 2.22 to version 2.23, and temporarily skips the tests with a `numpy.testing.IS_WASM` check, similar to the one for Pyston; as the Pyston tests fail in a similar fashion (the tests try to catch `RecursionError`s) as well.

## Additional context

- https://github.com/pyodide/pyodide/releases/tag/0.27.0
- https://github.com/pypa/cibuildwheel/releases/tag/v2.23.0
- gh-28457