### PR TITLE
TYP, TST: improved type-testing

### DIFF
--- a/numpy/typing/tests/data/fail/arithmetic.pyi
+++ b/numpy/typing/tests/data/fail/arithmetic.pyi
@@ -28,96 +28,96 @@ AR_LIKE_M: list[np.datetime64]
 # Array subtraction
 
 # NOTE: mypys `NoReturn` errors are, unfortunately, not that great
-_1 = AR_b - AR_LIKE_b  # E: Need type annotation
-_2 = AR_LIKE_b - AR_b  # E: Need type annotation
-AR_i - bytes()  # E: No overload variant
+_1 = AR_b - AR_LIKE_b  # type: ignore[var-annotated]
+_2 = AR_LIKE_b - AR_b  # type: ignore[var-annotated]
+AR_i - bytes()  # type: ignore[operator]
 
-AR_f - AR_LIKE_m  # E: Unsupported operand types
-AR_f - AR_LIKE_M  # E: Unsupported operand types
-AR_c - AR_LIKE_m  # E: Unsupported operand types
-AR_c - AR_LIKE_M  # E: Unsupported operand types
+AR_f - AR_LIKE_m  # type: ignore[operator]
+AR_f - AR_LIKE_M  # type: ignore[operator]
+AR_c - AR_LIKE_m  # type: ignore[operator]
+AR_c - AR_LIKE_M  # type: ignore[operator]
 
-AR_m - AR_LIKE_f  # E: Unsupported operand types
-AR_M - AR_LIKE_f  # E: Unsupported operand types
-AR_m - AR_LIKE_c  # E: Unsupported operand types
-AR_M - AR_LIKE_c  # E: Unsupported operand types
+AR_m - AR_LIKE_f  # type: ignore[operator]
+AR_M - AR_LIKE_f  # type: ignore[operator]
+AR_m - AR_LIKE_c  # type: ignore[operator]
+AR_M - AR_LIKE_c  # type: ignore[operator]
 
-AR_m - AR_LIKE_M  # E: Unsupported operand types
-AR_LIKE_m - AR_M  # E: Unsupported operand types
+AR_m - AR_LIKE_M  # type: ignore[operator]
+AR_LIKE_m - AR_M  # type: ignore[operator]
 
 # array floor division
 
-AR_M // AR_LIKE_b  # E: Unsupported operand types
-AR_M // AR_LIKE_u  # E: Unsupported operand types
-AR_M // AR_LIKE_i  # E: Unsupported operand types
-AR_M // AR_LIKE_f  # E: Unsupported operand types
-AR_M // AR_LIKE_c  # E: Unsupported operand types
-AR_M // AR_LIKE_m  # E: Unsupported operand types
-AR_M // AR_LIKE_M  # E: Unsupported operand types
+AR_M // AR_LIKE_b  # type: ignore[operator]
+AR_M // AR_LIKE_u  # type: ignore[operator]
+AR_M // AR_LIKE_i  # type: ignore[operator]
+AR_M // AR_LIKE_f  # type: ignore[operator]
+AR_M // AR_LIKE_c  # type: ignore[operator]
+AR_M // AR_LIKE_m  # type: ignore[operator]
+AR_M // AR_LIKE_M  # type: ignore[operator]
 
-AR_b // AR_LIKE_M  # E: Unsupported operand types
-AR_u // AR_LIKE_M  # E: Unsupported operand types
-AR_i // AR_LIKE_M  # E: Unsupported operand types
-AR_f // AR_LIKE_M  # E: Unsupported operand types
-AR_c // AR_LIKE_M  # E: Unsupported operand types
-AR_m // AR_LIKE_M  # E: Unsupported operand types
-AR_M // AR_LIKE_M  # E: Unsupported operand types
+AR_b // AR_LIKE_M  # type: ignore[operator]
+AR_u // AR_LIKE_M  # type: ignore[operator]
+AR_i // AR_LIKE_M  # type: ignore[operator]
+AR_f // AR_LIKE_M  # type: ignore[operator]
+AR_c // AR_LIKE_M  # type: ignore[operator]
+AR_m // AR_LIKE_M  # type: ignore[operator]
+AR_M // AR_LIKE_M  # type: ignore[operator]
 
-_3 = AR_m // AR_LIKE_b  # E: Need type annotation
-AR_m // AR_LIKE_c  # E: Unsupported operand types
+_3 = AR_m // AR_LIKE_b  # type: ignore[var-annotated]
+AR_m // AR_LIKE_c  # type: ignore[operator]
 
-AR_b // AR_LIKE_m  # E: Unsupported operand types
-AR_u // AR_LIKE_m  # E: Unsupported operand types
-AR_i // AR_LIKE_m  # E: Unsupported operand types
-AR_f // AR_LIKE_m  # E: Unsupported operand types
-AR_c // AR_LIKE_m  # E: Unsupported operand types
+AR_b // AR_LIKE_m  # type: ignore[operator]
+AR_u // AR_LIKE_m  # type: ignore[operator]
+AR_i // AR_LIKE_m  # type: ignore[operator]
+AR_f // AR_LIKE_m  # type: ignore[operator]
+AR_c // AR_LIKE_m  # type: ignore[operator]
 
 # Array multiplication
 
-AR_b *= AR_LIKE_u  # E: incompatible type
-AR_b *= AR_LIKE_i  # E: incompatible type
-AR_b *= AR_LIKE_f  # E: incompatible type
-AR_b *= AR_LIKE_c  # E: incompatible type
-AR_b *= AR_LIKE_m  # E: incompatible type
+AR_b *= AR_LIKE_u  # type: ignore[arg-type]
+AR_b *= AR_LIKE_i  # type: ignore[arg-type]
+AR_b *= AR_LIKE_f  # type: ignore[arg-type]
+AR_b *= AR_LIKE_c  # type: ignore[arg-type]
+AR_b *= AR_LIKE_m  # type: ignore[arg-type]
 
-AR_u *= AR_LIKE_i  # E: incompatible type
-AR_u *= AR_LIKE_f  # E: incompatible type
-AR_u *= AR_LIKE_c  # E: incompatible type
-AR_u *= AR_LIKE_m  # E: incompatible type
+AR_u *= AR_LIKE_i  # type: ignore[arg-type]
+AR_u *= AR_LIKE_f  # type: ignore[arg-type]
+AR_u *= AR_LIKE_c  # type: ignore[arg-type]
+AR_u *= AR_LIKE_m  # type: ignore[arg-type]
 
-AR_i *= AR_LIKE_f  # E: incompatible type
-AR_i *= AR_LIKE_c  # E: incompatible type
-AR_i *= AR_LIKE_m  # E: incompatible type
+AR_i *= AR_LIKE_f  # type: ignore[arg-type]
+AR_i *= AR_LIKE_c  # type: ignore[arg-type]
+AR_i *= AR_LIKE_m  # type: ignore[arg-type]
 
-AR_f *= AR_LIKE_c  # E: incompatible type
-AR_f *= AR_LIKE_m  # E: incompatible type
+AR_f *= AR_LIKE_c  # type: ignore[arg-type]
+AR_f *= AR_LIKE_m  # type: ignore[arg-type]
 
 # Array power
 
-AR_b **= AR_LIKE_b  # E: Invalid self argument
-AR_b **= AR_LIKE_u  # E: Invalid self argument
-AR_b **= AR_LIKE_i  # E: Invalid self argument
-AR_b **= AR_LIKE_f  # E: Invalid self argument
-AR_b **= AR_LIKE_c  # E: Invalid self argument
+AR_b **= AR_LIKE_b  # type: ignore[misc]
+AR_b **= AR_LIKE_u  # type: ignore[misc]
+AR_b **= AR_LIKE_i  # type: ignore[misc]
+AR_b **= AR_LIKE_f  # type: ignore[misc]
+AR_b **= AR_LIKE_c  # type: ignore[misc]
 
-AR_u **= AR_LIKE_i  # E: incompatible type
-AR_u **= AR_LIKE_f  # E: incompatible type
-AR_u **= AR_LIKE_c  # E: incompatible type
+AR_u **= AR_LIKE_i  # type: ignore[arg-type]
+AR_u **= AR_LIKE_f  # type: ignore[arg-type]
+AR_u **= AR_LIKE_c  # type: ignore[arg-type]
 
-AR_i **= AR_LIKE_f  # E: incompatible type
-AR_i **= AR_LIKE_c  # E: incompatible type
+AR_i **= AR_LIKE_f  # type: ignore[arg-type]
+AR_i **= AR_LIKE_c  # type: ignore[arg-type]
 
-AR_f **= AR_LIKE_c  # E: incompatible type
+AR_f **= AR_LIKE_c  # type: ignore[arg-type]
 
 # Scalars
 
-b_ - b_  # E: No overload variant
+b_ - b_  # type: ignore[call-overload]
 
-dt + dt  # E: Unsupported operand types
-td - dt  # E: Unsupported operand types
-td % 1  # E: Unsupported operand types
-td / dt  # E: No overload
-td % dt  # E: Unsupported operand types
+dt + dt  # type: ignore[operator]
+td - dt  # type: ignore[operator]
+td % 1  # type: ignore[operator]
+td / dt  # type: ignore[operator]
+td % dt  # type: ignore[operator]
 
--b_  # E: Unsupported operand type
-+b_  # E: Unsupported operand type
+-b_  # type: ignore[operator]
++b_  # type: ignore[operator]

--- a/numpy/typing/tests/data/fail/array_constructors.pyi
+++ b/numpy/typing/tests/data/fail/array_constructors.pyi
@@ -4,31 +4,31 @@ import numpy.typing as npt
 a: npt.NDArray[np.float64]
 generator = (i for i in range(10))
 
-np.require(a, requirements=1)  # E: No overload variant
-np.require(a, requirements="TEST")  # E: incompatible type
+np.require(a, requirements=1)  # type: ignore[call-overload]
+np.require(a, requirements="TEST")  # type: ignore[arg-type]
 
-np.zeros("test")  # E: incompatible type
-np.zeros()  # E: require at least one argument
+np.zeros("test")  # type: ignore[arg-type]
+np.zeros()  # type: ignore[call-overload]
 
-np.ones("test")  # E: incompatible type
-np.ones()  # E: require at least one argument
+np.ones("test")  # type: ignore[arg-type]
+np.ones()  # type: ignore[call-overload]
 
-np.array(0, float, True)  # E: No overload variant
+np.array(0, float, True)  # type: ignore[call-overload]
 
-np.linspace(None, 'bob')  # E: No overload variant
-np.linspace(0, 2, num=10.0)  # E: No overload variant
-np.linspace(0, 2, endpoint='True')  # E: No overload variant
-np.linspace(0, 2, retstep=b'False')  # E: No overload variant
-np.linspace(0, 2, dtype=0)  # E: No overload variant
-np.linspace(0, 2, axis=None)  # E: No overload variant
+np.linspace(None, 'bob')  # type: ignore[call-overload]
+np.linspace(0, 2, num=10.0)  # type: ignore[call-overload]
+np.linspace(0, 2, endpoint='True')  # type: ignore[call-overload]
+np.linspace(0, 2, retstep=b'False')  # type: ignore[call-overload]
+np.linspace(0, 2, dtype=0)  # type: ignore[call-overload]
+np.linspace(0, 2, axis=None)  # type: ignore[call-overload]
 
-np.logspace(None, 'bob')  # E: No overload variant
-np.logspace(0, 2, base=None)  # E: No overload variant
+np.logspace(None, 'bob')  # type: ignore[call-overload]
+np.logspace(0, 2, base=None)  # type: ignore[call-overload]
 
-np.geomspace(None, 'bob')  # E: No overload variant
+np.geomspace(None, 'bob')  # type: ignore[call-overload]
 
-np.stack(generator)  # E: No overload variant
-np.hstack({1, 2})  # E: No overload variant
-np.vstack(1)  # E: No overload variant
+np.stack(generator)  # type: ignore[call-overload]
+np.hstack({1, 2})  # type: ignore[call-overload]
+np.vstack(1)  # type: ignore[call-overload]
 
-np.array([1], like=1)  # E: No overload variant
+np.array([1], like=1)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/array_like.pyi
+++ b/numpy/typing/tests/data/fail/array_like.pyi
@@ -3,13 +3,13 @@ from numpy._typing import ArrayLike
 
 class A: ...
 
-x1: ArrayLike = (i for i in range(10))  # E: Incompatible types in assignment
-x2: ArrayLike = A()  # E: Incompatible types in assignment
-x3: ArrayLike = {1: "foo", 2: "bar"}  # E: Incompatible types in assignment
+x1: ArrayLike = (i for i in range(10))  # type: ignore[assignment]
+x2: ArrayLike = A()  # type: ignore[assignment]
+x3: ArrayLike = {1: "foo", 2: "bar"}  # type: ignore[assignment]
 
 scalar = np.int64(1)
-scalar.__array__(dtype=np.float64)  # E: No overload variant
+scalar.__array__(dtype=np.float64)  # type: ignore[call-overload]
 array = np.array([1])
-array.__array__(dtype=np.float64)  # E: No overload variant
+array.__array__(dtype=np.float64)  # type: ignore[call-overload]
 
-array.setfield(np.eye(1), np.int32, (0, 1))  # E: No overload variant
+array.setfield(np.eye(1), np.int32, (0, 1))  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/array_pad.pyi
+++ b/numpy/typing/tests/data/fail/array_pad.pyi
@@ -3,4 +3,4 @@ import numpy.typing as npt
 
 AR_i8: npt.NDArray[np.int64]
 
-np.pad(AR_i8, 2, mode="bob")  # E: No overload variant
+np.pad(AR_i8, 2, mode="bob")  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/arrayprint.pyi
+++ b/numpy/typing/tests/data/fail/arrayprint.pyi
@@ -8,9 +8,9 @@ AR: npt.NDArray[np.float64]
 func1: Callable[[Any], str]
 func2: Callable[[np.integer], str]
 
-np.array2string(AR, style=None)  # E: No overload variant
-np.array2string(AR, legacy="1.14")  # E: No overload variant
-np.array2string(AR, sign="*")  # E: No overload variant
-np.array2string(AR, floatmode="default")  # E: No overload variant
-np.array2string(AR, formatter={"A": func1})  # E: No overload variant
-np.array2string(AR, formatter={"float": func2})  # E: No overload variant
+np.array2string(AR, style=None)  # type: ignore[call-overload]
+np.array2string(AR, legacy="1.14")  # type: ignore[call-overload]
+np.array2string(AR, sign="*")  # type: ignore[call-overload]
+np.array2string(AR, floatmode="default")  # type: ignore[call-overload]
+np.array2string(AR, formatter={"A": func1})  # type: ignore[call-overload]
+np.array2string(AR, formatter={"float": func2})  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/arrayterator.pyi
+++ b/numpy/typing/tests/data/fail/arrayterator.pyi
@@ -4,11 +4,11 @@ import numpy.typing as npt
 AR_i8: npt.NDArray[np.int64]
 ar_iter = np.lib.Arrayterator(AR_i8)
 
-np.lib.Arrayterator(np.int64())  # E: incompatible type
-ar_iter.shape = (10, 5)  # E: is read-only
-ar_iter[None]  # E: Invalid index type
-ar_iter[None, 1]  # E: Invalid index type
-ar_iter[np.intp()]  # E: Invalid index type
-ar_iter[np.intp(), ...]  # E: Invalid index type
-ar_iter[AR_i8]  # E: Invalid index type
-ar_iter[AR_i8, :]  # E: Invalid index type
+np.lib.Arrayterator(np.int64())  # type: ignore[arg-type]
+ar_iter.shape = (10, 5)  # type: ignore[misc]
+ar_iter[None]  # type: ignore[index]
+ar_iter[None, 1]  # type: ignore[index]
+ar_iter[np.intp()]  # type: ignore[index]
+ar_iter[np.intp(), ...]  # type: ignore[index]
+ar_iter[AR_i8]  # type: ignore[index]
+ar_iter[AR_i8, :]  # type: ignore[index]

--- a/numpy/typing/tests/data/fail/bitwise_ops.pyi
+++ b/numpy/typing/tests/data/fail/bitwise_ops.pyi
@@ -8,14 +8,10 @@ i = int()
 
 f8 = np.float64()
 
