### PR TITLE
DOC: `numpy.i` will not be included as part of SWIG

### DIFF
--- a/tools/swig/README
+++ b/tools/swig/README
@@ -3,9 +3,7 @@ Notes for the numpy/tools/swig directory
 
 This set of files is for developing and testing file numpy.i, which is
 intended to be a set of typemaps for helping SWIG interface between C
-and C++ code that uses C arrays and the python module NumPy.  It is
-ultimately hoped that numpy.i will be included as part of the SWIG
-distribution.
+and C++ code that uses C arrays and the python module NumPy.
 
 Documentation
 -------------


### PR DESCRIPTION
https://github.com/swig/swig/issues/361#issuecomment-100635225

> SWIG provides library code for C and C++ standard library components. I don't ever envisage it providing wrappers for 3rd party libraries like numpy as it is up to those 3rd party libraries to maintain the SWIG wrappers and @ojwb gives some good reasons why.

Fixes #28873.