### PR TITLE
TYP: Allow passing `dtype=None` to `trace`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2395,7 +2395,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex = ...,
         axis1: SupportsIndex = ...,
         axis2: SupportsIndex = ...,
-        dtype: DTypeLike = ...,
+        dtype: DTypeLike | None = ...,
         out: None = ...,
     ) -> Any: ...
     @overload
@@ -2404,7 +2404,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex = ...,
         axis1: SupportsIndex = ...,
         axis2: SupportsIndex = ...,
-        dtype: DTypeLike = ...,
+        dtype: DTypeLike | None = ...,
         *,
         out: _ArrayT,
     ) -> _ArrayT: ...
@@ -2414,7 +2414,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex,
         axis1: SupportsIndex,
         axis2: SupportsIndex,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None,
         out: _ArrayT,
     ) -> _ArrayT: ...
 

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -531,7 +531,7 @@ def trace(
     offset: SupportsIndex = ...,
     axis1: SupportsIndex = ...,
     axis2: SupportsIndex = ...,
-    dtype: DTypeLike = ...,
+    dtype: DTypeLike | None = ...,
     out: None = ...,
 ) -> Any: ...
 @overload
@@ -540,7 +540,7 @@ def trace(
     offset: SupportsIndex,
     axis1: SupportsIndex,
     axis2: SupportsIndex,
-    dtype: DTypeLike,
+    dtype: DTypeLike | None,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
@@ -549,7 +549,7 @@ def trace(
     offset: SupportsIndex = ...,
     axis1: SupportsIndex = ...,
     axis2: SupportsIndex = ...,
-    dtype: DTypeLike = ...,
+    dtype: DTypeLike | None = ...,
     *,
     out: _ArrayT,
 ) -> _ArrayT: ...

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -440,7 +440,7 @@ def trace(
     /,
     *,
     offset: SupportsIndex = ...,
-    dtype: DTypeLike = ...,
+    dtype: DTypeLike | None = ...,
 ) -> Any: ...
 
 @overload

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -1177,7 +1177,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex = ...,
         axis1: SupportsIndex = ...,
         axis2: SupportsIndex = ...,
-        dtype: DTypeLike = ...,
+        dtype: DTypeLike | None = ...,
         out: None = ...,
     ) -> Any: ...
     @overload
@@ -1186,7 +1186,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex = ...,
         axis1: SupportsIndex = ...,
         axis2: SupportsIndex = ...,
-        dtype: DTypeLike = ...,
+        dtype: DTypeLike | None = ...,
         *,
         out: _ArrayT,
     ) -> _ArrayT: ...
@@ -1196,7 +1196,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         offset: SupportsIndex,
         axis1: SupportsIndex,
         axis2: SupportsIndex,
-        dtype: DTypeLike,
+        dtype: DTypeLike | None,
         out: _ArrayT,
     ) -> _ArrayT: ...
 

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -124,6 +124,7 @@ assert_type(np.diagonal(AR_f4), npt.NDArray[np.float32])
 assert_type(np.trace(AR_b), Any)
 assert_type(np.trace(AR_f4), Any)
 assert_type(np.trace(AR_f4, out=AR_subclass), NDArraySubclass)
+assert_type(np.trace(AR_f4, out=AR_subclass, dtype=None), NDArraySubclass)
 
 assert_type(np.ravel(b), np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(np.ravel(f4), np.ndarray[tuple[int], np.dtype[np.float32]])

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -394,6 +394,7 @@ assert_type(MAR_2d_f4.nonzero()[0], _Array1D[np.intp])
 
 assert_type(MAR_f8.trace(), Any)
 assert_type(MAR_f8.trace(out=MAR_subclass), MaskedArraySubclass)
+assert_type(MAR_f8.trace(out=MAR_subclass, dtype=None), MaskedArraySubclass)
 
 assert_type(MAR_f8.round(), MaskedArray[np.float64])
 assert_type(MAR_f8.round(out=MAR_subclass), MaskedArraySubclass)


### PR DESCRIPTION
`None` is explicitly documented as an acceptable argument

> dtype : dtype, optional
> 
> Determines the data-type of the returned array and of the accumulator where the elements are summed. If dtype has the value None and a is of integer type of precision less than the default integer precision, then the default integer precision is used. Otherwise, the precision is the same as that of a.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
