### PR TITLE
BUG: fix np.genfromtxt for all columns in usecols, in different order.

### DIFF
--- a/doc/release/upcoming_changes/28802.change.rst
+++ b/doc/release/upcoming_changes/28802.change.rst
@@ -1,0 +1,7 @@
+Correct behaviour for ``np.genfromtxt`` 
+---------------------------------------
+Earlier, whenever ``usecols`` had all the column names present in
+``fname`` (data), but in different order, columns would not match its
+names.
+Now, the name assignment is well done, even if names in ``usecols`` are
+out of order.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -2080,7 +2080,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                 dtype = np.dtype([descr[_] for _ in usecols])
                 names = list(dtype.names)
             # If `names` is not None, update the names
-            elif (names is not None) and (len(names) > nbcols):
+            elif names is not None:
                 names = [names[_] for _ in usecols]
         elif (names is not None) and (dtype is not None):
             names = list(dtype.names)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2547,6 +2547,15 @@ M   33  21.99
 
         assert_array_equal(a, b)
 
+    def test_usecols_all_names_different_order(self):
+        # Test that columns are well assigned, even when all column names are
+        # in usecols, in different orders too.
+        txt = TextIO("A B\n1 2")
+        cols = ("B", "A")
+        data = np.genfromtxt(txt, names=True, usecols=cols)
+
+        assert_array_equal(data["A"], np.array([1.]))
+        assert_array_equal(data["B"], np.array([2.]))
 
 class TestPathUsage:
     # Test that pathlib.Path can be used


### PR DESCRIPTION
Resolved an issue in genfromtxt where it produced incorrect results whenever it was used all columns in usecols and they were in an order different than the displayed in the first line. Added a test to ensure accurate assignment of columns names to the respective columns. (fixes #28225).

The issue arose when usecols had all the column names but in different order than the one in the original text. In this case, usecols was not being reordered before assigning data, resulting in data being assign to the wrong column. The reordering only happened when the number of columns of the original text was more than the length of usecols. I just made it to reorder when they have same length too.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
