### PR TITLE
BUG: f2py: thread-safe forcomb (#29091)

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -598,32 +598,37 @@ static int calcarrindextr(int *i,PyArrayObject *arr) {
     return ii;
 }"""
 cfuncs['forcomb'] = """
-static struct { int nd;npy_intp *d;int *i,*i_tr,tr; } forcombcache;
-static int initforcomb(npy_intp *dims,int nd,int tr) {
+struct ForcombCache { int nd;npy_intp *d;int *i,*i_tr,tr; };
+static int initforcomb(struct ForcombCache *cache, npy_intp *dims,int nd,int tr) {
   int k;
   if (dims==NULL) return 0;
   if (nd<0) return 0;
-  forcombcache.nd = nd;
-  forcombcache.d = dims;
-  forcombcache.tr = tr;
-  if ((forcombcache.i = (int *)malloc(sizeof(int)*nd))==NULL) return 0;
-  if ((forcombcache.i_tr = (int *)malloc(sizeof(int)*nd))==NULL) return 0;
+  cache->nd = nd;
+  cache->d = dims;
+  cache->tr = tr;
+
+  cache->i = (int *)malloc(sizeof(int)*nd);
+  if (cache->i==NULL) return 0;
+  cache->i_tr = (int *)malloc(sizeof(int)*nd);
+  if (cache->i_tr==NULL) {free(cache->i); return 0;};
+
   for (k=1;k<nd;k++) {
-    forcombcache.i[k] = forcombcache.i_tr[nd-k-1] = 0;
+    cache->i[k] = cache->i_tr[nd-k-1] = 0;
   }
-  forcombcache.i[0] = forcombcache.i_tr[nd-1] = -1;
+  cache->i[0] = cache->i_tr[nd-1] = -1;
   return 1;
 }
-static int *nextforcomb(void) {
+static int *nextforcomb(struct ForcombCache *cache) {
+  if (cache==NULL) return NULL;
   int j,*i,*i_tr,k;
-  int nd=forcombcache.nd;
-  if ((i=forcombcache.i) == NULL) return NULL;
-  if ((i_tr=forcombcache.i_tr) == NULL) return NULL;
-  if (forcombcache.d == NULL) return NULL;
+  int nd=cache->nd;
+  if ((i=cache->i) == NULL) return NULL;
+  if ((i_tr=cache->i_tr) == NULL) return NULL;
+  if (cache->d == NULL) return NULL;
   i[0]++;
-  if (i[0]==forcombcache.d[0]) {
+  if (i[0]==cache->d[0]) {
     j=1;
-    while ((j<nd) && (i[j]==forcombcache.d[j]-1)) j++;
+    while ((j<nd) && (i[j]==cache->d[j]-1)) j++;
     if (j==nd) {
       free(i);
       free(i_tr);
@@ -634,7 +639,7 @@ static int *nextforcomb(void) {
     i_tr[nd-j-1]++;
   } else
     i_tr[nd-1]++;
-  if (forcombcache.tr) return i_tr;
+  if (cache->tr) return i_tr;
   return i;
 }"""
 needs['try_pyarr_from_string'] = ['STRINGCOPYN', 'PRINTPYOBJERR', 'string']

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1184,9 +1184,10 @@ if (#varname#_cb.capi==Py_None) {
                 """\
         int *_i,capi_i=0;
         CFUNCSMESS(\"#name#: Initializing #varname#=#init#\\n\");
-        if (initforcomb(PyArray_DIMS(capi_#varname#_as_array),
+        struct ForcombCache cache;
+        if (initforcomb(&cache, PyArray_DIMS(capi_#varname#_as_array),
                         PyArray_NDIM(capi_#varname#_as_array),1)) {
-            while ((_i = nextforcomb()))
+            while ((_i = nextforcomb(&cache)))
                 #varname#[capi_i++] = #init#; /* fortran way */
         } else {
             PyObject *exc, *val, *tb;


### PR DESCRIPTION
Backport of #29091.

Closes #29086

There are zero tests for this (you could add a syntax error and the numpy test suite would still pass).
With my complete lack of knowledge of fortran, I'm unable to write one.

Tested in scipy: https://github.com/scipy/scipy/pull/23084


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
