### PR TITLE
MAINT: remove internal uses of assert_warns and suppress_warnings

### DIFF
--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -12,7 +12,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     assert_raises,
-    assert_warns,
 )
 
 
@@ -315,7 +314,7 @@ def test_object_array_astype_to_void():
 def test_array_astype_warning(t):
     # test ComplexWarning when casting from complex to float or int
     a = np.array(10, dtype=np.complex128)
-    assert_warns(np.exceptions.ComplexWarning, a.astype, t)
+    pytest.warns(np.exceptions.ComplexWarning, a.astype, t)
 
 @pytest.mark.parametrize(["dtype", "out_dtype"],
         [(np.bytes_, np.bool),

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -15,7 +15,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 from numpy.testing._private.utils import run_threaded
 
@@ -736,7 +735,7 @@ class TestPrintOptions:
         assert_equal(str(x), "1")
 
         # check `style` arg raises
-        assert_warns(DeprecationWarning, np.array2string,
+        pytest.warns(DeprecationWarning, np.array2string,
                                          np.array(1.), style=repr)
         # but not in legacy mode
         np.array2string(np.array(1.), style=repr, legacy='1.13')

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+import warnings
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
@@ -13,8 +14,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
-    suppress_warnings,
 )
 
 try:
@@ -1282,8 +1281,9 @@ class TestDateTime:
             assert_raises(TypeError, np.multiply, 1.5, dta)
 
         # NaTs
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in multiply")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "invalid value encountered in multiply", RuntimeWarning)
             nat = np.timedelta64('NaT')
 
             def check(a, b, res):
@@ -1344,7 +1344,7 @@ class TestDateTime:
          np.timedelta64(-1)),
         ])
     def test_timedelta_floor_div_warnings(self, op1, op2):
-        with assert_warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning):
             actual = op1 // op2
             assert_equal(actual, 0)
             assert_equal(actual.dtype, np.int64)
@@ -1428,9 +1428,9 @@ class TestDateTime:
          np.timedelta64(-1)),
         ])
     def test_timedelta_divmod_warnings(self, op1, op2):
-        with assert_warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning):
             expected = (op1 // op2, op1 % op2)
-        with assert_warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning):
             actual = divmod(op1, op2)
         assert_equal(actual, expected)
 
@@ -1482,8 +1482,9 @@ class TestDateTime:
             assert_raises(TypeError, np.divide, 1.5, dta)
 
         # NaTs
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning,  r".*encountered in divide")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', r".*encountered in divide", RuntimeWarning)
             nat = np.timedelta64('NaT')
             for tp in (int, float):
                 assert_equal(np.timedelta64(1) / tp(0), nat)
@@ -2045,7 +2046,7 @@ class TestDateTime:
 
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
     def test_timedelta_modulus_div_by_zero(self):
-        with assert_warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning):
             actual = np.timedelta64(10, 's') % np.timedelta64(0, 's')
             assert_equal(actual, np.timedelta64('NaT'))
 

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 import pytest
 
@@ -11,7 +12,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 
 # Setup for optimize einsum
@@ -455,8 +455,8 @@ class TestEinsum:
                          np.outer(a, b))
 
         # Suppress the complex warnings for the 'as f8' tests
-        with suppress_warnings() as sup:
-            sup.filter(np.exceptions.ComplexWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', np.exceptions.ComplexWarning)
 
             # matvec(a,b) / a.dot(b) where a is matrix, b is vector
             for n in range(1, 17):

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -16,7 +16,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 
 
@@ -784,12 +783,12 @@ class TestFancyIndexingCast:
         assert_equal(zero_array[0, 1], 1)
 
         # Fancy indexing works, although we get a cast warning.
-        assert_warns(ComplexWarning,
+        pytest.warns(ComplexWarning,
                      zero_array.__setitem__, ([0], [1]), np.array([2 + 1j]))
         assert_equal(zero_array[0, 1], 2)  # No complex part
 
         # Cast complex to float, throwing away the imaginary portion.
-        assert_warns(ComplexWarning,
+        pytest.warns(ComplexWarning,
                      zero_array.__setitem__, bool_index, np.array([1j]))
         assert_equal(zero_array[0, 1], 0)
 

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy as np
 from numpy._core.multiarray import get_handler_name
-from numpy.testing import IS_EDITABLE, IS_WASM, assert_warns, extbuild
+from numpy.testing import IS_EDITABLE, IS_WASM, extbuild
 
 
 @pytest.fixture
@@ -432,7 +432,7 @@ def test_switch_owner(get_module, policy):
         # The policy should be NULL, so we have to assume we can call
         # "free".  A warning is given if the policy == "1"
         if policy:
-            with assert_warns(RuntimeWarning) as w:
+            with pytest.warns(RuntimeWarning) as w:
                 del a
                 gc.collect()
         else:

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -1,6 +1,7 @@
 import mmap
 import os
 import sys
+import warnings
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile
 
@@ -26,7 +27,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     break_cycles,
-    suppress_warnings,
 )
 
 
@@ -167,8 +167,9 @@ class TestMemmap:
         fp = memmap(self.tmpfp, dtype=self.dtype, shape=self.shape)
         fp[:] = self.data
 
-        with suppress_warnings() as sup:
-            sup.filter(FutureWarning, "np.average currently does not preserve")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "np.average currently does not preserve", FutureWarning)
             for unary_op in [sum, average, prod]:
                 result = unary_op(fp)
                 assert_(isscalar(result))

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import textwrap
+import warnings
 
 import pytest
 
@@ -15,7 +16,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     assert_raises,
-    suppress_warnings,
 )
 from numpy.testing._private.utils import requires_memory
 
@@ -1899,8 +1899,8 @@ def test_iter_buffered_cast_byteswapped():
 
     assert_equal(a, 2 * np.arange(10, dtype='f4'))
 
-    with suppress_warnings() as sup:
-        sup.filter(np.exceptions.ComplexWarning)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', np.exceptions.ComplexWarning)
 
         a = np.arange(10, dtype='f8')
         a = a.view(a.dtype.newbyteorder()).byteswap()
@@ -3310,13 +3310,10 @@ def test_warn_noclose():
     a = np.arange(6, dtype='f4')
     au = a.byteswap()
     au = au.view(au.dtype.newbyteorder())
-    with suppress_warnings() as sup:
-        sup.record(RuntimeWarning)
+    with pytest.warns(RuntimeWarning):
         it = np.nditer(au, [], [['readwrite', 'updateifcopy']],
-                        casting='equiv', op_dtypes=[np.dtype('f4')])
+                       casting='equiv', op_dtypes=[np.dtype('f4')])
         del it
