### PR TITLE
BUG: Added manual checks for self-nested sequences during array creation

### DIFF
--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1197,6 +1197,16 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         copy = -1;
     }
 
+    if(is_sequence){
+        if (PySequence_Check(objects[0])){
+            if(objects[0] == obj){
+                  PyErr_SetString(PyExc_ValueError,
+                            "NumPy array cannot be created using cyclic self-nested sequence.");
+                return -1;
+            }
+        }
+    }
+
     /* Recursive call for each sequence item */
     for (Py_ssize_t i = 0; i < size; i++) {
         max_dims = PyArray_DiscoverDTypeAndShape_Recursive(

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1197,9 +1197,10 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         copy = -1;
     }
 
-    if(is_sequence){
-        if (PySequence_Check(objects[0])){
-            if(objects[0] == obj){
+    /* Check for self-nested sequences to prevent RAM exhaustion */
+    if (is_sequence) {
+        if (PySequence_Check(objects[0])) {
+            if (objects[0] == obj) {
                   PyErr_SetString(PyExc_ValueError,
                             "NumPy array cannot be created using self-nested sequences.");
                 return -1;

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1201,7 +1201,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         if (PySequence_Check(objects[0])){
             if(objects[0] == obj){
                   PyErr_SetString(PyExc_ValueError,
-                            "NumPy array cannot be created using cyclic self-nested sequence.");
+                            "NumPy array cannot be created using self-nested sequences.");
                 return -1;
             }
         }

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -507,12 +507,12 @@ class TestNested:
         l.append(l)
         
         # ValueError: NumPy array cannot be created using cyclic nested sequence.
-        with pytest.raises(ValueError, match="NumPy array cannot be created using cyclic self-nested sequence."):
+        with pytest.raises(ValueError, match="NumPy array cannot be created using self-nested sequences."):
             arr = np.array([l, l, l], dtype=object)
             # assert arr.shape == (3,) + (1,) * (ncu.MAXDIMS - 1)
 
         # Also check a ragged case:
-        with pytest.raises(ValueError, match="NumPy array cannot be created using cyclic self-nested sequence."):
+        with pytest.raises(ValueError, match="NumPy array cannot be created using self-nested sequences."):
             arr = np.array([l, [None], l], dtype=object)
             # assert arr.shape == (3, 1)
 

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -505,12 +505,19 @@ class TestNested:
         # Test that this also works for two nested sequences
         l = []
         l.append(l)
-        arr = np.array([l, l, l], dtype=object)
-        assert arr.shape == (3,) + (1,) * (ncu.MAXDIMS - 1)
+        
+        # ValueError: NumPy array cannot be created using cyclic nested sequence.
+        with pytest.raises(ValueError, match="NumPy array cannot be created using cyclic self-nested sequence."):
+            arr = np.array([l, l, l], dtype=object)
+            # assert arr.shape == (3,) + (1,) * (ncu.MAXDIMS - 1)
 
         # Also check a ragged case:
-        arr = np.array([l, [None], l], dtype=object)
-        assert arr.shape == (3, 1)
+        with pytest.raises(ValueError, match="NumPy array cannot be created using cyclic self-nested sequence."):
+            arr = np.array([l, [None], l], dtype=object)
+            # assert arr.shape == (3, 1)
+
+
+        
 
     @pytest.mark.parametrize("arraylike", arraylikes())
     def test_nested_arraylikes(self, arraylike):

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -505,19 +505,15 @@ class TestNested:
         # Test that this also works for two nested sequences
         l = []
         l.append(l)
-        
-        # ValueError: NumPy array cannot be created using cyclic nested sequence.
-        with pytest.raises(ValueError, match="NumPy array cannot be created using self-nested sequences."):
+
+        with pytest.raises(ValueError, match="cannot be created using self-nested"):
             arr = np.array([l, l, l], dtype=object)
             # assert arr.shape == (3,) + (1,) * (ncu.MAXDIMS - 1)
 
         # Also check a ragged case:
-        with pytest.raises(ValueError, match="NumPy array cannot be created using self-nested sequences."):
+        with pytest.raises(ValueError, match="cannot be created using self-nested"):
             arr = np.array([l, [None], l], dtype=object)
             # assert arr.shape == (3, 1)
-
-
-        
 
     @pytest.mark.parametrize("arraylike", arraylikes())
     def test_nested_arraylikes(self, arraylike):


### PR DESCRIPTION
Previously, when creating a NumPy array with self-nested sequences, it causes a quick RAM exhaustion, as also described in https://github.com/numpy/numpy/issues/29620, all due to the cyclic recursions.

With these changes, when creating an array with sequences, a check for self-nesting is performed first, which prevents any further cyclic recursions.

Before:

```python
>>> import numpy as np

>>> l = []
>>> l.append(l)
>>> l.append(l)
>>> np.array(l) # cause a hang here
```

Now:

```python
>>> np.array(l)
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    np.array(l)
    ~~~~~~~~^^^
ValueError: NumPy array cannot be created using self-nested sequences.
```

closes #29620 
