### PR TITLE
TYP: fix ``ravel_multi_index`` false rejections

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -499,33 +499,27 @@ def array(
     like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[Any]: ...
 
+#
 @overload
-def unravel_index(  # type: ignore[misc]
-    indices: _IntLike_co,
-    shape: _ShapeLike,
-    order: _OrderCF = ...,
-) -> tuple[intp, ...]: ...
-@overload
-def unravel_index(
-    indices: _ArrayLikeInt_co,
-    shape: _ShapeLike,
-    order: _OrderCF = ...,
-) -> tuple[NDArray[intp], ...]: ...
-
-@overload
-def ravel_multi_index(  # type: ignore[misc]
-    multi_index: Sequence[_IntLike_co],
-    dims: Sequence[SupportsIndex],
-    mode: _ModeKind | tuple[_ModeKind, ...] = ...,
-    order: _OrderCF = ...,
+def ravel_multi_index(
+    multi_index: SupportsLenAndGetItem[_IntLike_co],
+    dims: _ShapeLike,
+    mode: _ModeKind | tuple[_ModeKind, ...] = "raise",
+    order: _OrderCF = "C",
 ) -> intp: ...
 @overload
 def ravel_multi_index(
-    multi_index: Sequence[_ArrayLikeInt_co],
-    dims: Sequence[SupportsIndex],
-    mode: _ModeKind | tuple[_ModeKind, ...] = ...,
-    order: _OrderCF = ...,
+    multi_index: SupportsLenAndGetItem[_ArrayLikeInt_co],
+    dims: _ShapeLike,
+    mode: _ModeKind | tuple[_ModeKind, ...] = "raise",
+    order: _OrderCF = "C",
 ) -> NDArray[intp]: ...
+
+#
+@overload
+def unravel_index(indices: _IntLike_co, shape: _ShapeLike, order: _OrderCF = "C") -> tuple[intp, ...]: ...
+@overload
+def unravel_index(indices: _ArrayLikeInt_co, shape: _ShapeLike, order: _OrderCF = "C") -> tuple[NDArray[intp], ...]: ...
 
 # NOTE: Allow any sequence of array-like objects
 @overload


### PR DESCRIPTION
Valid uses like in https://github.com/numpy/numpy/blob/8ce860ffaeecf2a8d3939a6201994a44e58584e8/numpy/lib/_histograms_impl.py#L1055-L1057 will now be accepted by static type-checkers.