### PR TITLE
Fix incorrect grammar in TypeError message for ufunc argument count mismatch

### DIFF
--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -243,16 +243,18 @@ static int
 raise_incorrect_number_of_positional_args(const char *funcname,
         const _NpyArgParserCache *cache, Py_ssize_t len_args)
 {
+    const char *verb = (len_args == 1) ? "was" : "were";
     if (cache->npositional == cache->nrequired) {
         PyErr_Format(PyExc_TypeError,
-                "%s() takes %d positional arguments but %zd were given",
-                funcname, cache->npositional, len_args);
+                "%s() takes %d positional arguments but %zd %s given",
+                funcname, cache->npositional, len_args, verb);
     }
     else {
         PyErr_Format(PyExc_TypeError,
                 "%s() takes from %d to %d positional arguments but "
-                "%zd were given",
-                funcname, cache->nrequired, cache->npositional, len_args);
+                "%zd %s given",
+                funcname, cache->nrequired, cache->npositional,
+                len_args, verb);
     }
     return -1;
 }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4319,10 +4319,11 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
 
     /* Check number of arguments */
     if (NPY_UNLIKELY((len_args < nin) || (len_args > nop))) {
+        const char *verb = (len_args == 1) ? "was" : "were";
         PyErr_Format(PyExc_TypeError,
-                "%s() takes from %d to %d positional arguments but "
-                "%zd were given",
-                ufunc_get_name_cstr(ufunc) , nin, nop, len_args);
+            "%s() takes from %d to %d positional arguments but "
+            "%zd %s given",
+            ufunc_get_name_cstr(ufunc), nin, nop, len_args, verb);
         goto fail;
     }
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4917,3 +4917,12 @@ class TestAdd_newdoc_ufunc:
     @pytest.mark.filterwarnings("ignore:_add_newdoc_ufunc:DeprecationWarning")
     def test_string_arg(self):
         assert_raises(TypeError, ncu._add_newdoc_ufunc, np.add, 3)
+
+class TestHypotErrorMessages:
+    def test_hypot_error_message_single_arg(self):
+        with pytest.raises(TypeError, match="hypot\\(\\) takes .* but 1 was given"):
+            np.hypot(5)
+
+    def test_hypot_error_message_multiple_args(self):
+        with pytest.raises(TypeError, match="hypot\\(\\) takes .* but 4 were given"):
+            np.hypot(1, 2, 3, 4)


### PR DESCRIPTION
## Summary

This PR fixes a grammatical issue in the `TypeError` message raised when a ufunc (such as `np.hypot`) receives an incorrect number of positional arguments.

Previously, the message always used:
> `hypot() takes from 2 to 3 positional arguments but 1 were given`

This PR ensures that when exactly one argument is passed, the message reads:
> `hypot() takes from 2 to 3 positional arguments but 1 was given`

---

## Changes

- Updated error message formatting logic in:
  - `npy_argparse.c`
  - `ufunc_object.c`
- Added regression tests under `test_umath.py` to assert correct grammar for singular and plural argument count cases.

---

## Related Issue

Closes #29259 
---

## Additional Notes

- Follows TDD approach: test first, then fix.
- Verified via `pytest numpy/_core/tests/test_umath.py -k TestHypotErrorMessages`
- Thanks to maintainers for pointing to the relevant code sections.
