### PR TITLE
BLD: use newly released OpenBLAS 0.3.30, use ILP64 on win_arm64

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,4 +1,3 @@
 spin==0.13
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
-scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'
+scipy-openblas32==0.3.30.0.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,6 +1,4 @@
 spin==0.13
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
-scipy-openblas32==0.3.29.265.0 ; sys_platform == 'win32' and platform_machine == 'ARM64'
-# Note there is not yet a win-arm64 wheel, so we currently only exclude win-arm64
-scipy-openblas64==0.3.29.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'
+scipy-openblas32==0.3.30.0.0
+scipy-openblas64==0.3.30.0.0

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -36,10 +36,7 @@ if [[ "$INSTALL_OPENBLAS" = "true" ]] ; then
     # TODO: should we detect a missing RUNNER_ARCH and use platform.machine()
     #    when wheel build is run outside github?
     # On 32-bit platforms, use scipy_openblas32
-    # On win-arm64 use scipy_openblas32
     if [[ $RUNNER_ARCH == "X86" || $RUNNER_ARCH == "ARM" ]] ; then
-        OPENBLAS=openblas32
-    elif [[ $RUNNER_ARCH == "ARM64" && $RUNNER_OS == "Windows" ]] ; then
         OPENBLAS=openblas32
     fi
     echo PKG_CONFIG_PATH is $PKG_CONFIG_PATH, OPENBLAS is ${OPENBLAS}


### PR DESCRIPTION
OpenBLAS 0.3.30 was recently released, let's use it. Since we now have scipy-openblas64 wheels for win_arm64, use those in the wheel build.