### PR TITLE
BUG: allow `MaskedArray.fill_value` be a string when `dtype=StringDType`

### DIFF
--- a/doc/release/upcoming_changes/29423.new_feature.rst
+++ b/doc/release/upcoming_changes/29423.new_feature.rst
@@ -1,0 +1,7 @@
+``StringDType`` fill_value support in `numpy.ma.MaskedArray`
+------------------------------------------------------------
+Masked arrays now accept and preserve a Python ``str`` as their ``fill_value`` when
+using the variable‑width ``StringDType`` (kind ``'T'``), including through slicing
+and views.  The default is ``'N/A'`` and may be overridden by any valid string.
+This fixes issue `gh‑29421 <https://github.com/numpy/numpy/issues/29421>`__ and was 
+implemented in pull request `gh‑29423 <https://github.com/numpy/numpy/pull/29423>`__.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -181,7 +181,8 @@ default_filler = {'b': True,
                   'S': b'N/A',
                   'u': 999999,
                   'V': b'???',
-                  'U': 'N/A'
+                  'U': 'N/A',
+                  'T': 'N/A'
                   }
 
 # Add datetime64 and timedelta64 types
@@ -264,16 +265,17 @@ def default_fill_value(obj):
     The default filling value depends on the datatype of the input
     array or the type of the input scalar:
 
-       ========  ========
-       datatype  default
-       ========  ========
-       bool      True
-       int       999999
-       float     1.e20
-       complex   1.e20+0j
-       object    '?'
-       string    'N/A'
-       ========  ========
+       ===========  ========
+       datatype      default
+       ===========  ========
+       bool         True
+       int          999999
+       float        1.e20
+       complex      1.e20+0j
+       object       '?'
+       string       'N/A'
+       StringDType  'N/A'
+       ===========  ========
 
     For structured types, a structured scalar is returned, with each field the
     default fill value for its type.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -498,7 +498,7 @@ def _check_fill_value(fill_value, ndtype):
             fill_value = np.asarray(fill_value, dtype=object)
             fill_value = np.array(_recursive_set_fill_value(fill_value, ndtype),
                                   dtype=ndtype)
-    elif isinstance(fill_value, str) and (ndtype.char not in 'OSVU'):
+    elif isinstance(fill_value, str) and (ndtype.char not in 'OSTVU'):
         # Note this check doesn't work if fill_value is not a scalar
         err_msg = "Cannot set fill value of string with array of dtype %s"
         raise TypeError(err_msg % ndtype)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5700,28 +5700,30 @@ def test_default_fill_value_complex():
 def test_string_dtype_fill_value_on_construction():
     # Regression test for gh-29421: allow string fill_value on StringDType masked arrays
     dt = np.dtypes.StringDType()
-    data = np.array(['A', 'test', 'variable', ''], dtype=dt)
+    data = np.array(["A", "test", "variable", ""], dtype=dt)
     mask = [True, False, True, True]
     # Prior to the fix, this would TypeError; now it should succeed
-    arr = np.ma.MaskedArray(data, mask=mask, fill_value='FILL', dtype=dt)
+    arr = np.ma.MaskedArray(data, mask=mask, fill_value="FILL", dtype=dt)
     assert isinstance(arr.fill_value, str)
-    assert arr.fill_value == 'FILL'
+    assert arr.fill_value == "FILL"
     filled = arr.filled()
     # Masked positions should be replaced by 'FILL'
-    assert filled.tolist() == ['FILL', 'test', 'FILL', 'FILL']
+    assert filled.tolist() == ["FILL", "test", "FILL", "FILL"]
 
 
 def test_setting_fill_value_attribute():
     # Regression test for gh-29421: setting .fill_value post-construction works too
     dt = np.dtypes.StringDType()
-    arr = np.ma.MaskedArray(['x', 'longstring', 'mid'], mask=[False, True, False], dtype=dt)
+    arr = np.ma.MaskedArray(
+        ["x", "longstring", "mid"], mask=[False, True, False], dtype=dt
+    )
     # Setting the attribute should not raise
