### PR TITLE
DOC: Remove outdated  `numpy.exceptions` compatibility note.

### DIFF
--- a/numpy/exceptions.py
+++ b/numpy/exceptions.py
@@ -7,8 +7,7 @@ specific, such as linear algebra errors.
 
 .. versionadded:: NumPy 1.25
 
-    The exceptions module is new in NumPy 1.25.  Older exceptions remain
-    available through the main NumPy namespace for compatibility.
+    The exceptions module is new in NumPy 1.25.
 
 .. currentmodule:: numpy.exceptions
 


### PR DESCRIPTION
The exceptions were removed from the global `numpy` namespace in 2.0 (#24316).
