### PR TITLE
BUG: Missing array-api ``capabilities()`` key

### DIFF
--- a/numpy/_array_api_info.py
+++ b/numpy/_array_api_info.py
@@ -94,14 +94,14 @@ class __array_namespace_info__:
         >>> info = np.__array_namespace_info__()
         >>> info.capabilities()
         {'boolean indexing': True,
-         'data-dependent shapes': True}
+         'data-dependent shapes': True,
+         'max dimensions': 64}
 
         """
         return {
             "boolean indexing": True,
             "data-dependent shapes": True,
-            # 'max rank' will be part of the 2024.12 standard
-            # "max rank": 64,
+            "max dimensions": 64,
         }
 
     def default_device(self):


### PR DESCRIPTION
The ``"max dimensions"`` key is required since 2024.12, but was missing in the ``__array_namespace_info__.capabilities()`` dict.