### PR TITLE
TYP: some ``[arg]partition`` fixes

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2290,14 +2290,47 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         where: _ArrayLikeBool_co = True,
     ) -> _ArrayT: ...
 
+    #
+    @overload
+    def partition(
+        self,
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex = -1,
+        kind: _PartitionKind = "introselect",
+        order: None = None,
+    ) -> None: ...
+    @overload
+    def partition(
+        self: NDArray[void],
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex = -1,
+        kind: _PartitionKind = "introselect",
+        order: str | Sequence[str] | None = None,
+    ) -> None: ...
+
+    #
+    @overload
     def argpartition(
         self,
-        kth: _ArrayLikeInt_co,
-        axis: None | SupportsIndex = ...,
-        kind: _PartitionKind = ...,
-        order: None | str | Sequence[str] = ...,
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex | None = -1,
+        kind: _PartitionKind = "introselect",
+        order: None = None,
+    ) -> NDArray[intp]: ...
+    @overload
+    def argpartition(
+        self: NDArray[void],
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex | None = -1,
+        kind: _PartitionKind = "introselect",
+        order: str | Sequence[str] | None = None,
     ) -> NDArray[intp]: ...
 
+    #
     def diagonal(
         self,
         offset: SupportsIndex = ...,
@@ -2316,14 +2349,6 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
 
     # `nonzero()` is deprecated for 0d arrays/generics
     def nonzero(self) -> tuple[NDArray[intp], ...]: ...
-
-    def partition(
-        self,
-        kth: _ArrayLikeInt_co,
-        axis: SupportsIndex = ...,
-        kind: _PartitionKind = ...,
-        order: None | str | Sequence[str] = ...,
-    ) -> None: ...
 
     # `put` is technically available to `generic`,
     # but is pointless as `generic`s are immutable

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -17,7 +17,6 @@ from typing_extensions import deprecated
 
 import numpy as np
 from numpy import (
-    number,
     uint64,
     int_,
     int64,
@@ -48,11 +47,11 @@ from numpy._typing import (
     _ShapeLike,
     _ArrayLikeBool_co,
     _ArrayLikeUInt_co,
+    _ArrayLikeInt,
     _ArrayLikeInt_co,
     _ArrayLikeFloat_co,
     _ArrayLikeComplex_co,
     _ArrayLikeObject_co,
-    _ArrayLikeTD64_co,
     _IntLike_co,
     _BoolLike_co,
     _ComplexLike_co,
@@ -323,31 +322,42 @@ def matrix_transpose(x: _ArrayLike[_ScalarT], /) -> NDArray[_ScalarT]: ...
 @overload
 def matrix_transpose(x: ArrayLike, /) -> NDArray[Any]: ...
 
+#
 @overload
 def partition(
     a: _ArrayLike[_ScalarT],
-    kth: _ArrayLikeInt_co,
-    axis: SupportsIndex | None = ...,
-    kind: _PartitionKind = ...,
-    order: str | Sequence[str] | None = ...,
+    kth: _ArrayLikeInt,
+    axis: SupportsIndex | None = -1,
+    kind: _PartitionKind = "introselect",
+    order: None = None,
 ) -> NDArray[_ScalarT]: ...
 @overload
 def partition(
+    a: _ArrayLike[np.void],
+    kth: _ArrayLikeInt,
+    axis: SupportsIndex | None = -1,
+    kind: _PartitionKind = "introselect",
+    order: str | Sequence[str] | None = None,
+) -> NDArray[np.void]: ...
+@overload
+def partition(
     a: ArrayLike,
-    kth: _ArrayLikeInt_co,
-    axis: SupportsIndex | None = ...,
-    kind: _PartitionKind = ...,
-    order: str | Sequence[str] | None = ...,
+    kth: _ArrayLikeInt,
+    axis: SupportsIndex | None = -1,
+    kind: _PartitionKind = "introselect",
+    order: str | Sequence[str] | None = None,
 ) -> NDArray[Any]: ...
 
+#
 def argpartition(
     a: ArrayLike,
-    kth: _ArrayLikeInt_co,
+    kth: _ArrayLikeInt,
     axis: SupportsIndex | None = -1,
-    kind: _PartitionKind = ...,
-    order: str | Sequence[str] | None = ...,
+    kind: _PartitionKind = "introselect",
+    order: str | Sequence[str] | None = None,
 ) -> NDArray[intp]: ...
 
+#
 @overload
 def sort(
     a: _ArrayLike[_ScalarT],

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -7,6 +7,7 @@ from typing import Any, Literal, SupportsIndex, TypeAlias, TypeVar, overload
 from _typeshed import Incomplete
 from typing_extensions import deprecated
 
+import numpy as np
 from numpy import (
     _ModeKind,
     _OrderKACF,
@@ -681,19 +682,43 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
     ) -> _ArrayT: ...
 
     #
+    @overload
     def partition(
         self,
+        /,
         kth: _ArrayLikeInt,
         axis: SupportsIndex = -1,
         kind: _PartitionKind = "introselect",
-        order: str | Sequence[str] | None = None
+        order: None = None
     ) -> None: ...
+    @overload
+    def partition(
+        self: _MaskedArray[np.void],
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex = -1,
+        kind: _PartitionKind = "introselect",
+        order: str | Sequence[str] | None = None,
+    ) -> None: ...
+
+    #
+    @overload
     def argpartition(
         self,
+        /,
         kth: _ArrayLikeInt,
-        axis: SupportsIndex = -1,
+        axis: SupportsIndex | None = -1,
         kind: _PartitionKind = "introselect",
-        order: str | Sequence[str] | None = None
+        order: None = None,
+    ) -> _MaskedArray[intp]: ...
+    @overload
+    def argpartition(
+        self: _MaskedArray[np.void],
+        /,
+        kth: _ArrayLikeInt,
+        axis: SupportsIndex | None = -1,
+        kind: _PartitionKind = "introselect",
+        order: str | Sequence[str] | None = None,
     ) -> _MaskedArray[intp]: ...
 
     # Keep in-sync with np.ma.take

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -24,6 +24,7 @@ MAR_td64: MaskedNDArray[np.timedelta64]
 MAR_o: MaskedNDArray[np.object_]
 MAR_s: MaskedNDArray[np.str_]
 MAR_byte: MaskedNDArray[np.bytes_]
+MAR_V: MaskedNDArray[np.void]
 
 MAR_subclass: MaskedNDArraySubclass
 
@@ -163,7 +164,7 @@ assert_type(np.ma.take([1], [0]), MaskedNDArray[Any])
 assert_type(np.ma.take(np.eye(2), 1, axis=0), MaskedNDArray[np.float64])
 
 assert_type(MAR_f4.partition(1), None)
-assert_type(MAR_f4.partition(1, axis=0, kind='introselect', order='K'), None)
+assert_type(MAR_V.partition(1, axis=0, kind='introselect', order='K'), None)
 
 assert_type(MAR_f4.argpartition(1), MaskedNDArray[np.intp])
 assert_type(MAR_1d.argpartition(1, axis=0, kind='introselect', order='K'), MaskedNDArray[np.intp])


### PR DESCRIPTION
- reject boolean array indices
- reject `order: str | Sequence[str]` unless it's a `void` array
- reject passing `self` as keyword argument on classmethod calls
- accept `axis=None` in `ma.ndarray.argpartition`
- fill in the `...` parameter defaults &mdash; towards #28428
- resolve the LSP violation squiggly lines in `ma/core.pyi` &mdash; following #28746
