### PR TITLE
DOC: linalg.matrix_transpose: add alias note

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3396,7 +3396,12 @@ def matrix_transpose(x, /):
     return _core_matrix_transpose(x)
 
 
-matrix_transpose.__doc__ = _core_matrix_transpose.__doc__
+matrix_transpose.__doc__ = _core_matrix_transpose.__doc__ + ("""
+
+    Notes
+    -----
+    This function is an alias of `numpy.matrix_transpose`.
+""")
 
 
 # matrix_norm

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3396,12 +3396,12 @@ def matrix_transpose(x, /):
     return _core_matrix_transpose(x)
 
 
-matrix_transpose.__doc__ = _core_matrix_transpose.__doc__ + ("""
+matrix_transpose.__doc__ = f"""{_core_matrix_transpose.__doc__}
 
     Notes
     -----
     This function is an alias of `numpy.matrix_transpose`.
-""")
+"""
 
 
 # matrix_norm


### PR DESCRIPTION
<img width="743" alt="image" src="https://github.com/user-attachments/assets/528f4411-e2a2-49b4-b9a8-ee83f1442d28" />

This alleviates the problem that the examples use a different function.

cc @mtsokol 