### PR TITLE
MAINT: Improve astype performance and update documentation

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3202,7 +3202,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('astype',
     copy : bool, optional
         By default, astype always returns a newly allocated array. If this
         is set to false, and the `dtype`, `order`, and `subok`
-        requirements are satisfied, the input array is returned instead
+        requirements are satisfied, the input array may be returned instead
         of a copy.
 
     Returns

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2131,7 +2131,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
  *
  * #name = take, getfield, put, repeat, tofile, mean, trace, diagonal, clip,
  *         std, var, sum, cumsum, prod, cumprod, compress, sort, argsort,
- *         round, argmax, argmin, max, min, any, all, astype, resize,
+ *         round, argmax, argmin, max, min, any, all, resize,
  *         reshape, choose, tostring, tobytes, copy, searchsorted, view,
  *         flatten, ravel, squeeze#
  */
@@ -2142,6 +2142,22 @@ gentype_@name@(PyObject *self, PyObject *args, PyObject *kwds)
 }
 /**end repeat**/
 
+static PyObject *
+gentype_astype(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if ((kwds == NULL) && (PyTuple_Size(args)==1)) {
+        // no keyword arguments, single argument is the dtype
+        PyArray_Descr *dtype = PyArray_DescrFromScalar(self);
+        assert(dtype != NULL);
+        int same_dtype = ( (PyObject *)dtype == PyTuple_GET_ITEM(args, 0));
+        Py_DECREF(dtype);
+        if (same_dtype) {
+            // dtypes are equal, scalars are immutable so no copy is needed
+            return Py_NewRef(self);
+        }
+    }
+    return gentype_generic_method(self, args, kwds, "astype");
+}
 
 /**begin repeat
  * #name = integer, floating#


### PR DESCRIPTION
This pull request improves the behavior of astype by avoiding unnecessary copies when the requirements are already satisfied. I also updated the documentation to make it clear that in some cases the input array may be returned instead of always creating a new one. The main goal is to make astype more efficient and easier to understand.

Thanks to @eendebakpt for the initial work on this branch. 
I’ve picked it up to convert into a PR and will address any feedback, update docs, and add tests as needed.