-b_ >> f8  # E: No overload variant
-i8 << f8  # E: No overload variant
-i | f8  # E: Unsupported operand types
-i8 ^ f8  # E: No overload variant
-u8 & f8  # E: No overload variant
-~f8  # E: Unsupported operand type
+b_ >> f8  # type: ignore[call-overload]
+i8 << f8  # type: ignore[call-overload]
+i | f8  # type: ignore[operator]
+i8 ^ f8  # type: ignore[call-overload]
+u8 & f8  # type: ignore[call-overload]
+~f8  # type: ignore[operator]
 # TODO: Certain mixes like i4 << u8 go to float and thus should fail
-
-# mypys' error message for `NoReturn` is unfortunately pretty bad
-# TODO: Re-enable this once we add support for numerical precision for `number`s
-# a = u8 | 0  # E: Need type annotation

--- a/numpy/typing/tests/data/fail/char.pyi
+++ b/numpy/typing/tests/data/fail/char.pyi
@@ -4,66 +4,62 @@ import numpy.typing as npt
 AR_U: npt.NDArray[np.str_]
 AR_S: npt.NDArray[np.bytes_]
 
-np.char.equal(AR_U, AR_S)  # E: incompatible type
+np.char.equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.char.not_equal(AR_U, AR_S)  # type: ignore[arg-type]
 
-np.char.not_equal(AR_U, AR_S)  # E: incompatible type
+np.char.greater_equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.char.less_equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.char.greater(AR_U, AR_S)  # type: ignore[arg-type]
+np.char.less(AR_U, AR_S)  # type: ignore[arg-type]
 
-np.char.greater_equal(AR_U, AR_S)  # E: incompatible type
+np.char.encode(AR_S)  # type: ignore[arg-type]
+np.char.decode(AR_U)  # type: ignore[arg-type]
 
-np.char.less_equal(AR_U, AR_S)  # E: incompatible type
+np.char.join(AR_U, b"_")  # type: ignore[arg-type]
+np.char.join(AR_S, "_")  # type: ignore[arg-type]
 
-np.char.greater(AR_U, AR_S)  # E: incompatible type
+np.char.ljust(AR_U, 5, fillchar=b"a")  # type: ignore[arg-type]
+np.char.ljust(AR_S, 5, fillchar="a")  # type: ignore[arg-type]
+np.char.rjust(AR_U, 5, fillchar=b"a")  # type: ignore[arg-type]
+np.char.rjust(AR_S, 5, fillchar="a")  # type: ignore[arg-type]
 
-np.char.less(AR_U, AR_S)  # E: incompatible type
+np.char.lstrip(AR_U, chars=b"a")  # type: ignore[arg-type]
+np.char.lstrip(AR_S, chars="a")  # type: ignore[arg-type]
+np.char.strip(AR_U, chars=b"a")  # type: ignore[arg-type]
+np.char.strip(AR_S, chars="a")  # type: ignore[arg-type]
+np.char.rstrip(AR_U, chars=b"a")  # type: ignore[arg-type]
+np.char.rstrip(AR_S, chars="a")  # type: ignore[arg-type]
 
-np.char.encode(AR_S)  # E: incompatible type
-np.char.decode(AR_U)  # E: incompatible type
+np.char.partition(AR_U, b"a")  # type: ignore[arg-type]
+np.char.partition(AR_S, "a")  # type: ignore[arg-type]
+np.char.rpartition(AR_U, b"a")  # type: ignore[arg-type]
+np.char.rpartition(AR_S, "a")  # type: ignore[arg-type]
 
-np.char.join(AR_U, b"_")  # E: incompatible type
-np.char.join(AR_S, "_")  # E: incompatible type
+np.char.replace(AR_U, b"_", b"-")  # type: ignore[arg-type]
+np.char.replace(AR_S, "_", "-")  # type: ignore[arg-type]
 
-np.char.ljust(AR_U, 5, fillchar=b"a")  # E: incompatible type
-np.char.ljust(AR_S, 5, fillchar="a")  # E: incompatible type
-np.char.rjust(AR_U, 5, fillchar=b"a")  # E: incompatible type
-np.char.rjust(AR_S, 5, fillchar="a")  # E: incompatible type
+np.char.split(AR_U, b"_")  # type: ignore[arg-type]
+np.char.split(AR_S, "_")  # type: ignore[arg-type]
+np.char.rsplit(AR_U, b"_")  # type: ignore[arg-type]
+np.char.rsplit(AR_S, "_")  # type: ignore[arg-type]
 
