### PR TITLE
DOC: Fix NEP 49 Resolution Link Formatting (part of #29328)

### DIFF
--- a/doc/neps/nep-0038-SIMD-optimizations.rst
+++ b/doc/neps/nep-0038-SIMD-optimizations.rst
@@ -8,7 +8,7 @@ NEP 38 — Using SIMD optimization instructions for performance
 :Status: Final
 :Type: Standards
 :Created: 2019-11-25
-:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB/#PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB
+:Resolution: `NumPy Discussion <https://mail.python.org/archives/list/numpy-discussion@python.org/thread/FVKH4IWXYVZSTZEYKZJ7XWHU4EXX3YLS/>`_
 
 
 Abstract

--- a/doc/neps/nep-0038-SIMD-optimizations.rst
+++ b/doc/neps/nep-0038-SIMD-optimizations.rst
@@ -8,7 +8,7 @@ NEP 38 — Using SIMD optimization instructions for performance
 :Status: Final
 :Type: Standards
 :Created: 2019-11-25
-:Resolution: `NumPy Discussion <https://mail.python.org/archives/list/numpy-discussion@python.org/thread/FVKH4IWXYVZSTZEYKZJ7XWHU4EXX3YLS/>`_
+:Resolution: `NumPy Discussion <https://mail.python.org/archives/list/numpy-discussion@python.org/thread/PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB/#PVWJ74UVBRZ5ZWF6MDU7EUSJXVNILAQB>`_
 
 
 Abstract

--- a/doc/neps/nep-0049-data-allocation-strategies.rst
+++ b/doc/neps/nep-0049-data-allocation-strategies.rst
@@ -8,8 +8,7 @@ NEP 49 — Data allocation strategies
 :Status: Final
 :Type: Standards Track
 :Created: 2021-04-18
-:Resolution: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/YZ3PNTXZUT27B6ITFAD3WRSM3T3SRVK4/#PKYXCTG4R5Q6LIRZC4SEWLNBM6GLRF26
-
+:Resolution: `NumPy Discussion <https://mail.python.org/archives/list/numpy-discussion@python.org/thread/YZ3PNTXZUT27B6ITFAD3WRSM3T3SRVK4/#PKYXCTG4R5Q6LIRZC4SEWLNBM6GLRF26>`_
 
 Abstract
 --------


### PR DESCRIPTION
Closes #29328 

This PR fixes the formatting of the :Resolution: field in nep-0049-data-allocation-strategies.rst
to use proper ReStructuredText link syntax, making the link render correctly in documentation.

No other changes to content.
