### PR TITLE
ENH: Consistent formatting precision of compared arrays and errors

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -574,8 +574,8 @@ def assert_almost_equal(actual, desired, decimal=7, err_msg='', verbose=True):
     Arrays are not almost equal to 9 decimals
     <BLANKLINE>
     Mismatched elements: 1 / 2 (50%)
-    Max absolute difference among violations: 6.66669964e-09
-    Max relative difference among violations: 2.85715698e-09
+    Max absolute difference among violations: 6.666699637e-09
+    Max relative difference among violations: 2.857156979e-09
      ACTUAL: array([1.         , 2.333333333])
      DESIRED: array([1.        , 2.33333334])
 
@@ -893,7 +893,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                     else:
                         remarks.append(
                             'Max absolute difference among violations: '
-                            + array2string(max_abs_error))
+                            + array2string(max_abs_error, precision=precision))
 
                     # note: this definition of relative error matches that one
                     # used by assert_allclose (found in np.isclose)
@@ -917,7 +917,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                     else:
                         remarks.append(
                             'Max relative difference among violations: '
-                            + array2string(max_rel_error))
+                            + array2string(max_rel_error, precision=precision))
             err_msg = str(err_msg)
             err_msg += '\n' + '\n'.join(remarks)
             msg = build_err_msg([ox, oy], err_msg,
@@ -1013,8 +1013,8 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
     Arrays are not equal
     <BLANKLINE>
     Mismatched elements: 1 / 3 (33.3%)
-    Max absolute difference among violations: 4.4408921e-16
-    Max relative difference among violations: 1.41357986e-16
+    Max absolute difference among violations: 4.440892e-16
+    Max relative difference among violations: 1.41358e-16
      ACTUAL: array([1.      , 3.141593,      nan])
      DESIRED: array([1.      , 3.141593,      nan])
 
@@ -1127,7 +1127,7 @@ def assert_array_almost_equal(actual, desired, decimal=6, err_msg='',
     <BLANKLINE>
     Mismatched elements: 1 / 3 (33.3%)
     Max absolute difference among violations: 6.e-05
-    Max relative difference among violations: 2.57136612e-05
+    Max relative difference among violations: 2.57137e-05
      ACTUAL: array([1.     , 2.33333,     nan])
      DESIRED: array([1.     , 2.33339,     nan])
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -705,8 +705,7 @@ class TestAlmostEqual(_GenericTest):
             self._assert_func(x, y, decimal=12)
 
         # With the default value of decimal digits, only the 3rd element
-        # differs. Note that we only check for the formatting of the arrays
-        # themselves.
+        # differs.
         expected_msg = ('Mismatched elements: 1 / 3 (33.3%)\n'
                         'Max absolute difference among violations: 1.e-05\n'
                         'Max relative difference among violations: '

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -121,7 +121,7 @@ class TestArrayEqual(_GenericTest):
         y = np.array(0)
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: '
-                        '4.39506535e+12\n'
+                        '4.395065e+12\n'
                         'Max relative difference among violations: inf\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
@@ -275,7 +275,7 @@ class TestArrayEqual(_GenericTest):
                         'Max absolute difference among violations: '
                         '563766.\n'
                         'Max relative difference among violations: '
-                        '4.54902139e-07')
+                        '4.549021e-07')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -301,6 +301,19 @@ class TestArrayEqual(_GenericTest):
 
         with pytest.raises(AssertionError):
             self._assert_func(a, b, strict=True)
+
+    def test_error_message_consistent_precision(self):
+        """Test that the same precision is used for formatting the compared array
+           values and the maximum errors"""
+        a = np.array([0.23456789])
+        b = np.array([0.12345678])
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                'Max absolute difference among violations: 0.111111\n'
+                'Max relative difference among violations: 0.9\n'
+                ' ACTUAL: array([0.234568])\n'
+                ' DESIRED: array([0.123457])')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+            self._assert_func(a, b)
 
 
 class TestBuildErrorMessage:
@@ -457,7 +470,7 @@ class TestArrayAlmostEqual(_GenericTest):
 
         # test scalars
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
-                        'Max absolute difference among violations: 1.5\n'
+                        'Max absolute difference among violations: 2.\n'
                         'Max relative difference among violations: inf')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(1.5, 0.0, decimal=0)
@@ -466,7 +479,7 @@ class TestArrayAlmostEqual(_GenericTest):
         self._assert_func([1.499999], [0.0], decimal=0)
 
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
-                        'Max absolute difference among violations: 1.5\n'
+                        'Max absolute difference among violations: 2.\n'
                         'Max relative difference among violations: inf')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func([1.5], [0.0], decimal=0)
@@ -496,7 +509,7 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Max absolute difference among violations: '
                         '1.e-04\n'
                         'Max relative difference among violations: '
-                        '8.10226812e-08')
+                        '8.10227e-08')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y, decimal=5)
 
