### PR TITLE
MAINT: pin asv<0.6.5 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -218,7 +218,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libopenblas-dev ninja-build
-        pip install asv virtualenv packaging -r requirements/build_requirements.txt
+        pip install "asv<0.6.5" virtualenv packaging -r requirements/build_requirements.txt
     - name: Install NumPy
       run: |
         spin build -- -Dcpu-dispatch=none


### PR DESCRIPTION
ASV had a recent release, and it seems to have broken something in NumPy. I cannot reproduce locally, but maybe I am not being exact enough. In any case, let's pin this until someone can figure out what is broken.