### PR TITLE
TST: Fix np.random thread test failures

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1186,8 +1186,8 @@ class TestGradient:
         assert_(np.all(num_error < 0.03) == True)
 
         # test with unevenly spaced
-        np.random.seed(0)
-        x = np.sort(np.random.random(10))
+        rng = np.random.default_rng(0)
+        x = np.sort(rng.random(10))
         y = 2 * x ** 3 + 4 * x ** 2 + 2 * x
         analytical = 6 * x ** 2 + 8 * x + 2
         num_error = np.abs((np.gradient(y, x, edge_order=2) / analytical) - 1)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -1062,9 +1062,6 @@ class TestBroadcast:
     # correctly when presented with non-scalar arguments
     seed = 123456789
 
-    def setSeed(self):
-        return random.RandomState(self.seed)
-
     # TODO: Include test for randint once it can broadcast
     # Can steal the test written in PR #6938
 
@@ -1075,11 +1072,11 @@ class TestBroadcast:
                             0.53413660089041659,
                             0.50955303552646702])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.uniform(low * 3, high)
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.uniform(low, high * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
 
@@ -1091,12 +1088,12 @@ class TestBroadcast:
                             2.1283977976520019,
                             1.8417114045748335])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.normal(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.normal, loc * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.normal(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.normal, loc, bad_scale * 3)
@@ -1110,13 +1107,13 @@ class TestBroadcast:
                             0.075230336409423643,
                             0.24976865978980844])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.beta(a * 3, b)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.beta, bad_a * 3, b)
         assert_raises(ValueError, rng.beta, a * 3, bad_b)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.beta(a, b * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.beta, bad_a, b * 3)
@@ -1129,7 +1126,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.exponential(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.exponential, bad_scale * 3)
@@ -1141,7 +1138,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.standard_gamma(shape * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.standard_gamma, bad_shape * 3)
@@ -1155,13 +1152,13 @@ class TestBroadcast:
                             1.5277256455738331,
                             1.4248762625178359])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.gamma(shape * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gamma, bad_shape * 3, scale)
         assert_raises(ValueError, rng.gamma, shape * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.gamma(shape, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gamma, bad_shape, scale * 3)
@@ -1176,13 +1173,13 @@ class TestBroadcast:
                             0.86768719635363512,
                             2.7251095168386801])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.f(dfnum * 3, dfden)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.f, bad_dfnum * 3, dfden)
         assert_raises(ValueError, rng.f, dfnum * 3, bad_dfden)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.f(dfnum, dfden * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.f, bad_dfnum, dfden * 3)
@@ -1199,21 +1196,21 @@ class TestBroadcast:
                             13.025456344595602,
                             8.8018098359100545])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum * 3, dfden, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_f, bad_dfnum * 3, dfden, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum * 3, bad_dfden, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum * 3, dfden, bad_nonc)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum, dfden * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden * 3, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden * 3, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum, dfden * 3, bad_nonc)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum, dfden, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden, nonc * 3)
@@ -1221,7 +1218,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.noncentral_f, dfnum, dfden, bad_nonc * 3)
 
     def test_noncentral_f_small_df(self):
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         desired = np.array([6.869638627492048, 0.785880199263955])
         actual = rng.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
@@ -1233,7 +1230,7 @@ class TestBroadcast:
                             0.51947702108840776,
                             0.1320969254923558])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.chisquare(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.chisquare, bad_df * 3)
@@ -1247,13 +1244,13 @@ class TestBroadcast:
                             4.5804135049718742,
                             6.0872302432834564])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_chisquare(df * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_chisquare, bad_df * 3, nonc)
         assert_raises(ValueError, rng.noncentral_chisquare, df * 3, bad_nonc)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_chisquare(df, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_chisquare, bad_df, nonc * 3)
@@ -1266,7 +1263,7 @@ class TestBroadcast:
                             5.8560725167361607,
                             1.0274791436474273])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.standard_t(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.standard_t, bad_df * 3)
@@ -1279,12 +1276,12 @@ class TestBroadcast:
                             -2.7064099483995943,
                             -1.8672476700665914])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.vonmises(mu * 3, kappa)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.vonmises, mu * 3, bad_kappa)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.vonmises(mu, kappa * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.vonmises, mu, bad_kappa * 3)
@@ -1296,7 +1293,7 @@ class TestBroadcast:
                             1.1465519762044529,
                             1.0389564467453547])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.pareto(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.pareto, bad_a * 3)
@@ -1308,7 +1305,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.weibull(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.weibull, bad_a * 3)
@@ -1320,7 +1317,7 @@ class TestBroadcast:
                             0.53413660089041659,
                             0.50955303552646702])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.power(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.power, bad_a * 3)
@@ -1333,12 +1330,12 @@ class TestBroadcast:
                             0.070715642226971326,
                             0.019290950698972624])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.laplace(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.laplace, loc * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.laplace(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.laplace, loc, bad_scale * 3)
@@ -1351,12 +1348,12 @@ class TestBroadcast:
                             0.26936705726291116,
                             0.33906220393037939])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.gumbel(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gumbel, loc * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.gumbel(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gumbel, loc, bad_scale * 3)
@@ -1369,12 +1366,12 @@ class TestBroadcast:
                             0.13675915696285773,
                             0.038216792802833396])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.logistic(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.logistic, loc * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.logistic(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.logistic, loc, bad_scale * 3)
@@ -1387,12 +1384,12 @@ class TestBroadcast:
                             8.4013952870126261,
                             6.3073234116578671])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.lognormal(mean * 3, sigma)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.lognormal, mean * 3, bad_sigma)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.lognormal(mean, sigma * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.lognormal, mean, bad_sigma * 3)
@@ -1404,7 +1401,7 @@ class TestBroadcast:
                             1.2360119924878694,
                             1.1936818095781789])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.rayleigh(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.rayleigh, bad_scale * 3)
@@ -1418,13 +1415,13 @@ class TestBroadcast:
                             0.12450084820795027,
                             0.9096122728408238])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.wald(mean * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.wald, bad_mean * 3, scale)
         assert_raises(ValueError, rng.wald, mean * 3, bad_scale)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.wald(mean, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.wald, bad_mean, scale * 3)
@@ -1443,7 +1440,7 @@ class TestBroadcast:
                             2.0347400359389356,
                             2.0095991069536208])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left * 3, mode, right)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one * 3, mode, right)
@@ -1451,7 +1448,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.triangular, bad_left_two * 3, bad_mode_two,
                       right)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left, mode * 3, right)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one, mode * 3, right)
@@ -1459,7 +1456,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two * 3,
                       right)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left, mode, right * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one, mode, right * 3)
@@ -1475,14 +1472,14 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([1, 1, 1])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.binomial(n * 3, p)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.binomial, bad_n * 3, p)
         assert_raises(ValueError, rng.binomial, n * 3, bad_p_one)
         assert_raises(ValueError, rng.binomial, n * 3, bad_p_two)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.binomial(n, p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.binomial, bad_n, p * 3)
@@ -1497,14 +1494,14 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([1, 0, 1])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.negative_binomial(n * 3, p)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.negative_binomial, bad_n * 3, p)
         assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_one)
         assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_two)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.negative_binomial(n, p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.negative_binomial, bad_n, p * 3)
@@ -1519,7 +1516,7 @@ class TestBroadcast:
         bad_lam_two = [max_lam * 2]
         desired = np.array([1, 1, 0])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.poisson(lam * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.poisson, bad_lam_one * 3)
@@ -1530,7 +1527,7 @@ class TestBroadcast:
         bad_a = [0]
         desired = np.array([2, 2, 1])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.zipf(a * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.zipf, bad_a * 3)
@@ -1544,7 +1541,7 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([2, 2, 2])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.geometric(p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.geometric, bad_p_one * 3)
@@ -1560,7 +1557,7 @@ class TestBroadcast:
         bad_nsample_two = [4]
         desired = np.array([1, 1, 1])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood * 3, nbad, nsample)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood * 3, nbad, nsample)
@@ -1568,7 +1565,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_one)
         assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_two)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood, nbad * 3, nsample)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad * 3, nsample)
@@ -1576,7 +1573,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_one)
         assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_two)
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood, nbad, nsample * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad, nsample * 3)
@@ -1590,7 +1587,7 @@ class TestBroadcast:
         bad_p_two = [-1]
         desired = np.array([1, 1, 1])
 
-        rng = self.setSeed()
+        rng = random.RandomState(self.seed)
         actual = rng.logseries(p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.logseries, bad_p_one * 3)

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -165,47 +165,49 @@ class TestSetState:
 
 class TestRandint:
 
-    rfunc = np.random.randint
-
     # valid integer/boolean types
     itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
-        assert_raises(TypeError, self.rfunc, 1, dtype=float)
+        rng = random.RandomState()
+        assert_raises(TypeError, rng.randint, 1, dtype=float)
 
     def test_bounds_checking(self):
+        rng = random.RandomState()
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
-            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
+            assert_raises(ValueError, rng.randint, lbnd - 1, ubnd, dtype=dt)
+            assert_raises(ValueError, rng.randint, lbnd, ubnd + 1, dtype=dt)
+            assert_raises(ValueError, rng.randint, ubnd, lbnd, dtype=dt)
+            assert_raises(ValueError, rng.randint, 1, 0, dtype=dt)
 
     def test_rng_zero_and_extremes(self):
+        rng = random.RandomState()
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
             tgt = ubnd - 1
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
             tgt = lbnd
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
             tgt = (lbnd + ubnd) // 2
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
     def test_full_range(self):
         # Test for ticket #1690
+        rng = random.RandomState()
 
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
             try:
-                self.rfunc(lbnd, ubnd, dtype=dt)
+                rng.randint(lbnd, ubnd, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
@@ -213,15 +215,15 @@ class TestRandint:
 
     def test_in_bounds_fuzz(self):
         # Don't use fixed seed
-        np.random.seed()
+        rng = random.RandomState()
 
         for dt in self.itype[1:]:
             for ubnd in [4, 8, 16]:
-                vals = self.rfunc(2, ubnd, size=2**16, dtype=dt)
+                vals = rng.randint(2, ubnd, size=2**16, dtype=dt)
                 assert_(vals.max() < ubnd)
                 assert_(vals.min() >= 2)
 
-        vals = self.rfunc(0, 2, size=2**16, dtype=np.bool)
+        vals = rng.randint(0, 2, size=2**16, dtype=np.bool)
 
         assert_(vals.max() < 2)
         assert_(vals.min() >= 0)
@@ -284,11 +286,12 @@ class TestRandint:
 
     def test_respect_dtype_singleton(self):
         # See gh-7203
+        rng = random.RandomState()
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = rng.randint(lbnd, ubnd, dtype=dt)
             assert_equal(sample.dtype, np.dtype(dt))
 
         for dt in (bool, int):
@@ -297,7 +300,7 @@ class TestRandint:
             ubnd = 2 if dt is bool else np.iinfo("long").max + 1
 
             # gh-7284: Ensure that we get Python data types
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = rng.randint(lbnd, ubnd, dtype=dt)
             assert_(not hasattr(sample, 'dtype'))
             assert_equal(type(sample), dt)
 

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -242,20 +242,20 @@ class TestRandint:
                'uint8':  '001aac3a5acb935a9b186cbe14a1ca064b8bb2dd0b045d48abeacf74d0203404'}  # noqa: E501
 
         for dt in self.itype[1:]:
-            np.random.seed(1234)
+            rng = random.RandomState(1234)
 
             # view as little endian for hash
             if sys.byteorder == 'little':
-                val = self.rfunc(0, 6, size=1000, dtype=dt)
+                val = rng.randint(0, 6, size=1000, dtype=dt)
             else:
-                val = self.rfunc(0, 6, size=1000, dtype=dt).byteswap()
+                val = rng.randint(0, 6, size=1000, dtype=dt).byteswap()
 
             res = hashlib.sha256(val.view(np.int8)).hexdigest()
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianness
-        np.random.seed(1234)
-        val = self.rfunc(0, 2, size=1000, dtype=bool).view(np.int8)
+        rng = random.RandomState(1234)
+        val = rng.randint(0, 2, size=1000, dtype=bool).view(np.int8)
         res = hashlib.sha256(val).hexdigest()
         assert_(tgt[np.dtype(bool).name] == res)
 
@@ -308,33 +308,33 @@ class TestRandomDist:
     seed = 1234567890
 
     def test_rand(self):
-        np.random.seed(self.seed)
-        actual = np.random.rand(3, 2)
+        rng = random.RandomState(self.seed)
+        actual = rng.rand(3, 2)
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randn(self):
-        np.random.seed(self.seed)
-        actual = np.random.randn(3, 2)
+        rng = random.RandomState(self.seed)
+        actual = rng.randn(3, 2)
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                            [1.498988344300628, -0.2286433324536169],
                            [2.031033998682787, 2.17032494605655257]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randint(self):
-        np.random.seed(self.seed)
-        actual = np.random.randint(-99, 99, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.randint(-99, 99, size=(3, 2))
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
 
     def test_random_integers(self):
-        np.random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         with pytest.warns(DeprecationWarning):
-            actual = np.random.random_integers(-99, 99, size=(3, 2))
+            actual = rng.random_integers(-99, 99, size=(3, 2))
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
@@ -368,41 +368,41 @@ class TestRandomDist:
                           np.iinfo('l').max, np.iinfo('l').max)
 
     def test_random(self):
-        np.random.seed(self.seed)
-        actual = np.random.random((3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.random((3, 2))
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_choice_uniform_replace(self):
-        np.random.seed(self.seed)
-        actual = np.random.choice(4, 4)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 4)
         desired = np.array([2, 3, 2, 3])
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
-        np.random.seed(self.seed)
-        actual = np.random.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
         desired = np.array([1, 1, 2, 2])
         assert_array_equal(actual, desired)
 
     def test_choice_uniform_noreplace(self):
-        np.random.seed(self.seed)
-        actual = np.random.choice(4, 3, replace=False)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 3, replace=False)
         desired = np.array([0, 1, 3])
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):
-        np.random.seed(self.seed)
-        actual = np.random.choice(4, 3, replace=False,
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 3, replace=False,
                                   p=[0.1, 0.3, 0.5, 0.1])
         desired = np.array([2, 3, 1])
         assert_array_equal(actual, desired)
 
     def test_choice_noninteger(self):
-        np.random.seed(self.seed)
-        actual = np.random.choice(['a', 'b', 'c', 'd'], 4)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(['a', 'b', 'c', 'd'], 4)
         desired = np.array(['c', 'd', 'c', 'd'])
         assert_array_equal(actual, desired)
 
@@ -477,8 +477,8 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.choice, a, p=p)
 
     def test_bytes(self):
-        np.random.seed(self.seed)
-        actual = np.random.bytes(10)
+        rng = random.RandomState(self.seed)
+        actual = rng.bytes(10)
         desired = b'\x82Ui\x9e\xff\x97+Wf\xa5'
         assert_equal(actual, desired)
 
@@ -501,9 +501,9 @@ class TestRandomDist:
                      # gh-4270
                      lambda x: np.asarray([(i, i) for i in x],
                                           [("a", object), ("b", np.int32)])]:
-            np.random.seed(self.seed)
+            rng = random.RandomState(self.seed)
             alist = conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
-            np.random.shuffle(alist)
+            rng.shuffle(alist)
             actual = alist
             desired = conv([0, 1, 9, 6, 2, 4, 5, 8, 7, 3])
             assert_array_equal(actual, desired)
@@ -563,11 +563,11 @@ class TestRandomDist:
         # gh-18273
         # allow graceful handling of memoryviews
         # (treat the same as arrays)
-        np.random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         a = np.arange(5).data
-        np.random.shuffle(a)
+        rng.shuffle(a)
         assert_equal(np.asarray(a), [0, 1, 4, 3, 2])
-        rng = np.random.RandomState(self.seed)
+        rng = random.RandomState(self.seed)
         rng.shuffle(a)
         assert_equal(np.asarray(a), [0, 1, 2, 3, 4])
         rng = np.random.default_rng(self.seed)
@@ -581,8 +581,8 @@ class TestRandomDist:
             np.random.shuffle(a)
 
     def test_beta(self):
