### PR TITLE
BUG: Enforce integer limitation in concatenate

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -668,10 +668,17 @@ PyArray_ConcatenateInto(PyObject *op,
     }
 
     /* Convert the input list into arrays */
-    narrays = PySequence_Size(op);
-    if (narrays < 0) {
+    Py_ssize_t narrays_true = PySequence_Size(op);
+    if (narrays_true < 0) {
         return NULL;
     }
+    else if (narrays_true > NPY_MAX_INT) {
+        PyErr_Format(PyExc_ValueError,
+            "concatenate() only supports up to %d arrays but got %zd.",
+            NPY_MAX_INT, narrays_true);
+        return NULL;
+    }
+    narrays = (int)narrays_true;
     arrays = PyArray_malloc(narrays * sizeof(arrays[0]));
     if (arrays == NULL) {
         PyErr_NoMemory();

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -29,6 +29,7 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
+from numpy.testing._private.utils import requires_memory
 
 
 class TestAtleast1d:
@@ -289,6 +290,16 @@ class TestConcatenate:
 
         # No arrays to concatenate raises ValueError
         assert_raises(ValueError, concatenate, ())
+
+    @pytest.mark.slow
+    @requires_memory(2 * np.iinfo(np.intc).max)
+    def test_huge_list_error(self):
+        a = np.array([1])
+        max_int = np.iinfo(np.intc).max
+        arrs = (a,) * (max_int + 1)
+        msg = fr"concatenate\(\) only supports up to {max_int} arrays but got {max_int + 1}."
+        with pytest.raises(ValueError, match=msg):
+            np.concatenate(arrs)
 
     def test_concatenate_axis_None(self):
         a = np.arange(4, dtype=np.float64).reshape((2, 2))

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import numpy as np
@@ -292,6 +294,7 @@ class TestConcatenate:
         assert_raises(ValueError, concatenate, ())
 
     @pytest.mark.slow
+    @pytest.mark.skipif(sys.maxsize < 2**32, reason="only problematic on 64bit platforms")
     @requires_memory(2 * np.iinfo(np.intc).max)
     def test_huge_list_error(self):
         a = np.array([1])


### PR DESCRIPTION
Concatenate internals only deal with integer many arrays, that should be fine in practice, but a SystemError (or in principle maybe also a harder crash?) is not really.
