### PR TITLE
TST: migrating from pytz to zoneinfo + tzdata (where needed)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -271,7 +271,7 @@ jobs:
     # - name: Check docstests
     #   shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     #   run: |
-    #     pip install scipy-doctest>=1.8.0 hypothesis==6.104.1 matplotlib scipy pytz pandas
+    #     pip install scipy-doctest>=1.8.0 hypothesis==6.104.1 matplotlib scipy pandas
     #     spin check-docs -v
     #     spin check-tutorials -v
 

--- a/environment.yml
+++ b/environment.yml
@@ -49,4 +49,4 @@ dependencies:
   - gitpython
   # Used in some tests
   - cffi
-  - pytz
+  - tzdata

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -1723,7 +1723,7 @@ def datetime_as_string(arr, unit=None, timezone=None, casting=None):
     Examples
     --------
     >>> import numpy as np
-    >>> import pytz
+    >>> from zoneinfo import ZoneInfo
     >>> d = np.arange('2002-10-27T04:30', 4*60, 60, dtype='M8[m]')
     >>> d
     array(['2002-10-27T04:30', '2002-10-27T05:30', '2002-10-27T06:30',
@@ -1736,9 +1736,9 @@ def datetime_as_string(arr, unit=None, timezone=None, casting=None):
            '2002-10-27T07:30Z'], dtype='<U35')
 
     Note that we picked datetimes that cross a DST boundary. Passing in a
-    ``pytz`` timezone object will print the appropriate offset
+    ``ZoneInfo`` object will print the appropriate offset
 
-    >>> np.datetime_as_string(d, timezone=pytz.timezone('US/Eastern'))
+    >>> np.datetime_as_string(d, timezone=ZoneInfo('US/Eastern'))
     array(['2002-10-27T00:30-0400', '2002-10-27T01:30-0400',
            '2002-10-27T01:30-0500', '2002-10-27T02:30-0500'], dtype='<U39')
 

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -174,8 +174,8 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
                                         npy_bool from_pickle);
 
 /*
- * Gets a tzoffset in minutes by calling the fromutc() function on
- * the Python datetime.tzinfo object.
+ * Gets a tzoffset in minutes by calling the astimezone() function on
+ * the Python datetime.datetime object.
  */
 NPY_NO_EXPORT int
 get_tzoffset_from_pytzinfo(PyObject *timezone, npy_datetimestruct *dts);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2245,8 +2245,8 @@ invalid_time:
 }
 
 /*
- * Gets a tzoffset in minutes by calling the fromutc() function on
- * the Python datetime.tzinfo object.
+ * Gets a tzoffset in minutes by calling the astimezone() function on
+ * the Python datetime.datetime object.
  */
 NPY_NO_EXPORT int
 get_tzoffset_from_pytzinfo(PyObject *timezone_obj, npy_datetimestruct *dts)
@@ -2255,14 +2255,14 @@ get_tzoffset_from_pytzinfo(PyObject *timezone_obj, npy_datetimestruct *dts)
     npy_datetimestruct loc_dts;
 
     /* Create a Python datetime to give to the timezone object */
-    dt = PyDateTime_FromDateAndTime((int)dts->year, dts->month, dts->day,
-                            dts->hour, dts->min, 0, 0);
+    dt = PyDateTimeAPI->DateTime_FromDateAndTime((int)dts->year, dts->month, dts->day,
+                            dts->hour, dts->min, 0, 0, PyDateTime_TimeZone_UTC, PyDateTimeAPI->DateTimeType);
     if (dt == NULL) {
         return -1;
     }
 
     /* Convert the datetime from UTC to local time */
-    loc_dt = PyObject_CallMethod(timezone_obj, "fromutc", "O", dt);
+    loc_dt = PyObject_CallMethod(dt, "astimezone", "O", timezone_obj);
     Py_DECREF(dt);
     if (loc_dt == NULL) {
         return -1;

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -15,13 +16,6 @@ from numpy.testing import (
     assert_warns,
     suppress_warnings,
 )
-
-# Use pytz to test out various time zones if available
-try:
-    from pytz import timezone as tz
-    _has_pytz = True
-except ImportError:
-    _has_pytz = False
 
 try:
     RecursionError
@@ -1886,7 +1880,6 @@ class TestDateTime:
                 np.datetime64('2032-01-01T00:00:00', 'us'), unit='auto'),
                 '2032-01-01')
 
-    @pytest.mark.skipif(not _has_pytz, reason="The pytz module is not available.")
     def test_datetime_as_string_timezone(self):
         # timezone='local' vs 'UTC'
         a = np.datetime64('2010-03-15T06:30', 'm')
@@ -1901,29 +1894,29 @@ class TestDateTime:
 
         b = np.datetime64('2010-02-15T06:30', 'm')
 