-        np.random.seed(self.seed)
-        actual = np.random.beta(.1, .9, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.beta(.1, .9, size=(3, 2))
         desired = np.array(
                 [[1.45341850513746058e-02, 5.31297615662868145e-04],
                  [1.85366619058432324e-06, 4.19214516800110563e-03],
@@ -590,25 +590,25 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_binomial(self):
-        np.random.seed(self.seed)
-        actual = np.random.binomial(100, .456, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.binomial(100, .456, size=(3, 2))
         desired = np.array([[37, 43],
                             [42, 48],
                             [46, 45]])
         assert_array_equal(actual, desired)
 
     def test_chisquare(self):
-        np.random.seed(self.seed)
-        actual = np.random.chisquare(50, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.chisquare(50, size=(3, 2))
         desired = np.array([[63.87858175501090585, 68.68407748911370447],
                             [65.77116116901505904, 47.09686762438974483],
                             [72.3828403199695174, 74.18408615260374006]])
         assert_array_almost_equal(actual, desired, decimal=13)
 
     def test_dirichlet(self):
-        np.random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         alpha = np.array([51.72840233779265162, 39.74494232180943953])
-        actual = np.random.mtrand.dirichlet(alpha, size=(3, 2))
+        actual = rng.dirichlet(alpha, size=(3, 2))
         desired = np.array([[[0.54539444573611562, 0.45460555426388438],
                              [0.62345816822039413, 0.37654183177960598]],
                             [[0.55206000085785778, 0.44793999914214233],
@@ -641,8 +641,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.dirichlet, np.array([[5, 1], [1, 5]]))
 
     def test_exponential(self):
-        np.random.seed(self.seed)
-        actual = np.random.exponential(1.1234, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.exponential(1.1234, size=(3, 2))
         desired = np.array([[1.08342649775011624, 1.00607889924557314],
                             [2.46628830085216721, 2.49668106809923884],
                             [0.68717433461363442, 1.69175666993575979]])
@@ -653,16 +653,16 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.exponential, scale=-0.)
 
     def test_f(self):
-        np.random.seed(self.seed)
-        actual = np.random.f(12, 77, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.f(12, 77, size=(3, 2))
         desired = np.array([[1.21975394418575878, 1.75135759791559775],
                             [1.44803115017146489, 1.22108959480396262],
                             [1.02176975757740629, 1.34431827623300415]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_gamma(self):
-        np.random.seed(self.seed)
-        actual = np.random.gamma(5, 3, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.gamma(5, 3, size=(3, 2))
         desired = np.array([[24.60509188649287182, 28.54993563207210627],
                             [26.13476110204064184, 12.56988482927716078],
                             [31.71863275789960568, 33.30143302795922011]])
@@ -673,16 +673,16 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.gamma, shape=-0., scale=-0.)
 
     def test_geometric(self):
-        np.random.seed(self.seed)
-        actual = np.random.geometric(.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.geometric(.123456789, size=(3, 2))
         desired = np.array([[8, 7],
                             [17, 17],
                             [5, 12]])
         assert_array_equal(actual, desired)
 
     def test_gumbel(self):
-        np.random.seed(self.seed)
-        actual = np.random.gumbel(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.gumbel(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[0.19591898743416816, 0.34405539668096674],
                             [-1.4492522252274278, -1.47374816298446865],
                             [1.10651090478803416, -0.69535848626236174]])
@@ -693,34 +693,34 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.gumbel, scale=-0.)
 
     def test_hypergeometric(self):
-        np.random.seed(self.seed)
-        actual = np.random.hypergeometric(10, 5, 14, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.hypergeometric(10, 5, 14, size=(3, 2))
         desired = np.array([[10, 10],
                             [10, 10],
                             [9, 9]])
         assert_array_equal(actual, desired)
 
         # Test nbad = 0
-        actual = np.random.hypergeometric(5, 0, 3, size=4)
+        actual = rng.hypergeometric(5, 0, 3, size=4)
         desired = np.array([3, 3, 3, 3])
         assert_array_equal(actual, desired)
 
-        actual = np.random.hypergeometric(15, 0, 12, size=4)
+        actual = rng.hypergeometric(15, 0, 12, size=4)
         desired = np.array([12, 12, 12, 12])
         assert_array_equal(actual, desired)
 
         # Test ngood = 0
-        actual = np.random.hypergeometric(0, 5, 3, size=4)
+        actual = rng.hypergeometric(0, 5, 3, size=4)
         desired = np.array([0, 0, 0, 0])
         assert_array_equal(actual, desired)
 
-        actual = np.random.hypergeometric(0, 15, 12, size=4)
+        actual = rng.hypergeometric(0, 15, 12, size=4)
         desired = np.array([0, 0, 0, 0])
         assert_array_equal(actual, desired)
 
     def test_laplace(self):
-        np.random.seed(self.seed)
-        actual = np.random.laplace(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.laplace(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[0.66599721112760157, 0.52829452552221945],
                             [3.12791959514407125, 3.18202813572992005],
                             [-0.05391065675859356, 1.74901336242837324]])
@@ -731,16 +731,16 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.laplace, scale=-0.)
 
     def test_logistic(self):
-        np.random.seed(self.seed)
-        actual = np.random.logistic(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.logistic(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[1.09232835305011444, 0.8648196662399954],
                             [4.27818590694950185, 4.33897006346929714],
                             [-0.21682183359214885, 2.63373365386060332]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_lognormal(self):
-        np.random.seed(self.seed)
-        actual = np.random.lognormal(mean=.123456789, sigma=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.lognormal(mean=.123456789, sigma=2.0, size=(3, 2))
         desired = np.array([[16.50698631688883822, 36.54846706092654784],
                             [22.67886599981281748, 0.71617561058995771],
                             [65.72798501792723869, 86.84341601437161273]])
@@ -751,16 +751,16 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.lognormal, sigma=-0.)
 
     def test_logseries(self):
-        np.random.seed(self.seed)
-        actual = np.random.logseries(p=.923456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.logseries(p=.923456789, size=(3, 2))
         desired = np.array([[2, 2],
                             [6, 17],
                             [3, 6]])
         assert_array_equal(actual, desired)
 
     def test_multinomial(self):
-        np.random.seed(self.seed)
-        actual = np.random.multinomial(20, [1 / 6.] * 6, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.multinomial(20, [1 / 6.] * 6, size=(3, 2))
         desired = np.array([[[4, 3, 5, 4, 2, 2],
                              [5, 2, 8, 2, 2, 1]],
                             [[3, 4, 3, 6, 0, 4],
@@ -770,11 +770,11 @@ class TestRandomDist:
         assert_array_equal(actual, desired)
 
     def test_multivariate_normal(self):
-        np.random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         mean = (.123456789, 10)
         cov = [[1, 0], [0, 1]]
         size = (3, 2)
-        actual = np.random.multivariate_normal(mean, cov, size)
+        actual = rng.multivariate_normal(mean, cov, size)
         desired = np.array([[[1.463620246718631, 11.73759122771936],
                              [1.622445133300628, 9.771356667546383]],
                             [[2.154490787682787, 12.170324946056553],
@@ -785,7 +785,7 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=15)
 
         # Check for default size, was raising deprecation warning
-        actual = np.random.multivariate_normal(mean, cov)
+        actual = rng.multivariate_normal(mean, cov)
         desired = np.array([0.895289569463708, 9.17180864067987])
         assert_array_almost_equal(actual, desired, decimal=15)
 
@@ -793,53 +793,53 @@ class TestRandomDist:
         # RuntimeWarning
         mean = [0, 0]
         cov = [[1, 2], [2, 1]]
-        pytest.warns(RuntimeWarning, np.random.multivariate_normal, mean, cov)
+        pytest.warns(RuntimeWarning, rng.multivariate_normal, mean, cov)
 
         # and that it doesn't warn with RuntimeWarning check_valid='ignore'
-        assert_no_warnings(np.random.multivariate_normal, mean, cov,
+        assert_no_warnings(rng.multivariate_normal, mean, cov,
                            check_valid='ignore')
 
         # and that it raises with RuntimeWarning check_valid='raises'
-        assert_raises(ValueError, np.random.multivariate_normal, mean, cov,
+        assert_raises(ValueError, rng.multivariate_normal, mean, cov,
                       check_valid='raise')
 
         cov = np.array([[1, 0.1], [0.1, 1]], dtype=np.float32)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
-            np.random.multivariate_normal(mean, cov)
+            rng.multivariate_normal(mean, cov)
 
     def test_negative_binomial(self):
-        np.random.seed(self.seed)
-        actual = np.random.negative_binomial(n=100, p=.12345, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.negative_binomial(n=100, p=.12345, size=(3, 2))
         desired = np.array([[848, 841],
                             [892, 611],
                             [779, 647]])
         assert_array_equal(actual, desired)
 
     def test_noncentral_chisquare(self):
-        np.random.seed(self.seed)
-        actual = np.random.noncentral_chisquare(df=5, nonc=5, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_chisquare(df=5, nonc=5, size=(3, 2))
         desired = np.array([[23.91905354498517511, 13.35324692733826346],
                             [31.22452661329736401, 16.60047399466177254],
                             [5.03461598262724586, 17.94973089023519464]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        actual = np.random.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
+        actual = rng.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
         desired = np.array([[1.47145377828516666,  0.15052899268012659],
                             [0.00943803056963588,  1.02647251615666169],
                             [0.332334982684171,  0.15451287602753125]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        np.random.seed(self.seed)
-        actual = np.random.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
         desired = np.array([[9.597154162763948, 11.725484450296079],
                             [10.413711048138335, 3.694475922923986],
                             [13.484222138963087, 14.377255424602957]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_noncentral_f(self):
-        np.random.seed(self.seed)
-        actual = np.random.noncentral_f(dfnum=5, dfden=2, nonc=1,
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_f(dfnum=5, dfden=2, nonc=1,
                                         size=(3, 2))
         desired = np.array([[1.40598099674926669, 0.34207973179285761],
                             [3.57715069265772545, 7.92632662577829805],
@@ -847,8 +847,8 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_normal(self):
-        np.random.seed(self.seed)
-        actual = np.random.normal(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.normal(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[2.80378370443726244, 3.59863924443872163],
                             [3.121433477601256, -0.33382987590723379],
                             [4.18552478636557357, 4.46410668111310471]])
@@ -859,8 +859,8 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.normal, scale=-0.)
 
     def test_pareto(self):
-        np.random.seed(self.seed)
-        actual = np.random.pareto(a=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.pareto(a=.123456789, size=(3, 2))
         desired = np.array(
                 [[2.46852460439034849e+03, 1.41286880810518346e+03],
                  [5.28287797029485181e+07, 6.57720981047328785e+07],
@@ -874,8 +874,8 @@ class TestRandomDist:
         np.testing.assert_array_almost_equal_nulp(actual, desired, nulp=30)
 
     def test_poisson(self):
-        np.random.seed(self.seed)
-        actual = np.random.poisson(lam=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.poisson(lam=.123456789, size=(3, 2))
         desired = np.array([[0, 0],
                             [1, 0],
                             [0, 0]])
@@ -890,16 +890,16 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.poisson, [lambig] * 10)
 
     def test_power(self):
-        np.random.seed(self.seed)
-        actual = np.random.power(a=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.power(a=.123456789, size=(3, 2))
         desired = np.array([[0.02048932883240791, 0.01424192241128213],
                             [0.38446073748535298, 0.39499689943484395],
                             [0.00177699707563439, 0.13115505880863756]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_rayleigh(self):
-        np.random.seed(self.seed)
-        actual = np.random.rayleigh(scale=10, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.rayleigh(scale=10, size=(3, 2))
         desired = np.array([[13.8882496494248393, 13.383318339044731],
                             [20.95413364294492098, 21.08285015800712614],
                             [11.06066537006854311, 17.35468505778271009]])
@@ -910,24 +910,24 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.rayleigh, scale=-0.)
 
     def test_standard_cauchy(self):
-        np.random.seed(self.seed)
-        actual = np.random.standard_cauchy(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_cauchy(size=(3, 2))
         desired = np.array([[0.77127660196445336, -6.55601161955910605],
                             [0.93582023391158309, -2.07479293013759447],
                             [-4.74601644297011926, 0.18338989290760804]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_exponential(self):
-        np.random.seed(self.seed)
-        actual = np.random.standard_exponential(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_exponential(size=(3, 2))
         desired = np.array([[0.96441739162374596, 0.89556604882105506],
                             [2.1953785836319808, 2.22243285392490542],
                             [0.6116915921431676, 1.50592546727413201]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_gamma(self):
-        np.random.seed(self.seed)
-        actual = np.random.standard_gamma(shape=3, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_gamma(shape=3, size=(3, 2))
         desired = np.array([[5.50841531318455058, 6.62953470301903103],
                             [5.93988484943779227, 2.31044849402133989],
                             [7.54838614231317084, 8.012756093271868]])
@@ -938,24 +938,24 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.standard_gamma, shape=-0.)
 
     def test_standard_normal(self):
-        np.random.seed(self.seed)
-        actual = np.random.standard_normal(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_normal(size=(3, 2))
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                             [1.498988344300628, -0.2286433324536169],
                             [2.031033998682787, 2.17032494605655257]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_t(self):
-        np.random.seed(self.seed)
-        actual = np.random.standard_t(df=10, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_t(df=10, size=(3, 2))
         desired = np.array([[0.97140611862659965, -0.08830486548450577],
                             [1.36311143689505321, -0.55317463909867071],
                             [-0.18473749069684214, 0.61181537341755321]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_triangular(self):
-        np.random.seed(self.seed)
-        actual = np.random.triangular(left=5.12, mode=10.23, right=20.34,
+        rng = random.RandomState(self.seed)
+        actual = rng.triangular(left=5.12, mode=10.23, right=20.34,
                                       size=(3, 2))
         desired = np.array([[12.68117178949215784, 12.4129206149193152],
                             [16.20131377335158263, 16.25692138747600524],
@@ -963,8 +963,8 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_uniform(self):
-        np.random.seed(self.seed)
-        actual = np.random.uniform(low=1.23, high=10.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.uniform(low=1.23, high=10.54, size=(3, 2))
         desired = np.array([[6.99097932346268003, 6.73801597444323974],
                             [9.50364421400426274, 9.53130618907631089],
                             [5.48995325769805476, 8.47493103280052118]])
@@ -1011,8 +1011,8 @@ class TestRandomDist:
         assert_raises(TypeError, np.random.hypergeometric, throwing_int, 1, 1)
 
     def test_vonmises(self):
-        np.random.seed(self.seed)
-        actual = np.random.vonmises(mu=1.23, kappa=1.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.vonmises(mu=1.23, kappa=1.54, size=(3, 2))
         desired = np.array([[2.28567572673902042, 2.89163838442285037],
                             [0.38198375564286025, 2.57638023113890746],
                             [1.19153771588353052, 1.83509849681825354]])
@@ -1025,16 +1025,16 @@ class TestRandomDist:
         np.testing.assert_(np.isfinite(r).all())
 
     def test_wald(self):
-        np.random.seed(self.seed)
-        actual = np.random.wald(mean=1.23, scale=1.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.wald(mean=1.23, scale=1.54, size=(3, 2))
         desired = np.array([[3.82935265715889983, 5.13125249184285526],
                             [0.35045403618358717, 1.50832396872003538],
                             [0.24124319895843183, 0.22031101461955038]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_weibull(self):
-        np.random.seed(self.seed)
-        actual = np.random.weibull(a=1.23, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.weibull(a=1.23, size=(3, 2))
         desired = np.array([[0.97097342648766727, 0.91422896443565516],
                             [1.89517770034962929, 1.91414357960479564],
                             [0.67057783752390987, 1.39494046635066793]])
@@ -1046,8 +1046,8 @@ class TestRandomDist:
         assert_raises(ValueError, np.random.weibull, a=-0.)
 
     def test_zipf(self):
-        np.random.seed(self.seed)
-        actual = np.random.zipf(a=1.23, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.zipf(a=1.23, size=(3, 2))
         desired = np.array([[66, 29],
                             [1, 1],
                             [3, 13]])
@@ -1060,7 +1060,7 @@ class TestBroadcast:
     seed = 123456789
 
     def setSeed(self):
-        np.random.seed(self.seed)
+        return random.RandomState(self.seed)
 
     # TODO: Include test for randint once it can broadcast
     # Can steal the test written in PR #6938
@@ -1068,129 +1068,122 @@ class TestBroadcast:
     def test_uniform(self):
         low = [0]
         high = [1]
-        uniform = np.random.uniform
         desired = np.array([0.53283302478975902,
                             0.53413660089041659,
                             0.50955303552646702])
 
-        self.setSeed()
-        actual = uniform(low * 3, high)
+        rng = self.setSeed()
+        actual = rng.uniform(low * 3, high)
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        self.setSeed()
-        actual = uniform(low, high * 3)
+        rng = self.setSeed()
+        actual = rng.uniform(low, high * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_normal(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        normal = np.random.normal
         desired = np.array([2.2129019979039612,
                             2.1283977976520019,
                             1.8417114045748335])
 
-        self.setSeed()
-        actual = normal(loc * 3, scale)
+        rng = self.setSeed()
+        actual = rng.normal(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, normal, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.normal, loc * 3, bad_scale)
 
-        self.setSeed()
-        actual = normal(loc, scale * 3)
+        rng = self.setSeed()
+        actual = rng.normal(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, normal, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.normal, loc, bad_scale * 3)
 
     def test_beta(self):
         a = [1]
         b = [2]
         bad_a = [-1]
         bad_b = [-2]
-        beta = np.random.beta
         desired = np.array([0.19843558305989056,
                             0.075230336409423643,
                             0.24976865978980844])
 
-        self.setSeed()
-        actual = beta(a * 3, b)
+        rng = self.setSeed()
+        actual = rng.beta(a * 3, b)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, beta, bad_a * 3, b)
-        assert_raises(ValueError, beta, a * 3, bad_b)
+        assert_raises(ValueError, rng.beta, bad_a * 3, b)
+        assert_raises(ValueError, rng.beta, a * 3, bad_b)
 
-        self.setSeed()
-        actual = beta(a, b * 3)
+        rng = self.setSeed()
+        actual = rng.beta(a, b * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, beta, bad_a, b * 3)
-        assert_raises(ValueError, beta, a, bad_b * 3)
+        assert_raises(ValueError, rng.beta, bad_a, b * 3)
+        assert_raises(ValueError, rng.beta, a, bad_b * 3)
 
     def test_exponential(self):
         scale = [1]
         bad_scale = [-1]
-        exponential = np.random.exponential
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.setSeed()
-        actual = exponential(scale * 3)
+        rng = self.setSeed()
+        actual = rng.exponential(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, exponential, bad_scale * 3)
+        assert_raises(ValueError, rng.exponential, bad_scale * 3)
 
     def test_standard_gamma(self):
         shape = [1]
         bad_shape = [-1]
-        std_gamma = np.random.standard_gamma
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.setSeed()
-        actual = std_gamma(shape * 3)
+        rng = self.setSeed()
+        actual = rng.standard_gamma(shape * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, std_gamma, bad_shape * 3)
+        assert_raises(ValueError, rng.standard_gamma, bad_shape * 3)
 
     def test_gamma(self):
         shape = [1]
         scale = [2]
         bad_shape = [-1]
         bad_scale = [-2]
-        gamma = np.random.gamma
         desired = np.array([1.5221370731769048,
                             1.5277256455738331,
                             1.4248762625178359])
 
-        self.setSeed()
-        actual = gamma(shape * 3, scale)
+        rng = self.setSeed()
+        actual = rng.gamma(shape * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gamma, bad_shape * 3, scale)
-        assert_raises(ValueError, gamma, shape * 3, bad_scale)
+        assert_raises(ValueError, rng.gamma, bad_shape * 3, scale)
+        assert_raises(ValueError, rng.gamma, shape * 3, bad_scale)
 
-        self.setSeed()
-        actual = gamma(shape, scale * 3)
+        rng = self.setSeed()
+        actual = rng.gamma(shape, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gamma, bad_shape, scale * 3)
-        assert_raises(ValueError, gamma, shape, bad_scale * 3)
+        assert_raises(ValueError, rng.gamma, bad_shape, scale * 3)
+        assert_raises(ValueError, rng.gamma, shape, bad_scale * 3)
 
     def test_f(self):
         dfnum = [1]
         dfden = [2]
         bad_dfnum = [-1]
         bad_dfden = [-2]
-        f = np.random.f
         desired = np.array([0.80038951638264799,
                             0.86768719635363512,
                             2.7251095168386801])
 
-        self.setSeed()
-        actual = f(dfnum * 3, dfden)
+        rng = self.setSeed()
+        actual = rng.f(dfnum * 3, dfden)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, f, bad_dfnum * 3, dfden)
-        assert_raises(ValueError, f, dfnum * 3, bad_dfden)
+        assert_raises(ValueError, rng.f, bad_dfnum * 3, dfden)
+        assert_raises(ValueError, rng.f, dfnum * 3, bad_dfden)
 
-        self.setSeed()
-        actual = f(dfnum, dfden * 3)
+        rng = self.setSeed()
+        actual = rng.f(dfnum, dfden * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, f, bad_dfnum, dfden * 3)
-        assert_raises(ValueError, f, dfnum, bad_dfden * 3)
+        assert_raises(ValueError, rng.f, bad_dfnum, dfden * 3)
+        assert_raises(ValueError, rng.f, dfnum, bad_dfden * 3)
 
     def test_noncentral_f(self):
         dfnum = [2]
@@ -1199,256 +1192,242 @@ class TestBroadcast:
         bad_dfnum = [0]
         bad_dfden = [-1]
         bad_nonc = [-2]
-        nonc_f = np.random.noncentral_f
         desired = np.array([9.1393943263705211,
                             13.025456344595602,
                             8.8018098359100545])
 
-        self.setSeed()
-        actual = nonc_f(dfnum * 3, dfden, nonc)
+        rng = self.setSeed()
+        actual = rng.noncentral_f(dfnum * 3, dfden, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_f, bad_dfnum * 3, dfden, nonc)
-        assert_raises(ValueError, nonc_f, dfnum * 3, bad_dfden, nonc)
-        assert_raises(ValueError, nonc_f, dfnum * 3, dfden, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum * 3, dfden, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum * 3, bad_dfden, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum * 3, dfden, bad_nonc)
 
-        self.setSeed()
-        actual = nonc_f(dfnum, dfden * 3, nonc)
+        rng = self.setSeed()
+        actual = rng.noncentral_f(dfnum, dfden * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_f, bad_dfnum, dfden * 3, nonc)
-        assert_raises(ValueError, nonc_f, dfnum, bad_dfden * 3, nonc)
-        assert_raises(ValueError, nonc_f, dfnum, dfden * 3, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, dfden * 3, bad_nonc)
 
-        self.setSeed()
-        actual = nonc_f(dfnum, dfden, nonc * 3)
+        rng = self.setSeed()
+        actual = rng.noncentral_f(dfnum, dfden, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_f, bad_dfnum, dfden, nonc * 3)
-        assert_raises(ValueError, nonc_f, dfnum, bad_dfden, nonc * 3)
-        assert_raises(ValueError, nonc_f, dfnum, dfden, bad_nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, dfden, bad_nonc * 3)
 
     def test_noncentral_f_small_df(self):
-        self.setSeed()
+        rng = self.setSeed()
         desired = np.array([6.869638627492048, 0.785880199263955])
-        actual = np.random.noncentral_f(0.9, 0.9, 2, size=2)
+        actual = rng.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_chisquare(self):
         df = [1]
         bad_df = [-1]
-        chisquare = np.random.chisquare
         desired = np.array([0.57022801133088286,
                             0.51947702108840776,
                             0.1320969254923558])
 
-        self.setSeed()
-        actual = chisquare(df * 3)
+        rng = self.setSeed()
+        actual = rng.chisquare(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, chisquare, bad_df * 3)
+        assert_raises(ValueError, rng.chisquare, bad_df * 3)
 
     def test_noncentral_chisquare(self):
         df = [1]
         nonc = [2]
         bad_df = [-1]
         bad_nonc = [-2]
-        nonc_chi = np.random.noncentral_chisquare
         desired = np.array([9.0015599467913763,
                             4.5804135049718742,
                             6.0872302432834564])
 
-        self.setSeed()
-        actual = nonc_chi(df * 3, nonc)
+        rng = self.setSeed()
+        actual = rng.noncentral_chisquare(df * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_chi, bad_df * 3, nonc)
-        assert_raises(ValueError, nonc_chi, df * 3, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_chisquare, bad_df * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_chisquare, df * 3, bad_nonc)
 
-        self.setSeed()
-        actual = nonc_chi(df, nonc * 3)
+        rng = self.setSeed()
+        actual = rng.noncentral_chisquare(df, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_chi, bad_df, nonc * 3)
-        assert_raises(ValueError, nonc_chi, df, bad_nonc * 3)
+        assert_raises(ValueError, rng.noncentral_chisquare, bad_df, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_chisquare, df, bad_nonc * 3)
 
     def test_standard_t(self):
         df = [1]
         bad_df = [-1]
-        t = np.random.standard_t
         desired = np.array([3.0702872575217643,
                             5.8560725167361607,
                             1.0274791436474273])
 
-        self.setSeed()
-        actual = t(df * 3)
+        rng = self.setSeed()
+        actual = rng.standard_t(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, t, bad_df * 3)
+        assert_raises(ValueError, rng.standard_t, bad_df * 3)
 
     def test_vonmises(self):
         mu = [2]
         kappa = [1]
         bad_kappa = [-1]
-        vonmises = np.random.vonmises
         desired = np.array([2.9883443664201312,
                             -2.7064099483995943,
                             -1.8672476700665914])
 
-        self.setSeed()
-        actual = vonmises(mu * 3, kappa)
+        rng = self.setSeed()
+        actual = rng.vonmises(mu * 3, kappa)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, vonmises, mu * 3, bad_kappa)
+        assert_raises(ValueError, rng.vonmises, mu * 3, bad_kappa)
 
-        self.setSeed()
-        actual = vonmises(mu, kappa * 3)
+        rng = self.setSeed()
+        actual = rng.vonmises(mu, kappa * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, vonmises, mu, bad_kappa * 3)
+        assert_raises(ValueError, rng.vonmises, mu, bad_kappa * 3)
 
     def test_pareto(self):
         a = [1]
         bad_a = [-1]
-        pareto = np.random.pareto
         desired = np.array([1.1405622680198362,
                             1.1465519762044529,
                             1.0389564467453547])
 
-        self.setSeed()
-        actual = pareto(a * 3)
+        rng = self.setSeed()
+        actual = rng.pareto(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, pareto, bad_a * 3)
+        assert_raises(ValueError, rng.pareto, bad_a * 3)
 
     def test_weibull(self):
         a = [1]
         bad_a = [-1]
-        weibull = np.random.weibull
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.setSeed()
-        actual = weibull(a * 3)
+        rng = self.setSeed()
+        actual = rng.weibull(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, weibull, bad_a * 3)
+        assert_raises(ValueError, rng.weibull, bad_a * 3)
 
     def test_power(self):
         a = [1]
         bad_a = [-1]
-        power = np.random.power
         desired = np.array([0.53283302478975902,
                             0.53413660089041659,
                             0.50955303552646702])
 
-        self.setSeed()
-        actual = power(a * 3)
+        rng = self.setSeed()
+        actual = rng.power(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, power, bad_a * 3)
+        assert_raises(ValueError, rng.power, bad_a * 3)
 
     def test_laplace(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        laplace = np.random.laplace
         desired = np.array([0.067921356028507157,
                             0.070715642226971326,
                             0.019290950698972624])
 
-        self.setSeed()
-        actual = laplace(loc * 3, scale)
+        rng = self.setSeed()
+        actual = rng.laplace(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, laplace, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.laplace, loc * 3, bad_scale)
 
-        self.setSeed()
-        actual = laplace(loc, scale * 3)
+        rng = self.setSeed()
+        actual = rng.laplace(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, laplace, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.laplace, loc, bad_scale * 3)
 
     def test_gumbel(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        gumbel = np.random.gumbel
         desired = np.array([0.2730318639556768,
                             0.26936705726291116,
                             0.33906220393037939])
 
-        self.setSeed()
-        actual = gumbel(loc * 3, scale)
+        rng = self.setSeed()
+        actual = rng.gumbel(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gumbel, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.gumbel, loc * 3, bad_scale)
 
-        self.setSeed()
-        actual = gumbel(loc, scale * 3)
+        rng = self.setSeed()
+        actual = rng.gumbel(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gumbel, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.gumbel, loc, bad_scale * 3)
 
     def test_logistic(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        logistic = np.random.logistic
         desired = np.array([0.13152135837586171,
                             0.13675915696285773,
                             0.038216792802833396])
 
-        self.setSeed()
-        actual = logistic(loc * 3, scale)
+        rng = self.setSeed()
+        actual = rng.logistic(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, logistic, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.logistic, loc * 3, bad_scale)
 
-        self.setSeed()
-        actual = logistic(loc, scale * 3)
+        rng = self.setSeed()
+        actual = rng.logistic(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, logistic, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.logistic, loc, bad_scale * 3)
 
     def test_lognormal(self):
         mean = [0]
         sigma = [1]
         bad_sigma = [-1]
-        lognormal = np.random.lognormal
         desired = np.array([9.1422086044848427,
                             8.4013952870126261,
                             6.3073234116578671])
 
-        self.setSeed()
-        actual = lognormal(mean * 3, sigma)
+        rng = self.setSeed()
+        actual = rng.lognormal(mean * 3, sigma)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, lognormal, mean * 3, bad_sigma)
+        assert_raises(ValueError, rng.lognormal, mean * 3, bad_sigma)
 
-        self.setSeed()
-        actual = lognormal(mean, sigma * 3)
+        rng = self.setSeed()
+        actual = rng.lognormal(mean, sigma * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, lognormal, mean, bad_sigma * 3)
+        assert_raises(ValueError, rng.lognormal, mean, bad_sigma * 3)
 
     def test_rayleigh(self):
         scale = [1]
         bad_scale = [-1]
-        rayleigh = np.random.rayleigh
         desired = np.array([1.2337491937897689,
                             1.2360119924878694,
                             1.1936818095781789])
 
-        self.setSeed()
-        actual = rayleigh(scale * 3)
+        rng = self.setSeed()
+        actual = rng.rayleigh(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, rayleigh, bad_scale * 3)
+        assert_raises(ValueError, rng.rayleigh, bad_scale * 3)
 
     def test_wald(self):
         mean = [0.5]
         scale = [1]
         bad_mean = [0]
         bad_scale = [-2]
-        wald = np.random.wald
         desired = np.array([0.11873681120271318,
                             0.12450084820795027,
                             0.9096122728408238])
 
-        self.setSeed()
-        actual = wald(mean * 3, scale)
+        rng = self.setSeed()
+        actual = rng.wald(mean * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, wald, bad_mean * 3, scale)
-        assert_raises(ValueError, wald, mean * 3, bad_scale)
+        assert_raises(ValueError, rng.wald, bad_mean * 3, scale)
+        assert_raises(ValueError, rng.wald, mean * 3, bad_scale)
 
-        self.setSeed()
-        actual = wald(mean, scale * 3)
+        rng = self.setSeed()
+        actual = rng.wald(mean, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, wald, bad_mean, scale * 3)
-        assert_raises(ValueError, wald, mean, bad_scale * 3)
-        assert_raises(ValueError, wald, 0.0, 1)
-        assert_raises(ValueError, wald, 0.5, 0.0)
+        assert_raises(ValueError, rng.wald, bad_mean, scale * 3)
+        assert_raises(ValueError, rng.wald, mean, bad_scale * 3)
+        assert_raises(ValueError, rng.wald, 0.0, 1)
+        assert_raises(ValueError, rng.wald, 0.5, 0.0)
 
     def test_triangular(self):
         left = [1]
@@ -1457,33 +1436,32 @@ class TestBroadcast:
         bad_left_one = [3]
         bad_mode_one = [4]
         bad_left_two, bad_mode_two = right * 2
-        triangular = np.random.triangular
         desired = np.array([2.03339048710429,
                             2.0347400359389356,
                             2.0095991069536208])
 
-        self.setSeed()
-        actual = triangular(left * 3, mode, right)
+        rng = self.setSeed()
+        actual = rng.triangular(left * 3, mode, right)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one * 3, mode, right)
-        assert_raises(ValueError, triangular, left * 3, bad_mode_one, right)
-        assert_raises(ValueError, triangular, bad_left_two * 3, bad_mode_two,
+        assert_raises(ValueError, rng.triangular, bad_left_one * 3, mode, right)
+        assert_raises(ValueError, rng.triangular, left * 3, bad_mode_one, right)
+        assert_raises(ValueError, rng.triangular, bad_left_two * 3, bad_mode_two,
                       right)
 
-        self.setSeed()
-        actual = triangular(left, mode * 3, right)
+        rng = self.setSeed()
+        actual = rng.triangular(left, mode * 3, right)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one, mode * 3, right)
-        assert_raises(ValueError, triangular, left, bad_mode_one * 3, right)
-        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two * 3,
+        assert_raises(ValueError, rng.triangular, bad_left_one, mode * 3, right)
+        assert_raises(ValueError, rng.triangular, left, bad_mode_one * 3, right)
+        assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two * 3,
                       right)
 
-        self.setSeed()
-        actual = triangular(left, mode, right * 3)
+        rng = self.setSeed()
+        actual = rng.triangular(left, mode, right * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one, mode, right * 3)
-        assert_raises(ValueError, triangular, left, bad_mode_one, right * 3)
-        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two,
+        assert_raises(ValueError, rng.triangular, bad_left_one, mode, right * 3)
+        assert_raises(ValueError, rng.triangular, left, bad_mode_one, right * 3)
+        assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two,
                       right * 3)
 
     def test_binomial(self):
@@ -1492,22 +1470,21 @@ class TestBroadcast:
         bad_n = [-1]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        binom = np.random.binomial
         desired = np.array([1, 1, 1])
 
-        self.setSeed()
-        actual = binom(n * 3, p)
+        rng = self.setSeed()
+        actual = rng.binomial(n * 3, p)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, binom, bad_n * 3, p)
-        assert_raises(ValueError, binom, n * 3, bad_p_one)
-        assert_raises(ValueError, binom, n * 3, bad_p_two)
+        assert_raises(ValueError, rng.binomial, bad_n * 3, p)
+        assert_raises(ValueError, rng.binomial, n * 3, bad_p_one)
+        assert_raises(ValueError, rng.binomial, n * 3, bad_p_two)
 
-        self.setSeed()
-        actual = binom(n, p * 3)
+        rng = self.setSeed()
+        actual = rng.binomial(n, p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, binom, bad_n, p * 3)
-        assert_raises(ValueError, binom, n, bad_p_one * 3)
-        assert_raises(ValueError, binom, n, bad_p_two * 3)
+        assert_raises(ValueError, rng.binomial, bad_n, p * 3)
+        assert_raises(ValueError, rng.binomial, n, bad_p_one * 3)
+        assert_raises(ValueError, rng.binomial, n, bad_p_two * 3)
 
     def test_negative_binomial(self):
         n = [1]
@@ -1515,22 +1492,21 @@ class TestBroadcast:
         bad_n = [-1]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        neg_binom = np.random.negative_binomial
         desired = np.array([1, 0, 1])
 
-        self.setSeed()
-        actual = neg_binom(n * 3, p)
+        rng = self.setSeed()
+        actual = rng.negative_binomial(n * 3, p)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, neg_binom, bad_n * 3, p)
-        assert_raises(ValueError, neg_binom, n * 3, bad_p_one)
-        assert_raises(ValueError, neg_binom, n * 3, bad_p_two)
+        assert_raises(ValueError, rng.negative_binomial, bad_n * 3, p)
+        assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_one)
+        assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_two)
 
-        self.setSeed()
-        actual = neg_binom(n, p * 3)
+        rng = self.setSeed()
+        actual = rng.negative_binomial(n, p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, neg_binom, bad_n, p * 3)
-        assert_raises(ValueError, neg_binom, n, bad_p_one * 3)
-        assert_raises(ValueError, neg_binom, n, bad_p_two * 3)
+        assert_raises(ValueError, rng.negative_binomial, bad_n, p * 3)
+        assert_raises(ValueError, rng.negative_binomial, n, bad_p_one * 3)
+        assert_raises(ValueError, rng.negative_binomial, n, bad_p_two * 3)
 
     def test_poisson(self):
         max_lam = np.random.RandomState()._poisson_lam_max
@@ -1538,41 +1514,38 @@ class TestBroadcast:
         lam = [1]
         bad_lam_one = [-1]
         bad_lam_two = [max_lam * 2]
-        poisson = np.random.poisson
         desired = np.array([1, 1, 0])
 
-        self.setSeed()
-        actual = poisson(lam * 3)
+        rng = self.setSeed()
+        actual = rng.poisson(lam * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, poisson, bad_lam_one * 3)
-        assert_raises(ValueError, poisson, bad_lam_two * 3)
+        assert_raises(ValueError, rng.poisson, bad_lam_one * 3)
+        assert_raises(ValueError, rng.poisson, bad_lam_two * 3)
 
     def test_zipf(self):
         a = [2]
         bad_a = [0]
-        zipf = np.random.zipf
         desired = np.array([2, 2, 1])
 
-        self.setSeed()
-        actual = zipf(a * 3)
+        rng = self.setSeed()
+        actual = rng.zipf(a * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, zipf, bad_a * 3)
+        assert_raises(ValueError, rng.zipf, bad_a * 3)
         with np.errstate(invalid='ignore'):
-            assert_raises(ValueError, zipf, np.nan)
-            assert_raises(ValueError, zipf, [0, 0, np.nan])
+            assert_raises(ValueError, rng.zipf, np.nan)
+            assert_raises(ValueError, rng.zipf, [0, 0, np.nan])
 
     def test_geometric(self):
         p = [0.5]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        geom = np.random.geometric
         desired = np.array([2, 2, 2])
 
-        self.setSeed()
-        actual = geom(p * 3)
+        rng = self.setSeed()
+        actual = rng.geometric(p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, geom, bad_p_one * 3)
-        assert_raises(ValueError, geom, bad_p_two * 3)
+        assert_raises(ValueError, rng.geometric, bad_p_one * 3)
+        assert_raises(ValueError, rng.geometric, bad_p_two * 3)
 
     def test_hypergeometric(self):
         ngood = [1]
@@ -1582,45 +1555,43 @@ class TestBroadcast:
         bad_nbad = [-2]
         bad_nsample_one = [0]
         bad_nsample_two = [4]
-        hypergeom = np.random.hypergeometric
         desired = np.array([1, 1, 1])
 
-        self.setSeed()
-        actual = hypergeom(ngood * 3, nbad, nsample)
+        rng = self.setSeed()
+        actual = rng.hypergeometric(ngood * 3, nbad, nsample)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood * 3, nbad, nsample)
-        assert_raises(ValueError, hypergeom, ngood * 3, bad_nbad, nsample)
-        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_one)
-        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_two)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood * 3, nbad, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, bad_nbad, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_one)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_two)
 
-        self.setSeed()
-        actual = hypergeom(ngood, nbad * 3, nsample)
+        rng = self.setSeed()
+        actual = rng.hypergeometric(ngood, nbad * 3, nsample)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood, nbad * 3, nsample)
-        assert_raises(ValueError, hypergeom, ngood, bad_nbad * 3, nsample)
-        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_one)
-        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_two)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad * 3, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood, bad_nbad * 3, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_one)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_two)
 
-        self.setSeed()
-        actual = hypergeom(ngood, nbad, nsample * 3)
+        rng = self.setSeed()
+        actual = rng.hypergeometric(ngood, nbad, nsample * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood, nbad, nsample * 3)
-        assert_raises(ValueError, hypergeom, ngood, bad_nbad, nsample * 3)
-        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_one * 3)
-        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_two * 3)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad, nsample * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, bad_nbad, nsample * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad, bad_nsample_one * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad, bad_nsample_two * 3)
 
     def test_logseries(self):
         p = [0.5]
         bad_p_one = [2]
         bad_p_two = [-1]
-        logseries = np.random.logseries
         desired = np.array([1, 1, 1])
 
-        self.setSeed()
-        actual = logseries(p * 3)
+        rng = self.setSeed()
+        actual = rng.logseries(p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, logseries, bad_p_one * 3)
-        assert_raises(ValueError, logseries, bad_p_two * 3)
+        assert_raises(ValueError, rng.logseries, bad_p_one * 3)
+        assert_raises(ValueError, rng.logseries, bad_p_two * 3)
 
 
 @pytest.mark.skipif(IS_WASM, reason="can't start thread")

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -288,47 +288,49 @@ class TestSetState:
 
 class TestRandint:
 
-    rfunc = random.randint
-
     # valid integer/boolean types
     itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
              np.int32, np.uint32, np.int64, np.uint64]
 
     def test_unsupported_type(self):
-        assert_raises(TypeError, self.rfunc, 1, dtype=float)
+        rng = np.random.RandomState()
+        assert_raises(TypeError, rng.randint, 1, dtype=float)
 
     def test_bounds_checking(self):
+        rng = np.random.RandomState()
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
-            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
+            assert_raises(ValueError, rng.randint, lbnd - 1, ubnd, dtype=dt)
+            assert_raises(ValueError, rng.randint, lbnd, ubnd + 1, dtype=dt)
+            assert_raises(ValueError, rng.randint, ubnd, lbnd, dtype=dt)
+            assert_raises(ValueError, rng.randint, 1, 0, dtype=dt)
 
     def test_rng_zero_and_extremes(self):
+        rng = np.random.RandomState()
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
             tgt = ubnd - 1
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
             tgt = lbnd
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
             tgt = (lbnd + ubnd) // 2
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(rng.randint(tgt, tgt + 1, size=1000, dtype=dt), tgt)
 
     def test_full_range(self):
         # Test for ticket #1690
+        rng = np.random.RandomState()
 
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
             try:
-                self.rfunc(lbnd, ubnd, dtype=dt)
+                rng.randint(lbnd, ubnd, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
@@ -336,15 +338,15 @@ class TestRandint:
 
     def test_in_bounds_fuzz(self):
         # Don't use fixed seed
-        random.seed()
+        rng = np.random.RandomState()
 
         for dt in self.itype[1:]:
             for ubnd in [4, 8, 16]:
-                vals = self.rfunc(2, ubnd, size=2**16, dtype=dt)
+                vals = rng.randint(2, ubnd, size=2**16, dtype=dt)
                 assert_(vals.max() < ubnd)
                 assert_(vals.min() >= 2)
 
-        vals = self.rfunc(0, 2, size=2**16, dtype=np.bool)
+        vals = rng.randint(0, 2, size=2**16, dtype=np.bool)
 
         assert_(vals.max() < 2)
         assert_(vals.min() >= 0)
@@ -430,11 +432,13 @@ class TestRandint:
 
     def test_respect_dtype_singleton(self):
         # See gh-7203
+        rng = np.random.RandomState()
+
         for dt in self.itype:
             lbnd = 0 if dt is np.bool else np.iinfo(dt).min
             ubnd = 2 if dt is np.bool else np.iinfo(dt).max + 1
 
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = rng.randint(lbnd, ubnd, dtype=dt)
             assert_equal(sample.dtype, np.dtype(dt))
 
         for dt in (bool, int):
@@ -445,7 +449,7 @@ class TestRandint:
             lbnd = 0 if dt is bool else np.iinfo(op_dtype).min
             ubnd = 2 if dt is bool else np.iinfo(op_dtype).max + 1
 
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = rng.randint(lbnd, ubnd, dtype=dt)
             assert_(not hasattr(sample, 'dtype'))
             assert_equal(type(sample), dt)
 
@@ -1318,9 +1322,6 @@ class TestBroadcast:
     # correctly when presented with non-scalar arguments
     seed = 123456789
 
-    def set_seed(self):
-        return random.RandomState(self.seed)
-
     def test_uniform(self):
         low = [0]
         high = [1]
@@ -1328,11 +1329,11 @@ class TestBroadcast:
                             0.53413660089041659,
                             0.50955303552646702])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.uniform(low * 3, high)
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.uniform(low, high * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
 
@@ -1344,12 +1345,12 @@ class TestBroadcast:
                             2.1283977976520019,
                             1.8417114045748335])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.normal(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.normal, loc * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.normal(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.normal, loc, bad_scale * 3)
@@ -1363,13 +1364,13 @@ class TestBroadcast:
                             0.075230336409423643,
                             0.24976865978980844])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.beta(a * 3, b)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.beta, bad_a * 3, b)
         assert_raises(ValueError, rng.beta, a * 3, bad_b)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.beta(a, b * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.beta, bad_a, b * 3)
@@ -1382,7 +1383,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.exponential(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.exponential, bad_scale * 3)
@@ -1394,7 +1395,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.standard_gamma(shape * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.standard_gamma, bad_shape * 3)
@@ -1408,13 +1409,13 @@ class TestBroadcast:
                             1.5277256455738331,
                             1.4248762625178359])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.gamma(shape * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gamma, bad_shape * 3, scale)
         assert_raises(ValueError, rng.gamma, shape * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.gamma(shape, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gamma, bad_shape, scale * 3)
@@ -1429,13 +1430,13 @@ class TestBroadcast:
                             0.86768719635363512,
                             2.7251095168386801])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.f(dfnum * 3, dfden)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.f, bad_dfnum * 3, dfden)
         assert_raises(ValueError, rng.f, dfnum * 3, bad_dfden)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.f(dfnum, dfden * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.f, bad_dfnum, dfden * 3)
@@ -1452,7 +1453,7 @@ class TestBroadcast:
                             13.025456344595602,
                             8.8018098359100545])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum * 3, dfden, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert np.all(np.isnan(rng.noncentral_f(dfnum, dfden, [np.nan] * 3)))
@@ -1461,14 +1462,14 @@ class TestBroadcast:
         assert_raises(ValueError, rng.noncentral_f, dfnum * 3, bad_dfden, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum * 3, dfden, bad_nonc)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum, dfden * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden * 3, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden * 3, nonc)
         assert_raises(ValueError, rng.noncentral_f, dfnum, dfden * 3, bad_nonc)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_f(dfnum, dfden, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden, nonc * 3)
@@ -1476,7 +1477,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.noncentral_f, dfnum, dfden, bad_nonc * 3)
 
     def test_noncentral_f_small_df(self):
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         desired = np.array([6.869638627492048, 0.785880199263955])
         actual = rng.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
@@ -1488,7 +1489,7 @@ class TestBroadcast:
                             0.51947702108840776,
                             0.1320969254923558])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.chisquare(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.chisquare, bad_df * 3)
@@ -1502,13 +1503,13 @@ class TestBroadcast:
                             4.5804135049718742,
                             6.0872302432834564])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_chisquare(df * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_chisquare, bad_df * 3, nonc)
         assert_raises(ValueError, rng.noncentral_chisquare, df * 3, bad_nonc)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.noncentral_chisquare(df, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.noncentral_chisquare, bad_df, nonc * 3)
@@ -1521,7 +1522,7 @@ class TestBroadcast:
                             5.8560725167361607,
                             1.0274791436474273])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.standard_t(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.standard_t, bad_df * 3)
@@ -1535,12 +1536,12 @@ class TestBroadcast:
                             -2.7064099483995943,
                             -1.8672476700665914])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.vonmises(mu * 3, kappa)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.vonmises, mu * 3, bad_kappa)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.vonmises(mu, kappa * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.vonmises, mu, bad_kappa * 3)
@@ -1552,7 +1553,7 @@ class TestBroadcast:
                             1.1465519762044529,
                             1.0389564467453547])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.pareto(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.pareto, bad_a * 3)
@@ -1565,7 +1566,7 @@ class TestBroadcast:
                             0.76386282278691653,
                             0.71243813125891797])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.weibull(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.weibull, bad_a * 3)
@@ -1578,7 +1579,7 @@ class TestBroadcast:
                             0.53413660089041659,
                             0.50955303552646702])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.power(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.power, bad_a * 3)
@@ -1592,12 +1593,12 @@ class TestBroadcast:
                             0.070715642226971326,
                             0.019290950698972624])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.laplace(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.laplace, loc * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.laplace(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.laplace, loc, bad_scale * 3)
@@ -1610,12 +1611,12 @@ class TestBroadcast:
                             0.26936705726291116,
                             0.33906220393037939])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.gumbel(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gumbel, loc * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.gumbel(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.gumbel, loc, bad_scale * 3)
@@ -1628,12 +1629,12 @@ class TestBroadcast:
                             0.13675915696285773,
                             0.038216792802833396])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.logistic(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.logistic, loc * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.logistic(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.logistic, loc, bad_scale * 3)
@@ -1647,13 +1648,13 @@ class TestBroadcast:
                             8.4013952870126261,
                             6.3073234116578671])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.lognormal(mean * 3, sigma)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.lognormal, mean * 3, bad_sigma)
         assert_raises(ValueError, random.lognormal, mean * 3, bad_sigma)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.lognormal(mean, sigma * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.lognormal, mean, bad_sigma * 3)
@@ -1666,7 +1667,7 @@ class TestBroadcast:
                             1.2360119924878694,
                             1.1936818095781789])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.rayleigh(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.rayleigh, bad_scale * 3)
@@ -1680,7 +1681,7 @@ class TestBroadcast:
                             0.12450084820795027,
                             0.9096122728408238])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.wald(mean * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.wald, bad_mean * 3, scale)
