### PR TITLE
DOC: update documentation on how to prepare and do a release

### DIFF
--- a/doc/BRANCH_WALKTHROUGH.rst
+++ b/doc/BRANCH_WALKTHROUGH.rst
@@ -1,6 +1,6 @@
-This guide contains a walkthrough of branching NumPy 1.21.x on Linux.  The
-commands can be copied into the command line, but be sure to replace 1.21 and
-1.22 by the correct versions. It is good practice to make ``.mailmap`` as
+This guide contains a walkthrough of branching NumPy 2.3.x on Linux.  The
+commands can be copied into the command line, but be sure to replace 2.3 and
+2.4 by the correct versions. It is good practice to make ``.mailmap`` as
 current as possible before making the branch, that may take several weeks.
 
 This should be read together with the
@@ -12,14 +12,13 @@ Branching
 Make the branch
 ---------------
 
-This is only needed when starting a new maintenance branch. Because
-NumPy now depends on tags to determine the version, the start of a new
-development cycle in the main branch needs an annotated tag. That is done
+This is only needed when starting a new maintenance branch. The start of a new
+development cycle in the main branch should get an annotated tag. That is done
 as follows::
 
     $ git checkout main
     $ git pull upstream main
-    $ git commit --allow-empty -m'REL: Begin NumPy 1.22.0 development'
+    $ git commit --allow-empty -m'REL: Begin NumPy 2.4.0 development'
     $ git push upstream HEAD
 
 If the push fails because new PRs have been merged, do::
@@ -28,20 +27,20 @@ If the push fails because new PRs have been merged, do::
 
 and repeat the push. Once the push succeeds, tag it::
 
-    $ git tag -a -s v1.22.0.dev0 -m'Begin NumPy 1.22.0 development'
-    $ git push upstream v1.22.0.dev0
+    $ git tag -a -s v2.4.0.dev0 -m'Begin NumPy 2.4.0 development'
+    $ git push upstream v2.4.0.dev0
 
 then make the new branch and push it::
 
-    $ git branch maintenance/1.21.x HEAD^
-    $ git push upstream maintenance/1.21.x
+    $ git branch maintenance/2.3.x HEAD^
+    $ git push upstream maintenance/2.3.x
 
 Prepare the main branch for further development
 -----------------------------------------------
 
-Make a PR branch to prepare main for further development::
+Make a PR branch to prepare ``main`` for further development::
 
-    $ git checkout -b 'prepare-main-for-1.22.0-development' v1.22.0.dev0
+    $ git checkout -b 'prepare-main-for-2.4.0-development' v2.4.0.dev0
 
 Delete the release note fragments::
 
@@ -49,17 +48,11 @@ Delete the release note fragments::
 
 Create the new release notes skeleton and add to index::
 
-    $ cp doc/source/release/template.rst doc/source/release/1.22.0-notes.rst
-    $ gvim doc/source/release/1.22.0-notes.rst  # put the correct version
-    $ git add doc/source/release/1.22.0-notes.rst
+    $ cp doc/source/release/template.rst doc/source/release/2.4.0-notes.rst
+    $ gvim doc/source/release/2.4.0-notes.rst  # put the correct version
+    $ git add doc/source/release/2.4.0-notes.rst
     $ gvim doc/source/release.rst  # add new notes to notes index
     $ git add doc/source/release.rst
-
-Update ``pavement.py`` and update the ``RELEASE_NOTES`` variable to point to
-the new notes::
-
-    $ gvim pavement.py
-    $ git add pavement.py
 
 Update ``cversions.txt`` to add current release. There should be no new hash
 to worry about at this early point, just add a comment following previous
@@ -71,7 +64,7 @@ practice::
 Check your work, commit it, and push::
 
     $ git status  # check work
-    $ git commit -m'REL: Prepare main for NumPy 1.22.0 development'
+    $ git commit -m'REL: Prepare main for NumPy 2.4.0 development'
     $ git push origin HEAD
 
 Now make a pull request.

