### PR TITLE
DOC: Fix typo in ``numpy/typing/__init__.py``

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -125,7 +125,7 @@ During runtime numpy aggressively casts any passed 0D arrays into their
 corresponding `~numpy.generic` instance. Until the introduction of shape
 typing (see :pep:`646`) it is unfortunately not possible to make the
 necessary distinction between 0D and >0D arrays. While thus not strictly
-correct, all operations are that can potentially perform a 0D-array -> scalar
+correct, all operations that can potentially perform a 0D-array -> scalar
 cast are currently annotated as exclusively returning an `~numpy.ndarray`.
 
 If it is known in advance that an operation *will* perform a


### PR DESCRIPTION
DOC: Fix typo in Typing documentation.

Changes

> all operations are that can potentially perform a 0D-array -> scalar cast are currently annotated

to

> all operations that can potentially perform a 0D-array -> scalar cast are currently annotated

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
