### PR TITLE
MAINT: remove references to 256-bits extended precision types

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -129,27 +129,22 @@ cdef extern from "numpy/arrayobject.h":
         NPY_INT32
         NPY_INT64
         NPY_INT128
-        NPY_INT256
         NPY_UINT8
         NPY_UINT16
         NPY_UINT32
         NPY_UINT64
         NPY_UINT128
-        NPY_UINT256
         NPY_FLOAT16
         NPY_FLOAT32
         NPY_FLOAT64
         NPY_FLOAT80
         NPY_FLOAT96
         NPY_FLOAT128
-        NPY_FLOAT256
-        NPY_COMPLEX32
         NPY_COMPLEX64
         NPY_COMPLEX128
         NPY_COMPLEX160
         NPY_COMPLEX192
         NPY_COMPLEX256
-        NPY_COMPLEX512
 
         NPY_INTP
         NPY_UINTP

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -51,15 +51,11 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef signed short       npy_int16
     ctypedef signed int         npy_int32
     ctypedef signed long long   npy_int64
-    ctypedef signed long long   npy_int96
-    ctypedef signed long long   npy_int128
 
     ctypedef unsigned char      npy_uint8
     ctypedef unsigned short     npy_uint16
     ctypedef unsigned int       npy_uint32
     ctypedef unsigned long long npy_uint64
-    ctypedef unsigned long long npy_uint96
-    ctypedef unsigned long long npy_uint128
 
     ctypedef float        npy_float32
     ctypedef double       npy_float64
@@ -128,12 +124,10 @@ cdef extern from "numpy/arrayobject.h":
         NPY_INT16
         NPY_INT32
         NPY_INT64
-        NPY_INT128
         NPY_UINT8
         NPY_UINT16
         NPY_UINT32
         NPY_UINT64
-        NPY_UINT128
         NPY_FLOAT16
         NPY_FLOAT32
         NPY_FLOAT64
@@ -750,15 +744,11 @@ ctypedef npy_int8       int8_t
 ctypedef npy_int16      int16_t
 ctypedef npy_int32      int32_t
 ctypedef npy_int64      int64_t
-#ctypedef npy_int96      int96_t
-#ctypedef npy_int128     int128_t
 
 ctypedef npy_uint8      uint8_t
 ctypedef npy_uint16     uint16_t
 ctypedef npy_uint32     uint32_t
 ctypedef npy_uint64     uint64_t
-#ctypedef npy_uint96     uint96_t
-#ctypedef npy_uint128    uint128_t
 
 ctypedef npy_float32    float32_t
 ctypedef npy_float64    float64_t

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -60,15 +60,11 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef signed short       npy_int16
     ctypedef signed int         npy_int32
     ctypedef signed long long   npy_int64
-    ctypedef signed long long   npy_int96
-    ctypedef signed long long   npy_int128
 
     ctypedef unsigned char      npy_uint8
     ctypedef unsigned short     npy_uint16
     ctypedef unsigned int       npy_uint32
     ctypedef unsigned long long npy_uint64
-    ctypedef unsigned long long npy_uint96
-    ctypedef unsigned long long npy_uint128
 
     ctypedef float        npy_float32
     ctypedef double       npy_float64
@@ -137,12 +133,10 @@ cdef extern from "numpy/arrayobject.h":
         NPY_INT16
         NPY_INT32
         NPY_INT64
-        NPY_INT128
         NPY_UINT8
         NPY_UINT16
         NPY_UINT32
         NPY_UINT64
-        NPY_UINT128
         NPY_FLOAT16
         NPY_FLOAT32
         NPY_FLOAT64
@@ -665,15 +659,11 @@ ctypedef npy_int8       int8_t
 ctypedef npy_int16      int16_t
 ctypedef npy_int32      int32_t
 ctypedef npy_int64      int64_t
-#ctypedef npy_int96      int96_t
-#ctypedef npy_int128     int128_t
 
 ctypedef npy_uint8      uint8_t
 ctypedef npy_uint16     uint16_t
 ctypedef npy_uint32     uint32_t
 ctypedef npy_uint64     uint64_t
