### PR TITLE
TST: xfail test_kind::test_quad_precision on AIX/PPC

### DIFF
--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -10,7 +10,7 @@ from numpy.f2py.crackfortran import (
 
 from . import util
 
-IS_PPC = platform.machine().lower().startswith("ppc") or platform.processor().lower().startswith("powerpc")
+IS_PPC_OR_AIX = platform.machine().lower().startswith("ppc") or platform.system() == 'AIX'
 
 class TestKind(util.F2PyTest):
     sources = [util.getpath("tests", "src", "kind", "foo.f90")]
@@ -38,7 +38,7 @@ class TestKind(util.F2PyTest):
                 i
             ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
 
-    @pytest.mark.xfail(IS_PPC,
+    @pytest.mark.xfail(IS_PPC_OR_AIX,
                        reason="Some PowerPC may not support full IEEE 754 precision")
     def test_quad_precision(self):
         """

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -10,6 +10,7 @@ from numpy.f2py.crackfortran import (
 
 from . import util
 
+IS_PPC = platform.machine().lower().startswith("ppc") or platform.processor().lower().startswith("powerpc")
 
 class TestKind(util.F2PyTest):
     sources = [util.getpath("tests", "src", "kind", "foo.f90")]
@@ -37,7 +38,7 @@ class TestKind(util.F2PyTest):
                 i
             ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
 
-    @pytest.mark.xfail(platform.machine().lower().startswith("ppc"),
+    @pytest.mark.xfail(IS_PPC,
                        reason="Some PowerPC may not support full IEEE 754 precision")
     def test_quad_precision(self):
         """


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
On AIX, cmake's `platform.machine()` does not return a meaningful string that can be used to determine the architecture. This PR is to add the check of `platform.processor()` to xfail the test.