### PR TITLE
DOC: Suppress distutils doc build warnings for python 3.12+

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,8 +150,26 @@ default_role = "autolink"
 exclude_dirs = []
 
 exclude_patterns = []
+suppress_warnings = []
+nitpick_ignore = []
+
 if sys.version_info[:2] >= (3, 12):
-    exclude_patterns += ["reference/distutils.rst"]
+    exclude_patterns += [
+        "reference/distutils.rst",
+        "reference/distutils/misc_util.rst",
+    ]
+    suppress_warnings += [
+        'toc.excluded',  # Suppress warnings about excluded toctree entries
+    ]
+    nitpicky = True
+    nitpick_ignore += [
+        ('ref', 'numpy-distutils-refguide'),
+        # The first ignore is not catpured without nitpicky = True.
+        # These three ignores are required once nitpicky = True is set.
+        ('py:mod', 'numpy.distutils'),
+        ('py:class', 'Extension'),
+        ('py:class', 'numpy.distutils.misc_util.Configuration'),
+    ]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = False
@@ -612,7 +630,7 @@ breathe_default_project = "numpy"
 breathe_default_members = ("members", "undoc-members", "protected-members")
 
 # See https://github.com/breathe-doc/breathe/issues/696
-nitpick_ignore = [
+nitpick_ignore += [
     ('c:identifier', 'FILE'),
     ('c:identifier', 'size_t'),
     ('c:identifier', 'PyHeapTypeObject'),


### PR DESCRIPTION
Enables an error free build of the docs for python 3.12+. Excludes related files, supresses all warnings for excluded files, and ignores case-by-case individual references. Closes #29131.

[skip azp][skip cirrus][skip actions]