### PR TITLE
ENH: array comparison utils show calculations and indices of max errors

### DIFF
--- a/doc/release/upcoming_changes/29395.improvement.rst
+++ b/doc/release/upcoming_changes/29395.improvement.rst
@@ -1,0 +1,8 @@
+Comparison assertions now show indices and calculations of max errors
+---------------------------------------------------------------------
+Verbose assertion errors raised by `assert_allclose`, `assert_array_equal`,
+`assert_array_almost_equal` and `assert_array_less` now show the calculation
+and the indices of the maximum absolute and relative differences among the
+violations. Assertion errors raised by `assert_array_almost_equal_nulp` and
+`assert_array_max_ulp` (which have no verbose toggle) now show the indices of
+the maximum ULP difference.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -830,6 +830,12 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                 precision=precision)
             raise AssertionError(msg)
 
+    def error2string(error):
+        return (
+            str(error) if getattr(error, 'dtype', object_) == object_
+            else array2string(error)
+        )
+
     try:
         if strict:
             cond = x.shape == y.shape and x.dtype == y.dtype
@@ -948,14 +954,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
 
                     reduced_error = error[invalids]
                     max_abs_error = max(reduced_error)
-                    if getattr(error, 'dtype', object_) == object_:
-                        remarks.append(
-                            'Max absolute difference among violations: '
-                            + str(max_abs_error))
-                    else:
-                        remarks.append(
-                            'Max absolute difference among violations: '
-                            + array2string(max_abs_error))
+                    remarks.append('Max absolute difference among violations: '
+                        + error2string(max_abs_error))
 
                     # note: this definition of relative error matches that one
                     # used by assert_allclose (found in np.isclose)
@@ -972,14 +972,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                         max_rel_error = max(nonzero_invalid_error
                                             / abs(nonzero_invalid_y))
 
-                    if getattr(error, 'dtype', object_) == object_:
-                        remarks.append(
-                            'Max relative difference among violations: '
-                            + str(max_rel_error))
-                    else:
-                        remarks.append(
-                            'Max relative difference among violations: '
-                            + array2string(max_rel_error))
+                    remarks.append('Max relative difference among violations: '
+                        + error2string(max_rel_error))
             err_msg = str(err_msg)
             err_msg += '\n' + '\n'.join(remarks)
             msg = build_err_msg([ox, oy], err_msg,

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1931,11 +1931,10 @@ def nulp_diff(x, y, dtype=None):
     if np.iscomplexobj(x) or np.iscomplexobj(y):
         raise NotImplementedError("_nulp not implemented for complex array")
 
-    x = np.array([x], dtype=t)
-    y = np.array([y], dtype=t)
-
-    x[np.isnan(x)] = np.nan
-    y[np.isnan(y)] = np.nan
+    x = np.array(x, dtype=t)
+    y = np.array(y, dtype=t)
+    np.putmask(x, np.isnan(x), np.nan)
+    np.putmask(y, np.isnan(y), np.nan)
 
     if not x.shape == y.shape:
         raise ValueError(f"Arrays do not have the same shape: {x.shape} - {y.shape}")

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -969,8 +969,10 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                         nonzero_invalid_error = error[nonzero_and_invalid]
                         broadcasted_y = np.broadcast_to(y, error.shape)
                         nonzero_invalid_y = broadcasted_y[nonzero_and_invalid]
-                        max_rel_error = max(nonzero_invalid_error
-                                            / abs(nonzero_invalid_y))
+                        reduced_rel_error = (
+                            nonzero_invalid_error / abs(nonzero_invalid_y)
+                        )
+                        max_rel_error = max(reduced_rel_error)
 
                     remarks.append('Max relative difference among violations: '
                         + error2string(max_rel_error))

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -898,18 +898,17 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
 
         if isinstance(val, bool):
             cond = val
-            reduced = array([val])
+            val = array([val])
         else:
-            reduced = val.ravel()
-            cond = reduced.all()
+            cond = val.all()
 
         # The below comparison is a hack to ensure that fully masked
-        # results, for which val.ravel().all() returns np.ma.masked,
+        # results, for which val.all() returns np.ma.masked,
         # do not trigger a failure (np.ma.masked != True evaluates as
         # np.ma.masked, which is falsy).
         if cond != True:
-            n_mismatch = reduced.size - reduced.sum(dtype=intp)
-            n_elements = flagged.size if flagged.ndim != 0 else reduced.size
+            n_mismatch = val.size - val.sum(dtype=intp)
+            n_elements = flagged.size if flagged.ndim != 0 else val.size
             percent_mismatch = 100 * n_mismatch / n_elements
             remarks = [f'Mismatched elements: {n_mismatch} / {n_elements} '
                        f'({percent_mismatch:.3g}%)']

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -952,6 +952,9 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                         error2 = abs(y - x)
                         np.minimum(error, error2, out=error)
 
+                    if invalids is np.True_:
+                        # Avoids unintentionally adding a dimension
+                        invalids = np.ones_like(error, dtype=bool)
                     reduced_error = error[invalids]
                     max_abs_error = max(reduced_error)
                     remarks.append('Max absolute difference among violations: '

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -121,7 +121,9 @@ class TestArrayEqual(_GenericTest):
         y = np.array(0)
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 4.39506535e+12\n'
-                        'Max relative difference among violations: inf\n')
+                        ' |4.39506535e+12 - 0|\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |4.39506535e+12 - 0| / |0|\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -253,14 +255,18 @@ class TestArrayEqual(_GenericTest):
 
         expected_msg = ('Mismatched elements: 1 / 2 (50%)\n'
                         'Max absolute difference among violations: 1.\n'
-                        'Max relative difference among violations: 0.5')
+                        ' |1. - 2.| at index [0]\n'
+                        'Max relative difference among violations: 0.5\n'
+                        ' |1. - 2.| / |2.| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._test_equal(a, b)
 
         c = np.array([0., 2.9]).view(MyArray)
         expected_msg = ('Mismatched elements: 1 / 2 (50%)\n'
                         'Max absolute difference among violations: 2.\n'
-                        'Max relative difference among violations: inf')
+                        ' |2. - 0.| at index [0]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |2. - 0.| / |0.| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._test_equal(b, c)
 
@@ -301,7 +307,9 @@ class TestArrayEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [3]: 563766 (ACTUAL), 0 (DESIRED)\n'
                         'Max absolute difference among violations: 563766\n'
-                        'Max relative difference among violations: inf')
+                        ' |563766 - 0| at index [3]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |563766 - 0| / |0| at index [3]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -311,7 +319,9 @@ class TestArrayEqual(_GenericTest):
                         ' [2]: 439655.2 (ACTUAL), 439655 (DESIRED)\n'
                         ' [3]: 563766.0 (ACTUAL), 0 (DESIRED)\n'
                         'Max absolute difference among violations: 563766.\n'