-#ctypedef npy_uint96     uint96_t
-#ctypedef npy_uint128    uint128_t
 
 ctypedef npy_float32    float32_t
 ctypedef npy_float64    float64_t

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -138,27 +138,22 @@ cdef extern from "numpy/arrayobject.h":
         NPY_INT32
         NPY_INT64
         NPY_INT128
-        NPY_INT256
         NPY_UINT8
         NPY_UINT16
         NPY_UINT32
         NPY_UINT64
         NPY_UINT128
-        NPY_UINT256
         NPY_FLOAT16
         NPY_FLOAT32
         NPY_FLOAT64
         NPY_FLOAT80
         NPY_FLOAT96
         NPY_FLOAT128
-        NPY_FLOAT256
-        NPY_COMPLEX32
         NPY_COMPLEX64
         NPY_COMPLEX128
         NPY_COMPLEX160
         NPY_COMPLEX192
         NPY_COMPLEX256
-        NPY_COMPLEX512
 
         NPY_INTP
         NPY_UINTP

--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -410,9 +410,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #define NPY_MAX_INT128 NPY_LONGLONG_SUFFIX(85070591730234615865843651857942052864)
 #define NPY_MIN_INT128 (-NPY_MAX_INT128 - NPY_LONGLONG_SUFFIX(1))
 #define NPY_MAX_UINT128 NPY_ULONGLONG_SUFFIX(170141183460469231731687303715884105728)
-#define NPY_MAX_INT256 NPY_LONGLONG_SUFFIX(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-#define NPY_MIN_INT256 (-NPY_MAX_INT256 - NPY_LONGLONG_SUFFIX(1))
-#define NPY_MAX_UINT256 NPY_ULONGLONG_SUFFIX(115792089237316195423570985008687907853269984665640564039457584007913129639935)
 #define NPY_MIN_DATETIME NPY_MIN_INT64
 #define NPY_MAX_DATETIME NPY_MAX_INT64
 #define NPY_MIN_TIMEDELTA NPY_MIN_INT64
@@ -611,20 +608,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #  define NPY_MAX_LONGLONG NPY_MAX_INT128
 #  define NPY_MIN_LONGLONG NPY_MIN_INT128
 #  define NPY_MAX_ULONGLONG NPY_MAX_UINT128
-#elif NPY_BITSOF_LONGLONG == 256
-#  define NPY_INT256 NPY_LONGLONG
-#  define NPY_UINT256 NPY_ULONGLONG
-        typedef npy_longlong npy_int256;
-        typedef npy_ulonglong npy_uint256;
-#  define PyInt256ScalarObject PyLongLongScalarObject
-#  define PyInt256ArrType_Type PyLongLongArrType_Type
-#  define PyUInt256ScalarObject PyULongLongScalarObject
-#  define PyUInt256ArrType_Type PyULongLongArrType_Type
-#define NPY_INT256_FMT NPY_LONGLONG_FMT
-#define NPY_UINT256_FMT NPY_ULONGLONG_FMT
-#  define NPY_MAX_LONGLONG NPY_MAX_INT256
-#  define NPY_MIN_LONGLONG NPY_MIN_INT256
-#  define NPY_MAX_ULONGLONG NPY_MAX_UINT256
 #endif
 
 #if NPY_BITSOF_INT == 8
@@ -1046,17 +1029,6 @@ typedef npy_half npy_float16;
 #define NPY_FLOAT128_FMT NPY_LONGDOUBLE_FMT
 #define NPY_COMPLEX256_FMT NPY_CLONGDOUBLE_FMT
 #endif
-#elif NPY_BITSOF_LONGDOUBLE == 256
-#define NPY_FLOAT256 NPY_LONGDOUBLE
-#define NPY_COMPLEX512 NPY_CLONGDOUBLE
-        typedef npy_longdouble npy_float256;
-        typedef npy_clongdouble npy_complex512;
-#    define PyFloat256ScalarObject PyLongDoubleScalarObject
-#    define PyComplex512ScalarObject PyCLongDoubleScalarObject
-#    define PyFloat256ArrType_Type PyLongDoubleArrType_Type
-#    define PyComplex512ArrType_Type PyCLongDoubleArrType_Type
-#define NPY_FLOAT256_FMT NPY_LONGDOUBLE_FMT
-#define NPY_COMPLEX512_FMT NPY_CLONGDOUBLE_FMT
 #endif
 
 /* datetime typedefs */

