### PR TITLE
MNT: import numpy as np

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -1763,7 +1763,7 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     True
 
     """
-    import numpy as _nx
+    import numpy as np
     a, wrap = _makearray(a)
 
     if hermitian:
@@ -1775,9 +1775,9 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
             sgn = sign(s)
             s = abs(s)
             sidx = argsort(s)[..., ::-1]
-            sgn = _nx.take_along_axis(sgn, sidx, axis=-1)
-            s = _nx.take_along_axis(s, sidx, axis=-1)
-            u = _nx.take_along_axis(u, sidx[..., None, :], axis=-1)
+            sgn = np.take_along_axis(sgn, sidx, axis=-1)
+            s = np.take_along_axis(s, sidx, axis=-1)
+            u = np.take_along_axis(u, sidx[..., None, :], axis=-1)
             # singular values are unsigned, move the sign into v
             vt = transpose(u * sgn[..., None, :]).conjugate()
             return SVDResult(wrap(u), s, wrap(vt))


### PR DESCRIPTION
It's unclear why the non-standard `import numpy as _nx` was introduced here:
https://github.com/numpy/numpy/pull/15468
