### PR TITLE
BUG: Set writeable flag for writeable dlpacks.

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1663,8 +1663,8 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
     from_dlpack(x, /, *, device=None, copy=None)
 
     Create a NumPy array from an object implementing the ``__dlpack__``
-    protocol. Generally, the returned NumPy array is a read-only view
-    of the input object. See [1]_ and [2]_ for more details.
+    protocol. Generally, the returned NumPy array is a view of the input
+    object. See [1]_ and [2]_ for more details.
 
     Parameters
     ----------

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -601,7 +601,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
             return NULL;
         }
         dl_tensor = managed->dl_tensor;
-        readonly = 0;
+        readonly = 1;
     }
 
     const int ndim = dl_tensor.ndim;
@@ -702,13 +702,12 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     }
 
     PyObject *ret = PyArray_NewFromDescr(&PyArray_Type, descr, ndim, shape,
-            dl_tensor.strides != NULL ? strides : NULL, data, 0, NULL);
+            dl_tensor.strides != NULL ? strides : NULL, data, readonly ? 0 :
+            NPY_ARRAY_WRITEABLE, NULL);
+
     if (ret == NULL) {
         Py_DECREF(capsule);
         return NULL;
-    }
-    if (readonly) {
-        PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
     }
 
     PyObject *new_capsule;

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -144,6 +144,17 @@ class TestDLPack:
         y = np.from_dlpack(x)
         assert not y.flags.writeable
 
+    def test_writeable(self):
+        x_new, x_old = new_and_old_dlpack()
+
+        # new dlpacks respect writeability
+        y = np.from_dlpack(x_new)
+        assert y.flags.writeable
+
+        # old dlpacks are not writeable for backwards compatibility
+        y = np.from_dlpack(x_old)
+        assert not y.flags.writeable
+
     def test_ndim0(self):
         x = np.array(1.0)
         y = np.from_dlpack(x)


### PR DESCRIPTION
Explicitly set the writeable flag in from_dlpack as the inverse of the dlpack readable flag. Previously it was not actually being set.

Fixes #28599

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
