### PR TITLE
Feat: Adding support of `np.finfo` to the DType C API

### DIFF
--- a/doc/release/upcoming_changes/29763.c_api.rst
+++ b/doc/release/upcoming_changes/29763.c_api.rst
@@ -1,0 +1,14 @@
+DType C API support for ``np.finfo``
+------------------------------------
+User-defined dtypes can now provide floating-point information that integrates with
+`numpy.finfo`. A new C API slot ``NPY_DT_get_dtype_info`` has been added to the 
+DType API, which allows custom dtypes to specify their floating-point limits and 
+properties. The API is designed to be extensible for future support of integer info (`np.iinfo`) 
+and generic dtype information, though only floating-point info is currently 
+implemented. 
+Custom dtypes can implement this by providing a function with the signature::
+    PyObject *get_dtype_info(PyArray_Descr *descr, NPY_DTYPE_INFO_TYPE info_type)
+The function should handle ``NPY_DTYPE_INFO_FLOAT`` and return a Python object 
+with the appropriate finfo attributes (precision, eps, max, min, etc.).
+This fixes issue `gh‑27231 <https://github.com/numpy/numpy/issues/27231>`__ and was 
+implemented in pull request `gh‑29763 <https://github.com/numpy/numpy/pull/29763>`__.

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -693,3 +693,34 @@ Comparison operations:
    dtype.__gt__
    dtype.__le__
    dtype.__lt__
+
+
+Internal methods for custom user defined data types
+--------------------------------------
+
+These methods are primarily for developers implementing user-defined data types and are not intended for general use.
+
+.. method:: dtype._is_user_dtype()
+
+   Check if the dtype is a user-defined (custom) data type.
+
+   :returns: ``True`` if the dtype is user-defined, ``False`` otherwise.
+   :rtype: bool
+
+   .. note::
+      This method helps distinguish built-in dtypes from those created via the DType C API.
+      It returns ``True`` only for dtypes that have ``type_num == -1``.
+
+.. method:: dtype._get_finfo()
+
+   Retrieve the machine limits information (finfo) for user-defined dtypes.
+
+   :returns: A Python object with finfo attributes (e.g., 'bits', 'eps', 'max', 'min', etc.) if the dtype implements the ``NPY_DT_get_dtype_info`` slot, otherwise raises an error.
+   :rtype: object
+   :raises TypeError: If called on a non-dtype object or built-in dtype.
+   :raises RuntimeError: If the user dtype doesn't implement the ``NPY_DT_get_dtype_info`` slot.
+
+   .. note::
+      This method is specifically for user-defined dtypes and uses the ``NPY_DT_get_dtype_info`` C API slot with ``NPY_DTYPE_INFO_FLOAT`` to retrieve floating-point limits. It enables custom dtypes to integrate with ``np.finfo()``.
+      
+      The method will only work on dtypes where ``_is_user_dtype()`` returns ``True``.

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -205,6 +205,21 @@ Enumerated types
         example when calling np.zero(shape). This is equivalent to
         :c:data:`NPY_DOUBLE`.
 
+.. c:enum:: NPY_DTYPE_INFO_TYPE
+
+    Enumeration defining the type of dtype information (e.g., float, int or generic).
+
+    .. c:enumerator:: NPY_DTYPE_INFO_FLOAT
+
+        Indicates floating-point type information.
+
+    .. c:enumerator:: NPY_DTYPE_INFO_INTEGER
+
+        Indicates integer type information.
+    
+    .. c:enumerator:: NPY_DTYPE_INFO_GENERIC
+        Indicates generic type information
+
 Other useful related constants are
 
 .. c:macro:: NPY_NTYPES_LEGACY
@@ -502,3 +517,22 @@ format specifier in printf and related commands.
 .. c:macro:: NPY_UINTP_FMT
 
 .. c:macro:: NPY_LONGDOUBLE_FMT
