### PR TITLE
MAINT: address warning in SWIG tests

### DIFF
--- a/tools/swig/test/Array2.cxx
+++ b/tools/swig/test/Array2.cxx
@@ -160,7 +160,7 @@ void Array2::allocateRows()
 
 void Array2::deallocateMemory()
 {
-  if (_ownData && _nrows*_ncols && _buffer)
+  if (_ownData && _nrows && _ncols && _buffer)
   {
     delete [] _rows;
     delete [] _buffer;


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/28875#issuecomment-2845063245
```
Array2.cxx:163:25: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
  163 |   if (_ownData && _nrows*_ncols && _buffer)
      |                   ~~~~~~^~~~~~~
```