### PR TITLE
TYP: remove non-existent extended-precision scalar types

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -57,10 +57,8 @@ from numpy._typing import (
     NBitBase,
     # NOTE: Do not remove the extended precision bit-types even if seemingly unused;
     # they're used by the mypy plugin
-    _256Bit,
     _128Bit,
     _96Bit,
-    _80Bit,
     _64Bit,
     _32Bit,
     _16Bit,
@@ -160,21 +158,12 @@ from numpy._typing._callable import (
     _ComparisonOpGE,
 )
 
-# NOTE: Numpy's mypy plugin is used for removing the types unavailable
-# to the specific platform
+# NOTE: Numpy's mypy plugin is used for removing the types unavailable to the specific platform
 from numpy._typing._extended_precision import (
-    uint128,
-    uint256,
-    int128,
-    int256,
-    float80,
     float96,
     float128,
-    float256,
-    complex160,
     complex192,
     complex256,
-    complex512,
 )
 
 from numpy._array_api_info import __array_namespace_info__
@@ -698,8 +687,7 @@ __all__ = [  # noqa: RUF022
     "uint8", "ubyte", "int16", "short", "uint16", "ushort", "int32", "intc", "uint32",
     "uintc", "int64", "long", "uint64", "ulong", "longlong", "ulonglong", "intp",
     "uintp", "double", "cdouble", "single", "csingle", "half", "bool_", "int_", "uint",
-    "uint128", "uint256", "int128", "int256", "float80", "float96", "float128",
-    "float256", "complex160", "complex192", "complex256", "complex512",
+    "float96", "float128", "complex192", "complex256",
     "array2string", "array_str", "array_repr", "set_printoptions", "get_printoptions",
     "printoptions", "format_float_positional", "format_float_scientific", "require",
     "seterr", "geterr", "setbufsize", "getbufsize", "seterrcall", "geterrcall",

--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -68,20 +68,7 @@ from .multiarray import (
 )
 
 from numpy._typing import DTypeLike
-from numpy._typing._extended_precision import (
-    uint128,
-    uint256,
-    int128,
-    int256,
-    float80,
-    float96,
-    float128,
-    float256,
-    complex160,
-    complex192,
-    complex256,
-    complex512,
-)
+from numpy._typing._extended_precision import float96, float128, complex192, complex256
 
 __all__ = [
     "ScalarType",
@@ -146,18 +133,10 @@ __all__ = [
     "bool_",
     "int_",
     "uint",
-    "uint128",
-    "uint256",
-    "int128",
-    "int256",
-    "float80",
     "float96",
     "float128",
-    "float256",
-    "complex160",
     "complex192",
     "complex256",
-    "complex512",
 ]
 
 @type_check_only

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -11,10 +11,8 @@ from ._nbit_base import (
     _16Bit as _16Bit,
     _32Bit as _32Bit,
     _64Bit as _64Bit,
-    _80Bit as _80Bit,
     _96Bit as _96Bit,
     _128Bit as _128Bit,
-    _256Bit as _256Bit,
 )
 from ._nbit import (
     _NBitByte as _NBitByte,

--- a/numpy/_typing/_extended_precision.py
+++ b/numpy/_typing/_extended_precision.py
@@ -6,22 +6,9 @@ that they can be imported conditionally via the numpy's mypy plugin.
 """
 
 import numpy as np
-from . import (
-    _80Bit,
-    _96Bit,
-    _128Bit,
-    _256Bit,
-)
+from . import _96Bit, _128Bit
 
-uint128 = np.unsignedinteger[_128Bit]
-uint256 = np.unsignedinteger[_256Bit]
-int128 = np.signedinteger[_128Bit]
-int256 = np.signedinteger[_256Bit]
-float80 = np.floating[_80Bit]
 float96 = np.floating[_96Bit]
 float128 = np.floating[_128Bit]
-float256 = np.floating[_256Bit]
-complex160 = np.complexfloating[_80Bit, _80Bit]
 complex192 = np.complexfloating[_96Bit, _96Bit]
 complex256 = np.complexfloating[_128Bit, _128Bit]
-complex512 = np.complexfloating[_256Bit, _256Bit]

--- a/numpy/_typing/_nbit_base.py
+++ b/numpy/_typing/_nbit_base.py
@@ -51,8 +51,7 @@ class NBitBase:
 
     def __init_subclass__(cls) -> None:
         allowed_names = {
-            "NBitBase", "_256Bit", "_128Bit", "_96Bit", "_80Bit",
-            "_64Bit", "_32Bit", "_16Bit", "_8Bit",
+            "NBitBase", "_128Bit", "_96Bit", "_64Bit", "_32Bit", "_16Bit", "_8Bit"
         }
         if cls.__name__ not in allowed_names:
             raise TypeError('cannot inherit from final class "NBitBase"')
@@ -61,40 +60,30 @@ class NBitBase:
 @final
 @set_module("numpy._typing")
 # Silence errors about subclassing a `@final`-decorated class
-class _256Bit(NBitBase):  # type: ignore[misc]
+class _128Bit(NBitBase):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass
 
 @final
 @set_module("numpy._typing")
-class _128Bit(_256Bit):  # type: ignore[misc]
+class _96Bit(_128Bit):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass
 
 @final
 @set_module("numpy._typing")
-class _96Bit(_128Bit):  # type: ignore[misc]
+class _64Bit(_96Bit):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass
 
 @final
 @set_module("numpy._typing")
-class _80Bit(_96Bit):  # type: ignore[misc]
+class _32Bit(_64Bit):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass
 
 @final
 @set_module("numpy._typing")
-class _64Bit(_80Bit):  # type: ignore[misc]
+class _16Bit(_32Bit):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass
 
 @final
 @set_module("numpy._typing")
-class _32Bit(_64Bit):  # type: ignore[misc]
-    pass
-
-@final
-@set_module("numpy._typing")
-class _16Bit(_32Bit):  # type: ignore[misc]
-    pass
-
-@final
-@set_module("numpy._typing")
-class _8Bit(_16Bit):  # type: ignore[misc]
+class _8Bit(_16Bit):  # type: ignore[misc]  # pyright: ignore[reportGeneralTypeIssues]
     pass

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -65,18 +65,10 @@ def _get_precision_dict() -> dict[str, str]:
 
 def _get_extended_precision_list() -> list[str]:
     extended_names = [
-        "uint128",
-        "uint256",
-        "int128",
-        "int256",
-        "float80",
         "float96",
         "float128",
-        "float256",
-        "complex160",
         "complex192",
         "complex256",
-        "complex512",
     ]
     return [i for i in extended_names if hasattr(np, i)]
 
@@ -169,8 +161,7 @@ else:
             """Handle all import-based overrides.
 
             * Import platform-specific extended-precision `numpy.number`
-              subclasses (*e.g.* `numpy.float96`, `numpy.float128` and
-              `numpy.complex256`).
+              subclasses (*e.g.* `numpy.float96` and `numpy.float128`).
             * Import the appropriate `ctypes` equivalent to `numpy.intp`.
 
             """

--- a/numpy/typing/tests/data/misc/extended_precision.pyi
+++ b/numpy/typing/tests/data/misc/extended_precision.pyi
@@ -1,20 +1,9 @@
 import numpy as np
-from numpy._typing import _80Bit, _96Bit, _128Bit, _256Bit
+from numpy._typing import _96Bit, _128Bit
 
 from typing import assert_type
 
-assert_type(np.uint128(), np.unsignedinteger[_128Bit])
-assert_type(np.uint256(), np.unsignedinteger[_256Bit])
-
-assert_type(np.int128(), np.signedinteger[_128Bit])
-assert_type(np.int256(), np.signedinteger[_256Bit])
-
-assert_type(np.float80(), np.floating[_80Bit])
 assert_type(np.float96(), np.floating[_96Bit])
 assert_type(np.float128(), np.floating[_128Bit])
-assert_type(np.float256(), np.floating[_256Bit])
-
-assert_type(np.complex160(), np.complexfloating[_80Bit, _80Bit])
 assert_type(np.complex192(), np.complexfloating[_96Bit, _96Bit])
 assert_type(np.complex256(), np.complexfloating[_128Bit, _128Bit])
-assert_type(np.complex512(), np.complexfloating[_256Bit, _256Bit])

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -249,18 +249,10 @@ def test_code_runs(path: str) -> None:
 
 
 LINENO_MAPPING = {
-    6: "uint128",
-    7: "uint256",
-    9: "int128",
-    10: "int256",
-    12: "float80",
-    13: "float96",
-    14: "float128",
-    15: "float256",
-    17: "complex160",
-    18: "complex192",
-    19: "complex256",
-    20: "complex512",
+    6: "float96",
+    7: "float128",
+    8: "complex192",
+    9: "complex256",
 }
 
 


### PR DESCRIPTION
ported from numpy/numtype#209

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
