### PR TITLE
DOC: doctest ReST sources in `doc/source/reference`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -242,7 +242,7 @@ def check_tutorials(*, parent_callback, pytest_args, **kwargs):
     #   - `spin check-tutorials path/to/rst`, and
     #   - `spin check-tutorials path/to/rst -- --durations=3`
     if (not pytest_args) or all(arg.startswith('-') for arg in pytest_args):
-        pytest_args = ('doc/source/user',) + pytest_args
+        pytest_args = ('doc/source/user', 'doc/source/reference/') + pytest_args
 
     # make all paths relative to the numpy source folder
     pytest_args = tuple(

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -682,7 +682,7 @@ iterating. The ndenumerate iterator can achieve this.
   >>> import numpy as np
   >>> for i, val in np.ndenumerate(a):
   ...     if sum(i)%5 == 0:
-              print(i, val)
+  ...         print(i, val)
   (0, 0, 0) 10
   (1, 1, 3) 25
   (2, 0, 3) 29

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -90,12 +90,12 @@ returns the current UTC date with day precision.
     NAT (not a time):
 
     >>> np.datetime64('nat')
-    np.datetime64('NaT')
+    np.datetime64('NaT','generic')
 
     The current date:
 
     >>> np.datetime64('today')
-    np.datetime64('2025-08-05')  # result will depend on the current date
+    np.datetime64('2025-08-05')  # may vary: result will depend on the current date
 
 When creating an array of datetimes from a string, it is still possible
 to automatically select the unit from the inputs, by using the
@@ -232,7 +232,7 @@ simple datetime calculations.
     np.timedelta64('NaT','D')
 
     >>> np.datetime64('2009-01-01') + np.timedelta64('nat')
-    np.datetime64('NaT')
+    np.datetime64('NaT','D')
 
 There are two Timedelta units ('Y', years and 'M', months) which are treated
 specially, because how much time they represent changes depending
@@ -253,7 +253,7 @@ calculating the averaged values from the 400 year leap-year cycle.
     >>> a = np.timedelta64(1, 'Y')
 
     >>> np.timedelta64(a, 'M')
-    numpy.timedelta64(12,'M')
+    np.timedelta64(12,'M')
 
     >>> np.timedelta64(a, 'D')
     Traceback (most recent call last):
@@ -548,7 +548,7 @@ given below.
       >>> a = np.datetime64("0000-01-01", "us")
       >>> b = np.datetime64("1600-01-01", "us")
       >>> b - a
-      numpy.timedelta64(50491123200000000,'us')
+      np.timedelta64(50491123200000000,'us')
 
       The computed results, `50491123200` seconds, are obtained as the elapsed
       number of days (`584388`) times `86400` seconds; this is the number of

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -51,7 +51,7 @@ objects implementing the :class:`memoryview` or :ref:`array
 
       >>> # The element of x in the *second* row, *third* column, namely, 6.
       >>> x[1, 2]
-         6
+      np.int32(6)
 
       For example :ref:`slicing <arrays.indexing>` can produce views of
       the array:

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -114,9 +114,20 @@ cannot be coerced to the NumPy dtype, an error is raised:
   Traceback (most recent call last):
   ...
   OverflowError: Python int too large to convert to C long
+
+  For floating-point values, however, NumPy returns an infinity and emits a warning:
+
   >>> np.float32(1) + 1e300
+  Traceback (most recent call last):
+  ...
+  RuntimeWarning: overflow encountered in cast
+
+  >>> import warnings
+  >>> with warnings.catch_warnings():
+  ...     warnings.simplefilter('ignore')
+  ...     x = np.float32(1) + 1e300
+  >>> x
   np.float32(inf)
-  ... RuntimeWarning: overflow encountered in cast
 
 Second, since the Python float or integer precision is always ignored, a low
 precision NumPy scalar will keep using its lower precision unless explicitly
@@ -125,12 +136,19 @@ converted to a higher precision NumPy dtype or Python scalar (e.g. via ``int()``
 some calculations or lead to incorrect results, especially in the case of integer
 overflows:
 
-  >>> np.int8(100) + 100  # the result exceeds the capacity of int8
+  >>> import warnings
+  >>> with warnings.catch_warnings():
+  ...     warnings.simplefilter('ignore')
+  ...     x = np.int8(100) + 100  # the result exceeds the capacity of int8
+  >>> x
   np.int8(-56)
-  ... RuntimeWarning: overflow encountered in scalar add
 
-Note that NumPy warns when overflows occur for scalars, but not for arrays;
-e.g., ``np.array(100, dtype="uint8") + 100`` will *not* warn.
+
+Note that NumPy warns when overflows occur for scalars, but not for arrays:
+
+  >>> np.array(100, dtype="int8") + 100
+  np.int8(-56)   # overflows, does not warn
+
 
 Numerical promotion
 -------------------

--- a/doc/source/reference/constants.rst
+++ b/doc/source/reference/constants.rst
@@ -67,7 +67,11 @@ NumPy includes several constants:
     >>> import numpy as np
     >>> np.inf
     inf
-    >>> np.array([1]) / 0.
+    >>> import warnings
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')
+    ...     x = np.array([1]) / 0.      # emits a 'Division by zero' warning
+    >>> x
     array([inf])
 
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -220,6 +220,9 @@ if HAVE_SCPDT:
         'basics.dispatch.rst': 'errors out in /testing/overrides.py',
         'basics.subclassing.rst': '.. testcode:: admonitions not understood',
         'misc.rst': 'manipulates warnings',
+        'arrays.nditer.cython.rst': 'uses non-python syntax',
+        'distutils.rst': '',
+        'coremath.rst': 'numpy.distutils does not exis'
     }
 
     # ignores are for things fail doctest collection (optionals etc)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->


Prompted by https://github.com/numpy/numpy/issues/29544 : Add doctesting of ReST sources in `doc/source/reference`, which were never doctested IIUC.

This is a minimal fix. Several larger-scale potential improvements are discussed in gh-29544.


