### PR TITLE
BUG: Fix shape error path in array-interface

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2229,12 +2229,10 @@ PyArray_FromInterface(PyObject *origin)
         /* Shape must be specified when 'data' is specified */
         int result = PyDict_ContainsString(iface, "data");
         if (result < 0) {
-            Py_DECREF(attr);
             return NULL;
         }
         else if (result == 1) {
             Py_DECREF(iface);
-            Py_DECREF(attr);
             PyErr_SetString(PyExc_ValueError,
                     "Missing __array_interface__ shape");
             return NULL;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8849,6 +8849,14 @@ def test_interface_no_shape():
     assert_equal(np.array(ArrayLike()), 1)
 
 
+def test_interface_no_shape_error():
+    class ArrayLike:
+        __array_interface__ = {"data": None, "typestr": "f8"}
+
+    with pytest.raises(ValueError, match="Missing __array_interface__ shape"):
+        np.array(ArrayLike())
+
+
 def test_array_interface_itemsize():
     # See gh-6361
     my_dtype = np.dtype({'names': ['A', 'B'], 'formats': ['f4', 'f4'],


### PR DESCRIPTION
Avoids crash on missing shape.  Not a big issue overall, since the array-interface can always cause crashes and this is a bad interface. But also nice to tell users why it is a bad interface.

Backport of the bug-fix in gh-29338