### PR TITLE
TST: Replace xunit setup with methods

### DIFF
--- a/numpy/_core/tests/test_half.py
+++ b/numpy/_core/tests/test_half.py
@@ -18,56 +18,63 @@ def assert_raises_fpe(strmatch, callable, *args, **kwargs):
                 f"Did not raise floating point {strmatch} error")
 
 class TestHalf:
-    def setup_method(self):
+    def _create_arrays_all(self):
         # An array of all possible float16 values
-        self.all_f16 = np.arange(0x10000, dtype=uint16)
-        self.all_f16 = self.all_f16.view(float16)
+        all_f16 = np.arange(0x10000, dtype=uint16)
+        all_f16 = all_f16.view(float16)
 
         # NaN value can cause an invalid FP exception if HW is being used
         with np.errstate(invalid='ignore'):
-            self.all_f32 = np.array(self.all_f16, dtype=float32)
-            self.all_f64 = np.array(self.all_f16, dtype=float64)
+            all_f32 = np.array(all_f16, dtype=float32)
+            all_f64 = np.array(all_f16, dtype=float64)
+        return all_f16, all_f32, all_f64
 
+    def _create_arrays_nonan(self):
         # An array of all non-NaN float16 values, in sorted order
-        self.nonan_f16 = np.concatenate(
+        nonan_f16 = np.concatenate(
                                 (np.arange(0xfc00, 0x7fff, -1, dtype=uint16),
                                  np.arange(0x0000, 0x7c01, 1, dtype=uint16)))
-        self.nonan_f16 = self.nonan_f16.view(float16)
-        self.nonan_f32 = np.array(self.nonan_f16, dtype=float32)
-        self.nonan_f64 = np.array(self.nonan_f16, dtype=float64)
+        nonan_f16 = nonan_f16.view(float16)
+        nonan_f32 = np.array(nonan_f16, dtype=float32)
+        nonan_f64 = np.array(nonan_f16, dtype=float64)
+        return nonan_f16, nonan_f32, nonan_f64
 
-        # An array of all finite float16 values, in sorted order
-        self.finite_f16 = self.nonan_f16[1:-1]
-        self.finite_f32 = self.nonan_f32[1:-1]
-        self.finite_f64 = self.nonan_f64[1:-1]
+    def _create_arrays_finite(self):
+        nonan_f16, nonan_f32, nonan_f64 = self._create_arrays_nonan()
+        finite_f16 = nonan_f16[1:-1]
+        finite_f32 = nonan_f32[1:-1]
+        finite_f64 = nonan_f64[1:-1]
+        return finite_f16, finite_f32, finite_f64
 
     def test_half_conversions(self):
         """Checks that all 16-bit values survive conversion
            to/from 32-bit and 64-bit float"""
         # Because the underlying routines preserve the NaN bits, every
         # value is preserved when converting to/from other floats.
+        all_f16, all_f32, all_f64 = self._create_arrays_all()
+        nonan_f16, _, _ = self._create_arrays_nonan()
 
         # Convert from float32 back to float16
         with np.errstate(invalid='ignore'):
-            b = np.array(self.all_f32, dtype=float16)
+            b = np.array(all_f32, dtype=float16)
         # avoid testing NaNs due to differing bit patterns in Q/S NaNs
         b_nn = b == b
-        assert_equal(self.all_f16[b_nn].view(dtype=uint16),
+        assert_equal(all_f16[b_nn].view(dtype=uint16),
                      b[b_nn].view(dtype=uint16))
 
         # Convert from float64 back to float16
         with np.errstate(invalid='ignore'):
-            b = np.array(self.all_f64, dtype=float16)
+            b = np.array(all_f64, dtype=float16)
         b_nn = b == b
-        assert_equal(self.all_f16[b_nn].view(dtype=uint16),
+        assert_equal(all_f16[b_nn].view(dtype=uint16),
                      b[b_nn].view(dtype=uint16))
 
         # Convert float16 to longdouble and back
         # This doesn't necessarily preserve the extra NaN bits,
         # so exclude NaNs.
-        a_ld = np.array(self.nonan_f16, dtype=np.longdouble)
+        a_ld = np.array(nonan_f16, dtype=np.longdouble)
         b = np.array(a_ld, dtype=float16)
-        assert_equal(self.nonan_f16.view(dtype=uint16),
+        assert_equal(nonan_f16.view(dtype=uint16),
                      b.view(dtype=uint16))
 
         # Check the range for which all integers can be represented
@@ -171,34 +178,35 @@ class TestHalf:
             assert larger_value.astype(np.float16) == smallest_value
 
     def test_nans_infs(self):
+        all_f16, all_f32, _ = self._create_arrays_all()
         with np.errstate(all='ignore'):
             # Check some of the ufuncs
-            assert_equal(np.isnan(self.all_f16), np.isnan(self.all_f32))
-            assert_equal(np.isinf(self.all_f16), np.isinf(self.all_f32))
-            assert_equal(np.isfinite(self.all_f16), np.isfinite(self.all_f32))
-            assert_equal(np.signbit(self.all_f16), np.signbit(self.all_f32))
+            assert_equal(np.isnan(all_f16), np.isnan(all_f32))
+            assert_equal(np.isinf(all_f16), np.isinf(all_f32))
+            assert_equal(np.isfinite(all_f16), np.isfinite(all_f32))
+            assert_equal(np.signbit(all_f16), np.signbit(all_f32))
             assert_equal(np.spacing(float16(65504)), np.inf)
 
             # Check comparisons of all values with NaN
             nan = float16(np.nan)
 
-            assert_(not (self.all_f16 == nan).any())
-            assert_(not (nan == self.all_f16).any())
+            assert_(not (all_f16 == nan).any())
+            assert_(not (nan == all_f16).any())
 
-            assert_((self.all_f16 != nan).all())
-            assert_((nan != self.all_f16).all())
+            assert_((all_f16 != nan).all())
+            assert_((nan != all_f16).all())
 
-            assert_(not (self.all_f16 < nan).any())
-            assert_(not (nan < self.all_f16).any())
+            assert_(not (all_f16 < nan).any())
+            assert_(not (nan < all_f16).any())
 
-            assert_(not (self.all_f16 <= nan).any())
-            assert_(not (nan <= self.all_f16).any())
+            assert_(not (all_f16 <= nan).any())
+            assert_(not (nan <= all_f16).any())
 
-            assert_(not (self.all_f16 > nan).any())
-            assert_(not (nan > self.all_f16).any())
+            assert_(not (all_f16 > nan).any())
+            assert_(not (nan > all_f16).any())
 
-            assert_(not (self.all_f16 >= nan).any())
-            assert_(not (nan >= self.all_f16).any())
+            assert_(not (all_f16 >= nan).any())
+            assert_(not (nan >= all_f16).any())
 
     def test_half_values(self):
         """Confirms a small number of known half values"""
@@ -255,9 +263,10 @@ class TestHalf:
     def test_half_correctness(self):
         """Take every finite float16, and check the casting functions with
            a manual conversion."""
+        finite_f16, finite_f32, finite_f64 = self._create_arrays_finite()
 
         # Create an array of all finite float16s
-        a_bits = self.finite_f16.view(dtype=uint16)
+        a_bits = finite_f16.view(dtype=uint16)
 
         # Convert to 64-bit float manually
         a_sgn = (-1.0)**((a_bits & 0x8000) >> 15)
@@ -270,29 +279,30 @@ class TestHalf:
 
         a_manual = a_sgn * a_man * 2.0**a_exp
 
-        a32_fail = np.nonzero(self.finite_f32 != a_manual)[0]
+        a32_fail = np.nonzero(finite_f32 != a_manual)[0]
         if len(a32_fail) != 0:
             bad_index = a32_fail[0]
-            assert_equal(self.finite_f32, a_manual,
+            assert_equal(finite_f32, a_manual,
                  "First non-equal is half value 0x%x -> %g != %g" %
                             (a_bits[bad_index],
-                             self.finite_f32[bad_index],
+                             finite_f32[bad_index],
                              a_manual[bad_index]))
 
-        a64_fail = np.nonzero(self.finite_f64 != a_manual)[0]
+        a64_fail = np.nonzero(finite_f64 != a_manual)[0]
         if len(a64_fail) != 0:
             bad_index = a64_fail[0]
-            assert_equal(self.finite_f64, a_manual,
+            assert_equal(finite_f64, a_manual,
                  "First non-equal is half value 0x%x -> %g != %g" %
                             (a_bits[bad_index],
-                             self.finite_f64[bad_index],
+                             finite_f64[bad_index],
                              a_manual[bad_index]))
 
     def test_half_ordering(self):
         """Make sure comparisons are working right"""
+        nonan_f16, _, _ = self._create_arrays_nonan()
 
         # All non-NaN float16 values in reverse order
-        a = self.nonan_f16[::-1].copy()
+        a = nonan_f16[::-1].copy()
 
         # 32-bit float copy
         b = np.array(a, dtype=float32)

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -347,17 +347,16 @@ class TestEmptyField:
 
 
 class TestMultipleFields:
-    def setup_method(self):
-        self.ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
-
     def _bad_call(self):
-        return self.ary['f0', 'f1']
+        ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
+        return ary['f0', 'f1']
 
     def test_no_tuple(self):
         assert_raises(IndexError, self._bad_call)
 
     def test_return(self):
-        res = self.ary[['f0', 'f2']].tolist()
+        ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
+        res = ary[['f0', 'f2']].tolist()
         assert_(res == [(1, 3), (5, 7)])
 
 

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -359,26 +359,26 @@ class TestPathUsage:
 
 
 class TestRecord:
-    def setup_method(self):
-        self.data = np.rec.fromrecords([(1, 2, 3), (4, 5, 6)],
+    def _create_data(self):
+        return np.rec.fromrecords([(1, 2, 3), (4, 5, 6)],
                             dtype=[("col1", "<i4"),
                                    ("col2", "<i4"),
                                    ("col3", "<i4")])
 
     def test_assignment1(self):
-        a = self.data
+        a = self._create_data()
         assert_equal(a.col1[0], 1)
         a[0].col1 = 0
         assert_equal(a.col1[0], 0)
 
     def test_assignment2(self):
-        a = self.data
+        a = self._create_data()
         assert_equal(a.col1[0], 1)
         a.col1[0] = 0
         assert_equal(a.col1[0], 0)
 
     def test_invalid_assignment(self):
-        a = self.data
+        a = self._create_data()
 
         def assign_invalid_column(x):
             x[0].col5 = 1
@@ -396,14 +396,14 @@ class TestRecord:
 
     def test_out_of_order_fields(self):
         # names in the same order, padding added to descr
-        x = self.data[['col1', 'col2']]
+        x = self._create_data()[['col1', 'col2']]
         assert_equal(x.dtype.names, ('col1', 'col2'))
         assert_equal(x.dtype.descr,
                      [('col1', '<i4'), ('col2', '<i4'), ('', '|V4')])
 
         # names change order to match indexing, as of 1.14 - descr can't
         # represent that
-        y = self.data[['col2', 'col1']]
+        y = self._create_data()[['col2', 'col1']]
         assert_equal(y.dtype.names, ('col2', 'col1'))
         assert_raises(ValueError, lambda: y.dtype.descr)
 
@@ -416,7 +416,7 @@ class TestRecord:
                                                          protocol=proto)))
 
     def test_pickle_2(self):
-        a = self.data
+        a = self._create_data()
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
             assert_equal(a, pickle.loads(pickle.dumps(a, protocol=proto)))
             assert_equal(a[0], pickle.loads(pickle.dumps(a[0],
@@ -424,7 +424,7 @@ class TestRecord:
 
     def test_pickle_3(self):
         # Issue #7140
-        a = self.data
+        a = self._create_data()
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
             pa = pickle.loads(pickle.dumps(a[0], protocol=proto))
             assert_(pa.flags.c_contiguous)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552 and a continuation of #29596, with the goal of making NumPy's testing suite more thread safe. This changes the setup methods for 4 more testing files in numpy/_core, as well as moving some variables that were only used once to be inside the test they're used in instead of declared in a method.

With this PR, you should be able to call the tests from these files with [pytest-run-parallel](https://github.com/numpy/numpy/pull/github.com/Quansight-Labs/pytest-run-parallel) and have all tests successfully run in parallel threads (and also run normally without pytest-run-parallel).