### PR TITLE
MNT: fix CI issues on main

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,7 +115,7 @@ jobs:
         build_runner:
           - [ macos-13, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
-        version: ["3.11", "3.14t"]
+        version: ["3.11", "3.14t-dev"]
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -124,14 +124,9 @@ jobs:
         fetch-tags: true
         persist-credentials: false
 
-    - uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        activate-environment: true
         python-version: ${{ matrix.version }}
-        enable-cache: false
-
-    - run:
-        uv pip install --python=${{ matrix.version }} pip
 
     - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       if: ${{ matrix.build_runner[0] == 'macos-13' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         compiler-pyversion:
           - ["MSVC", "3.11"]
-          - ["Clang-cl", "3.14t"]
+          - ["Clang-cl", "3.14t-dev"]
 
     steps:
     - name: Checkout
@@ -35,14 +35,9 @@ jobs:
         persist-credentials: false
 
     - name: Setup Python
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        activate-environment: true
         python-version: ${{ matrix.compiler-pyversion[1] }}
-        enable-cache: false
-
-    - run:
-        uv pip install --python=${{ matrix.version }} pip
 
     - name: Install build dependencies from PyPI
       run: |

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2490,9 +2490,9 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
             raise FloatingPointError(err_msg)
         elif err_s == "print":
             print(err_msg)
-              
+
     with errstate(invalid='ignore'):
-  
+
         result = (less_equal(abs(x - y), atol + rtol * abs(y))
                   & isfinite(y)
                   | (x == y))

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3222,7 +3222,7 @@ class TestIsclose:
                 # Making sure that i and j are not both numbers, because that won't create a warning
                 if (i == 1) and (j == 1):
                     continue
-                
+
                 with warnings.catch_warnings(record=True) as w:
 
                     warnings.simplefilter("always")


### PR DESCRIPTION
I guess @charris merged something that broke the linter on `main`. Also fixes some build failures due to outdated cp314 builds from uv by switching to setup-python.