### PR TITLE
ENH: Enable RVV acceleration for auto-vectorization in RISC-V

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1068,7 +1068,7 @@ foreach gen_mtargets : [
       VSX2,
       VX,
       LSX,
-      RVV,
+      RVV
     ]
   ],
   [

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1068,6 +1068,7 @@ foreach gen_mtargets : [
       VSX2,
       VX,
       LSX,
+      RVV,
     ]
   ],
   [


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip)                    gcc version 14.2.0
Test command referenced from： https://github.com/numpy/numpy/commit/84526dd0f869e0f573c46991a567b3b7a65a1c05

Test command[1]:  spin bench --compare HEAD~1 -t bench_ufunc_strides.UnaryIntContig

Test command[2]:  spin bench --compare HEAD~1 -t bench_ufunc_strides.BinaryIntContig

The output/results can be found in the attached file.
[spin_bench_auto-vectorization.txt](https://github.com/user-attachments/files/21403709/spin_bench_auto-vectorization.txt)