--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -512,17 +512,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #define NPY_UINT64_FMT NPY_ULONG_FMT
 #define MyPyLong_FromInt64 PyLong_FromLong
 #define MyPyLong_AsInt64 PyLong_AsLong
-#elif NPY_BITSOF_LONG == 128
-#define NPY_INT128 NPY_LONG
-#define NPY_UINT128 NPY_ULONG
-        typedef long npy_int128;
-        typedef unsigned long npy_uint128;
-#define PyInt128ScalarObject PyLongScalarObject
-#define PyInt128ArrType_Type PyLongArrType_Type
-#define PyUInt128ScalarObject PyULongScalarObject
-#define PyUInt128ArrType_Type PyULongArrType_Type
-#define NPY_INT128_FMT NPY_LONG_FMT
-#define NPY_UINT128_FMT NPY_ULONG_FMT
 #endif
 
 #if NPY_BITSOF_LONGLONG == 8
@@ -592,22 +581,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #  define NPY_MAX_LONGLONG NPY_MAX_INT64
 #  define NPY_MIN_LONGLONG NPY_MIN_INT64
 #  define NPY_MAX_ULONGLONG NPY_MAX_UINT64
-#elif NPY_BITSOF_LONGLONG == 128
-#  ifndef NPY_INT128
-#    define NPY_INT128 NPY_LONGLONG
-#    define NPY_UINT128 NPY_ULONGLONG
-        typedef npy_longlong npy_int128;
-        typedef npy_ulonglong npy_uint128;
-#    define PyInt128ScalarObject PyLongLongScalarObject
-#    define PyInt128ArrType_Type PyLongLongArrType_Type
-#    define PyUInt128ScalarObject PyULongLongScalarObject
-#    define PyUInt128ArrType_Type PyULongLongArrType_Type
-#define NPY_INT128_FMT NPY_LONGLONG_FMT
-#define NPY_UINT128_FMT NPY_ULONGLONG_FMT
-#  endif
-#  define NPY_MAX_LONGLONG NPY_MAX_INT128
-#  define NPY_MIN_LONGLONG NPY_MIN_INT128
-#  define NPY_MAX_ULONGLONG NPY_MAX_UINT128
 #endif
 
 #if NPY_BITSOF_INT == 8
@@ -665,19 +638,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #    define MyPyLong_FromInt64 PyLong_FromLong
 #    define MyPyLong_AsInt64 PyLong_AsLong
 #endif
-#elif NPY_BITSOF_INT == 128
-#ifndef NPY_INT128
-#define NPY_INT128 NPY_INT
-#define NPY_UINT128 NPY_UINT
-        typedef int npy_int128;
-        typedef unsigned int npy_uint128;
-#    define PyInt128ScalarObject PyIntScalarObject
-#    define PyInt128ArrType_Type PyIntArrType_Type
-#    define PyUInt128ScalarObject PyUIntScalarObject
-#    define PyUInt128ArrType_Type PyUIntArrType_Type
-#define NPY_INT128_FMT NPY_INT_FMT
-#define NPY_UINT128_FMT NPY_UINT_FMT
-#endif
 #endif
 
 #if NPY_BITSOF_SHORT == 8
@@ -734,19 +694,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #define NPY_UINT64_FMT NPY_USHORT_FMT
 #    define MyPyLong_FromInt64 PyLong_FromLong
 #    define MyPyLong_AsInt64 PyLong_AsLong
-#endif
-#elif NPY_BITSOF_SHORT == 128
-#ifndef NPY_INT128
-#define NPY_INT128 NPY_SHORT
-#define NPY_UINT128 NPY_USHORT
-        typedef short npy_int128;
-        typedef unsigned short npy_uint128;
-#    define PyInt128ScalarObject PyShortScalarObject
-#    define PyInt128ArrType_Type PyShortArrType_Type
-#    define PyUInt128ScalarObject PyUShortScalarObject
-#    define PyUInt128ArrType_Type PyUShortArrType_Type
-#define NPY_INT128_FMT NPY_SHORT_FMT
-#define NPY_UINT128_FMT NPY_USHORT_FMT
 #endif
 #endif
 
