### PR TITLE
ENH: np.linalg.inv: Allow disabling error when one matrix is singular in a stack

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -491,12 +491,12 @@ def tensorinv(a, ind=2):
 
 # Matrix inversion
 
-def _unary_dispatcher(a):
+def _unary_dispatcher(a, *, noerr=None):
     return (a,)
 
 
 @array_function_dispatch(_unary_dispatcher)
-def inv(a):
+def inv(a, *, noerr=False):
     """
     Compute the inverse of a matrix.
 
@@ -507,6 +507,10 @@ def inv(a):
     ----------
     a : (..., M, M) array_like
         Matrix to be inverted.
+    noerr : bool, optional
+        If True, do not raise a LinAlgError when a matrix is singular.
+        Instead, return a matrix with NaN values for the singular matrices.
+        Default is False.
 
     Returns
     -------
@@ -579,6 +583,25 @@ def inv(a):
            [-0.5  ,  0.625,  0.25 ],
            [ 0.   ,  0.   ,  1.   ]])
 
+    Using the `noerr` parameter to handle singular matrices in a stack:
+
+    >>> a = np.array([
+    ...     [[1.0, 0.0], [0.0, 1.0]],  # invertible
+    ...     [[1.0, 1.0], [1.0, 1.0]],  # singular
+    ...     [[2.0, 1.0], [1.0, 2.0]]   # invertible
+    ... ])
+    >>> # Without noerr, a LinAlgError is raised
+    >>> try:
+    ...     inv(a)
+    ... except np.linalg.LinAlgError:
+    ...     print("LinAlgError raised")
+    LinAlgError raised
+    >>> # With noerr=True, NaN values are returned for singular matrices
+    >>> result = inv(a, noerr=True)
+    >>> # Check which matrices were singular
+    >>> np.isnan(result).any(axis=(1, 2))
+    array([False,  True, False])
+
     To detect ill-conditioned matrices, you can use `numpy.linalg.cond` to
     compute its *condition number* [1]_. The larger the condition number, the
     more ill-conditioned the matrix is. As a rule of thumb, if the condition
@@ -605,9 +628,13 @@ def inv(a):
     t, result_t = _commonType(a)
 
     signature = 'D->D' if isComplexType(t) else 'd->d'
-    with errstate(call=_raise_linalgerror_singular, invalid='call',
-                  over='ignore', divide='ignore', under='ignore'):
-        ainv = _umath_linalg.inv(a, signature=signature)
+    if noerr:
+        with errstate(all='ignore'):
+            ainv = _umath_linalg.inv(a, signature=signature)
+    else:
+        with errstate(call=_raise_linalgerror_singular, invalid='call',
+                      over='ignore', divide='ignore', under='ignore'):
+            ainv = _umath_linalg.inv(a, signature=signature)
     return wrap(ainv.astype(result_t, copy=False))
 
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -580,7 +580,7 @@ class TestInv(InvCases):
         result = linalg.inv(a, noerr=True)
 
         assert_almost_equal(result[0], np.array([[1.0, 0.0], [0.0, 1.0]]))
-        assert_almost_equal(result[2], np.array([[2/3, -1/3], [-1/3, 2/3]]))
+        assert_almost_equal(result[2], np.array([[2 / 3, -1 / 3], [-1 / 3, 2 / 3]]))
 
         assert_(np.isnan(result[1]).all())
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -569,6 +569,21 @@ class TestInv(InvCases):
         assert_equal(a.shape, res.shape)
         assert_(isinstance(res, ArraySubclass))
 
+    def test_noerr(self):
+        # test noerr=True case
+        a = np.array([
+            [[1.0, 0.0], [0.0, 1.0]],  # invertible
+            [[1.0, 1.0], [1.0, 1.0]],  # singular
+            [[2.0, 1.0], [1.0, 2.0]]   # invertible
+        ])
+
+        result = linalg.inv(a, noerr=True)
+
+        assert_almost_equal(result[0], np.array([[1.0, 0.0], [0.0, 1.0]]))
+        assert_almost_equal(result[2], np.array([[2/3, -1/3], [-1/3, 2/3]]))
+
+        assert_(np.isnan(result[1]).all())
+
 
 class EigvalsCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -580,9 +580,11 @@ class TestInv(InvCases):
         result = linalg.inv(a, noerr=True)
 
         assert_almost_equal(result[0], np.array([[1.0, 0.0], [0.0, 1.0]]))
+        assert_(np.isnan(result[1]).all())
         assert_almost_equal(result[2], np.array([[2 / 3, -1 / 3], [-1 / 3, 2 / 3]]))
 
-        assert_(np.isnan(result[1]).all())
+        with assert_raises(np.linalg.LinAlgError):
+            linalg.inv(a, noerr=False)
 
 
 class EigvalsCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -579,10 +579,16 @@ class TestInv(InvCases):
 
         result = linalg.inv(a, noerr=True)
 
-        assert_almost_equal(result[0], np.array([[1.0, 0.0], [0.0, 1.0]]))
-        assert_(np.isnan(result[1]).all())
-        assert_almost_equal(result[2], np.array([[2 / 3, -1 / 3], [-1 / 3, 2 / 3]]))
+        assert_allclose(
+            result,
+            [
+                [[1.0, 0.0], [0.0, 1.0]],
+                [[np.nan, np.nan], [np.nan, np.nan]],
+                [[2.0 / 3, -1.0 / 3], [-1.0 / 3, 2.0 / 3]],
+            ]
+        )
 
+        # test noerr=False case
         with assert_raises(np.linalg.LinAlgError):
             linalg.inv(a, noerr=False)
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
# Description
This PR introduces a new optional parameter noerr (default: False) to the numpy.linalg.inv function. The purpose of this parameter is to allow users to compute inverses of multiple matrices simultaneously (stacked matrices with shape (m, n, n)), without raising a LinAlgError if at least one matrix is singular. #27035 

# Example
```PYTHON
>>> import numpy as np
>>> a = np.array([
...    [[1, 0], [0, 1]],   # invertible
...    [[0, 0], [0, 0]],   # singular
... ])
>>> np.linalg.inv(matrices, noerr=True)
array([[[ 1.,  0.],
        [ 0.,  1.]],

       [[nan, nan],
        [nan, nan]]])
```


close #27035 