-                        'Max relative difference among violations: 4.54902139e-07')
+                        ' |563766. - 0| at index [3]\n'
+                        'Max relative difference among violations: 4.54902139e-07\n'
+                        ' |439655.2 - 439655| / |439655| at index [2]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -497,7 +507,9 @@ class TestArrayAlmostEqual(_GenericTest):
         # test scalars
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 1.5\n'
-                        'Max relative difference among violations: inf')
+                        ' |1.5 - 0.|\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |1.5 - 0.| / |0.|\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(1.5, 0.0, decimal=0)
 
@@ -508,7 +520,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [0]: 1.5 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: 1.5\n'
-                        'Max relative difference among violations: inf')
+                        ' |1.5 - 0.| at index [0]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |1.5 - 0.| / |0.| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func([1.5], [0.0], decimal=0)
 
@@ -518,7 +532,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [1]: 3e-05 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: 3.e-05\n'
-                        'Max relative difference among violations: inf')
+                        ' |3.e-05 - 0.| at index [1]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |3.e-05 - 0.| / |0.| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b, decimal=7)
 
@@ -526,7 +542,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [1]: 0.0 (ACTUAL), 3e-05 (DESIRED)\n'
                         'Max absolute difference among violations: 3.e-05\n'
-                        'Max relative difference among violations: 1.')
+                        ' |0. - 3.e-05| at index [1]\n'
+                        'Max relative difference among violations: 1.\n'
+                        ' |0. - 3.e-05| / |3.e-05| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=7)
 
@@ -541,7 +559,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [0]: 1234.2222 (ACTUAL), 1234.2223 (DESIRED)\n'
                         'Max absolute difference among violations: 1.e-04\n'
-                        'Max relative difference among violations: 8.10226812e-08')
+                        ' |1234.2222 - 1234.2223| at index [0]\n'
+                        'Max relative difference among violations: 8.10226812e-08\n'
+                        ' |1234.2222 - 1234.2223| / |1234.2223| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y, decimal=5)
 
@@ -553,7 +573,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         ' [1]: 849.54345 (ACTUAL), 5498.42354 (DESIRED)\n'
                         ' [2]: 0.0 (ACTUAL), 5498.42354 (DESIRED)\n'
                         'Max absolute difference among violations: 5498.42354\n'
