### PR TITLE
BUG: fix negative samples generated by Wald distribution

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -851,9 +851,12 @@ double random_wald(bitgen_t *bitgen_state, double mean, double scale) {
   double d;
 
   Y = random_standard_normal(bitgen_state);
+  if (Y == 0) {
+    return mean;
+  }
   Y = mean * Y * Y;
-  d = Y + sqrt(Y) * sqrt(Y + 4 * scale);
-  X = mean - (2 * mean * Y) / d;
+  d = 1 + sqrt(1 + 4 * scale / Y);
+  X = mean * (1 - 2 / d);
   U = next_double(bitgen_state);
   if (U <= mean / (mean + X)) {
     return X;

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -848,9 +848,8 @@ double random_noncentral_f(bitgen_t *bitgen_state, double dfnum, double dfden,
 
 double random_wald(bitgen_t *bitgen_state, double mean, double scale) {
   double U, X, Y;
-  double mu_2l, d;
+  double d;
 
-  mu_2l = mean / (2 * scale);
   Y = random_standard_normal(bitgen_state);
   Y = mean * Y * Y;
   d = Y + sqrt(Y) * sqrt(Y + 4 * scale);

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -851,9 +851,6 @@ double random_wald(bitgen_t *bitgen_state, double mean, double scale) {
   double d;
 
   Y = random_standard_normal(bitgen_state);
-  if (Y == 0) {
-    return mean;
-  }
   Y = mean * Y * Y;
   d = 1 + sqrt(1 + 4 * scale / Y);
   X = mean * (1 - 2 / d);

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -848,12 +848,13 @@ double random_noncentral_f(bitgen_t *bitgen_state, double dfnum, double dfden,
 
 double random_wald(bitgen_t *bitgen_state, double mean, double scale) {
   double U, X, Y;
-  double mu_2l;
+  double mu_2l, d;
 
   mu_2l = mean / (2 * scale);
   Y = random_standard_normal(bitgen_state);
   Y = mean * Y * Y;
-  X = mean + mu_2l * (Y - sqrt(4 * scale * Y + Y * Y));
+  d = Y + sqrt(Y) * sqrt(Y + 4 * scale);
+  X = mean - (2 * mean * Y) / d;
   U = next_double(bitgen_state);
   if (U <= mean / (mean + X)) {
     return X;

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1874,6 +1874,11 @@ class TestRandomDist:
                             [2.07093587449261, 0.73073890064369]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
+    def test_wald_nonnegative(self):
+        random = Generator(MT19937(self.seed))
+        samples = random.wald(mean=1e8, scale=2.25, size=1000)
+        assert_(np.all(samples >= 0.0))
+
     def test_weibull(self):
         random = Generator(MT19937(self.seed))
         actual = random.weibull(a=1.23, size=(3, 2))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1876,7 +1876,7 @@ class TestRandomDist:
 
     def test_wald_nonnegative(self):
         random = Generator(MT19937(self.seed))
-        samples = random.wald(mean=1e8, scale=2.25, size=1000)
+        samples = random.wald(mean=1e9, scale=2.25, size=1000)
         assert_(np.all(samples >= 0.0))
 
     def test_weibull(self):


### PR DESCRIPTION
In `numpy.random`, when generating Wald samples, if the mean and scale have a large discrepancy, the current implementation sometimes generates _negative samples_. An explicit example of this has been added to `test_generator_mt19937.py`, `mean=1e8, scale=2.25` (which is specific to the seed used in that test file). 

The key line implicated in `distributions.c`:
```
X = mean + mu_2l * (Y - sqrt(4 * scale * Y + Y * Y));
```

which has numerical issues when `Y >> scale`.
    
I have replaced this with the equivalent rationalized form:
```
d = Y + sqrt(Y) * sqrt(Y + 4 * scale);
X = mean - (2 * mean * Y) / d;
```

This can be seen my noting the following algebraic identity:
```
Y - sqrt(4 * scale * Y + Y * Y))
= - 4 * scale * Y / (Y + sqrt(Y^2 + 4 * scale * Y))
```

As `mu_2l = mean / (2 * scale)`, we then have:
```
X = mean - 2 * mean * Y / (Y + sqrt(Y^2 + 4 * scale * Y))
```

Introduce a new variable for the denominator and factoring gives the final expressions:
```
d = Y + sqrt(Y) * sqrt(Y + 4 * scale)
X = mean - (2 * mean * Y) / d
```

And now the test passes, i.e., all samples are non-negative.

I have not made this change to the legacy implementation (nor the legacy test) as I figure they are deprecated, although it also suffers from the same issue.

Disclaimer: I found this failing property during a research project I am working on using LLM agents to write property-based tests (i.e., in Hypothesis). This property, that all Wald samples should be non-negative, was proposed and written "autonomously" by the agent. I spent several hours analyzing the failure and becoming acquainted with the NumPy codebase myself in order to verify it was a real issue, running it with the seed in the test suite, etc. I also pinpointed the cause of the problem and wrote this fix and the PR myself. I take full responsibility for it.

The Hypothesis test that caught the issue was simply:
```
import numpy.random
from hypothesis import given, strategies as st, settings
from numpy.random import MT19937, Generator

@given(
    st.floats(min_value=1e8, max_value=1e15),
    st.floats(min_value=0.1, max_value=10.0)
)
@settings(max_examples=50)
def test_wald_negative_values(mean, scale):
    """Wald distribution should never produce negative values"""
    random = Generator(MT19937(1234567890))
    samples = random.wald(mean, scale, size=1000)
    assert all(s >= 0 for s in samples), f"Found negative values with mean={mean}, scale={scale}"
```

Note that even after this PR, this property fails, albeit the minimal example is now `mean=280432326968266.0, scale=0.25` (i.e., even more extreme values). But, at such values, it seems like we hit the limits of floating point computations.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
