### PR TITLE
BUG: standardize 'Mean of empty slice' inconsistent message #29711

### DIFF
--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -119,7 +119,7 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
     if rcount == 0 if where is True else umr_any(rcount == 0, axis=None):
-        warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
+        warnings.warn("Mean of empty slice", RuntimeWarning, stacklevel=2)
 
     # Cast bool, unsigned int, and int to float64 by default
     if dtype is None:


### PR DESCRIPTION
Problem:
There is a minor but annoying inconsistency in NumPy’s RuntimeWarning messages for empty slices:

np.nanmean([]) → "Mean of empty slice" (no period)

np.mean([]) internally via _methods.py → "Mean of empty slice." (with a period)

#29711 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------
*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
