### PR TITLE
CI: replace comment-hider action in mypy_primer workflow

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -49,10 +49,10 @@ jobs:
             return parseInt(fs.readFileSync("pr_number.txt", { encoding: "utf8" }))
 
       - name: Hide old comments
-        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf  # v0.4.0
+        uses: int128/hide-comment-action@a30d551065e4231e6d7a671bb5ce884f9ee6417b  # v1.43.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_number: ${{ steps.get-pr-number.outputs.result }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ steps.get-pr-number.outputs.result }}
 
       - run: cat diff_*.txt | tee fulldiff.txt
 


### PR DESCRIPTION
Backport of #29612.

[kanga333/comment-hider](https://github.com/kanga333/comment-hider) does not seem to be maintained and is still using node 16, which is deprecated. 

[int128/hide-comment-action](https://github.com/int128/hide-comment-action) looks somewhat more active, offerst the same relevant functionality, and uses node 20.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
