### PR TITLE
BUG: Avoid compile errors in f2py modules

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1047,9 +1047,12 @@ long_double_from_pyobj(long_double* v, PyObject *obj, const char *errmess)
             PyArray_ScalarAsCtype(obj, v);
             return 1;
         }
-        else if (PyArray_Check(obj) && PyArray_TYPE(obj) == NPY_LONGDOUBLE) {
-            (*v) = *((npy_longdouble *)PyArray_DATA(obj));
-            return 1;
+        else if (PyArray_Check(obj)) {
+            PyArrayObject *arr = (PyArrayObject *)obj;
+            if (PyArray_TYPE(arr) == NPY_LONGDOUBLE) {
+                (*v) = *((npy_longdouble *)PyArray_DATA(arr));
+                return 1;
+            }
         }
     }
     if (double_from_pyobj(&d, obj, errmess)) {
@@ -1131,10 +1134,13 @@ complex_long_double_from_pyobj(complex_long_double* v, PyObject *obj, const char
             PyArray_ScalarAsCtype(obj, v);
             return 1;
         }
-        else if (PyArray_Check(obj) && PyArray_TYPE(obj)==NPY_CLONGDOUBLE) {
-            (*v).r = npy_creall(*(((npy_clongdouble *)PyArray_DATA(obj))));
-            (*v).i = npy_cimagl(*(((npy_clongdouble *)PyArray_DATA(obj))));
-            return 1;
+        else if (PyArray_Check(obj)) {
+            PyArrayObject *arr = (PyArrayObject *)obj;
+            if (PyArray_TYPE(arr)==NPY_CLONGDOUBLE) {
+                (*v).r = npy_creall(*(((npy_clongdouble *)PyArray_DATA(arr))));
+                (*v).i = npy_cimagl(*(((npy_clongdouble *)PyArray_DATA(arr))));
+                return 1;
+            }
         }
     }
     if (complex_double_from_pyobj(&cd,obj,errmess)) {


### PR DESCRIPTION
I've hit a couple of compile errors when using `f2py -c ...`:
```
../module.c:341:53: error: passing argument 1 of ‘PyArray_TYPE’ from incompatible pointer type [-Wincompatible-pointer-types]
  341 |         else if (PyArray_Check(obj) && PyArray_TYPE(obj) == NPY_LONGDOUBLE) {
      |                                                     ^~~
      |                                                     |
      |                                                     PyObject * {aka struct _object *}
In file included from /usr/lib64/python3.13/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
                 from /usr/lib64/python3.13/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                 from /usr/lib64/python3.13/site-packages/numpy/f2py/src/fortranobject.h:16,
                 from ../flibmodule.c:23:
/usr/lib64/python3.13/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1567:35: note: expected ‘const PyArrayObject *’ {aka ‘const struct tagPyArrayObject *’} but argument is of type ‘PyObject *’ {aka ‘struct _object *’}
 1567 | PyArray_TYPE(const PyArrayObject *arr)
      |              ~~~~~~~~~~~~~~~~~~~~~^~~

../module.c:342:53: error: passing argument 1 of ‘PyArray_DATA’ from incompatible pointer type [-Wincompatible-pointer-types]
  342 |             (*v) = *((npy_longdouble *)PyArray_DATA(obj));
      |                                                     ^~~
      |                                                     |
      |                                                     PyObject * {aka struct _object *}
/usr/lib64/python3.13/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1512:35: note: expected ‘const PyArrayObject *’ {aka ‘const struct tagPyArrayObject *’} but argument is of type ‘PyObject *’ {aka ‘struct _object *’}
 1512 | PyArray_DATA(const PyArrayObject *arr)
      |              ~~~~~~~~~~~~~~~~~~~~~^~~
```

Following some of the other uses of this API in the cfuncs file, this just uses an explicit pointer cast, as we've already validated it upon use.