### PR TITLE
BUG: Fix repeatability issues in test suite

### DIFF
--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -448,6 +448,13 @@ class TestDeprecatedSaveFixImports(_DeprecationTestCase):
 class TestAddNewdocUFunc(_DeprecationTestCase):
     # Deprecated in Numpy 2.2, 2024-11
     def test_deprecated(self):
+        doc = struct_ufunc.add_triplet.__doc__
+        # gh-26718
+        # This test mutates the C-level docstring pointer for add_triplet,
+        # which is permanent once set. Skip when re-running tests.
+        if doc is not None and "new docs" in doc:
+            pytest.skip("Cannot retest deprecation, otherwise ValueError: "
+                "Cannot change docstring of ufunc with non-NULL docstring")
         self.assert_deprecated(
             lambda: np._core.umath._add_newdoc_ufunc(
                 struct_ufunc.add_triplet, "new docs"

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -378,6 +378,8 @@ def callcrackfortran(files, options):
             mod['gil_used'] = 'Py_MOD_GIL_USED'
         else:
             mod['gil_used'] = 'Py_MOD_GIL_NOT_USED'
+    # gh-26718 Reset global
+    crackfortran.f77modulename = ''
     return postlist
 
 

--- a/numpy/f2py/tests/test_docs.py
+++ b/numpy/f2py/tests/test_docs.py
@@ -60,5 +60,7 @@ class TestDocAdvanced(util.F2PyTest):
         ftype.data.x[1] = 45
         assert_array_equal(ftype.data.x,
                            np.array([1, 45, 3], dtype=np.float32))
+        # gh-26718 Cleanup for repeated test runs
+        ftype.data.a = 0
 
     # TODO: implement test methods for other example Fortran codes

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1276,12 +1276,16 @@ class TestLoadTxt(LoadTxtBase):
             (1, ["ignored\n", "1,2\n", "\n", "3,4\n"]),
             # "Bad" lines that do not end in newlines:
             (1, ["ignored", "1,2", "", "3,4"]),
-            (1, StringIO("ignored\n1,2\n\n3,4")),
+            (1, lambda: StringIO("ignored\n1,2\n\n3,4")),
             # Same as above, but do not skip any lines:
             (0, ["-1,0\n", "1,2\n", "\n", "3,4\n"]),
             (0, ["-1,0", "1,2", "", "3,4"]),
-            (0, StringIO("-1,0\n1,2\n\n3,4"))])
+            (0, lambda: StringIO("-1,0\n1,2\n\n3,4"))])
     def test_max_rows_empty_lines(self, skip, data):
+        # gh-26718 re-instantiate StringIO objects each time
+        if callable(data):
+            data = data()
+
         with pytest.warns(UserWarning,
                     match=f"Input line 3.*max_rows={3 - skip}"):
             res = np.loadtxt(data, dtype=int, skiprows=skip, delimiter=",",


### PR DESCRIPTION
Resolves test failures caused by persistent global state when running numpy.test() twice in the same Python session.

- core/tests: Skip TestAddNewdocUfunc on repeated runs. This avoids C-level mutation errors.
- f2py/tests: Reset f77modulename at end of callcrackfortran. This change alters the code base.
- lib/tests: Wrap StringIO parameters in lambdas.
- f2py/tests/test_docs: Reset ftype.data.a at end of test_ftype.

These changes ensure that the full test suite can be run multiple times in the same interpreter without failure. Closes #26718.

The change to `f2py/tests` cause a change in the behavior of `callcrackfortran`.  I'd like feedback. I believe the change here solves the root problem of the failing tests. An alternative is to just patch over the issue in the test suite alone using `setup_module()` + `reset_global_f2py_vars()`.

A more detailed description of each change is located at https://github.com/numpy/numpy/issues/26718#issuecomment-3073085466.  

@ngoldbaum , this should finish up the issue from the sprints at SciPy.