### PR TITLE
MAINT, CI: Update Ubuntu to 22.04 in azure-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-22.04'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'
@@ -40,7 +40,7 @@ stages:
   - job: Lint
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
     - task: UsePythonVersion@0
       inputs:
@@ -59,7 +59,7 @@ stages:
 
   - job: Linux_Python_311_32bit_full_with_asserts
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
     - script: |
         git submodule update --init


### PR DESCRIPTION
Azure-pipelines will be removing support for Ubuntu-20.04. There remain uses of Ubuntu-20.04 in github actions, we may want to update those also, one use is to test against Python 3.6, which seems rather old to worry about.

[skip cirrus] [skip actions]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
