### PR TITLE
BLD: bump OpenBLAS version, use OpenBLAS for win-arm64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -186,7 +186,8 @@ jobs:
           name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: ./wheelhouse/*.whl
 
-      - uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
+      - name: install micromamba
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
         if: ${{ matrix.buildplat[1] != 'win_arm64' }} # unsupported platform at the moment
         with:
           # for installation of anaconda-client, required for upload to
@@ -199,6 +200,16 @@ jobs:
           environment-name: upload-env
           create-args: >-
             anaconda-client
+
+      - name: win-arm64 install anaconda client
+        if: ${{ matrix.buildplat[1] == 'win_arm64' }}
+        run: |
+          # Rust installation needed for rpds-py.
+          Invoke-WebRequest https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe -UseBasicParsing -Outfile rustup-init.exe
+          .\rustup-init.exe -y
+          $env:PATH="$env:PATH;$env:USERPROFILE\.cargo\bin"
+          pip install anaconda-client
+
 
       - name: Upload wheels
         if: success() && github.repository == 'numpy/numpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,18 +178,13 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-# This does not work, use CIBW_ENVIRONMENT_WINDOWS
-environment = {PKG_CONFIG_PATH="./.openblas"}
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=false build-dir=build"
 repair-wheel-command = "bash -el ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
+# This does not work, use CIBW_ENVIRONMENT_WINDOWS
+environment = {PKG_CONFIG_PATH="./.openblas"}
 
 [[tool.cibuildwheel.overrides]]
 select = "*-win32"
-config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
-repair-wheel-command = ""
-
-[[tool.cibuildwheel.overrides]]
-select = "*-win_arm64"
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
 repair-wheel-command = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,11 @@ config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=false build-dir=
 repair-wheel-command = "bash -el ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
 
 [[tool.cibuildwheel.overrides]]
+select = "*-win32"
+config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
+repair-wheel-command = ""
+
+[[tool.cibuildwheel.overrides]]
 select = "*-win_arm64"
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
 repair-wheel-command = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,11 +184,6 @@ config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=false build-dir=
 repair-wheel-command = "bash -el ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
 
 [[tool.cibuildwheel.overrides]]
-select = "*-win32"
-config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
-repair-wheel-command = ""
-
-[[tool.cibuildwheel.overrides]]
 select = "*-win_arm64"
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
 repair-wheel-command = ""

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.13
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.29.0.0
+scipy-openblas32==0.3.29.265.0

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,4 @@
 spin==0.13
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.29.265.0
+scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.29.0.0
-scipy-openblas64==0.3.29.0.0
+scipy-openblas32==0.3.29.265.0
+scipy-openblas64==0.3.29.265.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -2,4 +2,5 @@ spin==0.13
 # Keep this in sync with ci32_requirements.txt
 scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
 scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'
+# Note there is not yet a win-arm64 wheel, so we currently only exclude win-arm64
 scipy-openblas64==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,5 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.29.265.0
-scipy-openblas64==0.3.29.265.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'
+scipy-openblas64==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
 scipy-openblas32==0.3.29.265.0
-scipy-openblas64==0.3.29.265.0
+scipy-openblas64==0.3.29.265.0 ; sys_platform != 'win32' or platform_machine != 'arm64'

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
 scipy-openblas32==0.3.29.265.0
-scipy-openblas64==0.3.29.265.0 ; sys_platform != 'win32' or platform_machine != 'arm64'
+scipy-openblas64==0.3.29.265.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,9 +22,6 @@ fi
 if [[ $(python -c"import sys; print(sys.maxsize)") < $(python -c"import sys; print(2**33)") ]]; then
     echo "No BLAS used for 32-bit wheels"
     export INSTALL_OPENBLAS=false
-elif [[ $(python -c"import sysconfig; print(sysconfig.get_platform())") == "win-arm64" ]]; then
-    echo "No BLAS used for ARM64 wheels"
-    export INSTALL_OPENBLAS=false
 elif [ -z $INSTALL_OPENBLAS ]; then
     # the macos_arm64 build might not set this variable
     export INSTALL_OPENBLAS=true

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -3,31 +3,8 @@ set -xe
 WHEEL="$1"
 DEST_DIR="$2"
 
-# create a temporary directory in the destination folder and unpack the wheel
-# into there
 cwd=$PWD
-
-pushd $DEST_DIR
-mkdir -p tmp
-pushd tmp
-wheel unpack $WHEEL
-pushd numpy*
-
-# To avoid DLL hell, the file name of libopenblas that's being vendored with
-# the wheel has to be name-mangled. delvewheel is unable to name-mangle PYD
-# containing extra data at the end of the binary, which frequently occurs when
-# building with mingw.
-# We therefore find each PYD in the directory structure and strip them.
-
-for f in $(find ./numpy* -name '*.pyd'); do strip $f; done
-
-
-# now repack the wheel and overwrite the original
-wheel pack .
-mv -fv *.whl $WHEEL
-
 cd $DEST_DIR
-rm -rf tmp
 
 # the libopenblas.dll is placed into this directory in the cibw_before_build
 # script.


### PR DESCRIPTION
Closes #29035 by adding openblas support to the arm64 windows builds

This bumps the version of OpenBLAS from the 0.3.29 release to the latest develop HEAD (which had wheels for OpenBLAS on win-arm64), so it may impact other things.