### PR TITLE
BLD: fix meson_version warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     ['numpy/_build_utils/gitversion.py'],
     check: true).stdout().strip(),
   license: 'BSD-3',
-  meson_version: '>=1.2.99',  # version in vendored-meson is 1.2.99
+  meson_version: '>=1.5.2',  # version in vendored-meson is 1.5.2
   default_options: [
     'buildtype=debugoptimized',
     'b_ndebug=if-release',


### PR DESCRIPTION
Closes gh-26223.

It looks like gh-26464 didn't deal with the warning in the linked issue because `project.meson_version` wasn't updated.

Version taken from https://github.com/numpy/meson/blob/0d93515fb826440d19707eee47fd92655fe2f166/mesonbuild/coredata.py#L75.

cc @charris