### PR TITLE
BUG: fix casting issue in center, ljust, rjust, and zfill

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1736,7 +1736,7 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
             size_t num_codepoints = inbuf.num_codepoints();
             npy_intp width = (npy_intp)*(npy_int64*)in2;
 
-            if (num_codepoints > (size_t)width) {
+            if ((npy_intp)num_codepoints > width) {
                 width = num_codepoints;
             }
 
@@ -1866,8 +1866,8 @@ zfill_strided_loop(PyArrayMethod_Context *context,
         {
             Buffer<ENCODING::UTF8> inbuf((char *)is.buf, is.size);
             size_t in_codepoints = inbuf.num_codepoints();
-            size_t width = (size_t)*(npy_int64 *)in2;
-            if (in_codepoints > width) {
+            npy_intp width = (npy_intp)*(npy_int64*)in2;
+            if ((npy_intp)in_codepoints > width) {
                 width = in_codepoints;
             }
             // number of leading one-byte characters plus the size of the

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -846,6 +846,7 @@ class TestMethods:
         ('abc', 6, ' ', ' abc  '),
         ('abc', 3, ' ', 'abc'),
         ('abc', 2, ' ', 'abc'),
+        ('abc', -2, ' ', 'abc'),
         ('abc', 10, '*', '***abc****'),
     ])
     def test_center(self, buf, width, fillchar, res, dt):
@@ -859,6 +860,7 @@ class TestMethods:
         ('abc', 6, ' ', 'abc   '),
         ('abc', 3, ' ', 'abc'),
         ('abc', 2, ' ', 'abc'),
+        ('abc', -2, ' ', 'abc'),
         ('abc', 10, '*', 'abc*******'),
     ])
     def test_ljust(self, buf, width, fillchar, res, dt):
@@ -872,6 +874,7 @@ class TestMethods:
         ('abc', 6, ' ', '   abc'),
         ('abc', 3, ' ', 'abc'),
         ('abc', 2, ' ', 'abc'),
+        ('abc', -2, ' ', 'abc'),
         ('abc', 10, '*', '*******abc'),
     ])
     def test_rjust(self, buf, width, fillchar, res, dt):
@@ -893,6 +896,7 @@ class TestMethods:
         ('-0123', 5, '-0123'),
         ('000', 3, '000'),
         ('34', 1, '34'),
+        ('34', -1, '34'),
         ('0034', 4, '0034'),
     ])
     def test_zfill(self, buf, width, res, dt):


### PR DESCRIPTION
Fixes #29359.

We were comparing signed and unsigned integers so any negative width wasn't being corrected.