### PR TITLE
MNT: add support for 3.14.0b1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,3 +27,6 @@ filterwarnings =
     ignore:\n\n  `numpy.distutils`:DeprecationWarning
 # Ignore DeprecationWarning from typing.mypy_plugin
     ignore:`numpy.typing.mypy_plugin` is deprecated:DeprecationWarning
+# Ignore DeprecationWarning from struct module
+# see https://github.com/numpy/numpy/issues/28926
+    ignore:Due to \'_pack_\', the


### PR DESCRIPTION
Removes our use of CPython internals in favor of the new API added for this purpose in 3.14. See https://github.com/python/cpython/issues/133164.

I also dropped support for 3.14.0a7 since that is known to be broken without using CPython internals. I could also not add the explicit error case, but it seemed better to break known-broken configurations we don't want to support. Happy to do it either way if anyone disagrees.

There's a new deprecation warning coming from the `struct` module. I ignored it for now and opened an issue (https://github.com/numpy/numpy/issues/28926).