### PR TITLE
TYP: ``numpy._NoValue``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -432,6 +432,8 @@ from numpy._core.shape_base import (
 )
 
 from ._expired_attrs_2_0 import __expired_attributes__ as __expired_attributes__
+from ._globals import _CopyMode as _CopyMode
+from ._globals import _NoValue as _NoValue
 
 from numpy.lib import (
     scimath as emath,
@@ -494,8 +496,6 @@ from numpy.lib._function_base_impl import (
     interp,
     quantile,
 )
-
-from numpy._globals import _CopyMode
 
 from numpy.lib._histograms_impl import (
     histogram_bin_edges,


### PR DESCRIPTION
This adds implicit re-exports for ``numpy._globals._NoValue`` and ``_CopyMode`` to ``__init__.pyi``. They're available at runtime, so the stubs should reflect that (even though it's not public API), IMO.

This gets rid of a bunch of red sguigglies in the internal python codebase, e.g. in ``lib/_function_base_impl.py`` there are references to ``_NoValue``.