### PR TITLE
TYP: Fix invalid inline annotations in ``lib._function_base_impl``

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4784,12 +4784,12 @@ def _get_indexes(arr, virtual_indexes, valid_values_count):
 
 
 def _quantile(
-    arr: np.typing.ArrayLike,
+    arr: "np.typing.ArrayLike",
     quantiles: np.ndarray,
     axis: int = -1,
     method: str = "linear",
     out: np.ndarray | None = None,
-    weights: np.typing.ArrayLike | None = None,
+    weights: "np.typing.ArrayLike | None" = None,
 ) -> np.ndarray:
     """
     Private function that doesn't support extended axis or keepdims.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4787,7 +4787,7 @@ def _quantile(
     arr: np.typing.ArrayLike,
     quantiles: np.ndarray,
     axis: int = -1,
-    method: str=  "linear",
+    method: str = "linear",
     out: np.ndarray | None = None,
     weights: np.typing.ArrayLike | None = None,
 ) -> np.ndarray:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4711,14 +4711,14 @@ def _inverted_cdf(n, quantiles):
 
 
 def _quantile_ureduce_func(
-        a: np.array,
-        q: np.array,
-        weights: np.array,
-        axis: int | None = None,
-        out=None,
-        overwrite_input: bool = False,
-        method="linear",
-) -> np.array:
+    a: np.ndarray,
+    q: np.ndarray,
+    weights: np.ndarray,
+    axis: int | None = None,
+    out: np.ndarray | None = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+) -> np.ndarray:
     if q.ndim > 2:
         # The code below works fine for nd, but it might not have useful
         # semantics. For now, keep the supported dimensions the same as it was
@@ -4784,13 +4784,13 @@ def _get_indexes(arr, virtual_indexes, valid_values_count):
 
 
 def _quantile(
-        arr: np.array,
-        quantiles: np.array,
-        axis: int = -1,
-        method="linear",
-        out=None,
-        weights=None,
-):
+    arr: np.typing.ArrayLike,
+    quantiles: np.ndarray,
+    axis: int = -1,
+    method: str=  "linear",
+    out: np.ndarray | None = None,
+    weights: np.typing.ArrayLike | None = None,
+) -> np.ndarray:
     """
     Private function that doesn't support extended axis or keepdims.
     These methods are extended to this function using _ureduce


### PR DESCRIPTION
``_ : np.array`` is not a valid type annotations, because ``np.array`` is a function, and not a type expression.