### PR TITLE
MAINT: use pypy 3.11 nightly which has a fix for ctypeslib

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,7 +82,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: 'pypy3.11-v7.3.19'
+        python-version: 'pypy3.11-nightly'
     - name: Setup using scipy-openblas
       run: |
         python -m pip install -r requirements/ci_requirements.txt


### PR DESCRIPTION
Backport of #29051.

Alternative to #29014. Fixes flaky ctypeslib test on PyPy. There are disadvantages to using PyPy's nightly build: it might cause spurious CI failures when the build is not available (it is not cached by the setup-python action, obviously), or the nightly is unusable. Both those should happen rarely but YMMV. I am tracking PyPy HEAD + Numpy HEAD on ubuntu, macos, windows in a weekly cron-driven CI job [here](https://github.com/pypy/binary-testing/actions/workflows/numpy.yml), the ubuntu one is generally green.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
