### PR TITLE
TYP: fix incorrect `random.Generator.integers` return type

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -1,29 +1,17 @@
 from collections.abc import Callable
-from typing import Any, TypeAlias, overload, TypeVar, Literal
+from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 import numpy as np
-from numpy import (
-    dtype,
-    float32,
-    float64,
-    int8,
-    int16,
-    int32,
-    int64,
-    int_,
-    uint,
-    uint8,
-    uint16,
-    uint32,
-    uint64,
-)
-from numpy.random import BitGenerator, SeedSequence, RandomState
+from numpy import dtype, float32, float64, int64
 from numpy._typing import (
     ArrayLike,
+    DTypeLike,
     NDArray,
     _ArrayLikeFloat_co,
     _ArrayLikeInt_co,
+    _BoolCodes,
     _DoubleCodes,
+    _DTypeLike,
     _DTypeLikeBool,
     _Float32Codes,
     _Float64Codes,
@@ -32,7 +20,7 @@ from numpy._typing import (
     _Int16Codes,
     _Int32Codes,
     _Int64Codes,
-    _IntCodes,
+    _IntPCodes,
     _ShapeLike,
     _SingleCodes,
     _SupportsDType,
@@ -40,10 +28,11 @@ from numpy._typing import (
     _UInt16Codes,
     _UInt32Codes,
     _UInt64Codes,
-    _UIntCodes,
+    _UIntPCodes,
 )
+from numpy.random import BitGenerator, RandomState, SeedSequence
 
-_ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
+_IntegerT = TypeVar("_IntegerT", bound=np.integer)
 
 _DTypeLikeFloat32: TypeAlias = (
     dtype[float32]
@@ -198,249 +187,296 @@ class Generator:
     ) -> float: ...  # type: ignore[misc]
     @overload
     def beta(
-        self, a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        a: _ArrayLikeFloat_co,
+        b: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
     def exponential(self, scale: _FloatLike_co = ..., size: None = ...) -> float: ...  # type: ignore[misc]
     @overload
-    def exponential(
-        self, scale: _ArrayLikeFloat_co = ..., size: None | _ShapeLike = ...
-    ) -> NDArray[float64]: ...
+    def exponential(self, scale: _ArrayLikeFloat_co = ..., size: None | _ShapeLike = ...) -> NDArray[float64]: ...
+
+    #
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: int,
-        high: None | int = ...,
-        size: None = ...,
+        high: int | None = None,
+        size: None = None,
+        dtype: _DTypeLike[np.int64] | _Int64Codes = ...,
+        endpoint: bool = False,
+    ) -> np.int64: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
         *,
-        endpoint: bool = ...,
-    ) -> int: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: type[bool] = ...,
-        endpoint: bool = ...,
+        dtype: type[bool],
+        endpoint: bool = False,
     ) -> bool: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: type[np.bool] = ...,
-        endpoint: bool = ...,
-    ) -> np.bool: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: type[int] = ...,
-        endpoint: bool = ...,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: type[int],
+        endpoint: bool = False,
     ) -> int: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | _SupportsDType[dtype[uint8]] = ...,
