### PR TITLE
BUG: random: Fix handling of very small p in Generator.binomial.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -770,7 +770,7 @@ RAND_INT_TYPE random_binomial_inversion(bitgen_t *bitgen_state, RAND_INT_TYPE n,
     binomial->psave = p;
     binomial->has_binomial = 1;
     binomial->q = q = 1.0 - p;
-    binomial->r = qn = exp(n * log(q));
+    binomial->r = qn = exp(n * log1p(-p));
     binomial->c = np = n * p;
     binomial->m = bound = (RAND_INT_TYPE)MIN(n, np + 10.0 * sqrt(np * q + 1));
   } else {

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -99,6 +99,24 @@ class TestBinomial:
         # Issue #4571.
         assert_raises(ValueError, random.binomial, 1, np.nan)
 
+    def test_p_extremely_small(self):
+        n = 50000000000
+        p = 5e-17
+        sample_size = 20000000
+        x = random.binomial(n, p, size=sample_size)
+        sample_mean = x.mean()
+        expected_mean = n*p
+        sigma = np.sqrt(n*p*(1 - p)/sample_size)
+        # Note: the parameters were chosen so that expected_mean - 6*sigma
+        # is a positive value.  The first `assert` below validates that
+        # assumption (in case someone edits the parameters in the future).
+        # The second `assert` is the actual test.
+        low_bound = expected_mean - 6*sigma
+        assert low_bound > 0, "bad test params: 6-sigma lower bound is negative"
+        test_msg = (f"sample mean {sample_mean} deviates from the expected mean "
+                    f"{expected_mean} by more than 6*sigma")
+        assert abs(expected_mean - sample_mean) < 6*sigma, test_msg
+
 
 class TestMultinomial:
     def test_basic(self):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -105,17 +105,17 @@ class TestBinomial:
         sample_size = 20000000
         x = random.binomial(n, p, size=sample_size)
         sample_mean = x.mean()
-        expected_mean = n*p
-        sigma = np.sqrt(n*p*(1 - p)/sample_size)
+        expected_mean = n * p
+        sigma = np.sqrt(n * p * (1 - p) / sample_size)
         # Note: the parameters were chosen so that expected_mean - 6*sigma
         # is a positive value.  The first `assert` below validates that
         # assumption (in case someone edits the parameters in the future).
         # The second `assert` is the actual test.
-        low_bound = expected_mean - 6*sigma
+        low_bound = expected_mean - 6 * sigma
         assert low_bound > 0, "bad test params: 6-sigma lower bound is negative"
         test_msg = (f"sample mean {sample_mean} deviates from the expected mean "
                     f"{expected_mean} by more than 6*sigma")
-        assert abs(expected_mean - sample_mean) < 6*sigma, test_msg
+        assert abs(expected_mean - sample_mean) < 6 * sigma, test_msg
 
 
 class TestMultinomial:


### PR DESCRIPTION
Use `log1p` to compute an expression of `1 - p` with more precision. To not change the legacy interface, a copy of the unaltered function `random_binomial_inversion` is used in the legacy distribution code.

-----

This example is from the unit test added in the PR.  Before this fix, or when using the legacy interface, the values in `x` will all be 0:

```
In [28]: n = 50000000000
    ...: p = 5e-17
    ...: sample_size = 20000000

In [29]: x = np.random.binomial(n, p, size=sample_size)  # Legacy interface

In [30]: x.max()  # Values are all 0
Out[30]: np.int64(0)
```
With the fixed `Generator.binomial` method:
```
In [31]: rng = np.random.default_rng()

In [32]: x = rng.binomial(n, p, size=sample_size)  # Fixed binomial method

In [33]: x.mean()
Out[33]: np.float64(2.25e-06)

In [34]: n*p  # Expected mean
Out[34]: 2.4999999999999998e-06
```
