### PR TITLE
ENH: Support Python 3.14

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -70,7 +70,7 @@ jobs:
         python-version: ${{ matrix.version }}
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
-      if: matrix.version == '3.13t'
+      if: contains(matrix.version, ['3.13t', '3.14t-dev'])
       run: |
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.11", "3.12", "3.13", "3.13t"]
+        version: ["3.11", "3.12", "3.13", "3.13t", "3.14-dev", "3.14t-dev"]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,12 +65,9 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ matrix.version }}
-        enable-cache: false
-    - run:
-        uv pip install --python=${{ matrix.version }} pip
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
       if: matrix.version == '3.13t'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.11", "3.12", "3.13", "3.13t", "3.14-dev", "3.14t-dev"]
+        version: ["3.11", "3.12", "3.13", "3.14-dev", "3.14t-dev"]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -70,7 +70,7 @@ jobs:
         python-version: ${{ matrix.version }}
     # TODO: remove cython nightly install when cython does a release
     - name: Install nightly Cython
-      if: contains(matrix.version, ['3.13t', '3.14t-dev'])
+      if: matrix.version == '3.14t-dev'
       run: |
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions

--- a/numpy/_core/src/multiarray/temp_elide.c
+++ b/numpy/_core/src/multiarray/temp_elide.c
@@ -122,7 +122,7 @@ check_unique_temporary(PyObject *lhs)
 #if PY_VERSION_HEX >= 0x030E00A7
     // In Python 3.14.0a7 and later, a reference count of one doesn't guarantee
     // that an object is a unique temporary variable. We scan the top of the
-    // interpreter stack to check if the object exists as an "onwned" reference
+    // interpreter stack to check if the object exists as an "owned" reference
     // in the temporary stack.
     PyFrameObject *frame = PyEval_GetFrame();
     if (frame == NULL) {

--- a/numpy/_core/src/multiarray/temp_elide.c
+++ b/numpy/_core/src/multiarray/temp_elide.c
@@ -62,7 +62,7 @@
 
 #include <feature_detection_misc.h>
 
-#if PY_VERSION_HEX >= 0x030E00A7
+#if PY_VERSION_HEX >= 0x030E00A7 && !defined(PYPY_VERSION)
 #define Py_BUILD_CORE
 #include "internal/pycore_frame.h"
 #include "internal/pycore_interpframe.h"
@@ -119,7 +119,7 @@ find_addr(void * addresses[], npy_intp naddr, void * addr)
 static int
 check_unique_temporary(PyObject *lhs)
 {
-#if PY_VERSION_HEX >= 0x030E00A7
+#if PY_VERSION_HEX >= 0x030E00A7 && !defined(PYPY_VERSION)
     // In Python 3.14.0a7 and later, a reference count of one doesn't guarantee
     // that an object is a unique temporary variable. We scan the top of the
     // interpreter stack to check if the object exists as an "owned" reference

--- a/numpy/_core/src/multiarray/temp_elide.c
+++ b/numpy/_core/src/multiarray/temp_elide.c
@@ -62,6 +62,13 @@
 
 #include <feature_detection_misc.h>
 
+#if PY_VERSION_HEX >= 0x030E00A7
+#define Py_BUILD_CORE
+#include "internal/pycore_frame.h"
+#include "internal/pycore_interpframe.h"
+#undef Py_BUILD_CORE
+#endif
+
 /* 1 prints elided operations, 2 prints stacktraces */
 #define NPY_ELIDE_DEBUG 0
 #define NPY_MAX_STACKSIZE 10
@@ -107,6 +114,41 @@ find_addr(void * addresses[], npy_intp naddr, void * addr)
         }
     }
     return 0;
+}
+
+static int
+check_unique_temporary(PyObject *lhs)
+{
+#if PY_VERSION_HEX >= 0x030E00A7
+    // In Python 3.14.0a7 and later, a reference count of one doesn't guarantee
+    // that an object is a unique temporary variable. We scan the top of the
+    // interpreter stack to check if the object exists as an "onwned" reference
+    // in the temporary stack.
+    PyFrameObject *frame = PyEval_GetFrame();
+    if (frame == NULL) {
+        return 0;
+    }
+    _PyInterpreterFrame *f = frame->f_frame;
+    _PyStackRef *base = _PyFrame_Stackbase(f);
+    _PyStackRef *stackpointer = f->stackpointer;
+    int found_once = 0;
+    while (stackpointer > base) {
+        stackpointer--;
+        PyObject *obj = PyStackRef_AsPyObjectBorrow(*stackpointer);
+        if (obj == lhs) {
+            if (!found_once && PyStackRef_IsHeapSafe(*stackpointer)) {
+                found_once = 1;
+            }
+            else {
+                return 0;
+            }
+        }
+        return found_once;
+    }
+    return 0;
+#else
+    return 1;
+#endif
 }
 
 static int
