### PR TITLE
MAINT: replace string.format() with f-strings

### DIFF
--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -12,7 +12,7 @@ class Records(Benchmark):
         self.formats_str = ','.join(self.formats)
         self.dtype_ = np.dtype(
             [
-                ('field_{}'.format(i), self.l50.dtype.str)
+                (f'field_{i}', self.l50.dtype.str)
                 for i in range(self.fields_number)
             ]
         )

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -520,7 +520,7 @@ class ArgPack:
     def __repr__(self):
         return '({})'.format(', '.join(
             [repr(a) for a in self.args] +
-            ['{}={}'.format(k, repr(v)) for k, v in self.kwargs.items()]
+            [f'{k}={repr(v)}' for k, v in self.kwargs.items()]
         ))
 
 

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -520,7 +520,7 @@ class ArgPack:
     def __repr__(self):
         return '({})'.format(', '.join(
             [repr(a) for a in self.args] +
-            [f'{k}={repr(v)}' for k, v in self.kwargs.items()]
+            [f'{k}={v!r}' for k, v in self.kwargs.items()]
         ))
 
 

--- a/numpy/_core/_add_newdocs_scalars.py
+++ b/numpy/_core/_add_newdocs_scalars.py
@@ -337,20 +337,20 @@ add_newdoc('numpy._core.numerictypes', "integer", ('is_integer',
 # TODO: work out how to put this on the base class, np.floating
 for float_name in ('half', 'single', 'double', 'longdouble'):
     add_newdoc('numpy._core.numerictypes', float_name, ('as_integer_ratio',
-        """
-        {ftype}.as_integer_ratio() -> (int, int)
+        f"""
+        {float_name}.as_integer_ratio() -> (int, int)
 
         Return a pair of integers, whose ratio is exactly equal to the original
         floating point number, and with a positive denominator.
         Raise `OverflowError` on infinities and a `ValueError` on NaNs.
 
-        >>> np.{ftype}(10.0).as_integer_ratio()
+        >>> np.{float_name}(10.0).as_integer_ratio()
         (10, 1)
-        >>> np.{ftype}(0.0).as_integer_ratio()
+        >>> np.{float_name}(0.0).as_integer_ratio()
         (0, 1)
-        >>> np.{ftype}(-.25).as_integer_ratio()
+        >>> np.{float_name}(-.25).as_integer_ratio()
         (-1, 4)
-        """.format(ftype=float_name)))
+        """))
 
     add_newdoc('numpy._core.numerictypes', float_name, ('is_integer',
         f"""

--- a/numpy/_core/_dtype.py
+++ b/numpy/_core/_dtype.py
@@ -26,8 +26,7 @@ def _kind_name(dtype):
         return _kind_to_stem[dtype.kind]
     except KeyError as e:
         raise RuntimeError(
-            "internal dtype error, unknown kind {!r}"
-            .format(dtype.kind)
+            f"internal dtype error, unknown kind {dtype.kind!r}"
         ) from None
 
 
@@ -46,7 +45,7 @@ def __repr__(dtype):
     arg_str = _construction_repr(dtype, include_align=False)
     if dtype.isalignedstruct:
         arg_str = arg_str + ", align=True"
-    return "dtype({})".format(arg_str)
+    return f"dtype({arg_str})"
 
 
 def _unpack_field(dtype, offset, title=None):
@@ -187,9 +186,9 @@ def _datetime_metadata_str(dtype):
     if unit == 'generic':
         return ''
     elif count == 1:
-        return '[{}]'.format(unit)
+        return f'[{unit}]'
     else:
-        return '[{}{}]'.format(count, unit)
+        return f'[{count}{unit}]'
 
 
 def _struct_dict_str(dtype, includealignedflag):
@@ -287,16 +286,13 @@ def _struct_list_str(dtype):
 
         item = "("
         if title is not None:
-            item += "({!r}, {!r}), ".format(title, name)
+            item += f"({title!r}, {name!r}), "
         else:
-            item += "{!r}, ".format(name)
+            item += f"{name!r}, "
         # Special case subarray handling here
         if fld_dtype.subdtype is not None:
             base, shape = fld_dtype.subdtype
-            item += "{}, {}".format(
-                _construction_repr(base, short=True),
-                shape
-            )
+            item += f"{_construction_repr(base, short=True)}, {shape}"
         else:
             item += _construction_repr(fld_dtype, short=True)
 
@@ -318,17 +314,14 @@ def _struct_str(dtype, include_align):
 
     # If the data type isn't the default, void, show it
     if dtype.type != np.void:
-        return "({t.__module__}.{t.__name__}, {f})".format(t=dtype.type, f=sub)
+        return f"({dtype.type.__module__}.{dtype.type.__name__}, {sub})"
     else:
         return sub
 
 
 def _subarray_str(dtype):
     base, shape = dtype.subdtype
-    return "({}, {})".format(
-        _construction_repr(base, short=True),
-        shape
-    )
+    return f"({_construction_repr(base, short=True)}, {shape})"
 
 
 def _name_includes_bit_suffix(dtype):
@@ -365,7 +358,7 @@ def _name_get(dtype):
 
     # append bit counts
     if _name_includes_bit_suffix(dtype):
-        name += "{}".format(dtype.itemsize * 8)
+        name += f"{dtype.itemsize * 8}"
 
     # append metadata to datetimes
     if dtype.type in (np.datetime64, np.timedelta64):

--- a/numpy/_core/_dtype_ctypes.py
+++ b/numpy/_core/_dtype_ctypes.py
@@ -117,4 +117,4 @@ def dtype_from_ctypes_type(t):
         return _from_ctypes_scalar(t)
     else:
         raise NotImplementedError(
-            "Unknown ctypes type {}".format(t.__name__))
+            f"Unknown ctypes type {t.__name__}")

--- a/numpy/_core/_exceptions.py
+++ b/numpy/_core/_exceptions.py
@@ -166,4 +166,5 @@ class _ArrayMemoryError(MemoryError):
 
     def __str__(self):
         size_str = self._size_to_string(self._total_size)
-        return f"Unable to allocate {size_str} for an array with shape {self.shape} and data type {self.dtype}"
+        return (f"Unable to allocate {size_str} for an array with shape "
+                f"{self.shape} and data type {self.dtype}")

--- a/numpy/_core/_exceptions.py
+++ b/numpy/_core/_exceptions.py
@@ -86,7 +86,7 @@ class _UFuncInputCastingError(_UFuncCastingError):
 
     def __str__(self):
         # only show the number if more than one input exists
-        i_str = "{} ".format(self.in_i) if self.ufunc.nin != 1 else ""
+        i_str = f"{self.in_i} " if self.ufunc.nin != 1 else ""
         return (
             "Cannot cast ufunc {!r} input {}from {!r} to {!r} with casting "
             "rule {!r}"
@@ -104,7 +104,7 @@ class _UFuncOutputCastingError(_UFuncCastingError):
 
     def __str__(self):
         # only show the number if more than one output exists
-        i_str = "{} ".format(self.out_i) if self.ufunc.nout != 1 else ""
+        i_str = f"{self.out_i} " if self.ufunc.nout != 1 else ""
         return (
             "Cannot cast ufunc {!r} output {}from {!r} to {!r} with casting "
             "rule {!r}"
@@ -156,17 +156,14 @@ class _ArrayMemoryError(MemoryError):
         # format with a sensible number of digits
         if unit_i == 0:
             # no decimal point on bytes
-            return '{:.0f} {}'.format(n_units, unit_name)
+            return f'{n_units:.0f} {unit_name}'
         elif round(n_units) < 1000:
             # 3 significant figures, if none are dropped to the left of the .
-            return '{:#.3g} {}'.format(n_units, unit_name)
+            return f'{n_units:#.3g} {unit_name}'
         else:
             # just give all the digits otherwise
-            return '{:#.0f} {}'.format(n_units, unit_name)
+            return f'{n_units:#.0f} {unit_name}'
 
     def __str__(self):
         size_str = self._size_to_string(self._total_size)
-        return (
-            "Unable to allocate {} for an array with shape {} and data type {}"
-            .format(size_str, self.shape, self.dtype)
-        )
+        return f"Unable to allocate {size_str} for an array with shape {self.shape} and data type {self.dtype}"

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -739,8 +739,7 @@ def __dtype_from_pep3118(stream, is_subdtype):
         elif stream.next in _pep3118_unsupported_map:
             desc = _pep3118_unsupported_map[stream.next]
             raise NotImplementedError(
-                "Unrepresentable PEP 3118 data type {!r} ({})"
-                .format(stream.next, desc))
+                f"Unrepresentable PEP 3118 data type {stream.next!r} ({desc})")
         else:
             raise ValueError(
                 "Unknown PEP 3118 data type specifier %r" % stream.s
@@ -873,8 +872,8 @@ def _lcm(a, b):
 
 def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
     """ Format the error message for when __array_ufunc__ gives up. """
-    args_string = ', '.join(['{!r}'.format(arg) for arg in inputs] +
-                            ['{}={!r}'.format(k, v)
+    args_string = ', '.join([f'{arg!r}' for arg in inputs] +
+                            [f'{k}={v!r}'
                              for k, v in kwargs.items()])
     args = inputs + kwargs.get('out', ())
     types_string = ', '.join(repr(type(arg).__name__) for arg in args)
@@ -885,7 +884,7 @@ def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
 
 def array_function_errmsg_formatter(public_api, types):
     """ Format the error message for when __array_ufunc__ gives up. """
-    func_name = '{}.{}'.format(public_api.__module__, public_api.__name__)
+    func_name = f'{public_api.__module__}.{public_api.__name__}'
     return ("no implementation found for '{}' on types that implement "
             '__array_function__: {}'.format(func_name, list(types)))
 
@@ -911,7 +910,7 @@ def _ufunc_doc_signature_formatter(ufunc):
     else:
         out_args = '[, {positional}], / [, out={default}]'.format(
             positional=', '.join(
-                'out{}'.format(i + 1) for i in range(ufunc.nout)),
+                f'out{i + 1}' for i in range(ufunc.nout)),
             default=repr((None,) * ufunc.nout)
         )
 
@@ -930,12 +929,7 @@ def _ufunc_doc_signature_formatter(ufunc):
         kwargs += "[, signature, axes, axis]"
 
     # join all the parts together
-    return '{name}({in_args}{out_args}, *{kwargs})'.format(
-        name=ufunc.__name__,
-        in_args=in_args,
-        out_args=out_args,
-        kwargs=kwargs
-    )
+    return f'{ufunc.__name__}({in_args}{out_args}, *{kwargs})'
 
 
 def npy_ctypes_check(cls):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -64,7 +64,7 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     modes = ['fixed', 'unique', 'maxprec', 'maxprec_equal']
     if floatmode not in modes + [None]:
         raise ValueError("floatmode option must be one of " +
-                         ", ".join('"{}"'.format(m) for m in modes))
+                         ", ".join(f'"{m}"' for m in modes))
 
     if sign not in [None, '-', '+', ' ']:
         raise ValueError("sign option must be one of ' ', '+', or '-'")
@@ -953,7 +953,7 @@ def _none_or_positive_arg(x, name):
     if x is None:
         return -1
     if x < 0:
-        raise ValueError("{} must be >= 0".format(name))
+        raise ValueError(f"{name} must be >= 0")
     return x
 
 class FloatingFormat:
@@ -1352,7 +1352,7 @@ class _TimelikeFormat:
         if len(non_nat) < data.size:
             # data contains a NaT
             max_str_len = max(max_str_len, 5)
-        self._format = '%{}s'.format(max_str_len)
+        self._format = f'%{max_str_len}s'
         self._nat = "'NaT'".rjust(max_str_len)
 
     def _format_non_nat(self, x):
@@ -1461,9 +1461,9 @@ class StructuredVoidFormat:
             for field, format_function in zip(x, self.format_functions)
         ]
         if len(str_fields) == 1:
-            return "({},)".format(str_fields[0])
+            return f"({str_fields[0]},)"
         else:
-            return "({})".format(", ".join(str_fields))
+            return f"({', '.join(str_fields)})"
 
 
 def _void_scalar_to_string(x, is_repr=True):

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -498,7 +498,7 @@ def check_api_dict(d):
                 doubled[index] = [name]
         fmt = "Same index has been used twice in api definition: {}"
         val = ''.join(
-            '\n\tindex {} -> {}'.format(index, names)
+            f'\n\tindex {index} -> {names}'
             for index, names in doubled.items() if len(names) != 1
         )
         raise ValueError(fmt.format(val))

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1499,7 +1499,7 @@ def make_ufuncs(funcdict):
         if uf.signature is None:
             sig = "NULL"
         else:
-            sig = '"{}"'.format(uf.signature)
+            sig = f'"{uf.signature}"'
         fmt = textwrap.dedent("""\
             identity = {identity_expr};
             if ({has_identity} && identity == NULL) {{

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -50,11 +50,11 @@ def add_newdoc(place, name, doc):
     )
     if name[0] != '_' and name not in skip:
         if '\nx :' in doc:
-            assert '$OUT_SCALAR_1' in doc, "in {}".format(name)
+            assert '$OUT_SCALAR_1' in doc, f"in {name}"
         elif '\nx2 :' in doc or '\nx1, x2 :' in doc:
-            assert '$OUT_SCALAR_2' in doc, "in {}".format(name)
+            assert '$OUT_SCALAR_2' in doc, f"in {name}"
         else:
-            assert False, "Could not detect number of inputs in {}".format(name)
+            assert False, f"Could not detect number of inputs in {name}"
 
     for k, v in subst.items():
         doc = doc.replace('$' + k, v)

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -220,8 +220,9 @@ class memmap(ndarray):
             mode = mode_equivalents[mode]
         except KeyError as e:
             if mode not in valid_filemodes:
+                all_modes = valid_filemodes + list(mode_equivalents.keys())
                 raise ValueError(
-                    f"mode must be one of {valid_filemodes + list(mode_equivalents.keys())!r} (got {mode!r})"
+                    f"mode must be one of {all_modes!r} (got {mode!r})"
                 ) from None
 
         if mode == 'w+' and shape is None:

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -221,8 +221,7 @@ class memmap(ndarray):
         except KeyError as e:
             if mode not in valid_filemodes:
                 raise ValueError(
-                    "mode must be one of {!r} (got {!r})"
-                    .format(valid_filemodes + list(mode_equivalents.keys()), mode)
+                    f"mode must be one of {valid_filemodes + list(mode_equivalents.keys())!r} (got {mode!r})"
                 ) from None
 
         if mode == 'w+' and shape is None:

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1435,7 +1435,7 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     axis = tuple(normalize_axis_index(ax, ndim, argname) for ax in axis)
     if not allow_duplicate and len(set(axis)) != len(axis):
         if argname:
-            raise ValueError('repeated axis in `{}` argument'.format(argname))
+            raise ValueError(f'repeated axis in `{argname}` argument')
         else:
             raise ValueError('repeated axis')
     return axis

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -127,7 +127,7 @@ class format_parser:
         if isinstance(formats, list):
             dtype = sb.dtype(
                 [
-                    ('f{}'.format(i), format_)
+                    (f'f{i}', format_)
                     for i, format_ in enumerate(formats)
                 ],
                 aligned,

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -552,7 +552,7 @@ def _block_format_index(index):
     """
     Convert a list of indices ``[0, 1, 2]`` into ``"arrays[0][1][2]"``.
     """
-    idx_str = ''.join('[{}]'.format(i) for i in index if i is not None)
+    idx_str = ''.join(f'[{i}]' for i in index if i is not None)
     return 'arrays' + idx_str
 
 
@@ -688,7 +688,7 @@ def _concatenate_shapes(shapes, axis):
     if any(shape[:axis] != first_shape_pre or
            shape[axis + 1:] != first_shape_post for shape in shapes):
         raise ValueError(
-            'Mismatched array shapes in block along axis {}.'.format(axis))
+            f'Mismatched array shapes in block along axis {axis}.')
 
     shape = (first_shape_pre + (sum(shape_at_axis),) + first_shape[axis + 1:])
 
@@ -967,9 +967,7 @@ def _block_setup(arrays):
     list_ndim = len(bottom_index)
     if bottom_index and bottom_index[-1] is None:
         raise ValueError(
-            'List at {} cannot be empty'.format(
-                _block_format_index(bottom_index)
-            )
+            f'List at {_block_format_index(bottom_index)} cannot be empty'
         )
     result_ndim = max(arr_ndim, list_ndim)
     return arrays, list_ndim, result_ndim, final_size

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -534,7 +534,7 @@ class TestArray2String:
         assert_equal(a[0], text)
         text = text.item()  # use raw python strings for repr below
         # and that np.array2string puts a newline in the expected location
-        expected_repr = "[{0!r} {0!r}\n {0!r}]".format(text)
+        expected_repr = f"[{text!r} {text!r}\n {text!r}]"
         result = np.array2string(a, max_line_width=len(repr(text)) * 2 + 3)
         assert_equal(result, expected_repr)
 
@@ -836,7 +836,7 @@ class TestPrintOptions:
         c = np.array([1.0 + 1.0j, 1.123456789 + 1.123456789j], dtype='c16')
 
         # also make sure 1e23 is right (is between two fp numbers)
-        w = np.array(['1e{}'.format(i) for i in range(25)], dtype=np.float64)
+        w = np.array([f'1e{i}' for i in range(25)], dtype=np.float64)
         # note: we construct w from the strings `1eXX` instead of doing
         # `10.**arange(24)` because it turns out the two are not equivalent in
         # python. On some architectures `1e23 != 10.**23`.
@@ -948,10 +948,10 @@ class TestPrintOptions:
 
         styp = '<U4'
         assert_equal(repr(np.ones(3, dtype=styp)),
-            "array(['1', '1', '1'], dtype='{}')".format(styp))
-        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
+            f"array(['1', '1', '1'], dtype='{styp}')")
+        assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent(f"""\
             array(['1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1'],
-                  dtype='{}')""".format(styp)))
+                  dtype='{styp}')"""))
 
     @pytest.mark.parametrize(
         ['native'],

--- a/numpy/_core/tests/test_conversion_utils.py
+++ b/numpy/_core/tests/test_conversion_utils.py
@@ -19,7 +19,7 @@ class StringConverterTestCase:
     warn = True
 
     def _check_value_error(self, val):
-        pattern = r'\(got {}\)'.format(re.escape(repr(val)))
+        pattern = fr'\(got {re.escape(repr(val))}\)'
         with pytest.raises(ValueError, match=pattern) as exc:
             self.conv(val)
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -494,7 +494,7 @@ class TestDateTime:
 
     def test_timedelta_nat_format(self):
         # gh-17552
-        assert_equal('NaT', '{0}'.format(np.timedelta64('nat')))
+        assert_equal('NaT', f'{np.timedelta64("nat")}')
 
     def test_timedelta_scalar_construction_units(self):
         # String construction detecting units

--- a/numpy/_core/tests/test_longdouble.py
+++ b/numpy/_core/tests/test_longdouble.py
@@ -266,8 +266,7 @@ def test_str_exact():
 @pytest.mark.skipif(string_to_longdouble_inaccurate,
                     reason="Need strtold_l")
 def test_format():
-    o = 1 + LD_INFO.eps
-    assert_(f"{o:.40g}" != '1')
+    assert_(f"{1 + LD_INFO.eps:.40g}" != '1')
 
 
 @pytest.mark.skipif(longdouble_longer_than_double, reason="BUG #2376")

--- a/numpy/_core/tests/test_longdouble.py
+++ b/numpy/_core/tests/test_longdouble.py
@@ -267,7 +267,7 @@ def test_str_exact():
                     reason="Need strtold_l")
 def test_format():
     o = 1 + LD_INFO.eps
-    assert_("{0:.40g}".format(o) != '1')
+    assert_(f"{o:.40g}" != '1')
 
 
 @pytest.mark.skipif(longdouble_longer_than_double, reason="BUG #2376")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2175,7 +2175,7 @@ class TestMethods:
                 arr = np.array([1 + 3.j, 2 + 2.j, 3 + 1.j], dtype=endianness + dt)
                 c = arr.copy()
                 c.sort()
-                msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
+                msg = f'byte-swapped complex sort, dtype={dt}'
                 assert_equal(c, arr, msg)
 
     @pytest.mark.parametrize('dtype', [np.bytes_, np.str_])
@@ -2262,7 +2262,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array sort with axis={0}'.format(axis)
+            msg = f'test empty array sort with axis={axis}'
             assert_equal(np.sort(a, axis=axis), a, msg)
         msg = 'test empty array sort with axis=None'
         assert_equal(np.sort(a, axis=None), a.ravel(), msg)
@@ -2443,7 +2443,7 @@ class TestMethods:
         for endianness in '<>':
             for dt in np.typecodes['Complex']:
                 arr = np.array([1 + 3.j, 2 + 2.j, 3 + 1.j], dtype=endianness + dt)
-                msg = 'byte-swapped complex argsort, dtype={0}'.format(dt)
+                msg = f'byte-swapped complex argsort, dtype={dt}'
                 assert_equal(arr.argsort(),
                              np.arange(len(arr), dtype=np.intp), msg)
 
@@ -2524,7 +2524,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array argsort with axis={0}'.format(axis)
+            msg = f'test empty array argsort with axis={axis}'
             assert_equal(np.argsort(a, axis=axis),
                          np.zeros_like(a, dtype=np.intp), msg)
         msg = 'test empty array argsort with axis=None'
@@ -2842,7 +2842,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array partition with axis={0}'.format(axis)
+            msg = f'test empty array partition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis), a, msg)
         msg = 'test empty array partition with axis=None'
         assert_equal(np.partition(a, kth, axis=None), a.ravel(), msg)
@@ -2854,7 +2854,7 @@ class TestMethods:
         a = np.array([])
         a.shape = (3, 2, 1, 0)
         for axis in range(-a.ndim, a.ndim):
-            msg = 'test empty array argpartition with axis={0}'.format(axis)
+            msg = f'test empty array argpartition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis),
                          np.zeros_like(a, dtype=np.intp), msg)
         msg = 'test empty array argpartition with axis=None'
@@ -3774,7 +3774,7 @@ class TestMethods:
             b = np.array([7], dtype=dt)
             c = np.array([[[[[7]]]]], dtype=dt)
 
-            msg = 'dtype: {0}'.format(dt)
+            msg = f'dtype: {dt}'
             ap = complex(a)
             assert_equal(ap, a, msg)
 
@@ -3906,9 +3906,9 @@ class TestBinop:
             if array_priority is not False:
                 class_namespace["__array_priority__"] = array_priority
             for op in ops:
-                class_namespace["__{0}__".format(op)] = op_impl
-                class_namespace["__r{0}__".format(op)] = rop_impl
-                class_namespace["__i{0}__".format(op)] = iop_impl
+                class_namespace[f"__{op}__"] = op_impl
+                class_namespace[f"__r{op}__"] = rop_impl
+                class_namespace[f"__i{op}__"] = iop_impl
             if array_ufunc is not False:
                 class_namespace["__array_ufunc__"] = array_ufunc
             eval_namespace = {"base": base,
@@ -3933,7 +3933,7 @@ class TestBinop:
                 if check_scalar:
                     check_objs.append(check_objs[0][0])
                 for arr in check_objs:
-                    arr_method = getattr(arr, "__{0}__".format(op))
+                    arr_method = getattr(arr, f"__{op}__")
 
                     def first_out_arg(result):
                         if op == "divmod":
@@ -3959,7 +3959,7 @@ class TestBinop:
                             assert_raises((TypeError, Coerced),
                                           arr_method, obj, err_msg=err_msg)
                     # obj __op__ arr
-                    arr_rmethod = getattr(arr, "__r{0}__".format(op))
+                    arr_rmethod = getattr(arr, f"__r{op}__")
                     if ufunc_override_expected:
                         res = arr_rmethod(obj)
                         assert_equal(res[0], "__array_ufunc__",
@@ -3980,7 +3980,7 @@ class TestBinop:
                     # arr __iop__ obj
                     # array scalars don't have in-place operators
                     if has_inplace and isinstance(arr, np.ndarray):
-                        arr_imethod = getattr(arr, "__i{0}__".format(op))
+                        arr_imethod = getattr(arr, f"__i{op}__")
                         if inplace_override_expected:
                             assert_equal(arr_method(obj), NotImplemented,
                                          err_msg=err_msg)
@@ -9391,12 +9391,12 @@ class TestFormat:
 
     def test_0d(self):
         a = np.array(np.pi)
-        assert_equal('{:0.3g}'.format(a), '3.14')
-        assert_equal('{:0.3g}'.format(a[()]), '3.14')
+        assert_equal(f'{a:0.3g}', '3.14')
+        assert_equal(f'{a[()]:0.3g}', '3.14')
 
     def test_1d_no_format(self):
         a = np.array([np.pi])
-        assert_equal('{}'.format(a), str(a))
+        assert_equal(f'{a}', str(a))
 
     def test_1d_format(self):
         # until gh-5543, ensure that the behaviour matches what it used to be

--- a/numpy/_core/tests/test_protocols.py
+++ b/numpy/_core/tests/test_protocols.py
@@ -24,7 +24,7 @@ def test_getattr_warning():
             return getattr(self.array, name)
 
         def __repr__(self):
-            return "<Wrapper({self.array})>".format(self=self)
+            return f"<Wrapper({self.array})>"
 
     array = Wrapper(np.arange(10))
     with pytest.raises(UserWarning, match="object got converted"):

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2126,7 +2126,7 @@ class TestRegression:
         # Ticket #4369.
         dt = np.dtype([('date', '<M8[D]'), ('val', '<f8')])
         arr = np.array([('2000-01-01', 1)], dt)
-        formatted = '{0}'.format(arr[0])
+        formatted = f'{arr[0]}'
         assert_equal(formatted, str(arr[0]))
 
     def test_deepcopy_on_0d_array(self):

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -105,7 +105,7 @@ class TestAsIntegerRatio:
                 # the values may not fit in any float type
                 pytest.skip("longdouble too small on this platform")
 
-            assert_equal(nf / df, f, "{}/{}".format(n, d))
+            assert_equal(nf / df, f, f"{n}/{d}")
 
 
 class TestIsInteger:

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -26,7 +26,7 @@ class TestRealScalars:
 
         for wants, val in zip(wanted, svals):
             for want, styp in zip(wants, styps):
-                msg = 'for str({}({}))'.format(np.dtype(styp).name, repr(val))
+                msg = f'for str({np.dtype(styp).name}({repr(val)}))'
                 assert_equal(str(styp(val)), want, err_msg=msg)
 
     def test_scalar_cutoffs(self):

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -26,7 +26,7 @@ class TestRealScalars:
 
         for wants, val in zip(wanted, svals):
             for want, styp in zip(wants, styps):
-                msg = f'for str({np.dtype(styp).name}({repr(val)}))'
+                msg = f'for str({np.dtype(styp).name}({val!r}))'
                 assert_equal(str(styp(val)), want, err_msg=msg)
 
     def test_scalar_cutoffs(self):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3119,8 +3119,8 @@ class TestSpecialMethods:
                 # assert_equal produces truly useless error messages
                 raise AssertionError("\n".join([
                     "Bad arguments passed in ufunc call",
-                    " expected:              {}".format(expected),
-                    " __array_wrap__ got:    {}".format(w)
+                    f" expected:              {expected}",
+                    f" __array_wrap__ got:    {w}"
                 ]))
 
         # method not on the out argument

--- a/numpy/_utils/_pep440.py
+++ b/numpy/_utils/_pep440.py
@@ -172,7 +172,7 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     def __repr__(self):
-        return "<LegacyVersion({0})>".format(repr(str(self)))
+        return f"<LegacyVersion({repr(str(self))})>"
 
     @property
     def public(self):
@@ -293,7 +293,7 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:
-            raise InvalidVersion("Invalid version: '{0}'".format(version))
+            raise InvalidVersion(f"Invalid version: '{version}'")
 
         # Store the parsed out pieces of the version
         self._version = _Version(
@@ -325,14 +325,14 @@ class Version(_BaseVersion):
         )
 
     def __repr__(self):
-        return "<Version({0})>".format(repr(str(self)))
+        return f"<Version({repr(str(self))})>"
 
     def __str__(self):
         parts = []
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))
@@ -343,16 +343,16 @@ class Version(_BaseVersion):
 
         # Post-release
         if self._version.post is not None:
-            parts.append(".post{0}".format(self._version.post[1]))
+            parts.append(f".post{self._version.post[1]}")
 
         # Development release
         if self._version.dev is not None:
-            parts.append(".dev{0}".format(self._version.dev[1]))
+            parts.append(f".dev{self._version.dev[1]}")
 
         # Local version segment
         if self._version.local is not None:
             parts.append(
-                "+{0}".format(".".join(str(x) for x in self._version.local))
+                f"+{'.'.join(str(x) for x in self._version.local)}"
             )
 
         return "".join(parts)
@@ -367,7 +367,7 @@ class Version(_BaseVersion):
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append(f"{self._version.epoch}!")
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))

--- a/numpy/_utils/_pep440.py
+++ b/numpy/_utils/_pep440.py
@@ -172,7 +172,7 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     def __repr__(self):
-        return f"<LegacyVersion({repr(str(self))})>"
+        return f"<LegacyVersion({str(self)!r})>"
 
     @property
     def public(self):
@@ -325,7 +325,7 @@ class Version(_BaseVersion):
         )
 
     def __repr__(self):
-        return f"<Version({repr(str(self))})>"
+        return f"<Version({str(self)!r})>"
 
     def __str__(self):
         parts = []

--- a/numpy/ctypeslib/_ctypeslib.py
+++ b/numpy/ctypeslib/_ctypeslib.py
@@ -385,7 +385,7 @@ if ctypes is not None:
             ctype = _scalar_type_map[dtype_native]
         except KeyError as e:
             raise NotImplementedError(
-                "Converting {!r} to a ctypes type".format(dtype)
+                f"Converting {dtype!r} to a ctypes type"
             ) from None
 
         if dtype_with_endian.byteorder == '>':

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -152,7 +152,7 @@ def load_f2cmap_file(f2cmap_file):
     # interpreted as C 'float'. This feature is useful for F90/95 users if
     # they use PARAMETERS in type specifications.
     try:
-        outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
+        outmess(f'Reading f2cmap from {f2cmap_file!r} ...\n')
         with open(f2cmap_file) as f:
             d = eval(f.read().lower(), {}, {})
         f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map, True)

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -673,8 +673,8 @@ def split_by_unquoted(line, characters):
     r = re.compile(
         r"\A(?P<before>({single_quoted}|{double_quoted}|{not_quoted})*)"
         r"(?P<after>{char}.*)\Z".format(
-            not_quoted="[^\"'{}]".format(re.escape(characters)),
-            char="[{}]".format(re.escape(characters)),
+            not_quoted=f"[^\"'{re.escape(characters)}]",
+            char=f"[{re.escape(characters)}]",
             single_quoted=r"('([^'\\]|(\\.))*')",
             double_quoted=r'("([^"\\]|(\\.))*")'))
     m = r.match(line)
@@ -1459,7 +1459,7 @@ def analyzeline(m, case, line):
                 vdim = getdimension(vars[v])
                 matches = re.findall(r"\(.*?\)", l[1]) if vtype == 'complex' else l[1].split(',')
                 try:
-                    new_val = "(/{}/)".format(", ".join(matches)) if vdim else matches[idx]
+                    new_val = f"(/{', '.join(matches)}/)" if vdim else matches[idx]
                 except IndexError:
                     # gh-24746
                     # Runs only if above code fails. Fixes the line
@@ -1477,7 +1477,7 @@ def analyzeline(m, case, line):
                             else:
                                 expanded_list.append(match.strip())
                         matches = expanded_list
-                    new_val = "(/{}/)".format(", ".join(matches)) if vdim else matches[idx]
+                    new_val = f"(/{', '.join(matches)}/)" if vdim else matches[idx]
                 current_val = vars[v].get('=')
                 if current_val and (current_val != new_val):
                     outmess('analyzeline: changing init expression of "%s" ("%s") to "%s"\n' % (v, current_val, new_val))

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -262,7 +262,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
         # need to change to record how big each module is, rather than
         # relying on rebase being able to find that from the files.
         _module_list.extend(
-            glob.glob(os.path.join(d, "{:s}*".format(module_name)))
+            glob.glob(os.path.join(d, f"{module_name:s}*"))
         )
         subprocess.check_call(
             ["/usr/bin/rebase", "--database", "--oblivious", "--verbose"]

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -794,10 +794,9 @@ def pad(array, pad_width, mode='constant', **kwargs):
     try:
         unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
     except KeyError:
-        raise ValueError("mode '{}' is not supported".format(mode)) from None
+        raise ValueError(f"mode '{mode}' is not supported") from None
     if unsupported_kwargs:
-        raise ValueError("unsupported keyword arguments for mode '{}': {}"
-                         .format(mode, unsupported_kwargs))
+        raise ValueError(f"unsupported keyword arguments for mode '{mode}': {unsupported_kwargs}")
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -796,7 +796,8 @@ def pad(array, pad_width, mode='constant', **kwargs):
     except KeyError:
         raise ValueError(f"mode '{mode}' is not supported") from None
     if unsupported_kwargs:
-        raise ValueError(f"unsupported keyword arguments for mode '{mode}': {unsupported_kwargs}")
+        raise ValueError("unsupported keyword arguments for mode "
+                         f"'{mode}': {unsupported_kwargs}")
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -311,7 +311,7 @@ def unique(ar, return_index=False, return_inverse=False,
     orig_shape, orig_dtype = ar.shape, ar.dtype
     ar = ar.reshape(orig_shape[0], np.prod(orig_shape[1:], dtype=np.intp))
     ar = np.ascontiguousarray(ar)
-    dtype = [('f{i}'.format(i=i), ar.dtype) for i in range(ar.shape[1])]
+    dtype = [(f'f{i}', ar.dtype) for i in range(ar.shape[1])]
 
     # At this point, `ar` has shape `(n, m)`, and `dtype` is a structured
     # data type with `m` fields where each field has the data type of `ar`.

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -408,7 +408,7 @@ def _wrap_header(header, version):
     try:
         header_prefix = magic(*version) + struct.pack(fmt, hlen + padlen)
     except struct.error:
-        msg = "Header length {} too big for version={}".format(hlen, version)
+        msg = f"Header length {hlen} too big for version={version}"
         raise ValueError(msg) from None
 
     # Pad the header with spaces and a final newline such that the magic
@@ -629,7 +629,7 @@ def _read_array_header(fp, version, max_header_size=_MAX_HEADER_SIZE):
     import struct
     hinfo = _header_size_info.get(version)
     if hinfo is None:
-        raise ValueError("Invalid version {!r}".format(version))
+        raise ValueError(f"Invalid version {version!r}")
     hlength_type, encoding = hinfo
 
     hlength_str = _read_bytes(fp, struct.calcsize(hlength_type), "array header length")

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -220,8 +220,7 @@ def rot90(m, k=1, axes=(0, 1)):
 
     if (axes[0] >= m.ndim or axes[0] < -m.ndim
         or axes[1] >= m.ndim or axes[1] < -m.ndim):
-        raise ValueError("Axes={} out of range for array of ndim={}."
-            .format(axes, m.ndim))
+        raise ValueError(f"Axes={axes} out of range for array of ndim={m.ndim}.")
 
     k %= 4
 
@@ -762,8 +761,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         n += 1
     elif n != n2:
         raise ValueError(
-            "with {} condition(s), either {} or {} functions are expected"
-            .format(n, n, n + 1)
+            f"with {n} condition(s), either {n} or {n + 1} functions are expected"
         )
 
     y = zeros_like(x)
@@ -870,7 +868,7 @@ def select(condlist, choicelist, default=0):
     for i, cond in enumerate(condlist):
         if cond.dtype.type is not np.bool:
             raise TypeError(
-                'invalid entry {} in condlist: should be boolean ndarray'.format(i))
+                f'invalid entry {i} in condlist: should be boolean ndarray')
 
     if choicelist[0].ndim == 0:
         # This may be common, so avoid the call.
@@ -2145,10 +2143,10 @@ def disp(mesg, device=None, linefeed=True):
 
 # See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
 _DIMENSION_NAME = r'\w+'
-_CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
-_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
-_ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
-_SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
+_CORE_DIMENSION_LIST = f'(?:{_DIMENSION_NAME}(?:,{_DIMENSION_NAME})*)?'
+_ARGUMENT = fr'\({_CORE_DIMENSION_LIST}\)'
+_ARGUMENT_LIST = f'{_ARGUMENT}(?:,{_ARGUMENT})*'
+_SIGNATURE = f'^{_ARGUMENT_LIST}->{_ARGUMENT_LIST}$'
 
 
 def _parse_gufunc_signature(signature):
@@ -2170,7 +2168,7 @@ def _parse_gufunc_signature(signature):
 
     if not re.match(_SIGNATURE, signature):
         raise ValueError(
-            'not a valid gufunc signature: {}'.format(signature))
+            f'not a valid gufunc signature: {signature}')
     return tuple([tuple(re.findall(_DIMENSION_NAME, arg))
                   for arg in re.findall(_ARGUMENT, arg_list)]
                  for arg_list in signature.split('->'))

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -280,8 +280,8 @@ def _ravel_and_check_weights(a, weights):
 
     # Ensure that the array is a "subtractable" dtype
     if a.dtype == np.bool:
-        warnings.warn(f"Converting input from {a.dtype} to {np.uint8} for compatibility.",
-                      RuntimeWarning, stacklevel=3)
+        msg = f"Converting input from {a.dtype} to {np.uint8} for compatibility."
+        warnings.warn(msg, RuntimeWarning, stacklevel=3)
         a = a.astype(np.uint8)
 
     if weights is not None:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -280,8 +280,7 @@ def _ravel_and_check_weights(a, weights):
 
     # Ensure that the array is a "subtractable" dtype
     if a.dtype == np.bool:
-        warnings.warn("Converting input from {} to {} for compatibility."
-                      .format(a.dtype, np.uint8),
+        warnings.warn(f"Converting input from {a.dtype} to {np.uint8} for compatibility.",
                       RuntimeWarning, stacklevel=3)
         a = a.astype(np.uint8)
 
@@ -307,7 +306,7 @@ def _get_outer_edges(a, range):
                 'max must be larger than min in range parameter.')
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                "supplied range of [{}, {}] is not finite".format(first_edge, last_edge))
+                f"supplied range of [{first_edge}, {last_edge}] is not finite")
     elif a.size == 0:
         # handle empty arrays. Can't determine range, so use 0-1.
         first_edge, last_edge = 0, 1
@@ -315,7 +314,7 @@ def _get_outer_edges(a, range):
         first_edge, last_edge = a.min(), a.max()
         if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
             raise ValueError(
-                "autodetected range of [{}, {}] is not finite".format(first_edge, last_edge))
+                f"autodetected range of [{first_edge}, {last_edge}] is not finite")
 
     # expand empty range to avoid divide by zero
     if first_edge == last_edge:
@@ -384,7 +383,7 @@ def _get_bin_edges(a, bins, range, weights):
         # this will replace it with the number of bins calculated
         if bin_name not in _hist_bin_selectors:
             raise ValueError(
-                "{!r} is not a valid estimator for `bins`".format(bin_name))
+                f"{bin_name!r} is not a valid estimator for `bins`")
         if weights is not None:
             raise TypeError("Automated estimation of the number of "
                             "bins is not supported for weighted data")
@@ -1012,14 +1011,14 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
         if np.ndim(bins[i]) == 0:
             if bins[i] < 1:
                 raise ValueError(
-                    '`bins[{}]` must be positive, when an integer'.format(i))
+                    f'`bins[{i}]` must be positive, when an integer')
             smin, smax = _get_outer_edges(sample[:, i], range[i])
             try:
                 n = operator.index(bins[i])
 
             except TypeError as e:
                 raise TypeError(
-                    "`bins[{}]` must be an integer, when a scalar".format(i)
+                    f"`bins[{i}]` must be an integer, when a scalar"
                 ) from e
 
             edges[i] = np.linspace(smin, smax, n + 1)
@@ -1027,11 +1026,10 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
             edges[i] = np.asarray(bins[i])
             if np.any(edges[i][:-1] > edges[i][1:]):
                 raise ValueError(
-                    '`bins[{}]` must be monotonically increasing, when an array'
-                    .format(i))
+                    f'`bins[{i}]` must be monotonically increasing, when an array')
         else:
             raise ValueError(
-                '`bins[{}]` must be a scalar or 1d array'.format(i))
+                f'`bins[{i}]` must be a scalar or 1d array')
 
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])

--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -399,7 +399,7 @@ class AxisConcatenator:
                         continue
                     except Exception as e:
                         raise ValueError(
-                            "unknown special directive {!r}".format(item)
+                            f"unknown special directive {item!r}"
                         ) from e
                 try:
                     axis = int(item)

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -19,7 +19,7 @@ def _binary_method(ufunc, name):
         if _disables_array_ufunc(other):
             return NotImplemented
         return ufunc(self, other)
-    func.__name__ = '__{}__'.format(name)
+    func.__name__ = f'__{name}__'
     return func
 
 
@@ -29,7 +29,7 @@ def _reflected_binary_method(ufunc, name):
         if _disables_array_ufunc(other):
             return NotImplemented
         return ufunc(other, self)
-    func.__name__ = '__r{}__'.format(name)
+    func.__name__ = f'__r{name}__'
     return func
 
 
@@ -37,7 +37,7 @@ def _inplace_binary_method(ufunc, name):
     """Implement an in-place binary method with a ufunc, e.g., __iadd__."""
     def func(self, other):
         return ufunc(self, other, out=(self,))
-    func.__name__ = '__i{}__'.format(name)
+    func.__name__ = f'__i{name}__'
     return func
 
 
@@ -52,7 +52,7 @@ def _unary_method(ufunc, name):
     """Implement a unary special method with a ufunc."""
     def func(self):
         return ufunc(self)
-    func.__name__ = '__{}__'.format(name)
+    func.__name__ = f'__{name}__'
     return func
 
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1009,7 +1009,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
         raise NotImplementedError("arr with no fields is not supported")
 
     dts, counts, offsets = zip(*fields)
-    names = ['f{}'.format(n) for n in range(n_fields)]
+    names = [f'f{n}' for n in range(n_fields)]
 
     if dtype is None:
         out_dtype = np.result_type(*[dt.base for dt in dts])
@@ -1138,7 +1138,7 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
 
     if dtype is None:
         if names is None:
-            names = ['f{}'.format(n) for n in range(n_elem)]
+            names = [f'f{n}' for n in range(n_elem)]
         out_dtype = np.dtype([(n, arr.dtype) for n in names], align=align)
         fields = _get_fields_and_offsets(out_dtype)
         dts, counts, offsets = zip(*fields)
@@ -1161,7 +1161,7 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
         if align and not out_dtype.isalignedstruct:
             raise ValueError("align was True but dtype is not aligned")
 
-    names = ['f{}'.format(n) for n in range(len(fields))]
+    names = [f'f{n}' for n in range(len(fields))]
 
     # Use a series of views and casts to convert to a structured array:
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1374,7 +1374,7 @@ def test_kwargs(mode):
     np.pad([1, 2, 3], 1, mode, **allowed)
     # Test if prohibited keyword arguments of other modes raise an error
     for key, value in not_allowed.items():
-        match = "unsupported keyword arguments for mode '{}'".format(mode)
+        match = f"unsupported keyword arguments for mode '{mode}'"
         with pytest.raises(ValueError, match=match):
             np.pad([1, 2, 3], 1, mode, **{key: value})
 
@@ -1386,7 +1386,7 @@ def test_constant_zero_default():
 
 @pytest.mark.parametrize("mode", [1, "const", object(), None, True, False])
 def test_unsupported_mode(mode):
-    match = "mode '{}' is not supported".format(mode)
+    match = f"mode '{mode}' is not supported"
     with pytest.raises(ValueError, match=match):
         np.pad([1, 2, 3], 4, mode=mode)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -170,7 +170,7 @@ class TestSetOps:
         # specifically, raise an appropriate
         # Exception when attempting to append or
         # prepend with an incompatible type
-        msg = 'dtype of `{}` must be compatible'.format(expected)
+        msg = f'dtype of `{expected}` must be compatible'
         with assert_raises_regex(TypeError, msg):
             ediff1d(ary=ary,
                     to_end=append,

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -589,8 +589,8 @@ class TestHistogramOptimBinNums:
             x = np.hstack((x1, x2, x3))
             for estimator, numbins in expectedResults.items():
                 a, b = np.histogram(x, estimator, range = (-20, 20))
-                msg = "For the {0} estimator".format(estimator)
-                msg += " with datasize of {0}".format(testlen)
+                msg = f"For the {estimator} estimator"
+                msg += f" with datasize of {testlen}"
                 assert_equal(len(a), numbins, err_msg=msg)
 
     @pytest.mark.parametrize("bins", ['auto', 'fd', 'doane', 'scott',

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -182,14 +182,14 @@ class TestNDArrayOperatorsMixin:
         for op in _ALL_BINARY_OPERATORS:
             expected = wrap_array_like(op(array, 1))
             actual = op(array_like, 1)
-            err_msg = 'failed for operator {}'.format(op)
+            err_msg = f'failed for operator {op}'
             _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
 
     def test_reflected_binary_methods(self):
         for op in _ALL_BINARY_OPERATORS:
             expected = wrap_array_like(op(2, 1))
             actual = op(2, ArrayLike(1))
-            err_msg = 'failed for operator {}'.format(op)
+            err_msg = f'failed for operator {op}'
             _assert_equal_type_and_value(expected, actual, err_msg=err_msg)
 
     def test_matmul(self):

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -314,7 +314,7 @@ class TestRecFunctions:
             return np.dtype((dt, shape))
 
         def structured(*dts):
-            return np.dtype([('x{}'.format(i), dt) for i, dt in enumerate(dts)])
+            return np.dtype([(f'x{i}', dt) for i, dt in enumerate(dts)])
 
         def inspect(dt, dtype=None):
             arr = np.zeros((), dt)

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -86,8 +86,7 @@ class FortranRoutine:
         return self._dependencies
 
     def __repr__(self):
-        return "FortranRoutine({!r}, filename={!r})".format(self.name,
-                                                            self.filename)
+        return f"FortranRoutine({self.name!r}, filename={self.filename!r})"
 
 class UnknownFortranRoutine(FortranRoutine):
     """Wrapper for a Fortran routine for which the corresponding file
@@ -363,7 +362,7 @@ def main():
         patch_file = os.path.basename(fortran_file) + '.patch'
         if os.path.exists(patch_file):
             subprocess.check_call(['patch', '-u', fortran_file, patch_file])
-            print("Patched {}".format(fortran_file))
+            print(f"Patched {fortran_file}")
         try:
             runF2C(fortran_file, output_dir)
         except F2CError:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4107,10 +4107,7 @@ class MaskedArray(ndarray):
                 'dtype': str(self.dtype)
             }
             is_structured = bool(self.dtype.names)
-            key = '{}_{}'.format(
-                'long' if is_long else 'short',
-                'flx' if is_structured else 'std'
-            )
+            key = f'{"long" if is_long else "short"}_{"flx" if is_structured else "std"}'
             return _legacy_print_templates[key] % parameters
 
         prefix = f"masked_{name}("
@@ -4178,7 +4175,7 @@ class MaskedArray(ndarray):
 
         # join keys with values and indentations
         result = ',\n'.join(
-            '{}{}={}'.format(indents[k], k, reprs[k])
+            f'{indents[k]}{k}={reprs[k]}'
             for k in keys
         )
         return prefix + result + ')'

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4107,7 +4107,10 @@ class MaskedArray(ndarray):
                 'dtype': str(self.dtype)
             }
             is_structured = bool(self.dtype.names)
