### PR TITLE
DOC: better differentiate arrays in dstack docstring

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -653,11 +653,11 @@ def column_stack(tup):
     --------
     >>> import numpy as np
     >>> a = np.array((1,2,3))
-    >>> b = np.array((2,3,4))
+    >>> b = np.array((4,5,6))
     >>> np.column_stack((a,b))
-    array([[1, 2],
-           [2, 3],
-           [3, 4]])
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
 
     """
     arrays = []
@@ -713,18 +713,18 @@ def dstack(tup):
     --------
     >>> import numpy as np
     >>> a = np.array((1,2,3))
-    >>> b = np.array((2,3,4))
+    >>> b = np.array((4,5,6))
     >>> np.dstack((a,b))
-    array([[[1, 2],
-            [2, 3],
-            [3, 4]]])
+    array([[[1, 4],
+            [2, 5],
+            [3, 6]]])
 
     >>> a = np.array([[1],[2],[3]])
-    >>> b = np.array([[2],[3],[4]])
+    >>> b = np.array([[4],[5],[6]])
     >>> np.dstack((a,b))
-    array([[[1, 2]],
-           [[2, 3]],
-           [[3, 4]]])
+    array([[[1, 4]],
+           [[2, 5]],
+           [[3, 6]]])
 
     """
     arrs = atleast_3d(*tup)


### PR DESCRIPTION
Really tiny change - I was getting a bit tripped up in the dstack examples because a was 1,2,3 and b was 2,3,4 so I changed b to 4,5,6 so it's a bit quicker to see how it works. Also updated column stack while I was at it. 