### PR TITLE
MAINT: Bump ``scipy-doctest`` to 1.8

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -271,7 +271,7 @@ jobs:
     # - name: Check docstests
     #   shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     #   run: |
-    #     pip install scipy-doctest==1.6.0 hypothesis==6.104.1 matplotlib scipy pytz pandas
+    #     pip install scipy-doctest>=1.8.0 hypothesis==6.104.1 matplotlib scipy pytz pandas
     #     spin check-docs -v
     #     spin check-tutorials -v
 

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -196,6 +196,8 @@ def check_docs(*, parent_callback, pytest_args, **kwargs):
         import scipy_doctest  # noqa: F401
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError("scipy-doctest not installed") from e
+    if scipy_doctest.__version__ < '1.8.0':
+        raise ModuleNotFoundError("please update scipy_doctests to >= 1.8.0")
 
     if (not pytest_args):
         pytest_args = ('--pyargs', 'numpy')
@@ -203,6 +205,7 @@ def check_docs(*, parent_callback, pytest_args, **kwargs):
     # turn doctesting on:
     doctest_args = (
         '--doctest-modules',
+        '--doctest-only-doctests=true',
         '--doctest-collect=api'
     )
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5944,7 +5944,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('fields',
     >>> import numpy as np
     >>> dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
     >>> print(dt.fields)
-    {'name': (dtype('|S16'), 0), 'grades': (dtype(('float64',(2,))), 16)}
+    {'name': (dtype('<U16'), 0), 'grades': (dtype(('<f8', (2,))), 64)}
 
     """))
 

--- a/numpy/lib/introspect.py
+++ b/numpy/lib/introspect.py
@@ -34,7 +34,7 @@ def opt_func_info(func_name=None, signature=None):
     ...     func_name="add|abs", signature="float64|complex64"
     ... )
     >>> import json
-    >>> print(json.dumps(dict, indent=2))
+    >>> print(json.dumps(dict, indent=2))   # may vary (architecture)
         {
           "absolute": {
             "dd": {

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -19,7 +19,7 @@ toml
 
 
 # for doctests, also needs pytz which is in test_requirements
-scipy-doctest==1.6.0
+scipy-doctest>=1.8.0
 
 # interactive documentation utilities
 # see https://github.com/jupyterlite/pyodide-kernel#compatibility


### PR DESCRIPTION
Bump the minimum scipy_doctest version to >=1.8.0

See https://discuss.scientific-python.org/t/scipy-doctest-select-only-doctests-or-both-doctests-and-unit-tests/1950 for the discussion, and the matching SciPy PR,  https://github.com/scipy/scipy/pull/23078

TL;DR: this change is currently a no-op; this is the only change needed to be forward compatible with an upcoming breaking change in `scipy-doctest`, no further action is needed in numpy itself. Unfortunately, all users who do `$ spin check-docs` locally will need to `pip install --update scipy-doctest` --- once.




<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
