### PR TITLE
ENH: Add SIMD sin/cos implementation with numpy-simd-routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ build
 build-*
 # meson python output
 .mesonpy-native-file.ini
+subprojects/.wraplock
 # sphinx build directory
 _build
 # dist directory is where sdist/wheel end up

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "numpy/_core/src/common/pythoncapi-compat"]
 	path = numpy/_core/src/common/pythoncapi-compat
 	url = https://github.com/python/pythoncapi-compat
+[submodule "subprojects/numpy-simd-routines/src"]
+	path = subprojects/numpy-simd-routines/src
+	url = https://github.com/numpy/numpy-simd-routines

--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -117,12 +117,24 @@
     #endif
 #endif
 
-#if defined(_MSC_VER)
-    #define NPY_NOINLINE static __declspec(noinline)
-#elif defined(__GNUC__) || defined(__clang__)
-    #define NPY_NOINLINE static __attribute__((noinline))
+#ifdef _MSC_VER
+    #ifdef __cplusplus
+        #define NPY_NOINLINE __declspec(noinline)
+    #else
+        #define NPY_NOINLINE static __declspec(noinline)
+    #endif
+#elif defined(__GNUC__)
+    #ifdef __cplusplus
+        #define NPY_NOINLINE __attribute__((noinline))
+    #else
+        #define NPY_NOINLINE static __attribute__((noinline))
+    #endif
 #else
