### PR TITLE
API,BUG: Fix scalar handling in array-interface allowing NULL pointers

### DIFF
--- a/doc/release/upcoming_changes/29338.change.rst
+++ b/doc/release/upcoming_changes/29338.change.rst
@@ -1,0 +1,9 @@
+``__array_interface__`` with NULL pointer changed
+-------------------------------------------------
+The array interface now accepts NULL pointers (NumPy will do
+its own dummy allocation, though).
+Previously, these incorrectly triggered an undocumented
+scalar path.
+In the unlikely event that the scalar path was actually desired,
+you can (for now) achieve the previous behavior via the correct
+scalar path by not providing a ``data`` field at all.

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -120,7 +120,7 @@ This approach to the interface consists of the object having an
 
        **Default**: ``[('', typestr)]``
 
-   **data** (optional)
+   **data**
        A 2-tuple whose first argument is a :doc:`Python integer <python:c-api/long>`
        that points to the data-area storing the array contents.
 
@@ -136,15 +136,23 @@ This approach to the interface consists of the object having an
 
        This attribute can also be an object exposing the
        :ref:`buffer interface <bufferobjects>` which
-       will be used to share the data. If this key is not present (or
-       returns None), then memory sharing will be done
-       through the buffer interface of the object itself.  In this
+       will be used to share the data. If this key is ``None``, then memory sharing
+       will be done through the buffer interface of the object itself.  In this
        case, the offset key can be used to indicate the start of the
        buffer.  A reference to the object exposing the array interface
        must be stored by the new object if the memory area is to be
        secured.
 
-       **Default**: ``None``
+        .. note::
+            Not specifying this field uses a "scalar" path that we may remove in the future
+            as we are not aware of any users.  In this case, NumPy assigns the original object
+            as a scalar into the array. 
+
+        .. versionchanged:: 2.4
+            Prior to NumPy 2.4 a ``NULL`` pointer used the undocumented "scalar" path
+            and was thus usually not accepted (and triggered crashes on some paths).
+            After NumPy 2.4, ``NULL`` is accepted, although NumPy will create a 1-byte sized
+            new allocation for the array.
 
    **strides** (optional)
        Either ``None`` to indicate a C-style contiguous array or

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2141,6 +2141,7 @@ PyArray_FromInterface(PyObject *origin)
     Py_ssize_t i, n;
     npy_intp dims[NPY_MAXDIMS], strides[NPY_MAXDIMS];
     int dataflags = NPY_ARRAY_BEHAVED;
+    int use_scalar_assign = 0;
 
     if (PyArray_LookupSpecial_OnInstance(
             origin, npy_interned_str.array_interface, &iface) < 0) {
@@ -2229,12 +2230,10 @@ PyArray_FromInterface(PyObject *origin)
         /* Shape must be specified when 'data' is specified */
         int result = PyDict_ContainsString(iface, "data");
         if (result < 0) {
-            Py_DECREF(attr);
             return NULL;
         }
         else if (result == 1) {
             Py_DECREF(iface);
-            Py_DECREF(attr);
             PyErr_SetString(PyExc_ValueError,
                     "Missing __array_interface__ shape");
             return NULL;
@@ -2277,7 +2276,10 @@ PyArray_FromInterface(PyObject *origin)
     }
 
     /* Case for data access through pointer */
-    if (attr && PyTuple_Check(attr)) {
+    if (attr == NULL) {
+        use_scalar_assign = 1;
+    }
+    else if (PyTuple_Check(attr)) {
         PyObject *dataptr;
         if (PyTuple_GET_SIZE(attr) != 2) {
             PyErr_SetString(PyExc_TypeError,
@@ -2309,7 +2311,7 @@ PyArray_FromInterface(PyObject *origin)
     }
 
     /* Case for data access through buffer */
-    else if (attr) {
+    else {
         if (attr != Py_None) {
             base = attr;
         }
@@ -2366,18 +2368,32 @@ PyArray_FromInterface(PyObject *origin)
     if (ret == NULL) {
         goto fail;
     }
-    if (data == NULL) {
+    if (use_scalar_assign) {
+        /* 
+         * NOTE(seberg): I honestly doubt anyone is using this scalar path and we
+         * could probably just deprecate (or just remove it in a 3.0 version).
+         */
         if (PyArray_SIZE(ret) > 1) {
             PyErr_SetString(PyExc_ValueError,
                     "cannot coerce scalar to array with size > 1");
             Py_DECREF(ret);
             goto fail;
         }
-        if (PyArray_SETITEM(ret, PyArray_DATA(ret), origin) < 0) {
+        if (PyArray_Pack(PyArray_DESCR(ret), PyArray_DATA(ret), origin) < 0) {
             Py_DECREF(ret);
             goto fail;
         }
     }
+    else if (data == NULL && PyArray_NBYTES(ret) != 0) {
+        /* Caller should ensure this, but <2.4 used the above scalar coerction path */
+        PyErr_SetString(PyExc_ValueError,
+                "data is NULL but array contains data, in older versions of NumPy "
+                "this may have used the scalar path.  To get the scalar path "
+                "you must leave the data field undefined.");
+        Py_DECREF(ret);
+        goto fail;
+    }
+
     result = PyDict_GetItemStringRef(iface, "strides", &attr);
     if (result == -1){
         return NULL;


### PR DESCRIPTION
This fixes the scalar handling in the array-interface and also a bug in the shape handling error path.

In theory it breaks code that used NULL to trigger the scalar path, but this path was:
1. Completely undocumented, and
2. correctly triggered by *ommitting* the data field instead.

I didn't remove/deprecate the scalar path in this PR, maybe we should. But, I do think we can ignore that theoretical use-case since it is nonsensical.

Closes gh-26037