### PR TITLE
DEP: deprecate ``numpy.typing.NBitBase``

### DIFF
--- a/doc/release/upcoming_changes/28884.deprecation.rst
+++ b/doc/release/upcoming_changes/28884.deprecation.rst
@@ -1,0 +1,28 @@
+``numpy.typing.NBitBase`` deprecation
+-------------------------------------
+The ``numpy.typing.NBitBase`` type has been deprecated and will be removed in a future version.
+
+This type was previously intended to be used as a generic upper bound for type-parameters, for example:
+
+.. code-block:: python
+
+    import numpy as np
+    import numpy.typing as npt
+
+    def f[NT: npt.NBitBase](x: np.complexfloating[NT]) -> np.floating[NT]: ...
+
+But in NumPy 2.2.0, ``float64`` and ``complex128`` were changed to concrete subtypes, causing static type-checkers to reject ``x: np.float64 = f(np.complex128(42j))``.
+
+So instead, the better approach is to use ``typing.overload``:
+
+.. code-block:: python
+
+    import numpy as np
+    from typing import overload
+
+    @overload
+    def f(x: np.complex64) -> np.float32: ...
+    @overload
+    def f(x: np.complex128) -> np.float64: ...
+    @overload
+    def f(x: np.clongdouble) -> np.longdouble: ...

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -6,7 +6,7 @@ from ._nested_sequence import (
     _NestedSequence as _NestedSequence,
 )
 from ._nbit_base import (
-    NBitBase as NBitBase,
+    NBitBase as NBitBase,  # pyright: ignore[reportDeprecated]
     _8Bit as _8Bit,
     _16Bit as _16Bit,
     _32Bit as _32Bit,

--- a/numpy/_typing/_nbit_base.py
+++ b/numpy/_typing/_nbit_base.py
@@ -9,12 +9,16 @@ class NBitBase:
     """
     A type representing `numpy.number` precision during static type checking.
 
-    Used exclusively for the purpose static type checking, `NBitBase`
+    Used exclusively for the purpose of static type checking, `NBitBase`
     represents the base of a hierarchical set of subclasses.
     Each subsequent subclass is herein used for representing a lower level
     of precision, *e.g.* ``64Bit > 32Bit > 16Bit``.
 
     .. versionadded:: 1.20
+
+    .. deprecated:: 2.3
+        Use ``@typing.overload`` or a ``TypeVar`` with a scalar-type as upper
+        bound, instead.
 
     Examples
     --------
@@ -48,6 +52,7 @@ class NBitBase:
         ...     # note:     out: numpy.floating[numpy.typing._64Bit*]
 
     """
+    # Deprecated in NumPy 2.3, 2025-05-01
 
     def __init_subclass__(cls) -> None:
         allowed_names = {

--- a/numpy/_typing/_nbit_base.pyi
+++ b/numpy/_typing/_nbit_base.pyi
@@ -1,0 +1,40 @@
+# pyright: reportDeprecated=false
+# pyright: reportGeneralTypeIssues=false
+# mypy: disable-error-code=misc
+
+from typing import final
+
+from typing_extensions import deprecated
+
+# Deprecated in NumPy 2.3, 2025-05-01
+@deprecated(
+    "`NBitBase` is deprecated and will be removed from numpy.typing in the "
+    "future. Use `@typing.overload` or a `TypeVar` with a scalar-type as upper "
+    "bound, instead. (deprecated in NumPy 2.3)",
+)
+@final
+class NBitBase: ...
+
+@final
+class _256Bit(NBitBase): ...
+
+@final
+class _128Bit(_256Bit): ...
+
+@final
+class _96Bit(_128Bit): ...
+
+@final
+class _80Bit(_96Bit): ...
+
+@final
+class _64Bit(_80Bit): ...
+
+@final
+class _32Bit(_64Bit): ...
+
+@final
+class _16Bit(_32Bit): ...
+
+@final
+class _8Bit(_16Bit): ...

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -155,14 +155,39 @@ API
 # NOTE: The API section will be appended with additional entries
 # further down in this file
 
-from numpy._typing import (
-    ArrayLike,
-    DTypeLike,
-    NBitBase,
-    NDArray,
-)
+# pyright: reportDeprecated=false
+
+from numpy._typing import ArrayLike, DTypeLike, NBitBase, NDArray
 
 __all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray"]
+
+
+__DIR = __all__ + [k for k in globals() if k.startswith("__") and k.endswith("__")]
+__DIR_SET = frozenset(__DIR)
+
+
+def __dir__() -> list[str]:
+    return __DIR
+
+def __getattr__(name: str):
+    if name == "NBitBase":
+        import warnings
+
+        # Deprecated in NumPy 2.3, 2025-05-01
+        warnings.warn(
+            "`NBitBase` is deprecated and will be removed from numpy.typing in the "
+            "future. Use `@typing.overload` or a `TypeVar` with a scalar-type as upper "
+            "bound, instead. (deprecated in NumPy 2.3)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return NBitBase
+
+    if name in __DIR_SET:
+        return globals()[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 if __doc__ is not None:
     from numpy._typing._add_docstring import _docstrings


### PR DESCRIPTION
`numpy.typing.NBitBase` is intended to be used as e.g.

```pyi
import numpy as np
import numpy.typing as npt

def f[NT: npt.NBitBase](x: np.complexfloating[NT]) -> np.floating[NT]: ...
```

This will lead to problems for `float64` and `complex128`, which were changed into concrete subtypes of `floating` and `complexfloating` in NumPy 2.2. That means that e.g. `floating[_64Bit]` is no longer assignable to `float64`, causing type-checkers to reject `x: float64 = f(complex128(1))`. This defeats its purpose, and should therefore no longer be used.

The general alternative is to use `typing.overload`:

```pyi
import numpy as np
from typing import overload

@overload
def f(x: np.complex64) -> np.float32: ...
@overload
def f(x: np.complex128) -> np.float64: ...
@overload
def f(x: np.clongdouble) -> np.longdouble: ...
```

And even though it has gotten more verbose, it requires less mental to interpret.

---

In situations where the input scalar type is the same as the output type, there's a simpler alternative:

Old:

```pyi
import numpy as np
import numpy.typing as npt

def f[NT: npt.NBitBase](x: np.floating[NT]) -> np.floating[NT]: ...
```

New:

```pyi
import numpy as np

def f[FloatT: np.floating](x: FloatT) -> FloatT: ...
```

This also makes the code more readable, IMO.

---

Note that at the moment, `float32` *is* assignable to `floating[_32Bit]`, because it is defined as a *type alias*, as opposed to a proper subtype. In NumType this has already been fixed (i.e. it's incorrect) for all scalar types.