+
+DType Slots
+===========
+
+The following slots are part of the DType C API for user-defined data types. They are defined as offsets in the PyArrayDTypeMeta_Spec structure and allow customization of dtype behavior.
+
+.. c:var:: NPY_DT_get_dtype_info
+
+    Slot for retrieving dtype information to support ``np.finfo`` and potentially ``np.iinfo`` on user-defined dtypes.
+
+    .. c:type:: PyObject *(PyArrayDTypeMeta_GetDTypeInfo)(PyArray_Descr *, NPY_DTYPE_INFO_TYPE)
+
+    This function should return a Python object with appropriate attributes based on the info type:
+    
+    - For ``NPY_DTYPE_INFO_FLOAT``: An object with finfo attributes (precision, eps, max, etc.)
+    - For ``NPY_DTYPE_INFO_INTEGER``: An object with iinfo attributes (min, max, etc.) - not implemented yet
+    - For ``NPY_DTYPE_INFO_GENERIC``: Generic dtype info - not implemented yet
+    
+    The function takes a dtype descriptor and an ``NPY_DTYPE_INFO_TYPE`` enum value indicating the type of information requested. It should return ``NULL`` to fall back to default behavior or on error. If not implemented, ``np.finfo`` will raise an error for the dtype.

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -469,6 +469,9 @@ class finfo:
     (e.g. numpy.finfo(numpy.csingle) is the same as numpy.finfo(numpy.single)).
     However, the output is true for the real and imaginary components.
 
+    User-defined dtypes can now support ``finfo`` by implementing the ``NPY_DT_get_dtype_info`` 
+    slot in their DTypeMeta at the C level. This provides the necessary machine limits (e.g., eps, min, max) for the dtype.
+
     References
     ----------
     .. [1] IEEE Standard for Floating-Point Arithmetic, IEEE Std 754-2008,

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -516,7 +516,7 @@ class finfo:
         obj = cls._finfo_cache.get(dtype)
         if obj is not None:
             return obj
-        
+
         if dtype._is_user_dtype() and issubclass(dtype.type, numeric.inexact):
             finfo = dtype._get_finfo()
             obj = object.__new__(cls)._init_from_finfo_obj(dtype, finfo)
@@ -577,7 +577,7 @@ class finfo:
         self._str_smallest_normal = machar._str_smallest_normal.strip()
         self._str_smallest_subnormal = machar._str_smallest_subnormal.strip()
         return self
-    
+
     def _init_from_finfo_obj(self, dtype, finfo_obj):
         self.dtype = numeric.dtype(dtype)
         self.precision = finfo_obj.get('precision')

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -516,6 +516,13 @@ class finfo:
         obj = cls._finfo_cache.get(dtype)
         if obj is not None:
             return obj
+        
+        if dtype._is_user_dtype() and issubclass(dtype.type, numeric.inexact):
+            finfo = dtype._get_finfo()
+            obj = object.__new__(cls)._init_from_finfo_obj(dtype, finfo)
+            cls._finfo_cache[dtype] = obj
+            return obj
+
         dtypes = [dtype]
         newdtype = ntypes.obj2sctype(dtype)
         if newdtype is not dtype:
@@ -549,7 +556,6 @@ class finfo:
     def _init(self, dtype):
         self.dtype = numeric.dtype(dtype)
         machar = _get_machar(dtype)
-
         for word in ['precision', 'iexp',
                      'maxexp', 'minexp', 'negep',
                      'machep']:
@@ -570,6 +576,33 @@ class finfo:
         self._str_resolution = machar._str_resolution.strip()
         self._str_smallest_normal = machar._str_smallest_normal.strip()
         self._str_smallest_subnormal = machar._str_smallest_subnormal.strip()
