### PR TITLE
DOC: remove very outdated info on ATLAS

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -135,22 +135,14 @@ For best performance, a development package providing BLAS and CBLAS should be
 installed.  Some of the options available are:
 
 - ``libblas-dev``: reference BLAS (not very optimized)
-- ``libatlas-base-dev``: generic tuned ATLAS, it is recommended to tune it to
-  the available hardware, see /usr/share/doc/libatlas3-base/README.Debian for
-  instructions
-- ``libopenblas-base``: fast and runtime detected so no tuning required but a
-  very recent version is needed (>=0.2.15 is recommended).  Older versions of
-  OpenBLAS suffered from correctness issues on some CPUs.
+- ``libopenblas-base``: (recommended) OpenBLAS is performant, and is what all
+  the NumPy wheels on PyPI are built with
 
 The package linked to when numpy is loaded can be chosen after installation via
 the alternatives mechanism::
 
     update-alternatives --config libblas.so.3
     update-alternatives --config liblapack.so.3
-
-Or by preloading a specific BLAS library with::
-
-    LD_PRELOAD=/usr/lib/atlas-base/atlas/libblas.so.3 python ...
 
 
 Build issues

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -135,8 +135,8 @@ For best performance, a development package providing BLAS and CBLAS should be
 installed.  Some of the options available are:
 
 - ``libblas-dev``: reference BLAS (not very optimized)
-- ``libopenblas-base``: (recommended) OpenBLAS is performant, and is what all
-  the NumPy wheels on PyPI are built with
+- ``libopenblas-base``: (recommended) OpenBLAS is performant, and used
+  in the NumPy wheels on PyPI except where Apple's Accelerate is tuned better for Apple hardware
 
 The package linked to when numpy is loaded can be chosen after installation via
 the alternatives mechanism::

--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -83,28 +83,6 @@ on how to properly configure Eclipse/PyDev to use Anaconda Python with specific
 conda environments.
 
 
-Raspberry Pi
-------------
-
-There are sometimes issues reported on Raspberry Pi setups when installing
-using ``pip3 install`` (or ``pip`` install). These will typically mention::
-
-    libf77blas.so.3: cannot open shared object file: No such file or directory
-
-
-The solution will be to either::
-
-    sudo apt-get install libatlas-base-dev
-
-to install the missing libraries expected by the self-compiled NumPy
-(ATLAS is a possible provider of linear algebra).
-
-*Alternatively* use the NumPy provided by Raspbian. In which case run::
-
-    pip3 uninstall numpy  # remove previously installed version
-    apt install python3-numpy
-
-
 Debug build on Windows
 ----------------------
 


### PR DESCRIPTION
ATLAS hasn't been developed for years, there is no reason to ever use it instead of OpenBLAS, BLIS, or MKL. So remove mentions of it. The troubleshooting instructions haven't been relevant in quite a while either.

Addresses a comment on gh-29108
