### PR TITLE
DOC: Document datetime and timedelta to python's object type conversion

### DIFF
--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -313,18 +313,18 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
 Converting datetime and timedelta to Python Object
 ==================================================
 
-NumPy follows a strict protocol when converting ``np.datetime64`` and/or ``np.timedelta64`` to Python Objects (e.g., ``tuple``, ``list``, ``datetime.datetime``). 
+NumPy follows a strict protocol when converting `datetime64` and/or `timedelta64` to Python Objects (e.g., `tuple`, `list`, `datetime.datetime`). 
 
 The protocol is described in the following table:
 
 ================================ ================================= ==================================
-         Input Type                         for ``datetime64``                    for ``timedelta64``
+         Input Type                         for `datetime64`               for `timedelta64`
 ================================ ================================= ==================================
-              ``NaT``                           ``None``                               ``None``
-     Finer than Microseconds                    ``int``                                ``int``
-     Microseconds or Coarser              ``datetime.datetime``                 ``datetime.timedelta``
-         Days or Coarser                    ``datetime.date``                   ``datetime.timedelta``
-Non-linear(Y/M) and genric units            ``datetime.date``                          ``int``
+              `NaT`                             `None`                           `None`
+     Finer than Microseconds                    `int`                            `int`
+     Microseconds or Coarser              `datetime.datetime`              `datetime.timedelta`
+         Days or Coarser                    `datetime.date`                `datetime.timedelta`
+Non-linear(Y/M) and genric units            `datetime.date`                      `int`
 ================================ ================================= ==================================
 
 .. admonition:: Example

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -309,6 +309,24 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
    as      attosecond       +/- 9.2 seconds         [  1969 AD,   1970 AD]
 ======== ================ ======================= ==========================
 
+Converting datetime and timedelta to Python Object
+==================================================
+
+NumPy follows a strict protocol when converting datetime and timedelta to Python Objects (e.g., tuple, list, datetime.datetime).
+
+For conversion of datetime to a Python Object:
+
+- For days or coarser, returns a datetime.date.
+- For days or coarser, returns a datetime.date.
+- For microseconds or coarser, returns a datetime.datetime.
+- For units finer than microseconds, returns an integer.
+
+For conversion of timedelta to Python Object
+
+- Not-a-time is returned as the string "NaT".
+- For microseconds or coarser, returns a datetime.timedelta.
+- For units finer than microseconds, returns an integer.
+
 Business day functionality
 ==========================
 

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -320,11 +320,12 @@ The protocol is described in the following table:
 ================================ ================================= ==================================
          Input Type                         for `datetime64`               for `timedelta64`
 ================================ ================================= ==================================
-              ``NaT``                           ``None``                           ``None``
-     Finer than Microseconds                    ``int``                            ``int``
-     Microseconds or Coarser              `datetime.datetime`              `datetime.timedelta`
-         Days or Coarser                    `datetime.date`                `datetime.timedelta`
-Non-linear(Y/M) and genric units            `datetime.date`                      ``int``
+          ``NaT``                             ``None``                           ``None``
+        ns/ps/fs/as                           ``int``                            ``int``
+        μs/ms/s/m/h                      `datetime.datetime`               `datetime.timedelta`
+      D/W (Linear units)                   `datetime.date`                 `datetime.timedelta` 
+    Y/M (Non-linear units)                 `datetime.date`                        ``int``
+        Generic units                      `datetime.date`                        ``int``
 ================================ ================================= ==================================
 
 .. admonition:: Example
@@ -333,20 +334,39 @@ Non-linear(Y/M) and genric units            `datetime.date`                     
 
     >>> import numpy as np
 
-    >>> type(np.datetime64('NaT').astype(object))
+    >>> type(np.datetime64('NaT').item())
     <class 'NoneType'>
 
-    >>> type(np.timedelta64('NaT').astype(object))
+    >>> type(np.timedelta64('NaT').item())
     <class 'NoneType'>
 
