### PR TITLE
MNT: Use isinstance() instead of comparing type()

### DIFF
--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -587,7 +587,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
         the choice of algorithm used using benchmarking wisdom.
 
     """
-    if type(arrays) is tuple:
+    if isinstance(arrays, tuple):
         # not strictly necessary, but saves us from:
         #  - more than one way to do things - no point treating tuples like
         #    lists
@@ -598,7 +598,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
             'Only lists can be used to arrange blocks, and np.block does '
             'not allow implicit conversion from tuple to ndarray.'
         )
-    elif type(arrays) is list and len(arrays) > 0:
+    elif isinstance(arrays, list) and len(arrays) > 0:
         idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
                       for i, arr in enumerate(arrays))
 
@@ -618,7 +618,7 @@ def _block_check_depths_match(arrays, parent_index=[]):
                 first_index = index
 
         return first_index, max_arr_ndim, final_size
-    elif type(arrays) is list and len(arrays) == 0:
+    elif isinstance(arrays, list) and len(arrays) == 0:
         # We've 'bottomed out' on an empty list
         return parent_index + [None], 0, 0
     else:
@@ -770,7 +770,7 @@ def _block_dispatcher(arrays):
     # Use type(...) is list to match the behavior of np.block(), which special
     # cases list specifically rather than allowing for generic iterables or
     # tuple. Also, we know that list.__array_function__ will never exist.
-    if type(arrays) is list:
+    if isinstance(arrays, list):
         for subarrays in arrays:
             yield from _block_dispatcher(subarrays)
     else:

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1486,7 +1486,7 @@ def test_iter_copy_casts_structured2():
     # Array of two structured scalars:
     for res in res1, res2:
         # Cast to tuple by getitem, which may be weird and changeable?:
-        assert type(res["a"][0]) == tuple
+        assert isinstance(res["a"][0], tuple)
         assert res["a"][0] == (1, 1)
 
     for res in res1, res2:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -82,7 +82,7 @@ def strptime(s, fmt=None):
     2.5.
 
     """
-    if type(s) == bytes:
+    if isinstance(s, bytes):
         s = s.decode("latin1")
     return datetime(*time.strptime(s, fmt)[:3])
 

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -1016,7 +1016,7 @@ class ABCPolyBase(abc.ABC):
             if domain[0] == domain[1]:
                 domain[0] -= 1
                 domain[1] += 1
-        elif type(domain) is list and len(domain) == 0:
+        elif isinstance(domain, list) and len(domain) == 0:
             domain = cls.domain
 
         if window is None:
@@ -1064,7 +1064,7 @@ class ABCPolyBase(abc.ABC):
         [roots] = pu.as_series([roots], trim=False)
         if domain is None:
             domain = pu.getdomain(roots)
-        elif type(domain) is list and len(domain) == 0:
+        elif isinstance(domain, list) and len(domain) == 0:
             domain = cls.domain
 
         if window is None:


### PR DESCRIPTION
Not entirely equivalent, in case of derived classes. Yet, I believe the new behaviour is the desired behaviour.