### PR TITLE
TYP: Simplified ``dtype.__new__`` overloads

### DIFF
--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -14,12 +14,8 @@ dtype_U: np.dtype[np.str_]
 dtype_V: np.dtype[np.void]
 dtype_i8: np.dtype[np.int64]
 
-py_int_co: type[int]
-py_float_co: type[float]
-py_complex_co: type[complex]
 py_object: type[_PyObjectLike]
 py_character: type[str | bytes]
-py_flexible: type[str | bytes | memoryview]
 
 ct_floating: type[ct.c_float | ct.c_double | ct.c_longdouble]
 ct_number: type[ct.c_uint8 | ct.c_float]
@@ -48,19 +44,16 @@ assert_type(np.dtype("str"), np.dtype[np.str_])
 
 # Python types
 assert_type(np.dtype(bool), np.dtype[np.bool])
-assert_type(np.dtype(py_int_co), np.dtype[np.int_ | np.bool])
 assert_type(np.dtype(int), np.dtype[np.int_ | np.bool])
-assert_type(np.dtype(py_float_co), np.dtype[np.float64 | np.int_ | np.bool])
 assert_type(np.dtype(float), np.dtype[np.float64 | np.int_ | np.bool])
-assert_type(np.dtype(py_complex_co), np.dtype[np.complex128 | np.float64 | np.int_ | np.bool])
 assert_type(np.dtype(complex), np.dtype[np.complex128 | np.float64 | np.int_ | np.bool])
 assert_type(np.dtype(py_object), np.dtype[np.object_])
 assert_type(np.dtype(str), np.dtype[np.str_])
 assert_type(np.dtype(bytes), np.dtype[np.bytes_])
-assert_type(np.dtype(py_character), np.dtype[np.character])
 assert_type(np.dtype(memoryview), np.dtype[np.void])
-assert_type(np.dtype(py_flexible), np.dtype[np.flexible])
+assert_type(np.dtype(py_character), np.dtype[np.character])
 
+# object types
 assert_type(np.dtype(list), np.dtype[np.object_])
 assert_type(np.dtype(dt.datetime), np.dtype[np.object_])
 assert_type(np.dtype(dt.timedelta), np.dtype[np.object_])
@@ -75,12 +68,9 @@ assert_type(np.dtype("l"), np.dtype[np.long])
 assert_type(np.dtype("longlong"), np.dtype[np.longlong])
 assert_type(np.dtype(">g"), np.dtype[np.longdouble])
 assert_type(np.dtype(cs_integer), np.dtype[np.integer])
-assert_type(np.dtype(cs_number), np.dtype[np.number])
-assert_type(np.dtype(cs_flex), np.dtype[np.flexible])
-assert_type(np.dtype(cs_generic), np.dtype[np.generic])
 
 # ctypes
-assert_type(np.dtype(ct.c_double), np.dtype[np.double])
+assert_type(np.dtype(ct.c_double), np.dtype[np.float64])  # see numpy/numpy#29155
 assert_type(np.dtype(ct.c_longlong), np.dtype[np.longlong])
 assert_type(np.dtype(ct.c_uint32), np.dtype[np.uint32])
 assert_type(np.dtype(ct.c_bool), np.dtype[np.bool])
@@ -90,7 +80,7 @@ assert_type(np.dtype(ct.py_object), np.dtype[np.object_])
 # Special case for None
 assert_type(np.dtype(None), np.dtype[np.float64])
 
-# Dypes of dtypes
+# dtypes of dtypes
 assert_type(np.dtype(np.dtype(np.float64)), np.dtype[np.float64])
 assert_type(np.dtype(dt_inexact), np.dtype[np.inexact])
 
@@ -99,6 +89,7 @@ assert_type(np.dtype("S8"), np.dtype)
 
 # Void
 assert_type(np.dtype(("U", 10)), np.dtype[np.void])
+assert_type(np.dtype({"formats": (int, "u8"), "names": ("n", "B")}), np.dtype[np.void])
 
 # StringDType
 assert_type(np.dtype(dt_string), StringDType)


### PR DESCRIPTION
This reduces the number of overloads from 65 to 40. Overloads are very computationally  expensive to typecheck, because all combinations of overloads have to be considered. I haven't tested it myself, but I wouldn't be surprised if this change reduces the average runtimes of the mypy's and the pyright's by a couple of seconds.

Most of the "removed" overloads were merged into another the same return type. Some others for abstract scalar-types like `flexible` and `generic` were also removed, because I doubt that they will ever be used in realistic use-cases. And I figured that the primer will tell us if that assumption is false.