### PR TITLE
BUG: handle case in mapiter where descriptors might get replaced (#29286)

### DIFF
--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -30,13 +30,15 @@
 /* Do not enable the alloc cache if the GIL is disabled, or if ASAN or MSAN
  * instrumentation is enabled. The cache makes ASAN use-after-free or MSAN
  * use-of-uninitialized-memory warnings less useful. */
-#define USE_ALLOC_CACHE 1
 #ifdef Py_GIL_DISABLED
-# define USE_ALLOC_CACHE 0
+  #define USE_ALLOC_CACHE 0
 #elif defined(__has_feature)
-# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
-#  define USE_ALLOC_CACHE 0
-# endif
+  #if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
+    #define USE_ALLOC_CACHE 0
+  #endif
+#endif
+#ifndef USE_ALLOC_CACHE
+  #define USE_ALLOC_CACHE 1
 #endif
 
 # define NBUCKETS 1024 /* number of buckets for data*/

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -3013,6 +3013,8 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
         if (extra_op == NULL) {
             goto fail;
         }
+        // extra_op_dtype might have been replaced, so get a new reference
+        extra_op_dtype = PyArray_DESCR(extra_op);
     }
 
     /*

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -518,6 +518,18 @@ def test_fancy_indexing(string_list):
                 assert_array_equal(a, b)
                 assert a[0] == 'd' * 25
 
+    # see gh-29279
+    data = [
+        ["AAAAAAAAAAAAAAAAA"],
+        ["BBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+        ["CCCCCCCCCCCCCCCCC"],
+        ["DDDDDDDDDDDDDDDDD"],
+    ]
+    sarr = np.array(data, dtype=np.dtypes.StringDType())
+    uarr = np.array(data, dtype="U30")
+    for ind in [[0], [1], [2], [3], [[0, 0]], [[1, 1, 3]], [[1, 1]]]:
+        assert_array_equal(sarr[ind], uarr[ind])
+
 
 def test_creation_functions():
     assert_array_equal(np.zeros(3, dtype="T"), ["", "", ""])


### PR DESCRIPTION
Backport of #29286.

Need to use the actual dtype, not the one passed to the array creation (because it can get replaced).

Fixes #29279.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
