### PR TITLE
TYP: correct default value of `unicode` in `chararray.__new__` and of `full` in `polyfit`

### DIFF
--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -117,8 +117,20 @@ class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
     def __new__(
         subtype,
         shape: _ShapeLike,
+        itemsize: SupportsIndex | SupportsInt,
+        unicode: L[True],
+        buffer: _SupportsBuffer = ...,
+        offset: SupportsIndex = ...,
+        strides: _ShapeLike = ...,
+        order: _OrderKACF = ...,
+    ) -> _CharArray[str_]: ...
+    @overload
+    def __new__(
+        subtype,
+        shape: _ShapeLike,
         itemsize: SupportsIndex | SupportsInt = ...,
-        unicode: L[True] = ...,
+        *,
+        unicode: L[True],
         buffer: _SupportsBuffer = ...,
         offset: SupportsIndex = ...,
         strides: _ShapeLike = ...,

--- a/numpy/lib/_polynomial_impl.pyi
+++ b/numpy/lib/_polynomial_impl.pyi
@@ -155,8 +155,19 @@ def polyfit(
     x: _ArrayLikeFloat_co,
     y: _ArrayLikeFloat_co,
     deg: SupportsIndex | SupportsInt,
+    rcond: float | None,
+    full: L[True],
+    w: _ArrayLikeFloat_co | None = ...,
+    cov: bool | L["unscaled"] = ...,
+) -> _5Tup[NDArray[float64]]: ...
+@overload
+def polyfit(
+    x: _ArrayLikeFloat_co,
+    y: _ArrayLikeFloat_co,
+    deg: SupportsIndex | SupportsInt,
     rcond: float | None = ...,
-    full: L[True] = ...,
+    *,
+    full: L[True],
     w: _ArrayLikeFloat_co | None = ...,
     cov: bool | L["unscaled"] = ...,
 ) -> _5Tup[NDArray[float64]]: ...
@@ -165,8 +176,19 @@ def polyfit(
     x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co,
     deg: SupportsIndex | SupportsInt,
+    rcond: float | None,
+    full: L[True],
+    w: _ArrayLikeFloat_co | None = ...,
+    cov: bool | L["unscaled"] = ...,
+) -> _5Tup[NDArray[complex128]]: ...
+@overload
+def polyfit(
+    x: _ArrayLikeComplex_co,
+    y: _ArrayLikeComplex_co,
+    deg: SupportsIndex | SupportsInt,
     rcond: float | None = ...,
-    full: L[True] = ...,
+    *,
+    full: L[True],
     w: _ArrayLikeFloat_co | None = ...,
     cov: bool | L["unscaled"] = ...,
 ) -> _5Tup[NDArray[complex128]]: ...


### PR DESCRIPTION
These annotations show `Literal[True]` as the default, even though the default is actually `False`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
