### PR TITLE
TST: delete global env_setup fixture

### DIFF
--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -147,14 +147,6 @@ def check_fpu_mode(request):
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
 
-@pytest.fixture(autouse=True, scope="session")
-def env_setup():
-    orig = os.environ.get("PYTHONHASHSEED")
-    os.environ["PYTHONHASHSEED"] = '0'
-    yield
-    if orig:
-        os.environ["PYTHONHASHSEED"] = orig
-
 
 if HAVE_SCPDT:
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -147,9 +147,13 @@ def check_fpu_mode(request):
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
 
-@pytest.fixture(autouse=True)
-def env_setup(monkeypatch):
-    monkeypatch.setenv('PYTHONHASHSEED', '0')
+@pytest.fixture(autouse=True, scope="session")
+def env_setup():
+    orig = os.environ.get("PYTHONHASHSEED")
+    os.environ["PYTHONHASHSEED"] = '0'
+    yield
+    if orig:
+        os.environ["PYTHONHASHSEED"] = orig
 
 
 if HAVE_SCPDT:


### PR DESCRIPTION
Towards https://github.com/numpy/numpy/issues/29552. Ping @bwhitt7.

We'd like to use `pytest-run-parallel` more but the `monkeypatch` fixture gets detected by the plugin as a thread-unsafe fixture.