--- a/doc/HOWTO_RELEASE.rst
+++ b/doc/HOWTO_RELEASE.rst
@@ -4,142 +4,113 @@ releases for NumPy.
 Current build and release info
 ==============================
 
-Useful info can be found in the following locations:
+Useful info can be found in `building-from-source` in the docs as well as in
+these three files:
 
-* **Source tree**
-
-  - `INSTALL.rst <https://github.com/numpy/numpy/blob/main/INSTALL.rst>`_
-  - `pavement.py <https://github.com/numpy/numpy/blob/main/pavement.py>`_
-
-* **NumPy docs**
-
-  - `HOWTO_RELEASE.rst <https://github.com/numpy/numpy/blob/main/doc/HOWTO_RELEASE.rst>`_
-  - `RELEASE_WALKTHROUGH.rst <https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst>`_
-  - `BRANCH_WALKTHROUGH.rst <https://github.com/numpy/numpy/blob/main/doc/BRANCH_WALKTHROUGH.rst>`_
+- `HOWTO_RELEASE.rst <https://github.com/numpy/numpy/blob/main/doc/HOWTO_RELEASE.rst>`_
+- `RELEASE_WALKTHROUGH.rst <https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst>`_
+- `BRANCH_WALKTHROUGH.rst <https://github.com/numpy/numpy/blob/main/doc/BRANCH_WALKTHROUGH.rst>`_
 
 Supported platforms and versions
 ================================
-:ref:`NEP 29 <NEP29>` outlines which Python versions
-are supported; For the first half of 2020, this will be Python >= 3.6. We test
-NumPy against all these versions every time we merge code to main.  Binary
-installers may be available for a subset of these versions (see below).
+:ref:`NEP 29 <NEP29>` outlines which Python versions are supported *at a
+minimum*. We usually decide to keep support for a given Python version slightly
+longer than that minimum, to avoid giving other projects issues - this is at
+the discretion of the release manager.
 
-* **OS X**
+* **macOS**
 
-  OS X versions >= 10.9 are supported, for Python version support see
-  :ref:`NEP 29 <NEP29>`. We build binary wheels for OSX that are compatible with
-  Python.org Python, system Python, homebrew and macports - see this
-  `OSX wheel building summary <https://github.com/MacPython/wiki/wiki/Spinning-wheels>`_
-  for details.
+  We aim to support the same set of macOS versions as are supported by
+  Python.org and `cibuildwheel`_ for any given Python version.
+  We build binary wheels for macOS that are compatible with common Python
+  installation methods, e.g., from python.org, ``python-build-standalone`` (the
+  ones ``uv`` installs), system Python, conda-forge, Homebrew and MacPorts.
 
 * **Windows**
 
   We build 32- and 64-bit wheels on Windows. Windows 7, 8 and 10 are supported.
-  We build NumPy using the `mingw-w64 toolchain`_, `cibuildwheels`_ and GitHub
-  actions.
+  We build NumPy using the most convenient compilers, which are (as of Aug
+  2025) MSVC for x86/x86-64 and Clang-cl for arm64, `cibuildwheel`_ and GitHub
+  Actions.
 
-.. _cibuildwheels: https://cibuildwheel.readthedocs.io/en/stable/
+.. _cibuildwheel: https://cibuildwheel.readthedocs.io/en/stable/
 
 * **Linux**
 
-  We build and ship `manylinux_2_28 <https://www.python.org/dev/peps/pep-0600>`_
-  wheels for NumPy.  Many Linux distributions include their own binary builds
-  of NumPy.
+  We build and ship ``manylinux`` and ``musllinux`` wheels for x86-64 and
+  aarch64 platforms on PyPI. Wheels for 32-bit platforms are not currently
+  provided. We aim to support the lowest non-EOL versions, and upgrade roughly
+  in sync with `cibuildwheel`_. See
+  `pypa/manylinux <https://github.com/pypa/manylinux>`__ and
+  `this distro compatibility table <https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#distro-compatibility>`__
+  for more details.
 
