### PR TITLE
MAINT: `%i` → `%d`

### DIFF
--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -103,7 +103,7 @@ class _DeprecationTestCase:
                         "expected %s but got: %s" %
                         (self.warning_cls.__name__, warning.category))
         if num is not None and num_found != num:
-            msg = "%i warnings found but %i expected." % (len(self.log), num)
+            msg = "%d warnings found but %d expected." % (len(self.log), num)
             lst = [str(w) for w in self.log]
             raise AssertionError("\n".join([msg] + lst))
 

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -103,7 +103,7 @@ class _DeprecationTestCase:
                         "expected %s but got: %s" %
                         (self.warning_cls.__name__, warning.category))
         if num is not None and num_found != num:
-            msg = "%d warnings found but %d expected." % (len(self.log), num)
+            msg = f"{len(self.log)} warnings found but {num} expected."
             lst = [str(w) for w in self.log]
             raise AssertionError("\n".join([msg] + lst))
 


### PR DESCRIPTION
While the [Format Specification Mini-Language](https://docs.python.org/3.13/library/string.html#formatspec) still supports `%i` for backwards compatibility, it has been removed from documentation.