### PR TITLE
TST: Replace xunit setup with methods

### DIFF
--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1314,11 +1314,11 @@ class TestMedian:
 
 class TestCov:
 
-    def setup_method(self):
-        self.data = array(np.random.rand(12))
+    def _create_data(self):
+        return array(np.random.rand(12))
 
     def test_covhelper(self):
-        x = self.data
+        x = self._create_data()
         # Test not mask output type is a float.
         assert_(_covhelper(x, rowvar=True)[1].dtype, np.float32)
         assert_(_covhelper(x, y=x, rowvar=False)[1].dtype, np.float32)
@@ -1339,7 +1339,7 @@ class TestCov:
 
     def test_1d_without_missing(self):
         # Test cov on 1D variable w/o missing values
-        x = self.data
+        x = self._create_data()
         assert_almost_equal(np.cov(x), cov(x))
         assert_almost_equal(np.cov(x, rowvar=False), cov(x, rowvar=False))
         assert_almost_equal(np.cov(x, rowvar=False, bias=True),
@@ -1347,7 +1347,7 @@ class TestCov:
 
     def test_2d_without_missing(self):
         # Test cov on 1 2D variable w/o missing values
-        x = self.data.reshape(3, 4)
+        x = self._create_data().reshape(3, 4)
         assert_almost_equal(np.cov(x), cov(x))
         assert_almost_equal(np.cov(x, rowvar=False), cov(x, rowvar=False))
         assert_almost_equal(np.cov(x, rowvar=False, bias=True),
@@ -1355,7 +1355,7 @@ class TestCov:
 
     def test_1d_with_missing(self):
         # Test cov 1 1D variable w/missing values
-        x = self.data
+        x = self._create_data()
         x[-1] = masked
         x -= x.mean()
         nx = x.compressed()
@@ -1379,7 +1379,7 @@ class TestCov:
 
     def test_2d_with_missing(self):
         # Test cov on 2D variable w/ missing value
-        x = self.data
+        x = self._create_data()
         x[-1] = masked
         x = x.reshape(3, 4)
         valid = np.logical_not(getmaskarray(x)).astype(int)
@@ -1401,13 +1401,14 @@ class TestCov:
 
 class TestCorrcoef:
 
-    def setup_method(self):
-        self.data = array(np.random.rand(12))
-        self.data2 = array(np.random.rand(12))
+    def _create_data(self):
+        data = array(np.random.rand(12))
+        data2 = array(np.random.rand(12))
+        return data, data2
 
     def test_ddof(self):
         # ddof raises DeprecationWarning
-        x, y = self.data, self.data2
+        x, y = self._create_data()
         expected = np.corrcoef(x)
         expected2 = np.corrcoef(x, y)
         with pytest.warns(DeprecationWarning):
@@ -1425,7 +1426,7 @@ class TestCorrcoef:
             assert_almost_equal(corrcoef(x, y, ddof=3), expected2)
 
     def test_bias(self):
-        x, y = self.data, self.data2
+        x, y = self._create_data()
         expected = np.corrcoef(x)
         # bias raises DeprecationWarning
         with pytest.warns(DeprecationWarning):
@@ -1443,7 +1444,7 @@ class TestCorrcoef:
 
     def test_1d_without_missing(self):
         # Test cov on 1D variable w/o missing values
-        x = self.data
+        x = self._create_data()[0]
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
@@ -1455,7 +1456,7 @@ class TestCorrcoef:
 
     def test_2d_without_missing(self):
         # Test corrcoef on 1 2D variable w/o missing values
-        x = self.data.reshape(3, 4)
+        x = self._create_data()[0].reshape(3, 4)
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
@@ -1467,7 +1468,7 @@ class TestCorrcoef:
 
     def test_1d_with_missing(self):
         # Test corrcoef 1 1D variable w/missing values
-        x = self.data
+        x = self._create_data()[0]
         x[-1] = masked
         x -= x.mean()
         nx = x.compressed()
@@ -1499,7 +1500,7 @@ class TestCorrcoef:
 
     def test_2d_with_missing(self):
         # Test corrcoef on 2D variable w/ missing value
-        x = self.data
+        x = self._create_data()[0]
         x[-1] = masked
         x = x.reshape(3, 4)
 
@@ -1519,7 +1520,7 @@ class TestCorrcoef:
 
 
 class TestPolynomial:
-    #
+
     def test_polyfit(self):
         # Tests polyfit
         # On ndarrays

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -349,6 +349,7 @@ class TestMRecords:
 
 
 class TestView:
+
     def _create_data(self):
         a, b = (np.arange(10), np.random.rand(10))
         ndtype = [('a', float), ('b', float)]

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -349,25 +349,24 @@ class TestMRecords:
 
 
 class TestView:
-
-    def setup_method(self):
-        (a, b) = (np.arange(10), np.random.rand(10))
+    def _create_data(self):
+        a, b = (np.arange(10), np.random.rand(10))
         ndtype = [('a', float), ('b', float)]
         arr = np.array(list(zip(a, b)), dtype=ndtype)
 
         mrec = fromarrays([a, b], dtype=ndtype, fill_value=(-9., -99.))
         mrec.mask[3] = (False, True)
-        self.data = (mrec, a, b, arr)
+        return mrec, a, b, arr
 
     def test_view_by_itself(self):
-        (mrec, a, b, arr) = self.data
+        mrec = self._create_data()[0]
         test = mrec.view()
         assert_(isinstance(test, MaskedRecords))
         assert_equal_records(test, mrec)
         assert_equal_records(test._mask, mrec._mask)
 
     def test_view_simple_dtype(self):
-        (mrec, a, b, arr) = self.data
+        mrec, a, b, _ = self._create_data()
         ntype = (float, 2)
         test = mrec.view(ntype)
         assert_(isinstance(test, ma.MaskedArray))
@@ -375,7 +374,7 @@ class TestView:
         assert_(test[3, 1] is ma.masked)
 
     def test_view_flexible_type(self):
-        (mrec, a, b, arr) = self.data
+        mrec, _, _, arr = self._create_data()
         alttype = [('A', float), ('B', float)]
         test = mrec.view(alttype)
         assert_(isinstance(test, MaskedRecords))

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -96,8 +96,7 @@ def eq(v, w, msg=''):
 
 
 class TestMa:
-
-    def setup_method(self):
+    def _create_data(self):
         x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         a10 = 10.
@@ -110,11 +109,11 @@ class TestMa:
         xf = np.where(m1, 1e+20, x)
         s = x.shape
         xm.set_fill_value(1e+20)
-        self.d = (x, y, a10, m1, m2, xm, ym, z, zm, xf, s)
+        return x, y, a10, m1, m2, xm, ym, z, zm, xf, s
 
     def test_testBasic1d(self):
         # Test of basic array creation and properties in 1 dimension.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, _, _, m1, _, xm, _, _, _, xf, s = self._create_data()
         assert_(not isMaskedArray(x))
         assert_(isMaskedArray(xm))
         assert_equal(shape(xm), s)
@@ -129,7 +128,7 @@ class TestMa:
     @pytest.mark.parametrize("s", [(4, 3), (6, 2)])
     def test_testBasic2d(self, s):
         # Test of basic array creation and properties in 2 dimensions.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, y, _, m1, _, xm, ym, _, _, xf, s = self._create_data()
         x.shape = s
         y.shape = s
         xm.shape = s
@@ -148,7 +147,7 @@ class TestMa:
 
     def test_testArithmetic(self):
         # Test of basic arithmetic.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, y, a10, _, _, xm, ym, _, _, xf, s = self._create_data()
         a2d = array([[1, 2], [0, 4]])
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])
         assert_(eq(a2d * a2d, a2d * a2dm))
