### PR TITLE
BUG: np.historgram doesn't have data overflow warning

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -887,7 +887,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]
                 cw = np.concatenate((zero, sw.cumsum()))
-                if (cw.max() > np.iinfo(ntype).max) and not warn:
+                if (issubclass(ntype.type, np.integer) and cw.max() > np.iinfo(ntype).max) and not warn:
                     warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
                                   RuntimeWarning, stacklevel=3)
                     warn = True
@@ -895,7 +895,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 bin_index = _search_sorted_inclusive(sa, bin_edges)
                 tmp_cum_n = cum_n.copy()
                 cum_n += cw[bin_index]
-                if (tmp_cum_n > cum_n).any() and not warn:
+
+                if issubclass(ntype.type, np.integer) and (tmp_cum_n > cum_n).any() and not warn:
                     warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
                                   RuntimeWarning, stacklevel=3)
                     warn = True

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -887,7 +887,14 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]
                 cw = np.concatenate((zero, sw.cumsum()))
-                if (issubclass(ntype.type, np.integer) and cw.max() > np.iinfo(ntype).max) and not warn:
+                if ntype.kind in ['i', 'u']:
+                    max_cw = np.iinfo(ntype).max 
+                elif ntype.kind in ['c', 'f']:
+                    max_cw = np.finfo(ntype).max
+                else:
+                    max_cw = np.inf
+
+                if cw.max() > max_cw and not warn:
                     warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
                                   RuntimeWarning, stacklevel=3)
                     warn = True
@@ -895,8 +902,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 bin_index = _search_sorted_inclusive(sa, bin_edges)
                 tmp_cum_n = cum_n.copy()
                 cum_n += cw[bin_index]
-
-                if issubclass(ntype.type, np.integer) and (tmp_cum_n > cum_n).any() and not warn:
+            
+                if (tmp_cum_n > cum_n).any() and not warn:
                     warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
                                   RuntimeWarning, stacklevel=3)
                     warn = True

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -888,16 +888,16 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 sw = tmp_w[sorting_index]
                 cw = np.concatenate((zero, sw.cumsum()))
                 if (cw.max() > np.iinfo(ntype).max) and not warn:
-                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue"\
-                            , RuntimeWarning, stacklevel=3)
+                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
+                                  RuntimeWarning, stacklevel=3)
                     warn = True
 
                 bin_index = _search_sorted_inclusive(sa, bin_edges)
                 tmp_cum_n = cum_n.copy()
                 cum_n += cw[bin_index]
                 if (tmp_cum_n > cum_n).any() and not warn:
-                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue"\
-                            , RuntimeWarning, stacklevel=3)
+                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue",
+                                  RuntimeWarning, stacklevel=3)
                     warn = True
 
         n = np.diff(cum_n)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -878,6 +878,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 sa = np.sort(a[i:i + BLOCK])
                 cum_n += _search_sorted_inclusive(sa, bin_edges)
         else:
+            warn = False
             zero = np.zeros(1, dtype=ntype)
             for i in _range(0, len(a), BLOCK):
                 tmp_a = a[i:i + BLOCK]
@@ -886,8 +887,18 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]
                 cw = np.concatenate((zero, sw.cumsum()))
+                if (cw.max() > np.iinfo(ntype).max) and not warn:
+                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue"\
+                            , RuntimeWarning, stacklevel=3)
+                    warn = True
+
                 bin_index = _search_sorted_inclusive(sa, bin_edges)
+                tmp_cum_n = cum_n.copy()
                 cum_n += cw[bin_index]
+                if (tmp_cum_n > cum_n).any() and not warn:
+                    warnings.warn("Overflow detected! Use a higher precision dtype for weights to prevent this issue"\
+                            , RuntimeWarning, stacklevel=3)
+                    warn = True
 
         n = np.diff(cum_n)
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -337,21 +337,21 @@ class TestHistogram:
 
     def test_cumulative_overflow(self):
         #when summation in block base method cause overflow
-        w = np.array([1] * (2** 17), dtype=np.uint8)
-        a = np.array([128] * (2** 17), dtype=np.uint8)
+        w = np.array([1] * (2 ** 17), dtype=np.uint8)
+        a = np.array([128] * (2 ** 17), dtype=np.uint8)
         bins = np.arange(256)
         with suppress_warnings() as sup:
             rec = sup.record(RuntimeWarning, 'Overflow.*')
-            hist,_=np.histogram(a=a,bins=bins,weights=w)
+            hist, _ = np.histogram(a=a, bins=bins, weights=w)
         assert_equal(len(rec), 1)
 
         #when cumsum cause overflow
-        a=np.array([0,0.5,1,1.5],dtype=float)
-        w=np.array([65534,2,65534,65534],dtype='uint16') # uint16: 0~65535
-        bins=[0,1,2]
+        a = np.array([0, 0.5, 1, 1.5], dtype=float)
+        w = np.array([65534, 2, 65534, 65534], dtype='uint16')  # uint16: 0~65535
+        bins = [0, 1, 2]
         with suppress_warnings() as sup:
             rec = sup.record(RuntimeWarning, 'Overflow.*')
-            hist,_=np.histogram(a=a,bins=bins,weights=w)
+            hist, _ = np.histogram(a=a, bins=bins, weights=w)
         assert_equal(len(rec), 1)
 
     def do_precision_lower_bound(self, float_small, float_large):

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -335,6 +335,25 @@ class TestHistogram:
         self.do_signed_overflow_bounds(np.int_)
         self.do_signed_overflow_bounds(np.longlong)
 
+    def test_cumulative_overflow(self):
+        #when summation in block base method cause overflow
+        w = np.array([1] * (2** 17), dtype=np.uint8)
+        a = np.array([128] * (2** 17), dtype=np.uint8)
+        bins = np.arange(256)
+        with suppress_warnings() as sup:
+            rec = sup.record(RuntimeWarning, 'Overflow.*')
+            hist,_=np.histogram(a=a,bins=bins,weights=w)
+        assert_equal(len(rec), 1)
+
+        #when cumsum cause overflow
+        a=np.array([0,0.5,1,1.5],dtype=float)
+        w=np.array([65534,2,65534,65534],dtype='uint16') # uint16: 0~65535
+        bins=[0,1,2]
+        with suppress_warnings() as sup:
+            rec = sup.record(RuntimeWarning, 'Overflow.*')
+            hist,_=np.histogram(a=a,bins=bins,weights=w)
+        assert_equal(len(rec), 1)
+
     def do_precision_lower_bound(self, float_small, float_large):
         eps = np.finfo(float_large).eps
 


### PR DESCRIPTION


This PR resolves issue #28472 by adding a warning to inform the user when an overflow occurs due to the dtype of the weight parameter. I discovered that the overflow happens when using the cumulative method, and without the correct bit size, this operation can lead to an overflow.

In this update, I've introduced a warning that advises the user to consider using a different bit size for weight to prevent overflow. The warning suggests adjusting the dtype when an overflow is detected to ensure proper handling of the operation.

I can also fix this issue by upgrading the dtype when necessary, similar to the behavior in non-cumulative operations, to prevent overflow automatically.