-    #define NPY_NOINLINE static
+    #ifdef __cplusplus
+        #define NPY_NOINLINE inline
+    #else
+        #define NPY_NOINLINE static inline
+    #endif
 #endif
 
 #ifdef __cplusplus

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1072,9 +1072,10 @@ foreach gen_mtargets : [
     [
       X86_V4, X86_V3,
       VSX4, VSX3, VSX2,
-      NEON_VFPV4,
+      NEON_VFPV4, SVE, 
       VXE2, VXE,
       LSX,
+      RVV
     ]
   ],
   [

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -981,6 +981,9 @@ umath_gen_headers = [
   src_file.process('src/umath/loops_utils.h.src'),
 ]
 
+npsr = subproject('numpy-simd-routines')
+npsr_dep = npsr.get_variable('npsr_dep')
+
 foreach gen_mtargets : [
   [
     'loops_arithm_fp.dispatch.h',
@@ -1145,7 +1148,7 @@ foreach gen_mtargets : [
     dispatch: gen_mtargets[2],
     baseline: CPU_BASELINE,
     prefix: 'NPY_',
-    dependencies: [py_dep, np_core_dep],
+    dependencies: [py_dep, np_core_dep, npsr_dep],
     c_args: c_args_common + max_opt,
     cpp_args: cpp_args_common + max_opt,
     include_directories: [

--- a/numpy/_core/src/common/simd/simd.hpp
+++ b/numpy/_core/src/common/simd/simd.hpp
@@ -1,6 +1,5 @@
 #ifndef NUMPY__CORE_SRC_COMMON_SIMD_SIMD_HPP_
 #define NUMPY__CORE_SRC_COMMON_SIMD_SIMD_HPP_
-
 /**
  * This header provides a thin wrapper over Google's Highway SIMD library.
  *
@@ -19,7 +18,9 @@
  */
 #ifndef NPY_DISABLE_OPTIMIZATION
 #include <hwy/highway.h>
-
+#include <npsr/npsr.h>
+#include <type_traits>
+#include <limits>
 /**
  * We avoid using Highway scalar operations for the following reasons:
  *
@@ -67,6 +68,37 @@ namespace hn = hwy::HWY_NAMESPACE;
 // internally used by the template header
 template <typename TLane>
 using _Tag = hn::ScalableTag<TLane>;
+
+/// NumPy SIMD Routines namespace alias
+/// npsr is tag free by design so we only include it within main namespace (np::simd)
+namespace sr = npsr::HWY_NAMESPACE;
+
+/// Default precision configrations for NumPy SIMD Routines
+// TODO: Allow user to configure the default precision at build time.
+namespace detail {
+using PreciseHigh = decltype(npsr::Precise{});
+using PreciseLow = decltype(npsr::Precise{npsr::kLowAccuracy});
+struct PresiceDummy {};
+template <typename T>
+struct PreciseByType {};
+template <>
+struct PreciseByType<float> { using Type = PreciseLow; };
+template <>
+struct PreciseByType<double> {
+#if NPY_HWY_F64
+    using Type = PreciseHigh;
+#else
+    // If float64 SIMD isn’t available, use a dummy type.
+    // The scalar path will run, but `Type` must still be defined.
+    // The dummy is never passed; it only satisfies interfaces.
+    // This also avoids spurious FP exceptions during RAII.
+    using Type = PresiceDummy;
+#endif
+};
+} // namespace detail
+template <typename T>
+using Precise = typename detail::PreciseByType<T>::Type;
+
 #endif
 #include "simd.inc.hpp"
 }  // namespace simd

--- a/numpy/_core/src/common/simd/simd.inc.hpp
+++ b/numpy/_core/src/common/simd/simd.inc.hpp
@@ -51,12 +51,26 @@ LoadU(const TLane *ptr)
     return hn::LoadU(_Tag<TLane>(), ptr);
 }
 
+template <typename TLane>
+HWY_API Vec<TLane>
+LoadN(const TLane *ptr, size_t n)
+{
+    return hn::LoadN(_Tag<TLane>(), ptr, n);
+}
+
 /// Unaligned store of a vector to memory.
 template <typename TLane>
 HWY_API void
 StoreU(const Vec<TLane> &a, TLane *ptr)
 {
     hn::StoreU(a, _Tag<TLane>(), ptr);
+}
+
+template <typename TLane>
+HWY_API void
+StoreN(const Vec<TLane> &a, TLane *ptr, size_t n)
+{
+    hn::StoreN(a, _Tag<TLane>(), ptr, n);
 }
 
 /// Returns the number of vector lanes based on the lane type.

--- a/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_trigonometric.dispatch.cpp
@@ -1,299 +1,119 @@
-#include "fast_loop_macros.h"
-#include "loops.h"
-#include "loops_utils.h"
+#include "numpy/npy_common.h"  // npy_intp
+#include "loops.h"        // forward declarations
+#include "loops_utils.h"  // is_mem_overlap
 
-#include "simd/simd.h"
-#include "simd/simd.hpp" 
-#include <hwy/highway.h>
+#include "simd/simd.hpp"  // Highway & NumPy SIMD Routines
+#include <type_traits>    // std::enable_if_t
+#include <algorithm>      // std::min
+#include <cmath>          // std::sin, std::cos
 
-namespace hn = hwy::HWY_NAMESPACE;
+// annonymous namespace for ODR since this source compiled multiple times
+// based on the dispatch targets
+namespace {
+using namespace np::simd;
 
-/*
- * Vectorized approximate sine/cosine algorithms: The following code is a
- * vectorized version of the algorithm presented here:
- * https://stackoverflow.com/questions/30463616/payne-hanek-algorithm-implementation-in-c/30465751#30465751
- * (1) Load data in registers and generate mask for elements that are within
- * range [-71476.0625f, 71476.0625f] for cosine and [-117435.992f, 117435.992f]
- * for sine.
- * (2) For elements within range, perform range reduction using
- * Cody-Waite's method: x* = x - y*PI/2, where y = rint(x*2/PI). x* \in [-PI/4,
- * PI/4].
- * (3) Map cos(x) to (+/-)sine or (+/-)cosine of x* based on the
- * quadrant k = int(y).
- * (4) For elements outside that range, Cody-Waite
- * reduction performs poorly leading to catastrophic cancellation. We compute
- * cosine by calling glibc in a scalar fashion.
- * (5) Vectorized implementation
- * has a max ULP of 1.49 and performs at least 5-7x(x86) - 2.5-3x(Power) -
- * 1-2x(Arm) faster than scalar implementations when magnitude of all elements
- * in the array < 71476.0625f (117435.992f for sine).  Worst case performance
- * is when all the elements are large leading to about 1-2% reduction in
- * performance.
- * TODO: use vectorized version of Payne-Hanek style reduction for large
- * elements or when there's no native FUSED support instead of fallback to libc
- */
-
-#if NPY_SIMD_FMA3  // native support
-typedef enum {
-    SIMD_COMPUTE_SIN,
-    SIMD_COMPUTE_COS
-} SIMD_TRIG_OP;
-
-const hn::ScalableTag<float> f32;
-const hn::ScalableTag<int32_t> s32;
-using vec_f32 = hn::Vec<decltype(f32)>;
-using vec_s32 = hn::Vec<decltype(s32)>;
-using opmask_t = hn::Mask<decltype(f32)>;
-
-HWY_INLINE HWY_ATTR vec_f32
-simd_range_reduction_f32(vec_f32 &x, vec_f32 &y, const vec_f32 &c1,
-                         const vec_f32 &c2, const vec_f32 &c3)
-{
-    vec_f32 reduced_x = hn::MulAdd(y, c1, x);
-    reduced_x = hn::MulAdd(y, c2, reduced_x);
-    reduced_x = hn::MulAdd(y, c3, reduced_x);
-    return reduced_x;
-}
-
-HWY_INLINE HWY_ATTR vec_f32
-simd_cosine_poly_f32(vec_f32 &x2)
-{
-    const vec_f32 invf8 = hn::Set(f32, 0x1.98e616p-16f);
-    const vec_f32 invf6 = hn::Set(f32, -0x1.6c06dcp-10f);
-    const vec_f32 invf4 = hn::Set(f32, 0x1.55553cp-05f);
-    const vec_f32 invf2 = hn::Set(f32, -0x1.000000p-01f);
-    const vec_f32 invf0 = hn::Set(f32, 0x1.000000p+00f);
-
-    vec_f32 r = hn::MulAdd(invf8, x2, invf6);
-    r = hn::MulAdd(r, x2, invf4);
-    r = hn::MulAdd(r, x2, invf2);
-    r = hn::MulAdd(r, x2, invf0);
-    return r;
-}
-/*
- * Approximate sine algorithm for x \in [-PI/4, PI/4]
- * Maximum ULP across all 32-bit floats = 0.647
- * Polynomial approximation based on unpublished work by T. Myklebust
- */
-HWY_INLINE HWY_ATTR vec_f32
-simd_sine_poly_f32(vec_f32 &x, vec_f32 &x2)
-{
-    const vec_f32 invf9 = hn::Set(f32, 0x1.7d3bbcp-19f);
-    const vec_f32 invf7 = hn::Set(f32, -0x1.a06bbap-13f);
-    const vec_f32 invf5 = hn::Set(f32, 0x1.11119ap-07f);
-    const vec_f32 invf3 = hn::Set(f32, -0x1.555556p-03f);
-
-    vec_f32 r = hn::MulAdd(invf9, x2, invf7);
-    r = hn::MulAdd(r, x2, invf5);
-    r = hn::MulAdd(r, x2, invf3);
-    r = hn::MulAdd(r, x2, hn::Zero(f32));
-    r = hn::MulAdd(r, x, x);
-    return r;
-}
-
-static void HWY_ATTR SIMD_MSVC_NOINLINE
-simd_sincos_f32(const float *src, npy_intp ssrc, float *dst, npy_intp sdst,
-                npy_intp len, SIMD_TRIG_OP trig_op)
-{
-    // Load up frequently used constants
-    const vec_f32 zerosf = hn::Zero(f32);
-    const vec_s32 ones = hn::Set(s32, 1);
-    const vec_s32 twos = hn::Set(s32, 2);
-    const vec_f32 two_over_pi = hn::Set(f32, 0x1.45f306p-1f);
-    const vec_f32 codyw_pio2_highf = hn::Set(f32, -0x1.921fb0p+00f);
-    const vec_f32 codyw_pio2_medf = hn::Set(f32, -0x1.5110b4p-22f);
-    const vec_f32 codyw_pio2_lowf = hn::Set(f32, -0x1.846988p-48f);
-    const vec_f32 rint_cvt_magic = hn::Set(f32, 0x1.800000p+23f);
-    // Cody-Waite's range
-    float max_codi = 117435.992f;
-    if (trig_op == SIMD_COMPUTE_COS) {
-        max_codi = 71476.0625f;
-    }
-    const vec_f32 max_cody = hn::Set(f32, max_codi);
-
-    const int lanes = hn::Lanes(f32);
-    const vec_s32 src_index = hn::Mul(hn::Iota(s32, 0), hn::Set(s32, ssrc));
-    const vec_s32 dst_index = hn::Mul(hn::Iota(s32, 0), hn::Set(s32, sdst));
-
-    for (; len > 0; len -= lanes, src += ssrc * lanes, dst += sdst * lanes) {
-        vec_f32 x_in;
-        if (ssrc == 1) {
-            x_in = hn::LoadN(f32, src, len);
-        }
-        else {
-            x_in = hn::GatherIndexN(f32, src, src_index, len);
-        }
-        opmask_t nnan_mask = hn::Not(hn::IsNaN(x_in));
-        // Eliminate NaN to avoid FP invalid exception
-        x_in = hn::IfThenElse(nnan_mask, x_in, zerosf);
-        opmask_t simd_mask = hn::Le(hn::Abs(x_in), max_cody);
-        /*
-         * For elements outside of this range, Cody-Waite's range reduction
-         * becomes inaccurate and we will call libc to compute cosine for
-         * these numbers
-         */
-        if (!hn::AllFalse(f32, simd_mask)) {
-            vec_f32 x = hn::IfThenElse(hn::And(nnan_mask, simd_mask), x_in,
-                                       zerosf);
-
-            vec_f32 quadrant = hn::Mul(x, two_over_pi);
-            // round to nearest, -0.0f -> +0.0f, and |a| must be <= 0x1.0p+22
-            quadrant = hn::Add(quadrant, rint_cvt_magic);
-            quadrant = hn::Sub(quadrant, rint_cvt_magic);
-
-            // Cody-Waite's range reduction algorithm
-            vec_f32 reduced_x =
-                    simd_range_reduction_f32(x, quadrant, codyw_pio2_highf,
-                                             codyw_pio2_medf, codyw_pio2_lowf);
-            vec_f32 reduced_x2 = hn::Mul(reduced_x, reduced_x);
-
-            // compute cosine and sine
-            vec_f32 cos = simd_cosine_poly_f32(reduced_x2);
-            vec_f32 sin = simd_sine_poly_f32(reduced_x, reduced_x2);
-
-            vec_s32 iquadrant = hn::NearestInt(quadrant);
-            if (trig_op == SIMD_COMPUTE_COS) {
-                iquadrant = hn::Add(iquadrant, ones);
-            }
-            // blend sin and cos based on the quadrant
-            opmask_t sine_mask = hn::RebindMask(
-                    f32, hn::Eq(hn::And(iquadrant, ones), hn::Zero(s32)));
-            cos = hn::IfThenElse(sine_mask, sin, cos);
-
-            // multiply by -1 for appropriate elements
-            opmask_t negate_mask = hn::RebindMask(
-                    f32, hn::Eq(hn::And(iquadrant, twos), twos));
-            cos = hn::MaskedSubOr(cos, negate_mask, zerosf, cos);
-            cos = hn::IfThenElse(nnan_mask, cos, hn::Set(f32, NPY_NANF));
-
-            if (sdst == 1) {
-                hn::StoreN(cos, f32, dst, len);
-            }
-            else {
-                hn::ScatterIndexN(cos, f32, dst, dst_index, len);
-            }
-        }
-        if (!hn::AllTrue(f32, simd_mask)) {
-            static_assert(hn::MaxLanes(f32) <= 64,
-                          "The following fallback is not applicable for "
-                          "SIMD widths larger than 2048 bits, or for scalable "
-                          "SIMD in general.");
-            npy_uint64 simd_maski;
-            hn::StoreMaskBits(f32, simd_mask, (uint8_t *)&simd_maski);
-#if HWY_IS_BIG_ENDIAN
-            static_assert(hn::MaxLanes(f32) <= 8,
-                          "This conversion is not supported for SIMD widths "
-                          "larger than 256 bits.");
-            simd_maski = ((uint8_t *)&simd_maski)[0];
+template <typename T>
+struct OPsin {
+    using LaneType = T;
+    NPY_FINLINE T operator()(T x) const { return std::sin(x); }
+#if NPY_HWY
+    template <class X = T, typename = std::enable_if_t<kSupportLane<X>>>
+    NPY_FINLINE Vec<T> operator()(const Vec<T>& x) {
+      return sr::Sin(prec, x);
+    }  
+    Precise<T> prec;
 #endif
-            float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) ip_fback[hn::MaxLanes(f32)];
-            hn::Store(x_in, f32, ip_fback);
+};
 
-            // process elements using libc for large elements
-            if (trig_op == SIMD_COMPUTE_COS) {
-                for (unsigned i = 0; i < hn::Lanes(f32); ++i) {
-                    if ((simd_maski >> i) & 1) {
-                        continue;
-                    }
-                    dst[sdst * i] = npy_cosf(ip_fback[i]);
-                }
-            }
-            else {
-                for (unsigned i = 0; i < hn::Lanes(f32); ++i) {
-                    if ((simd_maski >> i) & 1) {
-                        continue;
-                    }
-                    dst[sdst * i] = npy_sinf(ip_fback[i]);
-                }
-            }
+template <typename T>
+struct OPcos {
+    using LaneType = T;
+    NPY_FINLINE T operator()(T x) const { return std::cos(x); }
+#if NPY_HWY
+    template <class X = T, typename = std::enable_if_t<kSupportLane<X>>>
+    NPY_FINLINE Vec<T> operator()(const Vec<T>& x) {
+      return sr::Cos(prec, x);
+    }  
+    Precise<T> prec;
+#endif
+};
+
+template <typename OP, typename T = typename OP::LaneType>
+NPY_NOINLINE void
+UnaryContig(OP &op, const T *src, T *dst, npy_intp len)
+{
+#if NPY_HWY
+    if constexpr (kSupportLane<T>) {
+        const npy_intp nlanes = Lanes<T>();
+        for (; len > 0; len -= nlanes, src += nlanes, dst += nlanes) {
+            Vec<T> x = LoadN(src, len);
+            Vec<T> r = op(x);
+            StoreN(r, dst, len);
         }
-        npyv_cleanup();
+    }
+#else
+    if constexpr (0) {
+    }
+#endif
+    else {
+        for (const T *end = src + len; src < end; ++src, ++dst) {
+            *dst = op(*src);
+        }
+    }
+};
+
+template <typename OP, typename T = typename OP::LaneType>
+NPY_FINLINE void
+UnaryOP(OP &op, char **args, npy_intp const *dimensions, npy_intp const *steps)
+{
+    npy_intp len = dimensions[0];
+    npy_intp sin = steps[0], sout = steps[1];
+    char *in = args[0], *out = args[1];
+    // We are dealing with large math kernels allowing inlining
+    // or specialized implementations for non-contiguous, overlapping cases, or even
+    // providing a separate iteration for contiguous tailing would easily bloat the
+    // binary size.
+    // Especially if we may need to support runtime dispatching for precision control.
+    // If you really think that providing such specialization for these kinds of
+    // kernels will increase performance, please make sure to benchmark it first and
+    // compare the binary size before and after the change.
+    // Note: the intrinsics of NumPy SIMD routines are inlined by default.
+    if (NPY_UNLIKELY(is_mem_overlap(args[0], sin, args[1], sout, len) ||
+                     sin != sizeof(T) || sout != sizeof(T))) {
+        // this for non-contiguous or overlapping case
+        constexpr npy_intp kBufferLen = 4096 / sizeof(T);
+#if NPY_HWY
+        HWY_ALIGN
+#endif
+        T buffer[kBufferLen];
+        for (npy_intp processed = 0; processed < len;) {
+            npy_intp chunk = std::min(kBufferLen, len - processed);
+            for (npy_intp i = 0; i < chunk; ++i, in += sin) {
+                buffer[i] = *reinterpret_cast<const T *>(in);
+            }
+            UnaryContig(op, buffer, buffer, chunk);
+            for (npy_intp i = 0; i < chunk; ++i, out += sout) {
+                *reinterpret_cast<T *>(out) = buffer[i];
+            }
+            processed += chunk;
+        }
+    }
+    else {
+        UnaryContig(op, (T *)in, (T *)out, len);
     }
 }
-#endif  // NPY_SIMD_FMA3
+}  // namespace
 
-/* Disable SIMD code sin/cos f64 and revert to libm: see
- * https://mail.python.org/archives/list/numpy-discussion@python.org/thread/C6EYZZSR4EWGVKHAZXLE7IBILRMNVK7L/
- * for detailed discussion on this*/
-#define DISPATCH_DOUBLE_FUNC(func)                                          \
-    NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(DOUBLE_##func)(               \
+#define UMATH_UNARY_SR_IMPL(TYPE, type, op)                                 \
+    NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TYPE##_##op)(                 \
             char **args, npy_intp const *dimensions, npy_intp const *steps, \
             void *NPY_UNUSED(data))                                         \
     {                                                                       \
-        UNARY_LOOP                                                          \
-        {                                                                   \
-            const npy_double in1 = *(npy_double *)ip1;                      \
-            *(npy_double *)op1 = npy_##func(in1);                           \
-        }                                                                   \
+        OP##op<type> math_op;                                               \
+        UnaryOP(math_op, args, dimensions, steps);                          \
     }
 
-DISPATCH_DOUBLE_FUNC(sin)
-DISPATCH_DOUBLE_FUNC(cos)
-
-NPY_NO_EXPORT void
-NPY_CPU_DISPATCH_CURFX(FLOAT_sin)(char **args, npy_intp const *dimensions,
-                                  npy_intp const *steps,
-                                  void *NPY_UNUSED(data))
-{
-#if NPY_SIMD_FMA3
-    npy_intp len = dimensions[0];
-
-    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
-        !npyv_loadable_stride_f32(steps[0]) ||
-        !npyv_storable_stride_f32(steps[1])) {
-        UNARY_LOOP
-        {
-            simd_sincos_f32((npy_float *)ip1, 1, (npy_float *)op1, 1, 1,
-                            SIMD_COMPUTE_SIN);
-        }
-    }
-    else {
-        const npy_float *src = (npy_float *)args[0];
-        npy_float *dst = (npy_float *)args[1];
-        const npy_intp ssrc = steps[0] / sizeof(npy_float);
-        const npy_intp sdst = steps[1] / sizeof(npy_float);
-
-        simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_SIN);
-    }
-#else
-    UNARY_LOOP
-    {
-        const npy_float in1 = *(npy_float *)ip1;
-        *(npy_float *)op1 = npy_sinf(in1);
-    }
-#endif
-}
-
-NPY_NO_EXPORT void
-NPY_CPU_DISPATCH_CURFX(FLOAT_cos)(char **args, npy_intp const *dimensions,
-                                  npy_intp const *steps,
-                                  void *NPY_UNUSED(data))
-{
-#if NPY_SIMD_FMA3
-    npy_intp len = dimensions[0];
-
-    if (is_mem_overlap(args[0], steps[0], args[1], steps[1], len) ||
-        !npyv_loadable_stride_f32(steps[0]) ||
-        !npyv_storable_stride_f32(steps[1])) {
-        UNARY_LOOP
-        {
-            simd_sincos_f32((npy_float *)ip1, 1, (npy_float *)op1, 1, 1,
-                            SIMD_COMPUTE_COS);
-        }
-    }
-    else {
-        const npy_float *src = (npy_float *)args[0];
-        npy_float *dst = (npy_float *)args[1];
-        const npy_intp ssrc = steps[0] / sizeof(npy_float);
-        const npy_intp sdst = steps[1] / sizeof(npy_float);
-
-        simd_sincos_f32(src, ssrc, dst, sdst, len, SIMD_COMPUTE_COS);
-    }
-#else
-    UNARY_LOOP
-    {
-        const npy_float in1 = *(npy_float *)ip1;
-        *(npy_float *)op1 = npy_cosf(in1);
-    }
-#endif
-}
+UMATH_UNARY_SR_IMPL(FLOAT, float, sin)
+UMATH_UNARY_SR_IMPL(DOUBLE, double, sin)
+UMATH_UNARY_SR_IMPL(FLOAT, float, cos)
+UMATH_UNARY_SR_IMPL(DOUBLE, double, cos)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1649,6 +1649,54 @@ class TestSpecialFloats:
         callable(x[::stride], out=x[:M])
         assert_equal(x[:M], y)
 
+    @pytest.mark.parametrize("func", [np.sin, np.cos])
+    @pytest.mark.parametrize("dtype", ["f", "d"])
+    def test_trig_facts(self, dtype, func):
+        atol, max_ulp = (1e-6, 3) if dtype == "f" else (1e-15, 1)
+        test_data = {
+            np.sin: [
+                (0, 0),
+                (np.pi, 0),
+                (-np.pi, 0),
+                (2 * np.pi, 0),
+                (-2 * np.pi, 0),
+                (np.pi / 2, 1),
+                (-np.pi / 2, -1),
+                (3 * np.pi / 2, -1),
+                (-3 * np.pi / 2, 1),
+                (np.pi / 6, 0.5),
+                (5 * np.pi / 6, 0.5),
+                (-np.pi / 6, -0.5),
+                (-5 * np.pi / 6, -0.5),
+            ],
+            np.cos: [
+                (0, 1),
+                (np.pi, -1),
+                (-np.pi, -1),
+                (2 * np.pi, 1),
+                (-2 * np.pi, 1),
+                (np.pi / 2, 0),
+                (-np.pi / 2, 0),
+                (3 * np.pi / 2, 0),
+                (-3 * np.pi / 2, 0),
+                (np.pi / 3, 0.5),
+                (5 * np.pi / 3, 0.5),
+                (-np.pi / 3, 0.5),
+                (-5 * np.pi / 3, 0.5),
+            ],
+        }[func]
+        for s_x, s_expected in test_data:
+            x = np.array([s_x] * (128 + 1), dtype=dtype)
+            result = func(x)
+            # Check that all results are identical, to catch issues with
+            # vectorization
+            assert np.all(result == result[0])
+            expected = np.array([s_expected] * (128 + 1), dtype=dtype)
+            if s_expected == 0:
+                assert_allclose(result, expected, atol=atol, rtol=0)
+            else:
+                assert_array_max_ulp(result, expected, maxulp=max_ulp)
+
     @pytest.mark.parametrize('dt', ['e', 'f', 'd', 'g'])
     def test_sqrt_values(self, dt):
         with np.errstate(all='ignore'):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -34,6 +34,7 @@ from numpy.testing import (
 from numpy.testing._private.utils import (
     LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
     _glibc_older_than,
+    _ufunc_has_fma,
 )
 
 UFUNCS = [obj for obj in np._core.umath.__dict__.values()
@@ -2202,19 +2203,30 @@ class TestAVXFloat32Transcendental:
             # this is known to be problematic on old glibc, so skip it there
             x_f32[index] = np.float32(10E+10 * np.random.rand(M))
         x_f64 = np.float64(x_f32)
-        assert_array_max_ulp(np.sin(x_f32), np.float32(np.sin(x_f64)), maxulp=2)
-        assert_array_max_ulp(np.cos(x_f32), np.float32(np.cos(x_f64)), maxulp=2)
+        # numpy-simd-rounding gives ~3 ulp when fma is not available and kLowAccuracy
+        # been set in the precision mode
+        maxulp_f32 = 2 if _ufunc_has_fma(np.sin, np.float32) else 3
+        assert_array_max_ulp(
+            np.sin(x_f32),
+            np.float32(np.sin(x_f64)),
+            maxulp=maxulp_f32
+        )
+        assert_array_max_ulp(
+            np.cos(x_f32),
+            np.float32(np.cos(x_f64)),
+            maxulp=maxulp_f32
+        )
         # test aliasing(issue #17761)
         tx_f32 = x_f32.copy()
         assert_array_max_ulp(
             np.sin(x_f32, out=x_f32),
             np.float32(np.sin(x_f64)),
-            maxulp=2,
+            maxulp=maxulp_f32,
         )
         assert_array_max_ulp(
             np.cos(tx_f32, out=tx_f32),
             np.float32(np.cos(x_f64)),
-            maxulp=2,
+            maxulp=maxulp_f32,
         )
 
     def test_strided_float32(self):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2733,6 +2733,16 @@ def check_free_memory(free_bytes):
     return msg if mem_free < free_bytes else None
 
 
+# avx2 implies fma
+_fma_pattern = re.compile("fma|avx2|avx512|vsx|vx|asimd|vpfv4|rvv|lsx", re.IGNORECASE)
+
+def _ufunc_has_fma(ufunc, dtype) -> bool:
+    """Check if a ufunc has SIMD kernel with native FMA support for a given dtype."""
+    ufunc_name = ufunc.__name__
+    res = np.lib.introspect.opt_func_info(ufunc_name, signature=dtype.__name__)
+    dres = res[ufunc_name]
+    return all(bool(_fma_pattern.search(v["current"])) for v in dres.values())
+
 def _parse_size(size_str):
     """Convert memory size strings ('12 GB' etc.) to float"""
     suffixes = {'': 1, 'b': 1,

--- a/subprojects/numpy-simd-routines/meson.build
+++ b/subprojects/numpy-simd-routines/meson.build
@@ -1,0 +1,20 @@
+project(
+  'NumPy SIMD Routines',
+  'cpp', 
+  version: 'master',
+  license: 'BSD-3',
+  meson_version: '>=1.5.2', 
+  default_options: [
+    'buildtype=debugoptimized',
+    'cpp_std=c++17',
+  ],
+)
+fs = import('fs')
+if not fs.exists('src/npsr')
+  error('Missing the `numpy-simd-routines` git submodule! Run `git submodule update --init` to fix this.')
+endif
+npsr_inc = include_directories('src')
+npsr_dep = declare_dependency(
+  include_directories: npsr_inc
+)
+


### PR DESCRIPTION
  numpy-simd-routines added as subrepo in meson subprojects
  directory and the current FP configuration is static, ~1ulp used for double-precision
  ~4ulp for single-precision with handling floating-point errors,
  special-cases extended precision for large arguments,
  subnormals are enabled by default too.

  numpy-simd-routines supports all SIMD extensions that are supported
  by Google Highway including non-FMA extensions and is fully independent
  from libm to guarantee unified results across all compilers and
  platforms.

  Note: that there was no SIMD optimization enabled for sin/cos
  for double-precision before, only single-precision.

# Benchmark

## X86 Platform
The following benchmark was tested against GCC 14.3.0 on an x86 CPU (Ryzen 7 7700X).

<details>
<summary>Environment</summary>

```Bash
> uname -a
Linux seiko-pc 6.12.60 #1-NixOS SMP PREEMPT_DYNAMIC Mon Dec  1 10:43:41 UTC 2025 x86_64 GNU/Linux
> gcc --version
gcc (GCC) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
> python --version
Python 3.12.12
> lscpu
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             48 bits physical, 48 bits virtual
  Byte Order:                Little Endian
CPU(s):                      16
  On-line CPU(s) list:       0-15
Vendor ID:                   AuthenticAMD
  Model name:                AMD Ryzen 7 7700X 8-Core Processor
    CPU family:              25
    Model:                   97
    Thread(s) per core:      2
    Core(s) per socket:      8
    Socket(s):               1
    Stepping:                2
    Frequency boost:         enabled
    CPU(s) scaling MHz:      72%
    CPU max MHz:             5573.0000
    CPU min MHz:             545.0000
    BogoMIPS:                8982.62
    Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl 
                             xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_leg
                             acy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp
                              ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec
                              xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_cl
                             ean flushbyasid decodeassists pausefilter pfthreshold avic vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpo
                             pcntdq rdpid overflow_recov succor smca fsrm flush_l1d amd_lbr_pmc_freeze
```
</details>

<details>
<summary>x86-64-v4</summary>

```
export NPY_DISABLE_CPU_FEATURES=""
spin bench --compare parent/main --cpu-affinity 7 -t "\(<ufunc '(cos|sin)'>"
```

| Change   | Before [b70fc774] <brings_npsr~2>   | After [c5fc8423] <brings_npsr>   |   Ratio | Benchmark (Parameter)                                                   |
|----------|-------------------------------------|----------------------------------|---------|-------------------------------------------------------------------------|
| -        | 689±6μs                             | 640±30μs                         |    0.93 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'f')        |
| -        | 683±0.9μs                           | 602±2μs                          |    0.88 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'f')        |
| -        | 682±1μs                             | 603±1μs                          |    0.88 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'f')        |
| -        | 695±0.7μs                           | 604±1μs                          |    0.87 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 2, 'f')        |
| -        | 354±0.7μs                           | 231±0.4μs                        |    0.65 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'f')        |
| -        | 363±0.2μs                           | 234±4μs                          |    0.64 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'f')        |
| -        | 1.04±0.02ms                         | 632±20μs                         |    0.61 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'f')        |
| -        | 1.02±0ms                            | 612±10μs                         |    0.6  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'f')        |
| -        | 1.32±0.01ms                         | 795±2μs                          |    0.6  | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'f') |
| -        | 1.72±0.03ms                         | 806±3μs                          |    0.47 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'f') |
| -        | 1.44±0.02ms                         | 603±0.3μs                        |    0.42 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'f') |
| -        | 5.05±0.1ms                          | 2.07±0.01ms                      |    0.41 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 2, 'd') |
| -        | 4.98±0.01ms                         | 1.88±0.03ms                      |    0.38 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 1, 'd') |
| -        | 5.95±0.02ms                         | 2.26±0.07ms                      |    0.38 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'd') |
| -        | 2.18±0.05ms                         | 792±1μs                          |    0.36 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'f') |
| -        | 1.78±0.03ms                         | 608±4μs                          |    0.34 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 1, 'f') |
| -        | 5.65±0.02ms                         | 1.87±0.2ms                       |    0.33 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'd')        |
| -        | 5.65±0.01ms                         | 1.87±0.01ms                      |    0.33 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'd')        |
| -        | 5.77±0.01ms                         | 1.90±0.01ms                      |    0.33 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'd')        |
| -        | 6.00±0.04ms                         | 1.98±0.02ms                      |    0.33 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'd') |
| -        | 1.36±0.01ms                         | 443±2μs                          |    0.32 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'f') |
| -        | 5.75±0ms                            | 1.68±0.04ms                      |    0.29 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'd')        |
| -        | 4.97±0ms                            | 1.46±0.04ms                      |    0.29 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'd') |
| -        | 2.42±0.2ms                          | 609±2μs                          |    0.25 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 2, 'f') |
| -        | 5.62±0.01ms                         | 1.25±0.02ms                      |    0.22 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 2, 'd')        |
| -        | 5.72±0ms                            | 1.25±0.01ms                      |    0.22 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'd')        |
| -        | 4.97±0ms                            | 1.08±0ms                         |    0.22 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'd') |
| -        | 7.08±0.01ms                         | 1.58±0.02ms                      |    0.22 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'd') |
| -        | 7.07±0ms                            | 1.20±0.01ms                      |    0.17 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'd') |
| -        | 1.49±0ms                            | 233±10μs                         |    0.16 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'f') |
| -        | 5.61±0ms                            | 828±0.4μs                        |    0.15 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'd')        |
| -        | 5.73±0ms                            | 859±8μs                          |    0.15 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'd')        |

