### PR TITLE
BUG: fix for evaluation of random_f and random_standard_cauchy in distributions.c

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -470,7 +470,7 @@ double random_chisquare(bitgen_t *bitgen_state, double df) {
 double random_f(bitgen_t *bitgen_state, double dfnum, double dfden) {
   double subexpr1 = random_chisquare(bitgen_state, dfnum) * dfden;
   double subexpr2 = random_chisquare(bitgen_state, dfden) * dfnum;
-  return subexpr1/subexpr2;
+  return subexpr1 / subexpr2;
 }
 
 double random_standard_cauchy(bitgen_t *bitgen_state) {

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -476,7 +476,7 @@ double random_f(bitgen_t *bitgen_state, double dfnum, double dfden) {
 double random_standard_cauchy(bitgen_t *bitgen_state) {
   double subexpr1 = random_standard_normal(bitgen_state);
   double subexpr2 = random_standard_normal(bitgen_state);
-  return subexpr1/subexpr2;
+  return subexpr1 / subexpr2;
 }
 
 double random_pareto(bitgen_t *bitgen_state, double a) {

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -468,12 +468,15 @@ double random_chisquare(bitgen_t *bitgen_state, double df) {
 }
 
 double random_f(bitgen_t *bitgen_state, double dfnum, double dfden) {
-  return ((random_chisquare(bitgen_state, dfnum) * dfden) /
-          (random_chisquare(bitgen_state, dfden) * dfnum));
+  double subexpr1 = random_chisquare(bitgen_state, dfnum) * dfden;
+  double subexpr2 = random_chisquare(bitgen_state, dfden) * dfnum;
+  return subexpr1/subexpr2;
 }
 
 double random_standard_cauchy(bitgen_t *bitgen_state) {
-  return random_standard_normal(bitgen_state) / random_standard_normal(bitgen_state);
+  double subexpr1 = random_standard_normal(bitgen_state);
+  double subexpr2 = random_standard_normal(bitgen_state);
+  return subexpr1/subexpr2;
 }
 
 double random_pareto(bitgen_t *bitgen_state, double a) {

--- a/numpy/random/src/legacy/legacy-distributions.c
+++ b/numpy/random/src/legacy/legacy-distributions.c
@@ -182,9 +182,7 @@ int64_t legacy_negative_binomial(aug_bitgen_t *aug_state, double n, double p) {
 }
 
 double legacy_standard_cauchy(aug_bitgen_t *aug_state) {
-  double subexpr1 = legacy_gauss(aug_state);
-  double subexpr2 = legacy_gauss(aug_state);
-  return subexpr1/subexpr2;
+  return legacy_gauss(aug_state) / legacy_gauss(aug_state);
 }
 
 double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
@@ -222,9 +220,8 @@ double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
 }
 
 double legacy_f(aug_bitgen_t *aug_state, double dfnum, double dfden) {
-  double subexpr1 = legacy_chisquare(aug_state, dfnum) * dfden;
-  double subexpr2 = legacy_chisquare(aug_state, dfden) * dfnum;
-  return subexpr1/subexpr2;
+  return ((legacy_chisquare(aug_state, dfnum) * dfden) /
+          (legacy_chisquare(aug_state, dfden) * dfnum));
 }
 
 double legacy_exponential(aug_bitgen_t *aug_state, double scale) {

--- a/numpy/random/src/legacy/legacy-distributions.c
+++ b/numpy/random/src/legacy/legacy-distributions.c
@@ -182,7 +182,9 @@ int64_t legacy_negative_binomial(aug_bitgen_t *aug_state, double n, double p) {
 }
 
 double legacy_standard_cauchy(aug_bitgen_t *aug_state) {
-  return legacy_gauss(aug_state) / legacy_gauss(aug_state);
+  double subexpr1 = legacy_gauss(aug_state);
+  double subexpr2 = legacy_gauss(aug_state);
+  return subexpr1/subexpr2;
 }
 
 double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
@@ -220,8 +222,9 @@ double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
 }
 
 double legacy_f(aug_bitgen_t *aug_state, double dfnum, double dfden) {
-  return ((legacy_chisquare(aug_state, dfnum) * dfden) /
-          (legacy_chisquare(aug_state, dfden) * dfnum));
+  double subexpr1 = legacy_chisquare(aug_state, dfnum) * dfden;
+  double subexpr2 = legacy_chisquare(aug_state, dfden) * dfnum;
+  return subexpr1/subexpr2;
 }
 
 double legacy_exponential(aug_bitgen_t *aug_state, double scale) {


### PR DESCRIPTION
C program does not guarantee the order of evaluation of its operands, as a result if we have a function that returns f1()/f2(),
here f2() may get evaluated first. consider the following program,

```
#include <stdio.h>

/* Dummy bit generator state */
typedef struct {
    int call;
} bitgen_t;

/* Deterministic "random_standard_normal" function */
double random_standard_normal(bitgen_t *bitgen_state) {
    if (bitgen_state->call == 0) {
        bitgen_state->call++;
        return 8.0;   /* first fixed value */
    } else {
        return 2.0;   /* second fixed value */
    }
}

/* Function returning ratio of two standard normals */
double random_ratio(bitgen_t *bitgen_state) {
    return random_standard_normal(bitgen_state) /
           random_standard_normal(bitgen_state);
}

int main(void) {
    bitgen_t state = {0}; /* no randomness */

    double val = random_ratio(&state);
    printf("Deterministic ratio value: %f\n", val);

    return 0;
}
```

here the function random_standard_normal uses bitgen_state struct to evaluate the first and second call, but since C guarantees no order the first call might be f2() which can cause return of 8.0 in f2() and 2.0 in f1() clearly the result returned will be 2.0/8.0 which if 1/4, however if f1() evaluates first result returned will be 8.0/2.0 which is 4.
