### PR TITLE
MAINT: Replace setting of array shape by reshape operation

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1106,10 +1106,9 @@ def tensordot(a, b, axes=2):
 
     An extended example taking advantage of the overloading of + and \\*:
 
-    >>> a = np.array(range(1, 9))
-    >>> a.shape = (2, 2, 2)
+    >>> a = np.array(range(1, 9)).reshape((2, 2, 2))
     >>> A = np.array(('a', 'b', 'c', 'd'), dtype=object)
-    >>> A.shape = (2, 2)
+    >>> A = A.reshape((2, 2))
     >>> a; A
     array([[[1, 2],
             [3, 4]],

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -231,8 +231,7 @@ class TestEinsum:
     def test_einsum_views(self):
         # pass-through
         for do_opt in [True, False]:
-            a = np.arange(6)
-            a.shape = (2, 3)
+            a = np.arange(6).reshape( (2, 3))
 
             b = np.einsum("...", a, optimize=do_opt)
             assert_(b.base is a)
@@ -256,8 +255,7 @@ class TestEinsum:
             assert_(not b.flags['WRITEABLE'])
 
             # transpose
-            a = np.arange(6)
-            a.shape = (2, 3)
+            a = np.arange(6).reshape((2, 3))
 
             b = np.einsum("ji", a, optimize=do_opt)
             assert_(b.base is a)
@@ -268,8 +266,7 @@ class TestEinsum:
             assert_equal(b, a.T)
 
             # diagonal
-            a = np.arange(9)
-            a.shape = (3, 3)
+            a = np.arange(9).reshape((3, 3))
 
             b = np.einsum("ii->i", a, optimize=do_opt)
             assert_(b.base is a)
@@ -280,8 +277,7 @@ class TestEinsum:
             assert_equal(b, [a[i, i] for i in range(3)])
 
             # diagonal with various ways of broadcasting an additional dimension
-            a = np.arange(27)
-            a.shape = (3, 3, 3)
+            a = np.arange(27).reshape((3, 3, 3))
 
             b = np.einsum("...ii->...i", a, optimize=do_opt)
             assert_(b.base is a)
@@ -344,8 +340,7 @@ class TestEinsum:
                              for x in a.transpose(1, 0, 2)])
 
             # triple diagonal
-            a = np.arange(27)
-            a.shape = (3, 3, 3)
+            a = np.arange(27).reshape((3, 3, 3))
 
             b = np.einsum("iii->i", a, optimize=do_opt)
             assert_(b.base is a)
@@ -356,8 +351,7 @@ class TestEinsum:
             assert_equal(b, [a[i, i, i] for i in range(3)])
 
             # swap axes
