### PR TITLE
MAINT: Avoid use of deprecated _PyDict_GetItemStringWithError in f2py

### DIFF
--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -363,6 +363,8 @@ fortran_getattr(PyFortranObject *fp, char *name)
 {
     int i, j, k, flag;
     if (fp->dict != NULL) {
+        // python 3.13 added PyDict_GetItemRef
+#if PY_VERSION_HEX < 0x030D0000
         PyObject *v = _PyDict_GetItemStringWithError(fp->dict, name);
         if (v == NULL && PyErr_Occurred()) {
             return NULL;
@@ -371,6 +373,17 @@ fortran_getattr(PyFortranObject *fp, char *name)
             Py_INCREF(v);
             return v;
         }
+#else
+        PyObject *v;
+        int result = PyDict_GetItemStringRef(fp->dict, name, &v);
+        if (result == -1) {
+            return NULL;
+        }
+        else if (result == 1) {
+            return v;
+        }
+#endif
+
     }
     for (i = 0, j = 1; i < fp->len && (j = strcmp(name, fp->defs[i].name));
          i++)


### PR DESCRIPTION
c.f. https://github.com/numpy/numpy/pull/26282#issuecomment-2919383840

Ping @seberg to double check that the logic is identical between the two branches.