-        assert len(sup.log) == 1
-
 
 @pytest.mark.parametrize(["in_dtype", "buf_dtype"],
         [("i", "O"), ("O", "i"),  # most simple cases

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -3,6 +3,7 @@ import gc
 import pickle
 import sys
 import tempfile
+import warnings
 from io import BytesIO
 from itertools import chain
 from os import path
@@ -27,8 +28,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
-    suppress_warnings,
 )
 from numpy.testing._private.utils import _no_tracing, requires_memory
 
@@ -1619,9 +1618,9 @@ class TestRegression:
     def test_complex_scalar_warning(self):
         for tp in [np.csingle, np.cdouble, np.clongdouble]:
             x = tp(1 + 2j)
-            assert_warns(ComplexWarning, float, x)
-            with suppress_warnings() as sup:
-                sup.filter(ComplexWarning)
+            pytest.warns(ComplexWarning, float, x)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', ComplexWarning)
                 assert_equal(float(x), float(x.real))
 
     def test_complex_scalar_complex_cast(self):

--- a/numpy/_core/tests/test_scalar_ctors.py
+++ b/numpy/_core/tests/test_scalar_ctors.py
@@ -4,7 +4,7 @@ Test the scalar constructors, which also do type-coercion
 import pytest
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_warns
+from numpy.testing import assert_almost_equal, assert_equal
 
 
 class TestFromString:
@@ -25,7 +25,7 @@ class TestFromString:
         assert_equal(fsingle, np.inf)
         fdouble = np.double('1e10000')
         assert_equal(fdouble, np.inf)
-        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '1e10000')
+        flongdouble = pytest.warns(RuntimeWarning, np.longdouble, '1e10000')
         assert_equal(flongdouble, np.inf)
 
         fhalf = np.half('-1e10000')
@@ -34,7 +34,7 @@ class TestFromString:
         assert_equal(fsingle, -np.inf)
         fdouble = np.double('-1e10000')
         assert_equal(fdouble, -np.inf)
-        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
+        flongdouble = pytest.warns(RuntimeWarning, np.longdouble, '-1e10000')
         assert_equal(flongdouble, -np.inf)
 
 

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -368,17 +368,7 @@ class TestModulus:
             assert_(rem >= -b, f'dt: {dt}')
 
         # Check nans, inf
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "invalid value encountered in remainder", RuntimeWarning)
-            warnings.filterwarnings(
-                'ignore', "divide by zero encountered in remainder", RuntimeWarning)
-            warnings.filterwarnings(
-                'ignore', "divide by zero encountered in floor_divide", RuntimeWarning)
-            warnings.filterwarnings(
-                'ignore', "divide by zero encountered in divmod", RuntimeWarning)
-            warnings.filterwarnings(
-                'ignore', "invalid value encountered in divmod", RuntimeWarning)
+        with warnings.catch_warnings(), np.errstate(all='ignore'):
             for dt in np.typecodes['Float']:
                 fone = np.array(1.0, dtype=dt)
                 fzer = np.array(0.0, dtype=dt)

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -23,7 +23,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     check_support_sve,
-    suppress_warnings,
 )
 
 types = [np.bool, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -369,12 +368,17 @@ class TestModulus:
             assert_(rem >= -b, f'dt: {dt}')
 
         # Check nans, inf
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in remainder")
-            sup.filter(RuntimeWarning, "divide by zero encountered in remainder")
-            sup.filter(RuntimeWarning, "divide by zero encountered in floor_divide")
-            sup.filter(RuntimeWarning, "divide by zero encountered in divmod")
-            sup.filter(RuntimeWarning, "invalid value encountered in divmod")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "invalid value encountered in remainder", RuntimeWarning)
+            warnings.filterwarnings(
+                'ignore', "divide by zero encountered in remainder", RuntimeWarning)
+            warnings.filterwarnings(
+                'ignore', "divide by zero encountered in floor_divide", RuntimeWarning)
+            warnings.filterwarnings(
+                'ignore', "divide by zero encountered in divmod", RuntimeWarning)
+            warnings.filterwarnings(
+                'ignore', "invalid value encountered in divmod", RuntimeWarning)
             for dt in np.typecodes['Float']:
                 fone = np.array(1.0, dtype=dt)
                 fzer = np.array(0.0, dtype=dt)
@@ -522,21 +526,17 @@ class TestConversion:
         # gh-627
         x = np.longdouble(np.inf)
         assert_raises(OverflowError, int, x)
-        with suppress_warnings() as sup:
-            sup.record(ComplexWarning)
+        with pytest.warns(ComplexWarning):
             x = np.clongdouble(np.inf)
             assert_raises(OverflowError, int, x)
-            assert_equal(len(sup.log), 1)
 
     @pytest.mark.skipif(not IS_PYPY, reason="Test is PyPy only (gh-9972)")
     def test_int_from_infinite_longdouble___int__(self):
         x = np.longdouble(np.inf)
         assert_raises(OverflowError, x.__int__)
-        with suppress_warnings() as sup:
-            sup.record(ComplexWarning)
+        with pytest.warns(ComplexWarning):
             x = np.clongdouble(np.inf)
             assert_raises(OverflowError, x.__int__)
-            assert_equal(len(sup.log), 1)
 
     @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                         reason="long double is same as double")
@@ -731,8 +731,8 @@ class TestNegative:
 
     def test_result(self):
         types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             for dt in types:
                 a = np.ones((), dtype=dt)[()]
                 if dt in np.typecodes['UnsignedInteger']:
@@ -749,8 +749,8 @@ class TestSubtract:
 
     def test_result(self):
         types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             for dt in types:
                 a = np.ones((), dtype=dt)[()]
                 assert_equal(operator.sub(a, a), 0)
@@ -771,8 +771,8 @@ class TestAbs:
         x = test_dtype(np.finfo(test_dtype).max)
         assert_equal(absfunc(x), x.real)
 
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
             x = test_dtype(np.finfo(test_dtype).tiny)
             assert_equal(absfunc(x), x.real)
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -26,7 +26,6 @@ from numpy.testing import (
     assert_equal,
     assert_no_warnings,
     assert_raises,
-    suppress_warnings,
 )
 from numpy.testing._private.utils import requires_memory
 
@@ -686,8 +685,8 @@ class TestUfunc:
                         tgt = float(x) / float(y)
                         rtol = max(np.finfo(dtout).resolution, 1e-15)
                         # The value of tiny for double double is NaN
-                        with suppress_warnings() as sup:
-                            sup.filter(UserWarning)
+                        with warnings.catch_warnings():
+                            warnings.simplefilter('ignore', UserWarning)
                             if not np.isnan(np.finfo(dtout).tiny):
                                 atol = max(np.finfo(dtout).tiny, 3e-308)
                             else:
