### PR TITLE
BUG: Fix cache use regression

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -27,9 +27,22 @@
 #endif
 #endif
 
-#define NBUCKETS 1024 /* number of buckets for data*/
-#define NBUCKETS_DIM 16 /* number of buckets for dimensions/strides */
-#define NCACHE 7 /* number of cache entries per bucket */
+/* Do not enable the alloc cache if the GIL is disabled, or if ASAN or MSAN
+ * instrumentation is enabled. The cache makes ASAN use-after-free or MSAN
+ * use-of-uninitialized-memory warnings less useful. */
+#define USE_ALLOC_CACHE 1
+#ifdef Py_GIL_DISABLED
+# define USE_ALLOC_CACHE 0
+#elif defined(__has_feature)
+# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
+#  define USE_ALLOC_CACHE 0
+# endif
+#endif
+
+#if USE_ALLOC_CACHE
+# define NBUCKETS 1024 /* number of buckets for data*/
+# define NBUCKETS_DIM 16 /* number of buckets for dimensions/strides */
+# define NCACHE 7 /* number of cache entries per bucket */
 /* this structure fits neatly into a cacheline */
 typedef struct {
     npy_uintp available; /* number of cached pointers */
@@ -37,7 +50,7 @@ typedef struct {
 } cache_bucket;
 static cache_bucket datacache[NBUCKETS];
 static cache_bucket dimcache[NBUCKETS_DIM];
-
+#endif  /* USE_ALLOC_CACHE */
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with
@@ -97,20 +110,6 @@ indicate_hugepages(void *p, size_t size) {
     }
 #endif
 }
-
-
-/* Do not enable the alloc cache if the GIL is disabled, or if ASAN or MSAN
- * instrumentation is enabled. The cache makes ASAN use-after-free or MSAN
- * use-of-uninitialized-memory warnings less useful. */
-#ifdef Py_GIL_DISABLED
-#define USE_ALLOC_CACHE 0
-#elif defined(__has_feature)
-# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
-# define USE_ALLOC_CACHE 0
-# endif
-#else
-#define USE_ALLOC_CACHE 1
-#endif
 
 
 /* as the cache is managed in global variables verify the GIL is held */

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -39,7 +39,6 @@
 # endif
 #endif
 
-#if USE_ALLOC_CACHE
 # define NBUCKETS 1024 /* number of buckets for data*/
 # define NBUCKETS_DIM 16 /* number of buckets for dimensions/strides */
 # define NCACHE 7 /* number of cache entries per bucket */
@@ -50,7 +49,6 @@ typedef struct {
 } cache_bucket;
 static cache_bucket datacache[NBUCKETS];
 static cache_bucket dimcache[NBUCKETS_DIM];
-#endif  /* USE_ALLOC_CACHE */
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with


### PR DESCRIPTION
Backport of gh-29041.

gh-29006 got the branching wrong leaving the cache undefined on most GCC/clang, which means we wouldn't use it.

Also move it up so that we can just remove the unused globals entirely.

---

May not close gh-29038, but to me should remove the milestone (because we need more info to have confidence that there was a regression).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
