### PR TITLE
TST: Prevent import error when tests are not included in the wheel

### DIFF
--- a/numpy/_core/tests/_natype.py
+++ b/numpy/_core/tests/_natype.py
@@ -194,3 +194,11 @@ class NAType:
 
 
 pd_NA = NAType()
+
+
+def get_stringdtype_dtype(na_object, coerce=True):
+    # explicit is check for pd_NA because != with pd_NA returns pd_NA
+    if na_object is pd_NA or na_object != "unset":
+        return np.dtypes.StringDType(na_object=na_object, coerce=coerce)
+    else:
+        return np.dtypes.StringDType(coerce=coerce)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -9,9 +9,8 @@ import numpy as np
 import pytest
 
 from numpy.dtypes import StringDType
-from numpy._core.tests._natype import pd_NA
+from numpy._core.tests._natype import pd_NA, get_stringdtype_dtype as get_dtype
 from numpy.testing import assert_array_equal, IS_PYPY
-from numpy.testing._private.utils import get_stringdtype_dtype as get_dtype
 
 
 @pytest.fixture

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -14,8 +14,8 @@ import numpy
 import numpy as np
 
 from numpy._core._multiarray_tests import get_fpu_mode
-from numpy._core.tests._natype import pd_NA
-from numpy.testing._private.utils import NOGIL_BUILD, get_stringdtype_dtype
+from numpy._core.tests._natype import pd_NA, get_stringdtype_dtype
+from numpy.testing._private.utils import NOGIL_BUILD
 
 try:
     from scipy_doctest.conftest import dt_config

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -27,7 +27,6 @@ from numpy._core import (
      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
 from numpy import isfinite, isnan, isinf
 import numpy.linalg._umath_linalg
-from numpy._core.tests._natype import pd_NA
 
 from io import StringIO
 
@@ -2751,11 +2750,3 @@ def run_threaded(func, max_workers=8, pass_count=False,
                     barrier.abort()
             for f in futures:
                 f.result()
-
-
-def get_stringdtype_dtype(na_object, coerce=True):
-    # explicit is check for pd_NA because != with pd_NA returns pd_NA
-    if na_object is pd_NA or na_object != "unset":
-        return np.dtypes.StringDType(na_object=na_object, coerce=coerce)
-    else:
-        return np.dtypes.StringDType(coerce=coerce)


### PR DESCRIPTION
It is possible to build numpy without test directories using install tags. For example, passing the tags such as

```
install-args=--tags=runtime,python-runtime,devel
```

would exclude the test directories, such as `numpy._core.tests` from the output.

However, even when the test directories are excluded from the output, `numpy.testing` is still included in the wheel and one
of the files in numpy.testing tries to import the file from the test directory, which causes an error when loading numpy.

cc: @agriyakhetarpal 