### PR TITLE
MAINT: remove use of ld_classic on macOS

### DIFF
--- a/doc/release/upcoming_changes/28713.change.rst
+++ b/doc/release/upcoming_changes/28713.change.rst
@@ -1,0 +1,1 @@
+Remove use of -Wl,-ld_classic on macOS. This hack is no longer needed by Spack, and results in libraries that cannot link to other libraries built with ld (new).

--- a/meson.build
+++ b/meson.build
@@ -82,11 +82,5 @@ if cc_id.startswith('clang')
   endif
 endif
 
-if host_machine.system() == 'darwin' and cc.has_link_argument('-Wl,-ld_classic')
-  # New linker introduced in macOS 14 not working yet with at least OpenBLAS in Spack,
-  # see gh-24964 (and linked scipy issue from there).
-  add_project_link_arguments('-Wl,-ld_classic', language : ['c', 'cpp'])
-endif
-
 subdir('meson_cpu')
 subdir('numpy')


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/49983
Partially reverts https://github.com/numpy/numpy/pull/24967

On macOS, if one package uses ld (classic), all packages that link to it must also use ld (classic), otherwise you encounter issues with duplicate rpaths. Spack's OpenBLAS package no longer uses ld (classic), therefore numpy must also use ld (new) in order to build.

I _think_ this issue only matters for people who use rpath, which is mostly Spack.

@rgommers 