### PR TITLE
BUG: Correct ambiguous logic for `s390x` CPU feature detection

### DIFF
--- a/meson_cpu/s390x/meson.build
+++ b/meson_cpu/s390x/meson.build
@@ -7,12 +7,12 @@ VX = mod_features.new(
 )
 VXE = mod_features.new(
   'VXE', 2, implies: VX, args: {'val': '-march=arch12', 'match': '-march=.*'},
-  detect: {'val': 'VXE', 'match': 'VX'},
+  detect: {'val': 'VXE', 'match': '\\bvxe\\b'},
   test_code: files(source_root + '/numpy/distutils/checks/cpu_vxe.c')[0],
 )
 VXE2 = mod_features.new(
   'VXE2', 3, implies: VXE, args: {'val': '-march=arch13', 'match': '-march=.*'},
-  detect: {'val': 'VXE2', 'match': 'VX.*'},
+  detect: {'val': 'VXE2', 'match': '\\bvxe2\\b'},
   test_code: files(source_root + '/numpy/distutils/checks/cpu_vxe2.c')[0],
 )
 S390X_FEATURES = {'VX': VX, 'VXE': VXE, 'VXE2': VXE2}


### PR DESCRIPTION
This PR continues the work from #29678 to improve CPU feature detection in the Meson build system, specifically for the `s390x` architecture.

Problem:
The current detection for `VXE` and `VXE2` is ambiguous:
- VXE2: The regex 'VX.*' is overly greedy and could match any string containing “VX”.
- VXE: The simple match for 'VX' could incorrectly enable VXE on systems that only support VX.

These ambiguities may cause NumPy to compile with unsupported CPU instructions, risking Illegal Instruction crashes or performance issues.

Solution:
This PR replaces the fragile patterns with precise regular expressions using word boundaries (`\b`):
- `VXE → '\\bvxe\\b'`
- `VXE2 → '\\bvxe2\\b'`

No changes are made to the feature hierarchy, compiler flags, or test code.