### PR TITLE
TYP: Make ``datetime64`` a generic type at runtime

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2853,11 +2853,15 @@ static PyMethodDef numbertype_methods[] = {
     {NULL, NULL, 0, NULL}  /* sentinel */
 };
 
-static PyMethodDef booleantype_methods[] = {
-        /* for typing */
-        {"__class_getitem__", Py_GenericAlias, METH_CLASS | METH_O, NULL},
-        {NULL, NULL, 0, NULL} /* sentinel */
+/**begin repeat
+ * #name = boolean,datetime#
+ */
+static PyMethodDef @name@type_methods[] = {
+    /* for typing */
+    {"__class_getitem__", Py_GenericAlias, METH_CLASS | METH_O, NULL},
+    {NULL, NULL, 0, NULL} /* sentinel */
 };
+/**end repeat**/
 
 /**begin repeat
  * #name = cfloat,clongdouble#
@@ -4564,6 +4568,7 @@ initialize_numeric_types(void)
 
     /**end repeat**/
 
+    PyDatetimeArrType_Type.tp_methods = datetimetype_methods;
 
     /**begin repeat
      * #Type = Byte, UByte, Short, UShort, Int, UInt, Long,

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -171,8 +171,8 @@ class TestClassGetItem:
     @pytest.mark.parametrize("code", np.typecodes["All"])
     def test_concrete(self, code: str) -> None:
         cls = np.dtype(code).type
-        if cls == np.bool:
-            # np.bool allows subscript
+        if cls in {np.bool, np.datetime64}:
+            # these are intentionally subscriptable
             assert cls[Any]
         else:
             with pytest.raises(TypeError):


### PR DESCRIPTION
In the stubs, `datetime64` is a generic type with an optional type parameter. But due to the lack of `__class_getitem__`, something like `np.datetime64[int]` would fail at runtime, even though it's valid in static typing land.

This changes `datetime64` so that it's can also be used as generic type at runtime by adding a `__class_getitem__` method that returns a `types.GenericAliasType` (yea, the naming is horrible...).

Before:

```pycon
In [1]: np.__version__
Out[1]: '2.3.2'

In [2]: np.datetime64[int]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 np.datetime64[int]

TypeError: type 'numpy.datetime64' is not subscriptable
```

After:

```pycon
In [1]: np.__version__
Out[1]: '2.4.0.dev0+git20250825.47430c7'

In [2]: np.datetime64[int]
Out[2]: numpy.datetime64[int]
```

(I'm getting pretty good at pretending to know C, eh?)

---

related to #29370