### PR TITLE
ENH: Improve performance of numpy scalar __copy__ and __deepcopy__

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2126,7 +2126,9 @@ gentype___deepcopy__(PyObject *self, PyObject *args)
 
     // scalars are immutable, so we can return a new reference
     // the only expections are scalars with void dtype
-    if (PyObject_IsInstance(self, (PyObject *)&PyVoidArrType_Type)) {
+    // if the number of arguments is not 1, we let gentype_generic_method do the
+    // error handling
+    if (PyObject_IsInstance(self, (PyObject *)&PyVoidArrType_Type) || (PyTuple_Size(args)!=1)) {
         // path via array
         return gentype_generic_method(self, args, NULL, "__deepcopy__");
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2108,25 +2108,27 @@ gentype_@name@(PyObject *self, PyObject *args)
 /**end repeat**/
 
 static PyObject *
-gentype___copy__(PyObject *self)
+gentype___copy__(PyObject *self, PyObject *args)
 {
     // scalars are immutable, so we can return a new reference
     // the only expections are scalars with void dtype
-    if PyObject_IsInstance(obj, (PyObject *)&PyVoidScalarObject)) {
+    if (PyObject_IsInstance(self, (PyObject *)&PyVoidArrType_Type)) {
         // path via array
-        return gentype_generic_method(self, NULL, NULL, "__copy__");
+        return gentype_generic_method(self, args, NULL, "__copy__");
     }
     return Py_NewRef(self);
 }
 
 static PyObject *
-gentype___deepcopy__(PyObject *self)
+gentype___deepcopy__(PyObject *self, PyObject *args)
 {
+    // note: maybe the signature needs to be updated as __deepcopy__ can accept the keyword memo
+
     // scalars are immutable, so we can return a new reference
     // the only expections are scalars with void dtype
-    if PyObject_IsInstance(obj, (PyObject *)&PyVoidScalarObject)) {
+    if (PyObject_IsInstance(self, (PyObject *)&PyVoidArrType_Type)) {
         // path via array
-        return gentype_generic_method(self, NULL, NULL, "__deepcopy__");
+        return gentype_generic_method(self, args, NULL, "__deepcopy__");
     }
     return Py_NewRef(self);
 }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2093,12 +2093,11 @@ gentype_wraparray(PyObject *NPY_UNUSED(scalar), PyObject *args)
 
 /*
  * These gentype_* functions do not take keyword arguments.
- * The proper flag is METH_VARARGS.
+ * The proper flag is METH_VARARGS or METH_NOARGS.
  */
 /**begin repeat
  *
- * #name = tolist, item, __deepcopy__, __copy__,
- *         swapaxes, conj, conjugate, nonzero,
+ * #name = tolist, item, swapaxes, conj, conjugate, nonzero,
  *         fill, transpose#
  */
 static PyObject *
@@ -2107,6 +2106,30 @@ gentype_@name@(PyObject *self, PyObject *args)
     return gentype_generic_method(self, args, NULL, "@name@");
 }
 /**end repeat**/
+
+static PyObject *
+gentype___copy__(PyObject *self)
+{
+    // scalars are immutable, so we can return a new reference
+    // the only expections are scalars with void dtype
+    if PyObject_IsInstance(obj, (PyObject *)&PyVoidScalarObject)) {
+        // path via array
+        return gentype_generic_method(self, NULL, NULL, "__copy__");
+    }
+    return Py_NewRef(self);
+}
+
+static PyObject *
+gentype___deepcopy__(PyObject *self)
+{
+    // scalars are immutable, so we can return a new reference
+    // the only expections are scalars with void dtype
+    if PyObject_IsInstance(obj, (PyObject *)&PyVoidScalarObject)) {
+        // path via array
+        return gentype_generic_method(self, NULL, NULL, "__deepcopy__");
+    }
+    return Py_NewRef(self);
+}
 
 static PyObject *
 gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2108,13 +2108,13 @@ gentype_@name@(PyObject *self, PyObject *args)
 /**end repeat**/
 
 static PyObject *
