### PR TITLE
TYP: Fix type annotations for ``np.ma.nomask`` and ``np.ma.MaskType``

### DIFF
--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -230,8 +230,8 @@ _ScalarT_co = TypeVar("_ScalarT_co", bound=generic)
 # A subset of `MaskedArray` that can be parametrized w.r.t. `np.generic`
 _MaskedArray: TypeAlias = MaskedArray[_Shape, dtype[_ScalarT]]
 
-MaskType = bool
-nomask: bool
+MaskType: TypeAlias = bool_
+nomask: bool_
 
 class MaskedArrayFutureWarning(FutureWarning): ...
 class MAError(Exception): ...

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -230,8 +230,8 @@ _ScalarT_co = TypeVar("_ScalarT_co", bound=generic)
 # A subset of `MaskedArray` that can be parametrized w.r.t. `np.generic`
 _MaskedArray: TypeAlias = MaskedArray[_Shape, dtype[_ScalarT]]
 
-MaskType: TypeAlias = bool_
-nomask: bool_
+MaskType = bool_
+nomask: bool_[Literal[False]]
 
 class MaskedArrayFutureWarning(FutureWarning): ...
 class MAError(Exception): ...

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -281,6 +281,6 @@ assert_type(np.ma.allclose(AR_f4, MAR_f4), bool)
 assert_type(np.ma.allclose(AR_f4, MAR_f4, masked_equal=False), bool)
 assert_type(np.ma.allclose(AR_f4, MAR_f4, rtol=.4, atol=.3), bool)
 
-assert_type(np.ma.nomask, np.bool)
+assert_type(np.ma.nomask, np.bool[Literal[False]])
 # https://github.com/python/mypy/issues/18974
 assert_type(np.ma.MaskType, type[np.bool])  # type: ignore[assert-type]

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, TypeAlias, TypeVar, assert_type
+from typing import Any, Literal, TypeAlias, TypeVar, assert_type
 
 import numpy as np
 from numpy import dtype, generic
@@ -280,3 +280,7 @@ assert_type(np.ma.allequal(AR_f4, MAR_f4, fill_value=False), bool)
 assert_type(np.ma.allclose(AR_f4, MAR_f4), bool)
 assert_type(np.ma.allclose(AR_f4, MAR_f4, masked_equal=False), bool)
 assert_type(np.ma.allclose(AR_f4, MAR_f4, rtol=.4, atol=.3), bool)
+
+assert_type(np.ma.nomask, np.bool)
+# https://github.com/python/mypy/issues/18974
+assert_type(np.ma.MaskType, type[np.bool])  # type: ignore[assert-type]


### PR DESCRIPTION
Not sure that the current type hints are correct for these, as `np.ma.nomask` returns a NumPy boolean, not a stdlib one

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
