### PR TITLE
BUG: Fix metadata not roundtripping when pickling datetime

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2879,7 +2879,6 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
     char endian;
     PyObject *endian_obj;
     PyObject *subarray, *fields, *names = NULL, *metadata=NULL;
-    PyObject *old_metadata, *new_metadata;
     int incref_names = 1;
     int int_dtypeflags = 0;
     npy_uint64 dtypeflags;
@@ -3200,6 +3199,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         self->flags = _descr_find_object((PyArray_Descr *)self);
     }
 
+    PyObject *old_metadata, *new_metadata;
     if (PyDataType_ISDATETIME(self)) {
         PyArray_DatetimeMetaData temp_dt_data;
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2878,6 +2878,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
     char endian;
     PyObject *endian_obj;
     PyObject *subarray, *fields, *names = NULL, *metadata=NULL;
+    PyObject *old_metadata, *new_metadata;
     int incref_names = 1;
     int int_dtypeflags = 0;
     npy_uint64 dtypeflags;
@@ -3198,9 +3199,6 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         self->flags = _descr_find_object((PyArray_Descr *)self);
     }
 
-    PyObject *old_metadata, *new_metadata;
-    old_metadata = self->metadata;
-
     if (PyDataType_ISDATETIME(self)) {
         PyArray_DatetimeMetaData temp_dt_data;
 
@@ -3227,6 +3225,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         new_metadata = metadata;
     }
 
+    old_metadata = self->metadata;
     /*
      * We have a borrowed reference to metadata so no need
      * to alter reference count when throwing away Py_None.

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3226,7 +3226,6 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
 
         old_metadata = self->metadata;
         new_metadata = PyTuple_GET_ITEM(metadata, 0);
-
         if (new_metadata == Py_None) {
             new_metadata = NULL;
         }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2674,6 +2674,7 @@ _get_pickleabletype_from_datetime_metadata(PyArray_Descr *dtype)
     }
     else {
         PyTuple_SET_ITEM(ret, 0, Py_None);
+        Py_INCREF(Py_None);
     }
 
     /* Convert the datetime metadata into a tuple */

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -889,6 +889,15 @@ class TestDateTime:
                 b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
             assert_equal(pickle.loads(pkl), np.dtype('>M8[us]'))
 
+        # check that dtype metadata round-trips when none
+        # gh-29555
+        dt = np.dtype('>M8[us]')
+        assert dt.metadata is None
+        for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
+            res = pickle.loads(pickle.dumps(dt, protocol=proto))
+            assert_equal(res, dt)
+            assert res.metadata is None
+
     def test_setstate(self):
         "Verify that datetime dtype __setstate__ can handle bad arguments"
         dt = np.dtype('>M8[us]')

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -889,8 +889,8 @@ class TestDateTime:
                 b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
             assert_equal(pickle.loads(pkl), np.dtype('>M8[us]'))
 
+    def test_gh_29555(self):
         # check that dtype metadata round-trips when none
-        # gh-29555
         dt = np.dtype('>M8[us]')
         assert dt.metadata is None
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):


### PR DESCRIPTION
Fixes #29344.

It seems that for datetime dtypes, `arraydescr_reduce` was initializing a new mapping instead of setting to `Py_None`, and then `arraydescr_setstate` just read it in. I set the metadata to and then checked for `Py_None` and refactored some of the logic to be clearer hopefully. 

Adding a test. Thanks for reviewing!