-* **BSD / Solaris**
+* **BSD / Solaris / AIX**
 
-  No binaries are provided, but successful builds on Solaris and BSD have been
-  reported.
+  No binary wheels are provided on PyPI, however we expect building from source
+  on these platforms to work fine.
 
-Tool chain
+Toolchains
 ==========
-We build all our wheels on cloud infrastructure - so this list of compilers is
-for information and debugging builds locally.  See the ``.travis.yml`` script
-in the `numpy wheels`_ repo for an outdated source of the build recipes using
-multibuild.
+For building wheels, we use the following toolchains:
 
-.. _numpy wheels : https://github.com/MacPython/numpy-wheels
+- Linux: we use the default compilers in the ``manylinux``/``musllinux`` Docker
+  images, which is usually a relatively recent GCC version.
+- macOS: we use the Apple Clang compilers and XCode version installed on the
+  GitHub Actions runner image.
+- Windows: for x86 and x86-64 we use the default MSVC and Visual Studio
+  toolchain installed on the relevant GitHub actions runner image. Note that in
+  the past it has sometimes been necessary to use an older toolchain to avoid
+  causing problems through the static ``libnpymath`` library for SciPy - please
+  inspect the `numpy/numpy-release <https://github.com/numpy/numpy-release>`__
+  code and CI logs in case the exact version numbers need to be determined.
 
-Compilers
----------
-The same gcc version is used as the one with which Python itself is built on
-each platform. At the moment this means:
-
-- OS X builds on travis currently use `clang`.  It appears that binary wheels
-  for OSX >= 10.6 can be safely built from the travis-ci OSX 10.9 VMs
-  when building against the Python from the Python.org installers;
-- Windows builds use the `mingw-w64 toolchain`_;
-- Manylinux2014 wheels use the gcc provided on the Manylinux docker images.
-
-You will need Cython for building the binaries.  Cython compiles the ``.pyx``
-files in the NumPy distribution to ``.c`` files.
-
-.. _mingw-w64 toolchain : https://mingwpy.github.io
+For building from source, minimum compiler versions are tracked in the top-level
+``meson.build`` file.
 
 OpenBLAS
 --------
 
-All the wheels link to a version of OpenBLAS_ supplied via the openblas-libs_ repo.
-The shared object (or DLL) is shipped with in the wheel, renamed to prevent name
+Most wheels link to a version of OpenBLAS_ supplied via the openblas-libs_ repo.
+The shared object (or DLL) is shipped within the wheel, renamed to prevent name
 collisions with other OpenBLAS shared objects that may exist in the filesystem.
 
-.. _OpenBLAS: https://github.com/xianyi/OpenBLAS
+.. _OpenBLAS: https://github.com/OpenMathLib/OpenBLAS
 .. _openblas-libs: https://github.com/MacPython/openblas-libs
-
-
-Building source archives and wheels
------------------------------------
-The NumPy wheels and sdist are now built using cibuildwheel with
-github actions.
-
 
 Building docs
 -------------
-We are no longer building ``PDF`` files. All that will be needed is
-
-- virtualenv (pip).
-
-The other requirements will be filled automatically during the documentation
-build process.
-
+We are no longer building ``pdf`` files. The requirements for building the
+``html`` docs are no different than for regular development. See the README of
+the `numpy/doc <https://github.com/numpy/doc>`__ repository and the step by
+step instructions in ``doc/RELEASE_WALKTHROUGH.rst`` for more details.
 
 Uploading to PyPI
 -----------------
