### PR TITLE
MAINT: fix typo in cmds.py

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -455,7 +455,7 @@ def bench(ctx, tests, compare, verbose, quick, commits, build_dir):
         ] + bench_args
         _run_asv(cmd)
     else:
-        # Ensure that we don't have uncommited changes
+        # Ensure that we don't have uncommitted changes
         commit_a, commit_b = [_commit_to_sha(c) for c in commits]
 
         if commit_b == 'HEAD' and _dirty_git_working_dir():


### PR DESCRIPTION
Found typo in cmds.py "uncommited" line 458 