### PR TITLE
TYP: simplified type-aliases in ``numpy._typing``

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -18,12 +18,12 @@ else:
     from numpy._core.multiarray import StringDType
 
 _T = TypeVar("_T")
-_SCT = TypeVar("_SCT", bound=np.generic)
-_SCT_co = TypeVar("_SCT_co", bound=np.generic, covariant=True)
+_ScalarType = TypeVar("_ScalarType", bound=np.generic)
+_ScalarType_co = TypeVar("_ScalarType_co", bound=np.generic, covariant=True)
 _DType = TypeVar("_DType", bound=dtype[Any])
 _DType_co = TypeVar("_DType_co", covariant=True, bound=dtype[Any])
 
-NDArray: TypeAlias = np.ndarray[_Shape, dtype[_SCT_co]]
+NDArray: TypeAlias = np.ndarray[_Shape, dtype[_ScalarType_co]]
 
 # The `_SupportsArray` protocol only cares about the default dtype
 # (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
@@ -58,8 +58,8 @@ _FiniteNestedSequence: TypeAlias = (
 
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
 _ArrayLike: TypeAlias = (
-    _SupportsArray[dtype[_SCT]]
-    | _NestedSequence[_SupportsArray[dtype[_SCT]]]
+    _SupportsArray[dtype[_ScalarType]]
+    | _NestedSequence[_SupportsArray[dtype[_ScalarType]]]
 )
 
 # A union representing array-like objects; consists of two typevars:

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -5,22 +5,7 @@ from collections.abc import Collection, Callable, Sequence
 from typing import Any, Protocol, TypeAlias, TypeVar, runtime_checkable, TYPE_CHECKING
 
 import numpy as np
-from numpy import (
-    ndarray,
-    dtype,
-    generic,
-    unsignedinteger,
-    integer,
-    floating,
-    complexfloating,
-    number,
-    timedelta64,
-    datetime64,
-    object_,
-    void,
-    str_,
-    bytes_,
-)
+from numpy import dtype
 from ._nbit_base import _32Bit, _64Bit
 from ._nested_sequence import _NestedSequence
 from ._shape import _Shape
@@ -33,12 +18,12 @@ else:
     from numpy._core.multiarray import StringDType
 
 _T = TypeVar("_T")
-_ScalarType = TypeVar("_ScalarType", bound=generic)
-_ScalarType_co = TypeVar("_ScalarType_co", bound=generic, covariant=True)
+_SCT = TypeVar("_SCT", bound=np.generic)
+_SCT_co = TypeVar("_SCT_co", bound=np.generic, covariant=True)
 _DType = TypeVar("_DType", bound=dtype[Any])
 _DType_co = TypeVar("_DType_co", covariant=True, bound=dtype[Any])
 
-NDArray: TypeAlias = ndarray[_Shape, dtype[_ScalarType_co]]
+NDArray: TypeAlias = np.ndarray[_Shape, dtype[_SCT_co]]
 
 # The `_SupportsArray` protocol only cares about the default dtype
 # (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
@@ -47,7 +32,7 @@ NDArray: TypeAlias = ndarray[_Shape, dtype[_ScalarType_co]]
 # any and all remaining overloads
 @runtime_checkable
 class _SupportsArray(Protocol[_DType_co]):
-    def __array__(self) -> ndarray[Any, _DType_co]: ...
+    def __array__(self) -> np.ndarray[Any, _DType_co]: ...
 
 
 @runtime_checkable
@@ -73,8 +58,8 @@ _FiniteNestedSequence: TypeAlias = (
 
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
 _ArrayLike: TypeAlias = (
-    _SupportsArray[dtype[_ScalarType]]
-    | _NestedSequence[_SupportsArray[dtype[_ScalarType]]]
+    _SupportsArray[dtype[_SCT]]
+    | _NestedSequence[_SupportsArray[dtype[_SCT]]]
 )
 
 # A union representing array-like objects; consists of two typevars:
@@ -94,87 +79,33 @@ else:
     class _Buffer(Protocol):
         def __buffer__(self, flags: int, /) -> memoryview: ...
 
-ArrayLike: TypeAlias = _Buffer | _DualArrayLike[
-    dtype[Any],
-    bool | int | float | complex | str | bytes,
-]
+ArrayLike: TypeAlias = _Buffer | _DualArrayLike[dtype[Any], complex | bytes | str]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`
-_ArrayLikeBool_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool],
-    bool,
-]
-_ArrayLikeUInt_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool] | dtype[unsignedinteger[Any]],
-    bool,
-]
-_ArrayLikeInt_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool] | dtype[integer[Any]],
-    bool | int,
-]
-_ArrayLikeFloat_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool] | dtype[integer[Any]] | dtype[floating[Any]],
-    bool | int | float,
-]
-_ArrayLikeComplex_co: TypeAlias = _DualArrayLike[
-    (
-        dtype[np.bool]
-        | dtype[integer[Any]]
-        | dtype[floating[Any]]
-        | dtype[complexfloating[Any, Any]]
-    ),
-    bool | int | float | complex,
-]
-_ArrayLikeNumber_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool] | dtype[number[Any]],
-    bool | int | float | complex,
-]
-_ArrayLikeTD64_co: TypeAlias = _DualArrayLike[
-    dtype[np.bool] | dtype[integer[Any]] | dtype[timedelta64],
-    bool | int,
-]
-_ArrayLikeDT64_co: TypeAlias = (
-    _SupportsArray[dtype[datetime64]]
-    | _NestedSequence[_SupportsArray[dtype[datetime64]]]
-)
-_ArrayLikeObject_co: TypeAlias = (
-    _SupportsArray[dtype[object_]]
-    | _NestedSequence[_SupportsArray[dtype[object_]]]
-)
+_ArrayLikeBool_co: TypeAlias = _DualArrayLike[dtype[np.bool], bool]
+_ArrayLikeUInt_co: TypeAlias = _DualArrayLike[dtype[np.bool | np.unsignedinteger], bool]
+_ArrayLikeInt_co: TypeAlias = _DualArrayLike[dtype[np.bool | np.integer], int]
+_ArrayLikeFloat_co: TypeAlias = _DualArrayLike[dtype[np.bool | np.integer | np.floating], float]
+_ArrayLikeComplex_co: TypeAlias = _DualArrayLike[dtype[np.bool | np.number], complex]
+_ArrayLikeNumber_co: TypeAlias = _ArrayLikeComplex_co
+_ArrayLikeTD64_co: TypeAlias = _DualArrayLike[dtype[np.bool | np.integer | np.timedelta64], int]
+_ArrayLikeDT64_co: TypeAlias = _ArrayLike[np.datetime64]
+_ArrayLikeObject_co: TypeAlias = _ArrayLike[np.object_]
 
-_ArrayLikeVoid_co: TypeAlias = (
-    _SupportsArray[dtype[void]]
-    | _NestedSequence[_SupportsArray[dtype[void]]]
-)
-_ArrayLikeStr_co: TypeAlias = _DualArrayLike[
-    dtype[str_],
-    str,
-]
-_ArrayLikeBytes_co: TypeAlias = _DualArrayLike[
-    dtype[bytes_],
-    bytes,
-]
-_ArrayLikeString_co: TypeAlias = _DualArrayLike[
-    StringDType,
-    str
-]
-_ArrayLikeAnyString_co: TypeAlias = (
-    _ArrayLikeStr_co |
-    _ArrayLikeBytes_co |
-    _ArrayLikeString_co
-)
+_ArrayLikeVoid_co: TypeAlias = _ArrayLike[np.void]
+_ArrayLikeBytes_co: TypeAlias = _DualArrayLike[dtype[np.bytes_], bytes]
+_ArrayLikeStr_co: TypeAlias = _DualArrayLike[dtype[np.str_], str]
+_ArrayLikeString_co: TypeAlias = _DualArrayLike[StringDType, str]
+_ArrayLikeAnyString_co: TypeAlias = _DualArrayLike[dtype[np.character] | StringDType, bytes | str]
 
 __Float64_co: TypeAlias = np.floating[_64Bit] | np.float32 | np.float16 | np.integer | np.bool
 __Complex128_co: TypeAlias = np.number[_64Bit] | np.number[_32Bit] | np.float16 | np.integer | np.bool
-_ArrayLikeFloat64_co: TypeAlias = _DualArrayLike[dtype[__Float64_co], float | int]
-_ArrayLikeComplex128_co: TypeAlias = _DualArrayLike[dtype[__Complex128_co], complex | float | int]
+_ArrayLikeFloat64_co: TypeAlias = _DualArrayLike[dtype[__Float64_co], float]
+_ArrayLikeComplex128_co: TypeAlias = _DualArrayLike[dtype[__Complex128_co], complex]
 
 # NOTE: This includes `builtins.bool`, but not `numpy.bool`.
-_ArrayLikeInt: TypeAlias = _DualArrayLike[
-    dtype[integer[Any]],
-    int,
-]
+_ArrayLikeInt: TypeAlias = _DualArrayLike[dtype[np.integer], int]
 
 # Extra ArrayLike type so that pyright can deal with NDArray[Any]
 # Used as the first overload, should only match NDArray[Any],
@@ -185,8 +116,4 @@ if sys.version_info >= (3, 11):
 else:
     from typing import NoReturn as _UnknownType
 
-
-_ArrayLikeUnknown: TypeAlias = _DualArrayLike[
-    dtype[_UnknownType],
-    _UnknownType,
-]
+_ArrayLikeUnknown: TypeAlias = _DualArrayLike[dtype[_UnknownType], _UnknownType]

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -1,57 +1,26 @@
 from collections.abc import Sequence  # noqa: F811
 from typing import (
     Any,
+    Protocol,
     TypeAlias,
     TypeVar,
-    Protocol,
     TypedDict,
     runtime_checkable,
 )
 
 import numpy as np
 
-from ._shape import _ShapeLike
-
 from ._char_codes import (
     _BoolCodes,
-    _UInt8Codes,
-    _UInt16Codes,
-    _UInt32Codes,
-    _UInt64Codes,
-    _Int8Codes,
-    _Int16Codes,
-    _Int32Codes,
-    _Int64Codes,
-    _Float16Codes,
-    _Float32Codes,
-    _Float64Codes,
-    _Complex64Codes,
-    _Complex128Codes,
-    _ByteCodes,
-    _ShortCodes,
-    _IntCCodes,
-    _LongCodes,
-    _LongLongCodes,
-    _IntPCodes,
-    _IntCodes,
-    _UByteCodes,
-    _UShortCodes,
-    _UIntCCodes,
-    _ULongCodes,
-    _ULongLongCodes,
-    _UIntPCodes,
-    _UIntCodes,
-    _HalfCodes,
-    _SingleCodes,
-    _DoubleCodes,
-    _LongDoubleCodes,
-    _CSingleCodes,
-    _CDoubleCodes,
-    _CLongDoubleCodes,
+    _NumberCodes,
+    _SignedIntegerCodes,
+    _UnsignedIntegerCodes,
+    _FloatingCodes,
+    _ComplexFloatingCodes,
     _DT64Codes,
     _TD64Codes,
-    _StrCodes,
     _BytesCodes,
+    _StrCodes,
     _VoidCodes,
     _ObjectCodes,
 )
@@ -86,46 +55,56 @@ class _SupportsDType(Protocol[_DType_co]):
 
 
 # A subset of `npt.DTypeLike` that can be parametrized w.r.t. `np.generic`
-_DTypeLike: TypeAlias = (
-    np.dtype[_SCT]
-    | type[_SCT]
-    | _SupportsDType[np.dtype[_SCT]]
-)
+_DTypeLike: TypeAlias = type[_SCT] | np.dtype[_SCT] | _SupportsDType[np.dtype[_SCT]]
 
 
 # Would create a dtype[np.void]
 _VoidDTypeLike: TypeAlias = (
-    # (flexible_dtype, itemsize)
-    tuple[_DTypeLikeNested, int]
-    # (fixed_dtype, shape)
-    | tuple[_DTypeLikeNested, _ShapeLike]
+    # If a tuple, then it can be either:
+    # - (flexible_dtype, itemsize)
+    # - (fixed_dtype, shape)
+    # - (base_dtype, new_dtype)
+    # But because `_DTypeLikeNested = Any`, the first two cases are redundant
+
+    # tuple[_DTypeLikeNested, int] | tuple[_DTypeLikeNested, _ShapeLike] |
+    tuple[_DTypeLikeNested, _DTypeLikeNested]
+
     # [(field_name, field_dtype, field_shape), ...]
-    #
     # The type here is quite broad because NumPy accepts quite a wide
-    # range of inputs inside the list; see the tests for some
-    # examples.
+    # range of inputs inside the list; see the tests for some examples.
     | list[Any]
-    # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
-    #  'itemsize': ...}
+
+    # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ..., 'itemsize': ...}
     | _DTypeDict
-    # (base_dtype, new_dtype)
-    | tuple[_DTypeLikeNested, _DTypeLikeNested]
 )
+
+# Aliases for commonly used dtype-like objects.
+# Note that the precision of `np.number` subclasses is ignored herein.
+_DTypeLikeBool: TypeAlias = type[bool] | _DTypeLike[np.bool] | _BoolCodes
+_DTypeLikeInt: TypeAlias = (
+    type[int] | _DTypeLike[np.signedinteger] | _SignedIntegerCodes
+)
+_DTypeLikeUInt: TypeAlias = _DTypeLike[np.unsignedinteger] | _UnsignedIntegerCodes
+_DTypeLikeFloat: TypeAlias = type[float] | _DTypeLike[np.floating] | _FloatingCodes
+_DTypeLikeComplex: TypeAlias = (
+    type[complex] | _DTypeLike[np.complexfloating] | _ComplexFloatingCodes
+)
+_DTypeLikeComplex_co: TypeAlias = (
+    type[complex] | _DTypeLike[np.bool | np.number] | _BoolCodes | _NumberCodes
+)
+_DTypeLikeDT64: TypeAlias = _DTypeLike[np.timedelta64] | _TD64Codes
+_DTypeLikeTD64: TypeAlias = _DTypeLike[np.datetime64] | _DT64Codes
+_DTypeLikeBytes: TypeAlias = type[bytes] | _DTypeLike[np.bytes_] | _BytesCodes
+_DTypeLikeStr: TypeAlias = type[str] | _DTypeLike[np.str_] | _StrCodes
+_DTypeLikeVoid: TypeAlias = (
+    type[memoryview] | _DTypeLike[np.void] | _VoidDTypeLike | _VoidCodes
+)
+_DTypeLikeObject: TypeAlias = type[object] | _DTypeLike[np.object_] | _ObjectCodes
+
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
-DTypeLike: TypeAlias = (
-    np.dtype[Any]
-    # default data type (float64)
-    | None
-    # array-scalar types and generic types
-    | type[Any]  # NOTE: We're stuck with `type[Any]` due to object dtypes
-    # anything with a dtype attribute
-    | _SupportsDType[np.dtype[Any]]
-    # character codes, type strings or comma-separated fields, e.g., 'float64'
-    | str
-    | _VoidDTypeLike
-)
+DTypeLike: TypeAlias = _DTypeLike[Any] | _VoidDTypeLike | str | None
 
 # NOTE: while it is possible to provide the dtype as a dict of
 # dtype-like objects (e.g. `{'field1': ..., 'field2': ..., ...}`),
@@ -133,117 +112,3 @@ DTypeLike: TypeAlias = (
 # therefore not included in the type-union defining `DTypeLike`.
 #
 # See https://github.com/numpy/numpy/issues/16891 for more details.
-
-# Aliases for commonly used dtype-like objects.
-# Note that the precision of `np.number` subclasses is ignored herein.
-_DTypeLikeBool: TypeAlias = (
-    type[bool]
-    | type[np.bool]
-    | np.dtype[np.bool]
-    | _SupportsDType[np.dtype[np.bool]]
-    | _BoolCodes
-)
-_DTypeLikeUInt: TypeAlias = (
-    type[np.unsignedinteger[Any]]
-    | np.dtype[np.unsignedinteger[Any]]
-    | _SupportsDType[np.dtype[np.unsignedinteger[Any]]]
-    | _UInt8Codes
-    | _UInt16Codes
-    | _UInt32Codes
-    | _UInt64Codes
-    | _UByteCodes
-    | _UShortCodes
-    | _UIntCCodes
-    | _LongCodes
-    | _ULongLongCodes
-    | _UIntPCodes
-    | _UIntCodes
-)
-_DTypeLikeInt: TypeAlias = (
-    type[int]
-    | type[np.signedinteger[Any]]
-    | np.dtype[np.signedinteger[Any]]
-    | _SupportsDType[np.dtype[np.signedinteger[Any]]]
-    | _Int8Codes
-    | _Int16Codes
-    | _Int32Codes
-    | _Int64Codes
-    | _ByteCodes
-    | _ShortCodes
-    | _IntCCodes
-    | _LongCodes
-    | _LongLongCodes
-    | _IntPCodes
-    | _IntCodes
-)
-_DTypeLikeFloat: TypeAlias = (
-    type[float]
-    | type[np.floating[Any]]
-    | np.dtype[np.floating[Any]]
-    | _SupportsDType[np.dtype[np.floating[Any]]]
-    | _Float16Codes
-    | _Float32Codes
-    | _Float64Codes
-    | _HalfCodes
-    | _SingleCodes
-    | _DoubleCodes
-    | _LongDoubleCodes
-)
-_DTypeLikeComplex: TypeAlias = (
-    type[complex]
-    | type[np.complexfloating[Any]]
-    | np.dtype[np.complexfloating[Any]]
-    | _SupportsDType[np.dtype[np.complexfloating[Any]]]
-    | _Complex64Codes
-    | _Complex128Codes
-    | _CSingleCodes
-    | _CDoubleCodes
-    | _CLongDoubleCodes
-)
-_DTypeLikeDT64: TypeAlias = (
-    type[np.timedelta64]
-    | np.dtype[np.timedelta64]
-    | _SupportsDType[np.dtype[np.timedelta64]]
-    | _TD64Codes
-)
-_DTypeLikeTD64: TypeAlias = (
-    type[np.datetime64]
-    | np.dtype[np.datetime64]
-    | _SupportsDType[np.dtype[np.datetime64]]
-    | _DT64Codes
-)
-_DTypeLikeStr: TypeAlias = (
-    type[str]
-    | type[np.str_]
-    | np.dtype[np.str_]
-    | _SupportsDType[np.dtype[np.str_]]
-    | _StrCodes
-)
-_DTypeLikeBytes: TypeAlias = (
-    type[bytes]
-    | type[np.bytes_]
-    | np.dtype[np.bytes_]
-    | _SupportsDType[np.dtype[np.bytes_]]
-    | _BytesCodes
-)
-_DTypeLikeVoid: TypeAlias = (
-    type[np.void]
-    | np.dtype[np.void]
-    | _SupportsDType[np.dtype[np.void]]
-    | _VoidCodes
-    | _VoidDTypeLike
-)
-_DTypeLikeObject: TypeAlias = (
-    type
-    | np.dtype[np.object_]
-    | _SupportsDType[np.dtype[np.object_]]
-    | _ObjectCodes
-)
-
-_DTypeLikeComplex_co: TypeAlias = (
-    _DTypeLikeBool
-    | _DTypeLikeUInt
-    | _DTypeLikeInt
-    | _DTypeLikeFloat
-    | _DTypeLikeComplex
-)

--- a/numpy/_typing/_scalars.py
+++ b/numpy/_typing/_scalars.py
@@ -4,24 +4,17 @@ import numpy as np
 
 # NOTE: `_StrLike_co` and `_BytesLike_co` are pointless, as `np.str_` and
 # `np.bytes_` are already subclasses of their builtin counterpart
-
 _CharLike_co: TypeAlias = str | bytes
 
-# The 6 `<X>Like_co` type-aliases below represent all scalars that can be
+# The `<X>Like_co` type-aliases below represent all scalars that can be
 # coerced into `<X>` (with the casting rule `same_kind`)
 _BoolLike_co: TypeAlias = bool | np.bool
-_UIntLike_co: TypeAlias = np.unsignedinteger[Any] | _BoolLike_co
-_IntLike_co: TypeAlias = int | np.integer[Any] | _BoolLike_co
-_FloatLike_co: TypeAlias = float | np.floating[Any] | _IntLike_co
-_ComplexLike_co: TypeAlias = (
-    complex
-    | np.complexfloating[Any, Any]
-    | _FloatLike_co
-)
-_TD64Like_co: TypeAlias = np.timedelta64 | _IntLike_co
-
-_NumberLike_co: TypeAlias = int | float | complex | np.number[Any] | np.bool
-_ScalarLike_co: TypeAlias = int | float | complex | str | bytes | np.generic
-
+_UIntLike_co: TypeAlias = bool | np.unsignedinteger | np.bool
+_IntLike_co: TypeAlias = int | np.integer | np.bool
+_FloatLike_co: TypeAlias = float | np.floating | np.integer | np.bool
+_ComplexLike_co: TypeAlias = complex | np.number | np.bool
+_NumberLike_co: TypeAlias = _ComplexLike_co
+_TD64Like_co: TypeAlias = int | np.timedelta64 | np.integer | np.bool
 # `_VoidLike_co` is technically not a scalar, but it's close enough
 _VoidLike_co: TypeAlias = tuple[Any, ...] | np.void
+_ScalarLike_co: TypeAlias = complex | str | bytes | np.generic


### PR DESCRIPTION
These simplification could help improve the readability of reported (error) messages of type-checkers in certain situations. Type-checker might also run slightly faster now.  

This should not affect type-inference, but it might cause different error messages to be reported.