### PR TITLE
TYP: Test ``MaskedArray.transpose`` and ``MaskedArray.T``, remove unnecessary annotations

### DIFF
--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -887,9 +887,6 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         /
     ) -> MaskedArray[_Shape, _DTypeT_co]: ...
 
-    T: Any
-    transpose: Any
-
     #
     def toflex(self) -> Incomplete: ...
     def torecords(self) -> Incomplete: ...

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -360,5 +360,12 @@ assert_type(MAR_b.shrink_mask(), MaskedArray[np.bool_])
 assert_type(MAR_i8.hardmask, bool)
 assert_type(MAR_i8.sharedmask, bool)
 
+assert_type(MAR_b.transpose(), MaskedArray[np.bool])
+assert_type(MAR_2d_f4.transpose(), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]])
+assert_type(MAR_2d_f4.transpose(1, 0), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]])
+assert_type(MAR_2d_f4.transpose((1, 0)), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]])
+assert_type(MAR_b.T, MaskedArray[np.bool])
+assert_type(MAR_2d_f4.T, np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]])
+
 assert_type(MAR_2d_f4.nonzero(), tuple[_Array1D[np.intp], *tuple[_Array1D[np.intp], ...]])
 assert_type(MAR_2d_f4.nonzero()[0], _Array1D[np.intp])


### PR DESCRIPTION
These tests pass for free by just removing 
```python
    T: Any
    transpose: Any
```

These are inherited from `ndarray`, and are typed using `Self` anyway, so I don't think they're necessary?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
