### PR TITLE
MNT: deprecate numpy.f2py.diagnose (instead of discarding it)

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -16,7 +16,7 @@ import warnings
 
 from numpy.exceptions import VisibleDeprecationWarning
 
-from . import diagnose, f2py2e
+from . import f2py2e
 
 run_main = f2py2e.run_main
 main = f2py2e.main

--- a/numpy/f2py/diagnose.py
+++ b/numpy/f2py/diagnose.py
@@ -2,6 +2,12 @@
 import os
 import sys
 import tempfile
+import warnings
+
+# NumPy 2.3.0, 2025-05-01
+warnings.warn('The module numpy.f2py.diagnose is deprecated since NumPy 2.3.0.',
+              DeprecationWarning,
+              stacklevel=2)
 
 
 def run_command(cmd):

--- a/numpy/f2py/diagnose.py
+++ b/numpy/f2py/diagnose.py
@@ -4,6 +4,12 @@ import sys
 import tempfile
 
 
+def run_command(cmd):
+    print(f'Running {cmd!r}:')
+    os.system(cmd)
+    print('------')
+
+
 def run():
     _path = os.getcwd()
     os.chdir(tempfile.gettempdir())


### PR DESCRIPTION
Revert 4a3cbc4f6644bcb0f510d56c33382329004507c5 / #28876.

This module is part of the public API, so it needs to be deprecated before it can be discarded.

I'm not certain how to discard a module imported by `__init__.py`:
https://github.com/numpy/numpy/blob/c3fbf038d105beb81993d1a1c5328badc6e1b444/numpy/f2py/__init__.py#L19