+        return self
+    
+    def _init_from_finfo_obj(self, dtype, finfo_obj):
+        self.dtype = numeric.dtype(dtype)
+        self.precision = finfo_obj.get('precision')
+        self.iexp = finfo_obj.get('iexp')
+        self.maxexp = finfo_obj.get('maxexp')
+        self.minexp = finfo_obj.get('minexp')
+        self.negep = finfo_obj.get('negep')
+        self.machep = finfo_obj.get('machep')
+        self.resolution = finfo_obj.get('resolution')
+        self.epsneg = finfo_obj.get('epsneg')
+        self.smallest_subnormal = finfo_obj.get('smallest_subnormal')
+        self.bits = self.dtype.itemsize * 8
+        self.max = finfo_obj.get('max')
+        self.min = finfo_obj.get('min')
+        self.eps = finfo_obj.get('eps')
+        self.nexp = finfo_obj.get('nexp')
+        self.nmant = finfo_obj.get('nmant')
+        self._machar = None
+        self._str_tiny = str(finfo_obj.get("smallest_normal"))
+        self._str_max = str(self.max)
+        self._str_epsneg = str(self.epsneg)
+        self._str_eps = str(self.eps)
+        self._str_resolution = str(self.resolution)
+        self._str_smallest_normal = str(finfo_obj.get("smallest_normal"))
+        self._str_smallest_subnormal = str(self.smallest_subnormal)
         return self
 
     def __str__(self):

--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -469,9 +469,9 @@ class finfo:
     (e.g. numpy.finfo(numpy.csingle) is the same as numpy.finfo(numpy.single)).
     However, the output is true for the real and imaginary components.
 
-    User-defined dtypes can now support ``finfo`` by implementing the ``NPY_DT_get_dtype_info`` 
-    slot in their DTypeMeta at the C level. This provides the necessary machine limits (e.g., eps, min, max) for the dtype.
-
+    User-defined dtypes can now support ``finfo`` by implementing the
+    ``NPY_DT_get_dtype_info`` slot in their DTypeMeta at the C level.
+    This provides necessary machine limits (e.g., eps, min, max) for the dtype.
     References
     ----------
     .. [1] IEEE Standard for Floating-Point Arithmetic, IEEE Std 754-2008,

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -379,7 +379,7 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
 #define NPY_DT_get_clear_loop 9
 #define NPY_DT_get_fill_zero_loop 10
 #define NPY_DT_finalize_descr 11
-#define NPY_DT_get_finfo 12
+#define NPY_DT_get_dtype_info 12
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;
@@ -491,10 +491,27 @@ typedef int(PyArrayDTypeMeta_SetItem)(PyArray_Descr *, PyObject *, char *);
 typedef PyObject *(PyArrayDTypeMeta_GetItem)(PyArray_Descr *, char *);
 
 /*
- * Function to compute finfo for a custom dtype.
- * Should return a Python object with finfo attributes (precision, eps, max, etc.)
- * or NULL to fall back to default behavior.
+ * Enum for different types of dtype information that can be requested.
  */
-typedef PyObject *(PyArrayDTypeMeta_GetFinfo)(PyArray_Descr *);
+typedef enum {
+    NPY_DTYPE_INFO_FLOAT = 0,    /* For finfo() - floating point parameters */
+    NPY_DTYPE_INFO_INTEGER = 1,  /* For iinfo() - integer parameters (not implemented) */
+    NPY_DTYPE_INFO_GENERIC = 2   /* For generic dtype info (not implemented) */
+} NPY_DTYPE_INFO_TYPE;
+
+/*
+ * Function to compute dtype information for custom dtypes.
+ * 
+ * @param descr: The dtype descriptor
+ * @param info_type: The type of information requested (float, integer, etc.)
+ * 
+ * Should return a Python object with appropriate attributes based on info_type:
+ * - For NPY_DTYPE_INFO_FLOAT: finfo attributes (precision, eps, max, etc.)
+ * - For NPY_DTYPE_INFO_INTEGER: iinfo attributes (min, max, etc.) - not implemented yet
+ * - For NPY_DTYPE_INFO_GENERIC: generic dtype info - not implemented yet
+ * 
+ * Returns NULL to fall back to default behavior or on error.
+ */
+typedef PyObject *(PyArrayDTypeMeta_GetDTypeInfo)(PyArray_Descr *, NPY_DTYPE_INFO_TYPE);
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_ */

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -379,6 +379,7 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
 #define NPY_DT_get_clear_loop 9
 #define NPY_DT_get_fill_zero_loop 10
 #define NPY_DT_finalize_descr 11
