### PR TITLE
BLD: allow targeting webassembly without emscripten

### DIFF
--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -111,8 +111,9 @@
     #endif
 #elif defined(__loongarch_lp64)
     #define NPY_CPU_LOONGARCH64
-#elif defined(__EMSCRIPTEN__)
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
     /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */
+    /* __wasm__ is defined by clang when targeting wasm */
     #define NPY_CPU_WASM
 #else
     #error Unknown CPU, please report this to numpy maintainers with \


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This pull request updates NumPy's platform detection logic to support WebAssembly (WASM) targets compiled with Clang, independent of Emscripten.

Currently, the CPU architecture is only set to wasm when emscripten is detected (by checking for `__EMSCRIPTEN__`). However, Clang can compile to WebAssembly without Emscripten. By also including a check for `__wasm__`, this patch allows NumPy to detect WebAssembly targets compiled without Emscripten. 

This broadens NumPy's compatibility with WebAssembly toolchains and environments other than emscripten, such as WASIX.