### PR TITLE
TYP: add missing `"b1"` literals for `dtype[bool]`

### DIFF
--- a/numpy/_typing/_char_codes.py
+++ b/numpy/_typing/_char_codes.py
@@ -1,6 +1,10 @@
 from typing import Literal
 
-_BoolCodes = Literal["bool", "bool_", "?", "|?", "=?", "<?", ">?"]
+_BoolCodes = Literal[
+    "bool", "bool_",
+    "?", "|?", "=?", "<?", ">?",
+    "b1", "|b1", "=b1", "<b1", ">b1",
+]  # fmt: skip
 
 _UInt8Codes = Literal["uint8", "u1", "|u1", "=u1", "<u1", ">u1"]
 _UInt16Codes = Literal["uint16", "u2", "|u2", "=u2", "<u2", ">u2"]

--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -7,7 +7,7 @@ from typing import Any, Literal, TypeAlias
 import numpy as np
 from numpy.dtypes import StringDType
 
-from typing_extensions import assert_type
+from typing_extensions import LiteralString, assert_type
 
 # a combination of likely `object` dtype-like candidates (no `_co`)
 _PyObjectLike: TypeAlias = Decimal | Fraction | dt.datetime | dt.timedelta
@@ -71,6 +71,8 @@ assert_type(np.dtype(Decimal), np.dtype[np.object_])
 assert_type(np.dtype(Fraction), np.dtype[np.object_])
 
 # char-codes
+assert_type(np.dtype("?"), np.dtype[np.bool])
+assert_type(np.dtype("|b1"), np.dtype[np.bool])
 assert_type(np.dtype("u1"), np.dtype[np.uint8])
 assert_type(np.dtype("l"), np.dtype[np.long])
 assert_type(np.dtype("longlong"), np.dtype[np.longlong])
@@ -113,7 +115,7 @@ assert_type(dtype_U.base, np.dtype[Any])
 assert_type(dtype_U.subdtype, None | tuple[np.dtype[Any], tuple[int, ...]])
 assert_type(dtype_U.newbyteorder(), np.dtype[np.str_])
 assert_type(dtype_U.type, type[np.str_])
-assert_type(dtype_U.name, str)
+assert_type(dtype_U.name, LiteralString)
 assert_type(dtype_U.names, None | tuple[str, ...])
 
 assert_type(dtype_U * 0, np.dtype[np.str_])


### PR DESCRIPTION
Backport of #28674.

This fixes `np.dtype("b1")` from not being recognized by static-type-checkers as `dtype[bool]`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
