### PR TITLE
WIP memmap multithreaded segfault

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -96,5 +96,7 @@ jobs:
           export TSAN_OPTIONS="halt_on_error=0:allocator_may_return_null=1:suppressions=$GITHUB_WORKSPACE/tools/ci/tsan_suppressions.txt"
           echo "TSAN_OPTIONS=$TSAN_OPTIONS"
           python -m spin test \
-          `find numpy -name "test*.py" | xargs grep -l "import threading" | tr '\n' ' '` \
-           -- -v -s --timeout=600 --durations=10
+          `find numpy -name "test*.py" | \
+          xargs grep -l -E "import threading|from threading|run_threaded" | \
+          tr '\n' ' '` \
+          -- -v -s --timeout=600 --durations=10

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -249,6 +249,7 @@ class TestMemmap:
     def test_threads_share_fh(self):
         """Multiple threads create a memmap on an already-opened file handle
         of size 0."""
+
         def func():
             fp = memmap(self.tmpfp, dtype=self.dtype, mode='w+', shape=self.shape)
             fp[:] = self.data[:]
@@ -261,6 +262,7 @@ class TestMemmap:
         opening its own file handle.
         """
         tmpname = tmp_path / 'mmap'
+
         def func():
             fp = memmap(tmpname, dtype=self.dtype, mode='w+', shape=self.shape)
             fp[:] = self.data[:]

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -26,6 +26,7 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     break_cycles,
+    run_threaded,
     suppress_warnings,
 )
 
@@ -244,3 +245,25 @@ class TestMemmap:
         memmap(self.tmpfp, shape=self.shape, mode='w+')
         memmap(self.tmpfp, shape=list(self.shape), mode='w+')
         memmap(self.tmpfp, shape=asarray(self.shape), mode='w+')
+
+    def test_threads_share_fh(self):
+        """Multiple threads create a memmap on an already-opened file handle
+        of size 0."""
+        def func():
+            fp = memmap(self.tmpfp, dtype=self.dtype, mode='w+', shape=self.shape)
+            fp[:] = self.data[:]
+            assert_array_equal(fp, self.data)
+
+        run_threaded(func)
+
+    def test_threads_share_fname(self, tmp_path):
+        """Multiple threads create a memmap on the same file name, each
+        opening its own file handle.
+        """
+        tmpname = tmp_path / 'mmap'
+        def func():
+            fp = memmap(tmpname, dtype=self.dtype, mode='w+', shape=self.shape)
+            fp[:] = self.data[:]
+            assert_array_equal(fp, self.data)
+
+        run_threaded(func)


### PR DESCRIPTION
Reproduces https://github.com/numpy/numpy/issues/29126
This segfaults instantly for me on 3.13t
```bash
pixi run test-nogil -v -- -k TestMemmap
```
pixi from https://github.com/rgommers/pixi-dev-scipystack

[EDIT] looks like it segfaults with the GIL on too!