### PR TITLE
TYP: Use `AnyShape` in `MaskedArray` type alias

### DIFF
--- a/numpy/typing/tests/data/fail/ma.pyi
+++ b/numpy/typing/tests/data/fail/ma.pyi
@@ -2,10 +2,10 @@ from typing import TypeAlias, TypeVar
 
 import numpy as np
 import numpy.typing as npt
-from numpy._typing import _Shape
+from numpy._typing import _AnyShape
 
 _ScalarT = TypeVar("_ScalarT", bound=np.generic)
-MaskedArray: TypeAlias = np.ma.MaskedArray[_Shape, np.dtype[_ScalarT]]
+MaskedArray: TypeAlias = np.ma.MaskedArray[_AnyShape, np.dtype[_ScalarT]]
 
 MAR_1d_f8: np.ma.MaskedArray[tuple[int], np.dtype[np.float64]]
 MAR_b: MaskedArray[np.bool]


### PR DESCRIPTION
Really minor, but I noticed that `_Shape` is used here, as opposed to `_AnyShape` which is used in `ndarray`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
