### PR TITLE
BUG, BLD: Correct regex for ppc64 VSX3/VSX4 feature detection

### DIFF
--- a/meson_cpu/ppc64/meson.build
+++ b/meson_cpu/ppc64/meson.build
@@ -23,7 +23,7 @@ if host_machine.endian() == 'little'
   VSX.update(implies: VSX2)
 endif
 VSX3 = mod_features.new(
-  'VSX3', 3, implies: VSX2, args: {'val': '-mcpu=power9', 'match': '.*[mcpu=|vsx].*'},
+  'VSX3', 3, implies: VSX2, args: {'val': '-mcpu=power9', 'match': '.*(?:mcpu=|vsx).*'},
   detect: {'val': 'VSX3', 'match': 'VSX.*'},
   test_code: files(source_root + '/numpy/distutils/checks/cpu_vsx3.c')[0],
   extra_tests: {
@@ -31,7 +31,7 @@ VSX3 = mod_features.new(
   }
 )
 VSX4 = mod_features.new(
-  'VSX4', 4, implies: VSX3, args: {'val': '-mcpu=power10', 'match': '.*[mcpu=|vsx].*'},
+  'VSX4', 4, implies: VSX3, args: {'val': '-mcpu=power10', 'match': '.*(?:mcpu=|vsx).*'},
   detect: {'val': 'VSX4', 'match': 'VSX.*'},
   test_code: files(source_root + '/numpy/distutils/checks/cpu_vsx4.c')[0],
   extra_tests: {


### PR DESCRIPTION
Backport of #29678.

This PR fixes the regex patterns used to detect VSX3 and VSX4 CPU features
in the ppc64 Meson build scripts. Previously, the regex used a character
class:

    '.*[mcpu=|vsx].*'

This incorrectly matched individual characters instead of the intended
substrings "mcpu=" or "vsx".

Changes made:
- Updated the regex to use a non-capturing group with alternation:

      '.*(?:mcpu=|vsx).*'

- No changes were made to feature hierarchy, test code, extra tests, or
  compiler flags.

This ensures that the build system correctly detects VSX3/VSX4 features
on both GCC and Clang compilers on ppc64 platforms.

---

#### Before:
- VSX3/VSX4 detection could fail or mis-detect features because of
  improper regex.

#### After:
- Regex properly matches either "mcpu=" or "vsx" as intended.
- Extra tests and compiler flags remain unchanged.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