+#define NPY_DT_get_finfo 12
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;
@@ -488,5 +489,12 @@ typedef PyArray_Descr *(PyArrayDTypeMeta_FinalizeDescriptor)(PyArray_Descr *dtyp
  */
 typedef int(PyArrayDTypeMeta_SetItem)(PyArray_Descr *, PyObject *, char *);
 typedef PyObject *(PyArrayDTypeMeta_GetItem)(PyArray_Descr *, char *);
+
+/*
+ * Function to compute finfo for a custom dtype.
+ * Should return a Python object with finfo attributes (precision, eps, max, etc.)
+ * or NULL to fall back to default behavior.
+ */
+typedef PyObject *(PyArrayDTypeMeta_GetFinfo)(PyArray_Descr *);
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_ */

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3436,9 +3436,9 @@ PyObject * _get_user_def_finfo(PyObject *self, PyObject *Py_UNUSED(ignored)) {
         PyErr_SetString(PyExc_TypeError, "_get_finfo should be called on a user-defined dtype");
         return NULL;
     }
-    PyObject* finfo_obj = NPY_DT_CALL_get_finfo((PyArray_Descr *)self);
+    PyObject* finfo_obj = NPY_DT_CALL_get_dtype_info((PyArray_Descr *)self, NPY_DTYPE_INFO_FLOAT);
     if (finfo_obj == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "User DType needs to register NPY_DT_get_finfo slot");
+        PyErr_SetString(PyExc_RuntimeError, "User DType needs to register NPY_DT_get_dtype_info slot");
         return NULL;
     }
     return finfo_obj;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -179,7 +179,7 @@ dtypemeta_initialize_struct_from_spec(
     DType->dt_slots = PyMem_Calloc(1, sizeof(NPY_DType_Slots));
     if (DType->dt_slots == NULL) {
         return -1;
-    }
+  }
 
     /* Set default values (where applicable) */
     NPY_DT_SLOTS(DType)->discover_descr_from_pyobject =
