### PR TITLE
BUG: Avoid TypeError in `numpy.issubdtype` when uninterpretable input…

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -530,10 +530,15 @@ def issubdtype(arg1, arg2):
     True
 
     """
-    if not issubclass_(arg1, generic):
-        arg1 = dtype(arg1).type
-    if not issubclass_(arg2, generic):
-        arg2 = dtype(arg2).type
+    try:
+        if not issubclass_(arg1, generic):
+            arg1 = dtype(arg1).type
+        if not issubclass_(arg2, generic):
+            arg2 = dtype(arg2).type
+    except TypeError:
+        # If either arg1 or arg2 cannot be casted to dtype object,
+        # they are not subdtype. (See #-28946)
+        return False
 
     return issubclass(arg1, arg2)
 

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -407,6 +407,10 @@ class TestIsSubDType:
         assert not np.issubdtype(np.float32, "float")
         assert not np.issubdtype(np.float64, "f")
 
+        # Some type cannot be interpreted by numpy
+        assert not np.issubdtype(str | int, np.number)
+        assert not np.issubdtype(np.number, str | int | float)
+
         # Test the same for the correct first datatype and abstract one
         # in the case of int, float, complex:
         assert np.issubdtype(np.float64, 'float64')


### PR DESCRIPTION
## Overview

Add try-except guard in `numpy.issubdtype`.

## Details

* As reported in #28946, `numpy.issubdtype` raises TypeError when given uninterpretable type. 
* This commit adds try-except guard to handle such cases.
