### PR TITLE
BUG: fix uint64 overflow in triu_indices using operator.index

### DIFF
--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -1133,6 +1133,12 @@ def triu_indices(n, k=0, m=None):
 
     """
     n = operator.index(n)
+    if m is None:
+        m = n
+    else:
+        m = operator.index(m)
+    k = operator.index(k)
+    
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 
     return tuple(broadcast_to(inds, tri_.shape)[tri_]

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -429,11 +429,14 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
            [1.,  1.,  0.,  0.,  0.]])
 
     """
+    N = operator.index(N)
     if like is not None:
         return _tri_with_like(like, N, M=M, k=k, dtype=dtype)
 
     if M is None:
         M = N
+    else:
+        M = operator.index(M)
 
     m = greater_equal.outer(arange(N, dtype=_min_int(0, N)),
                             arange(-k, M - k, dtype=_min_int(-k, M - k)))
@@ -547,6 +550,7 @@ def triu(m, k=0):
 
     """
     m = asanyarray(m)
+    k = operator.index(k)
     mask = tri(*m.shape[-2:], k=k - 1, dtype=bool)
 
     return where(mask, zeros(1, m.dtype), m)
@@ -1132,11 +1136,6 @@ def triu_indices(n, k=0, m=None):
            [ 12,  13,  14,  -1]])
 
     """
