### PR TITLE
TST: disable overflow exception test of numpy.power on AIX

### DIFF
--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1033,8 +1033,11 @@ class TestFloatExceptions:
                                    lambda a, b: a + b, ft_max, ft_max * ft_eps)
             self.assert_raises_fpe(overflow,
                                    lambda a, b: a - b, -ft_max, ft_max * ft_eps)
-            self.assert_raises_fpe(overflow,
-                                   np.power, ftype(2), ftype(2**fi.nexp))
+            # On AIX, pow() with double does not raise the overflow exception,
+            # it returns inf. Long double is the same as double.
+            if sys.platform != 'aix' or typecode not in 'dDgG':
+                self.assert_raises_fpe(overflow,
+                                       np.power, ftype(2), ftype(2**fi.nexp))
             self.assert_raises_fpe(divbyzero,
                                    lambda a, b: a / b, ftype(1), ftype(0))
             self.assert_raises_fpe(


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
`numpy.power()` does not raise the overflow exception with numpy.float64 type.
It can be illustrated in the following code.
```python
import numpy as np
#fi = np.finfo(np.float64)
dtyp = np.dtype(np.float64).type
with np.errstate(all='raise'):
  try:
    x = np.power(dtyp(2), dtyp(2048))   # 2**fi.nexp == 2048
    print(f'No fpe error ({x})')
  except FloatingPointError as exc:
    print(f'FloatingPointError')
```
Output on AIX:
```
No fpe error (inf)
```
Output on Linux/PowerPC and Linux/x86:
```
FloatingPointError
```
This patch is to guard the `self.assert_raises_fpe(overflow, np.power, ftype(2), ftype(2**fi.nexp))` test to skip it on AIX.