### PR TITLE
BUG: prevent mutating multiter arguments while processing them

### DIFF
--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -6,4 +6,35 @@
 
 #define Npy_HashDouble _Py_HashDouble
 
+// These are slightly tweaked versions of macros defined in CPython in
+// pycore_critical_section.h, originally added in CPython commit baf347d91643.
+//
+// The tweaks are only to use public CPython C API symbols
+
+#ifdef Py_GIL_DISABLED
+// Specialized version of critical section locking to safely use
+// PySequence_Fast APIs without the GIL. For performance, the argument *to*
+// PySequence_Fast() is provided to the macro, not the *result* of
+// PySequence_Fast(), which would require an extra test to determine if the
+// lock must be acquired.
+# define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)              \
+    {                                                                   \
+        PyObject *_orig_seq = (PyOject *)(original);                    \
+        const int _should_lock_cs = PyList_CheckExact(_orig_seq);      \
+        PyCriticalSection _cs;                                          \
+        if (_should_lock_cs) {                                          \
+            PyCriticalSection_Begin(&_cs, _orig_seq);                   \
+        }
+
+#    define Py_END_CRITICAL_SECTION_SEQUENCE_FAST() \
+        if (_should_lock_cs) {                      \
+            PyCriticalSection_End(&_cs);            \
+        }                                           \
+    }
+#else
+#define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) {
+#define Py_END_CRITICAL_SECTION_SEQUENCE_FAST() }
+#endif
+
+
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_ */

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -23,6 +23,7 @@
 #include "item_selection.h"
 #include "lowlevel_strided_loops.h"
 #include "array_assign.h"
+#include "npy_pycompat.h"
 
 #define NEWAXIS_INDEX -1
 #define ELLIPSIS_INDEX -2
@@ -1476,6 +1477,7 @@ PyArray_MultiIterNew(int n, ...)
     return multiiter_new_impl(n, args_impl);
 }
 
+
 static PyObject*
 arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
                   PyObject *kwds)
@@ -1488,7 +1490,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
                         "keyword arguments not accepted.");
         return NULL;
     }
-
+    Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args)
     fast_seq = PySequence_Fast(args, "");  // needed for pypy
     if (fast_seq == NULL) {
         return NULL;
@@ -1500,6 +1502,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
     }
     ret = multiiter_new_impl(n, PySequence_Fast_ITEMS(fast_seq));
     Py_DECREF(fast_seq);
+    Py_END_CRITICAL_SECTION_SEQUENCE_FAST()
     return ret;
 }
 


### PR DESCRIPTION
This adds `Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST` and `Py_END_CRITICAL_SECTION_SEQUENCE_FAST` macros. These are adapted from CPython and are copied into NumPy because they aren't exposed publicly. The versions in CPython use slightly different definitions relying on private C API symbols.

I plan to use these macros elsewhere for other uses of `PySequence_Fast` inside NumPy but am opening this PR here for a relatively simple case as an illustrative example.