### PR TITLE
DOC: update array API standard version in compatibility page

### DIFF
--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -32,8 +32,8 @@ rather than anything NumPy-specific, the `array-api-strict
     NumPy 1.22.0 was the first version to include support for the array API
     standard, via a separate ``numpy.array_api`` submodule. This module was
     marked as experimental (it emitted a warning on import) and removed in
-    NumPy 2.0 because full support (2022.12 version [1]_) was included in the main namespace (with
-    2023.12 version support in NumPy 2.1).
+    NumPy 2.0 because full support (2022.12 version [1]_) was included in
+    the main namespace (with 2023.12 version support in NumPy 2.1).
     :ref:`NEP 47 <NEP47>` and
     :ref:`NEP 56 <NEP56>`
     describe the motivation and scope for implementing the array API standard

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -11,8 +11,8 @@ of the Python array API standard.
 
 NumPy aims to implement support for the
 `2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
-and future versions of the standard - assuming that those future versions can be
-upgraded to given NumPy's
+(in progress) and future versions of the standard - assuming that those future
+versions can be upgraded to given NumPy's
 :ref:`backwards compatibility policy <NEP23>`.
 
 For usage guidelines for downstream libraries and end users who want to write

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -5,12 +5,12 @@ Array API standard compatibility
 ********************************
 
 NumPy's main namespace as well as the `numpy.fft` and `numpy.linalg` namespaces
-are compatible [1]_ with the
-`2022.12 version <https://data-apis.org/array-api/2022.12/index.html>`__
+are compatible with the
+`2023.12 version <https://data-apis.org/array-api/2023.12/index.html>`__
 of the Python array API standard.
 
 NumPy aims to implement support for the
-`2023.12 version <https://data-apis.org/array-api/2023.12/index.html>`__
+`2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
 and future versions of the standard - assuming that those future versions can be
 upgraded to given NumPy's
 :ref:`backwards compatibility policy <NEP23>`.
@@ -32,7 +32,8 @@ rather than anything NumPy-specific, the `array-api-strict
     NumPy 1.22.0 was the first version to include support for the array API
     standard, via a separate ``numpy.array_api`` submodule. This module was
     marked as experimental (it emitted a warning on import) and removed in
-    NumPy 2.0 because full support was included in the main namespace.
+    NumPy 2.0 because full support (2022.12 version [1]_) was included in the main namespace (with
+    2023.12 version support in NumPy 2.1).
     :ref:`NEP 47 <NEP47>` and
     :ref:`NEP 56 <NEP56>`
     describe the motivation and scope for implementing the array API standard

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -4,8 +4,8 @@
 Array API standard compatibility
 ********************************
 
-NumPy's main namespace as well as the `numpy.fft` and `numpy.linalg` namespaces
-are compatible with the
+The NumPy 2.3.0 main namespace as well as the `numpy.fft` and `numpy.linalg`
+namespaces are compatible with the
 `2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
 of the Python array API standard.
 

--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -6,13 +6,11 @@ Array API standard compatibility
 
 NumPy's main namespace as well as the `numpy.fft` and `numpy.linalg` namespaces
 are compatible with the
-`2023.12 version <https://data-apis.org/array-api/2023.12/index.html>`__
+`2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
 of the Python array API standard.
 
-NumPy aims to implement support for the
-`2024.12 version <https://data-apis.org/array-api/2024.12/index.html>`__
-(in progress) and future versions of the standard - assuming that those future
-versions can be upgraded to given NumPy's
+NumPy aims to implement support for the future versions of the standard
+- assuming that those future versions can be upgraded to given NumPy's
 :ref:`backwards compatibility policy <NEP23>`.
 
 For usage guidelines for downstream libraries and end users who want to write
@@ -33,7 +31,7 @@ rather than anything NumPy-specific, the `array-api-strict
     standard, via a separate ``numpy.array_api`` submodule. This module was
     marked as experimental (it emitted a warning on import) and removed in
     NumPy 2.0 because full support (2022.12 version [1]_) was included in
-    the main namespace (with 2023.12 version support in NumPy 2.1).
+    the main namespace.
     :ref:`NEP 47 <NEP47>` and
     :ref:`NEP 56 <NEP56>`
     describe the motivation and scope for implementing the array API standard


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fixes #28625 

- 2023.12 is supported
- aims to support 2024.12 eventually (I am hoping!)
- moved down some bits to _History_
