### PR TITLE
MAINT: Optimize the logical implementation for RISC-V based on Highway Wrapper

### DIFF
--- a/numpy/_core/src/umath/loops_logical.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_logical.dispatch.cpp
@@ -4,17 +4,16 @@
 #include "lowlevel_strided_loops.h"
 #include "fast_loop_macros.h"
 #include <functional>
-
+#include "simd/simd.hpp"
 #include <hwy/highway.h>
-namespace hn = hwy::HWY_NAMESPACE;
 
 struct logical_and_t {};
 struct logical_or_t {};
 struct absolute_t {};
 struct logical_not_t {};
 
-const hn::ScalableTag<uint8_t> u8;
-using vec_u8 = hn::Vec<decltype(u8)>;
+namespace {
+using namespace np::simd;
 
 /*******************************************************************************
  ** Defining the SIMD kernels
@@ -24,86 +23,84 @@ using vec_u8 = hn::Vec<decltype(u8)>;
  * consistent, should not be required if bool is used correctly everywhere but
  * you never know
  */
-
-HWY_INLINE HWY_ATTR vec_u8 byte_to_true(vec_u8 v)
+#if NPY_HWY
+HWY_INLINE HWY_ATTR Vec<uint8_t> byte_to_true(Vec<uint8_t> v)
 {
-    return hn::IfThenZeroElse(hn::Eq(v, hn::Zero(u8)), hn::Set(u8, 1));
+    return hn::IfThenZeroElse(hn::Eq(v, Zero<uint8_t>()), Set(uint8_t(1)));
 }
+
 /*
  * convert mask vector (0xff/0x00) to boolean true.  similar to byte_to_true(),
  * but we've already got a mask and can skip negation.
  */
-HWY_INLINE HWY_ATTR vec_u8 mask_to_true(vec_u8 v)
+HWY_INLINE HWY_ATTR Vec<uint8_t> mask_to_true(Vec<uint8_t> v)
 {
-    const vec_u8 truemask = hn::Set(u8, 1 == 1);
-    return hn::And(truemask, v);
+    return hn::IfThenElseZero(hn::Ne(v, Zero<uint8_t>()), Set(uint8_t(1)));
 }
+
 /*
  * For logical_and, we have to be careful to handle non-bool inputs where
  * bits of each operand might not overlap. Example: a = 0x01, b = 0x80
  * Both evaluate to boolean true, however, a & b is false.  Return value
  * should be consistent with byte_to_true().
  */
-HWY_INLINE HWY_ATTR vec_u8 simd_logical_and_u8(vec_u8 a, vec_u8 b)
+HWY_INLINE HWY_ATTR Vec<uint8_t> simd_logical_and_u8(Vec<uint8_t> a, Vec<uint8_t> b)
 {
     return hn::IfThenZeroElse(
-        hn::Eq(hn::Zero(u8), hn::Min(a, b)), 
-        hn::Set(u8, 1)
+        hn::Eq(Zero<uint8_t>(), hn::Min(a, b)),
+        Set(uint8_t(1))
     );
 }
 /*
  * We don't really need the following, but it simplifies the templating code
  * below since it is paired with simd_logical_and_u8() above.
  */
-HWY_INLINE HWY_ATTR vec_u8 simd_logical_or_u8(vec_u8 a, vec_u8 b)
+HWY_INLINE HWY_ATTR Vec<uint8_t> simd_logical_or_u8(Vec<uint8_t> a, Vec<uint8_t> b)
 {
-    vec_u8 r = hn::Or(a, b);
+    auto r = hn::Or(a, b);
     return byte_to_true(r);
 }
 
-HWY_INLINE HWY_ATTR npy_bool simd_any_u8(vec_u8 v)
+HWY_INLINE HWY_ATTR npy_bool simd_any_u8(Vec<uint8_t> v)
 {
-    return hn::ReduceMax(u8, v) != 0;
+    return hn::ReduceMax(_Tag<uint8_t>(), v) != 0;
 }
 
-HWY_INLINE HWY_ATTR npy_bool simd_all_u8(vec_u8 v)
+HWY_INLINE HWY_ATTR npy_bool simd_all_u8(Vec<uint8_t> v)
 {
-    return hn::ReduceMin(u8, v) != 0;
+    return hn::ReduceMin(_Tag<uint8_t>(), v) != 0;
 }
+#endif
 
 template<typename Op>
 struct BinaryLogicalTraits;
 
 template<>
 struct BinaryLogicalTraits<logical_or_t> {
-    static constexpr bool is_and = false;
-    static constexpr auto scalar_op = std::logical_or<bool>{};
+    static constexpr bool is_and     = false;
+    static constexpr auto scalar_op  = std::logical_or<bool>{};
     static constexpr auto scalar_cmp = std::not_equal_to<bool>{};
+#if NPY_HWY
     static constexpr auto anyall = simd_any_u8;
 
-    HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 a, vec_u8 b) {
+    static HWY_INLINE HWY_ATTR Vec<uint8_t> simd_op(Vec<uint8_t> a, Vec<uint8_t> b) {
         return simd_logical_or_u8(a, b);
     }
-
-    HWY_INLINE HWY_ATTR vec_u8 reduce(vec_u8 a, vec_u8 b) {
-        return simd_logical_or_u8(a, b);
-    }
+#endif
 };
 
 template<>
 struct BinaryLogicalTraits<logical_and_t> {
-    static constexpr bool is_and = true;
-    static constexpr auto scalar_op = std::logical_and<bool>{};
+    static constexpr bool is_and     = true;
+    static constexpr auto scalar_op  = std::logical_and<bool>{};
     static constexpr auto scalar_cmp = std::equal_to<bool>{};
+#if NPY_HWY
     static constexpr auto anyall = simd_all_u8;
 
-    HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 a, vec_u8 b) {
+    static HWY_INLINE HWY_ATTR Vec<uint8_t> simd_op(Vec<uint8_t> a, Vec<uint8_t> b) {
         return simd_logical_and_u8(a, b);
     }
-
-    HWY_INLINE HWY_ATTR vec_u8 reduce(vec_u8 a, vec_u8 b) {
-        return simd_logical_and_u8(a, b);
-    }
+#endif
 };
 
 template<typename Op>
@@ -111,52 +108,54 @@ struct UnaryLogicalTraits;
 
 template<>
 struct UnaryLogicalTraits<logical_not_t> {
-    static constexpr bool is_not = true;
+    static constexpr bool is_not    = true;
     static constexpr auto scalar_op = std::equal_to<bool>{};
 
-    HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 v) {
-        const vec_u8 zero = hn::Zero(u8);
-        return mask_to_true(hn::VecFromMask(u8, hn::Eq(v, zero)));
+#if NPY_HWY
+    static HWY_INLINE HWY_ATTR Vec<uint8_t> simd_op(Vec<uint8_t> v) {
+        const auto zero = Zero<uint8_t>();
+        return mask_to_true(hn::VecFromMask(_Tag<uint8_t>(), hn::Eq(v, zero)));
     }
+#endif
 };
 
 template<>
 struct UnaryLogicalTraits<absolute_t> {
-    static constexpr bool is_not = false;
+    static constexpr bool is_not    = false;
     static constexpr auto scalar_op = std::not_equal_to<bool>{};
 
-    HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 v) {
+#if NPY_HWY
+    static HWY_INLINE HWY_ATTR Vec<uint8_t> simd_op(Vec<uint8_t> v) {
         return byte_to_true(v);
     }
+#endif
 };
 
-
+#if NPY_HWY
 template<typename Op>
 HWY_ATTR SIMD_MSVC_NOINLINE
 static void simd_binary_logical_BOOL(npy_bool* op, npy_bool* ip1, npy_bool* ip2, npy_intp len) {
     using Traits = BinaryLogicalTraits<Op>;
-    Traits traits;
     constexpr int UNROLL = 16;
-    const int vstep = hn::Lanes(u8);
+    HWY_LANES_CONSTEXPR int vstep = Lanes<uint8_t>();
     const int wstep = vstep * UNROLL;
 
     // Unrolled vectors loop
     for (; len >= wstep; len -= wstep, ip1 += wstep, ip2 += wstep, op += wstep) {
-
         for(int i = 0; i < UNROLL; i++) {
-            vec_u8 a = hn::LoadU(u8, ip1 + vstep * i);
-            vec_u8 b = hn::LoadU(u8, ip2 + vstep * i);
-            vec_u8 r = traits.simd_op(a, b);
-            hn::StoreU(r, u8, op + vstep * i);
+            auto a = LoadU(ip1 + vstep * i);
+            auto b = LoadU(ip2 + vstep * i);
+            auto r = Traits::simd_op(a, b);
+            StoreU(r, op + vstep * i);
         }
     }
 
     // Single vectors loop
     for (; len >= vstep; len -= vstep, ip1 += vstep, ip2 += vstep, op += vstep) {
-        vec_u8 a = hn::LoadU(u8, ip1);
-        vec_u8 b = hn::LoadU(u8, ip2);
-        vec_u8 r = traits.simd_op(a, b);
-        hn::StoreU(r, u8, op);
+        auto a = LoadU(ip1);
+        auto b = LoadU(ip2);
+        auto r = Traits::simd_op(a, b);
+        StoreU(r, op);
     }
 
     // Scalar loop to finish off
@@ -169,9 +168,8 @@ template<typename Op>
 HWY_ATTR SIMD_MSVC_NOINLINE
 static void simd_reduce_logical_BOOL(npy_bool* op, npy_bool* ip, npy_intp len) {
     using Traits = BinaryLogicalTraits<Op>;
-    Traits traits;
     constexpr int UNROLL = 8;
-    const int vstep = hn::Lanes(u8);
+    HWY_LANES_CONSTEXPR int vstep = Lanes<uint8_t>();
     const int wstep = vstep * UNROLL;
 
     // Unrolled vectors loop
@@ -179,24 +177,24 @@ static void simd_reduce_logical_BOOL(npy_bool* op, npy_bool* ip, npy_intp len) {
         #if defined(NPY_HAVE_SSE2)
             NPY_PREFETCH(reinterpret_cast<const char *>(ip + wstep), 0, 3);
         #endif
-        vec_u8 v0 = hn::LoadU(u8, ip);
-        vec_u8 v1 = hn::LoadU(u8, ip + vstep);
-        vec_u8 v2 = hn::LoadU(u8, ip + vstep * 2);
-        vec_u8 v3 = hn::LoadU(u8, ip + vstep * 3);
-        vec_u8 v4 = hn::LoadU(u8, ip + vstep * 4);
-        vec_u8 v5 = hn::LoadU(u8, ip + vstep * 5);
-        vec_u8 v6 = hn::LoadU(u8, ip + vstep * 6);
-        vec_u8 v7 = hn::LoadU(u8, ip + vstep * 7);
+        auto v0 = LoadU(ip);
+        auto v1 = LoadU(ip + vstep);
+        auto v2 = LoadU(ip + vstep * 2);
+        auto v3 = LoadU(ip + vstep * 3);
+        auto v4 = LoadU(ip + vstep * 4);
+        auto v5 = LoadU(ip + vstep * 5);
+        auto v6 = LoadU(ip + vstep * 6);
+        auto v7 = LoadU(ip + vstep * 7);
 
-        vec_u8 m01 = traits.reduce(v0, v1);
-        vec_u8 m23 = traits.reduce(v2, v3);
-        vec_u8 m45 = traits.reduce(v4, v5);
-        vec_u8 m67 = traits.reduce(v6, v7);
+        auto m01 = Traits::simd_op(v0, v1);
+        auto m23 = Traits::simd_op(v2, v3);
+        auto m45 = Traits::simd_op(v4, v5);
+        auto m67 = Traits::simd_op(v6, v7);
 
-        vec_u8 m0123 = traits.reduce(m01, m23);
-        vec_u8 m4567 = traits.reduce(m45, m67);
+        auto m0123 = Traits::simd_op(m01, m23);
+        auto m4567 = Traits::simd_op(m45, m67);
 
-        vec_u8 mv = traits.reduce(m0123, m4567);
+        auto mv = Traits::simd_op(m0123, m4567);
 
         if(Traits::anyall(mv) == !Traits::is_and) {
             *op = !Traits::is_and;
@@ -206,7 +204,7 @@ static void simd_reduce_logical_BOOL(npy_bool* op, npy_bool* ip, npy_intp len) {
 
     // Single vectors loop
     for (; len >= vstep; len -= vstep, ip += vstep) {
-        vec_u8 v = hn::LoadU(u8, ip);
+        auto v = LoadU(ip);
         if(Traits::anyall(v) == !Traits::is_and) {
             *op = !Traits::is_and;
             return;
@@ -226,25 +224,24 @@ template<typename Op>
 HWY_ATTR SIMD_MSVC_NOINLINE
 static void simd_unary_logical_BOOL(npy_bool* op, npy_bool* ip, npy_intp len) {
     using Traits = UnaryLogicalTraits<Op>;
-    Traits traits;
     constexpr int UNROLL = 16;
-    const int vstep = hn::Lanes(u8);
+    HWY_LANES_CONSTEXPR int vstep = Lanes<uint8_t>();
     const int wstep = vstep * UNROLL;
 
     // Unrolled vectors loop
     for (; len >= wstep; len -= wstep, ip += wstep, op += wstep) {
         for(int i = 0; i < UNROLL; i++) {
-            vec_u8 v = hn::LoadU(u8, ip + vstep * i);
-            vec_u8 r = traits.simd_op(v);
-            hn::StoreU(r, u8, op + vstep * i);
+            auto v = LoadU(ip + vstep * i);
+            auto r = Traits::simd_op(v);
+            StoreU(r, op + vstep * i);
         }
     }
 
     // Single vectors loop
     for (; len >= vstep; len -= vstep, ip += vstep, op += vstep) {
-        vec_u8 v = hn::LoadU(u8, ip);
-        vec_u8 r = traits.simd_op(v);
-        hn::StoreU(r, u8, op);
+        auto v = LoadU(ip);
+        auto r = Traits::simd_op(v);
+        StoreU(r, op);
     }
 
     // Scalar loop to finish off
@@ -253,6 +250,9 @@ static void simd_unary_logical_BOOL(npy_bool* op, npy_bool* ip, npy_intp len) {
     }
 }
 
+#endif  //NPY_HWY
+} // namespace anonymous
+
 /*******************************************************************************
  ** Defining ufunc inner functions
  ******************************************************************************/
@@ -260,12 +260,9 @@ template<typename Op>
 static NPY_INLINE int run_binary_simd_logical_BOOL(
     char** args, npy_intp const* dimensions, npy_intp const* steps)
 {
-#if NPY_SIMD
-    if (sizeof(npy_bool) == 1 &&
-            IS_BLOCKABLE_BINARY(sizeof(npy_bool), NPY_SIMD_WIDTH)) {
-        simd_binary_logical_BOOL<Op>((npy_bool*)args[2], (npy_bool*)args[0],
-                                    (npy_bool*)args[1], dimensions[0]
-        );
+#if NPY_HWY
+    if (sizeof(npy_bool) == 1 && IS_BLOCKABLE_BINARY(sizeof(npy_bool), kMaxLanes<uint8_t>)) {
+        simd_binary_logical_BOOL<Op>((npy_bool*)args[2], (npy_bool*)args[0], (npy_bool*)args[1], dimensions[0]);
         return 1;
     }
 #endif
@@ -276,12 +273,9 @@ template<typename Op>
 static NPY_INLINE int run_reduce_simd_logical_BOOL(
     char** args, npy_intp const* dimensions, npy_intp const* steps)
 {
-#if NPY_SIMD
-    if (sizeof(npy_bool) == 1 &&
-            IS_BLOCKABLE_REDUCE(sizeof(npy_bool), NPY_SIMD_WIDTH)) {
-        simd_reduce_logical_BOOL<Op>((npy_bool*)args[0], (npy_bool*)args[1],
-            dimensions[0]
-        );
+#if NPY_HWY
+    if (sizeof(npy_bool) == 1 && IS_BLOCKABLE_REDUCE(sizeof(npy_bool), kMaxLanes<uint8_t>)) {
+        simd_reduce_logical_BOOL<Op>((npy_bool*)args[0], (npy_bool*)args[1], dimensions[0]);
         return 1;
     }
 #endif
@@ -292,9 +286,8 @@ template<typename Op>
 static NPY_INLINE int run_unary_simd_logical_BOOL(
     char** args, npy_intp const* dimensions, npy_intp const* steps)
 {
-#if NPY_SIMD
-    if (sizeof(npy_bool) == 1 &&
-            IS_BLOCKABLE_UNARY(sizeof(npy_bool), NPY_SIMD_WIDTH)) {
+#if NPY_HWY
+    if (sizeof(npy_bool) == 1 && IS_BLOCKABLE_UNARY(sizeof(npy_bool), kMaxLanes<uint8_t>)) {
         simd_unary_logical_BOOL<Op>((npy_bool*)args[1], (npy_bool*)args[0], dimensions[0]);
         return 1;
     }
@@ -304,24 +297,34 @@ static NPY_INLINE int run_unary_simd_logical_BOOL(
 
 template <typename Op>
 void BOOL_binary_func_wrapper(char** args, npy_intp const* dimensions, npy_intp const* steps) {
+    char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
     using Traits = BinaryLogicalTraits<Op>;
-    
+
+#if NPY_HWY
     if (run_binary_simd_logical_BOOL<Op>(args, dimensions, steps)) {
         return;
     }
-    else {
-        BINARY_LOOP {
-            const npy_bool in1 = *(npy_bool*)ip1;
-            const npy_bool in2 = *(npy_bool*)ip2;
-            *((npy_bool*)op1) = Traits::scalar_op(in1, in2);
-        }
+#endif
+
+    for(npy_intp i = 0; i < n; i++, ip1 += is1, ip2 += is2, op1 += os1) {
+        const npy_bool in1 = *(npy_bool*)ip1;
+        const npy_bool in2 = *(npy_bool*)ip2;
+        *((npy_bool*)op1)  = Traits::scalar_op(in1, in2);
     }
 }
 
 template <typename Op>
 void BOOL_binary_reduce_wrapper(char** args, npy_intp const* dimensions, npy_intp const* steps) {
+    char *iop1 = args[0];
+    npy_bool io1 = *(npy_bool *)iop1;
+    char *ip2    = args[1];
+    npy_intp is2 = steps[1];
+    npy_intp n   = dimensions[0];
+    npy_intp i;
     using Traits = BinaryLogicalTraits<Op>;
-#if NPY_SIMD
+#if NPY_HWY
     if (run_reduce_simd_logical_BOOL<Op>(args, dimensions, steps)) {
         return;
     }
@@ -343,7 +346,6 @@ void BOOL_binary_reduce_wrapper(char** args, npy_intp const* dimensions, npy_int
              * with glibc >= 2.12 and memchr can only check for equal 1
              */
             static const npy_bool zero[4096]={0}; /* zero by C standard */
-            npy_uintp i, n = dimensions[0];
 
             for (i = 0; !*op && i < n - (n % sizeof(zero)); i += sizeof(zero)) {
                 *op = memcmp(&args[1][i], zero, sizeof(zero)) != 0;
@@ -355,14 +357,14 @@ void BOOL_binary_reduce_wrapper(char** args, npy_intp const* dimensions, npy_int
         return;
     }
 #endif
-    else {
-        BINARY_REDUCE_LOOP(npy_bool) {
-            const npy_bool in2 = *(npy_bool*)ip2;
-            io1 = Traits::scalar_op(io1, in2);
-            if ((Traits::is_and && !io1) || (!Traits::is_and && io1)) break;
-        }
-        *((npy_bool*)iop1) = io1;
+
+    for(i = 0; i < n; i++, ip2 += is2) {
+        const npy_bool in2 = *(npy_bool*)ip2;
+        io1 = Traits::scalar_op(io1, in2);
+        if ((Traits::is_and && !io1) || (!Traits::is_and && io1))
+            break;
     }
+    *((npy_bool*)iop1) = io1;
 }
 
 template <typename Op>
@@ -390,15 +392,18 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(BOOL_logical_or)(
 template <typename Op>
 void BOOL_func_wrapper(char** args, npy_intp const* dimensions, npy_intp const* steps)
 {
+    char *ip1 = args[0], *op1 = args[1];
+    npy_intp is1 = steps[0], os1 = steps[1];
+    npy_intp n = dimensions[0];
     using Traits = UnaryLogicalTraits<Op>;
+
     if (run_unary_simd_logical_BOOL<Op>(args, dimensions, steps)) {
         return;
     }
-    else {
-        UNARY_LOOP {
-            npy_bool in1 = *(npy_bool*)ip1;
-            *((npy_bool*)op1) = Traits::scalar_op(in1, 0);
-        }
+
+    for(npy_intp i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+        npy_bool in1 = *(npy_bool*)ip1;
+        *((npy_bool*)op1) = Traits::scalar_op(in1, 0);
     }
 }
 


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip) gcc version 14.2.0
Test command: spin bench --compare HEAD~1 -t bench_ufunc.LogicalSpecific

Add class LogicalSpecific in benchmarks/benchmarks/bench_ufunc.py for this test on Banana Pi BPI-F3

```
class LogicalSpecific(Benchmark):
    timeout = 10
    params = ['bool']
    param_names = ['dtype']

    def setup(self, dtype):
        np.seterr(all='ignore')
        self.logical_and_fn = np.logical_and
        self.logical_or_fn = np.logical_or
        self.logical_not_fn = np.logical_not
        self.absolute_fn = np.absolute

        from .common import get_square_
        arr1 = get_square_(dtype)
        arr2 = get_square_(dtype)

        self.data_and = (arr1, arr2)
        self.data_or  = (arr1, arr2)
        self.data_not = (arr1,)
        self.data_abs = (arr1,)

    def time_logical_and(self, dtype):
        self.logical_and_fn(*self.data_and)

    def time_logical_or(self, dtype):
        self.logical_or_fn(*self.data_or)

    def time_logical_not(self, dtype):
        self.logical_not_fn(*self.data_not)

    def time_absolute(self, dtype):
        self.absolute_fn(*self.data_abs)

```
(numpy_venv) root@yangwang:/home/yangwang/numpy# git log -2
commit e5446650f2f29ac2c21e459835d9b04baa1b131d (HEAD -> main)
Author: Wang Yang <yangwang@iscas.ac.cn>
Date:   Fri Aug 29 15:39:43 2025 +0800

ENH, SIMD: Optimize the logical implementation based on Highway Wrapper

commit b112b4e4cc12ae8a0968b26dcaa53ba032fced29
Author: Wang Yang <yangwang@iscas.ac.cn>
Date:   Fri Aug 29 15:38:43 2025 +0800

TST:Add logical test

(numpy_venv) root@yangwang:/home/yangwang/numpy#
(numpy_venv) root@yangwang:/home/yangwang/numpy# spin bench --compare HEAD~1 -t bench_ufunc.LogicalSpecific
| Change   | Before [b112b4e4] <main~1>   | After [e5446650] <main>   |   Ratio | Benchmark (Parameter)                                |
|----------|------------------------------|---------------------------|---------|------------------------------------------------------|
| -        | 92.2±0.5μs                   | 43.4±8μs                  |    0.47 | bench_ufunc.LogicalSpecific.time_logical_not('bool') |
| -        | 90.3±0.9μs                   | 41.9±8μs                  |    0.46 | bench_ufunc.LogicalSpecific.time_absolute('bool')    |
| -        | 128±0.3μs                    | 56.8±10μs                 |    0.44 | bench_ufunc.LogicalSpecific.time_logical_or('bool')  |
| -        | 127±1μs                      | 55.1±10μs                 |    0.43 | bench_ufunc.LogicalSpecific.time_logical_and('bool') |
