### PR TITLE
BUG: raise TypeError for in-place string multiply via arithmetic operator

### DIFF
--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -751,11 +751,18 @@ string_multiply_resolve_descriptors(
 {
     if (given_descrs[2] == NULL) {
         PyErr_SetString(
-            PyExc_TypeError,
-            "The 'out' kwarg is necessary. Use numpy.strings.multiply without it.");
+                PyExc_TypeError,
+                "The 'out' kwarg is necessary when using the string multiply ufunc "
+                "directly. Use numpy.strings.multiply to multiply strings without specifying "
+                "'out'.");
         return _NPY_ERROR_OCCURRED_IN_CAST;
     }
-
+    else if (given_descrs[0] == given_descrs[2]) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Cannot use arithmetic operators to in-place multiply a "
+                        "fixed-width string. Use np.strings.multiply instead.");
+        return _NPY_ERROR_OCCURRED_IN_CAST;
+    }
     loop_descrs[0] = NPY_DT_CALL_ensure_canonical(given_descrs[0]);
     if (loop_descrs[0] == NULL) {
         return _NPY_ERROR_OCCURRED_IN_CAST;

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -227,6 +227,14 @@ class TestMethods:
         with pytest.raises(MemoryError):
             np.strings.multiply(np.array("abc", dtype=dt), sys.maxsize)
 
+        arr = np.array(['foo', 'bar'], dtype=dt)
+        if dt != "T":
+            with pytest.raises(TypeError):
+                arr *= 2
+        else:
+            arr *= 2
+            assert_array_equal(arr, ['foofoo', 'barbar'])
+
     @pytest.mark.parametrize("i_dt", [np.int8, np.int16, np.int32,
                                       np.int64, np.int_])
     def test_multiply_integer_dtypes(self, i_dt, dt):

--- a/numpy/typing/tests/data/pass/ma.py
+++ b/numpy/typing/tests/data/pass/ma.py
@@ -16,7 +16,7 @@ MAR_td64: MaskedArray[np.timedelta64] = np.ma.MaskedArray([np.timedelta64(1, "D"
 MAR_M_dt64: MaskedArray[np.datetime64] = np.ma.MaskedArray([np.datetime64(1, "D")])
 MAR_S: MaskedArray[np.bytes_] = np.ma.MaskedArray([b'foo'], dtype=np.bytes_)
 MAR_U: MaskedArray[np.str_] = np.ma.MaskedArray(['foo'], dtype=np.str_)
-MAR_T = cast(np.ma.MaskedArray[Any, np.dtypes.StringDType], np.ma.MaskedArray(["a"], "T"))
+MAR_T = cast(np.ma.MaskedArray[Any, np.dtypes.StringDType], np.ma.MaskedArray(["a"], dtype="T"))
 
 AR_b: npt.NDArray[np.bool] = np.array([True, False, True])
 
@@ -149,8 +149,6 @@ MAR_td64 *= AR_LIKE_u
 MAR_td64 *= AR_LIKE_i
 MAR_td64 *= AR_LIKE_f
 
-MAR_S *= 2
-MAR_U *= 2
 MAR_T *= 2
 
 # Inplace power


### PR DESCRIPTION
Fixes #29011.

I could add bounds checking to the loops themselves too, if people think it's worth adding that defensively.