### PR TITLE
fix quantile all zeros error

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4537,6 +4537,8 @@ def quantile(a,
         weights = _weights_are_valid(weights=weights, a=a, axis=axis)
         if np.any(weights < 0):
             raise ValueError("Weights must be non-negative.")
+        if np.all(weights == 0):
+            raise ValueError("Weights must contain non-zero value.")
 
     return _quantile_unchecked(
         a, q, axis, out, overwrite_input, method, keepdims, weights)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4110,6 +4110,13 @@ class TestQuantile:
         with pytest.raises(ValueError, match="Weights must be non-negative"):
             np.quantile(y, 0.5, weights=w, method="inverted_cdf")
 
+    def test_quantile_weights_raises_all_zeros_weights(self):
+        y = [1, 2]
+        w = [0, 0]
+        with pytest.raises(ValueError, match="Weights must contain non-zero value."):
+            np.quantile(y, 0.5, weights=w, method="inverted_cdf")
+
+
     @pytest.mark.parametrize(
             "method",
             sorted(set(quantile_methods) - set(methods_supporting_weights)),


### PR DESCRIPTION
BUG: Raise error in `quantile` when `weights` sum to zero

Added a check in `np.quantile` to raise a `ValueError` when the `weights` parameter are all zero, preventing invalid computations. Added corresponding tests to verify this behavior.

Closes #28589.
