### PR TITLE
TST: Replace xunit setup with methods

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -974,18 +974,20 @@ class TestDiff:
 
 class TestDelete:
 
-    def setup_method(self):
-        self.a = np.arange(5)
-        self.nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
+    def _create_arrays(self):
+        a = np.arange(5)
+        nd_a = np.arange(5).repeat(2).reshape(1, 5, 2)
+        return a, nd_a
 
     def _check_inverse_of_slicing(self, indices):
-        a_del = delete(self.a, indices)
-        nd_a_del = delete(self.nd_a, indices, axis=1)
+        a, nd_a = self._create_arrays()
+        a_del = delete(a, indices)
+        nd_a_del = delete(nd_a, indices, axis=1)
         msg = f'Delete failed for obj: {indices!r}'
-        assert_array_equal(setxor1d(a_del, self.a[indices, ]), self.a,
+        assert_array_equal(setxor1d(a_del, a[indices, ]), a,
                            err_msg=msg)
-        xor = setxor1d(nd_a_del[0, :, 0], self.nd_a[0, indices, 0])
-        assert_array_equal(xor, self.nd_a[0, :, 0], err_msg=msg)
+        xor = setxor1d(nd_a_del[0, :, 0], nd_a[0, indices, 0])
+        assert_array_equal(xor, nd_a[0, :, 0], err_msg=msg)
 
     def test_slices(self):
         lims = [-6, -2, 0, 1, 2, 4, 5]
@@ -997,11 +999,12 @@ class TestDelete:
                     self._check_inverse_of_slicing(s)
 
     def test_fancy(self):
+        a = self._create_arrays()[0]
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
         with pytest.raises(IndexError):
-            delete(self.a, [100])
+            delete(a, [100])
         with pytest.raises(IndexError):
-            delete(self.a, [-100])
+            delete(a, [-100])
 
         self._check_inverse_of_slicing([0, -1, 2, 2])
 
@@ -1009,13 +1012,13 @@ class TestDelete:
 
         # not legal, indexing with these would change the dimension
         with pytest.raises(ValueError):
-            delete(self.a, True)
+            delete(a, True)
         with pytest.raises(ValueError):
-            delete(self.a, False)
+            delete(a, False)
 
         # not enough items
         with pytest.raises(ValueError):
-            delete(self.a, [False] * 4)
+            delete(a, [False] * 4)
 
     def test_single(self):
         self._check_inverse_of_slicing(0)
@@ -1031,7 +1034,8 @@ class TestDelete:
     def test_subclass(self):
         class SubClass(np.ndarray):
             pass
-        a = self.a.view(SubClass)
+
+        a = self._create_arrays()[0].view(SubClass)
         assert_(isinstance(delete(a, 0), SubClass))
         assert_(isinstance(delete(a, []), SubClass))
         assert_(isinstance(delete(a, [0, 1]), SubClass))
@@ -1056,12 +1060,13 @@ class TestDelete:
 
     @pytest.mark.parametrize("indexer", [np.array([1]), [1]])
     def test_single_item_array(self, indexer):
-        a_del_int = delete(self.a, 1)
-        a_del = delete(self.a, indexer)
+        a, nd_a = self._create_arrays()
+        a_del_int = delete(a, 1)
+        a_del = delete(a, indexer)
         assert_equal(a_del_int, a_del)
 
-        nd_a_del_int = delete(self.nd_a, 1, axis=1)
-        nd_a_del = delete(self.nd_a, np.array([1]), axis=1)
+        nd_a_del_int = delete(nd_a, 1, axis=1)
+        nd_a_del = delete(nd_a, np.array([1]), axis=1)
         assert_equal(nd_a_del_int, nd_a_del)
 
     def test_single_item_array_non_int(self):
@@ -2405,6 +2410,7 @@ class TestSinc:
         # before gh-27784, fill value for 0 in input would underflow float16,
         # resulting in nan
         assert_array_equal(sinc(x), np.asarray(1.0))
+
 
 class TestUnique:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -999,7 +999,7 @@ class TestDelete:
                     self._check_inverse_of_slicing(s)
 
     def test_fancy(self):
-        a = self._create_arrays()[0]
+        a, _ = self._create_arrays()
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
         with pytest.raises(IndexError):
             delete(a, [100])
@@ -1035,7 +1035,8 @@ class TestDelete:
         class SubClass(np.ndarray):
             pass
 
-        a = self._create_arrays()[0].view(SubClass)
+        a_orig, _ = self._create_arrays()
+        a = a_orig.view(SubClass)
         assert_(isinstance(delete(a, 0), SubClass))
         assert_(isinstance(delete(a, []), SubClass))
         assert_(isinstance(delete(a, [0, 1]), SubClass))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -313,8 +313,8 @@ class TestSetState:
         bit_generator = rg.bit_generator
         state = bit_generator.state
         legacy_state = (state['bit_generator'],
-                             state['state']['key'],
-                             state['state']['pos'])
+                        state['state']['key'],
+                        state['state']['pos'])
         return rg, bit_generator, state
 
     def test_gaussian_reset(self):
