### PR TITLE
BUG: fix heap buffer overflow in np.strings.find

### DIFF
--- a/numpy/_core/src/umath/string_fastsearch.h
+++ b/numpy/_core/src/umath/string_fastsearch.h
@@ -670,16 +670,8 @@ preprocess(CheckedIndexer<char_type> needle, Py_ssize_t len_needle,
     assert(p->period + p->cut <= len_needle);
 
     // Compare parts of the needle to check for periodicity.
-    int cmp;
-    if (std::is_same<char_type, npy_ucs4>::value) {
-        cmp = memcmp(needle.buffer,
-                needle.buffer + (p->period * sizeof(npy_ucs4)),
-                (size_t) p->cut);
-    }
-    else {
-        cmp = memcmp(needle.buffer, needle.buffer + p->period,
-                (size_t) p->cut);
-    }
+    int cmp = memcmp(needle.buffer, needle.buffer + p->period,
+                     (size_t) p->cut);
     p->is_periodic = (0 == cmp);
 
     // If periodic, gap is unused; otherwise, calculate period and gap.

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -381,6 +381,8 @@ class TestMethods:
          None, [3, -1]),
         ("Ae¢☃€ 😊" * 2, "😊", 0, None, 6),
         ("Ae¢☃€ 😊" * 2, "😊", 7, None, 13),
+        pytest.param("A" * (2 ** 17), r"[\w]+\Z", 0, None, -1,
+                     id=r"A*2**17-[\w]+\Z-0-None--1"),
     ])
     def test_find(self, a, sub, start, end, out, dt):
         if "😊" in a and dt == "S":


### PR DESCRIPTION
Fixes #28791 

Multiplying by `sizeof(npy_ucs4)` here is nonsense. I'm the one who added this if statement originally. No idea what I was thinking.