### PR TITLE
BUG: avoid deadlocks with C++ shared mutex in dispatch cache

### DIFF
--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -912,7 +912,9 @@ promote_and_get_info_and_ufuncimpl_with_locking(
         npy_bool legacy_promotion_is_possible)
 {
     std::shared_mutex *mutex = ((std::shared_mutex *)((PyArrayIdentityHash *)ufunc->_dispatch_cache)->mutex);
+    NPY_BEGIN_ALLOW_THREADS
     mutex->lock_shared();
+    NPY_END_ALLOW_THREADS
     PyObject *info = PyArrayIdentityHash_GetItem(
             (PyArrayIdentityHash *)ufunc->_dispatch_cache,
             (PyObject **)op_dtypes);
@@ -926,7 +928,9 @@ promote_and_get_info_and_ufuncimpl_with_locking(
 
     // cache miss, need to acquire a write lock and recursively calculate the
     // correct dispatch resolution
+    NPY_BEGIN_ALLOW_THREADS
     mutex->lock();
+    NPY_END_ALLOW_THREADS
     info = promote_and_get_info_and_ufuncimpl(ufunc,
             ops, signature, op_dtypes, legacy_promotion_is_possible);
     mutex->unlock();


### PR DESCRIPTION
Backport of #28577.

@pitrou correctly pointed out [here](https://github.com/numpy/numpy/pull/27896#discussion_r2004153080) that the C++ `shared_mutex` we use in the dispatch might deadlock with the GIL (if it's re-enabled) or other global synchronization events in the interpreter, and we need to explicitly call `Py_BEGIN_ALLOW_THREADS`/`Py_END_ALLOW_THREADS` around a possibly blocking call.

I don't have a case where a deadlock happens right now, so no new test. Happy to add one if someone can come up with a way to trigger the deadlock.

I ran the test script from #27786 and don't see any performance hit.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