-gentype___copy__(PyObject *self, PyObject *args)
+gentype___copy__(PyObject *self)
 {
     // scalars are immutable, so we can return a new reference
     // the only expections are scalars with void dtype
     if (PyObject_IsInstance(self, (PyObject *)&PyVoidArrType_Type)) {
         // path via array
-        return gentype_generic_method(self, args, NULL, "__copy__");
+        return gentype_generic_method(self, NULL, NULL, "__copy__");
     }
     return Py_NewRef(self);
 }
@@ -2677,7 +2677,7 @@ static PyMethodDef gentype_methods[] = {
     /* for the copy module */
     {"__copy__",
         (PyCFunction)gentype___copy__,
-        METH_VARARGS, NULL},
+        METH_NOARGS, NULL},
     {"__deepcopy__",
         (PyCFunction)gentype___deepcopy__,
         METH_VARARGS, NULL},

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2470,7 +2470,7 @@ class TestMethods:
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
 
-    def test__deepcopy___void_scalar(self, dtype):
+    def test__deepcopy___void_scalar(self):
         # see comments in gh-29643
         value = np.void('Rex', dtype=[('name', 'U10')])
         value_deepcopy = value.__deepcopy__(None)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2470,12 +2470,19 @@ class TestMethods:
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
 
-    def test__deepcopy___void_scalar(self):
-        # gh-xxxx
-        v = np.void('Rex', dtype=[('name', 'U10')])
-        w = v.__deepcopy__(None)
-        v[0] = None
-        assert w[0] == 'Rex'
+    def test__deepcopy___void_scalar(self, dtype):
+        # see comments in gh-29643
+        value = np.void('Rex', dtype=[('name', 'U10')])
+        value_deepcopy = value.__deepcopy__(None)
+        value[0] = None
+        assert value_deepcopy[0] == 'Rex'
+
+    @pytest.mark.parametrize("dtype", [np.int64, np.float32, np.float64])
+    def test__deepcopy__scalar(self):
+        # test optimization from gh-29656
+        value = dtype(1.1)
+        value_deepcopy = value.__deepcopy__(None)
+        assert value is value_deepcopy
 
     def test__deepcopy__catches_failure(self):
         class MyObj:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2470,6 +2470,13 @@ class TestMethods:
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
 
+    def test__deepcopy___void_scalar(self):
+        # gh-xxxx
+        v = np.void('Rex', dtype=[('name', 'U10') ])
+        w = v.__deepcopy__(None)
+        v[0]=None
+        assert w[0] == 'Rex'
+
     def test__deepcopy__catches_failure(self):
         class MyObj:
             def __deepcopy__(self, *args, **kwargs):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2477,10 +2477,10 @@ class TestMethods:
         value[0] = None
         assert value_deepcopy[0] == 'Rex'
 
-    @pytest.mark.parametrize("dtype", [np.int64, np.float32, np.float64])
-    def test__deepcopy__scalar(self):
+    @pytest.mark.parametrize("sctype", [np.int64, np.float32, np.float64])
+    def test__deepcopy__scalar(self, sctype):
         # test optimization from gh-29656
-        value = dtype(1.1)
+        value = sctype(1.1)
         value_deepcopy = value.__deepcopy__(None)
         assert value is value_deepcopy
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2472,9 +2472,9 @@ class TestMethods:
 
     def test__deepcopy___void_scalar(self):
         # gh-xxxx
-        v = np.void('Rex', dtype=[('name', 'U10') ])
+        v = np.void('Rex', dtype=[('name', 'U10')])
         w = v.__deepcopy__(None)
-        v[0]=None
+        v[0] = None
         assert w[0] == 'Rex'
 
     def test__deepcopy__catches_failure(self):


### PR DESCRIPTION
The numpy scalars are immutable (expect for subclasses of np.void), so copy or deepcopy can return the same object. This improves performance, since the current implementation converts to array, copies and converts back to scalar.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