-        endpoint: bool = ...,
-    ) -> uint8: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | _SupportsDType[dtype[uint16]] = ...,
-        endpoint: bool = ...,
-    ) -> uint16: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | _SupportsDType[dtype[uint32]] = ...,
-        endpoint: bool = ...,
-    ) -> uint32: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[uint] | type[uint] | _UIntCodes | _SupportsDType[dtype[uint]] = ...,
-        endpoint: bool = ...,
-    ) -> uint: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | _SupportsDType[dtype[uint64]] = ...,
-        endpoint: bool = ...,
-    ) -> uint64: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[int8] | type[int8] | _Int8Codes | _SupportsDType[dtype[int8]] = ...,
-        endpoint: bool = ...,
-    ) -> int8: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[int16] | type[int16] | _Int16Codes | _SupportsDType[dtype[int16]] = ...,
-        endpoint: bool = ...,
-    ) -> int16: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[int32] | type[int32] | _Int32Codes | _SupportsDType[dtype[int32]] = ...,
-        endpoint: bool = ...,
-    ) -> int32: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | _SupportsDType[dtype[int_]] = ...,
-        endpoint: bool = ...,
-    ) -> int_: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: int,
-        high: None | int = ...,
-        size: None = ...,
-        dtype: dtype[int64] | type[int64] | _Int64Codes | _SupportsDType[dtype[int64]] = ...,
-        endpoint: bool = ...,
-    ) -> int64: ...
-    @overload
-    def integers(  # type: ignore[misc]
-        self,
-        low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
+        high: int | None = None,
+        size: None = None,
         *,
-        endpoint: bool = ...
-    ) -> NDArray[int64]: ...
+        dtype: _DTypeLike[np.bool] | _BoolCodes,
+        endpoint: bool = False,
+    ) -> np.bool: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _DTypeLike[_IntegerT],
+        endpoint: bool = False,
+    ) -> _IntegerT: ...
+    @overload
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: _DTypeLikeBool = ...,
-        endpoint: bool = ...,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        dtype: _DTypeLike[np.int64] | _Int64Codes = ...,
+        endpoint: bool = False,
+    ) -> NDArray[np.int64]: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _DTypeLikeBool,
+        endpoint: bool = False,
     ) -> NDArray[np.bool]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[int8] | type[int8] | _Int8Codes | _SupportsDType[dtype[int8]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[int8]: ...
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _DTypeLike[_IntegerT],
+        endpoint: bool = False,
+    ) -> NDArray[_IntegerT]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
-        low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[int16] | type[int16] | _Int16Codes | _SupportsDType[dtype[int16]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[int16]: ...
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _Int8Codes,
+        endpoint: bool = False,
+    ) -> np.int8: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[int32] | type[int32] | _Int32Codes | _SupportsDType[dtype[int32]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[int32]: ...
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _Int8Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.int8]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
-        low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: None | dtype[int64] | type[int64] | _Int64Codes | _SupportsDType[dtype[int64]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[int64]: ...
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _UInt8Codes,
+        endpoint: bool = False,
+    ) -> np.uint8: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[uint8] | type[uint8] | _UInt8Codes | _SupportsDType[dtype[uint8]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[uint8]: ...
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _UInt8Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.uint8]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
-        low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[uint16] | type[uint16] | _UInt16Codes | _SupportsDType[dtype[uint16]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[uint16]: ...
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _Int16Codes,
+        endpoint: bool = False,
+    ) -> np.int16: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[uint32] | type[uint32] | _UInt32Codes | _SupportsDType[dtype[uint32]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[uint32]: ...
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _Int16Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.int16]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
-        low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[uint64] | type[uint64] | _UInt64Codes | _SupportsDType[dtype[uint64]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[uint64]: ...
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _UInt16Codes,
+        endpoint: bool = False,
+    ) -> np.uint16: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[int_] | type[int] | type[int_] | _IntCodes | _SupportsDType[dtype[int_]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[int_]: ...
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _UInt16Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.uint16]: ...
     @overload
-    def integers(  # type: ignore[misc]
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _Int32Codes,
+        endpoint: bool = False,
+    ) -> np.int32: ...
+    @overload
+    def integers(
         self,
         low: _ArrayLikeInt_co,
-        high: None | _ArrayLikeInt_co = ...,
-        size: None | _ShapeLike = ...,
-        dtype: dtype[uint] | type[uint] | _UIntCodes | _SupportsDType[dtype[uint]] = ...,
-        endpoint: bool = ...,
-    ) -> NDArray[uint]: ...
-    # TODO: Use a TypeVar _T here to get away from Any output?  Should be int->NDArray[int64], ArrayLike[_T] -> _T | NDArray[Any]
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _Int32Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.int32]: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _UInt32Codes,
+        endpoint: bool = False,
+    ) -> np.uint32: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _UInt32Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.uint32]: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _UInt64Codes,
+        endpoint: bool = False,
+    ) -> np.uint64: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _UInt64Codes,
+        endpoint: bool = False,
+    ) -> NDArray[np.uint64]: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _IntPCodes,
+        endpoint: bool = False,
+    ) -> np.intp: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _IntPCodes,
+        endpoint: bool = False,
+    ) -> NDArray[np.intp]: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        *,
+        dtype: _UIntPCodes,
+        endpoint: bool = False,
+    ) -> np.uintp: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        *,
+        dtype: _UIntPCodes,
+        endpoint: bool = False,
+    ) -> NDArray[np.uintp]: ...
+    @overload
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: None = None,
+        dtype: DTypeLike = ...,
+        endpoint: bool = False,
+    ) -> Any: ...
+    @overload
+    def integers(
+        self,
+        low: _ArrayLikeInt_co,
+        high: _ArrayLikeInt_co | None = None,
+        size: _ShapeLike | None = None,
+        dtype: DTypeLike = ...,
+        endpoint: bool = False,
+    ) -> NDArray[Any]: ...
+
+    # TODO: Use a TypeVar _T here to get away from Any output?
+    #       Should be int->NDArray[int64], ArrayLike[_T] -> _T | NDArray[Any]
     @overload
     def choice(
         self,
@@ -547,7 +583,9 @@ class Generator:
         out: None | NDArray[float64] = ...,
     ) -> NDArray[float64]: ...
     @overload
