### PR TITLE
BUG: allow MaskedArray min/max with dtype=object

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5942,8 +5942,9 @@ class MaskedArray(ndarray):
         # No explicit output
         if out is None:
             result = self.filled(fill_value).min(
-                axis=axis, out=out, **kwargs).view(type(self))
-            if result.ndim:
+                axis=axis, out=out, **kwargs)
+            if isinstance(result, ndarray) and result.ndim:
+                result = result.view(type(self))
                 # Set the mask
                 result.__setmask__(newmask)
                 # Get rid of Infs
@@ -6047,8 +6048,9 @@ class MaskedArray(ndarray):
         # No explicit output
         if out is None:
             result = self.filled(fill_value).max(
-                axis=axis, out=out, **kwargs).view(type(self))
-            if result.ndim:
+                axis=axis, out=out, **kwargs)
+            if isinstance(result, ndarray) and result.ndim:
+                result = result.view(type(self))
                 # Set the mask
                 result.__setmask__(newmask)
                 # Get rid of Infs

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1453,9 +1453,17 @@ class TestMaskedArrayArithmetic:
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
     def test_minmax_object_dtype(self):
-        a = masked_array([1, 2, 3], dtype=object)
-        assert a.min() == 1
-        assert a.max() == 3
+        one = 1
+        three = 3
+        a = masked_array([one, 2, three], dtype=object)
+        assert a.min() is one
+        assert a.max() is three
+
+        one_ao = np.array(1)
+        three_ao = np.array(3)
+        aoao = masked_array([one_ao, np.array(2), three_ao], dtype=object)
+        assert aoao.min() is one_ao
+        assert aoao.max() is three_ao
 
     @pytest.mark.parametrize("dtype", "bBiIqQ")
     @pytest.mark.parametrize("mask", [

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1452,12 +1452,13 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
+    @pytest.mark.parametrize("mask", [nomask, [False, True, False]])
     @pytest.mark.parametrize("arg1, arg2, arg3", [
         (1, 2, 3),
         (np.array(1), np.array(2), np.array(3)),
     ])
-    def test_minmax_object_dtype(self, arg1, arg2, arg3):
-        a = masked_array([arg1, arg2, arg3], dtype=object)
+    def test_minmax_object_dtype(self, arg1, arg2, arg3, mask):
+        a = masked_array([arg1, arg2, arg3], mask=mask, dtype=object)
         assert a.min() is arg1
         assert a.max() is arg3
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1452,18 +1452,14 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
-    def test_minmax_object_dtype(self):
-        one = 1
-        three = 3
-        a = masked_array([one, 2, three], dtype=object)
-        assert a.min() is one
-        assert a.max() is three
-
-        one_ao = np.array(1)
-        three_ao = np.array(3)
-        aoao = masked_array([one_ao, np.array(2), three_ao], dtype=object)
-        assert aoao.min() is one_ao
-        assert aoao.max() is three_ao
+    @pytest.mark.parametrize("arg1, arg2, arg3", [
+        (1, 2, 3),
+        (np.array(1), np.array(2), np.array(3)),
+    ])
+    def test_minmax_object_dtype(self, arg1, arg2, arg3):
+        a = masked_array([arg1, arg2, arg3], dtype=object)
+        assert a.min() is arg1
+        assert a.max() is arg3
 
     @pytest.mark.parametrize("dtype", "bBiIqQ")
     @pytest.mark.parametrize("mask", [

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1452,6 +1452,11 @@ class TestMaskedArrayArithmetic:
             assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
             assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
+    def test_minmax_object_dtype(self):
+        a = masked_array([1, 2, 3], dtype=object)
+        assert a.min() == 1
+        assert a.max() == 3
+
     @pytest.mark.parametrize("dtype", "bBiIqQ")
     @pytest.mark.parametrize("mask", [
         [False, False, False, True, True],  # masked min/max

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1462,6 +1462,10 @@ class TestMaskedArrayArithmetic:
         assert a.min() is arg1
         assert a.max() is arg3
 
+    def test_gh_9103(self):
+        arr = masked_array([1, 2, 3], dtype='object', mask=[True, False, False])
+        assert arr.min() == 2
+
     @pytest.mark.parametrize("dtype", "bBiIqQ")
     @pytest.mark.parametrize("mask", [
         [False, False, False, True, True],  # masked min/max


### PR DESCRIPTION
Fixes #9103.  There are actually 2 bugs here:
- The `AttributeError` is fixed by checking if the result of min/max is an `ndarray` before calling `.view()`.
- The `TypeError` (which is what you actually get when you run the [#9103](https://github.com/numpy/numpy/issues/9103#issue-228130721) reproducer, even though it is reported as the AttributeError) is fixed by adding a universal infinity filler object which (preferentially) compares greater than all other objects other than itself.  Previously, the string `'?'` was used as the default filler for object min/max, which was wrong even for the case of an array of string objects.

In the process of fixing this bug, I also found several other related issues by searching for uses of `.view()`.  I was initially planning to fix those in this PR, but I think some of them may require a bit more discussion.  I plan to open a new issue about that later.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
