### PR TITLE
MNT: Get rid of `version: $Id` CVS tags

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -5,7 +5,6 @@ A collection of utilities for `numpy.ma`.
 
 :author: Pierre Gerard-Marchant
 :contact: pierregm_at_uga_dot_edu
-:version: $Id: extras.py 3473 2007-10-29 15:18:13Z jarrod.millman $
 
 """
 __all__ = [

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -4,7 +4,6 @@ Adapted from the original test_ma by Pierre Gerard-Marchant
 
 :author: Pierre Gerard-Marchant
 :contact: pierregm_at_uga_dot_edu
-:version: $Id: test_extras.py 3473 2007-10-29 15:18:13Z jarrod.millman $
 
 """
 import warnings

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -3,7 +3,6 @@
 
 :author: Pierre Gerard-Marchant
 :contact: pierregm_at_uga_dot_edu
-:version: $Id: test_subclassing.py 3473 2007-10-29 15:18:13Z jarrod.millman $
 
 """
 import numpy as np

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -2,7 +2,6 @@
 
 :author: Pierre Gerard-Marchant
 :contact: pierregm_at_uga_dot_edu
-:version: $Id: testutils.py 3529 2007-11-13 08:01:14Z jarrod.millman $
 
 """
 import operator


### PR DESCRIPTION
From some `numpy/ma` files:
https://github.com/numpy/numpy/blob/c3fbf038d105beb81993d1a1c5328badc6e1b444/numpy/ma/extras.py#L6-L8