@@ -339,7 +339,7 @@ class TestSetState:
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        rg = self._create_rng()[0]
+        rg, _, _ = self._create_rng()
         rg.negative_binomial(0.5, 0.5)
 
 
@@ -2508,6 +2508,7 @@ class TestBroadcast:
         assert actual.shape == (3, 0, 7, 4)
 
 
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
 class TestThread:
     # make sure each state produces the same sequence even in threads
     seeds = range(4)
@@ -2556,11 +2557,7 @@ class TestThread:
 # See Issue #4263
 class TestSingleEltArrayInput:
     def _create_arrays(self):
-        argOne = np.array([2])
-        argTwo = np.array([3])
-        argThree = np.array([4])
-        tgtShape = (1,)
-        return argOne, argTwo, argThree, tgtShape
+        return np.array([2]), np.array([3]), np.array([4]), (1,)
 
     def test_one_arg_funcs(self):
         argOne, _, _, tgtShape = self._create_arrays()
@@ -2611,7 +2608,7 @@ class TestSingleEltArrayInput:
             assert_equal(out.shape, tgtShape)
 
     def test_integers(self, endpoint):
-        tgtShape = self._create_arrays()[3]
+        _, _, _, tgtShape = self._create_arrays()
         itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
                  np.int32, np.uint32, np.int64, np.uint64]
         func = random.integers

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -175,8 +175,7 @@ class TestMultinomial:
 
 class TestMultivariateHypergeometric:
 
-    def setup_method(self):
-        self.seed = 8675309
+    seed = 8675309
 
     def test_argument_validation(self):
         # Error cases...
@@ -308,37 +307,40 @@ class TestMultivariateHypergeometric:
 
 
 class TestSetState:
-    def setup_method(self):
-        self.seed = 1234567890
-        self.rg = Generator(MT19937(self.seed))
-        self.bit_generator = self.rg.bit_generator
-        self.state = self.bit_generator.state
-        self.legacy_state = (self.state['bit_generator'],
-                             self.state['state']['key'],
-                             self.state['state']['pos'])
+    def _create_rng(self):
+        seed = 1234567890
+        rg = Generator(MT19937(seed))
+        bit_generator = rg.bit_generator
+        state = bit_generator.state
+        legacy_state = (state['bit_generator'],
+                             state['state']['key'],
+                             state['state']['pos'])
+        return rg, bit_generator, state
 
     def test_gaussian_reset(self):
         # Make sure the cached every-other-Gaussian is reset.
-        old = self.rg.standard_normal(size=3)
-        self.bit_generator.state = self.state
-        new = self.rg.standard_normal(size=3)
+        rg, bit_generator, state = self._create_rng()
+        old = rg.standard_normal(size=3)
+        bit_generator.state = state
+        new = rg.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_gaussian_reset_in_media_res(self):
         # When the state is saved with a cached Gaussian, make sure the
         # cached Gaussian is restored.
-
-        self.rg.standard_normal()
-        state = self.bit_generator.state
-        old = self.rg.standard_normal(size=3)
-        self.bit_generator.state = state
-        new = self.rg.standard_normal(size=3)
+        rg, bit_generator, state = self._create_rng()
+        rg.standard_normal()
+        state = bit_generator.state
+        old = rg.standard_normal(size=3)
+        bit_generator.state = state
+        new = rg.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        self.rg.negative_binomial(0.5, 0.5)
+        rg = self._create_rng()[0]
+        rg.negative_binomial(0.5, 0.5)
 
 
 class TestIntegers:
@@ -736,9 +738,7 @@ class TestIntegers:
 class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
-
-    def setup_method(self):
-        self.seed = 1234567890
+    seed = 1234567890
 
     def test_integers(self):
         random = Generator(MT19937(self.seed))
@@ -1899,8 +1899,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup_method(self):
-        self.seed = 123456789
+    seed = 123456789
 
     def test_uniform(self):
         random = Generator(MT19937(self.seed))
@@ -2509,11 +2508,9 @@ class TestBroadcast:
         assert actual.shape == (3, 0, 7, 4)
 
 
-@pytest.mark.skipif(IS_WASM, reason="can't start thread")
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup_method(self):
-        self.seeds = range(4)
+    seeds = range(4)
 
     def check_function(self, function, sz):
         from threading import Thread