-                        'Max relative difference among violations: 1.')
+                        ' |0. - 5498.42354| at index [2]\n'
+                        'Max relative difference among violations: 1.\n'
+                        ' |0. - 5498.42354| / |5498.42354| at index [2]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b, decimal=9)
 
@@ -562,7 +584,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         ' [1]: 5498.42354 (ACTUAL), 849.54345 (DESIRED)\n'
                         ' [2]: 5498.42354 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: 5498.42354\n'
-                        'Max relative difference among violations: 5.47220991')
+                        ' |5498.42354 - 0.| at index [2]\n'
+                        'Max relative difference among violations: 5.47220991\n'
+                        ' |5498.42354 - 849.54345| / |849.54345| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=9)
 
@@ -571,7 +595,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [1]: 5498.42354 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: 5498.42354\n'
-                        'Max relative difference among violations: inf')
+                        ' |5498.42354 - 0.| at index [1]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |5498.42354 - 0.| / |0.| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=7)
 
@@ -580,7 +606,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [0]: 5498.42354 (ACTUAL), 0 (DESIRED)\n'
                         'Max absolute difference among violations: 5498.42354\n'
-                        'Max relative difference among violations: inf')
+                        ' |5498.42354 - 0| at index [0]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |5498.42354 - 0| / |0| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b, decimal=7)
 
@@ -669,7 +697,9 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [1]: 2.0 (ACTUAL), 202.0 (DESIRED)\n'
                         'Max absolute difference among violations: 200.\n'
-                        'Max relative difference among violations: 0.99009901')
+                        ' |2. - 202.| at index [1]\n'
+                        'Max relative difference among violations: 0.99009901\n'
+                        ' |2. - 202.| / |202.| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -763,7 +793,10 @@ class TestAlmostEqual(_GenericTest):
                 ' [1]: 2.00000000002 (ACTUAL), 2.00000000003 (DESIRED)\n'
                 ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
                 'Max absolute difference among violations: 1.e-05\n'
+                ' |3.00003 - 3.00004| at index [2]\n'
                 'Max relative difference among violations: 3.33328889e-06\n'
+                ' |3.00003 - 3.00004| / |3.00004| at index [2]\n'
+                '\n'
                 ' ACTUAL: array([1.00000000001, 2.00000000002, 3.00003      ])\n'
                 ' DESIRED: array([1.00000000002, 2.00000000003, 3.00004      ])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
@@ -776,7 +809,10 @@ class TestAlmostEqual(_GenericTest):
                 'Mismatch at index:\n'
                 ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
                 'Max absolute difference among violations: 1.e-05\n'
+                ' |3.00003 - 3.00004| at index [2]\n'
                 'Max relative difference among violations: 3.33328889e-06\n'
+                ' |3.00003 - 3.00004| / |3.00004| at index [2]\n'
+                '\n'
                 ' ACTUAL: array([1.     , 2.     , 3.00003])\n'
                 ' DESIRED: array([1.     , 2.     , 3.00004])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
@@ -789,7 +825,10 @@ class TestAlmostEqual(_GenericTest):
                 'Mismatch at index:\n'
                 ' [1]: 0.0 (ACTUAL), 1.0 (DESIRED)\n'
                 'Max absolute difference among violations: 1.\n'
+                ' |0. - 1.| at index [1]\n'
                 'Max relative difference among violations: 1.\n'
+                ' |0. - 1.| / |1.| at index [1]\n'
+                '\n'
                 ' ACTUAL: array([inf,  0.])\n'
                 ' DESIRED: array([inf,  1.])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
@@ -803,7 +842,9 @@ class TestAlmostEqual(_GenericTest):
                 ' [0]: 1 (ACTUAL), 0 (DESIRED)\n'
                 ' [1]: 2 (ACTUAL), 0 (DESIRED)\n'
                 'Max absolute difference among violations: 2\n'
-                'Max relative difference among violations: inf')
+                ' |2 - 0| at index [1]\n'
+                'Max relative difference among violations: inf\n'
+                ' |1 - 0| / |0| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -820,7 +861,9 @@ class TestAlmostEqual(_GenericTest):
                 ' [3]: 2 (ACTUAL), 1.0 (DESIRED)\n'
                 ' [4]: 2 (ACTUAL), 1.0 (DESIRED)\n'
                 'Max absolute difference among violations: 1.\n'
