### PR TITLE
BUG: linspace: Round towards `start` with integer dtype.

### DIFF
--- a/doc/release/upcoming_changes/XXX.change.rst
+++ b/doc/release/upcoming_changes/XXX.change.rst
@@ -1,0 +1,15 @@
+`np.linspace` on descending integers now use ceil
+-------------------------------------------------
+When using a `int` dtype in `numpy.linspace` on a descending interval,
+previously float values would be unconditionally rounded towards `-inf`.
+Now `numpy.ceil` is used instead, which rounds toward ``+inf``. This changes
+the results for descending intervals. For example, the following would
+previously give::
+
+    >>> np.linspace(3, -2, 10, endpoint=False, dtype=int)
+    array([ 3,  2,  2,  1,  1,  0,  0, -1, -1, -2])
+
+and now results in::
+
+    >>> np.linspace(3, -2, 10, endpoint=False, dtype=int)
+    array([ 3,  3,  2,  2,  1,  1,  0,  0, -1, -1])

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -39,6 +39,11 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         integer ``dtype`` is specified. The old behavior can
         still be obtained with ``np.linspace(start, stop, num).astype(int)``
 
+    .. versionchanged:: 2.4.0
+        Values are rounded towards ``+inf`` instead of ``-inf`` when an
+        integer ``dtype`` and a descending interval with ``stop`` < ``start``
+        are specified
+
     Parameters
     ----------
     start : array_like
@@ -178,7 +183,11 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         y = _nx.moveaxis(y, 0, axis)
 
     if integer_dtype:
-        _nx.floor(y, out=y)
+        # Round towards `start`
+        if delta < 0:
+            _nx.ceil(y, out=y)
+        else:
+            _nx.floor(y, out=y)
 
     y = conv.wrap(y.astype(dtype, copy=False))
     if retstep:

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -476,6 +476,11 @@ class TestLinspace:
         t = array([-1, -1, 0, 0, 1, 1, 2, 3], dtype=int)
         assert_array_equal(y, t)
 
+    def test_round_negative_decreasing(self):
+        y = -linspace(1, -3, num=8, dtype=int)
+        t = array([-1, -1, 0, 0, 1, 1, 2, 3], dtype=int)
+        assert_array_equal(y, t)
+
     def test_any_step_zero_and_not_mult_inplace(self):
         # any_step_zero is True, _mult_inplace is False
         start = array([0.0, 1.0])


### PR DESCRIPTION
The PR #16841 implemented rounding towards `-inf` for integer dtypes.
While this is for sure better than the old towards `0` approach, it does not produce good results for descending intervals with `start` > `stop`.

It violates (at least my) expected behavior of `-linspace(A, B) == linspace(-A, -B)`.
And it violates the documentation of `endpoint` as `stop` can be included.

However I'm not sure if these conflicts are worth to break the behavior of `linspace`, even for the edge cases of `dtype=integers` and `start > stop`.

Related to #16813
