### PR TITLE
BENCH: Increase array sizes for ufunc and sort benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -236,7 +236,7 @@ class Sort(Benchmark):
     param_names = ['kind', 'dtype', 'array_type']
 
     # The size of the benchmarked arrays.
-    ARRAY_SIZE = 10000
+    ARRAY_SIZE = 1000000
 
     def setup(self, kind, dtype, array_type):
         rnd = np.random.RandomState(507582308)

--- a/benchmarks/benchmarks/bench_ufunc_strides.py
+++ b/benchmarks/benchmarks/bench_ufunc_strides.py
@@ -10,7 +10,7 @@ class _AbstractBinary(Benchmark):
     params = []
     param_names = ['ufunc', 'stride_in0', 'stride_in1', 'stride_out', 'dtype']
     timeout = 10
-    arrlen = 10000
+    arrlen = 1000000
     data_finite = True
     data_denormal = False
     data_zeros = False
@@ -63,7 +63,7 @@ class _AbstractUnary(Benchmark):
     params = []
     param_names = ['ufunc', 'stride_in', 'stride_out', 'dtype']
     timeout = 10
-    arrlen = 10000
+    arrlen = 1000000
     data_finite = True
     data_denormal = False
     data_zeros = False


### PR DESCRIPTION
These are the array sizes used to generate https://r-devulap.github.io/numpy/. Benchmarking smaller arrays is a bit flaky.