-    arr.fill_value = 'Z'
-    assert arr.fill_value == 'Z'
+    arr.fill_value = "Z"
+    assert arr.fill_value == "Z"
     # And filled() should use the new fill_value
-    assert arr.filled()[0] == 'x'
-    assert arr.filled()[1] == 'Z'
-    assert arr.filled()[2] == 'mid'
+    assert arr.filled()[0] == "x"
+    assert arr.filled()[1] == "Z"
+    assert arr.filled()[2] == "mid"
 
 
 def test_ufunc_with_output():

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1807,7 +1807,7 @@ class TestMaskedArrayArithmetic:
                 el_by_el = [m1[name] != m2[name] for name in dt.names]
                 assert_equal(array(el_by_el, dtype=bool).any(), ne_expected)
 
-    @pytest.mark.parametrize('dt', ['S', 'U'])
+    @pytest.mark.parametrize('dt', ['S', 'U', 'T'])
     @pytest.mark.parametrize('fill', [None, 'A'])
     def test_eq_for_strings(self, dt, fill):
         # Test the equality of structured arrays
@@ -1839,7 +1839,7 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, False])
         assert_(test.fill_value == True)
 
-    @pytest.mark.parametrize('dt', ['S', 'U'])
+    @pytest.mark.parametrize('dt', ['S', 'U', 'T'])
     @pytest.mark.parametrize('fill', [None, 'A'])
     def test_ne_for_strings(self, dt, fill):
         # Test the equality of structured arrays
@@ -1989,16 +1989,25 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, False])
         assert_(test.fill_value == True)
 
+    @pytest.mark.parametrize('dt', ['S', 'U', 'T'])
     @pytest.mark.parametrize('op',
             [operator.le, operator.lt, operator.ge, operator.gt])
     @pytest.mark.parametrize('fill', [None, "N/A"])
-    def test_comparisons_strings(self, op, fill):
+    def test_comparisons_strings(self, dt, op, fill):
         # See gh-21770, mask propagation is broken for strings (and some other
         # cases) so we explicitly test strings here.
         # In principle only == and != may need special handling...
-        ma1 = masked_array(["a", "b", "cde"], mask=[0, 1, 0], fill_value=fill)
-        ma2 = masked_array(["cde", "b", "a"], mask=[0, 1, 0], fill_value=fill)
+        ma1 = masked_array(["a", "b", "cde"], mask=[0, 1, 0], fill_value=fill, dtype=dt)
+        ma2 = masked_array(["cde", "b", "a"], mask=[0, 1, 0], fill_value=fill, dtype=dt)
         assert_equal(op(ma1, ma2)._data, op(ma1._data, ma2._data))
+
+        if isinstance(fill, str):
+            fill = np.array(fill, dtype=dt)
+
+        ma1 = masked_array(["a", "b", "cde"], mask=[0, 1, 0], fill_value=fill, dtype=dt)
+        ma2 = masked_array(["cde", "b", "a"], mask=[0, 1, 0], fill_value=fill, dtype=dt)
+        assert_equal(op(ma1, ma2)._data, op(ma1._data, ma2._data))
+
 
     @pytest.mark.filterwarnings("ignore:.*Comparison to `None`.*:FutureWarning")
     def test_eq_with_None(self):


### PR DESCRIPTION
This pull request includes a minor fix in the `_check_fill_value` function in `numpy/ma/core.py`. The change adjusts the condition to include the character `'T'` in the type check for `ndtype.char`.

* [`numpy/ma/core.py`](diffhunk://#diff-49e69ad54f7c7cc793f99652b0147f0bafa178aeb14939648815d534932c61c1L501-R501): Updated the conditional check in `_check_fill_value` to include `'T'` in the list of valid `ndtype.char` values, ensuring compatibility with additional data types.

* This ensures that `MaskedArray` with `dtype=StringDType` and with `fill_value` set to a string value initializes, and also when `fill_value` is reassigned.

* "See #29421" Issue.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
