### PR TITLE
Revert "DEP: Deprecate `.T` property for non-2dim arrays and scalars"

### DIFF
--- a/doc/release/upcoming_changes/28678.deprecation.rst
+++ b/doc/release/upcoming_changes/28678.deprecation.rst
@@ -1,5 +1,0 @@
-* The ``arr.T`` property has been deprecated for array scalars and arrays with dimensionality
-  different than ``2`` to be compatible with the Array API standard. To achieve similar
-  behavior when ``arr.ndim != 2``, either ``arr.transpose()``, or ``arr.mT`` (swaps
-  the last two axes only), or ``np.permute_dims(arr, range(arr.ndim)[::-1])`` (compatible
-  with the Array API) can be used.

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2887,8 +2887,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('T',
     """
     View of the transposed array.
 
-    Same as ``self.transpose()`` except that it requires
-    the array to be 2-dimensional.
+    Same as ``self.transpose()``.
 
     Examples
     --------
@@ -2900,6 +2899,12 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('T',
     >>> a.T
     array([[1, 3],
            [2, 4]])
+
+    >>> a = np.array([1, 2, 3, 4])
+    >>> a
+    array([1, 2, 3, 4])
+    >>> a.T
+    array([1, 2, 3, 4])
 
     See Also
     --------

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -848,18 +848,6 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 static PyObject *
 array_transpose_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    int ndim = PyArray_NDIM(self);
-    if (ndim != 2) {
-        /* Deprecated 2025-04-19, NumPy 2.3 */
-        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
-                "In the future, the `.T` property will be supported for "
-                "2-dimensional arrays only. Received %d-dimensional "
-                "array. Either `arr.transpose()` or `.mT` (which swaps "
-                "the last two axes only) should be used instead."
-                "(Deprecated NumPy 2.3)", ndim) < 0) {
-            return NULL;
-        }
-    }
     return PyArray_Transpose(self, NULL);
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1925,16 +1925,6 @@ gentype_flat_get(PyObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 gentype_transpose_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
-    /* Deprecated 2025-04-19, NumPy 2.3 */
-    if (DEPRECATE(
-            "In the future, the `.T` property for array scalars will "
-            "raise an error. If you called `.T` on an array scalar "
-            "intentionally, you can safely drop it. In other cases, "
-            "`arr.transpose()` or `.mT` (which swaps the last "
-            "two axes only) should be used instead. "
-            "(Deprecated NumPy 2.3)") < 0) {
-        return NULL;
-    }
     Py_INCREF(self);
     return self;
 }

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -13,6 +13,12 @@ from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F4
 import numpy as np
 from numpy.testing import assert_raises, temppath
 
+try:
+    import pytz  # noqa: F401
+    _has_pytz = True
+except ImportError:
+    _has_pytz = False
+
 
 class _DeprecationTestCase:
     # Just as warning: warnings uses re.match, so the start of this message
@@ -446,22 +452,3 @@ class TestAddNewdocUFunc(_DeprecationTestCase):
                 struct_ufunc.add_triplet, "new docs"
             )
         )
-
-
-class TestDeprecatedTPropScalar(_DeprecationTestCase):
-    # Deprecated in Numpy 2.3, 2025-05
-    message = ("In the future, the `.T` property for array scalars will "
-               "raise an error.")
-
-    def test_deprecated(self):
-        self.assert_deprecated(lambda: np.int64(1).T)
-
-
-class TestDeprecatedTPropNon2Dim(_DeprecationTestCase):
-    # Deprecated in Numpy 2.3, 2025-05
-    message = ("In the future, the `.T` property will be supported for "
-               r"2-dimensional arrays only. Received \d+-dimensional array.")
-
-    def test_deprecated(self):
-        for shape in [(5,), (2, 3, 4)]:
-            self.assert_deprecated(lambda: np.ones(shape).T)

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -441,9 +441,9 @@ class TestEinsum:
             a = np.arange(n * 3 * 2, dtype=dtype).reshape(n, 3, 2)
             b = np.arange(n, dtype=dtype)
             assert_equal(np.einsum("i..., i...", a, b, optimize=do_opt),
-                         np.inner(a.transpose(), b.transpose()).transpose())
+                         np.inner(a.T, b.T).T)
             assert_equal(np.einsum(a, [0, Ellipsis], b, [0, Ellipsis], optimize=do_opt),
-                         np.inner(a.transpose(), b.transpose()).transpose())
+                         np.inner(a.T, b.T).T)
 
         # outer(a,b)
         for n in range(1, 17):
@@ -483,22 +483,22 @@ class TestEinsum:
             for n in range(1, 17):
                 a = np.arange(4 * n, dtype=dtype).reshape(4, n)
                 b = np.arange(n, dtype=dtype)
-                assert_equal(np.einsum("ji,j", a.T, b, optimize=do_opt),
-                             np.dot(b, a.T))
-                assert_equal(np.einsum(a.T, [1, 0], b, [1], optimize=do_opt),
-                             np.dot(b, a.T))
+                assert_equal(np.einsum("ji,j", a.T, b.T, optimize=do_opt),
+                             np.dot(b.T, a.T))
+                assert_equal(np.einsum(a.T, [1, 0], b.T, [1], optimize=do_opt),
+                             np.dot(b.T, a.T))
 
                 c = np.arange(4, dtype=dtype)
-                np.einsum("ji,j", a.T, b, out=c,
+                np.einsum("ji,j", a.T, b.T, out=c,
                           dtype='f8', casting='unsafe', optimize=do_opt)
                 assert_equal(c,
-                             np.dot(b.astype('f8'),
+                             np.dot(b.T.astype('f8'),
                                     a.T.astype('f8')).astype(dtype))
                 c[...] = 0
-                np.einsum(a.T, [1, 0], b, [1], out=c,
+                np.einsum(a.T, [1, 0], b.T, [1], out=c,
                           dtype='f8', casting='unsafe', optimize=do_opt)
                 assert_equal(c,
-                             np.dot(b.astype('f8'),
+                             np.dot(b.T.astype('f8'),
                                     a.T.astype('f8')).astype(dtype))
 
             # matmat(a,b) / a.dot(b) where a is matrix, b is matrix

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -331,8 +331,8 @@ class TestIndexing:
         a = np.full((3, 4, 2), -1)
         b = np.full((3, 4, 2), -1)
 
-        a[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).transpose()
-        b[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).transpose().copy()
+        a[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T
+        b[[0, 1]] = np.arange(2 * 4 * 2).reshape(2, 4, 2).T.copy()
 
         assert_equal(a, b)
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3235,7 +3235,7 @@ class TestMethods:
         assert_equal(x0.flatten('F'), x0.T.flatten())
         assert_equal(x1.flatten(), y1)
         assert_equal(x1.flatten('F'), y1f)
-        assert_equal(x1.flatten('F'), x1.transpose().flatten())
+        assert_equal(x1.flatten('F'), x1.T.flatten())
 
     @pytest.mark.parametrize('func', (np.dot, np.matmul))
     def test_arr_mult(self, func):
@@ -3340,8 +3340,8 @@ class TestMethods:
         ret2 = func(a.copy(), b.copy())
         assert_equal(ret1, ret2)
 
-        ret1 = func(b.transpose(), a.transpose())
-        ret2 = func(b.transpose().copy(), a.transpose().copy())
+        ret1 = func(b.T, a.T)
+        ret2 = func(b.T.copy(), a.T.copy())
         assert_equal(ret1, ret2)
 
     def test_dot(self):
@@ -4678,7 +4678,7 @@ class TestArgmaxArgminCommon:
                 wrong_shape[0] = 2
             wrong_outarray = np.empty(wrong_shape, dtype=res.dtype)
             with pytest.raises(ValueError):
-                method(arr.transpose(), axis=axis,
+                method(arr.T, axis=axis,
                         out=wrong_outarray, keepdims=True)
 
         # non-contiguous arrays
@@ -4689,14 +4689,14 @@ class TestArgmaxArgminCommon:
             new_shape[axis] = 1
         new_shape = tuple(new_shape)
 
-        _res_orig = method(arr.transpose(), axis=axis)
+        _res_orig = method(arr.T, axis=axis)
         res_orig = _res_orig.reshape(new_shape)
-        res = method(arr.transpose(), axis=axis, keepdims=True)
+        res = method(arr.T, axis=axis, keepdims=True)
         assert_equal(res, res_orig)
         assert_(res.shape == new_shape)
         outarray = np.empty(new_shape[::-1], dtype=res.dtype)
-        outarray = outarray.transpose()
-        res1 = method(arr.transpose(), axis=axis, out=outarray,
+        outarray = outarray.T
+        res1 = method(arr.T, axis=axis, out=outarray,
                             keepdims=True)
         assert_(res1 is outarray)
         assert_equal(res, outarray)
@@ -4716,7 +4716,7 @@ class TestArgmaxArgminCommon:
                 wrong_shape[0] = 2
             wrong_outarray = np.empty(wrong_shape, dtype=res.dtype)
             with pytest.raises(ValueError):
-                method(arr.transpose(), axis=axis,
+                method(arr.T, axis=axis,
                         out=wrong_outarray, keepdims=True)
 
     @pytest.mark.parametrize('method', ['max', 'min'])
@@ -8345,7 +8345,7 @@ class TestNewBufferProtocol:
         fd = io.BytesIO()
         fd.write(c.data)
 
-        fortran = c.transpose()
+        fortran = c.T
         assert_(memoryview(fortran).strides == (8, 80, 800))
 
         arr = np.ones((1, 10))

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -887,7 +887,7 @@ class TestRegression:
 
     def test_copy_detection_zero_dim(self):
         # Ticket #658
-        np.indices((0, 3, 4)).transpose().reshape(-1, 3)
+        np.indices((0, 3, 4)).T.reshape(-1, 3)
 
     def test_flat_byteorder(self):
         # Ticket #657
@@ -906,7 +906,7 @@ class TestRegression:
 
     def test_copy_detection_corner_case(self):
         # Ticket #658
-        np.indices((0, 3, 4)).transpose().reshape(-1, 3)
+        np.indices((0, 3, 4)).T.reshape(-1, 3)
 
     def test_object_array_refcounting(self):
         # Ticket #633

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -358,10 +358,7 @@ class TestConcatenate:
         a2 = res[..., 6:]
         assert_array_equal(concatenate((a0, a1, a2), 2), res)
         assert_array_equal(concatenate((a0, a1, a2), -1), res)
-        assert_array_equal(
-            concatenate((a0.transpose(), a1.transpose(), a2.transpose()), 0),
-            res.transpose(),
-        )
+        assert_array_equal(concatenate((a0.T, a1.T, a2.T), 0), res.T)
 
         out = res.copy()
         rout = concatenate((a0, a1, a2), 2, out=out)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1037,8 +1037,8 @@ class TestUfunc:
         assert_equal(x[0, 0, 0, 0, 0, 0], -1, err_msg=msg2)
         assert_array_equal(np.vecdot(a, b), np.sum(a * b, axis=-1), err_msg=msg)
         x = np.arange(24).reshape(2, 3, 4)
-        a = x.transpose()
-        b = x.transpose()
+        a = x.T
+        b = x.T
         a[0, 0, 0] = -1
         assert_equal(x[0, 0, 0], -1, err_msg=msg2)
         assert_array_equal(np.vecdot(a, b), np.sum(a * b, axis=-1), err_msg=msg)

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -413,7 +413,7 @@ class TestFFT1D:
     def test_fftn_out_argument(self, dtype, transpose, axes):
         def zeros_like(x):
             if transpose:
-                return np.zeros_like(x.transpose()).transpose()
+                return np.zeros_like(x.T).T
             else:
                 return np.zeros_like(x)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2771,7 +2771,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         >>> v1 = np.sum(w)
         >>> v2 = np.sum(w * a)
         >>> m -= np.sum(m * w, axis=None, keepdims=True) / v1
-        >>> cov = np.dot(m * w, m) * v1 / (v1**2 - ddof * v2)
+        >>> cov = np.dot(m * w, m.T) * v1 / (v1**2 - ddof * v2)
 
     Note that when ``a == 1``, the normalization factor
     ``v1 / (v1**2 - ddof * v2)`` goes over to ``1 / (np.sum(f) - ddof)``

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -673,7 +673,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     scale = NX.sqrt((lhs * lhs).sum(axis=0))
     lhs /= scale
     c, resids, rank, s = lstsq(lhs, rhs, rcond)
-    c = (c.transpose() / scale).transpose()  # broadcast scale coefficients
+    c = (c.T / scale).T  # broadcast scale coefficients
 
     # warn on rank reduction, which indicates an ill conditioned matrix
     if rank != order and not full:

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -49,8 +49,8 @@ def assert_same_as_ufunc(shape0, shape1, transposed=False, flipped=False):
     n = int(np.multiply.reduce(shape1))
     x1 = np.arange(n).reshape(shape1)
     if transposed:
-        x0 = x0.transpose()
-        x1 = x1.transpose()
+        x0 = x0.T
+        x1 = x1.T
     if flipped:
         x0 = x0[::-1]
         x1 = x1[::-1]

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -621,8 +621,8 @@ def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
         van = vander_f(x, lmax)[:, deg]
 
     # set up the least squares matrices in transposed form
-    lhs = van.transpose()
-    rhs = y.transpose()
+    lhs = van.T
+    rhs = y.T
     if w is not None:
         w = np.asarray(w) + 0.0
         if w.ndim != 1:
@@ -646,9 +646,8 @@ def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
     scl[scl == 0] = 1
 
     # Solve the least squares problem.
-    c, resids, rank, s = np.linalg.lstsq(lhs.transpose() / scl,
-                                         rhs.transpose(), rcond)
-    c = (c.transpose() / scl).transpose()
+    c, resids, rank, s = np.linalg.lstsq(lhs.T / scl, rhs.T, rcond)
+    c = (c.T / scl).T
 
     # Expand c to include non-fitted coefficients which are set to zero
     if deg.ndim > 0:


### PR DESCRIPTION
Reverts numpy/numpy#28678