### PR TITLE
STY: Apply assorted ruff/refurb rules (FURB)

### DIFF
--- a/numpy/_build_utils/tempita/_tempita.py
+++ b/numpy/_build_utils/tempita/_tempita.py
@@ -841,8 +841,7 @@ def parse_cond(tokens, name, context):
 def parse_one_cond(tokens, name, context):
     (first, pos), tokens = tokens[0], tokens[1:]
     content = []
-    if first.endswith(":"):
-        first = first[:-1]
+    first = first.removesuffix(":")
     if first.startswith("if "):
         part = ("if", pos, first[3:].lstrip(), content)
     elif first.startswith("elif "):
@@ -870,8 +869,7 @@ def parse_for(tokens, name, context):
     context = ("for",) + context
     content = []
     assert first.startswith("for "), first
-    if first.endswith(":"):
-        first = first[:-1]
+    first = first.removesuffix(":")
     first = first[3:].strip()
     match = in_re.search(first)
     if not match:
@@ -932,8 +930,7 @@ def parse_def(tokens, name, context):
     tokens = tokens[1:]
     assert first.startswith("def ")
     first = first.split(None, 1)[1]
-    if first.endswith(":"):
-        first = first[:-1]
+    first = first.removesuffix(":")
     if "(" not in first:
         func_name = first
         sig = ((), None, None, {})

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2091,7 +2091,7 @@ def binary_repr(num, width=None):
         return '0' * (width or 1)
 
     elif num > 0:
-        binary = bin(num)[2:]
+        binary = f'{num:b}'
         binwidth = len(binary)
         outwidth = (binwidth if width is None
                     else builtins.max(binwidth, width))
@@ -2100,10 +2100,10 @@ def binary_repr(num, width=None):
 
     else:
         if width is None:
-            return '-' + bin(-num)[2:]
+            return f'-{-num:b}'
 
         else:
-            poswidth = len(bin(-num)[2:])
+            poswidth = len(f'{-num:b}')
 
             # See gh-8679: remove extra digit
             # for numbers at boundaries.
@@ -2111,7 +2111,7 @@ def binary_repr(num, width=None):
                 poswidth -= 1
 
             twocomp = 2**(poswidth + 1) + num
-            binary = bin(twocomp)[2:]
+            binary = f'{twocomp:b}'
             binwidth = len(binary)
 
             outwidth = builtins.max(binwidth, width)

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -194,7 +194,7 @@ class TestBitCount:
     def test_small(self, itype):
         for a in range(max(np.iinfo(itype).min, 0), 128):
             msg = f"Smoke test for {itype}({a}).bit_count()"
-            assert itype(a).bit_count() == bin(a).count("1"), msg
+            assert itype(a).bit_count() == a.bit_count(), msg
 
     def test_bit_count(self):
         for exp in [10, 17, 63]:

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -68,7 +68,7 @@ class TestTypes:
                             (k, np.dtype(atype).char, l, np.dtype(btype).char))
 
     def test_type_create(self):
-        for k, atype in enumerate(types):
+        for atype in types:
             a = np.array([1, 2, 3], atype)
             b = atype([1, 2, 3])
             assert_equal(a, b)

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1434,8 +1434,7 @@ def analyzeline(m, case, line):
         last_name = None
         for l in ll:
             l[0], l[1] = l[0].strip(), l[1].strip()
-            if l[0].startswith(','):
-                l[0] = l[0][1:]
+            l[0] = l[0].removeprefix(',')
             if l[0].startswith('('):
                 outmess('analyzeline: implied-DO list "%s" is not supported. Skipping.\n' % l[0])
                 continue

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1433,8 +1433,7 @@ def analyzeline(m, case, line):
         vars = groupcache[groupcounter].get('vars', {})
         last_name = None
         for l in ll:
