### PR TITLE
ENH: Improve np.linalg.det performance

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -103,6 +103,8 @@ class LinalgNorm(Benchmark):
 class LinalgSmallArrays(Benchmark):
     """ Test overhead of linalg methods for small arrays """
     def setup(self):
+        self.array_3_3 = np.eye(3) + np.arange(9.).reshape((3, 3))
+        self.array_3 = np.arange(3.)
         self.array_5 = np.arange(5.)
         self.array_5_5 = np.reshape(np.arange(25.), (5, 5))
 
@@ -111,6 +113,16 @@ class LinalgSmallArrays(Benchmark):
 
     def time_det_small_array(self):
         np.linalg.det(self.array_5_5)
+
+    def time_det_3x3(self):
+        np.linalg.det(self.array_3_3)
+
+    def time_solve_3x3(self):
+        np.linalg.solve(self.array_3_3, self.array_3)
+
+    def time_eig_3x3(self):
+        np.linalg.eig(self.array_3_3)
+
 
 class Lstsq(Benchmark):
     def setup(self):

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -154,7 +154,6 @@ def _commonType(*arrays):
         if issubclass(type_, inexact):
             if isComplexType(type_):
                 is_complex = True
-
             rt = _realType(type_, default=None)
             if rt is double:
                 result_type = double

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -199,7 +199,7 @@ def _assert_stacked_square(*arrays):
     for a in arrays:
         try:
             m, n = a.shape[-2:]
-        except:
+        except ValueError:
             raise LinAlgError('%d-dimensional array given. Array must be '
                     'at least two-dimensional' % a.ndim)
         if m != n:

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -198,10 +198,11 @@ def _assert_stacked_2d(*arrays):
 
 def _assert_stacked_square(*arrays):
     for a in arrays:
-        if a.ndim < 2:
+        try:
+            m, n = a.shape[-2:]
+        except:
             raise LinAlgError('%d-dimensional array given. Array must be '
                     'at least two-dimensional' % a.ndim)
-        m, n = a.shape[-2:]
         if m != n:
             raise LinAlgError('Last 2 dimensions of the array must be square')
 

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -152,7 +152,8 @@ def _commonType(*arrays):
     for a in arrays:
         type_ = a.dtype.type
         if issubclass(type_, inexact):
-            is_complex = is_complex or isComplexType(type_)
+            if isComplexType(type_):
+                is_complex = True
 
             rt = _realType(type_, default=None)
             if rt is double:

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -152,7 +152,7 @@ def _commonType(*arrays):
     for a in arrays:
         type_ = a.dtype.type
         if issubclass(type_, inexact):
-            is_complex = is_complex or isComplexType(type_):
+            is_complex = is_complex or isComplexType(type_)
 
             rt = _realType(type_, default=None)
             if rt is double:

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -152,8 +152,8 @@ def _commonType(*arrays):
     for a in arrays:
         type_ = a.dtype.type
         if issubclass(type_, inexact):
-            if isComplexType(type_):
-                is_complex = True
+            is_complex = is_complex or isComplexType(type_):
+
             rt = _realType(type_, default=None)
             if rt is double:
                 result_type = double
@@ -197,6 +197,9 @@ def _assert_stacked_2d(*arrays):
 
 def _assert_stacked_square(*arrays):
     for a in arrays:
+        if a.ndim < 2:
+            raise LinAlgError('%d-dimensional array given. Array must be '
+                    'at least two-dimensional' % a.ndim)
         m, n = a.shape[-2:]
         if m != n:
             raise LinAlgError('Last 2 dimensions of the array must be square')
@@ -392,7 +395,6 @@ def solve(a, b):
 
     """
     a, _ = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     b, wrap = _makearray(b)
     t, result_t = _commonType(a, b)
@@ -599,7 +601,6 @@ def inv(a):
 
     """
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
 
@@ -681,7 +682,6 @@ def matrix_power(a, n):
 
     """
     a = asanyarray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
 
     try:
@@ -830,7 +830,6 @@ def cholesky(a, /, *, upper=False):
     """
     gufunc = _umath_linalg.cholesky_up if upper else _umath_linalg.cholesky_lo
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
     signature = 'D->D' if isComplexType(t) else 'd->d'
@@ -1201,7 +1200,6 @@ def eigvals(a):
 
     """
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     _assert_finite(a)
     t, result_t = _commonType(a)
@@ -1310,7 +1308,6 @@ def eigvalsh(a, UPLO='L'):
         gufunc = _umath_linalg.eigvalsh_up
 
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
     signature = 'D->d' if isComplexType(t) else 'd->d'
@@ -1319,11 +1316,6 @@ def eigvalsh(a, UPLO='L'):
                   under='ignore'):
         w = gufunc(a, signature=signature)
     return w.astype(_realType(result_t), copy=False)
-
-def _convertarray(a):
-    t, result_t = _commonType(a)
-    a = a.astype(t).T.copy()
-    return a, t, result_t
 
 
 # Eigenvectors
@@ -1461,7 +1453,6 @@ def eig(a):
 
     """
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     _assert_finite(a)
     t, result_t = _commonType(a)
@@ -1612,7 +1603,6 @@ def eigh(a, UPLO='L'):
         raise ValueError("UPLO argument must be 'L' or 'U'")
 
     a, wrap = _makearray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
 
@@ -1978,7 +1968,6 @@ def cond(x, p=None):
     else:
         # Call inv(x) ignoring errors. The result array will
         # contain nans in the entries where inversion failed.
-        _assert_stacked_2d(x)
         _assert_stacked_square(x)
         t, result_t = _commonType(x)
         signature = 'D->D' if isComplexType(t) else 'd->d'
@@ -2318,7 +2307,6 @@ def slogdet(a):
 
     """
     a = asarray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
     real_t = _realType(result_t)
@@ -2377,7 +2365,6 @@ def det(a):
 
     """
     a = asarray(a)
-    _assert_stacked_2d(a)
     _assert_stacked_square(a)
     t, result_t = _commonType(a)
     signature = 'D->D' if isComplexType(t) else 'd->d'


### PR DESCRIPTION
We can improve performance of `np.linalg.det` for small arrays by up to 40% with 3 changes:

- Move `_assert_stacked_2d` check into `_assert_stacked_square`
- Improve performance of `_commonType` by using a cache
- Avoid `r.astype(...)` for scalar arguments making a copy of the data (and internally converting to an array and back)

In this PR we perform the first step.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
