### PR TITLE
ENH: Enable RVV acceleration for Highway-based quick sort in RISC-V

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -873,6 +873,7 @@ foreach gen_mtargets : [
     'src/npysort/highway_qsort.dispatch.cpp',
     use_highway ? [
       ASIMD, VSX2,  # FIXME: disable VXE due to runtime segfault
+      RVV,
     ] : []
   ],
   [
@@ -880,6 +881,7 @@ foreach gen_mtargets : [
     'src/npysort/highway_qsort_16bit.dispatch.cpp',
     use_highway ? [
       ASIMDHP, VSX2,  # VXE FIXME: disable VXE due to runtime segfault
+      RVV,
     ] : []
   ],
 ]


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip)
Test command:  spin bench -t bench_function_base.Sort

cat /proc/cpuinfo
model name      : Spacemit(R) X60
isa             : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintpause_zihpm_zfh_zfhmin_zca_zcd_zba_zbb_zbc_zbs_zkt_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkt_sscofpmf_sstc_svinval_svnapot_svpbmt
mmu             : sv39
uarch           : spacemit,x60

RVV ​dramatically accelerates uniform integer sorting​ (especially 16/32-bit)

[83.33%] ··· bench_function_base.Sort.time_sort                               ok
[83.33%] ··· ======= ========= ======================== =============
  kind    dtype          array_type         Without_RVV     With_RVV
 quick   float64        ('random',)          1.35±0ms      2.07±0.01ms
 quick   float64        ('ordered',)         616±0.9μs     2.01±0.01ms
 quick   float64       ('reversed',)         1.02±0ms      1.99±0.01ms
 quick   float64        ('uniform',)         1.13±0ms       143±1μs
 quick   float64    ('sorted_block', 10)    1.36±0.01ms     2.06±0ms
 quick   float64   ('sorted_block', 100)     1.35±0ms      2.09±0.01ms
 quick   float64   ('sorted_block', 1000)    1.37±0ms      2.09±0.01ms
 quick    int64         ('random',)          686±3μs        2.01±0ms
 quick    int64         ('ordered',)         268±2μs       1.95±0.02ms
 quick    int64        ('reversed',)         397±3μs       1.94±0.01ms
 quick    int64         ('uniform',)         333±1μs        64.1±1μs
 quick    int64     ('sorted_block', 10)     679±2μs       2.00±0.01ms
 quick    int64    ('sorted_block', 100)     661±1μs        2.03±0ms
 quick    int64    ('sorted_block', 1000)    647±2μs        2.03±0ms
 quick   float32        ('random',)         1.32±0.01ms     842±4μs
 quick   float32        ('ordered',)         603±0.9μs      828±7μs
 quick   float32       ('reversed',)         1.01±0ms       827±4μs
 quick   float32        ('uniform',)         1.12±0ms      79.2±0.1μs
 quick   float32    ('sorted_block', 10)     1.34±0ms       850±30μs
 quick   float32   ('sorted_block', 100)     1.33±0ms       864±1μs
 quick   float32   ('sorted_block', 1000)    1.36±0ms       876±2μs
 quick    uint32        ('random',)          653±3μs        856±2μs
 quick    uint32        ('ordered',)        242±0.7μs       845±20μs
 quick    uint32       ('reversed',)         370±1μs        838±3μs
 quick    uint32        ('uniform',)        312±0.8μs      40.7±0.3μs
 quick    uint32    ('sorted_block', 10)    641±0.8μs       858±2μs
 quick    uint32   ('sorted_block', 100)    628±0.8μs       877±6μs
 quick    uint32   ('sorted_block', 1000)    613±1μs        886±3μs
 quick    int32         ('random',)          666±3μs        856±2μs
 quick    int32         ('ordered',)         251±4μs        841±4μs
 quick    int32        ('reversed',)         379±2μs        843±2μs
 quick    int32         ('uniform',)        319±0.6μs      40.7±0.2μs
 quick    int32     ('sorted_block', 10)     657±1μs       860±0.7μs
 quick    int32    ('sorted_block', 100)     641±2μs        878±5μs
 quick    int32    ('sorted_block', 1000)    620±2μs        888±2μs
 quick    int16         ('random',)          694±3μs        597±3μs
 quick    int16         ('ordered',)         278±1μs        584±2μs
 quick    int16        ('reversed',)         428±2μs        583±2μs
 quick    int16         ('uniform',)        323±0.9μs     30.2±0.09μs
 quick    int16     ('sorted_block', 10)     683±3μs        603±2μs
 quick    int16    ('sorted_block', 100)     658±2μs        596±2μs
 quick    int16    ('sorted_block', 1000)    631±1μs        607±2μs
 quick   float16        ('random',)         1.30±0.01ms     1.21±0ms
 quick   float16        ('ordered',)         963±20μs       914±8μs
 quick   float16       ('reversed',)         850±2μs       734±0.8μs
 quick   float16        ('uniform',)         846±4μs        735±4μs
 quick   float16    ('sorted_block', 10)     1.31±0ms       1.20±0ms
 quick   float16   ('sorted_block', 100)     1.38±0ms       1.28±0ms
 quick   float16   ('sorted_block', 1000)    1.39±0ms       1.29±0ms
======= ========= ======================== ============= =============
