### PR TITLE
DOC: Remove version switcher colors

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -22,18 +22,6 @@ body {
 
 /* Version switcher colors from PyData Sphinx Theme */
 
-.version-switcher__button[data-active-version-name*="devdocs"] {
-  background-color: var(--pst-color-warning);
-  border-color: var(--pst-color-warning);
-  opacity: 0.9;
-}
-
-.version-switcher__button:not([data-active-version-name*="stable"]):not([data-active-version-name*="dev"]):not([data-active-version-name*="pull"]) {
-  background-color: var(--pst-color-danger);
-  border-color: var(--pst-color-danger);
-  opacity: 0.9;
-}
-
 .version-switcher__menu a.list-group-item {
   font-size: small;
 }

--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -20,7 +20,7 @@ body {
   width: 15%;
 }
 
-/* Version switcher colors from PyData Sphinx Theme */
+/* Version switcher from PyData Sphinx Theme */
 
 .version-switcher__menu a.list-group-item {
   font-size: small;


### PR DESCRIPTION
Closes #27248 

In newer versions, the warning banner should be sufficient to highlight older or development versions as opposed to the stable version.

I will also follow-up with a PR to numpy/doc to remove the colors from 2.1 and 2.2

Current:

![Captura de imagem_20250609_120611](https://github.com/user-attachments/assets/335b1942-fd87-48c4-a70e-fbacb6e75804)

After this PR: 

![Captura de imagem_20250609_120729](https://github.com/user-attachments/assets/77f92d73-1871-49cf-acf1-5cbf56efa647)

