### PR TITLE
BUG: handle case in mapiter where descriptors might get replaced

### DIFF
--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -3013,6 +3013,8 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         if (extra_op == NULL) {
             goto fail;
         }
+        // extra_op_dtype might have been replaced, so get a new reference
+        extra_op_dtype = PyArray_DESCR(extra_op);
     }
 
     /*

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -517,6 +517,18 @@ def test_fancy_indexing(string_list):
                 assert_array_equal(a, b)
                 assert a[0] == 'd' * 25
 
+    # see gh-29279
+    data = [
+        ["AAAAAAAAAAAAAAAAA"],
+        ["BBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+        ["CCCCCCCCCCCCCCCCC"],
+        ["DDDDDDDDDDDDDDDDD"],
+    ]
+    sarr = np.array(data, dtype=np.dtypes.StringDType())
+    uarr = np.array(data, dtype="U30")
+    for ind in [[0], [1], [2], [3], [[0, 0]], [[1, 1, 3]], [[1, 1]]]:
+        assert_array_equal(sarr[ind], uarr[ind])
+
 
 def test_creation_functions():
     assert_array_equal(np.zeros(3, dtype="T"), ["", "", ""])


### PR DESCRIPTION
Fixes #29279.

I *think* the reference counts are all correct because `NewFromDescr` steals a reference.