### PR TITLE
TYP: remove ``from __future__ import annotations``

### DIFF
--- a/numpy/_core/tests/test_arraymethod.py
+++ b/numpy/_core/tests/test_arraymethod.py
@@ -3,8 +3,6 @@ This file tests the generic aspects of ArrayMethod.  At the time of writing
 this is private API, but when added, public API may be added here.
 """
 
-from __future__ import annotations
-
 import types
 from typing import Any
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import builtins
 import collections.abc
 import ctypes

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -1,7 +1,5 @@
 """Private counterpart of ``numpy.typing``."""
 
-from __future__ import annotations
-
 from ._array_like import ArrayLike as ArrayLike
 from ._array_like import NDArray as NDArray
 from ._array_like import _ArrayLike as _ArrayLike

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from collections.abc import Callable, Collection, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypeVar, runtime_checkable
@@ -20,7 +18,6 @@ else:
 
 _T = TypeVar("_T")
 _ScalarT = TypeVar("_ScalarT", bound=np.generic)
-_ScalarT_co = TypeVar("_ScalarT_co", bound=np.generic, covariant=True)
 _DTypeT = TypeVar("_DTypeT", bound=dtype[Any])
 _DTypeT_co = TypeVar("_DTypeT_co", covariant=True, bound=dtype[Any])
 

--- a/numpy/_typing/_nbit_base.py
+++ b/numpy/_typing/_nbit_base.py
@@ -30,7 +30,6 @@ class NBitBase:
 
     .. code-block:: python
 
-        >>> from __future__ import annotations
         >>> from typing import TypeVar, TYPE_CHECKING
         >>> import numpy as np
         >>> import numpy.typing as npt

--- a/numpy/_typing/_nested_sequence.py
+++ b/numpy/_typing/_nested_sequence.py
@@ -1,14 +1,6 @@
 """A module containing the `_NestedSequence` protocol."""
 
-from __future__ import annotations
-
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Protocol,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -36,8 +28,6 @@ class _NestedSequence(Protocol[_T_co]):
     --------
     .. code-block:: python
 
-        >>> from __future__ import annotations
-
         >>> from typing import TYPE_CHECKING
         >>> import numpy as np
         >>> from numpy._typing import _NestedSequence
@@ -64,7 +54,7 @@ class _NestedSequence(Protocol[_T_co]):
         """Implement ``len(self)``."""
         raise NotImplementedError
 
-    def __getitem__(self, index: int, /) -> _T_co | _NestedSequence[_T_co]:
+    def __getitem__(self, index: int, /) -> "_T_co | _NestedSequence[_T_co]":
         """Implement ``self[x]``."""
         raise NotImplementedError
 
@@ -72,11 +62,11 @@ class _NestedSequence(Protocol[_T_co]):
         """Implement ``x in self``."""
         raise NotImplementedError
 
-    def __iter__(self, /) -> Iterator[_T_co | _NestedSequence[_T_co]]:
+    def __iter__(self, /) -> "Iterator[_T_co | _NestedSequence[_T_co]]":
         """Implement ``iter(self)``."""
         raise NotImplementedError
 
-    def __reversed__(self, /) -> Iterator[_T_co | _NestedSequence[_T_co]]:
+    def __reversed__(self, /) -> "Iterator[_T_co | _NestedSequence[_T_co]]":
         """Implement ``reversed(self)``."""
         raise NotImplementedError
 

--- a/numpy/f2py/_backends/_backend.py
+++ b/numpy/f2py/_backends/_backend.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 
 

--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import errno
 import os
 import re

--- a/numpy/typing/tests/test_runtime.py
+++ b/numpy/typing/tests/test_runtime.py
@@ -1,11 +1,9 @@
 """Test the runtime usage of `numpy.typing`."""
 
-from __future__ import annotations
-
 from typing import (
     Any,
     NamedTuple,
-    Union,
+    Union,  # pyright: ignore[reportDeprecated]
     get_args,
     get_origin,
     get_type_hints,
@@ -55,10 +53,7 @@ def test_get_type_hints(name: type, tup: TypeTup) -> None:
     """Test `typing.get_type_hints`."""
     typ = tup.typ
 
-    # Explicitly set `__annotations__` in order to circumvent the
-    # stringification performed by `from __future__ import annotations`
-    def func(a): pass
-    func.__annotations__ = {"a": typ, "return": None}
+    def func(a: typ) -> None: pass
 
     out = get_type_hints(func)
     ref = {"a": typ, "return": type(None)}
@@ -70,10 +65,7 @@ def test_get_type_hints_str(name: type, tup: TypeTup) -> None:
     """Test `typing.get_type_hints` with string-representation of types."""
     typ_str, typ = f"npt.{name}", tup.typ
 
-    # Explicitly set `__annotations__` in order to circumvent the
-    # stringification performed by `from __future__ import annotations`
-    def func(a): pass
-    func.__annotations__ = {"a": typ_str, "return": None}
+    def func(a: typ_str) -> None: pass
 
     out = get_type_hints(func)
     ref = {"a": typ, "return": type(None)}

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib.util
 import os
 import re
@@ -118,7 +116,7 @@ def run_mypy() -> None:
                 filename = None
 
 
-def get_test_cases(*directories: str) -> Iterator[ParameterSet]:
+def get_test_cases(*directories: str) -> "Iterator[ParameterSet]":
     for directory in directories:
         for root, _, files in os.walk(directory):
             for fname in files:


### PR DESCRIPTION
There's no need for it, and will only make the life of runtime type-checkers more diffucult.