### PR TITLE
MAINT: update NPY_FEATURE_VERSION after dropping python 3.10

### DIFF
--- a/numpy/_core/include/numpy/numpyconfig.h
+++ b/numpy/_core/include/numpy/numpyconfig.h
@@ -123,8 +123,8 @@
     /* user provided a target version, use it */
     #define NPY_FEATURE_VERSION NPY_TARGET_VERSION
 #else
-    /* Use the default (increase when dropping Python 3.10 support) */
-    #define NPY_FEATURE_VERSION NPY_1_21_API_VERSION
+    /* Use the default (increase when dropping Python 3.11 support) */
+    #define NPY_FEATURE_VERSION NPY_1_23_API_VERSION
 #endif
 
 /* Sanity check the (requested) feature version */


### PR DESCRIPTION
Fixes #28992 

Python 3.10 was dropped in https://github.com/numpy/numpy/pull/27862, but the corresponding changes to `NPY_FEATURE_VERSION` got missed. The first release to support Python 3.11 [was](https://github.com/numpy/numpy/releases/tag/v1.23.2) v1.23.2, so now that Python 3.10 is dropped, the lowest possible `NPY_FEATURE_VERSION` is 1.23.

