### PR TITLE
TST: Replace xunit setup with methods

### DIFF
--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -1,3 +1,4 @@
+import pytest
 
 import numpy as np
 import numpy.ma as ma
@@ -31,19 +32,14 @@ zip_dtype = np.lib.recfunctions._zip_dtype
 
 class TestRecFunctions:
     # Misc tests
-
-    def setup_method(self):
+    def test_zip_descr(self):
+        # Test zip_descr
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array([('A', 1.), ('B', 2.)],
                      dtype=[('A', '|S3'), ('B', float)])
         w = np.array([(1, (2, 3.0)), (4, (5, 6.0))],
                      dtype=[('a', int), ('b', [('ba', float), ('bb', int)])])
-        self.data = (w, x, y, z)
-
-    def test_zip_descr(self):
-        # Test zip_descr
-        (w, x, y, z) = self.data
 
         # Std array
         test = zip_descr((x, x), flatten=True)
@@ -240,6 +236,7 @@ class TestRecFunctions:
         dt = np.dtype((np.record, dt))
         assert_(repack_fields(dt).type is np.record)
 
+    @pytest.mark.thread_unsafe
     def test_structured_to_unstructured(self, tmp_path):
         a = np.zeros(4, dtype=[('a', 'i4'), ('b', 'f4,u2'), ('c', 'f4', 2)])
         out = structured_to_unstructured(a)
@@ -448,7 +445,7 @@ class TestRecursiveFillFields:
 class TestMergeArrays:
     # Test merge_arrays
 
