### PR TITLE
BUG: add support for NaT (Not-a-Time) handling in nummpy.sign ufunc.

### DIFF
--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -687,8 +687,9 @@ NPY_NO_EXPORT void
 TIMEDELTA_sign(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     UNARY_LOOP {
+        /* Sign of NaT is NaT */
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
-        *((npy_timedelta *)op1) = in1 > 0 ? 1 : (in1 < 0 ? -1 : 0);
+        *((npy_timedelta *)op1) = in1 == NPY_DATETIME_NAT ? NPY_DATETIME_NAT : (in1 > 0 ? 1 : (in1 < 0 ? -1 : 0));
     }
 }
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

BUG FIX : #29496 

Added the support for handling special NaT values in `np.sign()`, for consistency with the behavior of the inexact types. Earlier `np.sign(np.timedelta64('nat'))` was returning `timedelta64(-1)` and for consistency with the behavior of the inexact types (e.g. `np.sign(np.nan)` returns `np.float64(nan)`), it should return `timedelta64('nat')`. After committing this change, it successfully returns  `timedelta64('nat')` on `np.timedelta64('nat')` inputs.

Previously :

```python
In [2]: np.sign(np.timedelta64('nat'))
Out[2]: np.timedelta64(-1)
```

After this fix :

```python
In [3]: np.sign(np.timedelta64('nat'))
Out[3]: np.timedelta64('NaT')
```

This change aligns the behavior with expectations for inexact types and addresses [issue #29496](https://github.com/numpy/numpy/issues/29496).
