### PR TITLE
MAINT: use a stable pypy release in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,7 +82,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: 'pypy3.11-nightly'
+        python-version: 'pypy3.11-v7.3.20'
     - name: Setup using scipy-openblas
       run: |
         python -m pip install -r requirements/ci_requirements.txt


### PR DESCRIPTION
PyPy 7.3.20 was released, try using it instead of the nightly builds to make CI more stable