@@ -192,7 +191,7 @@ class TestMa:
 
     def test_testUfuncs1(self):
         # Test various functions such as sin, cos.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, y, _, _, _, xm, ym, z, zm, _, _ = self._create_data()
         assert_(eq(np.cos(x), cos(xm)))
         assert_(eq(np.cosh(x), cosh(xm)))
         assert_(eq(np.sin(x), sin(xm)))
@@ -238,7 +237,7 @@ class TestMa:
 
     def test_testMinMax(self):
         # Test minimum and maximum.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, _, _, _, _, xm, _, _, _, _, _ = self._create_data()
         xr = np.ravel(x)  # max doesn't work if shaped
         xmr = ravel(xm)
 
@@ -248,7 +247,7 @@ class TestMa:
 
     def test_testAddSumProd(self):
         # Test add, sum, product.
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        x, y, _, _, _, xm, ym, _, _, _, s = self._create_data()
         assert_(eq(np.add.reduce(x), add.reduce(x)))
         assert_(eq(np.add.accumulate(x), add.accumulate(x)))
         assert_(eq(4, sum(array(4), axis=0)))
@@ -417,7 +416,7 @@ class TestMa:
         assert_(eq(x, [0, 1, 10, 40, 4]))
 
     def test_testMaPut(self):
