### PR TITLE
BUG: Fix crackfortran parsing error when a division occurs within a common block

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1489,26 +1489,9 @@ def analyzeline(m, case, line):
         line = m.group('after').strip()
         if not line[0] == '/':
             line = '//' + line
+
         cl = []
-        f = 0
-        bn = ''
-        ol = ''
-        for c in line:
-            if c == '/':
-                f = f + 1
-                continue
-            if f >= 3:
-                bn = bn.strip()
-                if not bn:
-                    bn = '_BLNK_'
-                cl.append([bn, ol])
-                f = f - 2
-                bn = ''
-                ol = ''
-            if f % 2:
-                bn = bn + c
-            else:
-                ol = ol + c
+        [_, bn, ol] = re.split('/', line, maxsplit=2)
         bn = bn.strip()
         if not bn:
             bn = '_BLNK_'

--- a/numpy/f2py/tests/src/crackfortran/common_with_division.f
+++ b/numpy/f2py/tests/src/crackfortran/common_with_division.f
@@ -1,0 +1,17 @@
+      subroutine common_with_division
+      integer lmu,lb,lub,lpmin
+      parameter (lmu=1)
+      parameter (lb=20)
+c     crackfortran fails to parse this  
+c     parameter (lub=(lb-1)*lmu+1)
+c     crackfortran can successfully parse this though
+      parameter (lub=lb*lmu-lmu+1)
+      parameter (lpmin=2)
+
+c     crackfortran fails to parse this correctly 
+c     common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
+      
+      common /mortmp/ ctmp(lub/lpmin+1)
+      
+      return
+      end

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -114,12 +114,16 @@ class TestExternal(util.F2PyTest):
 
 class TestCrackFortran(util.F2PyTest):
     # gh-2848: commented lines between parameters in subroutine parameter lists
-    sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90")]
+    sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90"),
+               util.getpath("tests", "src", "crackfortran", "common_with_division.f")
+              ]
 
     def test_gh2848(self):
         r = self.module.gh2848(1, 2)
         assert r == (1, 2)
 
+    def test_common_with_division(self):
+        assert len(self.module.mortmp.ctmp) == 11
 
 class TestMarkinnerspaces:
     # gh-14118: markinnerspaces does not handle multiple quotations


### PR DESCRIPTION
Backport of #28396.

The `analyzeline` function currently passes over all `/` characters, presumably assuming they only indicate the name of the common block. However, this means division operations after the common block name are also passed over. 
For instance 
``      common /mortmp/ ctmp((lub*(lub+1)*(lub+1))/lpmin+1)
``
fails to parse correctly.

This pull request attempts to rectify this by counting the number of slashes encountered in the line and only passing over the first two.

* BUG: Fix crackpython parsing error when a division occurs within a common block

* Add test for more complicated array sizing expression

* fix typos

* Simplify tests to currently supported syntax

* Use regular expression to find common block name

* Revert from broken regular expression version to prior version, add comment

* Add space before inline comment

* Use regular expression to split line

* Add missing white space to appease linter

* More linting fixes

* Pass maxsplit as a keyword argument

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
