### PR TITLE
TYP: mypy 1.18.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - typing_extensions>=4.5.0
-  - mypy=1.17.1
+  - mypy=1.18.1
   - orjson  # makes mypy faster
   # For building docs
   - sphinx>=4.5.0

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -227,19 +227,19 @@ assert_type(np.atleast_3d(A), npt.NDArray[np.float64])
 assert_type(np.atleast_3d(A, A), tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]])
 assert_type(np.atleast_3d(A, A, A), tuple[npt.NDArray[np.float64], ...])
 
-assert_type(np.vstack([A, A]), np.ndarray[Any, Any])  # pyright correctly infers this as NDArray[float64]
+assert_type(np.vstack([A, A]), npt.NDArray[np.float64])
 assert_type(np.vstack([A, A], dtype=np.float32), npt.NDArray[np.float32])
 assert_type(np.vstack([A, C]), npt.NDArray[Any])
 assert_type(np.vstack([C, C]), npt.NDArray[Any])
 
-assert_type(np.hstack([A, A]), np.ndarray[Any, Any])  # pyright correctly infers this as NDArray[float64]
+assert_type(np.hstack([A, A]), npt.NDArray[np.float64])
 assert_type(np.hstack([A, A], dtype=np.float32), npt.NDArray[np.float32])
 
-assert_type(np.stack([A, A]), np.ndarray[Any, Any])  # pyright correctly infers this as NDArray[float64]
+assert_type(np.stack([A, A]), npt.NDArray[np.float64]) 
 assert_type(np.stack([A, A], dtype=np.float32), npt.NDArray[np.float32])
 assert_type(np.stack([A, C]), npt.NDArray[Any])
 assert_type(np.stack([C, C]), npt.NDArray[Any])
-assert_type(np.stack([A, A], axis=0), np.ndarray[Any, Any])  # pyright correctly infers this as NDArray[float64]
+assert_type(np.stack([A, A], axis=0), npt.NDArray[np.float64])
 assert_type(np.stack([A, A], out=B), SubClass[np.float64])
 
 assert_type(np.block([[A, A], [A, A]]), npt.NDArray[Any])  # pyright correctly infers this as NDArray[float64]

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -235,7 +235,7 @@ assert_type(np.vstack([C, C]), npt.NDArray[Any])
 assert_type(np.hstack([A, A]), npt.NDArray[np.float64])
 assert_type(np.hstack([A, A], dtype=np.float32), npt.NDArray[np.float32])
 
-assert_type(np.stack([A, A]), npt.NDArray[np.float64]) 
+assert_type(np.stack([A, A]), npt.NDArray[np.float64])
 assert_type(np.stack([A, A], dtype=np.float32), npt.NDArray[np.float32])
 assert_type(np.stack([A, C]), npt.NDArray[Any])
 assert_type(np.stack([C, C]), npt.NDArray[Any])

--- a/numpy/typing/tests/data/reveal/testing.pyi
+++ b/numpy/typing/tests/data/reveal/testing.pyi
@@ -173,7 +173,7 @@ assert_type(np.testing.assert_array_max_ulp(AR_i8, AR_f8, maxulp=2), npt.NDArray
 assert_type(np.testing.assert_array_max_ulp(AR_i8, AR_f8, dtype=np.float32), npt.NDArray[Any])
 
 assert_type(np.testing.assert_warns(RuntimeWarning), contextlib._GeneratorContextManager[None])  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-assert_type(np.testing.assert_warns(RuntimeWarning, func3, 5), bool)
+assert_type(np.testing.assert_warns(RuntimeWarning, func3, 5), bool)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
 
 def func4(a: int, b: str) -> bool: ...
 

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -12,7 +12,7 @@ pytest-timeout
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.17.1; platform_python_implementation != "PyPy"
+mypy==1.18.1; platform_python_implementation != "PyPy"
 typing_extensions>=4.5.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-18

It's should be significantly faster now (~0.67x in case of scipy-stubs), and solves some issues that used to lead to some incorrectly inferred types in our type-tests (e.g. `np.vstack`)