@@ -1688,7 +1689,7 @@ class TestBroadcast:
         assert_raises(ValueError, random.wald, bad_mean * 3, scale)
         assert_raises(ValueError, random.wald, mean * 3, bad_scale)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.wald(mean, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.wald, bad_mean, scale * 3)
@@ -1707,7 +1708,7 @@ class TestBroadcast:
                             2.0347400359389356,
                             2.0095991069536208])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left * 3, mode, right)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one * 3, mode, right)
@@ -1715,7 +1716,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.triangular, bad_left_two * 3, bad_mode_two,
                       right)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left, mode * 3, right)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one, mode * 3, right)
@@ -1723,7 +1724,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two * 3,
                       right)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.triangular(left, mode, right * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, rng.triangular, bad_left_one, mode, right * 3)
@@ -1743,14 +1744,14 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([1, 1, 1])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.binomial(n * 3, p)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.binomial, bad_n * 3, p)
         assert_raises(ValueError, rng.binomial, n * 3, bad_p_one)
         assert_raises(ValueError, rng.binomial, n * 3, bad_p_two)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.binomial(n, p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.binomial, bad_n, p * 3)
@@ -1765,14 +1766,14 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([1, 0, 1])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.negative_binomial(n * 3, p)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.negative_binomial, bad_n * 3, p)
         assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_one)
         assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_two)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.negative_binomial(n, p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.negative_binomial, bad_n, p * 3)
