### PR TITLE
ENH: add np.array_info utility for quick array summaries

### DIFF
--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -39,6 +39,7 @@ from . import (
     npyio,
     scimath,
     stride_tricks,
+    array_info,
 )
 
 # numpy.lib namespace members
@@ -48,7 +49,7 @@ from ._version import NumpyVersion
 __all__ = [
     "Arrayterator", "add_docstring", "add_newdoc", "array_utils",
     "format", "introspect", "mixins", "NumpyVersion", "npyio", "scimath",
-    "stride_tricks", "tracemalloc_domain",
+    "stride_tricks", "tracemalloc_domain", "array_info"
 ]
 
 add_newdoc.__module__ = "numpy.lib"

--- a/numpy/lib/array_info.py
+++ b/numpy/lib/array_info.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Sequence, Tuple, Union
+
+import numpy as np
+
+__all__ = ["array_info"]
+
+Number = Union[int, float, complex, bool]
+ArrayLike = Union[np.ndarray, Sequence[Number], Number]
+
+
+def _safe_stat(fn, arr: np.ndarray, *args, **kwargs):
+    try:
+        return fn(arr, *args, **kwargs) if arr.size else None
+    except Exception:  
+        return None
+
+
+def _to_tuple(x: Union[int, Iterable[int]]) -> Tuple[int, ...]:
+    return (x,) if isinstance(x, (int, np.integer)) else tuple(x)
+
+
+def array_info(
+    arr: ArrayLike,
+    *,
+    axis: Union[int, Sequence[int], None] = None,
+    percentiles: Sequence[int] | None = (25, 50, 75),
+    sample_unique_threshold: int = 1_000_000,
+    example_values: int = 3,
+) -> Dict[str, Any]:
+    """
+   Return a dictionary (or nested dict) that summarises the **structure** and
+    **contents** of a NumPy array.
+
+    The function combines three layers of insight:
+
+    1. **Flat statistics** - min/max/mean/std, NaN/Inf/None counts, percentiles
+        and inter-quartile range (IQR) over the whole array.
+    2. **Axis-wise statistics** - the same metrics computed along a user-selected
+        axis or tuple of axes (optional, via ``axis=``), placed under
+        ``info["axis_stats"]``.
+    3. **Quick metadata** - shape, dtype, itemsize, contiguity flags, unique-value
+        count (sampled for very large arrays) and a small sample of actual values.
+
+    Parameters
+    ----------
+    arr : array-like
+        Data to analyse.  It is converted to an ``ndarray`` with ``np.asarray``.
+    axis : int or tuple of int, optional
+        If provided, compute statistics **along** the given axis/axes instead of
+        over the flattened array, and store them in the nested ``"axis_stats"`` dictionary.
+    percentiles : sequence of int or None, optional
+        Percentile values (0-100) to compute in addition to the core stats.
+        The default ``(25, 50, 75)`` returns Q1, median, and Q3.  Pass ``None``
+        to skip percentile and IQR output.
+    sample_unique_threshold : int, optional
+        Exact unique-element counting becomes expensive on very large arrays.  If
+        ``arr.size`` exceeds this threshold, a random subsample of that size is
+        used instead and the result is prefixed with ``">="``.
+    example_values : int, optional
+        Number of head elements (flattened order) to include under ``"example_values"``.
+
+    Returns
+    -------
+    dict
+        A mapping of summary keys to values.  Always present keys::
+            shape, dtype, size, ndim, itemsize, contiguous, aligned, min, max, mean, std,
+            nan_count, inf_count, none_count, num_unique, example_values
+        + ``pXX`` percentile keys and ``iqr`` if *percentiles* is not ``None``.
+        + ``axis_stats`` nested dictionary if *axis* is supplied.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from numpy.lib import array_info
+    >>> a = np.array([[1, 2, np.nan], [4, 5, 6]])
+    >>> array_info(a)
+    {'shape': (2, 3), 'dtype': 'float64', 'size': 6, ...}
+
+    >>> array_info(a, axis=0)["axis_stats"]["mean"]
+    array([2.5, 3.5, 4.5])
+    """
+
+    arr = np.asarray(arr)
+
+    info: Dict[str, Any] = {
+        "shape": arr.shape,
+        "dtype": str(arr.dtype),
+        "size": arr.size,
+        "ndim": arr.ndim,
+        "itemsize": arr.itemsize,
+        "contiguous": bool(arr.flags.c_contiguous),
+        "aligned": bool(arr.flags.aligned),
+    }
+
+
+    is_bool = arr.dtype == np.bool_
+    is_numeric = (
+        np.issubdtype(arr.dtype, np.number)
+        or np.issubdtype(arr.dtype, np.complexfloating)
+        or is_bool
+    )
+
+    def _numeric_stats(a: np.ndarray) -> Mapping[str, Any]:
+        if not is_numeric or a.size == 0:
+            return {k: None for k in ("min", "max", "mean", "std")}
+
+        a_float = a.astype(float, copy=False) if is_bool else a
+        finite = a_float[np.isfinite(a_float)]
+        if finite.size == 0:
+            return {k: None for k in ("min", "max", "mean", "std")}
+
+        out: Dict[str, Any] = {
+            "min": _safe_stat(np.nanmin, finite),
+            "max": _safe_stat(np.nanmax, finite),
+            "mean": _safe_stat(np.nanmean, finite),
+            "std": _safe_stat(np.nanstd, finite),
+        }
+
+
+        if percentiles:
+            pct_vals = _safe_stat(np.nanpercentile, finite, q=percentiles)
+            if pct_vals is not None:
+                out.update({f"p{p}": v for p, v in zip(percentiles, pct_vals)})
+                if 75 in percentiles and 25 in percentiles:
+                    out["iqr"] = out.get("p75") - out.get("p25")
+        return out
+
+
+    info.update(_numeric_stats(arr))
+
+    info["nan_count"] = int(np.isnan(arr).sum()) if arr.dtype.kind == "f" else 0
+    info["inf_count"] = int(np.isinf(arr).sum()) if arr.dtype.kind == "f" else 0
+    info["none_count"] = int(np.sum(arr == None)) if arr.dtype == object else 0  
+
+
+    if arr.size == 0:
+        info["num_unique"] = 0
+    elif arr.dtype == object:
+        info["num_unique"] = "n/a"
+    elif arr.size <= sample_unique_threshold:
+        info["num_unique"] = int(len(np.unique(arr)))
+    else:
+        rng = np.random.default_rng(0)
+        idx = rng.choice(arr.size, size=sample_unique_threshold, replace=False)
+        sample = arr.reshape(-1)[idx]
+        info["num_unique"] = f">= {len(np.unique(sample))} (sample)"
+
+
+    flat = arr.reshape(-1)
+    info["example_values"] = flat[:example_values].tolist() if flat.size else []
+
+
+    if axis is not None:
+        axis_tuple = _to_tuple(axis)
+        axis_stats: Dict[str, Any] = {}
+
+        axis_stats.update({
+            "min": _safe_stat(np.nanmin, arr, axis=axis_tuple),
+            "max": _safe_stat(np.nanmax, arr, axis=axis_tuple),
+            "mean": _safe_stat(np.nanmean, arr, axis=axis_tuple),
+            "std": _safe_stat(np.nanstd, arr, axis=axis_tuple),
+        })
+
+        if arr.dtype.kind == "f":
+            axis_stats["nan_count"] = np.isnan(arr).sum(axis=axis_tuple)
+            axis_stats["inf_count"] = np.isinf(arr).sum(axis=axis_tuple)
+        else:
+            axis_stats["nan_count"] = axis_stats["inf_count"] = None
+
+        if percentiles and is_numeric:
+            pcts = _safe_stat(np.nanpercentile, arr, axis=axis_tuple, q=percentiles)
+            if pcts is not None:
+                for p, arr_pct in zip(percentiles, pcts):
+                    axis_stats[f"p{p}"] = arr_pct
+                if 75 in percentiles and 25 in percentiles:
+                    axis_stats["iqr"] = axis_stats["p75"] - axis_stats["p25"]
+
+        info["axis_stats"] = axis_stats
+
+    return info

