### PR TITLE
API,ENH: Allow forcing an array result in ufuncs

### DIFF
--- a/doc/release/upcoming_changes/28576.new_feature.rst
+++ b/doc/release/upcoming_changes/28576.new_feature.rst
@@ -1,0 +1,15 @@
+Allow ``out=...`` in ufuncs to ensure array result
+--------------------------------------------------
+NumPy has the sometimes difficult behavior that it currently usually
+returns scalars rather than 0-D arrays (even if the inputs were 0-D arrays).
+This is especially problematic for non-numerical dtypes (e.g. ``object``).
+
+For ufuncs (i.e. most simple math functions) it is now possible
+to use ``out=...`` which is identical in behavior to no output
+being passed, but will ensure a non-scalar return.
+This spelling is borrowed from ``arr1d[0, ...]`` where the ``...``
+also ensures a non-scalar return.
+
+Other functions with an ``out=`` kwarg should gain support eventually.
+Downstream libraries that interoperate via ``__array_ufunc__`` or
+``__array_function__`` may need to adapt to support this.

--- a/doc/release/upcoming_changes/28576.new_feature.rst
+++ b/doc/release/upcoming_changes/28576.new_feature.rst
@@ -5,7 +5,7 @@ returns scalars rather than 0-D arrays (even if the inputs were 0-D arrays).
 This is especially problematic for non-numerical dtypes (e.g. ``object``).
 
 For ufuncs (i.e. most simple math functions) it is now possible
-to use ``out=...`` which is identical in behavior to no output
+to use ``out=...`` (literally `...`, e.g. ``out=Ellipsis``) which is identical in behavior to ``out`` not
 being passed, but will ensure a non-scalar return.
 This spelling is borrowed from ``arr1d[0, ...]`` where the ``...``
 also ensures a non-scalar return.

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -52,7 +52,8 @@ tuple holding a single array) is also valid.
 If 'out' is None (the default), a uninitialized output array is created,
 which will be filled in the ufunc.  At the end, this array is returned
 unless it is zero-dimensional, in which case it is converted to a scalar;
-this conversion can be avoided by passing in ``out=...``.
+this conversion can be avoided by passing in ``out=...``. This can also be 
+spelled `out=Ellipsis` if you think that is clearer.
 
 Note that the output is filled only in the places that the broadcast
 'where' is True. If 'where' is the scalar True (the default), then this

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -49,16 +49,15 @@ output (which can be None for arrays to be allocated by the ufunc).
 For ufuncs with a single output, passing a single array (instead of a
 tuple holding a single array) is also valid.
 
-Passing a single array in the 'out' keyword argument to a ufunc with
-multiple outputs is deprecated, and will raise a warning in numpy 1.10,
-and an error in a future release.
+If 'out' is None (the default), a uninitialized output array is created,
+which will be filled in the ufunc.  At the end, this array is returned
+unless it is zero-dimensional, in which case it is converted to a scalar;
+this conversion can be avoided by passing in ``out=...``.
 
-If 'out' is None (the default), a uninitialized return array is created.
-The output array is then filled with the results of the ufunc in the places
-that the broadcast 'where' is True. If 'where' is the scalar True (the
-default), then this corresponds to the entire output being filled.
-Note that outputs not explicitly filled are left with their
-uninitialized values.
+Note that the output is filled only in the places that the broadcast
+'where' is True. If 'where' is the scalar True (the default), then this
+corresponds to all elements of the output, but in other cases, the
+elements not explicitly filled are left with their uninitialized values.
 
 Operations where ufunc input and output operands have memory overlap are
 defined to be the same as for equivalent operations where there

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -74,7 +74,7 @@ an integer (or Boolean) data-type and smaller than the size of the
 :class:`numpy.int_` data type, it will be internally upcast to the :class:`.int_`
 (or :class:`numpy.uint`) data-type. In the previous example::
 
-   >>> x.dtype 
+   >>> x.dtype
    dtype('int64')
    >>> np.multiply.reduce(x, dtype=float)
    array([ 0., 28., 80.])
@@ -103,10 +103,16 @@ of the previous operation for that item.
 Output type determination
 =========================
 
