### PR TITLE
DOC: Remove references to Python 2/3

### DIFF
--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -13,11 +13,10 @@ The array interface protocol
    This page describes the NumPy-specific API for accessing the contents of
    a NumPy array from other C extensions. :pep:`3118` --
    :c:func:`The Revised Buffer Protocol <PyObject_GetBuffer>` introduces
-   similar, standardized API to Python 2.6 and 3.0 for any extension
-   module to use. Cython__'s buffer array support
-   uses the :pep:`3118` API; see the `Cython NumPy
+   similar, standardized API for any extension module to use. Cython__'s
+   buffer array support uses the :pep:`3118` API; see the `Cython NumPy
    tutorial`__. Cython provides a way to write code that supports the buffer
-   protocol with Python versions older than 2.6 because it has a
+   protocol of Python versions older than 2.6 because it has a
    backward-compatible implementation utilizing the array interface
    described here.
 

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -15,10 +15,7 @@ The array interface protocol
    :c:func:`The Revised Buffer Protocol <PyObject_GetBuffer>` introduces
    similar, standardized API for any extension module to use. Cython__'s
    buffer array support uses the :pep:`3118` API; see the `Cython NumPy
-   tutorial`__. Cython provides a way to write code that supports the buffer
-   protocol of Python versions older than 2.6 because it has a
-   backward-compatible implementation utilizing the array interface
-   described here.
+   tutorial`__.
 
 __ https://cython.org/
 __ https://github.com/cython/cython/wiki/tutorials-numpy

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -65,10 +65,10 @@ Some of the scalar types are essentially equivalent to fundamental
 Python types and therefore inherit from them as well as from the
 generic array scalar type:
 
-====================  ===========================  =============
+====================  ===========================  =========
 Array scalar type     Related Python type          Inherits?
-====================  ===========================  =============
-:class:`int_`         :class:`int`                 Python 2 only
+====================  ===========================  =========
+:class:`int_`         :class:`int`                 no
 :class:`double`       :class:`float`               yes
 :class:`cdouble`      :class:`complex`             yes
 :class:`bytes_`       :class:`bytes`               yes
@@ -76,7 +76,7 @@ Array scalar type     Related Python type          Inherits?
 :class:`bool_`        :class:`bool`                no
 :class:`datetime64`   :class:`datetime.datetime`   no
 :class:`timedelta64`  :class:`datetime.timedelta`  no
-====================  ===========================  =============
+====================  ===========================  =========
 
 The :class:`bool_` data type is very similar to the Python
 :class:`bool` but does not inherit from it because Python's
@@ -86,9 +86,9 @@ Python Boolean scalar.
 
 .. warning::
 
-   The :class:`int_` type does **not** inherit from the
-   :class:`int` built-in under Python 3, because type :class:`int` is no
-   longer a fixed-width integer type.
+   The :class:`int_` type does **not** inherit from the built-in
+   :class:`int`, because type :class:`int` is not a fixed-width
+   integer type.
 
 .. tip:: The default data type in NumPy is :class:`double`.
 

--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -134,9 +134,8 @@ A better technique would be to use a ``PyCapsule`` as a base object:
 Example of memory tracing with ``np.lib.tracemalloc_domain``
 ------------------------------------------------------------
 
-Note that since Python 3.6 (or newer), the builtin ``tracemalloc`` module can be used to
-track allocations inside NumPy. NumPy places its CPU memory allocations into the 
-``np.lib.tracemalloc_domain`` domain.
+The builtin ``tracemalloc`` module can be used to track allocations inside NumPy.
+NumPy places its CPU memory allocations into the  ``np.lib.tracemalloc_domain`` domain.
 For additional information, check: https://docs.python.org/3/library/tracemalloc.html.
 
 Here is an example on how to use ``np.lib.tracemalloc_domain``:

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -36,10 +36,10 @@ New types are defined in C by two basic steps:
 
 Instead of special method names which define behavior for Python
 classes, there are "function tables" which point to functions that
-implement the desired results. Since Python 2.2, the PyTypeObject
-itself has become dynamic which allows C types that can be "sub-typed
-"from other C-types in C, and sub-classed in Python. The children
-types inherit the attributes and methods from their parent(s).
+implement the desired results. The PyTypeObject itself is dynamic
+which allows C types that can be "sub-typed" from other C-types in C,
+and sub-classed in Python. The children types inherit the attributes
+and methods from their parent(s).
 
 There are two major new types: the ndarray ( :c:data:`PyArray_Type` )
 and the ufunc ( :c:data:`PyUFunc_Type` ). Additional types play a

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -9,8 +9,8 @@ well-behaved (writable and aligned). Under normal circumstances, arrays
 created using the common constructors such as :meth:`numpy.empty` will satisfy
 these requirements.
 
-This example makes use of Python 3 :mod:`concurrent.futures` to fill an array
-using multiple threads.  Threads are long-lived so that repeated calls do not
+This example makes use of:mod:`concurrent.futures` to fill an array using
+multiple threads.  Threads are long-lived so that repeated calls do not
 require any additional overheads from thread creation.
 
 The random numbers generated are reproducible in the sense that the same

