### PR TITLE
DOC: Fixes absent line numbers on link to classes decorated with set_module

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -539,14 +539,14 @@ def linkcode_resolve(domain, info):
     fn = None
     lineno = None
 
-    # Make a poor effort at linking C extension types
-    if isinstance(obj, type) and obj.__module__ == 'numpy':
-        fn = _get_c_source_file(obj)
+    if isinstance(obj, type):
+        # Make a poor effort at linking C extension types
+        if obj.__module__ == 'numpy':
+            fn = _get_c_source_file(obj)
 
-    # This can be removed when removing the decorator set_module. Fix issue #28629
-    if hasattr(obj, '_module_file'):
-        fn = obj._module_file
-        fn = relpath(fn, start=dirname(numpy.__file__))
+        # This can be removed when removing the decorator set_module. Fix issue #28629
+        if hasattr(obj, '_module_source'):
+            obj.__module__, obj._module_source = obj._module_source, obj.__module__
 
     if fn is None:
         try:
@@ -572,6 +572,9 @@ def linkcode_resolve(domain, info):
         linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
     else:
         linespec = ""
+
+    if isinstance(obj, type) and hasattr(obj, '_module_source'):
+        obj.__module__, obj._module_source = obj._module_source, obj.__module__
 
     if 'dev' in numpy.__version__:
         return f"https://github.com/numpy/numpy/blob/main/numpy/{fn}{linespec}"

--- a/numpy/_utils/__init__.py
+++ b/numpy/_utils/__init__.py
@@ -9,7 +9,6 @@ in ``numpy._core``.
 """
 
 import functools
-import sys
 import warnings
 from ._convertions import asunicode, asbytes
 
@@ -29,8 +28,8 @@ def set_module(module):
         if module is not None:
             if isinstance(func, type):
                 try:
-                    func._module_file = sys.modules.get(func.__module__).__file__
-                except (AttributeError, KeyError):
+                    func._module_source = func.__module__
+                except (AttributeError):
                     pass
 
             func.__module__ = module


### PR DESCRIPTION
PR #28645 was intended to fix issue #28629, which indicated that wrong links were appearing on documentation for classes decorated with set_module. A minor problem appeared on that fix, since line numbers were not assigned to the link on those decorated classes.

This PR fixes this problem by storing the original value of property `__module__` of decorated classes (instead of capturing the property `__file__` of the original module). 

In my opinion the current approach is simpler.