### PR TITLE
DOC: improves np.fromfile file description (#28840)

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1528,7 +1528,9 @@ add_newdoc('numpy._core.multiarray', 'fromfile',
     Parameters
     ----------
     file : file or str or Path
-        Open file object or filename.
+        An open file object, a string containing the filename, or a Path object.
+        When reading from a file object it must support random access
+        (i.e. it must have tell and seek methods).
     dtype : data-type
         Data type of the returned array.
         For binary files, it is used to determine the size and byte-order


### PR DESCRIPTION
This PR improves the description of the the `file` positional argument on `numpy.fromfile`'s documentation.

Although it intends to close issue #28840, it is possible to keep the issue  open and tag it as an enhancement.