### PR TITLE
TYP: fix `count_nonzero` signature

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -109,6 +109,7 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
     _ArrayLikeObject_co,
+    _ArrayLikeUnknown,
     _NestedSequence,
 )
 

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -109,7 +109,7 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
     _ArrayLikeObject_co,
-    _ArrayLikeUnknown,
+    _NestedSequence,
 )
 
 __all__ = [
@@ -456,21 +456,19 @@ def full_like(
     device: None | L["cpu"] = ...,
 ) -> NDArray[Any]: ...
 
+#
+@overload
+def count_nonzero(a: ArrayLike, axis: None = None, *, keepdims: L[False] = False) -> int: ...
+@overload
+def count_nonzero(a: _ScalarLike_co, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> np.intp: ...
 @overload
 def count_nonzero(
-    a: ArrayLike,
-    axis: None = ...,
-    *,
-    keepdims: L[False] = ...,
-) -> int: ...
+    a: NDArray[Any] | _NestedSequence[ArrayLike], axis: _ShapeLike | None = None, *, keepdims: L[True]
+) -> NDArray[np.intp]: ...
 @overload
-def count_nonzero(
-    a: ArrayLike,
-    axis: _ShapeLike = ...,
-    *,
-    keepdims: bool = ...,
-) -> Any: ...  # TODO: np.intp or ndarray[np.intp]
+def count_nonzero(a: ArrayLike, axis: _ShapeLike | None = None, *, keepdims: bool = False) -> Any: ...
 
+#
 def isfortran(a: NDArray[Any] | generic) -> bool: ...
 
 def argwhere(a: ArrayLike) -> NDArray[intp]: ...

--- a/numpy/typing/tests/data/reveal/numeric.pyi
+++ b/numpy/typing/tests/data/reveal/numeric.pyi
@@ -31,7 +31,7 @@ C: SubClass
 assert_type(np.count_nonzero(i8), int)
 assert_type(np.count_nonzero(AR_i8), int)
 assert_type(np.count_nonzero(B), int)
-assert_type(np.count_nonzero(AR_i8, keepdims=True), Any)
+assert_type(np.count_nonzero(AR_i8, keepdims=True), npt.NDArray[np.intp])
 assert_type(np.count_nonzero(AR_i8, axis=0), Any)
 
 assert_type(np.isfortran(i8), bool)


### PR DESCRIPTION
Backport of #28750.

This fixes the following valid usage in https://github.com/data-apis/array-api-compat/blob/16978e63b744185bc4ced4677c822468e6ddebd2/array_api_compat/numpy/_aliases.py#L126-L127 from being falsely rejected:


```py
def count_nonzero(
    x: Array,
    axis: int | tuple[int, ...] | None = None,
    keepdims: py_bool = False,
) -> Array:
    result = np.count_nonzero(x, axis=axis, keepdims=keepdims)
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