-    >>> type(np.timedelta64(123, 'ns').astype(object))
+    >>> type(np.timedelta64(123, 'ns').item())
     <class 'int'>
 
-    >>> type(np.datetime64('2025-01-01T12:00:00.123456').astype(object))
+    >>> type(np.datetime64('2025-01-01T12:00:00.123456').item())
     <class 'datetime.datetime'>
 
-    >>> type(np.timedelta64(10, 'D').astype(object))
+    >>> type(np.timedelta64(10, 'D').item())
     <class 'datetime.timedelta'>
+
+
+In the casea where conversion of `datetime64` and/or `timedelta64` is done against Python types like ``int``, ``float``, and ``str`` the corresponding return types will be ``np.str_``, ``np.int64`` and ``np.float64``.
+
+
+.. admonition:: Example
+
+  .. try_examples::
+
+    >>> import numpy as np
+    
+    >>> type(np.timedelta64(1, 'D').astype(int))
+    <class 'numpy.int64'>
+
+    >>> type(np.datetime64('2025-01-01T12:00:00.123456').astype(float))
+    <class 'numpy.float64'>
+
+    >>> type(np.timedelta64(123, 'ns').astype(str))
+    <class 'numpy.str_'>
 
 
 Business day functionality

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -316,7 +316,7 @@ NumPy follows a strict protocol when converting datetime and timedelta to Python
 
 For conversion of datetime to a Python Object:
 
-- For days or coarser, returns a datetime.date.
+- Not-a-time is returned as the string "NaT".
 - For days or coarser, returns a datetime.date.
 - For microseconds or coarser, returns a datetime.datetime.
 - For units finer than microseconds, returns an integer.

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -313,18 +313,18 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
 Converting datetime and timedelta to Python Object
 ==================================================
 
-NumPy follows a strict protocol when converting datetime64 and/or timedelta64 to Python Objects (e.g., tuple, list, datetime.datetime). 
+NumPy follows a strict protocol when converting ``np.datetime64`` and/or ``np.timedelta64`` to Python Objects (e.g., ``tuple``, ``list``, ``datetime.datetime``). 
 
 The protocol is described in the following table:
 
 ================================ ================================= ==================================
-         Input Type                         for datetime64                    for timedelta64
+         Input Type                         for ``datetime64``                    for ``timedelta64``
 ================================ ================================= ==================================
-              NaT                               None                               None
-     Finer than Microseconds                    int                                int
-     Microseconds or Coarser              datetime.datetime                 datetime.timedelta
-         Days or Coarser                    datetime.date                   datetime.timedelta
-Non-linear(Y/M) and genric units            datetime.date                          int
+              ``NaT``                           ``None``                               ``None``
+     Finer than Microseconds                    ``int``                                ``int``
+     Microseconds or Coarser              ``datetime.datetime``                 ``datetime.timedelta``
+         Days or Coarser                    ``datetime.date``                   ``datetime.timedelta``
+Non-linear(Y/M) and genric units            ``datetime.date``                          ``int``
 ================================ ================================= ==================================
 
 .. admonition:: Example

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -324,8 +324,8 @@ The protocol is described in the following table:
         ns/ps/fs/as                           ``int``                            ``int``
         μs/ms/s/m/h                      `datetime.datetime`               `datetime.timedelta`
       D/W (Linear units)                   `datetime.date`                 `datetime.timedelta` 
-    Y/M (Non-linear units)                 `datetime.date`                        ``int``
-        Generic units                      `datetime.date`                        ``int``
+    Y/M (Non-linear units)                 `datetime.date`                       ``int``
+        Generic units                      `datetime.date`                       ``int``
 ================================ ================================= ==================================
 
 .. admonition:: Example

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -313,18 +313,18 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
 Converting datetime and timedelta to Python Object
 ==================================================
 
