### PR TITLE
BUG: fix matmul with transposed out arg

### DIFF
--- a/doc/release/upcoming_changes/23752.performance.rst
+++ b/doc/release/upcoming_changes/23752.performance.rst
@@ -1,0 +1,6 @@
+Improve matmul performance when operands are non-contiguous
+-----------------------------------------------------------
+
+Enable using BLAS for matmul even when operands are non-contiguous by copying
+if needed. This performance enhancement's original implementation had a bug
+that was fixed for v2.3.1

--- a/doc/release/upcoming_changes/23752.performance.rst
+++ b/doc/release/upcoming_changes/23752.performance.rst
@@ -1,6 +1,0 @@
-Improve matmul performance when operands are non-contiguous
------------------------------------------------------------
-
-Enable using BLAS for matmul even when operands are non-contiguous by copying
-if needed. This performance enhancement's original implementation had a bug
-that was fixed for v2.3.1

--- a/doc/release/upcoming_changes/29179.change.rst
+++ b/doc/release/upcoming_changes/29179.change.rst
@@ -1,0 +1,4 @@
+Fix bug in ``matmul`` for non-contiguous out kwarg parameter
+------------------------------------------------------------
+In some cases, if ``out`` was non-contiguous, ``np.matmul`` would cause
+memory corruption or a c-level assert. This was new to v2.3.0 and fixed in v2.3.1.

--- a/doc/source/release/2.3.0-notes.rst
+++ b/doc/source/release/2.3.0-notes.rst
@@ -414,6 +414,12 @@ the best performance.
 
 (`gh-28769 <https://github.com/numpy/numpy/pull/28769>`__)
 
+Performance improvements for ``np.matmul``
+------------------------------------------
+Enable using BLAS for ``matmul`` even when operands are non-contiguous by copying
+if needed.
+
+(`gh-23752 <https://github.com/numpy/numpy/pull/23752>`__)
 
 Changes
 =======

--- a/numpy/_core/src/umath/matmul.c.src
+++ b/numpy/_core/src/umath/matmul.c.src
@@ -596,7 +596,7 @@ NPY_NO_EXPORT void
              * Use transpose equivalence:
              * matmul(a, b, o) == matmul(b.T, a.T, o.T)
              */
-            if (o_f_blasable) {
+            if (o_transpose) {
                 @TYPE@_matmul_matrixmatrix(
                     ip2_, is2_p_, is2_n_,
                     ip1_, is1_n_, is1_m_,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7272,10 +7272,6 @@ class TestMatmul(MatmulCommon):
         assert_array_equal(c, tgt_mv)
         c = self.matmul(v, a.T, out=out[:, 0, 0])
         assert_array_equal(c, tgt_mv)
-        # issue 29164
-        out_f = np.zeros((10, 4), dtype=float)
-        c = self.matmul(a, b, out=out_f[::-2, ::-2])
-        assert_array_equal(c, tgt)
 
         # test out contiguous in only last dim
         out = np.ones((10, 2), dtype=float)
@@ -7320,6 +7316,12 @@ class TestMatmul(MatmulCommon):
 
         r3 = np.matmul(args[0].copy(), args[1].copy())
         assert_equal(r1, r3)
+
+        # matrix matrix, issue 29164
+        if [len(args[0].shape), len(args[1].shape)] == [2, 2]:
+            out_f = np.zeros((r2.shape[0] * 2, r2.shape[1] * 2), order='F')
+            r4 = np.matmul(*args, out=out_f[::2, ::2])
+            assert_equal(r2, r4)
 
     def test_matmul_object(self):
         import fractions

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7272,6 +7272,10 @@ class TestMatmul(MatmulCommon):
         assert_array_equal(c, tgt_mv)
         c = self.matmul(v, a.T, out=out[:, 0, 0])
         assert_array_equal(c, tgt_mv)
+        # issue 29164
+        out_f = np.zeros((10, 4), dtype=float)
+        c = self.matmul(a, b, out=out_f[::-2, ::-2])
+        assert_array_equal(c, tgt)
 
         # test out contiguous in only last dim
         out = np.ones((10, 2), dtype=float)


### PR DESCRIPTION
Fixes #29164, the fix was suggested by @seberg

From the last comment in the issue:

> Ideally, make sure we have tests for all other cases as well.

I think that input is well tested via `numpy/_core/tests/test_multiarray.py::TestMatmul`'s `test_dot_equivalent`, and there are some tests in `test_out_contiguous` but that the specific case we hit here is missing. I added it: the test crashes before the fix, and passes after.