</details>

<details>
<summary>x86-64-v3</summary>

```
export NPY_DISABLE_CPU_FEATURES="X86_V4"
spin bench --compare parent/main --cpu-affinity 7 -t "\(<ufunc '(cos|sin)'>"
```

| Change   | Before [b70fc774] <brings_npsr~2>   | After [c5fc8423] <brings_npsr>   |   Ratio | Benchmark (Parameter)                                                   |
|----------|-------------------------------------|----------------------------------|---------|-------------------------------------------------------------------------|
| +        | 844±1μs                             | 939±50μs                         |    1.11 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'f')        |
| -        | 4.98±0ms                            | 4.57±0.1ms                       |    0.92 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'd') |
| -        | 4.98±0ms                            | 4.20±0.01ms                      |    0.84 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'd') |
| -        | 6.03±0.06ms                         | 5.00±0.06ms                      |    0.83 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'd') |
| -        | 6.06±0.06ms                         | 4.78±0.04ms                      |    0.79 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'd') |
| -        | 1.37±0.01ms                         | 913±40μs                         |    0.67 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'f')        |
| -        | 1.37±0.01ms                         | 901±10μs                         |    0.66 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'f')        |
| -        | 1.45±0ms                            | 941±2μs                          |    0.65 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'f')        |
| -        | 830±0.3μs                           | 511±2μs                          |    0.62 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'f')        |
| -        | 7.07±0.01ms                         | 4.35±0.1ms                       |    0.61 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'd') |
| -        | 844±2μs                             | 496±5μs                          |    0.59 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'f')        |
| -        | 1.46±0.01ms                         | 864±9μs                          |    0.59 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'f')        |
| -        | 3.21±0.03ms                         | 1.83±0ms                         |    0.57 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'f') |
| -        | 7.08±0.01ms                         | 3.98±0.06ms                      |    0.56 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'd') |
| -        | 3.63±0.09ms                         | 1.84±0.01ms                      |    0.51 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'f') |
| -        | 5.65±0.01ms                         | 2.82±0.1ms                       |    0.5  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'd')        |
| -        | 5.64±0ms                            | 2.74±0.3ms                       |    0.49 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'd')        |
| -        | 5.75±0ms                            | 2.76±0.1ms                       |    0.48 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'd')        |
| -        | 3.00±0.09ms                         | 1.44±0ms                         |    0.48 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'f') |
| -        | 3.78±0.1ms                          | 1.82±0.02ms                      |    0.48 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'f') |
| -        | 5.77±0.01ms                         | 2.68±0.02ms                      |    0.46 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'd')        |
| -        | 5.73±0ms                            | 2.11±0.03ms                      |    0.37 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'd')        |
| -        | 5.62±0ms                            | 2.03±0.01ms                      |    0.36 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 2, 'd')        |
| -        | 5.62±0.02ms                         | 1.67±0ms                         |    0.3  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'd')        |
| -        | 5.72±0ms                            | 1.73±0ms                         |    0.3  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'd')        |
| -        | 3.23±0.02ms                         | 866±10μs                         |    0.27 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'f') |
| -        | 3.48±0.1ms                          | 856±3μs                          |    0.25 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 2, 'f') |
| -        | 3.68±0.06ms                         | 851±2μs                          |    0.23 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 1, 'f') |
| -        | 3.03±0.08ms                         | 497±4μs                          |    0.16 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'f') |