-The output of the ufunc (and its methods) is not necessarily an
-:class:`ndarray <numpy.ndarray>`, if all input arguments are not
-:class:`ndarrays <numpy.ndarray>`. Indeed, if any input defines an
-:obj:`~.class.__array_ufunc__` method,
+If the input arguments of the ufunc (or its methods) are
+:class:`ndarrays <numpy.ndarray>`, then the output will be as well.
+The exception is when the result is zero-dimensional, in which case the
+output will be converted to an `array scalar <arrays.scalars>`. This can
+be avoided by passing in ``out=...``.
+
+If some or all of the input arguments are not
+:class:`ndarrays <numpy.ndarray>`, then the output may not be an
+:class:`ndarray <numpy.ndarray>` either.
+Indeed, if any input defines an :obj:`~.class.__array_ufunc__` method,
 control will be passed completely to that function, i.e., the ufunc is
 :ref:`overridden <ufuncs.overrides>`.
 
@@ -140,14 +146,14 @@ element is generally a scalar, but can be a vector or higher-order
 sub-array for generalized ufuncs). Standard
 :ref:`broadcasting rules <general-broadcasting-rules>` are applied
 so that inputs not sharing exactly the
-same shapes can still be usefully operated on. 
+same shapes can still be usefully operated on.
 
 By these rules, if an input has a dimension size of 1 in its shape, the
 first data entry in that dimension will be used for all calculations along
 that dimension. In other words, the stepping machinery of the
 :term:`ufunc` will simply not step along that dimension (the
 :ref:`stride <memory-layout>` will be 0 for that dimension).
-   
+
 
 .. _ufuncs.casting:
 
@@ -293,7 +299,7 @@ platform, these registers will be regularly checked during
 calculation. Error handling is controlled on a per-thread basis,
 and can be configured using the functions :func:`numpy.seterr` and
 :func:`numpy.seterrcall`.
-   
+
 
 .. _ufuncs.overrides:
 

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -107,7 +107,7 @@ If the input arguments of the ufunc (or its methods) are
 :class:`ndarrays <numpy.ndarray>`, then the output will be as well.
 The exception is when the result is zero-dimensional, in which case the
 output will be converted to an `array scalar <arrays.scalars>`. This can
