### PR TITLE
ENH, SIMD: Optimize the trigonometric implementation based on Highway…

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1004,7 +1004,7 @@ foreach gen_mtargets : [
     'src/umath/loops_trigonometric.dispatch.cpp',
     [
       AVX512_SKX, [AVX2, FMA3],
-      VSX4, VSX3, VSX2,
+      VSX3, VSX2,
       NEON_VFPV4,
       VXE2, VXE,
       LSX,

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1008,6 +1008,7 @@ foreach gen_mtargets : [
       NEON_VFPV4,
       VXE2, VXE,
       LSX,
+      RVV,
     ]
   ],
   [

--- a/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
@@ -6,7 +6,13 @@
 #include "simd/simd.hpp" 
 #include <hwy/highway.h>
 
-namespace hn = hwy::HWY_NAMESPACE;
+typedef enum {
+    SIMD_COMPUTE_SIN,
+    SIMD_COMPUTE_COS
+} SIMD_TRIG_OP;
+
+namespace {
+using namespace np::simd;
 
 /*
  * Vectorized approximate sine/cosine algorithms: The following code is a
@@ -32,166 +38,165 @@ namespace hn = hwy::HWY_NAMESPACE;
  * TODO: use vectorized version of Payne-Hanek style reduction for large
  * elements or when there's no native FUSED support instead of fallback to libc
  */
-
-#if NPY_SIMD_FMA3  // native support
-typedef enum {
-    SIMD_COMPUTE_SIN,
-    SIMD_COMPUTE_COS
-} SIMD_TRIG_OP;
-
-const hn::ScalableTag<float> f32;
-const hn::ScalableTag<int32_t> s32;
-using vec_f32 = hn::Vec<decltype(f32)>;
-using vec_s32 = hn::Vec<decltype(s32)>;
-using opmask_t = hn::Mask<decltype(f32)>;
-
-HWY_INLINE HWY_ATTR vec_f32
-simd_range_reduction_f32(vec_f32 &x, vec_f32 &y, const vec_f32 &c1,
-                         const vec_f32 &c2, const vec_f32 &c3)
+#if NPY_HWY_FMA  // native support
+HWY_INLINE Vec<float>
+simd_range_reduction_f32(Vec<float> &x, Vec<float> &y, const Vec<float> &c1,
+                         const Vec<float> &c2, const Vec<float> &c3)
 {
-    vec_f32 reduced_x = hn::MulAdd(y, c1, x);
+    Vec<float> reduced_x = hn::MulAdd(y, c1, x);
     reduced_x = hn::MulAdd(y, c2, reduced_x);
     reduced_x = hn::MulAdd(y, c3, reduced_x);
     return reduced_x;
 }
 
-HWY_INLINE HWY_ATTR vec_f32
-simd_cosine_poly_f32(vec_f32 &x2)
+HWY_INLINE Vec<float>
+simd_cosine_poly_f32(Vec<float> &x2)
 {
-    const vec_f32 invf8 = hn::Set(f32, 0x1.98e616p-16f);
-    const vec_f32 invf6 = hn::Set(f32, -0x1.6c06dcp-10f);
-    const vec_f32 invf4 = hn::Set(f32, 0x1.55553cp-05f);
-    const vec_f32 invf2 = hn::Set(f32, -0x1.000000p-01f);
-    const vec_f32 invf0 = hn::Set(f32, 0x1.000000p+00f);
+    const Vec<float> invf8 = Set(float(0x1.98e616p-16f));
+    const Vec<float> invf6 = Set(float(-0x1.6c06dcp-10f));
+    const Vec<float> invf4 = Set(float(0x1.55553cp-05f));
+    const Vec<float> invf2 = Set(float(-0x1.000000p-01f));
+    const Vec<float> invf0 = Set(float(0x1.000000p+00f));
 
-    vec_f32 r = hn::MulAdd(invf8, x2, invf6);
+    Vec<float> r = hn::MulAdd(invf8, x2, invf6);
     r = hn::MulAdd(r, x2, invf4);
     r = hn::MulAdd(r, x2, invf2);
     r = hn::MulAdd(r, x2, invf0);
     return r;
 }
+
 /*
  * Approximate sine algorithm for x \in [-PI/4, PI/4]
  * Maximum ULP across all 32-bit floats = 0.647
  * Polynomial approximation based on unpublished work by T. Myklebust
  */
-HWY_INLINE HWY_ATTR vec_f32
-simd_sine_poly_f32(vec_f32 &x, vec_f32 &x2)
+HWY_INLINE Vec<float>
+simd_sine_poly_f32(Vec<float> &x, Vec<float> &x2)
 {
-    const vec_f32 invf9 = hn::Set(f32, 0x1.7d3bbcp-19f);
-    const vec_f32 invf7 = hn::Set(f32, -0x1.a06bbap-13f);
-    const vec_f32 invf5 = hn::Set(f32, 0x1.11119ap-07f);
-    const vec_f32 invf3 = hn::Set(f32, -0x1.555556p-03f);
+    const Vec<float> invf9 = Set(float(0x1.7d3bbcp-19f));
+    const Vec<float> invf7 = Set(float(-0x1.a06bbap-13f));
+    const Vec<float> invf5 = Set(float(0x1.11119ap-07f));
+    const Vec<float> invf3 = Set(float(-0x1.555556p-03f));
 
-    vec_f32 r = hn::MulAdd(invf9, x2, invf7);
+    Vec<float> r = hn::MulAdd(invf9, x2, invf7);
     r = hn::MulAdd(r, x2, invf5);
     r = hn::MulAdd(r, x2, invf3);
-    r = hn::MulAdd(r, x2, hn::Zero(f32));
+    r = hn::MulAdd(r, x2, Zero<float>());
     r = hn::MulAdd(r, x, x);
     return r;
 }
 
-static void HWY_ATTR SIMD_MSVC_NOINLINE
+static void SIMD_MSVC_NOINLINE
 simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
                 npy_intp len, SIMD_TRIG_OP trig_op)
 {
     // Load up frequently used constants
-    const vec_f32 zerosf = hn::Zero(f32);
-    const vec_s32 ones = hn::Set(s32, 1);
-    const vec_s32 twos = hn::Set(s32, 2);
-    const vec_f32 two_over_pi = hn::Set(f32, 0x1.45f306p-1f);
-    const vec_f32 codyw_pio2_highf = hn::Set(f32, -0x1.921fb0p+00f);
-    const vec_f32 codyw_pio2_medf = hn::Set(f32, -0x1.5110b4p-22f);
-    const vec_f32 codyw_pio2_lowf = hn::Set(f32, -0x1.846988p-48f);
-    const vec_f32 rint_cvt_magic = hn::Set(f32, 0x1.800000p+23f);
+    const Vec<float> zerosf = Zero<float>();
+    const Vec<int32_t> ones = Set(int32_t(1));
+    const Vec<int32_t> twos = Set(int32_t(2));
+    const Vec<float> two_over_pi      = Set(float(0x1.45f306p-1f));
+    const Vec<float> codyw_pio2_highf = Set(float(-0x1.921fb0p+00f));
+    const Vec<float> codyw_pio2_medf  = Set(float(-0x1.5110b4p-22f));
+    const Vec<float> codyw_pio2_lowf  = Set(float(-0x1.846988p-48f));
+    const Vec<float> rint_cvt_magic   = Set(float(0x1.800000p+23f));
     // Cody-Waite's range
     float max_codi = 117435.992f;
     if (trig_op == SIMD_COMPUTE_COS) {
         max_codi = 71476.0625f;
     }
-    const vec_f32 max_cody = hn::Set(f32, max_codi);
+    const Vec<float> max_cody = Set(float(max_codi));
 
-    const int lanes = hn::Lanes(f32);
-    const vec_s32 src_index = hn::Mul(hn::Iota(s32, 0), hn::Set(s32, ssrc));
-    const vec_s32 dst_index = hn::Mul(hn::Iota(s32, 0), hn::Set(s32, sdst));
+    const int lanes = Lanes<float>();
+    const Vec<int32_t> src_index = hn::Mul(hn::Iota(_Tag<int32_t>(), 0), Set(int32_t(ssrc)));
+    const Vec<int32_t> dst_index = hn::Mul(hn::Iota(_Tag<int32_t>(), 0), Set(int32_t(sdst)));
 
     for (; len > 0; len -= lanes, src += ssrc * lanes, dst += sdst * lanes) {
-        vec_f32 x_in;
+        Vec<float> x_in = Zero<float>();
         if (ssrc == 1) {
-            x_in = hn::LoadN(f32, src, len);
+            x_in = hn::LoadN(_Tag<float>(), src, len);
         }
         else {
-            x_in = hn::GatherIndexN(f32, src, src_index, len);
+            
+            #if HWY_TARGET == HWY_RVV
+                for (npy_intp i = 0; i < std::min(len, static_cast<npy_intp>(Lanes<int32_t>())); i++) {
+                    float val = src[hn::ExtractLane(src_index, i)];
+                    x_in = hn::InsertLane(x_in, i, val);
+                }
+            #else
+                    x_in = hn::GatherIndexN(_Tag<float>(), src, src_index, len);
+            #endif
         }
-        opmask_t nnan_mask = hn::Not(hn::IsNaN(x_in));
+        Mask<float> nnan_mask = hn::Not(hn::IsNaN(x_in));
         // Eliminate NaN to avoid FP invalid exception
         x_in = hn::IfThenElse(nnan_mask, x_in, zerosf);
-        opmask_t simd_mask = hn::Le(hn::Abs(x_in), max_cody);
+        Mask<float> simd_mask = hn::Le(hn::Abs(x_in), max_cody);
         /*
          * For elements outside of this range, Cody-Waite's range reduction
          * becomes inaccurate and we will call libc to compute cosine for
          * these numbers
          */
-        if (!hn::AllFalse(f32, simd_mask)) {
-            vec_f32 x = hn::IfThenElse(hn::And(nnan_mask, simd_mask), x_in,
+        if (!hn::AllFalse(_Tag<float>(), simd_mask)) {
+            Vec<float> x = hn::IfThenElse(hn::And(nnan_mask, simd_mask), x_in,
                                        zerosf);
 
-            vec_f32 quadrant = hn::Mul(x, two_over_pi);
+            Vec<float> quadrant = hn::Mul(x, two_over_pi);
             // round to nearest, -0.0f -> +0.0f, and |a| must be <= 0x1.0p+22
             quadrant = hn::Add(quadrant, rint_cvt_magic);
             quadrant = hn::Sub(quadrant, rint_cvt_magic);
 
             // Cody-Waite's range reduction algorithm
-            vec_f32 reduced_x =
+            Vec<float> reduced_x =
                     simd_range_reduction_f32(x, quadrant, codyw_pio2_highf,
                                              codyw_pio2_medf, codyw_pio2_lowf);
-            vec_f32 reduced_x2 = hn::Mul(reduced_x, reduced_x);
+            Vec<float> reduced_x2 = hn::Mul(reduced_x, reduced_x);
 
             // compute cosine and sine
-            vec_f32 cos = simd_cosine_poly_f32(reduced_x2);
-            vec_f32 sin = simd_sine_poly_f32(reduced_x, reduced_x2);
+            Vec<float> cos = simd_cosine_poly_f32(reduced_x2);
+            Vec<float> sin = simd_sine_poly_f32(reduced_x, reduced_x2);
 
-            vec_s32 iquadrant = hn::NearestInt(quadrant);
+            Vec<int32_t> iquadrant = hn::NearestInt(quadrant);
             if (trig_op == SIMD_COMPUTE_COS) {
                 iquadrant = hn::Add(iquadrant, ones);
             }
             // blend sin and cos based on the quadrant
-            opmask_t sine_mask = hn::RebindMask(
-                    f32, hn::Eq(hn::And(iquadrant, ones), hn::Zero(s32)));
+            Mask<float> sine_mask = hn::RebindMask(
+                    _Tag<float>(), hn::Eq(hn::And(iquadrant, ones), Zero<int32_t>()));
             cos = hn::IfThenElse(sine_mask, sin, cos);
 
             // multiply by -1 for appropriate elements
-            opmask_t negate_mask = hn::RebindMask(
-                    f32, hn::Eq(hn::And(iquadrant, twos), twos));
+            Mask<float> negate_mask = hn::RebindMask(
+                    _Tag<float>(), hn::Eq(hn::And(iquadrant, twos), twos));
             cos = hn::MaskedSubOr(cos, negate_mask, zerosf, cos);
-            cos = hn::IfThenElse(nnan_mask, cos, hn::Set(f32, NPY_NANF));
+            cos = hn::IfThenElse(nnan_mask, cos, Set(float(NPY_NANF)));
 
             if (sdst == 1) {
-                hn::StoreN(cos, f32, dst, len);
+                hn::StoreN(cos, _Tag<float>(), dst, len);
             }
             else {
-                hn::ScatterIndexN(cos, f32, dst, dst_index, len);
+                hn::ScatterIndexN(cos, _Tag<float>(), dst, dst_index, len);
             }
         }
-        if (!hn::AllTrue(f32, simd_mask)) {
-            static_assert(hn::MaxLanes(f32) <= 64,
-                          "The following fallback is not applicable for "
-                          "SIMD widths larger than 2048 bits, or for scalable "
-                          "SIMD in general.");
-            npy_uint64 simd_maski;
-            hn::StoreMaskBits(f32, simd_mask, (uint8_t *)&simd_maski);
+        if (!hn::AllTrue(_Tag<float>(), simd_mask)) {
+#if HWY_TARGET != HWY_RVV
+            static_assert(hn::MaxLanes(_Tag<float>()) <= 64,
+                      "The following fallback is not applicable for "
+                      "SIMD widths larger than 2048 bits, or for scalable "
+                      "SIMD in general.");
+#endif
+            npy_uint64 simd_maski = 0;
+            hn::StoreMaskBits(_Tag<float>(), simd_mask, (uint8_t *)&simd_maski);
 #if HWY_IS_BIG_ENDIAN
-            static_assert(hn::MaxLanes(f32) <= 8,
-                          "This conversion is not supported for SIMD widths "
-                          "larger than 256 bits.");
+            static_assert(hn::MaxLanes(_Tag<float>()) <= 8,
+                      "This conversion is not supported for SIMD widths "
+                      "larger than 256 bits.");
             simd_maski = ((uint8_t *)&simd_maski)[0];
 #endif
-            float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) ip_fback[hn::MaxLanes(f32)];
-            hn::Store(x_in, f32, ip_fback);
+            float NPY_DECL_ALIGNED(kMaxLanes<uint8_t>) ip_fback[hn::MaxLanes(_Tag<float>())];
+            hn::Store(x_in, _Tag<float>(), ip_fback);
 
             // process elements using libc for large elements
             if (trig_op == SIMD_COMPUTE_COS) {
-                for (unsigned i = 0; i < hn::Lanes(f32); ++i) {
+                for (unsigned i = 0; i < Lanes<float>(); ++i) {
                     if ((simd_maski >> i) & 1) {
                         continue;
                     }
@@ -199,7 +204,7 @@ simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
                 }
             }
             else {
-                for (unsigned i = 0; i < hn::Lanes(f32); ++i) {
+                for (unsigned i = 0; i < Lanes<float>(); ++i) {
                     if ((simd_maski >> i) & 1) {
                         continue;
                     }
@@ -207,10 +212,58 @@ simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
                 }
             }
         }
-        npyv_cleanup();
     }
 }
-#endif  // NPY_SIMD_FMA3
+#endif  // NPY_HWY_FMA
+
+template <SIMD_TRIG_OP T>
+HWY_INLINE void
+sine_cosine(char **args, npy_intp const *dimensions, npy_intp const *steps)
+{
+    char *src = args[0]; char *dst = args[1];
+    const npy_intp src_step = steps[0];
+    const npy_intp dst_step = steps[1];
+    npy_intp len = dimensions[0];
+
+#if NPY_HWY_FMA
+        if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
+            !(alignof(npy_float) == sizeof(npy_float) && src_step % sizeof(npy_float) == 0) ||
+            !(alignof(npy_float) == sizeof(npy_float) && dst_step % sizeof(npy_float) == 0)
+        ) {
+            for (; len > 0; --len, src += src_step, dst += dst_step) {
+                simd_sincos_f32((npy_float *)src, 1, (npy_float *)dst, 1, 1, T);
+            }
+        } else {
+            const npy_intp ssrc = steps[0] / sizeof(npy_float);
+            const npy_intp sdst = steps[1] / sizeof(npy_float);
+
+            simd_sincos_f32((npy_float *)src, ssrc, (npy_float *)dst, sdst, len, T);
+        }
+#else
+        for (; len > 0; --len, src += src_step, dst += dst_step) {
+            const npy_float src0 = *reinterpret_cast<const npy_float*>(src);
+            *reinterpret_cast<npy_float*>(dst) = (SIMD_COMPUTE_SIN==T)?npy_sinf(src0):npy_cosf(src0);
+        }
+#endif
+}
+
+} // anonymous namespace
+
+/******************************************************************************************
+ ** Defining ufunc inner functions
+ *****************************************************************************************/
+#define DEFINE_SINE_COSINE_FUNCTION(FUNC, T)                                 \
+NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(FLOAT##_##FUNC)                                 \
+(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data)) \
+{                                                                                        \
+    sine_cosine<T>(args, dimensions, steps);                                \
+}
+
+DEFINE_SINE_COSINE_FUNCTION(sin, SIMD_COMPUTE_SIN)
+DEFINE_SINE_COSINE_FUNCTION(cos, SIMD_COMPUTE_COS)
+
+#undef DEFINE_SINE_COSINE_FUNCTION
+
 
 /* Disable SIMD code sin/cos f64 and revert to libm: see
  * https://mail.python.org/archives/list/numpy-discussion@python.org/thread/C6EYZZSR4EWGVKHAZXLE7IBILRMNVK7L/
@@ -229,71 +282,3 @@ simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
 
 DISPATCH_DOUBLE_FUNC(sin)
 DISPATCH_DOUBLE_FUNC(cos)
-
-NPY_NO_EXPORT void
-NPY_CPU_DISPATCH_CURFX(FLOAT_sin)(char **args, npy_intp const *dimensions,
-                                  npy_intp const *steps,
-                                  void *NPY_UNUSED(data))
-{
-#if NPY_SIMD_FMA3
-    npy_intp len = dimensions[0];
-
-    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
-        !npyv_loadable_stride_f32(steps[0]) ||
-        !npyv_storable_stride_f32(steps[1])) {
-        UNARY_LOOP
-        {
-            simd_sincos_f32((npy_float *)ip1, 1, (npy_float *)op1, 1, 1,
-                            SIMD_COMPUTE_SIN);
-        }
-    }
-    else {
-        const npy_float *src = (npy_float *)args[0];
-        npy_float *dst = (npy_float *)args[1];
-        const npy_intp ssrc = steps[0] / sizeof(npy_float);
-        const npy_intp sdst = steps[1] / sizeof(npy_float);
-
-        simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_SIN);
-    }
-#else
-    UNARY_LOOP
-    {
-        const npy_float in1 = *(npy_float *)ip1;
-        *(npy_float *)op1 = npy_sinf(in1);
-    }
-#endif
-}
-
-NPY_NO_EXPORT void
-NPY_CPU_DISPATCH_CURFX(FLOAT_cos)(char **args, npy_intp const *dimensions,
-                                  npy_intp const *steps,
-                                  void *NPY_UNUSED(data))
-{
-#if NPY_SIMD_FMA3
-    npy_intp len = dimensions[0];
-
-    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
-        !npyv_loadable_stride_f32(steps[0]) ||
-        !npyv_storable_stride_f32(steps[1])) {
-        UNARY_LOOP
-        {
-            simd_sincos_f32((npy_float *)ip1, 1, (npy_float *)op1, 1, 1,
-                            SIMD_COMPUTE_COS);
-        }
-    }
-    else {
-        const npy_float *src = (npy_float *)args[0];
-        npy_float *dst = (npy_float *)args[1];
-        const npy_intp ssrc = steps[0] / sizeof(npy_float);
-        const npy_intp sdst = steps[1] / sizeof(npy_float);
-
-        simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_COS);
-    }
-#else
-    UNARY_LOOP
-    {
-        const npy_float in1 = *(npy_float *)ip1;
-        *(npy_float *)op1 = npy_cosf(in1);
-    }
-#endif
-}


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip) gcc version 14.2.0
Test command: spin bench --compare HEAD~1 -t bench_ufunc.SinCosSpecific

Add class SinCosSpecific in benchmarks/benchmarks/bench_ufunc.py for this test on Banana Pi BPI-F3

```
class SinCosSpecific(Benchmark):
    timeout = 10
    params = ['float32', 'float64']
    param_names = ['dtype']

    def setup(self, dtype):
        np.seterr(all='ignore')
        self.sin_fn = np.sin
        self.cos_fn = np.cos
        from .common import get_square_
        self.data = (get_square_(dtype),)

    def time_sin(self, dtype):
        self.sin_fn(*self.data)

    def time_cos(self, dtype):
        self.cos_fn(*self.data)

```


(numpy_venv) root@yangwang:/home/yangwang/numpy# git log -2
commit 9daabaeda0796432d21ad55f25be7a14c53a812e (HEAD -> main)
Author: Wang Yang <yangwang@iscas.ac.cn>
Date:   Mon Aug 25 10:40:15 2025 +0800

ENH, SIMD: Optimize the trigonometric implementation based on Highway Wrapper

commit be3ea3200edcc09d7cce9dcb56808c4619730d60
Author: Wang Yang <yangwang@iscas.ac.cn>
Date:   Mon Aug 25 10:35:36 2025 +0800

TST:Add np.sin and np.cos test



(numpy_venv) root@yangwang:/home/yangwang/numpy# spin bench --compare HEAD~1 -t bench_ufunc.SinCosSpecific
| Change   | Before [be3ea320] <main~1>   | After [9daabaed] <main>   |   Ratio | Benchmark (Parameter)                          |
|----------|------------------------------|---------------------------|---------|------------------------------------------------|
| -        | 826±50μs                     | 411±30μs                  |    0.5  | bench_ufunc.SinCosSpecific.time_cos('float32') |
| -        | 951±5μs                      | 368±40μs                  |    0.39 | bench_ufunc.SinCosSpecific.time_sin('float32') |
