### PR TITLE
BUG: Any dtype should call `square` on `arr ** 2`

### DIFF
--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -363,7 +363,12 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
     }
 
     PyArrayObject *a1 = (PyArrayObject *)o1;
-    if (!(PyArray_ISFLOAT(a1) || PyArray_ISCOMPLEX(a1))) {
+    if (PyArray_ISOBJECT(a1)) {
+        return 1;
+    }
+    if (!is_square && !PyArray_ISFLOAT(a1) && !PyArray_ISCOMPLEX(a1)) {
+        // we special-case squaring for any array type
+        // gh-29388
         return 1;
     }
 

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -332,6 +332,8 @@ static int
 fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 {
     PyObject *fastop = NULL;
+    int is_square = 0;
+
     if (PyLong_CheckExact(o2)) {
         int overflow = 0;
         long exp = PyLong_AsLongAndOverflow(o2, &overflow);
@@ -344,6 +346,7 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
         }
         else if (exp == 2) {
             fastop = n_ops.square;
+            is_square = 1;
         }
         else {
             return 1;

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -332,7 +332,6 @@ static int
 fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 {
     PyObject *fastop = NULL;
-    int is_square = 0;
 
     if (PyLong_CheckExact(o2)) {
         int overflow = 0;
@@ -346,7 +345,6 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
         }
         else if (exp == 2) {
             fastop = n_ops.square;
-            is_square = 1;
         }
         else {
             return 1;
@@ -369,7 +367,7 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
     if (PyArray_ISOBJECT(a1)) {
         return 1;
     }
-    if (!is_square && !PyArray_ISFLOAT(a1) && !PyArray_ISCOMPLEX(a1)) {
+    if (fastop != n_ops.square && !PyArray_ISFLOAT(a1) && !PyArray_ISCOMPLEX(a1)) {
         // we special-case squaring for any array type
         // gh-29388
         return 1;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4218,7 +4218,7 @@ class TestBinop:
     def test_pow_calls_square_structured_dtype(self):
         # gh-29388
         dt = np.dtype([('a', 'i4'), ('b', 'i4')])
-        a = np.array([(1, 2), (3, 4)], dtype= dt)
+        a = np.array([(1, 2), (3, 4)], dtype=dt)
         with pytest.raises(TypeError, match="ufunc 'square' not supported"):
             a ** 2
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4215,6 +4215,13 @@ class TestBinop:
         assert_equal(obj_arr ** -1, pow_for(-1, obj_arr))
         assert_equal(obj_arr ** 2, pow_for(2, obj_arr))
 
+    def test_pow_calls_square_structured_dtype(self):
+        # gh-29388
+        dt = np.dtype([('a', 'i4'), ('b', 'i4')])
+        a = np.array([(1, 2), (3, 4)], dtype= dt)
+        with pytest.raises(TypeError, match="ufunc 'square' not supported"):
+            a ** 2
+
     def test_pos_array_ufunc_override(self):
         class A(np.ndarray):
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):


### PR DESCRIPTION
Fixes #29388.

The simplification in [gh-27901](https://github.com/numpy/numpy/pull/27901) seems to have removed special casing for squares, not considering the differing behavior of `np.power(x, 2)` and `np.square(x)` on structured dtypes.

There may be more edge cases to consider--I am looking! Also adding a test. Thanks.


