### PR TITLE
DEV: remove "packages" from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,23 +43,6 @@ GTAGS
 *.so
 *.mod
 
-# Packages #
-############
-# it's better to unpack these files and commit the raw source
-# git has its own built in compression methods
-*.7z
-*.bz2
-*.bzip2
-*.dmg
-*.gz
-*.iso
-*.jar
-*.rar
-*.tar
-*.tbz2
-*.tgz
-*.zip
-
 # Python files #
 ################
 # meson build/installation directories


### PR DESCRIPTION
not necessary now (and can interfere with niche build circumstances https://github.com/prefix-dev/pixi-build-backends/issues/243)

cc @rgommers