### PR TITLE
TYP: Accept objects that ``write()`` to ``str`` in ``savetxt``

### DIFF
--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -35,7 +35,7 @@ _SCT_co = TypeVar("_SCT_co", bound=np.generic, default=Any, covariant=True)
 _FName: TypeAlias = StrPath | Iterable[str] | Iterable[bytes]
 _FNameRead: TypeAlias = StrPath | SupportsRead[str] | SupportsRead[bytes]
 _FNameWriteBytes: TypeAlias = StrPath | SupportsWrite[bytes]
-_FNameWrite: TypeAlias = _FNameWriteBytes | SupportsWrite[bytes]
+_FNameWrite: TypeAlias = _FNameWriteBytes | SupportsWrite[str]
 
 @type_check_only
 class _SupportsReadSeek(SupportsRead[_T_co], Protocol[_T_co]):
@@ -160,7 +160,7 @@ def loadtxt(
 ) -> NDArray[Any]: ...
 
 def savetxt(
-    fname: StrPath | _FNameWrite,
+    fname: _FNameWrite,
     X: ArrayLike,
     fmt: str | Sequence[str] = "%.18e",
     delimiter: str = " ",


### PR DESCRIPTION
This fixes ``np.savetxt()`` from falsely rejecting types with a ``.write(str)`` method, such as ``io.StringIO``. 

This was causing a false-positive to be reported by pyright in [`colour.io.luts.sony_spimtx.write_LUT_SonySPImtx`](https://github.com/colour-science/colour/blob/42e9e0e49f4bee38f8ab08346cd277d87b0347f9/colour/io/luts/sony_spimtx.py#L85-L131), which I noticed through https://github.com/colour-science/colour/pull/1342.