</details>

<details>
<summary>x86-64-v2</summary>

```
export NPY_DISABLE_CPU_FEATURES="X86_V4 X86_V3"
spin bench --compare parent/main --cpu-affinity 7 -t "\(<ufunc '(cos|sin)'>"
```

| Change   | Before [b70fc774] <brings_npsr~2>   | After [c5fc8423] <brings_npsr>   |   Ratio | Benchmark (Parameter)                                                   |
|----------|-------------------------------------|----------------------------------|---------|-------------------------------------------------------------------------|
| +        | 4.98±0ms                            | 7.04±0.1ms                       |    1.41 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 2, 'd') |
| +        | 2.12±0ms                            | 2.88±0.05ms                      |    1.36 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'f') |
| +        | 4.97±0.01ms                         | 6.68±0.02ms                      |    1.34 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 1, 'd') |
| +        | 2.12±0ms                            | 2.84±0.01ms                      |    1.34 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'f') |
| +        | 2.13±0ms                            | 2.82±0ms                         |    1.32 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'f') |
| +        | 4.98±0.01ms                         | 6.19±0.05ms                      |    1.24 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'd') |
| +        | 4.97±0ms                            | 5.77±0.05ms                      |    1.16 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'd') |
| +        | 5.96±0.03ms                         | 6.90±0.2ms                       |    1.16 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 2, 'd') |
| +        | 2.13±0ms                            | 2.45±0ms                         |    1.15 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'f') |
| +        | 5.95±0.06ms                         | 6.75±0.03ms                      |    1.13 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 4, 1, 'd') |
| -        | 7.07±0.01ms                         | 6.31±0.02ms                      |    0.89 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 2, 'd') |
| -        | 7.08±0ms                            | 5.86±0.03ms                      |    0.83 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'sin'>, 1, 1, 'd') |
| -        | 5.64±0.01ms                         | 4.47±0.3ms                       |    0.79 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'd')        |
| -        | 5.76±0.01ms                         | 4.15±0.1ms                       |    0.72 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'd')        |
| -        | 5.64±0.02ms                         | 3.94±0.06ms                      |    0.7  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'd')        |
| -        | 5.76±0.01ms                         | 4.01±0.1ms                       |    0.7  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'd')        |
| -        | 2.01±0.01ms                         | 1.36±0.02ms                      |    0.67 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 1, 'f') |
| -        | 2.02±0.02ms                         | 1.35±0.03ms                      |    0.67 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 4, 2, 'f') |
| -        | 2.02±0ms                            | 1.30±0ms                         |    0.64 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 2, 'f') |
| -        | 5.62±0.01ms                         | 3.54±0.08ms                      |    0.63 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 2, 'd')        |
| -        | 5.73±0.01ms                         | 3.58±0.06ms                      |    0.62 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'd')        |
| -        | 5.62±0.01ms                         | 3.11±0.07ms                      |    0.55 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'd')        |
| -        | 5.72±0.01ms                         | 3.12±0.05ms                      |    0.54 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'd')        |
| -        | 2.01±0ms                            | 926±3μs                          |    0.46 | bench_ufunc_strides.UnaryFPSpecial.time_unary(<ufunc 'cos'>, 1, 1, 'f') |
| -        | 3.29±0ms                            | 1.45±0.1ms                       |    0.44 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 2, 'f')        |
| -        | 3.31±0ms                            | 1.41±0.04ms                      |    0.42 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 2, 'f')        |
| -        | 3.31±0ms                            | 1.36±0.01ms                      |    0.41 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 4, 1, 'f')        |
| -        | 3.28±0ms                            | 1.30±0ms                         |    0.4  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 2, 'f')        |
| -        | 3.29±0ms                            | 1.32±0.03ms                      |    0.4  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 4, 1, 'f')        |
| -        | 3.30±0ms                            | 1.32±0.03ms                      |    0.4  | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 2, 'f')        |
| -        | 3.30±0ms                            | 947±4μs                          |    0.29 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'sin'>, 1, 1, 'f')        |
| -        | 3.28±0ms                            | 925±2μs                          |    0.28 | bench_ufunc_strides.UnaryFP.time_unary(<ufunc 'cos'>, 1, 1, 'f')        |

</details>

#### Binary size change: _multiarray_umath.cpython-312-x86_64-linux-gnu.so

|  stripped |  size (bytes) |
|------------|--------------|
| **before** | 9,895,936    |
| **after**  | 10,014,720   |
| **diff**   | **+118,784** |