### PR TITLE
BUG: fix fencepost error in StringDType internals

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -478,7 +478,7 @@ heap_or_arena_allocate(npy_string_allocator *allocator,
         if (*flags == 0) {
             // string isn't previously allocated, so add to existing arena allocation
             char *ret = arena_malloc(arena, allocator->realloc, sizeof(char) * size);
-            if (size < NPY_MEDIUM_STRING_MAX_SIZE) {
+            if (size <= NPY_MEDIUM_STRING_MAX_SIZE) {
                 *flags = NPY_STRING_INITIALIZED;
             }
             else {

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1193,6 +1193,24 @@ def test_growing_strings(dtype):
     assert_array_equal(arr, uarr)
 
 
+def test_assign_medium_strings():
+    # see gh-29261
+    N = 9
+    src = np.array(
+        (
+            ['0' * 256] * 3 + ['0' * 255] + ['0' * 256] + ['0' * 255] +
+            ['0' * 256] * 2 + ['0' * 255]
+        ), dtype='T')
+    dst = np.array(
+        (
+            ['0' * 255] + ['0' * 256] * 2 + ['0' * 255] + ['0' * 256] +
+            ['0' * 255] + [''] * 5
+        ), dtype='T')
+
+    dst[1:N + 1] = src
+    assert_array_equal(dst[1:N + 1], src)
+
+
 UFUNC_TEST_DATA = [
     "hello" * 10,
     "Ae¢☃€ 😊" * 20,


### PR DESCRIPTION
Fixes #29261

This makes all the comparisons with `NPY_MEDIUM_STRING_MAX_SIZE` use `<=` consistently:

```
$ rg NPY_MEDIUM_STRING_MAX_SIZE
numpy/_core/src/multiarray/stringdtype/static_string.c
96:#define NPY_MEDIUM_STRING_MAX_SIZE 0xFF  // 255
165:    if (size <= NPY_MEDIUM_STRING_MAX_SIZE) {
199:    if (size <= NPY_MEDIUM_STRING_MAX_SIZE) {
481:            if (size <= NPY_MEDIUM_STRING_MAX_SIZE) {
```