### PR TITLE
MAINT: update spin to 0.14 in requirements files

### DIFF
--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.13.1
 Cython>=3.0.6
 ninja
-spin==0.13
+spin==0.14
 build

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
-spin==0.13
+spin==0.14
 # Keep this in sync with ci_requirements.txt
 scipy-openblas32==0.3.30.0.1

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
-spin==0.13
+spin==0.14
 # Keep this in sync with ci32_requirements.txt
 scipy-openblas32==0.3.30.0.1
 scipy-openblas64==0.3.30.0.1


### PR DESCRIPTION
I can't find a previous pull request or issue for this. Not sure if there's some reason why we're still pinned to 0.13. Let's see what the CI says.