### PR TITLE
DOC: Add 'now' string to datetime64 documentation

### DIFF
--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -59,7 +59,8 @@ you can specify a different unit (e.g., 'M', 'D', 'h') to truncate the result
 to that precision. Units finer than seconds (such as 'ms' or 'ns') are
 supported but will show fractional parts as zeros, effectively truncating to
 whole seconds. The string "today" is also supported and returns the current UTC
-date with day precision.
+date with day precision. It also supports the same precision specifiers
+as ``now``.
 
 .. admonition:: Example
 

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -53,8 +53,13 @@ months ('M'), weeks ('W'), and days ('D'), while the time units are
 hours ('h'), minutes ('m'), seconds ('s'), milliseconds ('ms'), and
 some additional SI-prefix seconds-based units. The `datetime64` data type
 also accepts the string "NAT", in any combination of lowercase/uppercase
-letters, for a "Not A Time" value. The string "today" is also supported and
-returns the current UTC date with day precision.
+letters, for a "Not A Time" value. The string "now" is also supported and
+returns the current UTC time. By default, it uses second ('s') precision, but
+you can specify a different unit (e.g., 'M', 'D', 'h') to truncate the result
+to that precision. Units finer than seconds (such as 'ms' or 'ns') are
+supported but will show fractional parts as zeros, effectively truncating to
+whole seconds. The string "today" is also supported and returns the current UTC
+date with day precision.
 
 .. admonition:: Example
 
@@ -91,6 +96,17 @@ returns the current UTC date with day precision.
 
     >>> np.datetime64('nat')
     np.datetime64('NaT')
+
+    The current time (UTC, default second precision):
+
+    >>> np.datetime64('now')
+    np.datetime64('2025-08-05T02:22:14')  # result will depend on the current time
+
+    >>> np.datetime64('now', 'D')
+    np.datetime64('2025-08-05')
+    
+    >>> np.datetime64('now', 'ms')
+    np.datetime64('2025-08-05T02:22:14.000')
 
     The current date:
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the string `"now"` as a valid argument to `np.datetime64`.

The string `"now"` returns the **current UTC time**. By default, it uses **second (`s`) precision**, but you can specify a different unit (e.g., `'M'`, `'D'`, `'h'`) to truncate the result to that precision. Units finer than seconds (such as `'ms'` or `'ns'`) are supported but will display fractional parts as zeros, effectively truncating to whole seconds. This behavior is already supported internally but was previously undocumented.

### ✅ Example added

```python
>>> np.datetime64('now')
np.datetime64('2025-08-05T02:22:14')  # result will depend on the current time

>>> np.datetime64('now', 'D')
np.datetime64('2025-08-05')

>>> np.datetime64('now', 'ms')
np.datetime64('2025-08-05T02:22:14.000')
```

The example is placed immediately before the `"today"` example in the "Basic datetimes" section, so readers can compare their behaviors easily.

---

## Context

* Issue [#10003](https://github.com/numpy/numpy/issues/10003) discusses undocumented support for `"now"` and notes its UTC semantics and default second-level precision.
* PR [#26477](https://github.com/numpy/numpy/pull/26477) proposed documenting `"now"` with an example, but was closed without merge due to procedural issues.
* PR [#29514](https://github.com/numpy/numpy/pull/29514) documented `"today"` string (merged), adding its explanation and example to this section.

This PR documents `"now"` with explicit mention of its default precision, UTC behavior, and unit truncation to address potential user confusion.

---

Thanks for considering this improvement!