@@ -706,8 +705,8 @@ class TestUfunc:
                     tgt = complex(x) / complex(y)
                     rtol = max(np.finfo(dtout).resolution, 1e-15)
                     # The value of tiny for double double is NaN
-                    with suppress_warnings() as sup:
-                        sup.filter(UserWarning)
+                    with warnings.catch_warnings():
+                        warnings.simplefilter('ignore', UserWarning)
                         if not np.isnan(np.finfo(dtout).tiny):
                             atol = max(np.finfo(dtout).tiny, 3e-308)
                         else:

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -30,7 +30,6 @@ from numpy.testing import (
     assert_no_warnings,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 from numpy.testing._private.utils import _glibc_older_than
 
@@ -703,8 +702,8 @@ class TestDivision:
         fone = np.array(1.0, dtype=dtype)
         fzer = np.array(0.0, dtype=dtype)
         finf = np.array(np.inf, dtype=dtype)
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in floor_divide")
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', "invalid value encountered in floor_divide", RuntimeWarning)
             div = np.floor_divide(fnan, fone)
             assert np.isnan(div), f"div: {div}"
             div = np.floor_divide(fone, fnan)
@@ -859,9 +858,9 @@ class TestRemainder:
             fone = np.array(1.0, dtype=dt)
             fzer = np.array(0.0, dtype=dt)
             finf = np.array(np.inf, dtype=dt)
-            with suppress_warnings() as sup:
-                sup.filter(RuntimeWarning, "invalid value encountered in divmod")
-                sup.filter(RuntimeWarning, "divide by zero encountered in divmod")
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', "invalid value encountered in divmod", RuntimeWarning)
+                warnings.filterwarnings('ignore', "divide by zero encountered in divmod", RuntimeWarning)
                 div, rem = np.divmod(fone, fzer)
                 assert np.isinf(div), f'dt: {dt}, div: {rem}'
                 assert np.isnan(rem), f'dt: {dt}, rem: {rem}'
@@ -898,9 +897,9 @@ class TestRemainder:
             assert_(rem >= -b, f'dt: {dt}')
 
         # Check nans, inf
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning, "invalid value encountered in remainder")
-            sup.filter(RuntimeWarning, "invalid value encountered in fmod")
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', "invalid value encountered in remainder", RuntimeWarning)
+            warnings.filterwarnings('ignore', "invalid value encountered in fmod", RuntimeWarning)
             for dt in np.typecodes['Float']:
                 fone = np.array(1.0, dtype=dt)
                 fzer = np.array(0.0, dtype=dt)
@@ -2957,9 +2956,11 @@ class TestMinMax:
                     inp[:] = np.arange(inp.size, dtype=dt)
                     inp[i] = np.nan
                     emsg = lambda: f'{inp!r}\n{msg}'
-                    with suppress_warnings() as sup:
-                        sup.filter(RuntimeWarning,
-                                   "invalid value encountered in reduce")
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            'ignore',
+                            "invalid value encountered in reduce",
+                            RuntimeWarning)
                         assert_(np.isnan(inp.max()), msg=emsg)
                         assert_(np.isnan(inp.min()), msg=emsg)
 
@@ -4603,8 +4604,8 @@ def test_nextafter_0():
     for t, direction in itertools.product(np._core.sctypes['float'], (1, -1)):
         # The value of tiny for double double is NaN, so we need to pass the
         # assert
-        with suppress_warnings() as sup:
-            sup.filter(UserWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
             if not np.isnan(np.finfo(t).tiny):
                 tiny = np.finfo(t).tiny
                 assert_(

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryFile
 
 from numpy.distutils import exec_command
 from numpy.distutils.exec_command import get_pythonexe
-from numpy.testing import tempdir, assert_, assert_warns, IS_WASM
+from numpy.testing import tempdir, assert_, IS_WASM
 
 
 # In python 3 stdout, stderr are text (unicode compliant) devices, so to
@@ -68,7 +68,7 @@ def test_exec_command_stdout():
     # Test posix version:
     with redirect_stdout(StringIO()):
         with redirect_stderr(TemporaryFile()):
-            with assert_warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning):
                 exec_command.exec_command("cd '.'")
 
     if os.name == 'posix':
@@ -76,14 +76,14 @@ def test_exec_command_stdout():
         with emulate_nonposix():
             with redirect_stdout(StringIO()):
                 with redirect_stderr(TemporaryFile()):
-                    with assert_warns(DeprecationWarning):
+                    with pytest.warns(DeprecationWarning):
                         exec_command.exec_command("cd '.'")
 
 def test_exec_command_stderr():
     # Test posix version:
     with redirect_stdout(TemporaryFile(mode='w+')):
         with redirect_stderr(StringIO()):
-            with assert_warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning):
                 exec_command.exec_command("cd '.'")
 
     if os.name == 'posix':
@@ -91,7 +91,7 @@ def test_exec_command_stderr():
         with emulate_nonposix():
             with redirect_stdout(TemporaryFile()):
                 with redirect_stderr(StringIO()):
-                    with assert_warns(DeprecationWarning):
+                    with pytest.warns(DeprecationWarning):
                         exec_command.exec_command("cd '.'")
 
 
@@ -206,7 +206,7 @@ class TestExecCommand:
     def test_basic(self):
         with redirect_stdout(StringIO()):
             with redirect_stderr(StringIO()):
-                with assert_warns(DeprecationWarning):
+                with pytest.warns(DeprecationWarning):
                     if os.name == "posix":
                         self.check_posix(use_tee=0)
                         self.check_posix(use_tee=1)

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -717,7 +717,6 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     inf
     >>> np.nansum([1, np.nan, -np.inf])
     -inf
-    >>> from numpy.testing import suppress_warnings
     >>> with np.errstate(invalid="ignore"):
     ...     np.nansum([1, np.nan, np.inf, -np.inf]) # both +/- infinity present
     np.float64(nan)

--- a/numpy/lib/_scimath_impl.py
+++ b/numpy/lib/_scimath_impl.py
@@ -628,9 +628,9 @@ def arctanh(x):
     >>> np.emath.arctanh(0.5)
     0.5493061443340549
 
