### PR TITLE
WIP, MAINT: scalar float str match array

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -705,7 +705,7 @@ format_@name@(@type@ val, npy_bool scientific,
     }
     else {
         return Dragon4_Positional_@Name@(&val,
-                        DigitMode_Unique, CutoffMode_TotalLength, precision,
+                        DigitMode_Exact, CutoffMode_TotalLength, precision,
                         -1, sign, trim, pad_left, pad_right);
     }
 }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -704,9 +704,16 @@ format_@name@(@type@ val, npy_bool scientific,
                         sign, trim, pad_left, exp_digits);
     }
     else {
-        return Dragon4_Positional_@Name@(&val,
-                        DigitMode_Exact, CutoffMode_TotalLength, precision,
-                        -1, sign, trim, pad_left, pad_right);
+        if (val == (long long)val) {
+            return Dragon4_Positional_@Name@(&val,
+                            DigitMode_Exact, CutoffMode_TotalLength, precision,
+                            -1, sign, trim, pad_left, pad_right);
+        }
+        else {
+            return Dragon4_Positional_@Name@(&val,
+                            DigitMode_Unique, CutoffMode_TotalLength, precision,
+                            -1, sign, trim, pad_left, pad_right);
+        }
     }
 }
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -686,7 +686,7 @@ class TestAssignment:
         # the expected precision.
         a = np.zeros(1, dtype='S20')
         a[:] = np.array(['1.12345678901234567890'], dtype='f8')
-        assert_equal(a[0], b"1.1234567890123457")
+        assert_equal(a[0], b"1.123456789012345691")
 
 
 class TestDtypedescr:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -686,7 +686,7 @@ class TestAssignment:
         # the expected precision.
         a = np.zeros(1, dtype='S20')
         a[:] = np.array(['1.12345678901234567890'], dtype='f8')
-        assert_equal(a[0], b"1.123456789012345691")
+        assert_equal(a[0], b"1.1234567890123457")
 
 
 class TestDtypedescr:

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -677,23 +677,22 @@ def test_unsized_integer_casts(typename, signed):
 
 
 @pytest.mark.parametrize(
-    "typename, exp_repr",
+    "typename",
     [
         pytest.param(
             "longdouble",
-            "0.1000000000000000055511151231257827021181583404541015625",
             marks=pytest.mark.xfail(
                 np.dtypes.LongDoubleDType() != np.dtypes.Float64DType(),
                 reason="numpy lacks an ld2a implementation",
                 strict=True,
             ),
         ),
-        ("float64", "0.1000000000000000055511151231257827021181583404541015625"),
-        ("float32", "0.100000001490116119384765625"),
-        ("float16", "0.0999755859375"),
+        "float64",
+        "float32",
+        "float16",
     ],
 )
-def test_float_casts(typename, exp_repr):
+def test_float_casts(typename):
     inp = [1.1, 2.8, -3.2, 2.7e4]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
@@ -702,7 +701,10 @@ def test_float_casts(typename, exp_repr):
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == exp_repr
+    if typename == "float16":
+        assert sres[0] == "0.0999755859375"
+    else:
+        assert sres[0] == "0.1"
 
     if typename == "longdouble":
         # let's not worry about platform-dependent rounding of longdouble
@@ -733,19 +735,16 @@ def test_float_nan_cast_na_object():
     inp = [1.2, 2.3, np.nan]
     arr = np.array(inp).astype(dt)
     assert arr[2] is np.nan
