### PR TITLE
BUG: Fix sinc for custom objects

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3856,8 +3856,10 @@ def sinc(x):
     """
     x = np.asanyarray(x)
     x = pi * x
-    # Hope that 1e-20 is sufficient for objects...
-    eps = np.finfo(x.dtype).eps if x.dtype.kind == "f" else 1e-20
+    if hasattr(x, "dtype") and getattr(x.dtype, "kind", None) == "f":
+        eps = np.finfo(x.dtype).eps
+    else:
+        eps = 1e-20
     y = where(x, x, eps)
     return sin(y) / y
 


### PR DESCRIPTION
This PR introduces a simple fix for the sinc function which stopped working for minimal custom objects. The problem was introduced in https://github.com/numpy/numpy/pull/27784 / numpy 2.3 and is caused by an explicit check for the kind of the associated dtype in order to determine an appropriate eps. This PR makes the check more robust.

Minimal breaking example:
```python
import numpy as np

class MyObject:

    def __init__(self, value):
        self.value = value

    def __rmul__(self, y):
        return self.value * y

number = MyObject(2)
print(np.sinc(number))
```

Fails with
```
Traceback (most recent call last):
  File ".../numpy_repro.py", line 12, in <module>
    print(np.sinc(number))
          ^^^^^^^^^^^^^^^
  File ".../python3.12/site-packages/numpy/lib/_function_base_impl.py", line 3852, in sinc
    eps = np.finfo(x.dtype).eps if x.dtype.kind == "f" else 1e-20
                                   ^^^^^^^
AttributeError: 'float' object has no attribute 'dtype'
```