@@ -195,6 +195,7 @@ dtypemeta_initialize_struct_from_spec(
     NPY_DT_SLOTS(DType)->get_clear_loop = NULL;
     NPY_DT_SLOTS(DType)->get_fill_zero_loop = NULL;
     NPY_DT_SLOTS(DType)->finalize_descr = NULL;
+    NPY_DT_SLOTS(DType)->get_finfo = NULL;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
     PyType_Slot *spec_slot = spec->slots;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -195,7 +195,7 @@ dtypemeta_initialize_struct_from_spec(
     NPY_DT_SLOTS(DType)->get_clear_loop = NULL;
     NPY_DT_SLOTS(DType)->get_fill_zero_loop = NULL;
     NPY_DT_SLOTS(DType)->finalize_descr = NULL;
-    NPY_DT_SLOTS(DType)->get_finfo = NULL;
+    NPY_DT_SLOTS(DType)->get_dtype_info = NULL;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
     PyType_Slot *spec_slot = spec->slots;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -67,7 +67,7 @@ typedef struct {
      * parameters, if any, as the operand dtype.
      */
     PyArrayDTypeMeta_FinalizeDescriptor *finalize_descr;
-    PyArrayDTypeMeta_GetFinfo *get_finfo;
+    PyArrayDTypeMeta_GetDTypeInfo *get_dtype_info;
     /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
@@ -103,8 +103,8 @@ typedef struct {
 #define NPY_DT_is_parametric(dtype) (((dtype)->flags & NPY_DT_PARAMETRIC) != 0)
 #define NPY_DT_is_numeric(dtype) (((dtype)->flags & NPY_DT_NUMERIC) != 0)
 #define NPY_DT_is_user_defined(dtype) (((dtype)->type_num == -1))
-#define NPY_DT_CALL_get_finfo(dtype) \
-    NPY_DT_SLOTS(NPY_DTYPE(dtype))->get_finfo(dtype)
+#define NPY_DT_CALL_get_dtype_info(dtype, info_type) \
+    NPY_DT_SLOTS(NPY_DTYPE(dtype))->get_dtype_info(dtype, info_type)
 
 /*
  * Macros for convenient classmethod calls, since these require

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -67,6 +67,7 @@ typedef struct {
      * parameters, if any, as the operand dtype.
      */
     PyArrayDTypeMeta_FinalizeDescriptor *finalize_descr;
+    PyArrayDTypeMeta_GetFinfo *get_finfo;
     /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
@@ -89,7 +90,7 @@ typedef struct {
 
 // This must be updated if new slots before within_dtype_castingimpl
 // are added
-#define NPY_NUM_DTYPE_SLOTS 11
+#define NPY_NUM_DTYPE_SLOTS 12
 #define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
 #define NPY_DT_MAX_ARRFUNCS_SLOT \
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET
@@ -102,6 +103,8 @@ typedef struct {
 #define NPY_DT_is_parametric(dtype) (((dtype)->flags & NPY_DT_PARAMETRIC) != 0)
 #define NPY_DT_is_numeric(dtype) (((dtype)->flags & NPY_DT_NUMERIC) != 0)
 #define NPY_DT_is_user_defined(dtype) (((dtype)->type_num == -1))
+#define NPY_DT_CALL_get_finfo(dtype) \
+    NPY_DT_SLOTS(NPY_DTYPE(dtype))->get_finfo(dtype)
 
 /*
  * Macros for convenient classmethod calls, since these require


### PR DESCRIPTION
closes #27231

This PR contibutes as follows:
- Adds a new slot ` NPY_DT_get_finfo`, allowing user to define the custom finfo object which can be used by the `np.finfo`
- Adds 2 `arraydescr_methods` 
    - `_get_finfo`: This available the finfo object coming from slot
    - `_is_user_dtype` This checks whether the dtype is user-defined or not
    
Subclassing inexact isn't an issue here, as it can be done by subclassing the scalar type to `PyFloatingArrType_Type`

 ## Usage
 ```cpp
static PyObject *
custom_get_dtype_info(PyArray_Descr *descr, NPY_DTypeInfo_Type info_type)
{    
   switch (info_type) {
       case NPY_DTYPE_INFO_FLOAT:
           {
               PyObject *finfo_dict = PyDict_New();
               if (!finfo_dict) return NULL;
               
               PyDict_SetItemString(finfo_dict, "precision", PyLong_FromLong(34));
               PyDict_SetItemString(finfo_dict, "bits", PyLong_FromLong(128));
               //  more fields
               return finfo_dict;
           }
       case NPY_DTYPE_INFO_INTEGER:
           // Not implemented yet, could add iinfo support later
           PyErr_SetString(PyExc_NotImplementedError, 
                          "Integer info not implemented for this dtype");
           return NULL;
       case NPY_DTYPE_INFO_GENERIC:
           // Not implemented yet, could add generic info later
           PyErr_SetString(PyExc_NotImplementedError, 
                          "Generic info not implemented for this dtype");
           return NULL;
       default:
           PyErr_SetString(PyExc_ValueError, "Unknown dtype info type");
           return NULL;
   }
}

static PyType_Slot CustomDType_Slots[] = {
       {NPY_DT_get_dtype_info, &custom_get_dtype_info},
       {0, NULL}
}
```

