### PR TITLE
BLD: enable x86-simd-sort to build on KNL with -mavx512f

### DIFF
--- a/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
@@ -17,11 +17,7 @@ namespace np { namespace qsort_simd {
  */
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
-#if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
-#else
-    avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true, false);
-#endif
 }
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
@@ -39,11 +35,7 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
  */
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, npy_intp size)
 {
-#if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qsort(reinterpret_cast<_Float16*>(arr), size, true);
-#else
-    avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size, true, false);
-#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, npy_intp size)
 {

--- a/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort_16bit.dispatch.cpp
@@ -17,7 +17,11 @@ namespace np { namespace qsort_simd {
  */
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(Half *arr, npy_intp num, npy_intp kth)
 {
+#if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qselect(reinterpret_cast<_Float16*>(arr), kth, num, true);
+#else
+    avx512_qselect_fp16(reinterpret_cast<uint16_t*>(arr), kth, num, true, false);
+#endif
 }
 
 template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(uint16_t *arr, npy_intp num, npy_intp kth)
@@ -35,7 +39,11 @@ template<> void NPY_CPU_DISPATCH_CURFX(QSelect)(int16_t *arr, npy_intp num, npy_
  */
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(Half *arr, npy_intp size)
 {
+#if defined(NPY_HAVE_AVX512_SPR)
     x86simdsortStatic::qsort(reinterpret_cast<_Float16*>(arr), size, true);
+#else
+    avx512_qsort_fp16(reinterpret_cast<uint16_t*>(arr), size, true, false);
+#endif
 }
 template<> void NPY_CPU_DISPATCH_CURFX(QSort)(uint16_t *arr, npy_intp size)
 {


### PR DESCRIPTION
Updates x86-simd-sort submodule and also fixes https://github.com/numpy/numpy/issues/29560

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