-                'Max relative difference among violations: 1.')
+                ' |2 - 1.| at index [0]\n'
+                'Max relative difference among violations: 1.\n'
+                ' |2 - 1.| / |1.| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -834,7 +877,9 @@ class TestAlmostEqual(_GenericTest):
                 ' [3]: 1.0 (ACTUAL), 2 (DESIRED)\n'
                 ' [4]: 1.0 (ACTUAL), 2 (DESIRED)\n'
                 'Max absolute difference among violations: 1.\n'
-                'Max relative difference among violations: 0.5')
+                ' |1. - 2| at index [0]\n'
+                'Max relative difference among violations: 0.5\n'
+                ' |1. - 2| / |2| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -925,7 +970,9 @@ class TestArrayAssertLess:
                         ' [2]: 6 (x), 6 (y)\n'
                         ' [3]: 20 (x), 8 (y)\n'
                         'Max absolute difference among violations: 12\n'
-                        'Max relative difference among violations: 1.5')
+                        ' |20 - 8| at index [3]\n'
+                        'Max relative difference among violations: 1.5\n'
+                        ' |20 - 8| / |8| at index [3]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -941,7 +988,9 @@ class TestArrayAssertLess:
                         ' [1, 0]: 3.4 (x), 3.3 (y)\n'
                         ' [1, 1]: 4.5 (x), 4.4 (y)\n'
                         'Max absolute difference among violations: 0.1\n'
-                        'Max relative difference among violations: 0.09090909')
+                        ' |3.4 - 3.3| at index [1, 0]\n'
+                        'Max relative difference among violations: 0.09090909\n'
+                        ' |1.2 - 1.1| / |1.1| at index [0, 0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -961,7 +1010,9 @@ class TestArrayAssertLess:
                         'Mismatch at index:\n'
                         ' [0, 0, 0]: 1.0 (x), 0.0 (y)\n'
                         'Max absolute difference among violations: 1.\n'
-                        'Max relative difference among violations: inf')
+                        ' |1. - 0.| at index [0, 0, 0]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |1. - 0.| / |0.| at index [0, 0, 0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -974,7 +1025,9 @@ class TestArrayAssertLess:
         self._assert_func(x, y)
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 1.1\n'
-                        'Max relative difference among violations: 1.')
+                        ' |2.2 - 1.1|\n'
+                        'Max relative difference among violations: 1.\n'
+                        ' |2.2 - 1.1| / |1.1|\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1006,7 +1059,9 @@ class TestArrayAssertLess:
                         'Mismatch at index:\n'
                         ' [1, 1]: 999090.54 (x), 999090.54 (y)\n'
                         'Max absolute difference among violations: 0.\n'
-                        'Max relative difference among violations: 0.')
+                        ' |999090.54 - 999090.54| at index [1, 1]\n'
+                        'Max relative difference among violations: 0.\n'
+                        ' |999090.54 - 999090.54| / |999090.54| at index [1, 1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -1018,7 +1073,9 @@ class TestArrayAssertLess:
                         ' [0, 3]: 999090.54 (x), 324525.4535 (y)\n'
                         ' [1, 0]: 999090.54 (x), 5449.54 (y)\n'
                         'Max absolute difference among violations: 999087.0864\n'
-                        'Max relative difference among violations: 289288.59346769')
+                        ' |999090.54 - 3.4536| at index [0, 0]\n'
+                        'Max relative difference among violations: 289288.59346769\n'
+                        ' |999090.54 - 3.4536| / |3.4536| at index [0, 0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1030,7 +1087,9 @@ class TestArrayAssertLess:
                         'Mismatch at index:\n'
                         ' [0]: 546456.0 (x), 87654.0 (y)\n'
                         'Max absolute difference among violations: 458802.\n'
-                        'Max relative difference among violations: 5.23423917')
+                        ' |546456. - 87654.| at index [0]\n'
+                        'Max relative difference among violations: 5.23423917\n'
+                        ' |546456. - 87654.| / |87654.| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -1039,7 +1098,9 @@ class TestArrayAssertLess:
                         ' [1]: 87654.0 (x), 0.0 (y)\n'
                         ' [2]: 87654.0 (x), 15.455 (y)\n'
                         'Max absolute difference among violations: 87654.\n'
-                        'Max relative difference among violations: 5670.5626011')
+                        ' |87654. - 0.| at index [1]\n'
+                        'Max relative difference among violations: 5670.5626011\n'
+                        ' |87654. - 15.455| / |15.455| at index [2]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1051,7 +1112,9 @@ class TestArrayAssertLess:
                         ' [1]: 0.0 (x), 0 (y)\n'
                         ' [2]: 15.455 (x), 0 (y)\n'
                         'Max absolute difference among violations: 546456.\n'
