### PR TITLE
TYP: update typing stubs for ``_pyinstaller/hook-numpy.py``

### DIFF
--- a/numpy/_pyinstaller/hook-numpy.pyi
+++ b/numpy/_pyinstaller/hook-numpy.pyi
@@ -1,13 +1,6 @@
 from typing import Final
 
-# from `PyInstaller.compat`
-is_conda: Final[bool]
-is_pure_conda: Final[bool]
+binaries: Final[list[tuple[str, str]]] = ...
 
-# from `PyInstaller.utils.hooks`
-def is_module_satisfies(requirements: str, version: None = None, version_attr: None = None) -> bool: ...
-
-binaries: Final[list[tuple[str, str]]]
-
-hiddenimports: Final[list[str]]
-excludedimports: Final[list[str]]
+hiddenimports: Final[list[str]] = ...
+excludedimports: Final[list[str]] = ...


### PR DESCRIPTION
It's not the most interesting fix, but stubtest was complaining about it in numtype.