### PR TITLE
SIMD: Resolve Highway QSort symbol linking error on aarch32/ASIMD

### DIFF
--- a/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qsort.dispatch.cpp
@@ -1,22 +1,27 @@
+#define VQSORT_ONLY_STATIC 1
+#include "hwy/highway.h"
+#include "hwy/contrib/sort/vqsort-inl.h"
+
 #include "highway_qsort.hpp"
+#include "quicksort.hpp"
 
+namespace np::highway::qsort_simd {
+template <typename T>
+void NPY_CPU_DISPATCH_CURFX(QSort)(T *arr, npy_intp size)
+{
 #if VQSORT_ENABLED
+    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending());
+#else
+    sort::Quick(arr, size);
+#endif
+}
 
-#define DISPATCH_VQSORT(TYPE) \
-template<> void NPY_CPU_DISPATCH_CURFX(QSort)(TYPE *arr, intptr_t size) \
-{ \
-    hwy::HWY_NAMESPACE::VQSortStatic(arr, size, hwy::SortAscending()); \
-} \
+template void NPY_CPU_DISPATCH_CURFX(QSort)<int32_t>(int32_t*, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSort)<uint32_t>(uint32_t*, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSort)<int64_t>(int64_t*, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSort)<uint64_t>(uint64_t*, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSort)<float>(float*, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSort)<double>(double*, npy_intp);
 
-namespace np { namespace highway { namespace qsort_simd {
+} // np::highway::qsort_simd
 
-    DISPATCH_VQSORT(int32_t)
-    DISPATCH_VQSORT(uint32_t)
-    DISPATCH_VQSORT(int64_t)
-    DISPATCH_VQSORT(uint64_t)
-    DISPATCH_VQSORT(double)
-    DISPATCH_VQSORT(float)
-
-} } } // np::highway::qsort_simd
-
-#endif // VQSORT_ENABLED

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -1,33 +1,20 @@
 #ifndef NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 #define NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
 
-#define VQSORT_ONLY_STATIC 1
-#include "hwy/highway.h"
-#include "hwy/contrib/sort/vqsort-inl.h"
-
 #include "common.hpp"
 
-#if !VQSORT_COMPILER_COMPATIBLE
-#define NPY_DISABLE_HIGHWAY_SORT
-#endif
-
-#ifndef NPY_DISABLE_HIGHWAY_SORT
-namespace np { namespace highway { namespace qsort_simd {
+namespace np::highway::qsort_simd {
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "highway_qsort.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
-NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
-
 
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "highway_qsort_16bit.dispatch.h"
 #endif
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size))
-NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T* arr, npy_intp num, npy_intp kth))
 
-} } } // np::highway::qsort_simd
+} // np::highway::qsort_simd
 
 #endif // NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP
-#endif // NPY_DISABLE_HIGHWAY_SORT

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -84,7 +84,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort_16bit.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
-            #elif !defined(NPY_DISABLE_HIGHWAY_SORT)
+            #else
                 #include "highway_qsort_16bit.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSort, <TF>);
             #endif
@@ -95,7 +95,7 @@ inline bool quicksort_dispatch(T *start, npy_intp num)
             #if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86) // x86 32-bit and 64-bit
                 #include "x86_simd_qsort.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSort, <TF>);
-            #elif !defined(NPY_DISABLE_HIGHWAY_SORT)
+            #else
                 #include "highway_qsort.dispatch.h"
                 NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSort, <TF>);
             #endif


### PR DESCRIPTION
Backport of #28671.  

The fix in numpy/meson#12 for ASIMD*(32-bit) compile-time feature detection revealed a new
  build error on aarch32 platforms:

    ImportError: /numpy/build-install/usr/lib/python3/dist-packages/numpy/_core/
    _multiarray_umath.cpython-310-arm-linux-gnueabihf.so: undefined symbol:
    _ZN2np7highway10qsort_simd11QSort_ASIMDIjEEvPT_i

  This patch prevents platform detection constants of Highway from being exposed across
  translation units with different compiler flags (baseline). This approach
  eliminates detection mismatches that were causing symbol resolution failures
  in the Highway QSort implementation.

relates numpy/meson#12

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
