### PR TITLE
BLD: provide explicit control over cpu-baseline detection

### DIFF
--- a/doc/source/reference/simd/build-options.rst
+++ b/doc/source/reference/simd/build-options.rst
@@ -17,6 +17,11 @@ that target certain CPU features:
      During the runtime, NumPy modules will fail to load if any of specified features
      are not supported by the target CPU (raises Python runtime error).
 
+- ``cpu-baseline-detect``: controls detection of CPU baseline based on compiler
+  flags. Default value is ``auto`` that enables detection if ``-march=``
+  or a similar compiler flag is used. The other possible values are ``enabled``
+  and ``disabled`` to respective enable or disable it unconditionally.
+
 - ``cpu-dispatch``: dispatched set of additional CPU features.
    Default value is ``max -xop -fma4`` which enables all CPU
    features, except for AMD legacy features (in case of X86).
@@ -182,7 +187,7 @@ Behaviors
 
 - ``cpu-baseline`` will be treated as "native" if compiler native flag
   ``-march=native`` or ``-xHost`` or ``/QxHost`` is enabled through environment variable
-  ``CFLAGS``::
+  ``CFLAGS`` and ``cpu-baseline-detect`` is not ``disabled``::
 
     export CFLAGS="-march=native"
     pip install .

--- a/meson.options
+++ b/meson.options
@@ -28,6 +28,8 @@ option('disable-optimization', type: 'boolean', value: false,
         description: 'Disable CPU optimized code (dispatch,simd,unroll...)')
 option('cpu-baseline', type: 'string', value: 'min',
         description: 'Minimal set of required CPU features')
+option('cpu-baseline-detect', type: 'feature', value: 'auto',
+        description: 'Detect CPU baseline from the compiler flags')
 option('cpu-dispatch', type: 'string', value: 'max -xop -fma4',
         description: 'Dispatched set of additional CPU features')
 option('test-simd', type: 'array',

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -46,20 +46,22 @@ if get_option('disable-optimization')
   CPU_CONF_BASELINE = 'none'
   CPU_CONF_DISPATCH = 'none'
 else
-  baseline_detect = false
+  baseline_detect = get_option('cpu-baseline-detect').enabled()
   c_args = get_option('c_args')
-  foreach arg : c_args
-    foreach carch : ['-march', '-mcpu', '-xhost', '/QxHost']
-      if arg.contains(carch)
-        message('Appending option "detect" to "cpu-baseline" due to detecting global architecture c_arg "' + arg + '"')
-        baseline_detect = true
+  if get_option('cpu-baseline-detect').auto()
+    foreach arg : c_args
+      foreach carch : ['-march', '-mcpu', '-xhost', '/QxHost']
+        if arg.contains(carch)
+          message('Appending option "detect" to "cpu-baseline" due to detecting global architecture c_arg "' + arg + '"')
+          baseline_detect = true
+          break
+        endif
+      endforeach
+      if baseline_detect
         break
       endif
     endforeach
-    if baseline_detect
-      break
-    endif
-  endforeach
+  endif
   # The required minimal set of required CPU features.
   CPU_CONF_BASELINE = get_option('cpu-baseline')
   if baseline_detect


### PR DESCRIPTION
Add a new `cpu-baseline-detect` feature flag that can be used to more precisely control the use of CPU baseline detection.  This can be used by packages to more precisely control used SIMD code independently of compiler flags specified.  The option follows typical feature semantics -- with `auto` preserving the current behavior of enabling when relevant compiler flags are found, `enabled` forcing it on based on the implicit compiler defaults, and `disabled` forcing it off.