### PR TITLE
TYP: Fix overloads in ``np.char.array`` and ``np.char.asarray`` for ``unicode`` argument

### DIFF
--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -1044,14 +1044,15 @@ def startswith(
 def str_len(A: UST_co) -> NDArray[int_]: ...
 
 # Overload 1 and 2: str- or bytes-based array-likes
-# overload 3: arbitrary object with unicode=False  (-> bytes_)
-# overload 4: arbitrary object with unicode=True  (-> str_)
+# overload 3 and 4: arbitrary object with unicode=False  (-> bytes_)
+# overload 5 and 6: arbitrary object with unicode=True  (-> str_)
+# overload 7: arbitrary object with unicode=None (default)  (-> str_ | bytes_)
 @overload
 def array(
     obj: U_co,
     itemsize: int | None = ...,
     copy: bool = ...,
-    unicode: L[False] = ...,
+    unicode: L[True] | None = ...,
     order: _OrderKACF = ...,
 ) -> _CharArray[str_]: ...
 @overload
@@ -1059,7 +1060,15 @@ def array(
     obj: S_co,
     itemsize: int | None = ...,
     copy: bool = ...,
-    unicode: L[False] = ...,
+    unicode: L[False] | None = ...,
+    order: _OrderKACF = ...,
+) -> _CharArray[bytes_]: ...
+@overload
+def array(
+    obj: object,
+    itemsize: int | None,
+    copy: bool,
+    unicode: L[False],
     order: _OrderKACF = ...,
 ) -> _CharArray[bytes_]: ...
 @overload
@@ -1067,43 +1076,84 @@ def array(
     obj: object,
     itemsize: int | None = ...,
     copy: bool = ...,
-    unicode: L[False] = ...,
+    *,
+    unicode: L[False],
     order: _OrderKACF = ...,
 ) -> _CharArray[bytes_]: ...
 @overload
 def array(
     obj: object,
-    itemsize: int | None = ...,
-    copy: bool = ...,
-    unicode: L[True] = ...,
+    itemsize: int | None,
+    copy: bool,
+    unicode: L[True],
     order: _OrderKACF = ...,
 ) -> _CharArray[str_]: ...
+@overload
+def array(
+    obj: object,
+    itemsize: int | None = ...,
+    copy: bool = ...,
+    *,
+    unicode: L[True],
+    order: _OrderKACF = ...,
+) -> _CharArray[str_]: ...
+@overload
+def array(
+    obj: object,
+    itemsize: int | None = ...,
+    copy: bool = ...,
+    unicode: bool | None = ...,
+    order: _OrderKACF = ...,
+) -> _CharArray[str_] | _CharArray[bytes_]: ...
 
 @overload
 def asarray(
     obj: U_co,
     itemsize: int | None = ...,
-    unicode: L[False] = ...,
+    unicode: L[True] | None = ...,
     order: _OrderKACF = ...,
 ) -> _CharArray[str_]: ...
 @overload
 def asarray(
     obj: S_co,
     itemsize: int | None = ...,
-    unicode: L[False] = ...,
+    unicode: L[False] | None = ...,
+    order: _OrderKACF = ...,
+) -> _CharArray[bytes_]: ...
+@overload
+def asarray(
+    obj: object,
+    itemsize: int | None,
+    unicode: L[False],
     order: _OrderKACF = ...,
 ) -> _CharArray[bytes_]: ...
 @overload
 def asarray(
     obj: object,
     itemsize: int | None = ...,
-    unicode: L[False] = ...,
+    *,
+    unicode: L[False],
     order: _OrderKACF = ...,
 ) -> _CharArray[bytes_]: ...
 @overload
 def asarray(
     obj: object,
-    itemsize: int | None = ...,
-    unicode: L[True] = ...,
+    itemsize: int | None,
+    unicode: L[True],
     order: _OrderKACF = ...,
 ) -> _CharArray[str_]: ...
+@overload
+def asarray(
+    obj: object,
+    itemsize: int | None = ...,
+    *,
+    unicode: L[True],
+    order: _OrderKACF = ...,
+) -> _CharArray[str_]: ...
+@overload
+def asarray(
+    obj: object,
+    itemsize: int | None = ...,
+    unicode: bool | None = ...,
+    order: _OrderKACF = ...,
+) -> _CharArray[str_] | _CharArray[bytes_]: ...

--- a/numpy/typing/tests/data/reveal/char.pyi
+++ b/numpy/typing/tests/data/reveal/char.pyi
@@ -209,6 +209,9 @@ assert_type(np.char.array("bob", copy=True), np.char.chararray[np_t._AnyShape, n
 assert_type(np.char.array(b"bob", itemsize=5), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
 assert_type(np.char.array(1, unicode=False), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
 assert_type(np.char.array(1, unicode=True), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]])
+assert_type(np.char.array(1), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]] | np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
+assert_type(np.char.array(AR_U, unicode=False), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
+assert_type(np.char.array(AR_S, unicode=True), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]])
 
 assert_type(np.char.asarray(AR_U), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]])
 assert_type(np.char.asarray(AR_S, order="K"), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
@@ -216,3 +219,6 @@ assert_type(np.char.asarray("bob"), np.char.chararray[np_t._AnyShape, np.dtype[n
 assert_type(np.char.asarray(b"bob", itemsize=5), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
 assert_type(np.char.asarray(1, unicode=False), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
 assert_type(np.char.asarray(1, unicode=True), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]])
+assert_type(np.char.asarray(1), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]] | np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
+assert_type(np.char.asarray(AR_U, unicode=False), np.char.chararray[np_t._AnyShape, np.dtype[np.bytes_]])
+assert_type(np.char.asarray(AR_S, unicode=True), np.char.chararray[np_t._AnyShape, np.dtype[np.str_]])


### PR DESCRIPTION


closes #29376

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
