### PR TITLE
BUG: Use unrotated companion matrix in polynomial.polyroots.

### DIFF
--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -126,7 +126,7 @@ class TestPolynomial:
         for i in np.logspace(10, 25, num = 1000, base = 10):
             tgt = np.array([-1, 1, i])
             res = np.sort(np.roots(poly.polyfromroots(tgt)[::-1]))
-            assert_almost_equal(res, tgt, 15 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
+            assert_almost_equal(res, tgt, 14 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
 
         for i in np.logspace(10, 25, num = 1000, base = 10):
             tgt = np.array([-1, 1.01, i])

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.polynomial.polynomial as poly
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_almost_equal,
     assert_array_almost_equal, assert_raises, assert_allclose
@@ -120,6 +121,17 @@ class TestPolynomial:
 
     def test_roots(self):
         assert_array_equal(np.roots([1, 0, 0]), [0, 0])
+
+        # Testing for larger root values
+        for i in np.logspace(10, 25, num = 1000, base = 10):
+            tgt = np.array([-1, 1, i])
+            res = np.sort(np.roots(poly.polyfromroots(tgt)[::-1]))
+            assert_almost_equal(res, tgt, 15 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
+
+        for i in np.logspace(10, 25, num = 1000, base = 10):
+            tgt = np.array([-1, 1.01, i])
+            res = np.sort(np.roots(poly.polyfromroots(tgt)[::-1]))
+            assert_almost_equal(res, tgt, 14 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
 
     def test_str_leading_zeros(self):
         p = np.poly1d([4, 3, 2, 1])

--- a/numpy/matlib.pyi
+++ b/numpy/matlib.pyi
@@ -446,7 +446,6 @@ from numpy import (
     tan,
     tanh,
     tensordot,
-    test,
     testing,
     tile,
     timedelta64,
@@ -503,6 +502,7 @@ from numpy import (
     zeros_like,
 )
 from numpy._typing import _ArrayLike, _DTypeLike
+from . import test
 
 __all__ = ["rand", "randn", "repmat"]
 __all__ += np.__all__

--- a/numpy/matlib.pyi
+++ b/numpy/matlib.pyi
@@ -446,6 +446,7 @@ from numpy import (
     tan,
     tanh,
     tensordot,
+    test,
     testing,
     tile,
     timedelta64,
@@ -502,7 +503,6 @@ from numpy import (
     zeros_like,
 )
 from numpy._typing import _ArrayLike, _DTypeLike
-from . import test
 
 __all__ = ["rand", "randn", "repmat"]
 __all__ += np.__all__

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1535,8 +1535,7 @@ def polyroots(c):
     if len(c) == 2:
         return np.array([-c[0] / c[1]])
 
-    # rotated companion matrix reduces error
-    m = polycompanion(c)[::-1, ::-1]
+    m = polycompanion(c)
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1535,7 +1535,7 @@ def polyroots(c):
     if len(c) == 2:
         return np.array([-c[0] / c[1]])
 
-    m = polycompanion(c)
+    m = polycompanion(c)[::-1, ::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1535,7 +1535,7 @@ def polyroots(c):
     if len(c) == 2:
         return np.array([-c[0] / c[1]])
 
-    m = polycompanion(c)[::-1, ::-1]
+    m = polycompanion(c)
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -543,6 +543,17 @@ class TestMisc:
             res = poly.polyroots(poly.polyfromroots(tgt))
             assert_almost_equal(trim(res), trim(tgt))
 
+        # Testing for larger root values
+        for i in np.logspace(10, 25, num = 1000, base = 10):
+            tgt = np.array([-1, 1, i])
+            res = poly.polyroots(poly.polyfromroots(tgt))
+            assert_almost_equal(res, tgt, 15 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
+
+        for i in np.logspace(10, 25, num = 1000, base = 10):
+            tgt = np.array([-1, 1.01, i])
+            res = poly.polyroots(poly.polyfromroots(tgt))
+            assert_almost_equal(res, tgt, 14 - int(np.log10(i)))    # Adapting the expected precision according to the root value, to take into account numerical calculation error
+
     def test_polyfit(self):
         def f(x):
             return x * (x - 1) * (x - 2)


### PR DESCRIPTION
Fixes #27881.

Both functions use numpy.linalg.eigvals, but while roots gives in argument the polynomial's companion matrix unchanged, polyroots rotates it.

https://github.com/numpy/numpy/blob/5570e92f8b604ab725a8a605221febf49e168629/numpy/polynomial/polynomial.py#L1538-L1539

Though in theory this rotation shouldn't change anything, in terms of numerical calcuations, eigvals gives significantly different results. This PR removes the rotation as an easy fix to the inconsistency.

This strange behavior by eigvals is however a bug. I did some research on it, which you can find on this [issue](https://github.com/numpy/numpy/issues/27881), but I haven't any solution.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
