### PR TITLE
CI: fix TSAN CI by using a different docker image

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -78,7 +78,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container:
-        image: ghcr.io/nascheme/numpy-tsan:3.14t-dev
+        image: ghcr.io/nascheme/numpy-tsan:3.14t
         options: --shm-size=2g # increase memory for large matrix ops
       
     steps:


### PR DESCRIPTION
Let's use a release build of CPython for this CI job. [I think](https://github.com/nascheme/cpython_sanity/actions/runs/14915168289/job/41898887723) this will also fix CI.