### PR TITLE
MAINT: Fix for segfaults with GCC 15

### DIFF
--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -119,16 +119,6 @@
     information about your platform (OS, CPU and compiler)
 #endif
 
-/*
- * Except for the following architectures, memory access is limited to the natural
- * alignment of data types otherwise it may lead to bus error or performance regression.
- * For more details about unaligned access, see https://www.kernel.org/doc/Documentation/unaligned-memory-access.txt.
-*/
-#if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64) || defined(__aarch64__) || defined(__powerpc64__)
-    #define NPY_ALIGNMENT_REQUIRED 0
-#endif
-#ifndef NPY_ALIGNMENT_REQUIRED
-    #define NPY_ALIGNMENT_REQUIRED 1
-#endif
+#define NPY_ALIGNMENT_REQUIRED 1
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_CPU_H_ */

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -1620,8 +1620,7 @@ pack_inner(const char *inptr,
             bb[1] = npyv_tobits_b8(npyv_cmpneq_u8(v1, v_zero));
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
-            if(out_stride == 1 && 
-                (!NPY_ALIGNMENT_REQUIRED || isAligned)) {
+            if(out_stride == 1 && isAligned) {
                 npy_uint64 *ptr64 = (npy_uint64*)outptr;
             #if NPY_SIMD_WIDTH == 16
                 npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2525,7 +2525,7 @@ count_nonzero_u8(const char *data, npy_intp bstride, npy_uintp len)
         len  -= len_m;
         count = len_m - zcount;
     #else
-        if (!NPY_ALIGNMENT_REQUIRED || npy_is_aligned(data, sizeof(npy_uint64))) {
+        if (npy_is_aligned(data, sizeof(npy_uint64))) {
             int step = 6 * sizeof(npy_uint64);
             int left_bytes = len % step;
             for (const char *end = data + len; data < end - left_bytes; data += step) {

--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -33,11 +33,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if NPY_ALIGNMENT_REQUIRED
-#  define NPY_USE_UNALIGNED_ACCESS 0
-#else
-#  define NPY_USE_UNALIGNED_ACCESS 0
-#endif
+#define NPY_USE_UNALIGNED_ACCESS 0
 
 #define _NPY_NOP1(x) (x)
 #define _NPY_NOP2(x) (x)


### PR DESCRIPTION
GCC 15 generates code that segfaults on newer hardware when running tests. See gh-28991 for details. A fix is to always require alignment, which can be done by setting `NPY_ALIGNMENT_REQUIRED = 1`.

We retain `NPY_ALIGNMENT_REQUIRED` here for downstream compatibility in the 2.3.x release series, but do remove its use in our own code. The associated macro `NPY_USE_UNALIGNED_ACCESS` could also be removed as it is always 0, but that is left for another PR.

This is a stripped down version of #29094.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
