### PR TITLE
DOC: numpy.concat version added

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -190,6 +190,9 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
     Join a sequence of arrays along an existing axis.
 
+    ..note:: In version 2.0.0 'numpy.concat' has been added as a shorthand
+        for 'numpy.concatenate'.
+
     Parameters
     ----------
     a1, a2, ... : sequence of array_like


### PR DESCRIPTION
Resolves: https://github.com/numpy/numpy/issues/28369

Added a note to the numpy.concatenate docstring explaining that numpy.concat has been added in version 2.0.0 as a shorthand for numpy.concatenate.

I hope this resolves the aforementioned issue. Thanks for reviewing!