-    assert arr[0] == '1.1999999999999999555910790149937383830547332763671875'
+    assert arr[0] == '1.2'
 
 
 @pytest.mark.parametrize(
-    "typename, exp_repr",
+    "typename",
     [
-        ("csingle",
-         "(0.100000001490116119384765625+0.100000001490116119384765625j)"),
-        ("cdouble",
-         "(0.1000000000000000055511151231257827021181583404541015625+0.1000000000000000055511151231257827021181583404541015625j)"),
+        "csingle",
+        "cdouble",
         pytest.param(
             "clongdouble",
-            "(0.1000000000000000055511151231257827021181583404541015625+0.1000000000000000055511151231257827021181583404541015625j)",
             marks=pytest.mark.xfail(
                 np.dtypes.CLongDoubleDType() != np.dtypes.Complex128DType(),
                 reason="numpy lacks an ld2a implementation",
@@ -754,7 +753,7 @@ def test_float_nan_cast_na_object():
         ),
     ],
 )
-def test_cfloat_casts(typename, exp_repr):
+def test_cfloat_casts(typename):
     inp = [1.1 + 1.1j, 2.8 + 2.8j, -3.2 - 3.2j, 2.7e4 + 2.7e4j]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
@@ -763,7 +762,7 @@ def test_cfloat_casts(typename, exp_repr):
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == exp_repr
+    assert sres[0] == "(0.1+0.1j)"
 
 
 def test_take(string_list):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -677,22 +677,23 @@ def test_unsized_integer_casts(typename, signed):
 
 
 @pytest.mark.parametrize(
-    "typename",
+    "typename, exp_repr",
     [
         pytest.param(
             "longdouble",
+            "0.1000000000000000055511151231257827021181583404541015625",
             marks=pytest.mark.xfail(
                 np.dtypes.LongDoubleDType() != np.dtypes.Float64DType(),
                 reason="numpy lacks an ld2a implementation",
                 strict=True,
             ),
         ),
-        "float64",
-        "float32",
-        "float16",
+        ("float64", "0.1000000000000000055511151231257827021181583404541015625"),
+        ("float32", "0.100000001490116119384765625"),
+        ("float16", "0.0999755859375"),
     ],
 )
-def test_float_casts(typename):
+def test_float_casts(typename, exp_repr):
     inp = [1.1, 2.8, -3.2, 2.7e4]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
@@ -701,7 +702,7 @@ def test_float_casts(typename):
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == "0.1"
+    assert sres[0] == exp_repr
 
     if typename == "longdouble":
         # let's not worry about platform-dependent rounding of longdouble
@@ -732,16 +733,19 @@ def test_float_nan_cast_na_object():
     inp = [1.2, 2.3, np.nan]
     arr = np.array(inp).astype(dt)
     assert arr[2] is np.nan
-    assert arr[0] == '1.2'
+    assert arr[0] == '1.1999999999999999555910790149937383830547332763671875'
 
 
 @pytest.mark.parametrize(
-    "typename",
+    "typename, exp_repr",
     [
-        "csingle",
-        "cdouble",
+        ("csingle",
+         "(0.100000001490116119384765625+0.100000001490116119384765625j)"),
+        ("cdouble",
+         "(0.1000000000000000055511151231257827021181583404541015625+0.1000000000000000055511151231257827021181583404541015625j)"),
         pytest.param(
             "clongdouble",
+            "(0.1000000000000000055511151231257827021181583404541015625+0.1000000000000000055511151231257827021181583404541015625j)",
             marks=pytest.mark.xfail(
                 np.dtypes.CLongDoubleDType() != np.dtypes.Complex128DType(),
                 reason="numpy lacks an ld2a implementation",
@@ -750,7 +754,7 @@ def test_float_nan_cast_na_object():
         ),
     ],
 )
-def test_cfloat_casts(typename):
+def test_cfloat_casts(typename, exp_repr):
     inp = [1.1 + 1.1j, 2.8 + 2.8j, -3.2 - 3.2j, 2.7e4 + 2.7e4j]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
@@ -759,7 +763,7 @@ def test_cfloat_casts(typename):
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == "(0.1+0.1j)"
+    assert sres[0] == exp_repr
 
 
 def test_take(string_list):


### PR DESCRIPTION
* Fixes gh-28679, but mostly an initial demo for now...

* This patch sends scalar floating point string representations through the exact dragon representation path rather than the unique path for the reasons outlined in the matching ticket. It does not concern itself with whether the final `integer.0` is printed or excluded via `integer.`. The main argument in favor is that it is pretty weird to follow a different path for 0-D arrays vs. multi-element arrays. The main argument against is likely the potential shenanigans this kind of large-scale reprsentation change could entail downstream if folks already have shims around it and if the rounded representations are not truly bugs but just different design decisions. Also, the impact on round-tripping behaviors in some cases looks like it may cause quite some degree of annoyance for us based on remaining local test failures for this branch.

* A `hypothesis` test was added that fails before and passes after the switch to the exact scalar float representations. `hypothesis` was chosen because the idiosyncrasies of asymmetric IEEE floating point number lines are well known and trying to test them with a few hard-coded manual cases seems like a recipe for missing something.

* I think the NumPy team tends not to like partial fixes, so if we do this we may also want to apply the same decision to scientific notation representations, which I have not touched here yet, but the changes here should suffice to provide enough of a preview for decision making on the matter.

* The `stringdtype` testing changes are rather egregious, so that's probably enough of a sample of potential drawbacks to weigh the design considerations for feedback. More gruesome changes would likely be needed for other tests based on local experiments--I see some other failures related to array/scalar/string round-tripping guarantees that would need careful thought and that are broken by this set of adjustments.

[ci skip] [skip ci]