### PR TITLE
MAINT: bump ``mypy`` to ``1.16.1``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.5.0
-  - mypy=1.16.0
+  - mypy=1.16.1
   - orjson  # makes mypy faster
   # For building docs
   - sphinx>=4.5.0

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -12,9 +12,8 @@ pytest-timeout
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.16.0; platform_python_implementation != "PyPy"
+mypy==1.16.1; platform_python_implementation != "PyPy"
 typing_extensions>=4.5.0
 # for optional f2py encoding detection
 charset-normalizer
 tzdata
-


### PR DESCRIPTION
It fixes some 1.16.0 regressions:
https://github.com/python/mypy/compare/v1.16.0...v1.16.1