-            key = f'{"long" if is_long else "short"}_{"flx" if is_structured else "std"}'
+            key = '{}_{}'.format(
+                'long' if is_long else 'short',
+                'flx' if is_structured else 'std'
+            )
             return _legacy_print_templates[key] % parameters
 
         prefix = f"masked_{name}("

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -430,7 +430,7 @@ class ABCPolyBase(abc.ABC):
     def _repr_latex_scalar(x, parens=False):
         # TODO: we're stuck with disabling math formatting until we handle
         # exponents in this function
-        return r'\text{{{}}}'.format(pu.format_float(x, parens=parens))
+        return fr'\text{{{pu.format_float(x, parens=parens)}}}'
 
     def _format_term(self, scalar_format: Callable, off: float, scale: float):
         """ Format a single term in the expansion """

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -141,12 +141,12 @@ def _make_methods(functions, modname):
             signature = '(PyObject *self, PyObject *args)'
         methods_table.append(
             "{\"%s\", (PyCFunction)%s, %s}," % (funcname, cfuncname, flags))
-        func_code = """
+        func_code = f"""
         static PyObject* {cfuncname}{signature}
         {{
         {code}
         }}
-        """.format(cfuncname=cfuncname, signature=signature, code=code)
+        """
         codes.append(func_code)
 
     body = "\n".join(codes) + """

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -866,8 +866,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
             n_elements = flagged.size if flagged.ndim != 0 else reduced.size
             percent_mismatch = 100 * n_mismatch / n_elements
             remarks = [
-                'Mismatched elements: {} / {} ({:.3g}%)'.format(
-                    n_mismatch, n_elements, percent_mismatch)]
+                f'Mismatched elements: {n_mismatch} / {n_elements} ({percent_mismatch:.3g}%)']
 
             with errstate(all='ignore'):
                 # ignore errors for non-numeric types
@@ -2654,8 +2653,7 @@ def _parse_size(size_str):
                 'kb': 1000, 'mb': 1000**2, 'gb': 1000**3, 'tb': 1000**4,
                 'kib': 1024, 'mib': 1024**2, 'gib': 1024**3, 'tib': 1024**4}
 
-    size_re = re.compile(r'^\s*(\d+|\d+\.\d+)\s*({0})\s*$'.format(
-        '|'.join(suffixes.keys())), re.I)
+    size_re = re.compile(fr'^\s*(\d+|\d+\.\d+)\s*({"|".join(suffixes.keys())})\s*$', re.I)
 
     m = size_re.match(size_str.lower())
     if not m or m.group(2) not in suffixes:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -865,8 +865,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
             n_mismatch = reduced.size - reduced.sum(dtype=intp)
             n_elements = flagged.size if flagged.ndim != 0 else reduced.size
             percent_mismatch = 100 * n_mismatch / n_elements
-            remarks = [
-                f'Mismatched elements: {n_mismatch} / {n_elements} ({percent_mismatch:.3g}%)']
+            remarks = [f'Mismatched elements: {n_mismatch} / {n_elements} '
+                       f'({percent_mismatch:.3g}%)']
 
             with errstate(all='ignore'):
                 # ignore errors for non-numeric types

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2653,7 +2653,9 @@ def _parse_size(size_str):
                 'kb': 1000, 'mb': 1000**2, 'gb': 1000**3, 'tb': 1000**4,
                 'kib': 1024, 'mib': 1024**2, 'gib': 1024**3, 'tib': 1024**4}
 
-    size_re = re.compile(fr'^\s*(\d+|\d+\.\d+)\s*({"|".join(suffixes.keys())})\s*$', re.I)
+    pipe_suffixes = "|".join(suffixes.keys())
+
+    size_re = re.compile(fr'^\s*(\d+|\d+\.\d+)\s*({pipe_suffixes})\s*$', re.I)
 
     m = size_re.match(size_str.lower())
     if not m or m.group(2) not in suffixes:


### PR DESCRIPTION
I generated this using the codemod CLI from `LibCST`: https://libcst.readthedocs.io/en/latest/

Using the following command in the root of the NumPy repo:

```bash
python3 -m libcst.tool codemod --no-format convert_format_to_fstring.ConvertFormatStringCommand .
```

along with the following config file (slightly tweaked from the default config to avoid black reformatting):

```yaml
# String that LibCST should look for in code which indicates that the
# module is generated code.
generated_code_marker: '@generated'
# Command line and arguments for invoking a code formatter. Anything
# specified here must be capable of taking code via stdin and returning
# formatted code via stdout.
formatter: []
# List of regex patterns which LibCST will evaluate against filenames to
# determine if the module should be touched.
blacklist_patterns: ["^.*numpy\/vendored-meson.*$", "^.*numpy\/distutils.*$"]
# List of modules that contain codemods inside of them.
modules:
- 'libcst.codemod.commands'
# Absolute or relative path of the repository root, used for providing
# full-repo metadata. Relative paths should be specified with this file
# location as the base.
repo_root: '.'
```

You'll also have to build LibCST from source right now because of a bug I fixed: https://github.com/Instagram/LibCST/pull/1319

As far as I can tell all the changes are purely mechanical. I really like how the transformation leaves the code nicely formatted for free.