### PR TITLE
BUG: Allow reading non-npy files in npz and add test

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -261,7 +261,7 @@ class NpzFile(Mapping):
                         max_header_size=self.max_header_size
                     )
                 else:
-                    return bytes.read(key)
+                    return bytes.read()
 
     def __contains__(self, key):
         return (key in self._files)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -217,7 +217,6 @@ class TestSavezLoad(RoundtripTest):
             if self.arr_reloaded.fid:
                 self.arr_reloaded.fid.close()
                 os.remove(self.arr_reloaded.fid.name)
-    
     def load_non_npy(self):
         """Test loading non-.npy files and name mapping in .npz."""
         with temppath(prefix="numpy_test_npz_load_non_npy_", suffix=".npz") as tmp:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -218,7 +218,7 @@ class TestSavezLoad(RoundtripTest):
                 self.arr_reloaded.fid.close()
                 os.remove(self.arr_reloaded.fid.name)
 
-    def load_non_npy(self):
+    def test_load_non_npy(self):
         """Test loading non-.npy files and name mapping in .npz."""
         with temppath(prefix="numpy_test_npz_load_non_npy_", suffix=".npz") as tmp:
             with zipfile.ZipFile(tmp) as npz:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -217,6 +217,7 @@ class TestSavezLoad(RoundtripTest):
             if self.arr_reloaded.fid:
                 self.arr_reloaded.fid.close()
                 os.remove(self.arr_reloaded.fid.name)
+
     def load_non_npy(self):
         """Test loading non-.npy files and name mapping in .npz."""
         with temppath(prefix="numpy_test_npz_load_non_npy_", suffix=".npz") as tmp:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -221,7 +221,7 @@ class TestSavezLoad(RoundtripTest):
     def test_load_non_npy(self):
         """Test loading non-.npy files and name mapping in .npz."""
         with temppath(prefix="numpy_test_npz_load_non_npy_", suffix=".npz") as tmp:
-            with zipfile.ZipFile(tmp) as npz:
+            with zipfile.ZipFile(tmp, "w") as npz:
                 with npz.open("test1.npy", "w") as out_file:
                     np.save(out_file, np.arange(10))
                 with npz.open("test2", "w") as out_file:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 import warnings
+import zipfile
 from ctypes import c_bool
 from datetime import datetime
 from io import BytesIO, StringIO
@@ -216,6 +217,22 @@ class TestSavezLoad(RoundtripTest):
             if self.arr_reloaded.fid:
                 self.arr_reloaded.fid.close()
                 os.remove(self.arr_reloaded.fid.name)
+    
+    def load_non_npy(self):
+        """Test loading non-.npy files and name mapping in .npz."""
+        with temppath(prefix="numpy_test_npz_load_non_npy_", suffix=".npz") as tmp:
+            with zipfile.ZipFile(tmp) as npz:
+                with npz.open("test1.npy", "w") as out_file:
+                    np.save(out_file, np.arange(10))
+                with npz.open("test2", "w") as out_file:
+                    np.save(out_file, np.arange(10))
+                with npz.open("metadata", "w") as out_file:
+                    out_file.write(b"Name: Test")
+            npz = np.load(tmp)
+            assert len(npz["test1"]) == 10
+            assert len(npz["test1.npy"]) == 10
+            assert len(npz["test2"]) == 10
+            assert npz["metadata"] == b"Name: Test"
 
     @pytest.mark.skipif(IS_PYPY, reason="Hangs on PyPy")
     @pytest.mark.skipif(not IS_64BIT, reason="Needs 64bit platform")

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -228,11 +228,11 @@ class TestSavezLoad(RoundtripTest):
                     np.save(out_file, np.arange(10))
                 with npz.open("metadata", "w") as out_file:
                     out_file.write(b"Name: Test")
-            npz = np.load(tmp)
-            assert len(npz["test1"]) == 10
-            assert len(npz["test1.npy"]) == 10
-            assert len(npz["test2"]) == 10
-            assert npz["metadata"] == b"Name: Test"
+            with np.load(tmp) as npz:
+                assert len(npz["test1"]) == 10
+                assert len(npz["test1.npy"]) == 10
+                assert len(npz["test2"]) == 10
+                assert npz["metadata"] == b"Name: Test"
 
     @pytest.mark.skipif(IS_PYPY, reason="Hangs on PyPy")
     @pytest.mark.skipif(not IS_64BIT, reason="Needs 64bit platform")


### PR DESCRIPTION
Retrieving `a` from an npz file will first check for a file `a`, then for `a.npy`; this checks both.

Fixes #29282 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