-        assert_equal(np.datetime_as_string(a, timezone=tz('US/Central')),
+        assert_equal(np.datetime_as_string(a, timezone=ZoneInfo('US/Central')),
                      '2010-03-15T01:30-0500')
-        assert_equal(np.datetime_as_string(a, timezone=tz('US/Eastern')),
+        assert_equal(np.datetime_as_string(a, timezone=ZoneInfo('US/Eastern')),
                      '2010-03-15T02:30-0400')
-        assert_equal(np.datetime_as_string(a, timezone=tz('US/Pacific')),
+        assert_equal(np.datetime_as_string(a, timezone=ZoneInfo('US/Pacific')),
                      '2010-03-14T23:30-0700')
 
-        assert_equal(np.datetime_as_string(b, timezone=tz('US/Central')),
+        assert_equal(np.datetime_as_string(b, timezone=ZoneInfo('US/Central')),
                      '2010-02-15T00:30-0600')
-        assert_equal(np.datetime_as_string(b, timezone=tz('US/Eastern')),
+        assert_equal(np.datetime_as_string(b, timezone=ZoneInfo('US/Eastern')),
                      '2010-02-15T01:30-0500')
-        assert_equal(np.datetime_as_string(b, timezone=tz('US/Pacific')),
+        assert_equal(np.datetime_as_string(b, timezone=ZoneInfo('US/Pacific')),
                      '2010-02-14T22:30-0800')
 
         # Dates to strings with a timezone attached is disabled by default
         assert_raises(TypeError, np.datetime_as_string, a, unit='D',
-                           timezone=tz('US/Pacific'))
+                           timezone=ZoneInfo('US/Pacific'))
         # Check that we can print out the date in the specified time zone
         assert_equal(np.datetime_as_string(a, unit='D',
-                           timezone=tz('US/Pacific'), casting='unsafe'),
+                           timezone=ZoneInfo('US/Pacific'), casting='unsafe'),
                      '2010-03-14')
         assert_equal(np.datetime_as_string(b, unit='D',
-                           timezone=tz('US/Central'), casting='unsafe'),
+                           timezone=ZoneInfo('US/Central'), casting='unsafe'),
                      '2010-02-15')
 
     def test_datetime_arange(self):

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1,6 +1,6 @@
 import datetime
 import pickle
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
 
@@ -22,6 +22,11 @@ try:
 except NameError:
     RecursionError = RuntimeError  # python < 3.5
 
+try:
+    ZoneInfo("US/Central")
+    _has_tz = True
+except ZoneInfoNotFoundError:
+    _has_tz = False
 
 def _assert_equal_hash(v1, v2):
     assert v1 == v2
@@ -1880,6 +1885,7 @@ class TestDateTime:
                 np.datetime64('2032-01-01T00:00:00', 'us'), unit='auto'),
                 '2032-01-01')
 
+    @pytest.mark.skipif(not _has_tz, reason="The tzdata module is not available.")
     def test_datetime_as_string_timezone(self):
         # timezone='local' vs 'UTC'
         a = np.datetime64('2010-03-15T06:30', 'm')

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -13,12 +13,6 @@ from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F4
 import numpy as np
 from numpy.testing import assert_raises, temppath
 
-try:
-    import pytz  # noqa: F401
-    _has_pytz = True
-except ImportError:
-    _has_pytz = False
-
 
 class _DeprecationTestCase:
     # Just as warning: warnings uses re.match, so the start of this message

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -17,8 +17,6 @@ pickleshare
 towncrier
 toml
 
-
-# for doctests, also needs pytz which is in test_requirements
 scipy-doctest>=1.8.0
 
 # interactive documentation utilities

--- a/requirements/emscripten_test_requirements.txt
+++ b/requirements/emscripten_test_requirements.txt
@@ -1,4 +1,4 @@
 hypothesis==6.81.1
 pytest==7.4.0
-pytz==2023.3.post1
+tzdata
 pytest-xdist

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -4,7 +4,6 @@ setuptools==65.5.1 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
 hypothesis==6.104.1
 pytest==7.4.0
-pytz==2023.3.post1
 pytest-cov==4.1.0
 meson
 ninja; sys_platform != "emscripten"
@@ -17,3 +16,5 @@ mypy==1.16.0; platform_python_implementation != "PyPy"
 typing_extensions>=4.5.0
 # for optional f2py encoding detection
 charset-normalizer
+tzdata
+


### PR DESCRIPTION
For migration from pytz to zoneinfo function **get_tzoffset_from_pytzinfo** from _numpy/_core/src/multiarray/datetime.c_ is modified to use **astimezone** instead of **fromutc**. As the object **ZoneInfo** is not directly compatible to be used with datetime object. Hence, something like this would result in an exception.

```
from datetime import datetime
from zoneinfo import ZoneInfo

a = datetime(2025, 6, 7, 10, 0, 0)
zoneInfo = ZoneInfo("US/Central")
b = zoneInfo.fromutc(a)
```

ValueError: fromutc: dt.tzinfo is not self

The function astimezone can be used with both pytz.timezone object and zoneinfo.ZoneInfo object But, if we want to use the datetime object consistently we cannot let it be a naive type i.e. without a timezone. As the default behaviour of astimezone would take the system timezone if the datetime object is not timezone aware.

Hence, I had to also change the call to create datetime object to take UTC timezone.

See #29064
