### PR TITLE
BUG: Fix incorrect behavior with unsigned int in np.unwrap (#29477)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1803,6 +1803,14 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     """
     p = asarray(p)
     nd = p.ndim
+    if np.issubdtype(p.dtype, np.unsignedinteger):
+        # covnert it to signed integer
+        if np.can_cast(p.dtype, np.int16):
+            p = p.astype(np.int16)
+        elif np.can_cast(p.dtype, np.int32):
+            p = p.astype(np.int32)
+        else:
+            p = p.astype(np.int64)
     dd = diff(p, axis=axis)
     if discont is None:
         discont = period / 2


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

BUG-FIX : #29477

Previously, `np.unwrap` gave incorrect results when passed unsigned integer arrays,  due to how np.diff handles unsigned inputs. This fix casts the input to a  larger signed integer type before applying `np.diff`.

Previously:
```python
In [4]: x1 = np.array([5, 1], dtype=np.uint64)
In [5]: np.unwrap(x1)
Out[5]: array([ 5.00000000e+00, -1.84467441e+19]) # Not Expected

```
After this fix:

```python
In [2]: x1 = np.array([5, 1], dtype=np.uint64)
In [3]: np.unwrap(x1)
Out[3]: array([5.        , 7.28318531])
```

Closes #29477 