### PR TITLE
ENH: Use openmp on x86-simd-sort to speed up np.sort and np.argsort

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -212,7 +212,7 @@ jobs:
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
     - name: Build
-      run: CC=gcc-13 CXX=g++-13 spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
+      run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
 
     - name: Meson Log
       if: always()
@@ -263,7 +263,7 @@ jobs:
         python -m pip install pytest pytest-xdist hypothesis typing_extensions
 
     - name: Build
-      run: CC=gcc-13 CXX=g++-13 spin build -- -Dallow-noblas=true -Dcpu-baseline=avx512_spr
+      run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_spr
 
     - name: Meson Log
       if: always()

--- a/doc/release/upcoming_changes/28619.highlight.rst
+++ b/doc/release/upcoming_changes/28619.highlight.rst
@@ -1,0 +1,6 @@
+Building NumPy with OpenMP Parallelization
+-------------------------------------------
+NumPy now supports OpenMP parallel processing capabilities when built with the
+``-Denable_openmp=true`` Meson build flag. This feature is disabled by default.
+When enabled, ``np.sort`` and ``np.argsort`` functions can utilize OpenMP for
+parallel thread execution, improving performance for these operations.

--- a/doc/release/upcoming_changes/28619.performance.rst
+++ b/doc/release/upcoming_changes/28619.performance.rst
@@ -1,0 +1,7 @@
+Performance improvements to ``np.sort`` and ``np.argsort``
+----------------------------------------------------------
+``np.sort`` and ``np.argsort`` functions now can leverage OpenMP for parallel
+thread execution, resulting in up to 3.5x speedups on x86 architectures with
+AVX2 or AVX-512 instructions. This opt-in feature requires NumPy to be built
+with the -Denable_openmp Meson flag. Users can control the number of threads
+used by setting the OMP_NUM_THREADS environment variable.

--- a/meson.options
+++ b/meson.options
@@ -22,6 +22,8 @@ option('disable-intel-sort', type: 'boolean', value: false,
         description: 'Disables SIMD-optimized operations related to Intel x86-simd-sort')
 option('disable-threading', type: 'boolean', value: false,
         description: 'Disable threading support (see `NPY_ALLOW_THREADS` docs)')
+option('enable-openmp', type: 'boolean', value: false,
+        description: 'Enable building NumPy with openmp support')
 option('disable-optimization', type: 'boolean', value: false,
         description: 'Disable CPU optimized code (dispatch,simd,unroll...)')
 option('cpu-baseline', type: 'string', value: 'min',

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -128,6 +128,16 @@ if use_intel_sort and not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
 
+# Setup openmp flags for x86-simd-sort:
+omp_cflags = []
+omp = []
+if use_intel_sort and cpp.has_argument('-fopenmp')
+  omp = dependency('openmp', required : false)
+  if omp.found()
+    omp_cflags = ['-fopenmp', '-DXSS_USE_OPENMP']
+  endif
+endif
+
 if not fs.exists('src/common/pythoncapi-compat')
   error('Missing the `pythoncapi-compat` git submodule! ' +
         'Run `git submodule update --init` to fix this.')
@@ -867,6 +877,9 @@ foreach gen_mtargets : [
     ] : []
   ],
 ]
