### PR TITLE
BUG: Ensure ``sign(timedelta64('nat'))`` returns ``timedelta64('nat')``

### DIFF
--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -688,7 +688,12 @@ TIMEDELTA_sign(char **args, npy_intp const *dimensions, npy_intp const *steps, v
 {
     UNARY_LOOP {
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
-        *((npy_timedelta *)op1) = in1 > 0 ? 1 : (in1 < 0 ? -1 : 0);
+        if (in1 == NPY_DATETIME_NAT) {
+            *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
+        }
+        else {
+            *((npy_timedelta *)op1) = in1 > 0 ? 1 : (in1 < 0 ? -1 : 0);
+        }
     }
 }
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -581,6 +581,15 @@ class TestDateTime:
         assert_equal(np.datetime64('now').dtype,
                      np.dtype('M8[s]'))
 
+    @pytest.mark.parametrize('args', [(), ('s',)])
+    def test_timedelta_sign_nat(self, args):
+        # Regression test for gh-29496.
+        # Verify that sign(timedelta64('nat')) returns a nat.
+        nat = np.timedelta64('nat', *args)
+        sgn = np.sign(nat)
+        assert sgn.dtype == nat.dtype
+        assert np.isnat(sgn)
+
     def test_datetime_nat_casting(self):
         a = np.array('NaT', dtype='M8[D]')
         b = np.datetime64('NaT', '[D]')


### PR DESCRIPTION
Closes gh-29496.