@@ -2558,13 +2555,15 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup_method(self):
-        self.argOne = np.array([2])
-        self.argTwo = np.array([3])
-        self.argThree = np.array([4])
-        self.tgtShape = (1,)
+    def _create_arrays(self):
+        argOne = np.array([2])
+        argTwo = np.array([3])
+        argThree = np.array([4])
+        tgtShape = (1,)
+        return argOne, argTwo, argThree, tgtShape
 
     def test_one_arg_funcs(self):
+        argOne, _, _, tgtShape = self._create_arrays()
         funcs = (random.exponential, random.standard_gamma,
                  random.chisquare, random.standard_t,
                  random.pareto, random.weibull,
@@ -2579,11 +2578,12 @@ class TestSingleEltArrayInput:
                 out = func(np.array([0.5]))
 
             else:
-                out = func(self.argOne)
+                out = func(argOne)
 
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
     def test_two_arg_funcs(self):
+        argOne, argTwo, _, tgtShape = self._create_arrays()
         funcs = (random.uniform, random.normal,
                  random.beta, random.gamma,
                  random.f, random.noncentral_chisquare,
@@ -2599,18 +2599,19 @@ class TestSingleEltArrayInput:
                 argTwo = np.array([0.5])
 
             else:
-                argTwo = self.argTwo
+                argTwo = argTwo
 
-            out = func(self.argOne, argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, argTwo[0])
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0])
+            assert_equal(out.shape, tgtShape)
 
     def test_integers(self, endpoint):
+        tgtShape = self._create_arrays()[3]
         itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
                  np.int32, np.uint32, np.int64, np.uint64]
         func = random.integers
