### PR TITLE
MAINT: Add ``build-*`` directories to ``.gitignore``

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ GTAGS
 ################
 # meson build/installation directories
 build
-build-install
+build-*
 # meson python output
 .mesonpy-native-file.ini
 # sphinx build directory


### PR DESCRIPTION
Add `build-*` to gitignore.
This is a companion PR to https://github.com/rgommers/pixi-dev-scipystack/pull/33, which adds to numpy `build-nogil` and `build-nogil-install`, following the same pattern already implemented for scipy.