-    >>> from numpy.testing import suppress_warnings
-    >>> with suppress_warnings() as sup:
-    ...     sup.filter(RuntimeWarning)
+    >>> import warnings
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore', RuntimeWarning)
     ...     np.emath.arctanh(np.eye(2))
     array([[inf,  0.],
            [ 0., inf]])

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -291,7 +291,6 @@ from numpy.testing import (
     assert_array_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 from numpy.testing._private.utils import requires_memory
 
@@ -1008,7 +1007,7 @@ def test_unicode_field_names(tmpdir):
 
     # notifies the user that 3.0 is selected
     with open(fname, 'wb') as f:
-        with assert_warns(UserWarning):
+        with pytest.warns(UserWarning):
             format.write_array(f, arr, version=None)
 
 def test_header_growth_axis():
@@ -1041,7 +1040,7 @@ def test_metadata_dtype(dt):
     # gh-14142
     arr = np.ones(10, dtype=dt)
     buf = BytesIO()
-    with assert_warns(UserWarning):
+    with pytest.warns(UserWarning):
         np.save(buf, arr)
     buf.seek(0)
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -61,8 +61,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
-    suppress_warnings,
 )
 
 np_floats = [np.half, np.single, np.double, np.longdouble]
@@ -2473,10 +2471,10 @@ class TestCorrCoef:
 
     def test_ddof(self):
         # ddof raises DeprecationWarning
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
             warnings.simplefilter("always")
-            assert_warns(DeprecationWarning, corrcoef, self.A, ddof=-1)
-            sup.filter(DeprecationWarning)
+            pytest.warns(DeprecationWarning, corrcoef, self.A, ddof=-1)
+            warnings.simplefilter('ignore', DeprecationWarning)
             # ddof has no or negligible effect on the function
             assert_almost_equal(corrcoef(self.A, ddof=-1), self.res1)
             assert_almost_equal(corrcoef(self.A, self.B, ddof=-1), self.res2)
@@ -2485,11 +2483,11 @@ class TestCorrCoef:
 
     def test_bias(self):
         # bias raises DeprecationWarning
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
             warnings.simplefilter("always")
-            assert_warns(DeprecationWarning, corrcoef, self.A, self.B, 1, 0)
-            assert_warns(DeprecationWarning, corrcoef, self.A, bias=0)
-            sup.filter(DeprecationWarning)
+            pytest.warns(DeprecationWarning, corrcoef, self.A, self.B, 1, 0)
+            pytest.warns(DeprecationWarning, corrcoef, self.A, bias=0)
+            warnings.simplefilter('ignore', DeprecationWarning)
             # bias has no or negligible effect on the function
             assert_almost_equal(corrcoef(self.A, bias=1), self.res1)
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 import numpy as np
@@ -12,7 +14,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 
 
@@ -138,11 +139,9 @@ class TestHistogram:
         # Should raise an warning on booleans
         # Ensure that the histograms are equivalent, need to suppress
         # the warnings to get the actual outputs
-        with suppress_warnings() as sup:
-            rec = sup.record(RuntimeWarning, 'Converting input from .*')
+        with pytest.warns(RuntimeWarning, match='Converting input from .*'):
             hist, edges = np.histogram([True, True, False])
             # A warning should be issued
-            assert_equal(len(rec), 1)
             assert_array_equal(hist, int_hist)
             assert_array_equal(edges, int_edges)
 
@@ -284,9 +283,8 @@ class TestHistogram:
         all_nan = np.array([np.nan, np.nan])
 
         # the internal comparisons with NaN give warnings
-        sup = suppress_warnings()
-        sup.filter(RuntimeWarning)
-        with sup:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             # can't infer range with nan
             assert_raises(ValueError, histogram, one_nan, bins='auto')
             assert_raises(ValueError, histogram, all_nan, bins='auto')
@@ -618,9 +616,9 @@ class TestHistogramOptimBinNums:
         """
         Test that bin width for integer data is at least 1.
         """
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
             if bins == 'stone':
-                sup.filter(RuntimeWarning)
+                warnings.simplefilter('ignore', RuntimeWarning)
             assert_equal(
                 np.histogram_bin_edges(np.tile(np.arange(9), 1000), bins),
                 np.arange(9))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -35,9 +35,7 @@ from numpy.testing import (
     assert_no_warnings,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
     break_cycles,
-    suppress_warnings,
     tempdir,
     temppath,
 )
@@ -319,8 +317,9 @@ class TestSavezLoad(RoundtripTest):
             # goes to zero.  Python running in debug mode raises a
             # ResourceWarning when file closing is left to the garbage
             # collector, so we catch the warnings.
-            with suppress_warnings() as sup:
-                sup.filter(ResourceWarning)  # TODO: specify exact message
+            with warnings.catch_warnings():
+                # TODO: specify exact message
+                warnings.simplefilter('ignore', ResourceWarning)
                 for i in range(1, 1025):
                     try:
                         np.load(tmp)["data"]
@@ -1429,8 +1428,8 @@ class TestFromTxt(LoadTxtBase):
         assert_equal(test, ctrl)
 
     def test_skip_footer_with_invalid(self):
-        with suppress_warnings() as sup:
-            sup.filter(ConversionWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ConversionWarning)
             basestr = '1 1\n2 2\n3 3\n4 4\n5  \n6  \n7  \n'
             # Footer too small to get rid of all invalid values
             assert_raises(ValueError, np.genfromtxt,
@@ -1828,8 +1827,8 @@ M   33  21.99
 
     def test_empty_file(self):
         # Test that an empty file raises the proper warning.
-        with suppress_warnings() as sup:
-            sup.filter(message="genfromtxt: Empty input file:")
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message="genfromtxt: Empty input file:")
             data = TextIO()
             test = np.genfromtxt(data)
             assert_equal(test, np.array([]))
@@ -1974,7 +1973,7 @@ M   33  21.99
 
         def f():
             return np.genfromtxt(mdata, invalid_raise=False, **kwargs)
-        mtest = assert_warns(ConversionWarning, f)
+        mtest = pytest.warns(ConversionWarning, f)
         assert_equal(len(mtest), 45)
         assert_equal(mtest, np.ones(45, dtype=[(_, int) for _ in 'abcde']))
         #
@@ -1995,7 +1994,7 @@ M   33  21.99
 
         def f():
             return np.genfromtxt(mdata, usecols=(0, 4), **kwargs)
-        mtest = assert_warns(ConversionWarning, f)
+        mtest = pytest.warns(ConversionWarning, f)
         assert_equal(len(mtest), 45)
         assert_equal(mtest, np.ones(45, dtype=[(_, int) for _ in 'ae']))
         #
@@ -2407,8 +2406,8 @@ M   33  21.99
         assert_raises(ValueError, np.genfromtxt, TextIO(data), max_rows=4)
 
         # Test with invalid not raise
-        with suppress_warnings() as sup:
-            sup.filter(ConversionWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ConversionWarning)
 
             test = np.genfromtxt(TextIO(data), max_rows=4, invalid_raise=False)
             control = np.array([[1., 1.], [2., 2.], [3., 3.], [4., 4.]])

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -15,7 +15,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 
 # Test data
