### PR TITLE
ENH: Add extended sorting APIs

### DIFF
--- a/doc/release/upcoming_changes/29642.c_api.rst
+++ b/doc/release/upcoming_changes/29642.c_api.rst
@@ -11,4 +11,4 @@ needed. The new names of interest are:
 * NPY_SORT_NANFIRST -- NaNs sort to the beginning
 
 The semantic change is that NPY_HEAPSORT is mapped to NPY_QUICKSORT when used.
-
+Note that NPY_SORT_DESCENDING and NPY_SORT_NANFIRST have yet to be implemented.

--- a/doc/release/upcoming_changes/29642.c_api.rst
+++ b/doc/release/upcoming_changes/29642.c_api.rst
@@ -8,7 +8,6 @@ needed. The new names of interest are:
 * NPY_SORT_DEFAULT -- default sort (same value as NPY_QUICKSORT)
 * NPY_SORT_STABLE  -- the sort must be stable (same value as NPY_MERGESORT)
 * NPY_SORT_DESCENDING -- the sort must be descending
-* NPY_SORT_NANFIRST -- NaNs sort to the beginning
 
 The semantic change is that NPY_HEAPSORT is mapped to NPY_QUICKSORT when used.
-Note that NPY_SORT_DESCENDING and NPY_SORT_NANFIRST have yet to be implemented.
+Note that NPY_SORT_DESCENDING is not yet implemented.

--- a/doc/release/upcoming_changes/29642.c_api.rst
+++ b/doc/release/upcoming_changes/29642.c_api.rst
@@ -1,0 +1,14 @@
+The NPY_SORTKIND enum has been enhanced with new variables
+----------------------------------------------------------
+This is of interest if you are using ``PyArray_Sort`` or ``PyArray_ArgSort``.
+We have changed the semantics of the old names in the NPY_SORTKIND enum and
+added new ones. The changes are backward compatible, and no recompilation is
+needed. The new names of interest are:
+
+* NPY_SORT_DEFAULT -- default sort (same value as NPY_QUICKSORT)
+* NPY_SORT_STABLE  -- the sort must be stable (same value as NPY_MERGESORT)
+* NPY_SORT_DESCENDING -- the sort must be descending
+* NPY_SORT_NANFIRST -- NaNs sort to the beginning
+
+The semantic change is that NPY_HEAPSORT is mapped to NPY_QUICKSORT when used.
+

--- a/doc/release/upcoming_changes/29642.change.rst
+++ b/doc/release/upcoming_changes/29642.change.rst
@@ -1,0 +1,4 @@
+Sorting ``kind='heapsort'`` now maps to ``kind='quicksort'``
+------------------------------------------------------------
+It is unlikely that this change will be noticed, but if you do see a change in
+execution time or unstable argsort order, this is likely the cause.

--- a/doc/release/upcoming_changes/29642.change.rst
+++ b/doc/release/upcoming_changes/29642.change.rst
@@ -1,4 +1,7 @@
 Sorting ``kind='heapsort'`` now maps to ``kind='quicksort'``
 ------------------------------------------------------------
 It is unlikely that this change will be noticed, but if you do see a change in
-execution time or unstable argsort order, this is likely the cause.
+execution time or unstable argsort order, that is likely the cause. Please let
+us know if there is a performance regression. Congratulate us if it is
+improved :)
+

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2303,29 +2303,36 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Sort(PyArrayObject* self, int axis, NPY_SORTKIND kind)
 