-        (x, y, a10, m1, m2, xm, ym, z, zm, xf, s) = self.d
+        _, _, _, _, _, _, ym, _, zm, _, _ = self._create_data()
         m = [1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1]
         i = np.nonzero(m)[0]
         put(ym, i, zm)
@@ -777,8 +776,8 @@ class TestMa:
 
 
 class TestUfuncs:
-    def setup_method(self):
-        self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
+    def _create_data(self):
+        return (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
 
     def test_testUfuncRegression(self):
@@ -807,7 +806,7 @@ class TestUfuncs:
             except AttributeError:
                 uf = getattr(fromnumeric, f)
             mf = getattr(np.ma, f)
-            args = self.d[:uf.nin]
+            args = self._create_data()[:uf.nin]
             with np.errstate():
                 if f in f_invalid_ignore:
                     np.seterr(invalid='ignore')
@@ -819,7 +818,7 @@ class TestUfuncs:
             assert_(eqmask(ur.mask, mr.mask))
 
     def test_reduce(self):
-        a = self.d[0]
+        a = self._create_data()[0]
         assert_(not alltrue(a, axis=0))
         assert_(sometrue(a, axis=0))
         assert_equal(sum(a[:3], axis=0), 0)
@@ -842,8 +841,7 @@ class TestUfuncs:
 
 
 class TestArrayMethods:
-
-    def setup_method(self):
+    def _create_data(self):
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
                       3.012, 6.022, 5.095, 3.116, 5.238, 3.957,
@@ -863,10 +861,10 @@ class TestArrayMethods:
         mX = array(data=X, mask=m.reshape(X.shape))
         mXX = array(data=XX, mask=m.reshape(XX.shape))
 
-        self.d = (x, X, XX, m, mx, mX, mXX)
+        return x, X, XX, m, mx, mX, mXX
 
     def test_trace(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        _, X, _, _, _, mX, _ = self._create_data()
         mXdiag = mX.diagonal()
         assert_equal(mX.trace(), mX.diagonal().compressed().sum())
         assert_(eq(mX.trace(),
@@ -874,15 +872,15 @@ class TestArrayMethods:
                                            axis=0)))
 
     def test_clip(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        x, _, _, _, mx, _, _ = self._create_data()
         clipped = mx.clip(2, 8)
         assert_(eq(clipped.mask, mx.mask))
         assert_(eq(clipped._data, x.clip(2, 8)))
         assert_(eq(clipped._data, mx._data.clip(2, 8)))
 
     def test_ptp(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
-        (n, m) = X.shape
+        _, X, _, m, mx, mX, _ = self._create_data()
+        n, m = X.shape
         # print(type(mx), mx.compressed())
         # raise Exception()
         assert_equal(mx.ptp(), np.ptp(mx.compressed()))
@@ -896,28 +894,28 @@ class TestArrayMethods:
         assert_(eq(mX.ptp(1), rows))
 
     def test_swapaxes(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        _, _, _, _, _, mX, mXX = self._create_data()
         mXswapped = mX.swapaxes(0, 1)
         assert_(eq(mXswapped[-1], mX[:, -1]))
         mXXswapped = mXX.swapaxes(0, 2)
         assert_equal(mXXswapped.shape, (2, 2, 3, 3))
 
     def test_cumprod(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        mX = self._create_data()[5]
         mXcp = mX.cumprod(0)
         assert_(eq(mXcp._data, mX.filled(1).cumprod(0)))
         mXcp = mX.cumprod(1)
         assert_(eq(mXcp._data, mX.filled(1).cumprod(1)))
 
     def test_cumsum(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        mX = self._create_data()[5]
         mXcp = mX.cumsum(0)
         assert_(eq(mXcp._data, mX.filled(0).cumsum(0)))
         mXcp = mX.cumsum(1)
         assert_(eq(mXcp._data, mX.filled(0).cumsum(1)))
 
     def test_varstd(self):
-        (x, X, XX, m, mx, mX, mXX,) = self.d
+        _, X, XX, _, _, mX, mXX = self._create_data()
         assert_(eq(mX.var(axis=None), mX.compressed().var()))
         assert_(eq(mX.std(axis=None), mX.compressed().std()))
         assert_(eq(mXX.var(axis=3).shape, XX.var(axis=3).shape))

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -96,6 +96,7 @@ def eq(v, w, msg=''):
 
 
 class TestMa:
+
     def _create_data(self):
         x = np.array([1., 1., 1., -2., pi / 2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -776,6 +777,7 @@ class TestMa:
 
 
 class TestUfuncs:
+
     def _create_data(self):
         return (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
@@ -841,6 +843,7 @@ class TestUfuncs:
 
 
 class TestArrayMethods:
+
     def _create_data(self):
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -4,7 +4,6 @@
 :contact: pierregm_at_uga_dot_edu
 
 """
-
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
 from numpy.ma.core import (
@@ -188,6 +187,7 @@ class WrappedArray(NDArrayOperatorsMixin):
 
 class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
+
     def _create_data(self):
         x = np.arange(5, dtype='float')
         mx = msubarray(x, mask=[0, 1, 0, 0, 0])
@@ -426,6 +426,7 @@ def test_array_no_inheritance():
 
 class TestClassWrapping:
     # Test suite for classes that wrap MaskedArrays
+
     def _create_data(self):
         m = np.ma.masked_array([1, 3, 5], mask=[False, True, False])
         wm = WrappedArray(m)

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -4,6 +4,7 @@
 :contact: pierregm_at_uga_dot_edu
 
 """
+
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
 from numpy.ma.core import (
@@ -187,11 +188,10 @@ class WrappedArray(NDArrayOperatorsMixin):
 
 class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
-
-    def setup_method(self):
+    def _create_data(self):
         x = np.arange(5, dtype='float')
         mx = msubarray(x, mask=[0, 1, 0, 0, 0])
-        self.data = (x, mx)
+        return x, mx
 
     def test_data_subclassing(self):
         # Tests whether the subclass is kept.
@@ -205,19 +205,19 @@ class TestSubclassing:
 
     def test_maskedarray_subclassing(self):
         # Tests subclassing MaskedArray
-        (x, mx) = self.data
+        mx = self._create_data()[1]
         assert_(isinstance(mx._data, subarray))
 
     def test_masked_unary_operations(self):
         # Tests masked_unary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         with np.errstate(divide='ignore'):
             assert_(isinstance(log(mx), msubarray))
             assert_equal(log(x), np.log(x))
 
     def test_masked_binary_operations(self):
         # Tests masked_binary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         # Result should be a msubarray
         assert_(isinstance(add(mx, mx), msubarray))
         assert_(isinstance(add(mx, x), msubarray))
@@ -230,7 +230,7 @@ class TestSubclassing:
 
     def test_masked_binary_operations2(self):
         # Tests domained_masked_binary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         xmx = masked_array(mx.data.__array__(), mask=mx.mask)
         assert_(isinstance(divide(mx, mx), msubarray))
         assert_(isinstance(divide(mx, x), msubarray))
@@ -426,21 +426,20 @@ def test_array_no_inheritance():
 
 class TestClassWrapping:
     # Test suite for classes that wrap MaskedArrays
-
-    def setup_method(self):
+    def _create_data(self):
         m = np.ma.masked_array([1, 3, 5], mask=[False, True, False])
         wm = WrappedArray(m)
-        self.data = (m, wm)
+        return m, wm
 
     def test_masked_unary_operations(self):
         # Tests masked_unary_operation
-        (m, wm) = self.data
+        wm = self._create_data()[1]
         with np.errstate(divide='ignore'):
             assert_(isinstance(np.log(wm), WrappedArray))
 
     def test_masked_binary_operations(self):
         # Tests masked_binary_operation
-        (m, wm) = self.data
+        m, wm = self._create_data()
         # Result should be a WrappedArray
         assert_(isinstance(np.add(wm, wm), WrappedArray))
         assert_(isinstance(np.add(m, wm), WrappedArray))

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -181,27 +181,26 @@ class TestMaskedMatrix:
 
 class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
-
-    def setup_method(self):
+    def _create_data(self):
         x = np.arange(5, dtype='float')
         mx = MMatrix(x, mask=[0, 1, 0, 0, 0])
-        self.data = (x, mx)
+        return x, mx
 
     def test_maskedarray_subclassing(self):
         # Tests subclassing MaskedArray
-        (x, mx) = self.data
+        mx = self._create_data()[1]
         assert_(isinstance(mx._data, np.matrix))
 
     def test_masked_unary_operations(self):
         # Tests masked_unary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         with np.errstate(divide='ignore'):
             assert_(isinstance(log(mx), MMatrix))
             assert_equal(log(x), np.log(x))
 
     def test_masked_binary_operations(self):
         # Tests masked_binary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         # Result should be a MMatrix
         assert_(isinstance(add(mx, mx), MMatrix))
         assert_(isinstance(add(mx, x), MMatrix))
@@ -215,7 +214,7 @@ class TestSubclassing:
 
     def test_masked_binary_operations2(self):
         # Tests domained_masked_binary_operation
-        (x, mx) = self.data
+        x, mx = self._create_data()
         xmx = masked_array(mx.data.__array__(), mask=mx.mask)
         assert_(isinstance(divide(mx, mx), MMatrix))
         assert_(isinstance(divide(mx, x), MMatrix))

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -181,6 +181,7 @@ class TestMaskedMatrix:
 
 class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
+
     def _create_data(self):
         x = np.arange(5, dtype='float')
         mx = MMatrix(x, mask=[0, 1, 0, 0, 0])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552. This PR has the goal of making NumPy's testing suite more thread safe. This introduces changes to the setup methods for 5 more testing files, 4 in numpy/ma and one in numpy/matrixlib. Pytest's classic xunit setup and teardown methods are thread unsafe, typically not running before the tests do, leading to AttributionErrors. This PR changes these setup method to basic "creation" methods that are called within the tests that need them.

For test_old_ma and test_subclassing, while all of the thread-unsafe setup methods have been replaced, there are still some thread safety issues with a few tests (either due to usage of global state or stdout), so you can't run them all with parallel threads just yet.