### PR TITLE
MNT: Get rif of `# pylint: ` pragma controls

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -19,7 +19,6 @@ Released for unlimited redistribution.
 .. moduleauthor:: Pierre Gerard-Marchant
 
 """
-# pylint: disable-msg=E1002
 import builtins
 import functools
 import inspect

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=W0400,W0511,W0611,W0612,W0614,R0201,E1102
 """Tests suite for MaskedArray & subclassing.
 
 :author: Pierre Gerard-Marchant

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=W0611, W0612, W0511
 """Tests suite for MaskedArray.
 Adapted from the original test_ma by Pierre Gerard-Marchant
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=W0611, W0612, W0511,R0201
 """Tests suite for mrecords.
 
 :author: Pierre Gerard-Marchant

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=W0611, W0612, W0511,R0201
 """Tests suite for MaskedArray & subclassing.
 
 :author: Pierre Gerard-Marchant


### PR DESCRIPTION
We use ruff instead:

| Pylint | ruff |
| ------------- | ------------- |
| E1002 super-on-old-class                                                                                                          | (Python 2 only)                                                                                                                  |
| [E1102 not-callable](https://pylint.readthedocs.io/en/stable/user_guide/messages/error/not-callable.html)                         | -                                                                                                                                |
| [R0201 no-self-use](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/no-self-use.html)                        | [PLR6301](https://docs.astral.sh/ruff/rules/no-self-use/)                                                                        |
| W0400                                                                                                                             | undocumented, perhaps [W0404](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/reimported.html)?              |
| [W0404 reimported](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/reimported.html)                           | [F811](https://docs.astral.sh/ruff/rules/redefined-while-unused/)                                                                |
| [W0511 fixme](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/fixme.html)                                     | [FIX001](https://docs.astral.sh/ruff/rules/line-contains-fixme/), [FIX003](https://docs.astral.sh/ruff/rules/line-contains-xxx/) |
| [W0611 unused-import](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/unused-import.html)                     | [F401](https://docs.astral.sh/ruff/rules/unused-import/)                                                                         |
| [W0612 unused-variable](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/unused-variable.html)                 | [F841](https://docs.astral.sh/ruff/rules/unused-variable/)                                                                       |
| [W0614 unused-wildcard-import](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/unused-wildcard-import.html)   | -        |

Equivalent Pylint and ruff rules are tracked here: https://github.com/astral-sh/ruff/issues/970