-    n = operator.index(n)
-    if m is None:
-        m = n
-    else:
-        m = operator.index(m)
     k = operator.index(k)
 
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -1132,6 +1132,7 @@ def triu_indices(n, k=0, m=None):
            [ 12,  13,  14,  -1]])
 
     """
+    n = operator.index(n)
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 
     return tuple(broadcast_to(inds, tri_.shape)[tri_]

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -1138,7 +1138,7 @@ def triu_indices(n, k=0, m=None):
     else:
         m = operator.index(m)
     k = operator.index(k)
-    
+
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 
     return tuple(broadcast_to(inds, tri_.shape)[tri_]

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -460,6 +460,15 @@ def test_tril_indices():
                               [-10, -10, -10, -10, -10],
                               [-10, -10, -10, -10, -10]]))
 
+def test_tril_indices_with_uint64():
+    n = np.uint64(3)   
+    k = -1
+    m = np.uint64(3)
+    il = np.tril_indices(n, k, m)
+    expected_row_tril = np.array([1, 2, 2])
+    expected_col_tril = np.array([0, 0, 1])
+    expected_tril = (expected_row_tril, expected_col_tril)
+    assert_equal(il, expected_tril, err_msg="tril_indices failed with k=-1, n or m is uint")
 
 class TestTriuIndices:
     def test_triu_indices(self):
@@ -512,22 +521,14 @@ class TestTriuIndices:
 
     def test_triu_indices_with_uint64(self):
         """Test that triu_indices works with uint64 inputs for n."""
-        n = np.uint64(4)
-        m = np.uint64(5)
-        k = np.uint64(0)
-
-        # Should not raise OverflowError
-        iu = np.triu_indices(n, k=k, m=m)
-
-        # Basic shape check
-        assert isinstance(iu, tuple)
-        assert len(iu) == 2
-        assert len(iu[0]) == 14  # 4x5 matrix, upper triangle size
-
-        # Compare with int version
-        iu_int = np.triu_indices(int(n), k=int(k), m=int(m))
-        assert_equal(iu[0], iu_int[0])
-        assert_equal(iu[1], iu_int[1])
+        n = np.uint64(3)   
+        k1 = np.uint64(0) 
+        m = np.uint64(3)              
+        iu = np.triu_indices(n, k1, m)
+        expected_row_triu = np.array([0, 0, 0, 1, 1, 2])
+        expected_col_triu = np.array([0, 1, 2, 1, 2, 2])
+        expected_triu = (expected_row_triu, expected_col_triu)
+        assert_equal(iu, expected_triu, err_msg="triu_indices failed with uint64 inputs")
 
 class TestTrilIndicesFrom:
     def test_exceptions(self):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -468,9 +468,8 @@ def test_tril_indices_with_uint64():
     expected_row_tril = np.array([1, 2, 2])
     expected_col_tril = np.array([0, 0, 1])
     expected_tril = (expected_row_tril, expected_col_tril)
-    assert_equal(
-        il, expected_tril, err_msg="tril_indices failed with k=-1, n or m is uint"
-    )
+    assert_equal(il, expected_tril,
+                 err_msg="tril_indices failed with k=-1, n or m is uint")
 
 class TestTriuIndices:
     def test_triu_indices(self):
@@ -530,7 +529,8 @@ class TestTriuIndices:
         expected_row_triu = np.array([0, 0, 0, 1, 1, 2])
         expected_col_triu = np.array([0, 1, 2, 1, 2, 2])
         expected_triu = (expected_row_triu, expected_col_triu)
-        assert_equal(iu, expected_triu, err_msg="triu_indices failed with uint64 inputs")
+        assert_equal(iu, expected_triu,
+                     err_msg="triu_indices failed with uint64 inputs")
 
 class TestTrilIndicesFrom:
     def test_exceptions(self):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -510,25 +510,24 @@ class TestTriuIndices:
                                   [11, 12, -1, -1, -10],
                                   [16, 17, 18, -1, -1]]))
 
-    def test_triu_indices_with_uint64():
+    def test_triu_indices_with_uint64(self):
         """Test that triu_indices works with uint64 inputs for n."""
         n = np.uint64(4)
         m = np.uint64(5)
         k = np.uint64(0)
-    
+
         # Should not raise OverflowError
         iu = np.triu_indices(n, k=k, m=m)
-    
+
         # Basic shape check
         assert isinstance(iu, tuple)
         assert len(iu) == 2
         assert len(iu[0]) == 14  # 4x5 matrix, upper triangle size
-    
+
         # Compare with int version
         iu_int = np.triu_indices(int(n), k=int(k), m=int(m))
         assert_equal(iu[0], iu_int[0])
         assert_equal(iu[1], iu_int[1])
-
 
 class TestTrilIndicesFrom:
     def test_exceptions(self):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -510,6 +510,25 @@ class TestTriuIndices:
                                   [11, 12, -1, -1, -10],
                                   [16, 17, 18, -1, -1]]))
 
+    def test_triu_indices_with_uint64():
+        """Test that triu_indices works with uint64 inputs for n."""
+        n = np.uint64(4)
+        m = np.uint64(5)
+        k = np.uint64(0)
+    
+        # Should not raise OverflowError
+        iu = np.triu_indices(n, k=k, m=m)
+    
+        # Basic shape check
+        assert isinstance(iu, tuple)
+        assert len(iu) == 2
+        assert len(iu[0]) == 14  # 4x5 matrix, upper triangle size
+    
+        # Compare with int version
+        iu_int = np.triu_indices(int(n), k=int(k), m=int(m))
+        assert_equal(iu[0], iu_int[0])
+        assert_equal(iu[1], iu_int[1])
+
 
 class TestTrilIndicesFrom:
     def test_exceptions(self):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -468,7 +468,9 @@ def test_tril_indices_with_uint64():
     expected_row_tril = np.array([1, 2, 2])
     expected_col_tril = np.array([0, 0, 1])
     expected_tril = (expected_row_tril, expected_col_tril)
-    assert_equal(il, expected_tril, err_msg="tril_indices failed with k=-1, n or m is uint")
+    assert_equal(
+        il, expected_tril, err_msg="tril_indices failed with k=-1, n or m is uint"
+    )
 
 class TestTriuIndices:
     def test_triu_indices(self):

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -461,7 +461,7 @@ def test_tril_indices():
                               [-10, -10, -10, -10, -10]]))
 
 def test_tril_indices_with_uint64():
-    n = np.uint64(3)   
+    n = np.uint64(3)
     k = -1
     m = np.uint64(3)
     il = np.tril_indices(n, k, m)
@@ -522,9 +522,9 @@ class TestTriuIndices:
 
     def test_triu_indices_with_uint64(self):
         """Test that triu_indices works with uint64 inputs for n."""
-        n = np.uint64(3)   
-        k1 = np.uint64(0) 
-        m = np.uint64(3)              
+        n = np.uint64(3)
+        k1 = np.uint64(0)
+        m = np.uint64(3)
         iu = np.triu_indices(n, k1, m)
         expected_row_triu = np.array([0, 0, 0, 1, 1, 2])
         expected_col_triu = np.array([0, 1, 2, 1, 2, 2])


### PR DESCRIPTION
Fixes #29488 

This PR fixes an OverflowError and RuntimeWarning when using `np.uint64` inputs with `np.triu_indices`(#29488).

Following a suggestion from @seberg, this PR ensures robust handling of unsigned integer inputs in `triu_indices`.

Initially, only `n` was converted using `operator.index(n)`. However, testing revealed that this partial fix still led to `RuntimeWarning: overflow encountered in scalar subtract`.

So I later added `operator.index()` for `m` and `k` as well to ensure all inputs are safely normalized:
- `n = operator.index(n)`
- `m = operator.index(m)` if provided
- `k = operator.index(k)`

This ensures consistent and safe integer handling across all inputs, preventing overflow and aligning behavior with functions like `tril_indices`.

A new test `test_triu_indices_with_uint64` has been added to verify correct behavior with `uint64` inputs.

