### PR TITLE
BUG: fix datetime/timedelta hash memory leak

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -3922,7 +3922,6 @@ static npy_hash_t
     meta = &((PyDatetimeScalarObject *)obj)->obmeta;
 
     npy_hash_t res = @lname@_hash(meta, val);
-    Py_DECREF(dtype);
     return res;
 }
 /**end repeat**/

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -3919,8 +3919,7 @@ static npy_hash_t
         return PyBaseObject_Type.tp_hash(obj);
     }
 
-    dtype = PyArray_DescrFromScalar(obj);
-    meta = get_datetime_metadata_from_dtype(dtype);
+    meta = &((PyDatetimeScalarObject *)obj)->obmeta;
 
     npy_hash_t res = @lname@_hash(meta, val);
     Py_DECREF(dtype);

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -3911,7 +3911,6 @@ static npy_hash_t
 @lname@_arrtype_hash(PyObject *obj)
 {
     PyArray_DatetimeMetaData *meta;
-    PyArray_Descr *dtype;
     npy_@lname@ val = PyArrayScalar_VAL(obj, @name@);
 
     if (val == NPY_DATETIME_NAT) {

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -3922,7 +3922,9 @@ static npy_hash_t
     dtype = PyArray_DescrFromScalar(obj);
     meta = get_datetime_metadata_from_dtype(dtype);
 
-    return @lname@_hash(meta, val);
+    npy_hash_t res = @lname@_hash(meta, val);
+    Py_DECREF(dtype);
+    return res;
 }
 /**end repeat**/
 


### PR DESCRIPTION
Fixes lack of a Py_DECREF() call in the datetime/timdelta hash function. Closes #29397.