-                        'Max relative difference among violations: inf')
+                        ' |546456. - 0| at index [0]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |546456. - 0| / |0| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -1059,7 +1122,9 @@ class TestArrayAssertLess:
                         'Mismatch at index:\n'
                         ' [1]: 0 (x), 0.0 (y)\n'
                         'Max absolute difference among violations: 0.\n'
-                        'Max relative difference among violations: inf')
+                        ' |0 - 0.| at index [1]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |0 - 0.| / |0.| at index [1]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1210,20 +1275,29 @@ class TestAssertAllclose:
 
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 0.001\n'
-                        'Max relative difference among violations: 999999.')
+                        ' |0.001 - 1.e-09|\n'
+                        'Max relative difference among violations: 999999.\n'
+                        ' |0.001 - 1.e-09| / |1.e-09|\n'
+        )
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(x, y)
 
         z = 0
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 1.e-09\n'
-                        'Max relative difference among violations: inf')
+                        ' |1.e-09 - 0|\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |1.e-09 - 0| / |0|\n'
+        )
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(y, z)
 
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Max absolute difference among violations: 1.e-09\n'
-                        'Max relative difference among violations: 1.')
+                        ' |0 - 1.e-09|\n'
+                        'Max relative difference among violations: 1.\n'
+                        ' |0 - 1.e-09| / |1.e-09|\n'
+        )
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(z, y)
 
@@ -1246,7 +1320,9 @@ class TestAssertAllclose:
                         'Mismatch at index:\n'
                         ' [3]: 0.001 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: 0.001\n'
-                        'Max relative difference among violations: inf')
+                        ' |0.001 - 0.| at index [3]\n'
+                        'Max relative difference among violations: inf\n'
+                        ' |0.001 - 0.| / |0.| at index [3]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(b, c)
 
@@ -1254,7 +1330,9 @@ class TestAssertAllclose:
                         'Mismatch at index:\n'
                         ' [3]: 0.0 (ACTUAL), 0.001 (DESIRED)\n'
                         'Max absolute difference among violations: 0.001\n'
-                        'Max relative difference among violations: 1.')
+                        ' |0. - 0.001| at index [3]\n'
+                        'Max relative difference among violations: 1.\n'
+                        ' |0. - 0.001| / |0.001| at index [3]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(c, b)
 
@@ -1271,7 +1349,9 @@ class TestAssertAllclose:
                         'Mismatch at index:\n'
                         ' [3]: 1 (ACTUAL), 2 (DESIRED)\n'
                         'Max absolute difference among violations: 1\n'
-                        'Max relative difference among violations: 0.5')
+                        ' |1 - 2| at index [3]\n'
+                        'Max relative difference among violations: 0.5\n'
+                        ' |1 - 2| / |2| at index [3]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(a, b)
 
@@ -1329,7 +1409,8 @@ class TestAssertAllclose:
         #        y - x
         x = np.asarray([0, 1, 8], dtype='uint8')
         y = np.asarray([4, 4, 4], dtype='uint8')
-        expected_msg = 'Max absolute difference among violations: 4'
+        expected_msg = ('Max absolute difference among violations: 4\n'
+                        ' |0 - 4| at index [0]\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             assert_allclose(x, y, atol=3)
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -120,8 +120,7 @@ class TestArrayEqual(_GenericTest):
         x = np.array(4395065348745.5643764887869876)
         y = np.array(0)
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
-                        'Max absolute difference among violations: '
-                        '4.39506535e+12\n'
+                        'Max absolute difference among violations: 4.39506535e+12\n'
                         'Max relative difference among violations: inf\n')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
@@ -311,10 +310,8 @@ class TestArrayEqual(_GenericTest):
                         'Mismatch at indices:\n'
                         ' [2]: 439655.2 (ACTUAL), 439655 (DESIRED)\n'
                         ' [3]: 563766.0 (ACTUAL), 0 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '563766.\n'