-    Equivalent to :meth:`ndarray.sort<numpy.ndarray.sort>` (*self*, *axis*,
-    *kind*).  Return an array with the items of *self* sorted along *axis*. The
-    array is sorted using an algorithm whose properties are specified by
-    *kind*, an integer/enum specifying the reguirements of the sorting
-    algorithm used. If *self* ->descr is a data-type with fields defined, then
-    self->descr->names is used to determine the sort order. A comparison where
-    the first field is equal will use the second field and so on. To alter the
-    sort order of a structured array, create a new data-type with a different
-    order of names and construct a view of the array with that new data-type.
+    Return an array with the items of ``self`` sorted along ``axis``. The array
+    is sorted using an algorithm whose properties are specified by the value of
+    ``kind``, an integer/enum specifying the reguirements of the sorting
+    algorithm used. If ``self* ->descr`` is a data-type with fields defined,
+    then ``self->descr->names`` is used to determine the sort order. A comparison
+    where the first field is equal will use the second field and so on. To
+    alter the sort order of a structured array, create a new data-type with a
+    different order of names and construct a view of the array with that new
+    data-type.
 
+    This is the C level function called by the ndarray method
+    :meth:`ndarray.sort<numpy.ndarray.sort>`, though with a different meaning
+    of ``kind`` -- see ``NPY_SORTKIND`` below.
 
 .. c:function:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis, NPY_SORTKIND kind)
 
-    Equivalent to :meth:`ndarray.argsort<numpy.ndarray.argsort>` (*self*,
-    *axis*, *kind*).  Return an array of indices such that selection of these
-    indices along the given ``axis`` would return a sorted version of *self*.
-    The array is sorted using an algorithm whose properties are specified by
-    *kind*, an integer/enum specifying the reguirements of the sorting
-    algorithm used. If *self* ->descr is a data-type with fields defined, then
-    self->descr->names is used to determine the sort order. A comparison where
-    the first field is equal will use the second field and so on. To alter the
-    sort order of a structured array, create a new data-type with a different
-    order of names and construct a view of the array with that new data-type.
+    Return an array of indices such that selection of these indices along the
+    given ``axis`` would return a sorted version of ``self``.  The array is
+    sorted using an algorithm whose properties are specified by ``kind``, an
+    integer/enum specifying the reguirements of the sorting algorithm used. If
+    ``self->descr`` is a data-type with fields defined, then
+    ``self->descr->names`` is used to determine the sort order. A comparison
+    where the first field is equal will use the second field and so on. To
+    alter the sort order of a structured array, create a new data-type with a
+    different order of names and construct a view of the array with that new
+    data-type.
+
+    This is the C level function called by the ndarray method
+    :meth:`ndarray.argsort<numpy.ndarray.argsort>`, though with a different
+    meaning of ``kind`` -- see ``NPY_SORTKIND`` below.
 
 .. c:function:: PyObject* PyArray_LexSort(PyObject* sort_keys, int axis)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4381,15 +4381,6 @@ Enumerated Types
         This functionality is not yet implemented for any of the NumPy types
         and cannot yet be set from the Python interface.
 
-    .. c:enumerator:: NPY_SORT_NANFIRST
-
-        (Requirement) Specifies that the sort must sort NaNs to
-        the beginning, e.g. NaNs compare less than any other value for the
-        type. This is only relevant if the type has NaN equivalents.
-        This functionality is not yet implemented for any of the NumPy types
-        and cannot yet be set from the Python interface. It may change in the
-        future.
-
 .. c:enum:: NPY_SCALARKIND
 
     A special variable type indicating the number of "kinds" of

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2303,21 +2303,29 @@ Item selection and manipulation
 
 .. c:function:: PyObject* PyArray_Sort(PyArrayObject* self, int axis, NPY_SORTKIND kind)
 
-    Equivalent to :meth:`ndarray.sort<numpy.ndarray.sort>` (*self*, *axis*, *kind*).
-    Return an array with the items of *self* sorted along *axis*. The array
-    is sorted using the algorithm denoted by *kind*, which is an integer/enum pointing
-    to the type of sorting algorithms used.
+    Equivalent to :meth:`ndarray.sort<numpy.ndarray.sort>` (*self*, *axis*,
+    *kind*).  Return an array with the items of *self* sorted along *axis*. The
+    array is sorted using an algorithm whose properties are specified by
+    *kind*, an integer/enum specifying the reguirements of the sorting
+    algorithm used. If *self* ->descr is a data-type with fields defined, then
+    self->descr->names is used to determine the sort order. A comparison where
+    the first field is equal will use the second field and so on. To alter the
+    sort order of a structured array, create a new data-type with a different
+    order of names and construct a view of the array with that new data-type.
 
