### PR TITLE
CI: more specific mypy_primer ``on:`` paths

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -4,9 +4,13 @@ on:
   # Only run on PR, since we diff against main
   pull_request:
     paths:
-      - "**/*.pyi"
       - ".github/workflows/mypy_primer.yml"
       - ".github/workflows/mypy_primer_comment.yml"
+      - "numpy/**/*.pyi"
+      - "numpy/_typing/*.py"
+      - "numpy/typing/*.py"
+      - "!numpy/typing/tests/**"
+      - "numpy/py.typed"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
mypy_primer will now also run on changes to `.py` files in `numpy/_typing` and `numpy/typing`, and will ignore changes in the `numpy/typing/tests`.