### PR TITLE
BUG: clongdouble(str) loses precision during string conversion

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -446,11 +446,11 @@ static PyObject *
 
 /**begin repeat
  *
- * #NAME = CFLOAT, CDOUBLE, CLONGDOUBLE#
- * #type = npy_cfloat, npy_cdouble, npy_clongdouble#
- * #ftype = npy_float, npy_double, npy_longdouble#
- * #kind = CFloat, CDouble, CLongDouble#
- * #suffix = f, , l#
+ * #NAME = CFLOAT, CDOUBLE#
+ * #type = npy_cfloat, npy_cdouble#
+ * #ftype = npy_float, npy_double#
+ * #kind = CFloat, CDouble#
+ * #suffix = f, #
  */
 NPY_NO_EXPORT int
 @NAME@_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
@@ -528,6 +528,7 @@ NPY_NO_EXPORT int
 }
 
 /**end repeat**/
+
 
 static inline npy_longdouble
 string_to_long_double(PyObject*op)
@@ -628,6 +629,177 @@ LONGDOUBLE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
     }
     // Support descr == NULL for scalarmath paths
     LONGDOUBLE_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
+    return 0;
+}
+
+static inline npy_clongdouble
+string_to_clong_double(PyObject *op)
+{
+    char *s;
+    char *start;
+    char *end;
+    npy_clongdouble temp;
+    npy_csetreall(&temp, 0);
+    npy_csetimagl(&temp, 0);
+    PyObject *b;
+
+    if (PyUnicode_Check(op)) {
+        b = PyUnicode_AsUTF8String(op);
+        if(!b) {
+            return temp;
+        }
+    }
+    else {
+        b = op;
+        Py_XINCREF(b);
+    }
+    s = PyBytes_AsString(b);
+    if (s) {
+        npy_bool has_brackets = NPY_FALSE;
+        start = s;
+
+        while (isspace((unsigned char) *s)) {
+            ++s;
+        }
+        if (*s == '(') {
+            has_brackets = NPY_TRUE;
+            s++;
+        }
+
+        errno = 0;
+        npy_longdouble real = NumPyOS_ascii_strtold(s, &end);
+        if (errno == ERANGE) {
+            if (PyErr_Warn(PyExc_RuntimeWarning,
+                    "overflow encountered in conversion from string") < 0) {
+                Py_XDECREF(b);
+                return temp;
+            }
+        }
+        else if (errno) {
+            goto parse_failure;
+        }
+
+        /* Nothing parsed */
+        if (end == s) {
+            goto parse_failure;
+        }
+
+        const char *p = end;
+        if (*p != '+' && *p != '-') {
+            // Case 1: Pure imaginary or pure real (e.g., "2j")
+            if(*p == 'j' || *p == 'J') {
+                p++;
+                npy_csetreall(&temp, 0);
+                npy_csetimagl(&temp, real);
+            } else {
+                npy_csetreall(&temp, real);
+                npy_csetimagl(&temp, 0);
+            }
+            end = (char *)p;
+        }
+        else {
+            // Case 2: Complex (e.g., "2+2j")
+            errno = 0;
+            npy_longdouble imag = NumPyOS_ascii_strtold(p, &end);
+            if (errno == ERANGE) {
+                if (PyErr_Warn(PyExc_RuntimeWarning,
+                      "overflow encountered in conversion from string") < 0) {
+                Py_XDECREF(b);
+                return temp;
+                }
+            }
+            else if (errno) {
+                goto parse_failure;
+            }
+
+            if (end == p) {
+                goto parse_failure;
+            }
+
+            if (*end != 'j' && *end != 'J') {
+                goto parse_failure;
+            }
+            end++;
+            npy_csetreall(&temp, real);
+            npy_csetimagl(&temp, imag);
+        }
+
+        while (*end != '\0' && isspace((unsigned char)*end)) {
+            end++;
+        }
+
+        if (has_brackets == NPY_TRUE) {
+            if (*end != ')') {
+                goto parse_failure;
+            }
+            end++;
+            while(isspace((unsigned char)*end)) {
+                end++;
+            }
+        }
+        
+        if (*end != '\0') {
+            goto parse_failure;
+        }
+        
+        Py_XDECREF(b);
+        return temp;
+    }
+    else {
+        PyErr_Clear();
+        Py_XDECREF(b);
+        return temp;
+    }
+
+parse_failure:
+    PyErr_Format(PyExc_ValueError,
+                "invalid literal for complex long double: %s",
+                start);
+    Py_XDECREF(b);
+    return temp;
+}
+
+NPY_NO_EXPORT int
+CLONGDOUBLE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
+{
+    npy_clongdouble temp;
+
+    if (PyArray_IsZeroDim(op)) {
+        return convert_to_scalar_and_retry(descr, op, ov, CLONGDOUBLE_setitem);
+    }
+
+    if (PyArray_IsScalar(op, CLongDouble)) {
+        temp = PyArrayScalar_VAL(op, CLongDouble);
+    }
+    else {
+        if (op == Py_None) {
+            npy_csetreall(&temp, NPY_NAN);
+            npy_csetimagl(&temp, NPY_NAN);
+        }
+        else if (PyBytes_Check(op) || PyUnicode_Check(op)) {
+            temp = string_to_clong_double(op);
+        }
+        else if ((PyLong_Check(op) && !PyBool_Check(op))) {
+            npy_longdouble real = npy_longdouble_from_PyLong(op);
+            npy_csetreall(&temp, real);
+            npy_csetimagl(&temp, 0);
+        }
+        else {
+            Py_complex oop = PyComplex_AsCComplex(op);
+            if (error_converting(oop.real)) {
+                return -1;
+            }
+            npy_csetreall(&temp, (npy_longdouble) oop.real);
+            npy_csetimagl(&temp, (npy_longdouble) oop.imag);
+        }
+    }
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    
+    memcpy(ov, &temp, NPY_SIZEOF_CLONGDOUBLE);
+    CLONGDOUBLE_copyswap(
         ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }

--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -70,7 +70,7 @@ def test_nep50_weak_integers_with_inexact(dtype):
 
     too_big_int = int(np.finfo(dtype).max) * 2
 
-    if dtype in "dDG":
+    if dtype in "dD":
         # These dtypes currently convert to Python float internally, which
         # raises an OverflowError, while the other dtypes overflow to inf.
         # NOTE: It may make sense to normalize the behavior!

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -1071,6 +1071,70 @@ def test_longdouble_complex():
     assert x + 1j == 1 + 1j
     assert 1j + x == 1 + 1j
 
+class TestCLongDoubleSetItem:
+    def test_clongdouble_precision(self):
+        # This tests that the precision of a long double is equivalent to the
+        # precision of the fields of a complex long double
+        s = "0.333333333333333333333333"
+        assert np.longdouble(s) == np.clongdouble(s).real
+
+    def test_from_clongdouble_scalar(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        py_val = 1.5 + 2.5j
+        x[0] = np.clongdouble(py_val)
+        assert np.allclose(x[0].real, py_val.real)
+        assert np.allclose(x[0].imag, py_val.imag)
+
+    def test_from_none(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        x[0] = None
+        assert np.isnan(x[0].real)
+        assert np.isnan(x[0].imag)
+
+    def test_from_string_complex(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        s = " ( 1.5+2.5j ) "
+        py_val = complex(s)
+        x[0] = s
+        assert np.allclose(complex(x[0]), py_val)
+
+    def test_from_byte_string(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        s_bytes = b"1.25+3.75j"
+        x[0] = s_bytes
+        assert x[0].real == np.longdouble("1.25")
+        assert x[0].imag == np.longdouble("3.75")
+
+    def test_from_integer(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        py_val = 42
+        x[0] = py_val
+        assert x[0].real == np.longdouble(py_val)
+        assert x[0].imag == 0
+
+    @pytest.mark.parametrize("bad_str", [
+        "not a number",
+        "(2+2j",  # Missing closing brackets
+        "2+5j )",  # Missing opening brackets
+        "3+4k",
+        "1.2.3+4j",
+        "2++3j",
+        "3j+3",
+        "3+-1j",
+        "1-j",
+        "1_000"
+    ])
+    def test_error_on_bad_string(self, bad_str):
+        x = np.zeros(1, dtype=np.clongdouble)
+        with pytest.raises(ValueError):
+            x[0] = bad_str
+
+    def test_from_zerodim_array(self):
+        x = np.zeros(1, dtype=np.clongdouble)
+        py_val = 2.0 + 3.0j
+        y = np.array(np.clongdouble(py_val))
+        x[0] = y
+        assert np.allclose(complex(x[0]), py_val)
 
 @pytest.mark.parametrize(["__op__", "__rop__", "op", "cmp"], ops_with_names)
 @pytest.mark.parametrize("subtype", [float, int, complex, np.float16])


### PR DESCRIPTION
This pull request addresses [#26701](https://github.com/numpy/numpy/issues/26701). Converting to a `np.clongdouble` from a string would result in a loss of precision. This is because the conversion process involves Python's complex type as an intermediate, which has less precision than `np.clongdouble`. The pull request adds a test which fails on the `main` branch on linux, x86.
