### PR TITLE
BUG: Fix np.unique with axis=0 and 1D input not collapsing NaNs with equal_nan=True #29336

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -290,7 +290,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
     """
     ar = np.asanyarray(ar)
-    if axis is None:
+    if axis is None or (axis == 0 and ar.ndim == 1):
         ret = _unique1d(ar, return_index, return_inverse, return_counts,
                         equal_nan=equal_nan, inverse_shape=ar.shape, axis=None,
                         sorted=sorted)

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -253,13 +253,14 @@ def unique(ar, return_index=False, return_inverse=False,
     >>> u = np.unique(a, axis=0, equal_nan=True)
     >>> u
     array([ 0., nan])
-    # Return the unique rows of a 2D array
+
+    Return the unique rows of a 2D array
 
     >>> a = np.array([[1, 0, 0], [1, 0, 0], [2, 3, 4]])
     >>> np.unique(a, axis=0)
     array([[1, 0, 0], [2, 3, 4]])
 
-    # Return the indices of the original array that give the unique values:
+    Return the indices of the original array that give the unique values:
 
     >>> a = np.array(['a', 'b', 'b', 'c', 'a'])
     >>> u, indices = np.unique(a, return_index=True)

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -290,7 +290,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
     """
     ar = np.asanyarray(ar)
-    if axis is None or (axis == 0 and ar.ndim == 1):
+    if ar.ndim == 1 or axis is None:
         ret = _unique1d(ar, return_index, return_inverse, return_counts,
                         equal_nan=equal_nan, inverse_shape=ar.shape, axis=None,
                         sorted=sorted)
@@ -1259,3 +1259,4 @@ def setdiff1d(ar1, ar2, assume_unique=False):
         ar1 = unique(ar1)
         ar2 = unique(ar2)
     return ar1[_in1d(ar1, ar2, assume_unique=True, invert=True)]
+ 

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -249,10 +249,6 @@ def unique(ar, return_index=False, return_inverse=False,
     >>> a = np.array([[1, 1], [2, 3]])
     >>> np.unique(a)
     array([1, 2, 3])
-    >>> a = np.array([np.nan,0,0,np.nan])
-    >>> u = np.unique(a, axis=0, equal_nan=True)
-    >>> u
-    array([ 0., nan])
 
     Return the unique rows of a 2D array
 

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -290,7 +290,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
     """
     ar = np.asanyarray(ar)
-    if ar.ndim == 1 or axis is None:
+    if axis is None or (axis == 0 and ar.ndim == 1):
         ret = _unique1d(ar, return_index, return_inverse, return_counts,
                         equal_nan=equal_nan, inverse_shape=ar.shape, axis=None,
                         sorted=sorted)
@@ -1259,4 +1259,3 @@ def setdiff1d(ar1, ar2, assume_unique=False):
         ar1 = unique(ar1)
         ar2 = unique(ar2)
     return ar1[_in1d(ar1, ar2, assume_unique=True, invert=True)]
- 

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -253,13 +253,13 @@ def unique(ar, return_index=False, return_inverse=False,
     >>> u = np.unique(a, axis=0, equal_nan=True)
     >>> u
     array([ 0., nan])
-    Return the unique rows of a 2D array
+    # Return the unique rows of a 2D array
 
     >>> a = np.array([[1, 0, 0], [1, 0, 0], [2, 3, 4]])
     >>> np.unique(a, axis=0)
     array([[1, 0, 0], [2, 3, 4]])
 
-    Return the indices of the original array that give the unique values:
+    # Return the indices of the original array that give the unique values:
 
     >>> a = np.array(['a', 'b', 'b', 'c', 'a'])
     >>> u, indices = np.unique(a, return_index=True)

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -21,6 +21,7 @@ from typing import NamedTuple
 import numpy as np
 from numpy._core import overrides
 from numpy._core._multiarray_umath import _array_converter, _unique_hash
+from numpy.lib.array_utils import normalize_axis_index
 
 array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
@@ -248,7 +249,10 @@ def unique(ar, return_index=False, return_inverse=False,
     >>> a = np.array([[1, 1], [2, 3]])
     >>> np.unique(a)
     array([1, 2, 3])
-
+    >>> a = np.array([np.nan,0,0,np.nan])
+    >>> u = np.unique(a, axis=0, equal_nan=True)
+    >>> u
+    array([ 0., nan])
     Return the unique rows of a 2D array
 
     >>> a = np.array([[1, 0, 0], [1, 0, 0], [2, 3, 4]])
@@ -290,7 +294,9 @@ def unique(ar, return_index=False, return_inverse=False,
 
     """
     ar = np.asanyarray(ar)
-    if axis is None or (axis == 0 and ar.ndim == 1):
+    if axis is None or ar.ndim == 1:
+        if axis is not None:
+            normalize_axis_index(axis, ar.ndim)
         ret = _unique1d(ar, return_index, return_inverse, return_counts,
                         equal_nan=equal_nan, inverse_shape=ar.shape, axis=None,
                         sorted=sorted)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1256,9 +1256,10 @@ class TestUnique:
         u = np.unique(mat)
         expected = np.unique(np.asarray(mat))
         assert_array_equal(u, expected, strict=True)
-        
-    def test_unique_axis0_equal_nan_on_1d_array():
+
+    def test_unique_axis0_equal_nan_on_1d_array(self):
+        # Test Issue #29336
         arr1d = np.array([np.nan, 0, 0, np.nan])
         expected = np.array([0., np.nan])
         result = np.unique(arr1d, axis=0, equal_nan=True)
-        np.testing.assert_array_equal(result, expected)
+        assert_array_equal(result, expected)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1263,3 +1263,14 @@ class TestUnique:
         expected = np.array([0., np.nan])
         result = np.unique(arr1d, axis=0, equal_nan=True)
         assert_array_equal(result, expected)
+
+    def test_unique_axis_minus1_eq_on_1d_array(self):
+        arr1d = np.array([np.nan, 0, 0, np.nan])
+        expected = np.array([0., np.nan])
+        result = np.unique(arr1d, axis=-1, equal_nan=True)
+        assert_array_equal(result, expected)
+
+    def test_unique_axis_float_raises_typeerror(self):
+        arr1d = np.array([np.nan, 0, 0, np.nan])
+        with pytest.raises(TypeError, match="integer argument expected"):
+            np.unique(arr1d, axis=0.0, equal_nan=False)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1256,3 +1256,9 @@ class TestUnique:
         u = np.unique(mat)
         expected = np.unique(np.asarray(mat))
         assert_array_equal(u, expected, strict=True)
+        
+    def test_unique_axis0_equal_nan_on_1d_array():
+        arr1d = np.array([np.nan, 0, 0, np.nan])
+        expected = np.array([0., np.nan])
+        result = np.unique(arr1d, axis=0, equal_nan=True)
+        np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
**What was the Issue**

Issue link :- https://github.com/numpy/numpy/issues/29336
Bug Description:- The equal_nan parameter in numpy.unique does not work correctly in some cases. Specifically:
       For 1D arrays, np.nan values are not treated as equal even when equal_nan=True.
       For 2D arrays with axis=0, the issue is similar — np.nan values are not treated as equal.

**What This PR Fixes**

This pull request fixes the issue for **1D arrays only.** 
Fixed: np.unique(..., equal_nan=True) now treats NaNs as equal in 1D arrays.

 **Notes**
 
This PR does not address the 2D case (e.g., np.unique(array, axis=0, equal_nan=True)) described in the same issue.In coming days i will investigate and provide fix for this case as well 