-                        'Max relative difference among violations: '
-                        '4.54902139e-07')
+                        'Max absolute difference among violations: 563766.\n'
+                        'Max relative difference among violations: 4.54902139e-07')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -350,9 +347,10 @@ class TestBuildErrorMessage:
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg)
-        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array(['
-             '1.00001, 2.00002, 3.00003])\n DESIRED: array([1.00002, '
-             '2.00003, 3.00004])')
+        b = ('\n'
+             'Items are not equal: There is a mismatch\n'
+             ' ACTUAL: array([1.00001, 2.00002, 3.00003])\n'
+             ' DESIRED: array([1.00002, 2.00003, 3.00004])')
         assert_equal(a, b)
 
     def test_build_err_msg_no_verbose(self):
@@ -370,9 +368,10 @@ class TestBuildErrorMessage:
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg, names=('FOO', 'BAR'))
-        b = ('\nItems are not equal: There is a mismatch\n FOO: array(['
-             '1.00001, 2.00002, 3.00003])\n BAR: array([1.00002, 2.00003, '
-             '3.00004])')
+        b = ('\n'
+             'Items are not equal: There is a mismatch\n'
+             ' FOO: array([1.00001, 2.00002, 3.00003])\n'
+             ' BAR: array([1.00002, 2.00003, 3.00004])')
         assert_equal(a, b)
 
     def test_build_err_msg_custom_precision(self):
@@ -381,9 +380,10 @@ class TestBuildErrorMessage:
         err_msg = 'There is a mismatch'
 
         a = build_err_msg([x, y], err_msg, precision=10)
-        b = ('\nItems are not equal: There is a mismatch\n ACTUAL: array(['
-             '1.000000001, 2.00002    , 3.00003    ])\n DESIRED: array(['
-             '1.000000002, 2.00003    , 3.00004    ])')
+        b = ('\n'
+             'Items are not equal: There is a mismatch\n'
+             ' ACTUAL: array([1.000000001, 2.00002    , 3.00003    ])\n'
+             ' DESIRED: array([1.000000002, 2.00003    , 3.00004    ])')
         assert_equal(a, b)
 
 
@@ -540,10 +540,8 @@ class TestArrayAlmostEqual(_GenericTest):
         expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
                         'Mismatch at index:\n'
                         ' [0]: 1234.2222 (ACTUAL), 1234.2223 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '1.e-04\n'
-                        'Max relative difference among violations: '
-                        '8.10226812e-08')
+                        'Max absolute difference among violations: 1.e-04\n'
+                        'Max relative difference among violations: 8.10226812e-08')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y, decimal=5)
 
@@ -554,8 +552,7 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at indices:\n'
                         ' [1]: 849.54345 (ACTUAL), 5498.42354 (DESIRED)\n'
                         ' [2]: 0.0 (ACTUAL), 5498.42354 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '5498.42354\n'
+                        'Max absolute difference among violations: 5498.42354\n'
                         'Max relative difference among violations: 1.')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b, decimal=9)
@@ -564,8 +561,7 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at indices:\n'
                         ' [1]: 5498.42354 (ACTUAL), 849.54345 (DESIRED)\n'
                         ' [2]: 5498.42354 (ACTUAL), 0.0 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '5498.42354\n'
+                        'Max absolute difference among violations: 5498.42354\n'
                         'Max relative difference among violations: 5.47220991')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=9)
@@ -574,8 +570,7 @@ class TestArrayAlmostEqual(_GenericTest):
         expected_msg = ('Mismatched elements: 1 / 2 (50%)\n'
                         'Mismatch at index:\n'
                         ' [1]: 5498.42354 (ACTUAL), 0.0 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '5498.42354\n'
+                        'Max absolute difference among violations: 5498.42354\n'
                         'Max relative difference among violations: inf')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=7)
@@ -584,8 +579,7 @@ class TestArrayAlmostEqual(_GenericTest):
         expected_msg = ('Mismatched elements: 1 / 2 (50%)\n'
                         'Mismatch at index:\n'
                         ' [0]: 5498.42354 (ACTUAL), 0 (DESIRED)\n'
-                        'Max absolute difference among violations: '
-                        '5498.42354\n'
+                        'Max absolute difference among violations: 5498.42354\n'
                         'Max relative difference among violations: inf')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b, decimal=7)
@@ -764,18 +758,14 @@ class TestAlmostEqual(_GenericTest):
 
         # Test with a different amount of decimal digits
         expected_msg = ('Mismatched elements: 3 / 3 (100%)\n'
-                        'Mismatch at indices:\n'
-                        ' [0]: 1.00000000001 (ACTUAL), 1.00000000002 (DESIRED)\n'
-                        ' [1]: 2.00000000002 (ACTUAL), 2.00000000003 (DESIRED)\n'
-                        ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
-                        'Max absolute difference among violations: 1.e-05\n'
-                        'Max relative difference among violations: '
-                        '3.33328889e-06\n'
-                        ' ACTUAL: array([1.00000000001, '
-                        '2.00000000002, '
-                        '3.00003      ])\n'
-                        ' DESIRED: array([1.00000000002, 2.00000000003, '
-                        '3.00004      ])')
+                'Mismatch at indices:\n'
+                ' [0]: 1.00000000001 (ACTUAL), 1.00000000002 (DESIRED)\n'
+                ' [1]: 2.00000000002 (ACTUAL), 2.00000000003 (DESIRED)\n'
+                ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
+                'Max absolute difference among violations: 1.e-05\n'
+                'Max relative difference among violations: 3.33328889e-06\n'
+                ' ACTUAL: array([1.00000000001, 2.00000000002, 3.00003      ])\n'
+                ' DESIRED: array([1.00000000002, 2.00000000003, 3.00004      ])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y, decimal=12)
 
