### PR TITLE
BUG: Stable ``ScalarType`` ordering

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -598,7 +598,7 @@ def _scalar_type_key(typ):
 
 
 ScalarType = [int, float, complex, bool, bytes, str, memoryview]
-ScalarType += sorted(set(sctypeDict.values()), key=_scalar_type_key)
+ScalarType += sorted(dict.fromkeys(sctypeDict.values()), key=_scalar_type_key)
 ScalarType = tuple(ScalarType)
 
 

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -616,6 +616,35 @@ class TestScalarTypeNames:
         assert np.dtype(t.__name__).type is t
 
 
+class TestScalarTypeOrder:
+    @pytest.mark.parametrize(('a', 'b'), [
+        # signedinteger
+        (np.byte, np.short),
+        (np.short, np.intc),
+        (np.intc, np.long),
+        (np.long, np.longlong),
+        # unsignedinteger
+        (np.ubyte, np.ushort),
+        (np.ushort, np.uintc),
+        (np.uintc, np.ulong),
+        (np.ulong, np.ulonglong),
+        # floating
+        (np.half, np.single),
+        (np.single, np.double),
+        (np.double, np.longdouble),
+        # complexfloating
+        (np.csingle, np.cdouble),
+        (np.cdouble, np.clongdouble),
+        # flexible
+        (np.bytes_, np.str_),
+        (np.str_, np.void),
+        # bouncy castles
+        (np.datetime64, np.timedelta64),
+    ])
+    def test_stable_ordering(self, a: type[np.generic], b: type[np.generic]):
+        assert np.ScalarType.index(a) <= np.ScalarType.index(b)
+
+
 class TestBoolDefinition:
     def test_bool_definition(self):
         assert nt.bool is np.bool


### PR DESCRIPTION
The key used to sort `np.ScalarType` is not unique (e.g. `int64` and `longlong` on linux both have key `('i', '8')`). To remove duplicates, `set` is used, whose iteration order depends on the hashes of the containing scalartype classes. So in case of ties, the hash would be the tiebreaker. The problem is that these hashes are arbitrary, leading to differences in `ScalarType` order between platforms, python versions, machines, etc.

In case you're wondering why I care: Stubtest is currently reporting errors for `ScalarType` for certain platform and python versions: https://github.com/numpy/numtype/actions/runs/17778048694/job/50530549124?pr=706. And I'm sure you can imagine that it wasn't easy to figure out what was going on here (especially if you consider the stubtest error spaghetti output, but I digress). Hence the pedantic "backport candidate" label ;)