### PR TITLE
ENH: enable processing object file for f2py meson backend

### DIFF
--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -44,6 +44,9 @@ ${source_list},
                      inc_np,
 ${inc_list}
                      ],
+                     objects: [
+${obj_list}
+                     ],
                      dependencies : [
                      py_dep,
                      quadmath_dep,

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -673,6 +673,25 @@ def test_inclheader(capfd, hello_world_f90, monkeypatch):
             assert "#include <stdbool.h>" in ocmr
             assert "#include <stdio.h>" in ocmr
 
+@pytest.mark.skipif((platform.system() != 'Linux'), reason='Compiler required')
+def test_cli_obj(capfd, hello_world_f90, monkeypatch):
+    """Ensures that the extra object can be specified when using meson backend
+    """
+    ipath = Path(hello_world_f90)
+    mname = "blah"
+    odir = "tttmp"
+    obj = "extra.o"
+    monkeypatch.setattr(sys, "argv",
+                        f'f2py --backend meson --build-dir {odir} -m {mname} -c {obj} {ipath}'.split())
+
+    with util.switchdir(ipath.parent):
+        Path(obj).touch()
+        compiler_check_f2pycli()
+        with Path(f"{odir}/meson.build").open() as mesonbuild:
+            mbld = mesonbuild.read()
+            assert "objects:" in mbld
+            assert f"'''{obj}'''" in mbld
+
 
 def test_inclpath():
     """Add to the include directories


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR is going to fix #28191, in which we just realized that all `.o` file in `f2py -c a.o b.f90 -m test` is ignored by the meson backend. This feature was smoothly supported in the disutils backend before. 

Given that the name of object file is already scanned by [f2py](https://github.com/numpy/numpy/blob/4e00e4df15528323f6d76bbd40157b582861af86/numpy/f2py/f2py2e.py#L713), it is not difficult to recover this feature.
Basically, I add `objects: []` in meson.build.template and create `objects_substitution`, `_prepare_objects` functions for passing and copying the object file. I'm new to contributing to f2py, all feedback is welcome.

Another question is: what if the `.o` file has a module? Currently my choice is not to copy the `.mod` file, since the directory of them can be specified by something like `-I$(PWD)` , which is a workaround mentioned in #27018. Please feel free to discuss any other treatment on the `.mod` files.