-            a = np.arange(24)
-            a.shape = (2, 3, 4)
+            a = np.arange(24).reshape((2, 3, 4))
 
             b = np.einsum("ijk->jik", a, optimize=do_opt)
             assert_(b.base is a)

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -234,17 +234,17 @@ class TestEinsum:
             a = np.arange(6).reshape((2, 3))
 
             b = np.einsum("...", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
 
             b = np.einsum(a, [Ellipsis], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
 
             b = np.einsum("ij", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a)
 
             b = np.einsum(a, [0, 1], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a)
 
             # output is writeable whenever input is writeable
@@ -258,84 +258,84 @@ class TestEinsum:
             a = np.arange(6).reshape((2, 3))
 
             b = np.einsum("ji", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a.T)
 
             b = np.einsum(a, [1, 0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a.T)
 
             # diagonal
             a = np.arange(9).reshape((3, 3))
 
             b = np.einsum("ii->i", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[i, i] for i in range(3)])
 
             b = np.einsum(a, [0, 0], [0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[i, i] for i in range(3)])
 
             # diagonal with various ways of broadcasting an additional dimension
             a = np.arange(27).reshape((3, 3, 3))
 
             b = np.einsum("...ii->...i", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)] for x in a])
 
             b = np.einsum(a, [Ellipsis, 0, 0], [Ellipsis, 0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)] for x in a])
 
             b = np.einsum("ii...->...i", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)]
                              for x in a.transpose(2, 0, 1)])
 
             b = np.einsum(a, [0, 0, Ellipsis], [Ellipsis, 0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)]
                              for x in a.transpose(2, 0, 1)])
 
             b = np.einsum("...ii->i...", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[:, i, i] for i in range(3)])
 
             b = np.einsum(a, [Ellipsis, 0, 0], [0, Ellipsis], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[:, i, i] for i in range(3)])
 
             b = np.einsum("jii->ij", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[:, i, i] for i in range(3)])
 
             b = np.einsum(a, [1, 0, 0], [0, 1], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[:, i, i] for i in range(3)])
 
             b = np.einsum("ii...->i...", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a.transpose(2, 0, 1)[:, i, i] for i in range(3)])
 
             b = np.einsum(a, [0, 0, Ellipsis], [0, Ellipsis], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a.transpose(2, 0, 1)[:, i, i] for i in range(3)])
 
             b = np.einsum("i...i->i...", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a.transpose(1, 0, 2)[:, i, i] for i in range(3)])
 
             b = np.einsum(a, [0, Ellipsis, 0], [0, Ellipsis], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a.transpose(1, 0, 2)[:, i, i] for i in range(3)])
 
             b = np.einsum("i...i->...i", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)]
                              for x in a.transpose(1, 0, 2)])
 
             b = np.einsum(a, [0, Ellipsis, 0], [Ellipsis, 0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [[x[i, i] for i in range(3)]
                              for x in a.transpose(1, 0, 2)])
 
@@ -343,22 +343,22 @@ class TestEinsum:
             a = np.arange(27).reshape((3, 3, 3))
 
             b = np.einsum("iii->i", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[i, i, i] for i in range(3)])
 
             b = np.einsum(a, [0, 0, 0], [0], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, [a[i, i, i] for i in range(3)])
 
             # swap axes
             a = np.arange(24).reshape((2, 3, 4))
 
             b = np.einsum("ijk->jik", a, optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a.swapaxes(0, 1))
 
             b = np.einsum(a, [0, 1, 2], [1, 0, 2], optimize=do_opt)
-            assert_(b.base is a)
+            assert_(b.base is a.base)
             assert_equal(b, a.swapaxes(0, 1))
 
     def check_einsum_sums(self, dtype, do_opt=False):

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -231,7 +231,7 @@ class TestEinsum:
     def test_einsum_views(self):
         # pass-through
         for do_opt in [True, False]:
-            a = np.arange(6).reshape( (2, 3))
+            a = np.arange(6).reshape((2, 3))
 
             b = np.einsum("...", a, optimize=do_opt)
             assert_(b.base is a)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2281,7 +2281,7 @@ class TestMethods:
 
     def test_sort_size_0(self):
         # check axis handling for multidimensional empty arrays
-        a = np.array([]).reshape( (3, 2, 1, 0))
+        a = np.array([]).reshape((3, 2, 1, 0))
         for axis in range(-a.ndim, a.ndim):
             msg = f'test empty array sort with axis={axis}'
             assert_equal(np.sort(a, axis=axis), a, msg)
@@ -5365,20 +5365,20 @@ class TestTake:
 
     def test_raise(self):
         x = np.random.random(24) * 100
-        x = x.reshape( ( 2, 3, 4))
+        x = x.reshape((2, 3, 4))
         assert_raises(IndexError, x.take, [0, 1, 2], axis=0)
         assert_raises(IndexError, x.take, [-3], axis=0)
         assert_array_equal(x.take([-1], axis=0)[0], x[1])
 
     def test_clip(self):
         x = np.random.random(24) * 100
-        x = x.reshape( ( 2, 3, 4))
+        x = x.reshape((2, 3, 4))
         assert_array_equal(x.take([-1], axis=0, mode='clip')[0], x[0])
         assert_array_equal(x.take([2], axis=0, mode='clip')[0], x[1])
 
     def test_wrap(self):
         x = np.random.random(24) * 100
-        x = x.reshape( ( 2, 3, 4))
+        x = x.reshape((2, 3, 4))
         assert_array_equal(x.take([-1], axis=0, mode='wrap')[0], x[1])
         assert_array_equal(x.take([2], axis=0, mode='wrap')[0], x[0])
         assert_array_equal(x.take([3], axis=0, mode='wrap')[0], x[1])
@@ -5958,7 +5958,7 @@ class TestFlat:
     def setup_method(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)
