### PR TITLE
BLD: Add sw_64 support

### DIFF
--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -20,6 +20,7 @@
  *              NPY_CPU_RISCV64
  *              NPY_CPU_RISCV32
  *              NPY_CPU_LOONGARCH
+ *              NPY_CPU_SW_64
  *              NPY_CPU_WASM
  */
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_CPU_H_
@@ -111,6 +112,8 @@
     #endif
 #elif defined(__loongarch_lp64)
     #define NPY_CPU_LOONGARCH64
+#elif defined(__sw_64__)
+    #define NPY_CPU_SW_64
 #elif defined(__EMSCRIPTEN__) || defined(__wasm__)
     /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */
     /* __wasm__ is defined by clang when targeting wasm */

--- a/numpy/_core/include/numpy/npy_endian.h
+++ b/numpy/_core/include/numpy/npy_endian.h
@@ -51,6 +51,7 @@
             || defined(NPY_CPU_RISCV64)       \
             || defined(NPY_CPU_RISCV32)       \
             || defined(NPY_CPU_LOONGARCH)     \
+            || defined(NPY_CPU_SW_64)     \
             || defined(NPY_CPU_WASM)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
 


### PR DESCRIPTION
In this commit, support for a new architecture sw_64 is added to numpy. sw_64 is a new RISC ISA, which is a bit like RISC-V or loongarch. Though it is a rather new ISA, it has been added to openEuler and openanolis port since  2020. So supporting this new architecture is meaningful.
It's PR is to solve compilation failure on sw_64 architecture.

Xinuos has assigned EM_SW64 is 268, I hope numpy can accept this patch. Thanks.

https://gabi.xinuos.com/elf/a-emachine.html

https://en.wikipedia.org/wiki/Sunway_(processor)
