### PR TITLE
BUG: Fix `dtype` refcount in `__array__`

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -980,7 +980,6 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return ret;
         } else { // copy == NPY_COPY_NEVER
             PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
-            // On error release a strong reference.
             Py_DECREF(newtype);
             Py_DECREF(self);
             return NULL;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -963,6 +963,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
         if (newtype == NULL) {
             newtype = PyArray_DESCR(self);
         }
+        Py_INCREF(newtype);
         ret = PyArray_CastToType(self, newtype, 0);
         Py_DECREF(self);
         return ret;
@@ -971,6 +972,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return (PyObject *)self;
         }
         if (copy == NPY_COPY_IF_NEEDED) {
+            Py_INCREF(newtype);
             ret = PyArray_CastToType(self, newtype, 0);
             Py_DECREF(self);
             return ret;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -962,17 +962,19 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
     if (copy == NPY_COPY_ALWAYS) {
         if (newtype == NULL) {
             newtype = PyArray_DESCR(self);
+            Py_INCREF(newtype);
         }
-        Py_INCREF(newtype);
         ret = PyArray_CastToType(self, newtype, 0);
         Py_DECREF(self);
         return ret;
     } else { // copy == NPY_COPY_IF_NEEDED || copy == NPY_COPY_NEVER
-        if (newtype == NULL || PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
+        if (newtype == NULL) {
+            return (PyObject *)self;
+        } else if (PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
+            Py_DECREF(newtype);
             return (PyObject *)self;
         }
         if (copy == NPY_COPY_IF_NEEDED) {
-            Py_INCREF(newtype);
             ret = PyArray_CastToType(self, newtype, 0);
             Py_DECREF(self);
             return ret;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -962,6 +962,8 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
     if (copy == NPY_COPY_ALWAYS) {
         if (newtype == NULL) {
             newtype = PyArray_DESCR(self);
+            // Take a new strong reference to compensate for
+            // PyArray_CastToType stealing a reference to newtype.
             Py_INCREF(newtype);
         }
         ret = PyArray_CastToType(self, newtype, 0);
@@ -969,6 +971,8 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return ret;
     } else { // copy == NPY_COPY_IF_NEEDED || copy == NPY_COPY_NEVER
         if (newtype == NULL || PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
+            // If newtype isn't NULL then release a strong reference
+            // introduced by PyArray_DescrConverter2 in arg parsing.
             Py_XDECREF(newtype);
             return (PyObject *)self;
         }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -968,10 +968,8 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
         Py_DECREF(self);
         return ret;
     } else { // copy == NPY_COPY_IF_NEEDED || copy == NPY_COPY_NEVER
-        if (newtype == NULL) {
-            return (PyObject *)self;
-        } else if (PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
-            Py_DECREF(newtype);
+        if (newtype == NULL || PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
+            Py_XDECREF(newtype);
             return (PyObject *)self;
         }
         if (copy == NPY_COPY_IF_NEEDED) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -951,6 +951,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
                 (PyObject *)self
         );
         if (new == NULL) {
+            Py_XDECREF(newtype);
             return NULL;
         }
         self = new;
@@ -982,6 +983,9 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return ret;
         } else { // copy == NPY_COPY_NEVER
             PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
+            // On error release a strong reference introduced by
+            // PyArray_DescrConverter2 in arg parsing.
+            Py_DECREF(newtype);
             Py_DECREF(self);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -934,6 +934,11 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
+    if (newtype == NULL) {
+        newtype = PyArray_DESCR(self);
+        Py_INCREF(newtype);  // newtype is owned.
+    }
+
     /* convert to PyArray_Type */
     if (!PyArray_CheckExact(self)) {
         PyArrayObject *new;
@@ -951,7 +956,7 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
                 (PyObject *)self
         );
         if (new == NULL) {
-            Py_XDECREF(newtype);
+            Py_DECREF(newtype);
             return NULL;
         }
         self = new;
@@ -961,30 +966,21 @@ array_getarray(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (copy == NPY_COPY_ALWAYS) {
-        if (newtype == NULL) {
-            newtype = PyArray_DESCR(self);
-            // Take a new strong reference to compensate for
-            // PyArray_CastToType stealing a reference to newtype.
-            Py_INCREF(newtype);
-        }
-        ret = PyArray_CastToType(self, newtype, 0);
+        ret = PyArray_CastToType(self, newtype, 0);  // steals newtype reference
         Py_DECREF(self);
         return ret;
     } else { // copy == NPY_COPY_IF_NEEDED || copy == NPY_COPY_NEVER
-        if (newtype == NULL || PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
-            // If newtype isn't NULL then release a strong reference
-            // introduced by PyArray_DescrConverter2 in arg parsing.
-            Py_XDECREF(newtype);
+        if (PyArray_EquivTypes(PyArray_DESCR(self), newtype)) {
+            Py_DECREF(newtype);
             return (PyObject *)self;
         }
         if (copy == NPY_COPY_IF_NEEDED) {
-            ret = PyArray_CastToType(self, newtype, 0);
+            ret = PyArray_CastToType(self, newtype, 0);  // steals newtype reference.
             Py_DECREF(self);
             return ret;
         } else { // copy == NPY_COPY_NEVER
             PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
-            // On error release a strong reference introduced by
-            // PyArray_DescrConverter2 in arg parsing.
+            // On error release a strong reference.
             Py_DECREF(newtype);
             Py_DECREF(self);
             return NULL;

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -168,7 +168,7 @@ def test___array___refcount():
             return self.val.__array__(dtype=dtype, copy=copy)
 
     # test all possible scenarios:
-    # dtype(none | same | different) x copy(true | false)
+    # dtype(none | same | different) x copy(true | false | none)
     dt = np.dtype(np.int32)
     old_refcount = sys.getrefcount(dt)
     np.array(MyArray(dt))
@@ -184,6 +184,9 @@ def test___array___refcount():
     np.array(MyArray(dt), dtype=dt2)
     assert_equal(old_refcount2, sys.getrefcount(dt2))
     np.array(MyArray(dt), dtype=dt2, copy=None)
+    assert_equal(old_refcount2, sys.getrefcount(dt2))
+    with pytest.raises(ValueError):
+        np.array(MyArray(dt), dtype=dt2, copy=False)
     assert_equal(old_refcount2, sys.getrefcount(dt2))
 
 

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -167,6 +167,8 @@ def test___array___refcount():
         def __array__(self, dtype=None, copy=None):
             return self.val.__array__(dtype=dtype, copy=copy)
 
+    # test all possible scenarios:
+    # dtype(none | same | different) x copy(true | false)
     dt = np.dtype(np.int32)
     old_refcount = sys.getrefcount(dt)
     np.array(MyArray(dt))

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -99,16 +99,28 @@ def test_array_array():
     assert_equal(np.array(o, dtype=np.float64), np.array(100.0, np.float64))
     if HAS_REFCOUNT:
         class MyArray:
-            def __init__(self):
-                self.val = np.array(-1, dtype=dt)
+            def __init__(self, dtype):
+                self.val = np.array(-1, dtype=dtype)
 
             def __array__(self, dtype=None, copy=None):
                 return self.val.__array__(dtype=dtype, copy=copy)
 
         dt = np.dtype(np.int32)
         old_refcount = sys.getrefcount(dt)
-        np.array(MyArray())
+        np.array(MyArray(dt))
         assert_equal(old_refcount, sys.getrefcount(dt))
+        np.array(MyArray(dt), dtype=dt)
+        assert_equal(old_refcount, sys.getrefcount(dt))
+        np.array(MyArray(dt), copy=None)
+        assert_equal(old_refcount, sys.getrefcount(dt))
+        np.array(MyArray(dt), dtype=dt, copy=None)
+        assert_equal(old_refcount, sys.getrefcount(dt))
+        dt2 = np.dtype(np.int16)
+        old_refcount2 = sys.getrefcount(dt2)
+        np.array(MyArray(dt), dtype=dt2)
+        assert_equal(old_refcount2, sys.getrefcount(dt2))
+        np.array(MyArray(dt), dtype=dt2, copy=None)
+        assert_equal(old_refcount2, sys.getrefcount(dt2))
 
     # test recursion
     nested = 1.5


### PR DESCRIPTION
This PR fixes a refcount bug raised in https://github.com/numpy/numpy/issues/29707 and adds a test which fails on `main` branch for linux, x86. 