-be avoided by passing in ``out=...``.
+be avoided by passing in ``out=...`` or ``out=Ellipsis``.
 
 If some or all of the input arguments are not
 :class:`ndarrays <numpy.ndarray>`, then the output may not be an

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4906,12 +4906,19 @@ add_newdoc('numpy._core', 'ufunc',
     ----------
     *x : array_like
         Input arrays.
-    out : ndarray, None, or tuple of ndarray and None, optional
+    out : ndarray, None, ..., or tuple of ndarray and None, optional
         Alternate array object(s) in which to put the result; if provided, it
         must have a shape that the inputs broadcast to. A tuple of arrays
         (possible only as a keyword argument) must have length equal to the
         number of outputs; use None for uninitialized outputs to be
         allocated by the ufunc.
+        If ``out=...`` is passed, the output is guaranteed to be an array
+        and not a scalar.  This is useful when the result may be 0-D and
+        especially when the result dtype is object.
+
+        .. versionadded:: 2.3
+            Support for ``out=...`` was added.
+
     where : array_like, optional
         This condition is broadcast over the input. At locations where the
         condition is True, the `out` array will be set to the ufunc result.
@@ -5163,11 +5170,18 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
         ``out`` if given, and the data type of ``array`` otherwise (though
         upcast to conserve precision for some cases, such as
         ``numpy.add.reduce`` for integer or boolean input).
-    out : ndarray, None, or tuple of ndarray and None, optional
+    out : ndarray, None, ..., or tuple of ndarray and None, optional
         A location into which the result is stored. If not provided or None,
         a freshly-allocated array is returned. For consistency with
         ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
         1-element tuple.
+        If ``out=...`` is passed, the output is guaranteed to be an array
+        and not a scalar.  This is useful when the result may be 0-D and
+        especially when the result dtype is object.
+
+        .. versionadded:: 2.3
+            Support for ``out=...`` was added.
+
     keepdims : bool, optional
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -5276,6 +5290,7 @@ add_newdoc('numpy._core', 'ufunc', ('accumulate',
         a freshly-allocated array is returned. For consistency with
         ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
         1-element tuple.
+        (``out=...`` is supported, but results are never scalar).
 
     Returns
     -------
@@ -5357,6 +5372,7 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
         a freshly-allocated array is returned. For consistency with
         ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
         1-element tuple.
+        (``out=...`` is supported, but results are never scalar).
 
     Returns
     -------

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4907,14 +4907,12 @@ add_newdoc('numpy._core', 'ufunc',
     *x : array_like
         Input arrays.
     out : ndarray, None, ..., or tuple of ndarray and None, optional
-        Alternate array object(s) in which to put the result; if provided, it
-        must have a shape that the inputs broadcast to. A tuple of arrays
-        (possible only as a keyword argument) must have length equal to the
-        number of outputs; use None for uninitialized outputs to be
-        allocated by the ufunc.
-        If ``out=...`` is passed, the output is guaranteed to be an array
-        and not a scalar.  This is useful when the result may be 0-D and
-        especially when the result dtype is object.
+        Location(s) into which the result(s) are stored.
+        If not provided or None, new array(s) are created by the ufunc.
+        If passed as a keyword argument, can be Ellipses (``out=...``) to
+        ensure an array is returned even if the result is 0-dimensional,
+        or a tuple with length equal to the number of outputs (where None
+        can be used for allocation by the ufunc).
 
         .. versionadded:: 2.3
             Support for ``out=...`` was added.
@@ -5171,13 +5169,12 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
         upcast to conserve precision for some cases, such as
         ``numpy.add.reduce`` for integer or boolean input).
     out : ndarray, None, ..., or tuple of ndarray and None, optional
-        A location into which the result is stored. If not provided or None,
-        a freshly-allocated array is returned. For consistency with
-        ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
-        1-element tuple.
-        If ``out=...`` is passed, the output is guaranteed to be an array
-        and not a scalar.  This is useful when the result may be 0-D and
-        especially when the result dtype is object.
+        Location into which the result is stored.
+        If not provided or None, a freshly-allocated array is returned.
+        If passed as a keyword argument, can be Ellipses (``out=...``) to
+        ensure an array is returned even if the result is 0-dimensional
+        (which is useful especially for object dtype), or a 1-element tuple
+        (latter for consistency with ``ufunc.__call__``).
 
         .. versionadded:: 2.3
             Support for ``out=...`` was added.
@@ -5286,11 +5283,11 @@ add_newdoc('numpy._core', 'ufunc', ('accumulate',
         to the data-type of the output array if such is provided, or the
         data-type of the input array if no output array is provided.
     out : ndarray, None, or tuple of ndarray and None, optional
-        A location into which the result is stored. If not provided or None,
-        a freshly-allocated array is returned. For consistency with
-        ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
-        1-element tuple.
-        (``out=...`` is supported, but results are never scalar).
+        Location into which the result is stored.
+        If not provided or None, a freshly-allocated array is returned.
+        For consistency with ``ufunc.__call__``, if passed as a keyword
+        argument, can be Ellipses (``out=...``, which has the same effect
+        as None as an array is always returned), or a 1-element tuple.
 
     Returns
     -------
@@ -5368,11 +5365,11 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
         upcast to conserve precision for some cases, such as
         ``numpy.add.reduce`` for integer or boolean input).
     out : ndarray, None, or tuple of ndarray and None, optional
-        A location into which the result is stored. If not provided or None,
-        a freshly-allocated array is returned. For consistency with
-        ``ufunc.__call__``, if given as a keyword, this may be wrapped in a
-        1-element tuple.
-        (``out=...`` is supported, but results are never scalar).
+        Location into which the result is stored.
+        If not provided or None, a freshly-allocated array is returned.
+        For consistency with ``ufunc.__call__``, if passed as a keyword
+        argument, can be Ellipses (``out=...``, which has the same effect
+        as None as an array is always returned), or a 1-element tuple.
 
     Returns
     -------

--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -132,19 +132,11 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
             dtype = mu.dtype('f4')
             is_float16_result = True
 
-    ret = umr_sum(arr, axis, dtype, out, keepdims, where=where)
-    if isinstance(ret, mu.ndarray):
-        ret = um.true_divide(
-                ret, rcount, out=ret, casting='unsafe', subok=False)
-        if is_float16_result and out is None:
-            ret = arr.dtype.type(ret)
-    elif hasattr(ret, 'dtype'):
-        if is_float16_result:
-            ret = arr.dtype.type(ret / rcount)
-        else:
-            ret = ret.dtype.type(ret / rcount)
-    else:
-        ret = ret / rcount
+    ret = umr_sum(arr, axis, dtype, ... if out is None else out, keepdims, where=where)
+    # TODO: dtype=type(ret.dtype) castst first and isn't quite ideal that way.
+    ret = um.true_divide(ret, rcount, out=out, dtype=type(ret.dtype), casting='unsafe')
+    if is_float16_result and out is None:
+        ret = arr.dtype.type(ret)
 
     return ret
 
@@ -168,7 +160,8 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
         # Compute the mean.
         # Note that if dtype is not of inexact type then arraymean will
         # not be either.
-        arrmean = umr_sum(arr, axis, dtype, keepdims=True, where=where)
+        arrmean = umr_sum(arr, axis, dtype, keepdims=True, where=where,
+                          out=Ellipsis)
         # The shape of rcount has to match arrmean to not change the shape of
         # out in broadcasting. Otherwise, it cannot be stored back to arrmean.
         if rcount.ndim == 0:
@@ -177,18 +170,14 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
         else:
             # matching rcount to arrmean when where is specified as array
             div = rcount.reshape(arrmean.shape)
-        if isinstance(arrmean, mu.ndarray):
-            arrmean = um.true_divide(arrmean, div, out=arrmean,
-                                     casting='unsafe', subok=False)
-        elif hasattr(arrmean, "dtype"):
-            arrmean = arrmean.dtype.type(arrmean / rcount)
-        else:
-            arrmean = arrmean / rcount
+
+        arrmean = um.true_divide(arrmean, div, out=arrmean,
+                                 casting='unsafe', subok=False)
 
     # Compute sum of squared deviations from mean
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
-    x = asanyarray(arr - arrmean)
+    x = np.subtract(arr, arrmean, out=...)
 
     if issubclass(arr.dtype.type, (nt.floating, nt.integer)):
         x = um.multiply(x, x, out=x)
@@ -202,34 +191,25 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
     else:
         x = um.multiply(x, um.conjugate(x), out=x).real
 
-    ret = umr_sum(x, axis, dtype, out, keepdims=keepdims, where=where)
+    ret = umr_sum(
+        x, axis, dtype, Ellipsis if out is None else out,
+        keepdims=keepdims, where=where)
 
     # Compute degrees of freedom and make sure it is not negative.
     rcount = um.maximum(rcount - ddof, 0)
 
     # divide by degrees of freedom
-    if isinstance(ret, mu.ndarray):
-        ret = um.true_divide(
-                ret, rcount, out=ret, casting='unsafe', subok=False)
-    elif hasattr(ret, 'dtype'):
-        ret = ret.dtype.type(ret / rcount)
-    else:
-        ret = ret / rcount
-
+    # TODO: dtype=ret.dtype castst first and isn't quite ideal that way.
+    ret = um.true_divide(
+            ret, rcount, out=out, casting='unsafe', dtype=type(ret.dtype))
     return ret
 
 def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
          where=True, mean=None):
-    ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
-               keepdims=keepdims, where=where, mean=mean)
+    ret = _var(a, axis=axis, dtype=dtype, out=out if out is not None else Ellipsis,
+               ddof=ddof, keepdims=keepdims, where=where, mean=mean)
 
-    if isinstance(ret, mu.ndarray):
-        ret = um.sqrt(ret, out=ret)
-    elif hasattr(ret, 'dtype'):
-        ret = ret.dtype.type(um.sqrt(ret))
-    else:
-        ret = um.sqrt(ret)
-
+    ret = um.sqrt(ret, out=out)
     return ret
 
 def _ptp(a, axis=None, out=None, keepdims=False):

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1717,7 +1717,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
             # cp1 = a2 * b0 - a0 * b2
             # cp2 = a0 * b1 - a1 * b0
             multiply(a1, b2, out=cp0)
-            tmp = array(a2 * b1)
+            tmp = np.multiply(a2, b1, out=...)
             cp0 -= tmp
             multiply(a2, b0, out=cp1)
             multiply(a0, b2, out=tmp)

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -506,8 +506,8 @@ fail:
 static int
 _set_out_array(PyObject *obj, PyArrayObject **store)
 {
-    if (obj == Py_None) {
-        /* Translate None to NULL */
+    if (obj == Py_None || obj == Py_Ellipsis) {
+        /* Translate None/Ellipsis to NULL; Ellipsis ensures an array return */
         return 0;
     }
     if (PyArray_Check(obj)) {
@@ -3596,7 +3596,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
-    if (out_obj && !PyArray_OutputConverter(out_obj, &out)) {
+    /* Out can be`out=...` to indicate no scalar return or an array */
+    if (out_obj && out_obj != Py_Ellipsis && !PyArray_OutputConverter(out_obj, &out)) {
         goto fail;
     }
     if (keepdims_obj && !PyArray_PythonPyIntFromInt(keepdims_obj, &keepdims)) {

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1066,6 +1066,34 @@ class TestUfunc:
         np.vecdot(a, b, out=c[..., 0])
         assert_array_equal(c[..., 0], np.sum(a * b, axis=-1), err_msg=msg)
 
+    def test_output_ellipsis(self):
+        assert type(np.add(1, 2, out=...)) is np.ndarray
+        assert type(np.add.reduce(1, out=...)) is np.ndarray
+        res1, res2 = np.divmod(1, 2, out=...)
+        assert type(res1) is type(res2) is np.ndarray
+
+    def test_output_ellipsis_errors(self):
+        with pytest.raises(TypeError,
+                match=r"out=\.\.\. is only allowed as a keyword argument."):
+            np.add(1, 2, ...)
+
+        with pytest.raises(TypeError,
+                match=r"out=\.\.\. is only allowed as a keyword argument."):
+            np.add.reduce(1, (), None, ...)
+
+        with pytest.raises(TypeError,
+                match=r"must use `\.\.\.` as `out=\.\.\.` and not per-operand/in a tuple"):
+            np.negative(1, out=(...,))
+
+        with pytest.raises(TypeError,
+                match=r"must use `\.\.\.` as `out=\.\.\.` and not per-operand/in a tuple"):
+            # We only allow out=... not individual args for now
+            np.divmod(1, 2, out=(np.empty(()), ...))
+
+        with pytest.raises(TypeError,
+                match=r"must use `\.\.\.` as `out=\.\.\.` and not per-operand/in a tuple"):
+            np.add.reduce(1, out=(...,))
+
     def test_axes_argument(self):
         # vecdot signature: '(n),(n)->()'
         a = np.arange(27.).reshape((3, 3, 3))

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4258,8 +4258,7 @@ def percentile(a,
 
     # Use dtype of array if possible (e.g., if q is a python int or float)
     # by making the divisor have the dtype of the data array.
-    q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100)
-    q = asanyarray(q)  # undo any decay that the ufunc performed (see gh-13105)
+    q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100, out=...)
     if not _quantile_is_valid(q):
         raise ValueError("Percentiles must be in the range [0, 100]")
 

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1389,9 +1389,7 @@ def nanpercentile(
     if a.dtype.kind == "c":
         raise TypeError("a must be an array of real numbers")
 
-    q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100)
-    # undo any decay that the ufunc performed (see gh-13105)
-    q = np.asanyarray(q)
+    q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100, out=...)
     if not fnb._quantile_is_valid(q):
         raise ValueError("Percentiles must be in the range [0, 100]")
 


### PR DESCRIPTION
As of now a WIP, because it would be nice to see what `_methods.py`.  *Happy if someone just picks it up also, thought I would show how trivial it is now.*

The API change is to allow `out=...`, for multi-argument outputs it is currently `out=(..., ...)`, although I guess we should allow short-handing that (nobody needs to pick it per argument).

I.e. all of these return arrays (and unlike the last time around it works with subclasses, although right now it passes `...` as context so that may confuse them or `__array_ufunc__` implementations.):
```
np.add(1, 2, out=...)
a = np.add.reduce(np.arange(10), out=...)
```

There is some discussion in gh-14489 about this.  I still think `...` is the best, because `out=np.ndarray` doesn't generalize for `__array_ufunc__`, and yes, I like `...` because it also indicates an array return in indexing.  (`arr[i, ...]` always returns an array.)

---

The ufunc part works (not sure if 100% complete), but the `_methods.py` changes do not (and change behavior subtlely, if possibly correctly). The actual change is trivial (after I had refactored this a while ago).

I think we should do this, but the fact that the `_methods.py` changes are not trivial makes me think there may be some idea missing.

It may be that the solution is for these functions to use conversion helper once at the start and then convert to scalars based on that at the end though (rather than dragging around subclasses).

---

CC @mdhaber you may be interested in this.  We could probably just put this through (with a few new tests) without the `_methods.py` changes hashed out.  (There must be a few other low-hanging places where this would simplify code, that are not as maze-like as `_methods.py`.)