### PR TITLE
MAINT: Avoid dereferencing/strict aliasing warnings 

### DIFF
--- a/numpy/_core/include/numpy/npy_math.h
+++ b/numpy/_core/include/numpy/npy_math.h
@@ -433,7 +433,7 @@ static inline void npy_csetreall(npy_clongdouble *z, const longdouble_t r)
 static inline npy_longdouble npy_cimagl(const npy_clongdouble z)
 {
 #if defined(__cplusplus)
-    return z._Val[1];
+    return (npy_longdouble)z._Val[1];
 #else
     return cimagl(z);
 #endif

--- a/numpy/_core/include/numpy/npy_math.h
+++ b/numpy/_core/include/numpy/npy_math.h
@@ -363,7 +363,7 @@ NPY_INPLACE npy_longdouble npy_heavisidel(npy_longdouble x, npy_longdouble h0);
 static inline double npy_creal(const npy_cdouble z)
 {
 #if defined(__cplusplus)
-    return ((double *) &z)[0];
+    return z._Val[0];
 #else
     return creal(z);
 #endif
@@ -377,7 +377,7 @@ static inline void npy_csetreal(npy_cdouble *z, const double r)
 static inline double npy_cimag(const npy_cdouble z)
 {
 #if defined(__cplusplus)
-    return ((double *) &z)[1];
+    return z._Val[1];
 #else
     return cimag(z);
 #endif
@@ -391,7 +391,7 @@ static inline void npy_csetimag(npy_cdouble *z, const double i)
 static inline float npy_crealf(const npy_cfloat z)
 {
 #if defined(__cplusplus)
-    return ((float *) &z)[0];
+    return z._Val[0];
 #else
     return crealf(z);
 #endif
@@ -405,7 +405,7 @@ static inline void npy_csetrealf(npy_cfloat *z, const float r)
 static inline float npy_cimagf(const npy_cfloat z)
 {
 #if defined(__cplusplus)
-    return ((float *) &z)[1];
+    return z._Val[1];
 #else
     return cimagf(z);
 #endif
@@ -419,7 +419,7 @@ static inline void npy_csetimagf(npy_cfloat *z, const float i)
 static inline npy_longdouble npy_creall(const npy_clongdouble z)
 {
 #if defined(__cplusplus)
-    return ((longdouble_t *) &z)[0];
+    return (npy_longdouble)z._Val[0];
 #else
     return creall(z);
 #endif
@@ -433,7 +433,7 @@ static inline void npy_csetreall(npy_clongdouble *z, const longdouble_t r)
 static inline npy_longdouble npy_cimagl(const npy_clongdouble z)
 {
 #if defined(__cplusplus)
-    return ((longdouble_t *) &z)[1];
+    return z._Val[1];
 #else
     return cimagl(z);
 #endif


### PR DESCRIPTION
I am aware that this file went through many iterations and complex support is a constant headache, and if there is any more appetite left, I'd like to offer another minor change. 

We have been having some warnings coming from non-C99-compliant compilers and C++ runs over SciPy since NumPy 2.0. This is mainly due to the `npy_crealX`/`npy_cimagX` functions, casting the input `struct` first and then dereferencing it in the new type, causing the strict-aliasing (type punning) rule to fire.

Here is a recent example how this manifests itself in the build process https://github.com/scipy/scipy/actions/runs/14770722795/job/41470198162#step:6:300

```bash
[snip]
 In file included from ..\scipy\_build_utils\src/npy_2_complexcompat.h:4,
                 from ../scipy/special/xsf_wrappers.h:13,
                 from ../scipy/special/xsf_wrappers.cpp:1:
C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\numpy\_core\include/numpy/npy_math.h: In function 'npy_longdouble npy_creall(npy_clongdouble)':
C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\numpy\_core\include/numpy/npy_math.h:422:13: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  422 |     return ((longdouble_t *) &z)[0];
      |            ~^~~~~~~~~~~~~~~~~~~~ 
[snip]
```

I don't know if the SciPy code is also commiting some C++ sins but the NumPy code can do better to avoid strange bugs. I don't claim to have the right solution but seems like the most obvious one to me to let the compiler handle the possible padding/endianness issues with a straight struct field access. However I don't have a strong opinion since I'm not a C++ expert. 

This is also somewhat related to our ambition to be warning free at some point.