-np.char.lstrip(AR_U, chars=b"a")  # E: incompatible type
-np.char.lstrip(AR_S, chars="a")  # E: incompatible type
-np.char.strip(AR_U, chars=b"a")  # E: incompatible type
-np.char.strip(AR_S, chars="a")  # E: incompatible type
-np.char.rstrip(AR_U, chars=b"a")  # E: incompatible type
-np.char.rstrip(AR_S, chars="a")  # E: incompatible type
+np.char.count(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.count(AR_S, "a", end=9)  # type: ignore[arg-type]
 
-np.char.partition(AR_U, b"a")  # E: incompatible type
-np.char.partition(AR_S, "a")  # E: incompatible type
-np.char.rpartition(AR_U, b"a")  # E: incompatible type
-np.char.rpartition(AR_S, "a")  # E: incompatible type
+np.char.endswith(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.endswith(AR_S, "a", end=9)  # type: ignore[arg-type]
+np.char.startswith(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.startswith(AR_S, "a", end=9)  # type: ignore[arg-type]
 
-np.char.replace(AR_U, b"_", b"-")  # E: incompatible type
-np.char.replace(AR_S, "_", "-")  # E: incompatible type
+np.char.find(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.find(AR_S, "a", end=9)  # type: ignore[arg-type]
+np.char.rfind(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.rfind(AR_S, "a", end=9)  # type: ignore[arg-type]
 
-np.char.split(AR_U, b"_")  # E: incompatible type
-np.char.split(AR_S, "_")  # E: incompatible type
-np.char.rsplit(AR_U, b"_")  # E: incompatible type
-np.char.rsplit(AR_S, "_")  # E: incompatible type
+np.char.index(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.index(AR_S, "a", end=9)  # type: ignore[arg-type]
+np.char.rindex(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.char.rindex(AR_S, "a", end=9)  # type: ignore[arg-type]
 
-np.char.count(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.count(AR_S, "a", end=9)  # E: incompatible type
-
-np.char.endswith(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.endswith(AR_S, "a", end=9)  # E: incompatible type
-np.char.startswith(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.startswith(AR_S, "a", end=9)  # E: incompatible type
-
-np.char.find(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.find(AR_S, "a", end=9)  # E: incompatible type
-np.char.rfind(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.rfind(AR_S, "a", end=9)  # E: incompatible type
-
-np.char.index(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.index(AR_S, "a", end=9)  # E: incompatible type
-np.char.rindex(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.char.rindex(AR_S, "a", end=9)  # E: incompatible type
-
-np.char.isdecimal(AR_S)  # E: incompatible type
-np.char.isnumeric(AR_S)  # E: incompatible type
+np.char.isdecimal(AR_S)  # type: ignore[arg-type]
+np.char.isnumeric(AR_S)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/chararray.pyi
+++ b/numpy/typing/tests/data/fail/chararray.pyi
@@ -3,59 +3,59 @@ import numpy as np
 AR_U: np.char.chararray[tuple[int, ...], np.dtype[np.str_]]
 AR_S: np.char.chararray[tuple[int, ...], np.dtype[np.bytes_]]
 
-AR_S.encode()  # E: Invalid self argument
-AR_U.decode()  # E: Invalid self argument
+AR_S.encode()  # type: ignore[misc]
+AR_U.decode()  # type: ignore[misc]
 
-AR_U.join(b"_")  # E: incompatible type
-AR_S.join("_")  # E: incompatible type
+AR_U.join(b"_")  # type: ignore[arg-type]
+AR_S.join("_")  # type: ignore[arg-type]
 
-AR_U.ljust(5, fillchar=b"a")  # E: incompatible type
-AR_S.ljust(5, fillchar="a")  # E: incompatible type
-AR_U.rjust(5, fillchar=b"a")  # E: incompatible type
-AR_S.rjust(5, fillchar="a")  # E: incompatible type
+AR_U.ljust(5, fillchar=b"a")  # type: ignore[arg-type]
+AR_S.ljust(5, fillchar="a")  # type: ignore[arg-type]
+AR_U.rjust(5, fillchar=b"a")  # type: ignore[arg-type]
+AR_S.rjust(5, fillchar="a")  # type: ignore[arg-type]
 
-AR_U.lstrip(chars=b"a")  # E: incompatible type
-AR_S.lstrip(chars="a")  # E: incompatible type
-AR_U.strip(chars=b"a")  # E: incompatible type
-AR_S.strip(chars="a")  # E: incompatible type
-AR_U.rstrip(chars=b"a")  # E: incompatible type
-AR_S.rstrip(chars="a")  # E: incompatible type
+AR_U.lstrip(chars=b"a")  # type: ignore[arg-type]
+AR_S.lstrip(chars="a")  # type: ignore[arg-type]
+AR_U.strip(chars=b"a")  # type: ignore[arg-type]
+AR_S.strip(chars="a")  # type: ignore[arg-type]
+AR_U.rstrip(chars=b"a")  # type: ignore[arg-type]
+AR_S.rstrip(chars="a")  # type: ignore[arg-type]
 
-AR_U.partition(b"a")  # E: incompatible type
-AR_S.partition("a")  # E: incompatible type
-AR_U.rpartition(b"a")  # E: incompatible type
-AR_S.rpartition("a")  # E: incompatible type
+AR_U.partition(b"a")  # type: ignore[arg-type]
+AR_S.partition("a")  # type: ignore[arg-type]
+AR_U.rpartition(b"a")  # type: ignore[arg-type]
+AR_S.rpartition("a")  # type: ignore[arg-type]
 
-AR_U.replace(b"_", b"-")  # E: incompatible type
-AR_S.replace("_", "-")  # E: incompatible type
+AR_U.replace(b"_", b"-")  # type: ignore[arg-type]
+AR_S.replace("_", "-")  # type: ignore[arg-type]
 
-AR_U.split(b"_")  # E: incompatible type
-AR_S.split("_")  # E: incompatible type
-AR_S.split(1)  # E: incompatible type
-AR_U.rsplit(b"_")  # E: incompatible type
-AR_S.rsplit("_")  # E: incompatible type
+AR_U.split(b"_")  # type: ignore[arg-type]
+AR_S.split("_")  # type: ignore[arg-type]
+AR_S.split(1)  # type: ignore[arg-type]
+AR_U.rsplit(b"_")  # type: ignore[arg-type]
+AR_S.rsplit("_")  # type: ignore[arg-type]
 
-AR_U.count(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.count("a", end=9)  # E: incompatible type
+AR_U.count(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.count("a", end=9)  # type: ignore[arg-type]
 
-AR_U.endswith(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.endswith("a", end=9)  # E: incompatible type
-AR_U.startswith(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.startswith("a", end=9)  # E: incompatible type
+AR_U.endswith(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.endswith("a", end=9)  # type: ignore[arg-type]
+AR_U.startswith(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.startswith("a", end=9)  # type: ignore[arg-type]
 
-AR_U.find(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.find("a", end=9)  # E: incompatible type
-AR_U.rfind(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.rfind("a", end=9)  # E: incompatible type
+AR_U.find(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.find("a", end=9)  # type: ignore[arg-type]
+AR_U.rfind(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.rfind("a", end=9)  # type: ignore[arg-type]
 
-AR_U.index(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.index("a", end=9)  # E: incompatible type
-AR_U.rindex(b"a", start=[1, 2, 3])  # E: incompatible type
-AR_S.rindex("a", end=9)  # E: incompatible type
+AR_U.index(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.index("a", end=9)  # type: ignore[arg-type]
+AR_U.rindex(b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+AR_S.rindex("a", end=9)  # type: ignore[arg-type]
 
-AR_U == AR_S  # E: Unsupported operand types
-AR_U != AR_S  # E: Unsupported operand types
-AR_U >= AR_S  # E: Unsupported operand types
-AR_U <= AR_S  # E: Unsupported operand types
-AR_U > AR_S  # E: Unsupported operand types
-AR_U < AR_S  # E: Unsupported operand types
+AR_U == AR_S  # type: ignore[operator]
+AR_U != AR_S  # type: ignore[operator]
+AR_U >= AR_S  # type: ignore[operator]
+AR_U <= AR_S  # type: ignore[operator]
+AR_U > AR_S  # type: ignore[operator]
+AR_U < AR_S  # type: ignore[operator]

--- a/numpy/typing/tests/data/fail/comparisons.pyi
+++ b/numpy/typing/tests/data/fail/comparisons.pyi
@@ -7,21 +7,21 @@ AR_c: npt.NDArray[np.complex128]
 AR_m: npt.NDArray[np.timedelta64]
 AR_M: npt.NDArray[np.datetime64]
 
-AR_f > AR_m  # E: Unsupported operand types
-AR_c > AR_m  # E: Unsupported operand types
+AR_f > AR_m  # type: ignore[operator]
+AR_c > AR_m  # type: ignore[operator]
 
-AR_m > AR_f  # E: Unsupported operand types
-AR_m > AR_c  # E: Unsupported operand types
+AR_m > AR_f  # type: ignore[operator]
+AR_m > AR_c  # type: ignore[operator]
 
-AR_i > AR_M  # E: Unsupported operand types
-AR_f > AR_M  # E: Unsupported operand types
-AR_m > AR_M  # E: Unsupported operand types
+AR_i > AR_M  # type: ignore[operator]
+AR_f > AR_M  # type: ignore[operator]
+AR_m > AR_M  # type: ignore[operator]
 
-AR_M > AR_i  # E: Unsupported operand types
-AR_M > AR_f  # E: Unsupported operand types
-AR_M > AR_m  # E: Unsupported operand types
+AR_M > AR_i  # type: ignore[operator]
+AR_M > AR_f  # type: ignore[operator]
+AR_M > AR_m  # type: ignore[operator]
 
-AR_i > str()  # E: No overload variant
-AR_i > bytes()  # E: No overload variant
-str() > AR_M  # E: Unsupported operand types
-bytes() > AR_M  # E: Unsupported operand types
+AR_i > str()  # type: ignore[operator]
+AR_i > bytes()  # type: ignore[operator]
+str() > AR_M  # type: ignore[operator]
+bytes() > AR_M  # type: ignore[operator]

--- a/numpy/typing/tests/data/fail/constants.pyi
+++ b/numpy/typing/tests/data/fail/constants.pyi
@@ -1,3 +1,3 @@
 import numpy as np
 
-np.little_endian = np.little_endian  # E: Cannot assign to final
+np.little_endian = np.little_endian  # type: ignore[misc]

--- a/numpy/typing/tests/data/fail/datasource.pyi
+++ b/numpy/typing/tests/data/fail/datasource.pyi
@@ -4,12 +4,12 @@ import numpy as np
 path: Path
 d1: np.lib.npyio.DataSource
 
-d1.abspath(path)  # E: incompatible type
-d1.abspath(b"...")  # E: incompatible type
+d1.abspath(path)  # type: ignore[arg-type]
+d1.abspath(b"...")  # type: ignore[arg-type]
 
-d1.exists(path)  # E: incompatible type
-d1.exists(b"...")  # E: incompatible type
+d1.exists(path)  # type: ignore[arg-type]
+d1.exists(b"...")  # type: ignore[arg-type]
 
-d1.open(path, "r")  # E: incompatible type
-d1.open(b"...", encoding="utf8")  # E: incompatible type
-d1.open(None, newline="/n")  # E: incompatible type
+d1.open(path, "r")  # type: ignore[arg-type]
+d1.open(b"...", encoding="utf8")  # type: ignore[arg-type]
+d1.open(None, newline="/n")  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/dtype.pyi
+++ b/numpy/typing/tests/data/fail/dtype.pyi
@@ -6,10 +6,10 @@ class Test1:
 class Test2:
     dtype = float
 
-np.dtype(Test1())  # E: No overload variant of "dtype" matches
-np.dtype(Test2())  # E: incompatible type
+np.dtype(Test1())  # type: ignore[call-overload]
+np.dtype(Test2())  # type: ignore[arg-type]
 
-np.dtype(  # E: No overload variant of "dtype" matches
+np.dtype(  # type: ignore[call-overload]
     {
         "field1": (float, 1),
         "field2": (int, 3),

--- a/numpy/typing/tests/data/fail/einsumfunc.pyi
+++ b/numpy/typing/tests/data/fail/einsumfunc.pyi
@@ -6,7 +6,7 @@ AR_f: npt.NDArray[np.float64]
 AR_m: npt.NDArray[np.timedelta64]
 AR_U: npt.NDArray[np.str_]
 
-np.einsum("i,i->i", AR_i, AR_m)  # E: incompatible type
-np.einsum("i,i->i", AR_f, AR_f, dtype=np.int32)  # E: incompatible type
-np.einsum("i,i->i", AR_i, AR_i, out=AR_U)  # E: Value of type variable "_ArrayT" of "einsum" cannot be
-np.einsum("i,i->i", AR_i, AR_i, out=AR_U, casting="unsafe")  # E: No overload variant
+np.einsum("i,i->i", AR_i, AR_m)  # type: ignore[arg-type]
+np.einsum("i,i->i", AR_f, AR_f, dtype=np.int32)  # type: ignore[arg-type]
+np.einsum("i,i->i", AR_i, AR_i, out=AR_U)  # type: ignore[type-var]
+np.einsum("i,i->i", AR_i, AR_i, out=AR_U, casting="unsafe")  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/flatiter.pyi
+++ b/numpy/typing/tests/data/fail/flatiter.pyi
@@ -1,5 +1,3 @@
-from typing import Any
-
 import numpy as np
 import numpy._typing as npt
 
@@ -9,14 +7,14 @@ class Index:
 a: np.flatiter[npt.NDArray[np.float64]]
 supports_array: npt._SupportsArray[np.dtype[np.float64]]
 
-a.base = Any  # E: Property "base" defined in "flatiter" is read-only
-a.coords = Any  # E: Property "coords" defined in "flatiter" is read-only
-a.index = Any  # E: Property "index" defined in "flatiter" is read-only
-a.copy(order='C')  # E: Unexpected keyword argument
+a.base = object()  # type: ignore[assignment, misc]
+a.coords = object()  # type: ignore[assignment, misc]
+a.index = object()  # type: ignore[assignment, misc]
+a.copy(order='C')  # type: ignore[call-arg]
 
 # NOTE: Contrary to `ndarray.__getitem__` its counterpart in `flatiter`
 # does not accept objects with the `__array__` or `__index__` protocols;
 # boolean indexing is just plain broken (gh-17175)
-a[np.bool()]  # E: No overload variant of "__getitem__"
-a[Index()]  # E: No overload variant of "__getitem__"
-a[supports_array]  # E: No overload variant of "__getitem__"
+a[np.bool()]  # type: ignore[index]
+a[Index()]  # type: ignore[call-overload]
+a[supports_array]  # type: ignore[index]

--- a/numpy/typing/tests/data/fail/fromnumeric.pyi
+++ b/numpy/typing/tests/data/fail/fromnumeric.pyi
@@ -10,156 +10,136 @@ AR_M: npt.NDArray[np.datetime64]
 
 a = np.bool(True)
 
-np.take(a, None)  # E: No overload variant
-np.take(a, axis=1.0)  # E: No overload variant
-np.take(A, out=1)  # E: No overload variant
-np.take(A, mode="bob")  # E: No overload variant
+np.take(a, None)  # type: ignore[call-overload]
+np.take(a, axis=1.0)  # type: ignore[call-overload]
+np.take(A, out=1)  # type: ignore[call-overload]
+np.take(A, mode="bob")  # type: ignore[call-overload]
 
-np.reshape(a, None)  # E: No overload variant
-np.reshape(A, 1, order="bob")  # E: No overload variant
+np.reshape(a, None)  # type: ignore[call-overload]
+np.reshape(A, 1, order="bob")  # type: ignore[call-overload]
 
-np.choose(a, None)  # E: No overload variant
-np.choose(a, out=1.0)  # E: No overload variant
-np.choose(A, mode="bob")  # E: No overload variant
+np.choose(a, None)  # type: ignore[call-overload]
+np.choose(a, out=1.0)  # type: ignore[call-overload]
+np.choose(A, mode="bob")  # type: ignore[call-overload]
 
-np.repeat(a, None)  # E: No overload variant
-np.repeat(A, 1, axis=1.0)  # E: No overload variant
+np.repeat(a, None)  # type: ignore[call-overload]
+np.repeat(A, 1, axis=1.0)  # type: ignore[call-overload]
 
-np.swapaxes(A, None, 1)  # E: No overload variant
-np.swapaxes(A, 1, [0])  # E: No overload variant
+np.swapaxes(A, None, 1)  # type: ignore[call-overload]
+np.swapaxes(A, 1, [0])  # type: ignore[call-overload]
 
-np.transpose(A, axes=1.0)  # E: No overload variant
+np.transpose(A, axes=1.0)  # type: ignore[call-overload]
 
-np.partition(a, None)  # E: No overload variant
-np.partition(  # E: No overload variant
-    a, 0, axis="bob"
-)
-np.partition(  # E: No overload variant
-    A, 0, kind="bob"
-)
-np.partition(
-    A, 0, order=range(5)  # E: Argument "order" to "partition" has incompatible type
-)
+np.partition(a, None)  # type: ignore[call-overload]
+np.partition(a, 0, axis="bob") # type: ignore[call-overload]
+np.partition(A, 0, kind="bob")  # type: ignore[call-overload]
+np.partition(A, 0, order=range(5))  # type: ignore[arg-type]
 
-np.argpartition(
-    a, None  # E: incompatible type
-)
-np.argpartition(
-    a, 0, axis="bob"  # E: incompatible type
-)
-np.argpartition(
-    A, 0, kind="bob"  # E: incompatible type
-)
-np.argpartition(
-    A, 0, order=range(5)  # E: Argument "order" to "argpartition" has incompatible type
-)
+np.argpartition(a, None)  # type: ignore[arg-type]
+np.argpartition(a, 0, axis="bob")  # type: ignore[arg-type]
+np.argpartition(A, 0, kind="bob") # type: ignore[arg-type]
+np.argpartition(A, 0, order=range(5))  # type: ignore[arg-type]
 
-np.sort(A, axis="bob")  # E: No overload variant
-np.sort(A, kind="bob")  # E: No overload variant
-np.sort(A, order=range(5))  # E: Argument "order" to "sort" has incompatible type
+np.sort(A, axis="bob")  # type: ignore[call-overload]
+np.sort(A, kind="bob")  # type: ignore[call-overload]
+np.sort(A, order=range(5)) # type: ignore[arg-type]
 
-np.argsort(A, axis="bob")  # E: Argument "axis" to "argsort" has incompatible type
-np.argsort(A, kind="bob")  # E: Argument "kind" to "argsort" has incompatible type
-np.argsort(A, order=range(5))  # E: Argument "order" to "argsort" has incompatible type
+np.argsort(A, axis="bob")  # type: ignore[arg-type]
+np.argsort(A, kind="bob")  # type: ignore[arg-type]
+np.argsort(A, order=range(5))  # type: ignore[arg-type]
 
-np.argmax(A, axis="bob")  # E: No overload variant of "argmax" matches argument type
-np.argmax(A, kind="bob")  # E: No overload variant of "argmax" matches argument type
+np.argmax(A, axis="bob")  # type: ignore[call-overload]
+np.argmax(A, kind="bob")  # type: ignore[call-overload]
 
-np.argmin(A, axis="bob")  # E: No overload variant of "argmin" matches argument type
-np.argmin(A, kind="bob")  # E: No overload variant of "argmin" matches argument type
+np.argmin(A, axis="bob")  # type: ignore[call-overload]
+np.argmin(A, kind="bob")  # type: ignore[call-overload]
 
-np.searchsorted(  # E: No overload variant of "searchsorted" matches argument type
-    A[0], 0, side="bob"
-)
-np.searchsorted(  # E: No overload variant of "searchsorted" matches argument type
-    A[0], 0, sorter=1.0
-)
+np.searchsorted(A[0], 0, side="bob")  # type: ignore[call-overload]
+np.searchsorted(A[0], 0, sorter=1.0)  # type: ignore[call-overload]
 
-np.resize(A, 1.0)  # E: No overload variant
+np.resize(A, 1.0)  # type: ignore[call-overload]
 
-np.squeeze(A, 1.0)  # E: No overload variant of "squeeze" matches argument type
+np.squeeze(A, 1.0)  # type: ignore[call-overload]
 
-np.diagonal(A, offset=None)  # E: No overload variant
-np.diagonal(A, axis1="bob")  # E: No overload variant
-np.diagonal(A, axis2=[])  # E: No overload variant
+np.diagonal(A, offset=None)  # type: ignore[call-overload]
+np.diagonal(A, axis1="bob")  # type: ignore[call-overload]
+np.diagonal(A, axis2=[])  # type: ignore[call-overload]
 
-np.trace(A, offset=None)  # E: No overload variant
-np.trace(A, axis1="bob")  # E: No overload variant
-np.trace(A, axis2=[])  # E: No overload variant
+np.trace(A, offset=None)  # type: ignore[call-overload]
+np.trace(A, axis1="bob")  # type: ignore[call-overload]
+np.trace(A, axis2=[])  # type: ignore[call-overload]
 
-np.ravel(a, order="bob")  # E: No overload variant
+np.ravel(a, order="bob")  # type: ignore[call-overload]
 
-np.nonzero(0)  # E: No overload variant
+np.nonzero(0)  # type: ignore[arg-type]
 
-np.compress(  # E: No overload variant
-    [True], A, axis=1.0
-)
+np.compress([True], A, axis=1.0)  # type: ignore[call-overload]
 
-np.clip(a, 1, 2, out=1)  # E: No overload variant of "clip" matches argument type
+np.clip(a, 1, 2, out=1)  # type: ignore[call-overload]
 
-np.sum(a, axis=1.0)  # E: No overload variant
-np.sum(a, keepdims=1.0)  # E: No overload variant
-np.sum(a, initial=[1])  # E: No overload variant
+np.sum(a, axis=1.0)  # type: ignore[call-overload]
+np.sum(a, keepdims=1.0)  # type: ignore[call-overload]
+np.sum(a, initial=[1])  # type: ignore[call-overload]
 
-np.all(a, axis=1.0)  # E: No overload variant
-np.all(a, keepdims=1.0)  # E: No overload variant
-np.all(a, out=1.0)  # E: No overload variant
+np.all(a, axis=1.0)  # type: ignore[call-overload]
+np.all(a, keepdims=1.0)  # type: ignore[call-overload]
+np.all(a, out=1.0)  # type: ignore[call-overload]
 
-np.any(a, axis=1.0)  # E: No overload variant
-np.any(a, keepdims=1.0)  # E: No overload variant
-np.any(a, out=1.0)  # E: No overload variant
+np.any(a, axis=1.0)  # type: ignore[call-overload]
+np.any(a, keepdims=1.0)  # type: ignore[call-overload]
+np.any(a, out=1.0)  # type: ignore[call-overload]
 
-np.cumsum(a, axis=1.0)  # E: No overload variant
-np.cumsum(a, dtype=1.0)  # E: No overload variant
-np.cumsum(a, out=1.0)  # E: No overload variant
+np.cumsum(a, axis=1.0)  # type: ignore[call-overload]
+np.cumsum(a, dtype=1.0)  # type: ignore[call-overload]
+np.cumsum(a, out=1.0)  # type: ignore[call-overload]
 
-np.ptp(a, axis=1.0)  # E: No overload variant
-np.ptp(a, keepdims=1.0)  # E: No overload variant
-np.ptp(a, out=1.0)  # E: No overload variant
+np.ptp(a, axis=1.0)  # type: ignore[call-overload]
+np.ptp(a, keepdims=1.0)  # type: ignore[call-overload]
+np.ptp(a, out=1.0)  # type: ignore[call-overload]
 
-np.amax(a, axis=1.0)  # E: No overload variant
-np.amax(a, keepdims=1.0)  # E: No overload variant
-np.amax(a, out=1.0)  # E: No overload variant
-np.amax(a, initial=[1.0])  # E: No overload variant
-np.amax(a, where=[1.0])  # E: incompatible type
+np.amax(a, axis=1.0)  # type: ignore[call-overload]
+np.amax(a, keepdims=1.0)  # type: ignore[call-overload]
+np.amax(a, out=1.0)  # type: ignore[call-overload]
+np.amax(a, initial=[1.0])  # type: ignore[call-overload]
+np.amax(a, where=[1.0])  # type: ignore[arg-type]
 
-np.amin(a, axis=1.0)  # E: No overload variant
-np.amin(a, keepdims=1.0)  # E: No overload variant
-np.amin(a, out=1.0)  # E: No overload variant
-np.amin(a, initial=[1.0])  # E: No overload variant
-np.amin(a, where=[1.0])  # E: incompatible type
+np.amin(a, axis=1.0)  # type: ignore[call-overload]
+np.amin(a, keepdims=1.0)  # type: ignore[call-overload]
+np.amin(a, out=1.0)  # type: ignore[call-overload]
+np.amin(a, initial=[1.0])  # type: ignore[call-overload]
+np.amin(a, where=[1.0])  # type: ignore[arg-type]
 
-np.prod(a, axis=1.0)  # E: No overload variant
-np.prod(a, out=False)  # E: No overload variant
-np.prod(a, keepdims=1.0)  # E: No overload variant
-np.prod(a, initial=int)  # E: No overload variant
-np.prod(a, where=1.0)  # E: No overload variant
-np.prod(AR_U)  # E: incompatible type
+np.prod(a, axis=1.0)  # type: ignore[call-overload]
+np.prod(a, out=False)  # type: ignore[call-overload]
+np.prod(a, keepdims=1.0)  # type: ignore[call-overload]
+np.prod(a, initial=int)  # type: ignore[call-overload]
+np.prod(a, where=1.0)  # type: ignore[call-overload]
+np.prod(AR_U)  # type: ignore[arg-type]
 
-np.cumprod(a, axis=1.0)  # E: No overload variant
-np.cumprod(a, out=False)  # E: No overload variant
-np.cumprod(AR_U)  # E: incompatible type
+np.cumprod(a, axis=1.0)  # type: ignore[call-overload]
+np.cumprod(a, out=False)  # type: ignore[call-overload]
+np.cumprod(AR_U)  # type: ignore[arg-type]
 
-np.size(a, axis=1.0)  # E: Argument "axis" to "size" has incompatible type
+np.size(a, axis=1.0)  # type: ignore[arg-type]
 
-np.around(a, decimals=1.0)  # E: No overload variant
-np.around(a, out=type)  # E: No overload variant
-np.around(AR_U)  # E: incompatible type
+np.around(a, decimals=1.0)  # type: ignore[call-overload]
+np.around(a, out=type)  # type: ignore[call-overload]
+np.around(AR_U)  # type: ignore[arg-type]
 
-np.mean(a, axis=1.0)  # E: No overload variant
-np.mean(a, out=False)  # E: No overload variant
-np.mean(a, keepdims=1.0)  # E: No overload variant
-np.mean(AR_U)  # E: incompatible type
-np.mean(AR_M)  # E: incompatible type
+np.mean(a, axis=1.0)  # type: ignore[call-overload]
+np.mean(a, out=False)  # type: ignore[call-overload]
+np.mean(a, keepdims=1.0)  # type: ignore[call-overload]
+np.mean(AR_U)  # type: ignore[arg-type]
+np.mean(AR_M)  # type: ignore[arg-type]
 
-np.std(a, axis=1.0)  # E: No overload variant
-np.std(a, out=False)  # E: No overload variant
-np.std(a, ddof='test')  # E: No overload variant
-np.std(a, keepdims=1.0)  # E: No overload variant
-np.std(AR_U)  # E: incompatible type
+np.std(a, axis=1.0)  # type: ignore[call-overload]
+np.std(a, out=False)  # type: ignore[call-overload]
+np.std(a, ddof='test')  # type: ignore[call-overload]
+np.std(a, keepdims=1.0)  # type: ignore[call-overload]
+np.std(AR_U)  # type: ignore[arg-type]
 
-np.var(a, axis=1.0)  # E: No overload variant
-np.var(a, out=False)  # E: No overload variant
-np.var(a, ddof='test')  # E: No overload variant
-np.var(a, keepdims=1.0)  # E: No overload variant
-np.var(AR_U)  # E: incompatible type
+np.var(a, axis=1.0)  # type: ignore[call-overload]
+np.var(a, out=False)  # type: ignore[call-overload]
+np.var(a, ddof='test')  # type: ignore[call-overload]
+np.var(a, keepdims=1.0)  # type: ignore[call-overload]
+np.var(AR_U)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/histograms.pyi
+++ b/numpy/typing/tests/data/fail/histograms.pyi
@@ -4,9 +4,9 @@ import numpy.typing as npt
 AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]
 
-np.histogram_bin_edges(AR_i8, range=(0, 1, 2))  # E: incompatible type
+np.histogram_bin_edges(AR_i8, range=(0, 1, 2))  # type: ignore[arg-type]
 
-np.histogram(AR_i8, range=(0, 1, 2))  # E: incompatible type
+np.histogram(AR_i8, range=(0, 1, 2))  # type: ignore[arg-type]
 
-np.histogramdd(AR_i8, range=(0, 1))  # E: incompatible type
-np.histogramdd(AR_i8, range=[(0, 1, 2)])  # E: incompatible type
+np.histogramdd(AR_i8, range=(0, 1))  # type: ignore[arg-type]
+np.histogramdd(AR_i8, range=[(0, 1, 2)])  # type: ignore[list-item]

--- a/numpy/typing/tests/data/fail/index_tricks.pyi
+++ b/numpy/typing/tests/data/fail/index_tricks.pyi
@@ -3,12 +3,12 @@ import numpy as np
 AR_LIKE_i: list[int]
 AR_LIKE_f: list[float]
 
-np.ndindex([1, 2, 3])  # E: No overload variant
-np.unravel_index(AR_LIKE_f, (1, 2, 3))  # E: incompatible type
-np.ravel_multi_index(AR_LIKE_i, (1, 2, 3), mode="bob")  # E: No overload variant
-np.mgrid[1]  # E: Invalid index type
-np.mgrid[...]  # E: Invalid index type
-np.ogrid[1]  # E: Invalid index type
-np.ogrid[...]  # E: Invalid index type
-np.fill_diagonal(AR_LIKE_f, 2)  # E: incompatible type
-np.diag_indices(1.0)  # E: incompatible type
+np.ndindex([1, 2, 3])  # type: ignore[call-overload]
+np.unravel_index(AR_LIKE_f, (1, 2, 3))  # type: ignore[arg-type]
+np.ravel_multi_index(AR_LIKE_i, (1, 2, 3), mode="bob")  # type: ignore[call-overload]
+np.mgrid[1]  # type: ignore[index]
+np.mgrid[...]  # type: ignore[index]
+np.ogrid[1]  # type: ignore[index]
+np.ogrid[...]  # type: ignore[index]
+np.fill_diagonal(AR_LIKE_f, 2)  # type: ignore[arg-type]
+np.diag_indices(1.0)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/lib_function_base.pyi
+++ b/numpy/typing/tests/data/fail/lib_function_base.pyi
@@ -13,50 +13,50 @@ AR_b_list: list[npt.NDArray[np.bool]]
 def fn_none_i(a: None, /) -> npt.NDArray[Any]: ...
 def fn_ar_i(a: npt.NDArray[np.float64], posarg: int, /) -> npt.NDArray[Any]: ...
 
-np.average(AR_m)  # E: incompatible type
-np.select(1, [AR_f8])  # E: incompatible type
-np.angle(AR_m)  # E: incompatible type
-np.unwrap(AR_m)  # E: incompatible type
-np.unwrap(AR_c16)  # E: incompatible type
-np.trim_zeros(1)  # E: incompatible type
-np.place(1, [True], 1.5)  # E: incompatible type
-np.vectorize(1)  # E: incompatible type
-np.place(AR_f8, slice(None), 5)  # E: incompatible type
+np.average(AR_m)  # type: ignore[arg-type]
+np.select(1, [AR_f8])  # type: ignore[arg-type]
+np.angle(AR_m)  # type: ignore[arg-type]
+np.unwrap(AR_m)  # type: ignore[arg-type]
+np.unwrap(AR_c16)  # type: ignore[arg-type]
+np.trim_zeros(1)  # type: ignore[arg-type]
+np.place(1, [True], 1.5)  # type: ignore[arg-type]
+np.vectorize(1)  # type: ignore[arg-type]
+np.place(AR_f8, slice(None), 5)  # type: ignore[arg-type]
 
-np.piecewise(AR_f8, True, [fn_ar_i], 42)  # E: No overload variants
+np.piecewise(AR_f8, True, [fn_ar_i], 42)  # type: ignore[call-overload]
 # TODO: enable these once mypy actually supports ParamSpec (released in 2021)
 # NOTE: pyright correctly reports errors for these (`reportCallIssue`)
-# np.piecewise(AR_f8, AR_b_list, [fn_none_i])  # E: No overload variants
-# np.piecewise(AR_f8, AR_b_list, [fn_ar_i])  # E: No overload variant
-# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 3.14)  # E: No overload variant
-# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 42, None)  # E: No overload variant
-# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 42, _=None)  # E: No overload variant
+# np.piecewise(AR_f8, AR_b_list, [fn_none_i])  # type: ignore[call-overload]s
+# np.piecewise(AR_f8, AR_b_list, [fn_ar_i])  # type: ignore[call-overload]
+# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 3.14)  # type: ignore[call-overload]
+# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 42, None)  # type: ignore[call-overload]
+# np.piecewise(AR_f8, AR_b_list, [fn_ar_i], 42, _=None)  # type: ignore[call-overload]
 
-np.interp(AR_f8, AR_c16, AR_f8)  # E: incompatible type
-np.interp(AR_c16, AR_f8, AR_f8)  # E: incompatible type
-np.interp(AR_f8, AR_f8, AR_f8, period=AR_c16)  # E: No overload variant
-np.interp(AR_f8, AR_f8, AR_O)  # E: incompatible type
+np.interp(AR_f8, AR_c16, AR_f8)  # type: ignore[arg-type]
+np.interp(AR_c16, AR_f8, AR_f8)  # type: ignore[arg-type]
+np.interp(AR_f8, AR_f8, AR_f8, period=AR_c16)  # type: ignore[call-overload]
+np.interp(AR_f8, AR_f8, AR_O)  # type: ignore[arg-type]
 
-np.cov(AR_m)  # E: incompatible type
-np.cov(AR_O)  # E: incompatible type
-np.corrcoef(AR_m)  # E: incompatible type
-np.corrcoef(AR_O)  # E: incompatible type
-np.corrcoef(AR_f8, bias=True)  # E: No overload variant
-np.corrcoef(AR_f8, ddof=2)  # E: No overload variant
-np.blackman(1j)  # E: incompatible type
-np.bartlett(1j)  # E: incompatible type
-np.hanning(1j)  # E: incompatible type
-np.hamming(1j)  # E: incompatible type
-np.hamming(AR_c16)  # E: incompatible type
-np.kaiser(1j, 1)  # E: incompatible type
-np.sinc(AR_O)  # E: incompatible type
-np.median(AR_M)  # E: incompatible type
+np.cov(AR_m)  # type: ignore[arg-type]
+np.cov(AR_O)  # type: ignore[arg-type]
+np.corrcoef(AR_m)  # type: ignore[arg-type]
+np.corrcoef(AR_O)  # type: ignore[arg-type]
+np.corrcoef(AR_f8, bias=True)  # type: ignore[call-overload]
+np.corrcoef(AR_f8, ddof=2)  # type: ignore[call-overload]
+np.blackman(1j)  # type: ignore[arg-type]
+np.bartlett(1j)  # type: ignore[arg-type]
+np.hanning(1j)  # type: ignore[arg-type]
+np.hamming(1j)  # type: ignore[arg-type]
+np.hamming(AR_c16)  # type: ignore[arg-type]
+np.kaiser(1j, 1)  # type: ignore[arg-type]
+np.sinc(AR_O)  # type: ignore[arg-type]
+np.median(AR_M)  # type: ignore[arg-type]
 
-np.percentile(AR_f8, 50j)  # E: No overload variant
-np.percentile(AR_f8, 50, interpolation="bob")  # E: No overload variant
-np.quantile(AR_f8, 0.5j)  # E: No overload variant
-np.quantile(AR_f8, 0.5, interpolation="bob")  # E: No overload variant
-np.meshgrid(AR_f8, AR_f8, indexing="bob")  # E: incompatible type
-np.delete(AR_f8, AR_f8)  # E: incompatible type
-np.insert(AR_f8, AR_f8, 1.5)  # E: incompatible type
-np.digitize(AR_f8, 1j)  # E: No overload variant
+np.percentile(AR_f8, 50j)  # type: ignore[call-overload]
+np.percentile(AR_f8, 50, interpolation="bob")  # type: ignore[call-overload]
+np.quantile(AR_f8, 0.5j)  # type: ignore[call-overload]
+np.quantile(AR_f8, 0.5, interpolation="bob")  # type: ignore[call-overload]
+np.meshgrid(AR_f8, AR_f8, indexing="bob")  # type: ignore[call-overload]
+np.delete(AR_f8, AR_f8)  # type: ignore[arg-type]
+np.insert(AR_f8, AR_f8, 1.5)  # type: ignore[arg-type]
+np.digitize(AR_f8, 1j)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/lib_polynomial.pyi
+++ b/numpy/typing/tests/data/fail/lib_polynomial.pyi
@@ -8,22 +8,22 @@ AR_U: npt.NDArray[np.str_]
 
 poly_obj: np.poly1d
 
-np.polymul(AR_f8, AR_U)  # E: incompatible type
-np.polydiv(AR_f8, AR_U)  # E: incompatible type
+np.polymul(AR_f8, AR_U)  # type: ignore[arg-type]
+np.polydiv(AR_f8, AR_U)  # type: ignore[arg-type]
 
-5**poly_obj  # E: No overload variant
+5**poly_obj  # type: ignore[operator]
 
-np.polyint(AR_U)  # E: incompatible type
-np.polyint(AR_f8, m=1j)  # E: No overload variant
+np.polyint(AR_U)  # type: ignore[arg-type]
+np.polyint(AR_f8, m=1j)  # type: ignore[call-overload]
 
-np.polyder(AR_U)  # E: incompatible type
-np.polyder(AR_f8, m=1j)  # E: No overload variant
+np.polyder(AR_U)  # type: ignore[arg-type]
+np.polyder(AR_f8, m=1j)  # type: ignore[call-overload]
 
-np.polyfit(AR_O, AR_f8, 1)  # E: incompatible type
-np.polyfit(AR_f8, AR_f8, 1, rcond=1j)  # E: No overload variant
-np.polyfit(AR_f8, AR_f8, 1, w=AR_c16)  # E: incompatible type
-np.polyfit(AR_f8, AR_f8, 1, cov="bob")  # E: No overload variant
+np.polyfit(AR_O, AR_f8, 1)  # type: ignore[arg-type]
+np.polyfit(AR_f8, AR_f8, 1, rcond=1j)  # type: ignore[call-overload]
+np.polyfit(AR_f8, AR_f8, 1, w=AR_c16)  # type: ignore[arg-type]
+np.polyfit(AR_f8, AR_f8, 1, cov="bob")  # type: ignore[call-overload]
 
-np.polyval(AR_f8, AR_U)  # E: incompatible type
-np.polyadd(AR_f8, AR_U)  # E: incompatible type
-np.polysub(AR_f8, AR_U)  # E: incompatible type
+np.polyval(AR_f8, AR_U)  # type: ignore[arg-type]
+np.polyadd(AR_f8, AR_U)  # type: ignore[arg-type]
+np.polysub(AR_f8, AR_U)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/lib_utils.pyi
+++ b/numpy/typing/tests/data/fail/lib_utils.pyi
@@ -1,3 +1,3 @@
 import numpy.lib.array_utils as array_utils
 
-array_utils.byte_bounds(1)  # E: incompatible type
+array_utils.byte_bounds(1)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/lib_version.pyi
+++ b/numpy/typing/tests/data/fail/lib_version.pyi
@@ -2,5 +2,5 @@ from numpy.lib import NumpyVersion
 
 version: NumpyVersion
 
-NumpyVersion(b"1.8.0")  # E: incompatible type
-version >= b"1.8.0"  # E: Unsupported operand types
+NumpyVersion(b"1.8.0")  # type: ignore[arg-type]
+version >= b"1.8.0"  # type: ignore[operator]

--- a/numpy/typing/tests/data/fail/linalg.pyi
+++ b/numpy/typing/tests/data/fail/linalg.pyi
@@ -5,44 +5,44 @@ AR_f8: npt.NDArray[np.float64]
 AR_O: npt.NDArray[np.object_]
 AR_M: npt.NDArray[np.datetime64]
 
-np.linalg.tensorsolve(AR_O, AR_O)  # E: incompatible type
+np.linalg.tensorsolve(AR_O, AR_O)  # type: ignore[arg-type]
 
-np.linalg.solve(AR_O, AR_O)  # E: incompatible type
+np.linalg.solve(AR_O, AR_O)  # type: ignore[arg-type]
 
-np.linalg.tensorinv(AR_O)  # E: incompatible type
+np.linalg.tensorinv(AR_O)  # type: ignore[arg-type]
 
-np.linalg.inv(AR_O)  # E: incompatible type
+np.linalg.inv(AR_O)  # type: ignore[arg-type]
 
-np.linalg.matrix_power(AR_M, 5)  # E: incompatible type
+np.linalg.matrix_power(AR_M, 5)  # type: ignore[arg-type]
 
-np.linalg.cholesky(AR_O)  # E: incompatible type
+np.linalg.cholesky(AR_O)  # type: ignore[arg-type]
 
-np.linalg.qr(AR_O)  # E: incompatible type
-np.linalg.qr(AR_f8, mode="bob")  # E: No overload variant
+np.linalg.qr(AR_O)  # type: ignore[arg-type]
+np.linalg.qr(AR_f8, mode="bob")  # type: ignore[call-overload]
 
-np.linalg.eigvals(AR_O)  # E: incompatible type
+np.linalg.eigvals(AR_O)  # type: ignore[arg-type]
 
-np.linalg.eigvalsh(AR_O)  # E: incompatible type
-np.linalg.eigvalsh(AR_O, UPLO="bob")  # E: No overload variant
+np.linalg.eigvalsh(AR_O)  # type: ignore[arg-type]
+np.linalg.eigvalsh(AR_O, UPLO="bob")  # type: ignore[call-overload]
 
-np.linalg.eig(AR_O)  # E: incompatible type
+np.linalg.eig(AR_O)  # type: ignore[arg-type]
 
-np.linalg.eigh(AR_O)  # E: incompatible type
-np.linalg.eigh(AR_O, UPLO="bob")  # E: No overload variant
+np.linalg.eigh(AR_O)  # type: ignore[arg-type]
+np.linalg.eigh(AR_O, UPLO="bob")  # type: ignore[call-overload]
 
-np.linalg.svd(AR_O)  # E: incompatible type
+np.linalg.svd(AR_O)  # type: ignore[arg-type]
 
-np.linalg.cond(AR_O)  # E: incompatible type
-np.linalg.cond(AR_f8, p="bob")  # E: incompatible type
+np.linalg.cond(AR_O)  # type: ignore[arg-type]
+np.linalg.cond(AR_f8, p="bob")  # type: ignore[arg-type]
 
-np.linalg.matrix_rank(AR_O)  # E: incompatible type
+np.linalg.matrix_rank(AR_O)  # type: ignore[arg-type]
 
-np.linalg.pinv(AR_O)  # E: incompatible type
+np.linalg.pinv(AR_O)  # type: ignore[arg-type]
 
-np.linalg.slogdet(AR_O)  # E: incompatible type
+np.linalg.slogdet(AR_O)  # type: ignore[arg-type]
 
-np.linalg.det(AR_O)  # E: incompatible type
+np.linalg.det(AR_O)  # type: ignore[arg-type]
 
-np.linalg.norm(AR_f8, ord="bob")  # E: No overload variant
+np.linalg.norm(AR_f8, ord="bob")  # type: ignore[call-overload]
 
-np.linalg.multi_dot([AR_M])  # E: incompatible type
+np.linalg.multi_dot([AR_M])  # type: ignore[list-item]

--- a/numpy/typing/tests/data/fail/ma.pyi
+++ b/numpy/typing/tests/data/fail/ma.pyi
@@ -8,129 +8,126 @@ m: np.ma.MaskedArray[tuple[int], np.dtype[np.float64]]
 
 AR_b: npt.NDArray[np.bool]
 
-m.shape = (3, 1)  # E: Incompatible types in assignment
-m.dtype = np.bool  # E: Incompatible types in assignment
+m.shape = (3, 1)  # type: ignore[assignment]
+m.dtype = np.bool  # type: ignore[assignment]
 
-np.ma.min(m, axis=1.0)  # E: No overload variant
-np.ma.min(m, keepdims=1.0)  # E: No overload variant
-np.ma.min(m, out=1.0)  # E: No overload variant
-np.ma.min(m, fill_value=lambda x: 27)  # E: No overload variant
+np.ma.min(m, axis=1.0)  # type: ignore[call-overload]
+np.ma.min(m, keepdims=1.0)  # type: ignore[call-overload]
+np.ma.min(m, out=1.0)  # type: ignore[call-overload]
+np.ma.min(m, fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.min(axis=1.0)  # E: No overload variant
-m.min(keepdims=1.0)  # E: No overload variant
-m.min(out=1.0)  # E: No overload variant
-m.min(fill_value=lambda x: 27)  # E: No overload variant
+m.min(axis=1.0)  # type: ignore[call-overload]
+m.min(keepdims=1.0)  # type: ignore[call-overload]
+m.min(out=1.0)  # type: ignore[call-overload]
+m.min(fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-np.ma.max(m, axis=1.0)  # E: No overload variant
-np.ma.max(m, keepdims=1.0)  # E: No overload variant
-np.ma.max(m, out=1.0)  # E: No overload variant
-np.ma.max(m, fill_value=lambda x: 27)  # E: No overload variant
+np.ma.max(m, axis=1.0)  # type: ignore[call-overload]
+np.ma.max(m, keepdims=1.0)  # type: ignore[call-overload]
+np.ma.max(m, out=1.0)  # type: ignore[call-overload]
+np.ma.max(m, fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.max(axis=1.0)  # E: No overload variant
-m.max(keepdims=1.0)  # E: No overload variant
-m.max(out=1.0)  # E: No overload variant
-m.max(fill_value=lambda x: 27)  # E: No overload variant
+m.max(axis=1.0)  # type: ignore[call-overload]
+m.max(keepdims=1.0)  # type: ignore[call-overload]
+m.max(out=1.0)  # type: ignore[call-overload]
+m.max(fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-np.ma.ptp(m, axis=1.0)  # E: No overload variant
-np.ma.ptp(m, keepdims=1.0)  # E: No overload variant
-np.ma.ptp(m, out=1.0)  # E: No overload variant
-np.ma.ptp(m, fill_value=lambda x: 27)  # E: No overload variant
+np.ma.ptp(m, axis=1.0)  # type: ignore[call-overload]
+np.ma.ptp(m, keepdims=1.0)  # type: ignore[call-overload]
+np.ma.ptp(m, out=1.0)  # type: ignore[call-overload]
+np.ma.ptp(m, fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.ptp(axis=1.0)  # E: No overload variant
-m.ptp(keepdims=1.0)  # E: No overload variant
-m.ptp(out=1.0)  # E: No overload variant
-m.ptp(fill_value=lambda x: 27)  # E: No overload variant
+m.ptp(axis=1.0)  # type: ignore[call-overload]
+m.ptp(keepdims=1.0)  # type: ignore[call-overload]
+m.ptp(out=1.0)  # type: ignore[call-overload]
+m.ptp(fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.argmin(axis=1.0)  # E: No overload variant
-m.argmin(keepdims=1.0)  # E: No overload variant
-m.argmin(out=1.0)  # E: No overload variant
-m.argmin(fill_value=lambda x: 27)  # E: No overload variant
+m.argmin(axis=1.0)  # type: ignore[call-overload]
+m.argmin(keepdims=1.0)  # type: ignore[call-overload]
+m.argmin(out=1.0)  # type: ignore[call-overload]
+m.argmin(fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-np.ma.argmin(m, axis=1.0)  # E: No overload variant
-np.ma.argmin(m, axis=(1,))  # E: No overload variant
-np.ma.argmin(m, keepdims=1.0)  # E: No overload variant
-np.ma.argmin(m, out=1.0)  # E: No overload variant
-np.ma.argmin(m, fill_value=lambda x: 27)  # E: No overload variant
+np.ma.argmin(m, axis=1.0)  # type: ignore[call-overload]
+np.ma.argmin(m, axis=(1,))  # type: ignore[call-overload]
+np.ma.argmin(m, keepdims=1.0)  # type: ignore[call-overload]
+np.ma.argmin(m, out=1.0)  # type: ignore[call-overload]
+np.ma.argmin(m, fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.argmax(axis=1.0)  # E: No overload variant
-m.argmax(keepdims=1.0)  # E: No overload variant
-m.argmax(out=1.0)  # E: No overload variant
-m.argmax(fill_value=lambda x: 27)  # E: No overload variant
+m.argmax(axis=1.0)  # type: ignore[call-overload]
+m.argmax(keepdims=1.0)  # type: ignore[call-overload]
+m.argmax(out=1.0)  # type: ignore[call-overload]
+m.argmax(fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-np.ma.argmax(m, axis=1.0)  # E: No overload variant
-np.ma.argmax(m, axis=(0,))  # E: No overload variant
-np.ma.argmax(m, keepdims=1.0)  # E: No overload variant
-np.ma.argmax(m, out=1.0)  # E: No overload variant
-np.ma.argmax(m, fill_value=lambda x: 27)  # E: No overload variant
+np.ma.argmax(m, axis=1.0)  # type: ignore[call-overload]
+np.ma.argmax(m, axis=(0,))  # type: ignore[call-overload]
+np.ma.argmax(m, keepdims=1.0)  # type: ignore[call-overload]
+np.ma.argmax(m, out=1.0)  # type: ignore[call-overload]
+np.ma.argmax(m, fill_value=lambda x: 27)  # type: ignore[call-overload]
 
-m.all(axis=1.0)  # E: No overload variant
-m.all(keepdims=1.0)  # E: No overload variant
-m.all(out=1.0)  # E: No overload variant
+m.all(axis=1.0)  # type: ignore[call-overload]
+m.all(keepdims=1.0)  # type: ignore[call-overload]
+m.all(out=1.0)  # type: ignore[call-overload]
 
-m.any(axis=1.0)  # E: No overload variant
-m.any(keepdims=1.0)  # E: No overload variant
-m.any(out=1.0)  # E: No overload variant
+m.any(axis=1.0)  # type: ignore[call-overload]
+m.any(keepdims=1.0)  # type: ignore[call-overload]
+m.any(out=1.0)  # type: ignore[call-overload]
 
-m.sort(axis=(0,1))  # E: No overload variant
-m.sort(axis=None)  # E: No overload variant
-m.sort(kind='cabbage')  # E: No overload variant
-m.sort(order=lambda: 'cabbage')  # E: No overload variant
-m.sort(endwith='cabbage')  # E: No overload variant
-m.sort(fill_value=lambda: 'cabbage')  # E: No overload variant
-m.sort(stable='cabbage')  # E: No overload variant
-m.sort(stable=True)  # E: No overload variant
+m.sort(axis=(0,1))  # type: ignore[arg-type]
+m.sort(axis=None)  # type: ignore[arg-type]
+m.sort(kind='cabbage')  # type: ignore[arg-type]
+m.sort(order=lambda: 'cabbage')  # type: ignore[arg-type]
+m.sort(endwith='cabbage')  # type: ignore[arg-type]
+m.sort(fill_value=lambda: 'cabbage')  # type: ignore[arg-type]
+m.sort(stable='cabbage')  # type: ignore[arg-type]
+m.sort(stable=True)  # type: ignore[arg-type]
 
-m.take(axis=1.0)  # E: No overload variant
-m.take(out=1)  # E: No overload variant
-m.take(mode="bob")  # E: No overload variant
+m.take(axis=1.0)  # type: ignore[call-overload]
+m.take(out=1)  # type: ignore[call-overload]
+m.take(mode="bob")  # type: ignore[call-overload]
 
-np.ma.take(None)  # E: No overload variant
-np.ma.take(axis=1.0)  # E: No overload variant
-np.ma.take(out=1)  # E: No overload variant
-np.ma.take(mode="bob")  # E: No overload variant
+np.ma.take(None)  # type: ignore[call-overload]
+np.ma.take(axis=1.0)  # type: ignore[call-overload]
+np.ma.take(out=1)  # type: ignore[call-overload]
+np.ma.take(mode="bob")  # type: ignore[call-overload]
 
-m.partition(['cabbage'])  # E: No overload variant
-m.partition(axis=(0,1))  # E: No overload variant
-m.partition(kind='cabbage')  # E: No overload variant
-m.partition(order=lambda: 'cabbage')  # E: No overload variant
-m.partition(AR_b)  # E: No overload variant
+m.partition(['cabbage'])  # type: ignore[arg-type]
+m.partition(axis=(0,1))  # type: ignore[arg-type, call-arg]
+m.partition(kind='cabbage')  # type: ignore[arg-type, call-arg]
+m.partition(order=lambda: 'cabbage')  # type: ignore[arg-type, call-arg]
+m.partition(AR_b)  # type: ignore[arg-type]
 
-m.argpartition(['cabbage'])  # E: No overload variant
-m.argpartition(axis=(0,1))  # E: No overload variant
-m.argpartition(kind='cabbage')  # E: No overload variant
-m.argpartition(order=lambda: 'cabbage')  # E: No overload variant
-m.argpartition(AR_b)  # E: No overload variant
+m.argpartition(['cabbage'])  # type: ignore[arg-type]
+m.argpartition(axis=(0,1))  # type: ignore[arg-type, call-arg]
+m.argpartition(kind='cabbage')  # type: ignore[arg-type, call-arg]
+m.argpartition(order=lambda: 'cabbage')  # type: ignore[arg-type, call-arg]
+m.argpartition(AR_b)  # type: ignore[arg-type]
 
-np.ma.ndim(lambda: 'lambda')  # E: No overload variant
+np.ma.ndim(lambda: 'lambda')  # type: ignore[arg-type]
 
-np.ma.size(AR_b, axis='0')  # E: No overload variant
+np.ma.size(AR_b, axis='0')  # type: ignore[arg-type]
 
-m >= (lambda x: 'mango') # E: No overload variant
+m >= (lambda x: 'mango') # type: ignore[operator]
+m > (lambda x: 'mango') # type: ignore[operator]
+m <= (lambda x: 'mango') # type: ignore[operator]
+m < (lambda x: 'mango') # type: ignore[operator]
 
-m > (lambda x: 'mango') # E: No overload variant
+m.count(axis=0.)  # type: ignore[call-overload]
 
-m <= (lambda x: 'mango') # E: No overload variant
+np.ma.count(m, axis=0.)  # type: ignore[call-overload]
 
-m < (lambda x: 'mango') # E: No overload variant
+m.put(4, 999, mode='flip')  # type: ignore[arg-type]
 
-m.count(axis=0.)  # E: No overload variant
+np.ma.put(m, 4, 999, mode='flip')  # type: ignore[arg-type]
 
-np.ma.count(m, axis=0.)  # E: No overload variant
+np.ma.put([1,1,3], 0, 999)  # type: ignore[arg-type]
 
-m.put(4, 999, mode='flip')  # E: No overload variant
+np.ma.compressed(lambda: 'compress me')  # type: ignore[call-overload]
 
-np.ma.put(m, 4, 999, mode='flip')  # E: No overload variant
+np.ma.allequal(m, [1,2,3], fill_value=1.5)  # type: ignore[arg-type]
 
-np.ma.put([1,1,3], 0, 999)  # E: No overload variant
+np.ma.allclose(m, [1,2,3], masked_equal=4.5)  # type: ignore[arg-type]
+np.ma.allclose(m, [1,2,3], rtol='.4')  # type: ignore[arg-type]
+np.ma.allclose(m, [1,2,3], atol='.5')  # type: ignore[arg-type]
 
-np.ma.compressed(lambda: 'compress me')  # E: No overload variant
+m.__setmask__('mask')  # type: ignore[arg-type]
 
-np.ma.allequal(m, [1,2,3], fill_value=1.5)  # E: No overload variant
-
-np.ma.allclose(m, [1,2,3], masked_equal=4.5)  # E: No overload variant
-np.ma.allclose(m, [1,2,3], rtol='.4')  # E: No overload variant
-np.ma.allclose(m, [1,2,3], atol='.5')  # E: No overload variant
-
-m.__setmask__('mask')  # E: No overload variant
-
-m.swapaxes(axis1=1, axis2=0)  # E: No overload variant
+m.swapaxes(axis1=1, axis2=0)  # type: ignore[call-arg]

--- a/numpy/typing/tests/data/fail/memmap.pyi
+++ b/numpy/typing/tests/data/fail/memmap.pyi
@@ -1,5 +1,5 @@
 import numpy as np
 
 with open("file.txt", "r") as f:
-    np.memmap(f)  # E: No overload variant
-np.memmap("test.txt", shape=[10, 5])  # E: No overload variant
+    np.memmap(f)  # type: ignore[call-overload]
+np.memmap("test.txt", shape=[10, 5])  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/modules.pyi
+++ b/numpy/typing/tests/data/fail/modules.pyi
@@ -1,17 +1,17 @@
 import numpy as np
 
-np.testing.bob  # E: Module has no attribute
-np.bob  # E: Module has no attribute
+np.testing.bob  # type: ignore[attr-defined]
+np.bob  # type: ignore[attr-defined]
 
 # Stdlib modules in the namespace by accident
-np.warnings  # E: Module has no attribute
-np.sys  # E: Module has no attribute
-np.os  # E: Module "numpy" does not explicitly export
-np.math  # E: Module has no attribute
+np.warnings  # type: ignore[attr-defined]
+np.sys  # type: ignore[attr-defined]
+np.os  # type: ignore[attr-defined]
+np.math  # type: ignore[attr-defined]
 
 # Public sub-modules that are not imported to their parent module by default;
 # e.g. one must first execute `import numpy.lib.recfunctions`
-np.lib.recfunctions  # E: Module has no attribute
+np.lib.recfunctions  # type: ignore[attr-defined]
 
-np.__deprecated_attrs__  # E: Module has no attribute
-np.__expired_functions__  # E: Module has no attribute
+np.__deprecated_attrs__  # type: ignore[attr-defined]
+np.__expired_functions__  # type: ignore[attr-defined]

--- a/numpy/typing/tests/data/fail/multiarray.pyi
+++ b/numpy/typing/tests/data/fail/multiarray.pyi
@@ -15,38 +15,38 @@ AR_LIKE_f: list[float]
 
 def func(a: int) -> None: ...
 
-np.where(AR_b, 1)  # E: No overload variant
+np.where(AR_b, 1)  # type: ignore[call-overload]
 
-np.can_cast(AR_f8, 1)  # E: incompatible type
+np.can_cast(AR_f8, 1)  # type: ignore[arg-type]
 
-np.vdot(AR_M, AR_M)  # E: incompatible type
+np.vdot(AR_M, AR_M)  # type: ignore[arg-type]
 
-np.copyto(AR_LIKE_f, AR_f8)  # E: incompatible type
+np.copyto(AR_LIKE_f, AR_f8)  # type: ignore[arg-type]
 
-np.putmask(AR_LIKE_f, [True, True, False], 1.5)  # E: incompatible type
+np.putmask(AR_LIKE_f, [True, True, False], 1.5)  # type: ignore[arg-type]
 
-np.packbits(AR_f8)  # E: incompatible type
-np.packbits(AR_u1, bitorder=">")  # E: incompatible type
+np.packbits(AR_f8)  # type: ignore[arg-type]
+np.packbits(AR_u1, bitorder=">")  # type: ignore[arg-type]
 
-np.unpackbits(AR_i8)  # E: incompatible type
-np.unpackbits(AR_u1, bitorder=">")  # E: incompatible type
+np.unpackbits(AR_i8)  # type: ignore[arg-type]
+np.unpackbits(AR_u1, bitorder=">")  # type: ignore[arg-type]
 
-np.shares_memory(1, 1, max_work=i8)  # E: incompatible type
-np.may_share_memory(1, 1, max_work=i8)  # E: incompatible type
+np.shares_memory(1, 1, max_work=i8)  # type: ignore[arg-type]
+np.may_share_memory(1, 1, max_work=i8)  # type: ignore[arg-type]
 
-np.arange(stop=10)  # E: No overload variant
+np.arange(stop=10)  # type: ignore[call-overload]
 
-np.datetime_data(int)  # E: incompatible type
+np.datetime_data(int)  # type: ignore[arg-type]
 
-np.busday_offset("2012", 10)  # E: No overload variant
+np.busday_offset("2012", 10)  # type: ignore[call-overload]
 
-np.datetime_as_string("2012")  # E: No overload variant
+np.datetime_as_string("2012")  # type: ignore[call-overload]
 
-np.char.compare_chararrays("a", b"a", "==", False)  # E: No overload variant
+np.char.compare_chararrays("a", b"a", "==", False)  # type: ignore[call-overload]
 
-np.nested_iters([AR_i8, AR_i8])  # E: Missing positional argument
-np.nested_iters([AR_i8, AR_i8], 0)  # E: incompatible type
-np.nested_iters([AR_i8, AR_i8], [0])  # E: incompatible type
-np.nested_iters([AR_i8, AR_i8], [[0], [1]], flags=["test"])  # E: incompatible type
-np.nested_iters([AR_i8, AR_i8], [[0], [1]], op_flags=[["test"]])  # E: incompatible type
-np.nested_iters([AR_i8, AR_i8], [[0], [1]], buffersize=1.0)  # E: incompatible type
+np.nested_iters([AR_i8, AR_i8])  # type: ignore[call-arg]
+np.nested_iters([AR_i8, AR_i8], 0)  # type: ignore[arg-type]
+np.nested_iters([AR_i8, AR_i8], [0])  # type: ignore[list-item]
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], flags=["test"])  # type: ignore[list-item]
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], op_flags=[["test"]])  # type: ignore[list-item]
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], buffersize=1.0)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/ndarray.pyi
+++ b/numpy/typing/tests/data/fail/ndarray.pyi
@@ -8,4 +8,4 @@ import numpy as np
 #
 # for more context.
 float_array = np.array([1.0])
-float_array.dtype = np.bool  # E: Property "dtype" defined in "ndarray" is read-only
+float_array.dtype = np.bool  # type: ignore[assignment, misc]

--- a/numpy/typing/tests/data/fail/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/fail/ndarray_misc.pyi
@@ -16,21 +16,21 @@ AR_b: npt.NDArray[np.bool]
 
 ctypes_obj = AR_f8.ctypes
 
-f8.argpartition(0)  # E: has no attribute
-f8.diagonal()  # E: has no attribute
-f8.dot(1)  # E: has no attribute
-f8.nonzero()  # E: has no attribute
-f8.partition(0)  # E: has no attribute
-f8.put(0, 2)  # E: has no attribute
-f8.setfield(2, np.float64)  # E: has no attribute
-f8.sort()  # E: has no attribute
-f8.trace()  # E: has no attribute
+f8.argpartition(0)  # type: ignore[attr-defined]
+f8.diagonal()  # type: ignore[attr-defined]
+f8.dot(1)  # type: ignore[attr-defined]
+f8.nonzero()  # type: ignore[attr-defined]
+f8.partition(0)  # type: ignore[attr-defined]
+f8.put(0, 2)  # type: ignore[attr-defined]
+f8.setfield(2, np.float64)  # type: ignore[attr-defined]
+f8.sort()  # type: ignore[attr-defined]
+f8.trace()  # type: ignore[attr-defined]
 
-AR_M.__complex__()  # E: Invalid self argument
-AR_b.__index__()  # E: Invalid self argument
+AR_M.__complex__()  # type: ignore[misc]
+AR_b.__index__()  # type: ignore[misc]
 
-AR_f8[1.5]  # E: No overload variant
-AR_f8["field_a"]  # E: No overload variant
-AR_f8[["field_a", "field_b"]]  # E: Invalid index type
+AR_f8[1.5]  # type: ignore[call-overload]
+AR_f8["field_a"]  # type: ignore[call-overload]
+AR_f8[["field_a", "field_b"]]  # type: ignore[index]
 
-AR_f8.__array_finalize__(object())  # E: incompatible type
+AR_f8.__array_finalize__(object())  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/nditer.pyi
+++ b/numpy/typing/tests/data/fail/nditer.pyi
@@ -1,8 +1,8 @@
 import numpy as np
 
-class Test(np.nditer): ...  # E: Cannot inherit from final class
+class Test(np.nditer): ...  # type: ignore[misc]
 
-np.nditer([0, 1], flags=["test"])  # E: incompatible type
-np.nditer([0, 1], op_flags=[["test"]])  # E: incompatible type
-np.nditer([0, 1], itershape=(1.0,))  # E: incompatible type
-np.nditer([0, 1], buffersize=1.0)  # E: incompatible type
+np.nditer([0, 1], flags=["test"])  # type: ignore[list-item]
+np.nditer([0, 1], op_flags=[["test"]])  # type: ignore[list-item]
+np.nditer([0, 1], itershape=(1.0,))  # type: ignore[arg-type]
+np.nditer([0, 1], buffersize=1.0)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/nested_sequence.pyi
+++ b/numpy/typing/tests/data/fail/nested_sequence.pyi
@@ -9,8 +9,8 @@ e: str
 
 def func(a: _NestedSequence[int]) -> None: ...
 
-reveal_type(func(a))  # E: incompatible type
-reveal_type(func(b))  # E: incompatible type
-reveal_type(func(c))  # E: incompatible type
-reveal_type(func(d))  # E: incompatible type
-reveal_type(func(e))  # E: incompatible type
+reveal_type(func(a))  # type: ignore[arg-type, misc]
+reveal_type(func(b))  # type: ignore[arg-type, misc]
+reveal_type(func(c))  # type: ignore[arg-type, misc]
+reveal_type(func(d))  # type: ignore[arg-type, misc]
+reveal_type(func(e))  # type: ignore[arg-type, misc]

--- a/numpy/typing/tests/data/fail/npyio.pyi
+++ b/numpy/typing/tests/data/fail/npyio.pyi
@@ -10,16 +10,15 @@ pathlib_path: pathlib.Path
 str_file: IO[str]
 AR_i8: npt.NDArray[np.int64]
 
-np.load(str_file)  # E: incompatible type
+np.load(str_file)  # type: ignore[arg-type]
 
-np.save(bytes_path, AR_i8)  # E: No overload variant
-# https://github.com/python/mypy/issues/16111
-# np.save(str_path, AR_i8, fix_imports=True)  # W: deprecated
+np.save(bytes_path, AR_i8)  # type: ignore[call-overload]
+np.save(str_path, AR_i8, fix_imports=True)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 
-np.savez(bytes_path, AR_i8)  # E: incompatible type
+np.savez(bytes_path, AR_i8)  # type: ignore[arg-type]
 
-np.savez_compressed(bytes_path, AR_i8)  # E: incompatible type
+np.savez_compressed(bytes_path, AR_i8)  # type: ignore[arg-type]
 
-np.loadtxt(bytes_path)  # E: incompatible type
+np.loadtxt(bytes_path)  # type: ignore[arg-type]
 
-np.fromregex(bytes_path, ".", np.int64)  # E: No overload variant
+np.fromregex(bytes_path, ".", np.int64)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/numerictypes.pyi
+++ b/numpy/typing/tests/data/fail/numerictypes.pyi
@@ -1,5 +1,5 @@
 import numpy as np
 
-np.isdtype(1, np.int64)  # E: incompatible type
+np.isdtype(1, np.int64)  # type: ignore[arg-type]
 
-np.issubdtype(1, np.int64)  # E: incompatible type
+np.issubdtype(1, np.int64)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/random.pyi
+++ b/numpy/typing/tests/data/fail/random.pyi
@@ -8,55 +8,55 @@ SEED_SEED_SEQ: np.random.SeedSequence = np.random.SeedSequence(0)
 SEED_STR: str = "String seeding not allowed"
 
 # default rng
-np.random.default_rng(SEED_FLOAT)  # E: incompatible type
-np.random.default_rng(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.default_rng(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.default_rng(SEED_STR)  # E: incompatible type
+np.random.default_rng(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.default_rng(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.default_rng(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.default_rng(SEED_STR)  # type: ignore[arg-type]
 
 # Seed Sequence
-np.random.SeedSequence(SEED_FLOAT)  # E: incompatible type
-np.random.SeedSequence(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.SeedSequence(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.SeedSequence(SEED_SEED_SEQ)  # E: incompatible type
-np.random.SeedSequence(SEED_STR)  # E: incompatible type
+np.random.SeedSequence(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.SeedSequence(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.SeedSequence(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.SeedSequence(SEED_SEED_SEQ)  # type: ignore[arg-type]
+np.random.SeedSequence(SEED_STR)  # type: ignore[arg-type]
 
 seed_seq: np.random.bit_generator.SeedSequence = np.random.SeedSequence()
-seed_seq.spawn(11.5)  # E: incompatible type
-seed_seq.generate_state(3.14)  # E: incompatible type
-seed_seq.generate_state(3, np.uint8)  # E: incompatible type
-seed_seq.generate_state(3, "uint8")  # E: incompatible type
-seed_seq.generate_state(3, "u1")  # E: incompatible type
-seed_seq.generate_state(3, np.uint16)  # E: incompatible type
-seed_seq.generate_state(3, "uint16")  # E: incompatible type
-seed_seq.generate_state(3, "u2")  # E: incompatible type
-seed_seq.generate_state(3, np.int32)  # E: incompatible type
-seed_seq.generate_state(3, "int32")  # E: incompatible type
-seed_seq.generate_state(3, "i4")  # E: incompatible type
+seed_seq.spawn(11.5)  # type: ignore[arg-type]
+seed_seq.generate_state(3.14)  # type: ignore[arg-type]
+seed_seq.generate_state(3, np.uint8)  # type: ignore[arg-type]
+seed_seq.generate_state(3, "uint8")  # type: ignore[arg-type]
+seed_seq.generate_state(3, "u1")  # type: ignore[arg-type]
+seed_seq.generate_state(3, np.uint16)  # type: ignore[arg-type]
+seed_seq.generate_state(3, "uint16")  # type: ignore[arg-type]
+seed_seq.generate_state(3, "u2")  # type: ignore[arg-type]
+seed_seq.generate_state(3, np.int32)  # type: ignore[arg-type]
+seed_seq.generate_state(3, "int32")  # type: ignore[arg-type]
+seed_seq.generate_state(3, "i4")  # type: ignore[arg-type]
 
 # Bit Generators
-np.random.MT19937(SEED_FLOAT)  # E: incompatible type
-np.random.MT19937(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.MT19937(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.MT19937(SEED_STR)  # E: incompatible type
+np.random.MT19937(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.MT19937(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.MT19937(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.MT19937(SEED_STR)  # type: ignore[arg-type]
 
-np.random.PCG64(SEED_FLOAT)  # E: incompatible type
-np.random.PCG64(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.PCG64(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.PCG64(SEED_STR)  # E: incompatible type
+np.random.PCG64(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.PCG64(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.PCG64(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.PCG64(SEED_STR)  # type: ignore[arg-type]
 
-np.random.Philox(SEED_FLOAT)  # E: incompatible type
-np.random.Philox(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.Philox(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.Philox(SEED_STR)  # E: incompatible type
+np.random.Philox(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.Philox(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.Philox(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.Philox(SEED_STR)  # type: ignore[arg-type]
 
-np.random.SFC64(SEED_FLOAT)  # E: incompatible type
-np.random.SFC64(SEED_ARR_FLOAT)  # E: incompatible type
-np.random.SFC64(SEED_ARRLIKE_FLOAT)  # E: incompatible type
-np.random.SFC64(SEED_STR)  # E: incompatible type
+np.random.SFC64(SEED_FLOAT)  # type: ignore[arg-type]
+np.random.SFC64(SEED_ARR_FLOAT)  # type: ignore[arg-type]
+np.random.SFC64(SEED_ARRLIKE_FLOAT)  # type: ignore[arg-type]
+np.random.SFC64(SEED_STR)  # type: ignore[arg-type]
 
 # Generator
-np.random.Generator(None)  # E: incompatible type
-np.random.Generator(12333283902830213)  # E: incompatible type
-np.random.Generator("OxFEEDF00D")  # E: incompatible type
-np.random.Generator([123, 234])  # E: incompatible type
-np.random.Generator(np.array([123, 234], dtype="u4"))  # E: incompatible type
+np.random.Generator(None)  # type: ignore[arg-type]
+np.random.Generator(12333283902830213)  # type: ignore[arg-type]
+np.random.Generator("OxFEEDF00D")  # type: ignore[arg-type]
+np.random.Generator([123, 234])  # type: ignore[arg-type]
+np.random.Generator(np.array([123, 234], dtype="u4"))  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/rec.pyi
+++ b/numpy/typing/tests/data/fail/rec.pyi
@@ -3,15 +3,15 @@ import numpy.typing as npt
 
 AR_i8: npt.NDArray[np.int64]
 
-np.rec.fromarrays(1)  # E: No overload variant
-np.rec.fromarrays([1, 2, 3], dtype=[("f8", "f8")], formats=["f8", "f8"])  # E: No overload variant
+np.rec.fromarrays(1)  # type: ignore[call-overload]
+np.rec.fromarrays([1, 2, 3], dtype=[("f8", "f8")], formats=["f8", "f8"])  # type: ignore[call-overload]
 
-np.rec.fromrecords(AR_i8)  # E: incompatible type
-np.rec.fromrecords([(1.5,)], dtype=[("f8", "f8")], formats=["f8", "f8"])  # E: No overload variant
+np.rec.fromrecords(AR_i8)  # type: ignore[arg-type]
+np.rec.fromrecords([(1.5,)], dtype=[("f8", "f8")], formats=["f8", "f8"])  # type: ignore[call-overload]
 
-np.rec.fromstring("string", dtype=[("f8", "f8")])  # E: No overload variant
-np.rec.fromstring(b"bytes")  # E: No overload variant
-np.rec.fromstring(b"(1.5,)", dtype=[("f8", "f8")], formats=["f8", "f8"])  # E: No overload variant
+np.rec.fromstring("string", dtype=[("f8", "f8")])  # type: ignore[call-overload]
+np.rec.fromstring(b"bytes")  # type: ignore[call-overload]
+np.rec.fromstring(b"(1.5,)", dtype=[("f8", "f8")], formats=["f8", "f8"])  # type: ignore[call-overload]
 
 with open("test", "r") as f:
-    np.rec.fromfile(f, dtype=[("f8", "f8")])  # E: No overload variant
+    np.rec.fromfile(f, dtype=[("f8", "f8")])  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/scalars.pyi
+++ b/numpy/typing/tests/data/fail/scalars.pyi
@@ -7,7 +7,7 @@ c8: np.complex64
 
 # Construction
 
-np.float32(3j)  # E: incompatible type
+np.float32(3j)  # type: ignore[arg-type]
 
 # Technically the following examples are valid NumPy code. But they
 # are not considered a best practice, and people who wish to use the
@@ -25,64 +25,63 @@ np.float32(3j)  # E: incompatible type
 # https://github.com/numpy/numpy-stubs/issues/41
 #
 # for more context.
-np.float32([1.0, 0.0, 0.0])  # E: incompatible type
-np.complex64([])  # E: incompatible type
+np.float32([1.0, 0.0, 0.0])  # type: ignore[arg-type]
+np.complex64([])  # type: ignore[call-overload]
 
 # TODO: protocols (can't check for non-existent protocols w/ __getattr__)
 
-np.datetime64(0)  # E: No overload variant
+np.datetime64(0)  # type: ignore[call-overload]
 
 class A:
-    def __float__(self):
-        return 1.0
+    def __float__(self) -> float: ...
 
-np.int8(A())  # E: incompatible type
-np.int16(A())  # E: incompatible type
-np.int32(A())  # E: incompatible type
-np.int64(A())  # E: incompatible type
-np.uint8(A())  # E: incompatible type
-np.uint16(A())  # E: incompatible type
-np.uint32(A())  # E: incompatible type
-np.uint64(A())  # E: incompatible type
+np.int8(A())  # type: ignore[arg-type]
+np.int16(A())  # type: ignore[arg-type]
+np.int32(A())  # type: ignore[arg-type]
+np.int64(A())  # type: ignore[arg-type]
+np.uint8(A())  # type: ignore[arg-type]
+np.uint16(A())  # type: ignore[arg-type]
+np.uint32(A())  # type: ignore[arg-type]
+np.uint64(A())  # type: ignore[arg-type]
 
-np.void("test")  # E: No overload variant
-np.void("test", dtype=None)  # E: No overload variant
+np.void("test")  # type: ignore[call-overload]
+np.void("test", dtype=None)  # type: ignore[call-overload]
 
-np.generic(1)  # E: Cannot instantiate abstract class
-np.number(1)  # E: Cannot instantiate abstract class
-np.integer(1)  # E: Cannot instantiate abstract class
-np.inexact(1)  # E: Cannot instantiate abstract class
-np.character("test")  # E: Cannot instantiate abstract class
-np.flexible(b"test")  # E: Cannot instantiate abstract class
+np.generic(1)  # type: ignore[abstract]
+np.number(1)  # type: ignore[abstract]
+np.integer(1)  # type: ignore[abstract]
+np.inexact(1)  # type: ignore[abstract]
+np.character("test")  # type: ignore[abstract]
+np.flexible(b"test")  # type: ignore[abstract]
 
-np.float64(value=0.0)  # E: Unexpected keyword argument
-np.int64(value=0)  # E: Unexpected keyword argument
-np.uint64(value=0)  # E: Unexpected keyword argument
-np.complex128(value=0.0j)  # E: No overload variant
-np.str_(value='bob')  # E: No overload variant
-np.bytes_(value=b'test')  # E: No overload variant
-np.void(value=b'test')  # E: No overload variant
-np.bool(value=True)  # E: Unexpected keyword argument
-np.datetime64(value="2019")  # E: No overload variant
-np.timedelta64(value=0)  # E: Unexpected keyword argument
+np.float64(value=0.0)  # type: ignore[call-arg]
+np.int64(value=0)  # type: ignore[call-arg]
+np.uint64(value=0)  # type: ignore[call-arg]
+np.complex128(value=0.0j)  # type: ignore[call-overload]
+np.str_(value='bob')  # type: ignore[call-overload]
+np.bytes_(value=b'test')  # type: ignore[call-overload]
+np.void(value=b'test')  # type: ignore[call-overload]
+np.bool(value=True)  # type: ignore[call-overload]
+np.datetime64(value="2019")  # type: ignore[call-overload]
+np.timedelta64(value=0)  # type: ignore[call-overload]
 
-np.bytes_(b"hello", encoding='utf-8')  # E: No overload variant
-np.str_("hello", encoding='utf-8')  # E: No overload variant
+np.bytes_(b"hello", encoding='utf-8')  # type: ignore[call-overload]
+np.str_("hello", encoding='utf-8')  # type: ignore[call-overload]
 
-f8.item(1)  # E: incompatible type
-f8.item((0, 1))  # E: incompatible type
-f8.squeeze(axis=1)  # E: incompatible type
-f8.squeeze(axis=(0, 1))  # E: incompatible type
-f8.transpose(1)  # E: incompatible type
+f8.item(1)  # type: ignore[call-overload]
+f8.item((0, 1))  # type: ignore[arg-type]
+f8.squeeze(axis=1)  # type: ignore[arg-type]
+f8.squeeze(axis=(0, 1))  # type: ignore[arg-type]
+f8.transpose(1)  # type: ignore[arg-type]
 
 def func(a: np.float32) -> None: ...
 
-func(f2)  # E: incompatible type
-func(f8)  # E: incompatible type
+func(f2)  # type: ignore[arg-type]
+func(f8)  # type: ignore[arg-type]
 
-c8.__getnewargs__()  # E: Invalid self argument
-f2.__getnewargs__()  # E: Invalid self argument
-f2.hex()  # E: Invalid self argument
-np.float16.fromhex("0x0.0p+0")  # E: Invalid self argument
-f2.__trunc__()  # E: Invalid self argument
-f2.__getformat__("float")  # E: Invalid self argument
+c8.__getnewargs__()  # type: ignore[attr-defined]
+f2.__getnewargs__()  # type: ignore[attr-defined]
+f2.hex()  # type: ignore[attr-defined]
+np.float16.fromhex("0x0.0p+0")  # type: ignore[attr-defined]
+f2.__trunc__()  # type: ignore[attr-defined]
+f2.__getformat__("float")  # type: ignore[attr-defined]

--- a/numpy/typing/tests/data/fail/shape.pyi
+++ b/numpy/typing/tests/data/fail/shape.pyi
@@ -3,4 +3,4 @@ import numpy as np
 
 # test bounds of _ShapeT_co
 
-np.ndarray[tuple[str, str], Any]  # E: Value of type variable
+np.ndarray[tuple[str, str], Any]  # type: ignore[type-var]

--- a/numpy/typing/tests/data/fail/shape_base.pyi
+++ b/numpy/typing/tests/data/fail/shape_base.pyi
@@ -5,4 +5,4 @@ class DTypeLike:
 
 dtype_like: DTypeLike
 
-np.expand_dims(dtype_like, (5, 10))  # E: No overload variant
+np.expand_dims(dtype_like, (5, 10))  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/stride_tricks.pyi
+++ b/numpy/typing/tests/data/fail/stride_tricks.pyi
@@ -3,7 +3,7 @@ import numpy.typing as npt
 
 AR_f8: npt.NDArray[np.float64]
 
-np.lib.stride_tricks.as_strided(AR_f8, shape=8)  # E: No overload variant
-np.lib.stride_tricks.as_strided(AR_f8, strides=8)  # E: No overload variant
+np.lib.stride_tricks.as_strided(AR_f8, shape=8)  # type: ignore[call-overload]
+np.lib.stride_tricks.as_strided(AR_f8, strides=8)  # type: ignore[call-overload]
 
-np.lib.stride_tricks.sliding_window_view(AR_f8, axis=(1,))  # E: No overload variant
+np.lib.stride_tricks.sliding_window_view(AR_f8, axis=(1,))  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/strings.pyi
+++ b/numpy/typing/tests/data/fail/strings.pyi
@@ -4,56 +4,49 @@ import numpy.typing as npt
 AR_U: npt.NDArray[np.str_]
 AR_S: npt.NDArray[np.bytes_]
 
-np.strings.equal(AR_U, AR_S)  # E: incompatible type
+np.strings.equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.strings.not_equal(AR_U, AR_S)  # type: ignore[arg-type]
 
-np.strings.not_equal(AR_U, AR_S)  # E: incompatible type
+np.strings.greater_equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.strings.less_equal(AR_U, AR_S)  # type: ignore[arg-type]
+np.strings.greater(AR_U, AR_S)  # type: ignore[arg-type]
+np.strings.less(AR_U, AR_S)  # type: ignore[arg-type]
 
-np.strings.greater_equal(AR_U, AR_S)  # E: incompatible type
+np.strings.encode(AR_S)  # type: ignore[arg-type]
+np.strings.decode(AR_U)  # type: ignore[arg-type]
 
-np.strings.less_equal(AR_U, AR_S)  # E: incompatible type
+np.strings.lstrip(AR_U, b"a")  # type: ignore[arg-type]
+np.strings.lstrip(AR_S, "a")  # type: ignore[arg-type]
+np.strings.strip(AR_U, b"a")  # type: ignore[arg-type]
+np.strings.strip(AR_S, "a")  # type: ignore[arg-type]
+np.strings.rstrip(AR_U, b"a")  # type: ignore[arg-type]
+np.strings.rstrip(AR_S, "a")  # type: ignore[arg-type]
 
-np.strings.greater(AR_U, AR_S)  # E: incompatible type
+np.strings.partition(AR_U, b"a")  # type: ignore[arg-type]
+np.strings.partition(AR_S, "a")  # type: ignore[arg-type]
+np.strings.rpartition(AR_U, b"a")  # type: ignore[arg-type]
+np.strings.rpartition(AR_S, "a")  # type: ignore[arg-type]
 
-np.strings.less(AR_U, AR_S)  # E: incompatible type
+np.strings.count(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.strings.count(AR_S, "a", 0, 9)  # type: ignore[arg-type]
 
-np.strings.encode(AR_S)  # E: incompatible type
-np.strings.decode(AR_U)  # E: incompatible type
+np.strings.endswith(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.strings.endswith(AR_S, "a", 0, 9)  # type: ignore[arg-type]
+np.strings.startswith(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.strings.startswith(AR_S, "a", 0, 9)  # type: ignore[arg-type]
 
-np.strings.join(AR_U, b"_")  # E: incompatible type
-np.strings.join(AR_S, "_")  # E: incompatible type
+np.strings.find(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.strings.find(AR_S, "a", 0, 9)  # type: ignore[arg-type]
+np.strings.rfind(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.strings.rfind(AR_S, "a", 0, 9)  # type: ignore[arg-type]
 
-np.strings.lstrip(AR_U, b"a")  # E: incompatible type
-np.strings.lstrip(AR_S, "a")  # E: incompatible type
-np.strings.strip(AR_U, b"a")  # E: incompatible type
-np.strings.strip(AR_S, "a")  # E: incompatible type
-np.strings.rstrip(AR_U, b"a")  # E: incompatible type
-np.strings.rstrip(AR_S, "a")  # E: incompatible type
+np.strings.index(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.strings.index(AR_S, "a", end=9)  # type: ignore[arg-type]
+np.strings.rindex(AR_U, b"a", start=[1, 2, 3])  # type: ignore[arg-type]
+np.strings.rindex(AR_S, "a", end=9)  # type: ignore[arg-type]
 
-np.strings.partition(AR_U, b"a")  # E: incompatible type
-np.strings.partition(AR_S, "a")  # E: incompatible type
-np.strings.rpartition(AR_U, b"a")  # E: incompatible type
-np.strings.rpartition(AR_S, "a")  # E: incompatible type
+np.strings.isdecimal(AR_S)  # type: ignore[arg-type]
+np.strings.isnumeric(AR_S)  # type: ignore[arg-type]
 
-np.strings.count(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.strings.count(AR_S, "a", 0, 9)  # E: incompatible type
-
-np.strings.endswith(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.strings.endswith(AR_S, "a", 0, 9)  # E: incompatible type
-np.strings.startswith(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.strings.startswith(AR_S, "a", 0, 9)  # E: incompatible type
-
-np.strings.find(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.strings.find(AR_S, "a", 0, 9)  # E: incompatible type
-np.strings.rfind(AR_U, b"a", [1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.strings.rfind(AR_S, "a", 0, 9)  # E: incompatible type
-
-np.strings.index(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.strings.index(AR_S, "a", end=9)  # E: incompatible type
-np.strings.rindex(AR_U, b"a", start=[1, 2, 3])  # E: incompatible type
-np.strings.rindex(AR_S, "a", end=9)  # E: incompatible type
-
-np.strings.isdecimal(AR_S)  # E: incompatible type
-np.strings.isnumeric(AR_S)  # E: incompatible type
-
-np.strings.replace(AR_U, b"_", b"-", 10)  # E: incompatible type
-np.strings.replace(AR_S, "_", "-", 1)  # E: incompatible type
+np.strings.replace(AR_U, b"_", b"-", 10)  # type: ignore[arg-type]
+np.strings.replace(AR_S, "_", "-", 1)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/testing.pyi
+++ b/numpy/typing/tests/data/fail/testing.pyi
@@ -5,24 +5,24 @@ AR_U: npt.NDArray[np.str_]
 
 def func(x: object) -> bool: ...
 
-np.testing.assert_(True, msg=1)  # E: incompatible type
-np.testing.build_err_msg(1, "test")  # E: incompatible type
-np.testing.assert_almost_equal(AR_U, AR_U)  # E: incompatible type
-np.testing.assert_approx_equal([1, 2, 3], [1, 2, 3])  # E: incompatible type
-np.testing.assert_array_almost_equal(AR_U, AR_U)  # E: incompatible type
-np.testing.assert_array_less(AR_U, AR_U)  # E: incompatible type
-np.testing.assert_string_equal(b"a", b"a")  # E: incompatible type
+np.testing.assert_(True, msg=1)  # type: ignore[arg-type]
+np.testing.build_err_msg(1, "test")  # type: ignore[arg-type]
+np.testing.assert_almost_equal(AR_U, AR_U)  # type: ignore[arg-type]
+np.testing.assert_approx_equal([1, 2, 3], [1, 2, 3])  # type: ignore[arg-type]
+np.testing.assert_array_almost_equal(AR_U, AR_U)  # type: ignore[arg-type]
+np.testing.assert_array_less(AR_U, AR_U)  # type: ignore[arg-type]
+np.testing.assert_string_equal(b"a", b"a")  # type: ignore[arg-type]
 
-np.testing.assert_raises(expected_exception=TypeError, callable=func)  # E: No overload variant
-np.testing.assert_raises_regex(expected_exception=TypeError, expected_regex="T", callable=func)  # E: No overload variant
+np.testing.assert_raises(expected_exception=TypeError, callable=func)  # type: ignore[call-overload]
+np.testing.assert_raises_regex(expected_exception=TypeError, expected_regex="T", callable=func)  # type: ignore[call-overload]
 
-np.testing.assert_allclose(AR_U, AR_U)  # E: incompatible type
-np.testing.assert_array_almost_equal_nulp(AR_U, AR_U)  # E: incompatible type
-np.testing.assert_array_max_ulp(AR_U, AR_U)  # E: incompatible type
+np.testing.assert_allclose(AR_U, AR_U)  # type: ignore[arg-type]
+np.testing.assert_array_almost_equal_nulp(AR_U, AR_U)  # type: ignore[arg-type]
+np.testing.assert_array_max_ulp(AR_U, AR_U)  # type: ignore[arg-type]
 
-np.testing.assert_warns(RuntimeWarning, func)  # E: No overload variant
-np.testing.assert_no_warnings(func=func)  # E: No overload variant
-np.testing.assert_no_warnings(func)  # E: Too many arguments
-np.testing.assert_no_warnings(func, y=None)  # E: No overload variant
+np.testing.assert_warns(RuntimeWarning, func)  # type: ignore[call-overload]
+np.testing.assert_no_warnings(func=func)  # type: ignore[call-overload]
+np.testing.assert_no_warnings(func)  # type: ignore[call-overload]
+np.testing.assert_no_warnings(func, y=None)  # type: ignore[call-overload]
 
-np.testing.assert_no_gc_cycles(func=func)  # E: No overload variant
+np.testing.assert_no_gc_cycles(func=func)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/twodim_base.pyi
+++ b/numpy/typing/tests/data/fail/twodim_base.pyi
@@ -12,21 +12,21 @@ AR_m: npt.NDArray[np.timedelta64]
 
 AR_LIKE_b: list[bool]
 
-np.eye(10, M=20.0)  # E: No overload variant
-np.eye(10, k=2.5, dtype=int)  # E: No overload variant
+np.eye(10, M=20.0)  # type: ignore[call-overload]
+np.eye(10, k=2.5, dtype=int)  # type: ignore[call-overload]
 
-np.diag(AR_b, k=0.5)  # E: No overload variant
-np.diagflat(AR_b, k=0.5)  # E: No overload variant
+np.diag(AR_b, k=0.5)  # type: ignore[call-overload]
+np.diagflat(AR_b, k=0.5)  # type: ignore[call-overload]
 
-np.tri(10, M=20.0)  # E: No overload variant
-np.tri(10, k=2.5, dtype=int)  # E: No overload variant
+np.tri(10, M=20.0)  # type: ignore[call-overload]
+np.tri(10, k=2.5, dtype=int)  # type: ignore[call-overload]
 
-np.tril(AR_b, k=0.5)  # E: No overload variant
-np.triu(AR_b, k=0.5)  # E: No overload variant
+np.tril(AR_b, k=0.5)  # type: ignore[call-overload]
+np.triu(AR_b, k=0.5)  # type: ignore[call-overload]
 
-np.vander(AR_m)  # E: incompatible type
+np.vander(AR_m)  # type: ignore[arg-type]
 
-np.histogram2d(AR_m)  # E: No overload variant
+np.histogram2d(AR_m)  # type: ignore[call-overload]
 
-np.mask_indices(10, func1)  # E: incompatible type
-np.mask_indices(10, func2, 10.5)  # E: incompatible type
+np.mask_indices(10, func1)  # type: ignore[arg-type]
+np.mask_indices(10, func2, 10.5)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/type_check.pyi
+++ b/numpy/typing/tests/data/fail/type_check.pyi
@@ -3,11 +3,11 @@ import numpy.typing as npt
 
 DTYPE_i8: np.dtype[np.int64]
 
-np.mintypecode(DTYPE_i8)  # E: incompatible type
-np.iscomplexobj(DTYPE_i8)  # E: incompatible type
-np.isrealobj(DTYPE_i8)  # E: incompatible type
+np.mintypecode(DTYPE_i8)  # type: ignore[arg-type]
+np.iscomplexobj(DTYPE_i8)  # type: ignore[arg-type]
+np.isrealobj(DTYPE_i8)  # type: ignore[arg-type]
 
-np.typename(DTYPE_i8)  # E: No overload variant
-np.typename("invalid")  # E: No overload variant
+np.typename(DTYPE_i8)  # type: ignore[call-overload]
+np.typename("invalid")  # type: ignore[call-overload]
 
-np.common_type(np.timedelta64())  # E: incompatible type
+np.common_type(np.timedelta64())  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/ufunc_config.pyi
+++ b/numpy/typing/tests/data/fail/ufunc_config.pyi
@@ -14,8 +14,8 @@ class Write2:
 class Write3:
     def write(self, *, a: str) -> None: ...
 
-np.seterrcall(func1)  # E: Argument 1 to "seterrcall" has incompatible type
-np.seterrcall(func2)  # E: Argument 1 to "seterrcall" has incompatible type
-np.seterrcall(Write1())  # E: Argument 1 to "seterrcall" has incompatible type
-np.seterrcall(Write2())  # E: Argument 1 to "seterrcall" has incompatible type
-np.seterrcall(Write3())  # E: Argument 1 to "seterrcall" has incompatible type
+np.seterrcall(func1)  # type: ignore[arg-type]
+np.seterrcall(func2)  # type: ignore[arg-type]
+np.seterrcall(Write1())  # type: ignore[arg-type]
+np.seterrcall(Write2())  # type: ignore[arg-type]
+np.seterrcall(Write3())  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/ufunclike.pyi
+++ b/numpy/typing/tests/data/fail/ufunclike.pyi
@@ -6,16 +6,16 @@ AR_m: npt.NDArray[np.timedelta64]
 AR_M: npt.NDArray[np.datetime64]
 AR_O: npt.NDArray[np.object_]
 
-np.fix(AR_c)  # E: incompatible type
-np.fix(AR_m)  # E: incompatible type
-np.fix(AR_M)  # E: incompatible type
+np.fix(AR_c)  # type: ignore[arg-type]
+np.fix(AR_m)  # type: ignore[arg-type]
+np.fix(AR_M)  # type: ignore[arg-type]
 
-np.isposinf(AR_c)  # E: incompatible type
-np.isposinf(AR_m)  # E: incompatible type
-np.isposinf(AR_M)  # E: incompatible type
-np.isposinf(AR_O)  # E: incompatible type
+np.isposinf(AR_c)  # type: ignore[arg-type]
+np.isposinf(AR_m)  # type: ignore[arg-type]
+np.isposinf(AR_M)  # type: ignore[arg-type]
+np.isposinf(AR_O)  # type: ignore[arg-type]
 
-np.isneginf(AR_c)  # E: incompatible type
-np.isneginf(AR_m)  # E: incompatible type
-np.isneginf(AR_M)  # E: incompatible type
-np.isneginf(AR_O)  # E: incompatible type
+np.isneginf(AR_c)  # type: ignore[arg-type]
+np.isneginf(AR_m)  # type: ignore[arg-type]
+np.isneginf(AR_M)  # type: ignore[arg-type]
+np.isneginf(AR_O)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/fail/ufuncs.pyi
+++ b/numpy/typing/tests/data/fail/ufuncs.pyi
@@ -3,15 +3,15 @@ import numpy.typing as npt
 
 AR_f8: npt.NDArray[np.float64]
 
-np.sin.nin + "foo"  # E: Unsupported operand types
-np.sin(1, foo="bar")  # E: No overload variant
+np.sin.nin + "foo"  # type: ignore[operator]
+np.sin(1, foo="bar")  # type: ignore[call-overload]
 
-np.abs(None)  # E: No overload variant
+np.abs(None)  # type: ignore[call-overload]
 
-np.add(1, 1, 1)  # E: No overload variant
-np.add(1, 1, axis=0)  # E: No overload variant
+np.add(1, 1, 1)  # type: ignore[call-overload]
+np.add(1, 1, axis=0)  # type: ignore[call-overload]
 
-np.matmul(AR_f8, AR_f8, where=True)  # E: No overload variant
+np.matmul(AR_f8, AR_f8, where=True)  # type: ignore[call-overload]
 
-np.frexp(AR_f8, out=None)  # E: No overload variant
-np.frexp(AR_f8, out=AR_f8)  # E: No overload variant
+np.frexp(AR_f8, out=None)  # type: ignore[call-overload]
+np.frexp(AR_f8, out=AR_f8)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/fail/warnings_and_errors.pyi
+++ b/numpy/typing/tests/data/fail/warnings_and_errors.pyi
@@ -1,5 +1,5 @@
 import numpy.exceptions as ex
 
-ex.AxisError(1.0)  # E: No overload variant
-ex.AxisError(1, ndim=2.0)  # E: No overload variant
-ex.AxisError(2, msg_prefix=404)  # E: No overload variant
+ex.AxisError(1.0)  # type: ignore[call-overload]
+ex.AxisError(1, ndim=2.0)  # type: ignore[call-overload]
+ex.AxisError(2, msg_prefix=404)  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/mypy.ini
+++ b/numpy/typing/tests/data/mypy.ini
@@ -1,8 +1,10 @@
 [mypy]
 plugins = numpy.typing.mypy_plugin
-show_absolute_path = True
+enable_error_code = deprecated, ignore-without-code, truthy-bool
+strict_bytes = True
+warn_unused_ignores = True
 implicit_reexport = False
-pretty = True
 disallow_any_unimported = True
 disallow_any_generics = True
-strict_bytes = True
+show_absolute_path = True
+pretty = True

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -188,10 +188,10 @@ A_void["yap"] = A_float[:, 1]
 # deprecated
 
 with np.testing.assert_warns(DeprecationWarning):
-    ctypes_obj.get_data()  # pyright: ignore[reportDeprecated]
+    ctypes_obj.get_data()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 with np.testing.assert_warns(DeprecationWarning):
-    ctypes_obj.get_shape()  # pyright: ignore[reportDeprecated]
+    ctypes_obj.get_shape()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 with np.testing.assert_warns(DeprecationWarning):
-    ctypes_obj.get_strides()  # pyright: ignore[reportDeprecated]
+    ctypes_obj.get_strides()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 with np.testing.assert_warns(DeprecationWarning):
-    ctypes_obj.get_as_parameter()  # pyright: ignore[reportDeprecated]
+    ctypes_obj.get_as_parameter()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]

--- a/numpy/typing/tests/data/reveal/nbit_base_example.pyi
+++ b/numpy/typing/tests/data/reveal/nbit_base_example.pyi
@@ -4,8 +4,8 @@ import numpy as np
 import numpy.typing as npt
 from numpy._typing import _32Bit, _64Bit
 
-T1 = TypeVar("T1", bound=npt.NBitBase)
-T2 = TypeVar("T2", bound=npt.NBitBase)
+T1 = TypeVar("T1", bound=npt.NBitBase)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
+T2 = TypeVar("T2", bound=npt.NBitBase)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 
 def add(a: np.floating[T1], b: np.integer[T2]) -> np.floating[T1 | T2]:
     return a + b

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -4,11 +4,11 @@ import importlib.util
 import os
 import re
 import shutil
+import textwrap
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import pytest
-from numpy.typing.mypy_plugin import _EXTENDED_PRECISION_LIST
 
 
 # Only trigger a full `mypy` run if this environment variable is set
@@ -99,9 +99,9 @@ def run_mypy() -> None:
             directory,
         ])
         if stderr:
-            pytest.fail(f"Unexpected mypy standard error\n\n{stderr}")
+            pytest.fail(f"Unexpected mypy standard error\n\n{stderr}", False)
         elif exit_code not in {0, 1}:
-            pytest.fail(f"Unexpected mypy exit code: {exit_code}\n\n{stdout}")
+            pytest.fail(f"Unexpected mypy exit code: {exit_code}\n\n{stdout}", False)
 
         str_concat = ""
         filename: str | None = None
@@ -118,98 +118,55 @@ def run_mypy() -> None:
                 filename = None
 
 
-def get_test_cases(directory: str) -> Iterator[ParameterSet]:
-    for root, _, files in os.walk(directory):
-        for fname in files:
-            short_fname, ext = os.path.splitext(fname)
-            if ext in (".pyi", ".py"):
+def get_test_cases(*directories: str) -> Iterator[ParameterSet]:
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for fname in files:
+                short_fname, ext = os.path.splitext(fname)
+                if ext not in (".pyi", ".py"):
+                    continue
+
                 fullpath = os.path.join(root, fname)
                 yield pytest.param(fullpath, id=short_fname)
 
 
-@pytest.mark.slow
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
-@pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
-def test_success(path) -> None:
-    # Alias `OUTPUT_MYPY` so that it appears in the local namespace
-    output_mypy = OUTPUT_MYPY
-    if path in output_mypy:
-        msg = "Unexpected mypy output\n\n"
-        msg += "\n".join(_strip_filename(v)[1] for v in output_mypy[path])
-        raise AssertionError(msg)
+_FAIL_INDENT = " " * 4
+_FAIL_SEP = "\n" + "_" * 79 +  "\n\n"
 
+_FAIL_MSG_REVEAL = """{}:{} - reveal mismatch:
 
-@pytest.mark.slow
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
-@pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
-def test_fail(path: str) -> None:
-    __tracebackhide__ = True
+{}"""
 
-    with open(path) as fin:
-        lines = fin.readlines()
-
-    errors = defaultdict(lambda: "")
-
-    output_mypy = OUTPUT_MYPY
-    assert path in output_mypy
-
-    for error_line in output_mypy[path]:
-        lineno, error_line = _strip_filename(error_line)
-        errors[lineno] += f'{error_line}\n'
-
-    for i, line in enumerate(lines):
-        lineno = i + 1
-        if (
-            line.startswith('#')
-            or (" E:" not in line and lineno not in errors)
-        ):
-            continue
-
-        target_line = lines[lineno - 1]
-        if "# E:" in target_line:
-            expression, _, marker = target_line.partition("  # E: ")
-            error = errors[lineno].strip()
-            expected_error = marker.strip()
-            _test_fail(path, expression, error, expected_error, lineno)
-        else:
-            pytest.fail(
-                f"Unexpected mypy output at line {lineno}\n\n{errors[lineno]}"
-            )
-
-
-_FAIL_MSG1 = """Extra error at line {}
-
-Expression: {}
-Extra error: {!r}
-"""
-
-_FAIL_MSG2 = """Error mismatch at line {}
+_FAIL_MSG_MISC = """{}:{} - error mismatch:
 
 Expression: {}
 Expected error: {}
-Observed error: {!r}
+Observed error: {}
 """
 
 
-def _test_fail(
-    path: str,
-    expression: str,
-    error: str,
-    expected_error: str | None,
-    lineno: int,
-) -> None:
-    if expected_error is None:
-        raise AssertionError(_FAIL_MSG1.format(lineno, expression, error))
-    elif expected_error not in error:
-        raise AssertionError(_FAIL_MSG2.format(
-            lineno, expression, expected_error, error
-        ))
+@pytest.mark.slow
+@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
+@pytest.mark.parametrize("path", get_test_cases(PASS_DIR, FAIL_DIR))
+def test_pass(path) -> None:
+    # Alias `OUTPUT_MYPY` so that it appears in the local namespace
+    output_mypy = OUTPUT_MYPY
 
+    if path not in output_mypy:
+        return
 
-_REVEAL_MSG = """Reveal mismatch at line {}
+    relpath = os.path.relpath(path)
 
-{}
-"""
+    # collect any reported errors, and clean up the output
+    messages = []
+    for message in output_mypy[path]:
+        lineno, content = _strip_filename(message)
+        content = content.removeprefix("error:").lstrip()
+        messages.append(f"{relpath}:{lineno} - {content}")
+
+    if messages:
+        pytest.fail("\n".join(messages), pytrace=False)
+
 
 
 @pytest.mark.slow
@@ -225,9 +182,62 @@ def test_reveal(path: str) -> None:
     if path not in output_mypy:
         return
 
+    relpath = os.path.relpath(path)
+
+    # collect any reported errors, and clean up the output
+    failures = []
     for error_line in output_mypy[path]:
-        lineno, error_line = _strip_filename(error_line)
-        raise AssertionError(_REVEAL_MSG.format(lineno, error_line))
+        lineno, error_msg = _strip_filename(error_line)
+        error_msg = textwrap.indent(error_msg, _FAIL_INDENT)
+        reason = _FAIL_MSG_REVEAL.format(relpath, lineno, error_msg)
+        failures.append(reason)
+
+    if failures:
+        reasons = _FAIL_SEP.join(failures)
+        pytest.fail(reasons, pytrace=False)
+
+
+LINENO_MAPPING = {
+    6: "float96",
+    7: "float128",
+    8: "complex192",
+    9: "complex256",
+}
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
+def test_extended_precision() -> None:
+    from numpy.typing.mypy_plugin import _EXTENDED_PRECISION_LIST
+
+    path = os.path.join(MISC_DIR, "extended_precision.pyi")
+    output_mypy = OUTPUT_MYPY
+    assert path in output_mypy
+
+    expected_msg = 'Expression is of type "Any"'
+
+    with open(path) as f:
+        expression_list = f.readlines()
+
+    failures = []
+    for _msg in output_mypy[path]:
+        lineno, error_msg = _strip_filename(_msg)
+        expr = expression_list[lineno - 1].rstrip("\n")
+
+        if LINENO_MAPPING[lineno] in _EXTENDED_PRECISION_LIST:
+            raise AssertionError(_FAIL_MSG_REVEAL.format(lineno, error_msg))
+        if "error" in error_msg or expected_msg not in error_msg:
+            continue
+
+        if "\n" in error_msg:
+            error_msg = "\n" + textwrap.indent(error_msg, _FAIL_INDENT)
+        relpath = os.path.relpath(path)
+        failure = _FAIL_MSG_MISC.format(relpath, lineno, expr, expected_msg, error_msg)
+        failures.append(failure)
+
+    if failures:
+        reasons = _FAIL_SEP.join(failures)
+        pytest.fail(reasons, pytrace=False)
 
 
 @pytest.mark.slow
@@ -246,33 +256,3 @@ def test_code_runs(path: str) -> None:
 
     test_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(test_module)
-
-
-LINENO_MAPPING = {
-    6: "float96",
-    7: "float128",
-    8: "complex192",
-    9: "complex256",
-}
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
-def test_extended_precision() -> None:
-    path = os.path.join(MISC_DIR, "extended_precision.pyi")
-    output_mypy = OUTPUT_MYPY
-    assert path in output_mypy
-
-    with open(path) as f:
-        expression_list = f.readlines()
-
-    for _msg in output_mypy[path]:
-        lineno, msg = _strip_filename(_msg)
-        expression = expression_list[lineno - 1].rstrip("\n")
-
-        if LINENO_MAPPING[lineno] in _EXTENDED_PRECISION_LIST:
-            raise AssertionError(_REVEAL_MSG.format(lineno, msg))
-        elif "error" not in msg:
-            _test_fail(
-                path, expression, msg, 'Expression is of type "Any"', lineno
-            )

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -131,7 +131,7 @@ def get_test_cases(*directories: str) -> Iterator[ParameterSet]:
 
 
 _FAIL_INDENT = " " * 4
-_FAIL_SEP = "\n" + "_" * 79 +  "\n\n"
+_FAIL_SEP = "\n" + "_" * 79 + "\n\n"
 
 _FAIL_MSG_REVEAL = """{}:{} - reveal mismatch:
 
@@ -166,7 +166,6 @@ def test_pass(path) -> None:
 
     if messages:
         pytest.fail("\n".join(messages), pytrace=False)
-
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The rejection type-tests (in `numpy/typing/tests/data/fail`) now use IDE-friendly `# type: ignore[...]` comments with specific error codes, instead of the somewhat broken "# E: ..." comments from before. By configuring mypy to report unused `# type: ignore` comments as an error, these rejection tests will fail if mypy doesn't reject them with the specified error code. If a wrong error code is used, mypy will yell at you (and that's a good thing).

Test failures will now also report the *relative* path to the type-test source and the line number (clickable in vscode). All mypy errors will be reported, not just the first one. The mypy error is moved to the first line, so that pytest will include it in the summary.

It now looks something like this:
![image](https://github.com/user-attachments/assets/6f9b30ce-228e-44d0-b2bd-0d3965ae774b)

Figuring out where an error originated from required digging through the (often huge) mypy output, which (for some reason) was stripped of its paths and line numbers. So figuring out where the error originated from, required quite a bit of detective work.
Now you can just click the error :)