### PR TITLE
TYP: use ``TypeAliasType`` for ``ArrayLike`` and ``DTypeLike`` on py312+

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -1,7 +1,8 @@
 """Private counterpart of ``numpy.typing``."""
 
+import sys
+
 from ._array_like import (
-    ArrayLike as ArrayLike,
     NDArray as NDArray,
     _ArrayLike as _ArrayLike,
     _ArrayLikeAnyString_co as _ArrayLikeAnyString_co,
@@ -84,7 +85,6 @@ from ._char_codes import (
 
 #
 from ._dtype_like import (
-    DTypeLike as DTypeLike,
     _DTypeLike as _DTypeLike,
     _DTypeLikeBool as _DTypeLikeBool,
     _DTypeLikeBytes as _DTypeLikeBytes,
@@ -156,3 +156,17 @@ from ._ufunc import (
     _UFunc_Nin2_Nout1 as _UFunc_Nin2_Nout1,
     _UFunc_Nin2_Nout2 as _UFunc_Nin2_Nout2,
 )
+
+# wrapping the public aliases in `TypeAliasType` helps with introspection readability
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+
+    from ._array_like import ArrayLike as _ArrayLikeAlias
+    from ._dtype_like import DTypeLike as _DTypeLikeAlias
+
+    ArrayLike = TypeAliasType("ArrayLike", _ArrayLikeAlias)
+    DTypeLike = TypeAliasType("DTypeLike", _DTypeLikeAlias)
+
+else:
+    from ._array_like import ArrayLike as ArrayLike
+    from ._dtype_like import DTypeLike as DTypeLike

--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -118,8 +118,8 @@ from ._nbit import (
 )
 
 #
-from ._nbit_base import (
-    NBitBase as NBitBase,  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
+from ._nbit_base import (  # type: ignore[deprecated]
+    NBitBase as NBitBase,  # pyright: ignore[reportDeprecated]
     _8Bit as _8Bit,
     _16Bit as _16Bit,
     _32Bit as _32Bit,


### PR DESCRIPTION
The main selling point is that it helps reduce introspection spaghetti.

```pycon
>>> import numpy.typing as npt
>>> def f(a: npt.ArrayLike, dtype: npt.DTypeLike) -> None: ...
... 
>>> help(f)
```

Before:

```py
f(
    a: Union[collections.abc.Buffer, numpy._typing._array_like._SupportsArray[numpy.dtype[Any]], numpy._typing._nested_sequence._NestedSequence[numpy._typing._array_like._SupportsArray[numpy.dtype[Any]]], complex, bytes, str, numpy._typing._nested_sequence._NestedSequence[complex | bytes | str]],
    dtype: Union[type[Any], numpy.dtype[Any], numpy._typing._dtype_like._SupportsDType[numpy.dtype[Any]], tuple[Any, Any], list[Any], numpy._typing._dtype_like._DTypeDict, str, NoneType]
) -> None
```

After:

```py
f(a: ArrayLike, dtype: DTypeLike) -> None
```

This can also help despaghettify type-checker output in some cases.

In case you're wondering about what those `typing.TypeAliasType` things are; they're what you get when you use the new Python 3.12+ [PEP 695](https://peps.python.org/pep-0695/#generic-type-alias) `type _ = ...` syntax.
They're a bit different from `typing.TypeAlias` because they actually wrap the alias, which is accessible through its `__value__` attribute.  I don't expect this to compat issues though, since there's usually no reason to dissect these aliases at runtime. 
Static type-checkers don't treat them any differently.