### PR TITLE
TYP: remove expired ``tostring`` methods

### DIFF
--- a/numpy/lib/_user_array_impl.pyi
+++ b/numpy/lib/_user_array_impl.pyi
@@ -2,7 +2,7 @@ from types import EllipsisType
 from typing import Any, Generic, Self, SupportsIndex, TypeAlias, overload
 
 from _typeshed import Incomplete
-from typing_extensions import TypeVar, deprecated, override
+from typing_extensions import TypeVar, override
 
 import numpy as np
 import numpy.typing as npt
@@ -220,8 +220,6 @@ class container(Generic[_ShapeT_co, _DTypeT_co]):
 
     #
     def copy(self, /) -> Self: ...
-    @deprecated("tostring() is deprecated. Use tobytes() instead.")
-    def tostring(self, /) -> bytes: ...
     def tobytes(self, /) -> bytes: ...
     def byteswap(self, /) -> Self: ...
     def astype(self, /, typecode: _DTypeLike[_ScalarT]) -> container[_ShapeT_co, np.dtype[_ScalarT]]: ...

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Any, Literal, Self, SupportsIndex, TypeAlias, overload
 
 from _typeshed import Incomplete
-from typing_extensions import TypeIs, TypeVar, deprecated
+from typing_extensions import TypeIs, TypeVar
 
 import numpy as np
 from numpy import (
@@ -1057,8 +1057,6 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
     def toflex(self) -> Incomplete: ...
     def torecords(self) -> Incomplete: ...
     def tolist(self, fill_value: Incomplete | None = None) -> Incomplete: ...
-    @deprecated("tostring() is deprecated. Use tobytes() instead.")
-    def tostring(self, /, fill_value: Incomplete | None = None, order: _OrderKACF = "C") -> bytes: ...  # type: ignore[override]
     def tobytes(self, /, fill_value: Incomplete | None = None, order: _OrderKACF = "C") -> bytes: ...  # type: ignore[override]
     def tofile(self, /, fid: Incomplete, sep: str = "", format: str = "%s") -> Incomplete: ...
 


### PR DESCRIPTION
This removes the stub annotations for

- `ma.MaskedArray.tostring()`
- `lib._user_array_impl.container.tostring()`