@@ -295,7 +337,8 @@ can_elide_temp(PyObject *olhs, PyObject *orhs, int *cannot)
             !PyArray_CHKFLAGS(alhs, NPY_ARRAY_OWNDATA) ||
             !PyArray_ISWRITEABLE(alhs) ||
             PyArray_CHKFLAGS(alhs, NPY_ARRAY_WRITEBACKIFCOPY) ||
-            PyArray_NBYTES(alhs) < NPY_MIN_ELIDE_BYTES) {
+            PyArray_NBYTES(alhs) < NPY_MIN_ELIDE_BYTES ||
+            !check_unique_temporary(olhs)) {
         return 0;
     }
     if (PyArray_CheckExact(orhs) ||
@@ -372,7 +415,8 @@ can_elide_temp_unary(PyArrayObject * m1)
             !PyArray_ISNUMBER(m1) ||
             !PyArray_CHKFLAGS(m1, NPY_ARRAY_OWNDATA) ||
             !PyArray_ISWRITEABLE(m1) ||
-            PyArray_NBYTES(m1) < NPY_MIN_ELIDE_BYTES) {
+            PyArray_NBYTES(m1) < NPY_MIN_ELIDE_BYTES ||
+            !check_unique_temporary((PyObject *)m1)) {
         return 0;
     }
     if (check_callers(&cannot)) {

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -22,9 +22,9 @@ class TestDLPack:
     def test_dunder_dlpack_refcount(self, max_version):
         x = np.arange(5)
         y = x.__dlpack__(max_version=max_version)
-        assert sys.getrefcount(x) == 3
+        startcount = sys.getrefcount(x)
         del y
-        assert sys.getrefcount(x) == 2
+        assert startcount - sys.getrefcount(x) == 1
 
     def test_dunder_dlpack_stream(self):
         x = np.arange(5)
@@ -58,9 +58,9 @@ class TestDLPack:
     def test_from_dlpack_refcount(self, arr):
         arr = arr.copy()
         y = np.from_dlpack(arr)
-        assert sys.getrefcount(arr) == 3
+        startcount = sys.getrefcount(arr)
         del y
-        assert sys.getrefcount(arr) == 2
+        assert startcount - sys.getrefcount(arr) == 1
 
     @pytest.mark.parametrize("dtype", [
         np.bool,

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1922,9 +1922,10 @@ class TestUserDType:
         if HAS_REFCOUNT:
             # Create an array and test that memory gets cleaned up (gh-25949)
             o = object()
+            startcount = sys.getrefcount(o)
             a = np.array([o], dtype=dt)
             del a
-            assert sys.getrefcount(o) == 2
+            assert sys.getrefcount(o) == startcount
 
     def test_custom_structured_dtype_errors(self):
         class mytype:

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -1164,6 +1164,8 @@ class TestMultiIndexingAutomated:
         """Compare mimicked result to indexing result.
         """
         arr = arr.copy()
+        if HAS_REFCOUNT:
+            startcount = sys.getrefcount(arr)
         indexed_arr = arr[index]
         assert_array_equal(indexed_arr, mimic_get)
         # Check if we got a view, unless its a 0-sized or 0-d array.
@@ -1174,9 +1176,9 @@ class TestMultiIndexingAutomated:
             if HAS_REFCOUNT:
                 if no_copy:
                     # refcount increases by one:
-                    assert_equal(sys.getrefcount(arr), 3)
+                    assert_equal(sys.getrefcount(arr), startcount + 1)
                 else:
-                    assert_equal(sys.getrefcount(arr), 2)
+                    assert_equal(sys.getrefcount(arr), startcount)
 
         # Test non-broadcast setitem:
         b = arr.copy()

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -50,19 +50,23 @@ class TestTake:
 
     def test_refcounting(self):
         objects = [object() for i in range(10)]
+        if HAS_REFCOUNT:
+            orig_rcs = [sys.getrefcount(o) for o in objects]
         for mode in ('raise', 'clip', 'wrap'):
             a = np.array(objects)
             b = np.array([2, 2, 4, 5, 3, 5])
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
-                assert_(all(sys.getrefcount(o) == 3 for o in objects))
+                assert_(all(sys.getrefcount(o) == rc + 1
+                            for o, rc in zip(objects, orig_rcs)))
             # not contiguous, example:
             a = np.array(objects * 2)[::2]
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
-                assert_(all(sys.getrefcount(o) == 3 for o in objects))
+                assert_(all(sys.getrefcount(o) == rc + 1
+                            for o, rc in zip(objects, orig_rcs)))
 
     def test_unicode_mode(self):
         d = np.arange(10)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6791,10 +6791,12 @@ class TestDot:
         v = np.random.random_sample((16, 32))
 
         r = np.empty((1024, 32))
+        if HAS_REFCOUNT:
+            orig_refcount = sys.getrefcount(r)
         for i in range(12):
             dot(f, v, r)
         if HAS_REFCOUNT:
-            assert_equal(sys.getrefcount(r), 2)
+            assert_equal(sys.getrefcount(r), orig_refcount)
         r2 = dot(f, v, out=None)
         assert_array_equal(r2, r)
         assert_(r is dot(f, v, out=r))

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1125,13 +1125,9 @@ def test_iter_object_arrays_conversions():
             rc = sys.getrefcount(ob)
         for x in i:
             x[...] += 1
-    if HAS_REFCOUNT:
-        # TODO: why did this change?
-        newrc = sys.getrefcount(ob)
-        if sys.version_info < (3, 14):
+        if HAS_REFCOUNT:
+            newrc = sys.getrefcount(ob)
             assert_(newrc == rc - 1)
-        else:
-            assert_(newrc == rc)
     assert_equal(a, np.arange(6) + 98172489)
 
 def test_iter_common_dtype():

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1126,7 +1126,12 @@ def test_iter_object_arrays_conversions():
         for x in i:
             x[...] += 1
     if HAS_REFCOUNT:
-        assert_(sys.getrefcount(ob) == rc - 1)
+        # TODO: why did this change?
+        newrc = sys.getrefcount(ob)
+        if sys.version_info < (3, 14):
+            assert_(newrc == rc - 1)
+        else:
+            assert_(newrc == rc)
     assert_equal(a, np.arange(6) + 98172489)
 
 def test_iter_common_dtype():

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1585,29 +1585,26 @@ class TestRegression:
     def test_fromfile_tofile_seeks(self):
         # On Python 3, tofile/fromfile used to get (#1610) the Python
         # file handle out of sync
-        f0 = tempfile.NamedTemporaryFile()
-        f = f0.file
-        f.write(np.arange(255, dtype='u1').tobytes())
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(np.arange(255, dtype='u1').tobytes())
 
-        f.seek(20)
-        ret = np.fromfile(f, count=4, dtype='u1')
-        assert_equal(ret, np.array([20, 21, 22, 23], dtype='u1'))
-        assert_equal(f.tell(), 24)
+            f.seek(20)
+            ret = np.fromfile(f, count=4, dtype='u1')
+            assert_equal(ret, np.array([20, 21, 22, 23], dtype='u1'))
+            assert_equal(f.tell(), 24)
 
-        f.seek(40)
-        np.array([1, 2, 3], dtype='u1').tofile(f)
-        assert_equal(f.tell(), 43)
+            f.seek(40)
+            np.array([1, 2, 3], dtype='u1').tofile(f)
+            assert_equal(f.tell(), 43)
 
-        f.seek(40)
-        data = f.read(3)
-        assert_equal(data, b"\x01\x02\x03")
+            f.seek(40)
+            data = f.read(3)
+            assert_equal(data, b"\x01\x02\x03")
 
-        f.seek(80)
-        f.read(4)
-        data = np.fromfile(f, dtype='u1', count=4)
-        assert_equal(data, np.array([84, 85, 86, 87], dtype='u1'))
-
-        f.close()
+            f.seek(80)
+            f.read(4)
+            data = np.fromfile(f, dtype='u1', count=4)
+            assert_equal(data, np.array([84, 85, 86, 87], dtype='u1'))
 
     def test_complex_scalar_warning(self):
         for tp in [np.csingle, np.cdouble, np.clongdouble]:

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -269,9 +269,9 @@ class TestOut:
             pass
 
         arr = np.arange(10).view(ArrSubclass)
-
+        orig_refcount = sys.getrefcount(arr)
         arr *= 1
-        assert sys.getrefcount(arr) == 2
+        assert sys.getrefcount(arr) == orig_refcount
 
 
 class TestComparisons:


### PR DESCRIPTION
Fixes #28681.

Hopefully we can create a `PyUnstable` C API that NumPy can use to replace the use of CPython internals. I'd like to merge this for now to enable downstream 3.14 testing without disabling temporary elision.

Also updates tests to use refcount deltas instead of precise refcount values, allowing the tests to pass on all supported Python versions. There's one test that already uses refcount deltas but still has different results on 3.14 and 3.13 I don't understand, but all the other changes make sense given upstream changes to internal refcounting semantics.

Also fixes a `ResourceWarning` that in 3.14 is now enough for pytest to treat as an error.

Finally, adds CI for 3.14 and 3.14t on the linux smoke tests. I think we're close enough to 3.14 beta 1 that it shouldn't be too noisy to add this, but we can also hold off until beta 1 happens.