--- a/numpy/lib/array_info.pyi
+++ b/numpy/lib/array_info.pyi
@@ -1,0 +1,9 @@
+from typing import Any, Dict, Union
+import numpy as np
+
+def array_info(
+    arr: Union[np.ndarray, Any],
+    *,
+    sample_unique_threshold: int = ...,
+    example_values: int = ...,
+) -> Dict[str, Any]: ...

--- a/numpy/lib/tests/test_array_info.py
+++ b/numpy/lib/tests/test_array_info.py
@@ -1,0 +1,181 @@
+import numpy as np
+import pytest
+
+array_info = np.array_info
+
+
+# ---------------------------------------------------------------------
+# Helper: verify required keys exist in every result
+# ---------------------------------------------------------------------
+REQUIRED_KEYS = {
+    "shape", "dtype", "size", "ndim", "itemsize",
+    "contiguous", "aligned", "min", "max", "mean", "std",
+    "nan_count", "inf_count", "none_count", "num_unique", "example_values"
+}
+
+
+def _check_keys(info):
+    missing = REQUIRED_KEYS - info.keys()
+    assert not missing, f"array_info missing keys: {missing}"
+
+
+# ---------------------------------------------------------------------
+# 1. Small numeric int array
+# ---------------------------------------------------------------------
+def test_small_int():
+    a = np.arange(5)
+    info = array_info(a)
+    _check_keys(info)
+    assert info["dtype"].startswith("int")
+    assert info["min"] == 0 and info["max"] == 4
+    assert info["nan_count"] == info["inf_count"] == 0
+    assert info["mean"] == 2
+
+
+# ---------------------------------------------------------------------
+# 2. NaN / Inf
+# ---------------------------------------------------------------------
+def test_nan_inf():
+    a = np.array([1.0, np.nan, np.inf, -np.inf])
+    info = array_info(a)
+    _check_keys(info)
+    assert info["nan_count"] == 1
+    assert info["inf_count"] == 2
+    assert np.isfinite(info["mean"])
+
+
+# ---------------------------------------------------------------------
+# 3. Complex numbers
+# ---------------------------------------------------------------------
+def test_complex():
+    a = np.array([1+2j, 3+4j])
+    info = array_info(a)
+    _check_keys(info)
+    assert "complex" in info["dtype"]
+    assert info["nan_count"] == 0
+    assert info["num_unique"] == 2
+
+
+# ---------------------------------------------------------------------
+# 4. Boolean array
+# ---------------------------------------------------------------------
+def test_bool():
+    a = np.array([True, False, True, True])
+    info = array_info(a)
+    assert info["dtype"] == "bool"
+    assert info["mean"] == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------
+# 5. Empty array
+# ---------------------------------------------------------------------
+def test_empty():
+    a = np.array([])
+    info = array_info(a)
+    assert info["size"] == 0
+    assert info["num_unique"] == 0
+    assert info["min"] is None and info["max"] is None
+
+
+# ---------------------------------------------------------------------
+# 6. Scalar (0-D)
+# ---------------------------------------------------------------------
+def test_scalar():
+    a = np.array(42)
+    info = array_info(a)
+    assert info["shape"] == ()
+    assert info["size"] == 1
+    assert info["mean"] == 42
+
+
+# ---------------------------------------------------------------------
+# 7. High-dim (>2)
+# ---------------------------------------------------------------------
+def test_high_dim():
+    a = np.ones((2, 3, 4, 5))
+    info = array_info(a)
+    assert info["ndim"] == 4
+    assert info["contiguous"] is True
+
+
+# ---------------------------------------------------------------------
+# 8. Non-contiguous view
+# ---------------------------------------------------------------------
+def test_non_contiguous():
+    base = np.arange(20)
+    view = base[::2]  
+    info = array_info(view)
+    assert info["contiguous"] is False
+    assert info["aligned"] is True
+
+
+# ---------------------------------------------------------------------
+# 9. Large array → sampling path
+# ---------------------------------------------------------------------
+def test_sampling_path():
+    big = np.arange(0, 2_000_000, dtype=np.int32)
+    info = array_info(big, sample_unique_threshold=1_000_000)
+    assert isinstance(info["num_unique"], str) and info["num_unique"].startswith(">=")
+
+
+# ---------------------------------------------------------------------
+# 10. Object array
+# ---------------------------------------------------------------------
+def test_object_array():
+    a = np.array(["apple", "banana", None, "banana"], dtype=object)
+    info = array_info(a)
+    assert info["dtype"] == "object"
+    assert info["none_count"] == 1
+    assert info["min"] is None and info["mean"] is None
+
+
+# ---------------------------------------------------------------------
+# 11. Unhashable objects force 'n/a' unique
+# ---------------------------------------------------------------------
+def test_unhashable_objects():
+    a = np.array([[1, 2], [1, 2]], dtype=object) 
+    info = array_info(a)
+    assert info["num_unique"] in ("n/a", "n/a (sample)")
+
+# ---------------------------------------------------------------------
+# 12. Pure string array (incompatible with numeric ops)
+# ---------------------------------------------------------------------
+def test_string_array():
+    a = np.array(["foo", "bar", "baz", "foo"])
+    info = array_info(a)
+    assert info["dtype"] == "<U3" or info["dtype"].startswith("<U")  
+    for key in ("min", "max", "mean", "std"):
+        assert info[key] is None
+    assert info["num_unique"] == 3
+
+
+# ---------------------------------------------------------------------
+# 13. Performance sanity on 1-million-element array
+# ---------------------------------------------------------------------
+def test_performance_1m(monkeypatch):
+    import time
+
+    a = np.random.rand(1_000_000) 
+    start = time.perf_counter()
+    _ = array_info(a)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, f"array_info too slow: {elapsed:.3f}s"
+
+# ---------------------------------------------------------------------
+# 14. Axis-wise mean check
+# ---------------------------------------------------------------------
+def test_axis_mean():
+    a = np.arange(6).reshape(2, 3)
+    stats = np.array_info(a, axis=0)["axis_stats"]
+    assert (stats["mean"] == np.array([1.5, 2.5, 3.5])).all()
+
+# ---------------------------------------------------------------------
+# 15. Percentile & IQR on flattened data
+# ---------------------------------------------------------------------
+def test_percentiles():
+    a = np.arange(1, 5)         
+    info = np.array_info(a, percentiles=(25, 50, 75))
+    assert info["p25"] == 1.75
+    assert info["p75"] == 3.25
+    assert info["iqr"] == 1.5


### PR DESCRIPTION
We propose the implementation of a new utility function np.array_info(). This function provides a quick
summary of the structure and content of ndarray objects. np.array_info(array) will return a dictionary of useful information and basic statistics.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
