### PR TITLE
STY: Use f-string instead of `format` call

### DIFF
--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -526,7 +526,7 @@ multiplication::
         def __init__(self, value):
             self.value = value
         def __repr__(self):
-            return "MyObject({!r})".format(self.value)
+            return f"MyObject({self.value!r})"
         def __mul__(self, other):
             return MyObject(1234)
         def __rmul__(self, other):

--- a/doc/source/reference/random/bit_generators/index.rst
+++ b/doc/source/reference/random/bit_generators/index.rst
@@ -91,7 +91,7 @@ user, which is up to you.
     # If the user did not provide a seed, it should return `None`.
     seed = get_user_seed()
     ss = SeedSequence(seed)
-    print('seed = {}'.format(ss.entropy))
+    print(f'seed = {ss.entropy}')
     bg = PCG64(ss)
 
 .. end_block

--- a/numpy/f2py/_src_pyf.py
+++ b/numpy/f2py/_src_pyf.py
@@ -169,8 +169,10 @@ def expand_sub(substr, names):
             elif num == numsubs:
                 rules[r] = rule
             else:
-                print("Mismatch in number of replacements (base <{}={}>) "
-                      "for <{}={}>. Ignoring.".format(base_rule, ','.join(rules[base_rule]), r, thelist))
+                rules_base_rule = ','.join(rules[base_rule])
+                print("Mismatch in number of replacements "
+                      f"(base <{base_rule}={rules_base_rule}>) "
+                      f"for <{r}={thelist}>. Ignoring.")
     if not rules:
         return substr
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -479,13 +479,14 @@ def run_main(comline_list):
                     isusedby[u] = []
                 isusedby[u].append(plist['name'])
     for plist in postlist:
-        if plist['block'] == 'python module' and '__user__' in plist['name']:
-            if plist['name'] in isusedby:
+        module_name = plist['name']
+        if plist['block'] == 'python module' and '__user__' in module_name:
+            if module_name in isusedby:
                 # if not quiet:
