### PR TITLE
BLD: allow targeting webassembly without emscripten

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -850,7 +850,7 @@ NPY_NO_EXPORT PyArrayMethod_StridedLoop *
 // Enable auto-vectorization for floating point casts with clang
 #if @is_native_half1@ || @is_float1@ || @is_double1@
     #if @is_native_half2@ || @is_float2@ || @is_double2@
-        #if defined(__clang__) && !defined(__EMSCRIPTEN__)
+        #if defined(__clang__) && !defined(__EMSCRIPTEN__) && !defined(__wasm__)
             #if __clang_major__ >= 12
                 _Pragma("clang fp exceptions(ignore)")
             #endif
@@ -965,7 +965,7 @@ static GCC_CAST_OPT_LEVEL int
 
 #if @is_native_half1@ || @is_float1@ || @is_double1@
     #if @is_native_half2@ || @is_float2@ || @is_double2@
-        #if defined(__clang__) && !defined(__EMSCRIPTEN__)
+        #if defined(__clang__) && !defined(__EMSCRIPTEN__) && !defined(__wasm__)
             #if __clang_major__ >= 12
                 _Pragma("clang fp exceptions(strict)")
             #endif


### PR DESCRIPTION
Backport of #29436.

#28769 introduced the usage of the `clang fp exceptions(strict)` pragma. However, this is broken when compiling for WebAssembly.

For that reason, the pragma is omitted when targeting Emscripten (by checking for `__EMSCRIPTEN__`). However, Clang can compile to WebAssembly without Emscripten. By also including a check for `__wasm__`, this patch allows NumPy to detect WebAssembly targets compiled without Emscripten.

This broadens NumPy's compatibility with WebAssembly toolchains and environments other than emscripten, such as WASIX. 

This PR is a follow-up to #29053, which also added `__wasm__` to a check that was previously Emscripten-only. When compiling for WASIX, we didn't encounter this issue previously, as we were targeting an older NumPy version.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
