### PR TITLE
CI: Replace QEMU armhf with native (32-bit compatibility mode)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -199,6 +199,51 @@ jobs:
       run: |
         spin test -j2 -m full -- --timeout=600 --durations=10
 
+
+  armhf_test:
+    # Tests NumPy on 32-bit ARM hard-float (armhf) via compatibility mode
+    # running on aarch64 (ARM 64-bit) GitHub runners.
+    needs: [smoke_test]
+    if: github.repository == 'numpy/numpy'
+    runs-on: ubuntu-22.04-arm
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: recursive
+        fetch-tags: true
+        persist-credentials: false
+    
+    - name: Creates new container
+      run: |
+        docker run --name the_container --interactive \
+          -v $(pwd):/numpy arm32v7/ubuntu:22.04 /bin/linux32 /bin/bash -c "
+          apt update &&
+          apt install -y ninja-build cmake git python3 python-is-python3 python3-dev python3-pip python3-venv &&
+          python -m pip install -r /numpy/requirements/build_requirements.txt &&
+          python -m pip install -r /numpy/requirements/test_requirements.txt
+        "
+        docker commit the_container the_container
+
+    - name: Meson Build
+      run: |
+        docker run --rm -e "TERM=xterm-256color" \
+          -v $(pwd):/numpy the_container \
+          /bin/script -e -q -c "/bin/linux32 /bin/bash --noprofile --norc -eo pipefail -c '
+            cd /numpy && spin build 
+          '"
+
+    - name: Meson Log
+      if: always()
+      run: 'cat build/meson-logs/meson-log.txt'
+
+    - name: Run Tests
+      run: |
+        docker run --rm -e "TERM=xterm-256color" \
+          -v $(pwd):/numpy the_container \
+          /bin/script -e -q -c "/bin/linux32 /bin/bash --noprofile --norc -eo pipefail -c '
+            cd /numpy && spin test -m full -- --timeout=600 --durations=10
+          '"
+
   benchmark:
     needs: [smoke_test]
     runs-on: ubuntu-latest

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -39,17 +39,6 @@ jobs:
       matrix:
         BUILD_PROP:
           - [
-              "armhf",
-              "arm-linux-gnueabihf",
-              "arm32v7/ubuntu:22.04",
-              "-Dallow-noblas=true",
-              # test_unary_spurious_fpexception is currently skipped
-              # FIXME(@seiko2plus): Requires confirmation for the following issue:
-              # The presence of an FP invalid exception caused by sqrt. Unsure if this is a qemu bug or not.
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_unary_spurious_fpexception",
-              "arm"
-            ]
-          - [
               "ppc64le",
               "powerpc64le-linux-gnu",
               "ppc64le/ubuntu:22.04",

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -772,34 +772,33 @@ npy__cpu_init_features_linux(void)
     #endif
     }
 #ifdef __arm__
+    npy__cpu_have[NPY_CPU_FEATURE_NEON]       = (hwcap & NPY__HWCAP_NEON)   != 0;
+    if (npy__cpu_have[NPY_CPU_FEATURE_NEON]) {
+        npy__cpu_have[NPY_CPU_FEATURE_NEON_FP16]  = (hwcap & NPY__HWCAP_HALF) != 0;
+        npy__cpu_have[NPY_CPU_FEATURE_NEON_VFPV4] = (hwcap & NPY__HWCAP_VFPv4) != 0;
+    }
     // Detect Arm8 (aarch32 state)
     if ((hwcap2 & NPY__HWCAP2_AES)  || (hwcap2 & NPY__HWCAP2_SHA1)  ||
         (hwcap2 & NPY__HWCAP2_SHA2) || (hwcap2 & NPY__HWCAP2_PMULL) ||
         (hwcap2 & NPY__HWCAP2_CRC32))
     {
-        hwcap = hwcap2;
-#else
-    if (1)
-    {
-        if (!(hwcap & (NPY__HWCAP_FP | NPY__HWCAP_ASIMD))) {
-            // Is this could happen? maybe disabled by kernel
-            // BTW this will break the baseline of AARCH64
-            return 1;
-        }
-#endif
-        npy__cpu_have[NPY_CPU_FEATURE_FPHP]       = (hwcap & NPY__HWCAP_FPHP)     != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_ASIMDHP]    = (hwcap & NPY__HWCAP_ASIMDHP)  != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_ASIMDDP]    = (hwcap & NPY__HWCAP_ASIMDDP)  != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_ASIMDFHM]   = (hwcap & NPY__HWCAP_ASIMDFHM) != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_SVE]        = (hwcap & NPY__HWCAP_SVE)      != 0;
-        npy__cpu_init_features_arm8();
-    } else {
-        npy__cpu_have[NPY_CPU_FEATURE_NEON]       = (hwcap & NPY__HWCAP_NEON)   != 0;
-        if (npy__cpu_have[NPY_CPU_FEATURE_NEON]) {
-            npy__cpu_have[NPY_CPU_FEATURE_NEON_FP16]  = (hwcap & NPY__HWCAP_HALF) != 0;
-            npy__cpu_have[NPY_CPU_FEATURE_NEON_VFPV4] = (hwcap & NPY__HWCAP_VFPv4) != 0;
-        }
+        npy__cpu_have[NPY_CPU_FEATURE_ASIMD] = npy__cpu_have[NPY_CPU_FEATURE_NEON];
     }