@@ -2619,27 +2620,28 @@ class TestSingleEltArrayInput:
 
         for dt in itype:
             out = func(low, high, endpoint=endpoint, dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
             out = func(low[0], high, endpoint=endpoint, dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
             out = func(low, high[0], endpoint=endpoint, dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
     def test_three_arg_funcs(self):
+        argOne, argTwo, argThree, tgtShape = self._create_arrays()
         funcs = [random.noncentral_f, random.triangular,
                  random.hypergeometric]
 
         for func in funcs:
-            out = func(self.argOne, self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, self.argTwo[0], self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0], argThree)
+            assert_equal(out.shape, tgtShape)
 
 
 @pytest.mark.parametrize("config", JUMP_TEST_DATA)

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -6,30 +6,32 @@ from numpy.testing import assert_, assert_array_equal
 
 
 class TestRegression:
-
-    def setup_method(self):
-        self.mt19937 = Generator(MT19937(121263137472525314065))
+    def _create_generator(self):
+        return Generator(MT19937(121263137472525314065))
 
     def test_vonmises_range(self):
         # Make sure generated random variables are in [-pi, pi].
         # Regression test for ticket #986.
+        mt19937 = self._create_generator()
         for mu in np.linspace(-7., 7., 5):
-            r = self.mt19937.vonmises(mu, 1, 50)
+            r = mt19937.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
     def test_hypergeometric_range(self):
         # Test for ticket #921
-        assert_(np.all(self.mt19937.hypergeometric(3, 18, 11, size=10) < 4))
-        assert_(np.all(self.mt19937.hypergeometric(18, 3, 11, size=10) > 0))
+        mt19937 = self._create_generator()
+        assert_(np.all(mt19937.hypergeometric(3, 18, 11, size=10) < 4))
+        assert_(np.all(mt19937.hypergeometric(18, 3, 11, size=10) > 0))
 
         # Test for ticket #5623
         args = (2**20 - 2, 2**20 - 2, 2**20 - 2)  # Check for 32-bit systems
-        assert_(self.mt19937.hypergeometric(*args) > 0)
+        assert_(mt19937.hypergeometric(*args) > 0)
 
     def test_logseries_convergence(self):
         # Test for ticket #923
+        mt19937 = self._create_generator()
         N = 1000
-        rvsn = self.mt19937.logseries(0.8, size=N)
+        rvsn = mt19937.logseries(0.8, size=N)
         # these two frequency counts should be close to theoretical
         # numbers with this large sample
         # theoretical large N result is 0.49706795
@@ -66,34 +68,39 @@ class TestRegression:
         # Test for multivariate_normal issue with 'size' argument.
         # Check that the multivariate_normal size argument can be a
         # numpy integer.
-        self.mt19937.multivariate_normal([0], [[0]], size=1)
-        self.mt19937.multivariate_normal([0], [[0]], size=np.int_(1))
-        self.mt19937.multivariate_normal([0], [[0]], size=np.int64(1))
+        mt19937 = self._create_generator()
+        mt19937.multivariate_normal([0], [[0]], size=1)
+        mt19937.multivariate_normal([0], [[0]], size=np.int_(1))
+        mt19937.multivariate_normal([0], [[0]], size=np.int64(1))
 
     def test_beta_small_parameters(self):
         # Test that beta with small a and b parameters does not produce
         # NaNs due to roundoff errors causing 0 / 0, gh-5851
-        x = self.mt19937.beta(0.0001, 0.0001, size=100)
+        mt19937 = self._create_generator()
+        x = mt19937.beta(0.0001, 0.0001, size=100)
         assert_(not np.any(np.isnan(x)), 'Nans in mt19937.beta')
 
     def test_beta_very_small_parameters(self):
         # gh-24203: beta would hang with very small parameters.
-        self.mt19937.beta(1e-49, 1e-40)
+        mt19937 = self._create_generator()
+        mt19937.beta(1e-49, 1e-40)
 
     def test_beta_ridiculously_small_parameters(self):
         # gh-24266: beta would generate nan when the parameters
         # were subnormal or a small multiple of the smallest normal.
+        mt19937 = self._create_generator()
         tiny = np.finfo(1.0).tiny
-        x = self.mt19937.beta(tiny / 32, tiny / 40, size=50)
+        x = mt19937.beta(tiny / 32, tiny / 40, size=50)
         assert not np.any(np.isnan(x))
 
     def test_beta_expected_zero_frequency(self):
         # gh-24475: For small a and b (e.g. a=0.0025, b=0.0025), beta
         # would generate too many zeros.
+        mt19937 = self._create_generator()
         a = 0.0025
         b = 0.0025
         n = 1000000
-        x = self.mt19937.beta(a, b, size=n)
+        x = mt19937.beta(a, b, size=n)
         nzeros = np.count_nonzero(x == 0)
         # beta CDF at x = np.finfo(np.double).smallest_subnormal/2
         # is p = 0.0776169083131899, e.g,
@@ -114,24 +121,26 @@ class TestRegression:
         # The sum of probs should be 1.0 with some tolerance.
         # For low precision dtypes the tolerance was too tight.
         # See numpy github issue 6123.
+        mt19937 = self._create_generator()
         a = [1, 2, 3]
         counts = [4, 4, 2]
         for dt in np.float16, np.float32, np.float64:
             probs = np.array(counts, dtype=dt) / sum(counts)
-            c = self.mt19937.choice(a, p=probs)
+            c = mt19937.choice(a, p=probs)
             assert_(c in a)
             with pytest.raises(ValueError):
-                self.mt19937.choice(a, p=probs * 0.9)
+                mt19937.choice(a, p=probs * 0.9)
 
     def test_shuffle_of_array_of_different_length_strings(self):
         # Test that permuting an array of different length strings
         # will not cause a segfault on garbage collection
         # Tests gh-7710
+        mt19937 = self._create_generator()
 
         a = np.array(['a', 'a' * 1000])
 
         for _ in range(100):
-            self.mt19937.shuffle(a)
+            mt19937.shuffle(a)
 
         # Force Garbage Collection - should not segfault.
         import gc
@@ -141,10 +150,11 @@ class TestRegression:
         # Test that permuting an array of objects will not cause
         # a segfault on garbage collection.
         # See gh-7719
+        mt19937 = self._create_generator()
         a = np.array([np.arange(1), np.arange(4)], dtype=object)
 
         for _ in range(1000):
-            self.mt19937.shuffle(a)
+            mt19937.shuffle(a)
 
         # Force Garbage Collection - should not segfault.
         import gc
@@ -174,10 +184,11 @@ class TestRegression:
         assert_array_equal(m.__array__(), np.arange(5))
 
     def test_gamma_0(self):
-        assert self.mt19937.standard_gamma(0.0) == 0.0
-        assert_array_equal(self.mt19937.standard_gamma([0.0]), 0.0)
+        mt19937 = self._create_generator()
+        assert mt19937.standard_gamma(0.0) == 0.0
+        assert_array_equal(mt19937.standard_gamma([0.0]), 0.0)
 
-        actual = self.mt19937.standard_gamma([0.0], dtype='float')
+        actual = mt19937.standard_gamma([0.0], dtype='float')
         expected = np.array([0.], dtype=np.float32)
         assert_array_equal(actual, expected)
 
@@ -185,21 +196,24 @@ class TestRegression:
         # Regression test for gh-17007.
         # When p = 1e-30, the probability that a sample will exceed 2**63-1
         # is 0.9999999999907766, so we expect the result to be all 2**63-1.
-        assert_array_equal(self.mt19937.geometric(p=1e-30, size=3),
+        mt19937 = self._create_generator()
+        assert_array_equal(mt19937.geometric(p=1e-30, size=3),
                            np.iinfo(np.int64).max)
 
     def test_zipf_large_parameter(self):
         # Regression test for part of gh-9829: a call such as rng.zipf(10000)
         # would hang.
+        mt19937 = self._create_generator()
         n = 8
-        sample = self.mt19937.zipf(10000, size=n)
+        sample = mt19937.zipf(10000, size=n)
         assert_array_equal(sample, np.ones(n, dtype=np.int64))
 
     def test_zipf_a_near_1(self):
         # Regression test for gh-9829: a call such as rng.zipf(1.0000000000001)
         # would hang.
+        mt19937 = self._create_generator()
         n = 100000
-        sample = self.mt19937.zipf(1.0000000000001, size=n)
+        sample = mt19937.zipf(1.0000000000001, size=n)
         # Not much of a test, but let's do something more than verify that
         # it doesn't hang.  Certainly for a monotonically decreasing
         # discrete distribution truncated to signed 64 bit integers, more

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -105,56 +105,62 @@ class TestMultinomial:
 
 
 class TestSetState:
-    def setup_method(self):
-        self.seed = 1234567890
-        self.prng = random.RandomState(self.seed)
-        self.state = self.prng.get_state()
+    def _create_rng(self):
+        seed = 1234567890
+        prng = random.RandomState(seed)
+        state = prng.get_state()
+        return prng, state
 
     def test_basic(self):
-        old = self.prng.tomaxint(16)
-        self.prng.set_state(self.state)
-        new = self.prng.tomaxint(16)
+        prng, state = self._create_rng()
+        old = prng.tomaxint(16)
+        prng.set_state(state)
+        new = prng.tomaxint(16)
         assert_(np.all(old == new))
 
     def test_gaussian_reset(self):
         # Make sure the cached every-other-Gaussian is reset.
-        old = self.prng.standard_normal(size=3)
-        self.prng.set_state(self.state)
-        new = self.prng.standard_normal(size=3)
+        prng, state = self._create_rng()
+        old = prng.standard_normal(size=3)
+        prng.set_state(state)
+        new = prng.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_gaussian_reset_in_media_res(self):
         # When the state is saved with a cached Gaussian, make sure the
         # cached Gaussian is restored.
-
-        self.prng.standard_normal()
-        state = self.prng.get_state()
-        old = self.prng.standard_normal(size=3)
-        self.prng.set_state(state)
-        new = self.prng.standard_normal(size=3)
+        prng, state = self._create_rng()
+        prng.standard_normal()
+        state = prng.get_state()
+        old = prng.standard_normal(size=3)
+        prng.set_state(state)
+        new = prng.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_backwards_compatibility(self):
         # Make sure we can accept old state tuples that do not have the
         # cached Gaussian value.
-        old_state = self.state[:-2]
-        x1 = self.prng.standard_normal(size=16)
-        self.prng.set_state(old_state)
-        x2 = self.prng.standard_normal(size=16)
-        self.prng.set_state(self.state)
-        x3 = self.prng.standard_normal(size=16)
+        prng, state = self._create_rng()
+        old_state = state[:-2]
+        x1 = prng.standard_normal(size=16)
+        prng.set_state(old_state)
+        x2 = prng.standard_normal(size=16)
+        prng.set_state(state)
+        x3 = prng.standard_normal(size=16)
         assert_(np.all(x1 == x2))
         assert_(np.all(x1 == x3))
 
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        self.prng.negative_binomial(0.5, 0.5)
+        prng = self._create_rng()[0]
+        prng.negative_binomial(0.5, 0.5)
 
     def test_set_invalid_state(self):
         # gh-25402
+        prng = self._create_rng()[0]
         with pytest.raises(IndexError):
-            self.prng.set_state(())
+            prng.set_state(())
 
 
 class TestRandint:
@@ -299,9 +305,7 @@ class TestRandint:
 class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
-
-    def setup_method(self):
-        self.seed = 1234567890
+    seed = 1234567890
 
     def test_rand(self):
         np.random.seed(self.seed)
@@ -1053,8 +1057,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup_method(self):
-        self.seed = 123456789
+    seed = 123456789
 
     def setSeed(self):
         np.random.seed(self.seed)
@@ -1623,8 +1626,7 @@ class TestBroadcast:
 @pytest.mark.skipif(IS_WASM, reason="can't start thread")
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup_method(self):
-        self.seeds = range(4)
+    seeds = range(4)
 
     def check_function(self, function, sz):
         from threading import Thread
@@ -1666,13 +1668,15 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup_method(self):
-        self.argOne = np.array([2])
-        self.argTwo = np.array([3])
-        self.argThree = np.array([4])
-        self.tgtShape = (1,)
+    def _create_arrays(self):
+        argOne = np.array([2])
+        argTwo = np.array([3])
+        argThree = np.array([4])
+        tgtShape = (1,)
+        return argOne, argTwo, argThree, tgtShape
 
     def test_one_arg_funcs(self):
+        argOne, _, _, tgtShape = self._create_arrays()
         funcs = (np.random.exponential, np.random.standard_gamma,
                  np.random.chisquare, np.random.standard_t,
                  np.random.pareto, np.random.weibull,
@@ -1687,11 +1691,12 @@ class TestSingleEltArrayInput:
                 out = func(np.array([0.5]))
 
             else:
-                out = func(self.argOne)
+                out = func(argOne)
 
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
     def test_two_arg_funcs(self):
+        argOne, argTwo, _, tgtShape = self._create_arrays()
         funcs = (np.random.uniform, np.random.normal,
                  np.random.beta, np.random.gamma,
                  np.random.f, np.random.noncentral_chisquare,
@@ -1707,18 +1712,19 @@ class TestSingleEltArrayInput:
                 argTwo = np.array([0.5])
 
             else:
-                argTwo = self.argTwo
+                argTwo = argTwo
 
-            out = func(self.argOne, argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, argTwo[0])
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0])
+            assert_equal(out.shape, tgtShape)
 
     def test_randint(self):
+        tgtShape = self._create_arrays()[3]
         itype = [bool, np.int8, np.uint8, np.int16, np.uint16,
                  np.int32, np.uint32, np.int64, np.uint64]
         func = np.random.randint
@@ -1727,24 +1733,25 @@ class TestSingleEltArrayInput:
 
         for dt in itype:
             out = func(low, high, dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
             out = func(low[0], high, dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
             out = func(low, high[0], dtype=dt)
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
     def test_three_arg_funcs(self):
+        argOne, argTwo, argThree, tgtShape = self._create_arrays()
         funcs = [np.random.noncentral_f, np.random.triangular,
                  np.random.hypergeometric]
 
         for func in funcs:
-            out = func(self.argOne, self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, self.argTwo[0], self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0], argThree)
+            assert_equal(out.shape, tgtShape)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -153,12 +153,12 @@ class TestSetState:
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        prng = self._create_rng()[0]
+        prng, _ = self._create_rng()
         prng.negative_binomial(0.5, 0.5)
 
     def test_set_invalid_state(self):
         # gh-25402
-        prng = self._create_rng()[0]
+        prng, _ = self._create_rng()
         with pytest.raises(IndexError):
             prng.set_state(())
 
@@ -1669,11 +1669,7 @@ class TestThread:
 # See Issue #4263
 class TestSingleEltArrayInput:
     def _create_arrays(self):
-        argOne = np.array([2])
-        argTwo = np.array([3])
-        argThree = np.array([4])
-        tgtShape = (1,)
-        return argOne, argTwo, argThree, tgtShape
+        return np.array([2]), np.array([3]), np.array([4]), (1,)
 
     def test_one_arg_funcs(self):
         argOne, _, _, tgtShape = self._create_arrays()
@@ -1724,7 +1720,7 @@ class TestSingleEltArrayInput:
             assert_equal(out.shape, tgtShape)
 
     def test_randint(self):
-        tgtShape = self._create_arrays()[3]
+        _, _, _, tgtShape = self._create_arrays()
         itype = [bool, np.int8, np.uint8, np.int16, np.uint16,
                  np.int32, np.uint32, np.int64, np.uint64]
         func = np.random.randint

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -191,52 +191,58 @@ class TestMultinomial:
         # Non-index integer types should gracefully truncate floats
         random.multinomial(100.5, [0.2, 0.8])
 
+
 class TestSetState:
-    def setup_method(self):
-        self.seed = 1234567890
-        self.random_state = random.RandomState(self.seed)
-        self.state = self.random_state.get_state()
+    def _create_state(self):
+        seed = 1234567890
+        random_state = random.RandomState(seed)
+        state = random_state.get_state()
+        return random_state, state
 
     def test_basic(self):
-        old = self.random_state.tomaxint(16)
-        self.random_state.set_state(self.state)
-        new = self.random_state.tomaxint(16)
+        random_state, state = self._create_state()
+        old = random_state.tomaxint(16)
+        random_state.set_state(state)
+        new = random_state.tomaxint(16)
         assert_(np.all(old == new))
 
     def test_gaussian_reset(self):
         # Make sure the cached every-other-Gaussian is reset.
-        old = self.random_state.standard_normal(size=3)
-        self.random_state.set_state(self.state)
-        new = self.random_state.standard_normal(size=3)
+        random_state, state = self._create_state()
+        old = random_state.standard_normal(size=3)
+        random_state.set_state(state)
+        new = random_state.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_gaussian_reset_in_media_res(self):
         # When the state is saved with a cached Gaussian, make sure the
         # cached Gaussian is restored.
-
-        self.random_state.standard_normal()
-        state = self.random_state.get_state()
-        old = self.random_state.standard_normal(size=3)
-        self.random_state.set_state(state)
-        new = self.random_state.standard_normal(size=3)
+        random_state, state = self._create_state()
+        random_state.standard_normal()
+        state = random_state.get_state()
+        old = random_state.standard_normal(size=3)
+        random_state.set_state(state)
+        new = random_state.standard_normal(size=3)
         assert_(np.all(old == new))
 
     def test_backwards_compatibility(self):
         # Make sure we can accept old state tuples that do not have the
         # cached Gaussian value.
-        old_state = self.state[:-2]
-        x1 = self.random_state.standard_normal(size=16)
-        self.random_state.set_state(old_state)
-        x2 = self.random_state.standard_normal(size=16)
-        self.random_state.set_state(self.state)
-        x3 = self.random_state.standard_normal(size=16)
+        random_state, state = self._create_state()
+        old_state = state[:-2]
+        x1 = random_state.standard_normal(size=16)
+        random_state.set_state(old_state)
+        x2 = random_state.standard_normal(size=16)
+        random_state.set_state(state)
+        x3 = random_state.standard_normal(size=16)
         assert_(np.all(x1 == x2))
         assert_(np.all(x1 == x3))
 
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        self.random_state.negative_binomial(0.5, 0.5)
+        random_state = self._create_state()[0]
+        random_state.negative_binomial(0.5, 0.5)
 
     def test_get_state_warning(self):
         rs = random.RandomState(PCG64())
@@ -246,34 +252,38 @@ class TestSetState:
         assert state['bit_generator'] == 'PCG64'
 
     def test_invalid_legacy_state_setting(self):
-        state = self.random_state.get_state()
+        random_state, state = self._create_state()
+        state = random_state.get_state()
         new_state = ('Unknown', ) + state[1:]
-        assert_raises(ValueError, self.random_state.set_state, new_state)
-        assert_raises(TypeError, self.random_state.set_state,
+        assert_raises(ValueError, random_state.set_state, new_state)
+        assert_raises(TypeError, random_state.set_state,
                       np.array(new_state, dtype=object))
-        state = self.random_state.get_state(legacy=False)
+        state = random_state.get_state(legacy=False)
         del state['bit_generator']
-        assert_raises(ValueError, self.random_state.set_state, state)
+        assert_raises(ValueError, random_state.set_state, state)
 
     def test_pickle(self):
-        self.random_state.seed(0)
-        self.random_state.random_sample(100)
-        self.random_state.standard_normal()
-        pickled = self.random_state.get_state(legacy=False)
+        random_state = self._create_state()[0]
+        random_state.seed(0)
+        random_state.random_sample(100)
+        random_state.standard_normal()
+        pickled = random_state.get_state(legacy=False)
         assert_equal(pickled['has_gauss'], 1)
-        rs_unpick = pickle.loads(pickle.dumps(self.random_state))
+        rs_unpick = pickle.loads(pickle.dumps(random_state))
         unpickled = rs_unpick.get_state(legacy=False)
         assert_mt19937_state_equal(pickled, unpickled)
 
     def test_state_setting(self):
-        attr_state = self.random_state.__getstate__()
-        self.random_state.standard_normal()
-        self.random_state.__setstate__(attr_state)
-        state = self.random_state.get_state(legacy=False)
+        random_state, state = self._create_state()
+        attr_state = random_state.__getstate__()
+        random_state.standard_normal()
+        random_state.__setstate__(attr_state)
+        state = random_state.get_state(legacy=False)
         assert_mt19937_state_equal(attr_state, state)
 
     def test_repr(self):
-        assert repr(self.random_state).startswith('RandomState(MT19937)')
+        random_state = self._create_state()[0]
+        assert repr(random_state).startswith('RandomState(MT19937)')
 
 
 class TestRandint:
@@ -443,9 +453,7 @@ class TestRandint:
 class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
-
-    def setup_method(self):
-        self.seed = 1234567890
+    seed = 1234567890
 
     def test_rand(self):
         random.seed(self.seed)
@@ -1309,8 +1317,7 @@ class TestRandomDist:
 class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
-    def setup_method(self):
-        self.seed = 123456789
+    seed = 123456789
 
     def set_seed(self):
         random.seed(self.seed)
@@ -1896,8 +1903,7 @@ class TestBroadcast:
 @pytest.mark.skipif(IS_WASM, reason="can't start thread")
 class TestThread:
     # make sure each state produces the same sequence even in threads
-    def setup_method(self):
-        self.seeds = range(4)
+    seeds = range(4)
 
     def check_function(self, function, sz):
         from threading import Thread
@@ -1942,13 +1948,15 @@ class TestThread:
 
 # See Issue #4263
 class TestSingleEltArrayInput:
-    def setup_method(self):
-        self.argOne = np.array([2])
-        self.argTwo = np.array([3])
-        self.argThree = np.array([4])
-        self.tgtShape = (1,)
+    def _create_arrays(self):
+        argOne = np.array([2])
+        argTwo = np.array([3])
+        argThree = np.array([4])
+        tgtShape = (1,)
+        return argOne, argTwo, argThree, tgtShape
 
     def test_one_arg_funcs(self):
+        argOne, _, _, tgtShape = self._create_arrays()
         funcs = (random.exponential, random.standard_gamma,
                  random.chisquare, random.standard_t,
                  random.pareto, random.weibull,
@@ -1963,11 +1971,12 @@ class TestSingleEltArrayInput:
                 out = func(np.array([0.5]))
 
             else:
-                out = func(self.argOne)
+                out = func(argOne)
 
-            assert_equal(out.shape, self.tgtShape)
+            assert_equal(out.shape, tgtShape)
 
     def test_two_arg_funcs(self):
+        argOne, argTwo, _, tgtShape = self._create_arrays()
         funcs = (random.uniform, random.normal,
                  random.beta, random.gamma,
                  random.f, random.noncentral_chisquare,
@@ -1983,30 +1992,31 @@ class TestSingleEltArrayInput:
                 argTwo = np.array([0.5])
 
             else:
-                argTwo = self.argTwo
+                argTwo = argTwo
 
-            out = func(self.argOne, argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], argTwo)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, argTwo[0])
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0])
+            assert_equal(out.shape, tgtShape)
 
     def test_three_arg_funcs(self):
+        argOne, argTwo, argThree, tgtShape = self._create_arrays()
         funcs = [random.noncentral_f, random.triangular,
                  random.hypergeometric]
 
         for func in funcs:
-            out = func(self.argOne, self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne[0], self.argTwo, self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne[0], argTwo, argThree)
+            assert_equal(out.shape, tgtShape)
 
-            out = func(self.argOne, self.argTwo[0], self.argThree)
-            assert_equal(out.shape, self.tgtShape)
+            out = func(argOne, argTwo[0], argThree)
+            assert_equal(out.shape, tgtShape)
 
 
 # Ensure returned array dtype is correct for platform

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -241,7 +241,7 @@ class TestSetState:
     def test_negative_binomial(self):
         # Ensure that the negative binomial results take floating point
         # arguments without truncation.
-        random_state = self._create_state()[0]
+        random_state, _ = self._create_state()
         random_state.negative_binomial(0.5, 0.5)
 
     def test_get_state_warning(self):
@@ -263,7 +263,7 @@ class TestSetState:
         assert_raises(ValueError, random_state.set_state, state)
 
     def test_pickle(self):
-        random_state = self._create_state()[0]
+        random_state, _ = self._create_state()
         random_state.seed(0)
         random_state.random_sample(100)
         random_state.standard_normal()
@@ -282,7 +282,7 @@ class TestSetState:
         assert_mt19937_state_equal(attr_state, state)
 
     def test_repr(self):
-        random_state = self._create_state()[0]
+        random_state, _ = self._create_state()
         assert repr(random_state).startswith('RandomState(MT19937)')
 
 
@@ -1949,11 +1949,7 @@ class TestThread:
 # See Issue #4263
 class TestSingleEltArrayInput:
     def _create_arrays(self):
-        argOne = np.array([2])
-        argTwo = np.array([3])
-        argThree = np.array([4])
-        tgtShape = (1,)
-        return argOne, argTwo, argThree, tgtShape
+        return np.array([2]), np.array([3]), np.array([4]), (1,)
 
     def test_one_arg_funcs(self):
         argOne, _, _, tgtShape = self._create_arrays()


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552. This PR has the goal of making NumPy's testing suite more thread safe. This introduces changes to the setup methods for 5 more testing files, 1 in numpy/lib and 4 in numpy/random. Pytest's classic xunit setup and teardown methods are thread unsafe, typically not running before the tests do, leading to AttributionErrors. This PR changes these setup method to basic "creation" methods that are called within the tests that need them, or set to class vars if they are very simple.

For a few of these files, while the thread-unsafe setup methods have been replaced, there are still other thread-safety issues present, such as the usage of stdout, np.random.seed(), and more. I'm close to finishing replacing the setup methods, so hopefully I'll be able to tackle some of these other issues (for example, tmp_path and np.random.seed) soon.