### PR TITLE
BUG: left bit shift undefined behavior

### DIFF
--- a/numpy/_core/src/common/simd/avx2/arithmetic.h
+++ b/numpy/_core/src/common/simd/avx2/arithmetic.h
@@ -215,9 +215,9 @@ NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
     // q               = (a + mulhi) >> sh
     __m256i q          = _mm256_add_epi64(a, mulhi);
     // emulate arithmetic right shift
-    const __m256i sigb = npyv_setall_s64(1ULL << 63);
-            q          = _mm256_srl_epi64(_mm256_add_epi64(q, sigb), shf1);
-            q          = _mm256_sub_epi64(q, _mm256_srl_epi64(sigb, shf1));
+    const __m256i sbit = npyv_setall_s64(0x8000000000000000);
+            q          = _mm256_srl_epi64(_mm256_add_epi64(q, sbit), shf1);
+            q          = _mm256_sub_epi64(q, _mm256_srl_epi64(sbit, shf1));
     // q               = q - XSIGN(a)
     // trunc(a/d)      = (q ^ dsign) - dsign
             q          = _mm256_sub_epi64(q, asign);

--- a/numpy/_core/src/common/simd/avx2/arithmetic.h
+++ b/numpy/_core/src/common/simd/avx2/arithmetic.h
@@ -215,7 +215,7 @@ NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
     // q               = (a + mulhi) >> sh
     __m256i q          = _mm256_add_epi64(a, mulhi);
     // emulate arithmetic right shift
-    const __m256i sigb = npyv_setall_s64(1LL << 63);
+    const __m256i sigb = npyv_setall_s64(1ULL << 63);
             q          = _mm256_srl_epi64(_mm256_add_epi64(q, sigb), shf1);
             q          = _mm256_sub_epi64(q, _mm256_srl_epi64(sigb, shf1));
     // q               = q - XSIGN(a)

--- a/numpy/_core/src/common/simd/sse/arithmetic.h
+++ b/numpy/_core/src/common/simd/sse/arithmetic.h
@@ -251,9 +251,9 @@ NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
     // q               = (a + mulhi) >> sh
     __m128i q          = _mm_add_epi64(a, mulhi);
     // emulate arithmetic right shift
-    const __m128i sigb = npyv_setall_s64(1ULL << 63);
-            q          = _mm_srl_epi64(_mm_add_epi64(q, sigb), divisor.val[1]);
-            q          = _mm_sub_epi64(q, _mm_srl_epi64(sigb, divisor.val[1]));
+    const __m128i sbit = npyv_setall_s64(0x8000000000000000);
+            q          = _mm_srl_epi64(_mm_add_epi64(q, sbit), divisor.val[1]);
+            q          = _mm_sub_epi64(q, _mm_srl_epi64(sbit, divisor.val[1]));
     // q               = q - XSIGN(a)
     // trunc(a/d)      = (q ^ dsign) - dsign
             q          = _mm_sub_epi64(q, asign);

--- a/numpy/_core/src/common/simd/sse/arithmetic.h
+++ b/numpy/_core/src/common/simd/sse/arithmetic.h
@@ -251,7 +251,7 @@ NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
     // q               = (a + mulhi) >> sh
     __m128i q          = _mm_add_epi64(a, mulhi);
     // emulate arithmetic right shift
-    const __m128i sigb = npyv_setall_s64(1LL << 63);
+    const __m128i sigb = npyv_setall_s64(1ULL << 63);
             q          = _mm_srl_epi64(_mm_add_epi64(q, sigb), divisor.val[1]);
             q          = _mm_sub_epi64(q, _mm_srl_epi64(sigb, divisor.val[1]));
     // q               = q - XSIGN(a)

--- a/tools/ci/ubsan_suppressions_x86_64.txt
+++ b/tools/ci/ubsan_suppressions_x86_64.txt
@@ -11,9 +11,6 @@ signed-integer-overflow:*
 # otherwise ubsan may detect system file alignment errors outside numpy
 alignment:*
 
-# suggested fix for runtime error: replace left bit shift with LLONG_MIN constant
-shift-base:_core/src/common/simd/sse/arithmetic.h
-shift-base:_core/src/common/simd/avx2/arithmetic.h
 # suggested fix for runtime error: use INT_MIN constant
 shift-base:_core/src/umath/_rational_tests.c
 # suggested fix for runtime error: check for overflow if signed


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
- Addresses UBSAN warnings for `sse/arithmetic.h` and `avx2/arithmetic.h` 
- adjusts variable names for operations (`sigb` to `sbit`) to match those in `sse/operations.h` `avx2/operations.h` for the same operation with a vector argument (see snippet below).
- Removes UBSAN suppressions for these files, `compiler_sanitizers.yml` workflow should succeed without errors.
- partially closes #29524 

From `sse/operations.h` L34:
```
NPY_FINLINE __m128i npyv_shr_s64(__m128i a, int c)
{
    const __m128i sbit = npyv_setall_s64(0x8000000000000000);
    const __m128i cv   = _mm_cvtsi32_si128(c);
    __m128i r = _mm_srl_epi64(_mm_add_epi64(a, sbit), cv);
    return _mm_sub_epi64(r, _mm_srl_epi64(sbit, cv));
}
```

The pattern throughout these implementations is to use the hex representation of the value, which I've done here. Not sure if it would be a better option to use the `limit` library instead.