### PR TITLE
BUG: Fix ` __array__(None)` to preserve dtype

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -928,7 +928,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
     PyObject *ret;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&$O&:__array__", kwlist,
-                                     PyArray_DescrConverter, &newtype,
+                                     PyArray_DescrConverter2, &newtype,
                                      PyArray_CopyConverter, &copy)) {
         Py_XDECREF(newtype);
         return NULL;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10468,5 +10468,4 @@ def test_array_dunder_array_preserves_dtype_on_none(dtype):
     """
     a = np.array([1], dtype=dtype)
     b = a.__array__(None)
-    assert_equal(a.dtype, b.dtype)
-    assert_array_equal(a, b)
+    assert_array_equal(a, b, strict=True)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10462,7 +10462,7 @@ def test_array_interface_excess_dimensions_raises():
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.complex128])
 def test_array_dunder_array_preserves_dtype_on_none(dtype):
-    """ 
+    """
     Regression test for: https://github.com/numpy/numpy/issues/27407
     Ensure that __array__(None) returns an array of the same dtype.
     """

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10459,3 +10459,14 @@ def test_array_interface_excess_dimensions_raises():
     # Now, using np.asanyarray on this dummy should trigger a ValueError (not segfault)
     with pytest.raises(ValueError, match="dimensions must be within"):
         np.asanyarray(dummy)
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.uint32, np.complex128])
+def test_array_dunder_array_preserves_dtype_on_none(dtype):
+    """ 
+    Regression test for: https://github.com/numpy/numpy/issues/27407
+    Ensure that __array__(None) returns an array of the same dtype.
+    """
+    a = np.array([1], dtype=dtype)
+    b = a.__array__(None)
+    assert_equal(a.dtype, b.dtype)
+    assert_array_equal(a, b)


### PR DESCRIPTION
This PR fixes a bug in the `__array__` method where calling `__array__(None)` would return an array with the default dtype `float64`, regardless of the original array's dtype.

For example, 

```python
 np.array([1], dtype=np.float32).__array__(None).dtype
```    

Would returned:

 ```python 
dtype('float64')
``` 

But should return:

```python
dtype('float32')
``` 

as the [documentation](https://numpy.org/doc/stable/user/basics.interoperability.html#dunder-array-interface) suggests. 

The fix involves replacing `PyArray_DescrConverter` with `PyArray_DescrConverter2`, which correctly interprets `None` to preserve the original dtype rather than defaulting to `float64`.

Closes #27407 
