### PR TITLE
BUG: fix test_npy_uintp_type_enum

### DIFF
--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -347,6 +347,6 @@ def test_npystring_allocators_other_dtype(install_temp):
 
 @pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64',
                     reason='no checks module on win-arm64')
-def test_npy_uintp_type_enum():
+def test_npy_uintp_type_enum(install_temp):
     import checks
     assert checks.check_npy_uintp_type_enum()


### PR DESCRIPTION
test_npy_uintp_type_enum will fail if it is run before any of the other tests in test_cython.py.  The reason is that although it imports the checks module, it does not contain the install_temp parameter that ensures that the checks module is compiled. Running test_npy_uintp_type_enum before any of the other tests in test_cython.py will result in a

No module named 'checks'

error.

If the test is run after one of the other tests in test_cython.py that do contain the install_temp parameter, test_npy_uintp_type_enum will run fine.

Here we fix the issue by adding the install_temp parameter to test_npy_uintp_type_enum.

Closes #29354

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
