### PR TITLE
DOC: avoid searching some directories for doxygen-commented source code

### DIFF
--- a/doc/preprocess.py
+++ b/doc/preprocess.py
@@ -24,14 +24,16 @@ def doxy_gen(root_path):
 class DoxyTpl(Template):
     delimiter = '@'
 
+
 # Do not look for doxygen commented code in these directories
-skiplist=[
+skiplist = [
     'numpy/build',
     'numpy/vendored-meson',
     'numpy/.git',
     'numpy/doc/build',
     'numpy/benchmarks/env',  # gh-29274
 ]
+
 
 def doxy_config(root_path):
     """
@@ -45,7 +47,7 @@ def doxy_config(root_path):
         confs.append(conf.substitute(CUR_DIR=dsrc_path, **sub))
 
     for dpath, _, files in os.walk(root_path):
-        if any([s in dpath for s in skiplist]):
+        if any(s in dpath for s in skiplist):
             continue
         if ".doxyfile" not in files:
             continue

--- a/doc/preprocess.py
+++ b/doc/preprocess.py
@@ -25,16 +25,6 @@ class DoxyTpl(Template):
     delimiter = '@'
 
 
-# Do not look for doxygen commented code in these directories
-skiplist = [
-    'numpy/build',
-    'numpy/vendored-meson',
-    'numpy/.git',
-    'numpy/doc/build',
-    'numpy/benchmarks/env',  # gh-29274
-]
-
-
 def doxy_config(root_path):
     """
     Fetch all Doxygen sub-config files and gather it with the main config file.
@@ -46,15 +36,14 @@ def doxy_config(root_path):
         conf = DoxyTpl(fd.read())
         confs.append(conf.substitute(CUR_DIR=dsrc_path, **sub))
 
-    for dpath, _, files in os.walk(root_path):
-        if any(s in dpath for s in skiplist):
-            continue
-        if ".doxyfile" not in files:
-            continue
-        conf_path = os.path.join(dpath, ".doxyfile")
-        with open(conf_path) as fd:
-            conf = DoxyTpl(fd.read())
-            confs.append(conf.substitute(CUR_DIR=dpath, **sub))
+    for subdir in ["doc", "numpy"]:
+        for dpath, _, files in os.walk(os.path.join(root_path, subdir)):
+            if ".doxyfile" not in files:
+                continue
+            conf_path = os.path.join(dpath, ".doxyfile")
+            with open(conf_path) as fd:
+                conf = DoxyTpl(fd.read())
+                confs.append(conf.substitute(CUR_DIR=dpath, **sub))
     return confs
 
 

--- a/doc/preprocess.py
+++ b/doc/preprocess.py
@@ -4,7 +4,7 @@ from string import Template
 
 
 def main():
-    doxy_gen(os.path.abspath(os.path.join('..')))
+    doxy_gen(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 def doxy_gen(root_path):
     """
@@ -24,6 +24,15 @@ def doxy_gen(root_path):
 class DoxyTpl(Template):
     delimiter = '@'
 
+# Do not look for doxygen commented code in these directories
+skiplist=[
+    'numpy/build',
+    'numpy/vendored-meson',
+    'numpy/.git',
+    'numpy/doc/build',
+    'numpy/benchmarks/env',  # gh-29274
+]
+
 def doxy_config(root_path):
     """
     Fetch all Doxygen sub-config files and gather it with the main config file.
@@ -36,6 +45,8 @@ def doxy_config(root_path):
         confs.append(conf.substitute(CUR_DIR=dsrc_path, **sub))
 
     for dpath, _, files in os.walk(root_path):
+        if any([s in dpath for s in skiplist]):
+            continue
         if ".doxyfile" not in files:
             continue
         conf_path = os.path.join(dpath, ".doxyfile")


### PR DESCRIPTION
Fixes #29274 when generating documentation. The important one to skip is `numpy/benchmark/env` since it has a copy of the source code, and will confuse breathe by generating duplicate documentation.

A separate PR to numpy/doc is needed to fix the problem with the already-uploaded documentation pointed to in the issue.