### PR TITLE
TST: Replace test_smoke xunit setup with methods

### DIFF
--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -8,12 +8,8 @@ import numpy as np
 from numpy.random import MT19937, PCG64, PCG64DXSM, SFC64, Generator, Philox
 from numpy.testing import assert_, assert_array_equal, assert_equal
 
-
-@pytest.fixture(scope='module',
-                params=(np.bool, np.int8, np.int16, np.int32, np.int64,
-                        np.uint8, np.uint16, np.uint32, np.uint64))
-def dtype(request):
-    return request.param
+DTYPES_BOOL_INT_UINT = (np.bool, np.int8, np.int16, np.int32, np.int64,
+                        np.uint8, np.uint16, np.uint32, np.uint64)
 
 
 def params_0(f):
@@ -99,32 +95,22 @@ class RNGData:
     advance: int
     seed: list[int]
     rg: Generator
-    initial_state: dict
     seed_vector_bits: int
-    seed_error: Exception
 
 
 class RNG:
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         # Overridden in test classes. Place holder to silence IDE noise
         bit_generator = PCG64
         advance = None
         seed = [12345]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
-
-    def _reset_state(self, data):
-        data.rg.bit_generator.state = data.initial_state
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
     def test_init(self):
-        data = self._create_gen()
+        data = self._create_rng()
         data.rg = Generator(data.bit_generator())
         state = data.rg.bit_generator.state
         data.rg.standard_normal(1)
@@ -134,7 +120,7 @@ class RNG:
         assert_(comp_state(state, new_state))
 
     def test_advance(self):
-        data = self._create_gen()
+        data = self._create_rng()
         state = data.rg.bit_generator.state
         if hasattr(data.rg.bit_generator, 'advance'):
             data.rg.bit_generator.advance(data.advance)
@@ -144,119 +130,119 @@ class RNG:
             pytest.skip(f'Advance is not supported by {bitgen_name}')
 
     def test_jump(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
-        if hasattr(data.rg.bit_generator, 'jumped'):
-            bit_gen2 = data.rg.bit_generator.jumped()
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
+        if hasattr(rg.bit_generator, 'jumped'):
+            bit_gen2 = rg.bit_generator.jumped()
             jumped_state = bit_gen2.state
             assert_(not comp_state(state, jumped_state))
-            data.rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
-            data.rg.bit_generator.state = state
-            bit_gen3 = data.rg.bit_generator.jumped()
+            rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
+            rg.bit_generator.state = state
+            bit_gen3 = rg.bit_generator.jumped()
             rejumped_state = bit_gen3.state
             assert_(comp_state(jumped_state, rejumped_state))
         else:
-            bitgen_name = data.rg.bit_generator.__class__.__name__
+            bitgen_name = rg.bit_generator.__class__.__name__
             if bitgen_name not in ('SFC64',):
                 raise AttributeError(f'no "jumped" in {bitgen_name}')
             pytest.skip(f'Jump is not supported by {bitgen_name}')
 
     def test_uniform(self):
-        data = self._create_gen()
-        r = data.rg.uniform(-1.0, 0.0, size=10)
+        rg = self._create_rng().rg
+        r = rg.uniform(-1.0, 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_uniform_array(self):
-        data = self._create_gen()
-        r = data.rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
+        rg = self._create_rng().rg
+        r = rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = data.rg.uniform(np.array([-1.0] * 10),
+        r = rg.uniform(np.array([-1.0] * 10),
                             np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = data.rg.uniform(-1.0, np.array([0.0] * 10), size=10)
+        r = rg.uniform(-1.0, np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_random(self):
-        data = self._create_gen()
-        assert_(len(data.rg.random(10)) == 10)
-        params_0(data.rg.random)
+        rg = self._create_rng().rg
+        assert_(len(rg.random(10)) == 10)
+        params_0(rg.random)
 
     def test_standard_normal_zig(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_normal(10)) == 10)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_normal(10)) == 10)
 
     def test_standard_normal(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_normal(10)) == 10)
-        params_0(data.rg.standard_normal)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_normal(10)) == 10)
+        params_0(rg.standard_normal)
 
     def test_standard_gamma(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_gamma(10, 10)) == 10)
-        assert_(len(data.rg.standard_gamma(np.array([10] * 10), 10)) == 10)
-        params_1(data.rg.standard_gamma)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_gamma(10, 10)) == 10)
+        assert_(len(rg.standard_gamma(np.array([10] * 10), 10)) == 10)
+        params_1(rg.standard_gamma)
 
     def test_standard_exponential(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_exponential(10)) == 10)
-        params_0(data.rg.standard_exponential)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_exponential(10)) == 10)
+        params_0(rg.standard_exponential)
 
     def test_standard_exponential_float(self):
-        data = self._create_gen()
-        randoms = data.rg.standard_exponential(10, dtype='float32')
+        rg = self._create_rng().rg
+        randoms = rg.standard_exponential(10, dtype='float32')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(data.rg.standard_exponential, dtype='float32'))
+        params_0(partial(rg.standard_exponential, dtype='float32'))
 
     def test_standard_exponential_float_log(self):
-        data = self._create_gen()
-        randoms = data.rg.standard_exponential(10, dtype='float32',
+        rg = self._create_rng().rg
+        randoms = rg.standard_exponential(10, dtype='float32',
                                                method='inv')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(data.rg.standard_exponential, dtype='float32',
+        params_0(partial(rg.standard_exponential, dtype='float32',
                          method='inv'))
 
     def test_standard_cauchy(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_cauchy(10)) == 10)
-        params_0(data.rg.standard_cauchy)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_cauchy(10)) == 10)
+        params_0(rg.standard_cauchy)
 
     def test_standard_t(self):
-        data = self._create_gen()
-        assert_(len(data.rg.standard_t(10, 10)) == 10)
-        params_1(data.rg.standard_t)
+        rg = self._create_rng().rg
+        assert_(len(rg.standard_t(10, 10)) == 10)
+        params_1(rg.standard_t)
 
     def test_binomial(self):
