### PR TITLE
BUG: Revert `np.vectorize` casting to legacy behavior

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2618,8 +2618,11 @@ class vectorize:
         elif not args:
             res = func()
         else:
-            args = [asanyarray(a, dtype=object) for a in args]
+            args = [asanyarray(a) for a in args]
             ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
+            # note: this second cast is here to match the legacy behavior of vectorize
+            # and should be eventually removed.
+            args = [asanyarray(a, dtype=object) for a in args]
             outputs = ufunc(*args, out=...)
 
             if ufunc.nout == 1:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2573,6 +2573,7 @@ class vectorize:
             # the subsequent call when the ufunc is evaluated.
             # Assumes that ufunc first evaluates the 0th elements in the input
             # arrays (the input values are not checked to ensure this)
+            args = [asarray(a) for a in args]
             if builtins.any(arg.size == 0 for arg in args):
                 raise ValueError('cannot call `vectorize` on size 0 inputs '
                                  'unless `otypes` is set')
@@ -2618,10 +2619,8 @@ class vectorize:
         elif not args:
             res = func()
         else:
-            args = [asanyarray(a) for a in args]
             ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
-            # note: this second cast is here to match the legacy behavior of vectorize
-            # and should be eventually removed.
+            # gh-29196: `dtype=object` should eventually be removed
             args = [asanyarray(a, dtype=object) for a in args]
             outputs = ufunc(*args, out=...)
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1738,7 +1738,7 @@ class TestVectorize:
 
         for dtype in dtypes:
             x = np.asarray([1, 2, 3], dtype=dtype)
-            y = np.vectorize(lambda x: x + x, x)
+            y = np.vectorize(lambda x: x + x)(x)
             assert x.dtype == y.dtype
 
     def test_cache(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1732,6 +1732,15 @@ class TestVectorize:
         s = '0123456789' * 10
         assert_equal(s, f(s))
 
+    def test_dtype_promotion_ticket_29189(self):
+        # dtype should not be silently promoted (int32 -> int64)
+        dtypes = [np.int16, np.int32, np.int64, np.float16, np.float32, np.float64, np.float128]
+
+        for dtype in dtypes:
+            x = np.asarray([1, 2, 3], dtype=dtype)
+            y = np.vectorize(lambda x: x + x, x)
+            assert x.dtype == y.dtype
+
     def test_cache(self):
         # Ensure that vectorized func called exactly once per argument.
         _calls = [0]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1734,7 +1734,7 @@ class TestVectorize:
 
     def test_dtype_promotion_ticket_29189(self):
         # dtype should not be silently promoted (int32 -> int64)
-        dtypes = [np.int16, np.int32, np.int64, np.float16, np.float32, np.float64, np.float128]
+        dtypes = [np.int16, np.int32, np.int64, np.float16, np.float32, np.float64]
 
         for dtype in dtypes:
             x = np.asarray([1, 2, 3], dtype=dtype)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1732,7 +1732,7 @@ class TestVectorize:
         s = '0123456789' * 10
         assert_equal(s, f(s))
 
-    def test_dtype_promotion_ticket_29189(self):
+    def test_dtype_promotion_gh_29189(self):
         # dtype should not be silently promoted (int32 -> int64)
         dtypes = [np.int16, np.int32, np.int64, np.float16, np.float32, np.float64]
 


### PR DESCRIPTION
Fixes #29189
