### PR TITLE
TYP: run mypy in strict mode

### DIFF
--- a/numpy/typing/tests/data/mypy.ini
+++ b/numpy/typing/tests/data/mypy.ini
@@ -1,9 +1,8 @@
 [mypy]
+strict = True
 enable_error_code = deprecated, ignore-without-code, truthy-bool
-strict_bytes = True
-warn_unused_ignores = True
-implicit_reexport = False
 disallow_any_unimported = True
-disallow_any_generics = True
+allow_redefinition_new = True
+local_partial_types = True
 show_absolute_path = True
 pretty = True

--- a/numpy/typing/tests/data/pass/ma.py
+++ b/numpy/typing/tests/data/pass/ma.py
@@ -7,6 +7,8 @@ from numpy._typing import _Shape
 _ScalarT = TypeVar("_ScalarT", bound=np.generic)
 MaskedArray: TypeAlias = np.ma.MaskedArray[_Shape, np.dtype[_ScalarT]]
 
+# mypy: disable-error-code=no-untyped-call
+
 MAR_b: MaskedArray[np.bool] = np.ma.MaskedArray([True])
 MAR_u: MaskedArray[np.uint32] = np.ma.MaskedArray([1], dtype=np.uint32)
 MAR_i: MaskedArray[np.int64] = np.ma.MaskedArray([1])

--- a/numpy/typing/tests/data/reveal/nbit_base_example.pyi
+++ b/numpy/typing/tests/data/reveal/nbit_base_example.pyi
@@ -7,8 +7,7 @@ from numpy._typing import _32Bit, _64Bit
 T1 = TypeVar("T1", bound=npt.NBitBase)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 T2 = TypeVar("T2", bound=npt.NBitBase)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 
-def add(a: np.floating[T1], b: np.integer[T2]) -> np.floating[T1 | T2]:
-    return a + b
+def add(a: np.floating[T1], b: np.integer[T2]) -> np.floating[T1 | T2]: ...
 
 i8: np.int64
 i4: np.int32


### PR DESCRIPTION
"Strict mode" is a combo-package-deal of mypy flags. In `mypy --help` it explains it as:

> Strict mode; enables the following flags: --warn-unused-configs, --disallow-any-generics, --disallow-subclassing-any, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs, --disallow-untyped-decorators, --warn-redundant-casts, --warn-unused-ignores, --warn-return-any, --no-implicit-reexport, --strict-equality, --strict-bytes, --extra-checks

This also enables `local_partial_types`, which will be enabled by default in a future mypy release. See the [docs](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-local-partial-types) for the details.

And last, but most certainly not least, is `allow_redefinition_new`. In short, it is a fix for #27957. See the [docs](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-allow-redefinition-new) for details.

