### PR TITLE
BUG: Fix test_configtool_pkgconfigdir to resolve PKG_CONFIG_DIR symlink

### DIFF
--- a/numpy/tests/test_configtool.py
+++ b/numpy/tests/test_configtool.py
@@ -35,7 +35,7 @@ class TestNumpyConfig:
 
     def test_configtool_pkgconfigdir(self):
         stdout = self.check_numpyconfig('--pkgconfigdir')
-        assert pathlib.Path(stdout) == PKG_CONFIG_DIR
+        assert pathlib.Path(stdout) == PKG_CONFIG_DIR.resolve()
 
 
 @pytest.mark.skipif(not IS_INSTALLED,


### PR DESCRIPTION
Fixes TestNumpyConfig.test_configtool_pkgconfigdir failure by resolving PKG_CONFIG_DIR with .resolve() to match _configtool.py behavior. Addresses assertion error in build environments where Python is configured with --with-platlibdir=lib64 and lib64 is a symlink to lib. 

Closes #29434