### PR TITLE
TYP: fix and improve ``numpy.lib._type_check_impl``

### DIFF
--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -2,7 +2,6 @@ from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
-from numpy._typing import _16Bit, _32Bit, _64Bit, _128Bit
 
 from typing_extensions import assert_type
 
@@ -14,7 +13,7 @@ AR_i8: npt.NDArray[np.int64]
 AR_i4: npt.NDArray[np.int32]
 AR_f2: npt.NDArray[np.float16]
 AR_f8: npt.NDArray[np.float64]
-AR_f16: npt.NDArray[np.floating[_128Bit]]
+AR_f16: npt.NDArray[np.longdouble]
 AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 
@@ -53,11 +52,8 @@ assert_type(np.nan_to_num(AR_f8, nan=1.5), npt.NDArray[np.float64])
 assert_type(np.nan_to_num(AR_LIKE_f, posinf=9999), npt.NDArray[Any])
 
 assert_type(np.real_if_close(AR_f8), npt.NDArray[np.float64])
-assert_type(
-    np.real_if_close(AR_c16),
-    npt.NDArray[np.floating[_64Bit]] | npt.NDArray[np.complexfloating[_64Bit, _64Bit]],
-)
-assert_type(np.real_if_close(AR_c8), npt.NDArray[np.float32] | npt.NDArray[np.complex64])
+assert_type(np.real_if_close(AR_c16), npt.NDArray[np.float64 | np.complex128])
+assert_type(np.real_if_close(AR_c8), npt.NDArray[np.float32 | np.complex64])
 assert_type(np.real_if_close(AR_LIKE_f), npt.NDArray[Any])
 
 assert_type(np.typename("h"), Literal["short"])
@@ -65,15 +61,9 @@ assert_type(np.typename("B"), Literal["unsigned char"])
 assert_type(np.typename("V"), Literal["void"])
 assert_type(np.typename("S1"), Literal["character"])
 
-assert_type(np.common_type(AR_i4), type[np.floating[_64Bit]])
+assert_type(np.common_type(AR_i4), type[np.float64])
 assert_type(np.common_type(AR_f2), type[np.float16])
-assert_type(np.common_type(AR_f2, AR_i4), type[np.floating[_16Bit | _64Bit]])
-assert_type(np.common_type(AR_f16, AR_i4), type[np.floating[_64Bit | _128Bit]])
-assert_type(
-    np.common_type(AR_c8, AR_f2),
-    type[np.complexfloating[_16Bit | _32Bit, _16Bit | _32Bit]],
-)
-assert_type(
-    np.common_type(AR_f2, AR_c8, AR_i4),
-    type[np.complexfloating[_16Bit | _32Bit | _64Bit, _16Bit | _32Bit | _64Bit]],
-)
+assert_type(np.common_type(AR_f2, AR_i4), type[np.float64])
+assert_type(np.common_type(AR_f16, AR_i4), type[np.longdouble])
+assert_type(np.common_type(AR_c8, AR_f2), type[np.complex64])
+assert_type(np.common_type(AR_f2, AR_c8, AR_i4), type[np.complexfloating])


### PR DESCRIPTION
Ported from numpy/numtype#171

---

This fixes some minor typing errors, incorrect `NBitBase` uses, and improves the typing annotations of the following public `numpy` functions:

- `real`, `imag`
- `iscomplex`, `isreal`
- `iscomplexobj`, `isrealobj`
- `nan_to_num`
- `real_if_close`
- `common_type`