-        a0 = a0.reshape( (4, 5))
+        a0 = a0.reshape((4, 5))
         a.flags.writeable = False
         self.a = a
         self.b = a[::2, ::2]

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2281,8 +2281,7 @@ class TestMethods:
 
     def test_sort_size_0(self):
         # check axis handling for multidimensional empty arrays
-        a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = np.array([]).reshape( (3, 2, 1, 0))
         for axis in range(-a.ndim, a.ndim):
             msg = f'test empty array sort with axis={axis}'
             assert_equal(np.sort(a, axis=axis), a, msg)
@@ -5369,20 +5368,20 @@ class TestTake:
 
     def test_raise(self):
         x = np.random.random(24) * 100
-        x.shape = 2, 3, 4
+        x = x.reshape( ( 2, 3, 4))
         assert_raises(IndexError, x.take, [0, 1, 2], axis=0)
         assert_raises(IndexError, x.take, [-3], axis=0)
         assert_array_equal(x.take([-1], axis=0)[0], x[1])
 
     def test_clip(self):
         x = np.random.random(24) * 100
-        x.shape = 2, 3, 4
+        x = x.reshape( ( 2, 3, 4))
         assert_array_equal(x.take([-1], axis=0, mode='clip')[0], x[0])
         assert_array_equal(x.take([2], axis=0, mode='clip')[0], x[1])
 
     def test_wrap(self):
         x = np.random.random(24) * 100
-        x.shape = 2, 3, 4
+        x = x.reshape( ( 2, 3, 4))
         assert_array_equal(x.take([-1], axis=0, mode='wrap')[0], x[1])
         assert_array_equal(x.take([2], axis=0, mode='wrap')[0], x[0])
         assert_array_equal(x.take([3], axis=0, mode='wrap')[0], x[1])
@@ -5962,7 +5961,7 @@ class TestFlat:
     def setup_method(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)
-        a0.shape = (4, 5)
+        a0 = a0.reshape( (4, 5))
         a.flags.writeable = False
         self.a = a
         self.b = a[::2, ::2]

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2542,8 +2542,7 @@ class TestMethods:
         assert_equal(a.copy().argsort(), c)
 
         # check axis handling for multidimensional empty arrays
-        a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = np.array([]).reshape((3, 2, 1, 0))
         for axis in range(-a.ndim, a.ndim):
             msg = f'test empty array argsort with axis={axis}'
             assert_equal(np.argsort(a, axis=axis),
@@ -2860,8 +2859,7 @@ class TestMethods:
     def test_partition_empty_array(self, kth_dtype):
         # check axis handling for multidimensional empty arrays
         kth = np.array(0, dtype=kth_dtype)[()]
-        a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = np.array([]).reshape((3, 2, 1, 0))
         for axis in range(-a.ndim, a.ndim):
             msg = f'test empty array partition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis), a, msg)
@@ -2872,8 +2870,7 @@ class TestMethods:
     def test_argpartition_empty_array(self, kth_dtype):
         # check axis handling for multidimensional empty arrays
         kth = np.array(0, dtype=kth_dtype)[()]
-        a = np.array([])
-        a.shape = (3, 2, 1, 0)
+        a = np.array([]).reshape((3, 2, 1, 0))
         for axis in range(-a.ndim, a.ndim):
             msg = f'test empty array argpartition with axis={axis}'
             assert_equal(np.partition(a, kth, axis=axis),
@@ -5357,7 +5354,7 @@ class TestTake:
         unchecked_types = [bytes, str, np.void]
 
         x = np.random.random(24) * 100
-        x.shape = 2, 3, 4
+        x = x.reshape((2, 3, 4))
         for types in np._core.sctypes.values():
             for T in types:
                 if T not in unchecked_types:

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -879,10 +879,10 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
             )
 
         if fortran_order:
-            array.shape = shape[::-1]
+            array = array.reshape(shape[::-1])
             array = array.transpose()
         else:
-            array.shape = shape
+            array = array.reshape(shape)
 
     return array
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1317,7 +1317,10 @@ def gradient(f, *varargs, axis=None, edge_order=1):
             # fix the shape for broadcasting
             shape = np.ones(N, dtype=int)
             shape[axis] = -1
-            a.shape = b.shape = c.shape = shape
+
+            a = a.reshape(shape)
+            b = b.reshape(shape)
+            c = c.reshape(shape)
             # 1D equivalent -- out[1:-1] = a * f[:-2] + b * f[1:-1] + c * f[2:]
             out[tuple(slice1)] = a * f[tuple(slice2)] + b * f[tuple(slice3)] \
                                                 + c * f[tuple(slice4)]

--- a/numpy/lib/tests/test_arrayterator.py
+++ b/numpy/lib/tests/test_arrayterator.py
@@ -14,8 +14,7 @@ def test():
     ndims = randint(5) + 1
     shape = tuple(randint(10) + 1 for dim in range(ndims))
     els = reduce(mul, shape)
-    a = np.arange(els)
-    a.shape = shape
+    a = np.arange(els).reshape(shape)
 
     buf_size = randint(2 * els)
     b = Arrayterator(a, buf_size)

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -317,8 +317,7 @@ def tensorsolve(a, b, axes=None):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.eye(2*3*4)
-    >>> a.shape = (2*3, 4, 2, 3, 4)
+    >>> a = np.eye(2*3*4).reshape((2*3, 4, 2, 3, 4))
     >>> rng = np.random.default_rng()
     >>> b = rng.normal(size=(2*3, 4))
     >>> x = np.linalg.tensorsolve(a, b)
@@ -495,8 +494,7 @@ def tensorinv(a, ind=2):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.eye(4*6)
-    >>> a.shape = (4, 6, 8, 3)
+    >>> a = np.eye(4*6).reshape((4, 6, 8, 3))
     >>> ainv = np.linalg.tensorinv(a, ind=2)
     >>> ainv.shape
     (8, 3, 4, 6)
@@ -505,8 +503,7 @@ def tensorinv(a, ind=2):
     >>> np.allclose(np.tensordot(ainv, b), np.linalg.tensorsolve(a, b))
     True
 
-    >>> a = np.eye(4*6)
-    >>> a.shape = (24, 8, 3)
+    >>> a = np.eye(4*6).reshape((24, 8, 3))
     >>> ainv = np.linalg.tensorinv(a, ind=1)
     >>> ainv.shape
     (8, 3, 24)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2203,8 +2203,7 @@ class TestTensorinv:
         ((24, 8, 3), 1),
         ])
     def test_tensorinv_shape(self, shape, ind):
