### PR TITLE
BUG: Fix precision loss with np.power for negative exponents (gh-29624)

### DIFF
--- a/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_umath_fp.dispatch.c.src
@@ -155,10 +155,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
         int fastop_found = 1;
         BINARY_LOOP_SLIDING {
             const @type@ in1 = *(@type@ *)ip1;
-            if (in2 == -1.0) {
-                *(@type@ *)op1 = 1.0 / in1;
-            }
-            else if (in2 == 0.0) {
+            if (in2 == 0.0) {
                 *(@type@ *)op1 = 1.0;
             }
             else if (in2 == 0.5) {

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2674,3 +2674,27 @@ class TestRegression:
         x = np.array([(0, 1.)], dtype=[('time', '<i8'), ('value', '<f8')])
         y = np.array((0, 0.), dtype=[('time', '<i8'), ('value', '<f8')])
         x.searchsorted(y)
+
+    def test_power_negative_exponent_precision_regression(self):
+        # gh-29624: Regression test for precision loss with np.power and negative exponents
+        # This test ensures that the fast path optimization for x ** -1.0 doesn't cause
+        # precision differences between np.power, np.float_power, and Python's ** operator
+        x = np.float64(141322)
+        
+        # Test scalar case
+        result_power = np.power(x, -1.0)
+        result_float_power = np.float_power(x, -1.0)
+        result_python = x ** -1.0
+        
+        # All three should produce identical results
+        assert_equal(result_power, result_float_power)
+        assert_equal(result_power, result_python)
+        
+        # Test array case
+        arr = np.array([141322.0, 1000.0, 50000.0], dtype=np.float64)
+        result_arr_power = np.power(arr, -1.0)
+        result_arr_float_power = np.float_power(arr, -1.0)
+        result_arr_python = arr ** -1.0
+        
+        assert_array_equal(result_arr_power, result_arr_float_power)
+        assert_array_equal(result_arr_power, result_arr_python)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1270,6 +1270,27 @@ class TestPower:
             result = np.power(a, 0.5)
             assert_array_max_ulp(result, expected, maxulp=1)
 
+    def test_power_negative_exponent_precision(self):
+        # gh-29624: Test that np.power has consistent precision with negative exponents
+        # This ensures the fast path optimization for x ** -1.0 doesn't cause precision loss
+        x = np.float64(141322)
+        result_power = np.power(x, -1.0)
+        result_float_power = np.float_power(x, -1.0)
+        result_python = x ** -1.0
+        
+        # All three should produce identical results
+        assert_equal(result_power, result_float_power)
+        assert_equal(result_power, result_python)
+        
+        # Test with array input
+        arr = np.array([141322.0, 1000.0, 50000.0], dtype=np.float64)
+        result_arr_power = np.power(arr, -1.0)
+        result_arr_float_power = np.float_power(arr, -1.0)
+        result_arr_python = arr ** -1.0
+        
+        assert_array_equal(result_arr_power, result_arr_float_power)
+        assert_array_equal(result_arr_power, result_arr_python)
+
 
 class TestFloat_power:
     def test_type_conversion(self):


### PR DESCRIPTION
This PR fixes a regression introduced in NumPy 2.3 where `np.power` produced different results than `np.float_power` for negative exponents, specifically `x ** -1.0`.

**Fixes:** #29624

### Problem
Starting with NumPy 2.3, `np.power` was using a fast path optimization for `x ** -1.0` that called direct division (`1.0 / x`) instead of the standard power function (`pow(x, -1.0)`). This caused precision differences:

### Solution
- Removed the problematic fast path optimization for negative exponents
- Now uses standard `pow()` function for consistent precision
- Added comprehensive tests to prevent future regressions

### Changes
- `loops_umath_fp.dispatch.c.src`: Remove fast path for `x ** -1.0`
- `test_umath.py`: Add test for precision consistency
- `test_regression.py`: Add regression test

This ensures reproducible results for scientific computing applications that depend on exact bit-level consistency.