@@ -1787,7 +1788,7 @@ class TestBroadcast:
         bad_lam_two = [max_lam * 2]
         desired = np.array([1, 1, 0])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.poisson(lam * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.poisson, bad_lam_one * 3)
@@ -1798,7 +1799,7 @@ class TestBroadcast:
         bad_a = [0]
         desired = np.array([2, 2, 1])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.zipf(a * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.zipf, bad_a * 3)
@@ -1812,7 +1813,7 @@ class TestBroadcast:
         bad_p_two = [1.5]
         desired = np.array([2, 2, 2])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.geometric(p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.geometric, bad_p_one * 3)
@@ -1828,7 +1829,7 @@ class TestBroadcast:
         bad_nsample_two = [4]
         desired = np.array([1, 1, 1])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood * 3, nbad, nsample)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood * 3, nbad, nsample)
@@ -1836,7 +1837,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_one)
         assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_two)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood, nbad * 3, nsample)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad * 3, nsample)
@@ -1844,7 +1845,7 @@ class TestBroadcast:
         assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_one)
         assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_two)
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.hypergeometric(ngood, nbad, nsample * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad, nsample * 3)
@@ -1863,7 +1864,7 @@ class TestBroadcast:
         bad_p_two = [-1]
         desired = np.array([1, 1, 1])
 
