### PR TITLE
MAINT: Bump hypothesis to 6.137.1

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ Cython
 wheel==0.38.1
 setuptools==65.5.1 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
-hypothesis==6.104.1
+hypothesis==6.137.1
 pytest==7.4.0
 pytest-cov==4.1.0
 meson


### PR DESCRIPTION
Running the test suite with [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel) results in some thread-unsafe issues with hypothesis. These issues should no longer be present in the latest version of hypothesis, so upgrading to 6.137.1 should make the test suite more thread-safe when running tests in parallel.