### PR TITLE
ENH: Improve performance for np.result_type

### DIFF
--- a/numpy/_core/src/common/get_attr_string.h
+++ b/numpy/_core/src/common/get_attr_string.h
@@ -3,7 +3,6 @@
 
 #include <Python.h>
 #include "npy_pycompat.h"
-#include "numpy/ndarraytypes.h"
 
 
 static inline npy_bool
@@ -60,11 +59,6 @@ PyArray_LookupSpecial(
         return 0;
     }
 
-    /* We do not need to check for special attributes on array descriptor types */
-    if (PyObject_TypeCheck(tp, &PyArrayDTypeMeta_Type)) {
-        *res = NULL;
-        return 0;
-    }
     return PyObject_GetOptionalAttr((PyObject *)tp, name_unicode, res);
 }
 

--- a/numpy/_core/src/common/get_attr_string.h
+++ b/numpy/_core/src/common/get_attr_string.h
@@ -3,6 +3,7 @@
 
 #include <Python.h>
 #include "npy_pycompat.h"
+#include "numpy/ndarraytypes.h"
 
 
 static inline npy_bool
@@ -59,6 +60,11 @@ PyArray_LookupSpecial(
         return 0;
     }
 
+    /* We do not need to check for special attributes on array descriptor types */
+    if (PyObject_TypeCheck(tp, &PyArrayDTypeMeta_Type)) {
+        *res = NULL;
+        return 0;
+    }
     return PyObject_GetOptionalAttr((PyObject *)tp, name_unicode, res);
 }
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -1597,13 +1597,12 @@ PyArray_ResultType(
         return NULL;
     }
 
-    PyArray_DTypeMeta **all_DTypes = (PyArray_DTypeMeta **)workspace;
+    PyArray_DTypeMeta **all_DTypes = (PyArray_DTypeMeta **)workspace; // borrowed references
     PyArray_Descr **all_descriptors = (PyArray_Descr **)(&all_DTypes[narrs+ndtypes]);
 
     /* Copy all dtypes into a single array defining non-value-based behaviour */
     for (npy_intp i=0; i < ndtypes; i++) {
         all_DTypes[i] = NPY_DTYPE(descrs[i]);
-        Py_INCREF(all_DTypes[i]);
         all_descriptors[i] = descrs[i];
     }
 
@@ -1628,14 +1627,10 @@ PyArray_ResultType(
             all_descriptors[i_all] = PyArray_DTYPE(arrs[i]);
             all_DTypes[i_all] = NPY_DTYPE(all_descriptors[i_all]);
         }
-        Py_INCREF(all_DTypes[i_all]);
     }
 
     PyArray_DTypeMeta *common_dtype = PyArray_PromoteDTypeSequence(
             narrs+ndtypes, all_DTypes);
-    for (npy_intp i=0; i < narrs+ndtypes; i++) {
-        Py_DECREF(all_DTypes[i]);
-    }
     if (common_dtype == NULL) {
         goto error;
     }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3583,7 +3583,6 @@ static PyObject *
 array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len)
 {
     npy_intp i, narr = 0, ndtypes = 0;
-    PyArrayObject **arr = NULL;
     PyArray_Descr **dtypes = NULL;
     PyObject *ret = NULL;
 
@@ -3593,7 +3592,10 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
         goto finish;
     }
 
-    arr = PyArray_malloc(2 * len * sizeof(void *));
+    NPY_ALLOC_WORKSPACE(arr, PyArrayObject *, 2 * 3, 2 * len);
+    if (arr == NULL) {
+        return NULL;
+    }
     if (arr == NULL) {
         return PyErr_NoMemory();
     }
@@ -3636,7 +3638,7 @@ finish:
     for (i = 0; i < ndtypes; ++i) {
         Py_DECREF(dtypes[i]);
     }
-    PyArray_free(arr);
+    npy_free_workspace(arr);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3583,13 +3583,12 @@ static PyObject *
 array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len)
 {
     npy_intp i, narr = 0, ndtypes = 0;
-    PyArray_Descr **dtypes = NULL;
     PyObject *ret = NULL;
 
     if (len == 0) {
         PyErr_SetString(PyExc_ValueError,
                         "at least one array or dtype is required");
-        goto finish;
+        return NULL;
     }
 
     NPY_ALLOC_WORKSPACE(arr, PyArrayObject *, 2 * 3, 2 * len);
@@ -3599,7 +3598,7 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
     if (arr == NULL) {
         return PyErr_NoMemory();
     }
-    dtypes = (PyArray_Descr**)&arr[len];
+    PyArray_Descr **dtypes = (PyArray_Descr**)&arr[len];
 
     PyObject *previous_obj = NULL;
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3595,17 +3595,15 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
     if (arr == NULL) {
         return NULL;
     }
-    if (arr == NULL) {
-        return PyErr_NoMemory();
-    }
     PyArray_Descr **dtypes = (PyArray_Descr**)&arr[len];
 
     PyObject *previous_obj = NULL;
 
     for (i = 0; i < len; ++i) {
         PyObject *obj = args[i];
-        if (obj == previous_obj)
+        if (obj == previous_obj) {
             continue;
+        }
 
         if (PyArray_Check(obj)) {
             Py_INCREF(obj);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3601,8 +3601,13 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
     }
     dtypes = (PyArray_Descr**)&arr[len];
 
+    PyObject *previous_obj = NULL;
+
     for (i = 0; i < len; ++i) {
         PyObject *obj = args[i];
+        if (obj == previous_obj)
+            continue;
+
         if (PyArray_Check(obj)) {
             Py_INCREF(obj);
             arr[narr] = (PyArrayObject *)obj;


### PR DESCRIPTION
Improve performance of  `np.result_type`

* Use `NPY_ALLOC_WORKSPACE` in `array_result_type`
* Avoid increfs/decrefs in `PyArray_ResultType`
* ~~Fast path for array method lookup on dtypes~~
* Fast path for identical arguments to `np.result_type`

Benchmark:
```
result_type(x): Mean +- std dev: [main] 156 ns +- 8 ns -> [pr] 135 ns +- 2 ns: 1.16x faster
result_type(x, x): Mean +- std dev: [main] 195 ns +- 5 ns -> [pr] 150 ns +- 4 ns: 1.30x faster
result_type(x, x32): Mean +- std dev: [main] 207 ns +- 5 ns -> [pr] 174 ns +- 5 ns: 1.18x faster
result_type(x, x32, x): Mean +- std dev: [main] 224 ns +- 11 ns -> [pr] 191 ns +- 5 ns: 1.17x faster
result_type(d, d): Mean +- std dev: [main] 269 ns +- 12 ns -> [pr] 177 ns +- 7 ns: 1.52x faster
result_type(d, d32): Mean +- std dev: [main] 276 ns +- 10 ns -> [pr] 214 ns +- 6 ns: 1.29x faster
result_type(d, d32, x): Mean +- std dev: [main] 303 ns +- 11 ns -> [pr] 245 ns +- 9 ns: 1.23x faster

Geometric mean: 1.26x faster
```
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
