### PR TITLE
ENH: Testing utils show max errors for 0-dim numeric object arrays

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -947,6 +947,10 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                         error2 = abs(y - x)
                         np.minimum(error, error2, out=error)
 
+                    if not hasattr(error, "__getitem__"):
+                        # Show max differences in case error is numeric but not
+                        # subscriptable. Occurs with 0-dim numeric object arrays.
+                        error = np.asanyarray(error)
                     reduced_error = error[invalids]
                     max_abs_error = max(reduced_error)
                     if getattr(error, 'dtype', object_) == object_:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -108,11 +108,13 @@ class TestArrayEqual(_GenericTest):
         x = np.array(473963742225900817127911193656584771)
         y = np.array(18535119325151578301457182298393896)
 
-        with pytest.raises(AssertionError) as exc_info:
+        expected_msg = ('Mismatched elements: 1 / 1 (100%)\n'
+                        'Max absolute difference among violations: '
+                        '455428622900749238826454011358190875\n'
+                        'Max relative difference among violations: '
+                        '24.571119015281806\n')
+        with pytest.raises(AssertionError, match=re.escape(expected_msg)):
             self._assert_func(x, y)
-        msg = str(exc_info.value)
-        assert_('Mismatched elements: 1 / 1 (100%)\n'
-                in msg)
 
         y = x
         self._assert_func(x, y)


### PR DESCRIPTION
Ran into this very minor omission while working on #29395

It wasn't visible due to the blanket `TypeError` suppression which was only meant for non-numeric types.
This could also handle other edge-cases in which the error is numeric but non-subscriptable.