### PR TITLE
TST: not to include the LONGDOUBLE test on AIX

### DIFF
--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -147,9 +147,9 @@ _cast_dict['CHARACTER'] = ['CHARACTER']
 # and several tests fail as the alignment flag can be randomly true or false
 # when numpy gains an aligned allocator the tests could be enabled again
 #
-# Furthermore, on macOS ARM64, LONGDOUBLE is an alias for DOUBLE.
+# Furthermore, on macOS ARM64 and AIX, LONGDOUBLE is an alias for DOUBLE.
 if ((np.intp().dtype.itemsize != 4 or np.clongdouble().dtype.alignment <= 8)
-        and sys.platform != "win32"
+        and sys.platform not in ["win32", "aix"]
         and (platform.system(), platform.processor()) != ("Darwin", "arm")):
     _type_names.extend(["LONGDOUBLE", "CDOUBLE", "CLONGDOUBLE"])
     _cast_dict["LONGDOUBLE"] = _cast_dict["LONG"] + [


### PR DESCRIPTION
On AIX, `double` and `long double` have the same size. This patch is
update the test to exclude `LONGDOUBLE` test.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
