### PR TITLE
BUG: SIMD Neon undefined behavior - pointer overflow

### DIFF
--- a/numpy/_core/src/common/simd/neon/memory.h
+++ b/numpy/_core/src/common/simd/neon/memory.h
@@ -52,6 +52,7 @@ NPYV_IMPL_NEON_MEM(f64, double)
  ***************************/
 NPY_FINLINE npyv_s32 npyv_loadn_s32(const npy_int32 *ptr, npy_intp stride)
 {
+    assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE32);
     int32x4_t a = vdupq_n_s32(0);
     a = vld1q_lane_s32((const int32_t*)ptr,            a, 0);
     a = vld1q_lane_s32((const int32_t*)ptr + stride,   a, 1);
@@ -75,6 +76,7 @@ NPY_FINLINE npyv_f32 npyv_loadn_f32(const float *ptr, npy_intp stride)
 //// 64
 NPY_FINLINE npyv_s64 npyv_loadn_s64(const npy_int64 *ptr, npy_intp stride)
 {
+    assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE64);
     return vcombine_s64(
         vld1_s64((const int64_t*)ptr), vld1_s64((const int64_t*)ptr + stride)
     );

--- a/numpy/_core/src/common/simd/neon/neon.h
+++ b/numpy/_core/src/common/simd/neon/neon.h
@@ -17,6 +17,8 @@
 #endif
 #define NPY_SIMD_BIGENDIAN 0
 #define NPY_SIMD_CMPSIGNAL 1
+#define NPY_SIMD_MAXLOAD_STRIDE32 (0x7ffffffff / 4)
+#define NPY_SIMD_MAXLOAD_STRIDE64 (0x7fffffffffffffff / 4)
 
 typedef uint8x16_t  npyv_u8;
 typedef int8x16_t   npyv_s8;

--- a/numpy/_core/src/common/simd/neon/neon.h
+++ b/numpy/_core/src/common/simd/neon/neon.h
@@ -17,8 +17,8 @@
 #endif
 #define NPY_SIMD_BIGENDIAN 0
 #define NPY_SIMD_CMPSIGNAL 1
-#define NPY_SIMD_MAXLOAD_STRIDE32 (0x7ffffffff / 4)
-#define NPY_SIMD_MAXLOAD_STRIDE64 (0x7fffffffffffffff / 4)
+#define NPY_SIMD_MAXLOAD_STRIDE32 (0x7fffffff / (3 * 4))
+#define NPY_SIMD_MAXLOAD_STRIDE64 (0x7fffffffffffffff / (1 * 8))
 
 typedef uint8x16_t  npyv_u8;
 typedef int8x16_t   npyv_s8;

--- a/tools/ci/ubsan_suppressions_arm64.txt
+++ b/tools/ci/ubsan_suppressions_arm64.txt
@@ -17,7 +17,6 @@ shift-base:_core/src/umath/_rational_tests.c
 shift-base:_core/src/npymath/npy_math_internal.h
 
 # suggested fix for runtime error: null check before loop
-pointer-overflow:_core/src/common/simd/neon/memory.h
 pointer-overflow:_core/src/multiarray/datetime_busdaycal.c
 pointer-overflow:_core/src/multiarray/nditer_templ.c
 pointer-overflow:_core/src/multiarray/nditer_constr.c


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
- Addresses UBSAN warnings for `simd/neon/memory.h` by adding bounds checking on stride size - (related to #29524)
- To resolve this, I looked at some of the other SIMD architectures, and used the same kind of assertion as that implemented in `avx2/memory.h` (also in `avx512`)

```
NPY_FINLINE npyv_u32 npyv_loadn_u32(const npy_uint32 *ptr, npy_intp stride)
{
    assert(llabs(stride) <= NPY_SIMD_MAXLOAD_STRIDE32);
    const __m256i steps = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
    const __m256i idx = _mm256_mullo_epi32(_mm256_set1_epi32((int)stride), steps);
    return _mm256_i32gather_epi32((const int*)ptr, idx, 4);
}
```

While looking at other architecture options for the same function `npyv_loadn_u32`, I noticed that `sse`, `lsx`, `vec` do not have a bounds check on the stride, but were not flagged by UBSAN (they all use array indexing instead of pointer arithmetic). For example for `sse/memory.h` L79:
```
NPY_FINLINE npyv_s32 npyv_loadn_s32(const npy_int32 *ptr, npy_intp stride)
{
    __m128i a = _mm_cvtsi32_si128(*ptr);
#ifdef NPY_HAVE_SSE41
    a = _mm_insert_epi32(a, ptr[stride],   1);
    a = _mm_insert_epi32(a, ptr[stride*2], 2);
    a = _mm_insert_epi32(a, ptr[stride*3], 3);
#else
    __m128i a1 = _mm_cvtsi32_si128(ptr[stride]);
    __m128i a2 = _mm_cvtsi32_si128(ptr[stride*2]);
    __m128i a3 = _mm_cvtsi32_si128(ptr[stride*3]);
    a = _mm_unpacklo_epi32(a, a1);
    a = _mm_unpacklo_epi64(a, _mm_unpacklo_epi32(a2, a3));
#endif
    return a;
}
```
Should these other implementations also include bounds checks?