@@ -783,13 +773,12 @@ class TestAlmostEqual(_GenericTest):
         # differs. Note that we only check for the formatting of the arrays
         # themselves.
         expected_msg = ('Mismatched elements: 1 / 3 (33.3%)\n'
-                        'Mismatch at index:\n'
-                        ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
-                        'Max absolute difference among violations: 1.e-05\n'
-                        'Max relative difference among violations: '
-                        '3.33328889e-06\n'
-                        ' ACTUAL: array([1.     , 2.     , 3.00003])\n'
-                        ' DESIRED: array([1.     , 2.     , 3.00004])')
+                'Mismatch at index:\n'
+                ' [2]: 3.00003 (ACTUAL), 3.00004 (DESIRED)\n'
+                'Max absolute difference among violations: 1.e-05\n'
+                'Max relative difference among violations: 3.33328889e-06\n'
+                ' ACTUAL: array([1.     , 2.     , 3.00003])\n'
+                ' DESIRED: array([1.     , 2.     , 3.00004])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -797,12 +786,12 @@ class TestAlmostEqual(_GenericTest):
         x = np.array([np.inf, 0])
         y = np.array([np.inf, 1])
         expected_msg = ('Mismatched elements: 1 / 2 (50%)\n'
-                        'Mismatch at index:\n'
-                        ' [1]: 0.0 (ACTUAL), 1.0 (DESIRED)\n'
-                        'Max absolute difference among violations: 1.\n'
-                        'Max relative difference among violations: 1.\n'
-                        ' ACTUAL: array([inf,  0.])\n'
-                        ' DESIRED: array([inf,  1.])')
+                'Mismatch at index:\n'
+                ' [1]: 0.0 (ACTUAL), 1.0 (DESIRED)\n'
+                'Max absolute difference among violations: 1.\n'
+                'Max relative difference among violations: 1.\n'
+                ' ACTUAL: array([inf,  0.])\n'
+                ' DESIRED: array([inf,  1.])')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -810,11 +799,11 @@ class TestAlmostEqual(_GenericTest):
         x = np.array([1, 2])
         y = np.array([0, 0])
         expected_msg = ('Mismatched elements: 2 / 2 (100%)\n'
-                        'Mismatch at indices:\n'
-                        ' [0]: 1 (ACTUAL), 0 (DESIRED)\n'
-                        ' [1]: 2 (ACTUAL), 0 (DESIRED)\n'
-                        'Max absolute difference among violations: 2\n'
-                        'Max relative difference among violations: inf')
+                'Mismatch at indices:\n'
+                ' [0]: 1 (ACTUAL), 0 (DESIRED)\n'
+                ' [1]: 2 (ACTUAL), 0 (DESIRED)\n'
+                'Max absolute difference among violations: 2\n'
+                'Max relative difference among violations: inf')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -824,28 +813,28 @@ class TestAlmostEqual(_GenericTest):
         x = 2
         y = np.ones(20)
         expected_msg = ('Mismatched elements: 20 / 20 (100%)\n'
-                        'First 5 mismatches are at indices:\n'
-                        ' [0]: 2 (ACTUAL), 1.0 (DESIRED)\n'
-                        ' [1]: 2 (ACTUAL), 1.0 (DESIRED)\n'
-                        ' [2]: 2 (ACTUAL), 1.0 (DESIRED)\n'
-                        ' [3]: 2 (ACTUAL), 1.0 (DESIRED)\n'
-                        ' [4]: 2 (ACTUAL), 1.0 (DESIRED)\n'
-                        'Max absolute difference among violations: 1.\n'
-                        'Max relative difference among violations: 1.')
+                'First 5 mismatches are at indices:\n'
+                ' [0]: 2 (ACTUAL), 1.0 (DESIRED)\n'
+                ' [1]: 2 (ACTUAL), 1.0 (DESIRED)\n'
+                ' [2]: 2 (ACTUAL), 1.0 (DESIRED)\n'
+                ' [3]: 2 (ACTUAL), 1.0 (DESIRED)\n'
+                ' [4]: 2 (ACTUAL), 1.0 (DESIRED)\n'
+                'Max absolute difference among violations: 1.\n'
+                'Max relative difference among violations: 1.')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
         y = 2
         x = np.ones(20)
         expected_msg = ('Mismatched elements: 20 / 20 (100%)\n'
-                        'First 5 mismatches are at indices:\n'
-                        ' [0]: 1.0 (ACTUAL), 2 (DESIRED)\n'
-                        ' [1]: 1.0 (ACTUAL), 2 (DESIRED)\n'
-                        ' [2]: 1.0 (ACTUAL), 2 (DESIRED)\n'
-                        ' [3]: 1.0 (ACTUAL), 2 (DESIRED)\n'
-                        ' [4]: 1.0 (ACTUAL), 2 (DESIRED)\n'
-                        'Max absolute difference among violations: 1.\n'
-                        'Max relative difference among violations: 0.5')
+                'First 5 mismatches are at indices:\n'
+                ' [0]: 1.0 (ACTUAL), 2 (DESIRED)\n'
+                ' [1]: 1.0 (ACTUAL), 2 (DESIRED)\n'
+                ' [2]: 1.0 (ACTUAL), 2 (DESIRED)\n'
+                ' [3]: 1.0 (ACTUAL), 2 (DESIRED)\n'
+                ' [4]: 1.0 (ACTUAL), 2 (DESIRED)\n'
+                'Max absolute difference among violations: 1.\n'
+                'Max relative difference among violations: 0.5')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
 
