### PR TITLE
BLD: bump OpenBLAS version, use OpenBLAS for win-arm64 [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -184,7 +184,8 @@ jobs:
           name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}
           path: ./wheelhouse/*.whl
 
-      - uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
+      - name: install micromamba
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
         if: ${{ matrix.buildplat[1] != 'win_arm64' }} # unsupported platform at the moment
         with:
           # for installation of anaconda-client, required for upload to
@@ -197,6 +198,16 @@ jobs:
           environment-name: upload-env
           create-args: >-
             anaconda-client
+
+      - name: win-arm64 install anaconda client
+        if: ${{ matrix.buildplat[1] == 'win_arm64' }}
+        run: |
+          # Rust installation needed for rpds-py.
+          Invoke-WebRequest https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe -UseBasicParsing -Outfile rustup-init.exe
+          .\rustup-init.exe -y
+          $env:PATH="$env:PATH;$env:USERPROFILE\.cargo\bin"
+          pip install anaconda-client
+
 
       - name: Upload wheels
         if: success() && github.repository == 'numpy/numpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,18 +178,13 @@ repair-wheel-command = [
 ]
 
 [tool.cibuildwheel.windows]
-# This does not work, use CIBW_ENVIRONMENT_WINDOWS
-environment = {PKG_CONFIG_PATH="./.openblas"}
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=false build-dir=build"
 repair-wheel-command = "bash -el ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
+# This does not work, use CIBW_ENVIRONMENT_WINDOWS
+environment = {PKG_CONFIG_PATH="./.openblas"}
 
 [[tool.cibuildwheel.overrides]]
 select = "*-win32"
-config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
-repair-wheel-command = ""
-
-[[tool.cibuildwheel.overrides]]
-select = "*-win_arm64"
 config-settings = "setup-args=--vsenv setup-args=-Dallow-noblas=true build-dir=build"
 repair-wheel-command = ""
 

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,4 @@
 spin==0.13
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.29.0.0
+scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,6 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.29.0.0
-scipy-openblas64==0.3.29.0.0
+scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'
+# Note there is not yet a win-arm64 wheel, so we currently only exclude win-arm64
+scipy-openblas64==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -22,9 +22,6 @@ fi
 if [[ $(python -c"import sys; print(sys.maxsize)") < $(python -c"import sys; print(2**33)") ]]; then
     echo "No BLAS used for 32-bit wheels"
     export INSTALL_OPENBLAS=false
-elif [[ $(python -c"import sysconfig; print(sysconfig.get_platform())") == "win-arm64" ]]; then
-    echo "No BLAS used for ARM64 wheels"
-    export INSTALL_OPENBLAS=false
 elif [ -z $INSTALL_OPENBLAS ]; then
     # the macos_arm64 build might not set this variable
     export INSTALL_OPENBLAS=true
@@ -32,20 +29,33 @@ fi
 
 # Install Openblas from scipy-openblas64
 if [[ "$INSTALL_OPENBLAS" = "true" ]] ; then
-    echo PKG_CONFIG_PATH $PKG_CONFIG_PATH
+    # by default, use scipy-openblas64
+    OPENBLAS=openblas64
+    # Possible values for RUNNER_ARCH in github are
+    # X86, X64, ARM, or ARM64
+    # TODO: should we detect a missing RUNNER_ARCH and use platform.machine()
+    #    when wheel build is run outside github?
+    # On 32-bit platforms, use scipy_openblas32
+    # On win-arm64 use scipy_openblas32
+    if [[ $RUNNER_ARCH == "X86" || $RUNNER_ARCH == "ARM" ]] ; then
+        OPENBLAS=openblas32
+    elif [[ $RUNNER_ARCH == "ARM64" && $RUNNER_OS == "Windows" ]] ; then
+        OPENBLAS=openblas32
+    fi
+    echo PKG_CONFIG_PATH is $PKG_CONFIG_PATH, OPENBLAS is ${OPENBLAS}
     PKG_CONFIG_PATH=$PROJECT_DIR/.openblas
     rm -rf $PKG_CONFIG_PATH
     mkdir -p $PKG_CONFIG_PATH
     python -m pip install -r requirements/ci_requirements.txt
-    python -c "import scipy_openblas64; print(scipy_openblas64.get_pkg_config())" > $PKG_CONFIG_PATH/scipy-openblas.pc
+    python -c "import scipy_${OPENBLAS}; print(scipy_${OPENBLAS}.get_pkg_config())" > $PKG_CONFIG_PATH/scipy-openblas.pc
     # Copy the shared objects to a path under $PKG_CONFIG_PATH, the build
     # will point $LD_LIBRARY_PATH there and then auditwheel/delocate-wheel will
     # pull these into the wheel. Use python to avoid windows/posix problems
     python <<EOF
-import os, scipy_openblas64, shutil
-srcdir = os.path.join(os.path.dirname(scipy_openblas64.__file__), "lib")
+import os, scipy_${OPENBLAS}, shutil
+srcdir = os.path.join(os.path.dirname(scipy_${OPENBLAS}.__file__), "lib")
 shutil.copytree(srcdir, os.path.join("$PKG_CONFIG_PATH", "lib"))
-srcdir = os.path.join(os.path.dirname(scipy_openblas64.__file__), ".dylibs")
+srcdir = os.path.join(os.path.dirname(scipy_${OPENBLAS}.__file__), ".dylibs")
 if os.path.exists(srcdir):  # macosx delocate
     shutil.copytree(srcdir, os.path.join("$PKG_CONFIG_PATH", ".dylibs"))
 EOF

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -3,31 +3,8 @@ set -xe
 WHEEL="$1"
 DEST_DIR="$2"
 
-# create a temporary directory in the destination folder and unpack the wheel
-# into there
 cwd=$PWD
-
-pushd $DEST_DIR
-mkdir -p tmp
-pushd tmp
-wheel unpack $WHEEL
-pushd numpy*
-
-# To avoid DLL hell, the file name of libopenblas that's being vendored with
-# the wheel has to be name-mangled. delvewheel is unable to name-mangle PYD
-# containing extra data at the end of the binary, which frequently occurs when
-# building with mingw.
-# We therefore find each PYD in the directory structure and strip them.
-
-for f in $(find ./numpy* -name '*.pyd'); do strip $f; done
-
-
-# now repack the wheel and overwrite the original
-wheel pack .
-mv -fv *.whl $WHEEL
-
 cd $DEST_DIR
-rm -rf tmp
 
 # the libopenblas.dll is placed into this directory in the cibw_before_build
 # script.


### PR DESCRIPTION
Backport of #29039.

BLD: bump OpenBLAS version, use OpenBLAS for win-arm64 [wheel build]

* Update requirements/ci_requirements.txt

* use pip to install anaconda-client on win-arm64 [wheel build]

* allow noblas in win32 wheels, use scipy-openblas32 on win-arm64 [wheel build]

* improve runner arch detection logic [wheel build]

* remove win_arm64 cibuildwheel override

* remove 'strip' before calling delvewheel [wheel build]

* use openblas 0.3.29.265 only on win-arm64 [wheel build]

* add comment about lack of win-arm64 openblas64 wheels [wheel build]

---------

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
