### PR TITLE
DEP: Deprecate NumPy warning control utilities

### DIFF
--- a/doc/release/upcoming_changes/29550.deprecation.rst
+++ b/doc/release/upcoming_changes/29550.deprecation.rst
@@ -1,0 +1,6 @@
+Assertion and warning control utilities are deprecated
+------------------------------------------------------
+
+`np.testing.assert_warns` and `np.testing.suppress_warnings` are deprecated.
+Use `warnings.catch_warnings`, `warnings.filterwarnings`, ``pytest.warns``, or
+``pytest.filterwarnings`` instead.

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -516,3 +516,36 @@ class TestFlatiterIndexingFloatIndex(_DeprecationTestCase):
             arr.flat[[1.]] = 10
 
         self.assert_deprecated(assign_to_index)
+
+
+class TestWarningUtilityDeprecations(_DeprecationTestCase):
+    # Deprecation in NumPy 2.5
+    message = r"NumPy warning suppression and assertion utilities are deprecated."
+
+    def test_assert_warns_deprecated(self):
+        def use_assert_warns():
+            with np.testing.assert_warns(RuntimeWarning):
+                warnings.warn("foo", RuntimeWarning)
+
+        self.assert_deprecated(use_assert_warns)
+
+    def test_assert_no_warns_deprecated(self):
+        def use_assert_no_warns():
+            with np.testing.assert_no_warnings():
+                pass
+
+        self.assert_deprecated(use_assert_no_warns)
+
+    def test_suppress_warnings_deprecated(self):
+        def use_suppress_warnings():
+            with np.testing.suppress_warnings() as sup:
+                sup.filter(RuntimeWarning, 'invalid value encountered in divide')
+
+        self.assert_deprecated(use_suppress_warnings)
+
+    def test_clear_and_catch_warnings_deprecated(self):
+        def use_clear_and_catch_warnings():
+            with np.testing.clear_and_catch_warnings():
+                pass
+
+        self.assert_deprecated(use_clear_and_catch_warnings)

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -536,9 +536,3 @@ class TestWarningUtilityDeprecations(_DeprecationTestCase):
 
         self.assert_deprecated(use_suppress_warnings)
 
-    def test_clear_and_catch_warnings_deprecated(self):
-        def use_clear_and_catch_warnings():
-            with np.testing.clear_and_catch_warnings():
-                pass
-
-        self.assert_deprecated(use_clear_and_catch_warnings)

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -535,4 +535,3 @@ class TestWarningUtilityDeprecations(_DeprecationTestCase):
                 sup.filter(RuntimeWarning, 'invalid value encountered in divide')
 
         self.assert_deprecated(use_suppress_warnings)
-

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -529,13 +529,6 @@ class TestWarningUtilityDeprecations(_DeprecationTestCase):
 
         self.assert_deprecated(use_assert_warns)
 
-    def test_assert_no_warns_deprecated(self):
-        def use_assert_no_warns():
-            with np.testing.assert_no_warnings():
-                pass
-
-        self.assert_deprecated(use_assert_no_warns)
-
     def test_suppress_warnings_deprecated(self):
         def use_suppress_warnings():
             with np.testing.suppress_warnings() as sup:

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -519,7 +519,7 @@ class TestFlatiterIndexingFloatIndex(_DeprecationTestCase):
 
 
 class TestWarningUtilityDeprecations(_DeprecationTestCase):
-    # Deprecation in NumPy 2.5
+    # Deprecation in NumPy 2.5, 2025-08
     message = r"NumPy warning suppression and assertion utilities are deprecated."
 
     def test_assert_warns_deprecated(self):

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -525,7 +525,7 @@ class TestWarningUtilityDeprecations(_DeprecationTestCase):
     def test_assert_warns_deprecated(self):
         def use_assert_warns():
             with np.testing.assert_warns(RuntimeWarning):
-                warnings.warn("foo", RuntimeWarning)
+                warnings.warn("foo", RuntimeWarning, stacklevel=1)
 
         self.assert_deprecated(use_assert_warns)
 

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -519,7 +519,7 @@ class TestFlatiterIndexingFloatIndex(_DeprecationTestCase):
 
 
 class TestWarningUtilityDeprecations(_DeprecationTestCase):
-    # Deprecation in NumPy 2.5, 2025-08
+    # Deprecation in NumPy 2.4, 2025-08
     message = r"NumPy warning suppression and assertion utilities are deprecated."
 
     def test_assert_warns_deprecated(self):

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -170,7 +170,9 @@ if HAVE_SCPDT:
                 "This function is deprecated.",    # random_integers
                 "Data type alias 'a'",     # numpy.rec.fromfile
                 "Arrays of 2-dimensional vectors",   # matlib.cross
