### PR TITLE
PERF: Use interned strings for Python attr methods: "real" and "imag"

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -393,7 +393,7 @@ __New_PyArray_Std(PyArrayObject *self, int axis, int rtype, PyArrayObject *out,
         return NULL;
     }
     if (PyArray_ISCOMPLEX(arr2)) {
-        obj3 = PyObject_GetAttrString((PyObject *)arr2, "real");
+        obj3 = PyObject_GetAttr((PyObject *)arr2, npy_interned_str.real);
         switch(rtype) {
         case NPY_CDOUBLE:
             rtype = NPY_DOUBLE;
@@ -583,7 +583,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
         }
 
         /* arr.real = a.real.round(decimals) */
-        part = PyObject_GetAttrString((PyObject *)a, "real");
+        part = PyObject_GetAttr((PyObject *)a, npy_interned_str.real);
         if (part == NULL) {
             Py_DECREF(arr);
             return NULL;
@@ -596,7 +596,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
             Py_DECREF(arr);
             return NULL;
         }
-        res = PyObject_SetAttrString(arr, "real", round_part);
+        res = PyObject_SetAttr(arr, npy_interned_str.real, round_part);
         Py_DECREF(round_part);
         if (res < 0) {
             Py_DECREF(arr);
@@ -604,7 +604,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
         }
 
         /* arr.imag = a.imag.round(decimals) */
-        part = PyObject_GetAttrString((PyObject *)a, "imag");
+        part = PyObject_GetAttr((PyObject *)a, npy_interned_str.imag);
         if (part == NULL) {
             Py_DECREF(arr);
             return NULL;
@@ -617,7 +617,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
             Py_DECREF(arr);
             return NULL;
         }
-        res = PyObject_SetAttrString(arr, "imag", round_part);
+        res = PyObject_SetAttr(arr, npy_interned_str.imag, round_part);
         Py_DECREF(round_part);
         if (res < 0) {
             Py_DECREF(arr);

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -64,6 +64,8 @@ intern_strings(void)
     INTERN_STRING(pyvals_name, "UFUNC_PYVALS_NAME");
     INTERN_STRING(legacy, "legacy");
     INTERN_STRING(__doc__, "__doc__");
+    INTERN_STRING(real, "real");
+    INTERN_STRING(imag, "imag");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -43,6 +43,8 @@ typedef struct npy_interned_str_struct {
     PyObject *pyvals_name;
     PyObject *legacy;
     PyObject *__doc__;
+    PyObject *real;
+    PyObject *imag;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1857,7 +1857,7 @@ gentype_real_get(PyObject *self, void *NPY_UNUSED(ignored))
     }
     else if (PyArray_IsScalar(self, Object)) {
         PyObject *obj = PyArrayScalar_VAL(self, Object);
-        ret = PyObject_GetAttrString(obj, "real");
+        ret = PyObject_GetAttr(obj, npy_interned_str.real);
         if (ret != NULL) {
             return ret;
         }
@@ -1883,7 +1883,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
     else if (PyArray_IsScalar(self, Object)) {
         PyObject *obj = PyArrayScalar_VAL(self, Object);
         PyArray_Descr *newtype;
-        ret = PyObject_GetAttrString(obj, "imag");
+        ret = PyObject_GetAttr(obj, npy_interned_str.imag);
         if (ret == NULL) {
             PyErr_Clear();
             obj = PyLong_FromLong(0);


### PR DESCRIPTION
Adds `"real"` and `"imag"` interned strings and uses them to get complex part attributes of Python objects in `PyArray_Round`, as recommended in #27120.