### PR TITLE
STY: Apply ruff/pyupgrade rule UP032

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -410,8 +410,7 @@ else:
             import numpy.char as char
             return char.chararray
 
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 
     def __dir__():
         public_symbols = (
@@ -485,7 +484,7 @@ else:
                             "\nIf you compiled yourself, more information is available at:"
                             "\nhttps://numpy.org/devdocs/building/index.html"
                             "\nOtherwise report this to the vendor "
-                            "that provided NumPy.\n\n{}\n".format(error_message))
+                            f"that provided NumPy.\n\n{error_message}\n")
                         raise RuntimeError(msg)
                 del _wn
             del w

--- a/numpy/_core/_exceptions.py
+++ b/numpy/_core/_exceptions.py
@@ -44,12 +44,9 @@ class _UFuncNoLoopError(UFuncTypeError):
 
     def __str__(self):
         return (
-            "ufunc {!r} did not contain a loop with signature matching types "
-            "{!r} -> {!r}"
-        ).format(
-            self.ufunc.__name__,
-            _unpack_tuple(self.dtypes[:self.ufunc.nin]),
-            _unpack_tuple(self.dtypes[self.ufunc.nin:])
+            f"ufunc {self.ufunc.__name__!r} did not contain a loop with signature "
+            f"matching types {_unpack_tuple(self.dtypes[:self.ufunc.nin])!r} "
+            f"-> {_unpack_tuple(self.dtypes[self.ufunc.nin:])!r}"
         )
 
 
@@ -88,10 +85,8 @@ class _UFuncInputCastingError(_UFuncCastingError):
         # only show the number if more than one input exists
         i_str = f"{self.in_i} " if self.ufunc.nin != 1 else ""
         return (
-            "Cannot cast ufunc {!r} input {}from {!r} to {!r} with casting "
-            "rule {!r}"
-        ).format(
-            self.ufunc.__name__, i_str, self.from_, self.to, self.casting
+            f"Cannot cast ufunc {self.ufunc.__name__!r} input {i_str}from "
+            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}"
         )
 
 
@@ -106,10 +101,8 @@ class _UFuncOutputCastingError(_UFuncCastingError):
         # only show the number if more than one output exists
         i_str = f"{self.out_i} " if self.ufunc.nout != 1 else ""
         return (
-            "Cannot cast ufunc {!r} output {}from {!r} to {!r} with casting "
-            "rule {!r}"
-        ).format(
-            self.ufunc.__name__, i_str, self.from_, self.to, self.casting
+            f"Cannot cast ufunc {self.ufunc.__name__!r} output {i_str}from "
+            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}"
         )
 
 

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -878,15 +878,15 @@ def array_ufunc_errmsg_formatter(dummy, ufunc, method, *inputs, **kwargs):
     args = inputs + kwargs.get('out', ())
     types_string = ', '.join(repr(type(arg).__name__) for arg in args)
     return ('operand type(s) all returned NotImplemented from '
-            '__array_ufunc__({!r}, {!r}, {}): {}'
-            .format(ufunc, method, args_string, types_string))
+            f'__array_ufunc__({ufunc!r}, {method!r}, {args_string}): {types_string}'
+            )
 
 
 def array_function_errmsg_formatter(public_api, types):
     """ Format the error message for when __array_ufunc__ gives up. """
     func_name = f'{public_api.__module__}.{public_api.__name__}'
-    return ("no implementation found for '{}' on types that implement "
-            '__array_function__: {}'.format(func_name, list(types)))
+    return (f"no implementation found for '{func_name}' on types that implement "
+            f'__array_function__: {list(types)}')
 
 
 def _ufunc_doc_signature_formatter(ufunc):

--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -267,10 +267,11 @@ def do_generate_api(targets, sources):
     if len(multiarray_api_dict) != len(multiarray_api_index):
         keys_dict = set(multiarray_api_dict.keys())
         keys_index = set(multiarray_api_index.keys())