-        rng = self.set_seed()
+        rng = random.RandomState(self.seed)
         actual = rng.logseries(p * 3)
         assert_array_equal(actual, desired)
         assert_raises(ValueError, rng.logseries, bad_p_one * 3)

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -173,10 +173,10 @@ class TestMultinomial:
         p = np.arange(15.)
         p /= np.sum(p[1::3])
         pvals = p[1::3]
-        random.seed(1432985819)
-        non_contig = random.multinomial(100, pvals=pvals)
-        random.seed(1432985819)
-        contig = random.multinomial(100, pvals=np.ascontiguousarray(pvals))
+        rng = random.RandomState(1432985819)
+        non_contig = rng.multinomial(100, pvals=pvals)
+        rng = random.RandomState(1432985819)
+        contig = rng.multinomial(100, pvals=np.ascontiguousarray(pvals))
         assert_array_equal(non_contig, contig)
 
     def test_multinomial_pvals_float32(self):
@@ -364,20 +364,20 @@ class TestRandint:
                'uint8':  '001aac3a5acb935a9b186cbe14a1ca064b8bb2dd0b045d48abeacf74d0203404'}  # noqa: E501
 
         for dt in self.itype[1:]:
-            random.seed(1234)
+            rng = random.RandomState(1234)
 
             # view as little endian for hash
             if sys.byteorder == 'little':
-                val = self.rfunc(0, 6, size=1000, dtype=dt)
+                val = rng.randint(0, 6, size=1000, dtype=dt)
             else:
-                val = self.rfunc(0, 6, size=1000, dtype=dt).byteswap()
+                val = rng.randint(0, 6, size=1000, dtype=dt).byteswap()
 
             res = hashlib.sha256(val.view(np.int8)).hexdigest()
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianness
-        random.seed(1234)
-        val = self.rfunc(0, 2, size=1000, dtype=bool).view(np.int8)
+        rng = random.RandomState(1234)
+        val = rng.randint(0, 2, size=1000, dtype=bool).view(np.int8)
         res = hashlib.sha256(val).hexdigest()
         assert_(tgt[np.dtype(bool).name] == res)
 
@@ -400,8 +400,8 @@ class TestRandint:
                              [2978368172,  764731833, 2282559898],
                              [ 105711276,  720447391, 3596512484]]])
         for size in [None, (5, 3, 3)]:
-            random.seed(12345)
-            x = self.rfunc([[-1], [0], [1]], [2**32 - 1, 2**32, 2**32 + 1],
+            rng = random.RandomState(12345)
+            x = rng.randint([[-1], [0], [1]], [2**32 - 1, 2**32, 2**32 + 1],
                            size=size)
             assert_array_equal(x, desired if size is not None else desired[0])
 
@@ -456,55 +456,54 @@ class TestRandomDist:
     seed = 1234567890
 
     def test_rand(self):
-        random.seed(self.seed)
-        actual = random.rand(3, 2)
+        rng = random.RandomState(self.seed)
+        actual = rng.rand(3, 2)
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_rand_singleton(self):
-        random.seed(self.seed)
-        actual = random.rand()
+        rng = random.RandomState(self.seed)
+        actual = rng.rand()
         desired = 0.61879477158567997
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randn(self):
-        random.seed(self.seed)
-        actual = random.randn(3, 2)
+        rng = random.RandomState(self.seed)
+        actual = rng.randn(3, 2)
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                            [1.498988344300628, -0.2286433324536169],
                            [2.031033998682787, 2.17032494605655257]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
-        random.seed(self.seed)
-        actual = random.randn()
+        rng = random.RandomState(self.seed)
+        actual = rng.randn()
         assert_array_almost_equal(actual, desired[0, 0], decimal=15)
 
     def test_randint(self):
-        random.seed(self.seed)
-        actual = random.randint(-99, 99, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.randint(-99, 99, size=(3, 2))
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
 
     def test_random_integers(self):
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         with pytest.warns(DeprecationWarning):
-            actual = random.random_integers(-99, 99, size=(3, 2))
+            actual = rng.random_integers(-99, 99, size=(3, 2))
         desired = np.array([[31, 3],
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
 
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         with pytest.warns(DeprecationWarning):
-            actual = random.random_integers(198, size=(3, 2))
+            actual = rng.random_integers(198, size=(3, 2))
         assert_array_equal(actual, desired + 100)
 
     def test_tomaxint(self):
-        random.seed(self.seed)
         rs = random.RandomState(self.seed)
         actual = rs.tomaxint(size=(3, 2))
         if np.iinfo(np.long).max == 2147483647:
@@ -556,44 +555,44 @@ class TestRandomDist:
                           np.iinfo('l').max, np.iinfo('l').max)
 
     def test_random_sample(self):
-        random.seed(self.seed)
-        actual = random.random_sample((3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.random_sample((3, 2))
         desired = np.array([[0.61879477158567997, 0.59162362775974664],
                             [0.88868358904449662, 0.89165480011560816],
                             [0.4575674820298663, 0.7781880808593471]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
-        random.seed(self.seed)
-        actual = random.random_sample()
+        rng = random.RandomState(self.seed)
+        actual = rng.random_sample()
         assert_array_almost_equal(actual, desired[0, 0], decimal=15)
 
     def test_choice_uniform_replace(self):
-        random.seed(self.seed)
-        actual = random.choice(4, 4)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 4)
         desired = np.array([2, 3, 2, 3])
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
-        random.seed(self.seed)
-        actual = random.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
         desired = np.array([1, 1, 2, 2])
         assert_array_equal(actual, desired)
 
     def test_choice_uniform_noreplace(self):
-        random.seed(self.seed)
-        actual = random.choice(4, 3, replace=False)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 3, replace=False)
         desired = np.array([0, 1, 3])
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):
-        random.seed(self.seed)
-        actual = random.choice(4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1])
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1])
         desired = np.array([2, 3, 1])
         assert_array_equal(actual, desired)
 
     def test_choice_noninteger(self):
-        random.seed(self.seed)
-        actual = random.choice(['a', 'b', 'c', 'd'], 4)
+        rng = random.RandomState(self.seed)
+        actual = rng.choice(['a', 'b', 'c', 'd'], 4)
         desired = np.array(['c', 'd', 'c', 'd'])
         assert_array_equal(actual, desired)
 
@@ -670,15 +669,15 @@ class TestRandomDist:
     def test_choice_p_non_contiguous(self):
         p = np.ones(10) / 5
         p[1::2] = 3.0
-        random.seed(self.seed)
-        non_contig = random.choice(5, 3, p=p[::2])
-        random.seed(self.seed)
-        contig = random.choice(5, 3, p=np.ascontiguousarray(p[::2]))
+        rng = random.RandomState(self.seed)
+        non_contig = rng.choice(5, 3, p=p[::2])
+        rng = random.RandomState(self.seed)
+        contig = rng.choice(5, 3, p=np.ascontiguousarray(p[::2]))
         assert_array_equal(non_contig, contig)
 
     def test_bytes(self):
-        random.seed(self.seed)
-        actual = random.bytes(10)
+        rng = random.RandomState(self.seed)
+        actual = rng.bytes(10)
         desired = b'\x82Ui\x9e\xff\x97+Wf\xa5'
         assert_equal(actual, desired)
 
@@ -702,9 +701,9 @@ class TestRandomDist:
                      lambda x: np.asarray([(i, i) for i in x],
                                           [("a", object, (1,)),
                                            ("b", np.int32, (1,))])]:
-            random.seed(self.seed)
+            rng = random.RandomState(self.seed)
             alist = conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
-            random.shuffle(alist)
+            rng.shuffle(alist)
             actual = alist
             desired = conv([0, 1, 9, 6, 2, 4, 5, 8, 7, 3])
             assert_array_equal(actual, desired)
@@ -728,35 +727,35 @@ class TestRandomDist:
             assert_raises(TypeError, random.shuffle, x)
 
     def test_permutation(self):
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         alist = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
-        actual = random.permutation(alist)
+        actual = rng.permutation(alist)
         desired = [0, 1, 9, 6, 2, 4, 5, 8, 7, 3]
         assert_array_equal(actual, desired)
 
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         arr_2d = np.atleast_2d([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]).T
-        actual = random.permutation(arr_2d)
+        actual = rng.permutation(arr_2d)
         assert_array_equal(actual, np.atleast_2d(desired).T)
 
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         bad_x_str = "abcd"
         assert_raises(IndexError, random.permutation, bad_x_str)
 
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         bad_x_float = 1.2
         assert_raises(IndexError, random.permutation, bad_x_float)
 
         integer_val = 10
         desired = [9, 0, 8, 5, 1, 3, 4, 7, 6, 2]
 
-        random.seed(self.seed)
-        actual = random.permutation(integer_val)
+        rng = random.RandomState(self.seed)
+        actual = rng.permutation(integer_val)
         assert_array_equal(actual, desired)
 
     def test_beta(self):
