### PR TITLE
BLD/CI: build macOS x86-64 wheel on macos-14 as a cross build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
           - [ubuntu-22.04, musllinux_x86_64, ""]
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
-          - [macos-13, macosx_x86_64, openblas]
+          - [macos-14, macosx_x86_64, openblas]
           - [macos-14, macosx_arm64, openblas]
           - [windows-2022, win_amd64, ""]
           - [windows-11-arm, win_arm64, ""]
@@ -77,24 +77,13 @@ jobs:
           # Needed due to https://github.com/actions/runner-images/issues/3371
           # Supported versions: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
           echo "FC=gfortran-13" >> "$GITHUB_ENV"
-          echo "F77=gfortran-13" >> "$GITHUB_ENV"
-          echo "F90=gfortran-13" >> "$GITHUB_ENV"
-          if [[ ${{ matrix.buildplat[2] }} == 'accelerate' ]]; then
-            # macosx_arm64 and macosx_x86_64 with accelerate
-            # only target Sonoma onwards
-            CIBW="MACOSX_DEPLOYMENT_TARGET=14.0 INSTALL_OPENBLAS=false RUNNER_OS=macOS"
-            echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$PWD/.openblas" >> "$GITHUB_ENV"
 
-            # the macos-13 image that's used for building the x86_64 wheel can't test
-            # a wheel with deployment target >= 14 without further work
-            echo "CIBW_TEST_SKIP=*-macosx_x86_64" >> "$GITHUB_ENV"
-          else
-            # macosx_x86_64 with OpenBLAS
-            # if INSTALL_OPENBLAS isn't specified then scipy-openblas is automatically installed
-            CIBW="RUNNER_OS=macOS"
-            PKG_CONFIG_PATH="$PWD/.openblas"
-            DYLD="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
-            echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
+          if [[ ${{ matrix.buildplat[1] }} == 'macosx_x86_64' ]]; then
+            # Needed because we're cross-compiling to x86-64 and testing under Rosetta
+            echo "CIBW_ARCHS_MACOS=x86_64" >> "$GITHUB_ENV"
+            # Note: pyproject.toml config-settings don't apply anymore when using this env var:
+            echo "CIBW_CONFIG_SETTINGS_MACOS=setup-args=--cross-file=$PWD/tools/ci/cross_macos_x86-64.ini setup-args=-Dblas=scipy-openblas setup-args=-Duse-ilp64=true setup-args=-Dallow-noblas=false" >> "$GITHUB_ENV"
           fi
 
       - name: Build wheels

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1030,6 +1030,10 @@ class TestCreation:
             assert_equal(np.count_nonzero(d), 0)
 
     @pytest.mark.slow
+    @pytest.mark.skipif(
+        os.environ.get("CIBW_ARCHS_MACOS") == "x86_64",
+        reason="Test fails when running on arm64 under Rosetta in wheel build jobs",
+    )
     def test_zeros_big(self):
         # test big array as they might be allocated different by the system
         types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1,6 +1,7 @@
 import fnmatch
 import itertools
 import operator
+import os
 import platform
 import sys
 import warnings
@@ -4342,6 +4343,10 @@ class TestComplexFunctions:
         reason="Older glibc versions are imprecise (maybe passes with SIMD?)"
     )
     @pytest.mark.xfail(IS_WASM, reason="doesn't work")
+    @pytest.mark.skipif(
+        os.environ.get("CIBW_ARCHS_MACOS") == "x86_64",
+        reason="Test fails when running on arm64 under Rosetta in wheel build jobs",
+    )
     @pytest.mark.parametrize('dtype', [
         np.complex64, np.complex128, np.clongdouble
     ])

--- a/numpy/f2py/tests/__init__.py
+++ b/numpy/f2py/tests/__init__.py
@@ -1,6 +1,9 @@
+import os
+
 import pytest
 
 from numpy.testing import IS_EDITABLE, IS_WASM
+
 
 if IS_WASM:
     pytest.skip(
@@ -12,5 +15,12 @@ if IS_WASM:
 if IS_EDITABLE:
     pytest.skip(
         "Editable install doesn't support tests with a compile step",
+        allow_module_level=True
+    )
+
+
+if os.environ.get("CIBW_ARCHS_MACOS") == "x86_64":
+    pytest.skip(
+        "f2py compile tests don't work when running on arm64 under Rosetta",
         allow_module_level=True
     )

--- a/tools/ci/cross_macos_x86-64.ini
+++ b/tools/ci/cross_macos_x86-64.ini
@@ -1,0 +1,5 @@
+[binaries]
+pkg-config = 'pkg-config'
+
+[properties]
+longdouble_format = 'INTEL_EXTENDED_16_BYTES_LE'

--- a/tools/ci/scipy-openblas-macos-x86-64.pc
+++ b/tools/ci/scipy-openblas-macos-x86-64.pc
@@ -1,0 +1,12 @@
+libdir=/Users/runner/work/numpy/numpy/host-env/scipy_openblas64/lib
+includedir=/Users/runner/work/numpy/numpy/host-env/scipy_openblas64/include
+openblas_config=Dont-trust-this-because-hardcoded-pcfile
+version=0.3.30
+extralib=-lm -lpthread -lgfortran -lquadmath -L${libdir} -lscipy_openblas64_
+Name: openblas
+Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
+Version: ${version}
+URL: https://github.com/xianyi/OpenBLAS
+Libs: ${libdir}/libscipy_openblas64_.dylib -Wl,-rpath,${libdir}
+Libs.private: ${extralib}
+Cflags: -I${includedir} -DBLAS_SYMBOL_PREFIX=scipy_ -DBLAS_SYMBOL_SUFFIX=64_ -DHAVE_BLAS_ILP64 -DOPENBLAS_ILP64_NAMING_SCHEME


### PR DESCRIPTION
The macos-13 image is deprecated, meaning GitHub Actions no longer offers x86-64 runners. Hence we need to cross compile. Cibuildwheel runs the tests under Rosetta2, and that works fine once we skip a couple of problematic cases.

A few of the changes in the macOS section were simple cleanups to bring things back in sync with the `numpy-release` repo. E.g., the F77/F90 env vars were distutils-specific and no longer used, and the `DYLD_LIBRARY_PATH` usage was also unnecessary.

Closes gh-29728

_Opened as Draft PR because the `.pc` file handling needs cleaning up and it's not yet 100% clear if `cibuildwheel` won't change how this works (xref https://github.com/pypa/cibuildwheel/issues/2592)._