### PR TITLE
TYP: fix slightly incorrect ``memoryview`` type argument in ``ScalarType``

### DIFF
--- a/numpy/_core/numerictypes.pyi
+++ b/numpy/_core/numerictypes.pyi
@@ -1,5 +1,5 @@
 from builtins import bool as py_bool
-from typing import Final, Literal as L, TypedDict, type_check_only
+from typing import Any, Final, Literal as L, TypedDict, type_check_only
 
 import numpy as np
 from numpy import (
@@ -166,7 +166,7 @@ ScalarType: Final[
         type[py_bool],
         type[bytes],
         type[str],
-        type[memoryview],
+        type[memoryview[Any]],
         type[np.bool],
         type[csingle],
         type[cdouble],

--- a/numpy/typing/tests/data/reveal/numerictypes.pyi
+++ b/numpy/typing/tests/data/reveal/numerictypes.pyi
@@ -2,42 +2,6 @@ from typing import Literal, assert_type
 
 import numpy as np
 
-assert_type(
-    np.ScalarType,
-    tuple[
-        type[int],
-        type[float],
-        type[complex],
-        type[bool],
-        type[bytes],
-        type[str],
-        type[memoryview],
-        type[np.bool],
-        type[np.csingle],
-        type[np.cdouble],
-        type[np.clongdouble],
-        type[np.half],
-        type[np.single],
-        type[np.double],
-        type[np.longdouble],
-        type[np.byte],
-        type[np.short],
-        type[np.intc],
-        type[np.long],
-        type[np.longlong],
-        type[np.timedelta64],
-        type[np.datetime64],
-        type[np.object_],
-        type[np.bytes_],
-        type[np.str_],
-        type[np.ubyte],
-        type[np.ushort],
-        type[np.uintc],
-        type[np.ulong],
-        type[np.ulonglong],
-        type[np.void],
-    ],
-)
 assert_type(np.ScalarType[0], type[int])
 assert_type(np.ScalarType[3], type[bool])
 assert_type(np.ScalarType[8], type[np.csingle])


### PR DESCRIPTION
ported from numpy/numtype#693

---

In static-typing land, `memoryview` is a generic type with a type parameter that defaults to `int`. For example `x: memoryview` is equivalent to `x: memoryview[int]`, and type-checkers treat them in exactly the same way.
But the `memoryview` **type** in the `numpy.ScalarType` tuple can be used to construct instances that aren't necessarily of `int`. So its type argument must be set to `Any`, because if omitted, it'll default to `int`.