### PR TITLE
DOC: Add 'today' string to datetime64 documentation

### DIFF
--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -53,7 +53,8 @@ months ('M'), weeks ('W'), and days ('D'), while the time units are
 hours ('h'), minutes ('m'), seconds ('s'), milliseconds ('ms'), and
 some additional SI-prefix seconds-based units. The `datetime64` data type
 also accepts the string "NAT", in any combination of lowercase/uppercase
-letters, for a "Not A Time" value.
+letters, for a "Not A Time" value. The string "today" is also supported and
+returns the current UTC date with day precision.
 
 .. admonition:: Example
 
@@ -90,6 +91,11 @@ letters, for a "Not A Time" value.
 
     >>> np.datetime64('nat')
     np.datetime64('NaT')
+
+    The current date:
+
+    >>> np.datetime64('today')
+    np.datetime64('2025-08-05')  # result will depend on the current date
 
 When creating an array of datetimes from a string, it is still possible
 to automatically select the unit from the inputs, by using the


### PR DESCRIPTION
## Summary

This PR adds documentation for the string `"today"` as a valid argument to `np.datetime64`.

The string `"today"` returns the **current UTC date** at **day (`D`) precision**. This behavior is already supported internally but was previously undocumented.

### ✅ Example added

```python
>>> np.datetime64('today')
np.datetime64('2025-08-05')  # result will depend on the current date
```

The example is placed immediately after `"nat"` in the "Basic datetimes" section, consistent with other special string inputs.

---

### Context

This PR builds on prior discussion about undocumented special strings in `np.datetime64`.

- Issue [#10003](https://github.com/numpy/numpy/issues/10003) discusses support for `"now"` and mentions it is internally implemented with second-level precision, but not documented due to precision and semantic concerns.
- PR [#26477](https://github.com/numpy/numpy/pull/26477) proposed documenting `"now"` with an example, but was closed without being merged.

Unlike `"now"`, the `"today"` string has clear behavior (UTC, day precision) and does not involve precision ambiguity. It is stable and safe to document independently.

---
Thanks for considering this small improvement!