### PR TITLE
STY: ruff/isort config tweaks

### DIFF
--- a/numpy/_core/_dtype.pyi
+++ b/numpy/_core/_dtype.pyi
@@ -1,6 +1,5 @@
 from typing import Final, TypeAlias, TypedDict, overload, type_check_only
 from typing import Literal as L
-
 from typing_extensions import ReadOnly, TypeVar
 
 import numpy as np

--- a/numpy/_core/_internal.pyi
+++ b/numpy/_core/_internal.pyi
@@ -2,7 +2,6 @@ import ctypes as ct
 import re
 from collections.abc import Callable, Iterable
 from typing import Any, Final, Generic, Self, overload
-
 from typing_extensions import TypeVar, deprecated
 
 import numpy as np

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,7 +1,6 @@
+from _typeshed import SupportsWrite
 from collections.abc import Callable
 from typing import Any, Literal, TypeAlias, TypedDict, type_check_only
-
-from _typeshed import SupportsWrite
 
 from numpy import errstate as errstate
 

--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -13,7 +13,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
 from typing_extensions import deprecated
 
 import numpy as np

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Self, SupportsIndex, SupportsInt, TypeAlias, overload
 from typing import Literal as L
-
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -1,4 +1,5 @@
 # ruff: noqa: ANN401
