### PR TITLE
DOC: add typing test to dev env page

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -185,6 +185,16 @@ For more extensive information, see :ref:`testing-guidelines`.
 Note: do not run the tests from the root directory of your numpy git repo without ``spin``,
 that will result in strange test errors.
 
+Running type checks
+-------------------
+Changes that involve static type declarations are also executed using ``spin``.
+The invocation will look like the following:
+
+    $ spin mypy
+
+This will look in the ``typing/tests`` directory for sets of operations to
+test for type incompatibility.
+
 Running linting
 ---------------
 Lint checks can be performed on newly added lines of Python code.


### PR DESCRIPTION
Adds a small entry to the development environment page on testing to show the spin command for invoking the typing tests.

[skip azp] [skip cirrus] [skip actions]

Closes https://github.com/numpy/numpy/issues/29365

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