-.. c:function:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis)
 
-    Equivalent to :meth:`ndarray.argsort<numpy.ndarray.argsort>` (*self*, *axis*).
-    Return an array of indices such that selection of these indices
-    along the given ``axis`` would return a sorted version of *self*. If *self* ->descr
-    is a data-type with fields defined, then self->descr->names is used
-    to determine the sort order. A comparison where the first field is equal
-    will use the second field and so on. To alter the sort order of a
-    structured array, create a new data-type with a different order of names
-    and construct a view of the array with that new data-type.
+.. c:function:: PyObject* PyArray_ArgSort(PyArrayObject* self, int axis, NPY_SORTKIND kind)
+
+    Equivalent to :meth:`ndarray.argsort<numpy.ndarray.argsort>` (*self*,
+    *axis*, *kind*).  Return an array of indices such that selection of these
+    indices along the given ``axis`` would return a sorted version of *self*.
+    The array is sorted using an algorithm whose properties are specified by
+    *kind*, an integer/enum specifying the reguirements of the sorting
+    algorithm used. If *self* ->descr is a data-type with fields defined, then
+    self->descr->names is used to determine the sort order. A comparison where
+    the first field is equal will use the second field and so on. To alter the
+    sort order of a structured array, create a new data-type with a different
+    order of names and construct a view of the array with that new data-type.
 
 .. c:function:: PyObject* PyArray_LexSort(PyObject* sort_keys, int axis)
 
@@ -4321,7 +4329,11 @@ Enumerated Types
 .. c:enum:: NPY_SORTKIND
 
     A special variable-type which can take on different values to indicate
-    the sorting algorithm being used.
+    the sorting algorithm being used. These algorithm types have not been
+    treated strictly for some time, but rather treated as stable/not stable.
+    In NumPy 2.4 they are replaced by requirements (see below), but done in a
+    backwards compatible way. These values will continue to work, except that
+    that NPY_HEAPSORT will do the same thing as NPY_QUICKSORT.
 
     .. c:enumerator:: NPY_QUICKSORT
 
@@ -4335,11 +4347,41 @@ Enumerated Types
 
     .. c:enumerator:: NPY_NSORTS
 
-       Defined to be the number of sorts. It is fixed at three by the need for
-       backwards compatibility, and consequently :c:data:`NPY_MERGESORT` and
-       :c:data:`NPY_STABLESORT` are aliased to each other and may refer to one
-       of several stable sorting algorithms depending on the data type.
+        Defined to be the number of sorts. It is fixed at three by the need for
+        backwards compatibility, and consequently :c:data:`NPY_MERGESORT` and
+        :c:data:`NPY_STABLESORT` are aliased to each other and may refer to one
+        of several stable sorting algorithms depending on the data type.
 
