### PR TITLE
BUG: np.setbufsize should raise ValueError for negative input

### DIFF
--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -187,6 +187,9 @@ def setbufsize(size):
     8192
 
     """
+    if size < 0:
+        raise ValueError("buffer size must be non-negative")
+        
     old = _get_extobj_dict()["bufsize"]
     extobj = _make_extobj(bufsize=size)
     _extobj_contextvar.set(extobj)

--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -189,7 +189,6 @@ def setbufsize(size):
     """
     if size < 0:
         raise ValueError("buffer size must be non-negative")
-        
     old = _get_extobj_dict()["bufsize"]
     extobj = _make_extobj(bufsize=size)
     _extobj_contextvar.set(extobj)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4708,6 +4708,18 @@ def test_reduceat():
     np.setbufsize(ncu.UFUNC_BUFSIZE_DEFAULT)
     assert_array_almost_equal(h1, h2)
 
+def test_negative_value_raises():
+    with pytest.raises(ValueError, match="buffer size must be non-negative"):
+        np.setbufsize(-5)
+
+    old = np.getbufsize()
+    try:
+        prev = np.setbufsize(4096)
+        assert prev == old
+        assert np.getbufsize() == 4096
+    finally:
+        np.setbufsize(old)
+
 def test_reduceat_empty():
     """Reduceat should work with empty arrays"""
     indices = np.array([], 'i4')


### PR DESCRIPTION
### Closes #29651

This PR fixes an issue where `np.setbufsize` silently accepted negative
values. Passing a negative value now raises a `ValueError` with a clear
error message.

### Changes
- Added a check in `np.setbufsize` to raise `ValueError` when `size < 0`.
- Added a new unit test `test_negative_value_raises` in
  `numpy/_core/tests/test_umath.py`.

### Example
```python
>>> import numpy as np
>>> np.setbufsize(-5)
Traceback (most recent call last):
    ...
ValueError: buffer size must be non-negative