### PR TITLE
MAINT: Enable linting with ruff E501

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -615,7 +615,8 @@ def notes(version_override):
     )
 
     try:
-        test_notes = _get_numpy_tools(pathlib.Path('ci', 'test_all_newsfragments_used.py'))
+        cmd = pathlib.Path('ci', 'test_all_newsfragments_used.py')
+        test_notes = _get_numpy_tools(cmd)
     except ModuleNotFoundError as e:
         raise click.ClickException(
             f"{e.msg}. Install the missing packages to use this command."

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,7 +20,8 @@ def replace_scalar_type_names():
     """ Rename numpy types to use the canonical names to make sphinx behave """
     import ctypes
 
-    Py_ssize_t = ctypes.c_int64 if ctypes.sizeof(ctypes.c_void_p) == 8 else ctypes.c_int32
+    sizeof_void_p = ctypes.sizeof(ctypes.c_void_p)
+    Py_ssize_t = ctypes.c_int64 if sizeof_void_p == 8 else ctypes.c_int32
 
     class PyObject(ctypes.Structure):
         pass

--- a/doc/source/reference/random/performance.py
+++ b/doc/source/reference/random/performance.py
@@ -74,7 +74,8 @@ rel = rel.T
 print(rel.to_csv(float_format='%0d'))
 
 # Cross-platform table
-rows = ['32-bit Unsigned Ints', '64-bit Unsigned Ints', 'Uniforms', 'Normals', 'Exponentials']
+rows = ['32-bit Unsigned Ints', '64-bit Unsigned Ints', 'Uniforms',
+        'Normals', 'Exponentials']
 xplat = rel.reindex(rows, axis=0)
 xplat = 100 * (xplat / xplat.MT19937.values[:, None])
 overall = np.exp(np.log(xplat).mean(0))

--- a/numpy/ctypeslib/_ctypeslib.py
+++ b/numpy/ctypeslib/_ctypeslib.py
@@ -409,7 +409,7 @@ if ctypes is not None:
         # ctypes doesn't care about field order
         field_data = sorted(field_data, key=lambda f: f[0])
 
-        if len(field_data) > 1 and all(offset == 0 for offset, name, ctype in field_data):
+        if len(field_data) > 1 and all(offset == 0 for offset, _, _ in field_data):
             # union, if multiple fields all at address 0
             size = 0
             _fields_ = []

--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -243,5 +243,5 @@ class DTypePromotionError(TypeError):
     DTypePromotionError: field names `('field1', 'field2')` and `('field1',)`
     mismatch.
 
-    """
+    """  # noqa: E501
     pass

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -198,8 +198,7 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
     >>> t = np.arange(256)
     >>> sp = np.fft.fft(np.sin(t))
     >>> freq = np.fft.fftfreq(t.shape[-1])
-    >>> plt.plot(freq, sp.real, freq, sp.imag)
-    [<matplotlib.lines.Line2D object at 0x...>, <matplotlib.lines.Line2D object at 0x...>]
+    >>> _ = plt.plot(freq, sp.real, freq, sp.imag)
     >>> plt.show()
 
     """

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -84,7 +84,7 @@ class TestFFTShift:
         assert_array_almost_equal(fft.ifftshift(shift_dim_both), freqs)
 
     def test_equal_to_original(self):
-        """ Test that the new (>=v1.15) implementation (see #10073) is equal to the original (<=v1.14) """
+        """ Test the new (>=v1.15) and old implementations are equal (see #10073) """
         from numpy._core import asarray, concatenate, arange, take
 
         def original_fftshift(x, axes=None):

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -233,7 +233,8 @@ def build(cfile, outputfilename, compile_extra, link_extra,
                               cwd=build_dir,
                               )
     else:
-        subprocess.check_call(["meson", "setup", "--vsenv", "..", f'--native-file={os.fspath(native_file_name)}'],
+        subprocess.check_call(["meson", "setup", "--vsenv",
+                               "..", f'--native-file={os.fspath(native_file_name)}'],
                               cwd=build_dir
                               )
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,6 +14,8 @@ extend-exclude = [
     "numpy/_core/src/common/pythoncapi-compat",
 ]
 
+line-length = 88
+
 [lint]
 preview = true
 extend-select = [
@@ -38,7 +40,6 @@ ignore = [
     "E266",   # Too many leading `#` before block comment
     "E302",   # TODO: Expected 2 blank lines, found 1
     "E402",   # Module level import not at top of file
-    "E501",   # TODO: Line too long
     "E712",   # Avoid equality comparisons to `True` or `False`
     "E721",   # TODO: Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance check
     "E731",   # Do not assign a `lambda` expression, use a `def`
@@ -49,3 +50,17 @@ ignore = [
 
 [lint.per-file-ignores]
 "test*.py" = ["E201", "E714"]
+"benchmarks/*py" = ["E501"]
+"numpy/_build_utils/*py" = ["E501"]
+"numpy/__init__.py" = ["E501"]
+"numpy/_core/**" = ["E501"]
+"numpy/core/**" = ["E501"]
+"numpy/_typing/*py" = ["E501"]
+"numpy/lib/*py" = ["E501"]
+"numpy/linalg/*py" = ["E501"]
+"numpy/ma/*py" = ["E501"]
+"numpy/polynomial/*py" = ["E501"]
+"numpy/tests/*py" = ["E501"]
+"numpy/random/*py" = ["E501"]
+"numpy*pyi" = ["E501"]
+"numpy/f2py/*py" = ["E501"]


### PR DESCRIPTION
In this PR we gradually start enforcing the maximum line length rules using ruff. In followup PRs (each one relatively small, could be done by new contributors) we can change the codebase step by step.

* The numpy max line width has most recently been changed to 88 in https://github.com/numpy/numpy/pull/27320. Also see https://github.com/numpy/numpy/issues/24994#issuecomment-2322129388

* The total number of max line length violations is quite large. We can reduce the number of changes by setting the ruff max-line-length to a larger value, but to me that only makes sense if we would consider increasing the official max line length value.

* If the PR is accepted I will create a tracking issue for other contributors. 
 
@charris 

**update**: tracking issue is #28947

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
