### PR TITLE
BLD: print long double format used

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -522,6 +522,7 @@ endif
 if longdouble_format == 'UNKNOWN' or longdouble_format == 'UNDEFINED'
   error('Unknown long double format of size: ' + cc.sizeof('long double').to_string())
 endif
+message(f'Long double format: @longdouble_format@')
 cdata.set10('HAVE_LDOUBLE_' + longdouble_format, true)
 
 if cc.has_header('endian.h')


### PR DESCRIPTION
Print the long double format that is used for the build.  This can be helpful when you're about to cross-compile, but can also run Meson first on the native host to check the right value.