### PR TITLE
ENH: Show unit information in repr for datetime64("NaT")

### DIFF
--- a/doc/release/upcoming_changes/29396.improvement.rst
+++ b/doc/release/upcoming_changes/29396.improvement.rst
@@ -1,0 +1,5 @@
+Show unit information in ``__repr__`` for ``datetime64("NaT")``
+------------------------------------------------------------------
+When a `datetime64` object is "Not a Time" (NaT), its ``__repr__`` method now
+includes the time unit of the datetime64 type. This makes it consistent with
+the behavior of a `timedelta64` object.

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -939,12 +939,23 @@ datetimetype_repr(PyObject *self)
         if (legacy_print_mode == -1) {
             return NULL;
         }
-        if (legacy_print_mode > 125) {
-            ret = PyUnicode_FromFormat("np.datetime64('%s')", iso);
+
+        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
+        if((scal->obval == NPY_DATETIME_NAT) && (meta != NULL)){
+            if (legacy_print_mode > 125) {
+                ret = PyUnicode_FromFormat("np.datetime64('%s','%S')", iso, meta);
+            } else {
+                ret = PyUnicode_FromFormat("numpy.datetime64('%s','%S')", iso, meta);
+            }
+        } else {
+            if (legacy_print_mode > 125) {
+                ret = PyUnicode_FromFormat("np.datetime64('%s')", iso);
+            }
+            else {
+                ret = PyUnicode_FromFormat("numpy.datetime64('%s')", iso);
+            }
         }
-        else {
-            ret = PyUnicode_FromFormat("numpy.datetime64('%s')", iso);
-        }
+
     }
     else {
         PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -264,10 +264,12 @@ class TestDateTime:
         # Some basic strings and repr
         assert_equal(str(np.datetime64('NaT')), 'NaT')
         assert_equal(repr(np.datetime64('NaT')),
-                     "np.datetime64('NaT')")
+                     "np.datetime64('NaT','generic')")
         assert_equal(str(np.datetime64('2011-02')), '2011-02')
         assert_equal(repr(np.datetime64('2011-02')),
                      "np.datetime64('2011-02')")
+        assert_equal(repr(np.datetime64('NaT').astype(np.dtype("datetime64[ns]"))),
+                     "np.datetime64('NaT','ns')")
 
         # None gets constructed as NaT
         assert_equal(np.datetime64(None), np.datetime64('NaT'))


### PR DESCRIPTION
## Overview

* Fix #28496 

## Details

* Unlike timedelta objects, datetime64 does not display its unit in the repr output (see #28496). 
* To maintain backward compatibility, this change adds unit information only when the datetime64 object has a NaT value.

