### PR TITLE
TYP: optional type parameters for ``ndarray`` and ``flatiter``

### DIFF
--- a/doc/release/upcoming_changes/28940.new_feature.rst
+++ b/doc/release/upcoming_changes/28940.new_feature.rst
@@ -1,0 +1,6 @@
+* Static type-checkers now interpret:
+
+  - ``_: np.ndarray`` as ``_: npt.NDArray[typing.Any]``.
+  - ``_: np.flatiter`` as ``_: np.flatiter[np.ndarray]``.
+
+  This is because their type parameters now have default values.

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -787,19 +787,19 @@ _ImagT_co = TypeVar("_ImagT_co", covariant=True)
 _CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 
 _DTypeT = TypeVar("_DTypeT", bound=dtype)
-_DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, covariant=True)
+_DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, default=dtype, covariant=True)
 _FlexDTypeT = TypeVar("_FlexDTypeT", bound=dtype[flexible])
 
-_ArrayT = TypeVar("_ArrayT", bound=NDArray[Any])
-_ArrayT_co = TypeVar("_ArrayT_co", bound=NDArray[Any], covariant=True)
+_ArrayT = TypeVar("_ArrayT", bound=ndarray)
+_ArrayT_co = TypeVar("_ArrayT_co", bound=ndarray, default=ndarray, covariant=True)
 _IntegralArrayT = TypeVar("_IntegralArrayT", bound=NDArray[integer | np.bool | object_])
 _RealArrayT = TypeVar("_RealArrayT", bound=NDArray[floating | integer | timedelta64 | np.bool | object_])
 _NumericArrayT = TypeVar("_NumericArrayT", bound=NDArray[number | timedelta64 | object_])
 
 _ShapeT = TypeVar("_ShapeT", bound=_Shape)
-_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, covariant=True)
+_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, default=_Shape, covariant=True)
 _1DShapeT = TypeVar("_1DShapeT", bound=_1D)
-_2DShapeT_co = TypeVar("_2DShapeT_co", bound=_2D, covariant=True)
+_2DShapeT_co = TypeVar("_2DShapeT_co", bound=_2D, default=_2D, covariant=True)
 _1NShapeT = TypeVar("_1NShapeT", bound=tuple[L[1], *tuple[L[1], ...]])  # (1,) | (1, 1) | (1, 1, 1) | ...
 
 _ScalarT = TypeVar("_ScalarT", bound=generic)
@@ -810,9 +810,9 @@ _FloatingT_co = TypeVar("_FloatingT_co", bound=floating, default=floating, covar
 _IntegerT = TypeVar("_IntegerT", bound=integer)
 _IntegerT_co = TypeVar("_IntegerT_co", bound=integer, default=integer, covariant=True)
 
-_NBit = TypeVar("_NBit", bound=NBitBase, default=Any)
-_NBit1 = TypeVar("_NBit1", bound=NBitBase, default=Any)
-_NBit2 = TypeVar("_NBit2", bound=NBitBase, default=_NBit1)
+_NBit = TypeVar("_NBit", bound=NBitBase, default=Any)  # pyright: ignore[reportDeprecated]
+_NBit1 = TypeVar("_NBit1", bound=NBitBase, default=Any)  # pyright: ignore[reportDeprecated]
+_NBit2 = TypeVar("_NBit2", bound=NBitBase, default=_NBit1)  # pyright: ignore[reportDeprecated]
 
 _ItemT_co = TypeVar("_ItemT_co", default=Any, covariant=True)
 _BoolItemT = TypeVar("_BoolItemT", bound=builtins.bool)

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -2,11 +2,11 @@ from typing import (
     Literal as L,
     overload,
     TypeAlias,
-    TypeVar,
     Any,
     SupportsIndex,
     SupportsInt,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy import (
@@ -89,10 +89,10 @@ __all__ = [
     "chararray",
 ]
 
-_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], covariant=True)
+_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, default=_Shape, covariant=True)
 _CharacterT = TypeVar("_CharacterT", bound=np.character)
-_CharDTypeT_co = TypeVar("_CharDTypeT_co", bound=dtype[np.character], covariant=True)
-_CharArray: TypeAlias = chararray[tuple[int, ...], dtype[_CharacterT]]
+_CharDTypeT_co = TypeVar("_CharDTypeT_co", bound=dtype[np.character], default=dtype, covariant=True)
+_CharArray: TypeAlias = chararray[_Shape, dtype[_CharacterT]]
 
 _StringDTypeArray: TypeAlias = np.ndarray[_Shape, np.dtypes.StringDType]
 _StringDTypeSupportsArray: TypeAlias = _SupportsArray[np.dtypes.StringDType]

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2,10 +2,10 @@
 # ruff: noqa: ANN001, ANN002, ANN003, ANN201, ANN202 ANN204, ANN401
 
 from collections.abc import Sequence
-from typing import Any, Literal, Self, SupportsIndex, TypeAlias, TypeVar, overload
+from typing import Any, Literal, Self, SupportsIndex, TypeAlias, overload
 
 from _typeshed import Incomplete
-from typing_extensions import TypeIs, deprecated
+from typing_extensions import TypeIs, TypeVar, deprecated
 
 import numpy as np
 from numpy import (
@@ -221,10 +221,10 @@ __all__ = [
     "zeros_like",
 ]
 
-_ShapeT = TypeVar("_ShapeT", bound=tuple[int, ...])
-_ShapeT_co = TypeVar("_ShapeT_co", bound=tuple[int, ...], covariant=True)
+_ShapeT = TypeVar("_ShapeT", bound=_Shape)
+_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, default=_Shape, covariant=True)
 _DTypeT = TypeVar("_DTypeT", bound=dtype)
-_DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, covariant=True)
+_DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, default=dtype, covariant=True)
 _ArrayT = TypeVar("_ArrayT", bound=ndarray[Any, Any])
 _ScalarT = TypeVar("_ScalarT", bound=generic)
 _ScalarT_co = TypeVar("_ScalarT_co", bound=generic, covariant=True)

--- a/numpy/typing/tests/data/pass/literal.py
+++ b/numpy/typing/tests/data/pass/literal.py
@@ -17,7 +17,6 @@ ACF = frozenset({None, "A", "C", "F"})
 CF = frozenset({None, "C", "F"})
 
 order_list: list[tuple[frozenset[str | None], Callable[..., Any]]] = [
-    (KACF, partial(np.ndarray, 1)),
     (KACF, AR.tobytes),
     (KACF, partial(AR.astype, int)),
     (KACF, AR.copy),
@@ -25,7 +24,8 @@ order_list: list[tuple[frozenset[str | None], Callable[..., Any]]] = [
     (KACF, AR.flatten),
     (KACF, AR.ravel),
     (KACF, partial(np.array, 1)),
-    # NOTE: __call__ is needed due to mypy 1.11 bugs (#17620, #17631)
+    # NOTE: __call__ is needed due to mypy bugs (#17620, #17631)
+    (KACF, partial(np.ndarray.__call__, 1)),
     (CF, partial(np.zeros.__call__, 1)),
     (CF, partial(np.ones.__call__, 1)),
     (CF, partial(np.empty.__call__, 1)),


### PR DESCRIPTION
Static type-checkers now consider ``_: np.ndarray`` as equivalent to ``_: npt.NDArray[Any]``.
Similarly, ``_: np.flatiter`` will now be considered equivalent to ``_: np.flatiter[np.ndarray]``.