### PR TITLE
BUG: Fix np.testing utils failing for masked scalar vs. scalar (#29317)

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -771,15 +771,15 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         y_id = func(y)
         # We include work-arounds here to handle three types of slightly
         # pathological ndarray subclasses:
-        # (1) all() on `masked` array scalars can return masked arrays, so we
-        #     use != True
+        # (1) all() on fully masked arrays returns np.ma.masked, so we use != True
+        #     (np.ma.masked != True evaluates as np.ma.masked, which is falsy).
         # (2) __eq__ on some ndarray subclasses returns Python booleans
         #     instead of element-wise comparisons, so we cast to np.bool() in
         #     that case (or in case __eq__ returns some other value with no
         #     all() method).
         # (3) subclasses with bare-bones __array_function__ implementations may
         #     not implement np.all(), so favor using the .all() method
-        # We are not committed to supporting such subclasses, but it's nice to
+        # We are not committed to supporting cases (2) and (3), but it's nice to
         # support them if possible.
         result = x_id == y_id
         if not hasattr(result, "all") or not callable(result.all):
@@ -794,6 +794,9 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
             raise AssertionError(msg)
         # If there is a scalar, then here we know the array has the same
         # flag as it everywhere, so we should return the scalar flag.
+        # np.ma.masked is also handled and converted to np.False_ (even if the other
+        # array has nans/infs etc.; that's OK given the handling later of fully-masked
+        # results).
         if isinstance(x_id, bool) or x_id.ndim == 0:
             return np.bool(x_id)
         elif isinstance(y_id, bool) or y_id.ndim == 0:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -774,13 +774,17 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         # (1) all() on `masked` array scalars can return masked arrays, so we
         #     use != True
         # (2) __eq__ on some ndarray subclasses returns Python booleans
-        #     instead of element-wise comparisons, so we cast to np.bool() and
-        #     use isinstance(..., bool) checks
+        #     instead of element-wise comparisons, so we cast to np.bool() in
+        #     that case (or in case __eq__ returns some other value with no
+        #     all() method).
         # (3) subclasses with bare-bones __array_function__ implementations may
         #     not implement np.all(), so favor using the .all() method
         # We are not committed to supporting such subclasses, but it's nice to
         # support them if possible.
-        if np.bool(x_id == y_id).all() != True:
+        result = x_id == y_id
+        if not hasattr(result, "all") or not callable(result.all):
+            result = np.bool(result)
+        if result.all() != True:
             msg = build_err_msg(
                 [x, y],
                 err_msg + '\n%s location mismatch:'

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -197,6 +197,14 @@ class TestArrayEqual(_GenericTest):
         self._test_equal(a, b)
         self._test_equal(b, a)
 
+    def test_masked_scalar(self):
+        a = np.ma.MaskedArray(3., mask=True)
+        b = np.array(3.)
+        self._test_equal(a, b)
+        # also a test case for gh-11121
+        b = np.array(np.nan)
+        self._test_equal(a, b)
+
     def test_subclass_that_overrides_eq(self):
         # While we cannot guarantee testing functions will always work for
         # subclasses, the tests should ideally rely only on subclasses having

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -197,13 +197,39 @@ class TestArrayEqual(_GenericTest):
         self._test_equal(a, b)
         self._test_equal(b, a)
 
+    # Also provides test cases for gh-11121
     def test_masked_scalar(self):
-        a = np.ma.MaskedArray(3., mask=True)
-        b = np.array(3.)
-        self._test_equal(a, b)
-        # also a test case for gh-11121
-        b = np.array(np.nan)
-        self._test_equal(a, b)
+        # Test masked scalar vs. plain/masked scalar
+        for a_val, b_val, b_masked in itertools.product(
+            [3., np.nan, np.inf],
+            [3., 4., np.nan, np.inf, -np.inf],
+            [False, True],
+        ):
+            a = np.ma.MaskedArray(a_val, mask=True)
+            b = np.ma.MaskedArray(b_val, mask=True) if b_masked else np.array(b_val)
+            self._test_equal(a, b)
+            self._test_equal(b, a)
+
+        # Test masked scalar vs. plain array
+        for a_val, b_val in itertools.product(
+            [3., np.nan, -np.inf],
+            itertools.product([3., 4., np.nan, np.inf, -np.inf], repeat=2),
+        ):
+            a = np.ma.MaskedArray(a_val, mask=True)
+            b = np.array(b_val)
+            self._test_equal(a, b)
+            self._test_equal(b, a)
+
+        # Test masked scalar vs. masked array
+        for a_val, b_val, b_mask in itertools.product(
+            [3., np.nan, np.inf],
+            itertools.product([3., 4., np.nan, np.inf, -np.inf], repeat=2),
+            itertools.product([False, True], repeat=2),
+        ):
+            a = np.ma.MaskedArray(a_val, mask=True)
+            b = np.ma.MaskedArray(b_val, mask=b_mask)
+            self._test_equal(a, b)
+            self._test_equal(b, a)
 
     def test_subclass_that_overrides_eq(self):
         # While we cannot guarantee testing functions will always work for


### PR DESCRIPTION
Resolves #29317 

Fixes `np.testing.assert_XXX` utilities failing when comparing a masked scalar against another scalar, with a "nan location mismatch" error.  The consistent behavior is to ignore any masked elements, in this case the only one, and therefore succeed.

See also #11121 