@@ -693,9 +706,9 @@ class TestAlmostEqual(_GenericTest):
 
         # Test with a different amount of decimal digits
         expected_msg = ('Mismatched elements: 3 / 3 (100%)\n'
-                        'Max absolute difference among violations: 1.e-05\n'
+                        'Max absolute difference among violations: 9.999999999621e-06\n'
                         'Max relative difference among violations: '
-                        '3.33328889e-06\n'
+                        '3.333288889355e-06\n'
                         ' ACTUAL: array([1.00000000001, '
                         '2.00000000002, '
                         '3.00003      ])\n'
@@ -709,11 +722,30 @@ class TestAlmostEqual(_GenericTest):
         expected_msg = ('Mismatched elements: 1 / 3 (33.3%)\n'
                         'Max absolute difference among violations: 1.e-05\n'
                         'Max relative difference among violations: '
-                        '3.33328889e-06\n'
+                        '3.3332889e-06\n'
                         ' ACTUAL: array([1.     , 2.     , 3.00003])\n'
                         ' DESIRED: array([1.     , 2.     , 3.00004])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
+
+        # Test that the same precision is used for formatting the compared array
+        # values and the maximum errors
+        x = [2.6]
+        y = [0.0]
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                        'Max absolute difference among violations: 2.6\n'
+                        'Max relative difference among violations: inf\n'
+                        ' ACTUAL: array([2.6])\n'
+                        ' DESIRED: array([0.])')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+            self._assert_func(x, y, decimal=1)
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                        'Max absolute difference among violations: 3.\n'
+                        'Max relative difference among violations: inf\n'
+                        ' ACTUAL: array([3.])\n'
+                        ' DESIRED: array([0.])')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+            self._assert_func(x, y, decimal=0)
 
         # Check the error message when input includes inf
         x = np.array([np.inf, 0])
@@ -849,7 +881,7 @@ class TestArrayAssertLess:
         self._assert_func(x, y)
         expected_msg = ('Mismatched elements: 4 / 4 (100%)\n'
                         'Max absolute difference among violations: 0.1\n'
-                        'Max relative difference among violations: 0.09090909')
+                        'Max relative difference among violations: 0.090909')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -918,7 +950,7 @@ class TestArrayAssertLess:
                         'Max absolute difference among violations: '
                         '999087.0864\n'
                         'Max relative difference among violations: '
-                        '289288.5934676')
+                        '289288.593468')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -928,14 +960,14 @@ class TestArrayAssertLess:
 
         expected_msg = ('Mismatched elements: 1 / 3 (33.3%)\n'
                         'Max absolute difference among violations: 458802.\n'
-                        'Max relative difference among violations: 5.23423917')
+                        'Max relative difference among violations: 5.234239')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
         expected_msg = ('Mismatched elements: 2 / 3 (66.7%)\n'
                         'Max absolute difference among violations: 87654.\n'
                         'Max relative difference among violations: '
-                        '5670.5626011')
+                        '5670.562601')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1206,6 +1238,28 @@ class TestAssertAllclose:
         expected_msg = 'Max absolute difference among violations: 4'
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(x, y, atol=3)
+
+    def test_error_message_consistent_precision(self):
+        """Test that the same precision is used for formatting the compared array
+           values and the maximum errors"""
+        x = 2.00000049
+        y = 0.0
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                'Max absolute difference among violations: 2.\n'
+                'Max relative difference among violations: inf\n'
+                ' ACTUAL: array(2.)\n'
+                ' DESIRED: array(0.)')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+            assert_allclose(x, y)
+
+        y = 1.00000048
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                'Max absolute difference among violations: 1.\n'
+                'Max relative difference among violations: 1.\n'
+                ' ACTUAL: array(2.)\n'
+                ' DESIRED: array(1.)')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+            assert_allclose(x, y)
 
     def test_strict(self):
         """Test the behavior of the `strict` option."""


### PR DESCRIPTION
`assert_array_compare` now passes its precision parameter to `array2string` for showing max errors. Previously, the precision parameter was only used for showing the compared array values (in the default verbose mode), whereas the displayed max errors precision was set to `numpy.get_printoptions()['precision']`.

For `assert_allclose`, that means a fixed precision (6) was used for showing the array values vs. a different, dynamic one (default 8) for showing the max errors, which seems arbitrary. Also, when comparing a value against zero, the absolute error was shown with more precision (by default) than the array values. Finally, that difference would become
more acute in case the actual and expected values producing the max errors were also displayed next to the errors (#28827).

A few examples of the previous behavior (with added tests):

```python
>>> np.testing.assert_almost_equal([2.6], [0.0], decimal=0)
AssertionError:
<...>
Max absolute difference among violations: 2.6
Max relative difference among violations: inf
 ACTUAL: array([3.])
 DESIRED: array([0.])

>>> np.testing.assert_array_equal(0.23456789, 0.12345678)
AssertionError:
<...>
Max absolute difference among violations: 0.11111111
Max relative difference among violations: 0.90000006
 ACTUAL: array(0.234568)
 DESIRED: array(0.123457)

>>> np.testing.assert_allclose(2.00000049, 0.0)
AssertionError:
<...>
Max absolute difference among violations: 2.00000049
Max relative difference among violations: inf
 ACTUAL: array(2.)
 DESIRED: array(0.)
```