+                usedby = ','.join(f'"{s}"' for s in isusedby[module_name])
                 outmess(
-                    f'Skipping Makefile build for module "{plist["name"]}" '
-                    'which is used by {}\n'.format(
-                        ','.join(f'"{s}"' for s in isusedby[plist['name']])))
+                    f'Skipping Makefile build for module "{module_name}" '
+                    f'which is used by {usedby}\n')
     if 'signsfile' in options:
         if options['verbose'] > 1:
             outmess(

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -224,8 +224,7 @@ cdef np.ndarray int_to_array(object value, object name, object bits, object uint
         value = int(value)
         upper = int(2)**int(bits)
         if value < 0 or value >= upper:
-            raise ValueError('{name} must be positive and '
-                             'less than 2**{bits}.'.format(name=name, bits=bits))
+            raise ValueError(f'{name} must be positive and less than 2**{bits}.')
 
         out = np.empty(len, dtype=dtype)
         for i in range(len):
@@ -234,8 +233,7 @@ cdef np.ndarray int_to_array(object value, object name, object bits, object uint
     else:
         out = value.astype(dtype)
         if out.shape != (len,):
-            raise ValueError('{name} must have {len} elements when using '
-                             'array form'.format(name=name, len=len))
+            raise ValueError(f'{name} must have {len} elements when using array form')
     return out
 
 
@@ -283,7 +281,7 @@ cdef check_output(object out, object dtype, object size, bint require_c_array):
         )
     if out_array.dtype != dtype:
         raise TypeError('Supplied output array has the wrong type. '
-                        'Expected {0}, got {1}'.format(np.dtype(dtype), out_array.dtype))
+                        f'Expected {np.dtype(dtype)}, got {out_array.dtype}')
     if size is not None:
         try:
             tup_size = tuple(size)
@@ -386,43 +384,43 @@ cdef int _check_array_cons_bounded_0_1(np.ndarray val, object name) except -1:
 cdef int check_array_constraint(np.ndarray val, object name, constraint_type cons) except -1:
     if cons == CONS_NON_NEGATIVE:
         if np.any(np.logical_and(np.logical_not(np.isnan(val)), np.signbit(val))):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
         if cons == CONS_POSITIVE_NOT_NAN and np.any(np.isnan(val)):
-            raise ValueError(name + " must not be NaN")
+            raise ValueError(f"{name} must not be NaN")
         elif np.any(np.less_equal(val, 0)):
-            raise ValueError(name + " <= 0")
+            raise ValueError(f"{name} <= 0")
     elif cons == CONS_BOUNDED_0_1:
         return _check_array_cons_bounded_0_1(val, name)
     elif cons == CONS_BOUNDED_GT_0_1:
         if not np.all(np.greater(val, 0)) or not np.all(np.less_equal(val, 1)):
-            raise ValueError("{0} <= 0, {0} > 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 0, {name} > 1 or {name} contains NaNs")
     elif cons == CONS_BOUNDED_LT_0_1:
         if not np.all(np.greater_equal(val, 0)) or not np.all(np.less(val, 1)):
-            raise ValueError("{0} < 0, {0} >= 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0, {name} >= 1 or {name} contains NaNs")
     elif cons == CONS_GT_1:
         if not np.all(np.greater(val, 1)):
-            raise ValueError("{0} <= 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 1 or {name} contains NaNs")
     elif cons == CONS_GTE_1:
         if not np.all(np.greater_equal(val, 1)):
-            raise ValueError("{0} < 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 1 or {name} contains NaNs")
     elif cons == CONS_POISSON:
         if not np.all(np.less_equal(val, POISSON_LAM_MAX)):
-            raise ValueError("{0} value too large".format(name))
+            raise ValueError(f"{name} value too large")
         elif not np.all(np.greater_equal(val, 0.0)):
-            raise ValueError("{0} < 0 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0 or {name} contains NaNs")
     elif cons == LEGACY_CONS_POISSON:
         if not np.all(np.less_equal(val, LEGACY_POISSON_LAM_MAX)):
-            raise ValueError("{0} value too large".format(name))
+            raise ValueError(f"{name} value too large")
         elif not np.all(np.greater_equal(val, 0.0)):
-            raise ValueError("{0} < 0 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} < 0 or {name} contains NaNs")
     elif cons == LEGACY_CONS_NON_NEGATIVE_INBOUNDS_LONG:
         # Note, we assume that array is integral:
         if not np.all(val >= 0):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
         elif not np.all(val <= int(LONG_MAX)):
             raise ValueError(
-                    name + " is out of bounds for long, consider using "
+                    f"{name} is out of bounds for long, consider using "
                     "the new generator API for 64bit integers.")
 
     return 0
@@ -432,44 +430,44 @@ cdef int check_constraint(double val, object name, constraint_type cons) except 
     cdef bint is_nan
     if cons == CONS_NON_NEGATIVE:
         if not isnan(val) and signbit(val):
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
         if cons == CONS_POSITIVE_NOT_NAN and isnan(val):
-            raise ValueError(name + " must not be NaN")
+            raise ValueError(f"{name} must not be NaN")
         elif val <= 0:
-            raise ValueError(name + " <= 0")
+            raise ValueError(f"{name} <= 0")
     elif cons == CONS_BOUNDED_0_1:
         if not (val >= 0) or not (val <= 1):
-            raise ValueError("{0} < 0, {0} > 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0, {name} > 1 or {name} is NaN")
     elif cons == CONS_BOUNDED_GT_0_1:
         if not val >0 or not val <= 1:
-            raise ValueError("{0} <= 0, {0} > 1 or {0} contains NaNs".format(name))
+            raise ValueError(f"{name} <= 0, {name} > 1 or {name} contains NaNs")
     elif cons == CONS_BOUNDED_LT_0_1:
         if not (val >= 0) or not (val < 1):
-            raise ValueError("{0} < 0, {0} >= 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0, {name} >= 1 or {name} is NaN")
     elif cons == CONS_GT_1:
         if not (val > 1):
-            raise ValueError("{0} <= 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} <= 1 or {name} is NaN")
     elif cons == CONS_GTE_1:
         if not (val >= 1):
-            raise ValueError("{0} < 1 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 1 or {name} is NaN")
     elif cons == CONS_POISSON:
         if not (val >= 0):
-            raise ValueError("{0} < 0 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0 or {name} is NaN")
         elif not (val <= POISSON_LAM_MAX):
-            raise ValueError(name + " value too large")
+            raise ValueError(f"{name} value too large")
     elif cons == LEGACY_CONS_POISSON:
         if not (val >= 0):
-            raise ValueError("{0} < 0 or {0} is NaN".format(name))
+            raise ValueError(f"{name} < 0 or {name} is NaN")
         elif not (val <= LEGACY_POISSON_LAM_MAX):
-            raise ValueError(name + " value too large")
+            raise ValueError(f"{name} value too large")
     elif cons == LEGACY_CONS_NON_NEGATIVE_INBOUNDS_LONG:
         # Note: Assume value is integral (double of LONG_MAX should work out)
         if val < 0:
-            raise ValueError(name + " < 0")
+            raise ValueError(f"{name} < 0")
         elif val > <double> LONG_MAX:
             raise ValueError(
-                    name + " is out of bounds for long, consider using "
+                    f"{name} is out of bounds for long, consider using "
                     "the new generator API for 64bit integers.")
 
     return 0

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -207,12 +207,10 @@ cdef class Generator:
         self.lock = bit_generator.lock
 
     def __repr__(self):
-        return self.__str__() + ' at 0x{:X}'.format(id(self))
+        return f'{self} at 0x{id(self):X}'
 
     def __str__(self):
-        _str = self.__class__.__name__
-        _str += '(' + self.bit_generator.__class__.__name__ + ')'
-        return _str
+        return f'{self.__class__.__name__}({self.bit_generator.__class__.__name__})'
 
     # Pickling support:
     def __getstate__(self):

--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -284,8 +284,7 @@ cdef class MT19937(BitGenerator):
             raise TypeError('state must be a dict')
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
-            raise ValueError('state must be for a {0} '
-                             'PRNG'.format(self.__class__.__name__))
+            raise ValueError(f'state must be for a {self.__class__.__name__} PRNG')
         key = value['state']['key']
         for i in range(624):
             self.rng_state.key[i] = key[i]

--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -225,8 +225,7 @@ cdef class PCG64(BitGenerator):
             raise TypeError('state must be a dict')
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
-            raise ValueError('state must be for a {0} '
-                             'RNG'.format(self.__class__.__name__))
+            raise ValueError(f'state must be for a {self.__class__.__name__} RNG')
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
         state_vec[0] = value['state']['state'] // 2 ** 64
         state_vec[1] = value['state']['state'] % 2 ** 64
@@ -460,8 +459,7 @@ cdef class PCG64DXSM(BitGenerator):
             raise TypeError('state must be a dict')
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
-            raise ValueError('state must be for a {0} '
-                             'RNG'.format(self.__class__.__name__))
+            raise ValueError(f'state must be for a {self.__class__.__name__} RNG')
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
         state_vec[0] = value['state']['state'] // 2 ** 64
         state_vec[1] = value['state']['state'] % 2 ** 64

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -238,8 +238,7 @@ cdef class Philox(BitGenerator):
             raise TypeError('state must be a dict')
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
-            raise ValueError('state must be for a {0} '
-                             'PRNG'.format(self.__class__.__name__))
+            raise ValueError(f'state must be for a {self.__class__.__name__} PRNG')
         for i in range(4):
             self.rng_state.ctr.v[i] = <uint64_t> value['state']['counter'][i]
             if i < 2:

--- a/numpy/random/_sfc64.pyx
+++ b/numpy/random/_sfc64.pyx
@@ -135,8 +135,7 @@ cdef class SFC64(BitGenerator):
             raise TypeError('state must be a dict')
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
-            raise ValueError('state must be for a {0} '
-                             'RNG'.format(self.__class__.__name__))
+            raise ValueError('state must be for a {self.__class__.__name__} RNG')
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
         state_vec[:] = value['state']['state']
         has_uint32 = value['has_uint32']

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -305,7 +305,7 @@ cdef class SeedSequence():
         elif not isinstance(entropy, (int, np.integer, list, tuple, range,
                                       np.ndarray)):
             raise TypeError('SeedSequence expects int or sequence of ints for '
-                            'entropy not {}'.format(entropy))
+                            f'entropy not {entropy}')
         self.entropy = entropy
         self.spawn_key = tuple(spawn_key)
         self.pool_size = pool_size

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -190,7 +190,7 @@ cdef class RandomState:
         self._initialize_bit_generator(bit_generator)
 
     def __repr__(self):
-        return self.__str__() + ' at 0x{:X}'.format(id(self))
+        return f'{self} at 0x{id(self):X}'
 
     def __str__(self):
         _str = self.__class__.__name__
@@ -1387,15 +1387,14 @@ cdef class RandomState:
         """
         if high is None:
             warnings.warn(("This function is deprecated. Please call "
-                           "randint(1, {low} + 1) instead".format(low=low)),
+                           f"randint(1, {low} + 1) instead"),
                           DeprecationWarning)
             high = low
             low = 1
 
         else:
             warnings.warn(("This function is deprecated. Please call "
-                           "randint({low}, {high} + 1) "
-                           "instead".format(low=low, high=high)),
+                           f"randint({low}, {high} + 1) instead"),
                           DeprecationWarning)
 
         return self.randint(low, int(high) + 1, size=size, dtype='l')


### PR DESCRIPTION
Fix residual occurrences not caught by ruff rule `UP032` in #28760, especially in `*.pyx` files.