### PR TITLE
MNT: clean up free-threaded CI configuration

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -53,12 +53,10 @@ jobs:
         echo CPPFLAGS="-I$LLVM_PREFIX/include" >> $GITHUB_ENV
     - name: Build Python with address sanitizer
       run: |
-        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.13t
-        pyenv global 3.13t
+        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.14t
+        pyenv global 3.14t
     - name: Install dependencies
       run: |
-        # TODO: remove when a released cython supports free-threaded python
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/ci_requirements.txt
         pip install -r requirements/test_requirements.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,11 +68,6 @@ jobs:
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.version }}
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      if: matrix.version == '3.14t-dev'
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - uses: ./.github/meson_actions
 
   pypy:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,7 +115,7 @@ jobs:
         build_runner:
           - [ macos-13, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
-        version: ["3.11", "3.13t"]
+        version: ["3.11", "3.14t"]
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -137,12 +137,6 @@ jobs:
       if: ${{ matrix.build_runner[0] == 'macos-13' }}
       with:
         xcode-version: '14.3'
-
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      if: matrix.version == '3.13t'
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -174,12 +174,6 @@ jobs:
             echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
           fi
 
-      - name: Set up free-threaded build
-        if: matrix.python == 'cp313t'
-        shell: bash -el {0}
-        run: |
-          echo "CIBW_BUILD_FRONTEND=pip; args: --no-build-isolation" >> "$GITHUB_ENV"
-
       - name: Build wheels
         uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a  # v2.23.3
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         compiler-pyversion:
           - ["MSVC", "3.11"]
-          - ["Clang-cl", "3.13t"]
+          - ["Clang-cl", "3.14t"]
 
     steps:
     - name: Checkout
@@ -43,12 +43,6 @@ jobs:
 
     - run:
         uv pip install --python=${{ matrix.version }} pip
-
-    # TODO: remove cython nightly install when cython does a release
-    - name: Install nightly Cython
-      if: matrix.compiler-pyversion[1] == '3.13t'
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
 
     - name: Install build dependencies from PyPI
       run: |

--- a/numpy/random/src/mt19937/mt19937-jump.c
+++ b/numpy/random/src/mt19937/mt19937-jump.c
@@ -13,7 +13,7 @@ unsigned long get_coef(unsigned long *pf, unsigned int deg) {
 void copy_state(mt19937_state *target_state, mt19937_state *state) {
   int i;
 
-  for (i = 0; i < N; i++)
+  for (i = 0; i < _MT19937_N; i++)
     target_state->key[i] = state->key[i];
 
   target_state->pos = state->pos;
@@ -26,17 +26,17 @@ void gen_next(mt19937_state *state) {
   static unsigned long mag02[2] = {0x0ul, MATRIX_A};
 
   num = state->pos;
-  if (num < N - M) {
+  if (num < _MT19937_N - _MT19937_M) {
     y = (state->key[num] & UPPER_MASK) | (state->key[num + 1] & LOWER_MASK);
-    state->key[num] = state->key[num + M] ^ (y >> 1) ^ mag02[y % 2];
+    state->key[num] = state->key[num + _MT19937_M] ^ (y >> 1) ^ mag02[y % 2];
     state->pos++;
-  } else if (num < N - 1) {
+  } else if (num < _MT19937_N - 1) {
     y = (state->key[num] & UPPER_MASK) | (state->key[num + 1] & LOWER_MASK);
-    state->key[num] = state->key[num + (M - N)] ^ (y >> 1) ^ mag02[y % 2];
+    state->key[num] = state->key[num + (_MT19937_M - _MT19937_N)] ^ (y >> 1) ^ mag02[y % 2];
     state->pos++;
-  } else if (num == N - 1) {
-    y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
-    state->key[N - 1] = state->key[M - 1] ^ (y >> 1) ^ mag02[y % 2];
+  } else if (num == _MT19937_N - 1) {
+    y = (state->key[_MT19937_N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
+    state->key[_MT19937_N - 1] = state->key[_MT19937_M - 1] ^ (y >> 1) ^ mag02[y % 2];
     state->pos = 0;
   }
 }
@@ -45,19 +45,19 @@ void add_state(mt19937_state *state1, mt19937_state *state2) {
   int i, pt1 = state1->pos, pt2 = state2->pos;
 
   if (pt2 - pt1 >= 0) {
-    for (i = 0; i < N - pt2; i++)
+    for (i = 0; i < _MT19937_N - pt2; i++)
       state1->key[i + pt1] ^= state2->key[i + pt2];
-    for (; i < N - pt1; i++)
-      state1->key[i + pt1] ^= state2->key[i + (pt2 - N)];
-    for (; i < N; i++)
-      state1->key[i + (pt1 - N)] ^= state2->key[i + (pt2 - N)];
+    for (; i < _MT19937_N - pt1; i++)
+      state1->key[i + pt1] ^= state2->key[i + (pt2 - _MT19937_N)];
+    for (; i < _MT19937_N; i++)
+      state1->key[i + (pt1 - _MT19937_N)] ^= state2->key[i + (pt2 - _MT19937_N)];
   } else {
-    for (i = 0; i < N - pt1; i++)
+    for (i = 0; i < _MT19937_N - pt1; i++)
       state1->key[i + pt1] ^= state2->key[i + pt2];
-    for (; i < N - pt2; i++)
-      state1->key[i + (pt1 - N)] ^= state2->key[i + pt2];
-    for (; i < N; i++)
-      state1->key[i + (pt1 - N)] ^= state2->key[i + (pt2 - N)];
+    for (; i < _MT19937_N - pt2; i++)
+      state1->key[i + (pt1 - _MT19937_N)] ^= state2->key[i + pt2];
+    for (; i < _MT19937_N; i++)
+      state1->key[i + (pt1 - _MT19937_N)] ^= state2->key[i + (pt2 - _MT19937_N)];
   }
 }
 
@@ -104,7 +104,7 @@ void mt19937_jump_state(mt19937_state *state) {
     pf[i] = poly_coef[i];
   }
 
-  if (state->pos >= N) {
+  if (state->pos >= _MT19937_N) {
     state->pos = 0;
   }
 

--- a/numpy/random/src/mt19937/mt19937.c
+++ b/numpy/random/src/mt19937/mt19937.c
@@ -83,16 +83,16 @@ void mt19937_gen(mt19937_state *state) {
   uint32_t y;
   int i;
 
-  for (i = 0; i < N - M; i++) {
+  for (i = 0; i < _MT19937_N - _MT19937_M; i++) {
     y = (state->key[i] & UPPER_MASK) | (state->key[i + 1] & LOWER_MASK);
-    state->key[i] = state->key[i + M] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+    state->key[i] = state->key[i + _MT19937_M] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
   }
-  for (; i < N - 1; i++) {
+  for (; i < _MT19937_N - 1; i++) {
     y = (state->key[i] & UPPER_MASK) | (state->key[i + 1] & LOWER_MASK);
-    state->key[i] = state->key[i + (M - N)] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+    state->key[i] = state->key[i + (_MT19937_M - _MT19937_N)] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
   }
-  y = (state->key[N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
-  state->key[N - 1] = state->key[M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
+  y = (state->key[_MT19937_N - 1] & UPPER_MASK) | (state->key[0] & LOWER_MASK);
+  state->key[_MT19937_N - 1] = state->key[_MT19937_M - 1] ^ (y >> 1) ^ (-(y & 1) & MATRIX_A);
 
   state->pos = 0;
 }

--- a/numpy/random/src/mt19937/mt19937.h
+++ b/numpy/random/src/mt19937/mt19937.h
@@ -8,8 +8,8 @@
 
 #define RK_STATE_LEN 624
 
-#define N 624
-#define M 397
+#define _MT19937_N 624
+#define _MT19937_M 397
 #define MATRIX_A 0x9908b0dfUL
 #define UPPER_MASK 0x80000000UL
 #define LOWER_MASK 0x7fffffffUL

--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -15,12 +15,7 @@ macosx_arm64_task:
 
   matrix:
     - env:
-        CIBW_BUILD: cp311-* cp312*
-    - env:
-        CIBW_BUILD: cp313-*
-    - env:
-        CIBW_BUILD: cp313t-*
-        CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+        CIBW_BUILD: cp311-* cp312* cp313*
   env:
     PATH: /usr/local/lib:/usr/local/include:$PATH
     CIBW_ARCHS: arm64

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -55,12 +55,3 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     # delvewheel is the equivalent of delocate/auditwheel for windows.
     python -m pip install delvewheel wheel
 fi
-
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when numpy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install meson-python ninja
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-fi

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -30,11 +30,6 @@ export NPY_AVAILABLE_MEM="4 GB"
 
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    # TODO: delete when numpy is buildable under free-threaded python
-    # with a released version of cython
-    python -m pip uninstall -y cython
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-
     # Manually check that importing NumPy does not re-enable the GIL.
     # In principle the tests should catch this but it seems harmless to leave it
     # here as a final sanity check before uploading broken wheels


### PR DESCRIPTION
The Cython 3.1 release today lets us clean up a bunch of free-threaded-specific workarounds.

I also took the opportunity to bump some builds from cp313t to using cp314t.

Opening as a draft initially to check CI status.