-        a = np.eye(24)
-        a.shape = shape
+        a = np.eye(24).reshape(shape)
         ainv = linalg.tensorinv(a=a, ind=ind)
         expected = a.shape[ind:] + a.shape[:ind]
         actual = ainv.shape
@@ -2214,15 +2213,13 @@ class TestTensorinv:
         0, -2,
         ])
     def test_tensorinv_ind_limit(self, ind):
-        a = np.eye(24)
-        a.shape = (4, 6, 8, 3)
+        a = np.eye(24).reshape((4, 6, 8, 3))
         with assert_raises(ValueError):
             linalg.tensorinv(a=a, ind=ind)
 
     def test_tensorinv_result(self):
         # mimic a docstring example
-        a = np.eye(24)
-        a.shape = (24, 8, 3)
+        a = np.eye(24).reshape((24, 8, 3))
         ainv = linalg.tensorinv(a, ind=1)
         b = np.ones(24)
         assert_allclose(np.tensordot(ainv, b, 1), np.linalg.tensorsolve(a, b))

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -33,7 +33,7 @@ class TestRegression:
                      1.51971555e-15 + 0.j,
                      -1.51308713e-15 + 0.j])
         a = arange(13 * 13, dtype=float64)
-        a.shape = (13, 13)
+        a = a.reshape((13, 13))
         a = a % 17
         va, ve = linalg.eig(a)
         va.sort()

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -224,11 +224,11 @@ class TestMaskedArray:
         # Test of basic array creation and properties in 2 dimensions.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         for s in [(4, 3), (6, 2)]:
-            x.shape = s
-            y.shape = s
-            xm.shape = s
-            ym.shape = s
-            xf.shape = s
+            x = x.reshape(s)
+            y = y.reshape(s)
+            xm = xm.reshape(s)
+            ym = ym.reshape(s)
+            xf = xf.reshape(s)
 
             assert_(not isMaskedArray(x))
             assert_(isMaskedArray(xm))
@@ -254,7 +254,12 @@ class TestMaskedArray:
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         # Concatenation along an axis
         s = (3, 4)
