### PR TITLE
BLD: Add missing <vector>

### DIFF
--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include <numpy/npy_common.h>
 #include "numpy/arrayobject.h"


### PR DESCRIPTION
https://github.com/numpy/numpy/issues/29703

Build is failing on macos:

```
FAILED: [code=1] numpy/_core/libunique_hash.a.p/src_multiarray_unique.cpp.o c++ -Inumpy/_core/libunique_hash.a.p -Inumpy/_core -I../numpy/_core -Inumpy/_core/include -I../numpy/_core/include -I../numpy/_core/src/common -I/Users/wrp/x86_64/Darwin/include/python3.15 -I/Users/wrp/github/numpy/numpy/build/meson_cpu -fdiagnostics-color=always -Wall -Winvalid-pch -std=c++17 -O2 -g -ftrapping-math -DNPY_HAVE_CLANG_FPSTRICT -msse -msse2 -msse3 -DNPY_HAVE_SSE2 -DNPY_HAVE_SSE -DNPY_HAVE_SSE3 -DNPY_INTERNAL_BUILD -DHAVE_NPY_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -fexceptions -fno-rtti -MD -MQ numpy/_core/libunique_hash.a.p/src_multiarray_unique.cpp.o -MF numpy/_core/libunique_hash.a.p/src_multiarray_unique.cpp.o.d -o numpy/_core/libunique_hash.a.p/src_multiarray_unique.cpp.o -c ../numpy/_core/src/multiarray/unique.cpp ../numpy/_core/src/multiarray/unique.cpp:243:36: error: implicit instantiation of undefined template 'std::vector<npy_unpacked_static_string>' std::vector<npy_static_string> unpacked_strings(isize, {0, NULL}); ^ /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/iosfwd:248:28: note: template is declared here class _LIBCPP_TEMPLATE_VIS vector; ^ 1 error generated. [273/523] Compiling C object numpy/_core/libloops_autovec.dispatch.h_AVX2.a.p/meson-generated_loops_autovec.dispatch.c.o ninja: build stopped: subcommand failed.
```
