### PR TITLE
BUG: Always return a real dtype from linalg.cond (gh-18304) (#29333)

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2007,6 +2007,7 @@ def cond(x, p=None):
         _assert_stacked_2d(x)
         _assert_stacked_square(x)
         t, result_t = _commonType(x)
+        result_t = _realType(result_t)  # condition number is always real
         signature = 'D->D' if isComplexType(t) else 'd->d'
         with errstate(all='ignore'):
             invx = _umath_linalg.inv(x, signature=signature)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -770,14 +770,27 @@ class CondCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
 
 class TestCond(CondCases):
-    def test_basic_nonsvd(self):
+    @pytest.mark.parametrize('is_complex', [False, True])
+    def test_basic_nonsvd(self, is_complex):
         # Smoketest the non-svd norms
         A = array([[1., 0, 1], [0, -2., 0], [0, 0, 3.]])
+        if is_complex:
+            # Since A is linearly scaled, the condition number should not change
+            A = A * (1 + 1j)
         assert_almost_equal(linalg.cond(A, inf), 4)
         assert_almost_equal(linalg.cond(A, -inf), 2/3)
         assert_almost_equal(linalg.cond(A, 1), 4)
         assert_almost_equal(linalg.cond(A, -1), 0.5)
         assert_almost_equal(linalg.cond(A, 'fro'), np.sqrt(265 / 12))
+
+    @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
+    @pytest.mark.parametrize('norm_ord', [1, -1, 2, -2, 'fro', np.inf, -np.inf])
+    def test_cond_dtypes(self, dtype, norm_ord):
+        # Check that the condition number is computed in the same dtype
+        # as the input matrix
+        A = array([[1., 0, 1], [0, -2., 0], [0, 0, 3.]], dtype=dtype)
+        out_type = get_real_dtype(dtype)
+        assert_equal(linalg.cond(A, p=norm_ord).dtype, out_type)
 
     def test_singular(self):
         # Singular matrices have infinite condition number for


### PR DESCRIPTION
* BUG: Always return a real dtype from linalg.cond.

Addresses gh-18304.

The condition number of a matrix is the product of two norms, which are always non-negative and real-valued, so the condition number itself should be non-negative and real-valued. This commit returns the proper real dtype from `linalg.cond`, and includes tests for the condition number of a complex matrix in various norms.

* ENH: Change type of complex results only.

This commit addresses a reviewer comment on the blanket application of `abs(r)`. It specifically ensures the return type of complex-valued matrices will be the corresponding real type.

This fix has already been backported to v2.3.x via merge commit [c6eac4](https://github.com/numpy/numpy/commit/c6eac44e914413ce48439d2435abbfd493149485).