@@ -281,8 +280,9 @@ class TestNanFunctions_ArgminArgmax:
     def test_result_values(self):
         for f, fcmp in zip(self.nanfuncs, [np.greater, np.less]):
             for row in _ndat:
-                with suppress_warnings() as sup:
-                    sup.filter(RuntimeWarning, "invalid value encountered in")
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        'ignore', "invalid value encountered in", RuntimeWarning)
                     ind = f(row)
                     val = row[ind]
                     # comparing with NaN is tricky as the result
@@ -491,10 +491,10 @@ class SharedNanFunctionsTestsMixin:
         codes = 'efdgFDG'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
-                with suppress_warnings() as sup:
+                with warnings.catch_warnings():
                     if nf in {np.nanstd, np.nanvar} and c in 'FDG':
                         # Giving the warning is a small bug, see gh-8000
-                        sup.filter(ComplexWarning)
+                        warnings.simplefilter('ignore', ComplexWarning)
                     tgt = rf(mat, dtype=np.dtype(c), axis=1).dtype.type
                     res = nf(mat, dtype=np.dtype(c), axis=1).dtype.type
                     assert_(res is tgt)
@@ -508,10 +508,10 @@ class SharedNanFunctionsTestsMixin:
         codes = 'efdgFDG'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
-                with suppress_warnings() as sup:
+                with warnings.catch_warnings():
                     if nf in {np.nanstd, np.nanvar} and c in 'FDG':
                         # Giving the warning is a small bug, see gh-8000
-                        sup.filter(ComplexWarning)
+                        warnings.simplefilter('ignore', ComplexWarning)
                     tgt = rf(mat, dtype=c, axis=1).dtype.type
                     res = nf(mat, dtype=c, axis=1).dtype.type
                     assert_(res is tgt)
@@ -723,22 +723,22 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
                 res = nf(_ndat, axis=1, ddof=ddof)
                 assert_almost_equal(res, tgt)
 
-    def test_ddof_too_big(self):
+    def test_ddof_too_big(self, recwarn):
         nanfuncs = [np.nanvar, np.nanstd]
         stdfuncs = [np.var, np.std]
         dsize = [len(d) for d in _rdat]
         for nf, rf in zip(nanfuncs, stdfuncs):
             for ddof in range(5):
-                with suppress_warnings() as sup:
-                    sup.record(RuntimeWarning)
-                    sup.filter(ComplexWarning)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', ComplexWarning)
                     tgt = [ddof >= d for d in dsize]
                     res = nf(_ndat, axis=1, ddof=ddof)
                     assert_equal(np.isnan(res), tgt)
-                    if any(tgt):
-                        assert_(len(sup.log) == 1)
-                    else:
-                        assert_(len(sup.log) == 0)
+                if any(tgt):
+                    assert_(len(recwarn) == 1)
+                    recwarn.pop(RuntimeWarning)
+                else:
+                    assert_(len(recwarn) == 0)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
     @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])
@@ -860,8 +860,8 @@ class TestNanFunctions_Median:
         w = np.random.random((4, 200)) * np.array(d.shape)[:, None]
         w = w.astype(np.intp)
         d[tuple(w)] = np.nan
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             res = np.nanmedian(d, axis=None, keepdims=True)
             assert_equal(res.shape, (1, 1, 1, 1))
             res = np.nanmedian(d, axis=(0, 1), keepdims=True)
@@ -946,17 +946,15 @@ class TestNanFunctions_Median:
     @pytest.mark.parametrize("dtype", _TYPE_CODES)
     def test_allnans(self, dtype, axis):
         mat = np.full((3, 3), np.nan).astype(dtype)
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning)
-
+        with pytest.warns(RuntimeWarning) as r:
             output = np.nanmedian(mat, axis=axis)
             assert output.dtype == mat.dtype
             assert np.isnan(output).all()
 
             if axis is None:
-                assert_(len(sup.log) == 1)
+                assert_(len(r) == 1)
             else:
-                assert_(len(sup.log) == 3)
+                assert_(len(r) == 3)
 
             # Check scalar
             scalar = np.array(np.nan).astype(dtype)[()]
@@ -965,9 +963,9 @@ class TestNanFunctions_Median:
             assert np.isnan(output_scalar)
 
             if axis is None:
-                assert_(len(sup.log) == 2)
+                assert_(len(r) == 2)
             else:
-                assert_(len(sup.log) == 4)
+                assert_(len(r) == 4)
 
     def test_empty(self):
         mat = np.zeros((0, 3))
@@ -995,8 +993,8 @@ class TestNanFunctions_Median:
         assert_raises(ValueError, np.nanmedian, d, axis=(1, 1))
 
     def test_float_special(self):
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             for inf in [np.inf, -np.inf]:
                 a = np.array([[inf,  np.nan], [np.nan, np.nan]])
                 assert_equal(np.nanmedian(a, axis=0), [inf,  np.nan])
@@ -1063,8 +1061,8 @@ class TestNanFunctions_Percentile:
         w = np.random.random((4, 200)) * np.array(d.shape)[:, None]
         w = w.astype(np.intp)
         d[tuple(w)] = np.nan
-        with suppress_warnings() as sup:
-            sup.filter(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             res = np.nanpercentile(d, 90, axis=None, keepdims=True)
             assert_equal(res.shape, (1, 1, 1, 1))
             res = np.nanpercentile(d, 90, axis=(0, 1), keepdims=True)
@@ -1233,8 +1231,9 @@ class TestNanFunctions_Percentile:
         large_mat[:, :, 3:] *= 2
         for axis in [None, 0, 1]:
             for keepdim in [False, True]:
-                with suppress_warnings() as sup:
-                    sup.filter(RuntimeWarning, "All-NaN slice encountered")
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        'ignore', "All-NaN slice encountered", RuntimeWarning)
                     val = np.percentile(mat, perc, axis=axis, keepdims=keepdim)
                     nan_val = np.nanpercentile(nan_mat, perc, axis=axis,
                                                keepdims=keepdim)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -16,7 +16,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 
 
@@ -593,9 +592,9 @@ def test_writeable():
         for array_is_broadcast, result in zip(is_broadcast, results):
             # This will change to False in a future version
             if array_is_broadcast:
-                with assert_warns(FutureWarning):
+                with pytest.warns(FutureWarning):
                     assert_equal(result.flags.writeable, True)
-                with assert_warns(DeprecationWarning):
+                with pytest.warns(DeprecationWarning):
                     result[:] = 0
                 # Warning not emitted, writing to the array resets it
                 assert_equal(result.flags.writeable, True)

