### PR TITLE
CI: bump to cibuildwheel 3.0.0b4

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a  # 2.23.3
+      - uses: pypa/cibuildwheel@cf078b0954f3fd08b8445a7bf2c3fb83ab3bb971  # v3.0.0b4
         env:
           CIBW_PLATFORM: pyodide
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@90a0ddeff0f23eebc21630e65d66d0f4955e9b94  # v3.0.0b1
+        uses: pypa/cibuildwheel@cf078b0954f3fd08b8445a7bf2c3fb83ab3bb971  # v3.0.0b4
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -4,10 +4,6 @@ set -xe
 
 PROJECT_DIR="$1"
 
-if [ -d tools ]; then
-    cd tools
-fi
-
 python -m pip install threadpoolctl
 python -c "import numpy; numpy.show_config()"
 


### PR DESCRIPTION
This bumps to cibuildwheel 3.0.0b4, which contains CPython 3.14.0b2, and removes the directory changing workaround.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