-The only application needed for uploading is
-
-- twine (pip).
-
-You will also need a PyPI token, which is best kept on a keyring. See the
-twine keyring_  documentation for how to do that.
-
-.. _keyring: https://twine.readthedocs.io/en/stable/#keyring-support
-
+Creating a release on PyPI and uploading wheels and sdist is automated in CI
+and uses `PyPI's trusted publishing <https://docs.pypi.org/trusted-publishers/>`__.
+See the README in the `numpy/numpy-release <https://github.com/numpy/numpy-release>`__
+repository and the step by step instructions in ``doc/RELEASE_WALKTHROUGH.rst``
+for more details.
 
 Generating author/PR lists
 --------------------------
 You will need a personal access token
 `<https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>`_
-so that scripts can access the github NumPy repository.
-
-- gitpython (pip)
-- pygithub (pip)
+so that scripts can access the GitHub NumPy repository. With that token, the
+author/PR changelog content can be generated by running ``spin changelog``. It
+may require a few extra packages, like ``gitpython`` and ``pygithub``.
 
 
 What is released
 ================
 
-* **Wheels**
-  We currently support Python 3.10-3.13 on Windows, OSX, and Linux.
+On PyPI we release wheels for a number of platforms (as discussed higher up),
+and an sdist.
 
-  * Windows: 32-bit and 64-bit wheels built using Github actions;
-  * OSX: x64_86 and arm64 OSX wheels built using Github actions;
-  * Linux: x64_86 and aarch64 Manylinux2014 wheels built using Github actions.
-
-* **Other**
-  Release notes and changelog
-
-* **Source distribution**
-  We build source releases in the .tar.gz format.
+On GitHub Releases we release the same sdist (because the source archives which
+are autogenerated by GitHub itself aren't complete), as well as the release
+notes and changelog.
 
 
 Release process
@@ -147,30 +118,11 @@ Release process
 
 Agree on a release schedule
 ---------------------------
-A typical release schedule is one beta, two release candidates and a final
-release.  It's best to discuss the timing on the mailing list first, in order
-for people to get their commits in on time, get doc wiki edits merged, etc.
-After a date is set, create a new maintenance/x.y.z branch, add new empty
-release notes for the next version in the main branch and update the Trac
-Milestones.
-
-
-Make sure current branch builds a package correctly
----------------------------------------------------
-The CI builds wheels when a PR header begins with ``REL``. Your last
-PR before releasing should be so marked and all the tests should pass.
-You can also do::
-
-    git clean -fxdq
-    python setup.py bdist_wheel
-    python setup.py sdist
-
-For details of the build process itself, it is best to read the
-Step-by-Step Directions below.
-
-.. note:: The following steps are repeated for the beta(s), release
-   candidates(s) and the final release.
-
+A typical release schedule for a feature release is two release candidates and
+a final release.  It's best to discuss the timing on the mailing list first, in
+order for people to get their commits in on time. After a date is set, create a
+new ``maintenance/x.y.z`` branch, add new empty release notes for the next version
+in the main branch and update the Milestones on the issue tracker.
 
 Check deprecations
 ------------------

--- a/doc/RELEASE_WALKTHROUGH.rst
+++ b/doc/RELEASE_WALKTHROUGH.rst
@@ -1,8 +1,9 @@
-This is a walkthrough of the NumPy 2.1.0 release on Linux, modified for
-building with GitHub Actions and cibuildwheels and uploading to the
-`anaconda.org staging repository for NumPy <https://anaconda.org/multibuild-wheels-staging/numpy>`_.
-The commands can be copied into the command line, but be sure to replace 2.1.0
-by the correct version. This should be read together with the
+This is a walkthrough of the NumPy 2.4.0 release on Linux, which will be the
+first feature release using the `numpy/numpy-release
+<https://github.com/numpy/numpy-release>`__ repository.
+
+The commands can be copied into the command line, but be sure to replace 2.4.0
+with the correct version. This should be read together with the
 :ref:`general release guide <prepare_release>`.
 
 Facility preparation
@@ -26,29 +27,24 @@ Prior to release
 Add/drop Python versions
 ------------------------
 
-When adding or dropping Python versions, two files need to be edited:
-
-- .github/workflows/wheels.yml  # for github cibuildwheel
-- pyproject.toml  # for classifier and minimum version check.
-
+When adding or dropping Python versions, multiple config and CI files need to
+be edited in addition to changing the minimum version in ``pyproject.toml``.
 Make these changes in an ordinary PR against main and backport if necessary.
-Add ``[wheel build]`` at the end of the title line of the commit summary so
-that wheel builds will be run to test the changes. We currently release wheels
-for new Python versions after the first Python rc once manylinux and
-cibuildwheel support it.
+We currently release wheels for new Python versions after the first Python RC
+once manylinux and cibuildwheel support that new Python version.
 
 
 Backport pull requests
 ----------------------
 
 Changes that have been marked for this release must be backported to the
-maintenance/2.1.x branch.
+maintenance/2.4.x branch.
 
 
-Update 2.1.0 milestones
+Update 2.4.0 milestones
 -----------------------
 
-Look at the issues/prs with 2.1.0 milestones and either push them off to a
+Look at the issues/prs with 2.4.0 milestones and either push them off to a
 later version, or maybe remove the milestone. You may need to add a milestone.
 
 
@@ -63,14 +59,13 @@ Four documents usually need to be updated or created for the release PR:
 - The ``pyproject.toml`` file
 
 These changes should be made in an ordinary PR against the maintenance branch.
-The commit heading should contain a ``[wheel build]`` directive to test if the
-wheels build. Other small, miscellaneous fixes may be part of this PR. The
-commit message might be something like::
+Other small, miscellaneous fixes may be part of this PR. The commit message
+might be something like::
 
-    REL: Prepare for the NumPy 2.1.0 release [wheel build]
+    REL: Prepare for the NumPy 2.4.0 release
 
-    - Create 2.1.0-changelog.rst.
-    - Update 2.1.0-notes.rst.
+    - Create 2.4.0-changelog.rst.
+    - Update 2.4.0-notes.rst.
     - Update .mailmap.
     - Update pyproject.toml
 
@@ -97,12 +92,12 @@ Generate the changelog
 
 The changelog is generated using the changelog tool::
 
-    $ spin changelog $GITHUB v2.0.0..maintenance/2.1.x > doc/changelog/2.1.0-changelog.rst
+    $ spin changelog $GITHUB v2.3.0..maintenance/2.4.x > doc/changelog/2.4.0-changelog.rst
 
 where ``GITHUB`` contains your GitHub access token. The text will need to be
 checked for non-standard contributor names. It is also a good idea to remove
 any links that may be present in the PR titles as they don't translate well to
-markdown, replace them with monospaced text. The non-standard contributor names
+Markdown, replace them with monospaced text. The non-standard contributor names
 should be fixed by updating the ``.mailmap`` file, which is a lot of work. It
 is best to make several trial runs before reaching this point and ping the
 malefactors using a GitHub issue to get the needed information.
@@ -116,7 +111,7 @@ run ``spin notes``, which will incorporate the snippets into the
 ``doc/source/release/notes-towncrier.rst`` file and delete the snippets::
 
     $ spin notes
-    $ gvim doc/source/release/notes-towncrier.rst doc/source/release/2.1.0-notes.rst
+    $ gvim doc/source/release/notes-towncrier.rst doc/source/release/2.4.0-notes.rst
     
 Once the ``notes-towncrier`` contents has been incorporated into release note
 the ``.. include:: notes-towncrier.rst`` directive can be removed.  The notes
@@ -142,8 +137,8 @@ isn't already present.
 Checkout the branch for the release, make sure it is up to date, and clean the
 repository::
 
-    $ git checkout maintenance/2.1.x
-    $ git pull upstream maintenance/2.1.x
+    $ git checkout maintenance/2.4.x
+    $ git pull upstream maintenance/2.4.x
     $ git submodule update
     $ git clean -xdfq
 
@@ -154,100 +149,71 @@ Sanity check::
 Tag the release and push the tag. This requires write permission for the numpy
 repository::
 
-    $ git tag -a -s v2.1.0 -m"NumPy 2.1.0 release"
-    $ git push upstream v2.1.0
+    $ git tag -a -s v2.4.0 -m"NumPy 2.4.0 release"
+    $ git push upstream v2.4.0
 
 If you need to delete the tag due to error::
 
-   $ git tag -d v2.1.0
-   $ git push --delete upstream v2.1.0
+   $ git tag -d v2.4.0
+   $ git push --delete upstream v2.4.0
 
 
-2. Build wheels
----------------
-
-Tagging the build at the beginning of this process will trigger a wheel build
-via cibuildwheel and upload wheels and an sdist to the staging repo. All wheels
-are currently built on GitHub actions and take about 1 1/4 hours to build. 
-
-If you wish to manually trigger a wheel build, you can do so:
-
-- On GitHub actions -> `Wheel builder`_ there is a "Run workflow" button, click
-  on it and choose the tag to build
-
-If some wheel builds fail for unrelated reasons, you can re-run them:
-
-- On GitHub actions select `Wheel builder`_ click on the task that contains
-  the build you want to re-run, it will have the tag as the branch. On the
-  upper right will be a re-run button, hit it and select "re-run failed"
-
-If some wheels fail to upload to anaconda, you can select those builds in the
-`Wheel builder`_ and manually download the build artifact. This is a temporary
-workaround, but sometimes the quickest way to get a release out.
-
-.. _`staging repository`: https://anaconda.org/multibuild-wheels-staging/numpy/files
-.. _`Wheel builder`: https://github.com/numpy/numpy/actions/workflows/wheels.yml
-
-
-3. Download wheels
-------------------
-
-When the wheels have all been successfully built and staged, download them from the
-Anaconda staging directory using the ``tools/download-wheels.py`` script::
-
-    $ cd ../numpy
-    $ mkdir -p release/installers
-    $ python3 tools/download-wheels.py 2.1.0
-
-
-4. Generate the README files
-----------------------------
-
-This needs to be done after all installers are downloaded, but before the pavement
-file is updated for continued development::
-
-    $ python write_release 2.1.0
-
-
-5. Upload to PyPI
------------------
-
-Upload to PyPI using ``twine``::
-
-    $ cd ../numpy
-    $ twine upload release/installers/*.whl
-    $ twine upload release/installers/*.gz  # Upload last.
-
-The source file should be uploaded last to avoid synchronization problems that
-might occur if pip users access the files while this is in process, causing pip
-to build from source rather than downloading a binary wheel. PyPI only allows a
-single source distribution, here we have chosen the gz version.  If the
-uploading breaks because of network related reasons, you can try re-running the
-commands, possibly after a fix. Twine will now handle the error generated by
-PyPI when the same file is uploaded twice.
-
-
-6. Upload files to GitHub
+2. Build wheels and sdist
 -------------------------
 
-Go to `<https://github.com/numpy/numpy/releases>`_, there should be a ``v2.1.0
+Create a ``maintenance/2.4.x`` branch in the ``numpy-release`` repository,
+and open a PR changing the ``SOURCE_REF_TO_BUILD`` identifier at the top of
+``.github/workflows/wheels.yml`` to ``v2.4.0``. That will do a full set of
+wheel builds on the PR, if everything looks good merge the PR.
+
+All wheels are currently built in that repository on GitHub Actions, they take
+about 1 hour to build. 
+
+If you wish to manually trigger a wheel build, you can do so: in your browser,
+go to `numpy-release/actions/workflows/wheels.yml <https://github.com/numpy/numpy-release/actions/workflows/wheels.yml>`__
+and click on the "Run workflow" button, then choose the tag to build. If some
+wheel builds fail for unrelated reasons, you can re-run them as normal
+in the GitHub Actions UI with "re-run failed".
+
+Once you are ready to publish a release to PyPI, use that same "Run workflow"
+button and choose ``pypi`` in the *environment* dropdown. All wheels and the
+sdist will build and be ready to release to PyPI after manual inspection that
+everything passed. E.g., the number of artifacts is correct, and the wheel
+filenames and sizes look as expected. If desired, you can also download an
+artifact for local unzipping and inspection. You will get an email notification
+as well with a "Review pending deployments" link. Once you're ready, press the
+button to start the uploads to PyPI, which will complete the release.
+
+
+3. Upload files to GitHub Releases
+----------------------------------
+
+Go to `<https://github.com/numpy/numpy/releases>`_, there should be a ``v2.4.0
 tag``, click on it and hit the edit button for that tag and update the title to
-'v2.1.0 (<date>). There are two ways to add files, using an editable text
-window and as binary uploads. Start by editing the ``release/README.md`` that
-is translated from the rst version using pandoc. Things that will need fixing:
-PR lines from the changelog, if included, are wrapped and need unwrapping,
-links should be changed to monospaced text.  Then copy the contents to the
-clipboard and paste them into the text window. It may take several tries to get
-it look right. Then
+"v2.4.0 (<date>)". There are two ways to add files, using an editable text
+window and as binary uploads.
 
-- Upload ``release/installers/numpy-2.1.0.tar.gz`` as a binary file.
+Start by running ``spin notes 2.4.0`` and then edit the ``release/README.md``
+that is translated from the rst version using pandoc. Things that will need
+fixing: PR lines from the changelog, if included, are wrapped and need
+unwrapping, links should be changed to monospaced text. Then copy the contents
+to the clipboard and paste them into the text window. It may take several tries
+to get it look right. Then
+
+- Download the sdist (``numpy-2.4.0.tar.gz``) from PyPI upload it to GitHub as
+  a binary file.
 - Upload ``release/README.rst`` as a binary file.
-- Upload ``doc/changelog/2.1.0-changelog.rst`` as a binary file.
+- Upload ``doc/changelog/2.4.0-changelog.rst`` as a binary file.
 - Check the pre-release button if this is a pre-releases.
-- Hit the ``{Publish,Update} release`` button at the bottom.
+- Hit the ``Publish release`` button at the bottom.
+
+.. note::
+   Please ensure that all 3 files are uploaded are present and the
+   release text is complete. Releases are configured to be immutable, so
+   mistakes can't (easily) be fixed anymore.
 
 
-7. Upload documents to numpy.org (skip for prereleases)
+4. Upload documents to numpy.org (skip for prereleases)
 -------------------------------------------------------
 
 .. note:: You will need a GitHub personal access token to push the update.
@@ -257,7 +223,7 @@ and most patch releases. ``make merge-doc`` clones the ``numpy/doc`` repo into
 ``doc/build/merge`` and updates it with the new documentation::
 
     $ git clean -xdfq
-    $ git co v2.1.0
+    $ git co v2.4.0
     $ rm -rf doc/build  # want version to be current
     $ python -m spin docs merge-doc --build
     $ pushd doc/build/merge
@@ -284,45 +250,41 @@ from ``numpy.org``::
 
 Update the stable link and update::
 
-    $ ln -sfn 2.1 stable
+    $ ln -sfn 2.4 stable
     $ ls -l  # check the link
 
 Once everything seems satisfactory, update, commit and upload the changes::
 
-    $ git commit -a -m"Add documentation for v2.1.0"
+    $ git commit -a -m"Add documentation for v2.4.0"
     $ git push git@github.com:numpy/doc
     $ popd
 
 
-8. Reset the maintenance branch into a development state (skip for prereleases)
+5. Reset the maintenance branch into a development state (skip for prereleases)
 -------------------------------------------------------------------------------
 
 Create release notes for next release and edit them to set the version. These
 notes will be a skeleton and have little content::
 
-    $ git checkout -b begin-2.1.1 maintenance/2.1.x
-    $ cp doc/source/release/template.rst doc/source/release/2.1.1-notes.rst
-    $ gvim doc/source/release/2.1.1-notes.rst
-    $ git add doc/source/release/2.1.1-notes.rst
+    $ git checkout -b begin-2.4.1 maintenance/2.4.x
+    $ cp doc/source/release/template.rst doc/source/release/2.4.1-notes.rst
+    $ gvim doc/source/release/2.4.1-notes.rst
+    $ git add doc/source/release/2.4.1-notes.rst
 
-Add new release notes to the documentation release list and update the
-``RELEASE_NOTES`` variable in ``pavement.py``::
-
-    $ gvim doc/source/release.rst pavement.py
-
-Update the ``version`` in ``pyproject.toml``::
+Add new release notes to the documentation release list. Then update the
+``version`` in ``pyproject.toml``::
 
     $ gvim pyproject.toml
 
 Commit the result::
 
-    $ git commit -a -m"MAINT: Prepare 2.1.x for further development"
+    $ git commit -a -m"MAINT: Prepare 2.4.x for further development"
     $ git push origin HEAD
 
 Go to GitHub and make a PR. It should be merged quickly.
 
 
-9. Announce the release on numpy.org (skip for prereleases)
+6. Announce the release on numpy.org (skip for prereleases)
 -----------------------------------------------------------
 
 This assumes that you have forked `<https://github.com/numpy/numpy.org>`_::
@@ -330,7 +292,7 @@ This assumes that you have forked `<https://github.com/numpy/numpy.org>`_::
     $ cd ../numpy.org
     $ git checkout main
     $ git pull upstream main
-    $ git checkout -b announce-numpy-2.1.0
+    $ git checkout -b announce-numpy-2.4.0
     $ gvim content/en/news.md
 
 - For all releases, go to the bottom of the page and add a one line link. Look
@@ -342,35 +304,35 @@ This assumes that you have forked `<https://github.com/numpy/numpy.org>`_::
 
 commit and push::
 
-    $ git commit -a -m"announce the NumPy 2.1.0 release"
+    $ git commit -a -m"announce the NumPy 2.4.0 release"
     $ git push origin HEAD
 
 Go to GitHub and make a PR.
 
 
-10. Announce to mailing lists
------------------------------
+7. Announce to mailing lists
+----------------------------
 
-The release should be announced on the numpy-discussion, scipy-devel, and
+The release should be announced on the numpy-discussion and
 python-announce-list mailing lists. Look at previous announcements for the
 basic template. The contributor and PR lists are the same as generated for the
 release notes above. If you crosspost, make sure that python-announce-list is
 BCC so that replies will not be sent to that list.
 
 
-11. Post-release update main (skip for prereleases)
----------------------------------------------------
+8. Post-release update main (skip for prereleases)
+--------------------------------------------------
 
 Checkout main and forward port the documentation changes. You may also want
 to update these notes if procedures have changed or improved::
 
-    $ git checkout -b post-2.1.0-release-update main
-    $ git checkout maintenance/2.1.x doc/source/release/2.1.0-notes.rst
-    $ git checkout maintenance/2.1.x doc/changelog/2.1.0-changelog.rst
-    $ git checkout maintenance/2.1.x .mailmap  # only if updated for release.
+    $ git checkout -b post-2.4.0-release-update main
+    $ git checkout maintenance/2.4.x doc/source/release/2.4.0-notes.rst
+    $ git checkout maintenance/2.4.x doc/changelog/2.4.0-changelog.rst
+    $ git checkout maintenance/2.4.x .mailmap  # only if updated for release.
     $ gvim doc/source/release.rst  # Add link to new notes
     $ git status  # check status before commit
-    $ git commit -a -m"MAINT: Update main after 2.1.0 release."
+    $ git commit -a -m"MAINT: Update main after 2.4.0 release."
     $ git push origin HEAD
 
 Go to GitHub and make a PR.


### PR DESCRIPTION
- Updates all the release docs for the change to the `numpy-release` repo
- Makes any other updates to the release docs to bring it up to date

Closes gh-29462