+        keys_index_dict = keys_index - keys_dict
+        keys_dict_index = keys_dict - keys_index
         raise AssertionError(
-            "Multiarray API size mismatch - "
-            "index has extra keys {}, dict has extra keys {}"
-            .format(keys_index - keys_dict, keys_dict - keys_index)
+            f"Multiarray API size mismatch - index has extra keys {keys_index_dict}, "
+            f"dict has extra keys {keys_dict_index}"
         )
 
     extension_list = []

--- a/numpy/_core/einsumfunc.py
+++ b/numpy/_core/einsumfunc.py
@@ -1013,8 +1013,8 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
         # Explicit "einsum_path" is usually trusted, but we detect this kind of
         # mistake in order to prevent from returning an intermediate value.
         raise RuntimeError(
-            "Invalid einsum_path is specified: {} more operands has to be "
-            "contracted.".format(len(input_list) - 1))
+            f"Invalid einsum_path is specified: {len(input_list) - 1} more "
+            "operands has to be contracted.")
 
     if einsum_call_arg:
         return (operands, contraction_list)

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -565,8 +565,7 @@ def put(a, ind, v, mode='raise'):
     try:
         put = a.put
     except AttributeError as e:
-        raise TypeError("argument 1 must be numpy.ndarray, "
-                        "not {name}".format(name=type(a).__name__)) from e
+        raise TypeError(f"argument 1 must be numpy.ndarray, not {type(a)}") from e
 
     return put(ind, v, mode=mode)
 

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -473,9 +473,8 @@ def _needs_add_docstring(obj):
 def _add_docstring(obj, doc, warn_on_python):
     if warn_on_python and not _needs_add_docstring(obj):
         warnings.warn(
-            "add_newdoc was used on a pure-python object {}. "
-            "Prefer to attach it directly to the source."
-            .format(obj),
+            f"add_newdoc was used on a pure-python object {obj}. "
+            "Prefer to attach it directly to the source.",
             UserWarning,
             stacklevel=3)
     try:

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -79,8 +79,8 @@ class MachArLike:
         value = self._smallest_subnormal
         if self.ftype(0) == value:
             warnings.warn(
-                'The value of the smallest subnormal for {} type '
-                'is zero.'.format(self.ftype), UserWarning, stacklevel=2)
+                f'The value of the smallest subnormal for {self.ftype} type is zero.',
+                UserWarning, stacklevel=2)
 
         return self._float_to_float(value)
 

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -594,11 +594,9 @@ def _block_check_depths_match(arrays, parent_index=[]):
         #  - horribly confusing behaviour that results when tuples are
         #    treated like ndarray
         raise TypeError(
-            '{} is a tuple. '
+            f'{_block_format_index(parent_index)} is a tuple. '
             'Only lists can be used to arrange blocks, and np.block does '
-            'not allow implicit conversion from tuple to ndarray.'.format(
-                _block_format_index(parent_index)
-            )
+            'not allow implicit conversion from tuple to ndarray.'
         )
     elif type(arrays) is list and len(arrays) > 0:
         idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
@@ -611,12 +609,9 @@ def _block_check_depths_match(arrays, parent_index=[]):
                 max_arr_ndim = ndim
             if len(index) != len(first_index):
                 raise ValueError(
-                    "List depths are mismatched. First element was at depth "
-                    "{}, but there is an element at depth {} ({})".format(
-                        len(first_index),
-                        len(index),
-                        _block_format_index(index)
-                    )
+                    "List depths are mismatched. First element was at "
+                    f"depth {len(first_index)}, but there is an element at "
+                    f"depth {len(index)} ({_block_format_index(index)})"
                 )
             # propagate our flag that indicates an empty list at the bottom
             if index[-1] is None:

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -261,9 +261,8 @@ class TestConcatenate:
             assert_raises_regex(
                 ValueError,
                 "all the input array dimensions except for the concatenation axis "
-                "must match exactly, but along dimension {}, the array at "
-                "index 0 has size 1 and the array at index 1 has size 2"
-                .format(i),
+                f"must match exactly, but along dimension {i}, the array at "
+                "index 0 has size 1 and the array at index 1 has size 2",
                 np.concatenate, (a, b), axis=axis[1])
             assert_raises(ValueError, np.concatenate, (a, b), axis=axis[2])
             a = np.moveaxis(a, -1, 0)

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -133,15 +133,14 @@ def check_fpu_mode(request):
     new_mode = get_fpu_mode()
 
     if old_mode != new_mode:
-        raise AssertionError("FPU precision mode changed from {:#x} to {:#x}"
-                             " during the test".format(old_mode, new_mode))
+        raise AssertionError(f"FPU precision mode changed from {old_mode:#x} to "
+                             f"{new_mode:#x} during the test")
 
     collect_result = _collect_results.get(request.node)
     if collect_result is not None:
         old_mode, new_mode = collect_result
-        raise AssertionError("FPU precision mode changed from {:#x} to {:#x}"
-                             " when collecting the test".format(old_mode,
-                                                                new_mode))
+        raise AssertionError(f"FPU precision mode changed from {old_mode:#x} to "
+                             f"{new_mode:#x} when collecting the test")
 
 
 @pytest.fixture(autouse=True)

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -79,8 +79,7 @@ def __getattr__(attr):
         return test
 
     else:
-        raise AttributeError("module {!r} has no attribute "
-                              "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 
 
 def __dir__():

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -91,5 +91,4 @@ def __getattr__(attr):
             name=None
         )
     else:
-        raise AttributeError("module {!r} has no attribute "
-                             "{!r}".format(__name__, attr))
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -826,8 +826,8 @@ def pad(array, pad_width, mode='constant', **kwargs):
         for axis, width_pair in zip(axes, pad_width):
             if array.shape[axis] == 0 and any(width_pair):
                 raise ValueError(
-                    "can't extend empty axis {} using modes other than "
-                    "'constant' or 'empty'".format(axis)
+                    f"can't extend empty axis {axis} using modes other than "
+                    "'constant' or 'empty'"
                 )
         # passed, don't need to do anything more as _pad_simple already
         # returned the correct result

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5436,7 +5436,7 @@ def delete(arr, obj, axis=None):
             if obj.shape != (N,):
                 raise ValueError('boolean array argument obj to delete '
                                  'must be one dimensional and match the axis '
-                                 'length of {}'.format(N))
+                                 f'length of {N}')
 
             # optimization, the other branch is slower
             keep = ~obj

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -462,8 +462,8 @@ class TestHistogramOptimBinNums:
             x = np.concatenate((x1, x2))
             for estimator, numbins in expectedResults.items():
                 a, b = np.histogram(x, estimator)
-                assert_equal(len(a), numbins, err_msg="For the {} estimator "
-                             "with datasize of {}".format(estimator, testlen))
+                assert_equal(len(a), numbins, err_msg=f"For the {estimator} estimator "
+                             f"with datasize of {testlen}")
 
     def test_small(self):
         """
@@ -482,8 +482,8 @@ class TestHistogramOptimBinNums:
             testdat = np.arange(testlen).astype(float)
             for estimator, expbins in expectedResults.items():
                 a, b = np.histogram(testdat, estimator)
-                assert_equal(len(a), expbins, err_msg="For the {} estimator "
-                             "with datasize of {}".format(estimator, testlen))
+                assert_equal(len(a), expbins, err_msg=f"For the {estimator} estimator "
+                             f"with datasize of {testlen}")
 
     def test_incorrect_methods(self):
         """
@@ -504,8 +504,8 @@ class TestHistogramOptimBinNums:
 
         for estimator, numbins in novar_resultdict.items():
             a, b = np.histogram(novar_dataset, estimator)
