### PR TITLE
DOC: Expand/clean up extension module import error

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -117,6 +117,7 @@ else:
             its source directory; please exit the numpy source tree, and relaunch
             your python interpreter from there."""
             raise ImportError(msg) from e
+        raise
 
     from . import _core
     from ._core import (

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -111,10 +111,12 @@ else:
     try:
         from numpy.__config__ import show_config
     except ImportError as e:
-        msg = """Error importing numpy: you should not try to import numpy from
-        its source directory; please exit the numpy source tree, and relaunch
-        your python interpreter from there."""
-        raise ImportError(msg) from e
+        if isinstance(e, ModuleNotFoundError) and e.name == "numpy.__config__":
+            # The __config__ module itself was not found, so add this info:
+            msg = """Error importing numpy: you should not try to import numpy from
+            its source directory; please exit the numpy source tree, and relaunch
+            your python interpreter from there."""
+            raise ImportError(msg) from e
 
     from . import _core
     from ._core import (

--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -35,7 +35,7 @@ except ImportError as exc:
                 f for f in os.listdir(path) if f.startswith("_multiarray_umath"))
         if len(candidates) == 0:
             bad_c_module_info = (
-                "We found no compiled module, was NumPy build successfully?\n")
+                "We found no compiled module, did NumPy build successfully?\n")
         else:
             candidate_str = '\n  * '.join(candidates)
             # cache_tag is documented to be possibly None, so just use name if it is

--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -24,11 +24,15 @@ except ImportError as exc:
     import sys
 
     # Basically always, the problem should be that the C module is wrong/missing...
-    if isinstance(exc, ModuleNotFoundError) and exc.name == "numpy._core._multiarray_umath":
+    if (
+        isinstance(exc, ModuleNotFoundError)
+        and exc.name == "numpy._core._multiarray_umath"
+    ):
         import sys
         candidates = []
         for path in __path__:
-            candidates.extend(f for f in os.listdir(path) if f.startswith("_multiarray_umath"))
+            candidates.extend(
+                f for f in os.listdir(path) if f.startswith("_multiarray_umath"))
         if len(candidates) == 0:
             bad_c_module_info = (
                 "We found no compiled module, was NumPy build successfully?\n")

--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -22,29 +22,56 @@ try:
     from . import multiarray
 except ImportError as exc:
     import sys
-    msg = """
+
+    # Basically always, the problem should be that the C module is wrong/missing...
+    if isinstance(exc, ModuleNotFoundError) and exc.name == "numpy._core._multiarray_umath":
+        import sys
+        candidates = []
+        for path in __path__:
+            candidates.extend(f for f in os.listdir(path) if f.startswith("_multiarray_umath"))
+        if len(candidates) == 0:
+            bad_c_module_info = (
+                "We found no compiled module, was NumPy build successfully?\n")
+        else:
+            candidate_str = '\n  * '.join(candidates)
+            # cache_tag is documented to be possibly None, so just use name if it is
+            # this guesses at cache_tag being the same as the extension module scheme
+            tag = sys.implementation.cache_tag or sys.implementation.name
+            bad_c_module_info = (
+                f"The following compiled module files exist, but seem incompatible\n"
+                f"with with either python '{tag}' or the "
+                f"platform '{sys.platform}':\n\n  * {candidate_str}\n"
+            )
+    else:
+        bad_c_module_info = ""
+
+    major, minor, *_ = sys.version_info
+    msg = f"""
 
 IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
 
 Importing the numpy C-extensions failed. This error can happen for
 many reasons, often due to issues with your setup or how NumPy was
 installed.
-
+{bad_c_module_info}
 We have compiled some common reasons and troubleshooting tips at:
 
     https://numpy.org/devdocs/user/troubleshooting-importerror.html
 
 Please note and check the following:
 
-  * The Python version is: Python%d.%d from "%s"
-  * The NumPy version is: "%s"
+  * The Python version is: Python {major}.{minor} from "{sys.executable}"
+  * The NumPy version is: "{__version__}"
 
 and make sure that they are the versions you expect.
-Please carefully study the documentation linked above for further help.
 
-Original error was: %s
-""" % (sys.version_info[0], sys.version_info[1], sys.executable,
-        __version__, exc)
+Please carefully study the information and documentation linked above.
+This is unlikely to be a NumPy issue but will be caused by a bad install
+or environment on your machine.
+
+Original error was: {exc}
+"""
+
     raise ImportError(msg) from exc
 finally:
     for envkey in env_added:


### PR DESCRIPTION
We get a lot of these reports and it is never us... But unfortunately, Python (currently) doesn't report *why* the module wasn't found. (I have  opened an issue asking for that.)

Until Python does, try to figure it out ourselves, i.e. list C modules (I guess its always one, but OK).
If anything it'll give *us* an immediate thing to point out if an issue is reported...

I also hid the "source import" thing to only occur if __config__ doesn't exist.  Not sure that catches this fully, but I also feel like this isn't an actual problem anymore (i.e. we could just delete it also).

Tested locally by renaming or deleting `_multiarray_umath`.