### PR TITLE
BLD: use sonoma image on Cirrus for wheel build

### DIFF
--- a/tools/ci/cirrus_wheels.yml
+++ b/tools/ci/cirrus_wheels.yml
@@ -11,7 +11,7 @@ macosx_arm64_task:
       CIRRUS_CLONE_SUBMODULES: true
   macos_instance:
     matrix:
-      image: ghcr.io/cirruslabs/macos-monterey-xcode
+      image: ghcr.io/cirruslabs/macos-runner:sonoma
 
   matrix:
     - env:


### PR DESCRIPTION
As noted in #29039, cirrus no longer supports monteray. The [only image they support](https://cirrus-ci.org/guide/macOS/) is sonoma. This is for the wheel build with OpenBLAS, targeting macos_11_arm64. Maybe we should move that build to github, which provides free runners?

When bumping the OpenBLAS version in #29039, I see many failures related to OpenBLAS. So this is an attempt to change only one parameter to see if the errors are due to the image/xcode version, or due to an OpenBLAS regression.