### PR TITLE
STY: ruff/isort config tweaks - episode 2

### DIFF
--- a/numpy/__config__.pyi
+++ b/numpy/__config__.pyi
@@ -1,7 +1,13 @@
 from enum import Enum
 from types import ModuleType
-from typing import Final, NotRequired, TypedDict, overload, type_check_only
-from typing import Literal as L
+from typing import (
+    Final,
+    Literal as L,
+    NotRequired,
+    TypedDict,
+    overload,
+    type_check_only,
+)
 
 _CompilerConfigDictValue = TypedDict(
     "_CompilerConfigDictValue",

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -454,8 +454,7 @@ else:
             pass
     del ta
 
-    from . import lib
-    from . import matrixlib as _mat
+    from . import lib, matrixlib as _mat
     from .lib import scimath as emath
     from .lib._arraypad_impl import pad
     from .lib._arraysetops_impl import (

--- a/numpy/_core/_add_newdocs_scalars.py
+++ b/numpy/_core/_add_newdocs_scalars.py
@@ -6,8 +6,7 @@ platform-dependent information.
 import os
 import sys
 
-from numpy._core import dtype
-from numpy._core import numerictypes as _numerictypes
+from numpy._core import dtype, numerictypes as _numerictypes
 from numpy._core.function_base import add_newdoc
 
 ##############################################################################

--- a/numpy/_core/_asarray.py
+++ b/numpy/_core/_asarray.py
@@ -4,11 +4,7 @@ Functions in the ``as*array`` family that promote array-likes into arrays.
 `require` fits this category despite its name not matching this pattern.
 """
 from .multiarray import array, asanyarray
-from .overrides import (
-    array_function_dispatch,
-    finalize_array_function_like,
-    set_module,
-)
+from .overrides import array_function_dispatch, finalize_array_function_like, set_module
 
 __all__ = ["require"]
 

--- a/numpy/_core/_dtype.pyi
+++ b/numpy/_core/_dtype.pyi
@@ -1,5 +1,4 @@
-from typing import Final, TypeAlias, TypedDict, overload, type_check_only
-from typing import Literal as L
+from typing import Final, Literal as L, TypeAlias, TypedDict, overload, type_check_only
 from typing_extensions import ReadOnly, TypeVar
 
 import numpy as np

--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -9,9 +9,7 @@ import warnings
 from contextlib import nullcontext
 
 import numpy as np
-from numpy._core import multiarray as mu
-from numpy._core import numerictypes as nt
-from numpy._core import umath as um
+from numpy._core import multiarray as mu, numerictypes as nt, umath as um
 from numpy._core.multiarray import asanyarray
 from numpy._globals import _NoValue
 

--- a/numpy/_core/_type_aliases.pyi
+++ b/numpy/_core/_type_aliases.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Collection
-from typing import Final, TypeAlias, TypedDict, type_check_only
-from typing import Literal as L
+from typing import Final, Literal as L, TypeAlias, TypedDict, type_check_only
 
 import numpy as np
 

--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -22,31 +22,19 @@ from numpy._core import overrides
 from numpy._core.multiarray import compare_chararrays
 from numpy._core.strings import (
     _join as join,
-)
-from numpy._core.strings import (
     _rsplit as rsplit,
-)
-from numpy._core.strings import (
     _split as split,
-)
-from numpy._core.strings import (
     _splitlines as splitlines,
 )
 from numpy._utils import set_module
 from numpy.strings import *
 from numpy.strings import (
     multiply as strings_multiply,
-)
-from numpy.strings import (
     partition as strings_partition,
-)
-from numpy.strings import (
     rpartition as strings_rpartition,
 )
 
-from .numeric import array as narray
-from .numeric import asarray as asnarray
-from .numeric import ndarray
+from .numeric import array as narray, asarray as asnarray, ndarray
 from .numerictypes import bytes_, character, str_
 
 __all__ = [

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -1,5 +1,12 @@
-from typing import Any, Self, SupportsIndex, SupportsInt, TypeAlias, overload
-from typing import Literal as L
+from typing import (
+    Any,
+    Literal as L,
+    Self,
+    SupportsIndex,
+    SupportsInt,
+    TypeAlias,
+    overload,
+)
 from typing_extensions import TypeVar
 
 import numpy as np
@@ -14,13 +21,19 @@ from numpy import (
     str_,
 )
 from numpy._core.multiarray import compare_chararrays
-from numpy._typing import NDArray, _AnyShape, _Shape, _ShapeLike, _SupportsArray
-from numpy._typing import _ArrayLikeAnyString_co as UST_co
-from numpy._typing import _ArrayLikeBool_co as b_co
-from numpy._typing import _ArrayLikeBytes_co as S_co
-from numpy._typing import _ArrayLikeInt_co as i_co
-from numpy._typing import _ArrayLikeStr_co as U_co
-from numpy._typing import _ArrayLikeString_co as T_co
+from numpy._typing import (
+    NDArray,
+    _AnyShape,
+    _ArrayLikeAnyString_co as UST_co,
+    _ArrayLikeBool_co as b_co,
+    _ArrayLikeBytes_co as S_co,
+    _ArrayLikeInt_co as i_co,
+    _ArrayLikeStr_co as U_co,
+    _ArrayLikeString_co as T_co,
+    _Shape,
+    _ShapeLike,
+    _SupportsArray,
+)
 
 __all__ = [
     "equal",

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -8,10 +8,7 @@ import warnings
 import numpy as np
 from numpy._utils import set_module
 
-from . import _methods, overrides
-from . import multiarray as mu
-from . import numerictypes as nt
-from . import umath as um
+from . import _methods, multiarray as mu, numerictypes as nt, overrides, umath as um
 from ._multiarray_umath import _array_converter
 from .multiarray import asanyarray, asarray, concatenate
 

--- a/numpy/_core/function_base.pyi
+++ b/numpy/_core/function_base.pyi
@@ -1,6 +1,5 @@
 from _typeshed import Incomplete
-from typing import Literal as L
-from typing import SupportsIndex, TypeAlias, TypeVar, overload
+from typing import Literal as L, SupportsIndex, TypeAlias, TypeVar, overload
 
 import numpy as np
 from numpy._typing import (

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -8,8 +8,7 @@ import warnings
 
 from numpy._utils import set_module
 
-from . import numeric
-from . import numerictypes as ntypes
+from . import numeric, numerictypes as ntypes
 from ._machar import MachAr
 from .numeric import array, inf, nan
 from .umath import exp2, isnan, log10, nextafter

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -6,6 +6,7 @@ from typing import (
     Any,
     ClassVar,
     Final,
+    Literal as L,
     Protocol,
     SupportsIndex,
     TypeAlias,
@@ -15,9 +16,6 @@ from typing import (
     final,
     overload,
     type_check_only,
-)
-from typing import (
-    Literal as L,
 )
 from typing_extensions import CapsuleType
 
@@ -41,6 +39,7 @@ from numpy import (  # type: ignore[attr-defined]
     count_nonzero,
     datetime64,
     dtype,
+    einsum as c_einsum,
     flatiter,
     float64,
     floating,
@@ -60,9 +59,6 @@ from numpy import (  # type: ignore[attr-defined]
     uint8,
     unsignedinteger,
     vecdot,
-)
-from numpy import (
-    einsum as c_einsum,
 )
 from numpy._typing import (
     ArrayLike,

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -10,8 +10,7 @@ import warnings
 import numpy as np
 from numpy.exceptions import AxisError
 
-from . import multiarray, numerictypes, overrides, shape_base, umath
-from . import numerictypes as nt
+from . import multiarray, numerictypes, numerictypes as nt, overrides, shape_base, umath
 from ._ufunc_config import errstate
 from .multiarray import (  # noqa: F401
     ALLOW_THREADS,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -3,6 +3,7 @@ from collections.abc import Callable, Sequence
 from typing import (
     Any,
     Final,
+    Literal as L,
     Never,
     NoReturn,
     SupportsAbs,
@@ -13,7 +14,6 @@ from typing import (
     Unpack,
     overload,
 )
-from typing import Literal as L
 
 import numpy as np
 from numpy import (
@@ -116,15 +116,15 @@ from .fromnumeric import (
     transpose,
     var,
 )
-from .multiarray import ALLOW_THREADS as ALLOW_THREADS
-from .multiarray import BUFSIZE as BUFSIZE
-from .multiarray import CLIP as CLIP
-from .multiarray import MAXDIMS as MAXDIMS
-from .multiarray import MAY_SHARE_BOUNDS as MAY_SHARE_BOUNDS
-from .multiarray import MAY_SHARE_EXACT as MAY_SHARE_EXACT
-from .multiarray import RAISE as RAISE
-from .multiarray import WRAP as WRAP
 from .multiarray import (
+    ALLOW_THREADS as ALLOW_THREADS,
+    BUFSIZE as BUFSIZE,
+    CLIP as CLIP,
+    MAXDIMS as MAXDIMS,
+    MAY_SHARE_BOUNDS as MAY_SHARE_BOUNDS,
+    MAY_SHARE_EXACT as MAY_SHARE_EXACT,
+    RAISE as RAISE,
+    WRAP as WRAP,
     _Array,
     _ConstructorEmpty,
     _KwargsEmpty,
@@ -156,6 +156,7 @@ from .multiarray import (
     ndarray,
     nditer,
     nested_iters,
+    normalize_axis_index as normalize_axis_index,
     promote_types,
     putmask,
     result_type,
@@ -164,7 +165,6 @@ from .multiarray import (
     where,
     zeros,
 )
-from .multiarray import normalize_axis_index as normalize_axis_index
 from .numerictypes import (
     ScalarType,
     bool,

--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -1,6 +1,5 @@
 from builtins import bool as py_bool
-from typing import Final, TypedDict, type_check_only
-from typing import Literal as L
+from typing import Final, Literal as L, TypedDict, type_check_only
 
 import numpy as np
 from numpy import (

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -8,8 +8,7 @@ from contextlib import nullcontext
 
 from numpy._utils import set_module
 
-from . import numeric as sb
-from . import numerictypes as nt
+from . import numeric as sb, numerictypes as nt
 from .arrayprint import _get_legacy_print_mode
 
 # All of the functions allow formats to be a dtype

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -5,9 +5,7 @@ import functools
 import itertools
 import operator
 
-from . import fromnumeric as _from_nx
-from . import numeric as _nx
-from . import overrides
+from . import fromnumeric as _from_nx, numeric as _nx, overrides
 from .multiarray import array, asanyarray, normalize_axis_index
 
 array_function_dispatch = functools.partial(

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -14,10 +14,8 @@ from numpy import (
     greater_equal,
     less,
     less_equal,
-    not_equal,
-)
-from numpy import (
     multiply as _multiply_ufunc,
+    not_equal,
 )
 from numpy._core.multiarray import _vec_string
 from numpy._core.overrides import array_function_dispatch, set_module
@@ -40,6 +38,10 @@ from numpy._core.umath import (
     _strip_chars,
     _strip_whitespace,
     _zfill,
+    count as _count_ufunc,
+    endswith as _endswith_ufunc,
+    find as _find_ufunc,
+    index as _index_ufunc,
     isalnum,
     isalpha,
     isdecimal,
@@ -49,28 +51,10 @@ from numpy._core.umath import (
     isspace,
     istitle,
     isupper,
-    str_len,
-)
-from numpy._core.umath import (
-    count as _count_ufunc,
-)
-from numpy._core.umath import (
-    endswith as _endswith_ufunc,
-)
-from numpy._core.umath import (
-    find as _find_ufunc,
-)
-from numpy._core.umath import (
-    index as _index_ufunc,
-)
-from numpy._core.umath import (
     rfind as _rfind_ufunc,
-)
-from numpy._core.umath import (
     rindex as _rindex_ufunc,
-)
-from numpy._core.umath import (
     startswith as _startswith_ufunc,
+    str_len,
 )
 
 

--- a/numpy/_core/strings.pyi
+++ b/numpy/_core/strings.pyi
@@ -1,12 +1,16 @@
 from typing import TypeAlias, overload
 
 import numpy as np
-from numpy._typing import NDArray, _AnyShape, _SupportsArray
-from numpy._typing import _ArrayLikeAnyString_co as UST_co
-from numpy._typing import _ArrayLikeBytes_co as S_co
-from numpy._typing import _ArrayLikeInt_co as i_co
-from numpy._typing import _ArrayLikeStr_co as U_co
-from numpy._typing import _ArrayLikeString_co as T_co
+from numpy._typing import (
+    NDArray,
+    _AnyShape,
+    _ArrayLikeAnyString_co as UST_co,
+    _ArrayLikeBytes_co as S_co,
+    _ArrayLikeInt_co as i_co,
+    _ArrayLikeStr_co as U_co,
+    _ArrayLikeString_co as T_co,
+    _SupportsArray,
+)
 
 __all__ = [
     "add",

--- a/numpy/_core/tests/test_argparse.py
+++ b/numpy/_core/tests/test_argparse.py
@@ -18,8 +18,6 @@ import pytest
 import numpy as np
 from numpy._core._multiarray_tests import (
     argparse_example_function as func,
-)
-from numpy._core._multiarray_tests import (
     threaded_argparse_example_function as thread_func,
 )
 from numpy.testing import IS_WASM

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -5,8 +5,8 @@ import pytest
 import numpy as np
 from numpy._core._multiarray_umath import (
     _discover_array_parameters as discover_array_params,
+    _get_sfloat_dtype,
 )
-from numpy._core._multiarray_umath import _get_sfloat_dtype
 from numpy.testing import assert_array_equal
 
 SF = _get_sfloat_dtype()

--- a/numpy/_core/tests/test_indexerrors.py
+++ b/numpy/_core/tests/test_indexerrors.py
@@ -1,8 +1,5 @@
 import numpy as np
-from numpy.testing import (
-    assert_raises,
-    assert_raises_regex,
-)
+from numpy.testing import assert_raises, assert_raises_regex
 
 
 class TestIndexErrors:

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -6,8 +6,7 @@ import warnings
 from decimal import Decimal
 
 import pytest
-from hypothesis import given
-from hypothesis import strategies as st
+from hypothesis import given, strategies as st
 from hypothesis.extra import numpy as hynp
 
 import numpy as np

--- a/numpy/_core/tests/test_scalar_ctors.py
+++ b/numpy/_core/tests/test_scalar_ctors.py
@@ -4,11 +4,7 @@ Test the scalar constructors, which also do type-coercion
 import pytest
 
 import numpy as np
-from numpy.testing import (
-    assert_almost_equal,
-    assert_equal,
-    assert_warns,
-)
+from numpy.testing import assert_almost_equal, assert_equal, assert_warns
 
 
 class TestFromString:

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -8,8 +8,7 @@ import tempfile
 import pytest
 
 import numpy as np
-from numpy._core.tests._natype import get_stringdtype_dtype as get_dtype
-from numpy._core.tests._natype import pd_NA
+from numpy._core.tests._natype import get_stringdtype_dtype as get_dtype, pd_NA
 from numpy.dtypes import StringDType
 from numpy.testing import IS_PYPY, assert_array_equal
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -12,8 +12,7 @@ import pytest
 
 import numpy as np
 import numpy._core.umath as ncu
-from numpy._core import _umath_tests as ncu_tests
-from numpy._core import sctypes
+from numpy._core import _umath_tests as ncu_tests, sctypes
 from numpy.testing import (
     HAS_REFCOUNT,
     IS_MUSL,

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -1,148 +1,158 @@
 """Private counterpart of ``numpy.typing``."""
 
-from ._array_like import ArrayLike as ArrayLike
-from ._array_like import NDArray as NDArray
-from ._array_like import _ArrayLike as _ArrayLike
-from ._array_like import _ArrayLikeAnyString_co as _ArrayLikeAnyString_co
-from ._array_like import _ArrayLikeBool_co as _ArrayLikeBool_co
-from ._array_like import _ArrayLikeBytes_co as _ArrayLikeBytes_co
-from ._array_like import _ArrayLikeComplex128_co as _ArrayLikeComplex128_co
-from ._array_like import _ArrayLikeComplex_co as _ArrayLikeComplex_co
-from ._array_like import _ArrayLikeDT64_co as _ArrayLikeDT64_co
-from ._array_like import _ArrayLikeFloat64_co as _ArrayLikeFloat64_co
-from ._array_like import _ArrayLikeFloat_co as _ArrayLikeFloat_co
-from ._array_like import _ArrayLikeInt as _ArrayLikeInt
-from ._array_like import _ArrayLikeInt_co as _ArrayLikeInt_co
-from ._array_like import _ArrayLikeNumber_co as _ArrayLikeNumber_co
-from ._array_like import _ArrayLikeObject_co as _ArrayLikeObject_co
-from ._array_like import _ArrayLikeStr_co as _ArrayLikeStr_co
-from ._array_like import _ArrayLikeString_co as _ArrayLikeString_co
-from ._array_like import _ArrayLikeTD64_co as _ArrayLikeTD64_co
-from ._array_like import _ArrayLikeUInt_co as _ArrayLikeUInt_co
-from ._array_like import _ArrayLikeVoid_co as _ArrayLikeVoid_co
-from ._array_like import _FiniteNestedSequence as _FiniteNestedSequence
-from ._array_like import _SupportsArray as _SupportsArray
-from ._array_like import _SupportsArrayFunc as _SupportsArrayFunc
+from ._array_like import (
+    ArrayLike as ArrayLike,
+    NDArray as NDArray,
+    _ArrayLike as _ArrayLike,
+    _ArrayLikeAnyString_co as _ArrayLikeAnyString_co,
+    _ArrayLikeBool_co as _ArrayLikeBool_co,
+    _ArrayLikeBytes_co as _ArrayLikeBytes_co,
+    _ArrayLikeComplex128_co as _ArrayLikeComplex128_co,
+    _ArrayLikeComplex_co as _ArrayLikeComplex_co,
+    _ArrayLikeDT64_co as _ArrayLikeDT64_co,
+    _ArrayLikeFloat64_co as _ArrayLikeFloat64_co,
+    _ArrayLikeFloat_co as _ArrayLikeFloat_co,
+    _ArrayLikeInt as _ArrayLikeInt,
+    _ArrayLikeInt_co as _ArrayLikeInt_co,
+    _ArrayLikeNumber_co as _ArrayLikeNumber_co,
+    _ArrayLikeObject_co as _ArrayLikeObject_co,
+    _ArrayLikeStr_co as _ArrayLikeStr_co,
+    _ArrayLikeString_co as _ArrayLikeString_co,
+    _ArrayLikeTD64_co as _ArrayLikeTD64_co,
+    _ArrayLikeUInt_co as _ArrayLikeUInt_co,
+    _ArrayLikeVoid_co as _ArrayLikeVoid_co,
+    _FiniteNestedSequence as _FiniteNestedSequence,
+    _SupportsArray as _SupportsArray,
+    _SupportsArrayFunc as _SupportsArrayFunc,
+)
 
 #
-from ._char_codes import _BoolCodes as _BoolCodes
-from ._char_codes import _ByteCodes as _ByteCodes
-from ._char_codes import _BytesCodes as _BytesCodes
-from ._char_codes import _CDoubleCodes as _CDoubleCodes
-from ._char_codes import _CharacterCodes as _CharacterCodes
-from ._char_codes import _CLongDoubleCodes as _CLongDoubleCodes
-from ._char_codes import _Complex64Codes as _Complex64Codes
-from ._char_codes import _Complex128Codes as _Complex128Codes
-from ._char_codes import _ComplexFloatingCodes as _ComplexFloatingCodes
-from ._char_codes import _CSingleCodes as _CSingleCodes
-from ._char_codes import _DoubleCodes as _DoubleCodes
-from ._char_codes import _DT64Codes as _DT64Codes
-from ._char_codes import _FlexibleCodes as _FlexibleCodes
-from ._char_codes import _Float16Codes as _Float16Codes
-from ._char_codes import _Float32Codes as _Float32Codes
-from ._char_codes import _Float64Codes as _Float64Codes
-from ._char_codes import _FloatingCodes as _FloatingCodes
-from ._char_codes import _GenericCodes as _GenericCodes
-from ._char_codes import _HalfCodes as _HalfCodes
-from ._char_codes import _InexactCodes as _InexactCodes
-from ._char_codes import _Int8Codes as _Int8Codes
-from ._char_codes import _Int16Codes as _Int16Codes
-from ._char_codes import _Int32Codes as _Int32Codes
-from ._char_codes import _Int64Codes as _Int64Codes
-from ._char_codes import _IntCCodes as _IntCCodes
-from ._char_codes import _IntCodes as _IntCodes
-from ._char_codes import _IntegerCodes as _IntegerCodes
-from ._char_codes import _IntPCodes as _IntPCodes
-from ._char_codes import _LongCodes as _LongCodes
-from ._char_codes import _LongDoubleCodes as _LongDoubleCodes
-from ._char_codes import _LongLongCodes as _LongLongCodes
-from ._char_codes import _NumberCodes as _NumberCodes
-from ._char_codes import _ObjectCodes as _ObjectCodes
-from ._char_codes import _ShortCodes as _ShortCodes
-from ._char_codes import _SignedIntegerCodes as _SignedIntegerCodes
-from ._char_codes import _SingleCodes as _SingleCodes
-from ._char_codes import _StrCodes as _StrCodes
-from ._char_codes import _StringCodes as _StringCodes
-from ._char_codes import _TD64Codes as _TD64Codes
-from ._char_codes import _UByteCodes as _UByteCodes
-from ._char_codes import _UInt8Codes as _UInt8Codes
-from ._char_codes import _UInt16Codes as _UInt16Codes
-from ._char_codes import _UInt32Codes as _UInt32Codes
-from ._char_codes import _UInt64Codes as _UInt64Codes
-from ._char_codes import _UIntCCodes as _UIntCCodes
-from ._char_codes import _UIntCodes as _UIntCodes
-from ._char_codes import _UIntPCodes as _UIntPCodes
-from ._char_codes import _ULongCodes as _ULongCodes
-from ._char_codes import _ULongLongCodes as _ULongLongCodes
-from ._char_codes import _UnsignedIntegerCodes as _UnsignedIntegerCodes
-from ._char_codes import _UShortCodes as _UShortCodes
-from ._char_codes import _VoidCodes as _VoidCodes
+from ._char_codes import (
+    _BoolCodes as _BoolCodes,
+    _ByteCodes as _ByteCodes,
+    _BytesCodes as _BytesCodes,
+    _CDoubleCodes as _CDoubleCodes,
+    _CharacterCodes as _CharacterCodes,
+    _CLongDoubleCodes as _CLongDoubleCodes,
+    _Complex64Codes as _Complex64Codes,
+    _Complex128Codes as _Complex128Codes,
+    _ComplexFloatingCodes as _ComplexFloatingCodes,
+    _CSingleCodes as _CSingleCodes,
+    _DoubleCodes as _DoubleCodes,
+    _DT64Codes as _DT64Codes,
+    _FlexibleCodes as _FlexibleCodes,
+    _Float16Codes as _Float16Codes,
+    _Float32Codes as _Float32Codes,
+    _Float64Codes as _Float64Codes,
+    _FloatingCodes as _FloatingCodes,
+    _GenericCodes as _GenericCodes,
+    _HalfCodes as _HalfCodes,
+    _InexactCodes as _InexactCodes,
+    _Int8Codes as _Int8Codes,
+    _Int16Codes as _Int16Codes,
+    _Int32Codes as _Int32Codes,
+    _Int64Codes as _Int64Codes,
+    _IntCCodes as _IntCCodes,
+    _IntCodes as _IntCodes,
+    _IntegerCodes as _IntegerCodes,
+    _IntPCodes as _IntPCodes,
+    _LongCodes as _LongCodes,
+    _LongDoubleCodes as _LongDoubleCodes,
+    _LongLongCodes as _LongLongCodes,
+    _NumberCodes as _NumberCodes,
+    _ObjectCodes as _ObjectCodes,
+    _ShortCodes as _ShortCodes,
+    _SignedIntegerCodes as _SignedIntegerCodes,
+    _SingleCodes as _SingleCodes,
+    _StrCodes as _StrCodes,
+    _StringCodes as _StringCodes,
+    _TD64Codes as _TD64Codes,
+    _UByteCodes as _UByteCodes,
+    _UInt8Codes as _UInt8Codes,
+    _UInt16Codes as _UInt16Codes,
+    _UInt32Codes as _UInt32Codes,
+    _UInt64Codes as _UInt64Codes,
+    _UIntCCodes as _UIntCCodes,
+    _UIntCodes as _UIntCodes,
+    _UIntPCodes as _UIntPCodes,
+    _ULongCodes as _ULongCodes,
+    _ULongLongCodes as _ULongLongCodes,
+    _UnsignedIntegerCodes as _UnsignedIntegerCodes,
+    _UShortCodes as _UShortCodes,
+    _VoidCodes as _VoidCodes,
+)
 
 #
-from ._dtype_like import DTypeLike as DTypeLike
-from ._dtype_like import _DTypeLike as _DTypeLike
-from ._dtype_like import _DTypeLikeBool as _DTypeLikeBool
-from ._dtype_like import _DTypeLikeBytes as _DTypeLikeBytes
-from ._dtype_like import _DTypeLikeComplex as _DTypeLikeComplex
-from ._dtype_like import _DTypeLikeComplex_co as _DTypeLikeComplex_co
-from ._dtype_like import _DTypeLikeDT64 as _DTypeLikeDT64
-from ._dtype_like import _DTypeLikeFloat as _DTypeLikeFloat
-from ._dtype_like import _DTypeLikeInt as _DTypeLikeInt
-from ._dtype_like import _DTypeLikeObject as _DTypeLikeObject
-from ._dtype_like import _DTypeLikeStr as _DTypeLikeStr
-from ._dtype_like import _DTypeLikeTD64 as _DTypeLikeTD64
-from ._dtype_like import _DTypeLikeUInt as _DTypeLikeUInt
-from ._dtype_like import _DTypeLikeVoid as _DTypeLikeVoid
-from ._dtype_like import _SupportsDType as _SupportsDType
-from ._dtype_like import _VoidDTypeLike as _VoidDTypeLike
+from ._dtype_like import (
+    DTypeLike as DTypeLike,
+    _DTypeLike as _DTypeLike,
+    _DTypeLikeBool as _DTypeLikeBool,
+    _DTypeLikeBytes as _DTypeLikeBytes,
+    _DTypeLikeComplex as _DTypeLikeComplex,
+    _DTypeLikeComplex_co as _DTypeLikeComplex_co,
+    _DTypeLikeDT64 as _DTypeLikeDT64,
+    _DTypeLikeFloat as _DTypeLikeFloat,
+    _DTypeLikeInt as _DTypeLikeInt,
+    _DTypeLikeObject as _DTypeLikeObject,
+    _DTypeLikeStr as _DTypeLikeStr,
+    _DTypeLikeTD64 as _DTypeLikeTD64,
+    _DTypeLikeUInt as _DTypeLikeUInt,
+    _DTypeLikeVoid as _DTypeLikeVoid,
+    _SupportsDType as _SupportsDType,
+    _VoidDTypeLike as _VoidDTypeLike,
+)
 
 #
-from ._nbit import _NBitByte as _NBitByte
-from ._nbit import _NBitDouble as _NBitDouble
-from ._nbit import _NBitHalf as _NBitHalf
-from ._nbit import _NBitInt as _NBitInt
-from ._nbit import _NBitIntC as _NBitIntC
-from ._nbit import _NBitIntP as _NBitIntP
-from ._nbit import _NBitLong as _NBitLong
-from ._nbit import _NBitLongDouble as _NBitLongDouble
-from ._nbit import _NBitLongLong as _NBitLongLong
-from ._nbit import _NBitShort as _NBitShort
-from ._nbit import _NBitSingle as _NBitSingle
+from ._nbit import (
+    _NBitByte as _NBitByte,
+    _NBitDouble as _NBitDouble,
+    _NBitHalf as _NBitHalf,
+    _NBitInt as _NBitInt,
+    _NBitIntC as _NBitIntC,
+    _NBitIntP as _NBitIntP,
+    _NBitLong as _NBitLong,
+    _NBitLongDouble as _NBitLongDouble,
+    _NBitLongLong as _NBitLongLong,
+    _NBitShort as _NBitShort,
+    _NBitSingle as _NBitSingle,
+)
 
 #
 from ._nbit_base import (
     NBitBase as NBitBase,  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
+    _8Bit as _8Bit,
+    _16Bit as _16Bit,
+    _32Bit as _32Bit,
+    _64Bit as _64Bit,
+    _96Bit as _96Bit,
+    _128Bit as _128Bit,
 )
-from ._nbit_base import _8Bit as _8Bit
-from ._nbit_base import _16Bit as _16Bit
-from ._nbit_base import _32Bit as _32Bit
-from ._nbit_base import _64Bit as _64Bit
-from ._nbit_base import _96Bit as _96Bit
-from ._nbit_base import _128Bit as _128Bit
 
 #
 from ._nested_sequence import _NestedSequence as _NestedSequence
 
 #
-from ._scalars import _BoolLike_co as _BoolLike_co
-from ._scalars import _CharLike_co as _CharLike_co
-from ._scalars import _ComplexLike_co as _ComplexLike_co
-from ._scalars import _FloatLike_co as _FloatLike_co
-from ._scalars import _IntLike_co as _IntLike_co
-from ._scalars import _NumberLike_co as _NumberLike_co
-from ._scalars import _ScalarLike_co as _ScalarLike_co
-from ._scalars import _TD64Like_co as _TD64Like_co
-from ._scalars import _UIntLike_co as _UIntLike_co
-from ._scalars import _VoidLike_co as _VoidLike_co
+from ._scalars import (
+    _BoolLike_co as _BoolLike_co,
+    _CharLike_co as _CharLike_co,
+    _ComplexLike_co as _ComplexLike_co,
+    _FloatLike_co as _FloatLike_co,
+    _IntLike_co as _IntLike_co,
+    _NumberLike_co as _NumberLike_co,
+    _ScalarLike_co as _ScalarLike_co,
+    _TD64Like_co as _TD64Like_co,
+    _UIntLike_co as _UIntLike_co,
+    _VoidLike_co as _VoidLike_co,
+)
 
 #
-from ._shape import _AnyShape as _AnyShape
-from ._shape import _Shape as _Shape
-from ._shape import _ShapeLike as _ShapeLike
+from ._shape import _AnyShape as _AnyShape, _Shape as _Shape, _ShapeLike as _ShapeLike
 
 #
-from ._ufunc import _GUFunc_Nin2_Nout1 as _GUFunc_Nin2_Nout1
-from ._ufunc import _UFunc_Nin1_Nout1 as _UFunc_Nin1_Nout1
-from ._ufunc import _UFunc_Nin1_Nout2 as _UFunc_Nin1_Nout2
-from ._ufunc import _UFunc_Nin2_Nout1 as _UFunc_Nin2_Nout1
-from ._ufunc import _UFunc_Nin2_Nout2 as _UFunc_Nin2_Nout2
+from ._ufunc import (
+    _GUFunc_Nin2_Nout1 as _GUFunc_Nin2_Nout1,
+    _UFunc_Nin1_Nout1 as _UFunc_Nin1_Nout1,
+    _UFunc_Nin1_Nout2 as _UFunc_Nin1_Nout2,
+    _UFunc_Nin2_Nout1 as _UFunc_Nin2_Nout1,
+    _UFunc_Nin2_Nout2 as _UFunc_Nin2_Nout2,
+)

--- a/numpy/_typing/_callable.pyi
+++ b/numpy/_typing/_callable.pyi
@@ -38,11 +38,7 @@ from . import NBitBase
 from ._array_like import NDArray
 from ._nbit import _NBitInt
 from ._nested_sequence import _NestedSequence
-from ._scalars import (
-    _BoolLike_co,
-    _IntLike_co,
-    _NumberLike_co,
-)
+from ._scalars import _BoolLike_co, _IntLike_co, _NumberLike_co
 
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -1,12 +1,5 @@
 from collections.abc import Sequence  # noqa: F811
-from typing import (
-    Any,
-    Protocol,
-    TypeAlias,
-    TypedDict,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import Any, Protocol, TypeAlias, TypedDict, TypeVar, runtime_checkable
 
 import numpy as np
 

--- a/numpy/_utils/__init__.pyi
+++ b/numpy/_utils/__init__.pyi
@@ -2,8 +2,7 @@ from _typeshed import IdentityFunction
 from collections.abc import Callable, Iterable
 from typing import Protocol, TypeVar, overload, type_check_only
 
-from ._convertions import asbytes as asbytes
-from ._convertions import asunicode as asunicode
+from ._convertions import asbytes as asbytes, asunicode as asunicode
 
 ###
 

--- a/numpy/_utils/_pep440.pyi
+++ b/numpy/_utils/_pep440.pyi
@@ -5,13 +5,11 @@ from typing import (
     ClassVar,
     Final,
     Generic,
+    Literal as L,
     NamedTuple,
     TypeVar,
     final,
     type_check_only,
-)
-from typing import (
-    Literal as L,
 )
 from typing_extensions import TypeIs
 

--- a/numpy/ctypeslib/__init__.pyi
+++ b/numpy/ctypeslib/__init__.pyi
@@ -3,31 +3,13 @@ from ctypes import c_int64 as _c_intp
 
 from ._ctypeslib import (
     __all__ as __all__,
-)
-from ._ctypeslib import (
     __doc__ as __doc__,
-)
-from ._ctypeslib import (
     _concrete_ndptr as _concrete_ndptr,
-)
-from ._ctypeslib import (
     _ndptr as _ndptr,
-)
-from ._ctypeslib import (
     as_array as as_array,
-)
-from ._ctypeslib import (
     as_ctypes as as_ctypes,
-)
-from ._ctypeslib import (
     as_ctypes_type as as_ctypes_type,
-)
-from ._ctypeslib import (
     c_intp as c_intp,
-)
-from ._ctypeslib import (
     load_library as load_library,
-)
-from ._ctypeslib import (
     ndpointer as ndpointer,
 )

--- a/numpy/ctypeslib/_ctypeslib.pyi
+++ b/numpy/ctypeslib/_ctypeslib.pyi
@@ -4,15 +4,7 @@ import ctypes
 from _typeshed import StrOrBytesPath
 from collections.abc import Iterable, Sequence
 from ctypes import c_int64 as _c_intp
-from typing import (
-    Any,
-    ClassVar,
-    Generic,
-    TypeAlias,
-    TypeVar,
-    overload,
-)
-from typing import Literal as L
+from typing import Any, ClassVar, Generic, Literal as L, TypeAlias, TypeVar, overload
 
 import numpy as np
 from numpy import (

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -2,6 +2,7 @@
 from typing import (
     Any,
     Generic,
+    Literal as L,
     LiteralString,
     Never,
     NoReturn,
@@ -11,7 +12,6 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing import Literal as L
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -1,5 +1,4 @@
-from .f2py2e import main as main
-from .f2py2e import run_main
+from .f2py2e import main as main, run_main
 
 __all__ = ["get_include", "run_main"]
 

--- a/numpy/f2py/_backends/_meson.pyi
+++ b/numpy/f2py/_backends/_meson.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 from pathlib import Path
-from typing import Final
-from typing import Literal as L
+from typing import Final, Literal as L
 from typing_extensions import override
 
 from ._backend import Backend

--- a/numpy/f2py/auxfuncs.pyi
+++ b/numpy/f2py/auxfuncs.pyi
@@ -1,8 +1,7 @@
 from _typeshed import FileDescriptorOrPath
 from collections.abc import Callable, Mapping
 from pprint import pprint as show
-from typing import Any, Final, Never, TypeAlias, TypeVar, overload
-from typing import Literal as L
+from typing import Any, Final, Literal as L, Never, TypeAlias, TypeVar, overload
 
 from .cfuncs import errmess
 

--- a/numpy/f2py/crackfortran.pyi
+++ b/numpy/f2py/crackfortran.pyi
@@ -1,8 +1,17 @@
 import re
 from _typeshed import StrOrBytesPath, StrPath
 from collections.abc import Callable, Iterable, Mapping
-from typing import IO, Any, Concatenate, Final, Never, ParamSpec, TypeAlias, overload
-from typing import Literal as L
+from typing import (
+    IO,
+    Any,
+    Concatenate,
+    Final,
+    Literal as L,
+    Never,
+    ParamSpec,
+    TypeAlias,
+    overload,
+)
 
 from .__version__ import version
 from .auxfuncs import isintent_dict as isintent_dict

--- a/numpy/f2py/f2py2e.pyi
+++ b/numpy/f2py/f2py2e.pyi
@@ -6,8 +6,7 @@ from typing import Any, Final, NotRequired, TypedDict, type_check_only
 from typing_extensions import TypeVar, override
 
 from .__version__ import version
-from .auxfuncs import _Bool
-from .auxfuncs import outmess as outmess
+from .auxfuncs import _Bool, outmess as outmess
 
 ###
 

--- a/numpy/f2py/rules.pyi
+++ b/numpy/f2py/rules.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, Final, TypeAlias
-from typing import Literal as L
+from typing import Any, Final, Literal as L, TypeAlias
 from typing_extensions import TypeVar
 
 from .__version__ import version

--- a/numpy/f2py/symbolic.pyi
+++ b/numpy/f2py/symbolic.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Mapping
 from enum import Enum
-from typing import Any, Generic, ParamSpec, Self, TypeAlias, overload
-from typing import Literal as L
+from typing import Any, Generic, Literal as L, ParamSpec, Self, TypeAlias, overload
 from typing_extensions import TypeVar
 
 __all__ = ["Expr"]

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -5,8 +5,6 @@ import pytest
 
 from numpy.f2py.crackfortran import (
     _selected_int_kind_func as selected_int_kind,
-)
-from numpy.f2py.crackfortran import (
     _selected_real_kind_func as selected_real_kind,
 )
 

--- a/numpy/fft/__init__.pyi
+++ b/numpy/fft/__init__.pyi
@@ -1,9 +1,4 @@
-from ._helper import (
-    fftfreq,
-    fftshift,
-    ifftshift,
-    rfftfreq,
-)
+from ._helper import fftfreq, fftshift, ifftshift, rfftfreq
 from ._pocketfft import (
     fft,
     fft2,

--- a/numpy/fft/_helper.pyi
+++ b/numpy/fft/_helper.pyi
@@ -1,5 +1,4 @@
-from typing import Any, Final, TypeVar, overload
-from typing import Literal as L
+from typing import Any, Final, Literal as L, TypeVar, overload
 
 from numpy import complexfloating, floating, generic, integer
 from numpy._typing import (

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
-from typing import Literal as L
-from typing import TypeAlias
+from typing import Literal as L, TypeAlias
 
 from numpy import complex128, float64
 from numpy._typing import ArrayLike, NDArray, _ArrayLikeNumber_co

--- a/numpy/fft/helper.pyi
+++ b/numpy/fft/helper.pyi
@@ -1,5 +1,4 @@
-from typing import Any
-from typing import Literal as L
+from typing import Any, Literal as L
 from typing_extensions import deprecated
 
 import numpy as np

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -3,28 +3,36 @@ from numpy._core.multiarray import add_docstring, tracemalloc_domain
 
 # all submodules of `lib` are accessible at runtime through `__getattr__`,
 # so we implicitly re-export them here
-from . import _array_utils_impl as _array_utils_impl
-from . import _arraypad_impl as _arraypad_impl
-from . import _arraysetops_impl as _arraysetops_impl
-from . import _arrayterator_impl as _arrayterator_impl
-from . import _datasource as _datasource
-from . import _format_impl as _format_impl
-from . import _function_base_impl as _function_base_impl
-from . import _histograms_impl as _histograms_impl
-from . import _index_tricks_impl as _index_tricks_impl
-from . import _iotools as _iotools
-from . import _nanfunctions_impl as _nanfunctions_impl
-from . import _npyio_impl as _npyio_impl
-from . import _polynomial_impl as _polynomial_impl
-from . import _scimath_impl as _scimath_impl
-from . import _shape_base_impl as _shape_base_impl
-from . import _stride_tricks_impl as _stride_tricks_impl
-from . import _twodim_base_impl as _twodim_base_impl
-from . import _type_check_impl as _type_check_impl
-from . import _ufunclike_impl as _ufunclike_impl
-from . import _utils_impl as _utils_impl
-from . import _version as _version
-from . import array_utils, format, introspect, mixins, npyio, scimath, stride_tricks
+from . import (
+    _array_utils_impl as _array_utils_impl,
+    _arraypad_impl as _arraypad_impl,
+    _arraysetops_impl as _arraysetops_impl,
+    _arrayterator_impl as _arrayterator_impl,
+    _datasource as _datasource,
+    _format_impl as _format_impl,
+    _function_base_impl as _function_base_impl,
+    _histograms_impl as _histograms_impl,
+    _index_tricks_impl as _index_tricks_impl,
+    _iotools as _iotools,
+    _nanfunctions_impl as _nanfunctions_impl,
+    _npyio_impl as _npyio_impl,
+    _polynomial_impl as _polynomial_impl,
+    _scimath_impl as _scimath_impl,
+    _shape_base_impl as _shape_base_impl,
+    _stride_tricks_impl as _stride_tricks_impl,
+    _twodim_base_impl as _twodim_base_impl,
+    _type_check_impl as _type_check_impl,
+    _ufunclike_impl as _ufunclike_impl,
+    _utils_impl as _utils_impl,
+    _version as _version,
+    array_utils,
+    format,
+    introspect,
+    mixins,
+    npyio,
+    scimath,
+    stride_tricks,
+)
 from ._arrayterator_impl import Arrayterator
 from ._version import NumpyVersion
 

--- a/numpy/lib/_arraypad_impl.pyi
+++ b/numpy/lib/_arraypad_impl.pyi
@@ -1,22 +1,15 @@
 from typing import (
     Any,
+    Literal as L,
     Protocol,
     TypeAlias,
     TypeVar,
     overload,
     type_check_only,
 )
-from typing import (
-    Literal as L,
-)
 
 from numpy import generic
-from numpy._typing import (
-    ArrayLike,
-    NDArray,
-    _ArrayLike,
-    _ArrayLikeInt,
-)
+from numpy._typing import ArrayLike, NDArray, _ArrayLike, _ArrayLikeInt
 
 __all__ = ["pad"]
 

--- a/numpy/lib/_arraysetops_impl.pyi
+++ b/numpy/lib/_arraysetops_impl.pyi
@@ -1,5 +1,12 @@
-from typing import Any, Generic, NamedTuple, SupportsIndex, TypeAlias, overload
-from typing import Literal as L
+from typing import (
+    Any,
+    Generic,
+    Literal as L,
+    NamedTuple,
+    SupportsIndex,
+    TypeAlias,
+    overload,
+)
 from typing_extensions import TypeVar, deprecated
 
 import numpy as np

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -10,9 +10,14 @@ import numpy._core.numeric as _nx
 from numpy._core import overrides, transpose
 from numpy._core._multiarray_umath import _array_converter
 from numpy._core.fromnumeric import any, mean, nonzero, partition, ravel, sum
-from numpy._core.multiarray import _monotonicity, _place, bincount, normalize_axis_index
-from numpy._core.multiarray import interp as compiled_interp
-from numpy._core.multiarray import interp_complex as compiled_interp_complex
+from numpy._core.multiarray import (
+    _monotonicity,
+    _place,
+    bincount,
+    interp as compiled_interp,
+    interp_complex as compiled_interp_complex,
+    normalize_axis_index,
+)
 from numpy._core.numeric import (
     absolute,
     arange,

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
     Concatenate,
+    Literal as L,
     ParamSpec,
     Protocol,
     SupportsIndex,
@@ -13,7 +14,6 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing import Literal as L
 from typing_extensions import TypeIs, deprecated
 
 import numpy as np

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -1,17 +1,7 @@
 from collections.abc import Sequence
-from typing import (
-    Any,
-    SupportsIndex,
-    TypeAlias,
-)
-from typing import (
-    Literal as L,
-)
+from typing import Any, Literal as L, SupportsIndex, TypeAlias
 
-from numpy._typing import (
-    ArrayLike,
-    NDArray,
-)
+from numpy._typing import ArrayLike, NDArray
 
 __all__ = ["histogram", "histogramdd", "histogram_bin_edges"]
 

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -1,7 +1,16 @@
 from _typeshed import Incomplete
 from collections.abc import Sequence
-from typing import Any, ClassVar, Final, Generic, Self, SupportsIndex, final, overload
-from typing import Literal as L
+from typing import (
+    Any,
+    ClassVar,
+    Final,
+    Generic,
+    Literal as L,
+    Self,
+    SupportsIndex,
+    final,
+    overload,
+)
 from typing_extensions import TypeVar, deprecated
 
 import numpy as np

--- a/numpy/lib/_nanfunctions_impl.pyi
+++ b/numpy/lib/_nanfunctions_impl.pyi
@@ -11,11 +11,7 @@ from numpy._core.fromnumeric import (
     sum,
     var,
 )
-from numpy.lib._function_base_impl import (
-    median,
-    percentile,
-    quantile,
-)
+from numpy.lib._function_base_impl import median, percentile, quantile
 
 __all__ = [
     "nansum",

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -14,13 +14,13 @@ from typing import (
     Any,
     ClassVar,
     Generic,
+    Literal as L,
     Protocol,
     Self,
     TypeAlias,
     overload,
     type_check_only,
 )
-from typing import Literal as L
 from typing_extensions import TypeVar, deprecated, override
 
 import numpy as np

--- a/numpy/lib/_polynomial_impl.pyi
+++ b/numpy/lib/_polynomial_impl.pyi
@@ -1,14 +1,12 @@
 from typing import (
     Any,
+    Literal as L,
     NoReturn,
     SupportsIndex,
     SupportsInt,
     TypeAlias,
     TypeVar,
     overload,
-)
-from typing import (
-    Literal as L,
 )
 
 import numpy as np

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -1,13 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import (
-    Any,
-    TypeAlias,
-    TypeVar,
-    overload,
-)
-from typing import (
-    Literal as L,
-)
+from typing import Any, Literal as L, TypeAlias, TypeVar, overload
 
 import numpy as np
 from numpy import (

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -1,7 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Container, Iterable
-from typing import Any, Protocol, TypeAlias, overload, type_check_only
-from typing import Literal as L
+from typing import Any, Literal as L, Protocol, TypeAlias, overload, type_check_only
 from typing_extensions import TypeVar
 
 import numpy as np

--- a/numpy/lib/array_utils.pyi
+++ b/numpy/lib/array_utils.pyi
@@ -1,12 +1,6 @@
 from ._array_utils_impl import (
     __all__ as __all__,
-)
-from ._array_utils_impl import (
     byte_bounds as byte_bounds,
-)
-from ._array_utils_impl import (
     normalize_axis_index as normalize_axis_index,
-)
-from ._array_utils_impl import (
     normalize_axis_tuple as normalize_axis_tuple,
 )

--- a/numpy/lib/format.pyi
+++ b/numpy/lib/format.pyi
@@ -1,66 +1,24 @@
 from ._format_impl import (
     ARRAY_ALIGN as ARRAY_ALIGN,
-)
-from ._format_impl import (
     BUFFER_SIZE as BUFFER_SIZE,
-)
-from ._format_impl import (
     EXPECTED_KEYS as EXPECTED_KEYS,
-)
-from ._format_impl import (
     GROWTH_AXIS_MAX_DIGITS as GROWTH_AXIS_MAX_DIGITS,
-)
-from ._format_impl import (
     MAGIC_LEN as MAGIC_LEN,
-)
-from ._format_impl import (
     MAGIC_PREFIX as MAGIC_PREFIX,
-)
-from ._format_impl import (
     __all__ as __all__,
-)
-from ._format_impl import (
     __doc__ as __doc__,
-)
-from ._format_impl import (
     descr_to_dtype as descr_to_dtype,
-)
-from ._format_impl import (
     drop_metadata as drop_metadata,
-)
-from ._format_impl import (
     dtype_to_descr as dtype_to_descr,
-)
-from ._format_impl import (
     header_data_from_array_1_0 as header_data_from_array_1_0,
-)
-from ._format_impl import (
     isfileobj as isfileobj,
-)
-from ._format_impl import (
     magic as magic,
-)
-from ._format_impl import (
     open_memmap as open_memmap,
-)
-from ._format_impl import (
     read_array as read_array,
-)
-from ._format_impl import (
     read_array_header_1_0 as read_array_header_1_0,
-)
-from ._format_impl import (
     read_array_header_2_0 as read_array_header_2_0,
-)
-from ._format_impl import (
     read_magic as read_magic,
-)
-from ._format_impl import (
     write_array as write_array,
-)
-from ._format_impl import (
     write_array_header_1_0 as write_array_header_1_0,
-)
-from ._format_impl import (
     write_array_header_2_0 as write_array_header_2_0,
 )

--- a/numpy/lib/introspect.py
+++ b/numpy/lib/introspect.py
@@ -65,8 +65,7 @@ def opt_func_info(func_name=None, signature=None):
     """
     import re
 
-    from numpy._core._multiarray_umath import __cpu_targets_info__ as targets
-    from numpy._core._multiarray_umath import dtype
+    from numpy._core._multiarray_umath import __cpu_targets_info__ as targets, dtype
 
     if func_name is not None:
         func_pattern = re.compile(func_name)

--- a/numpy/lib/mixins.pyi
+++ b/numpy/lib/mixins.pyi
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
-from typing import Literal as L
+from typing import Any, Literal as L
 
 from numpy import ufunc
 

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -1,9 +1,5 @@
 from numpy.lib._npyio_impl import (
     DataSource as DataSource,
-)
-from numpy.lib._npyio_impl import (
     NpzFile as NpzFile,
-)
-from numpy.lib._npyio_impl import (
     __doc__ as __doc__,
 )

--- a/numpy/lib/scimath.pyi
+++ b/numpy/lib/scimath.pyi
@@ -1,30 +1,12 @@
 from ._scimath_impl import (
     __all__ as __all__,
-)
-from ._scimath_impl import (
     arccos as arccos,
-)
-from ._scimath_impl import (
     arcsin as arcsin,
-)
-from ._scimath_impl import (
     arctanh as arctanh,
-)
-from ._scimath_impl import (
     log as log,
-)
-from ._scimath_impl import (
     log2 as log2,
-)
-from ._scimath_impl import (
     log10 as log10,
-)
-from ._scimath_impl import (
     logn as logn,
-)
-from ._scimath_impl import (
     power as power,
-)
-from ._scimath_impl import (
     sqrt as sqrt,
 )

--- a/numpy/lib/stride_tricks.pyi
+++ b/numpy/lib/stride_tricks.pyi
@@ -1,6 +1,4 @@
 from numpy.lib._stride_tricks_impl import (
     as_strided as as_strided,
-)
-from numpy.lib._stride_tricks_impl import (
     sliding_window_view as sliding_window_view,
 )

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -10,12 +10,7 @@ from numpy.lib._iotools import (
     flatten_dtype,
     has_nested_fields,
 )
-from numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_allclose, assert_equal, assert_raises
 
 
 class TestLineSplitter:

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -1,6 +1,4 @@
-from . import _linalg as _linalg
-from . import _umath_linalg as _umath_linalg
-from . import linalg as linalg
+from . import _linalg as _linalg, _umath_linalg as _umath_linalg, linalg as linalg
 from ._linalg import (
     cholesky,
     cond,

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -35,7 +35,9 @@ from numpy._core import (
     cdouble,
     complexfloating,
     count_nonzero,
+    cross as _core_cross,
     csingle,
+    diagonal as _core_diagonal,
     divide,
     dot,
     double,
@@ -49,10 +51,13 @@ from numpy._core import (
     intp,
     isfinite,
     isnan,
+    matmul as _core_matmul,
+    matrix_transpose as _core_matrix_transpose,
     moveaxis,
     multiply,
     newaxis,
     object_,
+    outer as _core_outer,
     overrides,
     prod,
     reciprocal,
@@ -62,34 +67,11 @@ from numpy._core import (
     sqrt,
     sum,
     swapaxes,
-    zeros,
-)
-from numpy._core import (
-    cross as _core_cross,
-)
-from numpy._core import (
-    diagonal as _core_diagonal,
-)
-from numpy._core import (
-    matmul as _core_matmul,
-)
-from numpy._core import (
-    matrix_transpose as _core_matrix_transpose,
-)
-from numpy._core import (
-    outer as _core_outer,
-)
-from numpy._core import (
     tensordot as _core_tensordot,
-)
-from numpy._core import (
     trace as _core_trace,
-)
-from numpy._core import (
     transpose as _core_transpose,
-)
-from numpy._core import (
     vecdot as _core_vecdot,
+    zeros,
 )
 from numpy._globals import _NoValue
 from numpy._typing import NDArray

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from typing import (
     Any,
+    Literal as L,
     NamedTuple,
     Never,
     SupportsIndex,
@@ -9,7 +10,6 @@ from typing import (
     TypeVar,
     overload,
 )
-from typing import Literal as L
 
 import numpy as np
 from numpy import (

--- a/numpy/linalg/_umath_linalg.pyi
+++ b/numpy/linalg/_umath_linalg.pyi
@@ -1,5 +1,4 @@
-from typing import Final
-from typing import Literal as L
+from typing import Final, Literal as L
 
 import numpy as np
 from numpy._typing._ufunc import _GUFunc_Nin2_Nout1

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -35,6 +35,7 @@ from numpy import (
     amax,
     amin,
     angle,
+    array as narray,  # noqa: F401
     bool_,
     expand_dims,
     finfo,  # noqa: F401
@@ -42,7 +43,6 @@ from numpy import (
     iscomplexobj,
     ndarray,
 )
-from numpy import array as narray  # noqa: F401
 from numpy._core import multiarray as mu
 from numpy._core.numeric import normalize_axis_tuple
 from numpy._utils import set_module

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -23,8 +23,7 @@ import itertools
 import warnings
 
 import numpy as np
-from numpy import array as nxarray
-from numpy import ndarray
+from numpy import array as nxarray, ndarray
 from numpy.lib._function_base_impl import _ureduce
 from numpy.lib._index_tricks_impl import AxisConcatenator
 from numpy.lib.array_utils import normalize_axis_index, normalize_axis_tuple

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -8,9 +8,11 @@ import pickle
 
 import numpy as np
 import numpy.ma as ma
-from numpy._core.records import fromarrays as recfromarrays
-from numpy._core.records import fromrecords as recfromrecords
-from numpy._core.records import recarray
+from numpy._core.records import (
+    fromarrays as recfromarrays,
+    fromrecords as recfromrecords,
+    recarray,
+)
 from numpy.ma import masked, nomask
 from numpy.ma.mrecords import (
     MaskedRecords,
@@ -20,11 +22,7 @@ from numpy.ma.mrecords import (
     fromtextfile,
     mrecarray,
 )
-from numpy.ma.testutils import (
-    assert_,
-    assert_equal,
-    assert_equal_records,
-)
+from numpy.ma.testutils import assert_, assert_equal, assert_equal_records
 from numpy.testing import temppath
 
 

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -83,11 +83,7 @@ from numpy.ma import (
     where,
     zeros,
 )
-from numpy.testing import (
-    assert_,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_equal, assert_raises
 
 pi = np.pi
 

--- a/numpy/matrixlib/tests/test_matrix_linalg.py
+++ b/numpy/matrixlib/tests/test_matrix_linalg.py
@@ -12,13 +12,13 @@ from numpy.linalg.tests.test_linalg import (
     PinvCases,
     SolveCases,
     SVDCases,
+    TestQR as _TestQR,
     _TestNorm2D,
     _TestNormDoubleBase,
     _TestNormInt64Base,
     _TestNormSingleBase,
     apply_tag,
 )
-from numpy.linalg.tests.test_linalg import TestQR as _TestQR
 
 CASES = []
 

--- a/numpy/polynomial/chebyshev.pyi
+++ b/numpy/polynomial/chebyshev.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Callable, Iterable
-from typing import Any, Concatenate, Final, Self, TypeVar, overload
-from typing import Literal as L
+from typing import Any, Concatenate, Final, Literal as L, Self, TypeVar, overload
 
 import numpy as np
 import numpy.typing as npt

--- a/numpy/polynomial/hermite.pyi
+++ b/numpy/polynomial/hermite.pyi
@@ -1,5 +1,4 @@
-from typing import Any, Final, TypeVar
-from typing import Literal as L
+from typing import Any, Final, Literal as L, TypeVar
 
 import numpy as np
 

--- a/numpy/polynomial/hermite_e.pyi
+++ b/numpy/polynomial/hermite_e.pyi
@@ -1,5 +1,4 @@
-from typing import Any, Final, TypeVar
-from typing import Literal as L
+from typing import Any, Final, Literal as L, TypeVar
 
 import numpy as np
 

--- a/numpy/polynomial/laguerre.pyi
+++ b/numpy/polynomial/laguerre.pyi
@@ -1,5 +1,4 @@
-from typing import Final
-from typing import Literal as L
+from typing import Final, Literal as L
 
 import numpy as np
 

--- a/numpy/polynomial/legendre.pyi
+++ b/numpy/polynomial/legendre.pyi
@@ -1,5 +1,4 @@
-from typing import Final
-from typing import Literal as L
+from typing import Final, Literal as L
 
 import numpy as np
 

--- a/numpy/polynomial/polynomial.pyi
+++ b/numpy/polynomial/polynomial.pyi
@@ -1,5 +1,4 @@
-from typing import Final
-from typing import Literal as L
+from typing import Final, Literal as L
 
 import numpy as np
 

--- a/numpy/polynomial/polyutils.pyi
+++ b/numpy/polynomial/polyutils.pyi
@@ -1,12 +1,5 @@
 from collections.abc import Callable, Iterable, Sequence
-from typing import (
-    Final,
-    Literal,
-    SupportsIndex,
-    TypeAlias,
-    TypeVar,
-    overload,
-)
+from typing import Final, Literal, SupportsIndex, TypeAlias, TypeVar, overload
 
 import numpy as np
 import numpy.typing as npt

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -6,12 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.chebyshev as cheb
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 
 def trim(x):

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -18,12 +18,7 @@ from numpy.polynomial import (
     Legendre,
     Polynomial,
 )
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 #
 # fixtures

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -6,12 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.hermite as herm
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 H0 = np.array([1])
 H1 = np.array([0, 2])

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -6,12 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.hermite_e as herme
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 He0 = np.array([1])
 He1 = np.array([0, 1])

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -6,12 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.laguerre as lag
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 L0 = np.array([1]) / 1
 L1 = np.array([1, -1]) / 1

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -6,12 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.legendre as leg
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 L0 = np.array([1])
 L1 = np.array([0, 1])

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -3,12 +3,7 @@
 """
 import numpy as np
 import numpy.polynomial.polyutils as pu
-from numpy.testing import (
-    assert_,
-    assert_almost_equal,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
 
 
 class TestMisc:

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -4,11 +4,7 @@ import pytest
 
 import numpy as np
 from numpy import random
-from numpy.testing import (
-    assert_,
-    assert_array_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_array_equal, assert_raises
 
 
 class TestRegression:

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -2,11 +2,7 @@ import sys
 
 import numpy as np
 from numpy import random
-from numpy.testing import (
-    assert_,
-    assert_array_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_array_equal, assert_raises
 
 
 class TestRegression:

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -14,6 +14,7 @@ from typing import (
     ClassVar,
     Final,
     Generic,
+    Literal as L,
     NoReturn,
     ParamSpec,
     Self,
@@ -23,7 +24,6 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing import Literal as L
 from typing_extensions import TypeVar
 from unittest.case import SkipTest
 

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -7,13 +7,7 @@ from importlib import reload
 import pytest
 
 import numpy.exceptions as ex
-from numpy.testing import (
-    IS_WASM,
-    assert_,
-    assert_equal,
-    assert_raises,
-    assert_warns,
-)
+from numpy.testing import IS_WASM, assert_, assert_equal, assert_raises, assert_warns
 
 
 def test_numpy_reloading():

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -5,8 +5,7 @@ Test that we can run executable scripts that have been installed with numpy.
 import os
 import subprocess
 import sys
-from os.path import dirname, isfile
-from os.path import join as pathjoin
+from os.path import dirname, isfile, join as pathjoin
 
 import pytest
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -130,3 +130,5 @@ builtins-allowed-modules = ["random", "typing"]
 # these are treated as stdlib within .pyi stubs
 extra-standard-library = ["_typeshed", "typing_extensions"]
 known-first-party = ["numpy"]
+combine-as-imports = true
+split-on-trailing-comma = false


### PR DESCRIPTION
This follows #29183. It's a separate PR, because not everyone might like these two config options. 

I feel like [`combine-as-imports` rule](https://docs.astral.sh/ruff/settings/#lint_isort_combine-as-imports) is a rather natural rule, but that's probably just a personal preference thing.

The [`split-on-trailing-comma` rule](https://docs.astral.sh/ruff/settings/#lint_isort_split-on-trailing-comma), on the other hand, is rather unforgiving. It can reduce diffs, but it takes away the freedom of choosing  to vertically align your imports. However, if you *really* want to do so anyway, then there's always the option of throwing a `# noqa: I001` at it. 

(and don't worry, I'm not planning on making this a trilogy)