-    def setup_method(self):
+    def _create_arrays(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
@@ -456,11 +453,11 @@ class TestMergeArrays:
         w = np.array(
             [(1, (2, 3.0, ())), (4, (5, 6.0, ()))],
             dtype=[('a', int), ('b', [('ba', float), ('bb', int), ('bc', [])])])
-        self.data = (w, x, y, z)
+        return w, x, y, z
 
     def test_solo(self):
         # Test merge_arrays on a single array.
-        (_, x, _, z) = self.data
+        _, x, _, z = self._create_arrays()
 
         test = merge_arrays(x)
         control = np.array([(1,), (2,)], dtype=[('f0', int)])
@@ -475,7 +472,7 @@ class TestMergeArrays:
 
     def test_solo_w_flatten(self):
         # Test merge_arrays on a single array w & w/o flattening
-        w = self.data[0]
+        w = self._create_arrays()[0]
         test = merge_arrays(w, flatten=False)
         assert_equal(test, w)
 
@@ -487,7 +484,7 @@ class TestMergeArrays:
     def test_standard(self):
         # Test standard & standard
         # Test merge arrays
-        (_, x, y, _) = self.data
+        _, x, y, _ = self._create_arrays()
         test = merge_arrays((x, y), usemask=False)
         control = np.array([(1, 10), (2, 20), (-1, 30)],
                            dtype=[('f0', int), ('f1', int)])
@@ -502,7 +499,7 @@ class TestMergeArrays:
 
     def test_flatten(self):
         # Test standard & flexible
-        (_, x, _, z) = self.data
+        _, x, _, z = self._create_arrays()
         test = merge_arrays((x, z), flatten=True)
         control = np.array([(1, 'A', 1.), (2, 'B', 2.)],
                            dtype=[('f0', int), ('A', '|S3'), ('B', float)])
@@ -516,7 +513,7 @@ class TestMergeArrays:
 
     def test_flatten_wflexible(self):
         # Test flatten standard & nested
-        (w, x, _, _) = self.data
+        w, x, _, _ = self._create_arrays()
         test = merge_arrays((x, w), flatten=True)
         control = np.array([(1, 1, 2, 3.0), (2, 4, 5, 6.0)],
                            dtype=[('f0', int),
@@ -532,7 +529,7 @@ class TestMergeArrays:
 
     def test_wmasked_arrays(self):
         # Test merge_arrays masked arrays
-        (_, x, _, _) = self.data
+        x = self._create_arrays()[1]
         mx = ma.array([1, 2, 3], mask=[1, 0, 0])
         test = merge_arrays((x, mx), usemask=True)
         control = ma.array([(1, 1), (2, 2), (-1, 3)],
@@ -554,7 +551,7 @@ class TestMergeArrays:
 
     def test_w_shorter_flex(self):
         # Test merge_arrays w/ a shorter flexndarray.
-        z = self.data[-1]
+        z = self._create_arrays()[-1]
 
         # Fixme, this test looks incomplete and broken
         #test = merge_arrays((z, np.array([10, 20, 30]).view([('C', int)])))
@@ -567,7 +564,7 @@ class TestMergeArrays:
                  dtype=[('A', '|S3'), ('B', float), ('C', int)])
 
     def test_singlerecord(self):
-        (_, x, y, z) = self.data
+        _, x, y, z = self._create_arrays()
         test = merge_arrays((x[0], y[0], z[0]), usemask=False)
         control = np.array([(1, 10, ('A', 1))],
                            dtype=[('f0', int),
@@ -579,18 +576,18 @@ class TestMergeArrays:
 class TestAppendFields:
     # Test append_fields
 
-    def setup_method(self):
+    def _create_arrays(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
             [('A', 1.), ('B', 2.)], dtype=[('A', '|S3'), ('B', float)])
         w = np.array([(1, (2, 3.0)), (4, (5, 6.0))],
                      dtype=[('a', int), ('b', [('ba', float), ('bb', int)])])
-        self.data = (w, x, y, z)
+        return w, x, y, z
 
     def test_append_single(self):
         # Test simple case
-        (_, x, _, _) = self.data
+        x = self._create_arrays()[1]
         test = append_fields(x, 'A', data=[10, 20, 30])
         control = ma.array([(1, 10), (2, 20), (-1, 30)],
                            mask=[(0, 0), (0, 0), (1, 0)],
@@ -599,7 +596,7 @@ class TestAppendFields:
 
     def test_append_double(self):
         # Test simple case
-        (_, x, _, _) = self.data
+        x = self._create_arrays()[1]
         test = append_fields(x, ('A', 'B'), data=[[10, 20, 30], [100, 200]])
         control = ma.array([(1, 10, 100), (2, 20, 200), (-1, 30, -1)],
                            mask=[(0, 0, 0), (0, 0, 0), (1, 0, 1)],
@@ -608,7 +605,7 @@ class TestAppendFields:
 
     def test_append_on_flex(self):
         # Test append_fields on flexible type arrays
-        z = self.data[-1]
+        z = self._create_arrays()[-1]
         test = append_fields(z, 'C', data=[10, 20, 30])
         control = ma.array([('A', 1., 10), ('B', 2., 20), (-1, -1., 30)],
                            mask=[(0, 0, 0), (0, 0, 0), (1, 1, 0)],
@@ -617,7 +614,7 @@ class TestAppendFields:
 
     def test_append_on_nested(self):
         # Test append_fields on nested fields
-        w = self.data[0]
+        w = self._create_arrays()[0]
         test = append_fields(w, 'C', data=[10, 20, 30])
         control = ma.array([(1, (2, 3.0), 10),
                             (4, (5, 6.0), 20),
@@ -632,18 +629,18 @@ class TestAppendFields:
 
 class TestStackArrays:
     # Test stack_arrays
-    def setup_method(self):
+    def _create_arrays(self):
         x = np.array([1, 2, ])
         y = np.array([10, 20, 30])
         z = np.array(
             [('A', 1.), ('B', 2.)], dtype=[('A', '|S3'), ('B', float)])
         w = np.array([(1, (2, 3.0)), (4, (5, 6.0))],
                      dtype=[('a', int), ('b', [('ba', float), ('bb', int)])])
-        self.data = (w, x, y, z)
+        return w, x, y, z
 
     def test_solo(self):
         # Test stack_arrays on single arrays
-        (_, x, _, _) = self.data
+        x = self._create_arrays()[1]
         test = stack_arrays((x,))
         assert_equal(test, x)
         assert_(test is x)
@@ -654,7 +651,7 @@ class TestStackArrays:
 
     def test_unnamed_fields(self):
         # Tests combinations of arrays w/o named fields
-        (_, x, y, _) = self.data
+        _, x, y, _ = self._create_arrays()
 
         test = stack_arrays((x, x), usemask=False)
         control = np.array([1, 2, 1, 2])
@@ -670,7 +667,7 @@ class TestStackArrays:
 
     def test_unnamed_and_named_fields(self):
         # Test combination of arrays w/ & w/o named fields
-        (_, x, _, z) = self.data
+        _, x, _, z = self._create_arrays()
 
         test = stack_arrays((x, z))
         control = ma.array([(1, -1, -1), (2, -1, -1),
@@ -702,7 +699,7 @@ class TestStackArrays:
 
     def test_matching_named_fields(self):
         # Test combination of arrays w/ matching field names
-        (_, x, _, z) = self.data
+        _, x, _, z = self._create_arrays()
         zz = np.array([('a', 10., 100.), ('b', 20., 200.), ('c', 30., 300.)],
                       dtype=[('A', '|S3'), ('B', float), ('C', float)])
         test = stack_arrays((z, zz))
@@ -730,7 +727,7 @@ class TestStackArrays:
 
     def test_defaults(self):
         # Test defaults: no exception raised if keys of defaults are not fields.
-        (_, _, _, z) = self.data
+        z = self._create_arrays()[-1]
         zz = np.array([('a', 10., 100.), ('b', 20., 200.), ('c', 30., 300.)],
                       dtype=[('A', '|S3'), ('B', float), ('C', float)])
         defaults = {'A': '???', 'B': -999., 'C': -9999., 'D': -99999.}
@@ -802,18 +799,18 @@ class TestStackArrays:
 
 
 class TestJoinBy:
-    def setup_method(self):
-        self.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
+    def _create_arrays(self):
+        a = np.array(list(zip(np.arange(10), np.arange(50, 60),
                                    np.arange(100, 110))),
                           dtype=[('a', int), ('b', int), ('c', int)])
-        self.b = np.array(list(zip(np.arange(5, 15), np.arange(65, 75),
+        b = np.array(list(zip(np.arange(5, 15), np.arange(65, 75),
                                    np.arange(100, 110))),
                           dtype=[('a', int), ('b', int), ('d', int)])
+        return a, b
 
     def test_inner_join(self):
         # Basic test of join_by
-        a, b = self.a, self.b
-
+        a, b = self._create_arrays()
         test = join_by('a', a, b, jointype='inner')
         control = np.array([(5, 55, 65, 105, 100), (6, 56, 66, 106, 101),
                             (7, 57, 67, 107, 102), (8, 58, 68, 108, 103),
@@ -823,8 +820,6 @@ class TestJoinBy:
         assert_equal(test, control)
 
     def test_join(self):
-        a, b = self.a, self.b
-
         # Fixme, this test is broken
         #test = join_by(('a', 'b'), a, b)
         #control = np.array([(5, 55, 105, 100), (6, 56, 106, 101),
@@ -833,7 +828,7 @@ class TestJoinBy:
         #                   dtype=[('a', int), ('b', int),
         #                          ('c', int), ('d', int)])
         #assert_equal(test, control)
-
+        a, b = self._create_arrays()
         join_by(('a', 'b'), a, b)
         np.array([(5, 55, 105, 100), (6, 56, 106, 101),
                   (7, 57, 107, 102), (8, 58, 108, 103),
@@ -851,8 +846,7 @@ class TestJoinBy:
         assert_equal(res, bar.view(ma.MaskedArray))
 
     def test_outer_join(self):
-        a, b = self.a, self.b
-
+        a, b = self._create_arrays()
         test = join_by(('a', 'b'), a, b, 'outer')
         control = ma.array([(0, 50, 100, -1), (1, 51, 101, -1),
                             (2, 52, 102, -1), (3, 53, 103, -1),
@@ -879,8 +873,7 @@ class TestJoinBy:
         assert_equal(test, control)
 
     def test_leftouter_join(self):
-        a, b = self.a, self.b
-
+        a, b = self._create_arrays()
         test = join_by(('a', 'b'), a, b, 'leftouter')
         control = ma.array([(0, 50, 100, -1), (1, 51, 101, -1),
                             (2, 52, 102, -1), (3, 53, 103, -1),
@@ -1029,19 +1022,17 @@ class TestJoinBy2:
         assert_equal(test.dtype, control.dtype)
         assert_equal(test, control)
 
+
 class TestAppendFieldsObj:
     """
     Test append_fields with arrays containing objects
     """
     # https://github.com/numpy/numpy/issues/2346
 
-    def setup_method(self):
-        from datetime import date
-        self.data = {'obj': date(2000, 1, 1)}
-
     def test_append_to_objects(self):
         "Test append_fields when the base array contains objects"
-        obj = self.data['obj']
+        from datetime import date
+        obj = date(2000, 1, 1)
         x = np.array([(obj, 1.), (obj, 2.)],
                       dtype=[('A', object), ('B', float)])
         y = np.array([10, 20], dtype=int)

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -817,6 +817,7 @@ class TestJoinBy:
         assert_equal(test, control)
 
     def test_join(self):
+        a, b = self._create_arrays()
         # Fixme, this test is broken
         #test = join_by(('a', 'b'), a, b)
         #control = np.array([(5, 55, 105, 100), (6, 56, 106, 101),
@@ -825,7 +826,6 @@ class TestJoinBy:
         #                   dtype=[('a', int), ('b', int),
         #                          ('c', int), ('d', int)])
         #assert_equal(test, control)
-        a, b = self._create_arrays()
         join_by(('a', 'b'), a, b)
         np.array([(5, 55, 105, 100), (6, 56, 106, 101),
                   (7, 57, 107, 102), (8, 58, 108, 103),

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 import numpy.ma as ma
 from numpy.lib.recfunctions import (
@@ -236,7 +234,6 @@ class TestRecFunctions:
         dt = np.dtype((np.record, dt))
         assert_(repack_fields(dt).type is np.record)
 
-    @pytest.mark.thread_unsafe
     def test_structured_to_unstructured(self, tmp_path):
         a = np.zeros(4, dtype=[('a', 'i4'), ('b', 'f4,u2'), ('c', 'f4', 2)])
         out = structured_to_unstructured(a)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -152,12 +152,11 @@ num_ids = [dt_.char for dt_ in num_dts]
 WARNING_MESSAGE = ("setting an item on a masked array which has a shared "
                    "mask will not copy")
 WARNING_MARK_SPEC = f"ignore:.*{WARNING_MESSAGE}:numpy.ma.core.MaskedArrayFutureWarning"
-
 class TestMaskedArray:
     # Base test class for MaskedArrays.
 
     # message for warning filters
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -170,7 +169,7 @@ class TestMaskedArray:
         zm = masked_array(z, mask=[0, 1, 0, 0])
         xf = np.where(m1, 1e+20, x)
         xm.set_fill_value(1e+20)
-        self.d = (x, y, a10, m1, m2, xm, ym, z, zm, xf)
+        return x, y, a10, m1, m2, xm, ym, z, zm, xf
 
     def test_basicattributes(self):
         # Tests some basic array attributes.
@@ -196,7 +195,7 @@ class TestMaskedArray:
 
     def test_basic1d(self):
         # Test of basic array creation and properties in 1 dimension.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, _, _, m1, _, xm, ym, z, zm, xf = self._create_data()
         assert_(not isMaskedArray(x))
         assert_(isMaskedArray(xm))
         assert_((xm - ym).filled(0).any())
@@ -214,7 +213,7 @@ class TestMaskedArray:
 
     def test_basic2d(self):
         # Test of basic array creation and properties in 2 dimensions.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, m1, _, xm, ym, _, _, xf = self._create_data()
         for s in [(4, 3), (6, 2)]:
             x = x.reshape(s)
             y = y.reshape(s)
@@ -234,7 +233,7 @@ class TestMaskedArray:
 
     def test_concatenate_basic(self):
         # Tests concatenations.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, _, _, xm, ym, _, _, _ = self._create_data()
         # basic concatenation
         assert_equal(np.concatenate((x, y)), concatenate((xm, ym)))
         assert_equal(np.concatenate((x, y)), concatenate((x, y)))
@@ -243,7 +242,7 @@ class TestMaskedArray:
 
     def test_concatenate_alongaxis(self):
         # Tests concatenations.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, m1, m2, xm, ym, z, _, xf = self._create_data()
         # Concatenation along an axis
         s = (3, 4)
         x = x.reshape(s)
@@ -367,7 +366,7 @@ class TestMaskedArray:
             MaskedArray([1, 2, 3], maks=[0, 1, 0])  # `mask` is misspelled.
 
     def test_asarray(self):
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        xm = self._create_data()[5]
         xm.fill_value = -9999
         xm._hardmask = True
         xmm = asarray(xm)
@@ -1123,8 +1122,7 @@ class TestMaskedArray:
 
 class TestMaskedArrayArithmetic:
     # Base test class for MaskedArrays.
-
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -1137,16 +1135,18 @@ class TestMaskedArrayArithmetic:
         zm = masked_array(z, mask=[0, 1, 0, 0])
         xf = np.where(m1, 1e+20, x)
         xm.set_fill_value(1e+20)
-        self.d = (x, y, a10, m1, m2, xm, ym, z, zm, xf)
-        self.err_status = np.geterr()
-        np.seterr(divide='ignore', invalid='ignore')
+        return x, y, a10, m1, m2, xm, ym, z, zm, xf
 
-    def teardown_method(self):
-        np.seterr(**self.err_status)
+    @pytest.fixture
+    def err_status(self):
+        err = np.geterr()
+        np.seterr(divide='ignore', invalid='ignore')
+        yield err
+        np.seterr(**err)
 
     def test_basic_arithmetic(self):
         # Test of basic arithmetic.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, a10, _, _, xm, ym, _, _, xf = self._create_data()
         a2d = array([[1, 2], [0, 4]])
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])
         assert_equal(a2d * a2d, a2d * a2dm)
@@ -1256,7 +1256,7 @@ class TestMaskedArrayArithmetic:
 
     def test_basic_ufuncs(self):
         # Test various functions such as sin, cos.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, _, _, xm, ym, z, zm, _ = self._create_data()
         assert_equal(np.cos(x), cos(xm))
         assert_equal(np.cosh(x), cosh(xm))
         assert_equal(np.sin(x), sin(xm))
@@ -1318,7 +1318,7 @@ class TestMaskedArrayArithmetic:
 
     def test_minmax_func(self):
         # Tests minimum and maximum.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, _, _, xm, _, _, _, _ = self._create_data()
         # max doesn't work if shaped
         xr = np.ravel(x)
         xmr = ravel(xm)
@@ -1390,7 +1390,7 @@ class TestMaskedArrayArithmetic:
 
     def test_minmax_methods(self):
         # Additional tests on max/min
-        (_, _, _, _, _, xm, _, _, _, _) = self.d
+        xm = self._create_data()[5]
         xm.shape = (xm.size,)
         assert_equal(xm.max(), 10)
         assert_(xm[0].max() is masked)
@@ -1491,7 +1491,7 @@ class TestMaskedArrayArithmetic:
 
     def test_addsumprod(self):
         # Tests add, sum, product.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, _, _, xm, ym, _, _, _ = self._create_data()
         assert_equal(np.add.reduce(x), add.reduce(x))
         assert_equal(np.add.accumulate(x), add.accumulate(x))
         assert_equal(4, sum(array(4), axis=0))
@@ -1612,7 +1612,7 @@ class TestMaskedArrayArithmetic:
 
     def test_mod(self):
         # Tests mod
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
+        x, y, _, _, _, xm, ym, _, _, _ = self._create_data()
         assert_equal(mod(x, y), mod(xm, ym))
         test = mod(ym, xm)
         assert_equal(test, np.mod(ym, xm))
@@ -2590,16 +2590,17 @@ class TestFillingValues:
 
 class TestUfuncs:
     # Test class for the application of ufuncs on MaskedArrays.
-
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
-        self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
+        return (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
-        self.err_status = np.geterr()
-        np.seterr(divide='ignore', invalid='ignore')
 
-    def teardown_method(self):
-        np.seterr(**self.err_status)
+    @pytest.fixture(autouse=True)
+    def err_status(self):
+        err = np.geterr()
+        np.seterr(divide='ignore', invalid='ignore')
+        yield err
+        np.seterr(**err)
 
     def test_testUfuncRegression(self):
         # Tests new ufuncs on MaskedArrays.
@@ -2625,7 +2626,7 @@ class TestUfuncs:
             except AttributeError:
                 uf = getattr(fromnumeric, f)
             mf = getattr(numpy.ma.core, f)
-            args = self.d[:uf.nin]
+            args = self._create_data()[:uf.nin]
             ur = uf(*args)
             mr = mf(*args)
             assert_equal(ur.filled(0), mr.filled(0), f)
@@ -2633,7 +2634,7 @@ class TestUfuncs:
 
     def test_reduce(self):
         # Tests reduce on MaskedArrays.
-        a = self.d[0]
+        a = self._create_data()[0]
         assert_(not alltrue(a, axis=0))
         assert_(sometrue(a, axis=0))
         assert_equal(sum(a[:3], axis=0), 0)
@@ -2739,32 +2740,38 @@ class TestUfuncs:
 
 class TestMaskedArrayInPlaceArithmetic:
     # Test MaskedArray Arithmetic
-
-    def setup_method(self):
+    def _create_intdata(self):
         x = arange(10)
         y = arange(10)
         xm = arange(10)
         xm[2] = masked
-        self.intdata = (x, y, xm)
-        self.floatdata = (x.astype(float), y.astype(float), xm.astype(float))
-        self.othertypes = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
-        self.othertypes = [np.dtype(_).type for _ in self.othertypes]
-        self.uint8data = (
+        return x, y, xm
+
+    def _create_floatdata(self):
+        x, y, xm = self._create_intdata()
+        return x.astype(float), y.astype(float), xm.astype(float)
+
+    def _create_otherdata(self):
+        o = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        othertypes = [np.dtype(_).type for _ in o]
+        (x, y, xm) = self._create_intdata()
+        uint8data = (
             x.astype(np.uint8),
             y.astype(np.uint8),
             xm.astype(np.uint8)
         )
+        return othertypes, uint8data
 
     def test_inplace_addition_scalar(self):
         # Test of inplace additions
-        (x, y, xm) = self.intdata
+        x, y, xm = self._create_intdata()
         xm[2] = masked
         x += 1
         assert_equal(x, y + 1)
         xm += 1
         assert_equal(xm, y + 1)
 
-        (x, _, xm) = self.floatdata
+        x, _, xm = self._create_floatdata()
         id1 = x.data.ctypes.data
         x += 1.
         assert_(id1 == x.data.ctypes.data)
@@ -2772,7 +2779,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_addition_array(self):
         # Test of inplace additions
-        (x, y, xm) = self.intdata
+        x, y, xm = self._create_intdata()
         m = xm.mask
         a = arange(10, dtype=np.int16)
         a[-1] = masked
@@ -2784,7 +2791,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_subtraction_scalar(self):
         # Test of inplace subtractions
-        (x, y, xm) = self.intdata
+        x, y, xm = self._create_intdata()
         x -= 1
         assert_equal(x, y - 1)
         xm -= 1
@@ -2792,7 +2799,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_subtraction_array(self):
         # Test of inplace subtractions
-        (x, y, xm) = self.floatdata
+        x, y, xm = self._create_floatdata()
         m = xm.mask
         a = arange(10, dtype=float)
         a[-1] = masked
@@ -2804,7 +2811,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_multiplication_scalar(self):
         # Test of inplace multiplication
-        (x, y, xm) = self.floatdata
+        x, y, xm = self._create_floatdata()
         x *= 2.0
         assert_equal(x, y * 2)
         xm *= 2.0
@@ -2812,7 +2819,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_multiplication_array(self):
         # Test of inplace multiplication
-        (x, y, xm) = self.floatdata
+        x, y, xm = self._create_floatdata()
         m = xm.mask
         a = arange(10, dtype=float)
         a[-1] = masked
@@ -2824,7 +2831,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_division_scalar_int(self):
         # Test of inplace division
-        (x, y, xm) = self.intdata
+        x, y, xm = self._create_intdata()
         x = arange(10) * 2
         xm = arange(10) * 2
         xm[2] = masked
@@ -2835,7 +2842,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_division_scalar_float(self):
         # Test of inplace division
-        (x, y, xm) = self.floatdata
+        x, y, xm = self._create_floatdata()
         x /= 2.0
         assert_equal(x, y / 2.0)
         xm /= arange(10)
@@ -2843,7 +2850,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_division_array_float(self):
         # Test of inplace division
-        (x, y, xm) = self.floatdata
+        x, y, xm = self._create_floatdata()
         m = xm.mask
         a = arange(10, dtype=float)
         a[-1] = masked
@@ -3020,10 +3027,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_addition_scalar_type(self):
         # Test of inplace additions
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 xm[2] = masked
                 x += t(1)
                 assert_equal(x, y + t(1))
@@ -3032,10 +3040,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_addition_array_type(self):
         # Test of inplace additions
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
                 a[-1] = masked
@@ -3047,10 +3056,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_subtraction_scalar_type(self):
         # Test of inplace subtractions
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 x -= t(1)
                 assert_equal(x, y - t(1))
                 xm -= t(1)
@@ -3058,10 +3068,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_subtraction_array_type(self):
         # Test of inplace subtractions
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
                 a[-1] = masked
@@ -3073,10 +3084,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_multiplication_scalar_type(self):
         # Test of inplace multiplication
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 x *= t(2)
                 assert_equal(x, y * t(2))
                 xm *= t(2)
@@ -3084,10 +3096,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_multiplication_array_type(self):
         # Test of inplace multiplication
-        for t in self.othertypes:
+        othertypes, uint8data = self._create_otherdata()
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
                 a[-1] = masked
@@ -3100,11 +3113,12 @@ class TestMaskedArrayInPlaceArithmetic:
     def test_inplace_floor_division_scalar_type(self):
         # Test of inplace division
         # Check for TypeError in case of unsupported types
+        othertypes, uint8data = self._create_otherdata()
         unsupported = {np.dtype(t).type for t in np.typecodes["Complex"]}
-        for t in self.othertypes:
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 x = arange(10, dtype=t) * t(2)
                 xm = arange(10, dtype=t) * t(2)
                 xm[2] = masked
@@ -3120,11 +3134,12 @@ class TestMaskedArrayInPlaceArithmetic:
     def test_inplace_floor_division_array_type(self):
         # Test of inplace division
         # Check for TypeError in case of unsupported types
+        othertypes, uint8data = self._create_otherdata()
         unsupported = {np.dtype(t).type for t in np.typecodes["Complex"]}
-        for t in self.othertypes:
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
                 a[-1] = masked
@@ -3143,10 +3158,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_division_scalar_type(self):
         # Test of inplace division
+        othertypes, uint8data = self._create_otherdata()
         with warnings.catch_warnings():
             warnings.simplefilter('error', DeprecationWarning)
-            for t in self.othertypes:
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+            for t in othertypes:
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 x = arange(10, dtype=t) * t(2)
                 xm = arange(10, dtype=t) * t(2)
                 xm[2] = masked
@@ -3179,10 +3195,11 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_division_array_type(self):
         # Test of inplace division
+        othertypes, uint8data = self._create_otherdata()
         with warnings.catch_warnings():
             warnings.simplefilter('error', DeprecationWarning)
-            for t in self.othertypes:
-                (x, y, xm) = (_.astype(t) for _ in self.uint8data)
+            for t in othertypes:
+                x, y, xm = (_.astype(t) for _ in uint8data)
                 m = xm.mask
                 a = arange(10, dtype=t)
                 a[-1] = masked
@@ -3219,7 +3236,8 @@ class TestMaskedArrayInPlaceArithmetic:
 
     def test_inplace_pow_type(self):
         # Test keeping data w/ (inplace) power
-        for t in self.othertypes:
+        othertypes = self._create_otherdata()[0]
+        for t in othertypes:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
                 # Test pow on scalar
@@ -3236,7 +3254,7 @@ class TestMaskedArrayInPlaceArithmetic:
 
 class TestMaskedArrayMethods:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -3266,7 +3284,7 @@ class TestMaskedArrayMethods:
         m2x = array(data=x, mask=m2)
         m2X = array(data=X, mask=m2.reshape(X.shape))
         m2XX = array(data=XX, mask=m2.reshape(XX.shape))
-        self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
+        return x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX
 
     def test_generic_methods(self):
         # Tests some MaskedArray methods.
@@ -3363,7 +3381,7 @@ class TestMaskedArrayMethods:
 
     def test_argmax_argmin(self):
         # Tests argmin & argmax on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, _, _, _, mx, mX, _, m2x, m2X, _ = self._create_data()
 
         assert_equal(mx.argmin(), 35)
         assert_equal(mX.argmin(), 35)
@@ -4015,8 +4033,7 @@ class TestMaskedArrayMethods:
 
 
 class TestMaskedArrayMathMethods:
-
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -4046,11 +4063,11 @@ class TestMaskedArrayMathMethods:
         m2x = array(data=x, mask=m2)
         m2X = array(data=X, mask=m2.reshape(X.shape))
         m2XX = array(data=XX, mask=m2.reshape(XX.shape))
-        self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
+        return x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX
 
     def test_cumsumprod(self):
         # Tests cumsum & cumprod on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        mX = self._create_data()[5]
         mXcp = mX.cumsum(0)
         assert_equal(mXcp._data, mX.filled(0).cumsum(0))
         mXcp = mX.cumsum(1)
@@ -4084,7 +4101,7 @@ class TestMaskedArrayMathMethods:
 
     def test_ptp(self):
         # Tests ptp on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, X, _, m, mx, mX, _, _, _, _ = self._create_data()
         (n, m) = X.shape
         assert_equal(mx.ptp(), np.ptp(mx.compressed()))
         rows = np.zeros(n, float)
@@ -4148,7 +4165,7 @@ class TestMaskedArrayMathMethods:
 
     def test_trace(self):
         # Tests trace on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, X, _, _, _, mX, _, _, _, _ = self._create_data()
         mXdiag = mX.diagonal()
         assert_equal(mX.trace(), mX.diagonal().compressed().sum())
         assert_almost_equal(mX.trace(),
@@ -4163,7 +4180,7 @@ class TestMaskedArrayMathMethods:
 
     def test_dot(self):
         # Tests dot on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, _, _, _, mx, mX, mXX, _, _, _ = self._create_data()
         fx = mx.filled(0)
         r = mx.dot(mx)
         assert_almost_equal(r.filled(0), fx.dot(fx))
@@ -4212,7 +4229,7 @@ class TestMaskedArrayMathMethods:
 
     def test_varstd(self):
         # Tests var & std on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, X, XX, _, _, mX, mXX, _, _, _ = self._create_data()
         assert_almost_equal(mX.var(axis=None), mX.compressed().var())
         assert_almost_equal(mX.std(axis=None), mX.compressed().std())
         assert_almost_equal(mX.std(axis=None, ddof=1),
@@ -4363,7 +4380,7 @@ class TestMaskedArrayMathMethods:
 
 class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup_method(self):
+    def _create_data(self):
         # Base data definition.
         x = np.array([8.375j, 7.545j, 8.828j, 8.5j, 1.757j, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -4393,11 +4410,11 @@ class TestMaskedArrayMathMethodsComplex:
         m2x = array(data=x, mask=m2)
         m2X = array(data=X, mask=m2.reshape(X.shape))
         m2XX = array(data=XX, mask=m2.reshape(XX.shape))
-        self.d = (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX)
+        return x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX
 
     def test_varstd(self):
         # Tests var & std on MaskedArrays.
-        (x, X, XX, m, mx, mX, mXX, m2x, m2X, m2XX) = self.d
+        _, X, XX, _, _, mX, mXX, _, _, _ = self._create_data()
         assert_almost_equal(mX.var(axis=None), mX.compressed().var())
         assert_almost_equal(mX.std(axis=None), mX.compressed().std())
         assert_equal(mXX.var(axis=3).shape, XX.var(axis=3).shape)
@@ -4416,17 +4433,6 @@ class TestMaskedArrayMathMethodsComplex:
 
 class TestMaskedArrayFunctions:
     # Test class for miscellaneous functions.
-
-    def setup_method(self):
-        x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
-        y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
-        m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
-        m2 = [0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
-        xm = masked_array(x, mask=m1)
-        ym = masked_array(y, mask=m2)
-        xm.set_fill_value(1e+20)
-        self.info = (xm, ym)
-
     def test_masked_where_bool(self):
         x = [1, 2]
         y = masked_where(False, x)
@@ -5131,8 +5137,7 @@ class TestMaskedArrayFunctions:
 
 
 class TestMaskedFields:
-
-    def setup_method(self):
+    def _create_data(self):
         ilist = [1, 2, 3, 4, 5]
         flist = [1.1, 2.2, 3.3, 4.4, 5.5]
         slist = ['one', 'two', 'three', 'four', 'five']
@@ -5140,11 +5145,12 @@ class TestMaskedFields:
         mdtype = [('a', bool), ('b', bool), ('c', bool)]
         mask = [0, 1, 0, 0, 1]
         base = array(list(zip(ilist, flist, slist)), mask=mask, dtype=ddtype)
-        self.data = {"base": base, "mask": mask, "ddtype": ddtype, "mdtype": mdtype}
+        return {"base": base, "mask": mask, "ddtype": ddtype, "mdtype": mdtype}
 
     def test_set_records_masks(self):
-        base = self.data['base']
-        mdtype = self.data['mdtype']
+        data = self._create_data()
+        base = data['base']
+        mdtype = data['mdtype']
         # Set w/ nomask or masked
         base.mask = nomask
         assert_equal_records(base._mask, np.zeros(base.shape, dtype=mdtype))
@@ -5163,7 +5169,7 @@ class TestMaskedFields:
 
     def test_set_record_element(self):
         # Check setting an element of a record)
-        base = self.data['base']
+        base = self._create_data()['base']
         (base_a, base_b, base_c) = (base['a'], base['b'], base['c'])
         base[0] = (pi, pi, 'pi')
 
@@ -5178,7 +5184,7 @@ class TestMaskedFields:
                      [b'pi', b'two', b'three', b'four', b'five'])
 
     def test_set_record_slice(self):
-        base = self.data['base']
+        base = self._create_data()['base']
         (base_a, base_b, base_c) = (base['a'], base['b'], base['c'])
         base[:3] = (pi, pi, 'pi')
 
@@ -5194,7 +5200,7 @@ class TestMaskedFields:
 
     def test_mask_element(self):
         "Check record access"
-        base = self.data['base']
+        base = self._create_data()['base']
         base[0] = masked
 
         for n in ('a', 'b', 'c'):
@@ -5287,9 +5293,10 @@ class TestMaskedFields:
         assert_array_equal(arr.mask, [True, False, False])
 
     def test_element_len(self):
+        data = self._create_data()
         # check that len() works for mvoid (Github issue #576)
-        for rec in self.data['base']:
-            assert_equal(len(rec), len(self.data['ddtype']))
+        for rec in data['base']:
+            assert_equal(len(rec), len(data['ddtype']))
 
 
 class TestMaskedObjectArray:
@@ -5341,31 +5348,30 @@ class TestMaskedObjectArray:
 
 
 class TestMaskedView:
-
-    def setup_method(self):
+    def _create_data(self):
         iterator = list(zip(np.arange(10), np.random.rand(10)))
         data = np.array(iterator)
         a = array(iterator, dtype=[('a', float), ('b', float)])
         a.mask[0] = (1, 0)
         controlmask = np.array([1] + 19 * [0], dtype=bool)
-        self.data = (data, a, controlmask)
+        return data, a, controlmask
 
     def test_view_to_nothing(self):
-        (data, a, controlmask) = self.data
+        a = self._create_data()[1]
         test = a.view()
         assert_(isinstance(test, MaskedArray))
         assert_equal(test._data, a._data)
         assert_equal(test._mask, a._mask)
 
     def test_view_to_type(self):
-        (data, a, controlmask) = self.data
+        data, a, _ = self._create_data()
         test = a.view(np.ndarray)
         assert_(not isinstance(test, MaskedArray))
         assert_equal(test, a._data)
         assert_equal_records(test, data.view(a.dtype).squeeze())
 
     def test_view_to_simple_dtype(self):
-        (data, a, controlmask) = self.data
+        data, a, controlmask = self._create_data()
         # View globally
         test = a.view(float)
         assert_(isinstance(test, MaskedArray))
@@ -5373,7 +5379,7 @@ class TestMaskedView:
         assert_equal(test.mask, controlmask)
 
     def test_view_to_flexible_dtype(self):
-        (data, a, controlmask) = self.data
+        a = self._create_data()[1]
 
         test = a.view([('A', float), ('B', float)])
         assert_equal(test.mask.dtype.names, ('A', 'B'))
@@ -5393,7 +5399,7 @@ class TestMaskedView:
         assert_equal(test['B'], a['b'][-1])
 
     def test_view_to_subdtype(self):
-        (data, a, controlmask) = self.data
+        data, a, controlmask = self._create_data()
         # View globally
         test = a.view((float, 2))
         assert_(isinstance(test, MaskedArray))
@@ -5410,7 +5416,7 @@ class TestMaskedView:
         assert_equal(test, data[-1])
 
     def test_view_to_dtype_and_type(self):
-        (data, a, controlmask) = self.data
+        data, a, _ = self._create_data()
 
         test = a.view((float, 2), np.recarray)
         assert_equal(test, data)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1137,7 +1137,7 @@ class TestMaskedArrayArithmetic:
         xm.set_fill_value(1e+20)
         return x, y, a10, m1, m2, xm, ym, z, zm, xf
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope="class")
     def err_status(self):
         err = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
@@ -2595,7 +2595,7 @@ class TestUfuncs:
         return (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope="class")
     def err_status(self):
         err = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
@@ -2737,6 +2737,7 @@ class TestUfuncs:
         with np.errstate(under="raise"):
             X2 = X / 2.0
             np.testing.assert_array_equal(X2, x / 2)
+
 
 class TestMaskedArrayInPlaceArithmetic:
     # Test MaskedArray Arithmetic
@@ -5649,6 +5650,7 @@ def test_masked_array():
     a = np.ma.array([0, 1, 2, 3], mask=[0, 0, 1, 0])
     assert_equal(np.argwhere(a), [[1], [3]])
 
+
 def test_masked_array_no_copy():
     # check nomask array is updated in place
     a = np.ma.array([1, 2, 3, 4])
@@ -5662,6 +5664,7 @@ def test_masked_array_no_copy():
     a = np.ma.array([np.inf, 1, 2, 3, 4])
     _ = np.ma.masked_invalid(a, copy=False)
     assert_array_equal(a.mask, [True, False, False, False, False])
+
 
 def test_append_masked_array():
     a = np.ma.masked_equal([1, 2, 3], value=2)
@@ -5700,6 +5703,7 @@ def test_append_masked_array_along_axis():
     expected = expected.reshape((3, 3))
     assert_array_equal(result.data, expected.data)
     assert_array_equal(result.mask, expected.mask)
+
 
 def test_default_fill_value_complex():
     # regression test for Python 3, where 'unicode' was not defined
@@ -5869,6 +5873,7 @@ def test_mask_shape_assignment_does_not_break_masked():
     b = np.ma.array(1, mask=a.mask)
     b.shape = (1,)
     assert_equal(a.mask.shape, ())
+
 
 @pytest.mark.skipif(sys.flags.optimize > 1,
                     reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")  # noqa: E501

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1137,7 +1137,7 @@ class TestMaskedArrayArithmetic:
         xm.set_fill_value(1e+20)
         return x, y, a10, m1, m2, xm, ym, z, zm, xf
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def err_status(self):
         err = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
@@ -2754,7 +2754,7 @@ class TestMaskedArrayInPlaceArithmetic:
     def _create_otherdata(self):
         o = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
         othertypes = [np.dtype(_).type for _ in o]
-        (x, y, xm) = self._create_intdata()
+        x, y, xm = self._create_intdata()
         uint8data = (
             x.astype(np.uint8),
             y.astype(np.uint8),


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552, with this being the fourth PR. This PR has the goal of making NumPy's testing suite more thread safe. This introduces changes to the setup methods for 2 more testing files, one in numpy/lib and one in numpy/ma. Pytest's classic xunit setup and teardown methods are thread unsafe, typically not running before the tests do, leading to AttributionErrors. This PR changes these setup method to basic "creation" methods that are called within the tests that need them.

For a few tests in test_core, the setup methods also utilizes np.seterr(). This was modified to be an autouse fixture.

For both files, while all of the thread-unsafe setup methods have been replaced, there are still some thread safety issues with a few tests (either due to usage of tmp_path, stdout, or something else), so you can't run them all with parallel threads just yet.