### PR TITLE
BUG: Allow reading non-npy files in npz and add test 

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -261,7 +261,7 @@ class NpzFile(Mapping):
                         max_header_size=self.max_header_size
                     )
                 else:
-                    return bytes.read(key)
+                    return bytes.read()
 
     def __contains__(self, key):
         return (key in self._files)


### PR DESCRIPTION
Backport of #29313.

Retrieving a from an npz file will first check for a file a, then for a.npy; this checks both.

Fixes #29282

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
