### PR TITLE
BUG: Prevent nanmax/nanmin from copying  memmap arrays

### DIFF
--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -351,7 +351,7 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     if where is not np._NoValue:
         kwargs['where'] = where
 
-    if type(a) is np.ndarray and a.dtype != np.object_:
+    if (type(a) is np.ndarray or type(a) is np.memmap) and a.dtype != np.object_:
         # Fast, but not safe for subclasses of ndarray, or object arrays,
         # which do not implement isnan (gh-9009), or fmin correctly (gh-8975)
         res = np.fmin.reduce(a, axis=axis, out=out, **kwargs)
@@ -480,7 +480,7 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     if where is not np._NoValue:
         kwargs['where'] = where
 
-    if type(a) is np.ndarray and a.dtype != np.object_:
+    if (type(a) is np.ndarray or type(a) is np.memmap) and a.dtype != np.object_:
         # Fast, but not safe for subclasses of ndarray, or object arrays,
         # which do not implement isnan (gh-9009), or fmax correctly (gh-8975)
         res = np.fmax.reduce(a, axis=axis, out=out, **kwargs)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1416,3 +1416,18 @@ def test__replace_nan():
         assert result_nan is not arr_nan
         assert_equal(result_nan, np.array([0, 1, 2]))
         assert np.isnan(arr_nan[-1])
+
+
+def test_memmap_takes_fast_route(tmpdir):
+    # We want memory mapped arrays to take the fast route through nanmax,
+    # which avoids creating a mask by using fmax.reduce (see gh-28721). So we
+    # check that on bad input, the error is from fmax (rather than maximum).
+    a = np.arange(10., dtype=float)
+    with open(tmpdir.join("data.bin"), "w+b") as fh:
+        fh.write(a.tobytes())
+        mm = np.memmap(fh, dtype=a.dtype, shape=a.shape)
+        with pytest.raises(ValueError, match="reduction operation fmax"):
+            np.nanmax(mm, out=np.zeros(2))
+        # For completeness, same for nanmin.
+        with pytest.raises(ValueError, match="reduction operation fmin"):
+            np.nanmin(mm, out=np.zeros(2))


### PR DESCRIPTION

Fixed nanmax and nanmin to special case memmap ndarrays to use the fast path. Previously the function would create copies which is problematic for large GB+ arrays.

Closes #28721