@@ -1028,10 +1017,8 @@ class TestArrayAssertLess:
                         ' [0, 2]: 999090.54 (x), 435.54657 (y)\n'
                         ' [0, 3]: 999090.54 (x), 324525.4535 (y)\n'
                         ' [1, 0]: 999090.54 (x), 5449.54 (y)\n'
-                        'Max absolute difference among violations: '
-                        '999087.0864\n'
-                        'Max relative difference among violations: '
-                        '289288.59346769')
+                        'Max absolute difference among violations: 999087.0864\n'
+                        'Max relative difference among violations: 289288.59346769')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 
@@ -1052,8 +1039,7 @@ class TestArrayAssertLess:
                         ' [1]: 87654.0 (x), 0.0 (y)\n'
                         ' [2]: 87654.0 (x), 15.455 (y)\n'
                         'Max absolute difference among violations: 87654.\n'
-                        'Max relative difference among violations: '
-                        '5670.5626011')
+                        'Max relative difference among violations: 5670.5626011')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -566,7 +566,7 @@ class TestArrayAlmostEqual(_GenericTest):
                         ' [2]: 5498.42354 (ACTUAL), 0.0 (DESIRED)\n'
                         'Max absolute difference among violations: '
                         '5498.42354\n'
-                        'Max relative difference among violations: 5.4722099')
+                        'Max relative difference among violations: 5.47220991')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(b, a, decimal=9)
 
@@ -675,7 +675,7 @@ class TestArrayAlmostEqual(_GenericTest):
                         'Mismatch at index:\n'
                         ' [1]: 2.0 (ACTUAL), 202.0 (DESIRED)\n'
                         'Max absolute difference among violations: 200.\n'
-                        'Max relative difference among violations: 0.99009')
+                        'Max relative difference among violations: 0.99009901')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(a, b)
 
@@ -1031,7 +1031,7 @@ class TestArrayAssertLess:
                         'Max absolute difference among violations: '
                         '999087.0864\n'
                         'Max relative difference among violations: '
-                        '289288.5934676')
+                        '289288.59346769')
         with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(y, x)
 


### PR DESCRIPTION
Resolves #28827

- Verbose assertion errors raised by `testing.assert_allclose` and `testing.assert_array_XXX` now show the calculation and the indices of the maximum absolute and relative differences among the violations.
- Assertion errors raised by `assert_array_almost_equal_nulp` and `assert_array_max_ulp`, which have no verbose toggle, now show the indices of the maximum ULP difference.

The main complexity adding this feature was that one could not 'simply' replace `max` with `argmax` due to masking: the absolute differences are calculated after masking out infs and nans, and the relative differences are additionally calculated after masking out zero denominators.

---

Notes to reviewer: 
1) Based over #29321 which should be merged first.
2) Best reviewed going over commits one-by-one. Main change is in the last commit, preceding commits lead up to it with minor preparations.

