### PR TITLE
TYP: remove `_typing._UnknownType` and `_ArrayLikeUnknown`

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Final, TypeAlias, overload, TypeVar, Literal as L, SupportsAbs, SupportsIndex, NoReturn, TypeGuard, Unpack
+from typing import Any, Final, Never, NoReturn, SupportsAbs, SupportsIndex, TypeAlias, TypeGuard, TypeVar, Unpack, overload
+from typing import Literal as L
 
 import numpy as np
 from numpy import (
@@ -97,7 +98,6 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
     _ArrayLikeObject_co,
-    _ArrayLikeUnknown,
 )
 
 __all__ = [
@@ -436,8 +436,8 @@ def flatnonzero(a: ArrayLike) -> NDArray[intp]: ...
 
 @overload
 def correlate(
-    a: _ArrayLikeUnknown,
-    v: _ArrayLikeUnknown,
+    a: _ArrayLike[Never],
+    v: _ArrayLike[Never],
     mode: _CorrelateMode = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -485,8 +485,8 @@ def correlate(
 
 @overload
 def convolve(
-    a: _ArrayLikeUnknown,
-    v: _ArrayLikeUnknown,
+    a: _ArrayLike[Never],
+    v: _ArrayLike[Never],
     mode: _CorrelateMode = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -534,8 +534,8 @@ def convolve(
 
 @overload
 def outer(
-    a: _ArrayLikeUnknown,
-    b: _ArrayLikeUnknown,
+    a: _ArrayLike[Never],
+    b: _ArrayLike[Never],
     out: None = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -589,8 +589,8 @@ def outer(
 
 @overload
 def tensordot(
-    a: _ArrayLikeUnknown,
-    b: _ArrayLikeUnknown,
+    a: _ArrayLike[Never],
+    b: _ArrayLike[Never],
     axes: int | tuple[_ShapeLike, _ShapeLike] = ...,
 ) -> NDArray[Any]: ...
 @overload
@@ -663,8 +663,8 @@ def moveaxis(
 
 @overload
 def cross(
-    a: _ArrayLikeUnknown,
-    b: _ArrayLikeUnknown,
+    a: _ArrayLike[Never],
+    b: _ArrayLike[Never],
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -138,11 +138,9 @@ from ._array_like import (
     _ArrayLikeBytes_co as _ArrayLikeBytes_co,
     _ArrayLikeString_co as _ArrayLikeString_co,
     _ArrayLikeAnyString_co as _ArrayLikeAnyString_co,
-    _ArrayLikeUnknown as _ArrayLikeUnknown,
     _FiniteNestedSequence as _FiniteNestedSequence,
     _SupportsArray as _SupportsArray,
     _SupportsArrayFunc as _SupportsArrayFunc,
-    _UnknownType as _UnknownType,
 )
 
 from ._ufunc import (

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -106,14 +106,3 @@ _ArrayLikeComplex128_co: TypeAlias = _DualArrayLike[dtype[__Complex128_co], comp
 
 # NOTE: This includes `builtins.bool`, but not `numpy.bool`.
 _ArrayLikeInt: TypeAlias = _DualArrayLike[dtype[np.integer], int]
-
-# Extra ArrayLike type so that pyright can deal with NDArray[Any]
-# Used as the first overload, should only match NDArray[Any],
-# not any actual types.
-# https://github.com/numpy/numpy/pull/22193
-if sys.version_info >= (3, 11):
-    from typing import Never as _UnknownType
-else:
-    from typing import NoReturn as _UnknownType
-
-_ArrayLikeUnknown: TypeAlias = _DualArrayLike[dtype[_UnknownType], _UnknownType]

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -1,14 +1,6 @@
 from collections.abc import Iterable
-from typing import (
-    Literal as L,
-    overload,
-    TypeAlias,
-    TypeVar,
-    Any,
-    SupportsIndex,
-    SupportsInt,
-    NamedTuple,
-)
+from typing import Any, NamedTuple, Never, SupportsIndex, SupportsInt, TypeAlias, TypeVar, overload
+from typing import Literal as L
 
 import numpy as np
 from numpy import (
@@ -33,7 +25,7 @@ from numpy._typing import (
     NDArray,
     ArrayLike,
     DTypeLike,
-    _ArrayLikeUnknown,
+    _ArrayLike,
     _ArrayLikeBool_co,
     _ArrayLikeInt_co,
     _ArrayLikeUInt_co,
@@ -182,7 +174,7 @@ def cholesky(a: _ArrayLikeFloat_co, /, *, upper: bool = False) -> NDArray[floati
 def cholesky(a: _ArrayLikeComplex_co, /, *, upper: bool = False) -> NDArray[complexfloating[Any, Any]]: ...
 
 @overload
-def outer(x1: _ArrayLikeUnknown, x2: _ArrayLikeUnknown) -> NDArray[Any]: ...
+def outer(x1: _ArrayLike[Never], x2: _ArrayLike[Never]) -> NDArray[Any]: ...
 @overload
 def outer(x1: _ArrayLikeBool_co, x2: _ArrayLikeBool_co) -> NDArray[np.bool]: ...
 @overload


### PR DESCRIPTION
ref https://github.com/numpy/numpy/pull/28728#discussion_r2047105976

---

The `_UnknownType` was but an alias for `typing.Never` and ironically it was never used.
The `_ArrayLikeUnknown` type alias can be replaced with `_ArrayLike[Never]` for the purposes that its used for, i.e. as workaround for microsoft/pyright#10232.