### PR TITLE
MNT: add linter for thread-unsafe C API uses

### DIFF
--- a/numpy/_core/include/numpy/npy_3kcompat.h
+++ b/numpy/_core/include/numpy/npy_3kcompat.h
@@ -242,7 +242,7 @@ static inline PyObject*
 npy_PyFile_OpenFile(PyObject *filename, const char *mode)
 {
     PyObject *open;
-    open = PyDict_GetItemString(PyEval_GetBuiltins(), "open");
+    open = PyDict_GetItemString(PyEval_GetBuiltins(), "open"); // noqa: borrowed-ref OK
     if (open == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/common/npy_cpu_dispatch.c
+++ b/numpy/_core/src/common/npy_cpu_dispatch.c
@@ -33,7 +33,7 @@ NPY_VISIBILITY_HIDDEN void
 npy_cpu_dispatch_trace(const char *fname, const char *signature,
                        const char **dispatch_info)
 {
-    PyObject *func_dict = PyDict_GetItemString(npy_static_pydata.cpu_dispatch_registry, fname);
+    PyObject *func_dict = PyDict_GetItemString(npy_static_pydata.cpu_dispatch_registry, fname); // noqa: borrowed-ref OK
     if (func_dict == NULL) {
         func_dict = PyDict_New();
         if (func_dict == NULL) {

--- a/numpy/_core/src/common/ufunc_override.c
+++ b/numpy/_core/src/common/ufunc_override.c
@@ -108,7 +108,7 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
          * PySequence_Fast* functions. This is required for PyPy
          */
         PyObject *seq;
-        seq = PySequence_Fast(*out_kwd_obj,
+        seq = PySequence_Fast(*out_kwd_obj, // noqa: borrowed-ref OK
                               "Could not convert object to sequence");
         if (seq == NULL) {
             Py_CLEAR(*out_kwd_obj);

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -644,7 +644,7 @@ incref_elide_l(PyObject *dummy, PyObject *args)
     }
     /* get item without increasing refcount, item may still be on the python
      * stack but above the inaccessible top */
-    r = PyList_GetItem(arg, 4);
+    r = PyList_GetItem(arg, 4); // noqa: borrowed-ref OK
     res = PyNumber_Add(r, r);
 
     return res;
@@ -863,7 +863,7 @@ get_all_cast_information(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args))
     if (classes == NULL) {
         goto fail;
     }
-    Py_SETREF(classes, PySequence_Fast(classes, NULL));
+    Py_SETREF(classes, PySequence_Fast(classes, NULL)); // noqa: borrowed-ref OK
     if (classes == NULL) {
         goto fail;
     }
@@ -883,7 +883,7 @@ get_all_cast_information(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args))
         PyObject *to_dtype, *cast_obj;
         Py_ssize_t pos = 0;
 
-        while (PyDict_Next(NPY_DT_SLOTS(from_dtype)->castingimpls,
+        while (PyDict_Next(NPY_DT_SLOTS(from_dtype)->castingimpls, // noqa: borrowed-ref OK
                            &pos, &to_dtype, &cast_obj)) {
             if (cast_obj == Py_None) {
                 continue;
@@ -965,7 +965,7 @@ identityhash_tester(PyObject *NPY_UNUSED(mod),
     }
 
     /* Replace the sequence with a guaranteed fast-sequence */
-    sequence = PySequence_Fast(sequence, "converting sequence.");
+    sequence = PySequence_Fast(sequence, "converting sequence."); // noqa: borrowed-ref OK
     if (sequence == NULL) {
         goto finish;
     }

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1148,7 +1148,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
   force_sequence_due_to_char_dtype:
 
     /* Ensure we have a sequence (required for PyPy) */
-    seq = PySequence_Fast(obj, "Could not convert object to sequence");
+    seq = PySequence_Fast(obj, "Could not convert object to sequence"); // noqa: borrowed-ref - manual fix needed
     if (seq == NULL) {
         /*
          * Specifically do not fail on things that look like a dictionary,

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -371,7 +371,7 @@ array__get_implementing_args(
         return NULL;
     }
 
-    relevant_args = PySequence_Fast(
+    relevant_args = PySequence_Fast( // noqa: borrowed-ref OK
         relevant_args,
         "dispatcher for __array_function__ did not return an iterable");
     if (relevant_args == NULL) {
@@ -518,7 +518,7 @@ dispatcher_vectorcall(PyArray_ArrayFunctionDispatcherObject *self,
             fix_name_if_typeerror(self);
             return NULL;
         }
-        Py_SETREF(relevant_args, PySequence_Fast(relevant_args,
+        Py_SETREF(relevant_args, PySequence_Fast(relevant_args, // noqa: borrowed-ref OK
                 "dispatcher for __array_function__ did not return an iterable"));
         if (relevant_args == NULL) {
             return NULL;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -881,7 +881,7 @@ VOID_getitem(void *input, void *vap)
             npy_intp offset;
             PyArray_Descr *new;
             key = PyTuple_GET_ITEM(names, i);
-            tup = PyDict_GetItem(descr->fields, key);
+            tup = PyDict_GetItem(descr->fields, key); // noqa: borrowed-ref OK
             if (_unpack_field(tup, &new, &offset) < 0) {
                 Py_DECREF(ret);
                 return NULL;
@@ -973,7 +973,7 @@ _setup_field(int i, _PyArray_LegacyDescr *descr, PyArrayObject *arr,
     npy_intp offset;
 
     key = PyTuple_GET_ITEM(descr->names, i);
-    tup = PyDict_GetItem(descr->fields, key);
+    tup = PyDict_GetItem(descr->fields, key); // noqa: borrowed-ref OK
     if (_unpack_field(tup, &new, &offset) < 0) {
         return -1;
     }
@@ -2274,7 +2274,7 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
         PyArrayObject_fields dummy_fields = get_dummy_stack_array(arr);
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
 
-        while (PyDict_Next(descr->fields, &pos, &key, &value)) {
+        while (PyDict_Next(descr->fields, &pos, &key, &value)) { // noqa: borrowed-ref OK
             npy_intp offset;
             PyArray_Descr *new;
             if (NPY_TITLE_KEY(key, value)) {
@@ -2359,7 +2359,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
         PyArrayObject_fields dummy_fields = get_dummy_stack_array(arr);
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
 
-        while (PyDict_Next(descr->fields, &pos, &key, &value)) {
+        while (PyDict_Next(descr->fields, &pos, &key, &value)) { // noqa: borrowed-ref OK
             npy_intp offset;
 
             PyArray_Descr * new;
@@ -2679,7 +2679,7 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
 
         _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)PyArray_DESCR(ap);
-        while (PyDict_Next(descr->fields, &pos, &key, &value)) {
+        while (PyDict_Next(descr->fields, &pos, &key, &value)) { // noqa: borrowed-ref OK
             PyArray_Descr * new;
             npy_intp offset;
             if (NPY_TITLE_KEY(key, value)) {
@@ -3041,7 +3041,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         PyArray_Descr *new;
         npy_intp offset;
         key = PyTuple_GET_ITEM(names, i);
-        tup = PyDict_GetItem(PyDataType_FIELDS(descr), key);
+        tup = PyDict_GetItem(PyDataType_FIELDS(descr), key); // noqa: borrowed-ref OK
         if (_unpack_field(tup, &new, &offset) < 0) {
             goto finish;
         }

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -268,7 +268,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             int ret;
 
             name = PyTuple_GET_ITEM(ldescr->names, k);
-            item = PyDict_GetItem(ldescr->fields, name);
+            item = PyDict_GetItem(ldescr->fields, name); // noqa: borrowed-ref OK
 
             child = (PyArray_Descr*)PyTuple_GetItem(item, 0);
             offset_obj = PyTuple_GetItem(item, 1);

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -1522,7 +1522,7 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
         PyTypeObject *new = (PyTypeObject *)obj;
         _ADDDOC(new->tp_doc, new->tp_name);
         if (new->tp_dict != NULL && PyDict_CheckExact(new->tp_dict) &&
-                PyDict_GetItemString(new->tp_dict, "__doc__") == Py_None) {
+                PyDict_GetItemString(new->tp_dict, "__doc__") == Py_None) { // noqa: borrowed-ref - manual fix needed
             /* Warning: Modifying `tp_dict` is not generally safe! */
             if (PyDict_SetItemString(new->tp_dict, "__doc__", str) < 0) {
                 return NULL;

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -130,7 +130,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
      * dimension_from_scalar as soon as possible.
      */
     if (!PyLong_CheckExact(obj) && PySequence_Check(obj)) {
-        seq_obj = PySequence_Fast(obj,
+        seq_obj = PySequence_Fast(obj, // noqa: borrowed-ref - manual fix needed
                "expected a sequence of integers or a single integer.");
         if (seq_obj == NULL) {
             /* continue attempting to parse as a single integer. */
@@ -1135,7 +1135,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
 {
     PyObject *seq_obj = NULL;
     if (!PyLong_CheckExact(seq) && PySequence_Check(seq)) {
-        seq_obj = PySequence_Fast(seq,
+        seq_obj = PySequence_Fast(seq, // noqa: borrowed-ref - manual fix needed
             "expected a sequence of integers or a single integer");
         if (seq_obj == NULL) {
             /* continue attempting to parse as a single integer. */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -344,7 +344,7 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
             PyObject *cobj;
 
             key = PyLong_FromLong(type_num);
-            cobj = PyDict_GetItem(obj, key);
+            cobj = PyDict_GetItem(obj, key); // noqa: borrowed-ref OK
             Py_DECREF(key);
             if (cobj && PyCapsule_CheckExact(cobj)) {
                 castfunc = PyCapsule_GetPointer(cobj, NULL);
@@ -2749,7 +2749,7 @@ nonstructured_to_structured_resolve_descriptors(
 
             Py_ssize_t pos = 0;
             PyObject *key, *tuple;
-            while (PyDict_Next(to_descr->fields, &pos, &key, &tuple)) {
+            while (PyDict_Next(to_descr->fields, &pos, &key, &tuple)) { // noqa: borrowed-ref OK
                 PyArray_Descr *field_descr = (PyArray_Descr *)PyTuple_GET_ITEM(tuple, 0);
                 npy_intp field_view_off = NPY_MIN_INTP;
                 NPY_CASTING field_casting = PyArray_GetCastInfo(
@@ -2898,7 +2898,7 @@ structured_to_nonstructured_resolve_descriptors(
             return -1;
         }
         PyObject *key = PyTuple_GetItem(PyDataType_NAMES(given_descrs[0]), 0);
-        PyObject *base_tup = PyDict_GetItem(PyDataType_FIELDS(given_descrs[0]), key);
+        PyObject *base_tup = PyDict_GetItem(PyDataType_FIELDS(given_descrs[0]), key); // noqa: borrowed-ref OK
         base_descr = (PyArray_Descr *)PyTuple_GET_ITEM(base_tup, 0);
         struct_view_offset = PyLong_AsSsize_t(PyTuple_GET_ITEM(base_tup, 1));
         if (error_converting(struct_view_offset)) {
@@ -3033,7 +3033,7 @@ can_cast_fields_safety(
     for (Py_ssize_t i = 0; i < field_count; i++) {
         npy_intp field_view_off = NPY_MIN_INTP;
         PyObject *from_key = PyTuple_GET_ITEM(PyDataType_NAMES(from), i);
-        PyObject *from_tup = PyDict_GetItemWithError(PyDataType_FIELDS(from), from_key);
+        PyObject *from_tup = PyDict_GetItemWithError(PyDataType_FIELDS(from), from_key); // noqa: borrowed-ref OK
         if (from_tup == NULL) {
             return give_bad_field_error(from_key);
         }
@@ -3041,7 +3041,7 @@ can_cast_fields_safety(
 
         /* Check whether the field names match */
         PyObject *to_key = PyTuple_GET_ITEM(PyDataType_NAMES(to), i);
-        PyObject *to_tup = PyDict_GetItem(PyDataType_FIELDS(to), to_key);
+        PyObject *to_tup = PyDict_GetItem(PyDataType_FIELDS(to), to_key); // noqa: borrowed-ref OK
         if (to_tup == NULL) {
             return give_bad_field_error(from_key);
         }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2114,7 +2114,7 @@ _is_default_descr(PyObject *descr, PyObject *typestr) {
     if (!PyList_Check(descr) || PyList_GET_SIZE(descr) != 1) {
         return 0;
     }
-    PyObject *tuple = PyList_GET_ITEM(descr, 0);
+    PyObject *tuple = PyList_GET_ITEM(descr, 0); // noqa: borrowed-ref - manual fix needed
     if (!(PyTuple_Check(tuple) && PyTuple_GET_SIZE(tuple) == 2)) {
         return 0;
     }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -424,7 +424,7 @@ _convert_from_array_descr(PyObject *obj, int align)
         return NULL;
     }
     for (int i = 0; i < n; i++) {
-        PyObject *item = PyList_GET_ITEM(obj, i);
+        PyObject *item = PyList_GET_ITEM(obj, i); // noqa: borrowed-ref - manual fix needed
         if (!PyTuple_Check(item) || (PyTuple_GET_SIZE(item) < 2)) {
             PyErr_Format(PyExc_TypeError,
 			 "Field elements must be 2- or 3-tuples, got '%R'",
@@ -507,10 +507,10 @@ _convert_from_array_descr(PyObject *obj, int align)
                          "StringDType is not currently supported for structured dtype fields.");
             goto fail;
         }
-        if ((PyDict_GetItemWithError(fields, name) != NULL)
+        if ((PyDict_GetItemWithError(fields, name) != NULL) // noqa: borrowed-ref OK
              || (title
                  && PyUnicode_Check(title)
-                 && (PyDict_GetItemWithError(fields, title) != NULL))) {
+                 && (PyDict_GetItemWithError(fields, title) != NULL))) { // noqa: borrowed-ref OK
             PyErr_Format(PyExc_ValueError,
                     "field %R occurs more than once", name);
             Py_DECREF(conv);
@@ -548,7 +548,7 @@ _convert_from_array_descr(PyObject *obj, int align)
                 goto fail;
             }
             if (PyUnicode_Check(title)) {
-                PyObject *existing = PyDict_GetItemWithError(fields, title);
+                PyObject *existing = PyDict_GetItemWithError(fields, title); // noqa: borrowed-ref OK
                 if (existing == NULL && PyErr_Occurred()) {
                     goto fail;
                 }
@@ -613,7 +613,7 @@ _convert_from_list(PyObject *obj, int align)
      * Ignore any empty string at end which _internal._commastring
      * can produce
      */
-    PyObject *last_item = PyList_GET_ITEM(obj, n-1);
+    PyObject *last_item = PyList_GET_ITEM(obj, n-1); // noqa: borrowed-ref OK
     if (PyUnicode_Check(last_item)) {
         Py_ssize_t s = PySequence_Size(last_item);
         if (s < 0) {
@@ -643,7 +643,7 @@ _convert_from_list(PyObject *obj, int align)
     int totalsize = 0;
     for (int i = 0; i < n; i++) {
         PyArray_Descr *conv = _convert_from_any(
-                PyList_GET_ITEM(obj, i), align);
+                PyList_GET_ITEM(obj, i), align); // noqa: borrowed-ref OK
         if (conv == NULL) {
             goto fail;
         }
@@ -794,7 +794,7 @@ _validate_union_object_dtype(_PyArray_LegacyDescr *new, _PyArray_LegacyDescr *co
     if (name == NULL) {
         return -1;
     }
-    tup = PyDict_GetItemWithError(conv->fields, name);
+    tup = PyDict_GetItemWithError(conv->fields, name); // noqa: borrowed-ref OK
     if (tup == NULL) {
         if (!PyErr_Occurred()) {
             /* fields was missing the name it claimed to contain */
@@ -940,7 +940,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
         if (key == NULL) {
             return -1;
         }
-        tup = PyDict_GetItemWithError(fields, key);
+        tup = PyDict_GetItemWithError(fields, key); // noqa: borrowed-ref OK
         if (tup == NULL) {
             if (!PyErr_Occurred()) {
                 /* fields was missing the name it claimed to contain */
@@ -960,7 +960,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
                     if (key == NULL) {
                         return -1;
                     }
-                    tup = PyDict_GetItemWithError(fields, key);
+                    tup = PyDict_GetItemWithError(fields, key); // noqa: borrowed-ref OK
                     if (tup == NULL) {
                         if (!PyErr_Occurred()) {
                             /* fields was missing the name it claimed to contain */
@@ -1213,7 +1213,7 @@ _convert_from_dict(PyObject *obj, int align)
         }
 
         /* Insert into dictionary */
-        if (PyDict_GetItemWithError(fields, name) != NULL) {
+        if (PyDict_GetItemWithError(fields, name) != NULL) { // noqa: borrowed-ref OK
             PyErr_SetString(PyExc_ValueError,
                     "name already used as a name or title");
             Py_DECREF(tup);
@@ -1232,7 +1232,7 @@ _convert_from_dict(PyObject *obj, int align)
         }
         if (len == 3) {
             if (PyUnicode_Check(title)) {
-                if (PyDict_GetItemWithError(fields, title) != NULL) {
+                if (PyDict_GetItemWithError(fields, title) != NULL) { // noqa: borrowed-ref OK
                     PyErr_SetString(PyExc_ValueError,
                             "title already used as a name or title.");
                     Py_DECREF(tup);
@@ -1895,7 +1895,7 @@ _convert_from_str(PyObject *obj, int align)
         if (typeDict == NULL) {
             goto fail;
         }
-        PyObject *item = PyDict_GetItemWithError(typeDict, obj);
+        PyObject *item = PyDict_GetItemWithError(typeDict, obj); // noqa: borrowed-ref - manual fix needed
         if (item == NULL) {
             if (PyErr_Occurred()) {
                 return NULL;
@@ -2276,7 +2276,7 @@ _arraydescr_isnative(PyArray_Descr *self)
         PyArray_Descr *new;
         int offset;
         Py_ssize_t pos = 0;
-        while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) {
+        while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
@@ -2422,7 +2422,7 @@ arraydescr_names_set(
         int ret;
         key = PyTuple_GET_ITEM(self->names, i);
         /* Borrowed references to item and new_key */
-        item = PyDict_GetItemWithError(self->fields, key);
+        item = PyDict_GetItemWithError(self->fields, key); // noqa: borrowed-ref OK
         if (item == NULL) {
             if (!PyErr_Occurred()) {
                 /* fields was missing the name it claimed to contain */
@@ -2848,7 +2848,7 @@ _descr_find_object(PyArray_Descr *self)
         int offset;
         Py_ssize_t pos = 0;
 
-        while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) {
+        while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
@@ -2964,7 +2964,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         if (fields != Py_None) {
             PyObject *key, *list;
             key = PyLong_FromLong(-1);
-            list = PyDict_GetItemWithError(fields, key);
+            list = PyDict_GetItemWithError(fields, key); // noqa: borrowed-ref OK
             if (!list) {
                 if (!PyErr_Occurred()) {
                     /* fields was missing the name it claimed to contain */
@@ -3140,7 +3140,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
 
             for (i = 0; i < PyTuple_GET_SIZE(names); ++i) {
                 name = PyTuple_GET_ITEM(names, i);
-                field = PyDict_GetItemWithError(fields, name);
+                field = PyDict_GetItemWithError(fields, name); // noqa: borrowed-ref OK
                 if (!field) {
                     if (!PyErr_Occurred()) {
                         /* fields was missing the name it claimed to contain */
@@ -3344,7 +3344,7 @@ PyArray_DescrNewByteorder(PyArray_Descr *oself, char newendian)
             return NULL;
         }
         /* make new dictionary with replaced PyArray_Descr Objects */
-        while (PyDict_Next(self->fields, &pos, &key, &value)) {
+        while (PyDict_Next(self->fields, &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
@@ -3470,7 +3470,7 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype)
         if (key == NULL) {
             return 0;
         }
-        tup = PyDict_GetItem(fields, key);
+        tup = PyDict_GetItem(fields, key); // noqa: borrowed-ref OK
         if (tup == NULL) {
             return 0;
         }
@@ -3635,7 +3635,7 @@ _check_has_fields(PyArray_Descr *self)
 static PyObject *
 _subscript_by_name(_PyArray_LegacyDescr *self, PyObject *op)
 {
-    PyObject *obj = PyDict_GetItemWithError(self->fields, op);
+    PyObject *obj = PyDict_GetItemWithError(self->fields, op); // noqa: borrowed-ref OK
     if (obj == NULL) {
         if (!PyErr_Occurred()) {
             PyErr_Format(PyExc_KeyError,
@@ -3672,7 +3672,7 @@ _is_list_of_strings(PyObject *obj)
     }
     seqlen = PyList_GET_SIZE(obj);
     for (i = 0; i < seqlen; i++) {
-        PyObject *item = PyList_GET_ITEM(obj, i);
+        PyObject *item = PyList_GET_ITEM(obj, i); // noqa: borrowed-ref - manual fix needed
         if (!PyUnicode_Check(item)) {
             return NPY_FALSE;
         }
@@ -3716,7 +3716,7 @@ arraydescr_field_subset_view(_PyArray_LegacyDescr *self, PyObject *ind)
          */
         PyTuple_SET_ITEM(names, i, name);
 
-        tup = PyDict_GetItemWithError(self->fields, name);
+        tup = PyDict_GetItemWithError(self->fields, name); // noqa: borrowed-ref OK
         if (tup == NULL) {
             if (!PyErr_Occurred()) {
                 PyErr_SetObject(PyExc_KeyError, name);

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -2319,7 +2319,7 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
         *out_flags = PyArrayMethod_MINIMAL_FLAGS;
         for (i = 0; i < field_count; ++i) {
             key = PyTuple_GET_ITEM(PyDataType_NAMES(dst_dtype), i);
-            tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key);
+            tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key); // noqa: borrowed-ref OK
             if (!PyArg_ParseTuple(tup, "Oi|O", &dst_fld_dtype,
                                                     &dst_offset, &title)) {
                 PyMem_Free(data);
@@ -2383,7 +2383,7 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
         NPY_traverse_info_init(&data->decref_src);
 
         key = PyTuple_GET_ITEM(PyDataType_NAMES(src_dtype), 0);
-        tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key);
+        tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key); // noqa: borrowed-ref OK
         if (!PyArg_ParseTuple(tup, "Oi|O",
                               &src_fld_dtype, &src_offset, &title)) {
             PyMem_Free(data);
@@ -2435,14 +2435,14 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
     /* set up the transfer function for each field */
     for (i = 0; i < field_count; ++i) {
         key = PyTuple_GET_ITEM(PyDataType_NAMES(dst_dtype), i);
-        tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key);
+        tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key); // noqa: borrowed-ref OK
         if (!PyArg_ParseTuple(tup, "Oi|O", &dst_fld_dtype,
                                                 &dst_offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);
             return NPY_FAIL;
         }
         key = PyTuple_GET_ITEM(PyDataType_NAMES(src_dtype), i);
-        tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key);
+        tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key); // noqa: borrowed-ref OK
         if (!PyArg_ParseTuple(tup, "Oi|O", &src_fld_dtype,
                                                 &src_offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);

--- a/numpy/_core/src/multiarray/dtype_traversal.c
+++ b/numpy/_core/src/multiarray/dtype_traversal.c
@@ -346,7 +346,7 @@ get_fields_traverse_function(
         int offset;
 
         key = PyTuple_GET_ITEM(names, i);
-        tup = PyDict_GetItem(dtype->fields, key);
+        tup = PyDict_GetItem(dtype->fields, key); // noqa: borrowed-ref OK
         if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);
             return -1;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -693,7 +693,7 @@ void_ensure_canonical(_PyArray_LegacyDescr *self)
         int maxalign = 1;
         for (Py_ssize_t i = 0; i < field_num; i++) {
             PyObject *name = PyTuple_GET_ITEM(self->names, i);
-            PyObject *tuple = PyDict_GetItem(self->fields, name);
+            PyObject *tuple = PyDict_GetItem(self->fields, name); // noqa: borrowed-ref OK
             PyObject *new_tuple = PyTuple_New(PyTuple_GET_SIZE(tuple));
             PyArray_Descr *field_descr = NPY_DT_CALL_ensure_canonical(
                     (PyArray_Descr *)PyTuple_GET_ITEM(tuple, 0));

--- a/numpy/_core/src/multiarray/hashdescr.c
+++ b/numpy/_core/src/multiarray/hashdescr.c
@@ -127,7 +127,7 @@ static int _array_descr_walk_fields(PyObject *names, PyObject* fields, PyObject*
          * For each field, add the key + descr + offset to l
          */
         key = PyTuple_GET_ITEM(names, pos);
-        value = PyDict_GetItem(fields, key);
+        value = PyDict_GetItem(fields, key); // noqa: borrowed-ref OK
         /* XXX: are those checks necessary ? */
         if (value == NULL) {
             PyErr_SetString(PyExc_SystemError,

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -1489,7 +1489,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
         return NULL;
     }
 
-    fast_seq = PySequence_Fast(args, "");  // needed for pypy
+    fast_seq = PySequence_Fast(args, "");  // needed for pypy // noqa: borrowed-ref - manual fix needed
     if (fast_seq == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/legacy_dtype_implementation.c
+++ b/numpy/_core/src/multiarray/legacy_dtype_implementation.c
@@ -320,8 +320,8 @@ can_cast_fields(PyObject *field1, PyObject *field2, NPY_CASTING casting)
 
     /* Iterate over all the fields and compare for castability */
     ppos = 0;
-    while (PyDict_Next(field1, &ppos, &key, &tuple1)) {
-        if ((tuple2 = PyDict_GetItem(field2, key)) == NULL) {
+    while (PyDict_Next(field1, &ppos, &key, &tuple1)) { // noqa: borrowed-ref OK
+        if ((tuple2 = PyDict_GetItem(field2, key)) == NULL) { // noqa: borrowed-ref OK
             return 0;
         }
         /* Compare the dtype of the field for castability */
@@ -372,7 +372,7 @@ PyArray_LegacyCanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
                 Py_ssize_t ppos = 0;
                 PyObject *tuple;
                 PyArray_Descr *field;
-                PyDict_Next(lfrom->fields, &ppos, NULL, &tuple);
+                PyDict_Next(lfrom->fields, &ppos, NULL, &tuple); // noqa: borrowed-ref OK
                 field = (PyArray_Descr *)PyTuple_GET_ITEM(tuple, 0);
                 /*
                  * For a subarray, we need to get the underlying type;

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1351,7 +1351,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
         npy_intp offset;
 
         /* get the field offset and dtype */
-        tup = PyDict_GetItemWithError(PyDataType_FIELDS(PyArray_DESCR(arr)), ind);
+        tup = PyDict_GetItemWithError(PyDataType_FIELDS(PyArray_DESCR(arr)), ind); // noqa: borrowed-ref OK
         if (tup == NULL && PyErr_Occurred()) {
             return 0;
         }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1005,7 +1005,7 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     if (nin < 0) {
         return -1;
     }
-    fast = PySequence_Fast(args, "Could not convert object to sequence");
+    fast = PySequence_Fast(args, "Could not convert object to sequence"); // noqa: borrowed-ref - manual fix needed
     if (fast == NULL) {
         return -1;
     }
@@ -1033,7 +1033,7 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     }
     Py_DECREF(out_kwd_obj);
     /* check where if it exists */
-    where_obj = PyDict_GetItemWithError(kwds, npy_interned_str.where);
+    where_obj = PyDict_GetItemWithError(kwds, npy_interned_str.where); // noqa: borrowed-ref OK
     if (where_obj == NULL) {
         if (PyErr_Occurred()) {
             return -1;
@@ -1115,7 +1115,7 @@ array_function(PyArrayObject *NPY_UNUSED(self), PyObject *c_args, PyObject *c_kw
         PyErr_SetString(PyExc_TypeError, "kwargs must be a dict.");
         return NULL;
     }
-    types = PySequence_Fast(
+    types = PySequence_Fast( // noqa: borrowed-ref - manual fix needed
         types,
         "types argument to ndarray.__array_function__ must be iterable");
     if (types == NULL) {
@@ -1566,7 +1566,7 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
         PyArray_Descr *new;
         int offset, res;
         Py_ssize_t pos = 0;
-        while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) {
+        while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
@@ -1733,7 +1733,7 @@ _setlist_pkl(PyArrayObject *self, PyObject *list)
         return -1;
     }
     while(iter->index < iter->size) {
-        theobject = PyList_GET_ITEM(list, iter->index);
+        theobject = PyList_GET_ITEM(list, iter->index); // noqa: borrowed-ref OK
         setitem(theobject, iter->dataptr, self);
         PyArray_ITER_NEXT(iter);
     }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2764,7 +2764,7 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
     npy_intp i, size;
     PyObject *item;
 
-    obj = PySequence_Fast(obj, "the subscripts for each operand must "
+    obj = PySequence_Fast(obj, "the subscripts for each operand must " // noqa: borrowed-ref - manual fix needed
                                "be a list or a tuple");
     if (obj == NULL) {
         return -1;

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -588,7 +588,7 @@ npyiter_prepare_ops(PyObject *op_in, PyObject **out_owner, PyObject ***out_objs)
 {
     /* Take ownership of op_in (either a tuple/list or single element): */
     if (PyTuple_Check(op_in) || PyList_Check(op_in)) {
-        PyObject *seq = PySequence_Fast(op_in, "failed accessing item list");
+        PyObject *seq = PySequence_Fast(op_in, "failed accessing item list"); // noqa: borrowed-ref - manual fix needed
         if (op_in == NULL) {
             Py_DECREF(op_in);
             return -1;

--- a/numpy/_core/src/multiarray/refcount.c
+++ b/numpy/_core/src/multiarray/refcount.c
@@ -184,7 +184,7 @@ PyArray_Item_INCREF(char *data, PyArray_Descr *descr)
         int offset;
         Py_ssize_t pos = 0;
 
-        while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) {
+        while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
@@ -246,7 +246,7 @@ PyArray_Item_XDECREF(char *data, PyArray_Descr *descr)
             int offset;
             Py_ssize_t pos = 0;
 
-            while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) {
+            while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) { // noqa: borrowed-ref OK
                 if (NPY_TITLE_KEY(key, value)) {
                     continue;
                 }
@@ -480,7 +480,7 @@ _fill_with_none(char *optr, PyArray_Descr *dtype)
         int offset;
         Py_ssize_t pos = 0;
 
-        while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) {
+        while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }

--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -61,7 +61,7 @@ create_conv_funcs(
     Py_ssize_t pos = 0;
     int error = 0;
     Py_BEGIN_CRITICAL_SECTION(converters);
-    while (PyDict_Next(converters, &pos, &key, &value)) {
+    while (PyDict_Next(converters, &pos, &key, &value)) { // noqa: borrowed-ref OK
         Py_ssize_t column = PyNumber_AsSsize_t(key, PyExc_IndexError);
         if (column == -1 && PyErr_Occurred()) {
             PyErr_Format(PyExc_TypeError,

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -344,7 +344,7 @@ static int _warn_if_cast_exists_already(
     if (to_DType == NULL) {
         return -1;
     }
-    PyObject *cast_impl = PyDict_GetItemWithError(
+    PyObject *cast_impl = PyDict_GetItemWithError( // noqa: borrowed-ref OK
             NPY_DT_SLOTS(NPY_DTYPE(descr))->castingimpls, (PyObject *)to_DType);
     Py_DECREF(to_DType);
     if (cast_impl == NULL) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -1368,7 +1368,7 @@ _parse_axes_arg(PyUFuncObject *ufunc, int op_core_num_dims[], PyObject *axes,
          * Get axes tuple for operand. If not a tuple already, make it one if
          * there is only one axis (its content is checked later).
          */
-        op_axes_tuple = PyList_GET_ITEM(axes, iop);
+        op_axes_tuple = PyList_GET_ITEM(axes, iop); // noqa: borrowed-ref - manual fix needed
         if (PyTuple_Check(op_axes_tuple)) {
             if (PyTuple_Size(op_axes_tuple) != op_ncore) {
                 /* must have been a tuple with too many entries. */
@@ -4944,7 +4944,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
         function, arg_typenums, data);
 
     if (result == 0) {
-        cobj = PyDict_GetItemWithError(ufunc->userloops, key);
+        cobj = PyDict_GetItemWithError(ufunc->userloops, key); // noqa: borrowed-ref OK
         if (cobj == NULL && PyErr_Occurred()) {
             result = -1;
         }
@@ -5075,7 +5075,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
      */
     int add_new_loop = 1;
     for (Py_ssize_t j = 0; j < PyList_GET_SIZE(ufunc->_loops); j++) {
-        PyObject *item = PyList_GET_ITEM(ufunc->_loops, j);
+        PyObject *item = PyList_GET_ITEM(ufunc->_loops, j); // noqa: borrowed-ref OK
         PyObject *existing_tuple = PyTuple_GET_ITEM(item, 0);
 
         int cmp = PyObject_RichCompareBool(existing_tuple, signature_tuple, Py_EQ);
@@ -5117,7 +5117,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     funcdata->nargs = 0;
 
     /* Get entry for this user-defined type*/
-    cobj = PyDict_GetItemWithError(ufunc->userloops, key);
+    cobj = PyDict_GetItemWithError(ufunc->userloops, key); // noqa: borrowed-ref OK
     if (cobj == NULL && PyErr_Occurred()) {
         goto fail;
     }

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -1455,7 +1455,7 @@ find_userloop(PyUFuncObject *ufunc,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItemWithError(ufunc->userloops, key);
+            obj = PyDict_GetItemWithError(ufunc->userloops, key); // noqa: borrowed-ref - manual fix needed
             Py_DECREF(key);
             if (obj == NULL && PyErr_Occurred()){
                 return -1;
@@ -1742,7 +1742,7 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItemWithError(self->userloops, key);
+            obj = PyDict_GetItemWithError(self->userloops, key); // noqa: borrowed-ref - manual fix needed
             Py_DECREF(key);
             if (obj == NULL && PyErr_Occurred()){
                 return -1;
@@ -1813,7 +1813,7 @@ type_tuple_userloop_type_resolver(PyUFuncObject *self,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItemWithError(self->userloops, key);
+            obj = PyDict_GetItemWithError(self->userloops, key); // noqa: borrowed-ref - manual fix needed
             Py_DECREF(key);
             if (obj == NULL && PyErr_Occurred()){
                 return -1;

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -267,11 +267,11 @@ int initumath(PyObject *m)
     PyModule_AddObject(m, "NZERO", PyFloat_FromDouble(NPY_NZERO));
     PyModule_AddObject(m, "NAN", PyFloat_FromDouble(NPY_NAN));
 
-    s = PyDict_GetItemString(d, "divide");
+    s = PyDict_GetItemString(d, "divide"); // noqa: borrowed-ref OK
     PyDict_SetItemString(d, "true_divide", s);
 
-    s = PyDict_GetItemString(d, "conjugate");
-    s2 = PyDict_GetItemString(d, "remainder");
+    s = PyDict_GetItemString(d, "conjugate"); // noqa: borrowed-ref OK
+    s2 = PyDict_GetItemString(d, "remainder"); // noqa: borrowed-ref OK
 
     /* Setup the array object's numerical structures with appropriate
        ufuncs in d*/

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -47,7 +47,7 @@ F2PySwapThreadLocalCallbackPtr(char *key, void *ptr)
                 "failed");
     }
 
-    value = PyDict_GetItemString(local_dict, key);
+    value = PyDict_GetItemString(local_dict, key); // noqa: borrowed-ref OK
     if (value != NULL) {
         prev = PyLong_AsVoidPtr(value);
         if (PyErr_Occurred()) {
@@ -87,7 +87,7 @@ F2PyGetThreadLocalCallbackPtr(char *key)
                 "F2PyGetThreadLocalCallbackPtr: PyThreadState_GetDict failed");
     }
 
-    value = PyDict_GetItemString(local_dict, key);
+    value = PyDict_GetItemString(local_dict, key); // noqa: borrowed-ref OK
     if (value != NULL) {
         prev = PyLong_AsVoidPtr(value);
         if (PyErr_Occurred()) {
@@ -365,7 +365,7 @@ fortran_getattr(PyFortranObject *fp, char *name)
     if (fp->dict != NULL) {
         // python 3.13 added PyDict_GetItemRef
 #if PY_VERSION_HEX < 0x030D0000
-        PyObject *v = _PyDict_GetItemStringWithError(fp->dict, name);
+        PyObject *v = _PyDict_GetItemStringWithError(fp->dict, name); // noqa: borrowed-ref OK
         if (v == NULL && PyErr_Occurred()) {
             return NULL;
         }
@@ -822,7 +822,7 @@ get_elsize(PyObject *obj) {
   } else if (PyUnicode_Check(obj)) {
     return PyUnicode_GET_LENGTH(obj);
   } else if (PySequence_Check(obj)) {
-    PyObject* fast = PySequence_Fast(obj, "f2py:fortranobject.c:get_elsize");
+    PyObject* fast = PySequence_Fast(obj, "f2py:fortranobject.c:get_elsize"); // noqa: borrowed-ref OK
     if (fast != NULL) {
       Py_ssize_t i, n = PySequence_Fast_GET_SIZE(fast);
       int sz, elsize = 0;

--- a/tools/ci/check_c_api_usage.sh
+++ b/tools/ci/check_c_api_usage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -e
+
+# List of suspicious function calls:
+SUSPICIOUS_FUNCS=(
+    "PyList_GetItem"
+    "PyDict_GetItem"
+    "PyDict_GetItemWithError"
+    "PyDict_GetItemString"
+    "PyDict_SetDefault"
+    "PyDict_Next"
+    "PyWeakref_GetObject"
+    "PyWeakref_GET_OBJECT"
+    "PyList_GET_ITEM"
+    "_PyDict_GetItemStringWithError"
+    "PySequence_Fast"
+)
+
+# Find all C/C++ source files in the repo
+ALL_FILES=$(find numpy -type f \( -name "*.c" -o -name "*.h" -o -name "*.c.src" -o -name "*.cpp" \) ! -path "*/pythoncapi-compat/*")
+
+# For debugging: print out file count
+echo "Scanning $(echo "$ALL_FILES" | wc -l) C/C++ source files..."
+
+# Prepare a result file
+mkdir -p .tmp
+OUTPUT=$(mktemp .tmp/c_api_usage_report.XXXXXX.txt)
+echo -e "Running Suspicious C API usage report workflow...\n" > $OUTPUT
+
+FAIL=0
+
+# Scan each changed file
+for file in $ALL_FILES; do
+    
+    for func in "${SUSPICIOUS_FUNCS[@]}"; do
+        # -n     : show line number
+        # -P     : perl-style boundaries
+        # (?<!\w): check - no letter/number/underscore before
+        # (?!\w) : check - no letter/number/underscore after
+        matches=$(grep -n -P "(?<!\w)$func(?!\w)" "$file" || true)
+
+        # Check each match for 'noqa' and comment filtering
+        if [[ -n "$matches" ]]; then
+            while IFS= read -r line; do
+
+                line_number=$(cut -d: -f1 <<< "$line")
+                code_line=$(cut -d: -f2- <<< "$line")
+
+                # Skip if line contains noqa
+                if [[ "$code_line" == *"noqa: borrowed-ref OK"* || "$code_line" == *"noqa: borrowed-ref - manual fix needed"* ]]; then
+                    continue
+                fi
+
+                # Skip if line is fully commented with //
+                if [[ "$code_line" =~ ^[[:space:]]*// ]]; then
+                    continue
+                fi
+
+                # Skip if match is inside a block comment
+                # Check previous lines up to this one for an opening /* without closing */
+                in_block_comment=0
+                while IFS= read -r prev_line && [[ $((--line_number)) -gt 0 ]]; do
+                    [[ "$prev_line" =~ /\* ]] && in_block_comment=1
+                    [[ "$prev_line" =~ \*/ ]] && in_block_comment=0
+                done < "$file"
+
+                if [[ "$in_block_comment" -eq 1 ]]; then
+                    continue
+                fi
+
+                
+                echo "Found suspcious call to $func in file: $file" >> "$OUTPUT"
+                echo " -> $line" >> "$OUTPUT"
+                echo "Recommendation:" >> "$OUTPUT"
+                echo "If this use is intentional and safe, add '// noqa: borrowed-ref OK' on the same line to silence this warning." >> "$OUTPUT"
+                echo "Otherwise, consider replacing $func with a thread-safe API function." >> "$OUTPUT"
+                echo "" >> "$OUTPUT"
+                FAIL=1
+            done <<< "$matches"
+        fi
+    done
+done
+
+if [[ $FAIL -eq 1 ]]; then
+    echo "C API borrow-ref linter found issues."
+else
+    echo "C API borrow-ref linter found no issues." > $OUTPUT
+fi
+
+cat "$OUTPUT"
+exit "$FAIL"

--- a/tools/linter.py
+++ b/tools/linter.py
@@ -32,20 +32,19 @@ class DiffLinter:
         return res.returncode, res.stdout
 
     def run_lint(self, fix: bool) -> None:
-        rc = 0
 
         # Ruff Linter
         retcode, ruff_errors = self.run_ruff(fix)
         ruff_errors and print(ruff_errors)
 
-        rc |= retcode
+        if retcode:
+            sys.exit(retcode)
 
         # C API Borrowed-ref Linter
         retcode, c_API_errors = self.run_check_c_api()
         c_API_errors and print(c_API_errors)
 
-        rc |= retcode
-        sys.exit(rc)
+        sys.exit(retcode)
 
     def run_check_c_api(self) -> tuple[int, str]:
         # Running borrowed ref checker

--- a/tools/linter.py
+++ b/tools/linter.py
@@ -18,6 +18,7 @@ class DiffLinter:
         Unlike pycodestyle, ruff by itself is not capable of limiting
         its output to the given diff.
         """
+        print("Running Ruff Check...")
         command = ["ruff", "check"]
         if fix:
             command.append("--fix")
@@ -31,11 +32,35 @@ class DiffLinter:
         return res.returncode, res.stdout
 
     def run_lint(self, fix: bool) -> None:
-        retcode, errors = self.run_ruff(fix)
+        rc = 0
 
-        errors and print(errors)
+        # Ruff Linter
+        retcode, ruff_errors = self.run_ruff(fix)
+        ruff_errors and print(ruff_errors)
 
-        sys.exit(retcode)
+        rc |= retcode
+
+        # C API Borrowed-ref Linter
+        retcode, c_API_errors = self.run_check_c_api()
+        c_API_errors and print(c_API_errors)
+
+        rc |= retcode
+        sys.exit(rc)
+
+    def run_check_c_api(self) -> tuple[int, str]:
+        # Running borrowed ref checker
+        print("Running C API borrow-reference linter...")
+        borrowed_ref_script = os.path.join(self.repository_root, "tools", "ci",
+                                           "check_c_api_usage.sh")
+        borrowed_res = subprocess.run(
+            ["bash", borrowed_ref_script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+        )
+
+        # Exit with non-zero if C API Check fails
+        return borrowed_res.returncode, borrowed_res.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a linter to audit PRs. 
This would lint out PRs that use problematic functions such as
- `PyList_GetItem`
- `PyList_GET_ITEM`
- `PyDict_GetItem`
- `PyDict_getItemWithError`
- `PyDict_Next`
- `PyDict_GetItemString`
- `_PyDict_GetItemStringWithError`
- And all the functions listed in this [Borrowed Reference table](https://docs.python.org/3/howto/free-threading-extensions.html#borrowed-references)

Attempts to resolve #26159 

Previous PR #28634 was closed accidentally.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