--- a/numpy/linalg/tests/test_deprecations.py
+++ b/numpy/linalg/tests/test_deprecations.py
@@ -1,8 +1,9 @@
 """Test deprecation and future warnings.
 
 """
+import pytest
+
 import numpy as np
-from numpy.testing import assert_warns
 
 
 def test_qr_mode_full_future_warning():
@@ -14,7 +15,7 @@ def test_qr_mode_full_future_warning():
 
     """
     a = np.eye(2)
-    assert_warns(DeprecationWarning, np.linalg.qr, a, mode='full')
-    assert_warns(DeprecationWarning, np.linalg.qr, a, mode='f')
-    assert_warns(DeprecationWarning, np.linalg.qr, a, mode='economic')
-    assert_warns(DeprecationWarning, np.linalg.qr, a, mode='e')
+    pytest.warns(DeprecationWarning, np.linalg.qr, a, mode='full')
+    pytest.warns(DeprecationWarning, np.linalg.qr, a, mode='f')
+    pytest.warns(DeprecationWarning, np.linalg.qr, a, mode='economic')
+    pytest.warns(DeprecationWarning, np.linalg.qr, a, mode='e')

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -8,6 +8,7 @@ import sys
 import textwrap
 import threading
 import traceback
+import warnings
 
 import pytest
 
@@ -42,7 +43,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    suppress_warnings,
 )
 
 try:
@@ -1318,8 +1318,9 @@ class _TestNormGeneral(_TestNormBase):
             self.check_dtype(at, an)
             assert_almost_equal(an, 0.0)
 
-            with suppress_warnings() as sup:
-                sup.filter(RuntimeWarning, "divide by zero encountered")
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore', "divide by zero encountered", RuntimeWarning)
                 an = norm(at, -1)
                 self.check_dtype(at, an)
                 assert_almost_equal(an, 0.0)
@@ -1481,8 +1482,9 @@ class _TestNorm2D(_TestNormBase):
             self.check_dtype(at, an)
             assert_almost_equal(an, 2.0)
 
-            with suppress_warnings() as sup:
-                sup.filter(RuntimeWarning, "divide by zero encountered")
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore', "divide by zero encountered", RuntimeWarning)
                 an = norm(at, -1)
                 self.check_dtype(at, an)
                 assert_almost_equal(an, 1.0)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -149,7 +149,8 @@ pi = np.pi
 num_dts = [np.dtype(dt_) for dt_ in '?bhilqBHILQefdgFD']
 num_ids = [dt_.char for dt_ in num_dts]
 
-WARNING_MESSAGE = "setting an item on a masked array which has a shared mask will not copy"
+WARNING_MESSAGE = ("setting an item on a masked array which has a shared "
+                   "mask will not copy")
 WARNING_MARK_SPEC = f"ignore:.*{WARNING_MESSAGE}:numpy.ma.core.MaskedArrayFutureWarning"
 
 class TestMaskedArray:

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -9,7 +9,6 @@ import pytest
 import numpy as np
 from numpy.ma.core import MaskedArrayFutureWarning
 from numpy.ma.testutils import assert_equal
-from numpy.testing import assert_warns
 
 
 class TestArgsort:
@@ -23,7 +22,7 @@ class TestArgsort:
 
         # argsort has a bad default for >1d arrays
         arr_2d = np.array([[1, 2], [3, 4]]).view(cls)
-        result = assert_warns(
+        result = pytest.warns(
             np.ma.core.MaskedArrayFutureWarning, argsort, arr_2d)
         assert_equal(result, argsort(arr_2d, axis=None))
 
@@ -53,10 +52,10 @@ class TestMinimumMaximum:
         ma_max = np.ma.maximum.reduce
 
         # check that the default axis is still None, but warns on 2d arrays
-        result = assert_warns(MaskedArrayFutureWarning, ma_max, data2d)
+        result = pytest.warns(MaskedArrayFutureWarning, ma_max, data2d)
         assert_equal(result, ma_max(data2d, axis=None))
 
-        result = assert_warns(MaskedArrayFutureWarning, ma_min, data2d)
+        result = pytest.warns(MaskedArrayFutureWarning, ma_min, data2d)
         assert_equal(result, ma_min(data2d, axis=None))
 
         # no warnings on 1d, as both new and old defaults are equivalent

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -68,7 +68,6 @@ from numpy.ma.testutils import (
     assert_array_equal,
     assert_equal,
 )
-from numpy.testing import assert_warns, suppress_warnings
 
 
 class TestGeneric:
@@ -746,7 +745,7 @@ class TestCompressFunctions:
         x = array(np.arange(9).reshape(3, 3),
                   mask=[[1, 0, 0], [0, 0, 0], [0, 0, 0]])
 
-        with assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             res = func(x, axis=axis)
             assert_equal(res, mask_rowcols(x, rowcols_axis))
 
@@ -1287,19 +1286,14 @@ class TestMedian:
     def test_empty(self):
         # empty arrays
         a = np.ma.masked_array(np.array([], dtype=float))
-        with suppress_warnings() as w:
-            w.record(RuntimeWarning)
+        with pytest.warns(RuntimeWarning):
             assert_array_equal(np.ma.median(a), np.nan)
-            assert_(w.log[0].category is RuntimeWarning)
 
         # multiple dimensions
         a = np.ma.masked_array(np.array([], dtype=float, ndmin=3))
         # no axis
-        with suppress_warnings() as w:
-            w.record(RuntimeWarning)
-            warnings.filterwarnings('always', '', RuntimeWarning)
+        with pytest.warns(RuntimeWarning):
             assert_array_equal(np.ma.median(a), np.nan)
-            assert_(w.log[0].category is RuntimeWarning)
 
         # axis 0 and 1
         b = np.ma.masked_array(np.array([], dtype=float, ndmin=2))
@@ -1308,10 +1302,8 @@ class TestMedian:
 
         # axis 2
         b = np.ma.masked_array(np.array(np.nan, dtype=float, ndmin=2))
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', RuntimeWarning)
+        with pytest.warns(RuntimeWarning):
             assert_equal(np.ma.median(a, axis=2), b)
-            assert_(w[0].category is RuntimeWarning)
 
     def test_object(self):
         o = np.ma.masked_array(np.arange(7.))
@@ -1418,10 +1410,13 @@ class TestCorrcoef:
         x, y = self.data, self.data2
         expected = np.corrcoef(x)
         expected2 = np.corrcoef(x, y)
-        with suppress_warnings() as sup:
-            warnings.simplefilter("always")
-            assert_warns(DeprecationWarning, corrcoef, x, ddof=-1)
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with pytest.warns(DeprecationWarning):
+            corrcoef(x, ddof=-1)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
+
             # ddof has no or negligible effect on the function
             assert_almost_equal(np.corrcoef(x, ddof=0), corrcoef(x, ddof=0))
             assert_almost_equal(corrcoef(x, ddof=-1), expected)
@@ -1433,12 +1428,16 @@ class TestCorrcoef:
         x, y = self.data, self.data2
         expected = np.corrcoef(x)
         # bias raises DeprecationWarning
-        with suppress_warnings() as sup:
-            warnings.simplefilter("always")
-            assert_warns(DeprecationWarning, corrcoef, x, y, True, False)
-            assert_warns(DeprecationWarning, corrcoef, x, y, True, True)
-            assert_warns(DeprecationWarning, corrcoef, x, bias=False)
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with pytest.warns(DeprecationWarning):
+            corrcoef(x, y, True, False)
+        with pytest.warns(DeprecationWarning):
+            corrcoef(x, y, True, True)
+        with pytest.warns(DeprecationWarning):
+            corrcoef(x, y, bias=False)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             # bias has no or negligible effect on the function
             assert_almost_equal(corrcoef(x, bias=1), expected)
 
@@ -1448,8 +1447,9 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
@@ -1459,8 +1459,9 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
 
@@ -1473,8 +1474,9 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(nx), corrcoef(x))
         assert_almost_equal(np.corrcoef(nx, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             assert_almost_equal(np.corrcoef(nx, rowvar=False, bias=True),
                                 corrcoef(x, rowvar=False, bias=True))
         try:
@@ -1486,8 +1488,9 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(nx, nx[::-1]), corrcoef(x, x[::-1]))
         assert_almost_equal(np.corrcoef(nx, nx[::-1], rowvar=False),
                             corrcoef(x, x[::-1], rowvar=False))
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             # ddof and bias have no or negligible effect on the function
             assert_almost_equal(np.corrcoef(nx, nx[::-1]),
                                 corrcoef(x, x[::-1], bias=1))
@@ -1503,8 +1506,9 @@ class TestCorrcoef:
         test = corrcoef(x)
         control = np.corrcoef(x)
         assert_almost_equal(test[:-1, :-1], control[:-1, :-1])
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             # ddof and bias have no or negligible effect on the function
             assert_almost_equal(corrcoef(x, ddof=-2)[:-1, :-1],
                                 control[:-1, :-1])

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,10 +1,7 @@
+import warnings
+
 import numpy as np
-from numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_array_equal,
-    suppress_warnings,
-)
+from numpy.testing import assert_, assert_allclose, assert_array_equal
 
 
 class TestRegression:
@@ -67,8 +64,9 @@ class TestRegression:
         x = np.ma.masked_equal([1, 2, 3, 4, 5], 4)
         y = np.array([2, 2.5, 3.1, 3, 5])
         # this test can be removed after deprecation.
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, "bias and ddof have no effect")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', "bias and ddof have no effect", DeprecationWarning)
             r0 = np.ma.corrcoef(x, y, ddof=0)
             r1 = np.ma.corrcoef(x, y, ddof=1)
             # ddof should not have an effect (it gets cancelled out)

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from fractions import Fraction
 from functools import reduce
 
+import pytest
+
 import numpy as np
 import numpy.polynomial.polynomial as poly
 import numpy.polynomial.polyutils as pu
@@ -16,7 +18,6 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
     assert_raises_regex,
-    assert_warns,
 )
 
 
@@ -656,7 +657,7 @@ class TestMisc:
         assert_equal(p.coef, [2.])
         p = poly.Polynomial.fit([1, 1], [2, 2.1], deg=0)
         assert_almost_equal(p.coef, [2.05])
-        with assert_warns(pu.RankWarning):
+        with pytest.warns(pu.RankWarning):
             p = poly.Polynomial.fit([1, 1], [2, 2.1], deg=1)
 
     def test_result_type(self):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1,6 +1,7 @@
 import hashlib
 import os.path
 import sys
+import warnings
 
 import pytest
 
@@ -17,8 +18,6 @@ from numpy.testing import (
     assert_equal,
     assert_no_warnings,
     assert_raises,
-    assert_warns,
-    suppress_warnings,
 )
 
 random = Generator(MT19937())
@@ -1463,8 +1462,8 @@ class TestRandomDist:
         # Check that non positive-semidefinite covariance warns with
         # RuntimeWarning
         cov = [[1, 2], [2, 1]]
-        assert_warns(RuntimeWarning, random.multivariate_normal, mean, cov)
-        assert_warns(RuntimeWarning, random.multivariate_normal, mean, cov,
+        pytest.warns(RuntimeWarning, random.multivariate_normal, mean, cov)
+        pytest.warns(RuntimeWarning, random.multivariate_normal, mean, cov,
                      method='eigh')
         assert_raises(LinAlgError, random.multivariate_normal, mean, cov,
                       method='cholesky')
@@ -1491,10 +1490,9 @@ class TestRandomDist:
                           method='cholesky')
 
         cov = np.array([[1, 0.1], [0.1, 1]], dtype=np.float32)
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             random.multivariate_normal(mean, cov, method=method)
-            w = sup.record(RuntimeWarning)
-            assert len(w) == 0
 
         mu = np.zeros(2)
         cov = np.eye(2)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -13,8 +13,6 @@ from numpy.testing import (
     assert_equal,
     assert_no_warnings,
     assert_raises,
-    assert_warns,
-    suppress_warnings,
 )
 
 
@@ -331,10 +329,8 @@ class TestRandomDist:
 
     def test_random_integers(self):
         np.random.seed(self.seed)
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             actual = np.random.random_integers(-99, 99, size=(3, 2))
-            assert_(len(w) == 1)
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
@@ -346,11 +342,9 @@ class TestRandomDist:
         # into a C long. Previous implementations of this
         # method have thrown an OverflowError when attempting
         # to generate this integer.
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             actual = np.random.random_integers(np.iinfo('l').max,
                                                np.iinfo('l').max)
-            assert_(len(w) == 1)
 
         desired = np.iinfo('l').max
         assert_equal(actual, desired)
@@ -795,7 +789,7 @@ class TestRandomDist:
         # RuntimeWarning
         mean = [0, 0]
         cov = [[1, 2], [2, 1]]
-        assert_warns(RuntimeWarning, np.random.multivariate_normal, mean, cov)
+        pytest.warns(RuntimeWarning, np.random.multivariate_normal, mean, cov)
 
         # and that it doesn't warn with RuntimeWarning check_valid='ignore'
         assert_no_warnings(np.random.multivariate_normal, mean, cov,
@@ -806,10 +800,9 @@ class TestRandomDist:
                       check_valid='raise')
 
         cov = np.array([[1, 0.1], [0.1, 1]], dtype=np.float32)
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
             np.random.multivariate_normal(mean, cov)
-            w = sup.record(RuntimeWarning)
-            assert len(w) == 0
 
     def test_negative_binomial(self):
         np.random.seed(self.seed)

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -16,8 +16,6 @@ from numpy.testing import (
     assert_equal,
     assert_no_warnings,
     assert_raises,
-    assert_warns,
-    suppress_warnings,
 )
 
 INT_FUNCS = {'binomial': (100.0, 0.6),
@@ -242,12 +240,10 @@ class TestSetState:
 
     def test_get_state_warning(self):
         rs = random.RandomState(PCG64())
-        with suppress_warnings() as sup:
-            w = sup.record(RuntimeWarning)
+        with pytest.warns(RuntimeWarning):
             state = rs.get_state()
-            assert_(len(w) == 1)
-            assert isinstance(state, dict)
-            assert state['bit_generator'] == 'PCG64'
+        assert isinstance(state, dict)
+        assert state['bit_generator'] == 'PCG64'
 
     def test_invalid_legacy_state_setting(self):
         state = self.random_state.get_state()
@@ -487,20 +483,16 @@ class TestRandomDist:
 
     def test_random_integers(self):
         random.seed(self.seed)
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             actual = random.random_integers(-99, 99, size=(3, 2))
-            assert_(len(w) == 1)
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
 
         random.seed(self.seed)
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             actual = random.random_integers(198, size=(3, 2))
-            assert_(len(w) == 1)
         assert_array_equal(actual, desired + 100)
 
     def test_tomaxint(self):
@@ -529,20 +521,16 @@ class TestRandomDist:
         # into a C long. Previous implementations of this
         # method have thrown an OverflowError when attempting
         # to generate this integer.
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             actual = random.random_integers(np.iinfo('l').max,
                                             np.iinfo('l').max)
-            assert_(len(w) == 1)
 
         desired = np.iinfo('l').max
         assert_equal(actual, desired)
-        with suppress_warnings() as sup:
-            w = sup.record(DeprecationWarning)
+        with pytest.warns(DeprecationWarning):
             typer = np.dtype('l').type
             actual = random.random_integers(typer(np.iinfo('l').max),
                                             typer(np.iinfo('l').max))
-            assert_(len(w) == 1)
         assert_equal(actual, desired)
 
     def test_random_integers_deprecated(self):
@@ -879,8 +867,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.geometric, [1.1] * 10)
         assert_raises(ValueError, random.geometric, -0.1)
         assert_raises(ValueError, random.geometric, [-0.1] * 10)
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             assert_raises(ValueError, random.geometric, np.nan)
             assert_raises(ValueError, random.geometric, [np.nan] * 10)
 
@@ -1012,7 +1000,7 @@ class TestRandomDist:
         # RuntimeWarning
         mean = [0, 0]
         cov = [[1, 2], [2, 1]]
-        assert_warns(RuntimeWarning, random.multivariate_normal, mean, cov)
+        pytest.warns(RuntimeWarning, random.multivariate_normal, mean, cov)
 
         # and that it doesn't warn with RuntimeWarning check_valid='ignore'
         assert_no_warnings(random.multivariate_normal, mean, cov,
@@ -1023,10 +1011,9 @@ class TestRandomDist:
                       check_valid='raise')
 
         cov = np.array([[1, 0.1], [0.1, 1]], dtype=np.float32)
-        with suppress_warnings() as sup:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RuntimeWarning)
             random.multivariate_normal(mean, cov)
-            w = sup.record(RuntimeWarning)
-            assert len(w) == 0
 
         mu = np.zeros(2)
         cov = np.eye(2)
@@ -1048,8 +1035,8 @@ class TestRandomDist:
         assert_array_equal(actual, desired)
 
     def test_negative_binomial_exceptions(self):
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             assert_raises(ValueError, random.negative_binomial, 100, np.nan)
             assert_raises(ValueError, random.negative_binomial, 100,
                           [np.nan] * 10)
@@ -1131,8 +1118,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.poisson, [lamneg] * 10)
         assert_raises(ValueError, random.poisson, lambig)
         assert_raises(ValueError, random.poisson, [lambig] * 10)
-        with suppress_warnings() as sup:
-            sup.record(RuntimeWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
             assert_raises(ValueError, random.poisson, np.nan)
             assert_raises(ValueError, random.poisson, [np.nan] * 10)
 

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -7,7 +7,7 @@ from importlib import reload
 import pytest
 
 import numpy.exceptions as ex
-from numpy.testing import IS_WASM, assert_, assert_equal, assert_raises, assert_warns
+from numpy.testing import IS_WASM, assert_, assert_equal, assert_raises
 
 
 def test_numpy_reloading():
@@ -19,14 +19,14 @@ def test_numpy_reloading():
     VisibleDeprecationWarning = ex.VisibleDeprecationWarning
     ModuleDeprecationWarning = ex.ModuleDeprecationWarning
 
-    with assert_warns(UserWarning):
+    with pytest.warns(UserWarning):
         reload(np)
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is ex.ModuleDeprecationWarning)
     assert_(VisibleDeprecationWarning is ex.VisibleDeprecationWarning)
 
     assert_raises(RuntimeError, reload, numpy._globals)
-    with assert_warns(UserWarning):
+    with pytest.warns(UserWarning):
         reload(np)
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is ex.ModuleDeprecationWarning)

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -34,10 +34,11 @@ class FindFuncs(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-            if node.args[0].value == "ignore" and 'test' not in self.__filename.name:
-                raise AssertionError(
-                    "ignore filters should only be used in tests; "
-                    f"found in {self.__filename} on line {node.lineno}")
+            if getattr(node.args[0], "value", None) == "ignore":
+                if not self.__filename.name.startswith("test_"):
+                    raise AssertionError(
+                        "ignore filters should only be used in tests; "
+                        f"found in {self.__filename} on line {node.lineno}")
 
         if p.ls[-1] == 'warn' and (
                 len(p.ls) == 1 or p.ls[-2] == 'warnings'):

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -34,9 +34,9 @@ class FindFuncs(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
         if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-            if node.args[0].value == "ignore":
+            if node.args[0].value == "ignore" and 'test' not in self.__filename.name:
                 raise AssertionError(
-                    "warnings should have an appropriate stacklevel; "
+                    "ignore filters should only be used in tests; "
                     f"found in {self.__filename} on line {node.lineno}")
 
         if p.ls[-1] == 'warn' and (


### PR DESCRIPTION
Towards fixing #29293, also see https://github.com/scipy/scipy/pull/23275 where I did this in SciPy.

The only nontrivial changes (IMO, anyway) are in `numpy/ma/tests/test_core.py`.