-            assert_equal(len(a), numbins, err_msg="{} estimator, "
-                         "No Variance test".format(estimator))
+            assert_equal(len(a), numbins,
+                         err_msg=f"{estimator} estimator, No Variance test")
 
     def test_limited_variance(self):
         """

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -94,8 +94,7 @@ def test_cython(tmp_path):
             if txt_to_find in line:
                 break
         else:
-            assert False, ("Could not find '{}' in C file, "
-                           "wrong pxd used".format(txt_to_find))
+            assert False, f"Could not find '{txt_to_find}' in C file, wrong pxd used"
     # import without adding the directory to sys.path
     suffix = sysconfig.get_config_var('EXT_SUFFIX')
 

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -378,7 +378,7 @@ def test_all_modules_are_expected_2():
 
     if unexpected_members:
         raise AssertionError("Found unexpected object(s) that look like "
-                             "modules: {}".format(unexpected_members))
+                             f"modules: {unexpected_members}")
 
 
 def test_api_importable():
@@ -404,7 +404,7 @@ def test_api_importable():
 
     if module_names:
         raise AssertionError("Modules in the public API that cannot be "
-                             "imported: {}".format(module_names))
+                             f"imported: {module_names}")
 
     for module_name in PUBLIC_ALIASED_MODULES:
         try:
@@ -414,7 +414,7 @@ def test_api_importable():
 
     if module_names:
         raise AssertionError("Modules in the public API that were not "
-                             "found: {}".format(module_names))
+                             f"found: {module_names}")
 
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings('always', category=DeprecationWarning)
@@ -426,7 +426,7 @@ def test_api_importable():
     if module_names:
         raise AssertionError("Modules that are not really public but looked "
                              "public and can not be imported: "
-                             "{}".format(module_names))
+                             f"{module_names}")
 
 
 @pytest.mark.xfail(

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -34,8 +34,8 @@ class FindFuncs(ast.NodeVisitor):
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
             if node.args[0].value == "ignore":
                 raise AssertionError(
-                    "warnings should have an appropriate stacklevel; found in "
-                    "{} on line {}".format(self.__filename, node.lineno))
+                    "warnings should have an appropriate stacklevel; "
+                    f"found in {self.__filename} on line {node.lineno}")
 
         if p.ls[-1] == 'warn' and (
                 len(p.ls) == 1 or p.ls[-2] == 'warnings'):
@@ -51,8 +51,8 @@ class FindFuncs(ast.NodeVisitor):
             if "stacklevel" in args:
                 return
             raise AssertionError(
-                "warnings should have an appropriate stacklevel; found in "
-                "{} on line {}".format(self.__filename, node.lineno))
+                "warnings should have an appropriate stacklevel; "
+                f"found in {self.__filename} on line {node.lineno}")
 
 
 @pytest.mark.slow

--- a/tools/swig/test/testFarray.py
+++ b/tools/swig/test/testFarray.py
@@ -15,7 +15,7 @@ else:
 
 # Add the distutils-generated build directory to the python search path and then
 # import the extension module
-libDir = "lib.{}-{}.{}".format(get_platform(), *sys.version_info[:2])
+libDir = f"lib.{get_platform()}-{sys.version_info[0]}.{sys.version_info[1]}"
 sys.path.insert(0, os.path.join("build", libDir))
 import Farray
 

--- a/tools/wheels/check_license.py
+++ b/tools/wheels/check_license.py
@@ -45,8 +45,8 @@ def main():
     ok = check_text(text)
     if not ok:
         print(
-            "ERROR: License text {} does not contain expected "
-            "text fragments\n".format(license_txt)
+            f"ERROR: License text {license_txt} does not contain expected "
+            "text fragments\n"
         )
         print(text)
         sys.exit(1)


### PR DESCRIPTION
Automatically modified by `ruff check --select UP032`, then manually fixed line breaks and line length (maximum line length should be 88).