### PR TITLE
BUG: avoid negating unsigned integers in resize implementation

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1607,7 +1607,8 @@ def resize(a, new_shape):
         # First case must zero fill. The second would have repeats == 0.
         return np.zeros_like(a, shape=new_shape)
 
-    repeats = -(-new_size // a.size)  # ceil division
+    # ceiling division without negating new_size
+    repeats = (new_size + a.size - 1) // a.size
     a = concatenate((a,) * repeats)[:new_size]
 
     return reshape(a, new_shape)

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -79,6 +79,13 @@ class TestResize:
         with pytest.raises(ValueError, match=r"negative"):
             np.resize(A, new_shape=new_shape)
 
+    def test_unsigned_resize(self):
+        # ensure unsigned integer sizes don't lead to underflows
+        for dt_pair in [(np.int32, np.uint32), (np.int64, np.uint64)]:
+            arr = np.array([[23, 95], [66, 37]])
+            assert_array_equal(np.resize(arr, dt_pair[0](1)),
+                               np.resize(arr, dt_pair[1](1)))
+
     def test_subclass(self):
         class MyArray(np.ndarray):
             __array_priority__ = 1.


### PR DESCRIPTION
Fixes #29225.

The negation of an unsigned int underflows and creates a large positive `repeats`, which leads to allocations failures and/or swapping.