### PR TITLE
MAINT: Remove cibuildwheel workaround [wheel build]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,13 +151,8 @@ test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 enable = ["cpython-freethreading", "pypy", "cpython-prerelease"]
 
 [tool.cibuildwheel.linux]
-# workaround https://github.com/numpy/numpy/issues/28570 by using
-# more recent images than the default ones in cibuildwheel 2.23.1
-# TODO remove this workaround once cibuildwheel gets updated to a version > 2.23.1
-manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28:2025.03.23-1"
-manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28:2025.03.23-1"
-# manylinux-x86_64-image = "manylinux_2_28"
-# manylinux-aarch64-image = "manylinux_2_28"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
 


### PR DESCRIPTION
Cibuildwheel has been updated to 2.23.2, so the workaround is no longer needed.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