-            l[0], l[1] = l[0].strip(), l[1].strip()
-            l[0] = l[0].removeprefix(',')
+            l[0], l[1] = l[0].strip().removeprefix(','), l[1].strip()
             if l[0].startswith('('):
                 outmess('analyzeline: implied-DO list "%s" is not supported. Skipping.\n' % l[0])
                 continue

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1621,8 +1621,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             for row in X:
                 row2 = []
                 for number in row:
-                    row2.append(number.real)
-                    row2.append(number.imag)
+                    row2.extend((number.real, number.imag))
                 s = format % tuple(row2) + newline
                 fh.write(s.replace('+-', '-'))
         else:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -2384,7 +2384,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     column_types[i] = np.bytes_
 
         # Update string types to be the right length
-        sized_column_types = column_types[:]
+        sized_column_types = column_types.copy()
         for i, col_type in enumerate(column_types):
             if np.issubdtype(col_type, np.character):
                 n_chars = max(len(row[i]) for row in data)

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -1290,8 +1290,7 @@ class poly1d:
 
         def fmt_float(q):
             s = '%.4g' % q
-            if s.endswith('.0000'):
-                s = s[:-5]
+            s = s.removesuffix('.0000')
             return s
 
         for k, coeff in enumerate(coeffs):

--- a/numpy/lib/mixins.pyi
+++ b/numpy/lib/mixins.pyi
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Literal as L, Any
 
 from numpy import ufunc
@@ -12,7 +12,7 @@ __all__ = ["NDArrayOperatorsMixin"]
 # completely dependent on how `__array_ufunc__` is implemented.
 # As such, only little type safety can be provided here.
 
-class NDArrayOperatorsMixin(metaclass=ABCMeta):
+class NDArrayOperatorsMixin(ABC):
     @abstractmethod
     def __array_ufunc__(
         self,

--- a/numpy/polynomial/_polybase.pyi
+++ b/numpy/polynomial/_polybase.pyi
@@ -58,7 +58,7 @@ _Other = TypeVar("_Other", bound=ABCPolyBase)
 _AnyOther: TypeAlias = ABCPolyBase | _CoefLike_co | _SeriesLikeCoef_co
 _Hundred: TypeAlias = Literal[100]
 
-class ABCPolyBase(Generic[_NameCo], metaclass=abc.ABCMeta):
+class ABCPolyBase(Generic[_NameCo], abc.ABC):
     __hash__: ClassVar[None]  # type: ignore[assignment]
     __array_ufunc__: ClassVar[None]
 


### PR DESCRIPTION
Some rules have been triggered by changing the minimum Python version to 3.11, for example [FURB188](https://docs.astral.sh/ruff/rules/slice-to-remove-prefix-or-suffix/).

I have left out these rules for now:
- [FURB101](https://docs.astral.sh/ruff/rules/read-whole-file/)
- [FURB103](https://docs.astral.sh/ruff/rules/write-whole-file/)
- [FURB105](https://docs.astral.sh/ruff/rules/print-empty-string/)
- [FURB110](https://docs.astral.sh/ruff/rules/if-exp-instead-of-or-operator/)
- [FURB113](https://docs.astral.sh/ruff/rules/repeated-append/)  (applied partially)
- [FURB116](https://docs.astral.sh/ruff/rules/f-string-number-format/)  (applied partially)
- [FURB118](https://docs.astral.sh/ruff/rules/reimplemented-operator/)
- [FURB122](https://docs.astral.sh/ruff/rules/for-loop-writes/)
- [FURB140](https://docs.astral.sh/ruff/rules/reimplemented-starmap/)
- [FURB152](https://docs.astral.sh/ruff/rules/math-constant/)
- [FURB154](https://docs.astral.sh/ruff/rules/repeated-global/)
- [FURB156](https://docs.astral.sh/ruff/rules/hardcoded-string-charset/)
- [FURB167](https://docs.astral.sh/ruff/rules/regex-flag-alias/)
- [FURB171](https://docs.astral.sh/ruff/rules/single-item-membership-test/)
- [FURB189](https://docs.astral.sh/ruff/rules/subclass-builtin/)