@@ -807,18 +754,6 @@ typedef longdouble_t _Complex npy_clongdouble;
 #    define MyPyLong_AsInt64 PyLong_AsLong
 #endif
 #elif NPY_BITSOF_CHAR == 128
-#ifndef NPY_INT128
-#define NPY_INT128 NPY_BYTE
-#define NPY_UINT128 NPY_UBYTE
-        typedef signed char npy_int128;
-        typedef unsigned char npy_uint128;
-#    define PyInt128ScalarObject PyByteScalarObject
-#    define PyInt128ArrType_Type PyByteArrType_Type
-#    define PyUInt128ScalarObject PyUByteScalarObject
-#    define PyUInt128ArrType_Type PyUByteArrType_Type
-#define NPY_INT128_FMT NPY_BYTE_FMT
-#define NPY_UINT128_FMT NPY_UBYTE_FMT
-#endif
 #endif
 
 

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -14,8 +14,8 @@ Exported symbols include:
 
     int8 int16 int32 int64 int128
     uint8 uint16 uint32 uint64 uint128
-    float16 float32 float64 float96 float128 float256
-    complex32 complex64 complex128 complex192 complex256 complex512
+    float16 float32 float64 float96 float128
+    complex64 complex128 complex192 complex256
     datetime64 timedelta64
 
     c-based names
@@ -113,12 +113,10 @@ from builtins import bool, int, float, complex, object, str, bytes  # noqa: F401
 generic = allTypes['generic']
 
 genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
-                   'int32', 'uint32', 'int64', 'uint64', 'int128',
-                   'uint128', 'float16',
-                   'float32', 'float64', 'float80', 'float96', 'float128',
-                   'float256',
-                   'complex32', 'complex64', 'complex128', 'complex160',
-                   'complex192', 'complex256', 'complex512', 'object']
+                   'int32', 'uint32', 'int64', 'uint64', 'int128', 'uint128',
+                   'float16', 'float32', 'float64', 'float96', 'float128',
+                   'complex64', 'complex128', 'complex192', 'complex256',
+                   'object']
 
 @set_module('numpy')
 def maximum_sctype(t):

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -12,8 +12,8 @@ Exported symbols include:
 
     Bit-width names
 
-    int8 int16 int32 int64 int128
-    uint8 uint16 uint32 uint64 uint128
+    int8 int16 int32 int64
+    uint8 uint16 uint32 uint64
     float16 float32 float64 float96 float128
     complex64 complex128 complex192 complex256
     datetime64 timedelta64
@@ -113,7 +113,7 @@ from builtins import bool, int, float, complex, object, str, bytes  # noqa: F401
 generic = allTypes['generic']
 
 genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
-                   'int32', 'uint32', 'int64', 'uint64', 'int128', 'uint128',
+                   'int32', 'uint32', 'int64', 'uint64',
                    'float16', 'float32', 'float64', 'float96', 'float128',
                    'complex64', 'complex128', 'complex192', 'complex256',
                    'object']

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1215,11 +1215,6 @@ PyArray_TypestrConvert(int itemsize, int gentype)
                 case 8:
                     newtype = NPY_INT64;
                     break;
-#ifdef NPY_INT128
-                case 16:
-                    newtype = NPY_INT128;
-                    break;
-#endif
             }
             break;
 
@@ -1237,11 +1232,6 @@ PyArray_TypestrConvert(int itemsize, int gentype)
                 case 8:
                     newtype = NPY_UINT64;
                     break;
-#ifdef NPY_INT128
-                case 16:
-                    newtype = NPY_UINT128;
-                    break;
-#endif
             }
             break;
 


### PR DESCRIPTION
Because `int256`, `uint256`, `float256`, and `complex512`, aren't a thing :shrug:.

(first time I've touched the C code btw)