### PR TITLE
MNT: Enforce ruff/Perflint rules (PERF)

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -53,7 +53,7 @@ class ArrayFunctionDispatcher(Benchmark):
         except AttributeError:
             raise NotImplementedError
         self.args = []
-        for _, aarg in get_squares_().items():
+        for aarg in get_squares_().values():
             arg = (aarg,) * 1  # no nin
             try:
                 self.afdn(*arg)
@@ -100,7 +100,7 @@ class UFunc(Benchmark):
         except AttributeError:
             raise NotImplementedError
         self.args = []
-        for _, aarg in get_squares_().items():
+        for aarg in get_squares_().values():
             arg = (aarg,) * self.ufn.nin
             try:
                 self.ufn(*arg)

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -466,8 +466,7 @@ def order_dict(d):
 def merge_api_dicts(dicts):
     ret = {}
     for d in dicts:
-        for k, v in d.items():
-            ret[k] = v
+        ret.update(dict(d.items()))
 
     return ret
 

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -466,7 +466,7 @@ def order_dict(d):
 def merge_api_dicts(dicts):
     ret = {}
     for d in dicts:
-        ret.update(dict(d.items()))
+        ret.update(d)
 
     return ret
 

--- a/numpy/f2py/func2subr.py
+++ b/numpy/f2py/func2subr.py
@@ -77,7 +77,7 @@ def var2fixfortran(vars, a, fa=None, f90mode=None):
 
 def useiso_c_binding(rout):
     useisoc = False
-    for key, value in rout['vars'].items():
+    for value in rout['vars'].values():
         kind_value = value.get('kindselector', {}).get('kind')
         if kind_value in isoc_kindmap:
             return True

--- a/numpy/lib/introspect.py
+++ b/numpy/lib/introspect.py
@@ -80,14 +80,13 @@ def opt_func_info(func_name=None, signature=None):
         sig_pattern = re.compile(signature)
         matching_sigs = {}
         for k, v in matching_funcs.items():
-            matching_chars = {
-                chars: targets
-                for chars, targets in v.items()
+            matching_chars = {}
+            for chars, targets in v.items():
                 if any(
                     sig_pattern.search(c) or sig_pattern.search(dtype(c).name)
                     for c in chars
-                )
-            }
+                ):
+                    matching_chars[chars] = targets  # noqa: PERF403
             if matching_chars:
                 matching_sigs[k] = matching_chars
     else:

--- a/numpy/lib/introspect.py
+++ b/numpy/lib/introspect.py
@@ -80,13 +80,14 @@ def opt_func_info(func_name=None, signature=None):
         sig_pattern = re.compile(signature)
         matching_sigs = {}
         for k, v in matching_funcs.items():
-            matching_chars = {}
-            for chars, targets in v.items():
+            matching_chars = {
+                chars: targets
+                for chars, targets in v.items()
                 if any(
                     sig_pattern.search(c) or sig_pattern.search(dtype(c).name)
                     for c in chars
-                ):
-                    matching_chars[chars] = targets
+                )
+            }
             if matching_chars:
                 matching_sigs[k] = matching_chars
     else:

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -124,7 +124,7 @@ def assert_equal(actual, desired, err_msg=''):
         for k, i in desired.items():
             if k not in actual:
                 raise AssertionError(f"{k} not in {actual}")
-            assert_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}')
+            assert_equal(actual[k], i, f'key={k!r}\n{err_msg}')
         return
     # Case #2: lists .....
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
@@ -162,12 +162,12 @@ def fail_if_equal(actual, desired, err_msg='',):
         for k, i in desired.items():
             if k not in actual:
                 raise AssertionError(repr(k))
-            fail_if_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}')
+            fail_if_equal(actual[k], i, f'key={k!r}\n{err_msg}')
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         fail_if_equal(len(actual), len(desired), err_msg)
-        for k in range(len(desired)):
-            fail_if_equal(actual[k], desired[k], f'item={k!r}\n{err_msg}')
+        for k, i in enumerate(desired):
+            fail_if_equal(actual[k], i, f'item={k!r}\n{err_msg}')
         return
     if isinstance(actual, np.ndarray) or isinstance(desired, np.ndarray):
         return fail_if_array_equal(actual, desired, err_msg)

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -121,10 +121,10 @@ def assert_equal(actual, desired, err_msg=''):
         if not isinstance(actual, dict):
             raise AssertionError(repr(type(actual)))
         assert_equal(len(actual), len(desired), err_msg)
-        for k, i in desired.items():
+        for k in desired:
             if k not in actual:
                 raise AssertionError(f"{k} not in {actual}")
-            assert_equal(actual[k], i, f'key={k!r}\n{err_msg}')
+            assert_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}')
         return
     # Case #2: lists .....
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
@@ -159,15 +159,15 @@ def fail_if_equal(actual, desired, err_msg='',):
         if not isinstance(actual, dict):
             raise AssertionError(repr(type(actual)))
         fail_if_equal(len(actual), len(desired), err_msg)
-        for k, i in desired.items():
+        for k in desired:
             if k not in actual:
                 raise AssertionError(repr(k))
-            fail_if_equal(actual[k], i, f'key={k!r}\n{err_msg}')
+            fail_if_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}')
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         fail_if_equal(len(actual), len(desired), err_msg)
-        for k, i in enumerate(desired):
-            fail_if_equal(actual[k], i, f'item={k!r}\n{err_msg}')
+        for k in range(len(desired)):
+            fail_if_equal(actual[k], desired[k], f'item={k!r}\n{err_msg}')
         return
     if isinstance(actual, np.ndarray) or isinstance(desired, np.ndarray):
         return fail_if_array_equal(actual, desired, err_msg)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -364,16 +364,16 @@ def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False):
         if not isinstance(actual, dict):
             raise AssertionError(repr(type(actual)))
         assert_equal(len(actual), len(desired), err_msg, verbose)