+from _typeshed import Incomplete
 from collections.abc import Sequence
 from typing import (
     Any,
@@ -11,8 +12,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
-from _typeshed import Incomplete
 from typing_extensions import deprecated
 
 import numpy as np

--- a/numpy/_core/function_base.pyi
+++ b/numpy/_core/function_base.pyi
@@ -1,7 +1,6 @@
+from _typeshed import Incomplete
 from typing import Literal as L
 from typing import SupportsIndex, TypeAlias, TypeVar, overload
-
-from _typeshed import Incomplete
 
 import numpy as np
 from numpy._typing import (

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -1,5 +1,6 @@
 # TODO: Sort out any and all missing functions in this namespace
 import datetime as dt
+from _typeshed import StrOrBytesPath, SupportsLenAndGetItem
 from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
@@ -18,8 +19,6 @@ from typing import (
 from typing import (
     Literal as L,
 )
-
-from _typeshed import StrOrBytesPath, SupportsLenAndGetItem
 from typing_extensions import CapsuleType
 
 import numpy as np

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -1,5 +1,6 @@
 # ruff: noqa: ANN401
 # pyright: reportSelfClsParameterName=false
+from _typeshed import StrOrBytesPath
 from collections.abc import Iterable, Sequence
 from typing import (
     Any,
@@ -11,8 +12,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
-from _typeshed import StrOrBytesPath
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -1,10 +1,10 @@
 import sys
 
 import pytest
-from numpy._core._rational_tests import rational
 
 import numpy as np
 import numpy._core.umath as ncu
+from numpy._core._rational_tests import rational
 from numpy.testing import (
     HAS_REFCOUNT,
     assert_,

--- a/numpy/_core/tests/test_argparse.py
+++ b/numpy/_core/tests/test_argparse.py
@@ -14,14 +14,14 @@ match exactly, and could be adjusted):
 import threading
 
 import pytest
+
+import numpy as np
 from numpy._core._multiarray_tests import (
     argparse_example_function as func,
 )
 from numpy._core._multiarray_tests import (
     threaded_argparse_example_function as thread_func,
 )
-
-import numpy as np
 from numpy.testing import IS_WASM
 
 

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -6,12 +6,12 @@ are tested (sometimes indirectly) elsewhere.
 
 from itertools import permutations, product
 
-import numpy._core._multiarray_umath as ncu
 import pytest
-from numpy._core._rational_tests import rational
 from pytest import param
 
 import numpy as np
+import numpy._core._multiarray_umath as ncu
+from numpy._core._rational_tests import rational
 from numpy.testing import IS_64BIT, IS_PYPY, assert_array_equal
 
 

--- a/numpy/_core/tests/test_arraymethod.py
+++ b/numpy/_core/tests/test_arraymethod.py
@@ -7,9 +7,9 @@ import types
 from typing import Any
 
 import pytest
-from numpy._core._multiarray_umath import _get_castingimpl as get_castingimpl
 
 import numpy as np
+from numpy._core._multiarray_umath import _get_castingimpl as get_castingimpl
 
 
 class TestResolveDescriptors:

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -12,9 +12,9 @@ import random
 import textwrap
 
 import pytest
-from numpy._core._multiarray_umath import _get_castingimpl as get_castingimpl
 
 import numpy as np
+from numpy._core._multiarray_umath import _get_castingimpl as get_castingimpl
 from numpy.lib.stride_tricks import as_strided
 from numpy.testing import assert_array_equal
 

--- a/numpy/_core/tests/test_conversion_utils.py
+++ b/numpy/_core/tests/test_conversion_utils.py
@@ -3,9 +3,9 @@ Tests for numpy/_core/src/multiarray/conversion_utils.c
 """
 import re
 
-import numpy._core._multiarray_tests as mt
 import pytest
 
+import numpy._core._multiarray_tests as mt
 from numpy._core.multiarray import CLIP, RAISE, WRAP
 from numpy.testing import assert_raises
 

--- a/numpy/_core/tests/test_cpu_dispatcher.py
+++ b/numpy/_core/tests/test_cpu_dispatcher.py
@@ -1,10 +1,9 @@
+from numpy._core import _umath_tests
 from numpy._core._multiarray_umath import (
     __cpu_baseline__,
     __cpu_dispatch__,
     __cpu_features__,
 )
-
-from numpy._core import _umath_tests
 from numpy.testing import assert_equal
 
 

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import pytest
+
 from numpy._core._multiarray_umath import (
     __cpu_baseline__,
     __cpu_dispatch__,

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -1,12 +1,12 @@
 from tempfile import NamedTemporaryFile
 
 import pytest
+
+import numpy as np
 from numpy._core._multiarray_umath import (
     _discover_array_parameters as discover_array_params,
 )
 from numpy._core._multiarray_umath import _get_sfloat_dtype
-
-import numpy as np
 from numpy.testing import assert_array_equal
 
 SF = _get_sfloat_dtype()

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -6,11 +6,11 @@ to document how deprecations should eventually be turned into errors.
 import contextlib
 import warnings
 
-import numpy._core._struct_ufunc_tests as struct_ufunc
 import pytest
-from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F401
 
 import numpy as np
+import numpy._core._struct_ufunc_tests as struct_ufunc
+from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F401
 from numpy.testing import assert_raises, temppath
 
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -11,11 +11,11 @@ from typing import Any
 import hypothesis
 import pytest
 from hypothesis.extra import numpy as hynp
-from numpy._core._multiarray_tests import create_custom_field_dtype
-from numpy._core._rational_tests import rational
 
 import numpy as np
 import numpy.dtypes
+from numpy._core._multiarray_tests import create_custom_field_dtype
+from numpy._core._rational_tests import rational
 from numpy.testing import (
     HAS_REFCOUNT,
     IS_PYSTON,

--- a/numpy/_core/tests/test_extint128.py
+++ b/numpy/_core/tests/test_extint128.py
@@ -2,10 +2,10 @@ import contextlib
 import itertools
 import operator
 
-import numpy._core._multiarray_tests as mt
 import pytest
 
 import numpy as np
+import numpy._core._multiarray_tests as mt
 from numpy.testing import assert_equal, assert_raises
 
 INT64_MAX = np.iinfo(np.int64).max

--- a/numpy/_core/tests/test_hashtable.py
+++ b/numpy/_core/tests/test_hashtable.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 from numpy._core._multiarray_tests import identityhash_tester
 
 

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -5,9 +5,9 @@ import warnings
 from itertools import product
 
 import pytest
-from numpy._core._multiarray_tests import array_indexing
 
 import numpy as np
+from numpy._core._multiarray_tests import array_indexing
 from numpy.exceptions import ComplexWarning, VisibleDeprecationWarning
 from numpy.testing import (
     HAS_REFCOUNT,

--- a/numpy/_core/tests/test_mem_overlap.py
+++ b/numpy/_core/tests/test_mem_overlap.py
@@ -1,10 +1,10 @@
 import itertools
 
 import pytest
-from numpy._core._multiarray_tests import internal_overlap, solve_diophantine
 
 import numpy as np
 from numpy._core import _umath_tests
+from numpy._core._multiarray_tests import internal_overlap, solve_diophantine
 from numpy.lib.stride_tricks import as_strided
 from numpy.testing import assert_, assert_array_equal, assert_equal, assert_raises
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -21,11 +21,11 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import numpy._core._multiarray_tests as _multiarray_tests
 import pytest
-from numpy._core._rational_tests import rational
 
 import numpy as np
+import numpy._core._multiarray_tests as _multiarray_tests
+from numpy._core._rational_tests import rational
 from numpy._core.multiarray import _get_ndarray_c_version, dot
 from numpy._core.tests._locales import CommaDecimalPointLocale
 from numpy.exceptions import AxisError, ComplexWarning

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -2,10 +2,10 @@ import subprocess
 import sys
 import textwrap
 
-import numpy._core._multiarray_tests as _multiarray_tests
 import pytest
 
 import numpy as np
+import numpy._core._multiarray_tests as _multiarray_tests
 import numpy._core.umath as ncu
 from numpy import all, arange, array, nditer
 from numpy.testing import (

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -9,11 +9,11 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hynp
-from numpy._core._rational_tests import rational
 
 import numpy as np
 from numpy import ma
 from numpy._core import sctypes
+from numpy._core._rational_tests import rational
 from numpy._core.numerictypes import obj2sctype
 from numpy.exceptions import AxisError
 from numpy.random import rand, randint, randn

--- a/numpy/_core/tests/test_scalarbuffer.py
+++ b/numpy/_core/tests/test_scalarbuffer.py
@@ -2,10 +2,10 @@
 Test scalar buffer interface adheres to PEP 3118
 """
 import pytest
-from numpy._core._multiarray_tests import get_buffer_info
-from numpy._core._rational_tests import rational
 
 import numpy as np
+from numpy._core._multiarray_tests import get_buffer_info
+from numpy._core._rational_tests import rational
 from numpy.testing import assert_, assert_equal, assert_raises
 
 # PEP3118 format strings for native (standard alignment and byteorder) types

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -9,9 +9,9 @@ import pytest
 from hypothesis import given, settings
 from hypothesis.extra import numpy as hynp
 from hypothesis.strategies import sampled_from
-from numpy._core._rational_tests import rational
 
 import numpy as np
+from numpy._core._rational_tests import rational
 from numpy._utils import _pep440
 from numpy.exceptions import ComplexWarning
 from numpy.testing import (

--- a/numpy/_core/tests/test_simd.py
+++ b/numpy/_core/tests/test_simd.py
@@ -6,8 +6,8 @@ import operator
 import re
 
 import pytest
-from numpy._core._multiarray_umath import __cpu_baseline__
 
+from numpy._core._multiarray_umath import __cpu_baseline__
 from numpy._core._simd import clear_floatstatus, get_floatstatus, targets
 
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -4,13 +4,13 @@ import pickle
 import sys
 import warnings
 
-import numpy._core._operand_flag_tests as opflag_tests
-import numpy._core._rational_tests as _rational_tests
-import numpy._core._umath_tests as umt
 import pytest
 from pytest import param
 
 import numpy as np
+import numpy._core._operand_flag_tests as opflag_tests
+import numpy._core._rational_tests as _rational_tests
+import numpy._core._umath_tests as umt
 import numpy._core.umath as ncu
 import numpy.linalg._umath_linalg as uml
 from numpy.exceptions import AxisError

--- a/numpy/_core/tests/test_umath_accuracy.py
+++ b/numpy/_core/tests/test_umath_accuracy.py
@@ -4,9 +4,9 @@ from ctypes import POINTER, c_double, c_float, c_int, c_longlong, cast, pointer
 from os import path
 
 import pytest
-from numpy._core._multiarray_umath import __cpu_features__
 
 import numpy as np
+from numpy._core._multiarray_umath import __cpu_features__
 from numpy.testing import assert_array_max_ulp
 from numpy.testing._private.utils import _glibc_older_than
 

--- a/numpy/_core/tests/test_umath_complex.py
+++ b/numpy/_core/tests/test_umath_complex.py
@@ -1,11 +1,12 @@
 import platform
 import sys
 
-# import the c-extension module directly since _arg is not exported via umath
-import numpy._core._multiarray_umath as ncu
 import pytest
 
 import numpy as np
+
+# import the c-extension module directly since _arg is not exported via umath
+import numpy._core._multiarray_umath as ncu
 from numpy.testing import (
     assert_almost_equal,
     assert_array_equal,

--- a/numpy/_typing/_nbit_base.pyi
+++ b/numpy/_typing/_nbit_base.pyi
@@ -3,7 +3,6 @@
 # mypy: disable-error-code=misc
 
 from typing import final
-
 from typing_extensions import deprecated
 
 # Deprecated in NumPy 2.3, 2025-05-01

--- a/numpy/_utils/__init__.pyi
+++ b/numpy/_utils/__init__.pyi
@@ -1,7 +1,6 @@
+from _typeshed import IdentityFunction
 from collections.abc import Callable, Iterable
 from typing import Protocol, TypeVar, overload, type_check_only
-
-from _typeshed import IdentityFunction
 
 from ._convertions import asbytes as asbytes
 from ._convertions import asunicode as asunicode

--- a/numpy/_utils/_inspect.pyi
+++ b/numpy/_utils/_inspect.pyi
@@ -1,8 +1,7 @@
 import types
+from _typeshed import SupportsLenAndGetItem
 from collections.abc import Callable, Mapping
 from typing import Any, Final, TypeAlias, TypeVar, overload
-
-from _typeshed import SupportsLenAndGetItem
 from typing_extensions import TypeIs
 
 __all__ = ["formatargspec", "getargspec"]

--- a/numpy/_utils/_pep440.pyi
+++ b/numpy/_utils/_pep440.pyi
@@ -13,7 +13,6 @@ from typing import (
 from typing import (
     Literal as L,
 )
-
 from typing_extensions import TypeIs
 
 __all__ = ["VERSION_PATTERN", "InvalidVersion", "LegacyVersion", "Version", "parse"]

--- a/numpy/ctypeslib/_ctypeslib.pyi
+++ b/numpy/ctypeslib/_ctypeslib.pyi
@@ -1,6 +1,7 @@
 # NOTE: Numpy's mypy plugin is used for importing the correct
 # platform-specific `ctypes._SimpleCData[int]` sub-type
 import ctypes
+from _typeshed import StrOrBytesPath
 from collections.abc import Iterable, Sequence
 from ctypes import c_int64 as _c_intp
 from typing import (
@@ -12,8 +13,6 @@ from typing import (
     overload,
 )
 from typing import Literal as L
-
-from _typeshed import StrOrBytesPath
 
 import numpy as np
 from numpy import (

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -12,7 +12,6 @@ from typing import (
     type_check_only,
 )
 from typing import Literal as L
-
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/f2py/_backends/_meson.pyi
+++ b/numpy/f2py/_backends/_meson.pyi
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Final
 from typing import Literal as L
-
 from typing_extensions import override
 
 from ._backend import Backend

--- a/numpy/f2py/_src_pyf.pyi
+++ b/numpy/f2py/_src_pyf.pyi
@@ -1,8 +1,7 @@
 import re
+from _typeshed import StrOrBytesPath
 from collections.abc import Mapping
 from typing import Final
-
-from _typeshed import StrOrBytesPath
 
 routine_start_re: Final[re.Pattern[str]] = ...
 routine_end_re: Final[re.Pattern[str]] = ...

--- a/numpy/f2py/auxfuncs.pyi
+++ b/numpy/f2py/auxfuncs.pyi
@@ -1,9 +1,8 @@
+from _typeshed import FileDescriptorOrPath
 from collections.abc import Callable, Mapping
 from pprint import pprint as show
 from typing import Any, Final, Never, TypeAlias, TypeVar, overload
 from typing import Literal as L
-
-from _typeshed import FileDescriptorOrPath
 
 from .cfuncs import errmess
 

--- a/numpy/f2py/crackfortran.pyi
+++ b/numpy/f2py/crackfortran.pyi
@@ -1,9 +1,8 @@
 import re
+from _typeshed import StrOrBytesPath, StrPath
 from collections.abc import Callable, Iterable, Mapping
 from typing import IO, Any, Concatenate, Final, Never, ParamSpec, TypeAlias, overload
 from typing import Literal as L
-
-from _typeshed import StrOrBytesPath, StrPath
 
 from .__version__ import version
 from .auxfuncs import isintent_dict as isintent_dict

--- a/numpy/f2py/f2py2e.pyi
+++ b/numpy/f2py/f2py2e.pyi
@@ -3,7 +3,6 @@ import pprint
 from collections.abc import Hashable, Iterable, Mapping, MutableMapping, Sequence
 from types import ModuleType
 from typing import Any, Final, NotRequired, TypedDict, type_check_only
-
 from typing_extensions import TypeVar, override
 
 from .__version__ import version

--- a/numpy/f2py/rules.pyi
+++ b/numpy/f2py/rules.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any, Final, TypeAlias
 from typing import Literal as L
-
 from typing_extensions import TypeVar
 
 from .__version__ import version

--- a/numpy/f2py/symbolic.pyi
+++ b/numpy/f2py/symbolic.pyi
@@ -2,7 +2,6 @@ from collections.abc import Callable, Mapping
 from enum import Enum
 from typing import Any, Generic, ParamSpec, Self, TypeAlias, overload
 from typing import Literal as L
-
 from typing_extensions import TypeVar
 
 __all__ = ["Expr"]

--- a/numpy/fft/helper.pyi
+++ b/numpy/fft/helper.pyi
@@ -1,6 +1,5 @@
 from typing import Any
 from typing import Literal as L
-
 from typing_extensions import deprecated
 
 import numpy as np

--- a/numpy/lib/_arraysetops_impl.pyi
+++ b/numpy/lib/_arraysetops_impl.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Generic, NamedTuple, SupportsIndex, TypeAlias, overload
 from typing import Literal as L
-
 from typing_extensions import TypeVar, deprecated
 
 import numpy as np

--- a/numpy/lib/_arrayterator_impl.pyi
+++ b/numpy/lib/_arrayterator_impl.pyi
@@ -3,7 +3,6 @@
 from collections.abc import Generator
 from types import EllipsisType
 from typing import Any, Final, TypeAlias, overload
-
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/lib/_datasource.pyi
+++ b/numpy/lib/_datasource.pyi
@@ -1,7 +1,6 @@
+from _typeshed import OpenBinaryMode, OpenTextMode
 from pathlib import Path
 from typing import IO, Any, TypeAlias
-
-from _typeshed import OpenBinaryMode, OpenTextMode
 
 _Mode: TypeAlias = OpenBinaryMode | OpenTextMode
 

--- a/numpy/lib/_format_impl.pyi
+++ b/numpy/lib/_format_impl.pyi
@@ -1,7 +1,6 @@
 import os
-from typing import Any, BinaryIO, Final, TypeAlias, TypeGuard
-
 from _typeshed import SupportsRead, SupportsWrite
+from typing import Any, BinaryIO, Final, TypeAlias, TypeGuard
 
 import numpy as np
 import numpy.typing as npt

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -1,4 +1,5 @@
 # ruff: noqa: ANN401
+from _typeshed import Incomplete
 from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
@@ -13,8 +14,6 @@ from typing import (
     type_check_only,
 )
 from typing import Literal as L
-
-from _typeshed import Incomplete
 from typing_extensions import TypeIs, deprecated
 
 import numpy as np

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -1,8 +1,7 @@
+from _typeshed import Incomplete
 from collections.abc import Sequence
 from typing import Any, ClassVar, Final, Generic, Self, SupportsIndex, final, overload
 from typing import Literal as L
-
-from _typeshed import Incomplete
 from typing_extensions import TypeVar, deprecated
 
 import numpy as np

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -1,5 +1,12 @@
 import types
 import zipfile
+from _typeshed import (
+    StrOrBytesPath,
+    StrPath,
+    SupportsKeysAndGetItem,
+    SupportsRead,
+    SupportsWrite,
+)
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
 from typing import (
@@ -14,14 +21,6 @@ from typing import (
     type_check_only,
 )
 from typing import Literal as L
-
-from _typeshed import (
-    StrOrBytesPath,
-    StrPath,
-    SupportsKeysAndGetItem,
-    SupportsRead,
-    SupportsWrite,
-)
 from typing_extensions import TypeVar, deprecated, override
 
 import numpy as np

--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -9,7 +9,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
 from typing_extensions import deprecated
 
 import numpy as np

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -1,8 +1,7 @@
+from _typeshed import Incomplete
 from collections.abc import Container, Iterable
 from typing import Any, Protocol, TypeAlias, overload, type_check_only
 from typing import Literal as L
-
-from _typeshed import Incomplete
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/lib/_user_array_impl.pyi
+++ b/numpy/lib/_user_array_impl.pyi
@@ -1,7 +1,6 @@
+from _typeshed import Incomplete
 from types import EllipsisType
 from typing import Any, Generic, Self, SupportsIndex, TypeAlias, overload
-
-from _typeshed import Incomplete
 from typing_extensions import TypeVar, override
 
 import numpy as np

--- a/numpy/lib/_utils_impl.pyi
+++ b/numpy/lib/_utils_impl.pyi
@@ -1,6 +1,5 @@
-from typing import LiteralString
-
 from _typeshed import SupportsWrite
+from typing import LiteralString
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/lib/recfunctions.pyi
+++ b/numpy/lib/recfunctions.pyi
@@ -1,7 +1,6 @@
+from _typeshed import Incomplete
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Literal, TypeAlias, overload
-
-from _typeshed import Incomplete
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -1,10 +1,9 @@
 # pyright: reportIncompatibleMethodOverride=false
 # ruff: noqa: ANN001, ANN002, ANN003, ANN201, ANN202 ANN204, ANN401
 
+from _typeshed import Incomplete
 from collections.abc import Sequence
 from typing import Any, Literal, NoReturn, Self, SupportsIndex, TypeAlias, overload
-
-from _typeshed import Incomplete
 from typing_extensions import TypeIs, TypeVar
 
 import numpy as np

--- a/numpy/polynomial/_polybase.pyi
+++ b/numpy/polynomial/_polybase.pyi
@@ -13,7 +13,6 @@ from typing import (
     TypeAlias,
     overload,
 )
-
 from typing_extensions import TypeIs, TypeVar
 
 import numpy as np

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -1,4 +1,5 @@
 import abc
+from _typeshed import Incomplete
 from collections.abc import Callable, Mapping, Sequence
 from threading import Lock
 from typing import (
@@ -12,8 +13,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
-from _typeshed import Incomplete
 from typing_extensions import CapsuleType
 
 import numpy as np

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -3,6 +3,7 @@ import sys
 import types
 import unittest
 import warnings
+from _typeshed import ConvertibleToFloat, GenericPath, StrOrBytesPath, StrPath
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import _GeneratorContextManager
 from pathlib import Path
@@ -23,10 +24,8 @@ from typing import (
     type_check_only,
 )
 from typing import Literal as L
-from unittest.case import SkipTest
-
-from _typeshed import ConvertibleToFloat, GenericPath, StrOrBytesPath, StrPath
 from typing_extensions import TypeVar
+from unittest.case import SkipTest
 
 import numpy as np
 from numpy._typing import (

--- a/numpy/testing/overrides.pyi
+++ b/numpy/testing/overrides.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Callable, Hashable
 from typing import Any
-
 from typing_extensions import TypeIs
 
 import numpy as np

--- a/numpy/testing/print_coercion_tables.pyi
+++ b/numpy/testing/print_coercion_tables.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from typing import ClassVar, Generic, Self
-
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,6 +16,9 @@ extend-exclude = [
 
 line-length = 88
 
+[format]
+line-ending = "lf"
+
 [lint]
 preview = true
 extend-select = [
@@ -115,3 +118,15 @@ ignore = [
 "numpy/ma/core.pyi" = ["F403", "F405"]
 "numpy/matlib.py" = ["F405"]
 "numpy/matlib.pyi" = ["F811"]
+
+[lint.flake8-builtins]
+builtins-allowed-modules = ["random", "typing"]
+
+[lint.flake8-import-conventions.extend-aliases]
+"numpy" = "np"
+"numpy.typing" = "npt"
+
+[lint.isort]
+# these are treated as stdlib within .pyi stubs
+extra-standard-library = ["_typeshed", "typing_extensions"]
+known-first-party = ["numpy"]


### PR DESCRIPTION
Ruff/isort now groups all `numpy` imports together, and will sort `_typeshed` and `typing_extensions` import as if they are stdlib (in `.pyi` stubs that's pretty close to the truth).