-NumPy follows a strict protocol when converting `datetime64` and/or `timedelta64` to Python Objects (e.g., `tuple`, `list`, `datetime.datetime`). 
+NumPy follows a strict protocol when converting `datetime64` and/or `timedelta64` to Python Objects (e.g., ``tuple``, ``list``, `datetime.datetime`). 
 
 The protocol is described in the following table:
 
 ================================ ================================= ==================================
          Input Type                         for `datetime64`               for `timedelta64`
 ================================ ================================= ==================================
-              `NaT`                             `None`                           `None`
-     Finer than Microseconds                    `int`                            `int`
+              ``NaT``                           ``None``                           ``None``
+     Finer than Microseconds                    ``int``                            ``int``
      Microseconds or Coarser              `datetime.datetime`              `datetime.timedelta`
          Days or Coarser                    `datetime.date`                `datetime.timedelta`
-Non-linear(Y/M) and genric units            `datetime.date`                      `int`
+Non-linear(Y/M) and genric units            `datetime.date`                      ``int``
 ================================ ================================= ==================================
 
 .. admonition:: Example

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -313,20 +313,40 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
 Converting datetime and timedelta to Python Object
 ==================================================
 
-NumPy follows a strict protocol when converting datetime and timedelta to Python Objects (e.g., tuple, list, datetime.datetime).
+NumPy follows a strict protocol when converting datetime64 and/or timedelta64 to Python Objects (e.g., tuple, list, datetime.datetime). 
 
-For conversion of datetime to a Python Object:
+The protocol is described in the following table:
 
-- Not-a-time is returned as None.
-- For days or coarser, returns a datetime.date.
-- For microseconds or coarser, returns a datetime.datetime.
-- For units finer than microseconds, returns an integer.
+================================ ================================= ==================================
+         Input Type                         for datetime64                    for timedelta64
+================================ ================================= ==================================
+              NaT                               None                               None
+     Finer than Microseconds                    int                                int
+     Microseconds or Coarser              datetime.datetime                 datetime.timedelta
+         Days or Coarser                    datetime.date                   datetime.timedelta
+Non-linear(Y/M) and genric units            datetime.date                          int
+================================ ================================= ==================================
 
-For conversion of timedelta to Python Object
+.. admonition:: Example
 
-- Not-a-time is returned as None.
-- For microseconds or coarser, returns a datetime.timedelta.
-- For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
+  .. try_examples::
+
+    >>> import numpy as np
+
+    >>> type(np.datetime64('NaT').astype(object))
+    <class 'NoneType'>
+
+    >>> type(np.timedelta64('NaT').astype(object))
+    <class 'NoneType'>
+
+    >>> type(np.timedelta64(123, 'ns').astype(object))
+    <class 'int'>
+
+    >>> type(np.datetime64('2025-01-01T12:00:00.123456').astype(object))
+    <class 'datetime.datetime'>
+
+    >>> type(np.timedelta64(10, 'D').astype(object))
+    <class 'datetime.timedelta'>
 
 
 Business day functionality

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -350,7 +350,7 @@ The protocol is described in the following table:
     <class 'datetime.timedelta'>
 
 
-In the casea where conversion of `datetime64` and/or `timedelta64` is done against Python types like ``int``, ``float``, and ``str`` the corresponding return types will be ``np.str_``, ``np.int64`` and ``np.float64``.
+In the case where conversion of `datetime64` and/or `timedelta64` is done against Python types like ``int``, ``float``, and ``str`` the corresponding return types will be ``np.str_``, ``np.int64`` and ``np.float64``.
 
 
 .. admonition:: Example

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -309,6 +309,7 @@ us / μs    microsecond      +/- 2.9e5 years         [290301 BC, 294241 AD]
    as      attosecond       +/- 9.2 seconds         [  1969 AD,   1970 AD]
 ======== ================ ======================= ==========================
 
+
 Converting datetime and timedelta to Python Object
 ==================================================
 