+    In NumPy 2.4 the algorithm names are replaced by requirements. You can still use
+    the old values, a recompile is not needed, but they are reinterpreted such that
+
+    * NPY_QUICKSORT and NPY_HEAPSORT -> NPY_SORT_DEFAULT
+    * NPY_MERGESORT and NPY_STABLE -> NPY_SORT_STABLE
+
+    .. c:enumerator:: NPY_SORT_DEFAULT
+
+        The default sort for the type. For the NumPy builtin types it may be
+        stable or not, but will be ascending and sort NaN types to the end. It
+        is usually chosen for speed and/or low memory.
+
+    .. c:enumerator:: NPY_SORT_STABLE
+
+        (Requirement) Specifies that the sort must be stable.
+
+    .. c:enumerator:: NPY_SORT_DESCENDING
+
+        (Requirement) Specifies that the sort must be in descending order.
+        This functionality is not yet implemented for any of the NumPy types
+        and cannot yet be set from the Python interface.
+
+    .. c:enumerator:: NPY_SORT_NANFIRST
+
+        (Requirement) Specifies that the sort must sort NaNs to
+        the beginning, e.g. NaNs compare less than any other value for the
+        type. This is only relevant if the type has NaN equivalents.
+        This functionality is not yet implemented for any of the NumPy types
+        and cannot yet be set from the Python interface. It may change in the
+        future.
 
 .. c:enum:: NPY_SCALARKIND
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -169,12 +169,11 @@ enum NPY_TYPECHAR {
  *
  * Updated in NumPy 2.4
  *
- * Updated with new names denoting requirements rather than the algorithm. All
- * the previous values are reused in a way that should be downstream
- * compatible, but the actual algorithms used may be different than before. The
- * new approach should be more flexible and easier to update. The idea is that
- * NPY_SORT_STABLE | NPY_SORT_DESCENDING | NPY_SORT_NANFIRST should provide an
- * index.
+ * Updated with new names denoting requirements rather than specifying a
+ * particular algorithm. All the previous values are reused in a way that
+ * should be downstream compatible, but the actual algorithms used may be
+ * different than before. The new approach should be more flexible and easier
+ * to update.
  * 
  * Names with a leading underscore are private, and should only be used
  * internally by NumPy.

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -193,7 +193,6 @@ typedef enum {
         NPY_SORT_DEFAULT = 0,
         NPY_SORT_STABLE = 2,
         NPY_SORT_DESCENDING = 4,
-        NPY_SORT_NANFIRST = 8,
 } NPY_SORTKIND;
 #define NPY_NSORTS (NPY_STABLESORT + 1)
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -162,18 +162,39 @@ enum NPY_TYPECHAR {
 };
 
 /*
- * Changing this may break Numpy API compatibility
- * due to changing offsets in PyArray_ArrFuncs, so be
- * careful. Here we have reused the mergesort slot for
- * any kind of stable sort, the actual implementation will
- * depend on the data type.
+ * Changing this may break Numpy API compatibility due to changing offsets in
+ * PyArray_ArrFuncs, so be careful. Here we have reused the mergesort slot for
+ * any kind of stable sort, the actual implementation will depend on the data
+ * type.
+ *
+ * Updated in NumPy 2.4
+ *
+ * Updated with new names denoting requirements rather than the algorithm. All
+ * the previous values are reused in a way that should be downstream
+ * compatible, but the actual algorithms used may be different than before. The
+ * new approach should be more flexible and easier to update. The idea is that
+ * NPY_SORT_STABLE | NPY_SORT_DESCENDING | NPY_SORT_NANFIRST should provide an
+ * index.
+ * 
+ * Names with a leading underscore are private, and should only be used
+ * internally by NumPy.
+ *
+ * NPY_NSORTS remains the same for backwards compatibility, it should not be
+ * changed.
  */
+
 typedef enum {
-        _NPY_SORT_UNDEFINED=-1,
-        NPY_QUICKSORT=0,
-        NPY_HEAPSORT=1,
-        NPY_MERGESORT=2,
-        NPY_STABLESORT=2,
+        _NPY_SORT_UNDEFINED = -1,
+        NPY_QUICKSORT = 0,
+        NPY_HEAPSORT = 1,
+        NPY_MERGESORT = 2,
+        NPY_STABLESORT = 2,
+        // new style names 
+        _NPY_SORT_HEAPSORT = 1,
+        NPY_SORT_DEFAULT = 0,
+        NPY_SORT_STABLE = 2,
+        NPY_SORT_DESCENDING = 4,
+        NPY_SORT_NANFIRST = 8,
 } NPY_SORTKIND;
 #define NPY_NSORTS (NPY_STABLESORT + 1)
 

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2089,10 +2089,18 @@ run_sortkind_converter(PyObject* NPY_UNUSED(self), PyObject *args)
         return NULL;
     }
     switch (kind) {
-        case _NPY_SORT_UNDEFINED: return PyUnicode_FromString("_NPY_SORT_UNDEFINED");
-        case NPY_QUICKSORT: return PyUnicode_FromString("NPY_QUICKSORT");
-        case NPY_HEAPSORT: return PyUnicode_FromString("NPY_HEAPSORT");
-        case NPY_STABLESORT: return PyUnicode_FromString("NPY_STABLESORT");
+        case _NPY_SORT_UNDEFINED:
+            return PyUnicode_FromString("_NPY_SORT_UNDEFINED");
+        case NPY_QUICKSORT:
+            return PyUnicode_FromString("NPY_QUICKSORT");
+        case NPY_HEAPSORT:
+            return PyUnicode_FromString("NPY_HEAPSORT");
+        case NPY_STABLESORT:
+            return PyUnicode_FromString("NPY_STABLESORT");
+        default:
+            // the other possible values in NPY_SORTKIND can only
+            // be set with keywords.
+            break;
     }
     return PyLong_FromLong(kind);
 }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1255,7 +1255,6 @@ array_sort(PyArrayObject *self,
     NPY_SORTKIND sortkind = _NPY_SORT_UNDEFINED;
     int stable = -1;
     int descending = -1;
-    int nanfirst = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("sort", args, len_args, kwnames,
@@ -1264,7 +1263,6 @@ array_sort(PyArrayObject *self,
             "|order", NULL, &order,
             "$stable", &PyArray_OptionalBoolConverter, &stable,
 //            "$descending", &PyArray_OptionalBoolConverter, &descending,
-//            "$nanfirst", &PyArray_OptionalBoolConverter, &nanfirst,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
@@ -1274,14 +1272,12 @@ array_sort(PyArrayObject *self,
         sortkind = 0;
         sortkind |= (stable > 0)? NPY_SORT_STABLE: 0;
         sortkind |= (descending > 0)? NPY_SORT_DESCENDING: 0;
-        sortkind |= (nanfirst > 0)? NPY_SORT_NANFIRST: 0;
     }
     else {
         // Check that no keywords are used
         int keywords_used = 0;
         keywords_used |= (stable != -1);
         keywords_used |= (descending != -1);
-        keywords_used |= (nanfirst != -1);
         if (keywords_used) {
             PyErr_SetString(PyExc_ValueError,
                     "`kind` and keyword parameters can't be provided at "
@@ -1421,7 +1417,6 @@ array_argsort(PyArrayObject *self,
     NPY_SORTKIND sortkind = _NPY_SORT_UNDEFINED;
     int stable = -1;
     int descending = -1;
-    int nanfirst = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argsort", args, len_args, kwnames,
@@ -1430,7 +1425,6 @@ array_argsort(PyArrayObject *self,
             "|order", NULL, &order,
             "$stable", &PyArray_OptionalBoolConverter, &stable,
 //            "$descending", &PyArray_OptionalBoolConverter, &descending,
-//            "$nanfirst", &PyArray_OptionalBoolConverter, &nanfirst,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
@@ -1440,14 +1434,12 @@ array_argsort(PyArrayObject *self,
         sortkind = 0;
         sortkind |= (stable > 0)? NPY_SORT_STABLE: 0;
         sortkind |= (descending > 0)? NPY_SORT_DESCENDING: 0;
-        sortkind |= (nanfirst > 0)? NPY_SORT_NANFIRST: 0;
     }
     else {
         // Check that no keywords are used
         int keywords_used = 0;
         keywords_used |= (stable != -1);
         keywords_used |= (descending != -1);
-        keywords_used |= (nanfirst != -1);
         if (keywords_used) {
             PyErr_SetString(PyExc_ValueError,
                     "`kind` and keyword parameters can't be provided at "

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1154,7 +1154,6 @@ array_copy_keeporder(PyArrayObject *self, PyObject *args)
     return PyArray_NewCopy(self, NPY_KEEPORDER);
 }
 
-#include <stdio.h>
 static PyObject *
 array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
@@ -1250,11 +1249,13 @@ array_sort(PyArrayObject *self,
 {
     int axis = -1;
     int val;
-    NPY_SORTKIND sortkind = _NPY_SORT_UNDEFINED;
     PyObject *order = NULL;
     PyArray_Descr *saved = NULL;
     PyArray_Descr *newd;
+    NPY_SORTKIND sortkind = _NPY_SORT_UNDEFINED;
     int stable = -1;
+    int descending = -1;
+    int nanfirst = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("sort", args, len_args, kwnames,
@@ -1262,18 +1263,42 @@ array_sort(PyArrayObject *self,
             "|kind", &PyArray_SortkindConverter, &sortkind,
             "|order", NULL, &order,
             "$stable", &PyArray_OptionalBoolConverter, &stable,
+//            "$descending", &PyArray_OptionalBoolConverter, &descending,
+//            "$nanfirst", &PyArray_OptionalBoolConverter, &nanfirst,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
-    if (order == Py_None) {
-        order = NULL;
+
+    if (sortkind == _NPY_SORT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = 0;
+        sortkind |= (stable > 0)? NPY_SORT_STABLE: 0;
+        sortkind |= (descending > 0)? NPY_SORT_DESCENDING: 0;
+        sortkind |= (nanfirst > 0)? NPY_SORT_NANFIRST: 0;
     }
+    else {
+        // Check that no keywords are used
+        int keywords_used = 0;
+        keywords_used |= (stable != -1);
+        keywords_used |= (descending != -1);
+        keywords_used |= (nanfirst != -1);
+        if (keywords_used) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
+    }
+
+    order = (order != Py_None)? order: NULL;
+    // Reorder field names if required.
     if (order != NULL) {
         PyObject *new_name;
         PyObject *_numpy_internal;
         saved = PyArray_DESCR(self);
         if (!PyDataType_HASFIELDS(saved)) {
-            PyErr_SetString(PyExc_ValueError, "Cannot specify " \
+            PyErr_SetString(PyExc_ValueError,
+                            "Cannot specify "
                             "order when the array has no fields.");
             return NULL;
         }
@@ -1296,20 +1321,9 @@ array_sort(PyArrayObject *self,
         ((_PyArray_LegacyDescr *)newd)->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
     }
-    if (sortkind != _NPY_SORT_UNDEFINED && stable != -1) {
-        PyErr_SetString(PyExc_ValueError,
-            "`kind` and `stable` parameters can't be provided at "
-            "the same time. Use only one of them.");
-        return NULL;
-    }
-    else if ((sortkind == _NPY_SORT_UNDEFINED && stable == -1) || (stable == 0)) {
-        sortkind = NPY_QUICKSORT;
-    }
-    else if (stable == 1) {
-        sortkind = NPY_STABLESORT;
-    }
 
     val = PyArray_Sort(self, axis, sortkind);
+
     if (order != NULL) {
         Py_XDECREF(PyArray_DESCR(self));
         ((PyArrayObject_fields *)self)->descr = saved;
@@ -1319,6 +1333,7 @@ array_sort(PyArrayObject *self,
     }
     Py_RETURN_NONE;
 }
+
 
 static PyObject *
 array_partition(PyArrayObject *self,
@@ -1393,15 +1408,20 @@ array_partition(PyArrayObject *self,
     Py_RETURN_NONE;
 }
 
+
 static PyObject *
 array_argsort(PyArrayObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = -1;
+    PyObject *res;
+    PyObject *order = NULL;
+    PyArray_Descr *saved = NULL;
+    PyArray_Descr *newd;
     NPY_SORTKIND sortkind = _NPY_SORT_UNDEFINED;
-    PyObject *order = NULL, *res;
-    PyArray_Descr *newd, *saved=NULL;
     int stable = -1;
+    int descending = -1;
+    int nanfirst = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argsort", args, len_args, kwnames,
@@ -1409,12 +1429,35 @@ array_argsort(PyArrayObject *self,
             "|kind", &PyArray_SortkindConverter, &sortkind,
             "|order", NULL, &order,
             "$stable", &PyArray_OptionalBoolConverter, &stable,
+//            "$descending", &PyArray_OptionalBoolConverter, &descending,
+//            "$nanfirst", &PyArray_OptionalBoolConverter, &nanfirst,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
-    if (order == Py_None) {
-        order = NULL;
+
+    if (sortkind == _NPY_SORT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = 0;
+        sortkind |= (stable > 0)? NPY_SORT_STABLE: 0;
+        sortkind |= (descending > 0)? NPY_SORT_DESCENDING: 0;
+        sortkind |= (nanfirst > 0)? NPY_SORT_NANFIRST: 0;
     }
+    else {
+        // Check that no keywords are used
+        int keywords_used = 0;
+        keywords_used |= (stable != -1);
+        keywords_used |= (descending != -1);
+        keywords_used |= (nanfirst != -1);
+        if (keywords_used) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
+    }
+
+    // Reorder field names if required.
+    order = (order != Py_None)? order: NULL;
     if (order != NULL) {
         PyObject *new_name;
         PyObject *_numpy_internal;
@@ -1443,20 +1486,9 @@ array_argsort(PyArrayObject *self,
         ((_PyArray_LegacyDescr *)newd)->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
     }
-    if (sortkind != _NPY_SORT_UNDEFINED && stable != -1) {
-        PyErr_SetString(PyExc_ValueError,
-            "`kind` and `stable` parameters can't be provided at "
-            "the same time. Use only one of them.");
-        return NULL;
-    }
-    else if ((sortkind == _NPY_SORT_UNDEFINED && stable == -1) || (stable == 0)) {
-        sortkind = NPY_QUICKSORT;
-    }
-    else if (stable == 1) {
-        sortkind = NPY_STABLESORT;
-    }
 
     res = PyArray_ArgSort(self, axis, sortkind);
+
     if (order != NULL) {
         Py_XDECREF(PyArray_DESCR(self));
         ((PyArrayObject_fields *)self)->descr = saved;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2211,7 +2211,7 @@ class TestMethods:
 
         with assert_raises_regex(
             ValueError,
-            "kind` and `stable` parameters can't be provided at the same time"
+            "`kind` and keyword parameters can't be provided at the same time"
         ):
             np.sort(a, kind="stable", stable=True)
 
@@ -2654,7 +2654,7 @@ class TestMethods:
 
         with assert_raises_regex(
             ValueError,
-            "kind` and `stable` parameters can't be provided at the same time"
+            "`kind` and keyword parameters can't be provided at the same time"
         ):
             np.argsort(a, kind="stable", stable=True)
 


### PR DESCRIPTION
This PR adds new sorting APIs that can be used for extending our current
sort types. The new C-APIs do not have the *which* argument of the
legacy C-APIs, instead they have *flags* request flag API. In this
transition, heapsort can no longer be called directly, introsort
(quicksort) is called instead. The sort/argsort methods get new keyword
arguments used to set the flags when *kind* is not given, so *flags* is
invisible at the Python level. The new keywords are:

- stable -- whether the sort should stable, default is False,
- descending -- whether to sort in descending order, default is False,
- nanfirst -- whether NaNs sort to the last or first, default is False.

The main difference here is that the keywords select by functionality,
whereas *kind* selects by algorithm. Note that descending and nanfirst
are not yet implemented, so an error is raised if either is specified.

The added C-API functions are:

- (API)PyArray_SortEx,
- (API)PyArray_ArgSortEx,

Those are the two functions that need changes depending on how we want
to implement adding new sort algorithms.  They should be pretty easy to
adapt to whatever we choose to do.

The legacy C-API functions, PyArray_Sort and PyArray_ArgSort, have been
modified to call through the new C-API functions. In order to do so
the *kind* function has been encoded in the *flags* like so:

- "quicksort" - default (0)
- "heapsort"  - default (0)
- "mergesort" - stable  (1)

I note that the partitioning/selection functions have not been modified,
we may want to do that a some point.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