-        data = self._create_gen()
-        assert_(data.rg.binomial(10, .5) >= 0)
-        assert_(data.rg.binomial(1000, .5) >= 0)
+        rg = self._create_rng().rg
+        assert_(rg.binomial(10, .5) >= 0)
+        assert_(rg.binomial(1000, .5) >= 0)
 
     def test_reset_state(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
-        int_1 = data.rg.integers(2**31)
-        data.rg.bit_generator.state = state
-        int_2 = data.rg.integers(2**31)
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
+        int_1 = rg.integers(2**31)
+        rg.bit_generator.state = state
+        int_2 = rg.integers(2**31)
         assert_(int_1 == int_2)
 
     def test_entropy_init(self):
-        data = self._create_gen()
-        rg = Generator(data.bit_generator())
-        rg2 = Generator(data.bit_generator())
+        bit_generator = self._create_rng().bit_generator
+        rg = Generator(bit_generator())
+        rg2 = Generator(bit_generator())
         assert_(not comp_state(rg.bit_generator.state,
                                rg2.bit_generator.state))
 
     def test_seed(self):
-        data = self._create_gen()
+        data = self._create_rng()
         rg = Generator(data.bit_generator(*data.seed))
         rg2 = Generator(data.bit_generator(*data.seed))
         rg.random()
@@ -264,7 +250,7 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_reset_state_gauss(self):
-        data = self._create_gen()
+        data = self._create_rng()
         rg = Generator(data.bit_generator(*data.seed))
         rg.standard_normal()
         state = rg.bit_generator.state
@@ -275,7 +261,7 @@ class RNG:
         assert_array_equal(n1, n2)
 
     def test_reset_state_uint32(self):
-        data = self._create_gen()
+        data = self._create_rng()
         rg = Generator(data.bit_generator(*data.seed))
         rg.integers(0, 2 ** 24, 120, dtype=np.uint32)
         state = rg.bit_generator.state
@@ -286,7 +272,7 @@ class RNG:
         assert_array_equal(n1, n2)
 
     def test_reset_state_float(self):
-        data = self._create_gen()
+        data = self._create_rng()
         rg = Generator(data.bit_generator(*data.seed))
         rg.random(dtype='float32')
         state = rg.bit_generator.state
@@ -297,221 +283,221 @@ class RNG:
         assert_((n1 == n2).all())
 
     def test_shuffle(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         original = np.arange(200, 0, -1)
-        permuted = data.rg.permutation(original)
+        permuted = rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_permutation(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         original = np.arange(200, 0, -1)
-        permuted = data.rg.permutation(original)
+        permuted = rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_beta(self):
-        data = self._create_gen()
-        vals = data.rg.beta(2.0, 2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.beta(2.0, 2.0, 10)
         assert_(len(vals) == 10)
-        vals = data.rg.beta(np.array([2.0] * 10), 2.0)
+        vals = rg.beta(np.array([2.0] * 10), 2.0)
         assert_(len(vals) == 10)
-        vals = data.rg.beta(2.0, np.array([2.0] * 10))
+        vals = rg.beta(2.0, np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = data.rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
+        vals = rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = data.rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
+        vals = rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
         assert_(vals.shape == (10, 10))
 
     def test_bytes(self):
-        data = self._create_gen()
-        vals = data.rg.bytes(10)
+        rg = self._create_rng().rg
+        vals = rg.bytes(10)
         assert_(len(vals) == 10)
 
     def test_chisquare(self):
-        data = self._create_gen()
-        vals = data.rg.chisquare(2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.chisquare(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(data.rg.chisquare)
+        params_1(rg.chisquare)
 
     def test_exponential(self):
-        data = self._create_gen()
-        vals = data.rg.exponential(2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.exponential(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(data.rg.exponential)
+        params_1(rg.exponential)
 
     def test_f(self):
-        data = self._create_gen()
-        vals = data.rg.f(3, 1000, 10)
+        rg = self._create_rng().rg
+        vals = rg.f(3, 1000, 10)
         assert_(len(vals) == 10)
 
     def test_gamma(self):
-        data = self._create_gen()
-        vals = data.rg.gamma(3, 2, 10)
+        rg = self._create_rng().rg
+        vals = rg.gamma(3, 2, 10)
         assert_(len(vals) == 10)
 
     def test_geometric(self):
-        data = self._create_gen()
-        vals = data.rg.geometric(0.5, 10)
+        rg = self._create_rng().rg
+        vals = rg.geometric(0.5, 10)
         assert_(len(vals) == 10)
-        params_1(data.rg.exponential, bounded=True)
+        params_1(rg.exponential, bounded=True)
 
     def test_gumbel(self):
-        data = self._create_gen()
-        vals = data.rg.gumbel(2.0, 2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.gumbel(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_laplace(self):
-        data = self._create_gen()
-        vals = data.rg.laplace(2.0, 2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.laplace(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logitic(self):
-        data = self._create_gen()
-        vals = data.rg.logistic(2.0, 2.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.logistic(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logseries(self):
-        data = self._create_gen()
-        vals = data.rg.logseries(0.5, 10)
+        rg = self._create_rng().rg
+        vals = rg.logseries(0.5, 10)
         assert_(len(vals) == 10)
 
     def test_negative_binomial(self):
-        data = self._create_gen()
-        vals = data.rg.negative_binomial(10, 0.2, 10)
+        rg = self._create_rng().rg
+        vals = rg.negative_binomial(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_chisquare(self):
-        data = self._create_gen()
-        vals = data.rg.noncentral_chisquare(10, 2, 10)
+        rg = self._create_rng().rg
+        vals = rg.noncentral_chisquare(10, 2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_f(self):
-        data = self._create_gen()
-        vals = data.rg.noncentral_f(3, 1000, 2, 10)
+        rg = self._create_rng().rg
+        vals = rg.noncentral_f(3, 1000, 2, 10)
         assert_(len(vals) == 10)
-        vals = data.rg.noncentral_f(np.array([3] * 10), 1000, 2)
+        vals = rg.noncentral_f(np.array([3] * 10), 1000, 2)
         assert_(len(vals) == 10)
-        vals = data.rg.noncentral_f(3, np.array([1000] * 10), 2)
+        vals = rg.noncentral_f(3, np.array([1000] * 10), 2)
         assert_(len(vals) == 10)
-        vals = data.rg.noncentral_f(3, 1000, np.array([2] * 10))
+        vals = rg.noncentral_f(3, 1000, np.array([2] * 10))
         assert_(len(vals) == 10)
 
     def test_normal(self):
-        data = self._create_gen()
-        vals = data.rg.normal(10, 0.2, 10)
+        rg = self._create_rng().rg
+        vals = rg.normal(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_pareto(self):
-        data = self._create_gen()
-        vals = data.rg.pareto(3.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.pareto(3.0, 10)
         assert_(len(vals) == 10)
 
     def test_poisson(self):
-        data = self._create_gen()
-        vals = data.rg.poisson(10, 10)
+        rg = self._create_rng().rg
+        vals = rg.poisson(10, 10)
         assert_(len(vals) == 10)
-        vals = data.rg.poisson(np.array([10] * 10))
+        vals = rg.poisson(np.array([10] * 10))
         assert_(len(vals) == 10)
-        params_1(data.rg.poisson)
+        params_1(rg.poisson)
 
     def test_power(self):
-        data = self._create_gen()
-        vals = data.rg.power(0.2, 10)
+        rg = self._create_rng().rg
+        vals = rg.power(0.2, 10)
         assert_(len(vals) == 10)
 
     def test_integers(self):
-        data = self._create_gen()
-        vals = data.rg.integers(10, 20, 10)
+        rg = self._create_rng().rg
+        vals = rg.integers(10, 20, 10)
         assert_(len(vals) == 10)
 
     def test_rayleigh(self):
-        data = self._create_gen()
-        vals = data.rg.rayleigh(0.2, 10)
+        rg = self._create_rng().rg
+        vals = rg.rayleigh(0.2, 10)
         assert_(len(vals) == 10)
-        params_1(data.rg.rayleigh, bounded=True)
+        params_1(rg.rayleigh, bounded=True)
 
     def test_vonmises(self):
-        data = self._create_gen()
-        vals = data.rg.vonmises(10, 0.2, 10)
+        rg = self._create_rng().rg
+        vals = rg.vonmises(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_wald(self):
-        data = self._create_gen()
-        vals = data.rg.wald(1.0, 1.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.wald(1.0, 1.0, 10)
         assert_(len(vals) == 10)
 
     def test_weibull(self):
-        data = self._create_gen()
-        vals = data.rg.weibull(1.0, 10)
+        rg = self._create_rng().rg
+        vals = rg.weibull(1.0, 10)
         assert_(len(vals) == 10)
 
     def test_zipf(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         vec_1d = np.arange(2.0, 102.0)
         vec_2d = np.arange(2.0, 102.0)[None, :]
         mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
-        vals = data.rg.zipf(10, 10)
+        vals = rg.zipf(10, 10)
         assert_(len(vals) == 10)
-        vals = data.rg.zipf(vec_1d)
+        vals = rg.zipf(vec_1d)
         assert_(len(vals) == 100)
-        vals = data.rg.zipf(vec_2d)
+        vals = rg.zipf(vec_2d)
         assert_(vals.shape == (1, 100))
-        vals = data.rg.zipf(mat)
+        vals = rg.zipf(mat)
         assert_(vals.shape == (100, 100))
 
     def test_hypergeometric(self):
-        data = self._create_gen()
-        vals = data.rg.hypergeometric(25, 25, 20)
+        rg = self._create_rng().rg
+        vals = rg.hypergeometric(25, 25, 20)
         assert_(np.isscalar(vals))
-        vals = data.rg.hypergeometric(np.array([25] * 10), 25, 20)
+        vals = rg.hypergeometric(np.array([25] * 10), 25, 20)
         assert_(vals.shape == (10,))
 
     def test_triangular(self):
-        data = self._create_gen()
-        vals = data.rg.triangular(-5, 0, 5)
+        rg = self._create_rng().rg
+        vals = rg.triangular(-5, 0, 5)
         assert_(np.isscalar(vals))
-        vals = data.rg.triangular(-5, np.array([0] * 10), 5)
+        vals = rg.triangular(-5, np.array([0] * 10), 5)
         assert_(vals.shape == (10,))
 
     def test_multivariate_normal(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         mean = [0, 0]
         cov = [[1, 0], [0, 100]]  # diagonal covariance
-        x = data.rg.multivariate_normal(mean, cov, 5000)
+        x = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_zig = data.rg.multivariate_normal(mean, cov, 5000)
+        x_zig = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_inv = data.rg.multivariate_normal(mean, cov, 5000)
+        x_inv = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
         assert_((x_zig != x_inv).any())
 
     def test_multinomial(self):
-        data = self._create_gen()
-        vals = data.rg.multinomial(100, [1.0 / 3, 2.0 / 3])
+        rg = self._create_rng().rg
+        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3])
         assert_(vals.shape == (2,))
-        vals = data.rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
+        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
         assert_(vals.shape == (10, 2))
 
     def test_dirichlet(self):
-        data = self._create_gen()
-        s = data.rg.dirichlet((10, 5, 3), 20)
+        rg = self._create_rng().rg
+        s = rg.dirichlet((10, 5, 3), 20)
         assert_(s.shape == (20, 3))
 
     def test_pickle(self):
-        data = self._create_gen()
-        pick = pickle.dumps(data.rg)
+        rg = self._create_rng().rg
+        pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(data.rg) == type(unpick))
-        assert_(comp_state(data.rg.bit_generator.state,
+        assert_(type(rg) == type(unpick))
+        assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 
-        pick = pickle.dumps(data.rg)
+        pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(data.rg) == type(unpick))
-        assert_(comp_state(data.rg.bit_generator.state,
+        assert_(type(rg) == type(unpick))
+        assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 
     def test_seed_array(self):
-        data = self._create_gen()
+        data = self._create_rng()
         if data.seed_vector_bits is None:
             bitgen_name = data.bit_generator.__name__
             pytest.skip(f'Vector seeding is not supported by {bitgen_name}')
@@ -550,12 +536,12 @@ class RNG:
         assert_(not comp_state(state1, state2))
 
     def test_uniform_float(self):
-        data = self._create_gen()
-        rg = Generator(data.bit_generator(12345))
+        bit_generator = self._create_rng().bit_generator
+        rg = Generator(bit_generator(12345))
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.random(11, dtype=np.float32)
-        rg2 = Generator(data.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.random(11, dtype=np.float32)
@@ -564,12 +550,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_gamma_floats(self):
-        data = self._create_gen()
-        rg = Generator(data.bit_generator())
+        bit_generator = self._create_rng().bit_generator
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_gamma(4.0, 11, dtype=np.float32)
-        rg2 = Generator(data.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_gamma(4.0, 11, dtype=np.float32)
@@ -578,12 +564,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_floats(self):
-        data = self._create_gen()
-        rg = Generator(data.bit_generator())
+        bit_generator = self._create_rng().bit_generator
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(data.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -592,12 +578,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_zig_floats(self):
-        data = self._create_gen()
-        rg = Generator(data.bit_generator())
+        bit_generator = self._create_rng().bit_generator
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(data.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -606,125 +592,131 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_output_fill(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        data.rg.bit_generator.state = state
-        data.rg.standard_normal(out=existing)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_normal(size=size)
+        rg.bit_generator.state = state
+        rg.standard_normal(out=existing)
+        rg.bit_generator.state = state
+        direct = rg.standard_normal(size=size)
         assert_equal(direct, existing)
 
         sized = np.empty(size)
-        data.rg.bit_generator.state = state
-        data.rg.standard_normal(out=sized, size=sized.shape)
+        rg.bit_generator.state = state
+        rg.standard_normal(out=sized, size=sized.shape)
 
         existing = np.empty(size, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        data.rg.standard_normal(out=existing, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_normal(size=size, dtype=np.float32)
+        rg.bit_generator.state = state
+        rg.standard_normal(out=existing, dtype=np.float32)
+        rg.bit_generator.state = state
+        direct = rg.standard_normal(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_uniform(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        data.rg.bit_generator.state = state
-        data.rg.random(out=existing)
-        data.rg.bit_generator.state = state
-        direct = data.rg.random(size=size)
+        rg.bit_generator.state = state
+        rg.random(out=existing)
+        rg.bit_generator.state = state
+        direct = rg.random(size=size)
         assert_equal(direct, existing)
 
         existing = np.empty(size, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        data.rg.random(out=existing, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        direct = data.rg.random(size=size, dtype=np.float32)
+        rg.bit_generator.state = state
+        rg.random(out=existing, dtype=np.float32)
+        rg.bit_generator.state = state
+        direct = rg.random(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_exponential(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        data.rg.bit_generator.state = state
-        data.rg.standard_exponential(out=existing)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_exponential(size=size)
+        rg.bit_generator.state = state
+        rg.standard_exponential(out=existing)
+        rg.bit_generator.state = state
+        direct = rg.standard_exponential(size=size)
         assert_equal(direct, existing)
 
         existing = np.empty(size, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        data.rg.standard_exponential(out=existing, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_exponential(size=size, dtype=np.float32)
+        rg.bit_generator.state = state
+        rg.standard_exponential(out=existing, dtype=np.float32)
+        rg.bit_generator.state = state
+        direct = rg.standard_exponential(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_gamma(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.zeros(size)
-        data.rg.bit_generator.state = state
-        data.rg.standard_gamma(1.0, out=existing)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_gamma(1.0, size=size)
+        rg.bit_generator.state = state
+        rg.standard_gamma(1.0, out=existing)
+        rg.bit_generator.state = state
+        direct = rg.standard_gamma(1.0, size=size)
         assert_equal(direct, existing)
 
         existing = np.zeros(size, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        data.rg.standard_gamma(1.0, out=existing, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_gamma(1.0, size=size, dtype=np.float32)
+        rg.bit_generator.state = state
+        rg.standard_gamma(1.0, out=existing, dtype=np.float32)
+        rg.bit_generator.state = state
+        direct = rg.standard_gamma(1.0, size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_gamma_broadcast(self):
-        data = self._create_gen()
-        state = data.rg.bit_generator.state
+        rg = self._create_rng().rg
+        state = rg.bit_generator.state
         size = (31, 7, 97)
         mu = np.arange(97.0) + 1.0
         existing = np.zeros(size)
-        data.rg.bit_generator.state = state
-        data.rg.standard_gamma(mu, out=existing)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_gamma(mu, size=size)
+        rg.bit_generator.state = state
+        rg.standard_gamma(mu, out=existing)
+        rg.bit_generator.state = state
+        direct = rg.standard_gamma(mu, size=size)
         assert_equal(direct, existing)
 
         existing = np.zeros(size, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        data.rg.standard_gamma(mu, out=existing, dtype=np.float32)
-        data.rg.bit_generator.state = state
-        direct = data.rg.standard_gamma(mu, size=size, dtype=np.float32)
+        rg.bit_generator.state = state
+        rg.standard_gamma(mu, out=existing, dtype=np.float32)
+        rg.bit_generator.state = state
+        direct = rg.standard_gamma(mu, size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_fill_error(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         size = (31, 7, 97)
         existing = np.empty(size)
         with pytest.raises(TypeError):
-            data.rg.standard_normal(out=existing, dtype=np.float32)
+            rg.standard_normal(out=existing, dtype=np.float32)
         with pytest.raises(ValueError):
-            data.rg.standard_normal(out=existing[::3])
+            rg.standard_normal(out=existing[::3])
         existing = np.empty(size, dtype=np.float32)
         with pytest.raises(TypeError):
-            data.rg.standard_normal(out=existing, dtype=np.float64)
+            rg.standard_normal(out=existing, dtype=np.float64)
 
         existing = np.zeros(size, dtype=np.float32)
         with pytest.raises(TypeError):
-            data.rg.standard_gamma(1.0, out=existing, dtype=np.float64)
+            rg.standard_gamma(1.0, out=existing, dtype=np.float64)
         with pytest.raises(ValueError):
-            data.rg.standard_gamma(1.0, out=existing[::3], dtype=np.float32)
+            rg.standard_gamma(1.0, out=existing[::3], dtype=np.float32)
         existing = np.zeros(size, dtype=np.float64)
         with pytest.raises(TypeError):
-            data.rg.standard_gamma(1.0, out=existing, dtype=np.float32)
+            rg.standard_gamma(1.0, out=existing, dtype=np.float32)
         with pytest.raises(ValueError):
-            data.rg.standard_gamma(1.0, out=existing[::3])
+            rg.standard_gamma(1.0, out=existing[::3])
 
+    @pytest.mark.parametrize("dtype", DTYPES_BOOL_INT_UINT)
     def test_integers_broadcast(self, dtype):
-        data = self._create_gen()
+        rg = self._create_rng().rg
+        initial_state = rg.bit_generator.state
+
+        def reset_state(rng):
+            rng.bit_generator.state = initial_state
+
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -732,47 +724,50 @@ class RNG:
             info = np.iinfo(dtype)
             upper = int(info.max) + 1
             lower = info.min
-        self._reset_state(data)
-        a = data.rg.integers(lower, [upper] * 10, dtype=dtype)
-        self._reset_state(data)
-        b = data.rg.integers([lower] * 10, upper, dtype=dtype)
+        reset_state(rg)
+        rg.bit_generator.state = initial_state
+        a = rg.integers(lower, [upper] * 10, dtype=dtype)
+        reset_state(rg)
+        b = rg.integers([lower] * 10, upper, dtype=dtype)
         assert_equal(a, b)
-        self._reset_state(data)
-        c = data.rg.integers(lower, upper, size=10, dtype=dtype)
+        reset_state(rg)
+        c = rg.integers(lower, upper, size=10, dtype=dtype)
         assert_equal(a, c)
-        self._reset_state(data)
-        d = data.rg.integers(np.array(
+        reset_state(rg)
+        d = rg.integers(np.array(
             [lower] * 10), np.array([upper], dtype=object), size=10,
             dtype=dtype)
         assert_equal(a, d)
-        self._reset_state(data)
-        e = data.rg.integers(
+        reset_state(rg)
+        e = rg.integers(
             np.array([lower] * 10), np.array([upper] * 10), size=10,
             dtype=dtype)
         assert_equal(a, e)
 
-        self._reset_state(data)
-        a = data.rg.integers(0, upper, size=10, dtype=dtype)
-        self._reset_state(data)
-        b = data.rg.integers([upper] * 10, dtype=dtype)
+        reset_state(rg)
+        a = rg.integers(0, upper, size=10, dtype=dtype)
+        reset_state(rg)
+        b = rg.integers([upper] * 10, dtype=dtype)
         assert_equal(a, b)
 
+    @pytest.mark.parametrize("dtype", DTYPES_BOOL_INT_UINT)
     def test_integers_numpy(self, dtype):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         high = np.array([1])
         low = np.array([0])
 
-        out = data.rg.integers(low, high, dtype=dtype)
+        out = rg.integers(low, high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = data.rg.integers(low[0], high, dtype=dtype)
+        out = rg.integers(low[0], high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = data.rg.integers(low, high[0], dtype=dtype)
+        out = rg.integers(low, high[0], dtype=dtype)
         assert out.shape == (1,)
 
+    @pytest.mark.parametrize("dtype", DTYPES_BOOL_INT_UINT)
     def test_integers_broadcast_errors(self, dtype):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -781,127 +776,97 @@ class RNG:
             upper = int(info.max) + 1
             lower = info.min
         with pytest.raises(ValueError):
-            data.rg.integers(lower, [upper + 1] * 10, dtype=dtype)
+            rg.integers(lower, [upper + 1] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            data.rg.integers(lower - 1, [upper] * 10, dtype=dtype)
+            rg.integers(lower - 1, [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            data.rg.integers([lower - 1], [upper] * 10, dtype=dtype)
+            rg.integers([lower - 1], [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            data.rg.integers([0], [0], dtype=dtype)
+            rg.integers([0], [0], dtype=dtype)
 
 
 class TestMT19937(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         bit_generator = MT19937
         advance = None
         seed = [2 ** 21 + 2 ** 16 + 2 ** 5 + 1]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 32
-        seed_error = ValueError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
     def test_numpy_state(self):
-        data = self._create_gen()
+        rg = self._create_rng().rg
         nprg = np.random.RandomState()
         nprg.standard_normal(99)
         state = nprg.get_state()
-        data.rg.bit_generator.state = state
-        state2 = data.rg.bit_generator.state
+        rg.bit_generator.state = state
+        state2 = rg.bit_generator.state
         assert_((state[1] == state2['state']['key']).all())
         assert_(state[2] == state2['state']['pos'])
 
 
 class TestPhilox(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         bit_generator = Philox
         advance = 2**63 + 2**31 + 2**15 + 1
         seed = [12345]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
 
 class TestSFC64(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         bit_generator = SFC64
         advance = None
         seed = [12345]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 192
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
 
 class TestPCG64(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         bit_generator = PCG64
         advance = 2**63 + 2**31 + 2**15 + 1
         seed = [12345]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
 
 class TestPCG64DXSM(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         bit_generator = PCG64DXSM
         advance = 2**63 + 2**31 + 2**15 + 1
         seed = [12345]
         rg = Generator(bit_generator(*seed))
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
 
 class TestDefaultRNG(RNG):
     @classmethod
-    def _create_gen(cls):
+    def _create_rng(cls):
         # This will duplicate some tests that directly instantiate a fresh
         # Generator(), but that's okay.
         bit_generator = PCG64
         advance = 2**63 + 2**31 + 2**15 + 1
         seed = [12345]
         rg = np.random.default_rng(*seed)
-        initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        seed_error = TypeError
-        return RNGData(
-            bit_generator, advance, seed, rg,
-            initial_state, seed_vector_bits, seed_error
-        )
+        return RNGData(bit_generator, advance, seed, rg, seed_vector_bits)
 
     def test_default_is_pcg64(self):
         # In order to change the default BitGenerator, we'll go through
         # a deprecation cycle to move to a different function.
-        data = self._create_gen()
-        assert_(isinstance(data.rg.bit_generator, PCG64))
+        rg = self._create_rng().rg
+        assert_(isinstance(rg.bit_generator, PCG64))
 
     def test_seed(self):
         np.random.default_rng()

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -94,28 +94,30 @@ def warmup(rg, n=None):
 
 class RNG:
     @classmethod
-    def setup_class(cls):
+    def _create_gen(cls):
         # Overridden in test classes. Place holder to silence IDE noise
-        cls.bit_generator = PCG64
-        cls.advance = None
-        cls.seed = [12345]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 64
-        cls._extra_setup()
+        bit_generator = PCG64
+        advance = None
+        seed = [12345]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 64
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
     @classmethod
-    def _extra_setup(cls):
-        cls.vec_1d = np.arange(2.0, 102.0)
-        cls.vec_2d = np.arange(2.0, 102.0)[None, :]
-        cls.mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
-        cls.seed_error = TypeError
+    def _extra_create_gen(cls):
+        vec_1d = np.arange(2.0, 102.0)
+        vec_2d = np.arange(2.0, 102.0)[None, :]
+        mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
+        seed_error = TypeError
+        return vec_1d, vec_2d, mat, seed_error
 
-    def _reset_state(self):
-        self.rg.bit_generator.state = self.initial_state
+    def _reset_state(self, rg, init):
+        rg.bit_generator.state = init
 
     def test_init(self):
-        rg = Generator(self.bit_generator())
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator())
         state = rg.bit_generator.state
         rg.standard_normal(1)
         rg.standard_normal(1)
@@ -124,371 +126,426 @@ class RNG:
         assert_(comp_state(state, new_state))
 
     def test_advance(self):
-        state = self.rg.bit_generator.state
-        if hasattr(self.rg.bit_generator, 'advance'):
-            self.rg.bit_generator.advance(self.advance)
-            assert_(not comp_state(state, self.rg.bit_generator.state))
+        _, advance, _, rg, _, _ = self._create_gen()
+        state = rg.bit_generator.state
+        if hasattr(rg.bit_generator, 'advance'):
+            rg.bit_generator.advance(advance)
+            assert_(not comp_state(state, rg.bit_generator.state))
         else:
-            bitgen_name = self.rg.bit_generator.__class__.__name__
+            bitgen_name = rg.bit_generator.__class__.__name__
             pytest.skip(f'Advance is not supported by {bitgen_name}')
 
     def test_jump(self):
-        state = self.rg.bit_generator.state
-        if hasattr(self.rg.bit_generator, 'jumped'):
-            bit_gen2 = self.rg.bit_generator.jumped()
+        _, _, _, rg, _, _ = self._create_gen()
+        state = rg.bit_generator.state
+        if hasattr(rg.bit_generator, 'jumped'):
+            bit_gen2 = rg.bit_generator.jumped()
             jumped_state = bit_gen2.state
             assert_(not comp_state(state, jumped_state))
-            self.rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
-            self.rg.bit_generator.state = state
-            bit_gen3 = self.rg.bit_generator.jumped()
+            rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
+            rg.bit_generator.state = state
+            bit_gen3 = rg.bit_generator.jumped()
             rejumped_state = bit_gen3.state
             assert_(comp_state(jumped_state, rejumped_state))
         else:
-            bitgen_name = self.rg.bit_generator.__class__.__name__
+            bitgen_name = rg.bit_generator.__class__.__name__
             if bitgen_name not in ('SFC64',):
                 raise AttributeError(f'no "jumped" in {bitgen_name}')
             pytest.skip(f'Jump is not supported by {bitgen_name}')
 
     def test_uniform(self):
-        r = self.rg.uniform(-1.0, 0.0, size=10)
+        _, _, _, rg, _, _ = self._create_gen()
+        r = rg.uniform(-1.0, 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_uniform_array(self):
-        r = self.rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
+        _, _, _, rg, _, _ = self._create_gen()
+        r = rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = self.rg.uniform(np.array([-1.0] * 10),
+        r = rg.uniform(np.array([-1.0] * 10),
                             np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = self.rg.uniform(-1.0, np.array([0.0] * 10), size=10)
+        r = rg.uniform(-1.0, np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_random(self):
-        assert_(len(self.rg.random(10)) == 10)
-        params_0(self.rg.random)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.random(10)) == 10)
+        params_0(rg.random)
 
     def test_standard_normal_zig(self):
-        assert_(len(self.rg.standard_normal(10)) == 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_normal(10)) == 10)
 
     def test_standard_normal(self):
-        assert_(len(self.rg.standard_normal(10)) == 10)
-        params_0(self.rg.standard_normal)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_normal(10)) == 10)
+        params_0(rg.standard_normal)
 
     def test_standard_gamma(self):
-        assert_(len(self.rg.standard_gamma(10, 10)) == 10)
-        assert_(len(self.rg.standard_gamma(np.array([10] * 10), 10)) == 10)
-        params_1(self.rg.standard_gamma)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_gamma(10, 10)) == 10)
+        assert_(len(rg.standard_gamma(np.array([10] * 10), 10)) == 10)
+        params_1(rg.standard_gamma)
 
     def test_standard_exponential(self):
-        assert_(len(self.rg.standard_exponential(10)) == 10)
-        params_0(self.rg.standard_exponential)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_exponential(10)) == 10)
+        params_0(rg.standard_exponential)
 
     def test_standard_exponential_float(self):
-        randoms = self.rg.standard_exponential(10, dtype='float32')
+        _, _, _, rg, _, _ = self._create_gen()
+        randoms = rg.standard_exponential(10, dtype='float32')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(self.rg.standard_exponential, dtype='float32'))
+        params_0(partial(rg.standard_exponential, dtype='float32'))
 
     def test_standard_exponential_float_log(self):
-        randoms = self.rg.standard_exponential(10, dtype='float32',
+        _, _, _, rg, _, _ = self._create_gen()
+        randoms = rg.standard_exponential(10, dtype='float32',
                                                method='inv')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(self.rg.standard_exponential, dtype='float32',
+        params_0(partial(rg.standard_exponential, dtype='float32',
                          method='inv'))
 
     def test_standard_cauchy(self):
-        assert_(len(self.rg.standard_cauchy(10)) == 10)
-        params_0(self.rg.standard_cauchy)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_cauchy(10)) == 10)
+        params_0(rg.standard_cauchy)
 
     def test_standard_t(self):
-        assert_(len(self.rg.standard_t(10, 10)) == 10)
-        params_1(self.rg.standard_t)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(len(rg.standard_t(10, 10)) == 10)
+        params_1(rg.standard_t)
 
     def test_binomial(self):
-        assert_(self.rg.binomial(10, .5) >= 0)
-        assert_(self.rg.binomial(1000, .5) >= 0)
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(rg.binomial(10, .5) >= 0)
+        assert_(rg.binomial(1000, .5) >= 0)
 
     def test_reset_state(self):
-        state = self.rg.bit_generator.state
-        int_1 = self.rg.integers(2**31)
-        self.rg.bit_generator.state = state
-        int_2 = self.rg.integers(2**31)
+        _, _, _, rg, _, _ = self._create_gen()
+        state = rg.bit_generator.state
+        int_1 = rg.integers(2**31)
+        rg.bit_generator.state = state
+        int_2 = rg.integers(2**31)
         assert_(int_1 == int_2)
 
     def test_entropy_init(self):
-        rg = Generator(self.bit_generator())
-        rg2 = Generator(self.bit_generator())
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator())
+        rg2 = Generator(bit_generator())
         assert_(not comp_state(rg.bit_generator.state,
                                rg2.bit_generator.state))
 
     def test_seed(self):
-        rg = Generator(self.bit_generator(*self.seed))
-        rg2 = Generator(self.bit_generator(*self.seed))
+        bit_generator, _, seed, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator(*seed))
+        rg2 = Generator(bit_generator(*seed))
         rg.random()
         rg2.random()
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_reset_state_gauss(self):
-        rg = Generator(self.bit_generator(*self.seed))
+        bit_generator, _, seed, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator(*seed))
         rg.standard_normal()
         state = rg.bit_generator.state
         n1 = rg.standard_normal(size=10)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.standard_normal(size=10)
         assert_array_equal(n1, n2)
 
     def test_reset_state_uint32(self):
-        rg = Generator(self.bit_generator(*self.seed))
+        bit_generator, _, seed, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator(*seed))
         rg.integers(0, 2 ** 24, 120, dtype=np.uint32)
         state = rg.bit_generator.state
         n1 = rg.integers(0, 2 ** 24, 10, dtype=np.uint32)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.integers(0, 2 ** 24, 10, dtype=np.uint32)
         assert_array_equal(n1, n2)
 
     def test_reset_state_float(self):
-        rg = Generator(self.bit_generator(*self.seed))
+        bit_generator, _, seed, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator(*seed))
         rg.random(dtype='float32')
         state = rg.bit_generator.state
         n1 = rg.random(size=10, dtype='float32')
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.random(size=10, dtype='float32')
         assert_((n1 == n2).all())
 
     def test_shuffle(self):
+        _, _, _, rg, _, _ = self._create_gen()
         original = np.arange(200, 0, -1)
-        permuted = self.rg.permutation(original)
+        permuted = rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_permutation(self):
+        _, _, _, rg, _, _ = self._create_gen()
         original = np.arange(200, 0, -1)
-        permuted = self.rg.permutation(original)
+        permuted = rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_beta(self):
-        vals = self.rg.beta(2.0, 2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.beta(2.0, 2.0, 10)
         assert_(len(vals) == 10)
-        vals = self.rg.beta(np.array([2.0] * 10), 2.0)
+        vals = rg.beta(np.array([2.0] * 10), 2.0)
         assert_(len(vals) == 10)
-        vals = self.rg.beta(2.0, np.array([2.0] * 10))
+        vals = rg.beta(2.0, np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = self.rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
+        vals = rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = self.rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
+        vals = rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
         assert_(vals.shape == (10, 10))
 
     def test_bytes(self):
-        vals = self.rg.bytes(10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.bytes(10)
         assert_(len(vals) == 10)
 
     def test_chisquare(self):
-        vals = self.rg.chisquare(2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.chisquare(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(self.rg.chisquare)
+        params_1(rg.chisquare)
 
     def test_exponential(self):
-        vals = self.rg.exponential(2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.exponential(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(self.rg.exponential)
+        params_1(rg.exponential)
 
     def test_f(self):
-        vals = self.rg.f(3, 1000, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.f(3, 1000, 10)
         assert_(len(vals) == 10)
 
     def test_gamma(self):
-        vals = self.rg.gamma(3, 2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.gamma(3, 2, 10)
         assert_(len(vals) == 10)
 
     def test_geometric(self):
-        vals = self.rg.geometric(0.5, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.geometric(0.5, 10)
         assert_(len(vals) == 10)
-        params_1(self.rg.exponential, bounded=True)
+        params_1(rg.exponential, bounded=True)
 
     def test_gumbel(self):
-        vals = self.rg.gumbel(2.0, 2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.gumbel(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_laplace(self):
-        vals = self.rg.laplace(2.0, 2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.laplace(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logitic(self):
-        vals = self.rg.logistic(2.0, 2.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.logistic(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logseries(self):
-        vals = self.rg.logseries(0.5, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.logseries(0.5, 10)
         assert_(len(vals) == 10)
 
     def test_negative_binomial(self):
-        vals = self.rg.negative_binomial(10, 0.2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.negative_binomial(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_chisquare(self):
-        vals = self.rg.noncentral_chisquare(10, 2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.noncentral_chisquare(10, 2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_f(self):
-        vals = self.rg.noncentral_f(3, 1000, 2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.noncentral_f(3, 1000, 2, 10)
         assert_(len(vals) == 10)
-        vals = self.rg.noncentral_f(np.array([3] * 10), 1000, 2)
+        vals = rg.noncentral_f(np.array([3] * 10), 1000, 2)
         assert_(len(vals) == 10)
-        vals = self.rg.noncentral_f(3, np.array([1000] * 10), 2)
+        vals = rg.noncentral_f(3, np.array([1000] * 10), 2)
         assert_(len(vals) == 10)
-        vals = self.rg.noncentral_f(3, 1000, np.array([2] * 10))
+        vals = rg.noncentral_f(3, 1000, np.array([2] * 10))
         assert_(len(vals) == 10)
 
     def test_normal(self):
-        vals = self.rg.normal(10, 0.2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.normal(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_pareto(self):
-        vals = self.rg.pareto(3.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.pareto(3.0, 10)
         assert_(len(vals) == 10)
 
     def test_poisson(self):
-        vals = self.rg.poisson(10, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.poisson(10, 10)
         assert_(len(vals) == 10)
-        vals = self.rg.poisson(np.array([10] * 10))
+        vals = rg.poisson(np.array([10] * 10))
         assert_(len(vals) == 10)
-        params_1(self.rg.poisson)
+        params_1(rg.poisson)
 
     def test_power(self):
-        vals = self.rg.power(0.2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.power(0.2, 10)
         assert_(len(vals) == 10)
 
     def test_integers(self):
-        vals = self.rg.integers(10, 20, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.integers(10, 20, 10)
         assert_(len(vals) == 10)
 
     def test_rayleigh(self):
-        vals = self.rg.rayleigh(0.2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.rayleigh(0.2, 10)
         assert_(len(vals) == 10)
-        params_1(self.rg.rayleigh, bounded=True)
+        params_1(rg.rayleigh, bounded=True)
 
     def test_vonmises(self):
-        vals = self.rg.vonmises(10, 0.2, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.vonmises(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_wald(self):
-        vals = self.rg.wald(1.0, 1.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.wald(1.0, 1.0, 10)
         assert_(len(vals) == 10)
 
     def test_weibull(self):
-        vals = self.rg.weibull(1.0, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.weibull(1.0, 10)
         assert_(len(vals) == 10)
 
     def test_zipf(self):
-        vals = self.rg.zipf(10, 10)
+        _, _, _, rg, _, _ = self._create_gen()
+        vec_1d, vec_2d, mat, _ = self._extra_create_gen()
+        vals = rg.zipf(10, 10)
         assert_(len(vals) == 10)
-        vals = self.rg.zipf(self.vec_1d)
+        vals = rg.zipf(vec_1d)
         assert_(len(vals) == 100)
-        vals = self.rg.zipf(self.vec_2d)
+        vals = rg.zipf(vec_2d)
         assert_(vals.shape == (1, 100))
-        vals = self.rg.zipf(self.mat)
+        vals = rg.zipf(mat)
         assert_(vals.shape == (100, 100))
 
     def test_hypergeometric(self):
-        vals = self.rg.hypergeometric(25, 25, 20)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.hypergeometric(25, 25, 20)
         assert_(np.isscalar(vals))
-        vals = self.rg.hypergeometric(np.array([25] * 10), 25, 20)
+        vals = rg.hypergeometric(np.array([25] * 10), 25, 20)
         assert_(vals.shape == (10,))
 
     def test_triangular(self):
-        vals = self.rg.triangular(-5, 0, 5)
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.triangular(-5, 0, 5)
         assert_(np.isscalar(vals))
-        vals = self.rg.triangular(-5, np.array([0] * 10), 5)
+        vals = rg.triangular(-5, np.array([0] * 10), 5)
         assert_(vals.shape == (10,))
 
     def test_multivariate_normal(self):
+        _, _, _, rg, _, _ = self._create_gen()
         mean = [0, 0]
         cov = [[1, 0], [0, 100]]  # diagonal covariance
-        x = self.rg.multivariate_normal(mean, cov, 5000)
+        x = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_zig = self.rg.multivariate_normal(mean, cov, 5000)
+        x_zig = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_inv = self.rg.multivariate_normal(mean, cov, 5000)
+        x_inv = rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
         assert_((x_zig != x_inv).any())
 
     def test_multinomial(self):
-        vals = self.rg.multinomial(100, [1.0 / 3, 2.0 / 3])
+        _, _, _, rg, _, _ = self._create_gen()
+        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3])
         assert_(vals.shape == (2,))
-        vals = self.rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
+        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
         assert_(vals.shape == (10, 2))
 
     def test_dirichlet(self):
-        s = self.rg.dirichlet((10, 5, 3), 20)
+        _, _, _, rg, _, _ = self._create_gen()
+        s = rg.dirichlet((10, 5, 3), 20)
         assert_(s.shape == (20, 3))
 
     def test_pickle(self):
-        pick = pickle.dumps(self.rg)
+        _, _, _, rg, _, _ = self._create_gen()
+        pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(self.rg) == type(unpick))
-        assert_(comp_state(self.rg.bit_generator.state,
+        assert_(type(rg) == type(unpick))
+        assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 
-        pick = pickle.dumps(self.rg)
+        pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(self.rg) == type(unpick))
-        assert_(comp_state(self.rg.bit_generator.state,
+        assert_(type(rg) == type(unpick))
+        assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 
     def test_seed_array(self):
-        if self.seed_vector_bits is None:
-            bitgen_name = self.bit_generator.__name__
+        bit_generator, _, _, _, _, seed_vector_bits = self._create_gen()
+        if seed_vector_bits is None:
+            bitgen_name = bit_generator.__name__
             pytest.skip(f'Vector seeding is not supported by {bitgen_name}')
 
-        if self.seed_vector_bits == 32:
+        if seed_vector_bits == 32:
             dtype = np.uint32
         else:
             dtype = np.uint64
         seed = np.array([1], dtype=dtype)
-        bg = self.bit_generator(seed)
+        bg = bit_generator(seed)
         state1 = bg.state
-        bg = self.bit_generator(1)
+        bg = bit_generator(1)
         state2 = bg.state
         assert_(comp_state(state1, state2))
 
         seed = np.arange(4, dtype=dtype)
-        bg = self.bit_generator(seed)
+        bg = bit_generator(seed)
         state1 = bg.state
-        bg = self.bit_generator(seed[0])
+        bg = bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
         seed = np.arange(1500, dtype=dtype)
-        bg = self.bit_generator(seed)
+        bg = bit_generator(seed)
         state1 = bg.state
-        bg = self.bit_generator(seed[0])
+        bg = bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
         seed = 2 ** np.mod(np.arange(1500, dtype=dtype),
-                           self.seed_vector_bits - 1) + 1
-        bg = self.bit_generator(seed)
+                           seed_vector_bits - 1) + 1
+        bg = bit_generator(seed)
         state1 = bg.state
-        bg = self.bit_generator(seed[0])
+        bg = bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
     def test_uniform_float(self):
-        rg = Generator(self.bit_generator(12345))
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator(12345))
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.random(11, dtype=np.float32)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.random(11, dtype=np.float32)
@@ -497,11 +554,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_gamma_floats(self):
-        rg = Generator(self.bit_generator())
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_gamma(4.0, 11, dtype=np.float32)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_gamma(4.0, 11, dtype=np.float32)
@@ -510,11 +568,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_floats(self):
-        rg = Generator(self.bit_generator())
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -523,11 +582,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_zig_floats(self):
-        rg = Generator(self.bit_generator())
+        bit_generator, _, _, _, _, _ = self._create_gen()
+        rg = Generator(bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(self.bit_generator())
+        rg2 = Generator(bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -536,7 +596,7 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_output_fill(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
@@ -558,7 +618,7 @@ class RNG:
         assert_equal(direct, existing)
 
     def test_output_filling_uniform(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
@@ -576,7 +636,7 @@ class RNG:
         assert_equal(direct, existing)
 
     def test_output_filling_exponential(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
@@ -594,7 +654,7 @@ class RNG:
         assert_equal(direct, existing)
 
     def test_output_filling_gamma(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         state = rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.zeros(size)
@@ -612,7 +672,7 @@ class RNG:
         assert_equal(direct, existing)
 
     def test_output_filling_gamma_broadcast(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         state = rg.bit_generator.state
         size = (31, 7, 97)
         mu = np.arange(97.0) + 1.0
@@ -631,7 +691,7 @@ class RNG:
         assert_equal(direct, existing)
 
     def test_output_fill_error(self):
-        rg = self.rg
+        _, _, _, rg, _, _ = self._create_gen()
         size = (31, 7, 97)
         existing = np.empty(size)
         with pytest.raises(TypeError):
@@ -654,6 +714,7 @@ class RNG:
             rg.standard_gamma(1.0, out=existing[::3])
 
     def test_integers_broadcast(self, dtype):
+        _, _, _, rg, initial_state, _ = self._create_gen()
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -661,45 +722,47 @@ class RNG:
             info = np.iinfo(dtype)
             upper = int(info.max) + 1
             lower = info.min
-        self._reset_state()
-        a = self.rg.integers(lower, [upper] * 10, dtype=dtype)
-        self._reset_state()
-        b = self.rg.integers([lower] * 10, upper, dtype=dtype)
+        self._reset_state(rg, initial_state)
+        a = rg.integers(lower, [upper] * 10, dtype=dtype)
+        self._reset_state(rg, initial_state)
+        b = rg.integers([lower] * 10, upper, dtype=dtype)
         assert_equal(a, b)
-        self._reset_state()
-        c = self.rg.integers(lower, upper, size=10, dtype=dtype)
+        self._reset_state(rg, initial_state)
+        c = rg.integers(lower, upper, size=10, dtype=dtype)
         assert_equal(a, c)
-        self._reset_state()
-        d = self.rg.integers(np.array(
+        self._reset_state(rg, initial_state)
+        d = rg.integers(np.array(
             [lower] * 10), np.array([upper], dtype=object), size=10,
             dtype=dtype)
         assert_equal(a, d)
-        self._reset_state()
-        e = self.rg.integers(
+        self._reset_state(rg, initial_state)
+        e = rg.integers(
             np.array([lower] * 10), np.array([upper] * 10), size=10,
             dtype=dtype)
         assert_equal(a, e)
 
-        self._reset_state()
-        a = self.rg.integers(0, upper, size=10, dtype=dtype)
-        self._reset_state()
-        b = self.rg.integers([upper] * 10, dtype=dtype)
+        self._reset_state(rg, initial_state)
+        a = rg.integers(0, upper, size=10, dtype=dtype)
+        self._reset_state(rg, initial_state)
+        b = rg.integers([upper] * 10, dtype=dtype)
         assert_equal(a, b)
 
     def test_integers_numpy(self, dtype):
+        _, _, _, rg, _, _ = self._create_gen()
         high = np.array([1])
         low = np.array([0])
 
-        out = self.rg.integers(low, high, dtype=dtype)
+        out = rg.integers(low, high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = self.rg.integers(low[0], high, dtype=dtype)
+        out = rg.integers(low[0], high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = self.rg.integers(low, high[0], dtype=dtype)
+        out = rg.integers(low, high[0], dtype=dtype)
         assert out.shape == (1,)
 
     def test_integers_broadcast_errors(self, dtype):
+        _, _, _, rg, _, _ = self._create_gen()
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -708,102 +771,108 @@ class RNG:
             upper = int(info.max) + 1
             lower = info.min
         with pytest.raises(ValueError):
-            self.rg.integers(lower, [upper + 1] * 10, dtype=dtype)
+            rg.integers(lower, [upper + 1] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            self.rg.integers(lower - 1, [upper] * 10, dtype=dtype)
+            rg.integers(lower - 1, [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            self.rg.integers([lower - 1], [upper] * 10, dtype=dtype)
+            rg.integers([lower - 1], [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            self.rg.integers([0], [0], dtype=dtype)
+            rg.integers([0], [0], dtype=dtype)
 
 
 class TestMT19937(RNG):
     @classmethod
-    def setup_class(cls):
-        cls.bit_generator = MT19937
-        cls.advance = None
-        cls.seed = [2 ** 21 + 2 ** 16 + 2 ** 5 + 1]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 32
-        cls._extra_setup()
-        cls.seed_error = ValueError
+    def _create_gen(cls):
+        bit_generator = MT19937
+        advance = None
+        seed = [2 ** 21 + 2 ** 16 + 2 ** 5 + 1]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 32
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+
+    @classmethod
+    def _extra_create_gen(cls):
+        vec_1d = np.arange(2.0, 102.0)
+        vec_2d = np.arange(2.0, 102.0)[None, :]
+        mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
+        seed_error = ValueError
+        return vec_1d, vec_2d, mat, seed_error
 
     def test_numpy_state(self):
+        _, _, _, rg, _, _ = self._create_gen()
         nprg = np.random.RandomState()
         nprg.standard_normal(99)
         state = nprg.get_state()
-        self.rg.bit_generator.state = state
-        state2 = self.rg.bit_generator.state
+        rg.bit_generator.state = state
+        state2 = rg.bit_generator.state
         assert_((state[1] == state2['state']['key']).all())
         assert_(state[2] == state2['state']['pos'])
 
 
 class TestPhilox(RNG):
     @classmethod
-    def setup_class(cls):
-        cls.bit_generator = Philox
-        cls.advance = 2**63 + 2**31 + 2**15 + 1
-        cls.seed = [12345]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 64
-        cls._extra_setup()
+    def _create_gen(cls):
+        bit_generator = Philox
+        advance = 2**63 + 2**31 + 2**15 + 1
+        seed = [12345]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 64
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
 
 class TestSFC64(RNG):
     @classmethod
-    def setup_class(cls):
-        cls.bit_generator = SFC64
-        cls.advance = None
-        cls.seed = [12345]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 192
-        cls._extra_setup()
-
+    def _create_gen(cls):
+        bit_generator = SFC64
+        advance = None
+        seed = [12345]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 192
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
 class TestPCG64(RNG):
     @classmethod
-    def setup_class(cls):
-        cls.bit_generator = PCG64
-        cls.advance = 2**63 + 2**31 + 2**15 + 1
-        cls.seed = [12345]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 64
-        cls._extra_setup()
-
+    def _create_gen(cls):
+        bit_generator = PCG64
+        advance = 2**63 + 2**31 + 2**15 + 1
+        seed = [12345]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 64
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
 class TestPCG64DXSM(RNG):
     @classmethod
-    def setup_class(cls):
-        cls.bit_generator = PCG64DXSM
-        cls.advance = 2**63 + 2**31 + 2**15 + 1
-        cls.seed = [12345]
-        cls.rg = Generator(cls.bit_generator(*cls.seed))
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 64
-        cls._extra_setup()
-
+    def _create_gen(cls):
+        bit_generator = PCG64DXSM
+        advance = 2**63 + 2**31 + 2**15 + 1
+        seed = [12345]
+        rg = Generator(bit_generator(*seed))
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 64
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
 class TestDefaultRNG(RNG):
     @classmethod
-    def setup_class(cls):
+    def _create_gen(cls):
         # This will duplicate some tests that directly instantiate a fresh
         # Generator(), but that's okay.
-        cls.bit_generator = PCG64
-        cls.advance = 2**63 + 2**31 + 2**15 + 1
-        cls.seed = [12345]
-        cls.rg = np.random.default_rng(*cls.seed)
-        cls.initial_state = cls.rg.bit_generator.state
-        cls.seed_vector_bits = 64
-        cls._extra_setup()
+        bit_generator = PCG64
+        advance = 2**63 + 2**31 + 2**15 + 1
+        seed = [12345]
+        rg = np.random.default_rng(*seed)
+        initial_state = rg.bit_generator.state
+        seed_vector_bits = 64
+        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
     def test_default_is_pcg64(self):
         # In order to change the default BitGenerator, we'll go through
         # a deprecation cycle to move to a different function.
-        assert_(isinstance(self.rg.bit_generator, PCG64))
+        _, _, _, rg, _, _ = self._create_gen()
+        assert_(isinstance(rg.bit_generator, PCG64))
 
     def test_seed(self):
         np.random.default_rng()

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -1,4 +1,5 @@
 import pickle
+from dataclasses import dataclass
 from functools import partial
 
 import pytest
@@ -92,6 +93,17 @@ def warmup(rg, n=None):
     rg.random(n, dtype=np.float32)
 
 
+@dataclass
+class RNGData:
+    bit_generator: type[np.random.BitGenerator]
+    advance: int
+    seed: list[int]
+    rg: Generator
+    initial_state: dict
+    seed_vector_bits: int
+    seed_error: Exception
+
+
 class RNG:
     @classmethod
     def _create_gen(cls):
@@ -102,450 +114,448 @@ class RNG:
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
-
-    @classmethod
-    def _extra_create_gen(cls):
-        vec_1d = np.arange(2.0, 102.0)
-        vec_2d = np.arange(2.0, 102.0)[None, :]
-        mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
         seed_error = TypeError
-        return vec_1d, vec_2d, mat, seed_error
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
-    def _reset_state(self, rg, init):
-        rg.bit_generator.state = init
+    def _reset_state(self, data):
+        data.rg.bit_generator.state = data.initial_state
 
     def test_init(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator())
-        state = rg.bit_generator.state
-        rg.standard_normal(1)
-        rg.standard_normal(1)
-        rg.bit_generator.state = state
-        new_state = rg.bit_generator.state
+        data = self._create_gen()
+        data.rg = Generator(data.bit_generator())
+        state = data.rg.bit_generator.state
+        data.rg.standard_normal(1)
+        data.rg.standard_normal(1)
+        data.rg.bit_generator.state = state
+        new_state = data.rg.bit_generator.state
         assert_(comp_state(state, new_state))
 
     def test_advance(self):
-        _, advance, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
-        if hasattr(rg.bit_generator, 'advance'):
-            rg.bit_generator.advance(advance)
-            assert_(not comp_state(state, rg.bit_generator.state))
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
+        if hasattr(data.rg.bit_generator, 'advance'):
+            data.rg.bit_generator.advance(data.advance)
+            assert_(not comp_state(state, data.rg.bit_generator.state))
         else:
-            bitgen_name = rg.bit_generator.__class__.__name__
+            bitgen_name = data.rg.bit_generator.__class__.__name__
             pytest.skip(f'Advance is not supported by {bitgen_name}')
 
     def test_jump(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
-        if hasattr(rg.bit_generator, 'jumped'):
-            bit_gen2 = rg.bit_generator.jumped()
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
+        if hasattr(data.rg.bit_generator, 'jumped'):
+            bit_gen2 = data.rg.bit_generator.jumped()
             jumped_state = bit_gen2.state
             assert_(not comp_state(state, jumped_state))
-            rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
-            rg.bit_generator.state = state
-            bit_gen3 = rg.bit_generator.jumped()
+            data.rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
+            data.rg.bit_generator.state = state
+            bit_gen3 = data.rg.bit_generator.jumped()
             rejumped_state = bit_gen3.state
             assert_(comp_state(jumped_state, rejumped_state))
         else:
-            bitgen_name = rg.bit_generator.__class__.__name__
+            bitgen_name = data.rg.bit_generator.__class__.__name__
             if bitgen_name not in ('SFC64',):
                 raise AttributeError(f'no "jumped" in {bitgen_name}')
             pytest.skip(f'Jump is not supported by {bitgen_name}')
 
     def test_uniform(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        r = rg.uniform(-1.0, 0.0, size=10)
+        data = self._create_gen()
+        r = data.rg.uniform(-1.0, 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_uniform_array(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        r = rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
+        data = self._create_gen()
+        r = data.rg.uniform(np.array([-1.0] * 10), 0.0, size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = rg.uniform(np.array([-1.0] * 10),
+        r = data.rg.uniform(np.array([-1.0] * 10),
                             np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
-        r = rg.uniform(-1.0, np.array([0.0] * 10), size=10)
+        r = data.rg.uniform(-1.0, np.array([0.0] * 10), size=10)
         assert_(len(r) == 10)
         assert_((r > -1).all())
         assert_((r <= 0).all())
 
     def test_random(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.random(10)) == 10)
-        params_0(rg.random)
+        data = self._create_gen()
+        assert_(len(data.rg.random(10)) == 10)
+        params_0(data.rg.random)
 
     def test_standard_normal_zig(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_normal(10)) == 10)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_normal(10)) == 10)
 
     def test_standard_normal(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_normal(10)) == 10)
-        params_0(rg.standard_normal)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_normal(10)) == 10)
+        params_0(data.rg.standard_normal)
 
     def test_standard_gamma(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_gamma(10, 10)) == 10)
-        assert_(len(rg.standard_gamma(np.array([10] * 10), 10)) == 10)
-        params_1(rg.standard_gamma)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_gamma(10, 10)) == 10)
+        assert_(len(data.rg.standard_gamma(np.array([10] * 10), 10)) == 10)
+        params_1(data.rg.standard_gamma)
 
     def test_standard_exponential(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_exponential(10)) == 10)
-        params_0(rg.standard_exponential)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_exponential(10)) == 10)
+        params_0(data.rg.standard_exponential)
 
     def test_standard_exponential_float(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        randoms = rg.standard_exponential(10, dtype='float32')
+        data = self._create_gen()
+        randoms = data.rg.standard_exponential(10, dtype='float32')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(rg.standard_exponential, dtype='float32'))
+        params_0(partial(data.rg.standard_exponential, dtype='float32'))
 
     def test_standard_exponential_float_log(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        randoms = rg.standard_exponential(10, dtype='float32',
+        data = self._create_gen()
+        randoms = data.rg.standard_exponential(10, dtype='float32',
                                                method='inv')
         assert_(len(randoms) == 10)
         assert randoms.dtype == np.float32
-        params_0(partial(rg.standard_exponential, dtype='float32',
+        params_0(partial(data.rg.standard_exponential, dtype='float32',
                          method='inv'))
 
     def test_standard_cauchy(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_cauchy(10)) == 10)
-        params_0(rg.standard_cauchy)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_cauchy(10)) == 10)
+        params_0(data.rg.standard_cauchy)
 
     def test_standard_t(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(len(rg.standard_t(10, 10)) == 10)
-        params_1(rg.standard_t)
+        data = self._create_gen()
+        assert_(len(data.rg.standard_t(10, 10)) == 10)
+        params_1(data.rg.standard_t)
 
     def test_binomial(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(rg.binomial(10, .5) >= 0)
-        assert_(rg.binomial(1000, .5) >= 0)
+        data = self._create_gen()
+        assert_(data.rg.binomial(10, .5) >= 0)
+        assert_(data.rg.binomial(1000, .5) >= 0)
 
     def test_reset_state(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
-        int_1 = rg.integers(2**31)
-        rg.bit_generator.state = state
-        int_2 = rg.integers(2**31)
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
+        int_1 = data.rg.integers(2**31)
+        data.rg.bit_generator.state = state
+        int_2 = data.rg.integers(2**31)
         assert_(int_1 == int_2)
 
     def test_entropy_init(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator())
-        rg2 = Generator(bit_generator())
+        data = self._create_gen()
+        rg = Generator(data.bit_generator())
+        rg2 = Generator(data.bit_generator())
         assert_(not comp_state(rg.bit_generator.state,
                                rg2.bit_generator.state))
 
     def test_seed(self):
-        bit_generator, _, seed, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator(*seed))
-        rg2 = Generator(bit_generator(*seed))
+        data = self._create_gen()
+        rg = Generator(data.bit_generator(*data.seed))
+        rg2 = Generator(data.bit_generator(*data.seed))
         rg.random()
         rg2.random()
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_reset_state_gauss(self):
-        bit_generator, _, seed, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator(*seed))
+        data = self._create_gen()
+        rg = Generator(data.bit_generator(*data.seed))
         rg.standard_normal()
         state = rg.bit_generator.state
         n1 = rg.standard_normal(size=10)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.standard_normal(size=10)
         assert_array_equal(n1, n2)
 
     def test_reset_state_uint32(self):
-        bit_generator, _, seed, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator(*seed))
+        data = self._create_gen()
+        rg = Generator(data.bit_generator(*data.seed))
         rg.integers(0, 2 ** 24, 120, dtype=np.uint32)
         state = rg.bit_generator.state
         n1 = rg.integers(0, 2 ** 24, 10, dtype=np.uint32)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.integers(0, 2 ** 24, 10, dtype=np.uint32)
         assert_array_equal(n1, n2)
 
     def test_reset_state_float(self):
-        bit_generator, _, seed, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator(*seed))
+        data = self._create_gen()
+        rg = Generator(data.bit_generator(*data.seed))
         rg.random(dtype='float32')
         state = rg.bit_generator.state
         n1 = rg.random(size=10, dtype='float32')
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         rg2.bit_generator.state = state
         n2 = rg2.random(size=10, dtype='float32')
         assert_((n1 == n2).all())
 
     def test_shuffle(self):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         original = np.arange(200, 0, -1)
-        permuted = rg.permutation(original)
+        permuted = data.rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_permutation(self):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         original = np.arange(200, 0, -1)
-        permuted = rg.permutation(original)
+        permuted = data.rg.permutation(original)
         assert_((original != permuted).any())
 
     def test_beta(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.beta(2.0, 2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.beta(2.0, 2.0, 10)
         assert_(len(vals) == 10)
-        vals = rg.beta(np.array([2.0] * 10), 2.0)
+        vals = data.rg.beta(np.array([2.0] * 10), 2.0)
         assert_(len(vals) == 10)
-        vals = rg.beta(2.0, np.array([2.0] * 10))
+        vals = data.rg.beta(2.0, np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
+        vals = data.rg.beta(np.array([2.0] * 10), np.array([2.0] * 10))
         assert_(len(vals) == 10)
-        vals = rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
+        vals = data.rg.beta(np.array([2.0] * 10), np.array([[2.0]] * 10))
         assert_(vals.shape == (10, 10))
 
     def test_bytes(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.bytes(10)
+        data = self._create_gen()
+        vals = data.rg.bytes(10)
         assert_(len(vals) == 10)
 
     def test_chisquare(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.chisquare(2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.chisquare(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(rg.chisquare)
+        params_1(data.rg.chisquare)
 
     def test_exponential(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.exponential(2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.exponential(2.0, 10)
         assert_(len(vals) == 10)
-        params_1(rg.exponential)
+        params_1(data.rg.exponential)
 
     def test_f(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.f(3, 1000, 10)
+        data = self._create_gen()
+        vals = data.rg.f(3, 1000, 10)
         assert_(len(vals) == 10)
 
     def test_gamma(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.gamma(3, 2, 10)
+        data = self._create_gen()
+        vals = data.rg.gamma(3, 2, 10)
         assert_(len(vals) == 10)
 
     def test_geometric(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.geometric(0.5, 10)
+        data = self._create_gen()
+        vals = data.rg.geometric(0.5, 10)
         assert_(len(vals) == 10)
-        params_1(rg.exponential, bounded=True)
+        params_1(data.rg.exponential, bounded=True)
 
     def test_gumbel(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.gumbel(2.0, 2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.gumbel(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_laplace(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.laplace(2.0, 2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.laplace(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logitic(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.logistic(2.0, 2.0, 10)
+        data = self._create_gen()
+        vals = data.rg.logistic(2.0, 2.0, 10)
         assert_(len(vals) == 10)
 
     def test_logseries(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.logseries(0.5, 10)
+        data = self._create_gen()
+        vals = data.rg.logseries(0.5, 10)
         assert_(len(vals) == 10)
 
     def test_negative_binomial(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.negative_binomial(10, 0.2, 10)
+        data = self._create_gen()
+        vals = data.rg.negative_binomial(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_chisquare(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.noncentral_chisquare(10, 2, 10)
+        data = self._create_gen()
+        vals = data.rg.noncentral_chisquare(10, 2, 10)
         assert_(len(vals) == 10)
 
     def test_noncentral_f(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.noncentral_f(3, 1000, 2, 10)
+        data = self._create_gen()
+        vals = data.rg.noncentral_f(3, 1000, 2, 10)
         assert_(len(vals) == 10)
-        vals = rg.noncentral_f(np.array([3] * 10), 1000, 2)
+        vals = data.rg.noncentral_f(np.array([3] * 10), 1000, 2)
         assert_(len(vals) == 10)
-        vals = rg.noncentral_f(3, np.array([1000] * 10), 2)
+        vals = data.rg.noncentral_f(3, np.array([1000] * 10), 2)
         assert_(len(vals) == 10)
-        vals = rg.noncentral_f(3, 1000, np.array([2] * 10))
+        vals = data.rg.noncentral_f(3, 1000, np.array([2] * 10))
         assert_(len(vals) == 10)
 
     def test_normal(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.normal(10, 0.2, 10)
+        data = self._create_gen()
+        vals = data.rg.normal(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_pareto(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.pareto(3.0, 10)
+        data = self._create_gen()
+        vals = data.rg.pareto(3.0, 10)
         assert_(len(vals) == 10)
 
     def test_poisson(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.poisson(10, 10)
+        data = self._create_gen()
+        vals = data.rg.poisson(10, 10)
         assert_(len(vals) == 10)
-        vals = rg.poisson(np.array([10] * 10))
+        vals = data.rg.poisson(np.array([10] * 10))
         assert_(len(vals) == 10)
-        params_1(rg.poisson)
+        params_1(data.rg.poisson)
 
     def test_power(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.power(0.2, 10)
+        data = self._create_gen()
+        vals = data.rg.power(0.2, 10)
         assert_(len(vals) == 10)
 
     def test_integers(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.integers(10, 20, 10)
+        data = self._create_gen()
+        vals = data.rg.integers(10, 20, 10)
         assert_(len(vals) == 10)
 
     def test_rayleigh(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.rayleigh(0.2, 10)
+        data = self._create_gen()
+        vals = data.rg.rayleigh(0.2, 10)
         assert_(len(vals) == 10)
-        params_1(rg.rayleigh, bounded=True)
+        params_1(data.rg.rayleigh, bounded=True)
 
     def test_vonmises(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.vonmises(10, 0.2, 10)
+        data = self._create_gen()
+        vals = data.rg.vonmises(10, 0.2, 10)
         assert_(len(vals) == 10)
 
     def test_wald(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.wald(1.0, 1.0, 10)
+        data = self._create_gen()
+        vals = data.rg.wald(1.0, 1.0, 10)
         assert_(len(vals) == 10)
 
     def test_weibull(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.weibull(1.0, 10)
+        data = self._create_gen()
+        vals = data.rg.weibull(1.0, 10)
         assert_(len(vals) == 10)
 
     def test_zipf(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vec_1d, vec_2d, mat, _ = self._extra_create_gen()
-        vals = rg.zipf(10, 10)
+        data = self._create_gen()
+        vec_1d = np.arange(2.0, 102.0)
+        vec_2d = np.arange(2.0, 102.0)[None, :]
+        mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
+        vals = data.rg.zipf(10, 10)
         assert_(len(vals) == 10)
-        vals = rg.zipf(vec_1d)
+        vals = data.rg.zipf(vec_1d)
         assert_(len(vals) == 100)
-        vals = rg.zipf(vec_2d)
+        vals = data.rg.zipf(vec_2d)
         assert_(vals.shape == (1, 100))
-        vals = rg.zipf(mat)
+        vals = data.rg.zipf(mat)
         assert_(vals.shape == (100, 100))
 
     def test_hypergeometric(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.hypergeometric(25, 25, 20)
+        data = self._create_gen()
+        vals = data.rg.hypergeometric(25, 25, 20)
         assert_(np.isscalar(vals))
-        vals = rg.hypergeometric(np.array([25] * 10), 25, 20)
+        vals = data.rg.hypergeometric(np.array([25] * 10), 25, 20)
         assert_(vals.shape == (10,))
 
     def test_triangular(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.triangular(-5, 0, 5)
+        data = self._create_gen()
+        vals = data.rg.triangular(-5, 0, 5)
         assert_(np.isscalar(vals))
-        vals = rg.triangular(-5, np.array([0] * 10), 5)
+        vals = data.rg.triangular(-5, np.array([0] * 10), 5)
         assert_(vals.shape == (10,))
 
     def test_multivariate_normal(self):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         mean = [0, 0]
         cov = [[1, 0], [0, 100]]  # diagonal covariance
-        x = rg.multivariate_normal(mean, cov, 5000)
+        x = data.rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_zig = rg.multivariate_normal(mean, cov, 5000)
+        x_zig = data.rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
-        x_inv = rg.multivariate_normal(mean, cov, 5000)
+        x_inv = data.rg.multivariate_normal(mean, cov, 5000)
         assert_(x.shape == (5000, 2))
         assert_((x_zig != x_inv).any())
 
     def test_multinomial(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3])
+        data = self._create_gen()
+        vals = data.rg.multinomial(100, [1.0 / 3, 2.0 / 3])
         assert_(vals.shape == (2,))
-        vals = rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
+        vals = data.rg.multinomial(100, [1.0 / 3, 2.0 / 3], size=10)
         assert_(vals.shape == (10, 2))
 
     def test_dirichlet(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        s = rg.dirichlet((10, 5, 3), 20)
+        data = self._create_gen()
+        s = data.rg.dirichlet((10, 5, 3), 20)
         assert_(s.shape == (20, 3))
 
     def test_pickle(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        pick = pickle.dumps(rg)
+        data = self._create_gen()
+        pick = pickle.dumps(data.rg)
         unpick = pickle.loads(pick)
-        assert_(type(rg) == type(unpick))
-        assert_(comp_state(rg.bit_generator.state,
+        assert_(type(data.rg) == type(unpick))
+        assert_(comp_state(data.rg.bit_generator.state,
                            unpick.bit_generator.state))
 
-        pick = pickle.dumps(rg)
+        pick = pickle.dumps(data.rg)
         unpick = pickle.loads(pick)
-        assert_(type(rg) == type(unpick))
-        assert_(comp_state(rg.bit_generator.state,
+        assert_(type(data.rg) == type(unpick))
+        assert_(comp_state(data.rg.bit_generator.state,
                            unpick.bit_generator.state))
 
     def test_seed_array(self):
-        bit_generator, _, _, _, _, seed_vector_bits = self._create_gen()
-        if seed_vector_bits is None:
-            bitgen_name = bit_generator.__name__
+        data = self._create_gen()
+        if data.seed_vector_bits is None:
+            bitgen_name = data.bit_generator.__name__
             pytest.skip(f'Vector seeding is not supported by {bitgen_name}')
 
-        if seed_vector_bits == 32:
+        if data.seed_vector_bits == 32:
             dtype = np.uint32
         else:
             dtype = np.uint64
         seed = np.array([1], dtype=dtype)
-        bg = bit_generator(seed)
+        bg = data.bit_generator(seed)
         state1 = bg.state
-        bg = bit_generator(1)
+        bg = data.bit_generator(1)
         state2 = bg.state
         assert_(comp_state(state1, state2))
 
         seed = np.arange(4, dtype=dtype)
-        bg = bit_generator(seed)
+        bg = data.bit_generator(seed)
         state1 = bg.state
-        bg = bit_generator(seed[0])
+        bg = data.bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
         seed = np.arange(1500, dtype=dtype)
-        bg = bit_generator(seed)
+        bg = data.bit_generator(seed)
         state1 = bg.state
-        bg = bit_generator(seed[0])
+        bg = data.bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
         seed = 2 ** np.mod(np.arange(1500, dtype=dtype),
-                           seed_vector_bits - 1) + 1
-        bg = bit_generator(seed)
+                           data.seed_vector_bits - 1) + 1
+        bg = data.bit_generator(seed)
         state1 = bg.state
-        bg = bit_generator(seed[0])
+        bg = data.bit_generator(seed[0])
         state2 = bg.state
         assert_(not comp_state(state1, state2))
 
     def test_uniform_float(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator(12345))
+        data = self._create_gen()
+        rg = Generator(data.bit_generator(12345))
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.random(11, dtype=np.float32)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.random(11, dtype=np.float32)
@@ -554,12 +564,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_gamma_floats(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator())
+        data = self._create_gen()
+        rg = Generator(data.bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_gamma(4.0, 11, dtype=np.float32)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_gamma(4.0, 11, dtype=np.float32)
@@ -568,12 +578,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_floats(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator())
+        data = self._create_gen()
+        rg = Generator(data.bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -582,12 +592,12 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_normal_zig_floats(self):
-        bit_generator, _, _, _, _, _ = self._create_gen()
-        rg = Generator(bit_generator())
+        data = self._create_gen()
+        rg = Generator(data.bit_generator())
         warmup(rg)
         state = rg.bit_generator.state
         r1 = rg.standard_normal(11, dtype=np.float32)
-        rg2 = Generator(bit_generator())
+        rg2 = Generator(data.bit_generator())
         warmup(rg2)
         rg2.bit_generator.state = state
         r2 = rg2.standard_normal(11, dtype=np.float32)
@@ -596,125 +606,125 @@ class RNG:
         assert_(comp_state(rg.bit_generator.state, rg2.bit_generator.state))
 
     def test_output_fill(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        rg.bit_generator.state = state
-        rg.standard_normal(out=existing)
-        rg.bit_generator.state = state
-        direct = rg.standard_normal(size=size)
+        data.rg.bit_generator.state = state
+        data.rg.standard_normal(out=existing)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_normal(size=size)
         assert_equal(direct, existing)
 
         sized = np.empty(size)
-        rg.bit_generator.state = state
-        rg.standard_normal(out=sized, size=sized.shape)
+        data.rg.bit_generator.state = state
+        data.rg.standard_normal(out=sized, size=sized.shape)
 
         existing = np.empty(size, dtype=np.float32)
-        rg.bit_generator.state = state
-        rg.standard_normal(out=existing, dtype=np.float32)
-        rg.bit_generator.state = state
-        direct = rg.standard_normal(size=size, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        data.rg.standard_normal(out=existing, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_normal(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_uniform(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        rg.bit_generator.state = state
-        rg.random(out=existing)
-        rg.bit_generator.state = state
-        direct = rg.random(size=size)
+        data.rg.bit_generator.state = state
+        data.rg.random(out=existing)
+        data.rg.bit_generator.state = state
+        direct = data.rg.random(size=size)
         assert_equal(direct, existing)
 
         existing = np.empty(size, dtype=np.float32)
-        rg.bit_generator.state = state
-        rg.random(out=existing, dtype=np.float32)
-        rg.bit_generator.state = state
-        direct = rg.random(size=size, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        data.rg.random(out=existing, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        direct = data.rg.random(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_exponential(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.empty(size)
-        rg.bit_generator.state = state
-        rg.standard_exponential(out=existing)
-        rg.bit_generator.state = state
-        direct = rg.standard_exponential(size=size)
+        data.rg.bit_generator.state = state
+        data.rg.standard_exponential(out=existing)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_exponential(size=size)
         assert_equal(direct, existing)
 
         existing = np.empty(size, dtype=np.float32)
-        rg.bit_generator.state = state
-        rg.standard_exponential(out=existing, dtype=np.float32)
-        rg.bit_generator.state = state
-        direct = rg.standard_exponential(size=size, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        data.rg.standard_exponential(out=existing, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_exponential(size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_gamma(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
         size = (31, 7, 97)
         existing = np.zeros(size)
-        rg.bit_generator.state = state
-        rg.standard_gamma(1.0, out=existing)
-        rg.bit_generator.state = state
-        direct = rg.standard_gamma(1.0, size=size)
+        data.rg.bit_generator.state = state
+        data.rg.standard_gamma(1.0, out=existing)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_gamma(1.0, size=size)
         assert_equal(direct, existing)
 
         existing = np.zeros(size, dtype=np.float32)
-        rg.bit_generator.state = state
-        rg.standard_gamma(1.0, out=existing, dtype=np.float32)
-        rg.bit_generator.state = state
-        direct = rg.standard_gamma(1.0, size=size, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        data.rg.standard_gamma(1.0, out=existing, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_gamma(1.0, size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_filling_gamma_broadcast(self):
-        _, _, _, rg, _, _ = self._create_gen()
-        state = rg.bit_generator.state
+        data = self._create_gen()
+        state = data.rg.bit_generator.state
         size = (31, 7, 97)
         mu = np.arange(97.0) + 1.0
         existing = np.zeros(size)
-        rg.bit_generator.state = state
-        rg.standard_gamma(mu, out=existing)
-        rg.bit_generator.state = state
-        direct = rg.standard_gamma(mu, size=size)
+        data.rg.bit_generator.state = state
+        data.rg.standard_gamma(mu, out=existing)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_gamma(mu, size=size)
         assert_equal(direct, existing)
 
         existing = np.zeros(size, dtype=np.float32)
-        rg.bit_generator.state = state
-        rg.standard_gamma(mu, out=existing, dtype=np.float32)
-        rg.bit_generator.state = state
-        direct = rg.standard_gamma(mu, size=size, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        data.rg.standard_gamma(mu, out=existing, dtype=np.float32)
+        data.rg.bit_generator.state = state
+        direct = data.rg.standard_gamma(mu, size=size, dtype=np.float32)
         assert_equal(direct, existing)
 
     def test_output_fill_error(self):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         size = (31, 7, 97)
         existing = np.empty(size)
         with pytest.raises(TypeError):
-            rg.standard_normal(out=existing, dtype=np.float32)
+            data.rg.standard_normal(out=existing, dtype=np.float32)
         with pytest.raises(ValueError):
-            rg.standard_normal(out=existing[::3])
+            data.rg.standard_normal(out=existing[::3])
         existing = np.empty(size, dtype=np.float32)
         with pytest.raises(TypeError):
-            rg.standard_normal(out=existing, dtype=np.float64)
+            data.rg.standard_normal(out=existing, dtype=np.float64)
 
         existing = np.zeros(size, dtype=np.float32)
         with pytest.raises(TypeError):
-            rg.standard_gamma(1.0, out=existing, dtype=np.float64)
+            data.rg.standard_gamma(1.0, out=existing, dtype=np.float64)
         with pytest.raises(ValueError):
-            rg.standard_gamma(1.0, out=existing[::3], dtype=np.float32)
+            data.rg.standard_gamma(1.0, out=existing[::3], dtype=np.float32)
         existing = np.zeros(size, dtype=np.float64)
         with pytest.raises(TypeError):
-            rg.standard_gamma(1.0, out=existing, dtype=np.float32)
+            data.rg.standard_gamma(1.0, out=existing, dtype=np.float32)
         with pytest.raises(ValueError):
-            rg.standard_gamma(1.0, out=existing[::3])
+            data.rg.standard_gamma(1.0, out=existing[::3])
 
     def test_integers_broadcast(self, dtype):
-        _, _, _, rg, initial_state, _ = self._create_gen()
+        data = self._create_gen()
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -722,47 +732,47 @@ class RNG:
             info = np.iinfo(dtype)
             upper = int(info.max) + 1
             lower = info.min
-        self._reset_state(rg, initial_state)
-        a = rg.integers(lower, [upper] * 10, dtype=dtype)
-        self._reset_state(rg, initial_state)
-        b = rg.integers([lower] * 10, upper, dtype=dtype)
+        self._reset_state(data)
+        a = data.rg.integers(lower, [upper] * 10, dtype=dtype)
+        self._reset_state(data)
+        b = data.rg.integers([lower] * 10, upper, dtype=dtype)
         assert_equal(a, b)
-        self._reset_state(rg, initial_state)
-        c = rg.integers(lower, upper, size=10, dtype=dtype)
+        self._reset_state(data)
+        c = data.rg.integers(lower, upper, size=10, dtype=dtype)
         assert_equal(a, c)
-        self._reset_state(rg, initial_state)
-        d = rg.integers(np.array(
+        self._reset_state(data)
+        d = data.rg.integers(np.array(
             [lower] * 10), np.array([upper], dtype=object), size=10,
             dtype=dtype)
         assert_equal(a, d)
-        self._reset_state(rg, initial_state)
-        e = rg.integers(
+        self._reset_state(data)
+        e = data.rg.integers(
             np.array([lower] * 10), np.array([upper] * 10), size=10,
             dtype=dtype)
         assert_equal(a, e)
 
-        self._reset_state(rg, initial_state)
-        a = rg.integers(0, upper, size=10, dtype=dtype)
-        self._reset_state(rg, initial_state)
-        b = rg.integers([upper] * 10, dtype=dtype)
+        self._reset_state(data)
+        a = data.rg.integers(0, upper, size=10, dtype=dtype)
+        self._reset_state(data)
+        b = data.rg.integers([upper] * 10, dtype=dtype)
         assert_equal(a, b)
 
     def test_integers_numpy(self, dtype):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         high = np.array([1])
         low = np.array([0])
 
-        out = rg.integers(low, high, dtype=dtype)
+        out = data.rg.integers(low, high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = rg.integers(low[0], high, dtype=dtype)
+        out = data.rg.integers(low[0], high, dtype=dtype)
         assert out.shape == (1,)
 
-        out = rg.integers(low, high[0], dtype=dtype)
+        out = data.rg.integers(low, high[0], dtype=dtype)
         assert out.shape == (1,)
 
     def test_integers_broadcast_errors(self, dtype):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         if dtype == np.bool:
             upper = 2
             lower = 0
@@ -771,13 +781,13 @@ class RNG:
             upper = int(info.max) + 1
             lower = info.min
         with pytest.raises(ValueError):
-            rg.integers(lower, [upper + 1] * 10, dtype=dtype)
+            data.rg.integers(lower, [upper + 1] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            rg.integers(lower - 1, [upper] * 10, dtype=dtype)
+            data.rg.integers(lower - 1, [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            rg.integers([lower - 1], [upper] * 10, dtype=dtype)
+            data.rg.integers([lower - 1], [upper] * 10, dtype=dtype)
         with pytest.raises(ValueError):
-            rg.integers([0], [0], dtype=dtype)
+            data.rg.integers([0], [0], dtype=dtype)
 
 
 class TestMT19937(RNG):
@@ -789,23 +799,19 @@ class TestMT19937(RNG):
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 32
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
-
-    @classmethod
-    def _extra_create_gen(cls):
-        vec_1d = np.arange(2.0, 102.0)
-        vec_2d = np.arange(2.0, 102.0)[None, :]
-        mat = np.arange(2.0, 102.0, 0.01).reshape((100, 100))
         seed_error = ValueError
-        return vec_1d, vec_2d, mat, seed_error
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
     def test_numpy_state(self):
-        _, _, _, rg, _, _ = self._create_gen()
+        data = self._create_gen()
         nprg = np.random.RandomState()
         nprg.standard_normal(99)
         state = nprg.get_state()
-        rg.bit_generator.state = state
-        state2 = rg.bit_generator.state
+        data.rg.bit_generator.state = state
+        state2 = data.rg.bit_generator.state
         assert_((state[1] == state2['state']['key']).all())
         assert_(state[2] == state2['state']['pos'])
 
@@ -819,7 +825,11 @@ class TestPhilox(RNG):
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+        seed_error = TypeError
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
 
 class TestSFC64(RNG):
@@ -831,7 +841,11 @@ class TestSFC64(RNG):
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 192
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+        seed_error = TypeError
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
 
 class TestPCG64(RNG):
@@ -843,7 +857,11 @@ class TestPCG64(RNG):
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+        seed_error = TypeError
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
 
 class TestPCG64DXSM(RNG):
@@ -855,7 +873,11 @@ class TestPCG64DXSM(RNG):
         rg = Generator(bit_generator(*seed))
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+        seed_error = TypeError
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
 
 class TestDefaultRNG(RNG):
@@ -869,13 +891,17 @@ class TestDefaultRNG(RNG):
         rg = np.random.default_rng(*seed)
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
-        return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+        seed_error = TypeError
+        return RNGData(
+            bit_generator, advance, seed, rg,
+            initial_state, seed_vector_bits, seed_error
+        )
 
     def test_default_is_pcg64(self):
         # In order to change the default BitGenerator, we'll go through
         # a deprecation cycle to move to a different function.
-        _, _, _, rg, _, _ = self._create_gen()
-        assert_(isinstance(rg.bit_generator, PCG64))
+        data = self._create_gen()
+        assert_(isinstance(data.rg.bit_generator, PCG64))
 
     def test_seed(self):
         np.random.default_rng()

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -833,6 +833,7 @@ class TestSFC64(RNG):
         seed_vector_bits = 192
         return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
+
 class TestPCG64(RNG):
     @classmethod
     def _create_gen(cls):
@@ -844,6 +845,7 @@ class TestPCG64(RNG):
         seed_vector_bits = 64
         return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
 
+
 class TestPCG64DXSM(RNG):
     @classmethod
     def _create_gen(cls):
@@ -854,6 +856,7 @@ class TestPCG64DXSM(RNG):
         initial_state = rg.bit_generator.state
         seed_vector_bits = 64
         return bit_generator, advance, seed, rg, initial_state, seed_vector_bits
+
 
 class TestDefaultRNG(RNG):
     @classmethod


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552. This PR has the goal of making NumPy's testing suite more thread safe. This introduces changes to the setup methods for numpy/random/tests/test_smoke.py. Pytest's classic xunit setup and teardown methods are thread unsafe, typically not running before the tests do, leading to AttributionErrors. Additionally, or test_smoke.py, defining the Generators at class level will lead to issues with parallel threads messing with the same Generator and creating unexpected results. This PR changes these setup method to basic "creation" methods that are called within the tests that need them.