### PR TITLE
BUG: Any dtype should call `square` on `arr ** 2` (#29392)

### DIFF
--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -332,6 +332,7 @@ static int
 fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
 {
     PyObject *fastop = NULL;
+
     if (PyLong_CheckExact(o2)) {
         int overflow = 0;
         long exp = PyLong_AsLongAndOverflow(o2, &overflow);
@@ -363,7 +364,12 @@ fast_scalar_power(PyObject *o1, PyObject *o2, int inplace, PyObject **result)
     }
 
     PyArrayObject *a1 = (PyArrayObject *)o1;
-    if (!(PyArray_ISFLOAT(a1) || PyArray_ISCOMPLEX(a1))) {
+    if (PyArray_ISOBJECT(a1)) {
+        return 1;
+    }
+    if (fastop != n_ops.square && !PyArray_ISFLOAT(a1) && !PyArray_ISCOMPLEX(a1)) {
+        // we special-case squaring for any array type
+        // gh-29388
         return 1;
     }
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4211,6 +4211,13 @@ class TestBinop:
         assert_equal(obj_arr ** -1, pow_for(-1, obj_arr))
         assert_equal(obj_arr ** 2, pow_for(2, obj_arr))
 
+    def test_pow_calls_square_structured_dtype(self):
+        # gh-29388
+        dt = np.dtype([('a', 'i4'), ('b', 'i4')])
+        a = np.array([(1, 2), (3, 4)], dtype=dt)
+        with pytest.raises(TypeError, match="ufunc 'square' not supported"):
+            a ** 2
+
     def test_pos_array_ufunc_override(self):
         class A(np.ndarray):
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):


### PR DESCRIPTION
Backport of #29392.

Fixes #29388.

The simplification in [gh-27901](https://github.com/numpy/numpy/pull/27901) seems to have removed special casing for squares, not considering the differing behavior of `np.power(x, 2)` and `np.square(x)` on structured dtypes.

There may be more edge cases to consider--I am looking! Also adding a test. Thanks.


* BUG: update fast_scalar_power to handle special-case squaring for any array type except object arrays

* BUG: fix missing declaration

* TST: add test to ensure `arr**2` calls square for structured dtypes

* STY: remove whitespace

* BUG: replace new variable `is_square` with direct op comparison in `fast_scalar_power` function

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
