### PR TITLE
DOC: Clarify (potentially misleading) nbytes docstring

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2684,7 +2684,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     If the array is a view, this shows how much memory it *would* use
     if it were copied into a separate array.
     The number of bytes does not include:
-        - Memory consumed by non-element attributes or the array object.
+        - Memory consumed by non-element attributes of the array object.
         - Memory indirectly held by the elements, e.g. in arrays storing
         python objects or `StringDType`.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2683,8 +2683,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     -----
     If the array is a view, this shows how much memory it *would* use
     if it were copied into a separate array.
-    Does not include memory consumed by non-element attributes of the
-    array object.
+    The number of bytes does not include:
+        - Memory consumed by non-element attributes or the array object.
+        - Memory indirectly held by the elements, e.g. in arrays storing
+        python objects or `StringDType`.
 
     See Also
     --------
@@ -2701,16 +2703,13 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     >>> np.prod(x.shape) * x.itemsize
     480
 
-    >>> import numpy as np
-    >>> arr = np.arange(100).reshape(10, 10, 1)
-    >>> arr_1 = np.broadcast_to(arr, (10, 10, 1000))
-    >>> arr_2 = np.lib.stride_tricks.sliding_window_view(arr, 5, 0)
+    Although an array and its view share the same data buffer, their `nbytes` are different:
+    >>> arr = np.arange(10)
+    >>> view = arr[::2]
     >>> arr.nbytes
-    800
-    >>> arr_1.nbytes
-    800000
-    >>> arr_2.nbytes
-    2400
+    80
+    >>> view.nbytes
+    40
 
     """))
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2676,10 +2676,14 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('flat',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     """
-    Total bytes consumed by the elements of the array.
+    Total number of bytes the array's data would consume if stored
+    contiguously in memory.
 
     Notes
     -----
+    If the array is a view, this shows how much memory it *would* use
+    if it were copied into a separate array.
+    
     Does not include memory consumed by non-element attributes of the
     array object.
 
@@ -2697,6 +2701,17 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     480
     >>> np.prod(x.shape) * x.itemsize
     480
+
+    >>> import numpy as np
+    >>> arr = np.arange(100).reshape(10, 10, 1)
+    >>> arr_1 = np.broadcast_to(arr, (10, 10, 1000))
+    >>> arr_2 = np.lib.stride_tricks.sliding_window_view(arr, 5, 0)
+    >>> arr.nbytes
+    800
+    >>> arr_1.nbytes
+    800000
+    >>> arr_2.nbytes
+    2400
 
     """))
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2683,7 +2683,6 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     -----
     If the array is a view, this shows how much memory it *would* use
     if it were copied into a separate array.
-    
     Does not include memory consumed by non-element attributes of the
     array object.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2683,10 +2683,8 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nbytes',
     -----
     If the array is a view, this shows how much memory it *would* use
     if it were copied into a separate array.
-    The number of bytes does not include:
-        - Memory consumed by non-element attributes of the array object.
-        - Memory indirectly held by the elements, e.g. in arrays storing
-        python objects or `StringDType`.
+    The number of bytes does not include overhead from non-element attributes and memory
+    indirectly held by elements such as Python objects or `StringDType`.
 
     See Also
     --------


### PR DESCRIPTION
The documentation for `numpy.ndarray.nbytes` has the potentially misleading description that it's the "total bytes consumed by the elements of the array", but the `nbytes` for a view doesn't reflect the memory *consumption* of its elements, but rather what that consumption would've been if it were a copy. This has been mentioned before in #22925, but the issue was closed before this was clarified. I have included an additional example in the docstring that demonstrates this.
