### PR TITLE
TST: Enable unit tests for RISC-V CPU dispatcher utilities

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -777,7 +777,7 @@ _umath_tests_mtargets = mod_features.multi_targets(
     AVX2, SSE41, SSE2,
     ASIMDHP, ASIMD, NEON,
     VSX3, VSX2, VSX,
-    VXE, VX,
+    VXE, VX, RVV,
   ],
   baseline: CPU_BASELINE,
   prefix: 'NPY_',

--- a/numpy/_core/tests/test_cpu_dispatcher.py
+++ b/numpy/_core/tests/test_cpu_dispatcher.py
@@ -15,7 +15,7 @@ def test_dispatcher():
         "SSE2", "SSE41", "AVX2",
         "VSX", "VSX2", "VSX3",
         "NEON", "ASIMD", "ASIMDHP",
-        "VX", "VXE", "LSX"
+        "VX", "VXE", "LSX", "RVV"
     )
     highest_sfx = ""  # no suffix for the baseline
     all_sfx = []


### PR DESCRIPTION
(numpy_venv) root@yangwang:/home/yangwang/numpy# spin test -- -k "test_cpu_dispatcher" -v
Invoking `build` prior to running tests:
$ /home/yangwang/numpy_venv/bin/python3.12 vendored-meson/meson/meson.py compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /home/yangwang/numpy_venv/bin/ninja -C /home/yangwang/numpy/build
ninja: Entering directory `/home/yangwang/numpy/build'
[1/1] Generating numpy/generate-version with a custom command
Saving version to numpy/version.py
$ /home/yangwang/numpy_venv/bin/python3.12 vendored-meson/meson/meson.py install --only-changed -C build --destdir ../build-install
$ export PYTHONPATH="/home/yangwang/numpy/build-install/usr/lib/python3/dist-packages"
$ /home/yangwang/numpy_venv/bin/python3.12 -P -c 'import numpy'
$ cd /home/yangwang/numpy/build-install/usr/lib/python3/dist-packages
$ /home/yangwang/numpy_venv/bin/python3.12 -P -m pytest -m 'not slow' -k test_cpu_dispatcher -v
=============================================================== test session starts ===============================================================
platform linux -- Python 3.12.3, pytest-7.4.0, pluggy-1.5.0 -- /home/yangwang/numpy_venv/bin/python3.12
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/home/yangwang/numpy/build-install/usr/lib/python3/dist-packages/.hypothesis/examples'))
rootdir: /home/yangwang/numpy
configfile: pytest.ini
plugins: xdist-3.6.1, benchmark-5.1.0, cov-4.1.0, hypothesis-6.104.1, timeout-2.3.1
collected 48307 items / 48306 deselected / 1 selected

numpy/_core/tests/test_cpu_dispatcher.py::test_dispatcher PASSED                                                                            [100%]