-                "`in1d` is deprecated", ]
+                "`in1d` is deprecated",
+                "NumPy warning suppression and assertion utilities are deprecated."
+        ]
         msg = "|".join(msgs)
 
         msgs_r = [

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -56,6 +56,10 @@ verbose = 0
 
 NUMPY_ROOT = pathlib.Path(np.__file__).parent
 
+WARNING_KWARGS = {}
+if sys.version_info >= (3, 12):
+    WARNING_KWARGS['skip_file_prefixes'] = (__file__, contextlib.__file__)
+
 try:
     np_dist = importlib.metadata.distribution('numpy')
 except importlib.metadata.PackageNotFoundError:
@@ -2009,6 +2013,11 @@ def assert_warns(warning_class, *args, **kwargs):
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
 
+    .. deprecated:: 2.5
+
+        This is deprecated. Use `warnings.catch_warnings` or
+        ``pytest.warns`` instead.
+
     Parameters
     ----------
     warning_class : class
@@ -2074,6 +2083,11 @@ def assert_no_warnings(*args, **kwargs):
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
 
+    .. deprecated:: 2.5
+
+        This is deprecated. Use `warnings.catch_warnings` or
+        ``pytest.warns`` instead.
+
     Parameters
     ----------
     func : callable
@@ -2088,6 +2102,10 @@ def assert_no_warnings(*args, **kwargs):
     The value returned by `func`.
 
     """
+    warnings.warn(
+        "NumPy warning suppression and assertion utilities are deprecated. "
+        "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
+        "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
     if not args:
         return _assert_no_warnings_context()
 
@@ -2227,6 +2245,11 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     For compatibility with Python, please consider all arguments to be
     keyword-only.
 
+    .. deprecated:: 2.5
+
+        This is deprecated. Use `warnings.filterwarnings` or
+        ``pytest.filterwarnings`` instead.
+
     Parameters
     ----------
     record : bool, optional
@@ -2253,6 +2276,10 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     class_modules = ()
 
     def __init__(self, record=False, modules=()):
+        warnings.warn(
+            "NumPy warning suppression and assertion utilities are deprecated. "
+            "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
+            "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
         self.modules = set(modules).union(self.class_modules)
         self._warnreg_copies = {}
         super().__init__(record=record)
@@ -2287,6 +2314,11 @@ class suppress_warnings:
     means that no "ignore" filter can be used easily, since following
     tests might need to see the warning. Additionally it allows easier
     specificity for testing warnings and can be nested.
+
+    .. deprecated:: 2.5
+
+        This is deprecated. Use `warnings.filterwarnings` or
+        ``pytest.filterwarnings`` instead.
 
     Parameters
     ----------
@@ -2349,6 +2381,11 @@ class suppress_warnings:
             pass
     """
     def __init__(self, forwarding_rule="always"):
+        # there isn't a unique stack level here, so don't set one at all on 3.11
+        warnings.warn(
+            "NumPy warning suppression and assertion utilities are deprecated. "
+            "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
+            "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
         self._entered = False
 
         # Suppressions are either instance or defined inside one with block:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -56,10 +56,6 @@ verbose = 0
 
 NUMPY_ROOT = pathlib.Path(np.__file__).parent
 
-WARNING_KWARGS = {}
-if sys.version_info >= (3, 12):
-    WARNING_KWARGS['skip_file_prefixes'] = (__file__, contextlib.__file__)
-
 try:
     np_dist = importlib.metadata.distribution('numpy')
 except importlib.metadata.PackageNotFoundError:
@@ -1989,7 +1985,7 @@ def integer_repr(x):
 @contextlib.contextmanager
 def _assert_warns_context(warning_class, name=None):
     __tracebackhide__ = True  # Hide traceback for py.test
-    with suppress_warnings() as sup:
+    with suppress_warnings(_warn=False) as sup:
         l = sup.record(warning_class)
         yield
         if not len(l) > 0:
@@ -2045,6 +2041,10 @@ def assert_warns(warning_class, *args, **kwargs):
     >>> ret = np.testing.assert_warns(DeprecationWarning, deprecated_func, 4)
     >>> assert ret == 16
     """
+    warnings.warn(
+        "NumPy warning suppression and assertion utilities are deprecated. "
+        "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
+        "or pytest.filterwarnings instead.", DeprecationWarning, stacklevel=2)
     if not args and not kwargs:
         return _assert_warns_context(warning_class)
     elif len(args) < 1:
@@ -2362,12 +2362,12 @@ class suppress_warnings:
             # do something which causes a warning in np.ma.core
             pass
     """
-    def __init__(self, forwarding_rule="always"):
-        # there isn't a unique stack level here, so don't set one at all on 3.11
-        warnings.warn(
-            "NumPy warning suppression and assertion utilities are deprecated. "
-            "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
-            "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
+    def __init__(self, forwarding_rule="always", _warn=True):
+        if _warn:
+            warnings.warn(
+                "NumPy warning suppression and assertion utilities are deprecated. "
+                "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
+                "or pytest.filterwarnings instead.", DeprecationWarning, stacklevel=2)
         self._entered = False
 
         # Suppressions are either instance or defined inside one with block:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2236,11 +2236,6 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     For compatibility with Python, please consider all arguments to be
     keyword-only.
 
-    .. deprecated:: 2.5
-
-        This is deprecated. Use `warnings.filterwarnings` or
-        ``pytest.filterwarnings`` instead.
-
     Parameters
     ----------
     record : bool, optional
@@ -2267,10 +2262,6 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     class_modules = ()
 
     def __init__(self, record=False, modules=()):
-        warnings.warn(
-            "NumPy warning suppression and assertion utilities are deprecated. "
-            "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
-            "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
         self.modules = set(modules).union(self.class_modules)
         self._warnreg_copies = {}
         super().__init__(record=record)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2083,11 +2083,6 @@ def assert_no_warnings(*args, **kwargs):
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
 
-    .. deprecated:: 2.5
-
-        This is deprecated. Use `warnings.catch_warnings` or
-        ``pytest.warns`` instead.
-
     Parameters
     ----------
     func : callable
@@ -2102,10 +2097,6 @@ def assert_no_warnings(*args, **kwargs):
     The value returned by `func`.
 
     """
-    warnings.warn(
-        "NumPy warning suppression and assertion utilities are deprecated. "
-        "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
-        "or pytest.filterwarnings instead.", DeprecationWarning, **WARNING_KWARGS)
     if not args:
         return _assert_no_warnings_context()
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2044,7 +2044,8 @@ def assert_warns(warning_class, *args, **kwargs):
     warnings.warn(
         "NumPy warning suppression and assertion utilities are deprecated. "
         "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
-        "or pytest.filterwarnings instead.", DeprecationWarning, stacklevel=2)
+        "or pytest.filterwarnings instead. (Deprecated NumPy 2.4)",
+        DeprecationWarning, stacklevel=2)
     if not args and not kwargs:
         return _assert_warns_context(warning_class)
     elif len(args) < 1:
@@ -2367,7 +2368,8 @@ class suppress_warnings:
             warnings.warn(
                 "NumPy warning suppression and assertion utilities are deprecated. "
                 "Use warnings.catch_warnings, warnings.filterwarnings, pytest.warns, "
-                "or pytest.filterwarnings instead.", DeprecationWarning, stacklevel=2)
+                "or pytest.filterwarnings instead. (Deprecated NumPy 2.4)",
+                DeprecationWarning, stacklevel=2)
         self._entered = False
 
         # Suppressions are either instance or defined inside one with block:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2009,7 +2009,7 @@ def assert_warns(warning_class, *args, **kwargs):
 
     The ability to be used as a context manager is new in NumPy v1.11.0.
 
-    .. deprecated:: 2.5
+    .. deprecated:: 2.4
 
         This is deprecated. Use `warnings.catch_warnings` or
         ``pytest.warns`` instead.
@@ -2297,7 +2297,7 @@ class suppress_warnings:
     tests might need to see the warning. Additionally it allows easier
     specificity for testing warnings and can be nested.
 
-    .. deprecated:: 2.5
+    .. deprecated:: 2.4
 
         This is deprecated. Use `warnings.filterwarnings` or
         ``pytest.filterwarnings`` instead.

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -24,7 +24,7 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, deprecated
 from unittest.case import SkipTest
 
 import numpy as np
@@ -148,6 +148,7 @@ class clear_and_catch_warnings(warnings.catch_warnings[_W_co], Generic[_W_co]): 
     @overload  # record; bool
     def __init__(self, /, record: bool, modules: _ToModules = ()) -> None: ...
 
+@deprecated("Please use warnings.filterwarnings or pytest.mark.filterwarnings instead")
 class suppress_warnings:
     log: Final[_WarnLog]
     def __init__(self, /, forwarding_rule: L["always", "module", "once", "location"] = "always") -> None: ...
@@ -358,8 +359,10 @@ def assert_array_max_ulp(
 ) -> NDArray[Any]: ...
 
 #
+@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 @overload
 def assert_warns(warning_class: _WarningSpec) -> _GeneratorContextManager[None]: ...
+@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 @overload
 def assert_warns(warning_class: _WarningSpec, func: Callable[_Tss, _T], *args: _Tss.args, **kwargs: _Tss.kwargs) -> _T: ...
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1140,7 +1140,9 @@ class TestArrayAssertLess:
         with pytest.raises(AssertionError):
             self._assert_func(x, y.astype(np.float32), strict=True)
 
-
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 class TestWarns:
 
     def test_warn(self):
@@ -1787,6 +1789,9 @@ def test_clear_and_catch_warnings():
     assert_warn_len_equal(my_mod, 0)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 def test_suppress_warnings_module():
     # Initial state of module, no warnings
     my_mod = _get_fresh_mod()
@@ -1833,6 +1838,9 @@ def test_suppress_warnings_module():
     assert_warn_len_equal(my_mod, 0)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 def test_suppress_warnings_type():
     # Initial state of module, no warnings
     my_mod = _get_fresh_mod()
@@ -1861,6 +1869,9 @@ def test_suppress_warnings_type():
     assert_warn_len_equal(my_mod, 0)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 def test_suppress_warnings_decorate_no_record():
     sup = suppress_warnings()
     sup.filter(UserWarning)
@@ -1876,6 +1887,9 @@ def test_suppress_warnings_decorate_no_record():
         assert_equal(len(w), 1)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 def test_suppress_warnings_record():
     sup = suppress_warnings()
     log1 = sup.record()
@@ -1913,9 +1927,13 @@ def test_suppress_warnings_record():
             warnings.warn('Some warning')
             warnings.warn('Some other warning')
             assert_equal(len(sup2.log), 1)
-        assert_equal(len(sup.log), 1)
+        # includes a DeprecationWarning for suppress_warnings
+        assert_equal(len(sup.log), 2)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
+    ".*:DeprecationWarning")
 def test_suppress_warnings_forwarding():
     def warn_other_module():
         # Apply along axis is implemented in python; stacklevel=2 means
@@ -1931,7 +1949,8 @@ def test_suppress_warnings_forwarding():
             for i in range(2):
                 warnings.warn("Some warning")
 
-        assert_equal(len(sup.log), 2)
+        # includes a DeprecationWarning for suppress_warnings
+        assert_equal(len(sup.log), 3)
 
     with suppress_warnings() as sup:
         sup.record()
@@ -1940,7 +1959,8 @@ def test_suppress_warnings_forwarding():
                 warnings.warn("Some warning")
                 warnings.warn("Some warning")
 
-        assert_equal(len(sup.log), 2)
+        # includes a DeprecationWarning for suppress_warnings
+        assert_equal(len(sup.log), 3)
 
     with suppress_warnings() as sup:
         sup.record()
@@ -1950,7 +1970,8 @@ def test_suppress_warnings_forwarding():
                 warnings.warn("Some warning")
                 warn_other_module()
 
-        assert_equal(len(sup.log), 2)
+        # includes a DeprecationWarning for suppress_warnings
+        assert_equal(len(sup.log), 3)
 
     with suppress_warnings() as sup:
         sup.record()
@@ -1960,7 +1981,8 @@ def test_suppress_warnings_forwarding():
                 warnings.warn("Some other warning")
                 warn_other_module()
 
-        assert_equal(len(sup.log), 2)
+        # includes a DeprecationWarning for suppress_warnings
+        assert_equal(len(sup.log), 3)
 
 
 def test_tempdir():

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -53,7 +53,6 @@ class FindFuncs(ast.NodeVisitor):
             args = {kw.arg for kw in node.keywords}
             if "stacklevel" in args:
                 return
-            breakpoint()
             raise AssertionError(
                 "warnings should have an appropriate stacklevel; "
                 f"found in {self.__filename} on line {node.lineno}")

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -53,6 +53,7 @@ class FindFuncs(ast.NodeVisitor):
             args = {kw.arg for kw in node.keywords}
             if "stacklevel" in args:
                 return
+            breakpoint()
             raise AssertionError(
                 "warnings should have an appropriate stacklevel; "
                 f"found in {self.__filename} on line {node.lineno}")

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import operator
 from typing import Any, cast
 
+import pytest
+
 import numpy as np
 import numpy.typing as npt
 
@@ -190,11 +192,11 @@ A_void["yap"] = A_float[:, 1]
 
 # deprecated
 
-with np.testing.assert_warns(DeprecationWarning):
+with pytest.warns(DeprecationWarning):
     ctypes_obj.get_data()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with np.testing.assert_warns(DeprecationWarning):
+with pytest.warns(DeprecationWarning):
     ctypes_obj.get_shape()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with np.testing.assert_warns(DeprecationWarning):
+with pytest.warns(DeprecationWarning):
     ctypes_obj.get_strides()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with np.testing.assert_warns(DeprecationWarning):
+with pytest.warns(DeprecationWarning):
     ctypes_obj.get_as_parameter()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -192,11 +192,11 @@ A_void["yap"] = A_float[:, 1]
 
 # deprecated
 
-with pytest.warns(DeprecationWarning):
+with pytest.deprecated_call():
     ctypes_obj.get_data()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.warns(DeprecationWarning):
+with pytest.deprecated_call():
     ctypes_obj.get_shape()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.warns(DeprecationWarning):
+with pytest.deprecated_call():
     ctypes_obj.get_strides()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.warns(DeprecationWarning):
+with pytest.deprecated_call():
     ctypes_obj.get_as_parameter()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]

--- a/numpy/typing/tests/data/reveal/testing.pyi
+++ b/numpy/typing/tests/data/reveal/testing.pyi
@@ -15,7 +15,7 @@ AR_f8: npt.NDArray[np.float64]
 AR_i8: npt.NDArray[np.int64]
 
 bool_obj: bool
-suppress_obj: np.testing.suppress_warnings
+suppress_obj: np.testing.suppress_warnings  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 FT = TypeVar("FT", bound=Callable[..., Any])
 
 def func() -> int: ...
@@ -58,12 +58,12 @@ with np.testing.clear_and_catch_warnings(True) as c1:
 with np.testing.clear_and_catch_warnings() as c2:
     assert_type(c2, None)
 
-assert_type(np.testing.suppress_warnings("once"), np.testing.suppress_warnings)
-assert_type(np.testing.suppress_warnings()(func), Callable[[], int])
+assert_type(np.testing.suppress_warnings("once"), np.testing.suppress_warnings)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
+assert_type(np.testing.suppress_warnings()(func), Callable[[], int])  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 assert_type(suppress_obj.filter(RuntimeWarning), None)
 assert_type(suppress_obj.record(RuntimeWarning), list[warnings.WarningMessage])
 with suppress_obj as c3:
-    assert_type(c3, np.testing.suppress_warnings)
+    assert_type(c3, np.testing.suppress_warnings)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 
 assert_type(np.testing.verbose, int)
 assert_type(np.testing.IS_PYPY, bool)
@@ -172,7 +172,7 @@ assert_type(np.testing.assert_array_almost_equal_nulp(AR_i8, AR_f8, nulp=2), Non
 assert_type(np.testing.assert_array_max_ulp(AR_i8, AR_f8, maxulp=2), npt.NDArray[Any])
 assert_type(np.testing.assert_array_max_ulp(AR_i8, AR_f8, dtype=np.float32), npt.NDArray[Any])
 
-assert_type(np.testing.assert_warns(RuntimeWarning), contextlib._GeneratorContextManager[None])
+assert_type(np.testing.assert_warns(RuntimeWarning), contextlib._GeneratorContextManager[None])  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 assert_type(np.testing.assert_warns(RuntimeWarning, func3, 5), bool)
 
 def func4(a: int, b: str) -> bool: ...


### PR DESCRIPTION
fixes #29293

Deprecates the following public API:

* `np.testing.assert_warns`
* `np.testing.suppress_warnings`

These solve problems that no longer exist in modern Python versions. As of Python 3.14, where warnings can be made thread-safe, they're actively harmful because the implementation is not thread-safe. We should deprecate these helpers and point people at the standard library or pytest.

`assert_warns` and `suppress_warnings` used to be used heavily in NumPy and SciPy, but https://github.com/numpy/numpy/pull/29322/ cleaned up NumPy and https://github.com/scipy/scipy/pull/23275 cleaned up SciPy. I don't think there are any substantial uses in active open source codebases besides NumPy and SciPy, judging by Github code searches.

I marked this for 2.5 but maybe we should backport it to the 2.4 branch?

I had to adjust some of the tests for `suppress_warnings` slightly, because now a new warning is getting generated.

I also used the `skip_file_prefixes` keyword for `warnings.warn`, which is only available on 3.12 and newer. Do I need to care about 3.11 support to make the warning context nice? There's no single `stacklevel` I can set.

An earlier version of this PR also deprecated `clear_and_suppress_warnings` and `assert_no_warnings`, but I ran into some issues getting the tests working again with the deprecation and I don't actually need to deprecate them, so I punted.