### PR TITLE
BUG: remove `NPY_ALIGNMENT_REQUIRED`

### DIFF
--- a/doc/release/upcoming_changes/29094.compatibility.rst
+++ b/doc/release/upcoming_changes/29094.compatibility.rst
@@ -1,0 +1,7 @@
+The Macro NPY_ALIGNMENT_REQUIRED has been removed
+-------------------------------------------------
+The macro was defined in the `npy_cpu.h` file, so might be regarded as
+semipublic. As it turns out, with modern compilers and hardware it is almost
+always the case that alignment is required, so numpy no longer uses the macro.
+It is unlikely anyone uses it, but you might want to compile with the `-Wundef`
+flag or equivalent to be sure.

--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -120,16 +120,4 @@
     information about your platform (OS, CPU and compiler)
 #endif
 
-/*
- * Except for the following architectures, memory access is limited to the natural
- * alignment of data types otherwise it may lead to bus error or performance regression.
- * For more details about unaligned access, see https://www.kernel.org/doc/Documentation/unaligned-memory-access.txt.
-*/
-#if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64) || defined(__aarch64__) || defined(__powerpc64__)
-    #define NPY_ALIGNMENT_REQUIRED 0
-#endif
-#ifndef NPY_ALIGNMENT_REQUIRED
-    #define NPY_ALIGNMENT_REQUIRED 1
-#endif
-
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_CPU_H_ */

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -11,6 +11,7 @@
 #include "npy_static_data.h"
 #include "npy_import.h"
 #include <limits.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -230,15 +231,6 @@ npy_uint_alignment(int itemsize)
  * compared to memchr it returns one stride past end instead of NULL if needle
  * is not found.
  */
-#ifdef __clang__
-    /*
-     * The code below currently makes use of !NPY_ALIGNMENT_REQUIRED, which
-     * should be OK but causes the clang sanitizer to warn.  It may make
-     * sense to modify the code to avoid this "unaligned" access but
-     * it would be good to carefully check the performance changes.
-     */
-    __attribute__((no_sanitize("alignment")))
-#endif
 static inline char *
 npy_memchr(char * haystack, char needle,
            npy_intp stride, npy_intp size, npy_intp * psubloopsize, int invert)
@@ -259,11 +251,12 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-        if (!NPY_ALIGNMENT_REQUIRED && needle == 0 && stride == 1) {
+        if (needle == 0 && stride == 1) {
             /* iterate until last multiple of 4 */
             char * block_end = haystack + size - (size % sizeof(unsigned int));
             while (p < block_end) {
-                unsigned int  v = *(unsigned int*)p;
+                unsigned int v;
+                memcpy(&v, p, sizeof(v));
                 if (v != 0) {
                     break;
                 }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -1620,19 +1620,15 @@ pack_inner(const char *inptr,
             bb[1] = npyv_tobits_b8(npyv_cmpneq_u8(v1, v_zero));
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
-            if(out_stride == 1 && 
-                (!NPY_ALIGNMENT_REQUIRED || isAligned)) {
-                npy_uint64 *ptr64 = (npy_uint64*)outptr;
+            if(out_stride == 1 && isAligned) {
             #if NPY_SIMD_WIDTH == 16
-                npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);
-                ptr64[0] = bcomp;
+                npy_uint64 arr[1] = {bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48)};
             #elif NPY_SIMD_WIDTH == 32
-                ptr64[0] = bb[0] | (bb[1] << 32);
-                ptr64[1] = bb[2] | (bb[3] << 32);
+                npy_uint64 arr[2] = {bb[0] | (bb[1] << 32), bb[2] | (bb[3] << 32)};
             #else
-                ptr64[0] = bb[0]; ptr64[1] = bb[1];
-                ptr64[2] = bb[2]; ptr64[3] = bb[3];
+                npy_uint64 arr[4] = {bb[0], bb[1], bb[2], bb[3]};
             #endif
+                memcpy(outptr, arr, sizeof(arr));
                 outptr += vstepx4;
             } else {
                 for(int i = 0; i < 4; i++) {

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -4,6 +4,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <structmember.h>
+#include <string.h>
 
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
@@ -2525,11 +2526,13 @@ count_nonzero_u8(const char *data, npy_intp bstride, npy_uintp len)
         len  -= len_m;
         count = len_m - zcount;
     #else
-        if (!NPY_ALIGNMENT_REQUIRED || npy_is_aligned(data, sizeof(npy_uint64))) {
+        if (npy_is_aligned(data, sizeof(npy_uint64))) {
             int step = 6 * sizeof(npy_uint64);
             int left_bytes = len % step;
             for (const char *end = data + len; data < end - left_bytes; data += step) {
-                 count += count_nonzero_bytes_384((const npy_uint64 *)data);
+                npy_uint64 arr[6];
+                memcpy(arr, data, step);
+                count += count_nonzero_bytes_384(arr);
             }
             len = left_bytes;
         }

--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -33,11 +33,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if NPY_ALIGNMENT_REQUIRED
-#  define NPY_USE_UNALIGNED_ACCESS 0
-#else
-#  define NPY_USE_UNALIGNED_ACCESS 0
-#endif
+#define NPY_USE_UNALIGNED_ACCESS 0
 
 #define _NPY_NOP1(x) (x)
 #define _NPY_NOP2(x) (x)


### PR DESCRIPTION
* This machinery requires strict-aliasing UB and isn't needed anymore with any GCC from the last 15 years.

Fixes: #28991