### PR TITLE
BUG: Fix test_configtool_pkgconfigdir to resolve PKG_CONFIG_DIR symlink

### DIFF
--- a/numpy/tests/test_configtool.py
+++ b/numpy/tests/test_configtool.py
@@ -33,7 +33,7 @@ class TestNumpyConfig:
 
     def test_configtool_pkgconfigdir(self):
         stdout = self.check_numpyconfig('--pkgconfigdir')
-        assert pathlib.Path(stdout) == PKG_CONFIG_DIR
+        assert pathlib.Path(stdout) == PKG_CONFIG_DIR.resolve()
 
 
 @pytest.mark.skipif(not IS_INSTALLED, reason="numpy must be installed to check its entrypoints")


### PR DESCRIPTION
Backport of #29435.

Fixes TestNumpyConfig.test_configtool_pkgconfigdir failure by resolving PKG_CONFIG_DIR with .resolve() to match _configtool.py behavior. Addresses assertion error in build environments where Python is configured with --with-platlibdir=lib64 and lib64 is a symlink to lib. 

Closes #29434

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