@@ -316,16 +317,17 @@ NumPy follows a strict protocol when converting datetime and timedelta to Python
 
 For conversion of datetime to a Python Object:
 
-- Not-a-time is returned as the string "NaT".
+- Not-a-time is returned as None.
 - For days or coarser, returns a datetime.date.
 - For microseconds or coarser, returns a datetime.datetime.
 - For units finer than microseconds, returns an integer.
 
 For conversion of timedelta to Python Object
 
-- Not-a-time is returned as the string "NaT".
+- Not-a-time is returned as None.
 - For microseconds or coarser, returns a datetime.timedelta.
-- For units finer than microseconds, returns an integer.
+- For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
+
 
 Business day functionality
 ==========================

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -243,6 +243,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
  * Converts a datetime into a PyObject *.
  *
  * For days or coarser, returns a datetime.date.
+ * For days or coarser, returns a datetime.date.
  * For microseconds or coarser, returns a datetime.datetime.
  * For units finer than microseconds, returns an integer.
  */

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -243,9 +243,9 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
  * Converts a datetime into a PyObject *.
  *
  * NaT (Not-a-time) is returned as None.
- * For days or coarser, returns a datetime.date.
- * For microseconds or coarser, returns a datetime.datetime.
- * For units finer than microseconds, returns an integer.
+ * For D/W/Y/M (days or coarser), returns a datetime.date.
+ * For μs/ms/s/m/h/D/W (microseconds or coarser), returns a datetime.datetime.
+ * For ns/ps/fs/as (units shorter than microseconds), returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta);
@@ -254,8 +254,8 @@ convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta);
  * Converts a timedelta into a PyObject *.
  *
  * NaT (Not-a-time) is returned as None.
