### PR TITLE
BLD: Fix PPC64LE build failure with -mcpu=power9 flag

### DIFF
--- a/meson_cpu/ppc64/meson.build
+++ b/meson_cpu/ppc64/meson.build
@@ -13,7 +13,7 @@ if compiler_id == 'clang'
   VSX.update(args: ['-mvsx', '-maltivec'])
 endif
 VSX2 = mod_features.new(
-  'VSX2', 2, implies: VSX, args: {'val': '-mcpu=power8', 'match': '.*vsx'},
+  'VSX2', 2, implies: VSX, args: ['-mcpu=power8', '-mvsx'],
   detect: {'val': 'VSX2', 'match': 'VSX'},
   test_code: files(source_root + '/numpy/distutils/checks/cpu_vsx2.c')[0],
 )

--- a/numpy/_core/src/common/half.hpp
+++ b/numpy/_core/src/common/half.hpp
@@ -30,7 +30,7 @@ class Half final {
     #if defined(NPY_HAVE_FP16)
         __m128 mf = _mm_load_ss(&f);
         bits_ = _mm_extract_epi16(_mm_cvtps_ph(mf, _MM_FROUND_TO_NEAREST_INT), 0);
-    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX_ASM)
+    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX_ASM) && defined(NPY__CPU_TARGET_VSX3)
         __vector float vf32 = vec_splats(f);
         __vector unsigned short vf16;
         __asm__ __volatile__ ("xvcvsphp %x0,%x1" : "=wa" (vf16) : "wa" (vf32));
@@ -55,7 +55,7 @@ class Half final {
     #if defined(NPY_HAVE_AVX512FP16)
         __m128d md = _mm_load_sd(&f);
         bits_ = _mm_extract_epi16(_mm_castph_si128(_mm_cvtpd_ph(md)), 0);
-    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX3_HALF_DOUBLE)
+    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX3_HALF_DOUBLE) && defined(NPY__CPU_TARGET_VSX3)
         __asm__ __volatile__ ("xscvdphp %x0,%x1" : "=wa" (bits_) : "wa" (f));
     #elif defined(__ARM_FP16_FORMAT_IEEE)
         __fp16 f16 = __fp16(f);
@@ -72,9 +72,9 @@ class Half final {
         float ret;
         _mm_store_ss(&ret, _mm_cvtph_ps(_mm_cvtsi32_si128(bits_)));
         return ret;
-    #elif defined(NPY_HAVE_VSX3) && defined(vec_extract_fp_from_shorth)
+    #elif defined(NPY_HAVE_VSX3) && defined(vec_extract_fp_from_shorth) && defined(NPY__CPU_TARGET_VSX3)
         return vec_extract(vec_extract_fp_from_shorth(vec_splats(bits_)), 0);
-    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX_ASM)
+    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX_ASM) && defined(NPY__CPU_TARGET_VSX3)
         __vector float vf32;
         __asm__ __volatile__("xvcvhpsp %x0,%x1"
                              : "=wa"(vf32)
@@ -94,7 +94,7 @@ class Half final {
         double ret;
         _mm_store_sd(&ret, _mm_cvtph_pd(_mm_castsi128_ph(_mm_cvtsi32_si128(bits_))));
         return ret;
-    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX3_HALF_DOUBLE)
+    #elif defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX3_HALF_DOUBLE) && defined(NPY__CPU_TARGET_VSX3)
         double f64;
         __asm__ __volatile__("xscvhpdp %x0,%x1"
                              : "=wa"(f64)

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -485,7 +485,7 @@ class _Config:
                     flags="-mvsx"
                 ),
                 VSX2 = dict(
-                    flags="-mcpu=power8", implies_detect=False
+                    flags="-mcpu=power8 -mvsx", implies_detect=False
                 ),
                 VSX3 = dict(
                     flags="-mcpu=power9 -mtune=power9", implies_detect=False
@@ -496,7 +496,7 @@ class _Config:
             )
             if self.cc_is_clang:
                 partial["VSX"]["flags"]  = "-maltivec -mvsx"
-                partial["VSX2"]["flags"] = "-mcpu=power8"
+                partial["VSX2"]["flags"] = "-mcpu=power8 -mvsx"
                 partial["VSX3"]["flags"] = "-mcpu=power9"
                 partial["VSX4"]["flags"] = "-mcpu=power10"
 

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -439,8 +439,8 @@ class _Test_CCompilerOpt:
             x86_gcc="-msse -msse2", x86_icc="-msse -msse2",
             x86_iccw="/arch:SSE2",
             x86_msvc="/arch:SSE2" if self.march() == "x86" else "",
-            ppc64_gcc= "-mcpu=power8",
-            ppc64_clang="-mcpu=power8",
+            ppc64_gcc= "-mcpu=power8 -mvsx",
+            ppc64_clang="-mcpu=power8 -mvsx",
             armhf_gcc="-mfpu=neon-fp16 -mfp16-format=ieee",
             aarch64="",
             s390x="-mzvector -march=arch12"


### PR DESCRIPTION
Fixes #29622

**Problem:**
When `CFLAGS='-mcpu=power9'` is set on PPC64LE systems, NumPy build fails with:
**Root Cause:**
 VSX2 targets were missing `-mvsx` flag
VSX2 targets incorrectly used VSX3 intrinsics even when compiled for VSX2
**Solution:**
1. Add `-mvsx` flag to VSX2 configuration in `meson_cpu/ppc64/meson.build`
2. Add `-mvsx` flag to VSX2 flags in `numpy/distutils/ccompiler_opt.py`  
3. Guard VSX3 intrinsics with `NPY__CPU_TARGET_VSX3` in `numpy/_core/src/common/half.hpp`

