### PR TITLE
ENH: Allow subscript access for `np.bool` by adding `__class_getitem__`

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2447,23 +2447,6 @@ numbertype_class_getitem_abc(PyObject *cls, PyObject *args)
     return Py_GenericAlias(cls, args);
 }
 
-
-static PyObject *
-booleantype_class_getitem_abc(PyObject *cls, PyObject *args)
-{
-    const Py_ssize_t args_len = PyTuple_Check(args) ? PyTuple_Size(args) : 1;
-    int args_len_expected = 1;
-
-    if ((args_len > args_len_expected) || (args_len == 0)) {
-        return PyErr_Format(PyExc_TypeError,
-                            "Too %s arguments for %s",
-                            args_len > args_len_expected ? "many" : "few",
-                            ((PyTypeObject *)cls)->tp_name);
-    }
-    return Py_GenericAlias(cls, args);
-}
-
-
 /*
  * Use for concrete np.number subclasses, making them act as if they
  * were subtyped from e.g. np.signedinteger[object], thus lacking any
@@ -2870,15 +2853,11 @@ static PyMethodDef numbertype_methods[] = {
     {NULL, NULL, 0, NULL}  /* sentinel */
 };
 
-
 static PyMethodDef booleantype_methods[] = {
-    /* for typing */
-    {"__class_getitem__",
-        (PyCFunction)booleantype_class_getitem_abc,
-        METH_CLASS | METH_O, NULL},
-    {NULL, NULL, 0, NULL}  /* sentinel */
+        /* for typing */
+        {"__class_getitem__", Py_GenericAlias, METH_CLASS | METH_O, NULL},
+        {NULL, NULL, 0, NULL} /* sentinel */
 };
-
 
 /**begin repeat
  * #name = cfloat,clongdouble#

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2447,6 +2447,23 @@ numbertype_class_getitem_abc(PyObject *cls, PyObject *args)
     return Py_GenericAlias(cls, args);
 }
 
+
+static PyObject *
+booleantype_class_getitem_abc(PyObject *cls, PyObject *args)
+{
+    const Py_ssize_t args_len = PyTuple_Check(args) ? PyTuple_Size(args) : 1;
+    int args_len_expected = 1;
+
+    if ((args_len > args_len_expected) || (args_len == 0)) {
+        return PyErr_Format(PyExc_TypeError,
+                            "Too %s arguments for %s",
+                            args_len > args_len_expected ? "many" : "few",
+                            ((PyTypeObject *)cls)->tp_name);
+    }
+    return Py_GenericAlias(cls, args);
+}
+
+
 /*
  * Use for concrete np.number subclasses, making them act as if they
  * were subtyped from e.g. np.signedinteger[object], thus lacking any
@@ -2852,6 +2869,16 @@ static PyMethodDef numbertype_methods[] = {
         METH_CLASS | METH_O, NULL},
     {NULL, NULL, 0, NULL}  /* sentinel */
 };
+
+
+static PyMethodDef booleantype_methods[] = {
+    /* for typing */
+    {"__class_getitem__",
+        (PyCFunction)booleantype_class_getitem_abc,
+        METH_CLASS | METH_O, NULL},
+    {NULL, NULL, 0, NULL}  /* sentinel */
+};
+
 
 /**begin repeat
  * #name = cfloat,clongdouble#
@@ -4571,6 +4598,7 @@ initialize_numeric_types(void)
 
     PyBoolArrType_Type.tp_str = genbool_type_str;
     PyBoolArrType_Type.tp_repr = genbool_type_repr;
+    PyBoolArrType_Type.tp_methods = booleantype_methods;
 
 
     /**begin repeat

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -171,8 +171,12 @@ class TestClassGetItem:
     @pytest.mark.parametrize("code", np.typecodes["All"])
     def test_concrete(self, code: str) -> None:
         cls = np.dtype(code).type
-        with pytest.raises(TypeError):
-            cls[Any]
+        if cls == np.bool:
+            # np.bool allows subscript
+            assert cls[Any]
+        else:
+            with pytest.raises(TypeError):
+                cls[Any]
 
     @pytest.mark.parametrize("arg_len", range(4))
     def test_subscript_tuple(self, arg_len: int) -> None:

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -4,7 +4,7 @@ Test the scalar constructors, which also do type-coercion
 import fractions
 import platform
 import types
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -189,6 +189,10 @@ class TestClassGetItem:
 
     def test_subscript_scalar(self) -> None:
         assert np.number[Any]
+
+    @pytest.mark.parametrize("subscript", [Literal[True], Literal[False]])
+    def test_subscript_bool(self, subscript: Literal[True, False]) -> None:
+        assert isinstance(np.bool[subscript], types.GenericAlias)
 
 
 class TestBitCount:


### PR DESCRIPTION
Fixes #29247

This PR adds support for subscript access to `np.bool` by implementing a `__class_getitem__` method.

## Implementation Details

- Implements `booleantype_class_getitem_abc`, following the pattern used for other scalar types.
- Adds `__class_getitem__` to the `np.bool` type.

@ngoldbaum 

I created new PR.
Would you mind reviewing this when you get a chance? Thank you!
