### PR TITLE
MAINT/BUG: Followups for PySequence_Fast locking

### DIFF
--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -15,45 +15,26 @@
 //
 // These are tweaked versions of macros defined in CPython in
 // pycore_critical_section.h, originally added in CPython commit baf347d91643.
-// They're defined in terms of the NPY_*_CRITICAL_SECTION_NO_BRACKETS to avoid
-// repition and should behave identically to the versions in CPython. Once the
-// macros are expanded, The only difference relative to those versions is the
+// They should behave identically to the versions in CPython. Once the
+// macros are expanded, the only difference relative to those versions is the
 // use of public C API symbols that are equivalent to the ones used in the
 // corresponding CPython definitions.
 #define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)              \
     {                                                                   \
-    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(               \
-            original, npy_cs_fast)
+        PyObject *_orig_seq = (PyObject *)(original);                   \
+        const int _should_lock_cs =                                     \
+                PyList_CheckExact(_orig_seq);                           \
+        PyCriticalSection _cs_fast;                                     \
+        if (_should_lock_cs) {                                          \
+            PyCriticalSection_Begin(&_cs_fast, _orig_seq);              \
+        }
 #define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST()                        \
-        NPY_END_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(npy_cs_fast) \
-    }
-
-// These macros are more flexible than the versions in the public CPython C API,
-// but that comes at a cost. Here are some differences and limitations:
-//
-// * cs_name is a named label for the critical section. If you must nest
-//   critical sections, do *not* use the same name for multiple nesting
-//   critical sections.
-// * The beginning and ending macros must happen within the same scope
-//   and the compiler won't necessarily enforce that.
-// * The macros ending critical sections accept a named label. The label
-//   must match the opening critical section.
-#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(original, cs_name) \
-    PyObject *_##cs_name##_orig_seq = (PyObject *)(original);           \
-    const int _##cs_name##_should_lock_cs =                             \
-            PyList_CheckExact(_##cs_name##_orig_seq);                   \
-    PyCriticalSection _##cs_name;                                       \
-    if (_##cs_name##_should_lock_cs) {                                  \
-        PyCriticalSection_Begin(&_##cs_name, _##cs_name##_orig_seq);    \
-    }
-#define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(cs_name)     \
-    if (_##cs_name##_should_lock_cs) {                                  \
-        PyCriticalSection_End(&_##cs_name);                             \
+        if (_should_lock_cs) {                                          \
+            PyCriticalSection_End(&_cs_fast);                           \
+        }                                                               \
     }
 #else
-#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(original, cs_name)
 #define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) {
-#define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(cs_name)
 #define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST() }
 #endif
 

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -93,10 +93,15 @@ _npy_init_workspace(
  * With some caches, it may be possible to malloc/calloc very quickly in which
  * case we should not hesitate to replace this pattern.
  */
-#define NPY_ALLOC_WORKSPACE(NAME, TYPE, fixed_size, size)  \
+#define NPY_DEFINE_WORKSPACE(NAME, TYPE, fixed_size)        \
     TYPE NAME##_static[fixed_size];                        \
-    TYPE *NAME;                                            \
+    TYPE *NAME;
+#define NPY_INIT_WORKSPACE(NAME, TYPE, fixed_size, size)   \
     _npy_init_workspace((void **)&NAME, NAME##_static, (fixed_size), sizeof(TYPE), (size))
+
+#define NPY_ALLOC_WORKSPACE(NAME, TYPE, fixed_size, size)  \
+    NPY_DEFINE_WORKSPACE(NAME, TYPE, fixed_size)            \
+    NPY_INIT_WORKSPACE(NAME, TYPE, fixed_size, size)
 
 
 static inline void

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -1494,7 +1494,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
     if (fast_seq == NULL) {
         return NULL;
     }
-    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(fast_seq)
+    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args)
     n = PySequence_Fast_GET_SIZE(fast_seq);
     if (n > NPY_MAXARGS) {
         ret = multiiter_wrong_number_of_args();

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2762,20 +2762,20 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
 {
     int ellipsis = 0, subindex = 0, ret = -1;
     npy_intp i, size;
-    PyObject *item;
+    PyObject *item, *seq;
 
-    obj = PySequence_Fast(obj, "the subscripts for each operand must " // noqa: borrowed-ref OK
+    seq = PySequence_Fast(obj, "the subscripts for each operand must " // noqa: borrowed-ref OK
                                "be a list or a tuple");
-    if (obj == NULL) {
+    if (seq == NULL) {
         return -1;
     }
 
     NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(obj);
 
-    size = PySequence_Size(obj);
+    size = PySequence_Size(seq);
 
     for (i = 0; i < size; ++i) {
-        item = PySequence_Fast_GET_ITEM(obj, i);
+        item = PySequence_Fast_GET_ITEM(seq, i);
         /* Ellipsis */
         if (item == Py_Ellipsis) {
             if (ellipsis) {
@@ -2837,10 +2837,9 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
   cleanup:;
 
     NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
-    Py_DECREF(obj);
+    Py_DECREF(seq);
 
     return ret;
-
 }
 
 /*

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -730,7 +730,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     NPY_DEFINE_WORKSPACE(op_axes_storage, int, 8 * NPY_MAXDIMS);
     NPY_DEFINE_WORKSPACE(op_axes, int *, 8);
 
-    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(op_in, nditer_cs);
+    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(op_in);
 
     nop = npyiter_prepare_ops(op_in, &op_in_owned, &op_objs);
     if (nop < 0) {
@@ -767,9 +767,9 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
         goto cleanup;
     }
 
-cleanup:
+cleanup:;
 
-    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(nditer_cs);
+    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
 
     if (pre_alloc_fail) {
         goto pre_alloc_fail;

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -725,6 +725,10 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     int pre_alloc_fail = 0;
     int post_alloc_fail = 0;
     int nop;
+    NPY_DEFINE_WORKSPACE(op, PyArrayObject *, 2 * 8);
+    NPY_DEFINE_WORKSPACE(op_flags, npy_uint32, 8);
+    NPY_DEFINE_WORKSPACE(op_axes_storage, int, 8 * NPY_MAXDIMS);
+    NPY_DEFINE_WORKSPACE(op_axes, int *, 8);
 
     NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST_NO_BRACKETS(op_in, nditer_cs);
 
@@ -735,7 +739,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     }
 
     /* allocate workspace for Python objects (operands and dtypes) */
-    NPY_ALLOC_WORKSPACE(op, PyArrayObject *, 2 * 8, 2 * nop);
+    NPY_INIT_WORKSPACE(op, PyArrayObject *, 2 * 8, 2 * nop);
     if (op == NULL) {
         pre_alloc_fail = 1;
         goto cleanup;
@@ -744,9 +748,9 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
     op_request_dtypes = (PyArray_Descr **)(op + nop);
 
     /* And other workspaces (that do not need to clean up their content) */
-    NPY_ALLOC_WORKSPACE(op_flags, npy_uint32, 8, nop);
-    NPY_ALLOC_WORKSPACE(op_axes_storage, int, 8 * NPY_MAXDIMS, nop * NPY_MAXDIMS);
-    NPY_ALLOC_WORKSPACE(op_axes, int *, 8, nop);
+    NPY_INIT_WORKSPACE(op_flags, npy_uint32, 8, nop);
+    NPY_INIT_WORKSPACE(op_axes_storage, int, 8 * NPY_MAXDIMS, nop * NPY_MAXDIMS);
+    NPY_INIT_WORKSPACE(op_axes, int *, 8, nop);
     /*
      * Trying to allocate should be OK if one failed, check for error now
      * that we can use `goto finish` to clean up everything.


### PR DESCRIPTION
Followup for https://github.com/numpy/numpy/pull/29394.

Removes the `NO_BRACKETS` variants for the critical section macros that I added in #29394. This allows us to diverge from the coding style in CPython a little less.

I initially thought this would be purely a refactor, but I noticed some bugs to fix as well. The `BEGIN_CRITICAL_SECTION_SEQUENCE_FAST` macro accepts the argument *to* `PySequence_Fast`, not the object returned by it. I incorrectly used it on the object returned by `PySequence_Fast` in a few spots in #29394.

Each commit is fairly atomic and explains what it does, so probably best to review commit-by-commit.