### PR TITLE
BUG: make round consistently return a copy

### DIFF
--- a/doc/release/upcoming_changes/29137.compatibility.rst
+++ b/doc/release/upcoming_changes/29137.compatibility.rst
@@ -1,0 +1,5 @@
+* For integer arrays, ``numpy.round`` function now returns a copy of input. Previously,
+  it returned a view for integer inputs and a copy for floating-point inputs. The change
+  brings ``round`` in line with ``ceil``, ``floor`` and ``trunc``--- all of which always
+  return a copy. 
+

--- a/doc/release/upcoming_changes/29137.compatibility.rst
+++ b/doc/release/upcoming_changes/29137.compatibility.rst
@@ -1,5 +1,3 @@
-* For integer arrays, ``numpy.round`` function now returns a copy of input. Previously,
-  it returned a view for integer inputs and a copy for floating-point inputs. The change
-  brings ``round`` in line with ``ceil``, ``floor`` and ``trunc``--- all of which always
-  return a copy. 
-
+* `numpy.round` now always returns a copy. Previously, it returned a view
+  for integer inputs for ``decimals >= 0`` and a copy in all other cases.
+  This change brings ``round`` in line with ``ceil``, ``floor`` and ``trunc``.

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -637,8 +637,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
                 return (PyObject *)out;
             }
             else {
-                Py_INCREF(a);
-                return (PyObject *)a;
+                return PyArray_Copy(a);
             }
         }
         if (decimals == 0) {

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -637,7 +637,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
                 return (PyObject *)out;
             }
             else {
-                return PyArray_Copy(a);
+                return PyArray_NewCopy(a, NPY_KEEPORDER);
             }
         }
         if (decimals == 0) {

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -576,7 +576,7 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
             Py_INCREF(arr);
         }
         else {
-            arr = PyArray_Copy(a);
+            arr = PyArray_NewCopy(a, NPY_KEEPORDER);
             if (arr == NULL) {
                 return NULL;
             }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2171,6 +2171,11 @@ class TestMethods:
         out = np.empty(3, dtype=dt)
         assert not np.shares_memory(a.round(out=out), a)
 
+        a = np.arange(12).astype(dt).reshape(3, 4).T
+
+        assert a.flags.f_contiguous
+        assert np.round(a).flags.f_contiguous
+
     def test_squeeze(self):
         a = np.array([[[1], [2], [3]]])
         assert_equal(a.squeeze(), [1, 2, 3])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2153,6 +2153,7 @@ class TestMethods:
             assert_equal(out, expected)
             assert out is res
 
+        check_round(np.array([1, 2, 3]), [1, 2, 3])
         check_round(np.array([1.2, 1.5]), [1, 2])
         check_round(np.array(1.5), 2)
         check_round(np.array([12.2, 15.5]), [10, 20], -1)
@@ -2160,6 +2161,15 @@ class TestMethods:
         # Complex rounding
         check_round(np.array([4.5 + 1.5j]), [4 + 2j])
         check_round(np.array([12.5 + 15.5j]), [10 + 20j], -1)
+
+    @pytest.mark.parametrize('dt', ['uint8', int, float, complex])
+    def test_round_copies(self, dt):
+        a = np.arange(3, dtype=dt)
+        assert not np.shares_memory(a.round(), a)
+        assert not np.shares_memory(a.round(decimals=2), a)
+
+        out = np.empty(3, dtype=dt)
+        assert not np.shares_memory(a.round(out=out), a)
 
     def test_squeeze(self):
         a = np.array([[[1], [2], [3]]])


### PR DESCRIPTION
Otherwise, `round` returns a view for integer arguments and a copy otherwise. All other "rounding" functions (ceil, floor, trunc, rint), always return copies. Thus, make `round` consistent with the rest of them.

fixes https://github.com/numpy/numpy/issues/29124

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
