### PR TITLE
DOC: Correct more ndarray defaults

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3080,7 +3080,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__setstate__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('all',
     """
-    a.all(axis=None, out=None, keepdims=False, *, where=True)
+    a.all(axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns True if all elements evaluate to True.
 
@@ -3095,7 +3095,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('all',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('any',
     """
-    a.any(axis=None, out=None, keepdims=False, *, where=True)
+    a.any(axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns True if any of the elements of `a` evaluate to True.
 
@@ -3303,7 +3303,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('choose',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('clip',
     """
-    a.clip(min=None, max=None, out=None, **kwargs)
+    a.clip(min=np._NoValue, max=np._NoValue, out=None, **kwargs)
 
     Return an array whose values are limited to ``[min, max]``.
     One of max or min must be given.
@@ -3708,7 +3708,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('item',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('max',
     """
-    a.max(axis=None, out=None, keepdims=False, initial=<no value>, where=True)
+    a.max(axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the maximum along a given axis.
 
@@ -3723,7 +3723,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('max',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('mean',
     """
-    a.mean(axis=None, dtype=None, out=None, keepdims=False, *, where=True)
+    a.mean(axis=None, dtype=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns the average of the array elements along given axis.
 
@@ -3738,7 +3738,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mean',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('min',
     """
-    a.min(axis=None, out=None, keepdims=False, initial=<no value>, where=True)
+    a.min(axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the minimum along a given axis.
 
@@ -3768,8 +3768,8 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nonzero',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('prod',
     """
-    a.prod(axis=None, dtype=None, out=None, keepdims=False,
-        initial=1, where=True)
+    a.prod(axis=None, dtype=None, out=None, keepdims=np._NoValue,
+        initial=np._NoValue, where=np._NoValue)
 
     Return the product of the array elements over the given axis
 
@@ -4240,7 +4240,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('squeeze',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('std',
     """
-    a.std(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True, mean=np._NoValue)
+    a.std(axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *, where=np._NoValue, mean=np._NoValue)
 
     Returns the standard deviation of the array elements along given axis.
 
@@ -4255,7 +4255,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('std',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('sum',
     """
-    a.sum(axis=None, dtype=None, out=None, keepdims=False, initial=0, where=True)
+    a.sum(axis=None, dtype=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the sum of the array elements over the given axis.
 
@@ -4518,7 +4518,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('transpose',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('var',
     """
-    a.var(axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, where=True, mean=np._NoValue)
+    a.var(axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *, where=np._NoValue, mean=np._NoValue)
 
     Returns the variance of the array elements, along given axis.
 


### PR DESCRIPTION
Follow-up to https://github.com/numpy/numpy/pull/29387/files

These are the other methods which have a `np._NoDefault` default, and all the arguments just get forwarded to the corresponding top-level function

all: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2489-L2494

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L2587-L2588

any: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2481-L2486

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L2475-L2476

clip: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2584-L2589

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L2239-L2241

max: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L349-L354

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L3050-L3053

min: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L356-L361

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L3188-L3190

mean: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2384-L2389

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L3738-L3740

prod: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2421-L2426

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L3326-L3328

std: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2496-L2501

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L3872-L3874

sum: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2391-L2396

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L2336-L2338

var: https://github.com/numpy/numpy/blob/b5d6eb4300f782f67dde893dc72f2dca94945b6c/numpy/_core/src/multiarray/methods.c#L2503-L2508

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L4076-L4078

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