+
+
+
   mtargets = mod_features.multi_targets(
     gen_mtargets[0], multiarray_gen_headers + gen_mtargets[1],
     dispatch: gen_mtargets[2],
@@ -874,7 +887,7 @@ foreach gen_mtargets : [
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
     c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    cpp_args: cpp_args_common + max_opt + omp_cflags,
     include_directories: [
       'include',
       'src/common',
@@ -1286,7 +1299,7 @@ py.extension_module('_multiarray_umath',
     'src/umath',
     'src/highway'
   ],
-  dependencies: [blas_dep],
+  dependencies: [blas_dep, omp],
   link_with: [
     npymath_lib,
     unique_hash_so,

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -128,10 +128,15 @@ if use_intel_sort and not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
 
+use_openmp = not get_option('disable-threading') and get_option('enable-openmp') and cpp.has_argument('-fopenmp')
+summary({
+  'Build with openMP? ' : use_openmp,
+})
+
 # Setup openmp flags for x86-simd-sort:
 omp_cflags = []
 omp = []
-if use_intel_sort and cpp.has_argument('-fopenmp')
+if use_intel_sort and use_openmp
   omp = dependency('openmp', required : false)
   if omp.found()
     omp_cflags = ['-fopenmp', '-DXSS_USE_OPENMP']

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -136,6 +136,7 @@ endif
 use_openmp = get_option('enable-openmp') and not get_option('disable-threading')
 
 # Setup openmp flags for x86-simd-sort:
+omp = []
 omp_dep = []
 if use_intel_sort and use_openmp
   omp = dependency('openmp', required : true)

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -128,19 +128,18 @@ if use_intel_sort and not fs.exists('src/npysort/x86-simd-sort/README.md')
   error('Missing the `x86-simd-sort` git submodule! Run `git submodule update --init` to fix this.')
 endif
 
-use_openmp = not get_option('disable-threading') and get_option('enable-openmp') and cpp.has_argument('-fopenmp')
-summary({
-  'Build with openMP? ' : use_openmp,
-})
+# openMP related settings:
+if get_option('disable-threading') and get_option('enable-openmp')
+  error('Build options `disable-threading` and `enable-openmp` are conflicting. Please set at most one to true.')
+endif
+
+use_openmp = get_option('enable-openmp') and not get_option('disable-threading')
 
 # Setup openmp flags for x86-simd-sort:
-omp_cflags = []
-omp = []
+omp_dep = []
 if use_intel_sort and use_openmp
-  omp = dependency('openmp', required : false)
-  if omp.found()
-    omp_cflags = ['-fopenmp', '-DXSS_USE_OPENMP']
-  endif
+  omp = dependency('openmp', required : true)
+  omp_dep = declare_dependency(dependencies: omp, compile_args: ['-DXSS_USE_OPENMP'])
 endif
 
 if not fs.exists('src/common/pythoncapi-compat')
@@ -890,9 +889,9 @@ foreach gen_mtargets : [
     dispatch: gen_mtargets[2],
     # baseline: CPU_BASELINE, it doesn't provide baseline fallback
     prefix: 'NPY_',
-    dependencies: [py_dep, np_core_dep],
+    dependencies: [py_dep, np_core_dep, omp_dep],
     c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt + omp_cflags,
+    cpp_args: cpp_args_common + max_opt,
     include_directories: [
       'include',
       'src/common',

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10296,8 +10296,17 @@ def test_argsort_int(N, dtype):
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_sort_largearrays(dtype):
     N = 1000000
-    arr = np.random.rand(N)
+    rnd = np.random.RandomState(1100710816)
+    arr = -0.5 + rnd.random(N).astype(dtype)
     assert_equal(np.sort(arr, kind='quick'), np.sort(arr, kind='heap'))
+
+# Test large arrays that leverage openMP implementations from x86-simd-sort:
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_argsort_largearrays(dtype):
+    N = 1000000
+    rnd = np.random.RandomState(1100710816)
+    arr = -0.5 + rnd.random(N).astype(dtype)
+    assert_arg_sorted(arr, np.argsort(arr, kind='quick'))
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 def test_gh_22683():

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10292,6 +10292,12 @@ def test_argsort_int(N, dtype):
     arr[N - 1] = maxv
     assert_arg_sorted(arr, np.argsort(arr, kind='quick'))
 
+# Test large arrays that leverage openMP implementations from x86-simd-sort:
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_sort_largearrays(dtype):
+    N = 1000000
+    arr = np.random.rand(N)
+    assert_equal(np.sort(arr, kind='quick'), np.sort(arr, kind='heap'))
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 def test_gh_22683():


### PR DESCRIPTION
Update x86-simd-sort module to latest to pull in 4 major changes:

- Fixes a performance regression on 16-bit dtype sorting (Ref https://github.com/intel/x86-simd-sort/pull/190)
- Adds openmp support for quicksort which speeds up sorting arrays >100,000 by up to 3x. (ref: https://github.com/intel/x86-simd-sort/pull/179)
- Adds openmp support for argsort which speeds up np.argsort for arrays > 10,000 by up to 3.5x (ref: https://github.com/intel/x86-simd-sort/pull/195)
- Fixes `np.argsort` perf regressions on sorted data (as reported in: https://github.com/numpy/numpy/issues/28714)

<details><summary>Benchmark numbers for `np.sort` on a TGL (sorting an array of 5 million numbers): </summary>
<p>

```
[100.00%] ··· bench_function_base.Sort.time_sort_worst                     9.64±0.05ms                                                                  12:53:12 [100/24308]
| Change   | Before [93898621] <main>   | After [19f94d3c] <xss-openmp>   |   Ratio | Benchmark (Parameter)                                                          |
|----------|----------------------------|---------------------------------|---------|--------------------------------------------------------------------------------|
| -        | 4.57±0.08ms                | 3.61±0.04ms                     |    0.79 | bench_function_base.Sort.time_sort('quick', 'float16', ('ordered',))           |
| -        | 4.51±0.04ms                | 3.57±0.04ms                     |    0.79 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 10))   |
| -        | 4.53±0.03ms                | 3.57±0.02ms                     |    0.79 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 100))  |
| -        | 4.54±0.03ms                | 3.58±0.03ms                     |    0.79 | bench_function_base.Sort.time_sort('quick', 'float16', ('sorted_block', 1000)) |
| -        | 54.8±0.2ms                 | 27.0±0.05ms                     |    0.49 | bench_function_base.Sort.time_sort('quick', 'float64', ('ordered',))           |
| -        | 60.6±0.3ms                 | 29.8±0.3ms                      |    0.49 | bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 1000)) |
| -        | 53.0±0.1ms                 | 25.2±0.1ms                      |    0.48 | bench_function_base.Sort.time_sort('quick', 'float64', ('random',))            |
| -        | 55.0±0.3ms                 | 26.2±0.2ms                      |    0.48 | bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 100))  |
| -        | 55.1±0.2ms                 | 25.7±0.06ms                     |    0.47 | bench_function_base.Sort.time_sort('quick', 'float64', ('reversed',))          |
| -        | 54.8±0.1ms                 | 25.9±0.3ms                      |    0.47 | bench_function_base.Sort.time_sort('quick', 'float64', ('sorted_block', 10))   |
| -        | 64.7±0.3ms                 | 29.0±0.2ms                      |    0.45 | bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 1000))   |
| -        | 28.4±0.1ms                 | 12.4±0.2ms                      |    0.44 | bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 1000)) |
| -        | 26.3±0.1ms                 | 11.6±0.7ms                      |    0.44 | bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 1000))   |
| -        | 59.3±0.2ms                 | 26.1±0.2ms                      |    0.44 | bench_function_base.Sort.time_sort('quick', 'int64', ('ordered',))             |
| -        | 26.8±1ms                   | 11.6±0.4ms                      |    0.43 | bench_function_base.Sort.time_sort('quick', 'float32', ('ordered',))           |
| -        | 57.3±0.2ms                 | 24.7±0.3ms                      |    0.43 | bench_function_base.Sort.time_sort('quick', 'int64', ('random',))              |
| -        | 58.9±0.09ms                | 25.2±1ms                        |    0.43 | bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 10))     |
| -        | 59.4±0.09ms                | 25.4±0.09ms                     |    0.43 | bench_function_base.Sort.time_sort('quick', 'int64', ('sorted_block', 100))    |
| -        | 60.1±0.1ms                 | 25.2±0.1ms                      |    0.42 | bench_function_base.Sort.time_sort('quick', 'int64', ('reversed',))            |
| -        | 26.0±0.2ms                 | 10.9±0.1ms                      |    0.42 | bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 1000))  |
| -        | 25.8±1ms                   | 10.3±0.2ms                      |    0.4  | bench_function_base.Sort.time_sort('quick', 'float32', ('random',))            |
| -        | 26.5±0.08ms                | 10.7±0.1ms                      |    0.4  | bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 10))   |
| -        | 9.64±0.05ms                | 3.89±0.1ms                      |    0.4  | bench_function_base.Sort.time_sort_worst                                       |
| -        | 26.8±0.4ms                 | 10.5±0.2ms                      |    0.39 | bench_function_base.Sort.time_sort('quick', 'float32', ('reversed',))          |
| -        | 26.8±0.1ms                 | 10.4±0.7ms                      |    0.39 | bench_function_base.Sort.time_sort('quick', 'float32', ('sorted_block', 100))  |
| -        | 24.9±0.6ms                 | 9.80±0.2ms                      |    0.39 | bench_function_base.Sort.time_sort('quick', 'int32', ('ordered',))             |
| -        | 24.6±0.7ms                 | 9.60±0.02ms                     |    0.39 | bench_function_base.Sort.time_sort('quick', 'uint32', ('ordered',))            |
| -        | 24.5±0.06ms                | 9.25±0.03ms                     |    0.38 | bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 10))     |
| -        | 24.0±0.08ms                | 9.22±0.02ms                     |    0.38 | bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 10))    |
| -        | 24.0±1ms                   | 8.85±0.08ms                     |    0.37 | bench_function_base.Sort.time_sort('quick', 'int32', ('random',))              |
| -        | 24.6±0.2ms                 | 9.06±0.05ms                     |    0.37 | bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 100))    |
| -        | 23.7±0.07ms                | 8.78±0.07ms                     |    0.37 | bench_function_base.Sort.time_sort('quick', 'uint32', ('random',))             |
| -        | 24.2±0.2ms                 | 8.88±0.3ms                      |    0.37 | bench_function_base.Sort.time_sort('quick', 'uint32', ('reversed',))           |
| -        | 24.4±0.2ms                 | 9.02±0.09ms                     |    0.37 | bench_function_base.Sort.time_sort('quick', 'uint32', ('sorted_block', 100))   |
| -        | 24.6±0.2ms                 | 8.95±0.08ms                     |    0.36 | bench_function_base.Sort.time_sort('quick', 'int32', ('reversed',))            |
| -        | 89.0±0.3ms                 | 7.42±0.07ms                     |    0.08 | bench_function_base.Sort.time_sort('quick', 'int16', ('ordered',))             |
| -        | 87.7±0.5ms                 | 6.67±0.06ms                     |    0.08 | bench_function_base.Sort.time_sort('quick', 'int16', ('random',))              |
| -        | 88.3±0.2ms                 | 6.81±0.04ms                     |    0.08 | bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 10))     |
| -        | 87.2±0.07ms                | 6.54±0.02ms                     |    0.08 | bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 100))    |
```
</p>
</details> 

<details><summary>Benchmark numbers for `np.argsort` on a TGL (sorting an array of 500,000 numbers): </summary>
<p>

```
| Change   | Before [93898621] <main>   | After [41eb9481] <xss-openmp>   |   Ratio | Benchmark (Parameter)                                                             |
|----------|----------------------------|---------------------------------|---------|-----------------------------------------------------------------------------------|
| +        | 530±20μs                   | 788±50μs                        |    1.49 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('uniform',))            |
| +        | 528±30μs                   | 759±30μs                        |    1.44 | bench_function_base.Sort.time_argsort('quick', 'int32', ('uniform',))             |
| +        | 608±30μs                   | 787±20μs                        |    1.29 | bench_function_base.Sort.time_argsort('quick', 'float32', ('uniform',))           |
| -        | 10.8±0.02ms                | 4.12±0.02ms                     |    0.38 | bench_function_base.Sort.time_argsort('quick', 'float32', ('sorted_block', 1000)) |
| -        | 11.3±0.03ms                | 4.28±0.03ms                     |    0.38 | bench_function_base.Sort.time_argsort('quick', 'float64', ('sorted_block', 1000)) |
| -        | 10.5±0.03ms                | 3.92±0.03ms                     |    0.37 | bench_function_base.Sort.time_argsort('quick', 'int32', ('sorted_block', 1000))   |
| -        | 11.0±0.03ms                | 3.95±0.02ms                     |    0.36 | bench_function_base.Sort.time_argsort('quick', 'float32', ('sorted_block', 100))  |
| -        | 11.7±0.04ms                | 4.23±0.03ms                     |    0.36 | bench_function_base.Sort.time_argsort('quick', 'float64', ('sorted_block', 100))  |
| -        | 10.7±0.02ms                | 3.84±0.05ms                     |    0.36 | bench_function_base.Sort.time_argsort('quick', 'int32', ('sorted_block', 100))    |
| -        | 11.8±0.04ms                | 4.23±0.02ms                     |    0.36 | bench_function_base.Sort.time_argsort('quick', 'int64', ('sorted_block', 1000))   |
| -        | 10.4±0.02ms                | 3.78±0.02ms                     |    0.36 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('sorted_block', 1000))  |
| -        | 8.28±0.2ms                 | 2.92±0.1ms                      |    0.35 | bench_function_base.Sort.time_argsort('quick', 'int32', ('reversed',))            |
| -        | 10.8±0.08ms                | 3.72±0.06ms                     |    0.35 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('sorted_block', 100))   |
| -        | 8.62±0.2ms                 | 2.96±0.09ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'float32', ('ordered',))           |
| -        | 8.71±0.2ms                 | 2.92±0.09ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'float32', ('reversed',))          |
| -        | 8.70±0.02ms                | 2.95±0.01ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'float64', ('ordered',))           |
| -        | 8.74±0.03ms                | 3.00±0.02ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'float64', ('reversed',))          |
| -        | 12.3±0.02ms                | 4.21±0.03ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'int64', ('sorted_block', 100))    |
| -        | 8.35±0.2ms                 | 2.81±0.08ms                     |    0.34 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('ordered',))            |
| -        | 8.34±0.1ms                 | 2.79±0.1ms                      |    0.33 | bench_function_base.Sort.time_argsort('quick', 'int32', ('ordered',))             |
| -        | 8.30±0.2ms                 | 2.78±0.09ms                     |    0.33 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('reversed',))           |
| -        | 12.0±0.3ms                 | 3.87±0.1ms                      |    0.32 | bench_function_base.Sort.time_argsort('quick', 'float32', ('random',))            |
| -        | 10.3±0.04ms                | 3.31±0.03ms                     |    0.32 | bench_function_base.Sort.time_argsort('quick', 'float32', ('sorted_block', 10))   |
| -        | 12.5±0.04ms                | 3.98±0.03ms                     |    0.32 | bench_function_base.Sort.time_argsort('quick', 'float64', ('sorted_block', 10))   |
| -        | 9.50±0.03ms                | 3.08±0.06ms                     |    0.32 | bench_function_base.Sort.time_argsort('quick', 'int64', ('ordered',))             |
| -        | 9.48±0.04ms                | 3.07±0.04ms                     |    0.32 | bench_function_base.Sort.time_argsort('quick', 'int64', ('reversed',))            |
| -        | 13.5±0.04ms                | 4.18±0.04ms                     |    0.31 | bench_function_base.Sort.time_argsort('quick', 'float64', ('random',))            |
| -        | 11.7±0.3ms                 | 3.66±0.1ms                      |    0.31 | bench_function_base.Sort.time_argsort('quick', 'int32', ('random',))              |
| -        | 9.97±0.03ms                | 3.12±0.03ms                     |    0.31 | bench_function_base.Sort.time_argsort('quick', 'int32', ('sorted_block', 10))     |
| -        | 13.0±0.02ms                | 4.03±0.05ms                     |    0.31 | bench_function_base.Sort.time_argsort('quick', 'int64', ('sorted_block', 10))     |
| -        | 11.7±0.3ms                 | 3.58±0.08ms                     |    0.31 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('random',))             |
| -        | 9.96±0.01ms                | 3.08±0.03ms                     |    0.31 | bench_function_base.Sort.time_argsort('quick', 'uint32', ('sorted_block', 10))    |
| -        | 14.2±0.06ms                | 4.11±0.07ms                     |    0.29 | bench_function_base.Sort.time_argsort('quick', 'int64', ('random',))              |

```
</p>
</details> 