### PR TITLE
BUG: Fix reference leakage for output arrays in reduction functions

### DIFF
--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -430,6 +430,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     }
 
     if (out != NULL) {
+        Py_DECREF(out);
         result = out;
     }
     Py_INCREF(result);

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -430,7 +430,6 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     }
 
     if (out != NULL) {
-        Py_DECREF(out);
         result = out;
     }
     Py_INCREF(result);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2730,6 +2730,9 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             }
         }
     }
+    else {
+        Py_INCREF(out);
+    }
 
     npy_intp fixed_strides[3];
     if (need_outer_iterator) {
@@ -3145,8 +3148,9 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
         if (out == NULL) {
             out = op[0];
-            Py_INCREF(out);
         }
+
+        Py_INCREF(out);
     }
     else {
         /*
@@ -3721,6 +3725,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     if (ret == NULL) {
         goto fail;
     }
+    
+    Py_XDECREF(out);
 
     Py_DECREF(signature[0]);
     Py_DECREF(signature[1]);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2611,9 +2611,6 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         return NULL;
     }
 
-    /* Take a reference to out for later returning */
-    Py_XINCREF(out);
-
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
             arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
@@ -3034,9 +3031,6 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     if (_get_bufsize_errmask(&buffersize, &errormask) < 0) {
         return NULL;
     }
-
-    /* Take a reference to out for later returning */
-    Py_XINCREF(out);
 
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3755,6 +3755,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     return wrapped_result;
 
 fail:
+    Py_XDECREF(out);
+
     Py_XDECREF(signature[0]);
     Py_XDECREF(signature[1]);
     Py_XDECREF(signature[2]);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3151,7 +3151,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
         if (out == NULL) {
             out = op[0];
-            Py_XINCREF(out);
+            Py_INCREF(out);
         }
     }
     else {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2611,6 +2611,9 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         return NULL;
     }
 
+    /* Take reference to output array to return later */
+    Py_XINCREF(out);
+
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
             arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
@@ -2729,9 +2732,6 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
                 goto fail;
             }
         }
-    }
-    else {
-        Py_INCREF(out);
     }
 
     npy_intp fixed_strides[3];
@@ -3035,6 +3035,9 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         return NULL;
     }
 
+    /* Take reference to output array to return later */
+    Py_XINCREF(out);
+
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
             arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
@@ -3148,9 +3151,8 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
         if (out == NULL) {
             out = op[0];
+            Py_XINCREF(out);
         }
-
-        Py_INCREF(out);
     }
     else {
         /*

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2611,7 +2611,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         return NULL;
     }
 
-    /* Take reference to output array to return later */
+    /* Take a reference to out for later returning */
     Py_XINCREF(out);
 
     PyArray_Descr *descrs[3];
@@ -3035,7 +3035,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         return NULL;
     }
 
-    /* Take reference to output array to return later */
+    /* Take a reference to out for later returning */
     Py_XINCREF(out);
 
     PyArray_Descr *descrs[3];

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -3021,16 +3021,25 @@ def test_reduction_no_reference_leak():
 
     # with `out=` the reference count is not changed
     out = np.empty((), dtype=np.int32)
+    out_count = sys.getrefcount(out)
+
     np.add.reduce(arr, dtype=np.int32, out=out, initial=0)
     assert count == sys.getrefcount(arr)
+    assert out_count == sys.getrefcount(out)
 
     out = np.empty(arr.shape, dtype=np.int32)
+    out_count = sys.getrefcount(out)
+
     np.add.accumulate(arr, dtype=np.int32, out=out)
     assert count == sys.getrefcount(arr)
+    assert out_count == sys.getrefcount(out)
 
     out = np.empty((2,), dtype=np.int32)
+    out_count = sys.getrefcount(out)
+
     np.add.reduceat(arr, [0, 1], dtype=np.int32, out=out)
     assert count == sys.getrefcount(arr)
+    assert out_count == sys.getrefcount(out)
 
 
 def test_object_reduce_cleanup_on_failure():

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -3003,6 +3003,36 @@ def test_reduce_casterrors(offset):
     assert out[()] < value * offset
 
 
+@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+def test_reduction_no_reference_leak():
+    # Test that the generic reduction does not leak references.
+    # gh-29358
+    arr = np.array([1, 2, 3], dtype=np.int32)
+    count = sys.getrefcount(arr)
+
+    np.add.reduce(arr, dtype=np.int32, initial=0)
+    assert count == sys.getrefcount(arr)
+
+    np.add.accumulate(arr, dtype=np.int32)
+    assert count == sys.getrefcount(arr)
+
+    np.add.reduceat(arr, [0, 1], dtype=np.int32)
+    assert count == sys.getrefcount(arr)
+
+    # with `out=` the reference count is not changed
+    out = np.empty((), dtype=np.int32)
+    np.add.reduce(arr, dtype=np.int32, out=out, initial=0)
+    assert count == sys.getrefcount(arr)
+
+    out = np.empty(arr.shape, dtype=np.int32)
+    np.add.accumulate(arr, dtype=np.int32, out=out)
+    assert count == sys.getrefcount(arr)
+
+    out = np.empty((2,), dtype=np.int32)
+    np.add.reduceat(arr, [0, 1], dtype=np.int32, out=out)
+    assert count == sys.getrefcount(arr)
+
+
 def test_object_reduce_cleanup_on_failure():
     # Test cleanup, including of the initial value (manually provided or not)
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #29355.

We already increment a reference to `out` in `_set_out_array` (in `ufunc_object.c`):

```
c
static int
_set_out_array(PyObject *obj, PyArrayObject **store)
{
    ...
    Py_INCREF(obj);
    *store = (PyArrayObject *)obj;

    return 0;
    ...
}
```

This PR removes additional increments and adds a missing decrement that caused the memory leakage.