-        x.shape = y.shape = xm.shape = ym.shape = s
+        x = x.reshape(s)
+        y = y.reshape(s)
+        xm = xm.reshape(s)
+        ym = ym.reshape(s)
+        xf = xf.reshape(s)
+
         assert_equal(xm.mask, np.reshape(m1, s))
         assert_equal(ym.mask, np.reshape(m2, s))
         xmym = concatenate((xm, ym), 1)
@@ -770,8 +775,7 @@ class TestMaskedArray:
 
     def test_pickling_keepalignment(self):
         # Tests pickling w/ F_CONTIGUOUS arrays
-        a = arange(10)
-        a.shape = (-1, 2)
+        a = arange(10).reshape( (-1, 2))
         b = a.T
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
             test = pickle.loads(pickle.dumps(b, protocol=proto))
@@ -1180,8 +1184,7 @@ class TestMaskedArrayArithmetic:
             assert_equal(np.divide(x, y), divide(xm, ym))
 
     def test_divide_on_different_shapes(self):
-        x = arange(6, dtype=float)
-        x.shape = (2, 3)
+        x = arange(6, dtype=float).reshape((2, 3))
         y = arange(3, dtype=float)
 
         z = x / y

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1078,7 +1078,7 @@ class TestMedian:
         x = np.ma.arange(24).reshape(3, 4, 2)
         x[x % 3 == 0] = masked
         assert_equal(median(x, 0), [[12, 9], [6, 15], [12, 9], [18, 15]])
-        x = X.reshape((4, 3, 2))
+        x = x.reshape((4, 3, 2))
         assert_equal(median(x, 0), [[99, 10], [11, 99], [13, 14]])
         x = np.ma.arange(24).reshape(4, 3, 2)
         x[x % 5 == 0] = masked

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1078,7 +1078,7 @@ class TestMedian:
         x = np.ma.arange(24).reshape(3, 4, 2)
         x[x % 3 == 0] = masked
         assert_equal(median(x, 0), [[12, 9], [6, 15], [12, 9], [18, 15]])
-        x.shape = (4, 3, 2)
+        x = X.reshape((4, 3, 2))
         assert_equal(median(x, 0), [[99, 10], [11, 99], [13, 14]])
         x = np.ma.arange(24).reshape(4, 3, 2)
         x[x % 5 == 0] = masked

--- a/tools/swig/test/testFlat.py
+++ b/tools/swig/test/testFlat.py
@@ -43,7 +43,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x = x.reshape( (2, 3, 4))
+        x = x.reshape((2, 3, 4))
         y = x.copy()
         process(y)
         self.assertEqual(np.all((x + 1) == y), True)
@@ -56,7 +56,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x = x.reshape( (2, 3, 4))
+        x = x.reshape((2, 3, 4))
         y = x.copy()
         process(y.T)
         self.assertEqual(np.all((x.T + 1) == y.T), True)
@@ -69,7 +69,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x = x.reshape( (2, 3, 4))
+        x = x.reshape((2, 3, 4))
         self.assertRaises(TypeError, process, x[:, :, 0])
 
 

--- a/tools/swig/test/testFlat.py
+++ b/tools/swig/test/testFlat.py
@@ -43,7 +43,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x.shape = (2, 3, 4)
+        x = x.reshape( (2, 3, 4))
         y = x.copy()
         process(y)
         self.assertEqual(np.all((x + 1) == y), True)
@@ -56,7 +56,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x.shape = (2, 3, 4)
+        x = x.reshape( (2, 3, 4))
         y = x.copy()
         process(y.T)
         self.assertEqual(np.all((x.T + 1) == y.T), True)
@@ -69,7 +69,7 @@ class FlatTestCase(unittest.TestCase):
         for i in range(24):
             pack_output += struct.pack(self.typeCode, i)
         x = np.frombuffer(pack_output, dtype=self.typeCode)
-        x.shape = (2, 3, 4)
+        x = x.reshape( (2, 3, 4))
         self.assertRaises(TypeError, process, x[:, :, 0])
 
 


### PR DESCRIPTION
Addresses part of https://github.com/numpy/numpy/issues/28800.

In this PR we replace some explicit setting of the `shape` of an array in favor of using `reshape`. Some cases are left out (e.g. masked arrays, tests to check the `.shape` setting works).

In followup PRs the remaining cases will be handled and the shape setting deprecated.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