-    def gamma(self, shape: _FloatLike_co, scale: _FloatLike_co = ..., size: None = ...) -> float: ...  # type: ignore[misc]
+    def gamma(
+        self, shape: _FloatLike_co, scale: _FloatLike_co = ..., size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def gamma(
         self,
@@ -556,13 +594,23 @@ class Generator:
         size: None | _ShapeLike = ...,
     ) -> NDArray[float64]: ...
     @overload
-    def f(self, dfnum: _FloatLike_co, dfden: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
+    def f(
+        self, dfnum: _FloatLike_co, dfden: _FloatLike_co, size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def f(
-        self, dfnum: _ArrayLikeFloat_co, dfden: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        dfnum: _ArrayLikeFloat_co,
+        dfden: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
-    def noncentral_f(self, dfnum: _FloatLike_co, dfden: _FloatLike_co, nonc: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
+    def noncentral_f(
+        self,
+        dfnum: _FloatLike_co,
+        dfden: _FloatLike_co,
+        nonc: _FloatLike_co, size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def noncentral_f(
         self,
@@ -578,10 +626,15 @@ class Generator:
         self, df: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
-    def noncentral_chisquare(self, df: _FloatLike_co, nonc: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
+    def noncentral_chisquare(
+        self, df: _FloatLike_co, nonc: _FloatLike_co, size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def noncentral_chisquare(
-        self, df: _ArrayLikeFloat_co, nonc: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        df: _ArrayLikeFloat_co,
+        nonc: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
     def standard_t(self, df: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
@@ -594,10 +647,15 @@ class Generator:
         self, df: _ArrayLikeFloat_co, size: _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
-    def vonmises(self, mu: _FloatLike_co, kappa: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
+    def vonmises(
+        self, mu: _FloatLike_co, kappa: _FloatLike_co, size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def vonmises(
-        self, mu: _ArrayLikeFloat_co, kappa: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        mu: _ArrayLikeFloat_co,
+        kappa: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
     def pareto(self, a: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
@@ -684,10 +742,15 @@ class Generator:
         self, scale: _ArrayLikeFloat_co = ..., size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
-    def wald(self, mean: _FloatLike_co, scale: _FloatLike_co, size: None = ...) -> float: ...  # type: ignore[misc]
+    def wald(
+        self, mean: _FloatLike_co, scale: _FloatLike_co, size: None = ...
+    ) -> float: ...  # type: ignore[misc]
     @overload
     def wald(
-        self, mean: _ArrayLikeFloat_co, scale: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        mean: _ArrayLikeFloat_co,
+        scale: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[float64]: ...
     @overload
     def triangular(
@@ -712,10 +775,15 @@ class Generator:
         self, n: _ArrayLikeInt_co, p: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
     ) -> NDArray[int64]: ...
     @overload
-    def negative_binomial(self, n: _FloatLike_co, p: _FloatLike_co, size: None = ...) -> int: ...  # type: ignore[misc]
+    def negative_binomial(
+        self, n: _FloatLike_co, p: _FloatLike_co, size: None = ...
+    ) -> int: ...  # type: ignore[misc]
     @overload
     def negative_binomial(
-        self, n: _ArrayLikeFloat_co, p: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
+        self,
+        n: _ArrayLikeFloat_co,
+        p: _ArrayLikeFloat_co,
+        size: None | _ShapeLike = ...
     ) -> NDArray[int64]: ...
     @overload
     def poisson(self, lam: _FloatLike_co = ..., size: None = ...) -> int: ...  # type: ignore[misc]
@@ -736,7 +804,9 @@ class Generator:
         self, p: _ArrayLikeFloat_co, size: None | _ShapeLike = ...
     ) -> NDArray[int64]: ...
     @overload
-    def hypergeometric(self, ngood: int, nbad: int, nsample: int, size: None = ...) -> int: ...  # type: ignore[misc]
+    def hypergeometric(
+        self, ngood: int, nbad: int, nsample: int, size: None = ...
+    ) -> int: ...  # type: ignore[misc]
     @overload
     def hypergeometric(
         self,

--- a/numpy/typing/tests/data/reveal/random.pyi
+++ b/numpy/typing/tests/data/reveal/random.pyi
@@ -504,8 +504,8 @@ assert_type(def_gen.hypergeometric(I_arr_like_20, I_arr_like_20, I_arr_like_10, 
 
 I_int64_100: npt.NDArray[np.int64] = np.array([100], dtype=np.int64)
 
-assert_type(def_gen.integers(0, 100), int)
-assert_type(def_gen.integers(100), int)
+assert_type(def_gen.integers(0, 100), np.int64)
+assert_type(def_gen.integers(100), np.int64)
 assert_type(def_gen.integers([100]), npt.NDArray[np.int64])
 assert_type(def_gen.integers(0, [100]), npt.NDArray[np.int64])
 


### PR DESCRIPTION
Backport of #28738.

closes #28736

I've checked out all of `numpy/random/_generator.pyi` due to extensive changes that were not backported. Let's see how the tests do.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