--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -676,8 +676,7 @@ are only a handful of key differences between the two.
 
    -  For ``array``, **``*`` means element-wise multiplication**, while
       **``@`` means matrix multiplication**; they have associated functions
-      ``multiply()`` and ``dot()``.  (Before Python 3.5, ``@`` did not exist
-      and one had to use ``dot()`` for matrix multiplication).
+      ``multiply()`` and ``dot()``.
    -  For ``matrix``, **``*`` means matrix multiplication**, and for
       element-wise multiplication one has to use the ``multiply()`` function.
 

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -2830,7 +2830,7 @@ add_newdoc('numpy._core.umath', 'matmul',
       >>> # n is 7, k is 4, m is 3
 
     The matmul function implements the semantics of the ``@`` operator
-    introduced in Python 3.5 following :pep:`465`.
+    defined in :pep:`465`.
 
     It uses an optimized BLAS library when possible (see `numpy.linalg`).
 
@@ -3581,8 +3581,8 @@ add_newdoc('numpy._core.umath', 'remainder',
 
         This should not be confused with:
 
-        * Python 3.7's `math.remainder` and C's ``remainder``, which
-          computes the IEEE remainder, which are the complement to
+        * Python's `math.remainder` and C's ``remainder``, which
+          compute the IEEE remainder, which are the complement to
           ``round(x1 / x2)``.
         * The MATLAB ``rem`` function and or the C ``%`` operator which is the
           complement to ``int(x1 / x2)``.

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -318,7 +318,7 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
     buf->len = (npy_intp) view.len;
 
     /*
-     * In Python 3 both of the deprecated functions PyObject_AsWriteBuffer and
+     * Both of the deprecated functions PyObject_AsWriteBuffer and
      * PyObject_AsReadBuffer that this code replaces release the buffer. It is
      * up to the object that supplies the buffer to guarantee that the buffer
      * sticks around after the release.

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2327,7 +2327,7 @@ PyArray_FromInterface(PyObject *origin)
         }
         data = (char *)view.buf;
         /*
-         * In Python 3 both of the deprecated functions PyObject_AsWriteBuffer and
+         * Both of the deprecated functions PyObject_AsWriteBuffer and
          * PyObject_AsReadBuffer that this code replaces release the buffer. It is
          * up to the object that supplies the buffer to guarantee that the buffer
          * sticks around after the release.

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1484,7 +1484,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
         if (argpart == NULL) {
             ret = argsort(valptr, idxptr, N, op);
-            /* Object comparisons may raise an exception in Python 3 */
+            /* Object comparisons may raise an exception */
             if (needs_api && PyErr_Occurred()) {
                 ret = -1;
             }
@@ -1498,7 +1498,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
             for (i = 0; i < nkth; ++i) {
                 ret = argpart(valptr, idxptr, N, kth[i], pivots, &npiv, nkth, op);
-                /* Object comparisons may raise an exception in Python 3 */
+                /* Object comparisons may raise an exception */
                 if (needs_api && PyErr_Occurred()) {
                     ret = -1;
                 }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1854,7 +1854,6 @@ array_reduce_ex_picklebuffer(PyArrayObject *self, int protocol)
 
     descr = PyArray_DESCR(self);
 
-    /* we expect protocol 5 to be available in Python 3.8 */
     if (npy_cache_import_runtime("pickle", "PickleBuffer", &picklebuf_class) == -1) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2310,7 +2310,7 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         buffer = view.buf;
         buflen = view.len;
         /*
-         * In Python 3 both of the deprecated functions PyObject_AsWriteBuffer and
+         * Both of the deprecated functions PyObject_AsWriteBuffer and
          * PyObject_AsReadBuffer that this code replaces release the buffer. It is
          * up to the object that supplies the buffer to guarantee that the buffer
          * sticks around after the release.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6133,15 +6133,13 @@ class TestRecord:
 
     def test_fromarrays_unicode(self):
         # A single name string provided to fromarrays() is allowed to be unicode
-        # on both Python 2 and 3:
         x = np._core.records.fromarrays(
             [[0], [1]], names='a,b', formats='i4,i4')
         assert_equal(x['a'][0], 0)
         assert_equal(x['b'][0], 1)
 
     def test_unicode_order(self):
-        # Test that we can sort with order as a unicode field name in both Python 2 and
-        # 3:
+        # Test that we can sort with order as a unicode field name
         name = 'b'
         x = np.array([1, 3, 2], dtype=[(name, int)])
         x.sort(order=name)

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1583,8 +1583,7 @@ class TestRegression:
         assert_equal(c1, c2)
 
     def test_fromfile_tofile_seeks(self):
-        # On Python 3, tofile/fromfile used to get (#1610) the Python
-        # file handle out of sync
+        # tofile/fromfile used to get (#1610) the Python file handle out of sync
         with tempfile.NamedTemporaryFile() as f:
             f.write(np.arange(255, dtype='u1').tobytes())
 

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -724,7 +724,7 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
     pickle_kwargs : dict, optional
         Additional keyword arguments to pass to pickle.dump, excluding
         'protocol'. These are only useful when pickling objects in object
-        arrays on Python 3 to Python 2 compatible format.
+        arrays to Python 2 compatible format.
 
     Raises
     ------
@@ -793,8 +793,7 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
         Whether to allow writing pickled data. Default: False
     pickle_kwargs : dict
         Additional keyword arguments to pass to pickle.load. These are only
-        useful when loading object arrays saved on Python 2 when using
-        Python 3.
+        useful when loading object arrays saved on Python 2.
     max_header_size : int, optional
         Maximum allowed size of the header.  Large headers may not be safe
         to load securely and thus require explicitly passing a larger value.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -136,7 +136,7 @@ class NpzFile(Mapping):
     pickle_kwargs : dict, optional
         Additional keyword arguments to pass on to pickle.load.
         These are only useful when loading object arrays saved on
-        Python 2 when using Python 3.
+        Python 2.
     max_header_size : int, optional
         Maximum allowed size of the header.  Large headers may not be safe
         to load securely and thus require explicitly passing a larger value.
@@ -338,13 +338,13 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         execute arbitrary code. If pickles are disallowed, loading object
         arrays will fail. Default: False
     fix_imports : bool, optional
-        Only useful when loading Python 2 generated pickled files on Python 3,
+        Only useful when loading Python 2 generated pickled files,
         which includes npy/npz files containing object arrays. If `fix_imports`
         is True, pickle will try to map the old Python 2 names to the new names
         used in Python 3.
     encoding : str, optional
         What encoding to use when reading Python 2 strings. Only useful when
-        loading Python 2 generated pickled files in Python 3, which includes
+        loading Python 2 generated pickled files, which includes
         npy/npz files containing object arrays. Values other than 'latin1',
         'ASCII', and 'bytes' are not allowed, as they can corrupt numerical
         data. Default: 'ASCII'
@@ -526,7 +526,7 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
 
         .. deprecated:: 2.1
             This flag is ignored since NumPy 1.17 and was only needed to
-            support loading some files in Python 2 written in Python 3.
+            support loading in Python 2 some files written in Python 3.
 
     See Also
     --------

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2009,8 +2009,8 @@ class TestLeaks:
         # exposed in gh-11867 as np.vectorized, but the problem stems from
         # frompyfunc.
         # class.attribute = np.frompyfunc(<method>) creates a
-        # reference cycle if <method> is a bound class method. It requires a
-        # gc collection cycle to break the cycle (on CPython 3)
+        # reference cycle if <method> is a bound class method.
+        # It requires a gc collection cycle to break the cycle.
         import gc
         A_func = getattr(self.A, name)
         gc.disable()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -305,7 +305,7 @@ class TestSavezLoad(RoundtripTest):
             np.savez(tmp, data='LOVELY LOAD')
             # We need to check if the garbage collector can properly close
             # numpy npz file returned by np.load when their reference count
-            # goes to zero.  Python 3 running in debug mode raises a
+            # goes to zero.  Python running in debug mode raises a
             # ResourceWarning when file closing is left to the garbage
             # collector, so we catch the warnings.
             with suppress_warnings() as sup:
@@ -625,7 +625,7 @@ class TestSaveTxt:
 
         # Since Python 3.8, the default start method for multiprocessing has
         # been changed from 'fork' to 'spawn' on macOS, causing inconsistency
-        # on memory sharing model, lead to failed test for check_large_zip
+        # on memory sharing model, leading to failed test for check_large_zip
         ctx = get_context('fork')
         p = ctx.Process(target=check_large_zip, args=(memoryerror_raised,))
         p.start()

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1306,7 +1306,7 @@ hypot = _MaskedBinaryOperation(umath.hypot)
 
 # Domained binary ufuncs
 divide = _DomainedBinaryOperation(umath.divide, _DomainSafeDivide(), 0, 1)
-true_divide = divide  # Since Python 3 just an alias for divide.
+true_divide = divide  # Just an alias for divide.
 floor_divide = _DomainedBinaryOperation(umath.floor_divide,
                                         _DomainSafeDivide(), 0, 1)
 remainder = _DomainedBinaryOperation(umath.remainder,

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2156,7 +2156,7 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     This makes it possible to trigger any warning afresh inside the context
     manager without disturbing the state of warnings outside.
 
-    For compatibility with Python 3.0, please consider all arguments to be
+    For compatibility with Python, please consider all arguments to be
     keyword-only.
 
     Parameters

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1526,7 +1526,7 @@ def assert_warn_len_equal(mod, n_in_context):
     num_warns = len(mod_warns)
 
     if 'version' in mod_warns:
-        # Python 3 adds a 'version' entry to the registry,
+        # Python adds a 'version' entry to the registry,
         # do not count it.
         num_warns -= 1
 


### PR DESCRIPTION
I have removed references to Python 2 or Python 3 wherever I feel it doesn't help intelligibility any more.

By the way, shouldn't `info` be deprecated?

https://github.com/numpy/numpy/blob/e4f0cd39589cbd6f6ada26b35f44d0bd55f0bdca/numpy/compat/py3k.py#L123-L130