### PR TITLE
TYP: Workaround for a mypy issue in ``ndarray.__iter__``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -807,6 +807,7 @@ _RealNumberT = TypeVar("_RealNumberT", bound=floating | integer)
 _FloatingT_co = TypeVar("_FloatingT_co", bound=floating, default=floating, covariant=True)
 _IntegerT = TypeVar("_IntegerT", bound=integer)
 _IntegerT_co = TypeVar("_IntegerT_co", bound=integer, default=integer, covariant=True)
+_NonObjectScalarT = TypeVar("_NonObjectScalarT", bound=np.bool | number | flexible | datetime64 | timedelta64)
 
 _NBit = TypeVar("_NBit", bound=NBitBase, default=Any)  # pyright: ignore[reportDeprecated]
 _NBit1 = TypeVar("_NBit1", bound=NBitBase, default=Any)  # pyright: ignore[reportDeprecated]
@@ -2572,10 +2573,13 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def __len__(self) -> int: ...
     def __contains__(self, value: object, /) -> builtins.bool: ...
 
-    @overload  # == 1-d & object_
-    def __iter__(self: ndarray[tuple[int], dtype[object_]], /) -> Iterator[Any]: ...
-    @overload  # == 1-d
-    def __iter__(self: ndarray[tuple[int], dtype[_ScalarT]], /) -> Iterator[_ScalarT]: ...
+    # NOTE: This weird `Never` tuple works around a strange mypy issue where it assigns
+    # `tuple[int]` to `tuple[Never]` or `tuple[int, int]` to `tuple[Never, Never]`.
+    # This way the bug only occurs for 9-D arrays, which are probably not very common.
+    @overload
+    def __iter__(self: ndarray[tuple[Never, Never, Never, Never, Never, Never, Never, Never, Never]], /) -> Iterator[Any]: ...
+    @overload  # == 1-d & dtype[T \ object_]
+    def __iter__(self: ndarray[tuple[int], dtype[_NonObjectScalarT]], /) -> Iterator[_NonObjectScalarT]: ...
     @overload  # >= 2-d
     def __iter__(self: ndarray[tuple[int, int, *tuple[int, ...]], dtype[_ScalarT]], /) -> Iterator[NDArray[_ScalarT]]: ...
     @overload  # ?-d

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -6,6 +6,7 @@ function-based counterpart in `../from_numeric.py`.
 
 """
 
+from collections.abc import Iterator
 import ctypes as ct
 import operator
 from types import ModuleType
@@ -28,6 +29,10 @@ AR_c8: npt.NDArray[np.complex64]
 AR_m: npt.NDArray[np.timedelta64]
 AR_U: npt.NDArray[np.str_]
 AR_V: npt.NDArray[np.void]
+
+AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
+AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
+AR_f8_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float64]]
 
 ctypes_obj = AR_f8.ctypes
 
@@ -235,3 +240,8 @@ assert_type(AR_m.to_device("cpu"), npt.NDArray[np.timedelta64])
 
 assert_type(f8.__array_namespace__(), ModuleType)
 assert_type(AR_f8.__array_namespace__(), ModuleType)
+
+assert_type(iter(AR_f8), Iterator[Any])  # any-D
+assert_type(iter(AR_f8_1d), Iterator[np.float64])  # 1-D
+assert_type(iter(AR_f8_2d), Iterator[npt.NDArray[np.float64]])  # 2-D
+assert_type(iter(AR_f8_3d), Iterator[npt.NDArray[np.float64]])  # 3-D


### PR DESCRIPTION
Closes #29214

---

The workaround I had in mind was also bugged, so I suppose that'd make it a workaroundaround. And just like that term, this workaroundaround itself also looks pretty absurd.