### PR TITLE
MAINT: delete unused variables in unary logical dispatch

### DIFF
--- a/numpy/_core/src/umath/loops_logical.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_logical.dispatch.cpp
@@ -108,7 +108,6 @@ struct UnaryLogicalTraits;
 
 template<>
 struct UnaryLogicalTraits<logical_not_t> {
-    static constexpr bool is_not    = true;
     static constexpr auto scalar_op = std::equal_to<bool>{};
 
 #if NPY_HWY
@@ -121,7 +120,6 @@ struct UnaryLogicalTraits<logical_not_t> {
 
 template<>
 struct UnaryLogicalTraits<absolute_t> {
-    static constexpr bool is_not    = false;
     static constexpr auto scalar_op = std::not_equal_to<bool>{};
 
 #if NPY_HWY


### PR DESCRIPTION
Clang complains on current `main`:

```
[2/5] Compiling C++ object numpy/_core/libloops_logical.dispatch.h_baseline.a.p/src_umath_loops_logical.dispatch.cpp.o
../numpy/_core/src/umath/loops_logical.dispatch.cpp:111:27: warning: unused variable 'is_not' [-Wunused-const-variable]
  111 |     static constexpr bool is_not    = true;
      |                           ^~~~~~
../numpy/_core/src/umath/loops_logical.dispatch.cpp:124:27: warning: unused variable 'is_not' [-Wunused-const-variable]
  124 |     static constexpr bool is_not    = false;
      |                           ^~~~~~
2 warnings generated.
```