### PR TITLE
ENH: Provide Windows 11 ARM64 wheels (#22530)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,10 +91,14 @@ jobs:
           - [macos-14, macosx_arm64, accelerate]  # always use accelerate
           - [windows-2019, win_amd64, ""]
           - [windows-2019, win32, ""]
+          - [windows-11-arm, win_arm64, ""]
         python: ["cp311", "cp312", "cp313", "cp313t", "pp311"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2019, win32, ""]
+            python: "pp311"
+          # Don't build PyPy arm64 windows
+          - buildplat: [windows-11-arm, win_arm64, ""]
             python: "pp311"
           # No PyPy on musllinux images
           - buildplat: [ ubuntu-22.04, musllinux_x86_64, "" ]
@@ -120,6 +124,12 @@ jobs:
         uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
         with:
           architecture: 'x86'
+
+      - name: Setup MSVC arm64
+        if: ${{ matrix.buildplat[1] == 'win_arm64' }}
+        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+        with:
+          architecture: 'arm64'
 
       - name: pkg-config-for-win
         run: |
@@ -181,6 +191,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
+        if: ${{ matrix.buildplat[1] != 'win_arm64' }} # unsupported platform at the moment
         with:
           # for installation of anaconda-client, required for upload to
           # anaconda.org

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,9 +96,17 @@ jobs:
       run: |
         spin test -- --timeout=600 --durations=10
 
-  msvc_32bit_python_no_openblas:
-    name: MSVC, 32-bit Python, no BLAS
-    runs-on: windows-2019
+  msvc_python_no_openblas:
+    name: MSVC, ${{ matrix.architecture }} Python , no BLAS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2019
+            architecture: x86
+          - os: windows-11-arm
+            architecture: arm64
     # To enable this job on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     steps:
@@ -109,16 +117,16 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Setup Python (32-bit)
+      - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
-          architecture: 'x86'
+          architecture: ${{ matrix.architecture }}
 
-      - name: Setup MSVC (32-bit)
+      - name: Setup MSVC
         uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
         with:
-          architecture: 'x86'
+          architecture: ${{ matrix.architecture }}
 
       - name: Build and install
         run: |

--- a/numpy/_core/tests/test_array_interface.py
+++ b/numpy/_core/tests/test_array_interface.py
@@ -5,7 +5,6 @@ from numpy.testing import extbuild, IS_WASM, IS_EDITABLE
 import sysconfig
 
 
-
 @pytest.fixture
 def get_module(tmp_path):
     """ Some codes to generate data and manage temporary buffers use when

--- a/numpy/_core/tests/test_array_interface.py
+++ b/numpy/_core/tests/test_array_interface.py
@@ -2,6 +2,8 @@ import sys
 import pytest
 import numpy as np
 from numpy.testing import extbuild, IS_WASM, IS_EDITABLE
+import sysconfig
+
 
 
 @pytest.fixture
@@ -123,6 +125,8 @@ def get_module(tmp_path):
         pass
 
     # if it does not exist, build and load it
+    if sysconfig.get_platform() == "win-arm64":
+        pytest.skip("Meson unable to find MSVC linker on win-arm64")
     return extbuild.build_and_import_extension('array_interface_testing',
                                                functions,
                                                prologue=prologue,

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import pytest
+import sysconfig
 
 import numpy as np
 from numpy.testing import assert_array_equal, IS_WASM, IS_EDITABLE
@@ -53,6 +54,8 @@ def install_temp(tmpdir_factory):
         subprocess.check_call(["meson", "--version"])
     except FileNotFoundError:
         pytest.skip("No usable 'meson' found")
+    if sysconfig.get_platform() == "win-arm64":
+        pytest.skip("Meson unable to find MSVC linker on win-arm64")
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
                                "--buildtype=release",
@@ -341,6 +344,7 @@ def test_npystring_allocators_other_dtype(install_temp):
     assert checks.npystring_allocators_other_types(arr1, arr2) == 0
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason='no checks module on win-arm64')
 def test_npy_uintp_type_enum():
     import checks
     assert checks.check_npy_uintp_type_enum()

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -52,6 +52,8 @@ def install_temp(tmpdir_factory):
         subprocess.check_call(["meson", "--version"])
     except FileNotFoundError:
         pytest.skip("No usable 'meson' found")
+    if sysconfig.get_platform() == "win-arm64":
+        pytest.skip("Meson unable to find MSVC linker on win-arm64")
     if sys.platform == "win32":
         subprocess.check_call(["meson", "setup",
                                "--werror",

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -3,6 +3,7 @@ import gc
 import os
 import sys
 import threading
+import sysconfig
 
 import pytest
 
@@ -220,6 +221,8 @@ def get_module(tmp_path):
     except ImportError:
         pass
     # if it does not exist, build and load it
+    if sysconfig.get_platform() == "win-arm64":
+        pytest.skip("Meson unable to find MSVC linker on win-arm64")
     return extbuild.build_and_import_extension('mem_policy',
                                                functions,
                                                prologue=prologue,

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -262,6 +262,7 @@ def generate_def(dll, dfile):
 def find_dll(dll_name):
 
     arch = {'AMD64' : 'amd64',
+            'ARM64' : 'arm64',
             'Intel' : 'x86'}[get_build_architecture()]
 
     def _find_dll_in_winsxs(dll_name):
@@ -351,6 +352,8 @@ def build_import_library():
     arch = get_build_architecture()
     if arch == 'AMD64':
         return _build_import_library_amd64()
+    if arch == 'ARM64':
+        return _build_import_library_arm64()
     elif arch == 'Intel':
         return _build_import_library_x86()
     else:
@@ -401,6 +404,26 @@ def _build_import_library_amd64():
     # get the runtime dll for which we are building import library
     dll_file = find_python_dll()
     log.info('Building import library (arch=AMD64): "%s" (from %s)' %
+             (out_file, dll_file))
+
+    # generate symbol list from this library
+    def_name = "python%d%d.def" % tuple(sys.version_info[:2])
+    def_file = os.path.join(sys.prefix, 'libs', def_name)
+    generate_def(dll_file, def_file)
+
+    # generate import library from this symbol list
+    cmd = ['dlltool', '-d', def_file, '-l', out_file]
+    subprocess.check_call(cmd)
+
+def _build_import_library_arm64():
+    out_exists, out_file = _check_for_import_lib()
+    if out_exists:
+        log.debug('Skip building import library: "%s" exists', out_file)
+        return
+
+    # get the runtime dll for which we are building import library
+    dll_file = find_python_dll()
+    log.info('Building import library (arch=ARM64): "%s" (from %s)' %
              (out_file, dll_file))
 
     # generate symbol list from this library

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import pytest
 import os
+import sysconfig
 
 from numpy.distutils import mingw32ccompiler
 
@@ -10,6 +11,7 @@ from numpy.distutils import mingw32ccompiler
 @pytest.mark.skipif(sys.platform != 'win32', reason='win32 only test')
 @pytest.mark.skipif(not os.path.exists(os.path.join(sys.prefix, 'libs')),
                     reason="test requires mingw library layout")
+@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason='mingw GNU objdump does not understand arm64 binary format yet')
 def test_build_import():
     '''Test the mingw32ccompiler.build_import_library, which builds a
     `python.a` from the MSVC `python.lib`

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -54,6 +54,7 @@ else:
 )
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")
+@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason='meson not working on win-arm64')
 @pytest.mark.slow
 def test_cython(tmp_path):
     import glob

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -54,7 +54,7 @@ else:
 )
 @pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
 @pytest.mark.skipif(cython is None, reason="requires cython")
-@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason='meson not working on win-arm64')
+@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason='Meson unable to find MSVC linker on win-arm64')
 @pytest.mark.slow
 def test_cython(tmp_path):
     import glob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,11 @@ config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=b
 repair-wheel-command = ""
 
 [[tool.cibuildwheel.overrides]]
+select = "*-win_arm64"
+config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
+repair-wheel-command = ""
+
+[[tool.cibuildwheel.overrides]]
 select = "*pyodide*"
 before-test = "pip install -r {project}/requirements/emscripten_test_requirements.txt"
 # Pyodide ensures that the wheels are already repaired by auditwheel-emscripten

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,6 +22,9 @@ fi
 if [[ $(python -c"import sys; print(sys.maxsize)") < $(python -c"import sys; print(2**33)") ]]; then
     echo "No BLAS used for 32-bit wheels"
     export INSTALL_OPENBLAS=false
+elif [[ $(python -c"import sysconfig; print(sysconfig.get_platform())") == "win-arm64" ]]; then
+    echo "No BLAS used for ARM64 wheels"
+    export INSTALL_OPENBLAS=false
 elif [ -z $INSTALL_OPENBLAS ]; then
     # the macos_arm64 build might not set this variable
     export INSTALL_OPENBLAS=true


### PR DESCRIPTION
This is mostly adapting and duplicating how the 32-bit no-OpenBLAS wheels are built, to make ARM64 wheels.

The mamba-org/setup-micromamba github action reports "win_arm64" as unsupported for installation of anaconda-client at the moment.

Beyond that, a number of tests need to be skipped. They are in three categories:
    - Meson outside of the msdevshell github action does not seems to be able to find the MSVC linker. (Possibly missing some PATH env)
    - No "checks" modules in win-arm64 (yet)
    - Mingw GNU objdump does not understand arm64 dll format (yet) to to generate import libraries.

closes #22530

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