-        for k, i in desired.items():
+        for k in desired:
             if k not in actual:
                 raise AssertionError(repr(k))
-            assert_equal(actual[k], i, f'key={k!r}\n{err_msg}',
+            assert_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}',
                          verbose)
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         assert_equal(len(actual), len(desired), err_msg, verbose)
-        for k, i in enumerate(desired):
-            assert_equal(actual[k], i, f'item={k!r}\n{err_msg}',
+        for k in range(len(desired)):
+            assert_equal(actual[k], desired[k], f'item={k!r}\n{err_msg}',
                          verbose)
         return
     from numpy import imag, iscomplexobj, real

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -367,13 +367,13 @@ def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False):
         for k, i in desired.items():
             if k not in actual:
                 raise AssertionError(repr(k))
-            assert_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}',
+            assert_equal(actual[k], i, f'key={k!r}\n{err_msg}',
                          verbose)
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         assert_equal(len(actual), len(desired), err_msg, verbose)
-        for k in range(len(desired)):
-            assert_equal(actual[k], desired[k], f'item={k!r}\n{err_msg}',
+        for k, i in enumerate(desired):
+            assert_equal(actual[k], i, f'item={k!r}\n{err_msg}',
                          verbose)
         return
     from numpy import imag, iscomplexobj, real

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,6 +32,7 @@ extend-select = [
     "FLY",
     "I",
     "PD",
+    "PERF",
     "E",
     "W",
     "PGH",
@@ -39,32 +40,33 @@ extend-select = [
     "UP",
 ]
 ignore = [
-    "B006",   # Do not use mutable data structures for argument defaults
-    "B007",   # Loop control variable not used within loop body
-    "B011",   # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
-    "B023",   # Function definition does not bind loop variable
-    "B028",   # No explicit `stacklevel` keyword argument found
-    "B904",   # Within an `except` clause distinguish raised exceptions from errors in exception handling
-    "B905",   #`zip()` without an explicit `strict=` parameter
-    "C408",   # Unnecessary `dict()` call (rewrite as a literal)
-    "ISC002", # Implicitly concatenated string literals over multiple lines
-    "PIE790", # Unnecessary `pass` statement
-    "PD901",  # Avoid using the generic variable name `df` for DataFrames
-    "E241",   # Multiple spaces after comma
-    "E265",   # Block comment should start with `# `
-    "E266",   # Too many leading `#` before block comment
-    "E302",   # TODO: Expected 2 blank lines, found 1
-    "E402",   # Module level import not at top of file
-    "E712",   # Avoid equality comparisons to `True` or `False`
-    "E721",   # TODO: Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance check
-    "E731",   # Do not assign a `lambda` expression, use a `def`
-    "E741",   # Ambiguous variable name
-    "F403",   # `from ... import *` used; unable to detect undefined names
-    "F405",   # may be undefined, or defined from star imports
-    "F821",   # Undefined name
-    "F841",   # Local variable is assigned to but never used
-    "UP015",  # Unnecessary mode argument
-    "UP031",  # TODO: Use format specifiers instead of percent format
+    "B006",    # Do not use mutable data structures for argument defaults
+    "B007",    # Loop control variable not used within loop body
+    "B011",    # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+    "B023",    # Function definition does not bind loop variable
+    "B028",    # No explicit `stacklevel` keyword argument found
+    "B904",    # Within an `except` clause distinguish raised exceptions from errors in exception handling
+    "B905",    #`zip()` without an explicit `strict=` parameter
+    "C408",    # Unnecessary `dict()` call (rewrite as a literal)
+    "ISC002",  # Implicitly concatenated string literals over multiple lines
+    "PIE790",  # Unnecessary `pass` statement
+    "PD901",   # Avoid using the generic variable name `df` for DataFrames
+    "PERF401", # PERF401 Use a list comprehension to create a transformed list
+    "E241",    # Multiple spaces after comma
+    "E265",    # Block comment should start with `# `
+    "E266",    # Too many leading `#` before block comment
+    "E302",    # TODO: Expected 2 blank lines, found 1
+    "E402",    # Module level import not at top of file
+    "E712",    # Avoid equality comparisons to `True` or `False`
+    "E721",    # TODO: Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance check
+    "E731",    # Do not assign a `lambda` expression, use a `def`
+    "E741",    # Ambiguous variable name
+    "F403",    # `from ... import *` used; unable to detect undefined names
+    "F405",    # may be undefined, or defined from star imports
+    "F821",    # Undefined name
+    "F841",    # Local variable is assigned to but never used
+    "UP015" ,  # Unnecessary mode argument
+    "UP031",   # TODO: Use format specifiers instead of percent format
 ]
 
 [lint.per-file-ignores]

--- a/ruff.toml
+++ b/ruff.toml
@@ -51,7 +51,7 @@ ignore = [
     "ISC002",  # Implicitly concatenated string literals over multiple lines
     "PIE790",  # Unnecessary `pass` statement
     "PD901",   # Avoid using the generic variable name `df` for DataFrames
-    "PERF401", # PERF401 Use a list comprehension to create a transformed list
+    "PERF401", # Use a list comprehension to create a transformed list
     "E241",    # Multiple spaces after comma
     "E265",    # Block comment should start with `# `
     "E266",    # Too many leading `#` before block comment


### PR DESCRIPTION
Left out because I seem to recall maintainers don't like it:
* [manual-list-comprehension (PERF401)](https://docs.astral.sh/ruff/rules/manual-list-comprehension/#manual-list-comprehension-perf401)