+#else
+    if (!(hwcap & (NPY__HWCAP_FP | NPY__HWCAP_ASIMD))) {
+        // Is this could happen? maybe disabled by kernel
+        // BTW this will break the baseline of AARCH64
+        return 1;
+    }
+    npy__cpu_init_features_arm8();
+#endif
+    npy__cpu_have[NPY_CPU_FEATURE_FPHP]       = (hwcap & NPY__HWCAP_FPHP)     != 0;
+    npy__cpu_have[NPY_CPU_FEATURE_ASIMDHP]    = (hwcap & NPY__HWCAP_ASIMDHP)  != 0;
+    npy__cpu_have[NPY_CPU_FEATURE_ASIMDDP]    = (hwcap & NPY__HWCAP_ASIMDDP)  != 0;
+    npy__cpu_have[NPY_CPU_FEATURE_ASIMDFHM]   = (hwcap & NPY__HWCAP_ASIMDFHM) != 0;
+#ifndef __arm__
+    npy__cpu_have[NPY_CPU_FEATURE_SVE]        = (hwcap & NPY__HWCAP_SVE)      != 0;
+#endif
     return 1;
 }
 #endif

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -407,8 +407,11 @@ class Test_ARM_Features(AbstractTest):
     def load_flags(self):
         self.load_flags_cpuinfo("Features")
         arch = self.get_cpuinfo_item("CPU architecture")
-        # in case of mounting virtual filesystem of aarch64 kernel
-        is_rootfs_v8 = int('0' + next(iter(arch))) > 7 if arch else 0
+        # in case of mounting virtual filesystem of aarch64 kernel without linux32
+        is_rootfs_v8 = (
+            not re.match("^armv[0-9]+l$", machine) and
+            (int('0' + next(iter(arch))) > 7 if arch else 0)
+        )
         if re.match("^(aarch64|AARCH64)", machine) or is_rootfs_v8:
             self.features_map = {
                 "NEON": "ASIMD", "HALF": "ASIMD", "VFPV4": "ASIMD"

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -1,5 +1,5 @@
 import sys
-
+import platform
 import pytest
 
 import numpy as np
@@ -14,6 +14,9 @@ from numpy.testing import (
     IS_PYPY
     )
 
+def _is_armhf():
+    # Check if the current platform is ARMHF (32-bit ARM architecture)
+    return platform.machine().startswith('arm') and platform.architecture()[0] == '32bit'
 
 class PhysicalQuantity(float):
     def __new__(cls, value):
@@ -414,6 +417,9 @@ class TestLinspace:
 
         assert_equal(linspace(one, five), linspace(1, 5))
 
+    # even when not explicitly enabled via FPSCR register
+    @pytest.mark.xfail(_is_armhf(),
+                       reason="ARMHF/AArch32 platforms seem to FTZ subnormals")
     def test_denormal_numbers(self):
         # Regression test for gh-5437. Will probably fail when compiled
         # with ICC, which flushes denormals to zero


### PR DESCRIPTION
This PR enhances support for ARM platforms with several important fixes:

1. Native ARMv7/armhf Testing: Adds a new CI workflow that tests NumPy on 32-bit ARM hard-float (armhf) using 32-bit compatibility mode on ARM64 GitHub runners, replacing the previous QEMU-based approach for more reliable and faster testing.

2. ARMv8 32-bit Feature Detection: Fixes detection of advanced ARMv8 features (FPHP, ASIMDHP, ASIMDDP, ASIMDFHM) when running in 32-bit mode (aarch32), and addresses memory leaks in CPU feature detection on Android.

3. ARM Floating-Point Error Handling: Adds protection against floating-point errors when processing positive infinity values in SIMD sqrt operations on ARMv7 architectures.

4. Subnormal Number Handling: Adds an xfail marker for linspace tests with subnormal numbers on ARM32 platforms, addressing the platform-specific behavior where subnormals are flushed to zero.

relates #24548, #28635