### PR TITLE
MAINT: Support python 314rc1

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a  # 2.23.3
+      - uses: pypa/cibuildwheel@ffd835cef18fa11522f608fc0fa973b89f5ddc87  # v3.1.0
         env:
           CIBW_PLATFORM: pyodide
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
           - [windows-2022, win_amd64, ""]
           - [windows-2022, win32, ""]
           - [windows-11-arm, win_arm64, ""]
-        python: ["cp311", "cp312", "cp313", "cp313t", "pp311"]
+        python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t", "pp311"]
         exclude:
           # Don't build PyPy 32-bit windows
           - buildplat: [windows-2022, win32, ""]
@@ -106,6 +106,8 @@ jobs:
             python: "pp311"
           - buildplat: [ macos13, macosx_x86_64, openblas ]
             python: "cp313t"
+          - buildplat: [ macos13, macosx_x86_64, openblas ]
+            python: "cp314t"
 
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}
@@ -172,7 +174,7 @@ jobs:
           fi
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a  # v2.23.3
+        uses: pypa/cibuildwheel@ffd835cef18fa11522f608fc0fa973b89f5ddc87  # v3.1.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
@@ -182,7 +184,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: install micromamba
-        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc
+        uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b
         if: ${{ matrix.buildplat[1] != 'win_arm64' }} # unsupported platform at the moment
         with:
           # for installation of anaconda-client, required for upload to
@@ -275,7 +277,7 @@ jobs:
           name: sdist
           path: ./dist/*
 
-      - uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
+      - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           # for installation of anaconda-client, required for upload to
           # anaconda.org


### PR DESCRIPTION
This should make us ready for the NumPy 2.3.2 release.
  
 - update to cibuildwheel 3.1.0, which supports Python 3.14.0rc1
 - update highway (again), it got changed back accidentally

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
