### PR TITLE
BUG: Fix #28730 histogram error with nan objects and add regression test 

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -789,6 +789,10 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
 
     bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
 
+    # If Histogram is of type object make it a float.
+    if a.dtype == object:
+        a = a.astype(float)
+
     # Histogram is an integer or a float array depending on the weights.
     if weights is None:
         ntype = np.dtype(np.intp)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -296,6 +296,16 @@ class TestHistogram:
             h, b = histogram(all_nan, bins=[0, 1])
             assert_equal(h.sum(), 0)  # nan is not counted
 
+    def test_nan_object_dtype_values(self):
+        # gh-28730
+        float_nan = np.asarray([0., 1., np.nan], dtype=float)
+        object_nan = np.asarray([0., 1., np.nan], dtype=object)
+        
+        h, b = histogram(float_nan, bins=np.arange(0,5))
+        assert_array_equal(h,[1,1,0,0])
+        h, b = histogram(object_nan, bins=np.arange(0,5))
+        assert_array_equal(h,[1,1,0,0])
+
     def test_datetime(self):
         begin = np.datetime64('2000-01-01', 'D')
         offsets = np.array([0, 0, 1, 1, 2, 3, 5, 10, 20])

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -300,11 +300,11 @@ class TestHistogram:
         # gh-28730
         float_nan = np.asarray([0., 1., np.nan], dtype=float)
         object_nan = np.asarray([0., 1., np.nan], dtype=object)
-        
-        h, b = histogram(float_nan, bins=np.arange(0,5))
-        assert_array_equal(h,[1,1,0,0])
-        h, b = histogram(object_nan, bins=np.arange(0,5))
-        assert_array_equal(h,[1,1,0,0])
+
+        h, b = histogram(float_nan, bins=np.arange(0, 5))
+        assert_array_equal(h, [1, 1, 0, 0])
+        h, b = histogram(object_nan, bins=np.arange(0, 5))
+        assert_array_equal(h, [1, 1, 0, 0])
 
     def test_datetime(self):
         begin = np.datetime64('2000-01-01', 'D')


### PR DESCRIPTION
<h2>Description</h2>
BUG: Fix #28730 histogram error when input has object dtype with NaNs

This Fixes a bug in np.histogram where object-dtyped arrays containing np.nan would cause a wrong output. Now such object arrays are cast to float before processing, fixing the bug.
<h2>Example</h2>

**Before fix:** 
```python
print(np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins=np.arange(0, 5))[0])

print(np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins=np.arange(0, 5))[0])
```
**Output:**
[1 1 0 1]
[1 1 0 0]

_Returned incorrect bins because of improper handling of np.nan in object-dtype arrays_

**After fix:**
```python
print(np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins=np.arange(0, 5))[0])

print(np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins=np.arange(0, 5))[0])
```

**Output:**
[1 1 0 0]
[1 1 0 0]

Closes: #28730