-        random.seed(self.seed)
-        actual = random.beta(.1, .9, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.beta(.1, .9, size=(3, 2))
         desired = np.array(
                 [[1.45341850513746058e-02, 5.31297615662868145e-04],
                  [1.85366619058432324e-06, 4.19214516800110563e-03],
@@ -764,30 +763,30 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_binomial(self):
-        random.seed(self.seed)
-        actual = random.binomial(100.123, .456, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.binomial(100.123, .456, size=(3, 2))
         desired = np.array([[37, 43],
                             [42, 48],
                             [46, 45]])
         assert_array_equal(actual, desired)
 
-        random.seed(self.seed)
-        actual = random.binomial(100.123, .456)
+        rng = random.RandomState(self.seed)
+        actual = rng.binomial(100.123, .456)
         desired = 37
         assert_array_equal(actual, desired)
 
     def test_chisquare(self):
-        random.seed(self.seed)
-        actual = random.chisquare(50, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.chisquare(50, size=(3, 2))
         desired = np.array([[63.87858175501090585, 68.68407748911370447],
                             [65.77116116901505904, 47.09686762438974483],
                             [72.3828403199695174, 74.18408615260374006]])
         assert_array_almost_equal(actual, desired, decimal=13)
 
     def test_dirichlet(self):
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         alpha = np.array([51.72840233779265162, 39.74494232180943953])
-        actual = random.dirichlet(alpha, size=(3, 2))
+        actual = rng.dirichlet(alpha, size=(3, 2))
         desired = np.array([[[0.54539444573611562, 0.45460555426388438],
                              [0.62345816822039413, 0.37654183177960598]],
                             [[0.55206000085785778, 0.44793999914214233],
@@ -798,9 +797,9 @@ class TestRandomDist:
         bad_alpha = np.array([5.4e-01, -1.0e-16])
         assert_raises(ValueError, random.dirichlet, bad_alpha)
 
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         alpha = np.array([51.72840233779265162, 39.74494232180943953])
-        actual = random.dirichlet(alpha)
+        actual = rng.dirichlet(alpha)
         assert_array_almost_equal(actual, desired[0, 0], decimal=15)
 
     def test_dirichlet_size(self):
@@ -823,16 +822,16 @@ class TestRandomDist:
     def test_dirichlet_alpha_non_contiguous(self):
         a = np.array([51.72840233779265162, -1.0, 39.74494232180943953])
         alpha = a[::2]
-        random.seed(self.seed)
-        non_contig = random.dirichlet(alpha, size=(3, 2))
-        random.seed(self.seed)
-        contig = random.dirichlet(np.ascontiguousarray(alpha),
+        rng = random.RandomState(self.seed)
+        non_contig = rng.dirichlet(alpha, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        contig = rng.dirichlet(np.ascontiguousarray(alpha),
                                   size=(3, 2))
         assert_array_almost_equal(non_contig, contig)
 
     def test_exponential(self):
-        random.seed(self.seed)
-        actual = random.exponential(1.1234, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.exponential(1.1234, size=(3, 2))
         desired = np.array([[1.08342649775011624, 1.00607889924557314],
                             [2.46628830085216721, 2.49668106809923884],
                             [0.68717433461363442, 1.69175666993575979]])
@@ -843,16 +842,16 @@ class TestRandomDist:
         assert_raises(ValueError, random.exponential, scale=-0.)
 
     def test_f(self):
-        random.seed(self.seed)
-        actual = random.f(12, 77, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.f(12, 77, size=(3, 2))
         desired = np.array([[1.21975394418575878, 1.75135759791559775],
                             [1.44803115017146489, 1.22108959480396262],
                             [1.02176975757740629, 1.34431827623300415]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_gamma(self):
-        random.seed(self.seed)
-        actual = random.gamma(5, 3, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.gamma(5, 3, size=(3, 2))
         desired = np.array([[24.60509188649287182, 28.54993563207210627],
                             [26.13476110204064184, 12.56988482927716078],
                             [31.71863275789960568, 33.30143302795922011]])
@@ -863,8 +862,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.gamma, shape=-0., scale=-0.)
 
     def test_geometric(self):
-        random.seed(self.seed)
-        actual = random.geometric(.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.geometric(.123456789, size=(3, 2))
         desired = np.array([[8, 7],
                             [17, 17],
                             [5, 12]])
@@ -881,8 +880,8 @@ class TestRandomDist:
             assert_raises(ValueError, random.geometric, [np.nan] * 10)
 
     def test_gumbel(self):
-        random.seed(self.seed)
-        actual = random.gumbel(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.gumbel(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[0.19591898743416816, 0.34405539668096674],
                             [-1.4492522252274278, -1.47374816298446865],
                             [1.10651090478803416, -0.69535848626236174]])
@@ -893,34 +892,34 @@ class TestRandomDist:
         assert_raises(ValueError, random.gumbel, scale=-0.)
 
     def test_hypergeometric(self):
-        random.seed(self.seed)
-        actual = random.hypergeometric(10.1, 5.5, 14, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.hypergeometric(10.1, 5.5, 14, size=(3, 2))
         desired = np.array([[10, 10],
                             [10, 10],
                             [9, 9]])
         assert_array_equal(actual, desired)
 
         # Test nbad = 0
-        actual = random.hypergeometric(5, 0, 3, size=4)
+        actual = rng.hypergeometric(5, 0, 3, size=4)
         desired = np.array([3, 3, 3, 3])
         assert_array_equal(actual, desired)
 
-        actual = random.hypergeometric(15, 0, 12, size=4)
+        actual = rng.hypergeometric(15, 0, 12, size=4)
         desired = np.array([12, 12, 12, 12])
         assert_array_equal(actual, desired)
 
         # Test ngood = 0
-        actual = random.hypergeometric(0, 5, 3, size=4)
+        actual = rng.hypergeometric(0, 5, 3, size=4)
         desired = np.array([0, 0, 0, 0])
         assert_array_equal(actual, desired)
 
-        actual = random.hypergeometric(0, 15, 12, size=4)
+        actual = rng.hypergeometric(0, 15, 12, size=4)
         desired = np.array([0, 0, 0, 0])
         assert_array_equal(actual, desired)
 
     def test_laplace(self):
-        random.seed(self.seed)
-        actual = random.laplace(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.laplace(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[0.66599721112760157, 0.52829452552221945],
                             [3.12791959514407125, 3.18202813572992005],
                             [-0.05391065675859356, 1.74901336242837324]])
@@ -931,16 +930,16 @@ class TestRandomDist:
         assert_raises(ValueError, random.laplace, scale=-0.)
 
     def test_logistic(self):
-        random.seed(self.seed)
-        actual = random.logistic(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.logistic(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[1.09232835305011444, 0.8648196662399954],
                             [4.27818590694950185, 4.33897006346929714],
                             [-0.21682183359214885, 2.63373365386060332]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_lognormal(self):
-        random.seed(self.seed)
-        actual = random.lognormal(mean=.123456789, sigma=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.lognormal(mean=.123456789, sigma=2.0, size=(3, 2))
         desired = np.array([[16.50698631688883822, 36.54846706092654784],
                             [22.67886599981281748, 0.71617561058995771],
                             [65.72798501792723869, 86.84341601437161273]])
@@ -951,8 +950,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.lognormal, sigma=-0.)
 
     def test_logseries(self):
-        random.seed(self.seed)
-        actual = random.logseries(p=.923456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.logseries(p=.923456789, size=(3, 2))
         desired = np.array([[2, 2],
                             [6, 17],
                             [3, 6]])
@@ -974,8 +973,8 @@ class TestRandomDist:
                 random.logseries(np.array([value] * 10)[::2])
 
     def test_multinomial(self):
-        random.seed(self.seed)
-        actual = random.multinomial(20, [1 / 6.] * 6, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.multinomial(20, [1 / 6.] * 6, size=(3, 2))
         desired = np.array([[[4, 3, 5, 4, 2, 2],
                              [5, 2, 8, 2, 2, 1]],
                             [[3, 4, 3, 6, 0, 4],
@@ -985,11 +984,11 @@ class TestRandomDist:
         assert_array_equal(actual, desired)
 
     def test_multivariate_normal(self):
-        random.seed(self.seed)
+        rng = random.RandomState(self.seed)
         mean = (.123456789, 10)
         cov = [[1, 0], [0, 1]]
         size = (3, 2)
-        actual = random.multivariate_normal(mean, cov, size)
+        actual = rng.multivariate_normal(mean, cov, size)
         desired = np.array([[[1.463620246718631, 11.73759122771936],
                              [1.622445133300628, 9.771356667546383]],
                             [[2.154490787682787, 12.170324946056553],
@@ -1000,7 +999,7 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=15)
 
         # Check for default size, was raising deprecation warning
-        actual = random.multivariate_normal(mean, cov)
+        actual = rng.multivariate_normal(mean, cov)
         desired = np.array([0.895289569463708, 9.17180864067987])
         assert_array_almost_equal(actual, desired, decimal=15)
 
@@ -1008,35 +1007,35 @@ class TestRandomDist:
         # RuntimeWarning
         mean = [0, 0]
         cov = [[1, 2], [2, 1]]
-        pytest.warns(RuntimeWarning, random.multivariate_normal, mean, cov)
+        pytest.warns(RuntimeWarning, rng.multivariate_normal, mean, cov)
 
         # and that it doesn't warn with RuntimeWarning check_valid='ignore'
-        assert_no_warnings(random.multivariate_normal, mean, cov,
+        assert_no_warnings(rng.multivariate_normal, mean, cov,
                            check_valid='ignore')
 
         # and that it raises with RuntimeWarning check_valid='raises'
-        assert_raises(ValueError, random.multivariate_normal, mean, cov,
+        assert_raises(ValueError, rng.multivariate_normal, mean, cov,
                       check_valid='raise')
 
         cov = np.array([[1, 0.1], [0.1, 1]], dtype=np.float32)
         with warnings.catch_warnings():
             warnings.simplefilter('error', RuntimeWarning)
-            random.multivariate_normal(mean, cov)
+            rng.multivariate_normal(mean, cov)
 
         mu = np.zeros(2)
         cov = np.eye(2)
-        assert_raises(ValueError, random.multivariate_normal, mean, cov,
+        assert_raises(ValueError, rng.multivariate_normal, mean, cov,
                       check_valid='other')
-        assert_raises(ValueError, random.multivariate_normal,
+        assert_raises(ValueError, rng.multivariate_normal,
                       np.zeros((2, 1, 1)), cov)
-        assert_raises(ValueError, random.multivariate_normal,
+        assert_raises(ValueError, rng.multivariate_normal,
                       mu, np.empty((3, 2)))
-        assert_raises(ValueError, random.multivariate_normal,
+        assert_raises(ValueError, rng.multivariate_normal,
                       mu, np.eye(3))
 
     def test_negative_binomial(self):
-        random.seed(self.seed)
-        actual = random.negative_binomial(n=100, p=.12345, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.negative_binomial(n=100, p=.12345, size=(3, 2))
         desired = np.array([[848, 841],
                             [892, 611],
                             [779, 647]])
@@ -1050,29 +1049,29 @@ class TestRandomDist:
                           [np.nan] * 10)
 
     def test_noncentral_chisquare(self):
-        random.seed(self.seed)
-        actual = random.noncentral_chisquare(df=5, nonc=5, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_chisquare(df=5, nonc=5, size=(3, 2))
         desired = np.array([[23.91905354498517511, 13.35324692733826346],
                             [31.22452661329736401, 16.60047399466177254],
                             [5.03461598262724586, 17.94973089023519464]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        actual = random.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
+        actual = rng.noncentral_chisquare(df=.5, nonc=.2, size=(3, 2))
         desired = np.array([[1.47145377828516666,  0.15052899268012659],
                             [0.00943803056963588,  1.02647251615666169],
                             [0.332334982684171,  0.15451287602753125]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        random.seed(self.seed)
-        actual = random.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_chisquare(df=5, nonc=0, size=(3, 2))
         desired = np.array([[9.597154162763948, 11.725484450296079],
                             [10.413711048138335, 3.694475922923986],
                             [13.484222138963087, 14.377255424602957]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_noncentral_f(self):
-        random.seed(self.seed)
-        actual = random.noncentral_f(dfnum=5, dfden=2, nonc=1,
+        rng = random.RandomState(self.seed)
+        actual = rng.noncentral_f(dfnum=5, dfden=2, nonc=1,
                                      size=(3, 2))
         desired = np.array([[1.40598099674926669, 0.34207973179285761],
                             [3.57715069265772545, 7.92632662577829805],
@@ -1085,8 +1084,8 @@ class TestRandomDist:
         assert np.isnan(actual)
 
     def test_normal(self):
-        random.seed(self.seed)
-        actual = random.normal(loc=.123456789, scale=2.0, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.normal(loc=.123456789, scale=2.0, size=(3, 2))
         desired = np.array([[2.80378370443726244, 3.59863924443872163],
                             [3.121433477601256, -0.33382987590723379],
                             [4.18552478636557357, 4.46410668111310471]])
@@ -1097,8 +1096,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.normal, scale=-0.)
 
     def test_pareto(self):
-        random.seed(self.seed)
-        actual = random.pareto(a=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.pareto(a=.123456789, size=(3, 2))
         desired = np.array(
                 [[2.46852460439034849e+03, 1.41286880810518346e+03],
                  [5.28287797029485181e+07, 6.57720981047328785e+07],
@@ -1112,8 +1111,8 @@ class TestRandomDist:
         np.testing.assert_array_almost_equal_nulp(actual, desired, nulp=30)
 
     def test_poisson(self):
-        random.seed(self.seed)
-        actual = random.poisson(lam=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.poisson(lam=.123456789, size=(3, 2))
         desired = np.array([[0, 0],
                             [1, 0],
                             [0, 0]])
@@ -1132,16 +1131,16 @@ class TestRandomDist:
             assert_raises(ValueError, random.poisson, [np.nan] * 10)
 
     def test_power(self):
-        random.seed(self.seed)
-        actual = random.power(a=.123456789, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.power(a=.123456789, size=(3, 2))
         desired = np.array([[0.02048932883240791, 0.01424192241128213],
                             [0.38446073748535298, 0.39499689943484395],
                             [0.00177699707563439, 0.13115505880863756]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_rayleigh(self):
-        random.seed(self.seed)
-        actual = random.rayleigh(scale=10, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.rayleigh(scale=10, size=(3, 2))
         desired = np.array([[13.8882496494248393, 13.383318339044731],
                             [20.95413364294492098, 21.08285015800712614],
                             [11.06066537006854311, 17.35468505778271009]])
@@ -1152,24 +1151,24 @@ class TestRandomDist:
         assert_raises(ValueError, random.rayleigh, scale=-0.)
 
     def test_standard_cauchy(self):
-        random.seed(self.seed)
-        actual = random.standard_cauchy(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_cauchy(size=(3, 2))
         desired = np.array([[0.77127660196445336, -6.55601161955910605],
                             [0.93582023391158309, -2.07479293013759447],
                             [-4.74601644297011926, 0.18338989290760804]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_exponential(self):
-        random.seed(self.seed)
-        actual = random.standard_exponential(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_exponential(size=(3, 2))
         desired = np.array([[0.96441739162374596, 0.89556604882105506],
                             [2.1953785836319808, 2.22243285392490542],
                             [0.6116915921431676, 1.50592546727413201]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_gamma(self):
-        random.seed(self.seed)
-        actual = random.standard_gamma(shape=3, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_gamma(shape=3, size=(3, 2))
         desired = np.array([[5.50841531318455058, 6.62953470301903103],
                             [5.93988484943779227, 2.31044849402133989],
                             [7.54838614231317084, 8.012756093271868]])
@@ -1180,30 +1179,30 @@ class TestRandomDist:
         assert_raises(ValueError, random.standard_gamma, shape=-0.)
 
     def test_standard_normal(self):
-        random.seed(self.seed)
-        actual = random.standard_normal(size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_normal(size=(3, 2))
         desired = np.array([[1.34016345771863121, 1.73759122771936081],
                             [1.498988344300628, -0.2286433324536169],
                             [2.031033998682787, 2.17032494605655257]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_randn_singleton(self):
-        random.seed(self.seed)
-        actual = random.randn()
+        rng = random.RandomState(self.seed)
+        actual = rng.randn()
         desired = np.array(1.34016345771863121)
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_standard_t(self):
-        random.seed(self.seed)
-        actual = random.standard_t(df=10, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.standard_t(df=10, size=(3, 2))
         desired = np.array([[0.97140611862659965, -0.08830486548450577],
                             [1.36311143689505321, -0.55317463909867071],
                             [-0.18473749069684214, 0.61181537341755321]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_triangular(self):
-        random.seed(self.seed)
-        actual = random.triangular(left=5.12, mode=10.23, right=20.34,
+        rng = random.RandomState(self.seed)
+        actual = rng.triangular(left=5.12, mode=10.23, right=20.34,
                                    size=(3, 2))
         desired = np.array([[12.68117178949215784, 12.4129206149193152],
                             [16.20131377335158263, 16.25692138747600524],
@@ -1211,8 +1210,8 @@ class TestRandomDist:
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_uniform(self):
-        random.seed(self.seed)
-        actual = random.uniform(low=1.23, high=10.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.uniform(low=1.23, high=10.54, size=(3, 2))
         desired = np.array([[6.99097932346268003, 6.73801597444323974],
                             [9.50364421400426274, 9.53130618907631089],
                             [5.48995325769805476, 8.47493103280052118]])
@@ -1257,8 +1256,8 @@ class TestRandomDist:
         assert_raises(TypeError, random.hypergeometric, throwing_int, 1, 1)
 
     def test_vonmises(self):
-        random.seed(self.seed)
-        actual = random.vonmises(mu=1.23, kappa=1.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.vonmises(mu=1.23, kappa=1.54, size=(3, 2))
         desired = np.array([[2.28567572673902042, 2.89163838442285037],
                             [0.38198375564286025, 2.57638023113890746],
                             [1.19153771588353052, 1.83509849681825354]])
@@ -1272,8 +1271,8 @@ class TestRandomDist:
 
     def test_vonmises_large(self):
         # guard against changes in RandomState when Generator is fixed
-        random.seed(self.seed)
-        actual = random.vonmises(mu=0., kappa=1e7, size=3)
+        rng = random.RandomState(self.seed)
+        actual = rng.vonmises(mu=0., kappa=1e7, size=3)
         desired = np.array([4.634253748521111e-04,
                             3.558873596114509e-04,
                             -2.337119622577433e-04])
@@ -1285,16 +1284,16 @@ class TestRandomDist:
         assert_(np.isnan(r))
 
     def test_wald(self):
-        random.seed(self.seed)
-        actual = random.wald(mean=1.23, scale=1.54, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.wald(mean=1.23, scale=1.54, size=(3, 2))
         desired = np.array([[3.82935265715889983, 5.13125249184285526],
                             [0.35045403618358717, 1.50832396872003538],
                             [0.24124319895843183, 0.22031101461955038]])
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_weibull(self):
-        random.seed(self.seed)
-        actual = random.weibull(a=1.23, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.weibull(a=1.23, size=(3, 2))
         desired = np.array([[0.97097342648766727, 0.91422896443565516],
                             [1.89517770034962929, 1.91414357960479564],
                             [0.67057783752390987, 1.39494046635066793]])
@@ -1306,8 +1305,8 @@ class TestRandomDist:
         assert_raises(ValueError, random.weibull, a=-0.)
 
     def test_zipf(self):
-        random.seed(self.seed)
-        actual = random.zipf(a=1.23, size=(3, 2))
+        rng = random.RandomState(self.seed)
+        actual = rng.zipf(a=1.23, size=(3, 2))
         desired = np.array([[66, 29],
                             [1, 1],
                             [3, 13]])
@@ -1320,134 +1319,127 @@ class TestBroadcast:
     seed = 123456789
 
     def set_seed(self):
-        random.seed(self.seed)
+        return random.RandomState(self.seed)
 
     def test_uniform(self):
         low = [0]
         high = [1]
-        uniform = random.uniform
         desired = np.array([0.53283302478975902,
                             0.53413660089041659,
                             0.50955303552646702])
 
-        self.set_seed()
-        actual = uniform(low * 3, high)
+        rng = self.set_seed()
+        actual = rng.uniform(low * 3, high)
         assert_array_almost_equal(actual, desired, decimal=14)
 
-        self.set_seed()
-        actual = uniform(low, high * 3)
+        rng = self.set_seed()
+        actual = rng.uniform(low, high * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_normal(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        normal = random.normal
         desired = np.array([2.2129019979039612,
                             2.1283977976520019,
                             1.8417114045748335])
 
-        self.set_seed()
-        actual = normal(loc * 3, scale)
+        rng = self.set_seed()
+        actual = rng.normal(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, normal, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.normal, loc * 3, bad_scale)
 
-        self.set_seed()
-        actual = normal(loc, scale * 3)
+        rng = self.set_seed()
+        actual = rng.normal(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, normal, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.normal, loc, bad_scale * 3)
 
     def test_beta(self):
         a = [1]
         b = [2]
         bad_a = [-1]
         bad_b = [-2]
-        beta = random.beta
         desired = np.array([0.19843558305989056,
                             0.075230336409423643,
                             0.24976865978980844])
 
-        self.set_seed()
-        actual = beta(a * 3, b)
+        rng = self.set_seed()
+        actual = rng.beta(a * 3, b)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, beta, bad_a * 3, b)
-        assert_raises(ValueError, beta, a * 3, bad_b)
+        assert_raises(ValueError, rng.beta, bad_a * 3, b)
+        assert_raises(ValueError, rng.beta, a * 3, bad_b)
 
-        self.set_seed()
-        actual = beta(a, b * 3)
+        rng = self.set_seed()
+        actual = rng.beta(a, b * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, beta, bad_a, b * 3)
-        assert_raises(ValueError, beta, a, bad_b * 3)
+        assert_raises(ValueError, rng.beta, bad_a, b * 3)
+        assert_raises(ValueError, rng.beta, a, bad_b * 3)
 
     def test_exponential(self):
         scale = [1]
         bad_scale = [-1]
-        exponential = random.exponential
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.set_seed()
-        actual = exponential(scale * 3)
+        rng = self.set_seed()
+        actual = rng.exponential(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, exponential, bad_scale * 3)
+        assert_raises(ValueError, rng.exponential, bad_scale * 3)
 
     def test_standard_gamma(self):
         shape = [1]
         bad_shape = [-1]
-        std_gamma = random.standard_gamma
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.set_seed()
-        actual = std_gamma(shape * 3)
+        rng = self.set_seed()
+        actual = rng.standard_gamma(shape * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, std_gamma, bad_shape * 3)
+        assert_raises(ValueError, rng.standard_gamma, bad_shape * 3)
 
     def test_gamma(self):
         shape = [1]
         scale = [2]
         bad_shape = [-1]
         bad_scale = [-2]
-        gamma = random.gamma
         desired = np.array([1.5221370731769048,
                             1.5277256455738331,
                             1.4248762625178359])
 
-        self.set_seed()
-        actual = gamma(shape * 3, scale)
+        rng = self.set_seed()
+        actual = rng.gamma(shape * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gamma, bad_shape * 3, scale)
-        assert_raises(ValueError, gamma, shape * 3, bad_scale)
+        assert_raises(ValueError, rng.gamma, bad_shape * 3, scale)
+        assert_raises(ValueError, rng.gamma, shape * 3, bad_scale)
 
-        self.set_seed()
-        actual = gamma(shape, scale * 3)
+        rng = self.set_seed()
+        actual = rng.gamma(shape, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gamma, bad_shape, scale * 3)
-        assert_raises(ValueError, gamma, shape, bad_scale * 3)
+        assert_raises(ValueError, rng.gamma, bad_shape, scale * 3)
+        assert_raises(ValueError, rng.gamma, shape, bad_scale * 3)
 
     def test_f(self):
         dfnum = [1]
         dfden = [2]
         bad_dfnum = [-1]
         bad_dfden = [-2]
-        f = random.f
         desired = np.array([0.80038951638264799,
                             0.86768719635363512,
                             2.7251095168386801])
 
-        self.set_seed()
-        actual = f(dfnum * 3, dfden)
+        rng = self.set_seed()
+        actual = rng.f(dfnum * 3, dfden)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, f, bad_dfnum * 3, dfden)
-        assert_raises(ValueError, f, dfnum * 3, bad_dfden)
+        assert_raises(ValueError, rng.f, bad_dfnum * 3, dfden)
+        assert_raises(ValueError, rng.f, dfnum * 3, bad_dfden)
 
-        self.set_seed()
-        actual = f(dfnum, dfden * 3)
+        rng = self.set_seed()
+        actual = rng.f(dfnum, dfden * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, f, bad_dfnum, dfden * 3)
-        assert_raises(ValueError, f, dfnum, bad_dfden * 3)
+        assert_raises(ValueError, rng.f, bad_dfnum, dfden * 3)
+        assert_raises(ValueError, rng.f, dfnum, bad_dfden * 3)
 
     def test_noncentral_f(self):
         dfnum = [2]
@@ -1456,267 +1448,253 @@ class TestBroadcast:
         bad_dfnum = [0]
         bad_dfden = [-1]
         bad_nonc = [-2]
-        nonc_f = random.noncentral_f
         desired = np.array([9.1393943263705211,
                             13.025456344595602,
                             8.8018098359100545])
 
-        self.set_seed()
-        actual = nonc_f(dfnum * 3, dfden, nonc)
+        rng = self.set_seed()
+        actual = rng.noncentral_f(dfnum * 3, dfden, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert np.all(np.isnan(nonc_f(dfnum, dfden, [np.nan] * 3)))
+        assert np.all(np.isnan(rng.noncentral_f(dfnum, dfden, [np.nan] * 3)))
 
-        assert_raises(ValueError, nonc_f, bad_dfnum * 3, dfden, nonc)
-        assert_raises(ValueError, nonc_f, dfnum * 3, bad_dfden, nonc)
-        assert_raises(ValueError, nonc_f, dfnum * 3, dfden, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum * 3, dfden, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum * 3, bad_dfden, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum * 3, dfden, bad_nonc)
 
-        self.set_seed()
-        actual = nonc_f(dfnum, dfden * 3, nonc)
+        rng = self.set_seed()
+        actual = rng.noncentral_f(dfnum, dfden * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_f, bad_dfnum, dfden * 3, nonc)
-        assert_raises(ValueError, nonc_f, dfnum, bad_dfden * 3, nonc)
-        assert_raises(ValueError, nonc_f, dfnum, dfden * 3, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, dfden * 3, bad_nonc)
 
-        self.set_seed()
-        actual = nonc_f(dfnum, dfden, nonc * 3)
+        rng = self.set_seed()
+        actual = rng.noncentral_f(dfnum, dfden, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_f, bad_dfnum, dfden, nonc * 3)
-        assert_raises(ValueError, nonc_f, dfnum, bad_dfden, nonc * 3)
-        assert_raises(ValueError, nonc_f, dfnum, dfden, bad_nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, bad_dfnum, dfden, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, bad_dfden, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_f, dfnum, dfden, bad_nonc * 3)
 
     def test_noncentral_f_small_df(self):
-        self.set_seed()
+        rng = self.set_seed()
         desired = np.array([6.869638627492048, 0.785880199263955])
-        actual = random.noncentral_f(0.9, 0.9, 2, size=2)
+        actual = rng.noncentral_f(0.9, 0.9, 2, size=2)
         assert_array_almost_equal(actual, desired, decimal=14)
 
     def test_chisquare(self):
         df = [1]
         bad_df = [-1]
-        chisquare = random.chisquare
         desired = np.array([0.57022801133088286,
                             0.51947702108840776,
                             0.1320969254923558])
 
-        self.set_seed()
-        actual = chisquare(df * 3)
+        rng = self.set_seed()
+        actual = rng.chisquare(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, chisquare, bad_df * 3)
+        assert_raises(ValueError, rng.chisquare, bad_df * 3)
 
     def test_noncentral_chisquare(self):
         df = [1]
         nonc = [2]
         bad_df = [-1]
         bad_nonc = [-2]
-        nonc_chi = random.noncentral_chisquare
         desired = np.array([9.0015599467913763,
                             4.5804135049718742,
                             6.0872302432834564])
 
-        self.set_seed()
-        actual = nonc_chi(df * 3, nonc)
+        rng = self.set_seed()
+        actual = rng.noncentral_chisquare(df * 3, nonc)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_chi, bad_df * 3, nonc)
-        assert_raises(ValueError, nonc_chi, df * 3, bad_nonc)
+        assert_raises(ValueError, rng.noncentral_chisquare, bad_df * 3, nonc)
+        assert_raises(ValueError, rng.noncentral_chisquare, df * 3, bad_nonc)
 
-        self.set_seed()
-        actual = nonc_chi(df, nonc * 3)
+        rng = self.set_seed()
+        actual = rng.noncentral_chisquare(df, nonc * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, nonc_chi, bad_df, nonc * 3)
-        assert_raises(ValueError, nonc_chi, df, bad_nonc * 3)
+        assert_raises(ValueError, rng.noncentral_chisquare, bad_df, nonc * 3)
+        assert_raises(ValueError, rng.noncentral_chisquare, df, bad_nonc * 3)
 
     def test_standard_t(self):
         df = [1]
         bad_df = [-1]
-        t = random.standard_t
         desired = np.array([3.0702872575217643,
                             5.8560725167361607,
                             1.0274791436474273])
 
-        self.set_seed()
-        actual = t(df * 3)
+        rng = self.set_seed()
+        actual = rng.standard_t(df * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, t, bad_df * 3)
+        assert_raises(ValueError, rng.standard_t, bad_df * 3)
         assert_raises(ValueError, random.standard_t, bad_df * 3)
 
     def test_vonmises(self):
         mu = [2]
         kappa = [1]
         bad_kappa = [-1]
-        vonmises = random.vonmises
         desired = np.array([2.9883443664201312,
                             -2.7064099483995943,
                             -1.8672476700665914])
 
-        self.set_seed()
-        actual = vonmises(mu * 3, kappa)
+        rng = self.set_seed()
+        actual = rng.vonmises(mu * 3, kappa)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, vonmises, mu * 3, bad_kappa)
+        assert_raises(ValueError, rng.vonmises, mu * 3, bad_kappa)
 
-        self.set_seed()
-        actual = vonmises(mu, kappa * 3)
+        rng = self.set_seed()
+        actual = rng.vonmises(mu, kappa * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, vonmises, mu, bad_kappa * 3)
+        assert_raises(ValueError, rng.vonmises, mu, bad_kappa * 3)
 
     def test_pareto(self):
         a = [1]
         bad_a = [-1]
-        pareto = random.pareto
         desired = np.array([1.1405622680198362,
                             1.1465519762044529,
                             1.0389564467453547])
 
-        self.set_seed()
-        actual = pareto(a * 3)
+        rng = self.set_seed()
+        actual = rng.pareto(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, pareto, bad_a * 3)
+        assert_raises(ValueError, rng.pareto, bad_a * 3)
         assert_raises(ValueError, random.pareto, bad_a * 3)
 
     def test_weibull(self):
         a = [1]
         bad_a = [-1]
-        weibull = random.weibull
         desired = np.array([0.76106853658845242,
                             0.76386282278691653,
                             0.71243813125891797])
 
-        self.set_seed()
-        actual = weibull(a * 3)
+        rng = self.set_seed()
+        actual = rng.weibull(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, weibull, bad_a * 3)
+        assert_raises(ValueError, rng.weibull, bad_a * 3)
         assert_raises(ValueError, random.weibull, bad_a * 3)
 
     def test_power(self):
         a = [1]
         bad_a = [-1]
-        power = random.power
         desired = np.array([0.53283302478975902,
                             0.53413660089041659,
                             0.50955303552646702])
 
-        self.set_seed()
-        actual = power(a * 3)
+        rng = self.set_seed()
+        actual = rng.power(a * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, power, bad_a * 3)
+        assert_raises(ValueError, rng.power, bad_a * 3)
         assert_raises(ValueError, random.power, bad_a * 3)
 
     def test_laplace(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        laplace = random.laplace
         desired = np.array([0.067921356028507157,
                             0.070715642226971326,
                             0.019290950698972624])
 
-        self.set_seed()
-        actual = laplace(loc * 3, scale)
+        rng = self.set_seed()
+        actual = rng.laplace(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, laplace, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.laplace, loc * 3, bad_scale)
 
-        self.set_seed()
-        actual = laplace(loc, scale * 3)
+        rng = self.set_seed()
+        actual = rng.laplace(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, laplace, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.laplace, loc, bad_scale * 3)
 
     def test_gumbel(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        gumbel = random.gumbel
         desired = np.array([0.2730318639556768,
                             0.26936705726291116,
                             0.33906220393037939])
 
-        self.set_seed()
-        actual = gumbel(loc * 3, scale)
+        rng = self.set_seed()
+        actual = rng.gumbel(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gumbel, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.gumbel, loc * 3, bad_scale)
 
-        self.set_seed()
-        actual = gumbel(loc, scale * 3)
+        rng = self.set_seed()
+        actual = rng.gumbel(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, gumbel, loc, bad_scale * 3)
+        assert_raises(ValueError, rng.gumbel, loc, bad_scale * 3)
 
     def test_logistic(self):
         loc = [0]
         scale = [1]
         bad_scale = [-1]
-        logistic = random.logistic
         desired = np.array([0.13152135837586171,
                             0.13675915696285773,
                             0.038216792802833396])
 
-        self.set_seed()
-        actual = logistic(loc * 3, scale)
+        rng = self.set_seed()
+        actual = rng.logistic(loc * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, logistic, loc * 3, bad_scale)
+        assert_raises(ValueError, rng.logistic, loc * 3, bad_scale)
 
-        self.set_seed()
-        actual = logistic(loc, scale * 3)
+        rng = self.set_seed()
+        actual = rng.logistic(loc, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, logistic, loc, bad_scale * 3)
-        assert_equal(random.logistic(1.0, 0.0), 1.0)
+        assert_raises(ValueError, rng.logistic, loc, bad_scale * 3)
+        assert_equal(rng.logistic(1.0, 0.0), 1.0)
 
     def test_lognormal(self):
         mean = [0]
         sigma = [1]
         bad_sigma = [-1]
-        lognormal = random.lognormal
         desired = np.array([9.1422086044848427,
                             8.4013952870126261,
                             6.3073234116578671])
 
-        self.set_seed()
-        actual = lognormal(mean * 3, sigma)
+        rng = self.set_seed()
+        actual = rng.lognormal(mean * 3, sigma)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, lognormal, mean * 3, bad_sigma)
+        assert_raises(ValueError, rng.lognormal, mean * 3, bad_sigma)
         assert_raises(ValueError, random.lognormal, mean * 3, bad_sigma)
 
-        self.set_seed()
-        actual = lognormal(mean, sigma * 3)
+        rng = self.set_seed()
+        actual = rng.lognormal(mean, sigma * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, lognormal, mean, bad_sigma * 3)
+        assert_raises(ValueError, rng.lognormal, mean, bad_sigma * 3)
         assert_raises(ValueError, random.lognormal, mean, bad_sigma * 3)
 
     def test_rayleigh(self):
         scale = [1]
         bad_scale = [-1]
-        rayleigh = random.rayleigh
         desired = np.array([1.2337491937897689,
                             1.2360119924878694,
                             1.1936818095781789])
 
-        self.set_seed()
-        actual = rayleigh(scale * 3)
+        rng = self.set_seed()
+        actual = rng.rayleigh(scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, rayleigh, bad_scale * 3)
+        assert_raises(ValueError, rng.rayleigh, bad_scale * 3)
 
     def test_wald(self):
         mean = [0.5]
         scale = [1]
         bad_mean = [0]
         bad_scale = [-2]
-        wald = random.wald
         desired = np.array([0.11873681120271318,
                             0.12450084820795027,
                             0.9096122728408238])
 
-        self.set_seed()
-        actual = wald(mean * 3, scale)
+        rng = self.set_seed()
+        actual = rng.wald(mean * 3, scale)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, wald, bad_mean * 3, scale)
-        assert_raises(ValueError, wald, mean * 3, bad_scale)
+        assert_raises(ValueError, rng.wald, bad_mean * 3, scale)
+        assert_raises(ValueError, rng.wald, mean * 3, bad_scale)
         assert_raises(ValueError, random.wald, bad_mean * 3, scale)
         assert_raises(ValueError, random.wald, mean * 3, bad_scale)
 
-        self.set_seed()
-        actual = wald(mean, scale * 3)
+        rng = self.set_seed()
+        actual = rng.wald(mean, scale * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, wald, bad_mean, scale * 3)
-        assert_raises(ValueError, wald, mean, bad_scale * 3)
-        assert_raises(ValueError, wald, 0.0, 1)
-        assert_raises(ValueError, wald, 0.5, 0.0)
+        assert_raises(ValueError, rng.wald, bad_mean, scale * 3)
+        assert_raises(ValueError, rng.wald, mean, bad_scale * 3)
+        assert_raises(ValueError, rng.wald, 0.0, 1)
+        assert_raises(ValueError, rng.wald, 0.5, 0.0)
 
     def test_triangular(self):
         left = [1]
@@ -1725,38 +1703,37 @@ class TestBroadcast:
         bad_left_one = [3]
         bad_mode_one = [4]
         bad_left_two, bad_mode_two = right * 2
-        triangular = random.triangular
         desired = np.array([2.03339048710429,
                             2.0347400359389356,
                             2.0095991069536208])
 
-        self.set_seed()
-        actual = triangular(left * 3, mode, right)
+        rng = self.set_seed()
+        actual = rng.triangular(left * 3, mode, right)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one * 3, mode, right)
-        assert_raises(ValueError, triangular, left * 3, bad_mode_one, right)
-        assert_raises(ValueError, triangular, bad_left_two * 3, bad_mode_two,
+        assert_raises(ValueError, rng.triangular, bad_left_one * 3, mode, right)
+        assert_raises(ValueError, rng.triangular, left * 3, bad_mode_one, right)
+        assert_raises(ValueError, rng.triangular, bad_left_two * 3, bad_mode_two,
                       right)
 
-        self.set_seed()
-        actual = triangular(left, mode * 3, right)
+        rng = self.set_seed()
+        actual = rng.triangular(left, mode * 3, right)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one, mode * 3, right)
-        assert_raises(ValueError, triangular, left, bad_mode_one * 3, right)
-        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two * 3,
+        assert_raises(ValueError, rng.triangular, bad_left_one, mode * 3, right)
+        assert_raises(ValueError, rng.triangular, left, bad_mode_one * 3, right)
+        assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two * 3,
                       right)
 
-        self.set_seed()
-        actual = triangular(left, mode, right * 3)
+        rng = self.set_seed()
+        actual = rng.triangular(left, mode, right * 3)
         assert_array_almost_equal(actual, desired, decimal=14)
-        assert_raises(ValueError, triangular, bad_left_one, mode, right * 3)
-        assert_raises(ValueError, triangular, left, bad_mode_one, right * 3)
-        assert_raises(ValueError, triangular, bad_left_two, bad_mode_two,
+        assert_raises(ValueError, rng.triangular, bad_left_one, mode, right * 3)
+        assert_raises(ValueError, rng.triangular, left, bad_mode_one, right * 3)
+        assert_raises(ValueError, rng.triangular, bad_left_two, bad_mode_two,
                       right * 3)
 
-        assert_raises(ValueError, triangular, 10., 0., 20.)
-        assert_raises(ValueError, triangular, 10., 25., 20.)
-        assert_raises(ValueError, triangular, 10., 10., 10.)
+        assert_raises(ValueError, rng.triangular, 10., 0., 20.)
+        assert_raises(ValueError, rng.triangular, 10., 25., 20.)
+        assert_raises(ValueError, rng.triangular, 10., 10., 10.)
 
     def test_binomial(self):
         n = [1]
@@ -1764,22 +1741,21 @@ class TestBroadcast:
         bad_n = [-1]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        binom = random.binomial
         desired = np.array([1, 1, 1])
 
-        self.set_seed()
-        actual = binom(n * 3, p)
+        rng = self.set_seed()
+        actual = rng.binomial(n * 3, p)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, binom, bad_n * 3, p)
-        assert_raises(ValueError, binom, n * 3, bad_p_one)
-        assert_raises(ValueError, binom, n * 3, bad_p_two)
+        assert_raises(ValueError, rng.binomial, bad_n * 3, p)
+        assert_raises(ValueError, rng.binomial, n * 3, bad_p_one)
+        assert_raises(ValueError, rng.binomial, n * 3, bad_p_two)
 
-        self.set_seed()
-        actual = binom(n, p * 3)
+        rng = self.set_seed()
+        actual = rng.binomial(n, p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, binom, bad_n, p * 3)
-        assert_raises(ValueError, binom, n, bad_p_one * 3)
-        assert_raises(ValueError, binom, n, bad_p_two * 3)
+        assert_raises(ValueError, rng.binomial, bad_n, p * 3)
+        assert_raises(ValueError, rng.binomial, n, bad_p_one * 3)
+        assert_raises(ValueError, rng.binomial, n, bad_p_two * 3)
 
     def test_negative_binomial(self):
         n = [1]
@@ -1787,22 +1763,21 @@ class TestBroadcast:
         bad_n = [-1]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        neg_binom = random.negative_binomial
         desired = np.array([1, 0, 1])
 
-        self.set_seed()
-        actual = neg_binom(n * 3, p)
+        rng = self.set_seed()
+        actual = rng.negative_binomial(n * 3, p)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, neg_binom, bad_n * 3, p)
-        assert_raises(ValueError, neg_binom, n * 3, bad_p_one)
-        assert_raises(ValueError, neg_binom, n * 3, bad_p_two)
+        assert_raises(ValueError, rng.negative_binomial, bad_n * 3, p)
+        assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_one)
+        assert_raises(ValueError, rng.negative_binomial, n * 3, bad_p_two)
 
-        self.set_seed()
-        actual = neg_binom(n, p * 3)
+        rng = self.set_seed()
+        actual = rng.negative_binomial(n, p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, neg_binom, bad_n, p * 3)
-        assert_raises(ValueError, neg_binom, n, bad_p_one * 3)
-        assert_raises(ValueError, neg_binom, n, bad_p_two * 3)
+        assert_raises(ValueError, rng.negative_binomial, bad_n, p * 3)
+        assert_raises(ValueError, rng.negative_binomial, n, bad_p_one * 3)
+        assert_raises(ValueError, rng.negative_binomial, n, bad_p_two * 3)
 
     def test_poisson(self):
         max_lam = random.RandomState()._poisson_lam_max
@@ -1810,41 +1785,38 @@ class TestBroadcast:
         lam = [1]
         bad_lam_one = [-1]
         bad_lam_two = [max_lam * 2]
-        poisson = random.poisson
         desired = np.array([1, 1, 0])
 
-        self.set_seed()
-        actual = poisson(lam * 3)
+        rng = self.set_seed()
+        actual = rng.poisson(lam * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, poisson, bad_lam_one * 3)
-        assert_raises(ValueError, poisson, bad_lam_two * 3)
+        assert_raises(ValueError, rng.poisson, bad_lam_one * 3)
+        assert_raises(ValueError, rng.poisson, bad_lam_two * 3)
 
     def test_zipf(self):
         a = [2]
         bad_a = [0]
-        zipf = random.zipf
         desired = np.array([2, 2, 1])
 
-        self.set_seed()
-        actual = zipf(a * 3)
+        rng = self.set_seed()
+        actual = rng.zipf(a * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, zipf, bad_a * 3)
+        assert_raises(ValueError, rng.zipf, bad_a * 3)
         with np.errstate(invalid='ignore'):
-            assert_raises(ValueError, zipf, np.nan)
-            assert_raises(ValueError, zipf, [0, 0, np.nan])
+            assert_raises(ValueError, rng.zipf, np.nan)
+            assert_raises(ValueError, rng.zipf, [0, 0, np.nan])
 
     def test_geometric(self):
         p = [0.5]
         bad_p_one = [-1]
         bad_p_two = [1.5]
-        geom = random.geometric
         desired = np.array([2, 2, 2])
 
-        self.set_seed()
-        actual = geom(p * 3)
+        rng = self.set_seed()
+        actual = rng.geometric(p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, geom, bad_p_one * 3)
-        assert_raises(ValueError, geom, bad_p_two * 3)
+        assert_raises(ValueError, rng.geometric, bad_p_one * 3)
+        assert_raises(ValueError, rng.geometric, bad_p_two * 3)
 
     def test_hypergeometric(self):
         ngood = [1]
@@ -1854,50 +1826,48 @@ class TestBroadcast:
         bad_nbad = [-2]
         bad_nsample_one = [0]
         bad_nsample_two = [4]
-        hypergeom = random.hypergeometric
         desired = np.array([1, 1, 1])
 
-        self.set_seed()
-        actual = hypergeom(ngood * 3, nbad, nsample)
+        rng = self.set_seed()
+        actual = rng.hypergeometric(ngood * 3, nbad, nsample)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood * 3, nbad, nsample)
-        assert_raises(ValueError, hypergeom, ngood * 3, bad_nbad, nsample)
-        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_one)
-        assert_raises(ValueError, hypergeom, ngood * 3, nbad, bad_nsample_two)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood * 3, nbad, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, bad_nbad, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_one)
+        assert_raises(ValueError, rng.hypergeometric, ngood * 3, nbad, bad_nsample_two)
 
-        self.set_seed()
-        actual = hypergeom(ngood, nbad * 3, nsample)
+        rng = self.set_seed()
+        actual = rng.hypergeometric(ngood, nbad * 3, nsample)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood, nbad * 3, nsample)
-        assert_raises(ValueError, hypergeom, ngood, bad_nbad * 3, nsample)
-        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_one)
-        assert_raises(ValueError, hypergeom, ngood, nbad * 3, bad_nsample_two)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad * 3, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood, bad_nbad * 3, nsample)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_one)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad * 3, bad_nsample_two)
 
-        self.set_seed()
-        actual = hypergeom(ngood, nbad, nsample * 3)
+        rng = self.set_seed()
+        actual = rng.hypergeometric(ngood, nbad, nsample * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, hypergeom, bad_ngood, nbad, nsample * 3)
-        assert_raises(ValueError, hypergeom, ngood, bad_nbad, nsample * 3)
-        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_one * 3)
-        assert_raises(ValueError, hypergeom, ngood, nbad, bad_nsample_two * 3)
+        assert_raises(ValueError, rng.hypergeometric, bad_ngood, nbad, nsample * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, bad_nbad, nsample * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad, bad_nsample_one * 3)
+        assert_raises(ValueError, rng.hypergeometric, ngood, nbad, bad_nsample_two * 3)
 
-        assert_raises(ValueError, hypergeom, -1, 10, 20)
-        assert_raises(ValueError, hypergeom, 10, -1, 20)
-        assert_raises(ValueError, hypergeom, 10, 10, 0)
-        assert_raises(ValueError, hypergeom, 10, 10, 25)
+        assert_raises(ValueError, rng.hypergeometric, -1, 10, 20)
+        assert_raises(ValueError, rng.hypergeometric, 10, -1, 20)
+        assert_raises(ValueError, rng.hypergeometric, 10, 10, 0)
+        assert_raises(ValueError, rng.hypergeometric, 10, 10, 25)
 
     def test_logseries(self):
         p = [0.5]
         bad_p_one = [2]
         bad_p_two = [-1]
-        logseries = random.logseries
         desired = np.array([1, 1, 1])
 
-        self.set_seed()
-        actual = logseries(p * 3)
+        rng = self.set_seed()
+        actual = rng.logseries(p * 3)
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, logseries, bad_p_one * 3)
-        assert_raises(ValueError, logseries, bad_p_two * 3)
+        assert_raises(ValueError, rng.logseries, bad_p_one * 3)
+        assert_raises(ValueError, rng.logseries, bad_p_two * 3)
 
 
 @pytest.mark.skipif(IS_WASM, reason="can't start thread")
@@ -2025,9 +1995,9 @@ def test_integer_dtype(int_func):
 
 
 def test_integer_repeat(int_func):
-    random.seed(123456789)
+    rng = random.RandomState(123456789)
     fname, args, sha256 = int_func
-    f = getattr(random, fname)
+    f = getattr(rng, fname)
     val = f(*args, size=1000000)
     if sys.byteorder != 'little':
         val = val.byteswap()

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -54,9 +54,9 @@ class TestRegression:
                   [(1, 1), (2, 2), (3, 3), None],
                   [1, (2, 2), (3, 3), None],
                   [(1, 1), 2, 3, None]]:
-            random.seed(12345)
+            rng = random.RandomState(12345)
             shuffled = list(t)
-            random.shuffle(shuffled)
+            rng.shuffle(shuffled)
             expected = np.array([t[0], t[3], t[1], t[2]], dtype=object)
             assert_array_equal(np.array(shuffled, dtype=object), expected)
 
@@ -131,9 +131,9 @@ class TestRegression:
         class N(np.ndarray):
             pass
 
-        random.seed(1)
+        rng = random.RandomState(1)
         orig = np.arange(3).view(N)
-        perm = random.permutation(orig)
+        perm = rng.permutation(orig)
         assert_array_equal(perm, np.array([0, 2, 1]))
         assert_array_equal(orig, np.arange(3).view(N))
 
@@ -143,9 +143,9 @@ class TestRegression:
             def __array__(self, dtype=None, copy=None):
                 return self.a
 
-        random.seed(1)
+        rng = random.RandomState(1)
         m = M()
-        perm = random.permutation(m)
+        perm = rng.permutation(m)
         assert_array_equal(perm, np.array([2, 1, 4, 0, 3]))
         assert_array_equal(m.__array__(), np.arange(5))
 
@@ -176,27 +176,27 @@ class TestRegression:
                         reason='Cannot test with 32-bit C long')
     def test_randint_117(self):
         # GH 14189
-        random.seed(0)
+        rng = random.RandomState(0)
         expected = np.array([2357136044, 2546248239, 3071714933, 3626093760,
                              2588848963, 3684848379, 2340255427, 3638918503,
                              1819583497, 2678185683], dtype='int64')
-        actual = random.randint(2**32, size=10)
+        actual = rng.randint(2**32, size=10)
         assert_array_equal(actual, expected)
 
     def test_p_zero_stream(self):
         # Regression test for gh-14522.  Ensure that future versions
         # generate the same variates as version 1.16.
-        np.random.seed(12345)
-        assert_array_equal(random.binomial(1, [0, 0.25, 0.5, 0.75, 1]),
+        rng = random.RandomState(12345)
+        assert_array_equal(rng.binomial(1, [0, 0.25, 0.5, 0.75, 1]),
                            [0, 0, 0, 1, 1])
 
     def test_n_zero_stream(self):
         # Regression test for gh-14522.  Ensure that future versions
         # generate the same variates as version 1.16.
-        np.random.seed(8675309)
+        rng = random.RandomState(8675309)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                              [3, 4, 2, 3, 3, 1, 5, 3, 1, 3]])
-        assert_array_equal(random.binomial([[0], [10]], 0.25, size=(2, 10)),
+        assert_array_equal(rng.binomial([[0], [10]], 0.25, size=(2, 10)),
                            expected)
 
 

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -52,9 +52,9 @@ class TestRegression:
                   [(1, 1), (2, 2), (3, 3), None],
                   [1, (2, 2), (3, 3), None],
                   [(1, 1), 2, 3, None]]:
-            np.random.seed(12345)
+            rng = np.random.RandomState(12345)
             shuffled = list(t)
-            random.shuffle(shuffled)
+            rng.shuffle(shuffled)
             expected = np.array([t[0], t[3], t[1], t[2]], dtype=object)
             assert_array_equal(np.array(shuffled, dtype=object), expected)
 
@@ -129,9 +129,9 @@ class TestRegression:
         class N(np.ndarray):
             pass
 
-        np.random.seed(1)
+        rng = np.random.RandomState(1)
         orig = np.arange(3).view(N)
-        perm = np.random.permutation(orig)
+        perm = rng.permutation(orig)
         assert_array_equal(perm, np.array([0, 2, 1]))
         assert_array_equal(orig, np.arange(3).view(N))
 
@@ -141,8 +141,8 @@ class TestRegression:
             def __array__(self, dtype=None, copy=None):
                 return self.a
 
-        np.random.seed(1)
+        rng = np.random.RandomState(1)
         m = M()
-        perm = np.random.permutation(m)
+        perm = rng.permutation(m)
         assert_array_equal(perm, np.array([2, 1, 4, 0, 3]))
         assert_array_equal(m.__array__(), np.arange(5))


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552, specifically seeking to address `np.random` thread safe issues. Calls to legacy `np.random` affects global state, and occasionally this results in test failures when running tests in parallel threads, especially when tests are expecting specific results for a specific seed (`np.random.seed` is a good indicator of this). This can be fixed by making these global state calls into local state calls using `Generator` or `RandomState` instances.

For now, most of these tests have been converted to use `np.random.RandomState` instances, since these test files are generally testing the legacy RandomState. Notably `numpy/random/test/test_random.py` and `numpy/random/test/test_regression.py` have not been touched since I figured they should continue to test the global `np.random` calls and not be run in parallel. If folks think it's okay to also convert these files, I can definitely do so.