### PR TITLE
MAINT: remove unnecessary `kwargs` update in `MaskedArray.reshape`

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4818,7 +4818,6 @@ class MaskedArray(ndarray):
           fill_value=999999)
 
         """
-        kwargs.update(order=kwargs.get('order', 'C'))
         result = self._data.reshape(*s, **kwargs).view(type(self))
         result._update_from(self)
         mask = self._mask


### PR DESCRIPTION
I was working on the type annotations for `MaskedArray.reshape` and looked into the implementation, and noticed there's an unnecessary update to `kwargs`

The line

https://github.com/numpy/numpy/blob/75e86ba27ae9f99ee67660204d7ca1e16cb323da/numpy/ma/core.py#L4821

sets `'C'` as the default if `order` wasn't passed, else it keeps what the user passed. This then gets passed to `ndarray.reshape` in

https://github.com/numpy/numpy/blob/75e86ba27ae9f99ee67660204d7ca1e16cb323da/numpy/ma/core.py#L4822

and

https://github.com/numpy/numpy/blob/75e86ba27ae9f99ee67660204d7ca1e16cb323da/numpy/ma/core.py#L4826

However, `order='C'` is already the default for `ndarray.reshape`

https://github.com/numpy/numpy/blob/8cf1f7dbf583dd7f55906e799a1108d485f54709/numpy/_core/fromnumeric.py#L209-L210

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
