### PR TITLE
DOC: document `mean` parameter in ``ndarray.std`` and ``ndarray.var`` docstring signatures

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4240,7 +4240,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('squeeze',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('std',
     """
-    a.std(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True)
+    a.std(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True, mean=np._NoValue)
 
     Returns the standard deviation of the array elements along given axis.
 
@@ -4518,7 +4518,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('transpose',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('var',
     """
-    a.var(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True)
+    a.var(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True, mean=np._NoValue)
 
     Returns the variance of the array elements, along given axis.
 


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/29384

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
