### PR TITLE
DOC: Fix typo in absolute_beginners.rst

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -863,12 +863,13 @@ NumPy also performs aggregation functions. In addition to ``min``, ``max``, and
 result of multiplying the elements together, ``std`` to get the standard
 deviation, and more. ::
 
+  >>> data = np.array([1, 2, 3])
   >>> data.max()
-  2.0
+  3
   >>> data.min()
-  1.0
+  1
   >>> data.sum()
-  3.0
+  6
 
 .. image:: images/np_aggregation.png
 


### PR DESCRIPTION
Fix a typo in the documentation (match the illustration).

<img width="3282" height="791" alt="image" src="https://github.com/user-attachments/assets/0ca17dbd-2cdd-4bd1-a72a-14050a73c053" />

```
data = np.array([1.0, 2.0, 3.0])
>>> data.max()
2.0 # this should be 3.0
>>> data.min()
1.0
>>> data.sum()
3.0 # this should be 6.0
```