### PR TITLE
TYP: Accept dispatcher function with optional returns in ``_core.overrides``

### DIFF
--- a/numpy/_core/overrides.pyi
+++ b/numpy/_core/overrides.pyi
@@ -1,11 +1,13 @@
 from collections.abc import Callable, Iterable
-from typing import Any, Final, NamedTuple, ParamSpec, TypeVar
+from typing import Any, Final, NamedTuple, ParamSpec, TypeAlias, TypeVar
 
 from numpy._typing import _SupportsArrayFunc
 
 _T = TypeVar("_T")
 _Tss = ParamSpec("_Tss")
-_FuncT = TypeVar("_FuncT", bound=Callable[..., object])
+_FuncLikeT = TypeVar("_FuncLikeT", bound=type | Callable[..., object])
+
+_Dispatcher: TypeAlias = Callable[_Tss, Iterable[_SupportsArrayFunc | None]]
 
 ###
 
@@ -18,14 +20,11 @@ class ArgSpec(NamedTuple):
     keywords: str | None
     defaults: tuple[Any, ...]
 
-def get_array_function_like_doc(public_api: Callable[..., Any], docstring_template: str = "") -> str: ...
-def finalize_array_function_like(public_api: _FuncT) -> _FuncT: ...
+def get_array_function_like_doc(public_api: Callable[..., object], docstring_template: str = "") -> str: ...
+def finalize_array_function_like(public_api: _FuncLikeT) -> _FuncLikeT: ...
 
 #
-def verify_matching_signatures(
-    implementation: Callable[_Tss, object],
-    dispatcher: Callable[_Tss, Iterable[_SupportsArrayFunc]],
-) -> None: ...
+def verify_matching_signatures(implementation: Callable[_Tss, object], dispatcher: _Dispatcher[_Tss]) -> None: ...
 
 # NOTE: This actually returns a `_ArrayFunctionDispatcher` callable wrapper object, with
 # the original wrapped callable stored in the `._implementation` attribute. It checks
@@ -33,11 +32,11 @@ def verify_matching_signatures(
 # specifies. Since the dispatcher only returns an iterable of passed array-like args,
 # this overridable behaviour is impossible to annotate.
 def array_function_dispatch(
-    dispatcher: Callable[_Tss, Iterable[_SupportsArrayFunc]] | None = None,
+    dispatcher: _Dispatcher[_Tss] | None = None,
     module: str | None = None,
     verify: bool = True,
     docs_from_dispatcher: bool = False,
-) -> Callable[[_FuncT], _FuncT]: ...
+) -> Callable[[_FuncLikeT], _FuncLikeT]: ...
 
 #
 def array_function_from_dispatcher(
@@ -45,4 +44,4 @@ def array_function_from_dispatcher(
     module: str | None = None,
     verify: bool = True,
     docs_from_dispatcher: bool = True,
-) -> Callable[[Callable[_Tss, Iterable[_SupportsArrayFunc]]], Callable[_Tss, _T]]: ...
+) -> Callable[[_Dispatcher[_Tss]], Callable[_Tss, _T]]: ...

--- a/numpy/_core/overrides.pyi
+++ b/numpy/_core/overrides.pyi
@@ -1,13 +1,11 @@
 from collections.abc import Callable, Iterable
 from typing import Any, Final, NamedTuple, ParamSpec, TypeAlias, TypeVar
 
-from numpy._typing import _SupportsArrayFunc
-
 _T = TypeVar("_T")
 _Tss = ParamSpec("_Tss")
 _FuncLikeT = TypeVar("_FuncLikeT", bound=type | Callable[..., object])
 
-_Dispatcher: TypeAlias = Callable[_Tss, Iterable[_SupportsArrayFunc | None]]
+_Dispatcher: TypeAlias = Callable[_Tss, Iterable[object]]
 
 ###
 


### PR DESCRIPTION
This was causing many false red squigglies in internal python sources such as [`lib/_arraysetops_impl.py`](https://github.com/numpy/numpy/blob/30a4883d32a720a4af8a273d34673e671819e7b1/numpy/lib/_arraysetops_impl.py#L40). So I suppose you could view this as a DX thing.