### PR TITLE
BUG: bugfix for #28589 (quantile should error when weights are all zeros)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4871,6 +4871,11 @@ def _quantile(
         weights = np.asanyarray(weights)
         if axis != 0:
             weights = np.moveaxis(weights, axis, destination=0)
+
+        # Check if all weights are zero
+        if np.all(weights == 0):
+            raise ValueError("All weights are zero, cannot compute quantile.")
+
         index_array = np.argsort(arr, axis=0, kind="stable")
 
         # arr = arr[index_array, ...]  # but this adds trailing dimensions of

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2331,7 +2331,7 @@ class TestSinc:
         expected = sinc(x.astype(np.float64))
         assert_allclose(actual, expected)
         assert actual.dtype == np.float64
-    
+
     @pytest.mark.parametrize(
             'dtype',
             [np.float16, np.float32, np.longdouble, np.complex64, np.complex128]
@@ -4510,3 +4510,33 @@ class TestSortComplex:
         actual = np.sort_complex(a)
         assert_equal(actual, expected)
         assert_equal(actual.dtype, expected.dtype)
+
+
+def test_quantile_zero_weights():
+    """
+    Test np.quantile raises an error when weights are all zeros.
+    (Corresponds to the example given in bug #28589)
+    """
+
+    arr = np.array([1, 2, 3, 4])
+    quantile = 0.5
+    weights = np.array([0, 0, 0, 0])
+
+    with pytest.raises(ValueError, match="All weights are zero, cannot compute quantile."):
+        np.quantile(arr, quantile, weights=weights, method='inverted_cdf')
+
+
+def test_quantile_valid_weights():
+    """
+    Test np.quantile with valid weights.
+    """
+    arr = np.array([1, 2, 3, 4])
+    quantile = 0.5
+    weights = np.array([1, 1, 1, 1])
+
+    result = np.quantile(arr, quantile, weights=weights, method='inverted_cdf')
+    expected = 2.5
+
+    assert np.isclose(result, expected)
+
+


### PR DESCRIPTION
This commit addresses the following BUG: quantile should error when weights are all zeros #28589

Previously, np.quantile with all weights set to zero returned the first sample. This is fixed now via adding an explicit check that raises a ValueError when all weights are zero, preventing division by zero in the CDF.

- Added the weight check in `_quantile` (line 4874 ff) to detect all-zero weights and raise an error.
- Added a test in `test_function_base.py` to verify this behavior.
- Added a second test to ensure existing quantile functionality remains unchanged.

This should close #28589 