### PR TITLE
TST: don't explicitly specify -j in TSAN build

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -89,7 +89,7 @@ jobs:
         run: pip uninstall -y pytest-xdist
 
       - name: Build NumPy with ThreadSanitizer
-        run: python -m spin build -j2 -- -Db_sanitize=thread
+        run: python -m spin build -- -Db_sanitize=thread
 
       - name: Run tests under prebuilt TSAN container
         run: |


### PR DESCRIPTION
c.f. https://github.com/numpy/numpy/pull/29487#discussion_r2254553295. It seemed easier just to send in a PR for this than ask @m-clare to do it.

I don't remember if I explicitly set it to build with 2 cores because TSAN builds use a lot of RAM or if I did it for some other reason. Let's see if letting meson choose the correct value is problematic.