### PR TITLE
DOC: Clarify numpy.asarray order='A' parameter behavior

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -970,7 +970,9 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         Memory layout.  'A' and 'K' depend on the order of input array a.
         'C' row-major (C-style),
         'F' column-major (Fortran-style) memory representation.
-        'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
+        'A' (any) means 'F' if `a` is Fortran contiguous in memory and a copy
+        is made, 'C' otherwise. 'A' preserves the layout of existing arrays 
+        when no copy is needed.
         'K' (keep) preserve input order
         Defaults to 'K'.
     device : str, optional
@@ -1042,6 +1044,15 @@ add_newdoc('numpy._core.multiarray', 'asarray',
     >>> np.asanyarray(a) is a
     True
 
+    The `order='A'` parameter preserves existing array layout when possible:
+
+    >>> f_array = np.array([[1, 2], [3, 4]], order='F')
+    >>> result = np.asarray(f_array, order='A')
+    >>> result is f_array
+    True
+    >>> result.flags.f_contiguous
+    True
+
     """)
 
 add_newdoc('numpy._core.multiarray', 'asanyarray',
@@ -1062,7 +1073,9 @@ add_newdoc('numpy._core.multiarray', 'asanyarray',
         Memory layout.  'A' and 'K' depend on the order of input array a.
         'C' row-major (C-style),
         'F' column-major (Fortran-style) memory representation.
-        'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
+        'A' (any) means 'F' if `a` is Fortran contiguous in memory and a copy
+        is made, 'C' otherwise. 'A' preserves the layout of existing arrays 
+        when no copy is needed.
         'K' (keep) preserve input order
         Defaults to 'C'.
     device : str, optional

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -971,7 +971,7 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         'C' row-major (C-style),
         'F' column-major (Fortran-style) memory representation.
         'A' (any) means 'F' if `a` is Fortran contiguous in memory and a copy
-        is made, 'C' otherwise. 'A' preserves the layout of existing arrays 
+        is made, 'C' otherwise. 'A' preserves the layout of existing arrays
         when no copy is needed.
         'K' (keep) preserve input order
         Defaults to 'K'.
@@ -1074,7 +1074,7 @@ add_newdoc('numpy._core.multiarray', 'asanyarray',
         'C' row-major (C-style),
         'F' column-major (Fortran-style) memory representation.
         'A' (any) means 'F' if `a` is Fortran contiguous in memory and a copy
-        is made, 'C' otherwise. 'A' preserves the layout of existing arrays 
+        is made, 'C' otherwise. 'A' preserves the layout of existing arrays
         when no copy is needed.
         'K' (keep) preserve input order
         Defaults to 'C'.


### PR DESCRIPTION
Fixes #28247 by updating the documentation for the order='A' parameter in numpy.asarray() and numpy.asanyarray().

The previous documentation incorrectly stated that order='A' means 'F' if input is Fortran contiguous, 'C' otherwise.

The actual behavior is:
- When no copy is needed: preserves the input array's layout exactly
- When a copy is made: uses 'F' if input is Fortran contiguous, 'C' otherwise

Added a clear example demonstrating that order='A' preserves existing array layout when possible.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
