### PR TITLE
MNT: Enforce ruff/pyupgrade rules (UP)

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9053,7 +9053,7 @@ class TestWhere:
         e = float('-Infinity')
         assert_equal(np.where(True, d, e).dtype, np.float32)
         # With NEP 50 adopted, the float will overflow here:
-        e = float(1e150)
+        e = 1e150
         with pytest.warns(RuntimeWarning, match="overflow"):
             res = np.where(True, d, e)
         assert res.dtype == np.float32

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,6 +21,7 @@ extend-select = [
     "W",
     "PGH",
     "PLE",
+    "UP",
 ]
 ignore = [
     "F",     # TODO: enable Pyflakes rules
@@ -35,6 +36,8 @@ ignore = [
     "E721",
     "E731",
     "E741",
+    "UP015", # Unnecessary mode argument
+    "UP031", # TODO: Use format specifiers instead of percent format
 ]
 
 [lint.per-file-ignores]


### PR DESCRIPTION
I have left out these rules:
* [UP015](https://docs.astral.sh/ruff/rules/redundant-open-modes/): Some developers prefer explicit over implicit. I'll leave that up to you maintainers.
* [UP031](https://docs.astral.sh/ruff/rules/printf-string-formatting/): With 273 occurrences even after merging #28768, this rule deserves its own PR.
  ```console
  $ ruff check --extend-select UP031
  [...]
  Found 273 errors.
  No fixes available (183 hidden fixes can be enabled with the `--unsafe-fixes` option).
  $ 
   ```