### PR TITLE
ENH: Use extern C in arraytypes.h.src file for cpp files

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.h.src
+++ b/numpy/_core/src/multiarray/arraytypes.h.src
@@ -1,6 +1,10 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_ARRAYTYPES_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_ARRAYTYPES_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "common.h"
 
 NPY_NO_EXPORT int
@@ -164,5 +168,9 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT int BOOL_argmax,
 
 NPY_NO_EXPORT npy_intp
 count_nonzero_trivial_dispatcher(npy_intp count, const char* data, npy_intp stride, int dtype_num);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_ARRAYTYPES_H_ */


### PR DESCRIPTION
Refer to https://github.com/numpy/numpy/commit/63d6f65ee9b1b8132290e8ef445b96a99170bd48

 Planned: Convert argfunc.dispatch.c.src to argfunc.dispatch.cpp to enable C++ language features and improve code maintainability.