- * For microseconds or coarser, returns a datetime.timedelta.
- * For Y/M (nonlinear units), generic units and units finer than microseconds, returns an integer.
+ * For μs/ms/s/m/h/D/W (microseconds or coarser), returns a datetime.timedelta.
+ * For Y/M (non-linear units), generic units and ns/ps/fs/as (units shorter than microseconds), returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta);

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -242,7 +242,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 /*
  * Converts a datetime into a PyObject *.
  *
- * For days or coarser, returns a datetime.date.
+ * Not-a-time is returned as the string "NaT".
  * For days or coarser, returns a datetime.date.
  * For microseconds or coarser, returns a datetime.datetime.
  * For units finer than microseconds, returns an integer.

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -242,7 +242,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 /*
  * Converts a datetime into a PyObject *.
  *
- * Not-a-time is returned as the string "NaT".
+ * Not-a-time is returned as None.
  * For days or coarser, returns a datetime.date.
  * For microseconds or coarser, returns a datetime.datetime.
  * For units finer than microseconds, returns an integer.
@@ -253,9 +253,9 @@ convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta);
 /*
  * Converts a timedelta into a PyObject *.
  *
- * Not-a-time is returned as the string "NaT".
+ * Not-a-time is returned as None.
  * For microseconds or coarser, returns a datetime.timedelta.
- * For units finer than microseconds, returns an integer.
+ * For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta);

--- a/numpy/_core/src/multiarray/_datetime.h
+++ b/numpy/_core/src/multiarray/_datetime.h
@@ -242,7 +242,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 /*
  * Converts a datetime into a PyObject *.
  *
- * Not-a-time is returned as None.
+ * NaT (Not-a-time) is returned as None.
  * For days or coarser, returns a datetime.date.
  * For microseconds or coarser, returns a datetime.datetime.
  * For units finer than microseconds, returns an integer.
@@ -253,9 +253,9 @@ convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta);
 /*
  * Converts a timedelta into a PyObject *.
  *
- * Not-a-time is returned as None.
+ * NaT (Not-a-time) is returned as None.
  * For microseconds or coarser, returns a datetime.timedelta.
- * For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
+ * For Y/M (nonlinear units), generic units and units finer than microseconds, returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2761,7 +2761,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 /*
  * Converts a datetime into a PyObject *.
  *
- * Not-a-time is returned as the string "NaT".
+ * Not-a-time is returned as None.
  * For days or coarser, returns a datetime.date.
  * For microseconds or coarser, returns a datetime.datetime.
  * For units finer than microseconds, returns an integer.
@@ -2945,9 +2945,9 @@ convert_timedelta_to_timedeltastruct(PyArray_DatetimeMetaData *meta,
 /*
  * Converts a timedelta into a PyObject *.
  *
- * Not-a-time is returned as the string "NaT".
+ * Not-a-time is returned as None.
  * For microseconds or coarser, returns a datetime.timedelta.
- * For units finer than microseconds, returns an integer.
+ * For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta)

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2761,10 +2761,10 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 /*
  * Converts a datetime into a PyObject *.
  *
- * Not-a-time is returned as None.
- * For days or coarser, returns a datetime.date.
- * For microseconds or coarser, returns a datetime.datetime.
- * For units finer than microseconds, returns an integer.
+ * NaT (Not-a-time) is returned as None.
+ * For D/W/Y/M (days or coarser), returns a datetime.date.
+ * For μs/ms/s/m/h/D/W (microseconds or coarser), returns a datetime.datetime.
+ * For ns/ps/fs/as (units shorter than microseconds), returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_datetime_to_pyobject(npy_datetime dt, PyArray_DatetimeMetaData *meta)
@@ -2946,8 +2946,8 @@ convert_timedelta_to_timedeltastruct(PyArray_DatetimeMetaData *meta,
  * Converts a timedelta into a PyObject *.
  *
  * NaT (Not-a-time) is returned as None.
- * For microseconds or coarser, returns a datetime.timedelta.
- * For Y/M (nonlinear units), generic units and units finer than microseconds, returns an integer.
+ * For μs/ms/s/m/h/D/W (microseconds or coarser), returns a datetime.timedelta.
+ * For Y/M (non-linear units), generic units and ns/ps/fs/as (units shorter than microseconds), returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta)

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2945,9 +2945,9 @@ convert_timedelta_to_timedeltastruct(PyArray_DatetimeMetaData *meta,
 /*
  * Converts a timedelta into a PyObject *.
  *
- * Not-a-time is returned as None.
+ * NaT (Not-a-time) is returned as None.
  * For microseconds or coarser, returns a datetime.timedelta.
- * For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.
+ * For Y/M (nonlinear units), generic units and units finer than microseconds, returns an integer.
  */
 NPY_NO_EXPORT PyObject *
 convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta)
@@ -2963,7 +2963,7 @@ convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta)
 
     /*
      * If the type's precision is greater than microseconds, is
-     * Y/M/B (nonlinear units), or is generic units, return an int
+     * Y/M (nonlinear units), or is generic units, return an int
      */
     if (meta->base > NPY_FR_us ||
                     meta->base == NPY_FR_Y ||


### PR DESCRIPTION
The need to document `datetime` and `timedelta` to Python object type conversions arose during a discussion in issue #29516 

NumPy follows a strict type conversion protocol when converting datetime64 or timedelta64 to standard Python objects. The rules are as follows:

Conversion of datetime64 to Python objects

- Not-a-time is returned as None.
- For days or coarser, returns a datetime.date.
- For microseconds or coarser, returns a datetime.datetime.
- For units finer than microseconds, returns an integer.

Conversion of timedelta64 to Python objects

- Not-a-time is returned as None.
- For microseconds or coarser, returns a datetime.timedelta.
- For Y/M/B (nonlinear units), generic units and units finer than microseconds, returns an integer.

Currently, this behavior is not clearly documented, which can lead to ambiguity for end users, forcing them to infer the conversion rules through experimentation.