### PR TITLE
STY: Apply assorted ruff/pyupgrade rules (UP)

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1000,10 +1000,7 @@ _SortSide: TypeAlias = L["left", "right"]
 
 _ConvertibleToInt: TypeAlias = SupportsInt | SupportsIndex | _CharLike_co
 _ConvertibleToFloat: TypeAlias = SupportsFloat | SupportsIndex | _CharLike_co
-if sys.version_info >= (3, 11):
-    _ConvertibleToComplex: TypeAlias = SupportsComplex | SupportsFloat | SupportsIndex | _CharLike_co
-else:
-    _ConvertibleToComplex: TypeAlias = complex | SupportsComplex | SupportsFloat | SupportsIndex | _CharLike_co
+_ConvertibleToComplex: TypeAlias = SupportsComplex | SupportsFloat | SupportsIndex | _CharLike_co
 _ConvertibleToTD64: TypeAlias = dt.timedelta | int | _CharLike_co | character | number | timedelta64 | np.bool | None
 _ConvertibleToDT64: TypeAlias = dt.date | int | _CharLike_co | character | number | datetime64 | np.bool | None
 

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -56,7 +56,7 @@ def test_array_array():
                  np.ones((), dtype=np.float64))
     assert_equal(np.array("1.0").dtype, U3)
     assert_equal(np.array("1.0", dtype=str).dtype, U3)
-    assert_equal(np.array("1.0", dtype=U2), np.array(str("1.")))
+    assert_equal(np.array("1.0", dtype=U2), np.array("1."))
     assert_equal(np.array("1", dtype=U5), np.ones((), dtype=U5))
 
     builtins = getattr(__builtins__, '__dict__', __builtins__)

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -379,7 +379,7 @@ class TestMethods:
 
     def test_encode(self):
         B = self.B.encode('unicode_escape')
-        assert_(B[0][0] == str(' \\u03a3 ').encode('latin1'))
+        assert_(B[0][0] == ' \\u03a3 '.encode('latin1'))
 
     def test_expandtabs(self):
         T = self.A.expandtabs()

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6123,10 +6123,10 @@ class TestRecord:
         assert_raises(IndexError, a['f1'].__setitem__, b'sf1', 1)
         assert_raises(IndexError, a['f1'].__getitem__, b'sf1')
         b = a.copy()
-        fn1 = str('f1')
+        fn1 = 'f1'
         b[fn1] = 1
         assert_equal(b[fn1], 1)
-        fnn = str('not at all')
+        fnn = 'not at all'
         assert_raises(ValueError, b.__setitem__, fnn, 1)
         assert_raises(ValueError, b.__getitem__, fnn)
         b[0][fn1] = 2
@@ -6135,14 +6135,14 @@ class TestRecord:
         assert_raises(ValueError, b[0].__setitem__, fnn, 1)
         assert_raises(ValueError, b[0].__getitem__, fnn)
         # Subfield
-        fn3 = str('f3')
-        sfn1 = str('sf1')
+        fn3 = 'f3'
+        sfn1 = 'sf1'
         b[fn3][sfn1] = 1
         assert_equal(b[fn3][sfn1], 1)
         assert_raises(ValueError, b[fn3].__setitem__, fnn, 1)
         assert_raises(ValueError, b[fn3].__getitem__, fnn)
         # multiple subfields
-        fn2 = str('f2')
+        fn2 = 'f2'
         b[fn2] = 3
 
         assert_equal(b[['f1', 'f2']][0].tolist(), (2, 3))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5499,7 +5499,7 @@ class TestIO:
 
     def test_roundtrip_repr(self, x):
         x = x.real.ravel()
-        s = "@".join((repr(x)[11:-1] for x in x))
+        s = "@".join(repr(x)[11:-1] for x in x)
         y = np.fromstring(s, sep="@")
         assert_array_equal(x, y)
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8977,16 +8977,6 @@ class TestConversion:
             assert_equal(5, int_func(np.bytes_(b'5')))
             assert_equal(6, int_func(np.str_('6')))
 
-            # The delegation of int() to __trunc__ was deprecated in
-            # Python 3.11.
-            if sys.version_info < (3, 11):
-                class HasTrunc:
-                    def __trunc__(self):
-                        return 3
-                assert_equal(3, int_func(np.array(HasTrunc())))
-                with assert_warns(DeprecationWarning):
-                    assert_equal(3, int_func(np.array([HasTrunc()])))
-
             class NotConvertible:
                 def __int__(self):
                     raise NotImplementedError

--- a/numpy/_core/tests/test_print.py
+++ b/numpy/_core/tests/test_print.py
@@ -129,10 +129,10 @@ def test_float_type_print(tp):
         _test_redirected_print(float(x), tp, _REF[x])
 
     if tp(1e16).itemsize > 4:
-        _test_redirected_print(float(1e16), tp)
+        _test_redirected_print(1e16, tp)
     else:
         ref = '1e+16'
-        _test_redirected_print(float(1e16), tp, ref)
+        _test_redirected_print(1e16, tp, ref)
 
 
 @pytest.mark.parametrize('tp', [np.complex64, np.cdouble, np.clongdouble])
@@ -191,12 +191,12 @@ def test_scalar_format():
 class TestCommaDecimalPointLocale(CommaDecimalPointLocale):
 
     def test_locale_single(self):
-        assert_equal(str(np.float32(1.2)), str(float(1.2)))
+        assert_equal(str(np.float32(1.2)), str(1.2))
 
     def test_locale_double(self):
-        assert_equal(str(np.double(1.2)), str(float(1.2)))
+        assert_equal(str(np.double(1.2)), str(1.2))
 
     @pytest.mark.skipif(IS_MUSL,
                         reason="test flaky on musllinux")
     def test_locale_longdouble(self):
-        assert_equal(str(np.longdouble('1.2')), str(float(1.2)))
+        assert_equal(str(np.longdouble('1.2')), str(1.2))

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1804,7 +1804,7 @@ class TestRegression:
         a = np.array(0, dtype=object)
         b = np.array(0, dtype=object)
         a[()] = b
-        assert_equal(int(a), int(0))
+        assert_equal(int(a), int(0))  # noqa: UP018
         assert_equal(float(a), float(0))
 
     def test_object_array_self_copy(self):

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -4,7 +4,7 @@ Test the scalar constructors, which also do type-coercion
 import fractions
 import platform
 import types
-from typing import Any, Type
+from typing import Any
 
 import pytest
 import numpy as np
@@ -143,7 +143,7 @@ class TestClassGetItem:
         np.signedinteger,
         np.floating,
     ])
-    def test_abc(self, cls: Type[np.number]) -> None:
+    def test_abc(self, cls: type[np.number]) -> None:
         alias = cls[Any]
         assert isinstance(alias, types.GenericAlias)
         assert alias.__origin__ is cls
@@ -164,7 +164,7 @@ class TestClassGetItem:
                 np.complexfloating[arg_tup]
 
     @pytest.mark.parametrize("cls", [np.generic, np.flexible, np.character])
-    def test_abc_non_numeric(self, cls: Type[np.generic]) -> None:
+    def test_abc_non_numeric(self, cls: type[np.generic]) -> None:
         with pytest.raises(TypeError):
             cls[Any]
 

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -156,7 +156,7 @@ class TestHstack:
         with pytest.raises(TypeError, match="arrays to stack must be"):
             hstack(np.arange(3) for _ in range(2))
         with pytest.raises(TypeError, match="arrays to stack must be"):
-            hstack((x for x in np.ones((3, 2))))
+            hstack(x for x in np.ones((3, 2)))
 
     def test_casting_and_dtype(self):
         a = np.array([1, 2, 3])

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -133,13 +133,13 @@ def check_fpu_mode(request):
     new_mode = get_fpu_mode()
 
     if old_mode != new_mode:
-        raise AssertionError("FPU precision mode changed from {0:#x} to {1:#x}"
+        raise AssertionError("FPU precision mode changed from {:#x} to {:#x}"
                              " during the test".format(old_mode, new_mode))
 
     collect_result = _collect_results.get(request.node)
     if collect_result is not None:
         old_mode, new_mode = collect_result
-        raise AssertionError("FPU precision mode changed from {0:#x} to {1:#x}"
+        raise AssertionError("FPU precision mode changed from {:#x} to {:#x}"
                              " when collecting the test".format(old_mode,
                                                                 new_mode))
 

--- a/numpy/f2py/f2py2e.pyi
+++ b/numpy/f2py/f2py2e.pyi
@@ -4,7 +4,8 @@ from collections.abc import Hashable, Iterable, Mapping, MutableMapping, Sequenc
 from types import ModuleType
 from typing import Any, Final, TypedDict, type_check_only
 
-from typing_extensions import NotRequired, TypeVar, override
+from typing_extensions import TypeVar, override
+from typing import NotRequired
 
 from .__version__ import version
 from .auxfuncs import _Bool

--- a/numpy/lib/_array_utils_impl.pyi
+++ b/numpy/lib/_array_utils_impl.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable
 
 from numpy import generic
 from numpy.typing import NDArray

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -1007,7 +1007,7 @@ def _read_bytes(fp, size, error_template="ran out of data"):
     Required as e.g. ZipExtFile in python 2.6 can return less data than
     requested.
     """
-    data = bytes()
+    data = b""
     while True:
         # io files (default in python3) return None or raise on
         # would-block, python2 file will truncate, probably nothing can be

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -263,7 +263,7 @@ def get_fieldstructure(adtype, lastname=None, parents=None,):
                 parents[name] = []
             parents.update(get_fieldstructure(current, name, parents))
         else:
-            lastparent = list((parents.get(lastname, []) or []))
+            lastparent = list(parents.get(lastname, []) or [])
             if lastparent:
                 lastparent.append(lastname)
             elif lastname:

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -462,8 +462,8 @@ class TestHistogramOptimBinNums:
             x = np.concatenate((x1, x2))
             for estimator, numbins in expectedResults.items():
                 a, b = np.histogram(x, estimator)
-                assert_equal(len(a), numbins, err_msg="For the {0} estimator "
-                             "with datasize of {1}".format(estimator, testlen))
+                assert_equal(len(a), numbins, err_msg="For the {} estimator "
+                             "with datasize of {}".format(estimator, testlen))
 
     def test_small(self):
         """
@@ -482,8 +482,8 @@ class TestHistogramOptimBinNums:
             testdat = np.arange(testlen).astype(float)
             for estimator, expbins in expectedResults.items():
                 a, b = np.histogram(testdat, estimator)
-                assert_equal(len(a), expbins, err_msg="For the {0} estimator "
-                             "with datasize of {1}".format(estimator, testlen))
+                assert_equal(len(a), expbins, err_msg="For the {} estimator "
+                             "with datasize of {}".format(estimator, testlen))
 
     def test_incorrect_methods(self):
         """
@@ -504,7 +504,7 @@ class TestHistogramOptimBinNums:
 
         for estimator, numbins in novar_resultdict.items():
             a, b = np.histogram(novar_dataset, estimator)
-            assert_equal(len(a), numbins, err_msg="{0} estimator, "
+            assert_equal(len(a), numbins, err_msg="{} estimator, "
                          "No Variance test".format(estimator))
 
     def test_limited_variance(self):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -27,7 +27,6 @@ import operator
 import warnings
 import textwrap
 import re
-from typing import Dict
 
 import numpy as np
 import numpy._core.umath as umath
@@ -185,8 +184,8 @@ for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
 float_types_list = [np.half, np.single, np.double, np.longdouble,
                     np.csingle, np.cdouble, np.clongdouble]
 
-_minvals: Dict[type, int] = {}
-_maxvals: Dict[type, int] = {}
+_minvals: dict[type, int] = {}
+_maxvals: dict[type, int] = {}
 
 for sctype in ntypes.sctypeDict.values():
     scalar_dtype = np.dtype(sctype)

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -9,7 +9,7 @@ abc module from the stdlib, hence it is only available for Python >= 2.6.
 import os
 import abc
 import numbers
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 from . import polyutils as pu

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -323,7 +323,7 @@ def test_truediv(Poly):
         s = stype(5, 0)
         assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)
-    for s in [(), [], {}, bool(), np.array([1])]:
+    for s in [(), [], {}, False, np.array([1])]:
         assert_raises(TypeError, op.truediv, p2, s)
         assert_raises(TypeError, op.truediv, s, p2)
     for ptype in classes:

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -563,20 +563,21 @@ def test_functions_single_location():
     Test performs BFS search traversing NumPy's public API. It flags
     any function-like object that is accessible from more that one place.
     """
-    from typing import Any, Callable, Dict, List, Set, Tuple
+    from typing import Any
+    from collections.abc import Callable
     from numpy._core._multiarray_umath import (
         _ArrayFunctionDispatcher as dispatched_function
     )
 
-    visited_modules: Set[types.ModuleType] = {np}
-    visited_functions: Set[Callable[..., Any]] = set()
+    visited_modules: set[types.ModuleType] = {np}
+    visited_functions: set[Callable[..., Any]] = set()
     # Functions often have `__name__` overridden, therefore we need
     # to keep track of locations where functions have been found.
-    functions_original_paths: Dict[Callable[..., Any], str] = {}
+    functions_original_paths: dict[Callable[..., Any], str] = {}
 
     # Here we aggregate functions with more than one location.
     # It must be empty for the test to pass.
-    duplicated_functions: List[Tuple] = []
+    duplicated_functions: list[tuple] = []
 
     modules_queue = [np]
 


### PR DESCRIPTION
Some rules have been triggered by changing the minimum Python version to 3.11, for example [UP036](https://docs.astral.sh/ruff/rules/outdated-version-block/).

I have left out these rules for now:
* [UP015](https://docs.astral.sh/ruff/rules/redundant-open-modes/) (left out because many developers prefer explicit over implicit)
* [UP018](https://docs.astral.sh/ruff/rules/native-literals/) (applied partially)
* [UP031](https://docs.astral.sh/ruff/rules/printf-string-formatting/) (changing to f-strings would be a major change)
* [UP032](https://docs.astral.sh/ruff/rules/f-string/) (changing to f-strings would be a major change)